### PR TITLE
feat(hosted): encode per-user access key as Base58 instead of hex

### DIFF
--- a/.github/workflows/lint-assets.yml
+++ b/.github/workflows/lint-assets.yml
@@ -1,15 +1,17 @@
 name: Lint server web assets
 
-# Prettier + ESLint over the JS/CSS/HTML the gateway server serves to clients.
-# These assets used to be embedded as Rust raw-string consts; issue #4017
-# extracted them into real files (loaded via include_str!) so they can be
-# linted. This workflow guards their syntax/style going forward.
+# Prettier + ESLint over the JS/CSS/HTML the gateway server serves to clients,
+# plus a Node unit test for the inline base58 access-key encoder. These assets
+# used to be embedded as Rust raw-string consts; issue #4017 extracted them into
+# real files (loaded via include_str!) so they can be linted. This workflow
+# guards their syntax/style and the encoder's output going forward.
 
 on:
   push:
     branches: [main]
     paths:
       - 'crates/core/src/server/**/assets/**'
+      - 'crates/core/src/server/base58_encode.test.mjs'
       - 'crates/core/src/server/package.json'
       - 'crates/core/src/server/package-lock.json'
       - 'crates/core/src/server/.prettierrc.json'
@@ -19,6 +21,7 @@ on:
   pull_request:
     paths:
       - 'crates/core/src/server/**/assets/**'
+      - 'crates/core/src/server/base58_encode.test.mjs'
       - 'crates/core/src/server/package.json'
       - 'crates/core/src/server/package-lock.json'
       - 'crates/core/src/server/.prettierrc.json'
@@ -51,3 +54,7 @@ jobs:
       - name: Lint (Prettier --check + ESLint)
         working-directory: crates/core/src/server
         run: npm run lint
+
+      - name: Test (base58 access-key encoder)
+        working-directory: crates/core/src/server
+        run: npm test

