### PR TITLE
feat(server): zero-friction magic-link secrets migration (#4592)

### DIFF
--- a/crates/core/src/contract/executor/runtime/delegates.rs
+++ b/crates/core/src/contract/executor/runtime/delegates.rs
@@ -22,19 +22,28 @@ impl Executor<Runtime> {
     /// AEAD authentication — a torn read fails authentication and surfaces a
     /// clean export error, never silent corruption.
     /// The bundle is scoped to `user_context.scope()` — strictly the per-user
-    /// namespace, never `Local`. The `token` is the bundle-key material so the
-    /// user re-imports on their own peer with the token they already hold.
+    /// namespace, never `Local`. `bundle_key_material` is the secret the bundle
+    /// is encrypted under; it is DELIBERATELY decoupled from the scope. In the
+    /// self-reimport case (`GET /v1/hosted/export`) it is the user's own token,
+    /// so they decrypt with the token they already hold; in the magic-link
+    /// migration case (`hosted_migrate` mint) it is a FRESH EPHEMERAL key, so
+    /// the durable token never leaves the hosting node. Do NOT re-couple this to
+    /// `user_context`'s token — the two are independent by design.
     ///
-    /// The token and the derived key material live only in borrowed/`Zeroizing`
-    /// buffers here and inside `export_secret_bundle`; nothing is logged.
+    /// The key material and the plaintext it derives live only in
+    /// borrowed/`Zeroizing` buffers here and inside `export_secret_bundle`;
+    /// nothing is logged.
     pub fn export_user_secrets(
         &self,
         user_context: &UserSecretContext,
-        token: &[u8],
+        bundle_key_material: &[u8],
     ) -> Result<Vec<u8>, ExecutorError> {
         use crate::wasm_runtime::secret_export::{BundleKeyMaterial, ExportError};
         self.runtime
-            .export_secret_bundle(user_context.scope(), &BundleKeyMaterial::Token(token))
+            .export_secret_bundle(
+                user_context.scope(),
+                &BundleKeyMaterial::Token(bundle_key_material),
+            )
             .map_err(|e| {
                 // Preserve the over-limit case as a typed marker so the HTTP
                 // layer can map it to a 413 rather than a generic 500. The

--- a/crates/core/src/server/.prettierignore
+++ b/crates/core/src/server/.prettierignore
@@ -9,3 +9,4 @@ node_modules/
 **/assets/peer.html
 **/assets/peer_not_found.html
 **/assets/permission_prompt.html
+**/assets/hosted_import_page.html

--- a/crates/core/src/server/client_api.rs
+++ b/crates/core/src/server/client_api.rs
@@ -96,6 +96,7 @@ fn sandbox_origin_from_headers(headers: &axum::http::HeaderMap) -> String {
 
 pub(crate) mod hosted_export;
 pub(crate) mod hosted_import;
+pub(crate) mod hosted_migrate;
 mod permission_prompts;
 mod v1;
 mod v2;
@@ -202,11 +203,23 @@ impl HttpClientApi {
         // the node via `set_op_manager`).
         let export_op_manager = hosted_export::ExportOpManagerHandle::default();
 
+        // Per-node store of one-time migration pull tokens (#4592 magic-link
+        // path). Injected as an Extension below; the hosted mint fills it and
+        // the public pull drains it.
+        let migrate_store = hosted_migrate::MigratePullStore::default();
+
         let router = Router::new()
             .route("/", axum::routing::get(home_page::homepage))
             .route(
                 "/peer/{address}",
                 axum::routing::get(home_page::peer_detail),
+            )
+            // Local peer's migration confirmation page (#4592). First-party
+            // origin so its POST to `pull-import` passes the import gate; it
+            // never auto-pulls (an explicit click is required).
+            .route(
+                "/hosted/import",
+                axum::routing::get(hosted_migrate::import_page),
             )
             .merge(v1::routes(config.clone()))
             .merge(v2::routes(config))
@@ -222,10 +235,16 @@ impl HttpClientApi {
             // `ExportOpManagerHandle` Extension below to reach the executor.
             .merge(hosted_import::routes(ApiVersion::V1))
             .merge(hosted_import::routes(ApiVersion::V2))
+            // Zero-friction magic-link migration (#4592): hosted mint + public
+            // pull + local pull-import. Reuses the export/import gates and the
+            // per-node `ExportOpManagerHandle`; the pull-token store below.
+            .merge(hosted_migrate::routes(ApiVersion::V1))
+            .merge(hosted_migrate::routes(ApiVersion::V2))
             .merge(permission_prompts::routes())
             .layer(Extension(origin_contracts.clone()))
             .layer(Extension(pending_prompts))
             .layer(Extension(export_op_manager.clone()))
+            .layer(Extension(migrate_store))
             .layer(Extension(HttpClientApiRequest(proxy_request_sender)));
 
         (

--- a/crates/core/src/server/client_api/assets/hosted_import_page.css
+++ b/crates/core/src/server/client_api/assets/hosted_import_page.css
@@ -1,0 +1,131 @@
+:root {
+  color-scheme: light dark;
+  --bg: #ffffff;
+  --fg: #1a1a1a;
+  --muted: #6b6b6b;
+  --border: #e2e2e2;
+  --accent: #0abab5;
+  --accent-fg: #ffffff;
+  --btn-bg: #f4f4f4;
+  --ok: #2a8a55;
+  --err: #c23b3b;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0f1113;
+    --fg: #ececee;
+    --muted: #9a9a9e;
+    --border: #2a2c30;
+    --accent: #0abab5;
+    --accent-fg: #04211f;
+    --btn-bg: #1c1e22;
+    --ok: #5cbd83;
+    --err: #f08a8a;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  background: var(--bg);
+  color: var(--fg);
+  font:
+    15px/1.5 system-ui,
+    -apple-system,
+    'Segoe UI',
+    sans-serif;
+}
+
+.wrap {
+  width: 100%;
+  max-width: 460px;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 1.75rem 1.75rem 1.5rem;
+}
+
+h1 {
+  margin: 0 0 0.5rem;
+  font-size: 1.35rem;
+}
+
+.lead {
+  margin: 0 0 1rem;
+  color: var(--fg);
+}
+
+.src {
+  margin: 0 0 1rem;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.mono {
+  font-family: ui-monospace, 'SF Mono', Menlo, monospace;
+  word-break: break-all;
+  color: var(--fg);
+}
+
+.status {
+  min-height: 1.4rem;
+  margin: 0.25rem 0 1rem;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.status-ok {
+  color: var(--ok);
+}
+
+.status-error {
+  color: var(--err);
+}
+
+.actions {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.btn {
+  display: inline-block;
+  font: inherit;
+  font-weight: 500;
+  padding: 0.55rem 1.1rem;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  cursor: pointer;
+  text-decoration: none;
+  color: var(--fg);
+  background: var(--btn-bg);
+}
+
+.btn-primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--accent-fg);
+}
+
+.btn-primary:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+
+.btn-secondary {
+  color: var(--muted);
+}
+
+.note {
+  margin: 1.25rem 0 0;
+  font-size: 0.8rem;
+  color: var(--muted);
+}

--- a/crates/core/src/server/client_api/assets/hosted_import_page.html
+++ b/crates/core/src/server/client_api/assets/hosted_import_page.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Import your Freenet data</title>
+    <style>{style}</style>
+  </head>
+  <body>
+    <main class="wrap">
+      <h1>Import your data</h1>
+      <p class="lead">
+        Bring the rooms, identities and other data from your hosted
+        &ldquo;try Freenet&rdquo; session onto this peer.
+      </p>
+      <p class="src" id="source-line" hidden>
+        Source: <span id="source" class="mono"></span>
+      </p>
+      <div class="status" id="status" role="status" aria-live="polite"></div>
+      <div class="actions">
+        <button type="button" id="import-btn" class="btn btn-primary">
+          Import my data
+        </button>
+        <a href="/" class="btn btn-secondary" id="cancel-link">Cancel</a>
+      </div>
+      <p class="note">
+        Your existing data on this peer is never overwritten. Anything that
+        already exists here is kept as it is.
+      </p>
+    </main>
+    <script>{script}</script>
+  </body>
+</html>

--- a/crates/core/src/server/client_api/assets/hosted_import_page.js
+++ b/crates/core/src/server/client_api/assets/hosted_import_page.js
@@ -1,0 +1,89 @@
+(function () {
+  var params = new URLSearchParams(window.location.search);
+  var source = params.get('source') || '';
+  var pt = params.get('pt') || '';
+
+  var statusEl = document.getElementById('status');
+  var btn = document.getElementById('import-btn');
+  var sourceLine = document.getElementById('source-line');
+  var sourceEl = document.getElementById('source');
+
+  function setStatus(msg, kind) {
+    statusEl.textContent = msg || '';
+    statusEl.className = 'status' + (kind ? ' status-' + kind : '');
+  }
+
+  function isHttps(u) {
+    return /^https:\/\//i.test(u);
+  }
+
+  // Show the source as TEXT (never HTML) so the user sees where the data comes
+  // from before confirming, with no injection surface.
+  if (source) {
+    sourceEl.textContent = source;
+    sourceLine.hidden = false;
+  }
+
+  // Basic client-side sanity check. The server re-validates the source against
+  // a strict allowlist regardless, so this is only for a friendly early error.
+  if (!source || !pt || !isHttps(source)) {
+    setStatus(
+      'This import link is missing or malformed. Open the link from your ' +
+        'hosted session again.',
+      'error',
+    );
+    if (btn) btn.disabled = true;
+    return;
+  }
+
+  // The import runs ONLY on an explicit click — never automatically on page
+  // load — so merely navigating to the link cannot import anything.
+  btn.addEventListener('click', function () {
+    btn.disabled = true;
+    setStatus('Importing your data. This can take a moment...', '');
+    fetch('/v1/hosted/pull-import', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ source: source, pt: pt }),
+    })
+      .then(function (r) {
+        return r.text().then(function (body) {
+          return { ok: r.ok, status: r.status, body: body };
+        });
+      })
+      .then(function (res) {
+        if (res.ok) {
+          var imported = 0;
+          var kept = 0;
+          try {
+            var data = JSON.parse(res.body);
+            imported = data.imported || 0;
+            kept = (data.skipped && data.skipped.length) || 0;
+          } catch (e) {
+            /* A 200 with an unparseable body still means success. */
+          }
+          var msg =
+            'Imported ' + imported + (imported === 1 ? ' item.' : ' items.');
+          if (kept) {
+            msg += ' ' + kept + ' already existed here and were kept.';
+          }
+          setStatus(msg + ' You can now open Freenet.', 'ok');
+          btn.textContent = 'Done';
+        } else {
+          var reason = (res.body || '').trim();
+          setStatus(
+            reason || 'Import failed (HTTP ' + res.status + ').',
+            'error',
+          );
+          btn.disabled = false;
+        }
+      })
+      .catch(function (e) {
+        setStatus(
+          'Import failed: ' + (e && e.message ? e.message : 'network error'),
+          'error',
+        );
+        btn.disabled = false;
+      });
+  });
+})();

--- a/crates/core/src/server/client_api/hosted_export.rs
+++ b/crates/core/src/server/client_api/hosted_export.rs
@@ -216,7 +216,10 @@ pub(crate) fn export_user_context_or_reject(
 /// On an admitted export this RECORDS the export time (advances the per-user
 /// interval clock), so the call has a side effect and must run exactly once per
 /// request.
-fn export_rate_limited(
+///
+/// `pub(crate)` so the magic-link migration mint endpoint (`hosted_migrate`),
+/// which runs the SAME per-user export, shares the identical throttle.
+pub(crate) fn export_rate_limited(
     limiter: Option<&crate::client_events::user_op_rate_limit::UserOpRateLimiter>,
     user_context: &UserSecretContext,
 ) -> bool {
@@ -348,7 +351,12 @@ async fn export_handler(req: axum::extract::Request) -> Response {
 ///
 /// The `token` is moved into a redacted, zeroizing wrapper on the handler event
 /// so it is wiped after the bundle key is derived and never reaches a log.
-async fn run_export(
+///
+/// `pub(crate)` so the migration mint endpoint (`hosted_migrate`) reuses the
+/// exact same executor round-trip, passing a FRESH EPHEMERAL key as the
+/// `token` (bundle-key material) instead of the durable user token — see the
+/// `export_user_secrets` rustdoc on why scope and key are decoupled.
+pub(crate) async fn run_export(
     op_manager: &OpManager,
     user_context: UserSecretContext,
     token: Vec<u8>,

--- a/crates/core/src/server/client_api/hosted_import.rs
+++ b/crates/core/src/server/client_api/hosted_import.rs
@@ -96,11 +96,15 @@ use super::{ApiVersion, OriginContractMap};
 /// HEADER (not a query param) so this high-value secret never lands in the
 /// request URI / access logs — same discipline as the export's
 /// `X-Freenet-User-Token`.
-const BUNDLE_KEY_HEADER: &str = "x-freenet-bundle-key";
+pub(crate) const BUNDLE_KEY_HEADER: &str = "x-freenet-bundle-key";
 
 /// Header selecting how to interpret [`BUNDLE_KEY_HEADER`]: `token` (default,
 /// the hosted-export form) or `passphrase` (the offline `--passphrase` form).
-const BUNDLE_KEY_KIND_HEADER: &str = "x-freenet-bundle-key-kind";
+///
+/// `pub(crate)` (with [`BUNDLE_KEY_HEADER`]) so the migration `pull` endpoint
+/// (`hosted_migrate`) returns the ephemeral bundle key under the SAME header
+/// names the local `pull-import` then forwards into the import path.
+pub(crate) const BUNDLE_KEY_KIND_HEADER: &str = "x-freenet-bundle-key-kind";
 
 /// Header controlling collision handling: `true` overwrites an existing secret,
 /// anything else (default) skips + reports it. Off unless explicitly opted in.
@@ -126,7 +130,8 @@ const AUTHORIZATION_NAME: &str = "authorization";
 /// covers the CBOR integer-array overhead and the 64 MiB margin generously
 /// covers the per-entry key/hash overhead (~200 B x up to 10k entries) plus
 /// framing. Over the cap → HTTP 413.
-const MAX_IMPORT_BUNDLE_BYTES: usize = 2 * MAX_EXPORT_TOTAL_PLAINTEXT_BYTES + 64 * 1024 * 1024;
+pub(crate) const MAX_IMPORT_BUNDLE_BYTES: usize =
+    2 * MAX_EXPORT_TOTAL_PLAINTEXT_BYTES + 64 * 1024 * 1024;
 
 /// Registers the live-import route for `version`. The handler reaches the node
 /// through the per-node [`ExportOpManagerHandle`] carried as a request
@@ -147,7 +152,12 @@ pub(super) fn routes(version: ApiVersion) -> Router {
 /// On rejection returns `(StatusCode::FORBIDDEN, reason)` with a fixed,
 /// non-secret reason string (never echoes the key or any token). See the module
 /// docs for the three layered checks. FAIL-CLOSED throughout.
-fn import_gate_or_reject(
+///
+/// `pub(crate)` so the magic-link migration's local `pull-import` endpoint
+/// (`hosted_migrate`) — which also WRITES secrets into the local store from a
+/// same-origin dashboard POST — reuses this EXACT gate rather than duplicating
+/// (and drifting from) the loopback + trusted-origin + no-contract-token checks.
+pub(crate) fn import_gate_or_reject(
     headers: &HeaderMap,
     source_ip: Option<IpAddr>,
     allowed_hosts: Option<&AllowedHosts>,
@@ -421,7 +431,11 @@ async fn import_handler(req: axum::extract::Request) -> Response {
 /// The bundle bytes and the key are moved into the (redacted/zeroizing) event
 /// wrappers so the high-value key is wiped after the bundle is decrypted and
 /// never reaches a log; the bundle's `Debug` prints only its length.
-async fn run_import(
+///
+/// `pub(crate)` so the magic-link migration's local `pull-import` endpoint
+/// (`hosted_migrate`) drives the import through the SAME executor round-trip
+/// (and the same 4xx/5xx classification) after fetching the bundle over HTTPS.
+pub(crate) async fn run_import(
     op_manager: &OpManager,
     bundle: Vec<u8>,
     key: String,

--- a/crates/core/src/server/client_api/hosted_migrate.rs
+++ b/crates/core/src/server/client_api/hosted_migrate.rs
@@ -1135,4 +1135,71 @@ mod tests {
             "the import must be behind an explicit user gesture, not auto-run"
         );
     }
+
+    /// Regression test: the confirmation page must ship anti-framing headers so
+    /// a remote page cannot frame it and steal the import-confirmation click
+    /// (clickjacking), plus `no-store` so the `pt`-bearing URL isn't cached.
+    #[tokio::test]
+    async fn import_page_sets_anti_framing_headers() {
+        let resp = import_page().await.into_response();
+        let h = resp.headers();
+        assert_eq!(
+            h.get("x-frame-options").expect("X-Frame-Options present"),
+            "DENY"
+        );
+        assert_eq!(
+            h.get("cache-control").expect("Cache-Control present"),
+            "no-store"
+        );
+        assert_eq!(
+            h.get("cross-origin-opener-policy").expect("COOP present"),
+            "same-origin"
+        );
+        let csp = h
+            .get("content-security-policy")
+            .expect("CSP present")
+            .to_str()
+            .unwrap();
+        assert!(
+            csp.contains("frame-ancestors 'none'"),
+            "CSP must forbid framing, got: {csp}"
+        );
+    }
+
+    /// Regression test: the pull response must carry `Cache-Control: no-store`
+    /// (it returns the encrypted bundle plus the ephemeral key header over a
+    /// single-use `pt` URL, which a shared/proxy cache must never persist),
+    /// alongside the bundle-key header the local import forwards.
+    #[tokio::test]
+    async fn pull_response_is_no_store_and_carries_key() {
+        let store = MigratePullStore::default();
+        let token = store
+            .insert(
+                user(1),
+                b"bundle-bytes".to_vec(),
+                "ephemeral-key".to_owned(),
+            )
+            .expect("mint");
+        let req = axum::http::Request::builder()
+            .uri(format!("/v1/hosted/migrate/pull?pt={token}"))
+            .extension(store)
+            .body(axum::body::Body::empty())
+            .unwrap();
+
+        let resp = pull_handler(req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let h = resp.headers();
+        assert_eq!(
+            h.get("cache-control").expect("Cache-Control present"),
+            "no-store"
+        );
+        assert_eq!(
+            h.get(BUNDLE_KEY_HEADER).expect("bundle key header present"),
+            "ephemeral-key"
+        );
+        assert_eq!(
+            h.get(BUNDLE_KEY_KIND_HEADER).expect("kind header present"),
+            "token"
+        );
+    }
 }

--- a/crates/core/src/server/client_api/hosted_migrate.rs
+++ b/crates/core/src/server/client_api/hosted_migrate.rs
@@ -53,6 +53,10 @@
 //!   bytes), so an authenticated token-holder cannot exhaust node memory by
 //!   minting repeatedly; minting also shares the per-user EXPORT rate limit.
 
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
 use axum::{
     Json, Router,
     extract::{ConnectInfo, DefaultBodyLimit},
@@ -60,14 +64,10 @@ use axum::{
     response::{Html, IntoResponse, Response},
     routing::{get, post},
 };
-use std::net::SocketAddr;
-use std::sync::Arc;
-use std::time::Duration;
-use tokio::time::Instant;
-
 use dashmap::DashMap;
 use serde::Deserialize;
 use serde_json::json;
+use tokio::time::Instant;
 use zeroize::Zeroizing;
 
 use crate::client_events::user_op_rate_limit::UserOpRateLimiter;
@@ -94,17 +94,27 @@ const PULL_TOKEN_TTL: Duration = Duration::from_secs(600);
 /// (minting also shares the per-user export rate limit).
 const MAX_PULL_TOKENS_PER_USER: usize = 5;
 
-/// Global cap on live pull tokens across all users. With the per-user cap and
-/// the byte budget, bounds total store memory. Minting past it evicts the
+/// Global cap on live pull tokens across all users. With the per-user caps and
+/// the byte budgets, bounds total store memory. Minting past it evicts the
 /// globally-oldest token first.
 const MAX_PULL_TOKENS_TOTAL: usize = 512;
 
-/// Global byte budget for buffered ephemeral bundles. Sized to comfortably hold
-/// at least one maximal export (`MAX_IMPORT_BUNDLE_BYTES`) plus headroom; real
-/// bundles are kilobytes. Minting evicts oldest tokens until the new bundle
-/// fits; a single bundle larger than the whole budget is refused (can't happen
-/// for a valid export, which is capped below this).
-const MAX_PULL_STORE_BYTES: usize = MAX_IMPORT_BUNDLE_BYTES + 512 * 1024 * 1024;
+/// Per-user byte budget for buffered ephemeral bundles. Sized to hold one
+/// maximal export (`MAX_IMPORT_BUNDLE_BYTES`) plus headroom, so a legitimate
+/// large migration always fits — while capping how much RAM ONE account can
+/// pin. This is the load-bearing anti-griefing bound: without it, a single user
+/// minting two ~max bundles could evict every OTHER user's pending migration
+/// via the global byte budget (a griefing/OOM vector raised in review). Real
+/// bundles are kilobytes, so this ceiling is only ever hit adversarially.
+const MAX_PULL_BYTES_PER_USER: usize = MAX_IMPORT_BUNDLE_BYTES + 64 * 1024 * 1024;
+
+/// Global byte budget for buffered ephemeral bundles — the last-resort OOM
+/// ceiling, only reached when MANY users have filled the store (a broad-load
+/// condition, since the per-user byte budget already bounds each account).
+/// Minting evicts globally-oldest tokens until the new bundle fits; a single
+/// bundle larger than the budget is refused (can't happen for a valid export,
+/// which is capped below this).
+const MAX_PULL_STORE_BYTES: usize = 2 * MAX_PULL_BYTES_PER_USER;
 
 /// Upper bound on the JSON body of a `pull-import` request (`{source, pt}` is a
 /// few hundred bytes; this is generous). Over ⇒ 413.
@@ -136,6 +146,24 @@ struct PullEntry {
     expires_at: Instant,
 }
 
+/// The four bounds [`MigratePullStore::insert_with_limits`] enforces. Factored
+/// into a struct so tests can pass tiny values.
+#[derive(Clone, Copy)]
+struct StoreLimits {
+    max_per_user_count: usize,
+    max_per_user_bytes: usize,
+    max_total_count: usize,
+    max_total_bytes: usize,
+}
+
+/// Production bounds, from the module constants.
+const PROD_STORE_LIMITS: StoreLimits = StoreLimits {
+    max_per_user_count: MAX_PULL_TOKENS_PER_USER,
+    max_per_user_bytes: MAX_PULL_BYTES_PER_USER,
+    max_total_count: MAX_PULL_TOKENS_TOTAL,
+    max_total_bytes: MAX_PULL_STORE_BYTES,
+};
+
 /// Per-node handle to the migration pull-token store. Cheap to clone (an `Arc`),
 /// injected as a router `Extension` in
 /// [`HttpClientApi::as_router_with_origin_contracts`](super::HttpClientApi).
@@ -146,57 +174,62 @@ pub(crate) struct MigratePullStore(Arc<DashMap<String, PullEntry>>);
 impl MigratePullStore {
     /// Store a freshly-minted ephemeral bundle under a new random single-use
     /// token, returning the token. Prunes expired entries, enforces the per-user
-    /// cap (evicting that user's oldest), then the global count + byte budget
-    /// (evicting the globally-oldest until the new bundle fits). Returns `None`
-    /// only if the new bundle alone exceeds the whole byte budget (a valid
-    /// export never does), which the caller maps to a 503.
+    /// count + byte budget (evicting THAT user's oldest first — so one account
+    /// can never push other users' pending migrations out of the store), then
+    /// the global count + byte budget (evicting the globally-oldest). Returns
+    /// `None` only if the new bundle alone exceeds a budget (a valid export
+    /// never does), which the caller maps to a 503.
+    ///
+    /// NOTE: `insert` is a sequence of DashMap ops, not one atomic transaction,
+    /// so two concurrent mints for the SAME user can each observe room and both
+    /// land, transiently exceeding the per-user count cap by one or two. That is
+    /// harmless (still bounded) and is additionally gated by the shared per-user
+    /// EXPORT rate limit on the mint path, which serializes a user's mints far
+    /// below any contention window.
     fn insert(&self, user_id: UserId, bundle: Vec<u8>, key: String) -> Option<String> {
+        self.insert_with_limits(user_id, bundle, key, PROD_STORE_LIMITS)
+    }
+
+    /// [`Self::insert`] with the bounds made explicit, so tests can exercise the
+    /// eviction / oversize-refusal paths at small limits without allocating
+    /// gigabyte buffers (mirrors `secret_export::export_bundle_with_limits`).
+    fn insert_with_limits(
+        &self,
+        user_id: UserId,
+        bundle: Vec<u8>,
+        key: String,
+        limits: StoreLimits,
+    ) -> Option<String> {
         let now = Instant::now();
         let new_len = bundle.len();
-        if new_len > MAX_PULL_STORE_BYTES {
+        // A bundle that can't fit either budget can never be stored.
+        if new_len > limits.max_per_user_bytes || new_len > limits.max_total_bytes {
             return None;
         }
 
         // (1) Drop expired entries so caps count only live tokens.
         self.0.retain(|_, e| e.expires_at > now);
 
-        // (2) Per-user cap: keep at most MAX_PULL_TOKENS_PER_USER - 1 of this
-        // user's existing tokens, evicting oldest, so this insert lands at the
-        // cap.
-        let mut mine: Vec<(String, Instant)> = self
-            .0
-            .iter()
-            .filter(|r| r.value().user_id == user_id)
-            .map(|r| (r.key().clone(), r.value().expires_at))
-            .collect();
-        if mine.len() >= MAX_PULL_TOKENS_PER_USER {
-            mine.sort_by_key(|(_, exp)| *exp);
-            let excess = mine.len() - (MAX_PULL_TOKENS_PER_USER - 1);
-            for (id, _) in mine.into_iter().take(excess) {
-                self.0.remove(&id);
-            }
-        }
+        // (2) Per-user budget (count AND bytes): evict THIS user's own oldest
+        // until adding the new entry stays within both caps. Evicting the
+        // minter's own oldest first is what stops one account from evicting
+        // other users' pending migrations.
+        self.evict_oldest_until(
+            |v| v.user_id == user_id,
+            |count, bytes| {
+                count < limits.max_per_user_count && bytes + new_len <= limits.max_per_user_bytes
+            },
+        );
 
-        // (3) Global count + byte budget: evict globally-oldest until the new
-        // bundle fits.
-        loop {
-            let count = self.0.len();
-            let total: usize = self.0.iter().map(|r| r.value().bundle.len()).sum();
-            if count < MAX_PULL_TOKENS_TOTAL && total + new_len <= MAX_PULL_STORE_BYTES {
-                break;
-            }
-            let oldest = self
-                .0
-                .iter()
-                .min_by_key(|r| r.value().expires_at)
-                .map(|r| r.key().clone());
-            match oldest {
-                Some(id) => {
-                    self.0.remove(&id);
-                }
-                None => break, // store empty but new bundle still didn't fit — impossible given the guard above
-            }
-        }
+        // (3) Global budget (count AND bytes): the last-resort OOM ceiling,
+        // rarely reached because (2) already bounds each user. Evict
+        // globally-oldest across all users.
+        self.evict_oldest_until(
+            |_| true,
+            |count, bytes| {
+                count < limits.max_total_count && bytes + new_len <= limits.max_total_bytes
+            },
+        );
 
         let token = random_token();
         self.0.insert(
@@ -209,6 +242,39 @@ impl MigratePullStore {
             },
         );
         Some(token)
+    }
+
+    /// Evict the oldest entries matching `scope` (by expiry) until
+    /// `fits(count, bytes)` holds for the matching set, or none remain. `count`
+    /// / `bytes` are the current totals of the in-scope entries; the caller's
+    /// `fits` closure accounts for the entry about to be added.
+    fn evict_oldest_until(
+        &self,
+        scope: impl Fn(&PullEntry) -> bool,
+        fits: impl Fn(usize, usize) -> bool,
+    ) {
+        loop {
+            let mut in_scope: Vec<(String, Instant, usize)> = self
+                .0
+                .iter()
+                .filter(|r| scope(r.value()))
+                .map(|r| {
+                    (
+                        r.key().clone(),
+                        r.value().expires_at,
+                        r.value().bundle.len(),
+                    )
+                })
+                .collect();
+            let count = in_scope.len();
+            let bytes: usize = in_scope.iter().map(|(_, _, len)| *len).sum();
+            if in_scope.is_empty() || fits(count, bytes) {
+                break;
+            }
+            in_scope.sort_by_key(|(_, exp, _)| *exp);
+            let (oldest_id, _, _) = in_scope.remove(0);
+            self.0.remove(&oldest_id);
+        }
     }
 
     /// Consume the entry for `token` (single-use). Returns `None` — uniformly,
@@ -234,9 +300,13 @@ fn random_token() -> String {
     // `OsRng` exception. Never `GlobalRng` here.
     use chacha20poly1305::aead::OsRng;
     use chacha20poly1305::aead::rand_core::RngCore;
-    let mut buf = [0u8; 32];
-    OsRng.fill_bytes(&mut buf);
-    bs58::encode(buf)
+    // Zeroize the raw 32 bytes after encoding: for the pull TOKEN this is only
+    // hygiene (it is a capability, not a secret), but this same function mints
+    // the ephemeral BUNDLE KEY, whose raw pre-encoding bytes must not linger in
+    // the stack frame.
+    let mut buf = Zeroizing::new([0u8; 32]);
+    OsRng.fill_bytes(buf.as_mut_slice());
+    bs58::encode(buf.as_ref())
         .with_alphabet(bs58::Alphabet::BITCOIN)
         .into_string()
 }
@@ -371,6 +441,13 @@ async fn mint_handler(req: axum::extract::Request) -> Response {
 /// `GET /v{1,2}/hosted/migrate/pull?pt=<token>` — hand the ephemeral bundle to
 /// the pulling peer. PUBLIC: the single-use pull token is the entire auth. A
 /// missing / expired / already-used token gets a uniform 404.
+///
+/// The pull token rides in the URL query (unlike the export/import credentials,
+/// which use a header to stay out of access logs) because a clickable magic
+/// link cannot set a header. That divergence is acceptable here: the token is
+/// single-use and short-TTL, so a copy captured from a log is already spent by
+/// the time anyone reads it, and the design assumes the public reverse proxy
+/// terminates TLS and does not itself log query strings for this path.
 async fn pull_handler(req: axum::extract::Request) -> Response {
     let Some(store) = req.extensions().get::<MigratePullStore>().cloned() else {
         return pull_not_found();
@@ -452,12 +529,31 @@ fn is_valid_pull_token(pt: &str) -> bool {
 /// CLIENT-side (so no untrusted input is interpolated server-side) and requires
 /// an explicit click before POSTing to `pull-import` — a state-changing import
 /// is never triggered by mere navigation to the link.
+///
+/// Ships anti-framing headers (mirroring the permission-prompt page): the click
+/// on "Import my data" is a state-changing confirmation, so a remote page must
+/// not be able to FRAME this page and steal that click (clickjacking) to drive
+/// the victim's node into importing an attacker-minted bundle. `frame-ancestors
+/// 'none'` + `X-Frame-Options: DENY` forbid framing; `Cache-Control: no-store`
+/// keeps the `pt`-bearing URL out of the disk cache.
 pub(super) async fn import_page() -> impl IntoResponse {
-    Html(format!(
-        include_str!("assets/hosted_import_page.html"),
-        style = HOSTED_IMPORT_PAGE_CSS,
-        script = HOSTED_IMPORT_PAGE_JS,
-    ))
+    let headers = [
+        ("X-Frame-Options", "DENY"),
+        (
+            "Content-Security-Policy",
+            "frame-ancestors 'none'; default-src 'self' 'unsafe-inline'",
+        ),
+        ("Cache-Control", "no-store"),
+        ("Cross-Origin-Opener-Policy", "same-origin"),
+    ];
+    (
+        headers,
+        Html(format!(
+            include_str!("assets/hosted_import_page.html"),
+            style = HOSTED_IMPORT_PAGE_CSS,
+            script = HOSTED_IMPORT_PAGE_JS,
+        )),
+    )
 }
 
 const HOSTED_IMPORT_PAGE_CSS: &str = include_str!("assets/hosted_import_page.css");
@@ -606,6 +702,11 @@ async fn pull_bundle_from_source(
         // would defeat it. The pull endpoint answers 200/404 directly, never a
         // redirect, so this only closes the SSRF-via-redirect hole.
         .redirect(reqwest::redirect::Policy::none())
+        // Ignore ambient HTTP(S)_PROXY/ALL_PROXY env vars: the outbound pull
+        // must go straight to the allowlisted origin, not through an
+        // operator-or-attacker-influenced proxy, keeping the fetch fully
+        // self-contained for the SSRF guarantee.
+        .no_proxy()
         .build()
         .map_err(|_| {
             (
@@ -614,12 +715,25 @@ async fn pull_bundle_from_source(
             )
         })?;
 
-    let mut resp = client.get(&url).send().await.map_err(|_| {
+    let resp = client.get(&url).send().await.map_err(|_| {
         (
             StatusCode::BAD_GATEWAY,
             "could not reach the migration source",
         )
     })?;
+    read_pull_response(resp).await
+}
+
+/// Consume a pull response into `(bundle, key, key_kind)`, enforcing: 2xx
+/// status, a non-empty bundle key header, a hard body-size cap
+/// ([`MAX_IMPORT_BUNDLE_BYTES`], read incrementally so an oversized/hostile
+/// response can't be buffered), and a non-empty body. Split out from the
+/// client-building [`pull_bundle_from_source`] so the response-handling logic
+/// (the part with branches) is unit-testable against a synthesized response
+/// without needing a live HTTPS server.
+async fn read_pull_response(
+    mut resp: reqwest::Response,
+) -> Result<(Vec<u8>, String, BundleKeyKind), (StatusCode, &'static str)> {
     if !resp.status().is_success() {
         return Err((
             StatusCode::BAD_GATEWAY,
@@ -764,6 +878,175 @@ mod tests {
         assert!(
             store.take(&other).is_some(),
             "another user's token must be unaffected by user-1's cap"
+        );
+    }
+
+    /// Small tunable limits so the byte-budget / count paths are exercised
+    /// without allocating gigabyte buffers.
+    fn tiny_limits() -> StoreLimits {
+        StoreLimits {
+            max_per_user_count: 10,
+            max_per_user_bytes: 100,
+            max_total_count: 10,
+            max_total_bytes: 1000,
+        }
+    }
+
+    /// The per-user BYTE budget evicts the minter's OWN oldest — never another
+    /// user's — which is the anti-griefing property. Two 60-byte user-1 bundles
+    /// exceed the 100-byte per-user budget, so the first is dropped; a small
+    /// user-2 bundle is untouched.
+    #[tokio::test(start_paused = true)]
+    async fn per_user_byte_budget_evicts_own_oldest_not_others() {
+        let store = MigratePullStore::default();
+        let limits = tiny_limits();
+
+        let t1 = store
+            .insert_with_limits(user(1), vec![0u8; 60], "k1".to_owned(), limits)
+            .expect("mint");
+        tokio::time::advance(Duration::from_secs(1)).await;
+        let other = store
+            .insert_with_limits(user(2), vec![0u8; 10], "ok".to_owned(), limits)
+            .expect("mint");
+        tokio::time::advance(Duration::from_secs(1)).await;
+        let t2 = store
+            .insert_with_limits(user(1), vec![0u8; 60], "k2".to_owned(), limits)
+            .expect("mint");
+
+        assert!(
+            store.take(&t1).is_none(),
+            "user-1's oldest must be evicted by the per-user byte budget"
+        );
+        assert!(
+            store.take(&t2).is_some(),
+            "the newest user-1 bundle remains"
+        );
+        assert!(
+            store.take(&other).is_some(),
+            "another user's bundle must NOT be evicted by user-1's byte pressure"
+        );
+    }
+
+    /// A bundle larger than a budget is refused outright (maps to 503), with
+    /// nothing stored.
+    #[tokio::test(start_paused = true)]
+    async fn oversize_bundle_is_refused() {
+        let store = MigratePullStore::default();
+        let limits = tiny_limits(); // per-user byte budget = 100
+        assert!(
+            store
+                .insert_with_limits(user(1), vec![0u8; 101], "k".to_owned(), limits)
+                .is_none(),
+            "a bundle over the per-user byte budget must be refused"
+        );
+        assert_eq!(store.0.len(), 0, "a refused oversize mint stores nothing");
+    }
+
+    /// The GLOBAL count cap evicts the globally-oldest across users once the
+    /// store is full.
+    #[tokio::test(start_paused = true)]
+    async fn global_count_cap_evicts_globally_oldest() {
+        let store = MigratePullStore::default();
+        // total count cap 3, generous bytes, per-user count high so the GLOBAL
+        // cap is the binding one.
+        let limits = StoreLimits {
+            max_per_user_count: 100,
+            max_per_user_bytes: 10_000,
+            max_total_count: 3,
+            max_total_bytes: 10_000,
+        };
+        let a = store
+            .insert_with_limits(user(1), vec![1], "a".to_owned(), limits)
+            .expect("mint");
+        tokio::time::advance(Duration::from_secs(1)).await;
+        let b = store
+            .insert_with_limits(user(2), vec![2], "b".to_owned(), limits)
+            .expect("mint");
+        tokio::time::advance(Duration::from_secs(1)).await;
+        let c = store
+            .insert_with_limits(user(3), vec![3], "c".to_owned(), limits)
+            .expect("mint");
+        tokio::time::advance(Duration::from_secs(1)).await;
+        // A 4th mint (from yet another user) evicts the globally-oldest (a).
+        let d = store
+            .insert_with_limits(user(4), vec![4], "d".to_owned(), limits)
+            .expect("mint");
+
+        assert!(store.take(&a).is_none(), "globally-oldest evicted at cap");
+        for (name, tok) in [("b", &b), ("c", &c), ("d", &d)] {
+            assert!(
+                store.take(tok).is_some(),
+                "{name} must remain under the cap"
+            );
+        }
+    }
+
+    /// Build a `reqwest::Response` from a synthesized HTTP response so
+    /// `read_pull_response` (the body-cap / key-extraction logic) is testable
+    /// without a live HTTPS server. `axum::http` is the same `http` crate
+    /// reqwest 0.12 consumes, so the `From` conversion type-checks.
+    fn synth_response(status: u16, headers: &[(&str, &str)], body: Vec<u8>) -> reqwest::Response {
+        let mut builder = axum::http::Response::builder().status(status);
+        for (name, value) in headers {
+            builder = builder.header(*name, *value);
+        }
+        reqwest::Response::from(builder.body(body).expect("valid synthetic response"))
+    }
+
+    #[tokio::test]
+    async fn read_pull_response_success_extracts_bundle_and_key() {
+        let resp = synth_response(
+            200,
+            &[
+                ("x-freenet-bundle-key", "ephemeral-key-xyz"),
+                ("x-freenet-bundle-key-kind", "token"),
+            ],
+            b"the-bundle-bytes".to_vec(),
+        );
+        let (bundle, key, kind) = read_pull_response(resp).await.expect("must succeed");
+        assert_eq!(bundle, b"the-bundle-bytes");
+        assert_eq!(key, "ephemeral-key-xyz");
+        assert!(matches!(kind, BundleKeyKind::Token));
+    }
+
+    #[tokio::test]
+    async fn read_pull_response_kind_defaults_token_and_honors_passphrase() {
+        // Missing kind header defaults to Token.
+        let resp = synth_response(200, &[("x-freenet-bundle-key", "k")], b"b".to_vec());
+        let (_, _, kind) = read_pull_response(resp).await.unwrap();
+        assert!(matches!(kind, BundleKeyKind::Token));
+        // Explicit passphrase kind is honored.
+        let resp = synth_response(
+            200,
+            &[
+                ("x-freenet-bundle-key", "k"),
+                ("x-freenet-bundle-key-kind", "passphrase"),
+            ],
+            b"b".to_vec(),
+        );
+        let (_, _, kind) = read_pull_response(resp).await.unwrap();
+        assert!(matches!(kind, BundleKeyKind::Passphrase));
+    }
+
+    #[tokio::test]
+    async fn read_pull_response_rejects_non_success_missing_key_and_empty() {
+        // Non-2xx (the source 404'd the link).
+        let resp = synth_response(404, &[("x-freenet-bundle-key", "k")], b"b".to_vec());
+        assert_eq!(
+            read_pull_response(resp).await.unwrap_err().0,
+            StatusCode::BAD_GATEWAY
+        );
+        // 200 but no bundle key header.
+        let resp = synth_response(200, &[], b"b".to_vec());
+        assert_eq!(
+            read_pull_response(resp).await.unwrap_err().0,
+            StatusCode::BAD_GATEWAY
+        );
+        // 200 with a key but an empty body.
+        let resp = synth_response(200, &[("x-freenet-bundle-key", "k")], Vec::new());
+        assert_eq!(
+            read_pull_response(resp).await.unwrap_err().0,
+            StatusCode::BAD_GATEWAY
         );
     }
 

--- a/crates/core/src/server/client_api/hosted_migrate.rs
+++ b/crates/core/src/server/client_api/hosted_migrate.rs
@@ -1,0 +1,839 @@
+//! Zero-friction "magic-link" secrets migration (#4592, the primary path).
+//!
+//! Turns the hosted → self-host handoff into a link the user clicks on their
+//! own peer. Three cooperating HTTP surfaces, on the SAME binary (a node can be
+//! either side), plus a small confirmation page:
+//!
+//! 1. **Hosted MINT** — `POST /v{1,2}/hosted/migrate/mint` (on try.freenet.org).
+//!    Gated exactly like the live EXPORT (hosted ON + loopback + `XFP:https` +
+//!    the durable `X-Freenet-User-Token`). Exports the user's secrets under a
+//!    FRESH EPHEMERAL key, stores the ephemeral-keyed bundle + key server-side
+//!    under a single-use, short-TTL, per-user-bounded pull token, and returns
+//!    the token. The frontend builds the link
+//!    `http://127.0.0.1:7509/hosted/import?source=<origin>&pt=<token>`.
+//!
+//! 2. **Hosted PULL** — `GET /v{1,2}/hosted/migrate/pull?pt=<token>` (public,
+//!    reachable over the internet through the hosting node's reverse proxy).
+//!    The ONLY auth is the pull token: a 256-bit unguessable, single-use,
+//!    short-TTL capability. Returns the ephemeral bundle bytes + the ephemeral
+//!    key (in headers, over TLS). NOT gated on the durable token — the pulling
+//!    peer never has it.
+//!
+//! 3. **Local IMPORT PAGE** — `GET /hosted/import` (on the user's own peer).
+//!    A first-party confirmation page ("Import your data from <source>?"). It
+//!    does NOT auto-pull: a state-changing import requires an explicit click,
+//!    defeating drive-by / CSRF navigation to the link.
+//!
+//! 4. **Local PULL-IMPORT** — `POST /v{1,2}/hosted/pull-import` (on the user's
+//!    own peer). Gated by the SAME loopback + trusted-origin gate as the live
+//!    import (`hosted_import`), so only the node's own dashboard/confirmation
+//!    page can drive it. Fetches the bundle over HTTPS from an ALLOWLISTED
+//!    source (`try.freenet.org` only, https, default port) — a strict SSRF
+//!    guard — then imports it into `Local` with `overwrite=false`
+//!    (NON-DESTRUCTIVE: a secret already present locally is kept and reported
+//!    in `skipped`, never clobbered).
+//!
+//! # Why the durable token never leaves the hosting node
+//!
+//! The bundle key and the user scope are DECOUPLED at the crypto layer
+//! (`export_bundle(store, scope, material)` — independent args). The mint
+//! exports the real user's scope under a random ephemeral key, so the pulling
+//! peer only ever handles the ephemeral key (delivered once, over TLS, then the
+//! token is burned). The durable `X-Freenet-User-Token` stays on the hosting
+//! node.
+//!
+//! # Pull-token lifecycle (the load-bearing auth object)
+//!
+//! - **Minted** only behind the authenticated mint gate.
+//! - **256-bit** from `OsRng` (unguessable capability — brute force infeasible).
+//! - **Single-use**: `take` removes it; a replay gets a uniform 404.
+//! - **Short-TTL** ([`PULL_TOKEN_TTL`]): expired tokens are pruned and read as
+//!   absent (same 404), so a leaked-but-stale link is inert.
+//! - **Bounded**: per-user ([`MAX_PULL_TOKENS_PER_USER`]) and global (count +
+//!   bytes), so an authenticated token-holder cannot exhaust node memory by
+//!   minting repeatedly; minting also shares the per-user EXPORT rate limit.
+
+use axum::{
+    Json, Router,
+    extract::{ConnectInfo, DefaultBodyLimit},
+    http::{HeaderMap, HeaderName, HeaderValue, StatusCode, header::CONTENT_TYPE},
+    response::{Html, IntoResponse, Response},
+    routing::{get, post},
+};
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::time::Instant;
+
+use dashmap::DashMap;
+use serde::Deserialize;
+use serde_json::json;
+use zeroize::Zeroizing;
+
+use crate::client_events::user_op_rate_limit::UserOpRateLimiter;
+use crate::contract::BundleKeyKind;
+use crate::server::{AllowedHosts, AllowedSourceCidrs, HostedMode};
+use crate::wasm_runtime::UserId;
+
+use super::hosted_export::{
+    ExportOpManagerHandle, export_rate_limited, export_user_context_or_reject, run_export,
+};
+use super::hosted_import::{
+    BUNDLE_KEY_HEADER, BUNDLE_KEY_KIND_HEADER, MAX_IMPORT_BUNDLE_BYTES, import_gate_or_reject,
+    run_import,
+};
+use super::{ApiVersion, OriginContractMap};
+
+/// How long a minted migration pull token stays valid. A focused "do it now"
+/// window: long enough to open the link on your own peer, short enough that a
+/// leaked-but-stale link is inert. Expired tokens read as absent (404).
+const PULL_TOKEN_TTL: Duration = Duration::from_secs(600);
+
+/// Max live pull tokens a single user may hold. Minting past the cap evicts the
+/// user's OLDEST token. Bounds a single authenticated token-holder's footprint
+/// (minting also shares the per-user export rate limit).
+const MAX_PULL_TOKENS_PER_USER: usize = 5;
+
+/// Global cap on live pull tokens across all users. With the per-user cap and
+/// the byte budget, bounds total store memory. Minting past it evicts the
+/// globally-oldest token first.
+const MAX_PULL_TOKENS_TOTAL: usize = 512;
+
+/// Global byte budget for buffered ephemeral bundles. Sized to comfortably hold
+/// at least one maximal export (`MAX_IMPORT_BUNDLE_BYTES`) plus headroom; real
+/// bundles are kilobytes. Minting evicts oldest tokens until the new bundle
+/// fits; a single bundle larger than the whole budget is refused (can't happen
+/// for a valid export, which is capped below this).
+const MAX_PULL_STORE_BYTES: usize = MAX_IMPORT_BUNDLE_BYTES + 512 * 1024 * 1024;
+
+/// Upper bound on the JSON body of a `pull-import` request (`{source, pt}` is a
+/// few hundred bytes; this is generous). Over ⇒ 413.
+const MAX_PULL_IMPORT_REQUEST_BYTES: usize = 64 * 1024;
+
+/// Timeout for the local peer's outbound HTTPS pull from the hosting node.
+const MIGRATION_PULL_TIMEOUT_SECS: u64 = 30;
+
+/// The ONLY hosts a local peer will pull a migration bundle FROM. A strict SSRF
+/// allowlist: a caller-supplied `source` must be `https`, on the default port,
+/// with a host in this list. Kept a small constant list so it is trivial to
+/// extend, but shipped locked to the one production hosting origin.
+const ALLOWED_MIGRATION_HOSTS: &[&str] = &["try.freenet.org"];
+
+// ---------------------------------------------------------------------------
+// Pull-token store
+// ---------------------------------------------------------------------------
+
+/// One minted, pre-computed migration bundle awaiting a single pull.
+struct PullEntry {
+    /// The ephemeral-keyed FNSX bundle bytes (encrypted under `key`).
+    bundle: Vec<u8>,
+    /// The ephemeral bundle key (bs58). Delivered to the pulling peer once, over
+    /// TLS; zeroized when the entry drops.
+    key: Zeroizing<String>,
+    /// The user this bundle was minted for — used ONLY for the per-user cap.
+    user_id: UserId,
+    /// Monotonic expiry. A token at or past this reads as absent.
+    expires_at: Instant,
+}
+
+/// Per-node handle to the migration pull-token store. Cheap to clone (an `Arc`),
+/// injected as a router `Extension` in
+/// [`HttpClientApi::as_router_with_origin_contracts`](super::HttpClientApi).
+/// Each node owns its own store, so parallel in-process nodes never collide.
+#[derive(Clone, Default)]
+pub(crate) struct MigratePullStore(Arc<DashMap<String, PullEntry>>);
+
+impl MigratePullStore {
+    /// Store a freshly-minted ephemeral bundle under a new random single-use
+    /// token, returning the token. Prunes expired entries, enforces the per-user
+    /// cap (evicting that user's oldest), then the global count + byte budget
+    /// (evicting the globally-oldest until the new bundle fits). Returns `None`
+    /// only if the new bundle alone exceeds the whole byte budget (a valid
+    /// export never does), which the caller maps to a 503.
+    fn insert(&self, user_id: UserId, bundle: Vec<u8>, key: String) -> Option<String> {
+        let now = Instant::now();
+        let new_len = bundle.len();
+        if new_len > MAX_PULL_STORE_BYTES {
+            return None;
+        }
+
+        // (1) Drop expired entries so caps count only live tokens.
+        self.0.retain(|_, e| e.expires_at > now);
+
+        // (2) Per-user cap: keep at most MAX_PULL_TOKENS_PER_USER - 1 of this
+        // user's existing tokens, evicting oldest, so this insert lands at the
+        // cap.
+        let mut mine: Vec<(String, Instant)> = self
+            .0
+            .iter()
+            .filter(|r| r.value().user_id == user_id)
+            .map(|r| (r.key().clone(), r.value().expires_at))
+            .collect();
+        if mine.len() >= MAX_PULL_TOKENS_PER_USER {
+            mine.sort_by_key(|(_, exp)| *exp);
+            let excess = mine.len() - (MAX_PULL_TOKENS_PER_USER - 1);
+            for (id, _) in mine.into_iter().take(excess) {
+                self.0.remove(&id);
+            }
+        }
+
+        // (3) Global count + byte budget: evict globally-oldest until the new
+        // bundle fits.
+        loop {
+            let count = self.0.len();
+            let total: usize = self.0.iter().map(|r| r.value().bundle.len()).sum();
+            if count < MAX_PULL_TOKENS_TOTAL && total + new_len <= MAX_PULL_STORE_BYTES {
+                break;
+            }
+            let oldest = self
+                .0
+                .iter()
+                .min_by_key(|r| r.value().expires_at)
+                .map(|r| r.key().clone());
+            match oldest {
+                Some(id) => {
+                    self.0.remove(&id);
+                }
+                None => break, // store empty but new bundle still didn't fit — impossible given the guard above
+            }
+        }
+
+        let token = random_token();
+        self.0.insert(
+            token.clone(),
+            PullEntry {
+                bundle,
+                key: Zeroizing::new(key),
+                user_id,
+                expires_at: now + PULL_TOKEN_TTL,
+            },
+        );
+        Some(token)
+    }
+
+    /// Consume the entry for `token` (single-use). Returns `None` — uniformly,
+    /// with no distinction an attacker could probe — if the token is unknown,
+    /// already used, or expired.
+    fn take(&self, token: &str) -> Option<PullEntry> {
+        let (_, entry) = self.0.remove(token)?;
+        if entry.expires_at <= Instant::now() {
+            return None;
+        }
+        Some(entry)
+    }
+}
+
+/// A cryptographically-random, unguessable 256-bit capability token, bs58
+/// encoded. Used for BOTH the pull token (a download-authorizing bearer
+/// capability) and the ephemeral bundle key (the decryption secret) — both must
+/// be unguessable, so `OsRng` (the documented crypto-material exception to
+/// `GlobalRng`) is correct: a `GlobalRng` seed leak would let an attacker
+/// predict tokens and either steal a pending migration or forge a valid link.
+fn random_token() -> String {
+    // OsRng: cryptographic capability/key material — see the module + code-style
+    // `OsRng` exception. Never `GlobalRng` here.
+    use chacha20poly1305::aead::OsRng;
+    use chacha20poly1305::aead::rand_core::RngCore;
+    let mut buf = [0u8; 32];
+    OsRng.fill_bytes(&mut buf);
+    bs58::encode(buf)
+        .with_alphabet(bs58::Alphabet::BITCOIN)
+        .into_string()
+}
+
+// ---------------------------------------------------------------------------
+// Routes
+// ---------------------------------------------------------------------------
+
+/// Registers the migration HTTP endpoints for `version`: the hosted `mint` +
+/// `pull` and the local `pull-import`. The confirmation PAGE (`/hosted/import`)
+/// is unversioned and registered separately in `client_api.rs` (like `/`).
+pub(super) fn routes(version: ApiVersion) -> Router {
+    let prefix = version.prefix();
+    Router::new()
+        .route(
+            &format!("/{prefix}/hosted/migrate/mint"),
+            post(mint_handler),
+        )
+        .route(&format!("/{prefix}/hosted/migrate/pull"), get(pull_handler))
+        .route(
+            &format!("/{prefix}/hosted/pull-import"),
+            post(pull_import_handler).layer(DefaultBodyLimit::max(MAX_PULL_IMPORT_REQUEST_BYTES)),
+        )
+}
+
+// ---------------------------------------------------------------------------
+// Hosted side: mint + pull
+// ---------------------------------------------------------------------------
+
+/// `POST /v{1,2}/hosted/migrate/mint` — mint a one-time migration link for the
+/// authenticated hosted user. Gated identically to the live export; the durable
+/// token authenticates the user but is NOT used as the bundle key.
+async fn mint_handler(req: axum::extract::Request) -> Response {
+    let hosted_mode = req
+        .extensions()
+        .get::<HostedMode>()
+        .map(|hm| hm.0)
+        .unwrap_or(false);
+    let source_ip = req
+        .extensions()
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|ci| ci.0.ip());
+    let headers = req.headers();
+
+    // Same gate as the live export (hosted + loopback + XFP:https + valid
+    // token). We take the user CONTEXT (the scope) and DISCARD the durable token
+    // — the bundle is sealed under a fresh ephemeral key instead.
+    let (user_context, _durable_token) =
+        match export_user_context_or_reject(headers, source_ip, hosted_mode) {
+            Ok(v) => v,
+            Err((status, reason)) => {
+                tracing::warn!(source_ip = ?source_ip, reason, "Rejected migration mint");
+                return (status, reason).into_response();
+            }
+        };
+
+    // Minting runs a full export, so it shares the per-user EXPORT rate limit.
+    let limiter = req.extensions().get::<UserOpRateLimiter>();
+    if export_rate_limited(limiter, &user_context) {
+        tracing::warn!(
+            user_id = ?user_context.user_id(),
+            "Rejected migration mint: per-user export rate limit exceeded"
+        );
+        return (
+            StatusCode::TOO_MANY_REQUESTS,
+            "migration rate limit exceeded; retry shortly",
+        )
+            .into_response();
+    }
+
+    let op_manager = req
+        .extensions()
+        .get::<ExportOpManagerHandle>()
+        .and_then(ExportOpManagerHandle::current);
+    let Some(op_manager) = op_manager else {
+        tracing::warn!("Migration mint requested but no running node is registered");
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "node is not ready to serve migrations",
+        )
+            .into_response();
+    };
+
+    let Some(store) = req.extensions().get::<MigratePullStore>().cloned() else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "migration is not available on this node",
+        )
+            .into_response();
+    };
+
+    // Fresh ephemeral bundle key (never derived from the durable token). The
+    // user id is only for the store's per-user cap.
+    let ephemeral_key = random_token();
+    let user_id = *user_context.user_id();
+
+    // Export the user's scope under the ephemeral key (same executor round-trip
+    // as the live export). Over-limit / busy / failure map to 413 / 503 / 500.
+    let bundle = match run_export(
+        &op_manager,
+        user_context,
+        ephemeral_key.clone().into_bytes(),
+    )
+    .await
+    {
+        Ok(b) => b,
+        Err((status, reason)) => return (status, reason).into_response(),
+    };
+
+    let Some(pull_token) = store.insert(user_id, bundle, ephemeral_key) else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "too many pending migrations; retry shortly",
+        )
+            .into_response();
+    };
+
+    (
+        StatusCode::OK,
+        Json(json!({
+            "pull_token": pull_token,
+            "expires_in_secs": PULL_TOKEN_TTL.as_secs(),
+        })),
+    )
+        .into_response()
+}
+
+/// `GET /v{1,2}/hosted/migrate/pull?pt=<token>` — hand the ephemeral bundle to
+/// the pulling peer. PUBLIC: the single-use pull token is the entire auth. A
+/// missing / expired / already-used token gets a uniform 404.
+async fn pull_handler(req: axum::extract::Request) -> Response {
+    let Some(store) = req.extensions().get::<MigratePullStore>().cloned() else {
+        return pull_not_found();
+    };
+    let Some(pt) = pt_from_query(req.uri().query()) else {
+        return pull_not_found();
+    };
+    let Some(entry) = store.take(&pt) else {
+        return pull_not_found();
+    };
+
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        CONTENT_TYPE,
+        HeaderValue::from_static("application/octet-stream"),
+    );
+    // The ephemeral key rides in a header (never the URL) — the same discipline
+    // and header names the local pull-import forwards into the import path.
+    match HeaderValue::from_str(entry.key.as_str()) {
+        Ok(v) => {
+            headers.insert(HeaderName::from_static(BUNDLE_KEY_HEADER), v);
+        }
+        Err(_) => {
+            // A bs58 key is always a valid header value; this cannot happen. Fail
+            // closed rather than serve a keyless bundle.
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "migration key encoding error",
+            )
+                .into_response();
+        }
+    }
+    headers.insert(
+        HeaderName::from_static(BUNDLE_KEY_KIND_HEADER),
+        HeaderValue::from_static("token"),
+    );
+
+    (StatusCode::OK, headers, entry.bundle).into_response()
+}
+
+/// Uniform "no such pull" response — identical for unknown / expired / used, so
+/// it is not an oracle for token existence.
+fn pull_not_found() -> Response {
+    (
+        StatusCode::NOT_FOUND,
+        "migration link not found, expired, or already used",
+    )
+        .into_response()
+}
+
+/// Extract and validate the `pt` query parameter. A valid pull token is
+/// non-empty, bounded, and bs58 (ASCII alphanumeric); anything else is treated
+/// as absent so a malformed `pt` can never reach the store as a lookup key.
+fn pt_from_query(query: Option<&str>) -> Option<String> {
+    let q = query?;
+    for pair in q.split('&') {
+        if let Some(val) = pair.strip_prefix("pt=")
+            && is_valid_pull_token(val)
+        {
+            return Some(val.to_owned());
+        }
+    }
+    None
+}
+
+/// A pull token is bs58 of 32 bytes: non-empty, at most 64 chars, ASCII
+/// alphanumeric. Rejecting anything else keeps injection/oversized values out
+/// of both the store lookup and the outbound pull URL.
+fn is_valid_pull_token(pt: &str) -> bool {
+    !pt.is_empty() && pt.len() <= 64 && pt.chars().all(|c| c.is_ascii_alphanumeric())
+}
+
+// ---------------------------------------------------------------------------
+// Local side: confirmation page + pull-import
+// ---------------------------------------------------------------------------
+
+/// `GET /hosted/import` — the local peer's confirmation page. Served from the
+/// node's own first-party origin. It reads `source`/`pt` from the URL
+/// CLIENT-side (so no untrusted input is interpolated server-side) and requires
+/// an explicit click before POSTing to `pull-import` — a state-changing import
+/// is never triggered by mere navigation to the link.
+pub(super) async fn import_page() -> impl IntoResponse {
+    Html(format!(
+        include_str!("assets/hosted_import_page.html"),
+        style = HOSTED_IMPORT_PAGE_CSS,
+        script = HOSTED_IMPORT_PAGE_JS,
+    ))
+}
+
+const HOSTED_IMPORT_PAGE_CSS: &str = include_str!("assets/hosted_import_page.css");
+const HOSTED_IMPORT_PAGE_JS: &str = include_str!("assets/hosted_import_page.js");
+
+#[derive(Deserialize)]
+struct PullImportRequest {
+    source: String,
+    pt: String,
+}
+
+/// `POST /v{1,2}/hosted/pull-import` — the local peer fetches the bundle from
+/// the allowlisted hosting node and imports it (non-destructively). Gated by the
+/// SAME loopback + trusted-origin gate as the live import, so only the node's
+/// own confirmation page can drive it.
+async fn pull_import_handler(req: axum::extract::Request) -> Response {
+    let (parts, body) = req.into_parts();
+    let headers = &parts.headers;
+
+    let source_ip = parts
+        .extensions
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|ci| ci.0.ip());
+    let allowed_hosts = parts.extensions.get::<AllowedHosts>();
+    let allowed_source_cidrs = parts.extensions.get::<AllowedSourceCidrs>();
+    let empty_origin_contracts: OriginContractMap = Arc::new(DashMap::new());
+    let origin_contracts = parts
+        .extensions
+        .get::<OriginContractMap>()
+        .unwrap_or(&empty_origin_contracts);
+
+    // Reuse the live-import gate verbatim: loopback + trusted first-party origin
+    // + no per-contract token. This is what makes the pull-import CSRF-safe (a
+    // sandboxed contract iframe presents Origin: null and is rejected).
+    if let Err((status, reason)) = import_gate_or_reject(
+        headers,
+        source_ip,
+        allowed_hosts,
+        allowed_source_cidrs,
+        parts.uri.query(),
+        origin_contracts,
+    ) {
+        tracing::warn!(source_ip = ?source_ip, reason, "Rejected migration pull-import");
+        return (status, reason).into_response();
+    }
+
+    let op_manager = parts
+        .extensions
+        .get::<ExportOpManagerHandle>()
+        .and_then(ExportOpManagerHandle::current);
+    let Some(op_manager) = op_manager else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "node is not ready to serve imports",
+        )
+            .into_response();
+    };
+
+    let body_bytes = match axum::body::to_bytes(body, MAX_PULL_IMPORT_REQUEST_BYTES).await {
+        Ok(b) => b,
+        Err(_) => {
+            return (StatusCode::PAYLOAD_TOO_LARGE, "request body too large").into_response();
+        }
+    };
+    let request: PullImportRequest = match serde_json::from_slice(&body_bytes) {
+        Ok(v) => v,
+        Err(_) => {
+            return (StatusCode::BAD_REQUEST, "invalid pull-import request body").into_response();
+        }
+    };
+
+    // SSRF guard: the source MUST be https, default port, allowlisted host. We
+    // then build the pull URL from the trusted constant host (not the raw
+    // source), so a path/port/userinfo in `source` cannot redirect the fetch.
+    let Some(host) = allowed_migration_host(&request.source) else {
+        tracing::warn!(source = %request.source, "Rejected migration pull-import: source not allowed");
+        return (
+            StatusCode::FORBIDDEN,
+            "migration source is not an allowed origin",
+        )
+            .into_response();
+    };
+    if !is_valid_pull_token(&request.pt) {
+        return (StatusCode::BAD_REQUEST, "invalid migration token").into_response();
+    }
+
+    let (bundle, key, key_kind) = match pull_bundle_from_source(host, &request.pt).await {
+        Ok(v) => v,
+        Err((status, reason)) => return (status, reason).into_response(),
+    };
+
+    // Non-destructive: overwrite=false. A secret already present locally is kept
+    // and reported in `skipped`, never clobbered. (TODO(#4592): an optional
+    // pre-import snapshot could add belt-and-suspenders, deferred for v1 since
+    // import is already non-destructive.)
+    match run_import(&op_manager, bundle, key, key_kind, false).await {
+        Ok(report) => (
+            StatusCode::OK,
+            Json(json!({
+                "imported": report.imported,
+                "skipped": report.skipped,
+            })),
+        )
+            .into_response(),
+        Err((status, reason)) => (status, reason).into_response(),
+    }
+}
+
+/// Validate a caller-supplied migration `source` against the SSRF allowlist,
+/// returning the matched trusted host on success. Requires `https`, no explicit
+/// (non-default) port, and an exact (case-insensitive) host match. Returns the
+/// CONSTANT host string so callers build the pull URL from trusted data.
+fn allowed_migration_host(source: &str) -> Option<&'static str> {
+    // `reqwest::Url` re-exports the `url` crate's `Url`; use it rather than a
+    // direct `url` dep (reqwest is already a lib dependency).
+    let url = reqwest::Url::parse(source).ok()?;
+    if url.scheme() != "https" {
+        return None;
+    }
+    // Only the default https port (443). An explicit port is rejected so a
+    // crafted `https://try.freenet.org:1234/` cannot redirect the fetch.
+    if url.port().is_some() {
+        return None;
+    }
+    let host = url.host_str()?;
+    ALLOWED_MIGRATION_HOSTS
+        .iter()
+        .copied()
+        .find(|allowed| allowed.eq_ignore_ascii_case(host))
+}
+
+/// Fetch the ephemeral bundle from the hosting node's public pull endpoint over
+/// HTTPS (TLS validated). The URL is built from the ALREADY-VALIDATED constant
+/// host and validated token. The body is read with a hard cap so a hostile /
+/// oversized response cannot exhaust memory.
+async fn pull_bundle_from_source(
+    host: &str,
+    pt: &str,
+) -> Result<(Vec<u8>, String, BundleKeyKind), (StatusCode, &'static str)> {
+    let url = format!("https://{host}/v1/hosted/migrate/pull?pt={pt}");
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(MIGRATION_PULL_TIMEOUT_SECS))
+        .https_only(true)
+        .build()
+        .map_err(|_| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "migration HTTP client init failed",
+            )
+        })?;
+
+    let mut resp = client.get(&url).send().await.map_err(|_| {
+        (
+            StatusCode::BAD_GATEWAY,
+            "could not reach the migration source",
+        )
+    })?;
+    if !resp.status().is_success() {
+        return Err((
+            StatusCode::BAD_GATEWAY,
+            "migration source rejected the link (expired or already used)",
+        ));
+    }
+
+    // Extract the key + kind (owned) BEFORE the streaming body read.
+    let key = resp
+        .headers()
+        .get(BUNDLE_KEY_HEADER)
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_owned)
+        .filter(|k| !k.is_empty());
+    let Some(key) = key else {
+        return Err((
+            StatusCode::BAD_GATEWAY,
+            "migration source returned no bundle key",
+        ));
+    };
+    let key_kind = match resp
+        .headers()
+        .get(BUNDLE_KEY_KIND_HEADER)
+        .and_then(|v| v.to_str().ok())
+    {
+        Some(s) if s.eq_ignore_ascii_case("passphrase") => BundleKeyKind::Passphrase,
+        _ => BundleKeyKind::Token,
+    };
+
+    let mut bundle = Vec::new();
+    loop {
+        match resp.chunk().await {
+            Ok(Some(chunk)) => {
+                if bundle.len() + chunk.len() > MAX_IMPORT_BUNDLE_BYTES {
+                    return Err((StatusCode::BAD_GATEWAY, "migration bundle too large"));
+                }
+                bundle.extend_from_slice(&chunk);
+            }
+            Ok(None) => break,
+            Err(_) => {
+                return Err((
+                    StatusCode::BAD_GATEWAY,
+                    "error reading the migration bundle",
+                ));
+            }
+        }
+    }
+    if bundle.is_empty() {
+        return Err((
+            StatusCode::BAD_GATEWAY,
+            "migration source returned an empty bundle",
+        ));
+    }
+    Ok((bundle, key, key_kind))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn user(tag: u8) -> UserId {
+        UserId::new([tag; 32])
+    }
+
+    /// A minted token round-trips exactly once: the first pull returns the
+    /// bundle + key, and a second pull of the same token gets nothing
+    /// (single-use).
+    #[tokio::test(start_paused = true)]
+    async fn pull_token_is_single_use() {
+        let store = MigratePullStore::default();
+        let token = store
+            .insert(
+                user(1),
+                b"bundle-bytes".to_vec(),
+                "ephemeral-key".to_owned(),
+            )
+            .expect("mint must store the bundle");
+
+        let first = store.take(&token).expect("first pull returns the entry");
+        assert_eq!(first.bundle, b"bundle-bytes");
+        assert_eq!(first.key.as_str(), "ephemeral-key");
+
+        assert!(
+            store.take(&token).is_none(),
+            "a second pull of the same token must find nothing (single-use)"
+        );
+    }
+
+    /// An unknown token is a miss (no panic, uniform None).
+    #[tokio::test(start_paused = true)]
+    async fn pull_unknown_token_is_none() {
+        let store = MigratePullStore::default();
+        assert!(store.take("never-minted").is_none());
+    }
+
+    /// A token past its TTL reads as absent, even though it was never pulled.
+    #[tokio::test(start_paused = true)]
+    async fn pull_token_expires() {
+        let store = MigratePullStore::default();
+        let token = store
+            .insert(user(1), b"b".to_vec(), "k".to_owned())
+            .expect("mint");
+        tokio::time::advance(PULL_TOKEN_TTL + Duration::from_secs(1)).await;
+        assert!(
+            store.take(&token).is_none(),
+            "an expired token must read as absent"
+        );
+    }
+
+    /// Minting past the per-user cap evicts that user's OLDEST token while
+    /// leaving other users untouched. Distinct users get distinct tokens/scopes.
+    #[tokio::test(start_paused = true)]
+    async fn per_user_cap_evicts_oldest() {
+        let store = MigratePullStore::default();
+        let mut tokens = Vec::new();
+        for i in 0..MAX_PULL_TOKENS_PER_USER {
+            let t = store
+                .insert(user(1), vec![i as u8], format!("k{i}"))
+                .expect("mint");
+            tokens.push(t);
+            // Space entries in time so "oldest" is well-defined.
+            tokio::time::advance(Duration::from_secs(1)).await;
+        }
+        // A user-2 token is independent and must survive user-1 churn.
+        let other = store
+            .insert(user(2), b"other".to_vec(), "ok".to_owned())
+            .expect("mint");
+
+        // One more user-1 mint pushes over the cap, evicting user-1's oldest.
+        let newest = store
+            .insert(user(1), b"newest".to_vec(), "kn".to_owned())
+            .expect("mint");
+
+        assert!(
+            store.take(&tokens[0]).is_none(),
+            "user-1's oldest token must have been evicted at the cap"
+        );
+        assert!(
+            store.take(&newest).is_some(),
+            "the newest user-1 token must be present"
+        );
+        assert!(
+            store.take(&other).is_some(),
+            "another user's token must be unaffected by user-1's cap"
+        );
+    }
+
+    #[test]
+    fn ssrf_allowlist_accepts_only_https_default_port_trusted_host() {
+        assert_eq!(
+            allowed_migration_host("https://try.freenet.org"),
+            Some("try.freenet.org")
+        );
+        assert_eq!(
+            allowed_migration_host("https://try.freenet.org/"),
+            Some("try.freenet.org")
+        );
+        // Case-insensitive host match.
+        assert_eq!(
+            allowed_migration_host("https://TRY.freenet.org"),
+            Some("try.freenet.org")
+        );
+    }
+
+    #[test]
+    fn ssrf_allowlist_rejects_non_https_and_untrusted() {
+        // Non-https (plaintext) is rejected.
+        assert!(allowed_migration_host("http://try.freenet.org").is_none());
+        // A different host is rejected.
+        assert!(allowed_migration_host("https://evil.example.com").is_none());
+        // A look-alike subdomain is rejected (exact host match).
+        assert!(allowed_migration_host("https://try.freenet.org.evil.com").is_none());
+        // An explicit port is rejected (only default 443).
+        assert!(allowed_migration_host("https://try.freenet.org:8443").is_none());
+        // An embedded-credential / host-confusion attempt is rejected.
+        assert!(allowed_migration_host("https://try.freenet.org@evil.com").is_none());
+        // Loopback (the classic SSRF target) is rejected.
+        assert!(allowed_migration_host("https://127.0.0.1").is_none());
+        // Garbage is rejected.
+        assert!(allowed_migration_host("not a url").is_none());
+    }
+
+    #[test]
+    fn pull_token_validation() {
+        assert!(is_valid_pull_token("abcDEF123"));
+        assert!(!is_valid_pull_token(""));
+        assert!(!is_valid_pull_token("has-dash"));
+        assert!(!is_valid_pull_token("has space"));
+        assert!(!is_valid_pull_token("has/slash"));
+        assert!(!is_valid_pull_token(&"a".repeat(65)));
+    }
+
+    #[test]
+    fn pt_extracted_and_validated_from_query() {
+        assert_eq!(pt_from_query(Some("pt=abc123")).as_deref(), Some("abc123"));
+        assert_eq!(
+            pt_from_query(Some("x=1&pt=tok9&y=2")).as_deref(),
+            Some("tok9")
+        );
+        // A malformed pt value is treated as absent.
+        assert!(pt_from_query(Some("pt=bad-token")).is_none());
+        assert!(pt_from_query(Some("nopt=here")).is_none());
+        assert!(pt_from_query(None).is_none());
+    }
+
+    /// The confirmation page must render the confirm control and wire the POST
+    /// to the local pull-import endpoint — and must NOT auto-run it (a
+    /// state-changing import needs an explicit click).
+    #[test]
+    fn import_page_wiring() {
+        // The page is a format-template; render it and scan the served bytes.
+        let html = format!(
+            include_str!("assets/hosted_import_page.html"),
+            style = HOSTED_IMPORT_PAGE_CSS,
+            script = HOSTED_IMPORT_PAGE_JS,
+        );
+        assert!(
+            html.contains("/v1/hosted/pull-import"),
+            "the page JS must POST to the local pull-import endpoint"
+        );
+        assert!(
+            HOSTED_IMPORT_PAGE_JS.contains("addEventListener"),
+            "the import must be behind an explicit user gesture, not auto-run"
+        );
+    }
+}

--- a/crates/core/src/server/client_api/hosted_migrate.rs
+++ b/crates/core/src/server/client_api/hosted_migrate.rs
@@ -464,6 +464,13 @@ async fn pull_handler(req: axum::extract::Request) -> Response {
         CONTENT_TYPE,
         HeaderValue::from_static("application/octet-stream"),
     );
+    // Never let a shared/proxy cache persist the response: it carries the
+    // ephemeral bundle key header and the encrypted secrets, keyed by a
+    // single-use `pt` URL a cache must not replay.
+    headers.insert(
+        axum::http::header::CACHE_CONTROL,
+        HeaderValue::from_static("no-store"),
+    );
     // The ephemeral key rides in a header (never the URL) — the same discipline
     // and header names the local pull-import forwards into the import path.
     match HeaderValue::from_str(entry.key.as_str()) {

--- a/crates/core/src/server/client_api/hosted_migrate.rs
+++ b/crates/core/src/server/client_api/hosted_migrate.rs
@@ -284,7 +284,7 @@ async fn mint_handler(req: axum::extract::Request) -> Response {
     // Same gate as the live export (hosted + loopback + XFP:https + valid
     // token). We take the user CONTEXT (the scope) and DISCARD the durable token
     // — the bundle is sealed under a fresh ephemeral key instead.
-    let (user_context, _durable_token) =
+    let (user_context, durable_token) =
         match export_user_context_or_reject(headers, source_ip, hosted_mode) {
             Ok(v) => v,
             Err((status, reason)) => {
@@ -292,6 +292,10 @@ async fn mint_handler(req: axum::extract::Request) -> Response {
                 return (status, reason).into_response();
             }
         };
+    // The durable token is only used to authenticate + scope; it is NEVER the
+    // bundle key here (the mint seals under a fresh ephemeral key). Wipe it now
+    // so it does not linger in freed memory — it must not leave this node.
+    drop(zeroize::Zeroizing::new(durable_token));
 
     // Minting runs a full export, so it shares the per-user EXPORT rate limit.
     let limiter = req.extensions().get::<UserOpRateLimiter>();
@@ -597,6 +601,11 @@ async fn pull_bundle_from_source(
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(MIGRATION_PULL_TIMEOUT_SECS))
         .https_only(true)
+        // Do NOT follow redirects: the SSRF allowlist only vets the FIRST URL's
+        // host, so a redirect from the allowlisted origin to an internal address
+        // would defeat it. The pull endpoint answers 200/404 directly, never a
+        // redirect, so this only closes the SSRF-via-redirect hole.
+        .redirect(reqwest::redirect::Policy::none())
         .build()
         .map_err(|_| {
             (

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -376,6 +376,57 @@ mod tests {
         );
     }
 
+    /// Pins the import-data UI wiring (#4592, file-upload path): the homepage
+    /// must render the import card's open button plus the modal form (file +
+    /// key inputs), and the modal must ship hidden. A source-scrape guard so a
+    /// refactor that drops the wiring fails CI rather than silently shipping a
+    /// dead "Import data file" button.
+    #[test]
+    fn homepage_renders_import_ui_wiring() {
+        let html = homepage_html();
+        assert!(
+            html.contains("import-open-btn"),
+            "homepage must render the import-data open button"
+        );
+        for id in [
+            "id=\"import-modal\"",
+            "id=\"import-file\"",
+            "id=\"import-key\"",
+            "id=\"import-submit\"",
+        ] {
+            assert!(
+                html.contains(id),
+                "homepage must render import modal element `{id}`"
+            );
+        }
+        // The modal ships hidden so it never flashes before the user opens it.
+        let modal = extract_element_line(&html, "id=\"import-modal\"");
+        assert!(
+            modal.contains("hidden"),
+            "import modal must be hidden by default, got: {modal}"
+        );
+    }
+
+    /// The served dashboard JS must POST the upload to `/v1/import` with the
+    /// bundle-key header the endpoint requires — the load-bearing half of the
+    /// export→import round-trip. Pinned so a JS refactor can't silently break
+    /// it while leaving the button in place.
+    #[test]
+    fn js_contains_import_upload_wiring() {
+        assert!(
+            JS.contains("/v1/import"),
+            "JS must POST the bundle to the /v1/import endpoint"
+        );
+        assert!(
+            JS.contains("X-Freenet-Bundle-Key"),
+            "JS must send the bundle decryption key in the X-Freenet-Bundle-Key header"
+        );
+        assert!(
+            JS.contains("runImport") && JS.contains("openImportModal"),
+            "JS must define the import submit + modal-open handlers"
+        );
+    }
+
     #[test]
     fn favicon_grey_when_no_snapshot() {
         let uri = build_favicon_data_uri(&None);

--- a/crates/core/src/server/home_page/assets/dashboard.js
+++ b/crates/core/src/server/home_page/assets/dashboard.js
@@ -296,6 +296,129 @@ function switchTab(el) {
   } catch (e) {}
 }
 
+/* ── Import data (.fnsx) modal ──
+   The receiving end of #4592: a user who exported a `freenet-data.fnsx` bundle
+   from a hosted "try Freenet" server uploads it here to import their delegate
+   secrets into THIS local peer via `POST /v1/import`. The modal lives outside
+   <main> (see home.html) so the 5s auto-refresh never wipes it. */
+function setImportStatus(msg, isError) {
+  var el = document.getElementById('import-status');
+  if (!el) return;
+  el.textContent = msg || '';
+  el.classList.toggle('import-status-error', !!isError);
+}
+
+function updateImportKeyLabel() {
+  var kind = document.getElementById('import-key-kind');
+  var label = document.getElementById('import-key-label');
+  var input = document.getElementById('import-key');
+  var isPass = kind && kind.value === 'passphrase';
+  if (label) label.textContent = isPass ? 'Passphrase' : 'Access key';
+  if (input)
+    input.placeholder = isPass
+      ? 'Enter your passphrase'
+      : 'Paste your access key';
+}
+
+function openImportModal() {
+  var modal = document.getElementById('import-modal');
+  if (!modal) return;
+  setImportStatus('', false);
+  updateImportKeyLabel();
+  modal.hidden = false;
+  var file = document.getElementById('import-file');
+  if (file) file.focus();
+}
+
+function closeImportModal() {
+  var modal = document.getElementById('import-modal');
+  if (!modal) return;
+  modal.hidden = true;
+  /* Clear the secret key (and the rest of the form) from the DOM on close. */
+  var key = document.getElementById('import-key');
+  if (key) key.value = '';
+  var file = document.getElementById('import-file');
+  if (file) file.value = '';
+  var overwrite = document.getElementById('import-overwrite');
+  if (overwrite) overwrite.checked = false;
+  setImportStatus('', false);
+}
+
+function runImport() {
+  var fileInput = document.getElementById('import-file');
+  var keyInput = document.getElementById('import-key');
+  var kindSel = document.getElementById('import-key-kind');
+  var overwrite = document.getElementById('import-overwrite');
+  var submit = document.getElementById('import-submit');
+
+  var file = fileInput && fileInput.files && fileInput.files[0];
+  if (!file) {
+    setImportStatus('Choose a .fnsx file to import.', true);
+    return;
+  }
+  var key = keyInput ? keyInput.value.trim() : '';
+  if (!key) {
+    setImportStatus('Enter the key that protects the bundle.', true);
+    return;
+  }
+
+  var headers = {
+    'X-Freenet-Bundle-Key': key,
+    'X-Freenet-Bundle-Key-Kind': kindSel ? kindSel.value : 'token',
+  };
+  if (overwrite && overwrite.checked) {
+    headers['X-Freenet-Import-Overwrite'] = 'true';
+  }
+
+  if (submit) submit.disabled = true;
+  setImportStatus('Importing…', false);
+
+  /* POST the raw file bytes as the body (application/octet-stream, NOT
+     multipart) — /v1/import reads the body verbatim. The browser attaches an
+     Origin header to this same-origin POST, which the import gate requires
+     (loopback + trusted dashboard origin, no per-contract token). */
+  fetch('/v1/import', { method: 'POST', headers: headers, body: file })
+    .then(function (r) {
+      return r.text().then(function (body) {
+        return { ok: r.ok, status: r.status, body: body };
+      });
+    })
+    .then(function (res) {
+      if (submit) submit.disabled = false;
+      if (res.ok) {
+        var imported = 0;
+        var skipped = 0;
+        try {
+          var data = JSON.parse(res.body);
+          imported = data.imported || 0;
+          skipped = (data.skipped && data.skipped.length) || 0;
+        } catch (e) {
+          /* A 200 with an unparseable body still means success. */
+        }
+        var msg =
+          'Imported ' + imported + (imported === 1 ? ' secret' : ' secrets');
+        if (skipped) msg += ', ' + skipped + ' skipped (already present)';
+        closeImportModal();
+        showToast(msg);
+      } else {
+        /* Non-2xx bodies are plain, non-secret reason strings from the
+           endpoint (wrong-key 422, forbidden 403, too-large 413, ...). */
+        var reason = (res.body || '').trim();
+        setImportStatus(
+          reason || 'Import failed (HTTP ' + res.status + ')',
+          true,
+        );
+      }
+    })
+    .catch(function (e) {
+      if (submit) submit.disabled = false;
+      setImportStatus(
+        'Import failed: ' + (e && e.message ? e.message : 'network error'),
+        true,
+      );
+    });
+}
+
 document.addEventListener('DOMContentLoaded', function () {
   var icon = document.getElementById('theme-icon');
   if (icon && document.documentElement.getAttribute('data-theme') === 'light') {
@@ -319,9 +442,47 @@ document.addEventListener('DOMContentLoaded', function () {
   checkForUpdate();
   checkVersionMismatch();
 
+  /* Import modal controls. These elements live OUTSIDE <main> (see home.html),
+     so they are stable across auto-refresh and can be bound directly, once. */
+  var importCancel = document.getElementById('import-cancel');
+  if (importCancel) importCancel.addEventListener('click', closeImportModal);
+  var importSubmit = document.getElementById('import-submit');
+  if (importSubmit) importSubmit.addEventListener('click', runImport);
+  var importKind = document.getElementById('import-key-kind');
+  if (importKind) importKind.addEventListener('change', updateImportKeyLabel);
+  var importOverlay = document.getElementById('import-modal');
+  if (importOverlay) {
+    importOverlay.addEventListener('click', function (ev) {
+      /* A click on the backdrop (not the card) dismisses the modal. */
+      if (ev.target === importOverlay) closeImportModal();
+    });
+  }
+  var importKey = document.getElementById('import-key');
+  if (importKey) {
+    importKey.addEventListener('keydown', function (ev) {
+      if (ev.key === 'Enter') {
+        ev.preventDefault();
+        runImport();
+      }
+    });
+  }
+  document.addEventListener('keydown', function (ev) {
+    if (ev.key !== 'Escape') return;
+    var modal = document.getElementById('import-modal');
+    if (modal && !modal.hidden) closeImportModal();
+  });
+
   /* Delegated click handler \u2014 survives <main> innerHTML swaps from auto-refresh,
        so we don't need to re-bind after each refresh. */
   document.addEventListener('click', function (ev) {
+    /* The open button is inside <main>, which auto-refresh re-renders, so it
+       must be handled via delegation to survive innerHTML swaps. */
+    var importOpen = ev.target.closest && ev.target.closest('.import-open-btn');
+    if (importOpen) {
+      ev.preventDefault();
+      openImportModal();
+      return;
+    }
     var copy = ev.target.closest && ev.target.closest('.copy-key');
     if (copy) {
       ev.preventDefault();

--- a/crates/core/src/server/home_page/assets/home.html
+++ b/crates/core/src/server/home_page/assets/home.html
@@ -42,6 +42,17 @@
         {ops_card}
 
         <div class="card">
+            <h2>Import your data</h2>
+            <p class="note">
+                Coming from a hosted "try Freenet" server? Import the
+                <code>freenet-data.fnsx</code> bundle you exported there to bring
+                your rooms, identities and other delegate data onto this peer.
+                The import runs live — no need to stop this node.
+            </p>
+            <button class="import-btn import-open-btn" type="button">Import data file&hellip;</button>
+        </div>
+
+        <div class="card">
             <h2>Freenet Links</h2>
             <ul class="app-list">
                 <li>
@@ -71,5 +82,45 @@
             </ul>
         </div>
     </main>
+
+    <!-- Import-data modal. Lives OUTSIDE <main> on purpose: the dashboard
+         auto-refresh (dashboard.js) swaps <main>'s innerHTML every 5s, which
+         would wipe a chosen file, a typed key, or an in-progress import if the
+         form were inside it. Kept here it survives every refresh. -->
+    <div class="modal-overlay" id="import-modal" hidden>
+        <div class="modal-card" role="dialog" aria-modal="true" aria-labelledby="import-modal-title">
+            <h2 id="import-modal-title">Import your data</h2>
+            <p class="note">
+                Choose the encrypted <code>.fnsx</code> bundle and enter the
+                access key that protects it. It is decrypted and imported
+                entirely on this peer &mdash; the key never leaves your browser
+                except to this local node.
+            </p>
+            <label class="modal-field">
+                <span>Data file (.fnsx)</span>
+                <input type="file" id="import-file" accept=".fnsx,application/octet-stream" />
+            </label>
+            <label class="modal-field">
+                <span>Key type</span>
+                <select id="import-key-kind">
+                    <option value="token" selected>Access key (from the hosted proxy)</option>
+                    <option value="passphrase">Passphrase (offline export)</option>
+                </select>
+            </label>
+            <label class="modal-field">
+                <span id="import-key-label">Access key</span>
+                <input type="password" id="import-key" autocomplete="off" autocapitalize="off" spellcheck="false" placeholder="Paste your access key" />
+            </label>
+            <label class="modal-check">
+                <input type="checkbox" id="import-overwrite" />
+                <span>Overwrite secrets that already exist on this peer</span>
+            </label>
+            <div class="modal-status" id="import-status" role="status" aria-live="polite"></div>
+            <div class="modal-actions">
+                <button class="import-btn import-btn-secondary" type="button" id="import-cancel">Cancel</button>
+                <button class="import-btn import-btn-primary" type="button" id="import-submit">Import</button>
+            </div>
+        </div>
+    </div>
 </body>
 </html>

--- a/crates/core/src/server/home_page/assets/home.html
+++ b/crates/core/src/server/home_page/assets/home.html
@@ -47,7 +47,7 @@
                 Coming from a hosted "try Freenet" server? Import the
                 <code>freenet-data.fnsx</code> bundle you exported there to bring
                 your rooms, identities and other delegate data onto this peer.
-                The import runs live — no need to stop this node.
+                The import runs live, with no need to stop this node.
             </p>
             <button class="import-btn import-open-btn" type="button">Import data file&hellip;</button>
         </div>
@@ -93,8 +93,8 @@
             <p class="note">
                 Choose the encrypted <code>.fnsx</code> bundle and enter the
                 access key that protects it. It is decrypted and imported
-                entirely on this peer &mdash; the key never leaves your browser
-                except to this local node.
+                entirely on this peer. The key never leaves your browser except
+                to this local node.
             </p>
             <label class="modal-field">
                 <span>Data file (.fnsx)</span>

--- a/crates/core/src/server/home_page/assets/style.css
+++ b/crates/core/src/server/home_page/assets/style.css
@@ -1343,3 +1343,120 @@ table.sortable thead th.sort-desc::after {
   margin-left: 0.1em;
   vertical-align: middle;
 }
+
+/* ── Import-data card + modal (#4592) ──────────────────────────────── */
+.import-btn {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--text-primary);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  padding: 0.4rem 0.85rem;
+  cursor: pointer;
+  transition:
+    border-color 0.15s,
+    background 0.15s;
+}
+.import-btn:hover {
+  border-color: var(--accent-primary);
+}
+.import-open-btn {
+  margin-top: 0.6rem;
+}
+.import-btn-primary {
+  background: rgba(10, 186, 181, 0.15);
+  border-color: rgba(10, 186, 181, 0.4);
+  color: var(--accent-light);
+}
+.import-btn-primary:hover {
+  border-color: var(--accent-primary);
+  background: rgba(10, 186, 181, 0.25);
+}
+[data-theme='light'] .import-btn-primary {
+  color: var(--accent-dark);
+}
+.import-btn:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(2px);
+}
+.modal-overlay[hidden] {
+  display: none;
+}
+.modal-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  padding: 1.25rem 1.4rem;
+  width: 100%;
+  max-width: 440px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4);
+}
+.modal-card h2 {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.75rem;
+  font-family: var(--font-mono);
+  font-weight: 500;
+}
+.modal-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  margin-top: 0.9rem;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+.modal-field input[type='file'],
+.modal-field input[type='password'],
+.modal-field select {
+  font-family: var(--font-sans);
+  font-size: 0.85rem;
+  color: var(--text-primary);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  padding: 0.4rem 0.5rem;
+}
+.modal-field input:focus,
+.modal-field select:focus {
+  outline: none;
+  border-color: var(--accent-primary);
+}
+.modal-check {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.9rem;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+.modal-status {
+  min-height: 1.2rem;
+  margin-top: 0.75rem;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+.modal-status.import-status-error {
+  color: #f87171;
+}
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.6rem;
+  margin-top: 1.1rem;
+}

--- a/crates/core/src/server/path_handlers/assets/hosted_bar.css
+++ b/crates/core/src/server/path_handlers/assets/hosted_bar.css
@@ -99,6 +99,33 @@ iframe {
   color: #2a8a55;
   font-size: 12px;
 }
+#fnmigrateout {
+  margin-top: 10px;
+}
+.mhint {
+  margin: 0 0 6px;
+  color: #666;
+  line-height: 1.45;
+}
+#fnmigratelink {
+  flex: 1 1 auto;
+  min-width: 0;
+  font:
+    12px/1.4 ui-monospace,
+    Menlo,
+    monospace;
+  color: #222;
+  background: #fff;
+  border: 1px solid #cfcfcf;
+  border-radius: 4px;
+  padding: 3px 6px;
+}
+#fnmigratemsg {
+  display: block;
+  margin-top: 6px;
+  color: #2a8a55;
+  font-size: 12px;
+}
 
 /* Respect the OS dark-mode preference. Same restrained, near-monochrome
    character as the light theme: charcoal bar, light-grey text, hairline
@@ -136,6 +163,17 @@ iframe {
     color: #a0a0a4;
   }
   #fnok {
+    color: #5cbd83;
+  }
+  .mhint {
+    color: #a0a0a4;
+  }
+  #fnmigratelink {
+    color: #e6e6e8;
+    background: #2c2c2f;
+    border-color: #46464a;
+  }
+  #fnmigratemsg {
     color: #5cbd83;
   }
 }

--- a/crates/core/src/server/path_handlers/assets/hosted_bar.html
+++ b/crates/core/src/server/path_handlers/assets/hosted_bar.html
@@ -22,13 +22,28 @@
       <div class="sec">
         <h4>Your own peer</h4>
         <p>
-          Export your data to run it on your own Freenet node, fully
+          Move your data to a Freenet peer you run yourself, fully
           decentralized.
         </p>
         <div class="row">
-          <button class="act" id="fnexport">Export data</button>
+          <button class="act" id="fnmigrate">Move to my peer</button
+          ><button class="act" id="fnexport">Export file</button>
         </div>
-      </div>
-    </div></span
-  >
+        <div id="fnmigrateout" hidden>
+          <p class="mhint">
+            Open this one-time link (it expires soon) in a browser on the
+            computer running your Freenet peer:
+          </p>
+          <div class="row">
+            <input id="fnmigratelink" type="text" readonly /><button
+              class="act"
+              id="fnmigratecopy"
+            >
+              Copy link
+            </button>
+          </div>
+          <span id="fnmigratemsg"></span>
+        </div>
+      </div></div
+  ></span>
 </div>

--- a/crates/core/src/server/path_handlers/assets/hosted_bar.html
+++ b/crates/core/src/server/path_handlers/assets/hosted_bar.html
@@ -27,7 +27,7 @@
         </p>
         <div class="row">
           <button class="act" id="fnmigrate">Move to my peer</button
-          ><button class="act" id="fnexport">Export file</button>
+          ><button class="act" id="fnexport">Export data</button>
         </div>
         <div id="fnmigrateout" hidden>
           <p class="mhint">

--- a/crates/core/src/server/path_handlers/assets/hosted_bar.js
+++ b/crates/core/src/server/path_handlers/assets/hosted_bar.js
@@ -114,4 +114,82 @@
         setOk('Export failed (' + e.message + ')');
       });
   });
+
+  // "Move to my peer" — the zero-friction magic-link migration (#4592). Mints a
+  // one-time pull token on this hosted node (authorized by the shell-only user
+  // token) and builds a link the user opens on their OWN peer, which then pulls
+  // the data over HTTPS and imports it. The durable access key never leaves this
+  // browser: the bundle is sealed under a fresh ephemeral key held server-side.
+  var migrateOut = document.getElementById('fnmigrateout');
+  var migrateLink = document.getElementById('fnmigratelink');
+  var migrateMsg = document.getElementById('fnmigratemsg');
+  // Default local-peer web/ws-api port (the freenet config default, see
+  // config.rs default_ws_api_port). Overriding a non-default local port is a
+  // future refinement.
+  var LOCAL_PEER_PORT = 7509;
+
+  function setMigrateMsg(m) {
+    if (migrateMsg) migrateMsg.textContent = m || '';
+  }
+
+  document.getElementById('fnmigrate').addEventListener('click', function () {
+    var t =
+      typeof __freenet_user_token !== 'undefined' ? __freenet_user_token : null;
+    if (!t) {
+      setOk('No key on this connection');
+      return;
+    }
+    setMigrateMsg('Preparing your one-time migration link...');
+    fetch('/v1/hosted/migrate/mint', {
+      method: 'POST',
+      headers: { 'X-Freenet-User-Token': t },
+    })
+      .then(function (r) {
+        if (!r.ok) {
+          throw new Error('HTTP ' + r.status);
+        }
+        return r.json();
+      })
+      .then(function (data) {
+        var pt = data && data.pull_token;
+        if (!pt) {
+          throw new Error('no token');
+        }
+        var link =
+          'http://127.0.0.1:' +
+          LOCAL_PEER_PORT +
+          '/hosted/import?source=' +
+          encodeURIComponent(window.location.origin) +
+          '&pt=' +
+          encodeURIComponent(pt);
+        if (migrateLink) migrateLink.value = link;
+        if (migrateOut) migrateOut.hidden = false;
+        setMigrateMsg('One-time link ready. It expires in a few minutes.');
+      })
+      .catch(function (e) {
+        setMigrateMsg('Could not prepare a link (' + e.message + ')');
+      });
+  });
+
+  document
+    .getElementById('fnmigratecopy')
+    .addEventListener('click', function () {
+      if (!migrateLink || !migrateLink.value) {
+        return;
+      }
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(migrateLink.value).then(
+          function () {
+            setMigrateMsg('Link copied to clipboard');
+          },
+          function () {
+            migrateLink.focus();
+            migrateLink.select();
+          },
+        );
+      } else {
+        migrateLink.focus();
+        migrateLink.select();
+      }
+    });
 })();

--- a/crates/core/tests/hosted_mode_migrate.rs
+++ b/crates/core/tests/hosted_mode_migrate.rs
@@ -1,0 +1,730 @@
+//! Live end-to-end integration test for the zero-friction "magic-link" secrets
+//! MIGRATION (#4592) — the hosted `mint` + public `pull` endpoints plus the
+//! local confirmation PAGE, all on ONE running node.
+//!
+//! The migration turns the hosted → self-host handoff into a link the user
+//! clicks on their own peer. The three cooperating HTTP surfaces exercised here
+//! (all served by the same binary — a node can be either side of the handoff):
+//!
+//!   * `POST /v1/hosted/migrate/mint` — HOSTED side. Gated EXACTLY like the live
+//!     export (`GET /v1/hosted/export`): hosted mode ON + loopback source +
+//!     `X-Forwarded-Proto: https` + a valid `X-Freenet-User-Token`. It exports
+//!     the token-user's secret scope under a FRESH EPHEMERAL key (never the
+//!     durable token) and buffers it server-side under a single-use pull token,
+//!     which it returns as JSON.
+//!   * `GET /v1/hosted/migrate/pull?pt=<token>` — PUBLIC. The single-use pull
+//!     token is the entire auth. Returns the raw ephemeral bundle bytes plus the
+//!     ephemeral key in the `X-Freenet-Bundle-Key` header. A second pull of the
+//!     same token — or an unknown token — is a uniform 404.
+//!   * `GET /hosted/import` — the LOCAL confirmation page. HTML with an explicit
+//!     import button; it never imports by itself (defeats drive-by / CSRF).
+//!
+//! The headline test walks the whole round-trip on a single hosted node and
+//! proves the load-bearing properties:
+//!
+//!   1. The durable token authenticates the mint but is NOT the bundle key — the
+//!      pulled bundle rides a fresh EPHEMERAL key, and that exact key round-trips
+//!      through `POST /v1/import` back to the original plaintext.
+//!   2. The pull token is SINGLE-USE: the first pull consumes it, a replay 404s.
+//!   3. The migrated secret decrypts to user A's original plaintext when read
+//!      back through the live delegate stack.
+//!
+//! The local `POST /v1/hosted/pull-import` endpoint is NOT driven here: its
+//! outbound HTTPS fetch is locked to `https://try.freenet.org` (a strict SSRF
+//! allowlist), so it cannot be exercised against a loopback-bound test server.
+//! Its gate + allowlist are covered by the `hosted_migrate` unit tests. To prove
+//! the pulled bundle is a real, importable bundle we feed it into the existing
+//! `POST /v1/import` endpoint directly (the same import `pull-import` would drive
+//! internally, with the same key headers).
+
+#![allow(clippy::wildcard_enum_match_arm)]
+
+use std::{
+    net::{Ipv4Addr, TcpListener},
+    path::Path,
+    time::{Duration, Instant},
+};
+
+use freenet::{local_node::NodeConfig, server::serve_client_api, test_utils::load_delegate};
+use freenet_stdlib::{
+    client_api::{ClientRequest, DelegateRequest, HostResponse, WebApi},
+    prelude::*,
+};
+use serde::{Deserialize, Serialize};
+use tokio::time::timeout;
+use tokio_tungstenite::{connect_async, tungstenite::client::IntoClientRequest};
+use tracing::info;
+
+const TEST_DELEGATE: &str = "test-delegate-2";
+
+const TEST_DELEGATE_CIPHER: [u8; 32] = [
+    0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00,
+    0x0f, 0x1e, 0x2d, 0x3c, 0x4b, 0x5a, 0x69, 0x78, 0x87, 0x96, 0xa5, 0xb4, 0xc3, 0xd2, 0xe1, 0xf0,
+];
+const TEST_DELEGATE_NONCE: [u8; 24] = [0u8; 24];
+
+// Mirror of the fixture's `InboundAppMessage` / `OutboundAppMessage` (variant
+// ORDER must match for bincode discriminants — see hosted_mode_export.rs).
+#[allow(dead_code)]
+#[derive(Debug, Serialize)]
+enum InboundAppMessage {
+    CreateInboxRequest,
+    PleaseSignMessage(Vec<u8>),
+    WriteContext(Vec<u8>),
+    ReadContext,
+    ClearContext,
+    IncrementCounter,
+    HasSecret(Vec<u8>),
+    GetNonExistentSecret(Vec<u8>),
+    StoreSecret { key: Vec<u8>, value: Vec<u8> },
+    RemoveSecret(Vec<u8>),
+    WriteLargeContext(usize),
+    StoreLargeSecret { key: Vec<u8>, size: usize },
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+enum OutboundAppMessage {
+    CreateInboxResponse(Vec<u8>),
+    MessageSigned(Vec<u8>),
+    ContextData(Vec<u8>),
+    CounterValue(u32),
+    SecretExists(bool),
+    SecretResult(Option<Vec<u8>>),
+    ContextWritten,
+    ContextCleared,
+    SecretStored,
+    SecretRemoved,
+    LargeContextWritten(usize),
+    LargeSecretStored(usize),
+    SecretStoreFailed,
+}
+
+fn reserve_port() -> anyhow::Result<u16> {
+    let listener = TcpListener::bind("127.0.0.1:0")?;
+    Ok(listener.local_addr()?.port())
+}
+
+fn node_config(
+    dir: &Path,
+    ws_port: u16,
+    network_port: u16,
+    keypair_path: &Path,
+    hosted_mode: bool,
+) -> freenet::config::ConfigArgs {
+    freenet::config::ConfigArgs {
+        ws_api: freenet::config::WebsocketApiArgs {
+            address: Some(Ipv4Addr::LOCALHOST.into()),
+            ws_api_port: Some(ws_port),
+            hosted_mode: Some(hosted_mode),
+            // Disable the per-user op rate limit (#4561) for these tests: the
+            // migration mint runs a full export and shares the export rate
+            // limit, which is unrelated to what we exercise here.
+            per_user_op_rate_limit: Some(0),
+            ..Default::default()
+        },
+        network_api: freenet::config::NetworkArgs {
+            public_address: Some(Ipv4Addr::LOCALHOST.into()),
+            public_port: Some(network_port),
+            is_gateway: true,
+            skip_load_from_network: true,
+            gateways: Some(vec![]),
+            location: Some(0.5),
+            ignore_protocol_checking: true,
+            address: Some(Ipv4Addr::LOCALHOST.into()),
+            network_port: Some(network_port),
+            ..Default::default()
+        },
+        config_paths: freenet::config::ConfigPathsArgs {
+            config_dir: Some(dir.to_path_buf()),
+            data_dir: Some(dir.to_path_buf()),
+            log_dir: Some(dir.to_path_buf()),
+        },
+        secrets: freenet::config::SecretArgs {
+            transport_keypair: Some(keypair_path.to_path_buf()),
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+struct TestNode {
+    ws_port: u16,
+    shutdown: freenet::ShutdownHandle,
+    run: tokio::task::JoinHandle<Result<std::convert::Infallible, anyhow::Error>>,
+    _data_dir: tempfile::TempDir,
+}
+
+impl TestNode {
+    async fn start(hosted_mode: bool) -> anyhow::Result<Self> {
+        let data_dir = tempfile::tempdir()?;
+        let data_path = data_dir.path().to_path_buf();
+
+        let key = freenet::dev_tool::TransportKeypair::new();
+        let keypair_path = data_path.join("private.pem");
+        key.save(&keypair_path)?;
+        key.public().save(data_path.join("public.pem"))?;
+
+        let ws_port = reserve_port()?;
+        let net_port = reserve_port()?;
+
+        let cfg = node_config(&data_path, ws_port, net_port, &keypair_path, hosted_mode)
+            .build()
+            .await?;
+        let node = NodeConfig::new(cfg.clone())
+            .await?
+            .build(serve_client_api(cfg.ws_api.clone()).await?)
+            .await?;
+        let shutdown = node.shutdown_handle();
+        let run = tokio::spawn(async move { node.run().await });
+
+        wait_ws_ready(ws_port, Duration::from_secs(30)).await?;
+
+        Ok(Self {
+            ws_port,
+            shutdown,
+            run,
+            _data_dir: data_dir,
+        })
+    }
+
+    async fn shutdown(self) {
+        self.shutdown.shutdown().await;
+        if timeout(Duration::from_secs(30), self.run).await.is_err() {
+            info!("node run loop did not exit within 30s of shutdown (cleanup only)");
+        }
+    }
+}
+
+async fn wait_ws_ready(port: u16, within: Duration) -> anyhow::Result<()> {
+    let url = format!("ws://127.0.0.1:{port}/v1/contract/command?encodingProtocol=native");
+    let deadline = Instant::now() + within;
+    loop {
+        match connect_async(&url).await {
+            Ok((stream, _)) => {
+                drop(stream);
+                return Ok(());
+            }
+            Err(e) => {
+                if Instant::now() >= deadline {
+                    anyhow::bail!("WS API on port {port} did not come up within {within:?}: {e}");
+                }
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+        }
+    }
+}
+
+/// Hosted WS connection: `user_token` → `userToken` query param; `xfp_https` →
+/// `X-Forwarded-Proto: https`. Honors the per-user token (User scope) only when
+/// both are set on a loopback source.
+async fn connect_hosted(
+    port: u16,
+    user_token: Option<&str>,
+    xfp_https: bool,
+) -> anyhow::Result<WebApi> {
+    let base = format!("ws://127.0.0.1:{port}/v1/contract/command?encodingProtocol=native");
+    let url = match user_token {
+        Some(t) => format!("{base}&userToken={t}"),
+        None => base,
+    };
+    let mut request = url.as_str().into_client_request()?;
+    if xfp_https {
+        request
+            .headers_mut()
+            .insert("X-Forwarded-Proto", "https".parse()?);
+    }
+    let (stream, _) = connect_async(request).await?;
+    Ok(WebApi::start(stream))
+}
+
+/// Plain WS connection (no user token). On a hosted node this maps to
+/// `SecretScope::Local` — the scope `POST /v1/import` writes into — so it is how
+/// we read the migrated secret back.
+async fn connect_plain(port: u16) -> anyhow::Result<WebApi> {
+    let url = format!("ws://127.0.0.1:{port}/v1/contract/command?encodingProtocol=native");
+    let request = url.as_str().into_client_request()?;
+    let (stream, _) = connect_async(request).await?;
+    Ok(WebApi::start(stream))
+}
+
+async fn register_delegate(
+    client: &mut WebApi,
+    delegate: &DelegateContainer,
+    delegate_key: &DelegateKey,
+) -> anyhow::Result<()> {
+    client
+        .send(ClientRequest::DelegateOp(
+            DelegateRequest::RegisterDelegate {
+                delegate: delegate.clone(),
+                cipher: TEST_DELEGATE_CIPHER,
+                nonce: TEST_DELEGATE_NONCE,
+            },
+        ))
+        .await?;
+    let resp = timeout(Duration::from_secs(15), client.recv()).await??;
+    match resp {
+        HostResponse::DelegateResponse { key, .. } => {
+            anyhow::ensure!(
+                &key == delegate_key,
+                "register acked a different key: {key}"
+            );
+            Ok(())
+        }
+        other => anyhow::bail!("unexpected response to RegisterDelegate: {other:?}"),
+    }
+}
+
+async fn store_secret(
+    client: &mut WebApi,
+    delegate_key: &DelegateKey,
+    key: &[u8],
+    value: &[u8],
+) -> anyhow::Result<()> {
+    let payload = bincode::serialize(&InboundAppMessage::StoreSecret {
+        key: key.to_vec(),
+        value: value.to_vec(),
+    })?;
+    client
+        .send(ClientRequest::DelegateOp(
+            DelegateRequest::ApplicationMessages {
+                key: delegate_key.clone(),
+                params: Parameters::from(vec![]),
+                inbound: vec![InboundDelegateMsg::ApplicationMessage(
+                    ApplicationMessage::new(payload),
+                )],
+            },
+        ))
+        .await?;
+    let resp = timeout(Duration::from_secs(15), client.recv()).await??;
+    match resp {
+        HostResponse::DelegateResponse { values, .. } => {
+            let out = match &values[0] {
+                OutboundDelegateMsg::ApplicationMessage(m) => m,
+                other => anyhow::bail!("expected ApplicationMessage, got {other:?}"),
+            };
+            match bincode::deserialize::<OutboundAppMessage>(&out.payload)? {
+                OutboundAppMessage::SecretStored => Ok(()),
+                other => anyhow::bail!("expected SecretStored, got {other:?}"),
+            }
+        }
+        other => anyhow::bail!("unexpected response to ApplicationMessages: {other:?}"),
+    }
+}
+
+/// Send a single `InboundAppMessage` to the delegate and decode the single
+/// `OutboundAppMessage` reply — the live secret read path.
+async fn delegate_app_msg(
+    client: &mut WebApi,
+    delegate_key: &DelegateKey,
+    msg: &InboundAppMessage,
+) -> anyhow::Result<OutboundAppMessage> {
+    let payload = bincode::serialize(msg)?;
+    client
+        .send(ClientRequest::DelegateOp(
+            DelegateRequest::ApplicationMessages {
+                key: delegate_key.clone(),
+                params: Parameters::from(vec![]),
+                inbound: vec![InboundDelegateMsg::ApplicationMessage(
+                    ApplicationMessage::new(payload),
+                )],
+            },
+        ))
+        .await?;
+    let resp = timeout(Duration::from_secs(15), client.recv()).await??;
+    match resp {
+        HostResponse::DelegateResponse { values, .. } => {
+            let out = match &values[0] {
+                OutboundDelegateMsg::ApplicationMessage(m) => m,
+                other => anyhow::bail!("expected ApplicationMessage, got {other:?}"),
+            };
+            Ok(bincode::deserialize::<OutboundAppMessage>(&out.payload)?)
+        }
+        other => anyhow::bail!("unexpected response to ApplicationMessages: {other:?}"),
+    }
+}
+
+/// Read a secret VALUE back through the live delegate (decrypts via the running
+/// node's `SecretsStore`).
+async fn get_secret_via_delegate(
+    client: &mut WebApi,
+    delegate_key: &DelegateKey,
+    key: &[u8],
+) -> anyhow::Result<Option<Vec<u8>>> {
+    match delegate_app_msg(
+        client,
+        delegate_key,
+        &InboundAppMessage::GetNonExistentSecret(key.to_vec()),
+    )
+    .await?
+    {
+        OutboundAppMessage::SecretResult(v) => Ok(v),
+        other => anyhow::bail!("expected SecretResult, got {other:?}"),
+    }
+}
+
+/// Whether a secret exists, through the live delegate.
+async fn has_secret_via_delegate(
+    client: &mut WebApi,
+    delegate_key: &DelegateKey,
+    key: &[u8],
+) -> anyhow::Result<bool> {
+    match delegate_app_msg(
+        client,
+        delegate_key,
+        &InboundAppMessage::HasSecret(key.to_vec()),
+    )
+    .await?
+    {
+        OutboundAppMessage::SecretExists(b) => Ok(b),
+        other => anyhow::bail!("expected SecretExists, got {other:?}"),
+    }
+}
+
+/// `POST /v1/hosted/migrate/mint`. `token` → `X-Freenet-User-Token`; `xfp_https`
+/// → `X-Forwarded-Proto: https`. Returns the raw response so callers assert on
+/// both the secure (200 + JSON) and insecure (403) paths.
+async fn http_mint(
+    port: u16,
+    token: Option<&str>,
+    xfp_https: bool,
+) -> anyhow::Result<reqwest::Response> {
+    let url = format!("http://127.0.0.1:{port}/v1/hosted/migrate/mint");
+    let mut req = reqwest::Client::new().post(&url);
+    if let Some(t) = token {
+        req = req.header("X-Freenet-User-Token", t);
+    }
+    if xfp_https {
+        req = req.header("X-Forwarded-Proto", "https");
+    }
+    Ok(req.send().await?)
+}
+
+/// `GET /v1/hosted/migrate/pull?pt=<pt>`. Public: the pull token is the entire
+/// auth. Returns the raw response so callers assert on 200 (bundle + key
+/// headers) and 404 (unknown / already-used / expired).
+async fn http_pull(port: u16, pt: &str) -> anyhow::Result<reqwest::Response> {
+    let url = format!("http://127.0.0.1:{port}/v1/hosted/migrate/pull?pt={pt}");
+    Ok(reqwest::Client::new().get(&url).send().await?)
+}
+
+/// `POST /v1/import`. `origin` → `Origin` header; `key`/`kind` → the bundle
+/// headers. Mirrors `hosted_mode_import.rs`'s import helper.
+async fn http_import(
+    port: u16,
+    bundle: Vec<u8>,
+    key: Option<&str>,
+    kind: Option<&str>,
+    overwrite: bool,
+    origin: Option<&str>,
+) -> anyhow::Result<reqwest::Response> {
+    let url = format!("http://127.0.0.1:{port}/v1/import");
+    let mut req = reqwest::Client::new()
+        .post(&url)
+        .header(reqwest::header::CONTENT_TYPE, "application/octet-stream")
+        .body(bundle);
+    if let Some(k) = key {
+        req = req.header("X-Freenet-Bundle-Key", k);
+    }
+    if let Some(kd) = kind {
+        req = req.header("X-Freenet-Bundle-Key-Kind", kd);
+    }
+    if overwrite {
+        req = req.header("X-Freenet-Import-Overwrite", "true");
+    }
+    if let Some(o) = origin {
+        req = req.header(reqwest::header::ORIGIN, o);
+    }
+    Ok(req.send().await?)
+}
+
+/// `GET /hosted/import` — the local confirmation page.
+async fn http_import_page(port: u16) -> anyhow::Result<reqwest::Response> {
+    let url = format!("http://127.0.0.1:{port}/hosted/import");
+    Ok(reqwest::Client::new().get(&url).send().await?)
+}
+
+#[derive(Deserialize)]
+struct MintResponseBody {
+    pull_token: String,
+    expires_in_secs: u64,
+}
+
+#[derive(Deserialize)]
+struct ImportResponseBody {
+    imported: usize,
+    skipped: Vec<(String, String)>,
+}
+
+/// Headline: the full magic-link round-trip on one hosted node.
+///
+/// Proves, in order, the load-bearing properties of #4592's primary path:
+///
+///  * MINT is gated like the live export (secure request → 200 + a pull token).
+///  * The bundle is sealed under a FRESH EPHEMERAL key (the durable token never
+///    leaves the node): the plaintext is absent from the bundle, and the key the
+///    PULL hands back — NOT the durable token — is what decrypts it via
+///    `POST /v1/import`.
+///  * The pull token is SINGLE-USE: the first pull consumes it; a replay and an
+///    unknown token are both a uniform 404.
+///  * The migrated secret decrypts to user A's ORIGINAL plaintext when read back
+///    through the live delegate stack (the import lands in the node-local scope,
+///    which a no-token connection reads).
+#[serial_test::serial]
+#[test_log::test(tokio::test(flavor = "multi_thread", worker_threads = 4))]
+async fn migrate_magic_link_round_trip() -> anyhow::Result<()> {
+    // Pin a multi-executor pool so the mint's export is admitted regardless of
+    // the CI runner's core count (a 1-core runner's default pool of 1 disables
+    // exports → 503). Mirrors the export/import live tests.
+    let _pool = PoolSizeEnv::set(4);
+    let node = TestNode::start(/* hosted_mode */ true).await?;
+    let port = node.ws_port;
+
+    let delegate = load_delegate(TEST_DELEGATE, Parameters::from(vec![]))?;
+    let delegate_key = delegate.key().clone();
+
+    const TOKEN: &str = "migrate-user-token-A-aaaaaaaaaaaaaaaa";
+    const SECRET_KEY: &[u8] = b"migrate-secret-key";
+    const VALUE: &[u8] = b"user-A-secret-to-migrate-home";
+
+    // (1) As user A over the secure hosted connection: register the delegate and
+    // store a secret in user A's per-user scope (what the mint will export).
+    let mut conn_a = connect_hosted(port, Some(TOKEN), true).await?;
+    register_delegate(&mut conn_a, &delegate, &delegate_key).await?;
+    store_secret(&mut conn_a, &delegate_key, SECRET_KEY, VALUE).await?;
+
+    // (2) MINT: the authenticated hosted user mints a one-time migration link.
+    let resp = http_mint(port, Some(TOKEN), true).await?;
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::OK,
+        "a secure mint (hosted + loopback + XFP:https + valid token) must be 200"
+    );
+    let mint: MintResponseBody = resp.json().await?;
+    assert!(
+        !mint.pull_token.is_empty(),
+        "mint must return a non-empty pull token"
+    );
+    assert_eq!(
+        mint.expires_in_secs, 600,
+        "the pull token TTL is the documented 600s window"
+    );
+
+    // (3) PULL: the public pull endpoint hands back the ephemeral bundle + key.
+    let resp = http_pull(port, &mint.pull_token).await?;
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::OK,
+        "the first pull of a fresh token must be 200"
+    );
+    // Read the key headers (owned) BEFORE consuming the body.
+    let bundle_key = resp
+        .headers()
+        .get("x-freenet-bundle-key")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .to_string();
+    assert!(
+        !bundle_key.is_empty(),
+        "pull must return a non-empty X-Freenet-Bundle-Key header"
+    );
+    let key_kind = resp
+        .headers()
+        .get("x-freenet-bundle-key-kind")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .to_string();
+    assert_eq!(
+        key_kind, "token",
+        "the ephemeral bundle key is a token-kind key (default import kind)"
+    );
+    let bundle = resp.bytes().await?.to_vec();
+    assert!(!bundle.is_empty(), "pull must return the bundle bytes");
+    assert_eq!(&bundle[0..4], b"FNSX", "pull must return an FNSX bundle");
+    // The ephemeral key is NOT the durable token: the token cannot be what
+    // sealed the bundle we just pulled.
+    assert_ne!(
+        bundle_key, TOKEN,
+        "the ephemeral bundle key must not be the durable user token"
+    );
+    // The plaintext value must NOT appear verbatim (sealed under the key).
+    assert!(
+        !bundle.windows(VALUE.len()).any(|w| w == VALUE),
+        "plaintext leaked into the bundle"
+    );
+
+    // (4) SINGLE-USE: the first pull consumed the token, so a replay is a uniform
+    // 404 — and an unknown token is the SAME 404 (no existence oracle).
+    let resp = http_pull(port, &mint.pull_token).await?;
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::NOT_FOUND,
+        "a second pull of the consumed token must be 404 (single-use)"
+    );
+    let resp = http_pull(port, "bogusnonexistenttoken123").await?;
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::NOT_FOUND,
+        "an unknown pull token must be 404"
+    );
+
+    // (5) IMPORT: feed the pulled bundle into POST /v1/import with the EPHEMERAL
+    // key the pull handed back (this is exactly what the local pull-import would
+    // forward). This proves the ephemeral key round-trips to a real import.
+    let origin = format!("http://127.0.0.1:{port}");
+    let resp = http_import(
+        port,
+        bundle,
+        Some(&bundle_key),
+        Some(&key_kind),
+        false,
+        Some(&origin),
+    )
+    .await?;
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::OK,
+        "importing the pulled bundle with its ephemeral key must be 200"
+    );
+    let report: ImportResponseBody = resp.json().await?;
+    assert_eq!(report.imported, 1, "exactly user A's one secret imports");
+    assert!(report.skipped.is_empty());
+
+    // (6) READBACK through the live stack: POST /v1/import targets the node-local
+    // scope, which a NO-TOKEN connection reads. Confirm the migrated secret
+    // decrypts to user A's ORIGINAL plaintext while the node stays up.
+    let mut conn_local = connect_plain(port).await?;
+    register_delegate(&mut conn_local, &delegate, &delegate_key).await?;
+    let read = get_secret_via_delegate(&mut conn_local, &delegate_key, SECRET_KEY).await?;
+    assert_eq!(
+        read.as_deref(),
+        Some(VALUE),
+        "the migrated secret must decrypt to user A's original plaintext via the live node"
+    );
+    assert!(
+        has_secret_via_delegate(&mut conn_local, &delegate_key, SECRET_KEY).await?,
+        "has_secret must see the migrated secret"
+    );
+
+    drop(conn_a);
+    drop(conn_local);
+    node.shutdown().await;
+    Ok(())
+}
+
+/// The mint gate is the export gate: every insecure variant is rejected with 403
+/// before any export runs (so the pool size is irrelevant here). Mirrors the
+/// export handler's truth table — the durable token is worthless without the
+/// loopback + `X-Forwarded-Proto: https` proof of a secure (TLS-terminated)
+/// request, and an absent/empty token is no token at all.
+#[serial_test::serial]
+#[test_log::test(tokio::test(flavor = "multi_thread", worker_threads = 4))]
+async fn migrate_mint_rejects_insecure_requests() -> anyhow::Result<()> {
+    let node = TestNode::start(/* hosted_mode */ true).await?;
+    let port = node.ws_port;
+
+    // Token but NO X-Forwarded-Proto: https (loopback alone is insufficient).
+    let resp = http_mint(port, Some("some-token-value"), false).await?;
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::FORBIDDEN,
+        "a mint without XFP:https must be 403"
+    );
+
+    // No token at all.
+    let resp = http_mint(port, None, true).await?;
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::FORBIDDEN,
+        "a mint without a user token must be 403"
+    );
+
+    // Empty token (treated as absent).
+    let resp = http_mint(port, Some(""), true).await?;
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::FORBIDDEN,
+        "a mint with an empty token must be 403"
+    );
+
+    node.shutdown().await;
+    Ok(())
+}
+
+/// The mint flag gate: with `hosted_mode = false` the whole migration feature is
+/// inert — a token + XFP mint is still 403 (no user namespaces exist).
+#[serial_test::serial]
+#[test_log::test(tokio::test(flavor = "multi_thread", worker_threads = 4))]
+async fn migrate_mint_flag_off_rejects() -> anyhow::Result<()> {
+    let node = TestNode::start(/* hosted_mode */ false).await?;
+    let port = node.ws_port;
+
+    let resp = http_mint(port, Some("ignored-because-flag-off"), true).await?;
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::FORBIDDEN,
+        "with hosted_mode=false the mint endpoint must 403"
+    );
+
+    node.shutdown().await;
+    Ok(())
+}
+
+/// The local confirmation page is served (200 HTML) with the explicit import
+/// button and the POST target wired to the local pull-import endpoint — and it
+/// does NOT import on its own (a state-changing import needs an explicit click,
+/// which the button provides; the page never auto-runs it).
+#[serial_test::serial]
+#[test_log::test(tokio::test(flavor = "multi_thread", worker_threads = 4))]
+async fn migrate_import_page_is_served_with_confirm_control() -> anyhow::Result<()> {
+    let node = TestNode::start(/* hosted_mode */ true).await?;
+    let port = node.ws_port;
+
+    let resp = http_import_page(port).await?;
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::OK,
+        "the confirmation page must be 200"
+    );
+    let ctype = resp
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .to_string();
+    assert!(
+        ctype.contains("text/html"),
+        "the confirmation page must be HTML, got Content-Type: {ctype}"
+    );
+    let body = resp.text().await?;
+    assert!(
+        body.contains("id=\"import-btn\""),
+        "the page must render the explicit import button"
+    );
+    assert!(
+        body.contains("/v1/hosted/pull-import"),
+        "the page must wire the POST to the local pull-import endpoint"
+    );
+
+    node.shutdown().await;
+    Ok(())
+}
+
+/// RAII guard that sets `FREENET_RUNTIME_POOL_SIZE` for the duration of a
+/// (serialized) test and restores it on drop, so a specific pool size can be
+/// forced when the node builds its `RuntimePool`. Safe only because these tests
+/// are `#[serial]` — no other node start overlaps the env-var window.
+struct PoolSizeEnv;
+impl PoolSizeEnv {
+    fn set(n: usize) -> Self {
+        // SAFETY: serialized tests; no concurrent node start reads this var.
+        unsafe { std::env::set_var("FREENET_RUNTIME_POOL_SIZE", n.to_string()) };
+        Self
+    }
+}
+impl Drop for PoolSizeEnv {
+    fn drop(&mut self) {
+        // SAFETY: serialized tests; no concurrent node start reads this var.
+        unsafe { std::env::remove_var("FREENET_RUNTIME_POOL_SIZE") };
+    }
+}


### PR DESCRIPTION
## Problem

The hosted "try Freenet" proxy (#4381) makes the **exit** one click (Account -> Export downloads an encrypted `freenet-data.fnsx`), but the **entrance** was a terminal command. #4603 removed the node-stop (live `POST /v1/import`), but a user still had to move a file and paste a key by hand — a friction cliff at the moment we want to convert a non-technical person who just tried Freenet in a browser.

## Solution

A **magic link** the user clicks on their own peer, which pulls the data over HTTPS and imports it live. The durable access key **never leaves the hosted browser**.

Four cooperating HTTP surfaces (same binary — a node can be either side):

- **`POST /v{1,2}/hosted/migrate/mint`** (hosted) — gated **identically to the live export** (hosted ON + loopback + `X-Forwarded-Proto: https` + valid `X-Freenet-User-Token`). Exports the user's scope under a **fresh ephemeral key** and stores the ephemeral-keyed bundle + key server-side under a **single-use, short-TTL, per-user-bounded** pull token. Returns the token; the hosted bar builds `http://127.0.0.1:7509/hosted/import?source=<origin>&pt=<token>`.
- **`GET /v{1,2}/hosted/migrate/pull?pt=`** (public) — the **pull token is the whole auth** (256-bit `OsRng`, single-use, short-TTL). Returns the bundle + ephemeral key over TLS. Unknown/expired/used ⇒ uniform `404` (no existence oracle).
- **`GET /hosted/import`** (local) — a first-party **confirmation page**; reads `source`/`pt` client-side and imports **only on an explicit click**, never on navigation ⇒ CSRF/drive-by safe.
- **`POST /v{1,2}/hosted/pull-import`** (local) — reuses the **live-import gate** (loopback + trusted origin + no per-contract token). **Strict SSRF allowlist** (`https` + default port + host == `try.freenet.org`); builds the pull URL from the trusted constant; fetches over HTTPS (size-capped); imports into `Local` with `overwrite=false` — **non-destructive**: an existing local secret is kept and reported in `skipped`, never clobbered (Ian's v1 decision: no overwrite path).

**Key insight (no crypto change):** `export_bundle(store, scope, material)` already decouples the user **scope** from the bundle **key**, so the mint reuses the existing `ExportUserSecrets` executor round-trip with an ephemeral key. The durable token stays on the hosting node. `Executor::export_user_secrets`'s param is renamed `token` -> `bundle_key_material` with a doc guard so nobody re-couples it.

Also included: the **file-upload fallback** UI on the local dashboard, and a **"Move to my peer"** button on the hosted bar. Reuses the merged #4603 import core throughout.

## Testing

- **Unit (`hosted_migrate`)**: pull-token lifecycle (single-use, unknown ⇒ none, **TTL expiry** via paused clock, per-user cap eviction with cross-user isolation); **SSRF allowlist** (https-only, exact host, no port, rejects loopback / look-alike subdomain / embedded-credential / non-url); pull-token + `pt` query validation; confirmation-page wiring (posts to `pull-import`, no auto-run).
- **Unit (`home_page`)**: file-upload card + modal wiring, dashboard JS `POST /v1/import` upload.
- **Integration (`hosted_mode_migrate.rs`)**: full **mint -> pull -> import** round-trip on a live hosted node (secret read back through the live stack), pull **single-use** (second pull 404), mint **gate** (no `XFP:https` / no token ⇒ 403), and `GET /hosted/import` serves the page without pulling.
- `cargo fmt` + `cargo clippy -- -D warnings` clean; prettier + eslint clean on shell assets.

Advances #4592

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jmCd1tvDH1EsVTtaDVnxJ