### PR TITLE
feat(hosting): flip reconcile controller to DRIVE interest-gated renewal + collapse (P6, #4642)

### DIFF
--- a/crates/core/src/client_events.rs
+++ b/crates/core/src/client_events.rs
@@ -1559,9 +1559,17 @@ async fn process_open_request(
                     );
                 }
 
-                // Send Unsubscribe upstream for contracts with no remaining interest
+                // Send Unsubscribe upstream for contracts with no remaining interest.
+                // FLIP (keystone P6, #4642): the collapse decision is driven by the
+                // reconcile controller's strict-farther interest gate
+                // (`reconcile_wants_collapse` = `!contract_in_use`), replacing the
+                // legacy ANY-downstream `should_unsubscribe_upstream`. The teardown
+                // still targets the STORED upstream (narrow flip keeps the flag).
                 for contract in &result.affected_contracts {
-                    if op_manager.ring.should_unsubscribe_upstream(contract) {
+                    if op_manager.reconcile_wants_collapse(
+                        contract,
+                        crate::node::network_status::ReconcileShadowSite::Collapse,
+                    ) {
                         let op_mgr = op_manager.clone();
                         let contract = *contract;
                         GlobalExecutor::spawn(async move {

--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -197,11 +197,14 @@ pub struct NetworkStatus {
     /// site's divergence must be separately gate-able — a single global tally
     /// would be dominated by the renewal set size and hide the other signals.
     ///
-    /// `collapse` and `renewal` are the MAINTENANCE sites (full action-set
-    /// comparison). The other three are single-aspect EDGE sites (focused
-    /// comparison on one action class): `inbound_unsubscribe` (teardown on a
-    /// downstream leave), `connection_drop` (re-root on an upstream loss),
-    /// `host_formation` (announce on first host).
+    /// `collapse`, `renewal`, and `inbound_unsubscribe` are the FLIPPED (P6) sites:
+    /// they no longer record a shadow divergence — the controller DRIVES — and their
+    /// counters are REPURPOSED to measure the flip's effect (renewal: strict gate
+    /// SUPPRESSED a renewal; collapse / inbound_unsubscribe: driven strict-farther
+    /// gate DISAGREED with the legacy `should_unsubscribe_upstream` predicate it
+    /// replaced, per collapse site). `connection_drop` (re-root on an upstream loss)
+    /// and `host_formation` (announce on first host) remain single-aspect EDGE
+    /// shadow sites (focused comparison, record-only).
     pub reconcile_shadow_collapse: ReconcileShadowStats,
     pub reconcile_shadow_renewal: ReconcileShadowStats,
     pub reconcile_shadow_inbound_unsubscribe: ReconcileShadowStats,
@@ -238,7 +241,15 @@ pub struct UpstreamDivergenceStats {
 /// ONE focused action class (see `action_set_divergence_focused`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReconcileShadowSite {
-    /// The interest-gated collapse (`OpManager::send_unsubscribe_upstream`).
+    /// The interest-gated collapse. **FLIPPED (keystone P6, #4642):** the collapse
+    /// DECISION is now DRIVEN by `OpManager::reconcile_wants_collapse` at the three
+    /// teardown sites (maintenance-loop downstream-expiry, client-disconnect,
+    /// inbound-unsubscribe), replacing the legacy ANY-downstream
+    /// `Ring::should_unsubscribe_upstream`. The counter is retained but repurposed:
+    /// `comparisons` counts collapse-gate decisions and `divergences`/`collapse`
+    /// count the times the driven strict-farther gate DISAGREED with that legacy
+    /// predicate — the "collapse diff" ship-gate falsifier (~0% in v0.2.93 shadow),
+    /// not a shadow divergence. Recorded in `reconcile_wants_collapse`.
     Collapse,
     /// The subscription-renewal set (`Ring::contracts_needing_renewal`, driven
     /// by the recovery loop). **FLIPPED (keystone sub-task 3, #4642):** this site
@@ -250,8 +261,12 @@ pub enum ReconcileShadowSite {
     /// not cache size" ship-gate falsifier (design §5a / #3763), not a divergence.
     Renewal,
     /// A downstream peer unsubscribed (`subscribe::handle_unsubscribe_inbound`):
-    /// did that leave us not-in-use (strict-farther), i.e. would the controller
-    /// tear down? Focused on `Collapse`.
+    /// did that leave us not-in-use (strict-farther), i.e. should the controller
+    /// tear down? **FLIPPED (keystone P6, #4642):** this collapse decision now
+    /// DRIVES via `reconcile_wants_collapse` (passed this `site`). The counter is
+    /// retained but repurposed like `Collapse`: it measures how often the driven
+    /// strict-farther gate DISAGREED with the legacy `should_unsubscribe_upstream`
+    /// predicate at THIS site (~0.00% in v0.2.93 shadow), not a shadow divergence.
     InboundUnsubscribe,
     /// A ring connection dropped (`OpManager::on_ring_connection_lost`): for a
     /// contract that peer co-hosted, would the controller re-root (upstream

--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -241,7 +241,13 @@ pub enum ReconcileShadowSite {
     /// The interest-gated collapse (`OpManager::send_unsubscribe_upstream`).
     Collapse,
     /// The subscription-renewal set (`Ring::contracts_needing_renewal`, driven
-    /// by the recovery loop).
+    /// by the recovery loop). **FLIPPED (keystone sub-task 3, #4642):** this site
+    /// no longer records a shadow — it DRIVES (`OpManager::reconcile_wants_renewal`
+    /// gates the renewal spawn). The counter is retained but its meaning shifted:
+    /// `comparisons` now counts renewal-gate decisions and `divergences`/`renew`
+    /// count the times the STRICT-farther interest gate SUPPRESSED a renewal the
+    /// old ANY-downstream set would have done — the "renewal tracks active demand,
+    /// not cache size" ship-gate falsifier (design §5a / #3763), not a divergence.
     Renewal,
     /// A downstream peer unsubscribed (`subscribe::handle_unsubscribe_inbound`):
     /// did that leave us not-in-use (strict-farther), i.e. would the controller

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -963,6 +963,60 @@ impl OpManager {
         }
     }
 
+    /// Reconcile-controller FLIP of the RENEWAL-site interest gate (#4642
+    /// keystone, sub-task 3 "the flip"; demand-driven-hosting design doc §5a).
+    ///
+    /// This is the first driver-backed reconcile decision: it no longer records a
+    /// shadow divergence, it DRIVES. Given a contract the renewal loop is about to
+    /// renew, it builds a FRESH [`reconcile::ReconcileInputs`] snapshot AT EMISSION
+    /// time (the TOCTOU revalidation guard — the decision is made from the live
+    /// maps at the instant the renewal would fire, never a stale earlier read) and
+    /// applies the controller's interest gate [`reconcile::wants_renewal`] =
+    /// design §5a `contract_in_use`: renew iff a **local client** OR a
+    /// **STRICTLY-farther** downstream subscriber depends on this peer hosting
+    /// (piece D: a downstream counts only when strictly farther from the key, so
+    /// two mutual co-hosts cannot renew each other forever).
+    ///
+    /// Returns `false` when the contract is no longer `contract_in_use` under that
+    /// strict gate. The renewal loop then SKIPS the spawn; the lease lapses and the
+    /// chain collapses inward. This is the load-bearing piece-D behavior:
+    /// **non-renewal IS the collapse primitive** (§5a), so live subscriptions track
+    /// ACTIVE demand rather than accumulated cache — the #3763 renewal-storm fix.
+    /// The previous (ANY-downstream, renew-everything) gate is what
+    /// `contracts_needing_renewal` still uses to build the candidate set; this
+    /// narrows it to the strict gate at drive time. It gates on DEMAND only, never
+    /// on lease/upstream/root state, so an in-use keyward root (or a peer still
+    /// acquiring its first lease) renews too — dropping those would strand a
+    /// demanded contract's lease.
+    ///
+    /// Fails **SAFE** (`true`, keep renewing) when the snapshot is distance-blind
+    /// (own ring location unknown at startup): collapsing a chain on an
+    /// unmeasurable snapshot is exactly the last-holder-on-a-stale-snapshot bug the
+    /// spec's at-emission-revalidation hardening exists to prevent. Behavior at
+    /// startup is therefore unchanged (renew everything in the set).
+    ///
+    /// # Per-contract rate cap
+    ///
+    /// The renewal wire action is already per-contract rate-capped by the two gates
+    /// the loop applies before this one: `can_request_subscription` (per-contract
+    /// exponential backoff) and `mark_subscription_pending` (blocks a second
+    /// concurrent renewal for the same contract until the prior one's guard
+    /// releases). Those ARE the "per-contract wire-action rate cap" the spec's
+    /// reconcile hardening requires for the driven renewal, so this flip adds no
+    /// redundant cap. (A dedicated cap is still owed for the destructive
+    /// `Unsubscribe` wire action when it is later flipped, since that path does not
+    /// pass through `can_request_subscription`.)
+    pub(crate) fn reconcile_wants_renewal(&self, contract: &ContractKey) -> bool {
+        let Some(inputs) = self.build_reconcile_inputs(contract) else {
+            // Distance-blind snapshot: never collapse a chain on a blind read.
+            return true;
+        };
+        // The controller's interest gate (design §5a `contract_in_use`), computed
+        // from the fresh at-emission snapshot. This wrapper only supplies the
+        // snapshot; the decision lives in the pure reconcile core.
+        reconcile::wants_renewal(&inputs)
+    }
+
     /// Send an Unsubscribe message to the upstream peer for a contract.
     ///
     /// Finds the upstream peer from the interest manager, resolves its address,

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -876,6 +876,12 @@ impl OpManager {
             has_local_client: self.ring.has_client_subscriptions(contract),
             has_farther_downstream_subscriber: self
                 .has_farther_downstream_subscriber(contract, my_location),
+            // Recent local GET/PUT access is REAL demand (invariant 3): a
+            // read-only / PUT-only contract (River UI container, web/UI
+            // containers) is emitted by `contracts_needing_renewal()` branch 3
+            // but has no subscription, so without this the P6 renewal gate would
+            // drop its lease and it would leave the update mesh.
+            has_recent_local_client_access: self.ring.has_recent_local_client_access(contract),
             state_present: self.ring.contract_state_present(contract),
             is_subscribed: self.ring.is_subscribed(contract),
             is_advertised: self.neighbor_hosting.is_hosted_locally(contract),
@@ -972,10 +978,13 @@ impl OpManager {
     /// time (the TOCTOU revalidation guard — the decision is made from the live
     /// maps at the instant the renewal would fire, never a stale earlier read) and
     /// applies the controller's interest gate [`reconcile::wants_renewal`] =
-    /// design §5a `contract_in_use`: renew iff a **local client** OR a
-    /// **STRICTLY-farther** downstream subscriber depends on this peer hosting
-    /// (piece D: a downstream counts only when strictly farther from the key, so
-    /// two mutual co-hosts cannot renew each other forever).
+    /// design §5a `contract_in_use`: renew iff a **local client**, a
+    /// **STRICTLY-farther** downstream subscriber (piece D: a downstream counts
+    /// only when strictly farther from the key, so two mutual co-hosts cannot renew
+    /// each other forever), OR **recent local GET/PUT access** (invariant 3:
+    /// reads/PUTs are permanent demand — a read-only / PUT-only contract like the
+    /// River UI container must stay renewed even without a subscription) depends on
+    /// this peer hosting.
     ///
     /// Returns `false` when the contract is no longer `contract_in_use` under that
     /// strict gate. The renewal loop then SKIPS the spawn; the lease lapses and the
@@ -1044,12 +1053,18 @@ impl OpManager {
     /// renewing AND collapse does not fire while distance-blind, the contract simply
     /// stays hosted through startup, unchanged from prior behavior.
     ///
-    /// Because the strict gate is a SUPERSET of the legacy gate
-    /// (`!has_any_downstream ⟹ !has_farther_downstream`), the flip can only collapse
-    /// MORE, never less — it never leaks a chain the legacy predicate would have
-    /// cleaned up. The only added collapses are the mutual-co-host case the strict
-    /// gate targets, which v0.2.93 shadow measured at ~0% divergence from the legacy
-    /// predicate (the "collapse diff" ship-gate falsifier).
+    /// Relative to the recent-access-aware baseline below, the strict gate is a
+    /// SUPERSET of the legacy gate (`!has_any_downstream ⟹ !has_farther_downstream`),
+    /// so it can only collapse MORE, never less — it never leaks a chain the legacy
+    /// predicate would have cleaned up. The only added collapses are the
+    /// mutual-co-host case the strict gate targets, which v0.2.93 shadow measured at
+    /// ~0% divergence from the legacy predicate (the "collapse diff" ship-gate
+    /// falsifier). Recent local GET/PUT access is a demand term (invariant 3) shared
+    /// by BOTH gates: it holds a read-only / PUT-only contract open, so relative to
+    /// the raw subscriptions-only `should_unsubscribe_upstream` the gate collapses
+    /// LESS for such contracts. That term is factored out of the divergence counter
+    /// (the baseline ANDs in `!has_recent_local_client_access`) so the counter still
+    /// isolates the strict-farther difference.
     ///
     /// # Post-flip legibility counter
     ///
@@ -1080,8 +1095,12 @@ impl OpManager {
         // legacy ANY-downstream predicate it replaced (the "collapse diff"
         // ship-gate falsifier, ~0% in v0.2.93 shadow). Recorded on the SAME per-site
         // counter the pre-flip shadow used, so the metric is continuous across the
-        // flip.
-        let legacy = self.ring.should_unsubscribe_upstream(contract);
+        // flip. The recent-GET/PUT-access demand term (invariant 3) is factored out
+        // of BOTH sides (`&& !has_recent_local_client_access`) so this counter keeps
+        // isolating the ONE difference it measures — strict-farther vs ANY-downstream
+        // — rather than double-counting the read/PUT demand both gates now honor.
+        let legacy = self.ring.should_unsubscribe_upstream(contract)
+            && !self.ring.has_recent_local_client_access(contract);
         let divergence = if wants != legacy {
             reconcile::ReconcileActionDivergence {
                 collapse: true,
@@ -2447,6 +2466,32 @@ mod tests {
         assert!(
             !sub.contains("ring.should_unsubscribe_upstream"),
             "the inbound-unsubscribe collapse must no longer gate on ring.should_unsubscribe_upstream"
+        );
+    }
+
+    /// Wiring pin (Codex P2 fix, #4642): the reconcile input-builder MUST feed
+    /// recent local GET/PUT access into `has_recent_local_client_access`, and the
+    /// collapse-gate legibility baseline MUST factor it out. Without the builder
+    /// wiring, `contract_in_use` (which now ORs the field) would always see it
+    /// `false` and the P6 flip would drop a read-only / PUT-only contract's lease
+    /// even though `contracts_needing_renewal()` branch 3 keeps emitting it — the
+    /// regression this fix closes (invariant 3: reads/PUTs are permanent demand).
+    #[test]
+    fn build_reconcile_inputs_wires_recent_local_client_access() {
+        const SRC: &str = include_str!("op_state_manager.rs");
+        let builder = braced_block_after(SRC, "pub(crate) fn build_reconcile_inputs(");
+        assert!(
+            builder.contains("has_recent_local_client_access: self")
+                && builder.contains("has_recent_local_client_access(contract)"),
+            "build_reconcile_inputs must populate has_recent_local_client_access from \
+             ring.has_recent_local_client_access(contract) so the P6 renewal/collapse \
+             gate honors read/PUT demand (invariant 3)"
+        );
+        let gate = braced_block_after(SRC, "pub(crate) fn reconcile_wants_collapse(");
+        assert!(
+            gate.contains("!self.ring.has_recent_local_client_access(contract)"),
+            "the collapse-gate legibility baseline must factor out recent-access so the \
+             divergence counter isolates the strict-farther difference"
         );
     }
 

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -1017,11 +1017,109 @@ impl OpManager {
         reconcile::wants_renewal(&inputs)
     }
 
-    /// Send an Unsubscribe message to the upstream peer for a contract.
+    /// Reconcile-controller FLIP of the COLLAPSE-site interest gate (keystone P6,
+    /// #4642; design doc §5a / §6). The exact INVERSE of
+    /// [`reconcile_wants_renewal`](Self::reconcile_wants_renewal): whether the
+    /// active teardown (`send_unsubscribe_upstream`) should fire for this contract.
+    ///
+    /// The three collapse-decision sites — the maintenance loop's downstream-expiry
+    /// teardown (`Ring::recover_orphaned_subscriptions`), the client-disconnect
+    /// teardown (`client_events`), and the inbound-unsubscribe teardown
+    /// (`subscribe::handle_unsubscribe_inbound`) — now gate on THIS instead of the
+    /// legacy ANY-downstream `Ring::should_unsubscribe_upstream` predicate. It
+    /// builds a FRESH [`reconcile::ReconcileInputs`] snapshot AT EMISSION time and
+    /// applies the controller's interest gate [`reconcile::wants_collapse`] =
+    /// `!contract_in_use`: tear down iff NO local client AND NO **STRICTLY-farther**
+    /// downstream subscriber (piece D: a downstream counts only when strictly
+    /// farther from the key, so two mutual co-hosts cannot perpetuate each other's
+    /// leases forever — the #3763 hollow-relay-storm fix). The teardown it gates
+    /// still drives the wire `Unsubscribe` toward the **STORED** `is_upstream`
+    /// upstream (the narrow flip KEEPS the stored flag; see
+    /// `send_unsubscribe_upstream`).
+    ///
+    /// Fails **SAFE** (`false`, DO NOT collapse) when the snapshot is distance-blind
+    /// (own ring location unknown at startup) — the mirror of
+    /// `reconcile_wants_renewal`'s fail-safe (which keeps renewing): neither ever
+    /// tears a chain down on an unmeasurable snapshot. Because renewal keeps
+    /// renewing AND collapse does not fire while distance-blind, the contract simply
+    /// stays hosted through startup, unchanged from prior behavior.
+    ///
+    /// Because the strict gate is a SUPERSET of the legacy gate
+    /// (`!has_any_downstream ⟹ !has_farther_downstream`), the flip can only collapse
+    /// MORE, never less — it never leaks a chain the legacy predicate would have
+    /// cleaned up. The only added collapses are the mutual-co-host case the strict
+    /// gate targets, which v0.2.93 shadow measured at ~0% divergence from the legacy
+    /// predicate (the "collapse diff" ship-gate falsifier).
+    ///
+    /// # Post-flip legibility counter
+    ///
+    /// Records how often the driven strict-farther gate DISAGREES with the legacy
+    /// predicate it replaced (the "collapse diff" ship-gate falsifier, ~0% in
+    /// v0.2.93 shadow), so the metric stays legible in `router_snapshot` telemetry
+    /// after the flip — repurposed exactly as the RENEWAL counter was. The `site`
+    /// argument preserves the pre-flip per-site counter mapping: the maintenance-loop
+    /// and client-disconnect teardowns record on `Collapse` (both went through
+    /// `send_unsubscribe_upstream`'s `Collapse` shadow before the flip), the
+    /// inbound-unsubscribe teardown records on `InboundUnsubscribe` (its own
+    /// focused-`Collapse` shadow before the flip). Skips recording (like the shadow
+    /// builder) when distance-blind, to avoid noise.
+    pub(crate) fn reconcile_wants_collapse(
+        &self,
+        contract: &ContractKey,
+        site: crate::node::network_status::ReconcileShadowSite,
+    ) -> bool {
+        let Some(inputs) = self.build_reconcile_inputs(contract) else {
+            // Distance-blind snapshot: never actively tear down a chain on a blind
+            // read (fail SAFE = do not collapse). Do not record — no measurable
+            // comparison exists at startup (mirrors the shadow builder's skip).
+            return false;
+        };
+        let wants = reconcile::wants_collapse(&inputs);
+
+        // Post-flip legibility: measure the driven strict-farther gate against the
+        // legacy ANY-downstream predicate it replaced (the "collapse diff"
+        // ship-gate falsifier, ~0% in v0.2.93 shadow). Recorded on the SAME per-site
+        // counter the pre-flip shadow used, so the metric is continuous across the
+        // flip.
+        let legacy = self.ring.should_unsubscribe_upstream(contract);
+        let divergence = if wants != legacy {
+            reconcile::ReconcileActionDivergence {
+                collapse: true,
+                ..Default::default()
+            }
+        } else {
+            reconcile::ReconcileActionDivergence::default()
+        };
+        crate::node::network_status::record_reconcile_shadow_comparison(site, divergence);
+        if wants != legacy {
+            tracing::debug!(
+                contract = %contract,
+                ?site,
+                reconcile_wants_collapse = wants,
+                legacy_should_unsubscribe = legacy,
+                "collapse gate: driven strict-farther gate disagrees with legacy \
+                 ANY-downstream predicate (#4642 P6 flip; expected ~0%)"
+            );
+        }
+        wants
+    }
+
+    /// Send an Unsubscribe message to the upstream peer for a contract — the
+    /// interest-gated COLLAPSE teardown.
     ///
     /// Finds the upstream peer from the interest manager, resolves its address,
     /// and sends a fire-and-forget Unsubscribe message via the operation routing
     /// mechanism. Also removes the local active subscription and interest tracking.
+    ///
+    /// FLIP (keystone P6, #4642): the DECISION to fire this teardown is now driven
+    /// by the reconcile controller — every caller gates on
+    /// [`reconcile_wants_collapse`](Self::reconcile_wants_collapse) (`!contract_in_use`,
+    /// the strict-farther interest gate), replacing the legacy ANY-downstream
+    /// `should_unsubscribe_upstream`. The UPSTREAM IDENTITY, however, stays on the
+    /// stored `is_upstream` flag: the narrow flip does NOT compute-upstream-
+    /// everywhere, so the wire `Unsubscribe` still targets the stored upstream and
+    /// the computed-vs-stored divergence (#4671) stays under the SHADOW telemetry
+    /// recorded below (`record_upstream_divergence_comparison`), unflipped.
     pub async fn send_unsubscribe_upstream(&self, contract: &ContractKey) {
         // Find the upstream peer for this contract
         let upstream = self
@@ -1072,54 +1170,14 @@ impl OpManager {
             }
         }
 
-        // Reconcile-controller SHADOW comparison (keystone step-2, #4642),
-        // COLLAPSE site. This function is the interest-gated collapse. Build the
-        // reconcile snapshot, compute what the pure controller would do, and
-        // compare BY SET MEMBERSHIP. DRIVES NOTHING — the teardown below runs
-        // unchanged. Skipped when the snapshot is distance-blind
-        // (`build_reconcile_inputs` returns `None`: own-location unknown), so a
-        // startup transient does not pollute the collapse-site signal.
-        //
-        // Actual→Action mapping (mirrors what this function actually EFFECTS):
-        //   - `Collapse` iff we hold a lease at snapshot (`is_subscribed`):
-        //     `ring.unsubscribe` is a NO-OP when not subscribed (hosting.rs), and
-        //     reconcile likewise emits `Collapse` only for a held lease — so a
-        //     verified-root / hosted-only (not-subscribed) contract collapsing on
-        //     last-client-leave must NOT record a false `collapse` diff, keeping
-        //     `collapse_diffs` the clean "controller would collapse a real lease"
-        //     signal.
-        //   - `Unsubscribe` iff a stored upstream was located (`upstream.is_some()`):
-        //     the wire `Unsubscribe` is sent whenever the stored flag resolves an
-        //     upstream, regardless of `is_subscribed`. The rare edge where a
-        //     located upstream fails later address resolution still counts as the
-        //     intent to unsubscribe. The `unsubscribe` diff thus captures the
-        //     stored-vs-computed upstream disagreement (#4671) at action
-        //     granularity.
-        // This site NEVER retracts a hosting advertisement, so reconcile's
-        // `Retract` (emitted when `is_advertised`) is a genuine recorded gap.
-        if let Some(inputs) = self.build_reconcile_inputs(contract) {
-            let reconcile_actions = reconcile::reconcile(&inputs);
-            let mut actual_actions: Vec<reconcile::Action> = Vec::new();
-            if inputs.is_subscribed {
-                actual_actions.push(reconcile::Action::Collapse);
-            }
-            if upstream.is_some() {
-                actual_actions.push(reconcile::Action::Unsubscribe);
-            }
-            let divergence = reconcile::action_set_divergence(&reconcile_actions, &actual_actions);
-            crate::node::network_status::record_reconcile_shadow_comparison(
-                crate::node::network_status::ReconcileShadowSite::Collapse,
-                divergence,
-            );
-            if divergence.any() {
-                tracing::debug!(
-                    contract = %contract,
-                    ?reconcile_actions,
-                    ?actual_actions,
-                    "reconcile shadow diverges from actual collapse behavior (#4642 keystone step-2)"
-                );
-            }
-        }
+        // NOTE (keystone P6 flip, #4642): the reconcile COLLAPSE decision no longer
+        // lives here as a record-only shadow — it DRIVES, one level up. Every caller
+        // of `send_unsubscribe_upstream` now gates on `reconcile_wants_collapse`
+        // (the strict-farther `!contract_in_use` gate), which also owns the
+        // repurposed `Collapse` reconcile counter (driven strict-vs-legacy
+        // divergence). So this function performs the teardown it is asked to; the
+        // only shadow it still records is the upstream-IDENTITY comparison above
+        // (stored vs computed), which stays UNFLIPPED per the narrow-flip scope.
 
         let Some((peer_key, _)) = upstream else {
             tracing::debug!(
@@ -2259,15 +2317,18 @@ mod tests {
         panic!("unbalanced braces after anchor: {anchor}");
     }
 
-    /// Behavior-preserving guard (keystone step-2, #4642): the collapse site
-    /// `send_unsubscribe_upstream` must STILL drive its decision off the stored
-    /// `is_upstream` flag and the local `ring.unsubscribe`, and the reconcile
-    /// controller must only RECORD a shadow comparison there — its `Vec<Action>`
-    /// flows ONLY into the set-membership divergence comparator, never into a
-    /// driver. This source-scrape pin fails if the flip lands (drive the action)
-    /// without a deliberate update, keeping the "drives nothing" invariant honest.
+    /// FLIP pin (keystone P6, #4642): the collapse teardown
+    /// `send_unsubscribe_upstream` still drives the wire `Unsubscribe` off the
+    /// STORED `is_upstream` flag and the local `ring.unsubscribe` (the narrow flip
+    /// KEEPS the stored upstream identity — it does NOT compute-upstream-
+    /// everywhere), and it STILL records the upstream-IDENTITY shadow
+    /// (`record_upstream_divergence_comparison`, unflipped). The record-only
+    /// reconcile COLLAPSE action-set shadow that used to live inside this function
+    /// is GONE — the collapse DECISION now DRIVES one level up
+    /// (`reconcile_wants_collapse` at the callers), so the function must no longer
+    /// build a reconcile snapshot or run the action-set comparator here.
     #[test]
-    fn send_unsubscribe_upstream_still_drives_and_shadow_is_record_only() {
+    fn send_unsubscribe_upstream_drives_off_stored_upstream_after_flip() {
         const SRC: &str = include_str!("op_state_manager.rs");
         let start = SRC
             .find("pub async fn send_unsubscribe_upstream(")
@@ -2281,57 +2342,120 @@ mod tests {
             .unwrap_or(SRC.len());
         let body = &SRC[start..end];
 
-        // Production still drives the collapse:
+        // Teardown still uses the STORED upstream identity + local ring.unsubscribe:
         assert!(
             body.contains("interest.is_upstream"),
-            "collapse must still locate the upstream via the stored is_upstream flag"
+            "collapse must still locate the upstream via the stored is_upstream flag \
+             (narrow flip keeps the stored flag)"
         );
         assert!(
             body.contains("self.ring.unsubscribe(contract)"),
             "collapse must still drop the local lease via ring.unsubscribe"
         );
-        // Reconcile is wired in SHADOW mode here and is record-only:
+        // The upstream-IDENTITY shadow (stored vs computed) STAYS wired, unflipped:
         assert!(
-            body.contains("record_reconcile_shadow_comparison"),
-            "the reconcile shadow comparison must be wired at the collapse site"
+            body.contains("record_upstream_divergence_comparison"),
+            "the upstream computed-vs-stored IDENTITY shadow must keep running \
+             (unflipped per the narrow-flip scope)"
+        );
+        // The record-only reconcile COLLAPSE action-set shadow is GONE from here —
+        // the decision drives at the callers (reconcile_wants_collapse). No reconcile
+        // snapshot build and no action-set comparator inside this function.
+        assert!(
+            !body.contains("build_reconcile_inputs"),
+            "the collapse decision drives one level up (reconcile_wants_collapse); \
+             send_unsubscribe_upstream must no longer build a reconcile snapshot"
         );
         assert!(
-            body.contains("action_set_divergence(&reconcile_actions"),
-            "reconcile output must flow ONLY into the set-membership divergence \
-             comparator (record-only), not into a driver/wire send"
+            !body.contains("action_set_divergence(&reconcile_actions"),
+            "the record-only collapse action-set shadow must be removed after the flip"
+        );
+        assert!(
+            !body.contains("ReconcileShadowSite::Collapse"),
+            "send_unsubscribe_upstream must no longer record the Collapse shadow — \
+             the repurposed Collapse counter is recorded in reconcile_wants_collapse"
+        );
+    }
+
+    /// FLIP pin (keystone P6, #4642): the COLLAPSE decision is DRIVEN by the
+    /// reconcile controller. `reconcile_wants_collapse` applies the pure
+    /// `reconcile::wants_collapse` gate, fails SAFE (does NOT collapse) on a
+    /// distance-blind snapshot, and all three collapse-decision sites gate on it
+    /// instead of the legacy ANY-downstream `should_unsubscribe_upstream`.
+    #[test]
+    fn collapse_decision_is_reconcile_driven() {
+        const SRC: &str = include_str!("op_state_manager.rs");
+        let gate = braced_block_after(SRC, "pub(crate) fn reconcile_wants_collapse(");
+        assert!(
+            gate.contains("reconcile::wants_collapse(&inputs)"),
+            "reconcile_wants_collapse must apply the pure wants_collapse gate"
+        );
+        assert!(
+            gate.contains("build_reconcile_inputs"),
+            "reconcile_wants_collapse must build a FRESH at-emission snapshot"
+        );
+        // Fail-safe: the distance-blind (`else`) arm must return false (do NOT
+        // collapse) — the mirror of reconcile_wants_renewal's keep-renewing default.
+        let blind = gate
+            .find("build_reconcile_inputs(contract) else")
+            .expect("reconcile_wants_collapse must guard the distance-blind snapshot");
+        let after = &gate[blind..];
+        let arm_end = after.find('}').expect("let-else arm must close");
+        assert!(
+            after[..arm_end].contains("return false"),
+            "reconcile_wants_collapse must FAIL SAFE (return false, do not collapse) \
+             when the snapshot is distance-blind"
         );
 
-        // NEGATIVE assertion (mirroring the renewal / edge-site pins): the shadow
-        // BLOCK itself must contain no driver call — reconcile's output can only
-        // be compared, never applied. Extract just the `if let Some(inputs) =
-        // self.build_reconcile_inputs(contract) { ... }` block so the function's
-        // real teardown drivers (which live OUTSIDE the block) don't trip it.
-        let block = braced_block_after(
-            SRC,
-            "if let Some(inputs) = self.build_reconcile_inputs(contract)",
+        // All three collapse-decision sites gate on reconcile_wants_collapse, each
+        // passing its pre-flip per-site counter (maintenance-loop + client-disconnect
+        // → Collapse; inbound-unsubscribe → InboundUnsubscribe).
+        let ring = include_str!("../ring.rs");
+        assert!(
+            ring.contains("op_manager.reconcile_wants_collapse(")
+                && ring.contains("ReconcileShadowSite::Collapse"),
+            "the renewal-loop downstream-expiry collapse must gate on \
+             reconcile_wants_collapse (Collapse site)"
         );
-        for driver in [
-            ".send(",
-            "self.ring.subscribe",
-            "self.ring.unsubscribe",
-            "send_unsubscribe",
-            "remove_peer_interest",
-            "on_contract_hosted",
-            "on_contract_unhosted",
-            "mark_subscription_pending",
-        ] {
-            assert!(
-                !block.contains(driver),
-                "collapse shadow block must not drive `{driver}` — it records only"
-            );
-        }
+        let client = include_str!("../client_events.rs");
+        assert!(
+            client.contains("op_manager.reconcile_wants_collapse(")
+                && client.contains("ReconcileShadowSite::Collapse"),
+            "the client-disconnect collapse must gate on reconcile_wants_collapse \
+             (Collapse site)"
+        );
+        let sub = include_str!("../operations/subscribe.rs");
+        assert!(
+            sub.contains("op_manager.reconcile_wants_collapse(")
+                && sub.contains("ReconcileShadowSite::InboundUnsubscribe"),
+            "the inbound-unsubscribe collapse must gate on reconcile_wants_collapse \
+             (InboundUnsubscribe site)"
+        );
+        // The legacy ANY-downstream predicate must no longer GATE any of the three
+        // collapse teardowns (matched on the `ring.should_unsubscribe_upstream(`
+        // call form, so the explanatory comments that name it don't false-trip). It
+        // survives only as the post-flip legibility baseline inside
+        // reconcile_wants_collapse and as a Ring/hosting helper.
+        assert!(
+            !ring.contains("if ring.should_unsubscribe_upstream(contract)"),
+            "the renewal-loop collapse must no longer gate on ring.should_unsubscribe_upstream"
+        );
+        assert!(
+            !client.contains("ring.should_unsubscribe_upstream"),
+            "the client-disconnect collapse must no longer gate on ring.should_unsubscribe_upstream"
+        );
+        assert!(
+            !sub.contains("ring.should_unsubscribe_upstream"),
+            "the inbound-unsubscribe collapse must no longer gate on ring.should_unsubscribe_upstream"
+        );
     }
 
     /// Hardening pin (keystone step-2 completion, #4642): the shared edge-site
     /// helper `record_reconcile_shadow_event` DRIVES NOTHING — reconcile's output
     /// flows only into the focused divergence comparator + the per-site counter.
-    /// One pin covers all four edge sites (inbound-unsubscribe, connection-drop,
-    /// host-formation) since they all route through this helper.
+    /// One pin covers the still-SHADOW edge sites (connection-drop, host-formation)
+    /// since they route through this helper. (The inbound-unsubscribe collapse was
+    /// FLIPPED to driving in P6 and no longer uses this record-only helper.)
     #[test]
     fn record_reconcile_shadow_event_drives_nothing() {
         const SRC: &str = include_str!("op_state_manager.rs");
@@ -2362,16 +2486,17 @@ mod tests {
         }
     }
 
-    /// Hardening pin (keystone step-2 completion, #4642): each of the four
-    /// EDGE decision sites is wired to the record-only helper with its own
+    /// Hardening pin (keystone step-2 completion, #4642): each still-SHADOW EDGE
+    /// decision site is wired to the record-only helper with its own
     /// `ReconcileShadowSite`, and the connection-drop site still runs the
     /// production disconnect bookkeeping unchanged. A future edit that drops a
-    /// site's shadow (or the production bookkeeping) fails here.
+    /// site's shadow (or the production bookkeeping) fails here. (Inbound-unsubscribe
+    /// was FLIPPED to driving in P6 — it is covered by
+    /// `collapse_decision_is_reconcile_driven`, not this shadow pin.)
     #[test]
     fn edge_sites_wire_the_record_only_helper() {
-        // Inbound-unsubscribe + host-formation live in operations/subscribe.rs.
+        // Host-formation lives in operations/subscribe.rs.
         let sub = include_str!("../operations/subscribe.rs");
-        assert!(sub.contains("ReconcileShadowSite::InboundUnsubscribe"));
         assert!(sub.contains("ReconcileShadowSite::HostFormation"));
         assert!(sub.contains("record_reconcile_shadow_event"));
         // Host-formation GET path lives in operations/get/op_ctx_task.rs.

--- a/crates/core/src/operations/subscribe.rs
+++ b/crates/core/src/operations/subscribe.rs
@@ -766,44 +766,32 @@ pub(crate) async fn handle_unsubscribe_inbound(
         );
     }
 
-    // Reconcile-controller SHADOW comparison (keystone step-2, #4642),
-    // INBOUND-UNSUBSCRIBE site. The downstream peer just left (removal above is
-    // complete, so the strict-farther gate reflects it); does that leave us
-    // not-in-use, i.e. would the controller tear down our lease? Focused on
-    // `Collapse`. Actual = `{Collapse}` iff production tears down the lease THIS
-    // event (`should_unsubscribe_upstream` AND we actually hold a lease —
-    // `ring.unsubscribe` is a no-op otherwise), else `{}`. The strict-farther
-    // "still-in-use by a CLOSER downstream, so keep hosting" case where the
-    // controller would collapse shows up here as a `collapse` diff. DRIVES
-    // NOTHING — the real decision below re-reads the gate and is unchanged.
-    {
-        let will_collapse = op_manager.ring.should_unsubscribe_upstream(&key);
-        op_manager.record_reconcile_shadow_event(
-            crate::node::network_status::ReconcileShadowSite::InboundUnsubscribe,
-            &key,
-            &[crate::ring::reconcile::Action::Collapse],
-            |inputs| {
-                if will_collapse && inputs.is_subscribed {
-                    vec![crate::ring::reconcile::Action::Collapse]
-                } else {
-                    Vec::new()
-                }
-            },
-        );
-    }
-
-    if op_manager.ring.should_unsubscribe_upstream(&key) {
+    // FLIP (keystone P6, #4642), INBOUND-UNSUBSCRIBE site. The downstream peer just
+    // left (removal above is complete, so the strict-farther gate reflects it);
+    // does that leave us not-in-use, i.e. should the controller tear down our lease?
+    // The collapse decision is now DRIVEN by the reconcile controller's
+    // strict-farther interest gate (`reconcile_wants_collapse` = `!contract_in_use`),
+    // replacing the legacy ANY-downstream `should_unsubscribe_upstream`. The strict
+    // gate collapses the "still-subscribed-only-by-a-CLOSER-downstream / mutual
+    // co-host" case the legacy predicate left hosting (v0.2.93 shadow measured this
+    // InboundUnsubscribe collapse diff at ~0.00%). The teardown still targets the
+    // STORED upstream (narrow flip keeps the flag); the repurposed `Collapse`
+    // reconcile counter is recorded inside `reconcile_wants_collapse`.
+    if op_manager.reconcile_wants_collapse(
+        &key,
+        crate::node::network_status::ReconcileShadowSite::InboundUnsubscribe,
+    ) {
         tracing::debug!(
             tx = %tx,
             contract = %key,
-            "No remaining subscribers, propagating unsubscribe upstream"
+            "No remaining strict-farther interest, propagating unsubscribe upstream"
         );
         op_manager.send_unsubscribe_upstream(&key).await;
     } else {
         tracing::debug!(
             tx = %tx,
             contract = %key,
-            "Still have subscribers, not propagating unsubscribe"
+            "Still have strict-farther interest, not propagating unsubscribe"
         );
     }
 }

--- a/crates/core/src/operations/subscribe/op_ctx_task.rs
+++ b/crates/core/src/operations/subscribe/op_ctx_task.rs
@@ -1631,6 +1631,12 @@ async fn run_relay_subscribe(
 /// without originating traffic), extend `OpCtx::send_to_and_await`
 /// to emit a stat update on `Err(_elapsed)` via a hook rather than
 /// reintroducing the signal on each relay driver.
+// NAMING LANDMINE: "relay" is a fossil of the hollow-relay firefight (#3763). This
+// driver IS the standalone SUBSCRIBE hop, the one genuinely hollow relay, being
+// retired as subscribe folds into GET/PUT (a routed GET/PUT is itself demand, so
+// those peers HOST rather than relay). Slated for removal/rename by piece D (chain
+// peers become real hosts). Do not name new code "relay".
+// See .claude/rules/hosting-invariants.md terminology + epic #4642.
 async fn drive_relay_subscribe(
     op_manager: &Arc<OpManager>,
     incoming_tx: Transaction,

--- a/crates/core/src/operations/subscribe/tests.rs
+++ b/crates/core/src/operations/subscribe/tests.rs
@@ -96,11 +96,14 @@ fn handle_unsubscribe_inbound_preserves_legacy_branches() {
          to drop the sender from the per-peer interest registry"
     );
     assert!(
-        body.contains("should_unsubscribe_upstream(&key)"),
-        "handle_unsubscribe_inbound must gate the upstream propagation on \
-         `ring.should_unsubscribe_upstream` — chain-propagating without \
-         the gate would over-unsubscribe contracts that still have \
-         downstream subscribers"
+        body.contains("reconcile_wants_collapse(")
+            && body.contains("ReconcileShadowSite::InboundUnsubscribe"),
+        "handle_unsubscribe_inbound must gate the upstream propagation on the \
+         reconcile controller's strict-farther interest gate \
+         (`op_manager.reconcile_wants_collapse`, InboundUnsubscribe site) — FLIPPED \
+         in P6 from the legacy ANY-downstream `should_unsubscribe_upstream`; \
+         chain-propagating without the gate would over-unsubscribe contracts that \
+         still have strict-farther downstream subscribers"
     );
     assert!(
         body.contains("send_unsubscribe_upstream(&key)"),

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -2329,9 +2329,11 @@ impl Ring {
                 // FLIP (#4642 keystone): interest-gated renewal DRIVEN by the
                 // reconcile controller's interest gate (design §5a
                 // `contract_in_use`). Build a FRESH snapshot at emission time and
-                // renew iff a local client OR a STRICTLY-farther downstream
-                // subscriber (piece D) depends on this peer hosting. When it goes
-                // false — no longer in use under the strict gate — SKIP: the lease
+                // renew iff a local client, a STRICTLY-farther downstream
+                // subscriber (piece D), OR recent local GET/PUT access (invariant
+                // 3: reads/PUTs are permanent demand — a read-only / PUT-only
+                // contract stays renewed without a subscription) depends on this
+                // peer hosting. When it goes false — no longer in use — SKIP: the lease
                 // lapses and the chain collapses inward (non-renewal is the collapse
                 // primitive; the #3763 storm fix). The gate narrows the
                 // ANY-downstream candidate set that `contracts_needing_renewal`
@@ -4078,6 +4080,13 @@ impl Ring {
     /// Check if a contract was accessed by a local client.
     pub fn has_local_client_access(&self, key: &ContractKey) -> bool {
         self.hosting_manager.has_local_client_access(key)
+    }
+
+    /// Whether a local client GET/PUT touched this contract within the renewal age
+    /// gate (`SUBSCRIPTION_LEASE_DURATION`) — the read/PUT demand signal the
+    /// reconcile input-builder feeds into `contract_in_use` (invariant 3).
+    pub fn has_recent_local_client_access(&self, key: &ContractKey) -> bool {
+        self.hosting_manager.has_recent_local_client_access(key)
     }
 
     /// Sweep for expired entries in the hosting cache.

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -402,66 +402,13 @@ fn most_keyward_among(
         .map(|(pkl, _)| pkl)
 }
 
-/// Map a renewal-loop per-tick outcome to the Action set the reconcile
-/// controller is compared against in shadow mode (keystone step-2, #4642).
-///
-/// `acted` = the loop spawned a fresh SUBSCRIBE for this contract THIS TICK (vs
-/// skipped/deferred → nothing). `run_renewal_subscribe` issues a real SUBSCRIBE,
-/// which per [`reconcile::Action`]'s docs is `Renew` when we already hold the
-/// lease and `Subscribe` when we do not — so a section-2/3 not-subscribed entry
-/// maps to `Subscribe`, never a phantom `Renew`.
-fn renewal_shadow_actual(acted: bool, is_subscribed: bool) -> &'static [reconcile::Action] {
-    match (acted, is_subscribed) {
-        (false, _) => &[],
-        (true, true) => &[reconcile::Action::Renew],
-        (true, false) => &[reconcile::Action::Subscribe],
-    }
-}
-
-/// Record one reconcile-controller SHADOW comparison for the RENEWAL site
-/// (keystone step-2, #4642), respecting the per-tick sample `budget`. DRIVES
-/// NOTHING: it builds a [`reconcile::ReconcileInputs`] snapshot, computes what
-/// the controller WOULD do, maps the loop's per-tick outcome to an Action set
-/// via [`renewal_shadow_actual`], and records only the set-membership
-/// divergence.
-///
-/// Skips (without consuming budget) when the snapshot is distance-blind — an
-/// unknown own-location makes the computed upstream / verified-root / strict
-/// downstream-demand fields unmeasurable, so recording then would be noise
-/// (`build_reconcile_inputs` returns `None`). Otherwise consumes one unit of
-/// `budget`; when the budget is exhausted the remaining contracts this tick are
-/// left unmeasured (they rotate in on later ticks via the renewal-set shuffle).
-fn record_renewal_shadow(
-    op_manager: &crate::node::OpManager,
-    budget: &mut usize,
-    contract: &ContractKey,
-    acted: bool,
-) {
-    if *budget == 0 {
-        return;
-    }
-    let Some(inputs) = op_manager.build_reconcile_inputs(contract) else {
-        // Distance-blind snapshot (own-location unknown): unmeasurable this tick,
-        // don't pollute the signal. Not counted against the budget.
-        return;
-    };
-    *budget -= 1;
-    let reconcile_actions = reconcile::reconcile(&inputs);
-    let actual = renewal_shadow_actual(acted, inputs.is_subscribed);
-    let divergence = reconcile::action_set_divergence(&reconcile_actions, actual);
-    crate::node::network_status::record_reconcile_shadow_comparison(
-        crate::node::network_status::ReconcileShadowSite::Renewal,
-        divergence,
-    );
-    if divergence.any() {
-        tracing::debug!(
-            %contract,
-            ?reconcile_actions,
-            ?actual,
-            "reconcile shadow diverges from actual renewal outcome (#4642 keystone step-2)"
-        );
-    }
-}
+// NOTE (#4642 keystone sub-task 3, "the flip"): the RENEWAL-site shadow helpers
+// (`renewal_shadow_actual` + `record_renewal_shadow`) were REMOVED when the
+// renewal site was flipped from record-only shadow to actually DRIVING the
+// controller's decision. The drive lives in `OpManager::reconcile_wants_renewal`
+// (built from a fresh at-emission snapshot) and is consulted inline in the
+// renewal loop; the RENEWAL reconcile counter now measures the flip's
+// interest-gate suppression rate rather than a shadow divergence.
 
 /// Race an `.await` point in a background loop against the Ring shutdown
 /// token. Returns `true` if shutdown fired (the caller should stop its loop)
@@ -2312,22 +2259,17 @@ impl Ring {
             let mut attempted = 0;
             let mut skipped = 0;
 
-            // Reconcile-controller SHADOW comparison budget (keystone step-2,
-            // #4642), RENEWAL site. The shadow compare is INLINED into this loop
-            // (below) so the recorded "actual" equals what production actually did
-            // THIS TICK — `{}` for a skipped/deferred contract, else the fresh
-            // SUBSCRIBE the loop spawns (mapped to `Renew` vs `Subscribe` by
-            // whether we hold a lease; see `renewal_shadow_actual`). It DRIVES
-            // NOTHING. Gated by the same `batch_limit` as the real renewal work:
-            // each sample builds a `ReconcileInputs` snapshot (a synchronous redb
-            // state-store read + an `is_subscription_root` scan that clones the
-            // connections map, i.e. redb read + O(neighbors) per sample), so
-            // bounding the sample count keeps the per-tick cost from scaling with
-            // the whole renewal set on near-key gateways. The shuffle above
-            // rotates which contracts get sampled across ticks; contracts past the
-            // budget or past a `break` gate are simply unmeasured this tick.
-            let mut shadow_budget = batch_limit;
-
+            // Reconcile-controller FLIP (keystone sub-task 3, #4642), RENEWAL
+            // site. The controller no longer records a shadow divergence here — it
+            // DRIVES: for each candidate the loop calls
+            // `OpManager::reconcile_wants_renewal`, which builds a FRESH
+            // `ReconcileInputs` snapshot AT EMISSION time and renews only while the
+            // controller wants the contract's place in the mesh maintained. The
+            // drive runs only for contracts that reach the pending-mark gate below
+            // (past the ban + backoff `continue`s and the `attempted >=
+            // batch_limit` break), so its per-tick cost — a redb state-store read +
+            // an `is_subscription_root` neighbor scan per snapshot — stays bounded
+            // by `batch_limit`, as the old shadow sample budget did.
             for contract in contracts_needing_renewal {
                 // Limit concurrent renewal attempts to avoid overwhelming the network
                 if attempted >= batch_limit {
@@ -2366,29 +2308,57 @@ impl Ring {
                         phase = "subscription_renewal_banned_skip",
                         "skipping subscription renewal for banned contract"
                     );
-                    // Shadow: production does NOTHING for a banned contract this
-                    // tick → actual is `{}`.
-                    record_renewal_shadow(&op_manager, &mut shadow_budget, &contract, false);
                     skipped += 1;
                     continue;
                 }
 
                 // Check spam prevention (respects exponential backoff and pending checks)
                 if !ring.can_request_subscription(&contract) {
-                    // Shadow: backoff/pending gate → production does NOTHING this
-                    // tick → actual is `{}`.
-                    record_renewal_shadow(&op_manager, &mut shadow_budget, &contract, false);
                     skipped += 1;
                     continue;
                 }
 
+                // FLIP (#4642 keystone): interest-gated renewal DRIVEN by the
+                // reconcile controller's interest gate (design §5a
+                // `contract_in_use`). Build a FRESH snapshot at emission time and
+                // renew iff a local client OR a STRICTLY-farther downstream
+                // subscriber (piece D) depends on this peer hosting. When it goes
+                // false — no longer in use under the strict gate — SKIP: the lease
+                // lapses and the chain collapses inward (non-renewal is the collapse
+                // primitive; the #3763 storm fix). The gate narrows the
+                // ANY-downstream candidate set that `contracts_needing_renewal`
+                // built to the strict gate; the suppression is recorded on the
+                // RENEWAL reconcile counter (post-flip that counter measures the
+                // flip's effect — the "renewal tracks active demand, not cache size"
+                // ship-gate falsifier — not a shadow divergence).
+                if !op_manager.reconcile_wants_renewal(&contract) {
+                    tracing::debug!(
+                        %contract,
+                        "renewal skipped: reconcile interest gate says not in use \
+                         (strict-farther gate) — letting the lease lapse so the \
+                         chain collapses inward"
+                    );
+                    crate::node::network_status::record_reconcile_shadow_comparison(
+                        crate::node::network_status::ReconcileShadowSite::Renewal,
+                        crate::ring::reconcile::ReconcileActionDivergence {
+                            renew: true,
+                            ..Default::default()
+                        },
+                    );
+                    skipped += 1;
+                    continue;
+                }
+                // Renewal proceeds: record a non-divergent renewal-gate evaluation
+                // so the counter's denominator (`comparisons`) tracks total gate
+                // decisions and the suppression ratio stays legible.
+                crate::node::network_status::record_reconcile_shadow_comparison(
+                    crate::node::network_status::ReconcileShadowSite::Renewal,
+                    crate::ring::reconcile::ReconcileActionDivergence::default(),
+                );
+
                 // Mark as pending and spawn subscription request
                 if ring.mark_subscription_pending(contract) {
                     attempted += 1;
-                    // Shadow: production spawns a fresh SUBSCRIBE
-                    // (`run_renewal_subscribe`) for this contract this tick →
-                    // actual is `{Renew}` if we hold a lease, else `{Subscribe}`.
-                    record_renewal_shadow(&op_manager, &mut shadow_budget, &contract, true);
 
                     // Spread tasks across the interval to avoid thundering-herd bursts.
                     let jitter_ms = GlobalRng::random_range(0u64..=15_000);
@@ -2507,12 +2477,11 @@ impl Ring {
                             }),
                         );
                     });
-                } else {
-                    // `mark_subscription_pending` returned false: a renewal for
-                    // this contract is already in flight, so production does
-                    // NOTHING more this tick → shadow actual is `{}`.
-                    record_renewal_shadow(&op_manager, &mut shadow_budget, &contract, false);
                 }
+                // `mark_subscription_pending` returning false (a renewal for this
+                // contract is already in flight) needs no separate handling: the
+                // controller drive + counter above already ran for this contract
+                // this tick, and the in-flight guard is the per-contract dedup.
             }
 
             if attempted > 0 || skipped > 0 {
@@ -6285,64 +6254,49 @@ mod k_closest_source_tests {
         );
     }
 
-    /// Source-scrape pin (keystone step-2, #4642): the RENEWAL-site reconcile
-    /// shadow (`record_renewal_shadow`) must feed the controller's output ONLY
-    /// into the set-membership divergence comparator + the per-site counter — it
-    /// must DRIVE NOTHING. Symmetric to the collapse-site pin
-    /// (`send_unsubscribe_upstream_still_drives_and_shadow_is_record_only`). A
-    /// future edit that consumes the renewal-site controller output as a control
-    /// signal must trip this guard.
+    /// Source-scrape pin (keystone sub-task 3 "the flip", #4642): the RENEWAL
+    /// site is FLIPPED — it no longer records a shadow, it DRIVES. The renewal
+    /// loop must gate its real renewal spawn on the reconcile controller via
+    /// `OpManager::reconcile_wants_renewal`, and the record-only shadow helper
+    /// (`record_renewal_shadow`) must be gone. A regression that re-introduces the
+    /// record-only helper, or drops the drive gate, trips this guard.
     #[test]
-    fn renewal_shadow_is_record_only_not_drive() {
+    fn renewal_site_is_driven_not_shadowed() {
         let src = production_source();
-        let body = extract_fn_body(src, "fn record_renewal_shadow(");
+        // The record-only renewal shadow helper is removed by the flip.
         assert!(
-            body.contains("action_set_divergence"),
-            "record_renewal_shadow must compare via action_set_divergence"
+            !src.contains("fn record_renewal_shadow("),
+            "record_renewal_shadow must be REMOVED — the renewal site now drives, \
+             it does not record a shadow"
         );
         assert!(
-            body.contains("record_reconcile_shadow_comparison"),
-            "record_renewal_shadow must record the per-site divergence"
+            !src.contains("fn renewal_shadow_actual("),
+            "renewal_shadow_actual must be REMOVED — the renewal site now drives"
         );
-        // Record-only: the shadow helper must NOT drive any renewal/subscription
-        // action off the controller's output.
-        for driver in [
-            "mark_subscription_pending",
-            "run_renewal_subscribe",
-            "ring.subscribe",
-            ".unsubscribe(",
-        ] {
-            assert!(
-                !body.contains(driver),
-                "record_renewal_shadow must not drive `{driver}` — the renewal shadow is record-only"
-            );
-        }
-        // The real renewal loop still drives the actual renewal (unchanged) and
-        // wires the record-only shadow helper.
+        // The renewal loop drives the controller's interest gate before spawning.
         let loop_body = extract_fn_body(src, "async fn recover_orphaned_subscriptions(");
+        assert!(
+            loop_body.contains("reconcile_wants_renewal"),
+            "the renewal loop must gate its spawn on the reconcile controller \
+             (OpManager::reconcile_wants_renewal) — the flip"
+        );
         assert!(
             loop_body.contains("mark_subscription_pending"),
             "the renewal loop still drives the real renewal via mark_subscription_pending"
         );
+        // The gate must be consulted BEFORE the pending-mark/spawn (interest-gated
+        // renewal), not after the work is already scheduled.
+        let gate = loop_body
+            .find("reconcile_wants_renewal")
+            .expect("gate present");
+        let spawn = loop_body
+            .find("mark_subscription_pending(contract)")
+            .expect("spawn present");
         assert!(
-            loop_body.contains("record_renewal_shadow"),
-            "the renewal loop wires the record-only shadow helper"
+            gate < spawn,
+            "the reconcile interest gate must run BEFORE mark_subscription_pending \
+             so a torn-down contract is never renewed"
         );
-    }
-
-    /// Unit (keystone step-2, #4642): `renewal_shadow_actual` maps the renewal
-    /// loop's per-tick outcome to the Action set the controller is compared
-    /// against. A not-acted (skipped/deferred) contract maps to `{}`; an acted
-    /// contract maps to `Renew` iff we already hold the lease, else `Subscribe` —
-    /// so a section-2/3 not-subscribed entry never records a phantom `Renew`.
-    #[test]
-    fn renewal_shadow_actual_maps_by_lease() {
-        use super::reconcile::Action::{Renew, Subscribe};
-        let empty: &[super::reconcile::Action] = &[];
-        assert_eq!(super::renewal_shadow_actual(false, true), empty);
-        assert_eq!(super::renewal_shadow_actual(false, false), empty);
-        assert_eq!(super::renewal_shadow_actual(true, true), &[Renew]);
-        assert_eq!(super::renewal_shadow_actual(true, false), &[Subscribe]);
     }
 
     /// Hardening pin (keystone step-2 completion, #4642): the

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -2181,8 +2181,16 @@ impl Ring {
                                 .remove_downstream_subscriber(contract);
                         }
 
-                        // Send Unsubscribe upstream if no remaining interest
-                        if ring.should_unsubscribe_upstream(contract) {
+                        // Send Unsubscribe upstream if no remaining interest.
+                        // FLIP (keystone P6, #4642): the collapse decision is driven
+                        // by the reconcile controller's strict-farther interest gate
+                        // (`reconcile_wants_collapse` = `!contract_in_use`), replacing
+                        // the legacy ANY-downstream `should_unsubscribe_upstream`. The
+                        // teardown still targets the STORED upstream (narrow flip).
+                        if op_manager.reconcile_wants_collapse(
+                            contract,
+                            crate::node::network_status::ReconcileShadowSite::Collapse,
+                        ) {
                             let op_mgr = op_manager.clone();
                             let contract = *contract;
                             GlobalExecutor::spawn(async move {

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -2266,18 +2266,34 @@ impl Ring {
 
             let mut attempted = 0;
             let mut skipped = 0;
+            // Per-tick budget on the number of interest-gate EVALUATIONS
+            // (`OpManager::reconcile_wants_renewal`) we run. Each evaluation builds
+            // a FRESH `ReconcileInputs` snapshot: a synchronous redb
+            // `get_state_size` read plus an `is_subscription_root` neighbor-map
+            // scan. The `attempted >= batch_limit` break below counts only SPAWNED
+            // renewals; a gate-SUPPRESSED candidate does `continue` WITHOUT
+            // advancing `attempted`, so on a high-hosting peer (every peer, now
+            // that every-hop placement is live) a single ~30s tick could otherwise
+            // build hundreds-to-thousands of these snapshots when the gate
+            // suppresses most candidates. Counting every gate evaluation against
+            // this budget restores the pre-flip `shadow_budget` bound: at most
+            // `batch_limit` snapshots per tick regardless of how many are
+            // suppressed. (Codex P2, #4725.)
+            let mut evaluated = 0;
 
             // Reconcile-controller FLIP (keystone sub-task 3, #4642), RENEWAL
-            // site. The controller no longer records a shadow divergence here — it
+            // site. The controller no longer records a shadow divergence here; it
             // DRIVES: for each candidate the loop calls
             // `OpManager::reconcile_wants_renewal`, which builds a FRESH
             // `ReconcileInputs` snapshot AT EMISSION time and renews only while the
-            // controller wants the contract's place in the mesh maintained. The
-            // drive runs only for contracts that reach the pending-mark gate below
-            // (past the ban + backoff `continue`s and the `attempted >=
-            // batch_limit` break), so its per-tick cost — a redb state-store read +
-            // an `is_subscription_root` neighbor scan per snapshot — stays bounded
-            // by `batch_limit`, as the old shadow sample budget did.
+            // controller wants the contract's place in the mesh maintained. Each
+            // snapshot is a redb state-store read plus an `is_subscription_root`
+            // neighbor scan, so the per-tick cost is bounded by the `evaluated`
+            // budget below (at most `batch_limit` gate evaluations per tick),
+            // mirroring the old shadow sample budget. The `attempted >=
+            // batch_limit` break bounds only the SPAWNED renewals and must NOT be
+            // relied on to bound the evaluations, because a gate-suppressed
+            // candidate does not advance `attempted`.
             for contract in contracts_needing_renewal {
                 // Limit concurrent renewal attempts to avoid overwhelming the network
                 if attempted >= batch_limit {
@@ -2325,6 +2341,27 @@ impl Ring {
                     skipped += 1;
                     continue;
                 }
+
+                // Per-tick evaluation budget (Codex P2, #4725): stop building
+                // expensive `ReconcileInputs` snapshots once we've run
+                // `batch_limit` interest-gate evaluations this tick, whether they
+                // led to a spawn or a suppression. This is the bound that keeps a
+                // high-hosting peer from building hundreds-to-thousands of
+                // snapshots per tick when the gate suppresses most candidates (the
+                // `attempted >= batch_limit` break above does NOT cover this,
+                // because a suppressed candidate never advances `attempted`).
+                // Remaining candidates are retried next cycle.
+                if evaluated >= batch_limit {
+                    tracing::debug!(
+                        limit = batch_limit,
+                        attempted,
+                        skipped,
+                        "Reached max renewal-gate evaluations for this interval, \
+                         remaining will be tried next cycle"
+                    );
+                    break;
+                }
+                evaluated += 1;
 
                 // FLIP (#4642 keystone): interest-gated renewal DRIVEN by the
                 // reconcile controller's interest gate (design §5a
@@ -6313,6 +6350,149 @@ mod k_closest_source_tests {
             gate < spawn,
             "the reconcile interest gate must run BEFORE mark_subscription_pending \
              so a torn-down contract is never renewed"
+        );
+    }
+
+    /// Regression pin for the per-tick renewal-gate EVALUATION budget (Codex P2,
+    /// #4725). The interest gate `OpManager::reconcile_wants_renewal` builds a
+    /// fresh `ReconcileInputs` snapshot (a redb `get_state_size` read + an
+    /// `is_subscription_root` neighbor scan) on EVERY call. The pre-fix loop
+    /// bounded only SPAWNED renewals via `attempted >= batch_limit`, but a
+    /// gate-suppressed candidate `continue`s WITHOUT advancing `attempted`, so on
+    /// a high-hosting peer (every peer, now that every-hop placement is live) one
+    /// ~30s maintenance tick could evaluate the gate for the whole renewal set —
+    /// hundreds-to-thousands of snapshots instead of the intended ~`batch_limit`.
+    /// This pins that a DISTINCT evaluation budget (`evaluated`) breaks the loop
+    /// BEFORE the expensive gate runs, and is advanced on every gate evaluation
+    /// (not only on spawn, which is what `attempted` counts). A refactor that
+    /// drops the budget or reverts to an `attempted`-only bound fails CI here.
+    #[test]
+    fn renewal_gate_evaluations_bounded_before_gate() {
+        let src = production_source();
+        let body = extract_fn_body(src, "async fn recover_orphaned_subscriptions(");
+
+        let budget_break = body.find("if evaluated >= batch_limit").expect(
+            "the renewal loop must bound the number of interest-gate evaluations \
+             per tick with `if evaluated >= batch_limit { break }` (Codex P2, \
+             #4725) — otherwise a gate-suppressed candidate never advances \
+             `attempted` and the loop builds an unbounded number of \
+             ReconcileInputs snapshots per tick",
+        );
+        let gate = body
+            .find("reconcile_wants_renewal(&contract)")
+            .expect("renewal loop must consult the reconcile interest gate");
+        assert!(
+            budget_break < gate,
+            "the evaluation-budget break (offset {budget_break}) must run BEFORE \
+             the expensive reconcile_wants_renewal gate (offset {gate}) so the \
+             per-snapshot cost is bounded by batch_limit"
+        );
+
+        // The budget must advance on every gate evaluation (between the break and
+        // the gate), which is what distinguishes it from the `attempted` spawn cap.
+        let increment = body.find("evaluated += 1").expect(
+            "the evaluation budget `evaluated` must be incremented per gate \
+             evaluation, not only when a renewal is spawned",
+        );
+        assert!(
+            budget_break < increment && increment < gate,
+            "`evaluated += 1` (offset {increment}) must sit between the budget \
+             break (offset {budget_break}) and the gate (offset {gate}) so every \
+             gate evaluation is counted toward the per-tick bound"
+        );
+    }
+
+    /// Behavioral regression for the per-tick evaluation budget (Codex P2,
+    /// #4725). Models the renewal loop's exact two-counter structure and asserts
+    /// the number of expensive interest-gate evaluations stays bounded by
+    /// `batch_limit` regardless of how many candidates the gate suppresses. The
+    /// pre-fix `attempted`-only bound (encoded in `simulate_attempted_only`)
+    /// evaluated the WHOLE candidate set when the gate suppressed everything —
+    /// this is the unbounded-per-heartbeat-read cost the fix removes.
+    #[test]
+    fn renewal_gate_evaluation_count_is_bounded_when_suppressed() {
+        // Faithful model of the loop's per-tick counting: `attempted` is the
+        // spawn cap (advanced only on a spawn) and `evaluated` is the evaluation
+        // budget (advanced on every gate call). Returns (evaluations, spawns).
+        fn simulate(
+            candidates: usize,
+            batch_limit: usize,
+            gate: impl Fn(usize) -> bool,
+        ) -> (usize, usize) {
+            let mut attempted = 0usize;
+            let mut evaluated = 0usize;
+            for i in 0..candidates {
+                if attempted >= batch_limit {
+                    break; // spawn cap
+                }
+                if evaluated >= batch_limit {
+                    break; // evaluation budget (the fix)
+                }
+                evaluated += 1;
+                if !gate(i) {
+                    continue; // suppressed: does NOT advance `attempted`
+                }
+                attempted += 1;
+            }
+            (evaluated, attempted)
+        }
+
+        // The pre-fix model: only the `attempted` spawn cap bounds the loop.
+        fn simulate_attempted_only(
+            candidates: usize,
+            batch_limit: usize,
+            gate: impl Fn(usize) -> bool,
+        ) -> usize {
+            let mut attempted = 0usize;
+            let mut evaluated = 0usize;
+            for i in 0..candidates {
+                if attempted >= batch_limit {
+                    break;
+                }
+                evaluated += 1;
+                if !gate(i) {
+                    continue;
+                }
+                attempted += 1;
+            }
+            evaluated
+        }
+
+        let batch_limit = 10usize;
+        let many = 5_000usize;
+
+        // Pathological case: the gate suppresses every candidate. Evaluations
+        // must still be capped at `batch_limit`, and nothing spawns.
+        let (evaluated, attempted) = simulate(many, batch_limit, |_| false);
+        assert!(
+            evaluated <= batch_limit,
+            "gate evaluations ({evaluated}) must be bounded by batch_limit \
+             ({batch_limit}) even when every candidate is suppressed"
+        );
+        assert_eq!(
+            attempted, 0,
+            "no renewals spawn when every candidate is suppressed"
+        );
+
+        // Demonstrates the bug the budget fixes: the old attempted-only bound
+        // evaluated the WHOLE set when the gate suppressed everything.
+        let unbounded = simulate_attempted_only(many, batch_limit, |_| false);
+        assert_eq!(
+            unbounded, many,
+            "sanity: without the evaluation budget an all-suppressing gate builds \
+             a snapshot for every candidate — the unbounded cost the fix removes"
+        );
+
+        // Happy path: the gate wants every candidate. The evaluation budget must
+        // NOT reduce throughput below the spawn cap.
+        let (evaluated, attempted) = simulate(many, batch_limit, |_| true);
+        assert_eq!(
+            attempted, batch_limit,
+            "the spawn cap is still reached in the happy path"
+        );
+        assert!(
+            evaluated <= batch_limit,
+            "evaluations never exceed batch_limit"
         );
     }
 

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -1748,6 +1748,20 @@ impl HostingManager {
         self.hosting_cache.read().has_local_client_access(key)
     }
 
+    /// Whether a local client GET or PUT touched this contract within the renewal
+    /// age gate (`SUBSCRIPTION_LEASE_DURATION`) — real, time-bounded local demand
+    /// that is NOT a subscription. This is the exact signal
+    /// `contracts_needing_renewal()` branch 3 uses to keep a read-only / PUT-only
+    /// contract (River UI container, web/UI containers) renewed in the update mesh
+    /// (`hosting-invariants.md` invariant 3: reads/PUTs are permanent demand). The
+    /// reconcile input-builder ORs it into `contract_in_use` so the P6 renewal /
+    /// collapse gate does not drop such a contract's lease.
+    pub fn has_recent_local_client_access(&self, key: &ContractKey) -> bool {
+        self.hosting_cache
+            .read()
+            .has_recent_local_client_access(key, SUBSCRIPTION_LEASE_DURATION)
+    }
+
     /// Touch a contract in the hosting cache (refresh demand without adding).
     ///
     /// Called when a user GET serves a hosted contract from local cache — the

--- a/crates/core/src/ring/hosting/reconcile.rs
+++ b/crates/core/src/ring/hosting/reconcile.rs
@@ -18,35 +18,45 @@
 //! the desired action set from current inputs, so a missed event is caught by the
 //! next tick and the whole stale-flag bug class disappears.
 //!
-//! # The flip: RENEWAL is driven; the other sites are still SHADOW
+//! # The flip: RENEWAL and COLLAPSE are driven; the other sites are still SHADOW
 //!
 //! Sub-task 1 landed the pure core + types + unit tests. Sub-task 2 wired it in
-//! **shadow mode** at the highest-signal on-`main` hosting decision sites.
-//! Sub-task 3 (the FLIP) makes the controller actually DRIVE, starting with the
-//! lowest-risk site — RENEWAL. The renewal loop
-//! (`Ring::recover_orphaned_subscriptions`) now gates its per-contract renewal
-//! spawn on `OpManager::reconcile_wants_renewal`, which builds a FRESH
-//! [`ReconcileInputs`] snapshot at emission time and applies the controller's
-//! interest gate [`wants_renewal`] = design §5a `contract_in_use` (renew iff a
-//! local client OR a STRICTLY-farther downstream depends on this peer). When it
-//! goes false (interest-gated collapse under the STRICT-farther gate) the loop
-//! skips the spawn and the lease lapses — non-renewal IS the collapse primitive
-//! (design §5a), so this single flip enacts interest-gated collapse without yet
-//! driving the destructive `Unsubscribe` wire action.
+//! **shadow mode** at the highest-signal on-`main` hosting decision sites. The
+//! FLIP (P6) makes the controller actually DRIVE. It lands as the **NARROW flip**:
+//! the two interest-gated maintenance decisions — RENEWAL and COLLAPSE — flip from
+//! shadow to driving, while the upstream IDENTITY stays on the stored flag.
 //!
-//! The remaining sites are **still in shadow mode** (record-only, drive nothing):
-//! the interest-gated COLLAPSE (`OpManager::send_unsubscribe_upstream`), the
-//! inbound-unsubscribe collapse, the connection-drop re-root, and the
-//! host-formation announce (subscribe + GET). Each builds a [`ReconcileInputs`]
-//! snapshot, computes what [`reconcile`] WOULD do, and records the divergence via
-//! [`action_set_divergence`] → `node::network_status::ReconcileShadowStats`.
-//! Their flips are entangled with piece-D machinery not yet present (the
-//! `actively_acquiring` source for host-formation announce; compute-upstream-
-//! everywhere / retiring the stored `is_upstream` flag for the `Unsubscribe`
-//! target) — see the sub-task-3 hand-off notes. Because those drivers and the
-//! `Retract`/`ReRootSearch` hooks are still unwired, some surface here is
-//! exercised only by the shadow compare and tests, so `#[allow(dead_code)]`
-//! stays.
+//! - **Renewal (driven).** The renewal loop (`Ring::recover_orphaned_subscriptions`)
+//!   gates its per-contract renewal spawn on `OpManager::reconcile_wants_renewal`,
+//!   which builds a FRESH [`ReconcileInputs`] snapshot at emission time and applies
+//!   the interest gate [`wants_renewal`] = design §5a `contract_in_use` (renew iff
+//!   a local client OR a STRICTLY-farther downstream depends on this peer). When it
+//!   goes false the loop skips the spawn and the lease lapses — non-renewal IS the
+//!   collapse primitive (§5a).
+//! - **Collapse (driven).** The three collapse-decision sites — the maintenance
+//!   loop's downstream-expiry teardown, the client-disconnect teardown, and the
+//!   inbound-unsubscribe teardown — gate the active `send_unsubscribe_upstream` on
+//!   `OpManager::reconcile_wants_collapse` = [`wants_collapse`] = `!contract_in_use`
+//!   (the exact inverse of the renewal gate; §6 "stops both together"), replacing
+//!   the legacy ANY-downstream `Ring::should_unsubscribe_upstream` predicate. The
+//!   destructive `Unsubscribe` wire action is driven toward the **stored**
+//!   `is_upstream` upstream, unchanged — the narrow flip **keeps the stored flag**.
+//!
+//! What the narrow flip deliberately does NOT do (deferred, and WHY): it does not
+//! **compute-upstream-everywhere / retire the stored `is_upstream` flag**. The
+//! computed upstream (#4671) diverges from the stored flag materially, so the
+//! `Unsubscribe` TARGET stays the stored one and that divergence stays under the
+//! SHADOW telemetry (`record_upstream_divergence_comparison`), still running so it
+//! can be re-measured before a future full flip. The remaining sites also stay in
+//! **shadow mode** (record-only, drive nothing): the connection-drop re-root
+//! (`ReRootSearch`) and the host-formation announce (`Announce`, needs the
+//! `actively_acquiring` source). The `Retract` action likewise stays deferred — it
+//! is wired live on EVICTION (#4722) but NOT yet driven from collapse/renewal
+//! teardown. Each shadow site builds a [`ReconcileInputs`] snapshot, computes what
+//! [`reconcile`] WOULD do, and records the divergence via [`action_set_divergence`]
+//! → `node::network_status::ReconcileShadowStats`. Because those drivers and the
+//! `Retract`/`ReRootSearch` hooks are still unwired, some surface here is exercised
+//! only by the shadow compare and tests, so `#[allow(dead_code)]` stays.
 //!
 //! Hosting is BINARY throughout: [`ReconcileInputs::state_present`] means this
 //! peer holds the FULL contract (code + params + state), never a partial tier.
@@ -71,18 +81,21 @@
 //!
 //! Read the counters as the reconcile-vs-today delta, never as a health alarm.
 //!
-//! # Notes for the shadow-compare wiring (next sub-task)
+//! # Action semantics + remaining-shadow-site notes
 //!
 //! - **`Collapse` is the LOCAL teardown** (drop our lease, `ring.unsubscribe`);
-//!   **`Unsubscribe` is the WIRE message** to the computed upstream; **`Retract`
-//!   withdraws the hosting advertisement** (on-`main` primitive
+//!   **`Unsubscribe` is the WIRE message** to the upstream; **`Retract` withdraws
+//!   the hosting advertisement** (on-`main` primitive
 //!   `neighbor_hosting.on_contract_unhosted`, now wired live on EVICTION inside
 //!   `RuntimePool::remove_contract` / #4722; the controller `Retract` flip that
-//!   would ALSO drive it from teardown is still a later step). The current code's
-//!   `send_unsubscribe_upstream` does the first two together ("send Unsubscribe +
-//!   `ring.unsubscribe`") in one call, so the shadow-compare must map it onto the
-//!   `{Collapse, Unsubscribe}` PAIR by SET membership, not exact-`Vec` equality.
-//!   `Retract` is INDEPENDENT of the lease: it can be emitted on its own (an
+//!   would ALSO drive it from teardown is still a later step). `send_unsubscribe_upstream`
+//!   does the first two together ("send Unsubscribe + `ring.unsubscribe`") in one
+//!   call. As of the P6 flip its collapse DECISION is DRIVEN (`reconcile_wants_collapse`
+//!   at the callers), but the `Unsubscribe` TARGET stays the **stored** `is_upstream`
+//!   upstream, not the abstract action's "computed upstream" — the narrow flip keeps
+//!   the stored flag, so the driver resolves the wire target itself while the
+//!   computed-vs-stored divergence stays under separate shadow telemetry. `Retract`
+//!   is INDEPENDENT of the lease: it can be emitted on its own (an
 //!   advertised-but-not-subscribed host that loses demand → `[Retract]`, no
 //!   `Collapse`/`Unsubscribe`), and maps to `on_contract_unhosted`.
 //! - **`ReRootSearch` covers BOTH** "upstream lost" (we were a host and the
@@ -521,6 +534,35 @@ pub(crate) fn wants_renewal(inputs: &ReconcileInputs) -> bool {
     contract_in_use(inputs)
 }
 
+/// The FLIP's COLLAPSE gate (keystone P6, #4642; design doc §5a / §6): the exact
+/// INVERSE of [`wants_renewal`]. "A peer keeps hosting exactly as long as it keeps
+/// renewing, and stops both together" (§6) — so an active collapse fires precisely
+/// when the interest gate goes false: no local client AND no STRICTLY-farther
+/// downstream subscriber. This is the same [`contract_in_use`] predicate the
+/// [`reconcile`] teardown branch already keys `Collapse` off, surfaced as a
+/// standalone gate for the driver.
+///
+/// Consumed by `OpManager::reconcile_wants_collapse`, which supplies the fresh
+/// snapshot and — because the NARROW flip **keeps the stored `is_upstream` flag**
+/// (it does NOT compute-upstream-everywhere) — drives the teardown toward the
+/// STORED upstream via the unchanged `send_unsubscribe_upstream` path. The
+/// computed-vs-stored upstream IDENTITY divergence (#4671) stays under the SHADOW
+/// telemetry (`record_upstream_divergence_comparison`), unflipped, so it can be
+/// re-measured before a future full compute-upstream flip.
+///
+/// Like [`wants_renewal`], it gates on DEMAND, never on lease/upstream/root state:
+/// the teardown mechanics below it are self-no-op'ing (`ring.unsubscribe` is a
+/// no-op without a lease; the wire `Unsubscribe` only fires when the stored flag
+/// resolves an upstream), so this gate does not re-derive them. It is only the
+/// DESTRUCTIVE half; the two gates are inverse but NOT a partition of all inputs —
+/// the benign, self-healing actions (`Renew`/`Subscribe`/`ReRootSearch`/`Announce`)
+/// belong to the maintained-hosting branch and stay out of scope for this gate.
+///
+/// Pure (no side effects): the DRIVING lives at the call site.
+pub(crate) fn wants_collapse(inputs: &ReconcileInputs) -> bool {
+    !contract_in_use(inputs)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -858,6 +900,84 @@ mod tests {
         // Cache-only copy (state present, advertised, but no client and no
         // strictly-farther downstream) → no renew (the #3763 storm signature).
         assert!(!wants_renewal(&ReconcileInputs {
+            is_advertised: true,
+            ..base()
+        }));
+    }
+
+    /// The FLIP's COLLAPSE gate (`wants_collapse`, keystone P6, #4642) is the EXACT
+    /// INVERSE of the renewal gate over every input snapshot: "a peer keeps hosting
+    /// exactly as long as it keeps renewing, and stops both together" (design §6).
+    /// Pins that duality directly, plus the load-bearing STRICT-farther collapse
+    /// (a lingering non-farther / mutual-co-host subscriber does NOT keep a chain
+    /// alive) and the demand-holds-open cases (a client, or a strictly-farther
+    /// downstream, blocks collapse).
+    #[test]
+    fn wants_collapse_is_exact_inverse_of_renewal() {
+        // `wants_collapse == !wants_renewal` for a representative spread of inputs.
+        let snapshots = [
+            // steady-state in-use host → renew, not collapse.
+            ReconcileInputs {
+                computed_upstream: upstream(),
+                has_local_client: true,
+                is_subscribed: true,
+                is_advertised: true,
+                ..base()
+            },
+            // in-use via a strictly-farther downstream → renew, not collapse.
+            ReconcileInputs {
+                has_farther_downstream_subscriber: true,
+                is_subscribed: true,
+                ..base()
+            },
+            // in-use verified root → renew, not collapse.
+            ReconcileInputs {
+                has_local_client: true,
+                is_verified_root: true,
+                ..base()
+            },
+            // NOT in use (strict gate), subscribed, has upstream → collapse.
+            ReconcileInputs {
+                computed_upstream: upstream(),
+                is_subscribed: true,
+                ..base()
+            },
+            // Truly idle → collapse (nothing to keep).
+            ReconcileInputs { ..base() },
+            // Cache-only advertised copy, no demand → collapse (the #3763 storm
+            // signature: a demand-blind copy must not perpetuate itself).
+            ReconcileInputs {
+                is_advertised: true,
+                ..base()
+            },
+        ];
+        for s in &snapshots {
+            assert_eq!(
+                wants_collapse(s),
+                !wants_renewal(s),
+                "collapse gate must be the exact inverse of the renewal gate: {s:?}"
+            );
+        }
+
+        // A local client holds the chain open (no collapse).
+        assert!(!wants_collapse(&ReconcileInputs {
+            has_local_client: true,
+            is_subscribed: true,
+            ..base()
+        }));
+        // A STRICTLY-farther downstream holds the chain open (no collapse).
+        assert!(!wants_collapse(&ReconcileInputs {
+            has_farther_downstream_subscriber: true,
+            is_subscribed: true,
+            ..base()
+        }));
+        // No local client and no strictly-farther downstream → collapse, EVEN
+        // when subscribed with a live upstream (the interest-gated teardown the
+        // strict gate enacts; a non-farther / mutual co-host subscriber is
+        // already excluded upstream by `has_farther_downstream_subscriber`).
+        assert!(wants_collapse(&ReconcileInputs {
+            computed_upstream: upstream(),
+            is_subscribed: true,
             is_advertised: true,
             ..base()
         }));

--- a/crates/core/src/ring/hosting/reconcile.rs
+++ b/crates/core/src/ring/hosting/reconcile.rs
@@ -18,24 +18,35 @@
 //! the desired action set from current inputs, so a missed event is caught by the
 //! next tick and the whole stale-flag bug class disappears.
 //!
-//! # Wired in SHADOW mode (drives nothing)
+//! # The flip: RENEWAL is driven; the other sites are still SHADOW
 //!
-//! Sub-task 1 landed the pure core + types + unit tests. Sub-task 2 (this
-//! change) wires it in **shadow mode** at the highest-signal on-`main` hosting
-//! decision sites: the interest-gated COLLAPSE (`OpManager::send_unsubscribe_
-//! upstream`) and the RENEWAL set (`Ring::contracts_needing_renewal`, driven by
-//! the recovery loop). At each site the wiring builds a [`ReconcileInputs`]
-//! snapshot from live node state, computes what [`reconcile`] WOULD do, and
-//! compares it — BY SET MEMBERSHIP — to what the current code actually does,
-//! recording the divergence in aggregate telemetry
-//! ([`action_set_divergence`] → `node::network_status::ReconcileShadowStats`).
-//! **The current scattered code still drives every decision**; nothing consumes
-//! [`reconcile`]'s output as a control signal. The FLIP (controller actually
-//! drives) is a later step, as are the remaining sites (inbound-unsubscribe
-//! collapse, connection-drop re-root, host-formation announce). Because the
-//! driver and those hooks are still unwired, some surface here is exercised only
-//! by the shadow compare and tests, so `#[allow(dead_code)]` stays until the
-//! flip.
+//! Sub-task 1 landed the pure core + types + unit tests. Sub-task 2 wired it in
+//! **shadow mode** at the highest-signal on-`main` hosting decision sites.
+//! Sub-task 3 (the FLIP) makes the controller actually DRIVE, starting with the
+//! lowest-risk site — RENEWAL. The renewal loop
+//! (`Ring::recover_orphaned_subscriptions`) now gates its per-contract renewal
+//! spawn on `OpManager::reconcile_wants_renewal`, which builds a FRESH
+//! [`ReconcileInputs`] snapshot at emission time and applies the controller's
+//! interest gate [`wants_renewal`] = design §5a `contract_in_use` (renew iff a
+//! local client OR a STRICTLY-farther downstream depends on this peer). When it
+//! goes false (interest-gated collapse under the STRICT-farther gate) the loop
+//! skips the spawn and the lease lapses — non-renewal IS the collapse primitive
+//! (design §5a), so this single flip enacts interest-gated collapse without yet
+//! driving the destructive `Unsubscribe` wire action.
+//!
+//! The remaining sites are **still in shadow mode** (record-only, drive nothing):
+//! the interest-gated COLLAPSE (`OpManager::send_unsubscribe_upstream`), the
+//! inbound-unsubscribe collapse, the connection-drop re-root, and the
+//! host-formation announce (subscribe + GET). Each builds a [`ReconcileInputs`]
+//! snapshot, computes what [`reconcile`] WOULD do, and records the divergence via
+//! [`action_set_divergence`] → `node::network_status::ReconcileShadowStats`.
+//! Their flips are entangled with piece-D machinery not yet present (the
+//! `actively_acquiring` source for host-formation announce; compute-upstream-
+//! everywhere / retiring the stored `is_upstream` flag for the `Unsubscribe`
+//! target) — see the sub-task-3 hand-off notes. Because those drivers and the
+//! `Retract`/`ReRootSearch` hooks are still unwired, some surface here is
+//! exercised only by the shadow compare and tests, so `#[allow(dead_code)]`
+//! stays.
 //!
 //! Hosting is BINARY throughout: [`ReconcileInputs::state_present`] means this
 //! peer holds the FULL contract (code + params + state), never a partial tier.
@@ -278,7 +289,7 @@ pub(crate) struct ReconcileInputs {
 /// `Renew`/`Subscribe` and `Subscribe`/`ReRootSearch` are each mutually exclusive
 /// by construction.
 pub(crate) fn reconcile(inputs: &ReconcileInputs) -> Vec<Action> {
-    let contract_in_use = inputs.has_local_client || inputs.has_farther_downstream_subscriber;
+    let contract_in_use = contract_in_use(inputs);
 
     // Interest-gated teardown (not in use) — runs FIRST and independent of
     // `state_present` (teardown needs no body). Tear down WHATEVER exists:
@@ -471,6 +482,43 @@ pub(crate) fn action_set_divergence_focused(
         .filter(|a| relevant.contains(a))
         .collect();
     action_set_divergence(&r, &a)
+}
+
+/// The interest gate (design doc §5a / §6): a peer keeps hosting AND keeps
+/// renewing iff it is `contract_in_use` — it has a **local client** OR a
+/// **STRICTLY-farther** downstream subscriber (piece D: a downstream counts only
+/// when strictly farther from the key, so two mutual co-hosts cannot renew each
+/// other forever). This is the SINGLE predicate that drives both the collapse
+/// rule inside [`reconcile`] (teardown fires iff `!contract_in_use`) and the FLIP's
+/// renewal gate ([`wants_renewal`]) — "a peer keeps hosting exactly as long as it
+/// keeps renewing, and stops both together" (design §6).
+pub(crate) fn contract_in_use(inputs: &ReconcileInputs) -> bool {
+    inputs.has_local_client || inputs.has_farther_downstream_subscriber
+}
+
+/// The FLIP's RENEWAL gate (keystone sub-task 3, #4642; design doc §5a): whether
+/// the renewal loop should spawn a renewal for this contract this tick.
+///
+/// This is exactly the controller's interest gate [`contract_in_use`] — renew
+/// while (and only while) a local client or a strictly-farther downstream
+/// subscriber depends on this peer hosting. When it goes false the renewal loop
+/// skips the spawn, the lease lapses, and the chain collapses inward — non-renewal
+/// IS the collapse primitive (§5a). Consumed by
+/// `OpManager::reconcile_wants_renewal`, which supplies the fresh snapshot.
+///
+/// It is deliberately NOT the reconcile *action set*: an in-use keyward ROOT (a
+/// local client, but no upstream to renew toward) emits `[]`/`[Announce]`, and an
+/// in-use peer still ACQUIRING its first lease can momentarily present as a root
+/// before its upstream advertisement is recorded. Gating on the action set would
+/// wrongly suppress those in-use contracts' renewals and drop their leases (the
+/// `test_subscription_count_tracks_demand_not_cache` seed-`4642d102` degeneracy).
+/// §5a gates on demand, not on lease/upstream state, so a root renews too — its
+/// `run_renewal_subscribe` is a harmless keyward no-op that also re-establishes a
+/// lease that lapsed under churn.
+///
+/// Pure (no side effects): the DRIVING lives at the call site.
+pub(crate) fn wants_renewal(inputs: &ReconcileInputs) -> bool {
+    contract_in_use(inputs)
 }
 
 #[cfg(test)]
@@ -737,6 +785,84 @@ mod tests {
         }
     }
 
+    /// The FLIP's renewal gate (`wants_renewal`) — the design §5a interest gate
+    /// (`contract_in_use`) that the renewal loop now drives (keystone sub-task 3,
+    /// #4642). Renew iff a local client OR a STRICTLY-farther downstream depends on
+    /// this peer; otherwise skip (→ lease lapses → chain collapses inward). It gates
+    /// on DEMAND, never on lease/upstream/root state — so an in-use root still
+    /// renews (regression pin for `test_subscription_count_tracks_demand_not_cache`
+    /// seed 4642d102, where the action-set gate wrongly dropped a demanded root's
+    /// lease).
+    #[test]
+    fn wants_renewal_drives_interest_gate() {
+        // In-use steady-state host (upstream, subscribed, advertised) → renew.
+        assert!(wants_renewal(&ReconcileInputs {
+            computed_upstream: upstream(),
+            has_local_client: true,
+            is_subscribed: true,
+            is_advertised: true,
+            ..base()
+        }));
+
+        // In-use, known upstream, no lease yet → renew (spawn links up).
+        assert!(wants_renewal(&ReconcileInputs {
+            computed_upstream: upstream(),
+            has_local_client: true,
+            ..base()
+        }));
+
+        // In-use, subscribed, upstream vanished, not root → renew (serve-during
+        // re-root via the same renewal driver).
+        assert!(wants_renewal(&ReconcileInputs {
+            has_local_client: true,
+            is_subscribed: true,
+            ..base()
+        }));
+
+        // In-use via a strictly-farther downstream, no upstream, not subscribed,
+        // not root → renew (first formation / re-root routes toward the key).
+        assert!(wants_renewal(&ReconcileInputs {
+            has_farther_downstream_subscriber: true,
+            ..base()
+        }));
+
+        // REGRESSION (seed 4642d102): in-use verified ROOT (a local client, no
+        // upstream, NOT subscribed) → MUST renew. reconcile emits `[]`/`[Announce]`
+        // here, so the old action-set gate wrongly suppressed it and dropped the
+        // demanded lease. §5a gates on demand, not on the action set.
+        assert!(wants_renewal(&ReconcileInputs {
+            has_local_client: true,
+            is_advertised: true,
+            is_verified_root: true,
+            ..base()
+        }));
+        // Same, but NOT advertised and NOT subscribed (fresh in-use root) → renew.
+        assert!(wants_renewal(&ReconcileInputs {
+            has_local_client: true,
+            is_verified_root: true,
+            ..base()
+        }));
+
+        // NOT in use (strict gate: no client, no strictly-farther downstream),
+        // subscribed, has upstream → DO NOT renew: the lease lapses and the chain
+        // collapses inward (§5a). This is the strict-gate collapse.
+        assert!(!wants_renewal(&ReconcileInputs {
+            computed_upstream: upstream(),
+            is_subscribed: true,
+            ..base()
+        }));
+
+        // Truly idle (no demand) → no renew.
+        assert!(!wants_renewal(&ReconcileInputs { ..base() }));
+
+        // Cache-only copy (state present, advertised, but no client and no
+        // strictly-farther downstream) → no renew (the #3763 storm signature).
+        assert!(!wants_renewal(&ReconcileInputs {
+            is_advertised: true,
+            ..base()
+        }));
+    }
+
     /// `action_set_divergence` is the set-membership comparator the shadow
     /// wiring feeds the divergence telemetry. Pin its semantics: order- and
     /// duplicate-insensitive, per-action symmetric difference, `any()` iff the
@@ -863,14 +989,16 @@ mod tests {
         );
     }
 
-    /// Behavior-preserving guard (keystone step-2, #4642): reconcile is a PURE
-    /// decision core wired only in SHADOW mode. No code in this module may apply
-    /// its `Vec<Action>` to the wire/state — the controller drives NOTHING until
-    /// the deliberate FLIP (a later step). This source-scrape pin fails if a
-    /// driver/apply entry point is added here without updating the shadow-vs-drive
-    /// story, keeping the "drives nothing" invariant of this sub-task honest.
+    /// Purity guard (keystone, #4642): `reconcile.rs` is the PURE decision core.
+    /// The FLIP (keystone sub-task 3) drives the controller's decisions, but the
+    /// DRIVERS live at the call sites (`OpManager::reconcile_wants_renewal`, the
+    /// renewal loop, ...), never here — this module must stay side-effect-free and
+    /// lock-free so it remains directly unit-testable and the at-emission re-read
+    /// stays a cleanly separable layer on top. This source-scrape pin fails if a
+    /// driver/apply entry point is ever added to `reconcile.rs` itself, keeping the
+    /// core pure regardless of how many sites are flipped.
     #[test]
-    fn reconcile_controller_has_no_driver_yet() {
+    fn reconcile_core_stays_pure() {
         const SRC: &str = include_str!("reconcile.rs");
         // Scan only the PRODUCTION portion (before the test module) so this
         // test's own forbidden-string literals don't self-match.
@@ -878,8 +1006,8 @@ mod tests {
         for forbidden in ["fn drive", "fn apply_action", "fn apply_actions"] {
             assert!(
                 !prod.contains(forbidden),
-                "reconcile.rs must not define `{forbidden}` in shadow mode — the \
-                 controller records divergence only and drives nothing until the flip"
+                "reconcile.rs must not define `{forbidden}` — the pure decision core \
+                 stays side-effect-free; drivers live at the call sites (the flip)"
             );
         }
     }

--- a/crates/core/src/ring/hosting/reconcile.rs
+++ b/crates/core/src/ring/hosting/reconcile.rs
@@ -125,6 +125,13 @@
 //! selection. See the pin test `distance_partialeq_is_fuzzy_but_cmp_is_exact` and
 //! `ring/location.rs:223-243`.
 
+// NAMING LANDMINE: the `is_upstream` stored flag and the upstream/relay framing in
+// this module are fossils of the hollow-relay era (#3763). Piece D (compute-upstream,
+// #4671) retires the stored flag and makes chain peers real subscribed HOSTS, not
+// relays: routing and hosting co-occur, there is no forward-without-hosting. Do not
+// name new code "relay" or add new stored-upstream flags.
+// See .claude/rules/hosting-invariants.md terminology + epic #4642.
+
 // Wired to production in SHADOW mode by keystone sub-task 2 (compare-only, drives
 // nothing). The driver that would apply a `Vec<Action>`, and the forward-looking
 // hooks (Retract's `on_contract_unhosted`, `actively_acquiring`, the not-yet-wired

--- a/crates/core/src/ring/hosting/reconcile.rs
+++ b/crates/core/src/ring/hosting/reconcile.rs
@@ -238,6 +238,26 @@ pub(crate) struct ReconcileInputs {
     /// silently dropped when the builder is written.
     pub has_farther_downstream_subscriber: bool,
 
+    /// A local client GET or PUT touched this contract recently (within the
+    /// renewal age gate, `SUBSCRIPTION_LEASE_DURATION`). This is REAL local
+    /// demand that is NOT a subscription: a read-only or write-only contract —
+    /// the River UI container, web/UI containers — is GET-read or PUT and never
+    /// subscribed, yet MUST stay renewed in the update mesh so later local reads
+    /// serve fresh state (`hosting-invariants.md` invariant 3: reads/PUTs are a
+    /// **permanent demand signal**, not merely a recency tiebreak).
+    ///
+    /// Set from `contracts_needing_renewal()` branch 3's signal
+    /// (`hosting_cache.has_recent_local_client_access`), which is refreshed by a
+    /// genuine local GET or PUT (`mark_local_client_access`) — never by automatic
+    /// subscription-renewal traffic. Together with
+    /// [`has_local_client`](Self::has_local_client) and
+    /// [`has_farther_downstream_subscriber`](Self::has_farther_downstream_subscriber)
+    /// this forms `contract_in_use`, the interest gate for renewal / collapse.
+    /// Without it, the FLIP's renewal gate ([`wants_renewal`]) drops a
+    /// read-only/PUT-only contract the builder still emits, its lease lapses, it
+    /// leaves the mesh, and later local reads serve stale.
+    pub has_recent_local_client_access: bool,
+
     /// We have the contract state locally (code + state present). Hosting requires
     /// state; a `Subscribe`/`Renew`/`ReRootSearch`/`Retract` may still be desired
     /// without it (they maintain the subscription/link/advertisement, not the
@@ -498,23 +518,30 @@ pub(crate) fn action_set_divergence_focused(
 }
 
 /// The interest gate (design doc §5a / §6): a peer keeps hosting AND keeps
-/// renewing iff it is `contract_in_use` — it has a **local client** OR a
+/// renewing iff it is `contract_in_use` — it has a **local client**, a
 /// **STRICTLY-farther** downstream subscriber (piece D: a downstream counts only
 /// when strictly farther from the key, so two mutual co-hosts cannot renew each
-/// other forever). This is the SINGLE predicate that drives both the collapse
-/// rule inside [`reconcile`] (teardown fires iff `!contract_in_use`) and the FLIP's
-/// renewal gate ([`wants_renewal`]) — "a peer keeps hosting exactly as long as it
-/// keeps renewing, and stops both together" (design §6).
+/// other forever), OR **recent local GET/PUT access**. Reads and PUTs are a
+/// permanent demand signal (`hosting-invariants.md` invariant 3): a contract
+/// that is only ever read or PUT and never subscribed — the River UI container,
+/// web/UI containers — must stay renewed in the mesh and retained. This is the
+/// SINGLE predicate that drives both the collapse rule inside [`reconcile`]
+/// (teardown fires iff `!contract_in_use`) and the FLIP's renewal gate
+/// ([`wants_renewal`]) — "a peer keeps hosting exactly as long as it keeps
+/// renewing, and stops both together" (design §6).
 pub(crate) fn contract_in_use(inputs: &ReconcileInputs) -> bool {
-    inputs.has_local_client || inputs.has_farther_downstream_subscriber
+    inputs.has_local_client
+        || inputs.has_farther_downstream_subscriber
+        || inputs.has_recent_local_client_access
 }
 
 /// The FLIP's RENEWAL gate (keystone sub-task 3, #4642; design doc §5a): whether
 /// the renewal loop should spawn a renewal for this contract this tick.
 ///
 /// This is exactly the controller's interest gate [`contract_in_use`] — renew
-/// while (and only while) a local client or a strictly-farther downstream
-/// subscriber depends on this peer hosting. When it goes false the renewal loop
+/// while (and only while) a local client, a strictly-farther downstream
+/// subscriber, or a recent local GET/PUT access depends on this peer hosting
+/// (reads/PUTs are permanent demand, invariant 3). When it goes false the renewal loop
 /// skips the spawn, the lease lapses, and the chain collapses inward — non-renewal
 /// IS the collapse primitive (§5a). Consumed by
 /// `OpManager::reconcile_wants_renewal`, which supplies the fresh snapshot.
@@ -537,8 +564,10 @@ pub(crate) fn wants_renewal(inputs: &ReconcileInputs) -> bool {
 /// The FLIP's COLLAPSE gate (keystone P6, #4642; design doc §5a / §6): the exact
 /// INVERSE of [`wants_renewal`]. "A peer keeps hosting exactly as long as it keeps
 /// renewing, and stops both together" (§6) — so an active collapse fires precisely
-/// when the interest gate goes false: no local client AND no STRICTLY-farther
-/// downstream subscriber. This is the same [`contract_in_use`] predicate the
+/// when the interest gate goes false: no local client, no STRICTLY-farther
+/// downstream subscriber, AND no recent local GET/PUT access (a recently read or
+/// PUT contract is in demand and does NOT collapse, invariant 3). This is the
+/// same [`contract_in_use`] predicate the
 /// [`reconcile`] teardown branch already keys `Collapse` off, surfaced as a
 /// standalone gate for the driver.
 ///
@@ -588,6 +617,7 @@ mod tests {
             computed_upstream: None,
             has_local_client: false,
             has_farther_downstream_subscriber: false,
+            has_recent_local_client_access: false,
             state_present: true,
             is_subscribed: false,
             is_advertised: false,
@@ -981,6 +1011,55 @@ mod tests {
             is_advertised: true,
             ..base()
         }));
+    }
+
+    /// REGRESSION (Codex P2, Ian 2026-07-08): a contract with ONLY recent local
+    /// GET/PUT access — NO local client subscription and NO downstream subscriber
+    /// — must be RENEWED, not collapsed. Reads and PUTs are a permanent demand
+    /// signal (`hosting-invariants.md` invariant 3): a read-only/PUT-only contract
+    /// (the River UI container, web/UI containers) is emitted by
+    /// `contracts_needing_renewal()` branch 3 but was DROPPED by the P6 flip's
+    /// gate, because that gate keyed only on subscriptions (`has_local_client ||
+    /// has_farther_downstream_subscriber`). Its lease then lapsed, it left the
+    /// update mesh, and later local reads served stale. This pins the FLIPPED
+    /// gate (the decision the renewal loop drives via
+    /// `OpManager::reconcile_wants_renewal`), not the builder the pre-existing
+    /// `test_local_client_access_enables_renewal` already covers. Fails before the
+    /// fix (recent access excluded from `contract_in_use`), passes after.
+    #[test]
+    fn recent_local_access_alone_renews_not_collapses() {
+        let recent_access_only = ReconcileInputs {
+            has_recent_local_client_access: true,
+            // Explicitly NOT subscribed by any client and NO downstream subscriber:
+            // this is the read-only / PUT-only demand the flip must not drop.
+            has_local_client: false,
+            has_farther_downstream_subscriber: false,
+            ..base()
+        };
+        assert!(
+            wants_renewal(&recent_access_only),
+            "recent local GET/PUT access alone must RENEW (invariant 3: reads/PUTs \
+             are permanent demand) — the P6 flip regression"
+        );
+        assert!(
+            !wants_collapse(&recent_access_only),
+            "recent local GET/PUT access alone must NOT collapse — collapse is the \
+             exact inverse of the demand-inclusive renewal gate"
+        );
+        // And it is genuinely `contract_in_use`, so the pure reconcile controller
+        // does not emit a teardown for it either.
+        assert!(contract_in_use(&recent_access_only));
+        assert!(!reconcile(&recent_access_only).contains(&Action::Collapse));
+
+        // Guard the demand direction: once BOTH the subscription signals AND recent
+        // access are absent, the contract is idle and DOES collapse (so the added
+        // term did not wire renewal permanently on).
+        let idle = ReconcileInputs {
+            has_recent_local_client_access: false,
+            ..base()
+        };
+        assert!(!wants_renewal(&idle));
+        assert!(wants_collapse(&idle));
     }
 
     /// `action_set_divergence` is the set-membership comparator the shadow

--- a/crates/core/tests/operations.rs
+++ b/crates/core/tests/operations.rs
@@ -4188,12 +4188,31 @@ async fn test_delegate_contract_get(ctx: &mut TestContext) -> TestResult {
     Ok(())
 }
 
-/// Test that disconnecting a subscribed client triggers an upstream Unsubscribe message.
+/// Test that disconnecting a subscribed client does NOT trigger an *immediate*
+/// upstream Unsubscribe when the contract was recently read (demand-gated collapse).
 ///
-/// Scenario: node-b subscribes to a contract hosted on node-a. After verifying
-/// the subscription works (update propagates), client B disconnects. The test
-/// asserts that node-b sent an UnsubscribeSent event and the upstream peer
-/// logged an UnsubscribeReceived event in the aggregated event logs.
+/// Scenario: node-b GETs then subscribes to a contract hosted on node-a. After
+/// verifying the subscription works (update propagates), client B disconnects.
+///
+/// Post-flip (#4642) behavior — why the old immediate-unsubscribe assertion is
+/// stale: the reconcile controller now gates the destructive collapse on
+/// `reconcile_wants_collapse == !contract_in_use`, the exact INVERSE of the
+/// renewal gate (`wants_renewal == contract_in_use`), so a peer "keeps hosting
+/// exactly as long as it keeps renewing, and stops both together" (design §6).
+/// A recent local GET/PUT is a permanent demand signal
+/// (`has_recent_local_client_access`, recency window = `SUBSCRIPTION_LEASE_DURATION`
+/// = 8 min; `hosting-invariants.md` invariant 3). node-b's GET in setup is only
+/// seconds old, so `contract_in_use` stays true after the client disconnects: the
+/// peer keeps renewing and does NOT send an upstream Unsubscribe. Cleanup instead
+/// happens via lease-lapse once the read falls out of the recency window and
+/// renewal stops.
+///
+/// This test therefore asserts the demand-gated behavior — no upstream Unsubscribe
+/// fires while the read is recent. Driving recency past the 8-min window to prove
+/// the deferred collapse THEN fires needs an injected clock the node process does
+/// not expose to a `#[freenet_test]` (real nodes, real time), so it is out of
+/// scope here. Restoring evidence-gated instant cleanup on last-client-disconnect
+/// is tracked in #4738.
 #[freenet_test(
     nodes = ["gateway", "node-a", "node-b"],
     timeout_secs = 600,
@@ -4203,7 +4222,9 @@ async fn test_delegate_contract_get(ctx: &mut TestContext) -> TestResult {
     tokio_flavor = "multi_thread",
     tokio_worker_threads = 4
 )]
-async fn test_client_disconnect_triggers_upstream_unsubscribe(ctx: &mut TestContext) -> TestResult {
+async fn test_client_disconnect_does_not_immediately_unsubscribe_with_recent_read(
+    ctx: &mut TestContext,
+) -> TestResult {
     const TEST_CONTRACT: &str = "test-contract-integration";
     let contract = test_utils::load_contract(TEST_CONTRACT, vec![].into())?;
     let contract_key = contract.key();
@@ -4323,7 +4344,10 @@ async fn test_client_disconnect_triggers_upstream_unsubscribe(ctx: &mut TestCont
         "Client B should receive update notification while subscribed"
     );
 
-    // Phase 2: Disconnect client B — should trigger upstream Unsubscribe
+    // Phase 2: Disconnect client B — demand-gated: because node-b did a recent
+    // GET (setup above), the contract is still `contract_in_use`, so the collapse
+    // gate (`reconcile_wants_collapse == !contract_in_use`) stays false and NO
+    // immediate upstream Unsubscribe should fire. See the doc comment / #4738.
     tracing::info!("Phase 2: Disconnect client B");
     // Drain buffered responses so the client's background request_handler is not
     // blocked on response_tx.send() — otherwise it can't process the Disconnect.
@@ -4338,26 +4362,34 @@ async fn test_client_disconnect_triggers_upstream_unsubscribe(ctx: &mut TestCont
     );
     drop(client_b);
 
-    // Poll for Unsubscribe events with retries — the disconnect → unsubscribe
+    // Dwell and confirm NO upstream Unsubscribe fires while the GET is recent.
+    // The collapse decision (`reconcile_wants_collapse == !contract_in_use`) is
+    // the exact inverse of the renewal gate, and a recent GET/PUT keeps
+    // `contract_in_use` true (recency window = SUBSCRIPTION_LEASE_DURATION, 8 min),
+    // so the peer keeps renewing rather than tearing down. Cleanup happens later
+    // via lease-lapse (deferred instant cleanup tracked in #4738).
+    //
+    // We poll for 30s and fail fast if any Unsubscribe appears: the pre-flip
+    // immediate-collapse behavior delivered the Unsubscribe well within 30s
+    // (that was the window the old positive assertion relied on), so a regression
+    // to that behavior would surface here quickly. The disconnect → collapse
     // chain traverses multiple async hops (websocket → event loop → spawn →
-    // interest lookup → notification channel → transport → network → receive)
-    // so a single fixed sleep is insufficient under CI load.
+    // interest lookup → notification channel → transport → network → receive),
+    // which is exactly the path we assert stays silent.
     //
     // Note: tokio::time::Instant is fine here — this is a #[freenet_test]
     // integration test with real nodes, not a DST simulation test. The
     // TimeSource abstraction is only required within crates/core/src/.
     let instance_id = *contract_key.id();
-    let mut unsubscribe_sent_count = 0;
-    let mut unsubscribe_received_count = 0;
-    let poll_deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    let dwell_deadline = tokio::time::Instant::now() + Duration::from_secs(30);
 
-    while tokio::time::Instant::now() < poll_deadline {
+    while tokio::time::Instant::now() < dwell_deadline {
         tokio::time::sleep(Duration::from_secs(5)).await;
 
         let aggregator = ctx.aggregate_events().await?;
         let events = aggregator.get_all_events().await?;
 
-        unsubscribe_sent_count = events
+        let unsubscribe_sent_count = events
             .iter()
             .filter(|e| {
                 e.kind
@@ -4365,7 +4397,7 @@ async fn test_client_disconnect_triggers_upstream_unsubscribe(ctx: &mut TestCont
                     .is_some_and(|id| *id == instance_id)
             })
             .count();
-        unsubscribe_received_count = events
+        let unsubscribe_received_count = events
             .iter()
             .filter(|e| {
                 e.kind
@@ -4375,24 +4407,24 @@ async fn test_client_disconnect_triggers_upstream_unsubscribe(ctx: &mut TestCont
             .count();
 
         tracing::info!(
-            "Unsubscribe events for {}: sent={}, received={}",
+            "Unsubscribe events for {} (expected 0 while read is recent): sent={}, received={}",
             instance_id,
             unsubscribe_sent_count,
             unsubscribe_received_count
         );
 
-        if unsubscribe_received_count > 0 {
-            break;
-        }
+        // Demand-gated collapse (#4642): a recently-read contract stays
+        // `contract_in_use`, so neither an upstream Unsubscribe send nor receive
+        // may occur on the client disconnect. If either fires, the collapse gate
+        // has regressed to the pre-flip immediate-unsubscribe behavior.
+        assert!(
+            unsubscribe_sent_count == 0 && unsubscribe_received_count == 0,
+            "A recently-read contract must NOT trigger an immediate upstream Unsubscribe \
+             on client disconnect — collapse is demand-gated (inverse of renewal), and the \
+             GET keeps contract_in_use true (see #4642/#4738) \
+             (sent={unsubscribe_sent_count}, received={unsubscribe_received_count})"
+        );
     }
-
-    // The polling loop above waits up to 30s for UnsubscribeReceived.
-    // Assert the strong condition: upstream must have received the unsubscribe.
-    assert!(
-        unsubscribe_received_count > 0,
-        "Upstream node should have received the Unsubscribe message after client disconnect \
-         (sent={unsubscribe_sent_count}, received={unsubscribe_received_count})"
-    );
 
     // Cleanup
     client_a

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -2399,14 +2399,18 @@ fn test_subscribe_forwarding_ack_relay() {
 /// subscribed client disconnects, the node MUST emit an upstream Unsubscribe
 /// so the hoster can drop the downstream subscriber registration.
 ///
-/// This test exercises the same code path the failing integration test
-/// `test_client_disconnect_triggers_upstream_unsubscribe` exercises — the
+/// This test exercises the same disconnect code path as the integration test
+/// `test_client_disconnect_does_not_immediately_unsubscribe_with_recent_read` — the
 /// `ClientRequest::Disconnect` arm in `client_events::process_open_request`,
 /// which calls `remove_client_from_all_subscriptions` /
 /// `should_unsubscribe_upstream` / `send_unsubscribe_upstream` — but through
 /// the simulation harness where the bug's preconditions (completed PUT
 /// replay from GC, subscription resurrection, etc.) can be controlled and
-/// reproduced deterministically.
+/// reproduced deterministically. Note the two tests now assert OPPOSITE outcomes
+/// after the P6 reconcile flip (#4642): this sim node SUBSCRIBEs without a recent
+/// GET, so `contract_in_use` is false on disconnect and the collapse fires (an
+/// Unsubscribe is emitted); the integration test does a recent GET first, so its
+/// collapse is demand-gated and deferred to lease-lapse (see #4738).
 ///
 /// Before this test existed, `SimOperation` had no client-disconnect variant
 /// and simulation had NO coverage of the disconnect → unsubscribe chain —


### PR DESCRIPTION
## Problem

The pure `reconcile()` controller (`crates/core/src/ring/hosting/reconcile.rs`,
#4642 "the maintenance / reconcile loop") was wired in **shadow mode** at the
hosting decision sites: it computed an `Action` set, recorded per-site divergence
telemetry, and **drove nothing**. The FLIP (P6, release-2 keystone) makes the
controller actually drive.

This PR is the **NARROW flip** — a data-driven decision made from v0.2.93 shadow
telemetry. It flips the two interest-gated **maintenance** decisions from shadow
to driving:

1. **Interest-gated RENEWAL** (the first increment).
2. **Interest-gated COLLAPSE** (this increment) — so both key off the single
   strict-farther `contract_in_use` gate: *"a peer keeps hosting exactly as long
   as it keeps renewing, and stops both together"* (design doc §6).

It deliberately does **NOT** compute-upstream-everywhere. The shadow data:

| Signal | v0.2.93 shadow | Decision |
|---|---|---|
| Emitted **actions** vs production | collapse **0%**, renew **0.3%**, focused edge sites 0.00% / 0.02% / 0.67% | driving renewal + collapse is **de-risked** → FLIP |
| Computed-vs-stored upstream **identity** (#4671) | **~79% divergence** (verified real) | keep the stored `is_upstream` flag → stays SHADOW |

So the upstream-picking stays on the stored `is_upstream` flag; the wire
`Unsubscribe` still targets the **stored** upstream, and the computed-vs-stored
identity divergence keeps being measured under the unchanged
`record_upstream_divergence_comparison` shadow, unflipped, so it can be
re-measured before a future full flip.

## Approach

### Renewal (driven — first increment)

`Ring::recover_orphaned_subscriptions` gates its per-contract renewal spawn on
`OpManager::reconcile_wants_renewal` = design §5a `contract_in_use` (renew iff a
local client OR a STRICTLY-farther downstream depends on this peer). Non-renewal
is the collapse primitive (§5a): a peer that stops renewing lets its lease lapse
and the chain collapses inward.

### Collapse (driven — this increment)

The three collapse-decision sites now gate the active `send_unsubscribe_upstream`
on `OpManager::reconcile_wants_collapse` = `reconcile::wants_collapse` =
`!contract_in_use` (the exact inverse of the renewal gate), replacing the legacy
ANY-downstream `Ring::should_unsubscribe_upstream`:

- the maintenance loop's downstream-expiry teardown,
- the client-disconnect teardown (`client_events`),
- the inbound-unsubscribe teardown (`handle_unsubscribe_inbound`).

**Keeps the stored upstream identity:** `send_unsubscribe_upstream` still resolves
the wire target via the stored `is_upstream` flag and drops the local lease via
`ring.unsubscribe`. Only the *decision* flips.

**Fail-safe:** `reconcile_wants_collapse` returns `false` (do NOT collapse) on a
distance-blind snapshot — the mirror of `reconcile_wants_renewal`'s keep-renewing
default. Neither tears a chain down on an unmeasurable read.

**Superset, not a leak:** the strict gate is a superset of the legacy gate
(`!has_any_downstream ⟹ !has_farther_downstream`), so the flip can only collapse
MORE (the mutual-co-host case), never leak a chain the legacy predicate would
have cleaned up. The active Unsubscribe toward the stored upstream is a
best-effort accelerant; the **load-bearing collapse remains the passive
lease-lapse** from non-renewal.

**Telemetry:** the Collapse and InboundUnsubscribe reconcile counters are
retained but repurposed (as the renewal counter was) to measure how often the
driven strict-farther gate DISAGREES with the legacy predicate it replaced — the
"collapse diff" ship-gate falsifier — recorded per-site inside
`reconcile_wants_collapse`.

### Still deferred (unchanged)

- **Compute-upstream-everywhere / retiring `is_upstream`** — blocked on the ~79%
  identity divergence; stays under shadow measurement.
- **`ReRootSearch` (connection-drop re-root) and `Announce` (host-formation)** —
  stay in shadow.
- **`Retract`** — wired on eviction only (#4722); not driven from teardown yet.

## Testing

- **Pure-core units** (`reconcile.rs`): `wants_collapse_is_exact_inverse_of_renewal`
  (gate duality + strict-gate collapse), `wants_renewal_drives_interest_gate`.
- **Driver pins** (`op_state_manager.rs`): `collapse_decision_is_reconcile_driven`
  (all three sites gate on `reconcile_wants_collapse`, fail-safe `false`),
  `send_unsubscribe_upstream_drives_off_stored_upstream_after_flip` (stored
  upstream + `record_upstream_divergence_comparison` kept, Collapse action-set
  shadow removed), `renewal_site_is_driven_not_shadowed`, and the updated
  inbound-unsubscribe gate pin.
- **Sim falsifiers** (`--features simulation_tests,testing`), which now exercise
  the flipped collapse decision sites:
  `test_subscription_chain_collapses_on_client_leave` (client-leave → no hollow
  relay), `test_subscription_count_tracks_demand_not_cache` (demand chains
  survive the strict gate; cache-only chains collapse), `test_interest_renewal`,
  `test_subscription_root_renewal_does_not_storm`.

**Why no new "active-collapse without lease-expiry" sim test:** the active
Unsubscribe toward the *stored* upstream is best-effort (it can miss under the
known ~79% #4671 stored-flag drift), so a test asserting prompt collapse *without*
the lease-lapse would be flaky. The load-bearing collapse is the passive
lease-lapse, which the existing falsifiers validate; the strict-gate decision is
pinned by the unit tests.

`cargo build -p freenet`, `cargo clippy --locked -p freenet -- -D warnings`, and
`cargo fmt --check` are green.

## Ship gate (do NOT merge)

Highest-risk release-2 keystone: **FULL multi-model review + Ian sign-off**
required, and it ships **only** in the inseparable 0.2.94 demand-driven-hosting
bundle after R1+R2 field-validate. Draft for review of the complete narrow flip
(renewal + collapse) + the deferral analysis. Past the late-night merge line.

Refs #4642

[AI-assisted - Claude]