--- a/crates/core/src/server/base58_encode.test.mjs
+++ b/crates/core/src/server/base58_encode.test.mjs
@@ -1,0 +1,173 @@
+// Executable unit test for the inline `base58Encode` in
+// `path_handlers/assets/shell_user_token.js`.
+//
+// Why this exists: that encoder is a from-scratch big-integer (base-256 ->
+// base-58) implementation with edge cases (leading-zero bytes, all-zero input,
+// digit-array trimming). It runs in the browser shell, where the surrounding
+// IIFE touches browser-only globals (`location`, `localStorage`, `crypto`) and
+// so can't run under Node. Rather than pull in a browser test runner, this test
+// EXTRACTS the self-contained `base58Encode` function verbatim from the asset
+// (between the `base58-encoder:BEGIN`/`:END` markers) and checks its output:
+//
+//   1. against an INDEPENDENT BigInt reference encoder, exhaustively for all
+//      1- and 2-byte inputs and for all-zero / leading-zero shapes — a bug in
+//      the extracted encoder is unlikely to be shared by the BigInt reference,
+//      which uses a different technique; and
+//   2. against a handful of fixed, authoritative bs58 (Bitcoin alphabet)
+//      vectors cross-checked against the Rust `bs58` crate — this guards the
+//      alphabet itself, which both JS impls would otherwise share.
+//
+// Run via `npm test` in crates/core/src/server (wired into the lint-assets CI
+// job). No dependencies beyond Node's stdlib. Exits non-zero on any mismatch.
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const assetPath = join(here, 'path_handlers/assets/shell_user_token.js');
+const src = readFileSync(assetPath, 'utf8');
+
+// --- Extract the encoder verbatim from the asset -------------------------
+const BEGIN = 'base58-encoder:BEGIN';
+const END = 'base58-encoder:END';
+const b = src.indexOf(BEGIN);
+const e = src.indexOf(END);
+if (b < 0 || e < 0 || e < b) {
+  console.error(
+    `FAIL: could not find ${BEGIN}/${END} markers in ${assetPath}. ` +
+      'The base58 encoder must stay bracketed by those markers so this test ' +
+      'can extract and verify it.',
+  );
+  process.exit(1);
+}
+const region = src.slice(b, e);
+const fnStart = region.indexOf('function base58Encode');
+if (fnStart < 0) {
+  console.error('FAIL: no `function base58Encode` between the markers.');
+  process.exit(1);
+}
+const fnSource = region.slice(fnStart);
+// eslint is not run on this file (it lints only assets/**), but keep it clean.
+// Build the extracted function in an isolated scope and return it.
+const base58Encode = new Function(`${fnSource}\nreturn base58Encode;`)();
+
+// --- Independent reference encoder (BigInt technique) --------------------
+const ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+function refBase58(bytes) {
+  let zeros = 0;
+  while (zeros < bytes.length && bytes[zeros] === 0) zeros++;
+  let n = 0n;
+  for (const byte of bytes) n = (n << 8n) | BigInt(byte);
+  let s = '';
+  while (n > 0n) {
+    s = ALPHABET[Number(n % 58n)] + s;
+    n /= 58n;
+  }
+  return ALPHABET[0].repeat(zeros) + s;
+}
+
+let failures = 0;
+function check(cond, msg) {
+  if (!cond) {
+    failures++;
+    console.error(`FAIL: ${msg}`);
+  }
+}
+
+function hexToBytes(hex) {
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+// --- 0. Alphabet sanity (guards the shared-alphabet risk) ----------------
+check(ALPHABET.length === 58, 'alphabet must be 58 chars');
+for (const bad of ['0', 'O', 'I', 'l']) {
+  check(!ALPHABET.includes(bad), `alphabet must omit ambiguous char '${bad}'`);
+}
+check(base58Encode(hexToBytes('00')) === '1', 'byte 0x00 -> "1"');
+check(base58Encode(hexToBytes('ff')) === '5Q', 'byte 0xff -> "5Q"');
+
+// --- 1. Exhaustive cross-check vs the independent reference ---------------
+for (let x = 0; x < 256; x++) {
+  const got = base58Encode(Uint8Array.of(x));
+  check(got === refBase58(Uint8Array.of(x)), `1-byte [${x}] mismatch (${got})`);
+}
+for (let x = 0; x < 65536; x++) {
+  const arr = Uint8Array.of(x >> 8, x & 0xff);
+  const got = base58Encode(arr);
+  if (got !== refBase58(arr)) {
+    check(false, `2-byte [${x >> 8},${x & 0xff}] mismatch (${got})`);
+    break; // one report is enough
+  }
+}
+// All-zero and leading-zero shapes across lengths (up to > token length).
+for (let len = 0; len <= 40; len++) {
+  const allZero = new Uint8Array(len);
+  check(
+    base58Encode(allZero) === '1'.repeat(len),
+    `all-zero length ${len} must be ${len} '1's`,
+  );
+  check(base58Encode(allZero) === refBase58(allZero), `all-zero len ${len} vs ref`);
+  if (len >= 3) {
+    const leading = new Uint8Array(len);
+    leading[len - 2] = 0x01;
+    leading[len - 1] = 0x2a;
+    check(
+      base58Encode(leading) === refBase58(leading),
+      `leading-zero shape len ${len} vs ref`,
+    );
+  }
+}
+
+// --- 2. Fixed authoritative vectors (verified vs the Rust bs58 crate) -----
+// hex input -> expected Bitcoin-alphabet base58.
+const vectors = [
+  ['', ''],
+  ['00', '1'],
+  ['0000', '11'],
+  ['01', '2'],
+  ['0001', '12'],
+  ['61', '2g'],
+  ['626262', 'a3gV'],
+  ['636363', 'aPEr'],
+  ['516b6fcd0f', 'ABnLTmg'],
+  ['ffeeddccbbaa', '3CSwN61PP'],
+  ['73696d706c792061206c6f6e6720737472696e67', '2cFupjhnEsSn59qHXstmK2ffpLv2'],
+  [
+    '00eb15231dfceb60925886b67d065299925915aeb172c06647',
+    '1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L',
+  ],
+  // 32 bytes of 0xff — the max 32-byte value, matches the token length domain.
+  [
+    'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+    'JEKNVnkbo3jma5nREBBJCDoXFVeKkD56V3xKrvRmWxFG',
+  ],
+];
+for (const [hex, expected] of vectors) {
+  const got = base58Encode(hexToBytes(hex));
+  check(got === expected, `vector ${hex || '(empty)'} -> ${expected}, got ${got}`);
+}
+
+// --- 3. Token-shape sanity: a 32-byte input encodes to a base58 string of
+//        the length range bs58 produces for 256-bit values (43-44 chars),
+//        using only alphabet characters.
+const sample = new Uint8Array(32).fill(0x7f);
+const enc = base58Encode(sample);
+check(
+  enc.length >= 43 && enc.length <= 44,
+  `32-byte input should encode to 43-44 base58 chars, got ${enc.length}`,
+);
+check(
+  [...enc].every((c) => ALPHABET.includes(c)),
+  'encoded token must contain only alphabet characters',
+);
+
+if (failures > 0) {
+  console.error(`\nbase58Encode: ${failures} check(s) FAILED`);
+  process.exit(1);
+}
+console.log('base58Encode: all checks passed');

--- a/crates/core/src/server/base58_encode.test.mjs
+++ b/crates/core/src/server/base58_encode.test.mjs
@@ -42,9 +42,9 @@ if (b < 0 || e < 0 || e < b) {
   process.exit(1);
 }
 const region = src.slice(b, e);
-const fnStart = region.indexOf('function base58Encode');
+const fnStart = region.indexOf('function base58Encode(');
 if (fnStart < 0) {
-  console.error('FAIL: no `function base58Encode` between the markers.');
+  console.error('FAIL: no `function base58Encode(` between the markers.');
   process.exit(1);
 }
 const fnSource = region.slice(fnStart);
@@ -157,6 +157,10 @@ for (const [hex, expected] of vectors) {
 //        using only alphabet characters.
 const sample = new Uint8Array(32).fill(0x7f);
 const enc = base58Encode(sample);
+check(
+  enc === refBase58(sample),
+  `32-byte 0x7f sample must match the independent reference (got ${enc})`,
+);
 check(
   enc.length >= 43 && enc.length <= 44,
   `32-byte input should encode to 43-44 base58 chars, got ${enc.length}`,

--- a/crates/core/src/server/package.json
+++ b/crates/core/src/server/package.json
@@ -2,7 +2,7 @@
   "name": "freenet-server-assets-lint",
   "version": "0.0.0",
   "private": true,
-  "description": "Prettier/ESLint tooling for the server's extracted JS/CSS/HTML assets (issue #4017). The assets are served from Rust via include_str!; this package only lints/formats them.",
+  "description": "Prettier/ESLint tooling (issue #4017) plus a Node unit test for the inline base58 access-key encoder, for the server's extracted JS/CSS/HTML assets. The assets are served from Rust via include_str!; this package lints/formats/tests them.",
   "engines": {
     "node": ">=20"
   },
@@ -10,7 +10,8 @@
     "lint": "npm run lint:prettier && npm run lint:eslint",
     "lint:prettier": "prettier --check \"**/assets/**/*.{js,css,html}\"",
     "lint:eslint": "eslint \"**/assets/**/*.js\"",
-    "format": "prettier --write \"**/assets/**/*.{js,css,html}\""
+    "format": "prettier --write \"**/assets/**/*.{js,css,html}\"",
+    "test": "node base58_encode.test.mjs"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.0",

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -1061,10 +1061,17 @@ async fn sandbox_content_body(
 /// Injected into the shell page (P2-frontend of #4381) ONLY when the node runs
 /// in hosted mode. The shell is same-origin with the node, so it can persist a
 /// token in `localStorage`; the sandboxed iframe cannot. The token is a 32-byte
-/// secret minted from `crypto.getRandomValues` (never from request input), hex
-/// encoded, and reused across every visit and every contract app on this node —
-/// one durable identity per visitor. The bridge presents it on the proxied
-/// WebSocket upgrade as `?userToken=<token>`.
+/// secret minted from `crypto.getRandomValues` (never from request input),
+/// base58 (Bitcoin/bs58 alphabet) encoded, and reused across every visit and
+/// every contract app on this node — one durable identity per visitor. The
+/// bridge presents it on the proxied WebSocket upgrade as `?userToken=<token>`.
+///
+/// The server treats the token as an OPAQUE namespace key (it hashes the raw
+/// string bytes — see [`crate::wasm_runtime::UserSecretContext::from_token`]),
+/// so the encoding is a purely client-side, display-facing choice: older builds
+/// stored a hex string and those tokens keep resolving to the same per-user
+/// namespace, while new identities are base58 (shorter and less error-prone for
+/// a user to copy or transcribe).
 ///
 /// On a non-`https:` page the IIFE returns undefined BEFORE touching
 /// `localStorage`, so the durable token is never loaded, minted, or transmitted
@@ -3202,6 +3209,20 @@ mod tests {
         assert!(
             html.contains("localStorage.setItem"),
             "hosted-mode token must be persisted to localStorage"
+        );
+        // New identities must mint a base58 access key: the shell must carry the
+        // inline base58 encoder and the Bitcoin/bs58 alphabet, and must NOT use
+        // the old hex encoding (`toString(16)`). The server hashes the raw token
+        // string, so a previously stored hex token still works — this only pins
+        // the format newly minted tokens take. See shell_user_token.js.
+        assert!(
+            html.contains("base58Encode")
+                && html.contains("123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"),
+            "hosted-mode token must be minted as base58 via the inline encoder; got: {html}"
+        );
+        assert!(
+            !html.contains("toString(16)"),
+            "hosted-mode token must no longer be hex-encoded (toString(16)); got: {html}"
         );
         // The bridge must be called with the user-token argument AND the
         // hosted-mode flag (so it can fail closed over http).

--- a/crates/core/src/server/path_handlers/assets/shell_user_token.js
+++ b/crates/core/src/server/path_handlers/assets/shell_user_token.js
@@ -27,6 +27,13 @@ var __freenet_user_token = (function () {
   // error-prone, and it matches the bs58 (Bitcoin alphabet) used by the rest of
   // Freenet's identifiers. This encoder is byte-for-byte compatible with the
   // `bs58` crate's BITCOIN alphabet output.
+  //
+  // The BEGIN/END markers below let base58_encode.test.mjs extract this exact
+  // function and unit-test its output against known bs58 vectors + edge cases
+  // (this repo has no browser JS test runner, and the shell page's browser-only
+  // globals make the surrounding IIFE non-executable under Node). Keep the
+  // function self-contained (no free variables) so the extraction stays valid.
+  // base58-encoder:BEGIN
   function base58Encode(bytes) {
     var ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
     // Leading zero bytes carry no numeric value but must survive as leading
@@ -71,6 +78,7 @@ var __freenet_user_token = (function () {
     }
     return out;
   }
+  // base58-encoder:END
 
   try {
     var KEY = '__freenet_user_token__';

--- a/crates/core/src/server/path_handlers/assets/shell_user_token.js
+++ b/crates/core/src/server/path_handlers/assets/shell_user_token.js
@@ -12,17 +12,79 @@ var __freenet_user_token = (function () {
   if (location.protocol !== 'https:') {
     return undefined;
   }
+
+  // Minimal, self-contained Base58 encoder (Bitcoin/bs58 alphabet). There is no
+  // bs58 in the browser and we deliberately avoid pulling in an external JS
+  // dependency, so this inlines the standard big-endian base-256 -> base-58 long
+  // division. `bytes` is a Uint8Array (here always the 32 random token bytes);
+  // the return value is the base58 string.
+  //
+  // The server treats the token as an OPAQUE namespace key — it hashes the raw
+  // string bytes (blake3(domain || token), see UserSecretContext::from_token) —
+  // so the ONLY hard requirement is a stable, valid encoding. Base58 is chosen
+  // over hex because it drops the visually ambiguous characters, which makes an
+  // "access key" that the user copies, pastes, or transcribes by hand far less
+  // error-prone, and it matches the bs58 (Bitcoin alphabet) used by the rest of
+  // Freenet's identifiers. This encoder is byte-for-byte compatible with the
+  // `bs58` crate's BITCOIN alphabet output.
+  function base58Encode(bytes) {
+    var ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+    // Leading zero bytes carry no numeric value but must survive as leading
+    // '1's (base58's zero digit), so count and skip them before the division.
+    var zeros = 0;
+    while (zeros < bytes.length && bytes[zeros] === 0) {
+      zeros++;
+    }
+    // Treat the remaining bytes as a big-endian base-256 integer and convert it
+    // to base-58, accumulating the base-58 digits little-endian via repeated
+    // long division. Intermediate `carry` stays small (< 58 * 256 + 255), well
+    // within a 32-bit int, so `<< 8` and `| 0` are safe.
+    var digits = [0];
+    for (var i = zeros; i < bytes.length; i++) {
+      var carry = bytes[i];
+      for (var j = 0; j < digits.length; j++) {
+        carry += digits[j] << 8;
+        digits[j] = carry % 58;
+        carry = (carry / 58) | 0;
+      }
+      while (carry > 0) {
+        digits.push(carry % 58);
+        carry = (carry / 58) | 0;
+      }
+    }
+    var out = '';
+    for (var z = 0; z < zeros; z++) {
+      out += ALPHABET[0];
+    }
+    // Emit base-58 digits most-significant first. Skip a lone most-significant
+    // zero digit, which only appears for an all-zero input (already fully
+    // represented by the leading '1's above); for any non-zero input the top
+    // digit is non-zero.
+    var top = digits.length - 1;
+    while (top > 0 && digits[top] === 0) {
+      top--;
+    }
+    if (!(top === 0 && digits[0] === 0)) {
+      for (var k = top; k >= 0; k--) {
+        out += ALPHABET[digits[k]];
+      }
+    }
+    return out;
+  }
+
   try {
     var KEY = '__freenet_user_token__';
     var t = localStorage.getItem(KEY);
     if (!t) {
       var b = new Uint8Array(32);
       crypto.getRandomValues(b);
-      t = Array.prototype.map
-        .call(b, function (x) {
-          return ('0' + x.toString(16)).slice(-2);
-        })
-        .join('');
+      // New identities mint a base58 access key. Existing users keep whatever
+      // string is already in localStorage verbatim (older builds stored hex),
+      // and the "restore" flow in hosted_bar.js stores any pasted key as-is, so
+      // both formats keep working: the server hashes the raw token string either
+      // way, so a previously stored hex token maps to the same per-user
+      // namespace as before and old data stays reachable.
+      t = base58Encode(b);
       localStorage.setItem(KEY, t);
     }
     return t;

--- a/crates/core/src/wasm_runtime/secrets_store/user.rs
+++ b/crates/core/src/wasm_runtime/secrets_store/user.rs
@@ -194,3 +194,64 @@ pub fn user_dek_secret(token: &[u8]) -> Zeroizing<[u8; 32]> {
     hasher.update(token);
     Zeroizing::new(*hasher.finalize().as_bytes())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The user token is an OPAQUE bearer string: the namespace is
+    /// `blake3(domain || raw_token_bytes)`, with NO hex decode and NO
+    /// length/charset validation anywhere on the path. That is the property the
+    /// shell's hex -> base58 access-key change relies on — both encodings are
+    /// just different UTF-8 strings, so:
+    ///
+    /// - a NEW base58 token is honored exactly like a hex one (no backend change
+    ///   was needed for the switch), and
+    /// - an EXISTING user's stored hex token keeps mapping to the same namespace
+    ///   (back-compat: their data stays reachable).
+    ///
+    /// This pins that contract so a future "validate the token is 32-byte hex"
+    /// well-meaning tightening would fail CI instead of silently locking every
+    /// pre-existing hex user out of their data.
+    #[test]
+    fn user_token_is_opaque_hex_and_base58_both_accepted() {
+        // A representative hex token (what older shell builds minted) and a
+        // representative base58 token (what new builds mint, Bitcoin alphabet).
+        // Both are just strings as far as the backend is concerned.
+        let hex_token = b"0f1e2d3c4b5a69788796a5b4c3d2e1f00f1e2d3c4b5a69788796a5b4c3d2e1f0";
+        let base58_realistic = b"7Nsp3W1kZ2vQmYb8xR4tHgD6cF5aLj9UeKq";
+
+        // Every token yields a stable, non-panicking derivation.
+        for tok in [hex_token.as_slice(), base58_realistic.as_slice()] {
+            let a = UserSecretContext::from_token(tok);
+            let b = UserSecretContext::from_token(tok);
+            assert_eq!(
+                a.user_id(),
+                b.user_id(),
+                "same token string must derive the same namespace (existing hex \
+                 users must keep their namespace across restarts/versions)"
+            );
+        }
+
+        // Distinct token strings derive distinct namespaces — a hex token and a
+        // base58 token never collide (they are different byte strings).
+        let hex_id = user_id(hex_token);
+        let b58_id = user_id(base58_realistic);
+        assert_ne!(
+            hex_id.as_bytes(),
+            b58_id.as_bytes(),
+            "different token strings must derive different namespaces"
+        );
+
+        // The derivation depends ONLY on the raw bytes: a hex string and its
+        // uppercased form are DIFFERENT tokens (no normalization), which is the
+        // correct behavior for an opaque bearer secret.
+        let lower = b"abcdef0123456789";
+        let upper = b"ABCDEF0123456789";
+        assert_ne!(
+            user_id(lower).as_bytes(),
+            user_id(upper).as_bytes(),
+            "token derivation is over raw bytes with no case/format normalization"
+        );
+    }
+}

--- a/crates/core/src/wasm_runtime/secrets_store/user.rs
+++ b/crates/core/src/wasm_runtime/secrets_store/user.rs
@@ -199,20 +199,28 @@ pub fn user_dek_secret(token: &[u8]) -> Zeroizing<[u8; 32]> {
 mod tests {
     use super::*;
 
-    /// The user token is an OPAQUE bearer string: the namespace is
-    /// `blake3(domain || raw_token_bytes)`, with NO hex decode and NO
-    /// length/charset validation anywhere on the path. That is the property the
-    /// shell's hex -> base58 access-key change relies on — both encodings are
-    /// just different UTF-8 strings, so:
+    /// Pins the DERIVATION-level opacity invariant: `from_token` / [`user_id`] /
+    /// [`user_dek_secret`] treat the token as raw opaque bytes
+    /// (`blake3(domain || raw_token_bytes)`) with NO hex decode and NO
+    /// length/charset validation. This derivation is the single load-bearing
+    /// construction site for a per-user namespace (see the `UserSecretContext`
+    /// security invariant), so it is the place that must stay format-agnostic.
+    ///
+    /// That is the property the shell's hex -> base58 access-key change relies
+    /// on — both encodings are just different UTF-8 strings, so:
     ///
     /// - a NEW base58 token is honored exactly like a hex one (no backend change
     ///   was needed for the switch), and
     /// - an EXISTING user's stored hex token keeps mapping to the same namespace
     ///   (back-compat: their data stays reachable).
     ///
-    /// This pins that contract so a future "validate the token is 32-byte hex"
-    /// well-meaning tightening would fail CI instead of silently locking every
-    /// pre-existing hex user out of their data.
+    /// This pins the derivation contract so a future "validate the token is
+    /// 32-byte hex" tightening added HERE would fail CI instead of silently
+    /// locking every pre-existing hex user out of their data. Note the scope: it
+    /// exercises the derivation directly, not the WS-handshake / hosted
+    /// export/import boundaries — those carry no token-format validation today
+    /// either (only a non-empty check), but that is a separate property not
+    /// asserted by this test.
     #[test]
     fn user_token_is_opaque_hex_and_base58_both_accepted() {
         // A representative hex token (what older shell builds minted) and a


### PR DESCRIPTION
## Problem

In hosted mode (try.freenet.org, #4381) the shell page mints a durable per-user "access key" token, stores it in `localStorage` under `__freenet_user_token__`, shows it to the user in the account bar (copy / restore / export), and presents it on the proxied WebSocket upgrade as `?userToken=<token>` (and on `/v1/hosted/export` as the `X-Freenet-User-Token` header). Today that token is a 32-byte random value **hex** encoded (64 chars).

Ian's request: the access key should be **Base58** (Bitcoin/bs58 alphabet), not hex. Base58 is shorter and drops the visually ambiguous characters, so a key a user copies, pastes, or transcribes by hand is far less error-prone, and it matches the encoding used by the rest of Freenet's identifiers.

## Solution

Client-only generation change, no backend change required.

- **`shell_user_token.js`**: mint new tokens as Base58 of the 32 random bytes. There is no `bs58` in the browser and we don't want an external JS dependency, so the change adds a small, self-contained inline Base58 encoder (standard big-endian base-256 -> base-58 long division, Bitcoin alphabet). It is byte-for-byte compatible with the `bs58` crate's `BITCOIN` alphabet output (verified against the crate and against Bitcoin test vectors, including leading-zero / all-zero edge cases).

- **No backend change.** The server treats the token as an OPAQUE namespace key: `UserSecretContext::from_token` derives the namespace as `blake3(domain || raw_token_bytes)`, with no hex decode and no length/charset validation anywhere on the path (`decide_user_token`, the WS handshake, and `/v1/hosted/*` all pass the raw string through). So a Base58 token is honored exactly like a hex one.

- **Back-compat is preserved.** Existing users already have a hex token in `localStorage`, and the "restore" flow (`hosted_bar.js` `fnrestore`) stores any pasted key verbatim. Because the server hashes the raw string either way, a stored hex token keeps resolving to the same per-user namespace, so old data stays reachable. New identities get Base58; existing ones keep their hex token; both work.

- Doc comment on `SHELL_USER_TOKEN_JS` updated (hex -> base58) and now states the opaque-namespace-key property the encoding choice rests on.

## Testing

- **Client shape pin** (`shell_page_hosted_mode_injects_user_token`): asserts the hosted shell carries the inline `base58Encode` encoder + Bitcoin alphabet and no longer emits the hex path (`toString(16)`).
- **Backend accept-both pin** (`user_token_is_opaque_hex_and_base58_both_accepted`, new): pins that the token is an opaque bearer string — a hex token and a Base58 token both derive stable, distinct namespaces, the same string always derives the same namespace (existing hex users keep their data), and there is no case/format normalization. This fails CI if someone later adds "validate the token is 32-byte hex", which would lock every pre-existing hex user out.
- Encoder verified out-of-band with Node against the `bs58` crate and Bitcoin test vectors.
- `cargo fmt`, `cargo clippy -- -D warnings`, `cargo test -p freenet` clean; Prettier + ESLint clean on the shell assets.

Fixes #4721

[AI-assisted - Claude]
