### PR TITLE
fix(ci): release.yml auto-merge fails under merge queue (drop --squash)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,14 @@ jobs:
       - name: Self-test announce-to-river
         run: bash scripts/release-agent/announce-to-river_test.sh
 
+      # Regression gate for the v0.2.93 release failure (2026-07-07): the
+      # version-bump auto-merge step ran `gh pr merge --squash --auto`, but the
+      # merge queue rejects --squash, so the step exited non-zero (under bash -e)
+      # and skipped the entire publish cascade. Pins that release.yml's merge
+      # invocation stays --auto and never re-adds --squash.
+      - name: Self-test release.yml merge-queue auto-merge
+        run: bash scripts/release_mergequeue_test.sh
+
       # install.sh now sets up a supervised service by default (issue #4073) so
       # new nodes auto-update. The system-vs-user + lingering decision is the
       # load-bearing new logic; these smoke tests pin it without needing real

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,7 +202,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
         run: |
-          gh pr merge ${{ steps.create_pr.outputs.pr_number }} --squash --auto
+          # The merge queue owns the merge strategy, so do NOT pass --squash
+          # here: it makes `gh pr merge` exit non-zero and, under `bash -e`,
+          # fails this step and skips the whole publish cascade (this is what
+          # broke the v0.2.93 release on 2026-07-07; the queue's strict-strategy
+          # enforcement was enabled between v0.2.92 and v0.2.93). Just enable
+          # auto-merge; the queue applies its configured strategy.
+          gh pr merge ${{ steps.create_pr.outputs.pr_number }} --auto
           echo "✅ Auto-merge enabled"
 
   wait_for_pr:

--- a/scripts/release_mergequeue_test.sh
+++ b/scripts/release_mergequeue_test.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Regression test for the v0.2.93 release failure (2026-07-07).
+#
+# release.yml's `update_versions` job auto-merges the version-bump PR with
+# `gh pr merge ... --squash --auto`. The repo's merge queue (strict-strategy
+# enforcement enabled between v0.2.92 and v0.2.93) OWNS the merge strategy and
+# rejects an explicit `--squash`, so `gh pr merge` exits non-zero. Under
+# `shell: bash -e` that fails the step, fails the `update_versions` job, and
+# skips the ENTIRE publish cascade (wait_for_pr -> publish_crates -> tag ->
+# gateway update). Net effect: the bump PR is created but nothing publishes.
+#
+# The fix drops `--squash` (the queue applies its configured strategy). This
+# test pins that no `gh pr merge` invocation in release.yml re-adds `--squash`,
+# and that the auto-merge step still enables auto-merge with `--auto`.
+#
+# Run manually with: bash scripts/release_mergequeue_test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RELEASE_YML="$SCRIPT_DIR/../.github/workflows/release.yml"
+
+FAILURES=0
+check() {
+    # check <description> <actual> <expected>
+    local desc="$1" actual="$2" expected="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        echo "ok   - $desc"
+    else
+        echo "FAIL - $desc (got '$actual', expected '$expected')" >&2
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+# Non-comment `gh pr merge` invocations in release.yml.
+MERGE_LINES=$(grep -E 'gh pr merge' "$RELEASE_YML" | grep -vE '^\s*#' || true)
+
+check "release.yml still has a gh pr merge invocation" \
+  "$([ -n "$MERGE_LINES" ] && echo present || echo missing)" "present"
+
+# The merge queue owns the strategy; an explicit --squash makes `gh pr merge`
+# exit non-zero and skips the whole publish cascade (broke v0.2.93).
+check "gh pr merge does NOT pass --squash" \
+  "$(echo "$MERGE_LINES" | grep -q -- '--squash' && echo has-squash || echo no-squash)" "no-squash"
+
+# Auto-merge must still be enabled, or wait_for_pr times out.
+check "gh pr merge still enables --auto" \
+  "$(echo "$MERGE_LINES" | grep -q -- '--auto' && echo has-auto || echo no-auto)" "has-auto"
+
+if [ "$FAILURES" -eq 0 ]; then
+    echo "PASS: release.yml auto-merge is merge-queue-compatible (--auto, no --squash)."
+else
+    echo "$FAILURES check(s) failed" >&2
+    exit 1
+fi


### PR DESCRIPTION
## Problem
The v0.2.93 release workflow **failed** at the `update_versions` job's "Enable auto-merge" step:
```
gh pr merge <bump-pr> --squash --auto   →  exit code 1
```
The repo's **merge queue** now owns the merge strategy (strict enforcement was enabled between v0.2.92 and v0.2.93 — v0.2.92's bump PR #4701 merged fine yesterday with `--squash`, today #4728 did not). `gh pr merge --squash` under a queue-controlled branch exits non-zero, and `shell: bash -e` turns that into a job failure, which skips the whole publish cascade (`wait_for_pr` → `publish_crates` → tag → gateway update). Net: the bump PR is created but the release never publishes. This breaks **every** release until fixed.

## Approach
Drop `--squash` from the `gh pr merge` call. `--auto` alone enables auto-merge and the queue applies its configured strategy (this is exactly what worked when the same PRs were merged manually today). Added a guard comment so `--squash` isn't reintroduced.

## Testing
CI on this PR + the next release run is the real test. `wait_for_pr` is already queue-aware (75-min timeout, polls for merge), so no other change is needed. Verified the same `--auto`-without-`--squash` form successfully queued #4720/#4722 earlier today.

[AI-assisted - Claude]