### PR TITLE
fix(sim): make direct-runner fault injection actually drop packets (#4694)

### DIFF
--- a/crates/core/src/node/network_bridge/in_memory.rs
+++ b/crates/core/src/node/network_bridge/in_memory.rs
@@ -97,13 +97,15 @@ pub struct FaultInjectorState {
     /// Network name for delivering pending messages
     pub network_name: Option<String>,
     /// Opt-in: when true, the sim's global packet-delivery callback DROPS every
-    /// packet to/from a node in `config.crashed_nodes` (counting it in
-    /// `stats.messages_dropped_crash`). Off by default so installing the global
-    /// callback does not silently change fault behavior for networks that never
-    /// opted in (e.g. the direct-runner churn driver, whose crash semantics are
-    /// unchanged). `SimNetwork::run_controlled_simulation` sets it so
-    /// `SimOperation::CrashNode` is a real crash rather than a no-op (#4642 piece F).
-    pub enforce_crash_drops: bool,
+    /// packet to/from a crashed node (`config.crashed_nodes`, counted in
+    /// `stats.messages_dropped_crash`) OR blocked by an active partition
+    /// (`config.partitions`, counted in `stats.messages_dropped_partition`).
+    /// Off by default so merely installing the global callback does not silently
+    /// change fault behavior for networks that never opted in. Both
+    /// `SimNetwork::run_controlled_simulation` (scripted `CrashNode`, #4642 piece F)
+    /// and `SimNetwork::run_simulation_direct` (churn driver crashes, #4694) set it
+    /// so their injected faults are real packet drops rather than silent no-ops.
+    pub enforce_fault_drops: bool,
 }
 
 impl FaultInjectorState {
@@ -116,7 +118,7 @@ impl FaultInjectorState {
             pending_messages: Vec::new(),
             stats: NetworkStats::default(),
             network_name: None,
-            enforce_crash_drops: false,
+            enforce_fault_drops: false,
         }
     }
 

--- a/crates/core/src/node/testing_impl.rs
+++ b/crates/core/src/node/testing_impl.rs
@@ -388,16 +388,18 @@ impl ScheduledOperation {
 }
 
 /// Packet-delivery decision consulted by every `SimulationSocket` (via the
-/// global delivery callback set in `run_controlled_simulation`) so a scripted
-/// node crash actually drops packets instead of being a silent no-op.
+/// global delivery callback installed by `run_controlled_simulation` and
+/// `run_simulation_direct`) so an injected node crash or partition actually
+/// drops packets instead of being a silent no-op.
 ///
 /// Per-network: it looks up the fault injector for the socket's own network and,
-/// only if that network opted in (`enforce_crash_drops`), DROPS any packet whose
-/// source or destination is a crashed node — counting it in
-/// `stats.messages_dropped_crash`. Every other packet (and every network that
-/// did not opt in) is delivered unchanged, so installing this callback cannot
-/// alter fault behavior for the direct-runner churn driver or any other path.
-/// See #4642 piece F.
+/// only if that network opted in (`enforce_fault_drops`), DROPS any packet whose
+/// source or destination is a crashed node (counted in
+/// `stats.messages_dropped_crash`) or that is blocked by an active partition
+/// (counted in `stats.messages_dropped_partition`). Every other packet (and
+/// every network that did not opt in) is delivered unchanged, so installing this
+/// callback cannot alter fault behavior for any path that did not opt in.
+/// See #4642 piece F (scripted crashes) and #4694 (direct-runner churn).
 #[cfg(any(test, feature = "testing"))]
 fn fault_injection_delivery_decision(
     network_name: &str,
@@ -407,9 +409,21 @@ fn fault_injection_delivery_decision(
     use crate::transport::in_memory_socket::PacketDeliveryDecision;
     if let Some(injector) = crate::node::network_bridge::get_fault_injector(network_name) {
         let mut inj = injector.lock().unwrap();
-        if inj.enforce_crash_drops && (inj.config.is_crashed(&from) || inj.config.is_crashed(&to)) {
-            inj.stats.messages_dropped_crash += 1;
-            return PacketDeliveryDecision::Drop;
+        if inj.enforce_fault_drops {
+            if inj.config.is_crashed(&from) || inj.config.is_crashed(&to) {
+                inj.stats.messages_dropped_crash += 1;
+                return PacketDeliveryDecision::Drop;
+            }
+            // Partitions are time-scoped (start/heal), so use this network's
+            // VirtualTime as the current time; without VirtualTime a partition
+            // cannot be evaluated deterministically, so treat it as inactive.
+            use crate::simulation::TimeSource;
+            if let Some(now) = inj.virtual_time.as_ref().map(|vt| vt.now_nanos()) {
+                if inj.config.is_partitioned(&from, &to, now) {
+                    inj.stats.messages_dropped_partition += 1;
+                    return PacketDeliveryDecision::Drop;
+                }
+            }
         }
     }
     PacketDeliveryDecision::Deliver
@@ -4171,7 +4185,7 @@ impl SimNetwork {
         // Make `SimOperation::CrashNode` a REAL crash: install the global
         // packet-delivery callback that consults each network's fault injector
         // and DROPS every packet to/from a crashed node, then opt THIS network
-        // in via `enforce_crash_drops`. The callback is per-network aware (keyed
+        // in via `enforce_fault_drops`. The callback is per-network aware (keyed
         // on the network name it is handed) and inert for any network that did
         // not opt in, so the direct-runner churn driver's crash semantics stay
         // unchanged. `SimNetwork::Drop` clears the callback. Without this, a
@@ -4181,7 +4195,7 @@ impl SimNetwork {
             std::sync::Arc::new(fault_injection_delivery_decision),
         ));
         if let Some(injector) = crate::node::network_bridge::get_fault_injector(&network_name) {
-            injector.lock().unwrap().enforce_crash_drops = true;
+            injector.lock().unwrap().enforce_fault_drops = true;
         }
 
         // Build Turmoil simulation with seeded RNG for deterministic execution
@@ -4978,6 +4992,30 @@ impl SimNetwork {
         GlobalSimulationTime::set_time_ms(BASE_EPOCH_MS + epoch_offset);
 
         set_current_network_name(&self.name);
+
+        // Make direct-runner ChurnConfig crashes REAL packet drops (#4694).
+        //
+        // The chaos driver below marks nodes crashed in this network's fault
+        // injector, but a crash only drops packets if the global packet-delivery
+        // callback is installed AND this network opted in via
+        // `enforce_fault_drops`. Neither happened on the direct runner, so churn
+        // faults were inert: a "crashed" node kept exchanging packets and every
+        // near-K churn / partition validation on this runner was false-green
+        // (#4694; blocker for the demand-driven-hosting release-2 gate, #4642).
+        //
+        // Gated on `churn_config.is_some()` so non-churn direct-runner tests are
+        // byte-for-byte unchanged (the callback is inert unless a node is
+        // actually crashed/partitioned, but gating keeps the change surgical and
+        // makes the wiring impossible to miss when churn IS configured).
+        // `SimNetwork::Drop` clears the global callback.
+        if self.churn_config.is_some() {
+            crate::transport::in_memory_socket::set_packet_delivery_callback(Some(
+                std::sync::Arc::new(fault_injection_delivery_decision),
+            ));
+            if let Some(injector) = crate::node::network_bridge::get_fault_injector(&self.name) {
+                injector.lock().unwrap().enforce_fault_drops = true;
+            }
+        }
 
         // Single-threaded runtime with paused time for deterministic execution
         let rt = tokio::runtime::Builder::new_current_thread()
@@ -5998,6 +6036,93 @@ use crate::contract::OperationMode;
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Unit test for the fault-injection delivery decision (#4694 / #4642 piece F).
+    ///
+    /// Directly exercises `fault_injection_delivery_decision` — the callback the
+    /// direct/controlled runners install so injected crashes and partitions
+    /// become real packet drops. Verifies:
+    ///   1. Without `enforce_fault_drops`, every packet is delivered (the inert
+    ///      state that made fault injection false-green before #4694).
+    ///   2. With `enforce_fault_drops`, packets to/from a crashed node are
+    ///      dropped (either direction) and counted in `messages_dropped_crash`.
+    ///   3. With `enforce_fault_drops`, partitioned pairs are dropped and counted
+    ///      in `messages_dropped_partition`.
+    ///   4. Unaffected pairs are still delivered.
+    #[test]
+    fn test_fault_injection_delivery_decision_drops_crash_and_partition() {
+        use crate::node::network_bridge::{FaultInjectorState, set_fault_injector};
+        use crate::simulation::{FaultConfig, Partition, VirtualTime};
+        use crate::transport::in_memory_socket::PacketDeliveryDecision;
+        use std::collections::HashSet;
+        use std::sync::{Arc, Mutex};
+
+        const NETWORK: &str = "fault-decision-unit-test";
+
+        let crashed: SocketAddr = "127.0.0.1:20001".parse().unwrap();
+        let live_a: SocketAddr = "127.0.0.1:20002".parse().unwrap();
+        let part_x: SocketAddr = "127.0.0.1:20003".parse().unwrap();
+        let part_y: SocketAddr = "127.0.0.1:20004".parse().unwrap();
+
+        let mut config = FaultConfig::default();
+        config.crash_node(crashed);
+        config.add_partition(
+            Partition::new(HashSet::from([part_x]), HashSet::from([part_y])).permanent(0),
+        );
+
+        let state = FaultInjectorState::new(config, 42).with_virtual_time(VirtualTime::new());
+        let injector = Arc::new(Mutex::new(state));
+        set_fault_injector(NETWORK, Some(injector.clone()));
+
+        let is_drop = |d: PacketDeliveryDecision| matches!(d, PacketDeliveryDecision::Drop);
+
+        // (1) Not opted in: faults are inert, everything is delivered.
+        assert!(
+            !is_drop(fault_injection_delivery_decision(NETWORK, crashed, live_a)),
+            "crash must be inert without enforce_fault_drops (pre-#4694 behavior)"
+        );
+        assert!(
+            !is_drop(fault_injection_delivery_decision(NETWORK, part_x, part_y)),
+            "partition must be inert without enforce_fault_drops"
+        );
+
+        injector.lock().unwrap().enforce_fault_drops = true;
+
+        // (2) Crashed node: dropped in both directions.
+        assert!(
+            is_drop(fault_injection_delivery_decision(NETWORK, crashed, live_a)),
+            "packet FROM a crashed node must be dropped"
+        );
+        assert!(
+            is_drop(fault_injection_delivery_decision(NETWORK, live_a, crashed)),
+            "packet TO a crashed node must be dropped"
+        );
+
+        // (3) Partitioned pair: dropped in both directions.
+        assert!(
+            is_drop(fault_injection_delivery_decision(NETWORK, part_x, part_y)),
+            "packet across an active partition must be dropped (x->y)"
+        );
+        assert!(
+            is_drop(fault_injection_delivery_decision(NETWORK, part_y, part_x)),
+            "packet across an active partition must be dropped (y->x)"
+        );
+
+        // (4) Unaffected pair: delivered.
+        assert!(
+            !is_drop(fault_injection_delivery_decision(NETWORK, live_a, part_x)),
+            "healthy, non-partitioned pair must be delivered"
+        );
+
+        let stats = injector.lock().unwrap().stats.clone();
+        assert_eq!(stats.messages_dropped_crash, 2, "two crash drops expected");
+        assert_eq!(
+            stats.messages_dropped_partition, 2,
+            "two partition drops expected"
+        );
+
+        set_fault_injector(NETWORK, None);
+    }
 
     /// Test that peer locations are deterministic with the same seed.
     ///

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -7469,6 +7469,105 @@ fn test_direct_runner_churn() {
     );
 }
 
+/// Regression test for #4694: direct-runner `ChurnConfig` crashes must actually
+/// DROP packets, not merely set fault config.
+///
+/// Before the fix, `run_simulation_direct` never installed the global
+/// packet-delivery callback and never set `enforce_fault_drops`, so the chaos
+/// driver's `crash_node()` calls were inert: a "crashed" node kept exchanging
+/// packets. Any near-K churn / partition validation on the direct runner was
+/// therefore false-green — it asserted recovery from a fault that never
+/// happened. This blocked trusting the demand-driven-hosting release-2 gate
+/// (#4642), whose churn validation runs on this exact runner.
+///
+/// The discriminating signal is the fault injector's `messages_dropped_crash`
+/// counter: it is `> 0` only if a crash was scheduled AND real traffic to/from
+/// the crashed node was subsequently blocked by the delivery callback. We use
+/// permanent crashes so a downed node stays down and keeps dropping traffic
+/// (its own event loop keeps trying to send, and neighbours keep routing to
+/// it), guaranteeing drops accumulate once faults are actually enforced.
+///
+/// - RED (pre-fix): callback never installed / never enforced → counter stays
+///   exactly `0` → assertion fails.
+/// - GREEN (post-fix): crashed-node packets are dropped → counter `> 0`.
+#[test]
+fn test_direct_runner_churn_actually_drops_packets() {
+    use freenet::dev_tool::ChurnConfig;
+
+    const SEED: u64 = 0xC1_0055_D009;
+    const NETWORK_NAME: &str = "test-churn-drops";
+
+    setup_deterministic_state(SEED);
+
+    let rt = create_runtime();
+
+    let mut sim = rt.block_on(async {
+        SimNetwork::new(
+            NETWORK_NAME,
+            2,  // gateways
+            8,  // nodes
+            10, // ring_max_htl
+            5,  // rnd_if_htl_above
+            15, // max_connections
+            3,  // min_connections
+            SEED,
+        )
+        .await
+    });
+
+    // Aggressive, permanent churn so at least one node is genuinely crashed
+    // shortly after warmup and stays down accumulating dropped packets.
+    sim.with_churn(ChurnConfig {
+        crash_probability: 0.5,
+        tick_interval: Duration::from_millis(200),
+        recovery_delay: Duration::from_millis(500),
+        max_simultaneous_crashes: Some(3),
+        permanent_crash_rate: 1.0, // every crash is permanent → stays down
+        // Must be >= connection wait (2s) + buffer to avoid crashing nodes during startup
+        warmup_delay: Duration::from_secs(5),
+    });
+
+    // Retain a clone of this network's fault injector Arc BEFORE the run.
+    // `run_simulation_direct` consumes `sim`; on drop, `SimNetwork::Drop` removes
+    // the injector from the global registry, but our retained Arc keeps the same
+    // underlying `FaultInjectorState` alive — and the chaos driver + delivery
+    // callback mutate that same state during the run, so we can read the final
+    // drop count afterwards.
+    let injector = freenet::dev_tool::get_fault_injector(NETWORK_NAME)
+        .expect("fault injector is registered at SimNetwork construction");
+
+    let logs_handle = sim.event_logs_handle();
+
+    drop(rt);
+
+    sim.run_simulation_direct::<rand::rngs::SmallRng>(
+        SEED,
+        10, // max_contract_num
+        30, // iterations
+        Duration::from_millis(200),
+    )
+    .expect("Direct simulation with churn should complete without panic");
+
+    let crash_drops = injector.lock().unwrap().stats.messages_dropped_crash;
+
+    // Sanity: the run actually did something.
+    let rt = create_runtime();
+    let event_count = rt.block_on(async { logs_handle.lock().await.len() });
+    assert!(event_count > 0, "churn simulation produced no events");
+
+    assert!(
+        crash_drops > 0,
+        "expected crashed-node packets to be DROPPED (messages_dropped_crash > 0), \
+         but got {crash_drops}. Fault injection is inert on the direct runner — the \
+         packet-delivery callback was not installed / enforced (regression of #4694)."
+    );
+
+    tracing::info!(
+        "CHURN DROP TEST PASSED: {crash_drops} packets dropped for crashed nodes \
+         ({event_count} events produced)"
+    );
+}
+
 // =============================================================================
 // Unhealthy Peer Eviction Tests
 // =============================================================================


### PR DESCRIPTION
## Problem

`set_packet_delivery_callback` was only ever installed by `run_controlled_simulation` (opt-in `enforce_crash_drops`, added in #4657). The **direct runner** (`run_simulation_direct`) never installed the callback and never opted in, so `check_packet_delivery()` always returned `Deliver`.

The direct runner's chaos driver (`ChurnConfig`) calls `config.crash_node(addr)` on the fault injector, but with no callback + no enforcement those calls only mutate fault **config** — they never drop a single packet. A "crashed" node keeps exchanging packets.

**Consequence (test-integrity bug):** any near-K churn / crash / partition validation on the direct runner is **false-green** — it asserts recovery from a fault that never actually happened. `ChurnConfig` is a direct-runner-only feature and the demand-driven-hosting **release-2 (0.3.0)** churn/OOM gate (#4642) runs on this exact runner, so trusting that gate first requires the fault to be real.

## Approach — option (a): fix the direct runner

Two options were considered:

- **(a) Install the callback on the direct runner** so `ChurnConfig` crashes/partitions genuinely drop packets. **← chosen.**
- (b) Move the near-K churn/OOM gate onto the controlled-sim (Turmoil) path where drops already work.

(a) wins on both "genuinely drops packets on the runner the gate uses" and "least blast radius": `ChurnConfig` (random crash/recover) and 500+ node scale are direct-runner-only; option (b) would require reworking the churn model onto Turmoil's scripted-op path, losing both. #4657 avoided the direct-runner path to limit blast radius, but there are only two direct-runner churn tests in-tree and both tolerate real crashes (see Testing), so the risk is small.

### Changes

- **`run_simulation_direct`**: install the global packet-delivery callback and set `enforce_fault_drops = true` on this network's fault injector, **gated on `churn_config.is_some()`** so non-churn direct-runner tests are byte-for-byte unchanged. Gating (rather than always-on) keeps the change surgical and makes the wiring impossible to miss when churn IS configured. `SimNetwork::Drop` already clears the callback.
- **`fault_injection_delivery_decision`**: now also drops packets blocked by an **active partition** (counted in `messages_dropped_partition`), not just crashed nodes. Renamed the opt-in flag `enforce_crash_drops` → `enforce_fault_drops` to reflect both fault classes. Purely additive for existing callers (no in-tree test adds a partition on a callback-installed network).

## Testing

- **`test_direct_runner_churn_actually_drops_packets`** (new regression, non-nightly): runs the direct runner with permanent churn, retains the fault-injector `Arc` across the run, and asserts `messages_dropped_crash > 0`.
  - **RED** on current `main` behavior (counter stays exactly `0` — verified by temporarily disabling the install block: `messages_dropped_crash = 0`, assertion fails).
  - **GREEN** with the fix.
- **`test_fault_injection_delivery_decision_drops_crash_and_partition`** (new unit): crash (both directions) + partition (both directions) + the opt-in gate + counter accounting.
- Regression checks (all pass): `test_direct_runner_churn` (existing churn test, unchanged assertions), `test_scripted_node_crash_mid_run` (#4657 controlled-sim path, exercises the renamed flag), `test_direct_runner_determinism` (direct-runner determinism preserved — install is gated on churn), `test_topology_single_hoster` (controlled-sim path).
- `cargo fmt --check`, `cargo clippy --locked -p freenet -- -D warnings` clean.

## Scope note

This fixes the **direct-runner** path (the issue's stated fix target and the release-2 gate's runner). The Turmoil `run_simulation` path (`test_partition_heal_convergence`, `test_crash_recover_convergence`, `test_multi_step_churn`) *also* injects faults via the freenet fault injector without installing the callback and is likewise inert — but wiring it has a larger blast radius across convergence tests and is a separate surface from the release-2 gate. Flagging for a follow-up audit rather than smuggling it into this focused fix.

Closes #4694
Refs #4642

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AI-assisted - Claude]