### PR TITLE
feat(hosting): advertisement-layer reliability + retraction (Fix 1)

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -3351,6 +3351,9 @@ std::thread_local! {
     static GLOBAL_PENDING_OP_REMOVES: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
     static GLOBAL_PENDING_OP_HWM: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
     static GLOBAL_NEIGHBOR_HOSTING_UPDATES: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+    // Hosting advertisement retractions emitted on stop-hosting (eviction).
+    // Advertisement-layer reliability + retraction, #4642 spec step 1.
+    static GLOBAL_NEIGHBOR_HOSTING_RETRACTIONS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
     static GLOBAL_ANTI_STARVATION_TRIGGERS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
     // Terminal advertisement consult (hosting redesign piece C, invariant 5).
     static GLOBAL_TERMINAL_CONSULT_ATTEMPTS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
@@ -3390,6 +3393,7 @@ impl GlobalTestMetrics {
         GLOBAL_PENDING_OP_REMOVES.with(|c| c.set(0));
         GLOBAL_PENDING_OP_HWM.with(|c| c.set(0));
         GLOBAL_NEIGHBOR_HOSTING_UPDATES.with(|c| c.set(0));
+        GLOBAL_NEIGHBOR_HOSTING_RETRACTIONS.with(|c| c.set(0));
         GLOBAL_ANTI_STARVATION_TRIGGERS.with(|c| c.set(0));
         GLOBAL_TERMINAL_CONSULT_ATTEMPTS.with(|c| c.set(0));
         GLOBAL_TERMINAL_CONSULT_HITS.with(|c| c.set(0));
@@ -3461,6 +3465,17 @@ impl GlobalTestMetrics {
 
     pub fn neighbor_hosting_updates() -> u64 {
         GLOBAL_NEIGHBOR_HOSTING_UPDATES.with(|c| c.get())
+    }
+
+    /// A hosting advertisement retraction was emitted because this node stopped
+    /// hosting a contract (eviction). Advertisement-layer reliability +
+    /// retraction, #4642 spec step 1 — see `NeighborHostingManager::on_contract_unhosted`.
+    pub fn record_neighbor_hosting_retraction() {
+        GLOBAL_NEIGHBOR_HOSTING_RETRACTIONS.with(|c| c.set(c.get() + 1));
+    }
+
+    pub fn neighbor_hosting_retractions() -> u64 {
+        GLOBAL_NEIGHBOR_HOSTING_RETRACTIONS.with(|c| c.get())
     }
 
     pub fn record_anti_starvation_trigger() {

--- a/crates/core/src/contract/executor/runtime/pool.rs
+++ b/crates/core/src/contract/executor/runtime/pool.rs
@@ -948,6 +948,24 @@ impl ContractExecutor for RuntimePool {
                     .pending_reclamation_add(*key, current_gen);
             }
         }
+
+        // Retract our hosting advertisement once ANY required on-disk half (state
+        // or WASM code) is gone — i.e. on `Full` (both gone) OR `Partial` (one gone,
+        // the other queued for retry): in either case we can no longer reliably
+        // serve `key`, so we must stop advertising it (Fix 1, #4642 spec step 1;
+        // invariant 1: advertise iff a fresh in-mesh host). `Err` (BOTH deletes
+        // failed → nothing removed → still fully present) keeps the advertisement
+        // and retries. Wired HERE on the confirmed-delete path, NOT at the eviction
+        // decision, so the three guards above that DELIBERATELY skip the delete
+        // (contract re-hosted / re-subscribed / written to a newer generation in
+        // the eviction→reclaim window) also skip the retraction — a contract kept
+        // alive by that race retains BOTH its state AND its advertisement.
+        // Best-effort (`try_notify_node_event`), healed by the periodic re-request
+        // on drop; idempotent, so a later Full retry after a Partial (or any repeat)
+        // re-retracts harmlessly.
+        if matches!(&result, Ok(ReclaimOutcome::Full | ReclaimOutcome::Partial)) {
+            crate::operations::announce_contract_unhosted(self.op_manager.as_ref(), key);
+        }
         // Drop the outcome detail at the trait boundary: callers expect
         // `Result<(), ExecutorError>` and cannot act on Full vs Partial.
         result.map(|_| ())
@@ -1312,5 +1330,188 @@ impl ContractExecutor for RuntimePool {
 
     fn take_delegate_notification_rx(&mut self) -> Option<super::DelegateNotificationReceiver> {
         self.delegate_notification_rx.take()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{ConfigArgs, GlobalTestMetrics};
+    use freenet_stdlib::prelude::{
+        ContractCode, ContractContainer, ContractKey, ContractWasmAPIVersion, Parameters,
+        WrappedContract, WrappedState,
+    };
+    use std::num::NonZeroUsize;
+    use std::sync::Arc;
+
+    /// Synthetic contract container. The bytes are never executed
+    /// (`remove_contract` only deletes files / DB rows), so a fake blob is
+    /// sufficient — mirrors `runtime.rs`'s `make_contract` helper.
+    fn make_contract(code_seed: u8, param_seed: u8) -> (ContractContainer, ContractKey) {
+        let code = ContractCode::from(vec![code_seed; 64]);
+        let params = Parameters::from(vec![param_seed; 8]);
+        let key = ContractKey::from_params_and_code(&params, &code);
+        let wrapped = WrappedContract::new(Arc::new(code), params);
+        let container = ContractContainer::Wasm(ContractWasmAPIVersion::V1(wrapped));
+        (container, key)
+    }
+
+    /// End-to-end proof that evicting an advertised contract through the real
+    /// `RuntimePool::remove_contract` path retracts the hosting advertisement
+    /// and records `GlobalTestMetrics::neighbor_hosting_retractions()` — giving
+    /// that (otherwise unread) counter a real reader.
+    ///
+    /// The path exercised: `RuntimePool::remove_contract` → reclaim on-disk
+    /// storage (`ReclaimOutcome::Full`) → `announce_contract_unhosted` →
+    /// `NeighborHostingManager::on_contract_unhosted` →
+    /// `record_neighbor_hosting_retraction()`.
+    ///
+    /// Must run on a `current_thread` runtime (the `#[tokio::test]` default):
+    /// the retraction counter is a `thread_local!`, and `remove_contract` (with
+    /// its synchronous `announce_contract_unhosted` call) is polled on the same
+    /// thread the assertion reads from. A `multi_thread` runtime could poll the
+    /// future on a worker thread whose thread-local the assertion would not see.
+    ///
+    /// This CANNOT be exercised via `SimNetwork`: the simulation contract
+    /// handlers use the direct inner `Executor` (no `op_manager`, no
+    /// retraction); only the real `RuntimePool` used by `NetworkContractHandler`
+    /// wires the retraction. So the test builds a real `OpManager` + `RuntimePool`
+    /// directly.
+    #[tokio::test]
+    async fn test_eviction_emits_hosting_retraction() {
+        // Reset thread-local counters at the start of the (current_thread) test.
+        GlobalTestMetrics::reset();
+
+        // --- Build a real OpManager backed by a temp-dir Config -----------
+        // Mirrors the wiring in `node::testing_impl::in_memory::Builder`, minus
+        // the node event loop. `id: Some(..)` isolates the on-disk state in a
+        // fresh temp dir (cleaned on each run — see `ConfigPathsArgs::default_dirs`).
+        let config_args = ConfigArgs {
+            id: Some("evict-retraction-step1".to_string()),
+            mode: Some(OperationMode::Local),
+            ..Default::default()
+        };
+        let node_config =
+            crate::node::NodeConfig::new(config_args.build().await.expect("build Config"))
+                .await
+                .expect("build NodeConfig");
+        let config = node_config.config.clone();
+
+        // Keep the receivers / task monitor alive for the whole test (the
+        // `_`-prefixed bindings live to end of scope) so the OpManager's
+        // channels and background sweeps aren't torn down mid-run.
+        let (_notification_rx, notification_tx) = crate::node::event_loop_notification_channel();
+        let (ops_ch_channel, _ch_channel, _wait_for_event) =
+            crate::contract::contract_handler_channel();
+        let connection_manager = crate::ring::ConnectionManager::new(&node_config);
+        let (result_router_tx, _result_router_rx) = tokio::sync::mpsc::channel(100);
+        let task_monitor = crate::node::background_task_monitor::BackgroundTaskMonitor::new();
+
+        let op_manager = Arc::new(
+            OpManager::new(
+                notification_tx,
+                ops_ch_channel,
+                &node_config,
+                // Empty no-op event register — the eviction path emits no
+                // NetEventLog we need to capture here.
+                crate::tracing::DynamicRegister::new(vec![]),
+                connection_manager,
+                result_router_tx,
+                &task_monitor,
+            )
+            .expect("build OpManager"),
+        );
+        op_manager.ring.attach_op_manager(&op_manager);
+
+        // --- Build a real RuntimePool over that OpManager -----------------
+        let mut pool = RuntimePool::new(
+            config.clone(),
+            op_manager.clone(),
+            NonZeroUsize::new(1).expect("nonzero pool size"),
+        )
+        .await
+        .expect("build RuntimePool");
+
+        // --- Store a contract (state + wasm) on disk through the pool -----
+        let (container, key) = make_contract(0x11, 0x22);
+        let params = container.params();
+        let state = WrappedState::new(b"hosted state payload".to_vec());
+
+        // WASM blob: stored via a pool executor's ContractStore. All executors
+        // share the pool's single ReDb handle and on-disk contracts dir, so the
+        // executor reclaimed by `remove_contract` sees it.
+        pool.runtimes[0]
+            .as_mut()
+            .expect("pool executor present")
+            .runtime
+            .contract_store
+            .store_contract(container)
+            .expect("store contract code");
+        // State: stored via the pool's shared StateStore — the very store the
+        // checked-out executor reclaims from (clones share the ReDb + caches).
+        pool.shared_state_store
+            .store(key, state.clone(), params)
+            .await
+            .expect("store contract state");
+
+        assert_eq!(
+            pool.shared_state_store
+                .get(&key)
+                .await
+                .expect("state present before eviction"),
+            state,
+            "stored state must round-trip before eviction",
+        );
+
+        // Register the contract as an advertised host — the retraction (and its
+        // counter) only fire when the contract is in `neighbor_hosting.my_contracts`.
+        op_manager.neighbor_hosting.on_contract_hosted(&key);
+        assert!(
+            op_manager.neighbor_hosting.is_hosted_locally(&key),
+            "contract advertised as hosted before eviction",
+        );
+
+        // The three `remove_contract` guards must NOT bail:
+        //   1. is_hosting_contract(key) — false; we never touched the ring hosting cache.
+        //   2. contract_in_use(key)     — false; no subscription/downstream interest.
+        //   3. state_generation(key)    — pass it as expected_generation so it matches.
+        assert!(
+            !op_manager.ring.is_hosting_contract(&key),
+            "guard precondition: contract must not be in the ring hosting cache",
+        );
+        assert!(
+            !op_manager.ring.contract_in_use(&key),
+            "guard precondition: contract must not be in use",
+        );
+        let expected_generation = op_manager.ring.state_generation(&key);
+
+        // --- Evict via the real RuntimePool::remove_contract path ---------
+        let before = GlobalTestMetrics::neighbor_hosting_retractions();
+        pool.remove_contract(&key, expected_generation)
+            .await
+            .expect("remove_contract reclaim must succeed");
+        let after = GlobalTestMetrics::neighbor_hosting_retractions();
+
+        // (i) On-disk state is gone.
+        match pool.shared_state_store.get(&key).await {
+            Err(StateStoreError::MissingContract(missing)) => assert_eq!(missing, key),
+            other => panic!("expected MissingContract after eviction, got {other:?}"),
+        }
+        // ...and the advertisement was retracted from the local hosted set.
+        assert!(
+            !op_manager.neighbor_hosting.is_hosted_locally(&key),
+            "eviction must retract the hosting advertisement",
+        );
+
+        // (ii) The retraction counter advanced by exactly one — the real reader
+        // this test exists to provide.
+        assert_eq!(
+            after,
+            before + 1,
+            "eviction of an advertised contract must emit exactly one hosting retraction",
+        );
+
+        // Explicitly hold the guards to end of scope.
+        drop(task_monitor);
     }
 }

--- a/crates/core/src/node/neighbor_hosting.rs
+++ b/crates/core/src/node/neighbor_hosting.rs
@@ -32,6 +32,23 @@ use tracing::{debug, info, trace};
 use crate::message::NeighborHostingMessage;
 use crate::transport::TransportPublicKey;
 
+// Advertisement-layer anti-entropy cadence (#4642 spec step 1, "Fix 1").
+//
+// The on-connect `HostingStateRequest`/`HostingStateResponse` exchange and the
+// per-eviction retraction broadcast are both best-effort; a dropped one leaves a
+// co-host with a stale view of what its neighbor hosts (a missed add ⇒ lost
+// fan-out; a missed retraction ⇒ a phantom host that poisons fan-out and
+// read-routing, invariant 1). The reliability backstop is a periodic full-set
+// re-request: it is PIGGYBACKED on the InterestSync `interest_heartbeat` loop
+// (`ring.rs`), so it runs on that loop's `INTEREST_HEARTBEAT_INTERVAL` (~5 min)
+// cadence and shares its RNG-free scheduling — a separate task with its own
+// `GlobalRng` initial-delay draw would perturb the deterministic simulation
+// harness. The `HostingStateResponse` handler REPLACES our view of the responding
+// neighbor, so both a dropped add and a dropped retraction self-heal within one
+// interval. That interval is also the advertisement-staleness / reconcile TOCTOU
+// bound the spec calls out: a co-host advertisement can be stale for at most one
+// heartbeat interval after a dropped update.
+
 /// Result from handling a neighbor hosting message.
 ///
 /// Contains an optional response message to send back, plus any contracts
@@ -123,11 +140,24 @@ impl NeighborHostingManager {
         }
     }
 
-    /// Called when we stop hosting a contract (eviction).
+    /// Called when we STOP hosting a contract — the state has left this node
+    /// (background eviction; and, once built, evict-to-admit displacement and
+    /// interest-gated collapse-then-evict, which all funnel through the same disk
+    /// reclamation path). Removes the contract from our advertised set and returns
+    /// a retraction `HostingAnnounce{removed}` to broadcast to connected co-hosts,
+    /// or `None` if we were not advertising it (idempotent).
     ///
-    /// Returns a `HostingAnnounce` message to broadcast to neighbors if the
-    /// contract was hosted, or `None` if it wasn't.
-    #[allow(dead_code)]
+    /// Wiring this is Fix 1's retraction half (#4642 spec step 1). Without it a
+    /// co-host keeps a phantom advertisement for a contract we evicted, so it
+    /// fans updates to us and routes reads to us for state we no longer hold — the
+    /// stale-advertisement failure class (invariant 1: advertise iff a fresh
+    /// in-mesh host). Idempotent by construction (`DashSet::remove` returns `None`
+    /// on a repeat), so the pending-reclamation retry path at the call site can
+    /// re-fire safely; the broadcast only happens on the transition.
+    ///
+    /// Best-effort like its `on_contract_hosted` sibling: a dropped retraction is
+    /// healed by the periodic full-set re-request (piggybacked on the interest
+    /// heartbeat, ~5 min).
     pub fn on_contract_unhosted(
         &self,
         contract_key: &ContractKey,
@@ -137,8 +167,9 @@ impl NeighborHostingManager {
         if self.my_contracts.remove(&contract_id).is_some() {
             debug!(
                 contract = %contract_key,
-                "NEIGHBOR_HOSTING: Removed contract from locally hosted"
+                "NEIGHBOR_HOSTING: Removed contract from locally hosted (retracting advertisement)"
             );
+            crate::config::GlobalTestMetrics::record_neighbor_hosting_retraction();
 
             Some(NeighborHostingMessage::HostingAnnounce {
                 added: vec![],
@@ -277,17 +308,44 @@ impl NeighborHostingManager {
             NeighborHostingMessage::HostingStateResponse { contracts } => {
                 let count = contracts.len();
 
-                // Find contracts that overlap with our local cache BEFORE storing.
-                // We need to announce these back so the peer knows we also have them.
+                // Capture what we previously knew this peer hosted BEFORE the full
+                // replace below, so `overlapping` (which drives the proactive
+                // state sync) is computed only over NEWLY-learned shared contracts,
+                // mirroring the `HostingAnnounce` arm's `previously_known` diff.
+                //
+                // This is what makes the periodic full-set re-request
+                // (piggybacked on the interest heartbeat, Fix 1) cheap and purely
+                // advertisement-layer: without the diff, every re-request would
+                // re-trigger a targeted state sync for EVERY actively-served shared
+                // contract every interval — redundant with the InterestSync STATE
+                // anti-entropy and a needless per-interval fetch load. On a fresh
+                // connection (or a reconnect, where `on_peer_disconnected` cleared
+                // this peer's entry) `previously_known` is empty, so every shared
+                // contract counts as new and the reconnection-recovery sync is
+                // preserved exactly.
+                let previously_known: HashSet<ContractInstanceId> = self
+                    .neighbor_contracts
+                    .get(from)
+                    .map(|entry| entry.value().clone())
+                    .unwrap_or_default();
+
+                // A `HostingStateResponse` is a FULL SNAPSHOT: it REPLACES our
+                // whole view of this peer, so a contract the peer stopped hosting
+                // silently disappears from our view here. That full-replace is what
+                // lets the periodic re-request heal a dropped retraction (Fix 1).
+                self.neighbor_contracts
+                    .insert(from.clone(), contracts.iter().copied().collect());
+                crate::config::GlobalTestMetrics::record_neighbor_hosting_update();
+
+                // Announce back only the NEWLY-learned overlaps so the peer can
+                // include us in its UPDATE targets for shared contracts it did not
+                // previously know we host.
                 let overlapping: Vec<ContractInstanceId> = contracts
                     .iter()
-                    .filter(|id| self.my_contracts.contains(*id))
+                    .filter(|id| !previously_known.contains(*id)) // Only NEW from this peer
+                    .filter(|id| self.my_contracts.contains(*id)) // That we also host
                     .copied()
                     .collect();
-
-                self.neighbor_contracts
-                    .insert(from.clone(), contracts.into_iter().collect());
-                crate::config::GlobalTestMetrics::record_neighbor_hosting_update();
 
                 info!(
                     peer = %from,
@@ -449,7 +507,7 @@ impl NeighborHostingManager {
         self.my_contracts.contains(contract_key.id())
     }
 
-    /// Get the number of contracts we're hosting locally.
+    /// Get the number of contracts we advertise hosting locally (`my_contracts`).
     #[allow(dead_code)]
     pub fn local_hosted_count(&self) -> usize {
         self.my_contracts.len()
@@ -1222,5 +1280,176 @@ mod tests {
 
         // Hosting an already-initialized contract should return None (no duplicate announcement)
         assert!(manager.on_contract_hosted(&key1).is_none());
+    }
+
+    // === Advertisement-layer retraction + reliability (Fix 1, #4642 step 1) ===
+
+    #[test]
+    fn test_removed_announce_converges_at_receiver() {
+        // Fix 1 retraction propagation: a `HostingAnnounce{removed}` drops the
+        // contract from our view of the neighbor, so we stop treating it as a
+        // host for Source-1 fan-out and terminal read-routing.
+        let manager = NeighborHostingManager::new();
+        let key = test_contract_key();
+        let neighbor = make_pub_key(1);
+
+        manager.handle_message(
+            &neighbor,
+            NeighborHostingMessage::HostingAnnounce {
+                added: vec![*key.id()],
+                removed: vec![],
+                is_response: false,
+            },
+        );
+        assert_eq!(
+            manager.neighbors_with_contract(&key),
+            vec![neighbor.clone()]
+        );
+
+        // The neighbor retracts (stopped hosting) → we must drop it.
+        let result = manager.handle_message(
+            &neighbor,
+            NeighborHostingMessage::HostingAnnounce {
+                added: vec![],
+                removed: vec![*key.id()],
+                is_response: false,
+            },
+        );
+        assert!(
+            manager.neighbors_with_contract(&key).is_empty(),
+            "a removed-announce must retract the neighbor's advertisement"
+        );
+        // A pure retraction has no overlap to sync back and needs no response.
+        assert!(result.response.is_none());
+        assert!(result.overlapping_contracts.is_empty());
+    }
+
+    #[test]
+    fn test_hosting_state_response_full_replace_drops_stale() {
+        // The periodic full-set re-request (piggybacked on `interest_heartbeat`,
+        // Fix 1) heals a DROPPED retraction: a `HostingStateResponse` is a full snapshot
+        // that REPLACES our view of the peer, so a contract the peer stopped
+        // hosting disappears even though we never saw its removed-announce.
+        let manager = NeighborHostingManager::new();
+        let key_x = test_contract_key();
+        let key_y = test_contract_key_2();
+        let neighbor = make_pub_key(1);
+
+        // We believe the neighbor hosts X and Y (from earlier announces).
+        manager.handle_message(
+            &neighbor,
+            NeighborHostingMessage::HostingAnnounce {
+                added: vec![*key_x.id(), *key_y.id()],
+                removed: vec![],
+                is_response: false,
+            },
+        );
+        assert_eq!(
+            manager.neighbors_with_contract(&key_x),
+            vec![neighbor.clone()]
+        );
+        assert_eq!(
+            manager.neighbors_with_contract(&key_y),
+            vec![neighbor.clone()]
+        );
+
+        // A periodic re-request response shows the neighbor now hosts only X (it
+        // evicted Y and our retraction was dropped). Full-replace drops Y.
+        manager.handle_message(
+            &neighbor,
+            NeighborHostingMessage::HostingStateResponse {
+                contracts: vec![*key_x.id()],
+            },
+        );
+        assert_eq!(
+            manager.neighbors_with_contract(&key_x),
+            vec![neighbor.clone()]
+        );
+        assert!(
+            manager.neighbors_with_contract(&key_y).is_empty(),
+            "a full-set re-request must drop a contract the peer stopped hosting \
+             (the dropped-retraction heal)"
+        );
+    }
+
+    #[test]
+    fn test_hosting_state_response_overlap_only_for_newly_learned() {
+        // The periodic re-request must NOT re-trigger the proactive state sync for
+        // an already-known overlap every interval (that would duplicate the
+        // InterestSync STATE anti-entropy and re-arm needless per-interval fetch
+        // load). `overlapping` is computed only over NEWLY-learned shared
+        // contracts, mirroring the `HostingAnnounce` path.
+        let manager = NeighborHostingManager::new();
+        let key = test_contract_key();
+        let neighbor = make_pub_key(1);
+
+        manager.on_contract_hosted(&key);
+
+        // First response (fresh view): the shared contract is new → overlap.
+        let first = manager.handle_message(
+            &neighbor,
+            NeighborHostingMessage::HostingStateResponse {
+                contracts: vec![*key.id()],
+            },
+        );
+        assert_eq!(
+            first.overlapping_contracts,
+            vec![*key.id()],
+            "first response must report the shared contract as a new overlap"
+        );
+
+        // Second (periodic) response with the SAME set: already known → no
+        // overlap, so no redundant per-interval state sync.
+        let second = manager.handle_message(
+            &neighbor,
+            NeighborHostingMessage::HostingStateResponse {
+                contracts: vec![*key.id()],
+            },
+        );
+        assert!(
+            second.overlapping_contracts.is_empty(),
+            "a periodic re-request of an already-known overlap must NOT re-sync state"
+        );
+        assert!(second.response.is_none());
+
+        // Reconnection recovery preserved: after a disconnect clears our view, the
+        // same shared contract is new again → overlap re-reported (fast recovery).
+        manager.on_peer_disconnected(&neighbor);
+        let after_reconnect = manager.handle_message(
+            &neighbor,
+            NeighborHostingMessage::HostingStateResponse {
+                contracts: vec![*key.id()],
+            },
+        );
+        assert_eq!(
+            after_reconnect.overlapping_contracts,
+            vec![*key.id()],
+            "after reconnect (view cleared) the overlap must be re-reported"
+        );
+    }
+
+    #[test]
+    fn test_on_contract_unhosted_is_idempotent() {
+        // The eviction call site (`reclaim_evicted_contract`) can re-fire on the
+        // pending-reclamation retry, so the retraction primitive must be
+        // idempotent: it emits the retraction once and returns `None` thereafter.
+        let manager = NeighborHostingManager::new();
+        let key = test_contract_key();
+
+        manager.on_contract_hosted(&key);
+        assert!(manager.is_hosted_locally(&key), "advertised after hosting");
+
+        assert!(
+            manager.on_contract_unhosted(&key).is_some(),
+            "first unhost emits a retraction"
+        );
+        assert!(
+            !manager.is_hosted_locally(&key),
+            "no longer advertised after retraction"
+        );
+        assert!(
+            manager.on_contract_unhosted(&key).is_none(),
+            "repeat unhost is a no-op (idempotent) — the retry path must not re-broadcast"
+        );
     }
 }

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -354,7 +354,13 @@ impl Drop for ClientOpGuard {
 }
 
 impl OpManager {
-    pub(super) fn new<ER: NetEventRegister + Clone>(
+    // `pub(crate)` (widened from `pub(super)`) so in-crate unit tests outside
+    // `crate::node` can stand up a real `OpManager` — specifically the
+    // `RuntimePool` eviction→retraction test in
+    // `contract::executor::runtime::pool`, which must drive
+    // `RuntimePool::remove_contract` against a genuine `OpManager`. Constructor
+    // only; no behavior change.
+    pub(crate) fn new<ER: NetEventRegister + Clone>(
         notification_channel: EventLoopNotificationsSender,
         ch_outbound: ContractHandlerChannel<SenderHalve>,
         config: &NodeConfig,

--- a/crates/core/src/operations.rs
+++ b/crates/core/src/operations.rs
@@ -295,6 +295,50 @@ pub(crate) async fn announce_contract_hosted(op_manager: &OpManager, key: &Contr
     }
 }
 
+/// Retracts our advertisement that we host `key`, telling connected co-hosts to
+/// stop fanning updates to us and stop routing reads to us for it. The retraction
+/// half of Fix 1 (#4642 spec step 1).
+///
+/// Called from `RuntimePool::remove_contract` once a required on-disk half is
+/// actually gone — the confirmed-`ReclaimOutcome::Full | Partial` delete path (a
+/// `Partial` half-delete can no longer be served, so it retracts too; `Err`, with
+/// nothing deleted, does not) — i.e. AFTER the re-host / re-subscribe /
+/// newer-generation guards that would otherwise keep the contract. Wiring it there
+/// (not at the eviction *decision* in [`reclaim_evicted_contract`]) is what keeps
+/// a contract kept alive by that race both fresh AND advertised.
+///
+/// Best-effort and non-blocking (`try_notify_node_event`): unlike
+/// [`announce_contract_hosted`] (a one-shot hosting announce that MUST be
+/// delivered, hence its blocking await), a dropped retraction self-heals within
+/// one interest-heartbeat interval (~5 min) when a co-host re-requests our full
+/// hosted set and full-replaces its view of us (the piggybacked hosting
+/// re-request in `interest_heartbeat`). `on_contract_unhosted` is idempotent, so
+/// a pending-reclamation retry that reaches this after the state is already gone
+/// is a harmless no-op.
+pub(crate) fn announce_contract_unhosted(op_manager: &OpManager, key: &ContractKey) {
+    if let Some(retraction) = op_manager.neighbor_hosting.on_contract_unhosted(key) {
+        tracing::debug!(
+            %key,
+            "NEIGHBOR_HOSTING: Retracting hosting advertisement to neighbors"
+        );
+        if let Err(err) =
+            op_manager.try_notify_node_event(crate::message::NodeEvent::BroadcastHostingUpdate {
+                message: retraction,
+            })
+        {
+            // Best-effort by design — the periodic full-set re-request
+            // (piggybacked on `interest_heartbeat`) is the convergence backstop for
+            // a dropped retraction. Debug, not warn: benign back-pressure under load.
+            tracing::debug!(
+                contract = %key,
+                error = %err,
+                "NEIGHBOR_HOSTING: retraction broadcast dropped (best-effort; \
+                 healed by periodic full-set re-request)"
+            );
+        }
+    }
+}
+
 /// Terminal advertisement consult (hosting redesign piece C, invariant 5:
 /// "findability is routing + on-demand advertisement").
 ///
@@ -456,6 +500,23 @@ pub(crate) fn reclaim_evicted_contract(
             .pending_reclamation_add(key, expected_generation);
         return;
     }
+    // NOTE (Fix 1 retraction, #4642 spec step 1): the hosting-advertisement
+    // retraction is NOT emitted here at the eviction DECISION. `EvictContract` is
+    // fire-and-forget and the deletion-time guards in `RuntimePool::remove_contract`
+    // DELIBERATELY skip the delete if the contract was re-hosted / re-subscribed /
+    // written to a newer generation in the eviction→reclaim window. Retracting
+    // here would then leave the node holding fresh state it no longer advertises
+    // (an under-advertisement the periodic heartbeat cannot heal). Instead the
+    // retraction is wired on the confirmed-delete path (`ReclaimOutcome::Full |
+    // Partial`) in `RuntimePool::remove_contract`, so it fires exactly when a
+    // required on-disk half is truly gone. That single point covers every eviction
+    // funnel (GET/PUT insert
+    // eviction, the periodic sweep, and — once built — evict-to-admit). (Interest-
+    // gated COLLAPSE does not stop hosting on current `main`: `send_unsubscribe_
+    // upstream` drops only the lease, leaving a still-fresh cached copy that must
+    // keep advertising; when the reconcile-core flip makes demand-loss stop
+    // hosting, that collapse-then-evict flows through this very funnel too.)
+
     // Disk reclamation after hosting-cache eviction is best-effort GC —
     // background-tier so it yields the contract loop to client/relay work (#4534).
     op_manager.notify_contract_handler_fire_and_forget_prioritized(
@@ -1152,6 +1213,106 @@ mod sub_op_subscribe_pin_tests {
              subscribe driver `subscribe::run_client_subscribe` — \
              matches the `maybe_subscribe_child` pattern in \
              `put/op_ctx_task.rs` and `get/op_ctx_task.rs`."
+        );
+    }
+}
+
+#[cfg(test)]
+mod reclaim_retraction_pin_tests {
+    //! Pin tests for the Fix 1 retraction wiring (#4642 spec step 1). The
+    //! hosting-advertisement retraction must fire on the CONFIRMED-delete path
+    //! (`RuntimePool::remove_contract`, gated `ReclaimOutcome::Full | Partial`),
+    //! NOT at the eviction DECISION in `reclaim_evicted_contract`: the deletion-time
+    //! guards
+    //! (re-host / re-subscribe / newer-generation) may skip the delete, and a
+    //! retraction at the decision site would then leave the node holding fresh
+    //! state it no longer advertises. A future refactor — including the
+    //! reconcile-core `Retract` flip — must neither move it back to the decision
+    //! site nor drop it. (Every eviction funnels through `remove_contract`:
+    //! GET/PUT insert eviction, the periodic sweep, and — once built —
+    //! evict-to-admit.)
+
+    fn extract_fn_body(src: &'static str, needle: &str) -> &'static str {
+        let start = src
+            .find(needle)
+            .unwrap_or_else(|| panic!("`{needle}` must exist"));
+        let body_open = src[start..]
+            .find('{')
+            .map(|off| start + off)
+            .expect("expected `{` after function signature");
+        let mut depth: i32 = 0;
+        let mut end = body_open;
+        for (i, ch) in src[body_open..].char_indices() {
+            match ch {
+                '{' => depth += 1,
+                '}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        end = body_open + i + 1;
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        assert!(
+            end > body_open,
+            "failed to find matching `}}` for `{needle}`"
+        );
+        &src[start..end]
+    }
+
+    #[test]
+    fn reclaim_evicted_contract_does_not_retract_at_the_decision_site() {
+        let src = include_str!("operations.rs");
+        // Runtime-compose the needle so this pin does not match itself.
+        let needle = ["fn ", "reclaim_evicted_contract("].concat();
+        let body = extract_fn_body(src, &needle);
+        assert!(
+            !body.contains("announce_contract_unhosted("),
+            "`reclaim_evicted_contract` must NOT retract at the eviction decision — \
+             the deletion-time guards may skip the delete, which would leave the \
+             node holding fresh state it no longer advertises. The retraction is \
+             wired on the confirmed-delete path in `RuntimePool::remove_contract`."
+        );
+    }
+
+    #[test]
+    fn remove_contract_retracts_on_any_confirmed_delete_not_on_err() {
+        // pool.rs is the ONLY layer with the deletion-time generation guard and
+        // the Full/Partial reclaim outcome, so the retraction lives there.
+        let src = include_str!("contract/executor/runtime/pool.rs");
+        let needle = ["fn ", "remove_contract("].concat();
+        let body = extract_fn_body(src, &needle);
+        assert!(
+            body.contains("announce_contract_unhosted("),
+            "`RuntimePool::remove_contract` must retract the hosting advertisement \
+             on the confirmed delete (Fix 1, invariant 1)."
+        );
+        // It must fire only when a required on-disk half is actually gone — i.e.
+        // gated on `ReclaimOutcome::Full | ReclaimOutcome::Partial`. `Err` (both
+        // deletes failed → nothing removed → still serveable) must KEEP advertising.
+        assert!(
+            body.contains("ReclaimOutcome::Full | ReclaimOutcome::Partial"),
+            "the retraction must be gated on `ReclaimOutcome::Full | ReclaimOutcome::\
+             Partial` (any required half gone) — a `Partial` half-delete can no \
+             longer be served, so it must retract too; `Err` (nothing deleted) must \
+             not."
+        );
+        // It must come AFTER the deletion-time guards / the reclaim match — never at
+        // the eviction decision (the premature-retraction bug Codex flagged): a
+        // guard-bail (re-host / re-subscribe / newer generation) returns early
+        // BEFORE reaching the reclaim, so it never retracts a still-present contract.
+        let outcome = body
+            .find("ReclaimOutcome::Full")
+            .expect("the reclaim-outcome match must exist");
+        let retract = body
+            .find("announce_contract_unhosted(")
+            .expect("the retraction call must exist");
+        assert!(
+            retract > outcome,
+            "the retraction must come after the reclaim-outcome match (post-guards), \
+             so a guard-bail does NOT retract a contract whose state is still present"
         );
     }
 }

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -728,6 +728,14 @@ impl Ring {
             GlobalExecutor::spawn(Self::interest_heartbeat(ring.clone())),
         );
 
+        // NOTE: the advertisement-layer anti-entropy re-request (#4642 spec step 1,
+        // "Fix 1") is NOT a separate task — it is piggybacked on the
+        // `interest_heartbeat` loop above (see the `HostingStateRequest` send
+        // there). A separate task with its own `GlobalRng` initial-delay draw
+        // perturbed the shared per-thread seeded RNG stream that the deterministic
+        // simulation harness depends on; riding the existing heartbeat loop adds no
+        // RNG consumer and no second timer, so the sim stream is unchanged.
+
         // Spawn periodic governance reaper tick.
         // Computes per-contract state from accumulated cost/benefit
         // samples and logs `ReaperDecision`s. Mode defaults to `Off`
@@ -1384,11 +1392,17 @@ impl Ring {
                 continue;
             };
 
-            // Get our current interest hashes
+            // Get our current interest hashes. NOTE: unlike the pre-Fix-1 loop,
+            // an empty `hashes` does NOT skip the cycle. The InterestSync interest
+            // send is gated on `hashes` per-peer below, but the piggybacked
+            // advertisement-layer re-request (Fix 1) must run for ANY connected
+            // node: every node consults its `neighbor_contracts` view for terminal
+            // GET/SUBSCRIBE advertisement lookups (invariant 5) and Source-1 UPDATE
+            // fan-out, even a pure relay that hosts nothing and has no interests,
+            // so that view must be reconciled on the anti-entropy cadence — else a
+            // dropped retraction leaves a phantom advertised host unhealed
+            // indefinitely. The only gate is having connected peers (below).
             let hashes = op_manager.interest_manager.get_all_interest_hashes();
-            if hashes.is_empty() {
-                continue;
-            }
 
             // Get all connected peer addresses (deduplicated)
             let connections = ring.connection_manager.get_connections_by_location();
@@ -1419,26 +1433,76 @@ impl Ring {
             let sender = op_manager.to_event_listener.notifications_sender();
             let mut peers_sent = 0usize;
             for (i, peer_addr) in peer_addrs.into_iter().enumerate() {
-                let message = crate::message::InterestMessage::Interests {
-                    hashes: hashes.clone(),
-                };
-                if let Err(e) = sender
-                    .send(either::Either::Right(
-                        crate::message::NodeEvent::SendInterestMessage {
-                            target: peer_addr,
-                            message,
-                        },
-                    ))
-                    .await
-                {
-                    // Channel send failure means the receiver is dropped (node
-                    // shutting down). No point sending to remaining peers.
+                // InterestSync STATE heartbeat: only when we actually have
+                // interest hashes to advertise.
+                if !hashes.is_empty() {
+                    let message = crate::message::InterestMessage::Interests {
+                        hashes: hashes.clone(),
+                    };
+                    if let Err(e) = sender
+                        .send(either::Either::Right(
+                            crate::message::NodeEvent::SendInterestMessage {
+                                target: peer_addr,
+                                message,
+                            },
+                        ))
+                        .await
+                    {
+                        // Channel send failure means the receiver is dropped (node
+                        // shutting down). No point sending to remaining peers.
+                        tracing::debug!(
+                            peer = %peer_addr,
+                            error = %e,
+                            "Interest heartbeat: failed to queue message"
+                        );
+                        break;
+                    }
+                }
+
+                // Advertisement-layer anti-entropy (#4642 spec step 1, "Fix 1"),
+                // PIGGYBACKED on the InterestSync heartbeat's cycle / peer / cadence.
+                // Re-request this neighbor's full hosted-contract set; the
+                // `HostingStateResponse` handler REPLACES our view of it, so a
+                // dropped on-connect exchange or a dropped per-eviction retraction
+                // self-heals within one heartbeat interval (both directions, since
+                // every node runs this). ALWAYS sent when the cycle runs —
+                // decoupled from the interest send above, so an advertising-but-not-
+                // interested node (e.g. just-restarted with disk-loaded hosts) still
+                // reconciles. Carried in THIS loop rather than a separate background
+                // task on purpose: an independent task's random initial-delay draw
+                // from the shared `GlobalRng` shifts every seeded simulation's RNG
+                // stream (perturbing routing/topology) and a second per-node timer
+                // adds cross-run determinism surface — reusing this loop keeps the
+                // sim RNG stream byte-identical. It is WASM-free / state-free (only
+                // contract IDs move), so it cannot re-arm the #4440/#4473 summarize
+                // storm.
+                // Best-effort and NON-BLOCKING: `try_send`, never `send().await`.
+                // This is the anti-entropy backstop that heals next cycle, so a
+                // request dropped under backpressure is the DESIGNED behavior — and
+                // it rides the cap-2048 event-loop notification channel (the
+                // #4145/#4231/#4442 wedge channel), which a blocking send inside a
+                // background loop must never stall on (channel-safety rule). Mirrors
+                // the sibling retraction path (`announce_contract_unhosted` uses
+                // `try_notify_node_event`). No `break` on error: shutdown is caught
+                // by the `sleep_or_shutdown` on the spread delay below (and by the
+                // interest `send().await` above), so a dropped/closed send here just
+                // moves on.
+                if let Err(e) = sender.try_send(either::Either::Right(
+                    crate::message::NodeEvent::SendNetMessage {
+                        target: peer_addr,
+                        msg: Box::new(crate::message::NetMessage::V1(
+                            crate::message::NetMessageV1::NeighborHosting {
+                                message:
+                                    crate::message::NeighborHostingMessage::HostingStateRequest,
+                            },
+                        )),
+                    },
+                )) {
                     tracing::debug!(
                         peer = %peer_addr,
                         error = %e,
-                        "Interest heartbeat: failed to queue message"
+                        "Interest heartbeat: hosting re-request dropped (best-effort; heals next cycle)"
                     );
-                    break;
                 }
                 peers_sent += 1;
 
@@ -7295,6 +7359,81 @@ mod instant_now_pin_test {
              (#4277). If you intentionally added or removed a TEST-only call site, \
              update EXPECTED_BARE_INSTANT_NOW; if this fired on PRODUCTION code, \
              migrate it to `self.time_source.now()` instead of bumping the count."
+        );
+    }
+}
+
+/// Pin tests for the periodic hosting-advertisement re-request (#4642 spec step
+/// 1, "Fix 1"): the reliability backstop that heals a dropped on-connect
+/// advertisement exchange or a dropped per-eviction retraction. It is PIGGYBACKED
+/// on the `interest_heartbeat` loop (NOT a separate task) so it adds no
+/// `GlobalRng` draw / second timer that would perturb the deterministic sim
+/// harness. These source-scrape pins lock that: the re-request rides
+/// `interest_heartbeat`, and it carries only contract IDs (no state), so it can't
+/// re-arm the #4440/#4473 summarize storm.
+#[cfg(test)]
+mod hosting_heartbeat_pin_test {
+    fn extract_interest_heartbeat_body() -> &'static str {
+        let src = include_str!("ring.rs");
+        let head = ["async fn ", "interest_heartbeat("].concat();
+        let start = src
+            .find(&head)
+            .expect("`async fn interest_heartbeat(` must exist in ring.rs");
+        let body_open = src[start..].find('{').map(|off| start + off).unwrap();
+        let mut depth: i32 = 0;
+        let mut end = body_open;
+        for (i, ch) in src[body_open..].char_indices() {
+            match ch {
+                '{' => depth += 1,
+                '}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        end = body_open + i + 1;
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        &src[start..end]
+    }
+
+    #[test]
+    fn hosting_re_request_is_piggybacked_on_interest_heartbeat() {
+        let body = extract_interest_heartbeat_body();
+        assert!(
+            body.contains("HostingStateRequest"),
+            "the advertisement-layer re-request (Fix 1) must be PIGGYBACKED on \
+             `interest_heartbeat` — it must send a `HostingStateRequest` in that \
+             loop. Do NOT move it to a separate task: a task with its own \
+             `GlobalRng` initial-delay draw perturbs the shared seeded RNG stream \
+             the deterministic sim harness depends on."
+        );
+    }
+
+    #[test]
+    fn hosting_re_request_carries_no_state() {
+        // Advertisement-layer ONLY: the re-request must NOT reach into the STATE
+        // anti-entropy (no WASM summarize / state fetch), or it would risk
+        // re-arming the #4440/#4473 summarize storm the ring.md gate guards against.
+        let body = extract_interest_heartbeat_body();
+        assert!(
+            !body.contains("get_contract_summary") && !body.contains("summarize_state"),
+            "the piggybacked hosting re-request must carry only contract IDs — \
+             never fetch / summarize STATE — so it cannot re-arm the summarize storm."
+        );
+    }
+
+    #[test]
+    fn no_separate_hosting_heartbeat_task() {
+        let src = include_str!("ring.rs");
+        // Runtime-compose so this test does not match itself.
+        let needle = ["async fn ", "hosting_heartbeat("].concat();
+        assert!(
+            !src.contains(&needle),
+            "there must be NO separate `hosting_heartbeat` task — its startup \
+             `GlobalRng` draw perturbed the deterministic sim harness. The \
+             re-request is piggybacked on `interest_heartbeat` instead."
         );
     }
 }

--- a/crates/core/src/ring/hosting/reconcile.rs
+++ b/crates/core/src/ring/hosting/reconcile.rs
@@ -45,9 +45,11 @@
 //! Several divergence classes are EXPECTED because the on-`main` sites do not yet
 //! implement the controller's model — they are the delta the keystone closes, not
 //! bugs:
-//! - **`retract` / `reroot_search`**: no on-`main` driver retracts a hosting
-//!   advertisement on teardown or re-roots on upstream loss, so the controller
-//!   emits these where production does nothing.
+//! - **`retract` / `reroot_search`**: no on-`main` driver retracts on *teardown*
+//!   (collapse/renewal) or re-roots on upstream loss, so the controller emits
+//!   these where the shadow-compared sites do nothing. (Eviction DOES now retract
+//!   via `on_contract_unhosted` / #4722, but that is a distinct eviction path, not
+//!   the collapse/renewal teardown these counters compare.)
 //! - **`renew` / `subscribe` / `unsubscribe`**: the controller's STRICT
 //!   downstream-demand gate (a downstream subscriber counts only when strictly
 //!   FARTHER from the key) and its lease-aware split (`Renew` iff we hold a
@@ -63,8 +65,9 @@
 //! - **`Collapse` is the LOCAL teardown** (drop our lease, `ring.unsubscribe`);
 //!   **`Unsubscribe` is the WIRE message** to the computed upstream; **`Retract`
 //!   withdraws the hosting advertisement** (on-`main` primitive
-//!   `neighbor_hosting.on_contract_unhosted`, `node/neighbor_hosting.rs:131`,
-//!   currently dead code a later flip must wire). The current code's
+//!   `neighbor_hosting.on_contract_unhosted`, now wired live on EVICTION inside
+//!   `RuntimePool::remove_contract` / #4722; the controller `Retract` flip that
+//!   would ALSO drive it from teardown is still a later step). The current code's
 //!   `send_unsubscribe_upstream` does the first two together ("send Unsubscribe +
 //!   `ring.unsubscribe`") in one call, so the shadow-compare must map it onto the
 //!   `{Collapse, Unsubscribe}` PAIR by SET membership, not exact-`Vec` equality.
@@ -147,7 +150,9 @@ pub(crate) enum Action {
     /// present, never before (reconcile-before-announce).
     Announce,
     /// Withdraw a hosting advertisement (on-`main` primitive:
-    /// `neighbor_hosting.on_contract_unhosted`, currently dead code). Emitted on
+    /// `neighbor_hosting.on_contract_unhosted`, now wired live on EVICTION inside
+    /// `RuntimePool::remove_contract` / #4722; the controller `Retract` flip that
+    /// would ALSO drive it from teardown is still a later step). Emitted on
     /// the teardown branch whenever we were advertising, INDEPENDENT of whether we
     /// held a lease — a verified root advertises without ever subscribing
     /// upstream, so a torn-down (not-in-use) advertised host must retract or its

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -304,9 +304,13 @@ pub(crate) struct RouterSnapshotInfo {
     /// downstream gate and lease-aware `Renew`-vs-`Subscribe` split legitimately
     /// disagree with today's ANY-downstream renewal path), and `announce` (a
     /// subscribed, state-present, not-yet-advertised host). Read them as the
-    /// reconcile-vs-today delta. `retract_diffs` in particular reflects the
-    /// missing retraction driver (`is_hosted_locally` is monotonic in production
-    /// today), not a live-advertisement leak.
+    /// reconcile-vs-today delta. `retract_diffs` in particular reflects that no
+    /// on-`main` COLLAPSE/RENEWAL driver retracts at these shadow-compared sites
+    /// (the controller would). NOTE: `is_hosted_locally` is no longer strictly
+    /// monotonic in production — eviction now retracts via `on_contract_unhosted`
+    /// (#4722) — but that eviction path is distinct from these sites, so a nonzero
+    /// `retract_diffs` still reflects the missing site-local retraction, not a
+    /// live-advertisement leak.
     pub reconcile_shadow_collapse_comparisons: Option<u64>,
     pub reconcile_shadow_collapse_divergences: Option<u64>,
     pub reconcile_shadow_collapse_subscribe_diffs: Option<u64>,


### PR DESCRIPTION
## Problem

The hosting **advertisement layer** (`NeighborHostingManager`, Source-1 — distinct from the InterestSync *state* anti-entropy) has two reliability gaps that leave co-hosts with **stale advertisements**, violating invariant 1 ("advertise iff a fresh in-mesh host"):

1. **On-connect exchange is best-effort with no recovery.** The full-set advertised-contract exchange (`HostingStateRequest`/`HostingStateResponse`) is a `try_send` and — unlike InterestSync's 5-min heartbeat — has **no periodic re-request**. A dropped exchange leaves two co-hosts permanently unaware of what each other hosts (lost Source-1 fan-out, missed terminal read consult).
2. **Retraction on stop-hosting was dead code.** `on_contract_unhosted` had **no production caller**, so eviction left `my_contracts` (the advertised set) permanently stale — a co-host keeps a **phantom host** for a contract we evicted, fans updates to us and routes reads to us for state we no longer hold. Same stale-advertisement failure class behind #4440/#4473/#4610.

Spec **step 1 ("Fix 1")** of the demand-driven hosting redesign (epic #4642).

## Solution

Scoped **strictly to the advertisement (ID) layer**. The InterestSync STATE anti-entropy is untouched, and nothing here fetches or summarizes state, so the #4440/#4473 summarize storm cannot be re-armed. No wire-format change (reuses existing `NeighborHostingMessage` + `NodeEvent::{SendNetMessage, BroadcastHostingUpdate}`).

**Reliability — periodic full-set re-request, piggybacked on `interest_heartbeat`** (NOT a separate task). Each ~5-min cycle sends each connected neighbor a `HostingStateRequest`; `HostingStateResponse` **full-replaces** our view of the peer, so BOTH a dropped on-connect exchange AND a dropped retraction self-heal within one interval (both directions, since every node runs it). Piggybacking is deliberate: a separate task's `GlobalRng` initial-delay draw perturbs the shared seeded RNG stream the deterministic sim harness depends on — riding the existing loop adds no RNG consumer and no second timer. The re-request is **decoupled from interest state** (runs for any connected node — even a pure relay consults its `neighbor_contracts` view) and uses **`try_send`** (best-effort; a dropped cycle heals next interval and must never block the event-loop notification channel, per channel-safety). `HostingStateResponse` computes overlap (which drives the proactive state sync) only over **newly-learned** contracts, so steady-state re-requests do zero redundant state sync while a fresh/reconnected view still recovers.

**Retraction — on the confirmed-delete path.** `RuntimePool::remove_contract` now calls `announce_contract_unhosted` once a required on-disk half is actually gone — `ReclaimOutcome::Full` (both state + WASM removed) OR `Partial` (one removed, the other queued for retry, so the contract can no longer be served); `Err` (nothing removed → still serveable) keeps advertising. It runs **after** the three deletion-time guards (re-host / re-subscribe / newer-generation), so a contract re-hosted in the eviction→reclaim window keeps both its state AND its advertisement. It is **not** wired at the eviction *decision* in `reclaim_evicted_contract` (which only gates on `contract_in_use` and can't see a concurrent re-cache) nor at **collapse** (`send_unsubscribe_upstream` doesn't stop hosting on current `main`). Every eviction funnels through `remove_contract` (GET/PUT insert eviction, the periodic sweep, and — once built — evict-to-admit). Idempotent, so a pending-reclamation retry (incl. a Full retry after a Partial) is a safe no-op.

## Testing

- **Behavioral / integration** (`pool.rs::tests::test_eviction_emits_hosting_retraction`): builds a **real `OpManager` + `RuntimePool`**, stores a contract (state + WASM) on disk, advertises it, then drives the real `RuntimePool::remove_contract` path and asserts BOTH (a) the on-disk state is gone AND the advertisement is retracted, AND (b) `GlobalTestMetrics::neighbor_hosting_retractions()` advanced by exactly one. This is the counter's real reader and proves the eviction path reaches the retraction at runtime (verified load-bearing: commenting out the retraction fails the test). Runs on a `current_thread` runtime because the counter is thread-local and the retraction is synchronous. (The `SimNetwork` handlers use the direct inner `Executor` with no `op_manager`, so a sim can't reach this path — hence the direct pool test.)
- **Unit** (`neighbor_hosting.rs`): removed-announce convergence; full-set re-request drops a stale (dropped-retraction) advertisement; overlap-only-for-newly-learned (+ reconnection recovery); `on_contract_unhosted` idempotency.
- **Source-scrape pins**: the re-request is piggybacked on `interest_heartbeat`, carries only IDs (never state), and there is no separate hosting task; the retraction is in `RuntimePool::remove_contract` gated `Full | Partial` (after the guards), and `reclaim_evicted_contract` does NOT retract.
- **Sim** (unchanged behavior): terminal-advertisement-consult (GET + SUBSCRIBE) dead-end, get-routing-coverage, subscription-chain collapse, direct-runner determinism, neighbor-hosting-bounded — all green.

`cargo build -p freenet`, `cargo clippy --locked -p freenet -- -D warnings`, `cargo fmt --check`, and all new + touched tests are green.

## Review notes (high-risk surface)

- Advertisement layer only; InterestSync state anti-entropy untouched; no WASM summarize / state fetch on the new path (does not re-arm #4440/#4473).
- No wire-format change.
- One production visibility widening: `OpManager::new` `pub(super)` → `pub(crate)` (constructor-only, no behavior change) so the in-crate `RuntimePool` eviction→retraction test can stand up a real `OpManager`.
- Interaction with the reconcile-core keystone (step 2): the shadow controller's `Retract` action maps to this same `on_contract_unhosted` primitive; wiring it here makes `is_hosted_locally` non-monotonic in production (reconcile-shadow docs updated accordingly).
- Follow-ups noted in review (not in this PR): uncapped full-set payload + per-peer request rate-limit (both bounded today, pre-existing shape).

Refs #4642 (spec step 1 / "Fix 1"; `hosting-invariants` invariant 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6iqkKTXDfMCi3nkShGCTi

[AI-assisted - Claude]