### PR TITLE
feat(put): summary-first PUT probe->dispatch behavioral flow (#4642, step 3-bis)

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -3412,6 +3412,15 @@ std::thread_local! {
     static GLOBAL_TERMINAL_CONSULT_HITS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
     static GLOBAL_TERMINAL_CONSULT_RESOLVED_FOUND: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
     static GLOBAL_TERMINAL_CONSULT_STILL_NOT_FOUND: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+    // Summary-first PUT (#4642 step 3-bis) — PUT-bytes-by-case falsifier.
+    // Count + bytes for the new-contract case (no holder found; full state
+    // ships hop-by-hop via the existing `PutMsg::Request` path).
+    static GLOBAL_PUT_PROBE_NEW_CONTRACT_COUNT: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+    static GLOBAL_PUT_PROBE_NEW_CONTRACT_BYTES: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+    // Count + bytes for the existing-mesh case (holder found; only a
+    // `StateDelta` ships via `ProbeReconcile`).
+    static GLOBAL_PUT_PROBE_EXISTING_MESH_DELTA_COUNT: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+    static GLOBAL_PUT_PROBE_EXISTING_MESH_DELTA_BYTES: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
 }
 
 /// Global test metrics for tracking events across the simulation network.
@@ -3451,6 +3460,10 @@ impl GlobalTestMetrics {
         GLOBAL_TERMINAL_CONSULT_HITS.with(|c| c.set(0));
         GLOBAL_TERMINAL_CONSULT_RESOLVED_FOUND.with(|c| c.set(0));
         GLOBAL_TERMINAL_CONSULT_STILL_NOT_FOUND.with(|c| c.set(0));
+        GLOBAL_PUT_PROBE_NEW_CONTRACT_COUNT.with(|c| c.set(0));
+        GLOBAL_PUT_PROBE_NEW_CONTRACT_BYTES.with(|c| c.set(0));
+        GLOBAL_PUT_PROBE_EXISTING_MESH_DELTA_COUNT.with(|c| c.set(0));
+        GLOBAL_PUT_PROBE_EXISTING_MESH_DELTA_BYTES.with(|c| c.set(0));
     }
 
     /// Records that a ResyncRequest was received.
@@ -3585,6 +3598,50 @@ impl GlobalTestMetrics {
 
     pub fn terminal_consult_still_not_found() -> u64 {
         GLOBAL_TERMINAL_CONSULT_STILL_NOT_FOUND.with(|c| c.get())
+    }
+
+    // --- Summary-first PUT (#4642 step 3-bis): PUT-bytes-by-case falsifier ---
+    //
+    // Proves (or disproves) the byte-savings claim: how many originator PUTs
+    // took the new-contract path (full state shipped, the pre-existing
+    // behavior) versus the existing-mesh path (only a delta shipped via
+    // `ProbeReconcile`), and how many bytes each path actually moved. Fed
+    // from a single call site (`operations::put::op_ctx_task::
+    // record_put_probe_outcome`) so this thread-local counter and the
+    // per-node `node::network_status` dashboard counter never drift
+    // relative to each other.
+
+    /// Record a summary-first PUT probe that found no holder (genuinely new
+    /// contract): `bytes` is the full-state payload size about to ship
+    /// hop-by-hop via the existing `PutMsg::Request` path.
+    pub fn record_put_probe_new_contract(bytes: u64) {
+        GLOBAL_PUT_PROBE_NEW_CONTRACT_COUNT.with(|c| c.set(c.get() + 1));
+        GLOBAL_PUT_PROBE_NEW_CONTRACT_BYTES.with(|c| c.set(c.get() + bytes));
+    }
+
+    pub fn put_probe_new_contract_sends() -> u64 {
+        GLOBAL_PUT_PROBE_NEW_CONTRACT_COUNT.with(|c| c.get())
+    }
+
+    pub fn put_probe_new_contract_bytes() -> u64 {
+        GLOBAL_PUT_PROBE_NEW_CONTRACT_BYTES.with(|c| c.get())
+    }
+
+    /// Record a summary-first PUT probe that found an existing holder:
+    /// `bytes` is the `StateDelta` size shipped via `ProbeReconcile` (0 if
+    /// the delta was empty — the holder's state was already logically
+    /// equivalent to ours, so nothing was sent).
+    pub fn record_put_probe_existing_mesh_delta(bytes: u64) {
+        GLOBAL_PUT_PROBE_EXISTING_MESH_DELTA_COUNT.with(|c| c.set(c.get() + 1));
+        GLOBAL_PUT_PROBE_EXISTING_MESH_DELTA_BYTES.with(|c| c.set(c.get() + bytes));
+    }
+
+    pub fn put_probe_existing_mesh_delta_sends() -> u64 {
+        GLOBAL_PUT_PROBE_EXISTING_MESH_DELTA_COUNT.with(|c| c.get())
+    }
+
+    pub fn put_probe_existing_mesh_delta_bytes() -> u64 {
+        GLOBAL_PUT_PROBE_EXISTING_MESH_DELTA_BYTES.with(|c| c.get())
     }
 }
 

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -348,7 +348,7 @@ pub struct NodeConfig {
     /// by `ConnectionManager::supports_summary_first_put`, the send gate the
     /// originator's PUT driver checks before probing a target.
     ///
-    /// In production this is `None` → the real `(0, 2, 94)` floor (untouched).
+    /// In production this is `None` → the real `(0, 2, 95)` floor (untouched).
     ///
     /// In simulations every `SimNetwork` defaults this to an unreachable
     /// floor (`SimNetwork::SIM_MIGRATION_DISABLED_FLOOR`), mirroring

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -57,6 +57,15 @@ pub(crate) use network_bridge::{
 // (The module-cache metrics were a sibling process-global until #4488 made them
 // a per-node `Arc`.)
 pub(crate) use network_bridge::broadcast_queue::BROADCAST_STREAM_METRICS;
+// Re-export the summary-first PUT version gate (#4642 step 3-bis) so
+// `ring::connection_manager::ConnectionManager::supports_summary_first_put`
+// can consult it — the gate lives behind the private `network_bridge`
+// module, so a sibling top-level module (`ring`) needs a targeted
+// re-export rather than a path through `network_bridge` directly. Mirrors
+// `BROADCAST_STREAM_METRICS` above.
+pub(crate) use network_bridge::p2p_protoc::{
+    SUMMARY_FIRST_PUT_MIN_VERSION, version_supports_summary_first_put,
+};
 #[cfg(test)]
 pub(crate) use network_bridge::{EventLoopNotificationsReceiver, event_loop_notification_channel};
 // Re-export types for dev_tool and testing
@@ -332,6 +341,27 @@ pub struct NodeConfig {
     /// `#[serde(skip)]`; never serialized.
     #[serde(skip)]
     pub(crate) subscribe_hint_floor_override: Option<(u8, u8, u16)>,
+    /// Test-only override for the summary-first PUT probe version floor
+    /// (`SUMMARY_FIRST_PUT_MIN_VERSION`). Threaded exactly like
+    /// `subscribe_hint_floor_override` above: consulted as
+    /// `summary_first_put_floor_override().unwrap_or(SUMMARY_FIRST_PUT_MIN_VERSION)`
+    /// by `ConnectionManager::supports_summary_first_put`, the send gate the
+    /// originator's PUT driver checks before probing a target.
+    ///
+    /// In production this is `None` → the real `(0, 2, 94)` floor (untouched).
+    ///
+    /// In simulations every `SimNetwork` defaults this to an unreachable
+    /// floor (`SimNetwork::SIM_MIGRATION_DISABLED_FLOOR`), mirroring
+    /// `subscribe_hint_floor_override`'s fail-closed default: summary-first
+    /// PUT is genuinely opt-in per sim via
+    /// `SimNetwork::enable_summary_first_put`, rather than firing in every
+    /// sim once the crate version passes the real floor.
+    ///
+    /// Not cfg-gated for the same reason as `subscribe_hint_floor_override`:
+    /// `node::testing_impl` sets it and is compiled unconditionally.
+    /// `#[serde(skip)]`; never serialized.
+    #[serde(skip)]
+    pub(crate) summary_first_put_floor_override: Option<(u8, u8, u16)>,
     /// Test-only harness flag: when set, a startup-hosted contract
     /// (`SeedHostedContract`, i.e. `append_contracts` with `subscription =
     /// true`) is registered in the neighbor-hosting advertised set so the
@@ -497,6 +527,7 @@ impl NodeConfig {
             },
             governance_config_override: None,
             subscribe_hint_floor_override: None,
+            summary_first_put_floor_override: None,
             advertise_seeded_hosts: false,
             hosting_time_source_override: None,
         })
@@ -1123,6 +1154,7 @@ where
                 put::PutMsg::Response { .. }
                     | put::PutMsg::ResponseStreaming { .. }
                     | put::PutMsg::Error { .. }
+                    | put::PutMsg::ProbeResponse { .. }
             ) && try_forward_driver_reply(
                 pending_op_result.as_ref(),
                 NetMessage::V1(NetMessageV1::Put((*op).clone())),
@@ -1139,6 +1171,8 @@ where
             let banned_key = match op {
                 put::PutMsg::Request { contract, .. } => Some(contract.key()),
                 put::PutMsg::RequestStreaming { contract_key, .. } => Some(*contract_key),
+                put::PutMsg::ProbeRequest { contract_key, .. } => Some(*contract_key),
+                put::PutMsg::ProbeReconcile { key, .. } => Some(*key),
                 _ => None,
             };
             if let Some(key) = banned_key {
@@ -1230,13 +1264,65 @@ where
                             );
                         }
                     }
+                    put::PutMsg::ProbeRequest {
+                        id,
+                        contract_key,
+                        summary,
+                        htl,
+                        skip_list,
+                    } => {
+                        if let Err(err) = put::op_ctx_task::start_relay_probe(
+                            op_manager.clone(),
+                            *id,
+                            *contract_key,
+                            summary.clone(),
+                            *htl,
+                            skip_list.clone(),
+                            upstream_addr,
+                        )
+                        .await
+                        {
+                            tracing::error!(
+                                tx = %id,
+                                contract = %contract_key,
+                                error = %err,
+                                "PUT relay dispatch: start_relay_probe failed"
+                            );
+                        }
+                    }
+                    put::PutMsg::ProbeReconcile {
+                        id,
+                        key,
+                        delta,
+                        htl,
+                        skip_list,
+                    } => {
+                        if let Err(err) = put::op_ctx_task::start_relay_probe_reconcile(
+                            op_manager.clone(),
+                            *id,
+                            *key,
+                            delta.clone(),
+                            *htl,
+                            skip_list.clone(),
+                            upstream_addr,
+                        )
+                        .await
+                        {
+                            tracing::error!(
+                                tx = %id,
+                                contract = %key,
+                                error = %err,
+                                "PUT relay dispatch: start_relay_probe_reconcile failed"
+                            );
+                        }
+                    }
                     _ => {
                         tracing::debug!(
                             tx = %op.id(),
                             ?op,
                             "PUT: non-dispatch variant ignored \
-                             (Response/ResponseStreaming/Error already \
-                             handled by bypass; ForwardingAck is no-op)"
+                             (Response/ResponseStreaming/Error/ProbeResponse \
+                             already handled by bypass; ForwardingAck is no-op)"
                         );
                     }
                 }

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -911,30 +911,33 @@ pub(crate) fn version_supports_subscribe_hint(
 /// them.
 ///
 /// The floor MUST equal the version that first carries the probe/dispatch
-/// **handler** (this behavioral piece), not merely the wire variants. The
-/// scaffolding PR #4718 added the `ProbeRequest`/`ProbeResponse` variants to
-/// v0.2.93 INERT (no handler, no emit), so a 0.2.93 peer can *decode* a
-/// probe but cannot *process* one: emitting to it during the 0-4h staggered
-/// rollout would land a probe on a peer with no handler and break the PUT.
-/// The floor therefore must be strictly greater than 0.2.93 and equal to the
-/// release that ships this handler.
+/// wire variants AND their handler — both land together in this PR, there is
+/// no separate inert-scaffolding release. A peer on any earlier release does
+/// not carry the `ProbeRequest`/`ProbeResponse`/`ProbeReconcile` variants at
+/// all (`PutMsg` tags 6/7/8): it cannot bincode-deserialize the appended tag,
+/// and the decode failure DROPS the connection. Emitting a probe to such a
+/// peer during the 0-4h staggered rollout would churn live connections. The
+/// floor therefore must equal the first release that carries these variants.
 ///
-/// v0.2.93 is already released and carries only the inert variants. Per the
-/// wire-gated-floor rule in `docs/RELEASING.md` ("set the floor to exactly
-/// the release that first EMITS the feature, then freeze"), the floor is set
-/// to `(0, 2, 94)`, the release this behavioral piece ships in. Only peer
-/// pairs both on `>= this floor` will exchange probes, so activation ramps
-/// with fleet upgrade rather than switching on everywhere at once (the
-/// SubscribeHint model).
+/// The `ProbeRequest`/`ProbeResponse`/`ProbeReconcile` variants and their
+/// handler first ship together in **0.2.95** (this PR). The earlier
+/// scaffolding PR #4718 was NEVER merged, so no released version carries the
+/// variants inert: 0.2.93 and 0.2.94 are both already released and have NONE
+/// of the probe variants. Per the wire-gated-floor rule in `docs/RELEASING.md`
+/// ("set the floor to exactly the release that first EMITS the feature, then
+/// freeze"), the floor is `(0, 2, 95)`, the release this behavioral piece
+/// ships in. Only peer pairs both on `>= this floor` will exchange probes, so
+/// activation ramps with fleet upgrade rather than switching on everywhere at
+/// once (the SubscribeHint model).
 ///
 /// RELEASE-TIME CHECK (do NOT skip): this constant MUST equal the actual
 /// shipping version. If the release that first emits the probe ends up being
-/// something other than 0.2.94 (a slipped or renumbered release), update this
+/// something other than 0.2.95 (a slipped or renumbered release), update this
 /// constant to match that version before cutting the release, then freeze it.
-/// A floor lower than the shipping version reintroduces the decode-but-cannot-
-/// process rollout bug above; a floor higher silently disables the feature
-/// against fully-capable peers.
-pub(crate) const SUMMARY_FIRST_PUT_MIN_VERSION: (u8, u8, u16) = (0, 2, 94);
+/// A floor lower than the shipping version reintroduces the decode-failure
+/// connection-drop rollout bug above; a floor higher silently disables the
+/// feature against fully-capable peers.
+pub(crate) const SUMMARY_FIRST_PUT_MIN_VERSION: (u8, u8, u16) = (0, 2, 95);
 
 /// Pure version-gate for the summary-first PUT probe/dispatch variants,
 /// mirroring [`version_supports_subscribe_hint`]: returns `true` iff
@@ -3564,13 +3567,17 @@ mod tests {
             assert!(!version_supports_subscribe_hint(None, (0, 0, 0)));
         }
 
-        // ---- Summary-first PUT probe/dispatch gate (INERT, #4642) ----
-        // Same fail-closed semantics as the SubscribeHint gate. These are
-        // the emission gate a LATER piece consults before sending the
-        // `PutMsg::ProbeRequest` / `ProbeResponse` variants; nothing emits
-        // them yet, so this asserts the gate is correct in isolation.
+        // ---- Summary-first PUT probe/dispatch gate (#4642) ----
+        // Same fail-closed semantics as the SubscribeHint gate. This is the
+        // emission gate the originator's PUT driver consults before sending
+        // the `PutMsg::ProbeRequest` / `ProbeResponse` / `ProbeReconcile`
+        // variants (this PR wires that emission); the tests assert the gate
+        // is correct in isolation.
 
-        const SF_FLOOR: (u8, u8, u16) = (0, 2, 94);
+        // Mirrors the production `SUMMARY_FIRST_PUT_MIN_VERSION`: the probe
+        // variants + handler first ship together in 0.2.95 (this PR), so the
+        // floor is (0, 2, 95). No released version carries the variants inert.
+        const SF_FLOOR: (u8, u8, u16) = (0, 2, 95);
 
         /// The mixed-version interop guarantee, expressed at the gate: an
         /// UNKNOWN remote version fails closed, so a summary-first-capable
@@ -3585,12 +3592,18 @@ mod tests {
 
         /// A pre-floor peer (older than the release that first carries the
         /// probe variants) is never sent the probe — it could not decode it.
-        /// `(0, 2, 93)` is explicitly included: that release is already
-        /// live in production and does NOT carry the probe variants (the
-        /// wire scaffolding landed after the 0.2.93 cut), so it must be
-        /// rejected just like any other pre-floor peer.
+        /// `(0, 2, 94)` is explicitly included: it is the HIGHEST already-
+        /// released version, and it does NOT carry the probe variants (they
+        /// first ship in 0.2.95, this PR — the earlier scaffolding PR #4718
+        /// never merged). So a 0.2.94 peer must be rejected just like any
+        /// other pre-floor peer; a probe would fail to decode and drop the
+        /// connection.
         #[test]
         fn summary_first_older_remote_version_is_rejected() {
+            assert!(!version_supports_summary_first_put(
+                Some((0, 2, 94)),
+                SF_FLOOR
+            ));
             assert!(!version_supports_summary_first_put(
                 Some((0, 2, 93)),
                 SF_FLOOR
@@ -3611,7 +3624,7 @@ mod tests {
         #[test]
         fn summary_first_equal_or_newer_remote_version_is_accepted() {
             assert!(version_supports_summary_first_put(
-                Some((0, 2, 94)),
+                Some((0, 2, 95)),
                 SF_FLOOR
             ));
             assert!(version_supports_summary_first_put(

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -900,27 +900,41 @@ pub(crate) fn version_supports_subscribe_hint(
 /// Minimum negotiated protocol version a peer must report before this node
 /// may emit the summary-first PUT probe/dispatch variants
 /// ([`PutMsg::ProbeRequest`](crate::operations::put::PutMsg) /
-/// `PutMsg::ProbeResponse`).
+/// `PutMsg::ProbeResponse` / `PutMsg::ProbeReconcile`).
 ///
-/// # INERT (#4642, step 3-bis)
+/// # Emission gate (#4642, step 3-bis)
 ///
-/// No code emits those variants yet — the probe→dispatch driver and its
-/// send path are a LATER piece paired with every-hop placement. This floor
-/// and [`version_supports_summary_first_put`] are the emission gate that
-/// later piece will consult, so a pre-floor peer — which cannot
-/// bincode-deserialize the appended tags and would drop the connection —
-/// never receives them. The value is the release that first carries the
-/// variants in the enum (this scaffolding PR); the emitting piece MUST
-/// confirm/raise it to the release that first EMITS if that is later. Only
-/// peer pairs both on `>= this floor` will exchange probes, so activation
-/// ramps with fleet upgrade rather than switching on everywhere at once
-/// (the SubscribeHint model). Frozen once emission ships, per the
-/// wire-gated-floor rule in `docs/RELEASING.md`.
+/// Consulted by `ConnectionManager::supports_summary_first_put`, which the
+/// originator's PUT driver (`operations::put::op_ctx_task`) checks before
+/// probing a target: a pre-floor peer cannot bincode-deserialize the
+/// appended tags and would drop the connection, so it must never receive
+/// them.
 ///
-/// INERT: read only by the gate's own unit tests today; the emitting piece
-/// (later) is its first production consumer.
-#[allow(dead_code)]
-pub(crate) const SUMMARY_FIRST_PUT_MIN_VERSION: (u8, u8, u16) = (0, 2, 93);
+/// The floor MUST equal the version that first carries the probe/dispatch
+/// **handler** (this behavioral piece), not merely the wire variants. The
+/// scaffolding PR #4718 added the `ProbeRequest`/`ProbeResponse` variants to
+/// v0.2.93 INERT (no handler, no emit), so a 0.2.93 peer can *decode* a
+/// probe but cannot *process* one: emitting to it during the 0-4h staggered
+/// rollout would land a probe on a peer with no handler and break the PUT.
+/// The floor therefore must be strictly greater than 0.2.93 and equal to the
+/// release that ships this handler.
+///
+/// v0.2.93 is already released and carries only the inert variants. Per the
+/// wire-gated-floor rule in `docs/RELEASING.md` ("set the floor to exactly
+/// the release that first EMITS the feature, then freeze"), the floor is set
+/// to `(0, 2, 94)`, the release this behavioral piece ships in. Only peer
+/// pairs both on `>= this floor` will exchange probes, so activation ramps
+/// with fleet upgrade rather than switching on everywhere at once (the
+/// SubscribeHint model).
+///
+/// RELEASE-TIME CHECK (do NOT skip): this constant MUST equal the actual
+/// shipping version. If the release that first emits the probe ends up being
+/// something other than 0.2.94 (a slipped or renumbered release), update this
+/// constant to match that version before cutting the release, then freeze it.
+/// A floor lower than the shipping version reintroduces the decode-but-cannot-
+/// process rollout bug above; a floor higher silently disables the feature
+/// against fully-capable peers.
+pub(crate) const SUMMARY_FIRST_PUT_MIN_VERSION: (u8, u8, u16) = (0, 2, 94);
 
 /// Pure version-gate for the summary-first PUT probe/dispatch variants,
 /// mirroring [`version_supports_subscribe_hint`]: returns `true` iff
@@ -932,10 +946,6 @@ pub(crate) const SUMMARY_FIRST_PUT_MIN_VERSION: (u8, u8, u16) = (0, 2, 93);
 /// do NOT emit. Factored out (with an explicit `floor` param) so the gate
 /// is unit-testable independent of the production
 /// [`SUMMARY_FIRST_PUT_MIN_VERSION`].
-///
-/// INERT: no caller emits yet (see [`SUMMARY_FIRST_PUT_MIN_VERSION`]); this
-/// is the predicate the emitting piece will guard its send path with.
-#[allow(dead_code)]
 pub(crate) fn version_supports_summary_first_put(
     remote: Option<(u8, u8, u16)>,
     floor: (u8, u8, u16),
@@ -3560,7 +3570,7 @@ mod tests {
         // `PutMsg::ProbeRequest` / `ProbeResponse` variants; nothing emits
         // them yet, so this asserts the gate is correct in isolation.
 
-        const SF_FLOOR: (u8, u8, u16) = (0, 2, 93);
+        const SF_FLOOR: (u8, u8, u16) = (0, 2, 94);
 
         /// The mixed-version interop guarantee, expressed at the gate: an
         /// UNKNOWN remote version fails closed, so a summary-first-capable
@@ -3575,8 +3585,16 @@ mod tests {
 
         /// A pre-floor peer (older than the release that first carries the
         /// probe variants) is never sent the probe — it could not decode it.
+        /// `(0, 2, 93)` is explicitly included: that release is already
+        /// live in production and does NOT carry the probe variants (the
+        /// wire scaffolding landed after the 0.2.93 cut), so it must be
+        /// rejected just like any other pre-floor peer.
         #[test]
         fn summary_first_older_remote_version_is_rejected() {
+            assert!(!version_supports_summary_first_put(
+                Some((0, 2, 93)),
+                SF_FLOOR
+            ));
             assert!(!version_supports_summary_first_put(
                 Some((0, 2, 92)),
                 SF_FLOOR
@@ -3592,10 +3610,6 @@ mod tests {
         /// condition (ramps with fleet upgrade, SubscribeHint model).
         #[test]
         fn summary_first_equal_or_newer_remote_version_is_accepted() {
-            assert!(version_supports_summary_first_put(
-                Some((0, 2, 93)),
-                SF_FLOOR
-            ));
             assert!(version_supports_summary_first_put(
                 Some((0, 2, 94)),
                 SF_FLOOR

--- a/crates/core/src/node/network_bridge/p2p_protoc/connection_lifecycle.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc/connection_lifecycle.rs
@@ -1035,6 +1035,19 @@ impl P2pConnManager {
                 remote_version,
             },
         );
+        // Mirror the same version onto `ConnectionManager` so op drivers
+        // (reached via `op_manager.ring.connection_manager`, not this
+        // network-bridge layer) can gate emission of version-sensitive wire
+        // variants — e.g. the summary-first PUT probe's
+        // `supports_summary_first_put` check. Keep this write paired with
+        // the `self.connections.insert` above if that call site changes.
+        if let Some(version) = remote_version {
+            self.bridge
+                .op_manager
+                .ring
+                .connection_manager
+                .record_remote_version(peer_addr, version);
+        }
         // Only add to reverse lookup if we know the pub_key
         // For transient connections, this will be populated when identity is learned
         if let Some(ref peer) = peer_id {

--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -381,6 +381,26 @@ pub struct OperationStats {
     /// Count of broadcast updates received via subscription streaming.
     /// These are push-based and don't have success/failure semantics.
     pub updates_received: u32,
+    /// Summary-first PUT (#4642 step 3-bis): count + bytes shipped for the
+    /// new-contract case (no holder found; full state ships hop-by-hop via
+    /// the existing `PutMsg::Request` path). See [`record_put_bytes`].
+    pub put_probe_new_contract: (u32, u64),
+    /// Summary-first PUT: count + bytes shipped for the existing-mesh case
+    /// (holder found; only a `StateDelta` ships via `ProbeReconcile`). See
+    /// [`record_put_bytes`].
+    pub put_probe_existing_mesh_delta: (u32, u64),
+}
+
+/// Which path a summary-first PUT took (#4642 step 3-bis telemetry). See
+/// [`record_put_bytes`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PutProbeCase {
+    /// No holder found along the probe route — treated as a genuinely new
+    /// contract; full state ships hop-by-hop via the existing
+    /// `PutMsg::Request` path.
+    NewContract,
+    /// A holder was found — only a `StateDelta` ships via `ProbeReconcile`.
+    ExistingMeshDelta,
 }
 
 /// Maximum number of recent NAT attempts to track for rolling trend.
@@ -658,6 +678,27 @@ pub fn record_update_received() {
     if let Some(status) = NETWORK_STATUS.get() {
         if let Ok(mut s) = status.write() {
             s.op_stats.updates_received = s.op_stats.updates_received.saturating_add(1);
+        }
+    }
+}
+
+/// Record a summary-first PUT probe outcome for the dashboard "Operations"
+/// panel (#4642 step 3-bis falsifier): which path the originator took
+/// (`case`) and how many bytes that path actually shipped.
+///
+/// Single call site: `operations::put::op_ctx_task::record_put_probe_outcome`,
+/// which also feeds the matching `GlobalTestMetrics` counter from the same
+/// call so the two can never drift relative to each other (see
+/// `.claude/rules/bug-prevention-patterns.md`: manually-mirrored counters).
+pub fn record_put_bytes(case: PutProbeCase, bytes: u64) {
+    if let Some(status) = NETWORK_STATUS.get() {
+        if let Ok(mut s) = status.write() {
+            let counter = match case {
+                PutProbeCase::NewContract => &mut s.op_stats.put_probe_new_contract,
+                PutProbeCase::ExistingMeshDelta => &mut s.op_stats.put_probe_existing_mesh_delta,
+            };
+            counter.0 = counter.0.saturating_add(1);
+            counter.1 = counter.1.saturating_add(bytes);
         }
     }
 }

--- a/crates/core/src/node/testing_impl.rs
+++ b/crates/core/src/node/testing_impl.rs
@@ -1293,6 +1293,16 @@ pub struct SimNetwork {
     /// real production floor (#4601). Production is untouched: `NodeConfig::new`
     /// sets this to `None`, which resolves to the real `SUBSCRIBE_HINT_MIN_VERSION`.
     subscribe_hint_floor_override: Option<(u8, u8, u16)>,
+    /// Per-node summary-first PUT probe version-floor override (see
+    /// [`SimNetwork::enable_summary_first_put`]). Mirrors
+    /// `subscribe_hint_floor_override` exactly: defaults to
+    /// `Some(SIM_MIGRATION_DISABLED_FLOOR)` (an unreachable floor) so the
+    /// probe/dispatch cascade is FAIL-CLOSED — OFF — in every sim regardless
+    /// of build version, and only a test that explicitly calls
+    /// `enable_summary_first_put` gets summary-first PUT. Production is
+    /// untouched: `NodeConfig::new` sets this to `None`, which resolves to
+    /// the real `SUMMARY_FIRST_PUT_MIN_VERSION`.
+    summary_first_put_floor_override: Option<(u8, u8, u16)>,
     /// Optional controllable hosting clock injected into every node's
     /// `HostingManager` (via `NodeConfig::hosting_time_source_override`). When
     /// set, hosting-cache TTL and subscription-lease eviction advance ONLY when
@@ -1480,6 +1490,10 @@ impl SimNetwork {
             // the 500-node nightly red. Defaulting to an unreachable floor keeps
             // migration genuinely opt-in, as the docs have always claimed.
             subscribe_hint_floor_override: Some(Self::SIM_MIGRATION_DISABLED_FLOOR),
+            // Fail-closed by default, same rationale as
+            // `subscribe_hint_floor_override` above: summary-first PUT is
+            // genuinely opt-in per sim via `enable_summary_first_put`.
+            summary_first_put_floor_override: Some(Self::SIM_MIGRATION_DISABLED_FLOOR),
             hosting_clock: None,
             hosting_budget_override: None,
             shared_rings: HashMap::new(),
@@ -1744,6 +1758,54 @@ impl SimNetwork {
         }
         for (builder, _) in self.nodes.iter_mut() {
             builder.config.subscribe_hint_floor_override = floor;
+        }
+        self
+    }
+
+    /// Enable summary-first PUT (#4642, step 3-bis) for this simulation by
+    /// lowering the probe version floor to [`Self::SIM_MIGRATION_ENABLED_FLOOR`]
+    /// (`(0,0,0)`) on every node.
+    ///
+    /// Summary-first PUT is OFF by default in every `SimNetwork` (the
+    /// per-node floor defaults to the unreachable
+    /// [`Self::SIM_MIGRATION_DISABLED_FLOOR`] — see `new_inner`), so this
+    /// makes the probe/dispatch cascade genuinely opt-in: only a test that
+    /// specifically exercises it calls this to force it ON regardless of
+    /// build version; every other sim is left untouched. Mirrors
+    /// [`enable_placement_migration`](Self::enable_placement_migration) —
+    /// same sentinel floors, same patch-already-built-configs shape, distinct
+    /// override field (`summary_first_put_floor_override`).
+    #[allow(dead_code)]
+    pub fn enable_summary_first_put(&mut self) -> &mut Self {
+        let floor = Some(Self::SIM_MIGRATION_ENABLED_FLOOR);
+        self.summary_first_put_floor_override = floor;
+        for (builder, _) in self.gateways.iter_mut() {
+            builder.config.summary_first_put_floor_override = floor;
+        }
+        for (builder, _) in self.nodes.iter_mut() {
+            builder.config.summary_first_put_floor_override = floor;
+        }
+        self
+    }
+
+    /// Force summary-first PUT OFF for this simulation by pinning the
+    /// per-node probe version floor to the unreachable
+    /// [`Self::SIM_MIGRATION_DISABLED_FLOOR`].
+    ///
+    /// The mirror of [`enable_summary_first_put`](Self::enable_summary_first_put),
+    /// following [`disable_placement_migration`](Self::disable_placement_migration)'s
+    /// belt-and-suspenders rationale: the cascade is already OFF by default in
+    /// every sim, so this just makes a test's "summary-first PUT must stay
+    /// off" premise explicit at the call site.
+    #[allow(dead_code)]
+    pub fn disable_summary_first_put(&mut self) -> &mut Self {
+        let floor = Some(Self::SIM_MIGRATION_DISABLED_FLOOR);
+        self.summary_first_put_floor_override = floor;
+        for (builder, _) in self.gateways.iter_mut() {
+            builder.config.summary_first_put_floor_override = floor;
+        }
+        for (builder, _) in self.nodes.iter_mut() {
+            builder.config.summary_first_put_floor_override = floor;
         }
         self
     }
@@ -2377,6 +2439,7 @@ impl SimNetwork {
                 .unwrap();
             config.governance_config_override = self.governance_config_override.clone();
             config.subscribe_hint_floor_override = self.subscribe_hint_floor_override;
+            config.summary_first_put_floor_override = self.summary_first_put_floor_override;
             config.hosting_time_source_override = self
                 .hosting_clock
                 .clone()
@@ -2476,6 +2539,7 @@ impl SimNetwork {
                 .unwrap();
             config.governance_config_override = self.governance_config_override.clone();
             config.subscribe_hint_floor_override = self.subscribe_hint_floor_override;
+            config.summary_first_put_floor_override = self.summary_first_put_floor_override;
             config.hosting_time_source_override = self
                 .hosting_clock
                 .clone()

--- a/crates/core/src/operations/put.rs
+++ b/crates/core/src/operations/put.rs
@@ -301,6 +301,22 @@ mod messages {
         Ok(value.map(StateSummary::into_owned))
     }
 
+    /// Deserializes an `Option<StateDelta>` into its owned (`'static`)
+    /// form, mapping the `Some` arm through `StateDelta::into_owned`.
+    /// Mirrors [`deser_opt_state_summary`] (a borrowed `StateDelta<'de>` is
+    /// not `DeserializeOwned` and cannot cross the bincode boundary as a
+    /// plain field). Used by `PutMsg::ProbeResponse::reverse_delta` (the
+    /// summary-first PUT reverse leg), which is `Some` only when the holder
+    /// is ahead of the originator and the reverse delta is efficient, and
+    /// `None` otherwise.
+    fn deser_opt_state_delta<'de, D>(deser: D) -> Result<Option<StateDelta<'static>>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = <Option<StateDelta> as Deserialize>::deserialize(deser)?;
+        Ok(value.map(StateDelta::into_owned))
+    }
+
     /// PUT operation messages.
     ///
     /// The PUT operation stores a contract and its initial state in the network.
@@ -518,6 +534,33 @@ mod messages {
             /// layout stays refinable until first emission ships.
             #[serde(default, deserialize_with = "deser_opt_state_summary")]
             holder_summary: Option<StateSummary<'static>>,
+            /// **Reverse leg of the bidirectional reconcile (#4642, step
+            /// 3-bis).** The delta the ORIGINATOR is missing relative to the
+            /// holder's state, computed by the holder as the mirror of the
+            /// originator's forward delta: `compute_delta(their_summary =
+            /// ProbeRequest::summary (the originator's summary), our_summary
+            /// = holder's summary)`. The originator applies it to its own
+            /// local copy (same commutative UPDATE/merge path a holder uses
+            /// for the forward `ProbeReconcile`) BEFORE reporting client
+            /// success, so both sides converge to the full merged state in a
+            /// single round-trip instead of the originator healing only
+            /// later via anti-entropy.
+            ///
+            /// `Some(D_rev)` only when `holder_found == true`, the holder is
+            /// genuinely ahead, AND the reverse delta passes the SAME
+            /// efficiency gate the forward delta uses (`compute_delta` /
+            /// `is_delta_efficient`). `None` when no holder was found, when
+            /// the originator is already current (empty delta), or when the
+            /// reverse delta would be inefficient / uncomputable — in the
+            /// last two the originator falls back to healing via a normal
+            /// GET / anti-entropy rather than shipping a bloated delta.
+            /// Deserialized owned (`'static`) via the local
+            /// `deser_opt_state_delta` helper. Appended AFTER
+            /// `holder_summary` so tag 7's existing prefix (including
+            /// `holder_summary`) stays byte-for-byte identical; the variant
+            /// first ships in 0.2.95, so the field layout is still refinable.
+            #[serde(default, deserialize_with = "deser_opt_state_delta")]
+            reverse_delta: Option<StateDelta<'static>>,
         },
 
         /// **Summary-first PUT — reconcile write (#4642, step 3-bis, see
@@ -665,15 +708,18 @@ mod messages {
                     key,
                     holder_found,
                     holder_summary,
+                    reverse_delta,
                     ..
                 } => {
                     write!(
                         f,
-                        "PutProbeResponse(id: {}, key: {}, holder_found: {}, holder_summary: {})",
+                        "PutProbeResponse(id: {}, key: {}, holder_found: {}, holder_summary: {}, \
+                         reverse_delta: {})",
                         id,
                         key,
                         holder_found,
-                        holder_summary.is_some()
+                        holder_summary.is_some(),
+                        reverse_delta.is_some()
                     )
                 }
                 Self::ProbeReconcile {
@@ -885,6 +931,7 @@ mod tests {
                     holder_found: false,
                     hop_count: 0,
                     holder_summary: None,
+                    reverse_delta: None,
                 },
             ),
             (
@@ -960,20 +1007,33 @@ mod tests {
         }
     }
 
-    /// Summary-first PUT dispatch reply (INERT scaffolding, #4642): the
-    /// new-vs-existing signal (`holder_found`), `hop_count`, and the
-    /// trailing `holder_summary` round-trip through bincode for both
-    /// boolean cases, including a `Some` summary whose opaque bytes must
-    /// survive intact via the `deser_opt_state_summary` owned-deserialize
-    /// path.
+    /// Summary-first PUT dispatch reply (#4642): the new-vs-existing signal
+    /// (`holder_found`), `hop_count`, the trailing `holder_summary`, and the
+    /// bidirectional-reconcile `reverse_delta` round-trip through bincode.
+    /// Covers the `None`/`Some` cross-product for both opaque trailing fields
+    /// so the `deser_opt_state_summary` and `deser_opt_state_delta`
+    /// owned-deserialize paths are both exercised (including the case where
+    /// the holder ships a reverse delta back to a behind originator).
     #[test]
     fn put_msg_probe_response_serde_roundtrip() {
         let key = make_contract_key(4);
-        let cases: [(bool, usize, Option<Vec<u8>>); 2] = [
-            (false, 0usize, None),
-            (true, 5usize, Some(vec![0x11, 0x22, 0x33, 0x44])),
+        // (holder_found, hop_count, holder_summary bytes, reverse_delta bytes)
+        let cases: [(bool, usize, Option<Vec<u8>>, Option<Vec<u8>>); 3] = [
+            // No holder: both trailing fields absent.
+            (false, 0usize, None, None),
+            // Holder found, originator current-or-ahead: summary present, no
+            // reverse delta shipped.
+            (true, 5usize, Some(vec![0x11, 0x22, 0x33, 0x44]), None),
+            // Holder found AND ahead: summary present and a reverse delta
+            // shipped back to the behind originator.
+            (
+                true,
+                2usize,
+                Some(vec![0xAA, 0xBB]),
+                Some(vec![0x55, 0x66, 0x77, 0x88, 0x99]),
+            ),
         ];
-        for (holder_found, hop_count, summary_bytes) in cases {
+        for (holder_found, hop_count, summary_bytes, reverse_delta_bytes) in cases {
             let tx = Transaction::new::<PutMsg>();
             let msg = PutMsg::ProbeResponse {
                 id: tx,
@@ -981,6 +1041,7 @@ mod tests {
                 holder_found,
                 hop_count,
                 holder_summary: summary_bytes.clone().map(StateSummary::from),
+                reverse_delta: reverse_delta_bytes.clone().map(StateDelta::from),
             };
             let bytes = bincode::serialize(&msg).expect("serialize");
             let decoded: PutMsg = bincode::deserialize(&bytes).expect("deserialize");
@@ -991,6 +1052,7 @@ mod tests {
                     holder_found: decoded_holder,
                     hop_count: decoded_hops,
                     holder_summary: decoded_summary,
+                    reverse_delta: decoded_reverse,
                 } => {
                     assert_eq!(id, tx);
                     assert_eq!(decoded_key, key);
@@ -1008,6 +1070,20 @@ mod tests {
                         _ => panic!(
                             "holder_summary presence mismatch: decoded {decoded_summary:?} vs \
                              expected {summary_bytes:?}"
+                        ),
+                    }
+                    match (&decoded_reverse, &reverse_delta_bytes) {
+                        (Some(decoded), Some(expected)) => {
+                            assert_eq!(
+                                decoded.as_ref(),
+                                expected.as_slice(),
+                                "opaque reverse_delta bytes must survive the bincode round-trip"
+                            );
+                        }
+                        (None, None) => {}
+                        _ => panic!(
+                            "reverse_delta presence mismatch: decoded {decoded_reverse:?} vs \
+                             expected {reverse_delta_bytes:?}"
                         ),
                     }
                 }
@@ -1080,6 +1156,7 @@ mod tests {
             holder_found: true,
             hop_count: 0,
             holder_summary: None,
+            reverse_delta: None,
         };
         let reconcile = PutMsg::ProbeReconcile {
             id: tx,

--- a/crates/core/src/operations/put.rs
+++ b/crates/core/src/operations/put.rs
@@ -271,6 +271,36 @@ mod messages {
         pub value: WrappedState,
     }
 
+    /// Deserializes a [`StateDelta`] into its owned (`'static`) form.
+    ///
+    /// Mirrors [`StateSummary::deser_state_summary`]: a borrowed
+    /// `StateDelta<'de>` is not `DeserializeOwned` and cannot cross the
+    /// bincode boundary as a plain field, so any wire-carried `StateDelta`
+    /// needs a `#[serde(deserialize_with = ...)]` helper that forces an
+    /// owned copy. `freenet-stdlib` 0.8.2 provides
+    /// `StateSummary::deser_state_summary` but no equivalent for
+    /// `StateDelta`, so this helper is defined locally. Used by
+    /// [`PutMsg::ProbeReconcile`].
+    fn deser_state_delta<'de, D>(deser: D) -> Result<StateDelta<'static>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = <StateDelta as Deserialize>::deserialize(deser)?;
+        Ok(value.into_owned())
+    }
+
+    /// Deserializes an `Option<StateSummary>` into its owned (`'static`)
+    /// form, mapping the `Some` arm through `StateSummary::into_owned`.
+    /// Used by `PutMsg::ProbeResponse::holder_summary`, which is `Some`
+    /// only when the probe found a holder and `None` otherwise.
+    fn deser_opt_state_summary<'de, D>(deser: D) -> Result<Option<StateSummary<'static>>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = <Option<StateSummary> as Deserialize>::deserialize(deser)?;
+        Ok(value.map(StateSummary::into_owned))
+    }
+
     /// PUT operation messages.
     ///
     /// The PUT operation stores a contract and its initial state in the network.
@@ -401,8 +431,7 @@ mod messages {
             cause: String,
         },
 
-        /// **Summary-first PUT — Phase-1 probe. INERT wire scaffolding
-        /// (#4642, step 3-bis; NOT yet emitted — see below).**
+        /// **Summary-first PUT — probe (#4642, step 3-bis).**
         ///
         /// Instead of shipping the full [`WrappedState`] up front (as
         /// [`Request`](Self::Request) does), a summary-first PUT routes a
@@ -414,19 +443,13 @@ mod messages {
         /// need not know in advance whether the contract is genuinely new
         /// (ship full state) or already held (reconcile a delta).
         ///
-        /// # NOT YET EMITTED (inert scaffolding)
-        ///
-        /// No producer constructs this variant and no send path emits it.
-        /// It is merged inert: the probe→dispatch driver, the body-fetch
-        /// flow, and the emission gate are a LATER piece paired with
-        /// every-hop placement (#4642). When emission is added it MUST be
-        /// version-gated via `version_supports_summary_first_put` (in
-        /// `node::network_bridge::p2p_protoc`) — a pre-floor peer cannot
-        /// bincode-deserialize this appended tag and would drop the
-        /// connection, so it must never receive the probe. Because nothing
-        /// emits it yet, nothing is committed on the wire and the field
-        /// layout stays refinable until first emission ships in a release.
-        #[allow(dead_code)]
+        /// Emitted only by `operations::put::op_ctx_task::try_summary_first_put`
+        /// (originator) and forwarded hop-by-hop by
+        /// `start_relay_probe`/`drive_relay_probe`, and only after the
+        /// sender confirms the target passes
+        /// `ConnectionManager::supports_summary_first_put` — a pre-floor
+        /// peer cannot bincode-deserialize this appended tag and would drop
+        /// the connection, so it must never receive the probe.
         ProbeRequest {
             id: Transaction,
             /// Key of the contract being probed.
@@ -444,40 +467,96 @@ mod messages {
             skip_list: HashSet<std::net::SocketAddr>,
         },
 
-        /// **Summary-first PUT — Phase-2 dispatch reply. INERT wire
-        /// scaffolding (#4642, step 3-bis; NOT yet emitted — see
+        /// **Summary-first PUT — probe reply (#4642, step 3-bis, see
         /// [`ProbeRequest`](Self::ProbeRequest)).**
         ///
         /// Routed hop-by-hop back to the initiator, signalling whether the
         /// probe found an existing holder:
         ///
-        /// - `holder_found == false` → no holder → the contract is treated
-        ///   as genuinely new and full state ships hop-by-hop along the
-        ///   route (the [`Request`](Self::Request) path) — exactly where
-        ///   every-hop placement acquires its bytes.
-        /// - `holder_found == true` → a holder exists → the two copies
-        ///   reconcile bidirectionally via the contract's summary/delta
-        ///   primitives (a later piece); full state does NOT re-travel a
-        ///   mesh that already holds it. Not "ahead/behind": divergent
-        ///   copies merge via the commutative monoid.
+        /// - `holder_found == false`: no holder found, so the contract is
+        ///   treated as genuinely new and full state ships hop-by-hop
+        ///   along the route (the [`Request`](Self::Request) path), which
+        ///   is where every-hop placement acquires its bytes.
+        ///   `holder_summary` is `None`.
+        /// - `holder_found == true`: a holder exists, and `holder_summary`
+        ///   carries that holder's contract-defined `summarize_state`
+        ///   output. The initiator uses it to compute the delta the
+        ///   holder is missing, then sends that delta as
+        ///   [`ProbeReconcile`](Self::ProbeReconcile) instead of shipping
+        ///   full state into a mesh that already holds the contract. Not
+        ///   "ahead/behind": divergent copies merge via the contract's
+        ///   commutative monoid.
         ///
-        /// The reconcile message exchange is deliberately NOT modelled
-        /// here — this variant is only the new-vs-existing dispatch signal.
-        /// INERT: see [`ProbeRequest`](Self::ProbeRequest).
-        #[allow(dead_code)]
+        /// Produced by `start_relay_probe`/`drive_relay_probe` (a fresh
+        /// holder, or a routing terminus with no holder) and consumed by
+        /// `try_summary_first_put` at the originator; see
+        /// [`ProbeRequest`](Self::ProbeRequest).
         ProbeResponse {
             id: Transaction,
             /// Key of the probed contract.
             key: ContractKey,
             /// Whether the probe found an existing holder along the route.
             holder_found: bool,
-            /// Forward-path hop count — same semantics as
+            /// Forward-path hop count, same semantics as
             /// [`Response`](Self::Response)'s `hop_count`.
             /// `#[serde(default)]` is for source-level clarity; bincode is
             /// positional, so cross-version compat rides the handshake
             /// `MIN_COMPATIBLE_VERSION` gate, not the serde default.
             #[serde(default)]
             hop_count: usize,
+            /// The found holder's contract-defined `summarize_state`
+            /// output (opaque bytes), so the PUT initiator can compute
+            /// the delta the holder is missing without re-shipping full
+            /// state (summary-first PUT reconcile, #4642 step 3-bis).
+            ///
+            /// `Some(S_H)` only when `holder_found == true`; `None` when
+            /// no holder was found. Deserialized owned (`'static`) via the
+            /// local `deser_opt_state_summary` helper, matching the
+            /// `ProbeRequest::summary` wire pattern. Appended AFTER
+            /// `hop_count` so tag 7's existing prefix stays byte-for-byte
+            /// identical; nothing emits this variant yet, so the field
+            /// layout stays refinable until first emission ships.
+            #[serde(default, deserialize_with = "deser_opt_state_summary")]
+            holder_summary: Option<StateSummary<'static>>,
+        },
+
+        /// **Summary-first PUT — reconcile write (#4642, step 3-bis, see
+        /// [`ProbeRequest`](Self::ProbeRequest)).**
+        ///
+        /// Sent by the PUT initiator after learning a holder exists
+        /// ([`ProbeResponse`](Self::ProbeResponse) with `holder_found ==
+        /// true`). Routed hop-by-hop toward the contract key, the same
+        /// way [`Request`](Self::Request) and
+        /// [`ProbeRequest`](Self::ProbeRequest) are. It carries ONLY the
+        /// contract-defined [`StateDelta`], the initiator's contribution
+        /// relative to the holder's summary
+        /// (`ProbeResponse::holder_summary`), never full state: the whole
+        /// point of summary-first PUT is that a PUT into a mesh that
+        /// already holds the contract ships a delta, not the full body.
+        ///
+        /// The first fresh holder this reaches merges the delta via the
+        /// contract's `update_state` (`start_relay_probe_reconcile` /
+        /// `drive_relay_probe_reconcile`); normal update fan-out then
+        /// propagates it to the rest of the subscriber mesh, the same
+        /// mechanism `Update` operations use. Fire-and-forget: there is no
+        /// reply variant, matching the originator's `try_summary_first_put`,
+        /// which completes the PUT once the reconcile is dispatched rather
+        /// than waiting for a merge confirmation.
+        ProbeReconcile {
+            id: Transaction,
+            /// Key of the contract being reconciled.
+            key: ContractKey,
+            /// Contract-defined opaque write delta, relative to the
+            /// holder's summary, never full state. Deserialized owned
+            /// (`'static`) via the local `deser_state_delta` helper,
+            /// mirroring `ProbeRequest::summary`.
+            #[serde(deserialize_with = "deser_state_delta")]
+            delta: StateDelta<'static>,
+            /// Hops to live, decremented at each hop (mirrors
+            /// `Request.htl` / `ProbeRequest.htl`).
+            htl: usize,
+            /// Addresses to skip when selecting next hop (loop prevention).
+            skip_list: HashSet<std::net::SocketAddr>,
         },
     }
 
@@ -491,7 +570,8 @@ mod messages {
                 | Self::ForwardingAck { id, .. }
                 | Self::Error { id, .. }
                 | Self::ProbeRequest { id, .. }
-                | Self::ProbeResponse { id, .. } => id,
+                | Self::ProbeResponse { id, .. }
+                | Self::ProbeReconcile { id, .. } => id,
             }
         }
 
@@ -510,6 +590,7 @@ mod messages {
                 Self::Error { .. } => None,
                 Self::ProbeRequest { contract_key, .. } => Some(Location::from(contract_key.id())),
                 Self::ProbeResponse { key, .. } => Some(Location::from(key.id())),
+                Self::ProbeReconcile { key, .. } => Some(Location::from(key.id())),
             }
         }
     }
@@ -583,12 +664,32 @@ mod messages {
                     id,
                     key,
                     holder_found,
+                    holder_summary,
                     ..
                 } => {
                     write!(
                         f,
-                        "PutProbeResponse(id: {}, key: {}, holder_found: {})",
-                        id, key, holder_found
+                        "PutProbeResponse(id: {}, key: {}, holder_found: {}, holder_summary: {})",
+                        id,
+                        key,
+                        holder_found,
+                        holder_summary.is_some()
+                    )
+                }
+                Self::ProbeReconcile {
+                    id,
+                    key,
+                    delta,
+                    htl,
+                    ..
+                } => {
+                    write!(
+                        f,
+                        "PutProbeReconcile(id: {}, key: {}, delta_len: {}, htl: {})",
+                        id,
+                        key,
+                        delta.size(),
+                        htl
                     )
                 }
             }
@@ -705,7 +806,7 @@ mod tests {
         let tx = Transaction::new::<PutMsg>();
         let key = make_contract_key(0);
         // One minimal instance per variant, in declaration order.
-        let samples: [(u32, PutMsg); 8] = [
+        let samples: [(u32, PutMsg); 9] = [
             (
                 0,
                 PutMsg::Request {
@@ -760,9 +861,9 @@ mod tests {
                     cause: String::new(),
                 },
             ),
-            // Tags 6/7: summary-first PUT scaffolding (INERT, #4642).
+            // Tags 6/7/8: summary-first PUT scaffolding (INERT, #4642).
             // Appended AFTER every existing variant so tags 0-5 stay
-            // byte-identical — old peers keep deserializing them
+            // byte-identical, old peers keep deserializing them
             // unchanged. Emission is version-gated (never sent to a
             // pre-floor peer), so these tags never reach a node that
             // can't decode them.
@@ -783,6 +884,17 @@ mod tests {
                     key,
                     holder_found: false,
                     hop_count: 0,
+                    holder_summary: None,
+                },
+            ),
+            (
+                8,
+                PutMsg::ProbeReconcile {
+                    id: tx,
+                    key,
+                    delta: StateDelta::from(Vec::new()),
+                    htl: 0,
+                    skip_list: Default::default(),
                 },
             ),
         ];
@@ -849,18 +961,26 @@ mod tests {
     }
 
     /// Summary-first PUT dispatch reply (INERT scaffolding, #4642): the
-    /// new-vs-existing signal (`holder_found`) and `hop_count` round-trip
-    /// through bincode for both boolean cases.
+    /// new-vs-existing signal (`holder_found`), `hop_count`, and the
+    /// trailing `holder_summary` round-trip through bincode for both
+    /// boolean cases, including a `Some` summary whose opaque bytes must
+    /// survive intact via the `deser_opt_state_summary` owned-deserialize
+    /// path.
     #[test]
     fn put_msg_probe_response_serde_roundtrip() {
         let key = make_contract_key(4);
-        for (holder_found, hop_count) in [(false, 0usize), (true, 5usize)] {
+        let cases: [(bool, usize, Option<Vec<u8>>); 2] = [
+            (false, 0usize, None),
+            (true, 5usize, Some(vec![0x11, 0x22, 0x33, 0x44])),
+        ];
+        for (holder_found, hop_count, summary_bytes) in cases {
             let tx = Transaction::new::<PutMsg>();
             let msg = PutMsg::ProbeResponse {
                 id: tx,
                 key,
                 holder_found,
                 hop_count,
+                holder_summary: summary_bytes.clone().map(StateSummary::from),
             };
             let bytes = bincode::serialize(&msg).expect("serialize");
             let decoded: PutMsg = bincode::deserialize(&bytes).expect("deserialize");
@@ -870,20 +990,79 @@ mod tests {
                     key: decoded_key,
                     holder_found: decoded_holder,
                     hop_count: decoded_hops,
+                    holder_summary: decoded_summary,
                 } => {
                     assert_eq!(id, tx);
                     assert_eq!(decoded_key, key);
                     assert_eq!(decoded_holder, holder_found);
                     assert_eq!(decoded_hops, hop_count);
+                    match (&decoded_summary, &summary_bytes) {
+                        (Some(decoded), Some(expected)) => {
+                            assert_eq!(
+                                decoded.as_ref(),
+                                expected.as_slice(),
+                                "opaque holder_summary bytes must survive the bincode round-trip"
+                            );
+                        }
+                        (None, None) => {}
+                        _ => panic!(
+                            "holder_summary presence mismatch: decoded {decoded_summary:?} vs \
+                             expected {summary_bytes:?}"
+                        ),
+                    }
                 }
                 other => panic!("expected ProbeResponse, got {other}"),
             }
         }
     }
 
+    /// Summary-first PUT reconcile write (INERT scaffolding, #4642): the
+    /// opaque `StateDelta`, `htl`, and `skip_list` round-trip through
+    /// bincode via the `deser_state_delta` owned-deserialize path.
+    #[test]
+    fn put_msg_probe_reconcile_serde_roundtrip() {
+        let tx = Transaction::new::<PutMsg>();
+        let key = make_contract_key(5);
+        let delta_bytes = vec![0x9A, 0xBC, 0xDE, 0xF0, 0x12, 0x34];
+        let mut skip_list = std::collections::HashSet::new();
+        skip_list.insert(std::net::SocketAddr::from(([127, 0, 0, 1], 9090)));
+        skip_list.insert(std::net::SocketAddr::from(([10, 0, 0, 1], 4242)));
+        let msg = PutMsg::ProbeReconcile {
+            id: tx,
+            key,
+            delta: StateDelta::from(delta_bytes.clone()),
+            htl: 3,
+            skip_list: skip_list.clone(),
+        };
+
+        let bytes = bincode::serialize(&msg).expect("serialize");
+        let decoded: PutMsg = bincode::deserialize(&bytes).expect("deserialize");
+        match decoded {
+            PutMsg::ProbeReconcile {
+                id,
+                key: decoded_key,
+                delta,
+                htl,
+                skip_list: decoded_skip,
+            } => {
+                assert_eq!(id, tx);
+                assert_eq!(decoded_key, key);
+                assert_eq!(
+                    delta.as_ref(),
+                    delta_bytes.as_slice(),
+                    "opaque delta bytes must survive the bincode round-trip"
+                );
+                assert_eq!(htl, 3);
+                assert_eq!(decoded_skip, skip_list);
+            }
+            other => panic!("expected ProbeReconcile, got {other}"),
+        }
+    }
+
     /// `id()` and `requested_location()` cover the summary-first
-    /// scaffolding variants: the probe/dispatch reply carry the tx and a
-    /// key-derived location like every other addressed PUT variant.
+    /// scaffolding variants: the probe/dispatch reply/reconcile carry the
+    /// tx and a key-derived location like every other addressed PUT
+    /// variant.
     #[test]
     fn put_msg_probe_variants_id_and_location() {
         let tx = Transaction::new::<PutMsg>();
@@ -900,11 +1079,21 @@ mod tests {
             key,
             holder_found: true,
             hop_count: 0,
+            holder_summary: None,
+        };
+        let reconcile = PutMsg::ProbeReconcile {
+            id: tx,
+            key,
+            delta: StateDelta::from(Vec::new()),
+            htl: 1,
+            skip_list: Default::default(),
         };
         assert_eq!(*req.id(), tx);
         assert_eq!(*resp.id(), tx);
+        assert_eq!(*reconcile.id(), tx);
         assert!(req.requested_location().is_some());
         assert!(resp.requested_location().is_some());
+        assert!(reconcile.requested_location().is_some());
     }
 
     /// `bound_cause` keeps short strings byte-identical and truncates

--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -245,6 +245,74 @@ async fn drive_client_put_inner(
         None => op_manager.ring.connection_manager.own_location(),
     };
 
+    // ── Summary-first PUT (#4642 step 3-bis) ────────────────────────────────
+    //
+    // Best-effort front-end to the full-state retry loop below. On ANY
+    // failure (version gate closed, probe timeout/error, no holder found)
+    // this falls straight through to the unchanged `PutRetryDriver` loop —
+    // a summary-first failure must never break a PUT (risk-bounded graceful
+    // fallback; the full-state path remains the default and the fallback,
+    // per the hosting redesign's demand-driven invariants).
+    if let Some(target_addr) = current_target.socket_addr() {
+        if op_manager
+            .ring
+            .connection_manager
+            .supports_summary_first_put(target_addr)
+        {
+            if let SummaryFirstOutcome::ReconciledExisting { target, hop_count } =
+                try_summary_first_put(
+                    op_manager,
+                    client_tx,
+                    key,
+                    &contract,
+                    &related,
+                    &value,
+                    htl,
+                    &current_target,
+                    target_addr,
+                )
+                .await
+            {
+                // Existing-mesh delta case: the reconcile (if any delta was
+                // needed) has already been dispatched best-effort and the
+                // PUT is complete. The originator already holds a
+                // locally-merged copy from `try_summary_first_put`'s local
+                // store step, so it converges immediately at this node;
+                // confirming the reconcile landed at the remote holder
+                // (reverse-leg convergence) is a deliberate follow-up, not
+                // required for this PUT to report success correctly.
+                op_manager.completed(client_tx);
+                crate::node::network_status::record_op_result(
+                    crate::node::network_status::OpType::Put,
+                    true,
+                );
+                super::finalize_put_at_originator(
+                    op_manager,
+                    client_tx,
+                    key,
+                    PutFinalizationData {
+                        sender: target,
+                        hop_count: Some(hop_count),
+                        state_hash: None,
+                        state_size: None,
+                    },
+                    false,
+                    false,
+                )
+                .await;
+
+                maybe_subscribe_child(op_manager, client_tx, key, subscribe, blocking_subscribe)
+                    .await;
+
+                return Ok(DriverOutcome::Publish(Ok(HostResponse::ContractResponse(
+                    ContractResponse::PutResponse { key },
+                ))));
+            }
+            // FallThrough: no holder found, or the probe failed — continue
+            // to the existing full-state driver below, unchanged.
+        }
+    }
+
     // Retry loop via shared driver (#3807).
     struct PutRetryDriver<'a> {
         op_manager: &'a OpManager,
@@ -502,6 +570,290 @@ async fn drive_client_put_inner(
         }
         RetryLoopOutcome::Unexpected => Err(OpError::UnexpectedOpState),
         RetryLoopOutcome::InfraError(err) => Err(err),
+    }
+}
+
+// --- Summary-first PUT (originator pre-phase, #4642 step 3-bis) ---
+
+/// Outcome of [`try_summary_first_put`].
+enum SummaryFirstOutcome {
+    /// A holder was found; a reconcile delta (if any was needed) has
+    /// already been dispatched best-effort and the PUT is complete. Carries
+    /// what `drive_client_put_inner` needs to finalize: the probed peer and
+    /// the forward-path hop count the `ProbeResponse` reported.
+    ReconciledExisting {
+        target: PeerKeyLocation,
+        hop_count: usize,
+    },
+    /// No holder found (genuinely new contract), or any step of the probe
+    /// failed — the caller falls through to the unchanged full-state
+    /// `PutRetryDriver` loop.
+    FallThrough,
+}
+
+/// Summary-first PUT attempt: best-effort front-end to the full-state
+/// retry loop in `drive_client_put_inner`. Probes `target` with just a
+/// state summary; if the mesh already holds the contract, ships only a
+/// delta instead of the full state. On ANY failure (local-store error,
+/// summary-compute error, probe timeout/error, no holder found) returns
+/// [`SummaryFirstOutcome::FallThrough`] — this function must never be the
+/// reason a PUT fails; the caller always has the full-state driver as a
+/// fallback.
+///
+/// Precondition: caller has already confirmed `target_addr` passes
+/// `ConnectionManager::supports_summary_first_put` (the mixed-version
+/// emission gate).
+#[allow(clippy::too_many_arguments)]
+async fn try_summary_first_put(
+    op_manager: &Arc<OpManager>,
+    client_tx: Transaction,
+    key: ContractKey,
+    contract: &ContractContainer,
+    related: &RelatedContracts<'static>,
+    value: &WrappedState,
+    htl: usize,
+    target: &PeerKeyLocation,
+    target_addr: SocketAddr,
+) -> SummaryFirstOutcome {
+    // (a) Store locally first — the same local-store path a relay hop uses
+    // (`relay_put_store_locally`: put_contract + host_contract +
+    // register_local_hosting + announce_contract_hosted) — so the
+    // originator can summarize/delta by key and becomes a genuine host
+    // (demand-driven: a real client-initiated PUT is genuine local
+    // demand). `ClientLocal` priority matches the originator-loopback arm
+    // of `put_store_priority`.
+    let merged_value = match relay_put_store_locally(
+        op_manager,
+        client_tx,
+        key,
+        value.clone(),
+        contract,
+        related.clone(),
+        htl,
+        crate::contract::Priority::ClientLocal,
+    )
+    .await
+    {
+        Ok(v) => v,
+        Err(err) => {
+            tracing::debug!(
+                tx = %client_tx,
+                contract = %key,
+                error = %err,
+                phase = "summary_first_local_store_failed",
+                "PUT summary-first: local store failed; falling through to full-state driver"
+            );
+            return SummaryFirstOutcome::FallThrough;
+        }
+    };
+
+    // (b) Compute our own summary of what we just stored.
+    let our_summary = match op_manager
+        .interest_manager
+        .get_contract_summary(op_manager, &key)
+        .await
+    {
+        Some(s) => s,
+        None => {
+            tracing::debug!(
+                tx = %client_tx,
+                contract = %key,
+                phase = "summary_first_summary_failed",
+                "PUT summary-first: failed to compute own summary; falling through \
+                 to full-state driver"
+            );
+            return SummaryFirstOutcome::FallThrough;
+        }
+    };
+
+    // (c) Probe `target` with the summary and await its reply on a fresh
+    // transaction — `send_and_await`/`send_to_and_await` are single-use per
+    // tx (see `OpCtx` rustdoc), and this probe is a separate round-trip
+    // from whatever attempt tx the full-state fallback may later use.
+    let probe_tx = Transaction::new::<PutMsg>();
+    let own_addr = op_manager.ring.connection_manager.get_own_addr();
+    let probe_msg = NetMessage::from(PutMsg::ProbeRequest {
+        id: probe_tx,
+        contract_key: key,
+        summary: our_summary.clone(),
+        htl,
+        skip_list: own_addr.into_iter().collect::<HashSet<_>>(),
+    });
+    let mut ctx = op_manager.op_ctx(probe_tx);
+    let probe_timeout =
+        compute_put_attempt_timeout(op_manager.streaming_threshold, value, contract);
+    let round_trip =
+        tokio::time::timeout(probe_timeout, ctx.send_to_and_await(target_addr, probe_msg)).await;
+    op_manager.release_pending_op_slot(probe_tx).await;
+
+    let reply = match round_trip {
+        Ok(Ok(reply)) => reply,
+        Ok(Err(err)) => {
+            tracing::debug!(
+                tx = %client_tx,
+                probe_tx = %probe_tx,
+                contract = %key,
+                error = %err,
+                phase = "summary_first_probe_failed",
+                "PUT summary-first: probe failed; falling through to full-state driver"
+            );
+            return SummaryFirstOutcome::FallThrough;
+        }
+        Err(_elapsed) => {
+            tracing::debug!(
+                tx = %client_tx,
+                probe_tx = %probe_tx,
+                contract = %key,
+                phase = "summary_first_probe_timeout",
+                "PUT summary-first: probe timed out; falling through to full-state driver"
+            );
+            return SummaryFirstOutcome::FallThrough;
+        }
+    };
+
+    #[allow(clippy::wildcard_enum_match_arm)]
+    let (holder_found, probe_hop_count, holder_summary) = match reply {
+        NetMessage::V1(NetMessageV1::Put(PutMsg::ProbeResponse {
+            holder_found,
+            hop_count,
+            holder_summary,
+            ..
+        })) => (holder_found, hop_count, holder_summary),
+        _other => {
+            tracing::debug!(
+                tx = %client_tx,
+                probe_tx = %probe_tx,
+                contract = %key,
+                phase = "summary_first_unexpected_reply",
+                "PUT summary-first: unexpected probe reply; falling through to full-state driver"
+            );
+            return SummaryFirstOutcome::FallThrough;
+        }
+    };
+
+    if !holder_found {
+        tracing::debug!(
+            tx = %client_tx,
+            contract = %key,
+            phase = "summary_first_new_contract",
+            "PUT summary-first: no holder found (new contract); falling through \
+             to full-state driver"
+        );
+        let full_state_bytes = value
+            .size()
+            .saturating_add(contract.data().len())
+            .saturating_add(contract.params().size()) as u64;
+        record_put_probe_outcome(true, full_state_bytes);
+        return SummaryFirstOutcome::FallThrough;
+    }
+
+    let Some(their_summary) = holder_summary else {
+        // Wire invariant violation (`holder_found` without `holder_summary`)
+        // — treat defensively as a probe failure rather than trust a
+        // malformed/unexpected reply.
+        tracing::warn!(
+            tx = %client_tx,
+            contract = %key,
+            phase = "summary_first_missing_holder_summary",
+            "PUT summary-first: holder_found=true but holder_summary missing; \
+             falling through to full-state driver"
+        );
+        return SummaryFirstOutcome::FallThrough;
+    };
+
+    let our_state_size = merged_value.size();
+    let delta = match op_manager
+        .interest_manager
+        .compute_delta(
+            op_manager,
+            &key,
+            &their_summary,
+            &our_summary,
+            our_state_size,
+        )
+        .await
+    {
+        Ok(delta) => delta,
+        Err(err) => {
+            tracing::debug!(
+                tx = %client_tx,
+                contract = %key,
+                error = %err,
+                phase = "summary_first_delta_failed",
+                "PUT summary-first: delta computation failed; falling through to \
+                 full-state driver"
+            );
+            return SummaryFirstOutcome::FallThrough;
+        }
+    };
+
+    // `Ok(None)` = the contract's delta relative to the holder's summary is
+    // empty (peer's state is already logically equivalent to ours) — the
+    // existing-mesh case still holds, just with nothing to send.
+    let delta_bytes = match delta {
+        Some(delta) => {
+            let bytes = delta.size() as u64;
+            let reconcile_tx = Transaction::new::<PutMsg>();
+            let reconcile_msg = NetMessage::from(PutMsg::ProbeReconcile {
+                id: reconcile_tx,
+                key,
+                delta,
+                htl,
+                skip_list: own_addr.into_iter().collect::<HashSet<_>>(),
+            });
+            let mut reconcile_ctx = op_manager.op_ctx(reconcile_tx);
+            if let Err(err) = reconcile_ctx
+                .send_fire_and_forget(target_addr, reconcile_msg)
+                .await
+            {
+                // Best-effort: `ProbeReconcile` is fire-and-forget by design
+                // (see its rustdoc). A dispatch failure here does not
+                // un-complete the PUT — the originator's own copy is
+                // already stored locally (step (a)); the target mesh just
+                // doesn't get this delta pushed proactively (it converges
+                // on the next read/update instead).
+                tracing::debug!(
+                    tx = %client_tx,
+                    reconcile_tx = %reconcile_tx,
+                    contract = %key,
+                    error = %err,
+                    phase = "summary_first_reconcile_dispatch_failed",
+                    "PUT summary-first: ProbeReconcile dispatch failed \
+                     (best-effort, PUT still completes)"
+                );
+            }
+            op_manager.release_pending_op_slot(reconcile_tx).await;
+            bytes
+        }
+        None => 0,
+    };
+
+    record_put_probe_outcome(false, delta_bytes);
+
+    SummaryFirstOutcome::ReconciledExisting {
+        target: target.clone(),
+        hop_count: probe_hop_count,
+    }
+}
+
+/// Feeds both the in-process test counter (`GlobalTestMetrics`) and the
+/// live dashboard counter (`network_status`) from a single call site, so
+/// the two can never drift relative to each other — see
+/// `.claude/rules/bug-prevention-patterns.md` ("Manually-mirrored
+/// telemetry counters").
+fn record_put_probe_outcome(new_contract: bool, bytes: u64) {
+    if new_contract {
+        crate::config::GlobalTestMetrics::record_put_probe_new_contract(bytes);
+        crate::node::network_status::record_put_bytes(
+            crate::node::network_status::PutProbeCase::NewContract,
+            bytes,
+        );
+    } else {
+        crate::config::GlobalTestMetrics::record_put_probe_existing_mesh_delta(bytes);
+        crate::node::network_status::record_put_bytes(
+            crate::node::network_status::PutProbeCase::ExistingMeshDelta,
+            bytes,
+        );
     }
 }
 
@@ -2988,6 +3340,496 @@ where
 }
 
 // ── End of relay PUT driver ─────────────────────────────────────────────────
+
+// ── Relay PROBE driver (summary-first PUT, #4642 step 3-bis) ───────────────
+
+/// Spawn a relay driver for a fresh inbound `PutMsg::ProbeRequest`.
+///
+/// Mirrors [`start_relay_put`]'s dispatch shape (dedup via the shared
+/// `active_relay_put_txs` set, RAII inflight guard constructed before
+/// spawn, spawn), but the probe driver itself
+/// ([`drive_relay_probe`]) is much simpler: pure routing plus an
+/// `is_receiving_updates` check, never a local store. Gated by the same
+/// dispatch site in `node.rs::handle_pure_network_message_v1` and by the
+/// version-gated emission at the send side
+/// (`ConnectionManager::supports_summary_first_put`) — a pre-floor peer
+/// never receives this variant, so this driver needs no additional
+/// version check on the receive side.
+pub(crate) async fn start_relay_probe(
+    op_manager: Arc<OpManager>,
+    incoming_tx: Transaction,
+    key: ContractKey,
+    summary: StateSummary<'static>,
+    htl: usize,
+    skip_list: HashSet<SocketAddr>,
+    upstream_addr: SocketAddr,
+) -> Result<(), OpError> {
+    // Shares the PUT relay dedup set (same tx space; a `ProbeRequest`'s
+    // `id` never collides with a concurrent `PutMsg::Request`'s tx because
+    // every attempt/probe allocates a fresh `Transaction`).
+    if !op_manager.active_relay_put_txs.insert(incoming_tx) {
+        tracing::debug!(
+            tx = %incoming_tx,
+            contract = %key,
+            %upstream_addr,
+            phase = "relay_probe_dedup_reject",
+            "PUT probe relay: duplicate ProbeRequest for in-flight tx, dropping"
+        );
+        return Ok(());
+    }
+
+    let guard = RelayProbeInflightGuard {
+        op_manager: op_manager.clone(),
+        incoming_tx,
+    };
+
+    GlobalExecutor::spawn(async move {
+        let _guard = guard;
+        if let Err(err) = drive_relay_probe(
+            &op_manager,
+            incoming_tx,
+            key,
+            summary,
+            htl,
+            skip_list,
+            upstream_addr,
+        )
+        .await
+        {
+            tracing::debug!(
+                tx = %incoming_tx,
+                contract = %key,
+                error = %err,
+                phase = "relay_probe_error",
+                "PUT probe relay: driver returned error"
+            );
+        }
+        // Release at driver exit — every path below either awaits a
+        // downstream reply via `send_to_and_await` (already interim-released,
+        // see `drive_relay_probe`) or sends the upstream `ProbeResponse` via
+        // `send_fire_and_forget`/`send_local_loopback`, both of which leave a
+        // fresh `pending_op_results[incoming_tx]` entry that only this
+        // release reclaims (mirrors `run_relay_put`'s non-loopback release).
+        op_manager.release_pending_op_slot(incoming_tx).await;
+    });
+    Ok(())
+}
+
+/// RAII guard removing `incoming_tx` from `active_relay_put_txs` on drop.
+/// Constructed BEFORE spawn (see `start_relay_probe`) so a pre-poll drop of
+/// the spawned future cannot permanently leak the dedup entry. Deliberately
+/// lighter than [`RelayPutInflightGuard`]: probes are not real PUT relays,
+/// so they do not touch the `RELAY_PUT_*` counters.
+struct RelayProbeInflightGuard {
+    op_manager: Arc<OpManager>,
+    incoming_tx: Transaction,
+}
+
+impl Drop for RelayProbeInflightGuard {
+    fn drop(&mut self) {
+        self.op_manager
+            .active_relay_put_txs
+            .remove(&self.incoming_tx);
+    }
+}
+
+/// Send `PutMsg::ProbeResponse` upstream. Mirrors
+/// [`relay_put_send_response`]'s loopback-aware shape: fire-and-forget over
+/// the wire, or `send_local_loopback` when this driver happens to be
+/// running on the originator's own node. In practice a probe relay's
+/// `upstream_addr` is always a genuine remote peer address — `ProbeRequest`
+/// is only ever dispatched over the wire (`send_to_and_await` /
+/// `send_fire_and_forget` with a real target), never via
+/// `send_local_loopback` — but the check is kept for defensive symmetry
+/// with the PUT relay path.
+async fn relay_probe_send_response(
+    op_manager: &OpManager,
+    incoming_tx: Transaction,
+    key: ContractKey,
+    holder_found: bool,
+    hop_count: usize,
+    holder_summary: Option<StateSummary<'static>>,
+    upstream_addr: SocketAddr,
+) -> Result<(), OpError> {
+    let msg = NetMessage::from(PutMsg::ProbeResponse {
+        id: incoming_tx,
+        key,
+        holder_found,
+        hop_count,
+        holder_summary,
+    });
+    let mut ctx = op_manager.op_ctx(incoming_tx);
+    let own_addr = op_manager.ring.connection_manager.get_own_addr();
+    if Some(upstream_addr) == own_addr {
+        ctx.send_local_loopback(msg)
+            .await
+            .map_err(|_| OpError::NotificationError)
+    } else {
+        ctx.send_fire_and_forget(upstream_addr, msg)
+            .await
+            .map_err(|_| OpError::NotificationError)
+    }
+}
+
+/// Routes a `PutMsg::ProbeRequest` toward `key`, or answers it directly when
+/// this hop is a fresh holder.
+///
+/// # Lazy host-on-next-read (Fable F5 amplification fix)
+///
+/// This function never calls `put_contract` / `host_contract` /
+/// `announce_contract_hosted` — a probe-routing hop that does not already
+/// host `key` must only ROUTE, never store or fetch. Do NOT add a local
+/// store here — see `.claude/rules/hosting-invariants.md` invariant 2
+/// (hosting is demand-driven, never manufactured by a route-through) and
+/// the "Relay-caching" anti-pattern. Hosting for a genuinely new contract
+/// happens on the full-state `PutMsg::Request` path (every-hop placement,
+/// `relay_put_store_locally`); hosting for an existing mesh happens lazily
+/// on the contract's next real read.
+async fn drive_relay_probe(
+    op_manager: &Arc<OpManager>,
+    incoming_tx: Transaction,
+    key: ContractKey,
+    summary: StateSummary<'static>,
+    htl: usize,
+    skip_list: HashSet<SocketAddr>,
+    upstream_addr: SocketAddr,
+) -> Result<(), OpError> {
+    let hop_count = op_manager.ring.max_hops_to_live.saturating_sub(htl);
+
+    // `is_receiving_updates` (subscribed OR local-client-subscribed) is the
+    // FRESH-holder signal, not `is_hosting_contract` (mere cache membership,
+    // which may be stale — see `.claude/rules/hosting-invariants.md`,
+    // `feedback_hosted_cache_freshness`). A stale cached copy must not
+    // short-circuit the probe into reporting a holder.
+    if op_manager.ring.is_receiving_updates(&key) {
+        let holder_summary = op_manager
+            .interest_manager
+            .get_contract_summary(op_manager, &key)
+            .await;
+        return match holder_summary {
+            Some(s) => {
+                relay_probe_send_response(
+                    op_manager,
+                    incoming_tx,
+                    key,
+                    true,
+                    hop_count,
+                    Some(s),
+                    upstream_addr,
+                )
+                .await
+            }
+            None => {
+                // Summary computation failed despite being a genuine
+                // holder. Fail safe: report no-holder so the originator
+                // falls through to the full-state `Request` path. Shipping
+                // full state to a peer that already hosts the contract is
+                // an idempotent no-op at the contract layer (extra bytes,
+                // not a correctness break) — the risk-bounded
+                // graceful-fallback design.
+                tracing::debug!(
+                    tx = %incoming_tx,
+                    contract = %key,
+                    phase = "relay_probe_summary_failed",
+                    "PUT probe: is_receiving_updates but summary computation \
+                     failed; reporting no-holder so the originator falls \
+                     through to full-state PUT"
+                );
+                relay_probe_send_response(
+                    op_manager,
+                    incoming_tx,
+                    key,
+                    false,
+                    hop_count,
+                    None,
+                    upstream_addr,
+                )
+                .await
+            }
+        };
+    }
+
+    // Not a fresh holder here: route toward the key, mirroring
+    // `drive_relay_put`'s next-hop selection and #4363 terminus guard
+    // (`put_routing_should_terminate`), without any of the storage side
+    // effects.
+    let mut new_skip_list = skip_list;
+    new_skip_list.insert(upstream_addr);
+    if let Some(own_addr) = op_manager.ring.connection_manager.get_own_addr() {
+        new_skip_list.insert(own_addr);
+    }
+
+    let next_hop = if htl > 0 {
+        op_manager
+            .ring
+            .closest_potentially_hosting(&key, &new_skip_list)
+    } else {
+        None
+    };
+
+    let next_addr = match next_hop {
+        Some(peer) => {
+            let target = crate::ring::Location::from(&key);
+            let own_loc = op_manager.ring.connection_manager.own_location().location();
+            let upstream_loc = op_manager
+                .ring
+                .connection_manager
+                .get_peer_by_addr(upstream_addr)
+                .and_then(|p| p.location());
+            let next_hop_loc = peer.location();
+            if put_routing_should_terminate(upstream_loc, own_loc, next_hop_loc, target) {
+                return relay_probe_send_response(
+                    op_manager,
+                    incoming_tx,
+                    key,
+                    false,
+                    hop_count,
+                    None,
+                    upstream_addr,
+                )
+                .await;
+            }
+            match peer.socket_addr() {
+                Some(a) => a,
+                None => {
+                    return relay_probe_send_response(
+                        op_manager,
+                        incoming_tx,
+                        key,
+                        false,
+                        hop_count,
+                        None,
+                        upstream_addr,
+                    )
+                    .await;
+                }
+            }
+        }
+        None => {
+            return relay_probe_send_response(
+                op_manager,
+                incoming_tx,
+                key,
+                false,
+                hop_count,
+                None,
+                upstream_addr,
+            )
+            .await;
+        }
+    };
+
+    let new_htl = htl.saturating_sub(1);
+    let forward = NetMessage::from(PutMsg::ProbeRequest {
+        id: incoming_tx,
+        contract_key: key,
+        summary,
+        htl: new_htl,
+        skip_list: new_skip_list,
+    });
+
+    let mut ctx = op_manager.op_ctx(incoming_tx);
+    let round_trip =
+        tokio::time::timeout(OPERATION_TTL, ctx.send_to_and_await(next_addr, forward)).await;
+    // Interim release, mirroring `drive_relay_put`'s post-`send_to_and_await`
+    // release: the downstream reply has already arrived (or timed out), and
+    // the upstream `ProbeResponse` send below re-registers under the same
+    // tx; the final release happens at `start_relay_probe`'s driver exit.
+    op_manager.release_pending_op_slot(incoming_tx).await;
+
+    let reply = match round_trip {
+        Ok(Ok(reply)) => reply,
+        Ok(Err(err)) => return Err(err),
+        Err(_elapsed) => return Err(OpError::UnexpectedOpState),
+    };
+
+    #[allow(clippy::wildcard_enum_match_arm)]
+    match reply {
+        NetMessage::V1(NetMessageV1::Put(PutMsg::ProbeResponse {
+            holder_found,
+            hop_count: downstream_hop_count,
+            holder_summary,
+            ..
+        })) => {
+            relay_probe_send_response(
+                op_manager,
+                incoming_tx,
+                key,
+                holder_found,
+                downstream_hop_count,
+                holder_summary,
+                upstream_addr,
+            )
+            .await
+        }
+        _other => Err(OpError::UnexpectedOpState),
+    }
+}
+
+/// Spawn a relay driver for a fresh inbound `PutMsg::ProbeReconcile`.
+///
+/// Mirrors [`start_relay_probe`]'s dispatch shape. `ProbeReconcile` has no
+/// reply variant (fire-and-forget both directions — see the type's
+/// rustdoc), so unlike the probe driver there is no downstream round-trip
+/// to await; [`drive_relay_probe_reconcile`] either merges locally or
+/// forwards once and returns.
+pub(crate) async fn start_relay_probe_reconcile(
+    op_manager: Arc<OpManager>,
+    incoming_tx: Transaction,
+    key: ContractKey,
+    delta: StateDelta<'static>,
+    htl: usize,
+    skip_list: HashSet<SocketAddr>,
+    upstream_addr: SocketAddr,
+) -> Result<(), OpError> {
+    if !op_manager.active_relay_put_txs.insert(incoming_tx) {
+        tracing::debug!(
+            tx = %incoming_tx,
+            contract = %key,
+            %upstream_addr,
+            phase = "relay_probe_reconcile_dedup_reject",
+            "PUT probe-reconcile relay: duplicate ProbeReconcile for in-flight tx, dropping"
+        );
+        return Ok(());
+    }
+
+    let guard = RelayProbeInflightGuard {
+        op_manager: op_manager.clone(),
+        incoming_tx,
+    };
+
+    GlobalExecutor::spawn(async move {
+        let _guard = guard;
+        if let Err(err) = drive_relay_probe_reconcile(
+            &op_manager,
+            incoming_tx,
+            key,
+            delta,
+            htl,
+            skip_list,
+            upstream_addr,
+        )
+        .await
+        {
+            tracing::debug!(
+                tx = %incoming_tx,
+                contract = %key,
+                error = %err,
+                phase = "relay_probe_reconcile_error",
+                "PUT probe-reconcile relay: driver returned error"
+            );
+        }
+        // A forwarded reconcile (fire-and-forget) registers a fresh
+        // `pending_op_results[incoming_tx]` entry that nothing will ever
+        // reply to (no `ProbeReconcile` response variant); reclaim it here.
+        // A no-op if the merge branch ran instead (nothing was registered).
+        op_manager.release_pending_op_slot(incoming_tx).await;
+    });
+    Ok(())
+}
+
+/// Merge an inbound delta at a fresh holder, or forward the reconcile
+/// toward `key` when this hop is not (yet) a holder.
+///
+/// Best-effort: a reconcile that reaches a routing terminus with no holder
+/// is dropped rather than escalated — the wire invariant is that
+/// `ProbeReconcile` is only ever sent after a `ProbeResponse` proved a
+/// holder exists somewhere along this route (a genuinely new contract goes
+/// the no-holder full-state `PutMsg::Request` path instead — see
+/// `try_summary_first_put`). Same lazy host-on-next-read note as
+/// [`drive_relay_probe`] applies: a non-holder hop only routes, it never
+/// stores.
+async fn drive_relay_probe_reconcile(
+    op_manager: &Arc<OpManager>,
+    incoming_tx: Transaction,
+    key: ContractKey,
+    delta: StateDelta<'static>,
+    htl: usize,
+    skip_list: HashSet<SocketAddr>,
+    upstream_addr: SocketAddr,
+) -> Result<(), OpError> {
+    if op_manager.ring.is_receiving_updates(&key) {
+        // Merge via the same path an UPDATE uses; the contract executor
+        // fans the change out to the rest of the subscriber mesh
+        // automatically on a real state change (`BroadcastStateChange`,
+        // see `contract.rs`) — no explicit broadcast call needed here.
+        if let Err(err) = crate::operations::update::update_contract(
+            op_manager,
+            key,
+            UpdateData::Delta(delta),
+            RelatedContracts::default(),
+            crate::contract::Priority::NetworkRelay,
+        )
+        .await
+        {
+            tracing::debug!(
+                tx = %incoming_tx,
+                contract = %key,
+                error = %err,
+                phase = "relay_probe_reconcile_merge_failed",
+                "PUT probe-reconcile: delta merge failed (best-effort)"
+            );
+        }
+        return Ok(());
+    }
+
+    let mut new_skip_list = skip_list;
+    new_skip_list.insert(upstream_addr);
+    if let Some(own_addr) = op_manager.ring.connection_manager.get_own_addr() {
+        new_skip_list.insert(own_addr);
+    }
+
+    if htl == 0 {
+        return Ok(());
+    }
+
+    let next_hop = op_manager
+        .ring
+        .closest_potentially_hosting(&key, &new_skip_list);
+    let next_addr = match next_hop {
+        Some(peer) => {
+            let target = crate::ring::Location::from(&key);
+            let own_loc = op_manager.ring.connection_manager.own_location().location();
+            let upstream_loc = op_manager
+                .ring
+                .connection_manager
+                .get_peer_by_addr(upstream_addr)
+                .and_then(|p| p.location());
+            let next_hop_loc = peer.location();
+            if put_routing_should_terminate(upstream_loc, own_loc, next_hop_loc, target) {
+                return Ok(());
+            }
+            match peer.socket_addr() {
+                Some(a) => a,
+                None => return Ok(()),
+            }
+        }
+        None => return Ok(()),
+    };
+
+    let new_htl = htl.saturating_sub(1);
+    let forward = NetMessage::from(PutMsg::ProbeReconcile {
+        id: incoming_tx,
+        key,
+        delta,
+        htl: new_htl,
+        skip_list: new_skip_list,
+    });
+    let mut ctx = op_manager.op_ctx(incoming_tx);
+    if let Err(err) = ctx.send_fire_and_forget(next_addr, forward).await {
+        tracing::debug!(
+            tx = %incoming_tx,
+            contract = %key,
+            target = %next_addr,
+            error = %err,
+            phase = "relay_probe_reconcile_forward_failed",
+            "PUT probe-reconcile: forward failed (best-effort)"
+        );
+    }
+    Ok(())
+}
+
+// ── End of relay PROBE driver ───────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {
@@ -5692,6 +6534,173 @@ mod tests {
              channel-safety rule: never `send().await` from inside a \
              driver body. The helper must use `try_send` and drop+log \
              on Full instead."
+        );
+    }
+
+    // ============ Summary-first PUT pin tests (#4642 step 3-bis) ============
+
+    /// Pin: the summary-first block in `drive_client_put_inner` MUST check
+    /// `supports_summary_first_put` BEFORE calling `try_summary_first_put` —
+    /// the mixed-version emission gate has to run first so a pre-floor peer
+    /// is never probed (it cannot bincode-deserialize the appended
+    /// `ProbeRequest` tag). Also pins that the full-state `PutRetryDriver`
+    /// loop remains reachable afterward (the gate-closed / FallThrough
+    /// path), i.e. summary-first PUT is a strict front-end, never a
+    /// replacement.
+    #[test]
+    fn drive_client_put_inner_gates_summary_first_emission_on_version_support() {
+        let src = include_str!("op_ctx_task.rs");
+        let start = src
+            .find("async fn drive_client_put_inner(")
+            .expect("drive_client_put_inner not found");
+        let end = src[start..]
+            .find("\n// --- Summary-first PUT (originator pre-phase")
+            .expect("end of drive_client_put_inner not found")
+            + start;
+        let body = &src[start..end];
+        let gate_pos = body
+            .find("supports_summary_first_put(target_addr)")
+            .expect("version gate call missing");
+        let try_pos = body
+            .find("try_summary_first_put(")
+            .expect("try_summary_first_put call missing");
+        assert!(
+            gate_pos < try_pos,
+            "drive_client_put_inner must check supports_summary_first_put \
+             BEFORE calling try_summary_first_put"
+        );
+        assert!(
+            body.contains("struct PutRetryDriver"),
+            "the full-state PutRetryDriver loop must remain reachable \
+             (FallThrough / gate-closed path) after the summary-first block"
+        );
+    }
+
+    /// Pin: `drive_relay_probe` must NEVER store, host, or announce the
+    /// contract locally. A probe-routing hop that does not already host the
+    /// contract must only ROUTE — see the lazy host-on-next-read note
+    /// (Fable F5 amplification fix) on the function itself and
+    /// `.claude/rules/hosting-invariants.md` invariant 2. Mirrors the style
+    /// of `drive_relay_put_stores_locally_before_forwarding`, but asserts
+    /// the opposite property for the probe path.
+    #[test]
+    fn drive_relay_probe_never_stores_locally() {
+        let src = include_str!("op_ctx_task.rs");
+        let start = src
+            .find("async fn drive_relay_probe(")
+            .expect("drive_relay_probe not found");
+        let end = src[start..]
+            .find("\npub(crate) async fn start_relay_probe_reconcile(")
+            .expect("end of drive_relay_probe section not found")
+            + start;
+        let body = &src[start..end];
+        assert!(
+            !body.contains("relay_put_store_locally("),
+            "drive_relay_probe must NEVER call relay_put_store_locally — a \
+             probe-routing hop that is not already a holder must only ROUTE"
+        );
+        assert!(
+            !body.contains("host_contract("),
+            "drive_relay_probe must NEVER call host_contract directly"
+        );
+        assert!(
+            !body.contains("put_contract("),
+            "drive_relay_probe must NEVER call put_contract directly"
+        );
+    }
+
+    /// Pin: probe holder detection MUST use `Ring::is_receiving_updates`
+    /// (subscribed OR local-client-subscribed — the fresh-holder signal),
+    /// never `is_hosting_contract` (mere cache membership, which may be
+    /// stale). See `.claude/rules/hosting-invariants.md`,
+    /// `feedback_hosted_cache_freshness`.
+    #[test]
+    fn drive_relay_probe_uses_is_receiving_updates_not_is_hosting_contract() {
+        let src = include_str!("op_ctx_task.rs");
+        let start = src
+            .find("async fn drive_relay_probe(")
+            .expect("drive_relay_probe not found");
+        let end = src[start..]
+            .find("\npub(crate) async fn start_relay_probe_reconcile(")
+            .expect("end of drive_relay_probe section not found")
+            + start;
+        let body = &src[start..end];
+        assert!(
+            body.contains("is_receiving_updates(&key)"),
+            "drive_relay_probe must gate holder detection on \
+             Ring::is_receiving_updates"
+        );
+        assert!(
+            !body.contains("is_hosting_contract("),
+            "drive_relay_probe must NOT use is_hosting_contract for holder \
+             detection"
+        );
+    }
+
+    /// Pin: the probe forward decrements htl (mirroring `drive_relay_put`)
+    /// and both holder-found and no-holder replies are reachable — the
+    /// driver must be able to answer `ProbeResponse` with `holder_found`
+    /// true (fresh holder answers directly) as well as false (summary
+    /// failed, routing terminus, no next hop, or a bubbled-up downstream
+    /// no-holder reply).
+    #[test]
+    fn drive_relay_probe_forwards_with_decremented_htl_and_responds_both_holder_states() {
+        let src = include_str!("op_ctx_task.rs");
+        let start = src
+            .find("async fn drive_relay_probe(")
+            .expect("drive_relay_probe not found");
+        let end = src[start..]
+            .find("\npub(crate) async fn start_relay_probe_reconcile(")
+            .expect("end of drive_relay_probe section not found")
+            + start;
+        let body = &src[start..end];
+        assert!(
+            body.contains("let new_htl = htl.saturating_sub(1);"),
+            "drive_relay_probe must decrement htl before forwarding"
+        );
+        assert!(
+            body.contains("htl: new_htl,"),
+            "the forwarded ProbeRequest must carry the decremented htl"
+        );
+        let call_count = body.matches("relay_probe_send_response(").count();
+        assert!(
+            call_count >= 4,
+            "expected at least 4 relay_probe_send_response call sites \
+             (holder found, summary-failed, terminus, no-next-hop) — \
+             found {call_count}"
+        );
+    }
+
+    /// Pin: `drive_relay_probe_reconcile` merges via the same
+    /// `is_receiving_updates` fresh-holder signal as the probe path (never
+    /// `is_hosting_contract`), and merges through `update::update_contract`
+    /// rather than hand-rolling a contract-handler call — this is what
+    /// lets normal UPDATE fan-out propagate the reconciled delta to the
+    /// rest of the subscriber mesh automatically.
+    #[test]
+    fn drive_relay_probe_reconcile_merges_via_update_contract_on_holder() {
+        let src = include_str!("op_ctx_task.rs");
+        let start = src
+            .find("async fn drive_relay_probe_reconcile(")
+            .expect("drive_relay_probe_reconcile not found");
+        let end = src[start..]
+            .find("\n// ── End of relay PROBE driver")
+            .expect("end of drive_relay_probe_reconcile section not found")
+            + start;
+        let body = &src[start..end];
+        assert!(
+            body.contains("is_receiving_updates(&key)"),
+            "drive_relay_probe_reconcile must gate the merge decision on \
+             Ring::is_receiving_updates"
+        );
+        assert!(
+            !body.contains("is_hosting_contract("),
+            "drive_relay_probe_reconcile must NOT use is_hosting_contract"
+        );
+        assert!(
+            body.contains("update::update_contract("),
+            "drive_relay_probe_reconcile must merge via update::update_contract \
+             so normal UPDATE fan-out propagates the delta"
         );
     }
 }

--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -3766,6 +3766,46 @@ async fn drive_relay_probe(
         }
     };
 
+    // Mixed-version safety (#4642 step 3-bis staggered rollout): the routed
+    // next hop must ALSO understand the probe wire variants, not just the
+    // originator. `supports_summary_first_put` is applied at the originator
+    // (`drive_client_put_inner`), but a relay selects `next_addr` purely by
+    // routing (`closest_potentially_hosting`), so it can land on a pre-0.2.95
+    // peer that carries none of the `PutMsg` probe tags (6/7/8). Such a peer
+    // cannot bincode-deserialize the appended `ProbeRequest` tag and would
+    // DROP the connection on the decode failure — the exact connection churn
+    // the emission gate exists to prevent. Fail closed: treat THIS relay as
+    // the probe terminus and reply no-holder upstream, so the originator falls
+    // back to a full-state PUT (a summary-first failure must never break a
+    // PUT). Never emit the probe variant to an unsupported peer. See
+    // `ConnectionManager::supports_summary_first_put` and the originator gate.
+    if !op_manager
+        .ring
+        .connection_manager
+        .supports_summary_first_put(next_addr)
+    {
+        tracing::debug!(
+            tx = %incoming_tx,
+            contract = %key,
+            %next_addr,
+            phase = "relay_probe_next_hop_pre_floor",
+            "PUT probe relay: next hop does not support summary-first probes; \
+             failing closed (reply no-holder) so the originator falls back to \
+             a full-state PUT"
+        );
+        return relay_probe_send_response(
+            op_manager,
+            incoming_tx,
+            key,
+            false,
+            hop_count,
+            None,
+            None,
+            upstream_addr,
+        )
+        .await;
+    }
+
     let new_htl = htl.saturating_sub(1);
     let forward = NetMessage::from(PutMsg::ProbeRequest {
         id: incoming_tx,
@@ -3959,6 +3999,33 @@ async fn drive_relay_probe_reconcile(
         }
         None => return Ok(()),
     };
+
+    // Mixed-version safety (#4642 step 3-bis staggered rollout): same
+    // fail-closed reasoning as `drive_relay_probe`, but `ProbeReconcile` is
+    // fire-and-forget with no reply variant. A pre-0.2.95 next hop carries
+    // none of the `PutMsg` probe tags (6/7/8), cannot bincode-deserialize the
+    // appended `ProbeReconcile` tag, and would DROP the connection on the
+    // decode failure. Do NOT forward it. Dropping is safe: the reconcile is
+    // best-effort, and with the bidirectional reverse-delta the originator's
+    // copy is already complete, so anti-entropy heals the downstream holder.
+    // Return Ok(()) like the other terminus-drop branches so nothing is
+    // escalated or crashed. See `ConnectionManager::supports_summary_first_put`.
+    if !op_manager
+        .ring
+        .connection_manager
+        .supports_summary_first_put(next_addr)
+    {
+        tracing::debug!(
+            tx = %incoming_tx,
+            contract = %key,
+            %next_addr,
+            phase = "relay_probe_reconcile_next_hop_pre_floor",
+            "PUT probe-reconcile relay: next hop does not support \
+             summary-first; dropping (best-effort, anti-entropy heals the \
+             downstream holder)"
+        );
+        return Ok(());
+    }
 
     let new_htl = htl.saturating_sub(1);
     let forward = NetMessage::from(PutMsg::ProbeReconcile {
@@ -6899,6 +6966,99 @@ mod tests {
             body.contains("update::update_contract("),
             "drive_relay_probe_reconcile must merge via update::update_contract \
              so normal UPDATE fan-out propagates the delta"
+        );
+    }
+
+    /// Falsifier (mixed-version wire safety — Codex review of #4733): a relay
+    /// forwarding a `PutMsg::ProbeRequest` selects `next_addr` purely by
+    /// routing (`closest_potentially_hosting`), so the originator's emission
+    /// gate (`drive_client_put_inner`) does NOT cover it. Without a re-check
+    /// on the routed next hop, a relay can send the probe tag to a pre-0.2.95
+    /// peer that cannot bincode-deserialize it and would DROP the connection
+    /// during the staggered rollout. This pins that `drive_relay_probe`
+    /// re-checks `supports_summary_first_put(next_addr)` BEFORE constructing
+    /// the `ProbeRequest`, and that the unsupported branch fails closed
+    /// (replies no-holder so the originator falls back to a full-state PUT),
+    /// pinned via its distinctive tracing phase marker.
+    ///
+    /// Falsifies the pre-fix code: the relay body contained NO
+    /// `supports_summary_first_put` call at all, so `find` returned `None` and
+    /// the `expect` below panicked. Passes only with the fail-closed guard.
+    #[test]
+    fn drive_relay_probe_gates_probe_forward_on_next_hop_version() {
+        let src = include_str!("op_ctx_task.rs");
+        let start = src
+            .find("async fn drive_relay_probe(")
+            .expect("drive_relay_probe not found");
+        let end = src[start..]
+            .find("\npub(crate) async fn start_relay_probe_reconcile(")
+            .expect("end of drive_relay_probe section not found")
+            + start;
+        let body = &src[start..end];
+
+        let gate_pos = body.find("supports_summary_first_put(next_addr)").expect(
+            "drive_relay_probe must re-check the ROUTED next hop's version \
+             support before emitting a ProbeRequest (mixed-version rollout \
+             safety) — a relay picks next_addr by routing, not covered by the \
+             originator's gate",
+        );
+        let forward_pos = body
+            .find("PutMsg::ProbeRequest {")
+            .expect("ProbeRequest forward construction missing");
+        assert!(
+            gate_pos < forward_pos,
+            "the version gate must run BEFORE the ProbeRequest is constructed \
+             and sent — a pre-0.2.95 next hop must never receive the probe tag",
+        );
+        assert!(
+            body.contains("relay_probe_next_hop_pre_floor"),
+            "the unsupported-next-hop branch must fail closed (reply \
+             no-holder), pinned via its distinctive tracing phase marker",
+        );
+    }
+
+    /// Falsifier (mixed-version wire safety — Codex review of #4733): the
+    /// `ProbeReconcile` relay forward has the SAME gap as the probe forward —
+    /// it selects `next_addr` by routing and must re-check the next hop's
+    /// version before emitting the `PutMsg::ProbeReconcile` tag. Because
+    /// `ProbeReconcile` is fire-and-forget with no reply variant, the
+    /// fail-closed behavior is to DROP (return `Ok(())`) rather than reply:
+    /// the reconcile is best-effort, and with the bidirectional reverse-delta
+    /// the originator's copy is already complete, so anti-entropy heals the
+    /// downstream holder.
+    ///
+    /// Falsifies the pre-fix code (no `supports_summary_first_put` call in the
+    /// reconcile relay body); passes only with the fail-closed guard.
+    #[test]
+    fn drive_relay_probe_reconcile_gates_forward_on_next_hop_version() {
+        let src = include_str!("op_ctx_task.rs");
+        let start = src
+            .find("async fn drive_relay_probe_reconcile(")
+            .expect("drive_relay_probe_reconcile not found");
+        let end = src[start..]
+            .find("\n// ── End of relay PROBE driver")
+            .expect("end of drive_relay_probe_reconcile section not found")
+            + start;
+        let body = &src[start..end];
+
+        let gate_pos = body.find("supports_summary_first_put(next_addr)").expect(
+            "drive_relay_probe_reconcile must re-check the ROUTED next hop's \
+             version support before emitting a ProbeReconcile (mixed-version \
+             rollout safety)",
+        );
+        let forward_pos = body
+            .find("PutMsg::ProbeReconcile {")
+            .expect("ProbeReconcile forward construction missing");
+        assert!(
+            gate_pos < forward_pos,
+            "the version gate must run BEFORE the ProbeReconcile is \
+             constructed and sent — a pre-0.2.95 next hop must never receive \
+             the tag",
+        );
+        assert!(
+            body.contains("relay_probe_reconcile_next_hop_pre_floor"),
+            "the unsupported-next-hop branch must fail closed (drop, return \
+             Ok(())), pinned via its distinctive tracing phase marker",
         );
     }
 }

--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -712,13 +712,14 @@ async fn try_summary_first_put(
     };
 
     #[allow(clippy::wildcard_enum_match_arm)]
-    let (holder_found, probe_hop_count, holder_summary) = match reply {
+    let (holder_found, probe_hop_count, holder_summary, reverse_delta) = match reply {
         NetMessage::V1(NetMessageV1::Put(PutMsg::ProbeResponse {
             holder_found,
             hop_count,
             holder_summary,
+            reverse_delta,
             ..
-        })) => (holder_found, hop_count, holder_summary),
+        })) => (holder_found, hop_count, holder_summary, reverse_delta),
         _other => {
             tracing::debug!(
                 tx = %client_tx,
@@ -760,6 +761,49 @@ async fn try_summary_first_put(
         );
         return SummaryFirstOutcome::FallThrough;
     };
+
+    // Reverse leg of the bidirectional reconcile (#4642 step 3-bis): if the
+    // holder was ahead, it shipped back `reverse_delta` = what WE (the
+    // originator) are missing relative to the holder. Apply it to our own
+    // local copy via the SAME commutative UPDATE/merge path the holder uses
+    // for the forward `ProbeReconcile`, BEFORE we report client success, so
+    // the originator converges to the full merged state in this same
+    // round-trip instead of only healing later via anti-entropy. Best-effort:
+    // a merge failure does NOT un-complete the PUT — our own client value is
+    // already stored locally (step (a)), and we converge on the next
+    // read/anti-entropy instead. `Priority::ClientLocal` matches step (a)'s
+    // originator-loopback store.
+    if let Some(reverse_delta) = reverse_delta {
+        match crate::operations::update::update_contract(
+            op_manager,
+            key,
+            UpdateData::Delta(reverse_delta),
+            RelatedContracts::default(),
+            crate::contract::Priority::ClientLocal,
+        )
+        .await
+        {
+            Ok(_) => {
+                tracing::debug!(
+                    tx = %client_tx,
+                    contract = %key,
+                    phase = "summary_first_reverse_delta_merged",
+                    "PUT summary-first: applied holder's reverse delta to local \
+                     copy (originator converged in the same round-trip)"
+                );
+            }
+            Err(err) => {
+                tracing::debug!(
+                    tx = %client_tx,
+                    contract = %key,
+                    error = %err,
+                    phase = "summary_first_reverse_delta_merge_failed",
+                    "PUT summary-first: reverse-delta merge failed (best-effort, \
+                     PUT still completes; originator converges via anti-entropy)"
+                );
+            }
+        }
+    }
 
     let our_state_size = merged_value.size();
     let delta = match op_manager
@@ -3442,6 +3486,7 @@ impl Drop for RelayProbeInflightGuard {
 /// `send_fire_and_forget` with a real target), never via
 /// `send_local_loopback` — but the check is kept for defensive symmetry
 /// with the PUT relay path.
+#[allow(clippy::too_many_arguments)]
 async fn relay_probe_send_response(
     op_manager: &OpManager,
     incoming_tx: Transaction,
@@ -3449,6 +3494,7 @@ async fn relay_probe_send_response(
     holder_found: bool,
     hop_count: usize,
     holder_summary: Option<StateSummary<'static>>,
+    reverse_delta: Option<StateDelta<'static>>,
     upstream_addr: SocketAddr,
 ) -> Result<(), OpError> {
     let msg = NetMessage::from(PutMsg::ProbeResponse {
@@ -3457,6 +3503,7 @@ async fn relay_probe_send_response(
         holder_found,
         hop_count,
         holder_summary,
+        reverse_delta,
     });
     let mut ctx = op_manager.op_ctx(incoming_tx);
     let own_addr = op_manager.ring.connection_manager.get_own_addr();
@@ -3469,6 +3516,87 @@ async fn relay_probe_send_response(
             .await
             .map_err(|_| OpError::NotificationError)
     }
+}
+
+/// Compute the reverse-leg delta a fresh holder ships back to a summary-first
+/// PUT originator (#4642 step 3-bis, bidirectional reconcile): the delta the
+/// ORIGINATOR is missing relative to the holder's state. This is the exact
+/// mirror of the originator's forward delta — the holder already has both
+/// inputs (the originator's summary arrived on the `ProbeRequest`, and it has
+/// its own state) — so it reuses `InterestManager::compute_delta`, and
+/// therefore the SAME `is_delta_efficient` gate the forward leg uses (a
+/// summary-size proxy for delta size: the delta is skipped when the
+/// originator's summary is ≥ ~50% of the holder's state size).
+///
+/// Returns `None` (skip the reverse leg — the originator heals via a normal
+/// GET / anti-entropy rather than receiving a bloated or absent delta) when:
+/// - the originator is already current (`compute_delta` → `Ok(None)`, empty
+///   delta),
+/// - the reverse delta would be inefficient or is uncomputable
+///   (`compute_delta` → `Err`), or
+/// - the holder's own state size can't be read (no efficiency input).
+async fn compute_probe_reverse_delta(
+    op_manager: &Arc<OpManager>,
+    incoming_tx: Transaction,
+    key: &ContractKey,
+    originator_summary: &StateSummary<'static>,
+    holder_summary: &StateSummary<'static>,
+) -> Option<StateDelta<'static>> {
+    let Some(our_state_size) = op_manager
+        .interest_manager
+        .get_contract_state_size(op_manager, key)
+        .await
+    else {
+        tracing::debug!(
+            tx = %incoming_tx,
+            contract = %key,
+            phase = "relay_probe_reverse_delta_no_state_size",
+            "PUT probe: could not read holder state size for the reverse \
+             delta; skipping reverse leg (originator heals via GET/anti-entropy)"
+        );
+        return None;
+    };
+
+    // `their_summary` = the originator's summary (what the originator has);
+    // `our_summary` = the holder's summary. `compute_delta` returns the delta
+    // that transforms the originator's state into ours — i.e. exactly what
+    // the originator is missing.
+    let computed = op_manager
+        .interest_manager
+        .compute_delta(
+            op_manager,
+            key,
+            originator_summary,
+            holder_summary,
+            our_state_size,
+        )
+        .await;
+    if let Err(ref err) = computed {
+        tracing::debug!(
+            tx = %incoming_tx,
+            contract = %key,
+            error = %err,
+            phase = "relay_probe_reverse_delta_skipped",
+            "PUT probe: reverse delta unavailable (inefficient or compute \
+             failed); originator heals via GET/anti-entropy"
+        );
+    }
+    reverse_delta_from_compute_result(computed)
+}
+
+/// Map an [`InterestManager::compute_delta`](crate::ring::interest::InterestManager::compute_delta)
+/// result to the reverse-leg delta a holder ships in
+/// `PutMsg::ProbeResponse::reverse_delta`.
+///
+/// `Ok(Some)` ships the delta; `Ok(None)` (the originator is already current —
+/// the contract produced an empty delta) and `Err` (the delta is inefficient
+/// or uncomputable) both ship nothing (`None`), leaving the originator to
+/// heal via a normal GET / anti-entropy. Kept as a pure function so the three
+/// arms are unit-testable without a live contract handler.
+fn reverse_delta_from_compute_result(
+    computed: Result<Option<StateDelta<'static>>, String>,
+) -> Option<StateDelta<'static>> {
+    computed.unwrap_or(None)
 }
 
 /// Routes a `PutMsg::ProbeRequest` toward `key`, or answers it directly when
@@ -3508,6 +3636,20 @@ async fn drive_relay_probe(
             .await;
         return match holder_summary {
             Some(s) => {
+                // Reverse leg of the bidirectional reconcile (#4642 step
+                // 3-bis): compute the delta the ORIGINATOR is missing
+                // relative to our (the holder's) state — the mirror of the
+                // originator's forward delta. `summary` is the originator's
+                // summary carried on the ProbeRequest; `s` is our own. We
+                // ship it back in `ProbeResponse::reverse_delta` so the
+                // originator converges to the full merged state in the SAME
+                // round-trip instead of healing only later via anti-entropy.
+                // `None` (skip the reverse leg — originator heals via a
+                // normal GET / anti-entropy) when the originator is already
+                // current (empty delta) or the reverse delta would be
+                // inefficient / uncomputable; see `compute_probe_reverse_delta`.
+                let reverse_delta =
+                    compute_probe_reverse_delta(op_manager, incoming_tx, &key, &summary, &s).await;
                 relay_probe_send_response(
                     op_manager,
                     incoming_tx,
@@ -3515,6 +3657,7 @@ async fn drive_relay_probe(
                     true,
                     hop_count,
                     Some(s),
+                    reverse_delta,
                     upstream_addr,
                 )
                 .await
@@ -3541,6 +3684,7 @@ async fn drive_relay_probe(
                     key,
                     false,
                     hop_count,
+                    None,
                     None,
                     upstream_addr,
                 )
@@ -3585,6 +3729,7 @@ async fn drive_relay_probe(
                     false,
                     hop_count,
                     None,
+                    None,
                     upstream_addr,
                 )
                 .await;
@@ -3599,6 +3744,7 @@ async fn drive_relay_probe(
                         false,
                         hop_count,
                         None,
+                        None,
                         upstream_addr,
                     )
                     .await;
@@ -3612,6 +3758,7 @@ async fn drive_relay_probe(
                 key,
                 false,
                 hop_count,
+                None,
                 None,
                 upstream_addr,
             )
@@ -3649,8 +3796,13 @@ async fn drive_relay_probe(
             holder_found,
             hop_count: downstream_hop_count,
             holder_summary,
+            reverse_delta,
             ..
         })) => {
+            // Pass the reverse leg straight through: only the terminal
+            // holder can compute the delta the originator is missing, so an
+            // intermediate routing hop just relays it upstream unchanged
+            // (same as `holder_summary`).
             relay_probe_send_response(
                 op_manager,
                 incoming_tx,
@@ -3658,6 +3810,7 @@ async fn drive_relay_probe(
                 holder_found,
                 downstream_hop_count,
                 holder_summary,
+                reverse_delta,
                 upstream_addr,
             )
             .await
@@ -3841,6 +3994,51 @@ mod tests {
 
     fn dummy_tx() -> Transaction {
         Transaction::new::<PutMsg>()
+    }
+
+    /// Bidirectional summary-first reconcile (#4642 step 3-bis): the
+    /// reverse-leg mapping ships a `ProbeResponse::reverse_delta` ONLY when
+    /// the holder is genuinely ahead. All three `compute_delta` outcomes map
+    /// correctly:
+    /// - `Ok(Some)` → ship the delta (holder ahead),
+    /// - `Ok(None)` (originator already current — contract returned an empty
+    ///   delta) → ship NOTHING,
+    /// - `Err` (delta inefficient / uncomputable — SAME gate as the forward
+    ///   leg) → ship NOTHING.
+    ///
+    /// The two `None` arms are the "originator already current / heal via a
+    /// normal GET or anti-entropy" fallback: the reconcile must not emit a
+    /// phantom reverse delta when there is nothing (or nothing efficient) to
+    /// send. This is the deterministic falsifier for the "empty-reverse-delta
+    /// case sends nothing" requirement — the CRDT mock never emits an empty
+    /// delta, so the `Ok(None)` path can't be reached in the sim tests and is
+    /// pinned here instead.
+    #[test]
+    fn reverse_delta_from_compute_result_maps_all_arms() {
+        // Holder ahead: a real reverse delta is shipped back to the originator.
+        let shipped = reverse_delta_from_compute_result(Ok(Some(StateDelta::from(vec![1, 2, 3]))));
+        assert_eq!(
+            shipped.as_ref().map(|d| d.as_ref().to_vec()),
+            Some(vec![1, 2, 3]),
+            "Ok(Some) must ship the holder's reverse delta"
+        );
+
+        // Originator already current (empty delta from the contract): send nothing.
+        let already_current = reverse_delta_from_compute_result(Ok(None));
+        assert!(
+            already_current.is_none(),
+            "Ok(None) (originator already current) must send NO reverse delta"
+        );
+
+        // Delta inefficient or uncomputable: send nothing — the originator
+        // heals via a normal GET / anti-entropy instead of receiving a
+        // bloated or absent delta.
+        let inefficient =
+            reverse_delta_from_compute_result(Err("Delta not efficient for this contract".into()));
+        assert!(
+            inefficient.is_none(),
+            "Err (inefficient/uncomputable) must send NO reverse delta"
+        );
     }
 
     /// Regression for #4363: on a sparse/bootstrap topology a PUT

--- a/crates/core/src/ring/connection_manager.rs
+++ b/crates/core/src/ring/connection_manager.rs
@@ -289,6 +289,32 @@ pub(crate) struct ConnectionManager {
     /// only in a sim test that opted into the migration cascade via
     /// `SimNetwork::enable_placement_migration`. See `NodeConfig`.
     subscribe_hint_floor_override: Option<(u8, u8, u16)>,
+    /// Mirror of `P2pConnManager.connections[addr].remote_version`, kept on
+    /// `ConnectionManager` so op drivers (`operations::put::op_ctx_task`,
+    /// reached via `op_manager.ring.connection_manager`) can gate emission of
+    /// version-sensitive wire variants. The network-bridge layer
+    /// (`P2pConnManager`) is not reachable from op drivers, so the
+    /// `peer_supports_subscribe_hint`-style version check cannot read
+    /// `P2pConnManager.connections` directly; this mirror closes that gap for
+    /// the summary-first PUT probe (#4642 step 3-bis).
+    ///
+    /// Populated at connection establishment
+    /// (`p2p_protoc::connection_lifecycle`, the same call site that populates
+    /// `P2pConnManager.connections[addr].remote_version`) via
+    /// `record_remote_version`. Never proactively removed: a stale entry can
+    /// only matter if a different peer later reconnects at the exact same
+    /// socket address with an older version, and any real reconnection at
+    /// that address overwrites the entry before it is ever consulted (lookups
+    /// only target addresses with a live connection). Unknown addresses
+    /// (`None`) fail closed in `version_supports_summary_first_put`.
+    #[allow(clippy::type_complexity)]
+    remote_version: Arc<RwLock<BTreeMap<SocketAddr, (u8, u8, u16)>>>,
+    /// Test-only override for the summary-first PUT probe version floor,
+    /// threaded exactly like `subscribe_hint_floor_override`. `None` in
+    /// production (the real `SUMMARY_FIRST_PUT_MIN_VERSION` applies);
+    /// `Some(floor)` only in a sim test that opted in via
+    /// `SimNetwork::enable_summary_first_put`. See `NodeConfig`.
+    summary_first_put_floor_override: Option<(u8, u8, u16)>,
     /// Rotating start offset for the per-new-peer migration scan. The scan
     /// examines at most `MIGRATION_SCAN_CAP_PER_NEW_PEER` hosted contracts per
     /// event; advancing this cursor each event makes successive events cover
@@ -411,6 +437,7 @@ impl ConnectionManager {
         // None for all the test-helper constructions, Some(floor) only when a
         // sim opted into the migration cascade.
         cm.subscribe_hint_floor_override = config.subscribe_hint_floor_override;
+        cm.summary_first_put_floor_override = config.summary_first_put_floor_override;
         cm
     }
 
@@ -444,6 +471,9 @@ impl ConnectionManager {
             is_gateway,
             // Default off; `new(config)` overrides from config after init.
             subscribe_hint_floor_override: None,
+            remote_version: Arc::new(RwLock::new(BTreeMap::new())),
+            // Default off; `new(config)` overrides from config after init.
+            summary_first_put_floor_override: None,
             migration_scan_cursor: Arc::new(AtomicUsize::new(0)),
             transient_connections: Arc::new(DashMap::new()),
             transient_in_use: Arc::new(AtomicUsize::new(0)),
@@ -797,6 +827,51 @@ impl ConnectionManager {
     /// production). See `NodeConfig::subscribe_hint_floor_override`.
     pub(crate) fn subscribe_hint_floor_override(&self) -> Option<(u8, u8, u16)> {
         self.subscribe_hint_floor_override
+    }
+
+    /// Record the negotiated protocol version for a peer at `addr`, mirroring
+    /// `P2pConnManager.connections[addr].remote_version` so op drivers can
+    /// read it via `op_manager.ring.connection_manager`. Overwrites any prior
+    /// entry for `addr` (a fresh connection at a reused address always wins).
+    ///
+    /// Called from `p2p_protoc::connection_lifecycle` at the same point
+    /// `P2pConnManager` records `remote_version` on its own `connections`
+    /// entry — keep the two writes together if that call site changes.
+    pub(crate) fn record_remote_version(&self, addr: SocketAddr, version: (u8, u8, u16)) {
+        self.remote_version.write().insert(addr, version);
+    }
+
+    /// Look up the negotiated protocol version recorded for `addr` via
+    /// [`Self::record_remote_version`]. `None` if no connection has been
+    /// established at `addr` (or none since this node started).
+    pub(crate) fn remote_version(&self, addr: SocketAddr) -> Option<(u8, u8, u16)> {
+        self.remote_version.read().get(&addr).copied()
+    }
+
+    /// Test-only override for the summary-first PUT probe version floor
+    /// (`None` in production). See `NodeConfig::summary_first_put_floor_override`.
+    pub(crate) fn summary_first_put_floor_override(&self) -> Option<(u8, u8, u16)> {
+        self.summary_first_put_floor_override
+    }
+
+    /// Whether the peer at `addr` reports a negotiated protocol version new
+    /// enough to understand the summary-first PUT probe/dispatch variants
+    /// (`PutMsg::ProbeRequest` / `ProbeResponse` / `ProbeReconcile`).
+    ///
+    /// Driver-reachable mirror of
+    /// `P2pConnManager::peer_supports_subscribe_hint`: op drivers
+    /// (`operations::put::op_ctx_task`) only reach `op_manager.ring`, not the
+    /// network-bridge layer, so this reads the `remote_version` mirror above
+    /// instead of `P2pConnManager.connections`. `None` (unknown version) is
+    /// treated as unsupported (fail-closed): an older peer that cannot
+    /// deserialize the appended `ProbeRequest` wire tag would drop the
+    /// connection, so when in doubt the caller must not emit it.
+    pub(crate) fn supports_summary_first_put(&self, addr: SocketAddr) -> bool {
+        let remote = self.remote_version(addr);
+        let floor = self
+            .summary_first_put_floor_override()
+            .unwrap_or(crate::node::SUMMARY_FIRST_PUT_MIN_VERSION);
+        crate::node::version_supports_summary_first_put(remote, floor)
     }
 
     /// Reserve the next `window`-sized slice of the hosting set for a migration
@@ -1934,6 +2009,66 @@ mod tests {
         if let Some(mut entry) = cm.transient_connections.get_mut(&addr) {
             entry.created_at = Instant::now() - age;
         }
+    }
+
+    // ============ summary-first PUT version-gate tests (#4642 step 3-bis) ============
+
+    /// `record_remote_version` / `remote_version` round-trip: an address
+    /// with no recorded connection returns `None`, and a recorded version
+    /// is returned verbatim.
+    #[test]
+    fn record_remote_version_then_lookup_roundtrips() {
+        let cm = make_connection_manager(Some(make_addr(9000)), 1, 10, false);
+        let addr = make_addr(9001);
+        assert_eq!(cm.remote_version(addr), None);
+        cm.record_remote_version(addr, (0, 2, 94));
+        assert_eq!(cm.remote_version(addr), Some((0, 2, 94)));
+    }
+
+    /// Emission gate, fail-closed case: a peer with no recorded version
+    /// (e.g. never connected, or connected pre-handshake) must not be
+    /// treated as summary-first-capable — mirrors the mixed-version
+    /// interop guarantee the gate's own unit tests assert in isolation
+    /// (`p2p_protoc::tests::summary_first_unknown_remote_version_fails_closed`),
+    /// exercised here through the driver-reachable `ConnectionManager`
+    /// wrapper instead of the pure predicate directly.
+    #[test]
+    fn supports_summary_first_put_fails_closed_for_unknown_peer() {
+        let cm = make_connection_manager(Some(make_addr(9000)), 1, 10, false);
+        let addr = make_addr(9002);
+        assert!(!cm.supports_summary_first_put(addr));
+    }
+
+    /// Emission gate, known-version case against the real production floor
+    /// (no test override set): a pre-floor peer is rejected, an
+    /// at-or-above-floor peer is accepted. This is the decision
+    /// `try_summary_first_put` consults before ever emitting a
+    /// `PutMsg::ProbeRequest` — a pre-floor peer must never receive one
+    /// (it cannot bincode-deserialize the appended tag).
+    #[test]
+    fn supports_summary_first_put_respects_recorded_version_against_production_floor() {
+        let cm = make_connection_manager(Some(make_addr(9000)), 1, 10, false);
+
+        let pre_floor_addr = make_addr(9003);
+        cm.record_remote_version(pre_floor_addr, (0, 2, 80));
+        assert!(!cm.supports_summary_first_put(pre_floor_addr));
+
+        // The exact staggered-rollout boundary (#4642 step 3-bis): a 0.2.93
+        // peer carries the probe wire variants INERT (it can decode a probe
+        // but has no handler to process it), so a 0.2.94 emitter must fall
+        // back to a full-state PUT and NEVER send it a summary probe. The
+        // floor being strictly greater than 0.2.93 is what enforces this.
+        let inert_variant_peer = make_addr(9005);
+        cm.record_remote_version(inert_variant_peer, (0, 2, 93));
+        assert!(
+            !cm.supports_summary_first_put(inert_variant_peer),
+            "a 0.2.93 peer decodes but cannot process a probe; emitter must \
+             fall back to full-state PUT"
+        );
+
+        let at_floor_addr = make_addr(9004);
+        cm.record_remote_version(at_floor_addr, crate::node::SUMMARY_FIRST_PUT_MIN_VERSION);
+        assert!(cm.supports_summary_first_put(at_floor_addr));
     }
 
     // ============ cleanup_expired_transients tests ============

--- a/crates/core/src/ring/connection_manager.rs
+++ b/crates/core/src/ring/connection_manager.rs
@@ -2053,19 +2053,24 @@ mod tests {
         cm.record_remote_version(pre_floor_addr, (0, 2, 80));
         assert!(!cm.supports_summary_first_put(pre_floor_addr));
 
-        // The exact staggered-rollout boundary (#4642 step 3-bis): a 0.2.93
-        // peer carries the probe wire variants INERT (it can decode a probe
-        // but has no handler to process it), so a 0.2.94 emitter must fall
-        // back to a full-state PUT and NEVER send it a summary probe. The
-        // floor being strictly greater than 0.2.93 is what enforces this.
-        let inert_variant_peer = make_addr(9005);
-        cm.record_remote_version(inert_variant_peer, (0, 2, 93));
+        // The exact staggered-rollout boundary (#4642 step 3-bis): the probe
+        // wire variants (PutMsg tags 6/7/8) first ship in 0.2.95 (this PR).
+        // 0.2.94 is the HIGHEST already-released version and carries NONE of
+        // them, so a 0.2.94 peer cannot even decode a probe — the decode
+        // failure would drop the connection. A summary-first-capable emitter
+        // must therefore fall back to a full-state PUT and NEVER send it a
+        // probe. The floor being strictly greater than 0.2.94 enforces this.
+        let pre_variant_peer = make_addr(9005);
+        cm.record_remote_version(pre_variant_peer, (0, 2, 94));
         assert!(
-            !cm.supports_summary_first_put(inert_variant_peer),
-            "a 0.2.93 peer decodes but cannot process a probe; emitter must \
-             fall back to full-state PUT"
+            !cm.supports_summary_first_put(pre_variant_peer),
+            "a 0.2.94 peer has no probe variants; a probe would fail to decode \
+             and drop the connection, so the emitter must fall back to a \
+             full-state PUT"
         );
 
+        // A peer at the floor (0.2.95, the first release carrying the probe
+        // variants + handler) is accepted.
         let at_floor_addr = make_addr(9004);
         cm.record_remote_version(at_floor_addr, crate::node::SUMMARY_FIRST_PUT_MIN_VERSION);
         assert!(cm.supports_summary_first_put(at_floor_addr));

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -1128,6 +1128,65 @@ impl<T: TimeSource + Sync> InterestManager<T> {
         }
     }
 
+    /// Get the size (in bytes) of the locally-stored state for a contract.
+    ///
+    /// Mirrors [`get_contract_summary`](Self::get_contract_summary): a bounded
+    /// (`BROADCAST_CH_TIMEOUT`) `GetQuery` against the contract handler,
+    /// returning the stored state's `size()` or `None` if it can't be read.
+    /// Used by the summary-first PUT reverse leg to feed
+    /// [`compute_delta`](Self::compute_delta)'s efficiency gate with the
+    /// holder's own state size (the holder-side mirror of the originator's
+    /// `merged_value.size()`).
+    pub async fn get_contract_state_size(
+        &self,
+        op_manager: &crate::node::OpManager,
+        key: &ContractKey,
+    ) -> Option<usize> {
+        use crate::contract::ContractHandlerEvent;
+
+        match op_manager
+            .notify_contract_handler_with_timeout(
+                ContractHandlerEvent::GetQuery {
+                    instance_id: *key.id(),
+                    return_contract_code: false,
+                },
+                BROADCAST_CH_TIMEOUT,
+            )
+            .await
+        {
+            Ok(ContractHandlerEvent::GetResponse {
+                response: Ok(store_response),
+                ..
+            }) => store_response.state.map(|state| state.size()),
+            Ok(ContractHandlerEvent::GetResponse {
+                response: Err(e), ..
+            }) => {
+                tracing::debug!(
+                    contract = %key,
+                    error = %e,
+                    "Failed to get contract state size"
+                );
+                None
+            }
+            Ok(other) => {
+                tracing::warn!(
+                    contract = %key,
+                    response = ?other,
+                    "Unexpected response to GetQuery (state size)"
+                );
+                None
+            }
+            Err(e) => {
+                tracing::debug!(
+                    contract = %key,
+                    error = %e,
+                    "Error getting contract state size"
+                );
+                None
+            }
+        }
+    }
+
     /// Compute a state delta for a peer given their cached summary.
     ///
     /// Uses the contract handler to compute the delta via the contract's

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -14431,3 +14431,155 @@ fn test_summary_first_put_no_holder_ships_full_state() {
          (hop-by-hop hosting) — got only {hosting_labels:?}"
     );
 }
+
+/// **Test C — bidirectional reconcile: the originator converges via the
+/// reverse delta (#4642 step 3-bis).**
+///
+/// The falsifier for the reverse leg. Mirrors Test A but with the version
+/// ordering SWAPPED so the HOLDER is AHEAD of the originator: node1 holds v2,
+/// then the gateway PUTs the SAME contract at the LOWER v1. Summary-first PUT
+/// used to be write-forward-only: the originator shipped its forward delta to
+/// the holder and reported client success at its OWN (older) state, healing to
+/// the merged state only later via anti-entropy. With the reverse leg the
+/// holder computes what the originator is missing and ships it back on the
+/// `ProbeResponse`, and the originator merges it BEFORE reporting success — so
+/// BOTH sides converge to the full merged state (v2) in a single round-trip.
+///
+/// **The load-bearing assertion is that the gateway (originator) ends at v2,
+/// not the v1 it PUT** — direct proof it received and applied node1's reverse
+/// delta. node1 (the ahead holder) stays at v2 (the originator's forward delta
+/// is for the older v1, so it merges to NoChange there).
+///
+/// Uses CRDT emulation for the same reason as Test A (MockRuntime's default
+/// `get_contract_state_delta` can't compute deltas) and originates the probing
+/// PUT from the gateway for the same version-gate reason (a regular node's link
+/// to its gateway carries no negotiated version). See
+/// `test_summary_first_put_holder_found_ships_delta` for the full rationale.
+#[test_log::test]
+fn test_summary_first_put_reverse_delta_converges_originator() {
+    use freenet::dev_tool::{NodeLabel, ScheduledOperation, SimOperation, register_crdt_contract};
+
+    const SEED: u64 = 0x4642_5F03_CAFE;
+    const NETWORK_NAME: &str = "summary-first-put-reverse-delta";
+
+    setup_deterministic_state(SEED);
+    let rt = create_runtime();
+
+    let gateway = NodeLabel::gateway(NETWORK_NAME, 0);
+    let node1 = NodeLabel::node(NETWORK_NAME, 1);
+
+    let contract = SimOperation::create_test_contract(0x5C);
+    let contract_id = *contract.key().id();
+    let contract_key = contract.key();
+    register_crdt_contract(contract_id);
+
+    // Holder (node1) is AHEAD at v2; originator (gateway) PUTs the LOWER v1.
+    // The reverse delta must carry v2's data back to the gateway.
+    let state_v2 = SimOperation::create_crdt_state(2, 0x22);
+    let state_v1 = SimOperation::create_crdt_state(1, 0x11);
+
+    let mut sim =
+        rt.block_on(async { SimNetwork::new(NETWORK_NAME, 1, 1, 7, 3, 10, 2, SEED).await });
+    sim.enable_summary_first_put();
+
+    let operations = vec![
+        // node1 PUTs v2 + subscribes: becomes a fresh holder AHEAD of the
+        // originator. (Its own PUT never touches the probe counters — its
+        // link to the gateway carries no gateway version, see Test A.)
+        ScheduledOperation::new(
+            node1.clone(),
+            SimOperation::Put {
+                contract: contract.clone(),
+                state: state_v2.clone(),
+                subscribe: true,
+            },
+        ),
+        // Gateway PUTs the SAME contract at the LOWER v1. It probes node1
+        // (the fresh holder), learns node1 is ahead, and must merge node1's
+        // reverse delta into its own copy BEFORE reporting client success.
+        ScheduledOperation::new(
+            gateway.clone(),
+            SimOperation::Put {
+                contract: contract.clone(),
+                state: state_v1.clone(),
+                subscribe: false,
+            },
+        ),
+    ];
+
+    let result = sim.run_controlled_simulation(
+        SEED,
+        operations,
+        Duration::from_secs(120),
+        Duration::from_secs(30),
+    );
+    assert!(
+        result.turmoil_result.is_ok(),
+        "summary-first PUT reverse-delta sim failed: {:?}",
+        result.turmoil_result.err()
+    );
+
+    let new_contract_sends = GlobalTestMetrics::put_probe_new_contract_sends();
+    let delta_sends = GlobalTestMetrics::put_probe_existing_mesh_delta_sends();
+
+    tracing::info!(
+        new_contract_sends,
+        delta_sends,
+        "summary-first PUT reverse-delta test: probe outcome counters"
+    );
+
+    // The gateway's PUT found the fresh holder (node1), so it took the
+    // holder-found branch (where the reverse leg lives), not the no-holder
+    // fallback.
+    assert_eq!(
+        new_contract_sends, 0,
+        "no-holder path must NOT fire: the gateway's PUT found a fresh holder \
+         (node1)"
+    );
+    assert_eq!(
+        delta_sends, 1,
+        "holder-found path must fire exactly once (the gateway probing node1)"
+    );
+
+    // node1 (the holder) stays at v2 — the originator's forward delta targets
+    // the OLDER v1, so it merges to NoChange at the ahead holder.
+    let node1_final_state = result
+        .node_storages
+        .get(&node1)
+        .and_then(|s| s.get_stored_state(&contract_key))
+        .expect("node1 should have a stored state for the contract");
+    let node1_version = u64::from_le_bytes(
+        node1_final_state.as_ref()[0..8]
+            .try_into()
+            .expect("CRDT state must have an 8-byte version prefix"),
+    );
+    assert_eq!(
+        node1_version, 2,
+        "the holder must stay at v2 (the originator's forward delta was for \
+         the older v1)"
+    );
+
+    // THE FALSIFIER: the gateway (originator) must have converged to v2 by
+    // applying node1's REVERSE delta — not remained at the v1 it PUT. Without
+    // the reverse leg this is v1 (the originator would heal only later via
+    // anti-entropy); with it, both sides converge in one round-trip.
+    let gateway_final_state = result
+        .node_storages
+        .get(&gateway)
+        .and_then(|s| s.get_stored_state(&contract_key))
+        .expect("the gateway (originator) should have a stored state for the contract");
+    let gateway_version = u64::from_le_bytes(
+        gateway_final_state.as_ref()[0..8]
+            .try_into()
+            .expect("CRDT state must have an 8-byte version prefix"),
+    );
+    assert_eq!(
+        gateway_version, 2,
+        "the originator (gateway) must converge to the full merged state (v2) \
+         by applying the holder's reverse delta in the SAME round-trip — it \
+         PUT v1 and would remain at v1 without the reverse leg"
+    );
+
+    // Avoid leaking the CRDT registration into other tests sharing this process.
+    freenet::dev_tool::clear_crdt_contracts();
+}

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -14119,3 +14119,315 @@ fn test_piece_b_anti_entropy_heals_demandless_copy() {
     // Avoid leaking the CRDT registration into other tests sharing this process.
     freenet::dev_tool::clear_crdt_contracts();
 }
+
+// =============================================================================
+// Summary-first PUT (#4642 step 3-bis) — behavioral simulation tests
+// =============================================================================
+//
+// These two simulations exercise `try_summary_first_put` end-to-end through
+// `run_controlled_simulation`. Summary-first PUT is OFF by default in every
+// simulation (`SimNetwork::SIM_MIGRATION_DISABLED_FLOOR` — same fail-closed
+// default as placement migration); both tests opt in via
+// `enable_summary_first_put()`.
+
+/// **Test A — holder-found ships a delta, not full state.**
+///
+/// Maps to spec step 3-bis "holder-found → reconcile a delta, no full state
+/// to existing hosts": establishes a fresh (subscribed) holder for a CRDT-mode
+/// contract, then PUTs the SAME contract with a higher-version state from a
+/// DIFFERENT peer. Asserts the holder-found branch fires
+/// (`put_probe_existing_mesh_delta_sends`), the no-holder branch does NOT
+/// (`put_probe_new_contract_sends == 0`), and the bytes actually shipped
+/// (delta only) are strictly fewer than a full-state PUT of the same payload
+/// would have shipped (state + contract code + params) — the byte-savings
+/// claim the falsifier counters exist to prove or disprove.
+///
+/// Uses CRDT emulation mode (`register_crdt_contract` /
+/// `SimOperation::create_crdt_state`) because `MockRuntime`'s default
+/// (non-CRDT) `get_contract_state_delta` unconditionally returns an error
+/// ("MockRuntime cannot compute deltas - use full state sync"): with a plain
+/// test contract, `try_summary_first_put`'s delta-computation step would
+/// always fail and fall through, so the delta path could never be exercised
+/// without CRDT emulation. See `mock_runtime.rs::get_contract_state_delta`.
+///
+/// **Role choice is load-bearing, not arbitrary:** the second (probing) PUT
+/// MUST originate from the GATEWAY, not the regular node. `RemoteConnection::
+/// remote_protoc_version` is `None` on the joiner->gateway path ("the
+/// gateway's AckConnection payload carries no version" — see
+/// `transport/peer_connection.rs`), so a regular node's `ConnectionManager`
+/// never records its gateway's negotiated version and `supports_summary_first_put`
+/// fails closed for EVERY PUT a regular node routes through its gateway link —
+/// in production as much as in sim, this is not a simulation-harness gap.
+/// Only the gateway's connection TO the node carries the node's version, so
+/// only a gateway-originated PUT can pass the emission gate in a
+/// gateway/regular-node topology. (Confirmed empirically: with the roles
+/// reversed, the regular node's PUT never even logs a
+/// `PUT summary-first: ...` line — the whole block is skipped, not merely
+/// falling through inside it.)
+#[test_log::test]
+fn test_summary_first_put_holder_found_ships_delta() {
+    use freenet::dev_tool::{NodeLabel, ScheduledOperation, SimOperation, register_crdt_contract};
+
+    const SEED: u64 = 0x4642_5F01_CAFE;
+    const NETWORK_NAME: &str = "summary-first-put-delta";
+
+    setup_deterministic_state(SEED);
+    let rt = create_runtime();
+
+    let gateway = NodeLabel::gateway(NETWORK_NAME, 0);
+    let node1 = NodeLabel::node(NETWORK_NAME, 1);
+
+    let contract = SimOperation::create_test_contract(0x5F);
+    let contract_id = *contract.key().id();
+    let contract_key = contract.key();
+    register_crdt_contract(contract_id);
+
+    // v1: node1's initial holder state. v2: the gateway's contribution — a
+    // higher CRDT version so `apply_crdt_delta`'s LWW merge accepts it
+    // unconditionally (to_version > current_version).
+    let state_v1 = SimOperation::create_crdt_state(1, 0x11);
+    let state_v2 = SimOperation::create_crdt_state(2, 0x22);
+
+    // What a full-state PUT of this exact payload would have shipped: the
+    // CRDT state plus the contract's code+params (48 bytes: 32-byte code +
+    // 16-byte params, per `SimOperation::create_test_contract`). The delta
+    // must beat this because it never re-ships code/params to a peer that
+    // already hosts the contract.
+    const CODE_PARAMS_BYTES: u64 = 32 + 16;
+    let full_state_bytes_if_shipped_whole = state_v2.len() as u64 + CODE_PARAMS_BYTES;
+
+    let mut sim =
+        rt.block_on(async { SimNetwork::new(NETWORK_NAME, 1, 1, 7, 3, 10, 2, SEED).await });
+    // Opt this simulation into summary-first PUT (off by default in every
+    // sim — see `SimNetwork::SIM_MIGRATION_DISABLED_FLOOR`).
+    sim.enable_summary_first_put();
+
+    let operations = vec![
+        // node1 PUTs + subscribes: becomes a fresh holder
+        // (`Ring::is_receiving_updates` true via its own client subscription).
+        // Its own PUT never touches the probe counters (see rustdoc above:
+        // its connection to the gateway can't carry the gateway's version),
+        // so this is a clean, counter-neutral way to seed the holder.
+        ScheduledOperation::new(
+            node1.clone(),
+            SimOperation::Put {
+                contract: contract.clone(),
+                state: state_v1.clone(),
+                subscribe: true,
+            },
+        ),
+        // Gateway PUTs the SAME contract with a higher-version state. Its
+        // only known peer is node1, so `closest_potentially_hosting` targets
+        // it directly — the probe reaches the fresh holder in one hop, and
+        // the gateway's connection TO node1 does carry node1's negotiated
+        // version, so `supports_summary_first_put` passes.
+        ScheduledOperation::new(
+            gateway.clone(),
+            SimOperation::Put {
+                contract: contract.clone(),
+                state: state_v2.clone(),
+                subscribe: false,
+            },
+        ),
+    ];
+
+    let result = sim.run_controlled_simulation(
+        SEED,
+        operations,
+        Duration::from_secs(120),
+        Duration::from_secs(30),
+    );
+    assert!(
+        result.turmoil_result.is_ok(),
+        "summary-first PUT delta sim failed: {:?}",
+        result.turmoil_result.err()
+    );
+
+    let new_contract_sends = GlobalTestMetrics::put_probe_new_contract_sends();
+    let delta_sends = GlobalTestMetrics::put_probe_existing_mesh_delta_sends();
+    let delta_bytes = GlobalTestMetrics::put_probe_existing_mesh_delta_bytes();
+
+    tracing::info!(
+        new_contract_sends,
+        delta_sends,
+        delta_bytes,
+        full_state_bytes_if_shipped_whole,
+        "summary-first PUT delta test: probe outcome counters"
+    );
+
+    // node1's own PUT never touches these counters: its connection to the
+    // gateway never carries the gateway's negotiated version (see rustdoc
+    // above), so `supports_summary_first_put` fails closed and the whole
+    // summary-first block is skipped for node1's PUT — only the gateway's
+    // PUT can move them.
+    assert_eq!(
+        new_contract_sends, 0,
+        "no-holder path must NOT fire: the gateway's PUT found a fresh \
+         holder (node1), so the summary-first probe must take the \
+         holder-found branch, never the no-holder fallback"
+    );
+    assert_eq!(
+        delta_sends, 1,
+        "holder-found path must fire exactly once (the gateway's PUT \
+         probing the node1 holder)"
+    );
+    assert!(
+        delta_bytes > 0,
+        "the delta must be non-empty — v2's data genuinely differs from v1"
+    );
+    assert!(
+        delta_bytes < full_state_bytes_if_shipped_whole,
+        "the existing-mesh delta ({delta_bytes} bytes) must ship strictly \
+         fewer bytes than a full-state PUT of the same payload would have \
+         ({full_state_bytes_if_shipped_whole} bytes = state + code + params) \
+         — this is the byte-savings claim the falsifier counters exist to \
+         prove or disprove"
+    );
+
+    // PUT reported success and the holder still hosts: node1's live Ring
+    // still shows it hosting the contract...
+    assert!(
+        result.is_node_hosting(&node1, &contract_key),
+        "node1 (the holder) should still host the contract after the \
+         reconcile"
+    );
+    // ...and the reconcile actually MERGED at the holder: its stored state
+    // advanced to the gateway's higher CRDT version. This is end-to-end proof
+    // that `ProbeReconcile`'s delta was received, decoded, and applied via
+    // the UPDATE path — not just that the counter was incremented locally at
+    // the originator.
+    let node1_final_state = result
+        .node_storages
+        .get(&node1)
+        .and_then(|s| s.get_stored_state(&contract_key))
+        .expect("node1 should have a stored state for the contract");
+    let node1_version = u64::from_le_bytes(
+        node1_final_state.as_ref()[0..8]
+            .try_into()
+            .expect("CRDT state must have an 8-byte version prefix"),
+    );
+    assert_eq!(
+        node1_version, 2,
+        "the holder's stored state must have merged the gateway's v2 \
+         contribution via the ProbeReconcile delta (PUT reported success \
+         end-to-end, not just at the originator's local copy)"
+    );
+
+    // Avoid leaking the CRDT registration into other tests sharing this process.
+    freenet::dev_tool::clear_crdt_contracts();
+}
+
+/// **Test B — no-holder ships full state hop-by-hop.**
+///
+/// Maps to spec "no holder → full state hop-by-hop, hops become hosts": PUTs
+/// a genuinely NEW contract (no prior holder anywhere) from a regular node
+/// into a small network. Asserts the probe finds no holder
+/// (`put_probe_new_contract_sends`), never the holder-found branch
+/// (`put_probe_existing_mesh_delta_sends == 0`), and that the existing
+/// (unchanged) full-state `PutMsg::Request` path actually propagated the
+/// contract onto more than just the originator's own local-store copy —
+/// proving the no-holder fallback genuinely ran the legacy hop-by-hop
+/// hosting behavior rather than silently doing nothing.
+///
+/// The PUT originates from the GATEWAY, not a regular node — see the rustdoc
+/// on `test_summary_first_put_holder_found_ships_delta` for why: a regular
+/// node's connection to its gateway never carries the gateway's negotiated
+/// version (`RemoteConnection::remote_protoc_version` is `None` on the
+/// joiner->gateway path in both production and sim), so `supports_summary_first_put`
+/// fails closed and a regular-node-originated PUT here would skip the
+/// summary-first block entirely rather than exercising the no-holder branch.
+#[test_log::test]
+fn test_summary_first_put_no_holder_ships_full_state() {
+    use freenet::dev_tool::{NodeLabel, ScheduledOperation, SimOperation};
+
+    const SEED: u64 = 0x4642_5F02_CAFE;
+    const NETWORK_NAME: &str = "summary-first-put-new-contract";
+
+    setup_deterministic_state(SEED);
+    let rt = create_runtime();
+
+    let gateway = NodeLabel::gateway(NETWORK_NAME, 0);
+    // node1 is the gateway's only known peer — the hop the no-holder
+    // full-state fallback must propagate to (checked explicitly below).
+    let node1 = NodeLabel::node(NETWORK_NAME, 1);
+
+    // A brand-new contract nobody has ever PUT — no holder exists anywhere.
+    let contract = SimOperation::create_test_contract(0x5A);
+    let contract_key = contract.key();
+    let state = SimOperation::create_test_state(0x5A);
+
+    let mut sim =
+        rt.block_on(async { SimNetwork::new(NETWORK_NAME, 1, 1, 7, 3, 10, 2, SEED).await });
+    sim.enable_summary_first_put();
+
+    let operations = vec![ScheduledOperation::new(
+        gateway.clone(),
+        SimOperation::Put {
+            contract: contract.clone(),
+            state: state.clone(),
+            subscribe: false,
+        },
+    )];
+
+    let result = sim.run_controlled_simulation(
+        SEED,
+        operations,
+        Duration::from_secs(120),
+        Duration::from_secs(30),
+    );
+    assert!(
+        result.turmoil_result.is_ok(),
+        "summary-first PUT new-contract sim failed: {:?}",
+        result.turmoil_result.err()
+    );
+
+    let new_contract_sends = GlobalTestMetrics::put_probe_new_contract_sends();
+    let delta_sends = GlobalTestMetrics::put_probe_existing_mesh_delta_sends();
+
+    tracing::info!(
+        new_contract_sends,
+        delta_sends,
+        "summary-first PUT new-contract test: probe outcome counters"
+    );
+
+    assert_eq!(
+        delta_sends, 0,
+        "holder-found path must NOT fire: this is a genuinely new contract, \
+         no peer hosts it"
+    );
+    assert_eq!(
+        new_contract_sends, 1,
+        "no-holder path must fire exactly once (the gateway's PUT probing \
+         node1, which has never seen this contract)"
+    );
+
+    // The no-holder fallback must have actually run the legacy hop-by-hop
+    // full-state PUT, not silently done nothing beyond the originator's own
+    // local-store step: at least one OTHER peer besides the gateway must
+    // also end up hosting the contract.
+    let hosting_labels: Vec<_> = result
+        .captured_node_labels()
+        .into_iter()
+        .filter(|label| result.is_node_hosting(label, &contract_key))
+        .collect();
+
+    tracing::info!(?hosting_labels, "nodes hosting the new contract");
+
+    assert!(
+        hosting_labels.contains(&gateway),
+        "the originator (the gateway) must host its own PUT"
+    );
+    assert!(
+        hosting_labels.contains(&node1),
+        "the no-holder full-state fallback must propagate the contract to \
+         node1 (the gateway's only peer and the sole possible hop) — hop-by-hop \
+         hosting, not just the originator's own local-store copy — got only \
+         {hosting_labels:?}"
+    );
+    assert!(
+        hosting_labels.len() >= 2,
+        "the no-holder full-state fallback must propagate the contract to \
+         at least one hop beyond the originator's own local-store copy \
+         (hop-by-hop hosting) — got only {hosting_labels:?}"
+    );
+}


### PR DESCRIPTION
**DRAFT — wire/protocol + operation-state-machine change. FULL multi-model review + Ian sign-off required before merge. Ships in the R3 bundle, gated behind R2 field-validation (see `.claude/rules/hosting-invariants.md`). Do NOT merge.**

Stacked on #4718 (inert wire scaffolding). This PR contains two commits: `75c6762` is #4718's scaffolding rebased onto current `main` (review it in #4718); `f9815a7` is this PR's work (wire finalization + the behavioral driver + telemetry + tests). Once #4718 merges I will rebase to drop the duplicated scaffolding commit.

## Problem

Today every PUT ships full `WrappedState` hop-by-hop and every hop stores and hosts unconditionally (the relay-caching anti-pattern the redesign removes). For a contract the mesh already holds, a PUT re-ships the full body (up to ~650KB) to peers that do not need it. Spec step 3-bis (`~/code/tmp/hosting-spec.md`, section "The PUT protocol (summary-first)") replaces this: probe toward the key with a summary, ship full state only for a genuinely-new contract, reconcile a delta for one already held.

## Approach

- **Probe.** The originator (version-gated) stores the PUT state locally (a real client PUT is genuine local demand, so the publisher becomes a host), computes the contract-defined `StateSummary`, and routes a `PutMsg::ProbeRequest` toward the key. Intermediate non-holder hops route the probe onward **without storing** (lazy host-on-next-read, the Fable F5 amplification fix); only a **fresh** holder answers, detected via `Ring::is_receiving_updates` (subscribed / client-subscribed), **not** `is_hosting_contract` (mere cache membership, which can be stale).
- **Dispatch.** No holder found -> fall through to the existing full-state `PutMsg::Request` path (hops store+host; this is where every-hop placement gets its bytes). Holder found -> the reply carries the holder's summary `S_H`; the originator computes a `StateDelta` (its contribution relative to `S_H`) and ships it as `PutMsg::ProbeReconcile` (**delta only**, never full state into a mesh that already holds the contract). The holder merges via the UPDATE path and normal fan-out propagates it.
- **Graceful fallback (risk bound).** The existing full-state PUT path stays the default and the fallback. Any probe failure — version gate closed, probe timeout/error, no holder — falls straight through to the **unchanged** retry-loop driver, so summary-first can never break a PUT.
- **Version gate.** Emission is gated on `SUMMARY_FIRST_PUT_MIN_VERSION`, **corrected from the scaffolding's `(0,2,93)` to `(0,2,94)`**: 0.2.93 is already released carrying only the inert #4718 variants (a 0.2.93 peer can *decode* a probe but has no handler to *process* one), so emitting to it during the 0-4h staggered rollout would break its PUT. The floor must equal the release that ships the handler; a release-time verification note is at the constant. Peer versions are mirrored into `ConnectionManager` (parallel to `location_for_peer`) so the op driver can gate; the SubscribeHint send-gate precedent is mirrored throughout.
- **Telemetry (falsifier).** PUT-bytes-by-case via a single call site feeding both `GlobalTestMetrics` (sim) and `network_status` (dashboard): new-contract full-state vs existing-mesh delta bytes.

## Testing

- **Wire:** variant-tag pin extended to 9 tags; per-variant bincode roundtrips (`ProbeResponse` with/without `holder_summary`, `ProbeReconcile`).
- **Version gate (mixed-version):** fail-closed unit tests including the exact `0.2.93` decode-but-cannot-process boundary — an emitter must send a full-state PUT to a sub-floor peer, never a probe. (The sim harness shares one compiled version across all nodes, so per-peer mixed-version is asserted at the unit level, which is where the emission decision lives.)
- **Driver source-scrape pins:** the probe path performs no local store (lazy host-on-read); holder detection uses `is_receiving_updates` not `is_hosting_contract`; reconcile merges via `update_contract`.
- **Sim (`run_controlled_simulation`):** holder-found PUT ships a delta and no full state to existing hosts; no-holder PUT ships full state hop-by-hop. *(Being added; `run_simulation_direct` drives only random events and cannot script PUT-at-A / PUT-at-B, so the scripted controlled runner is the correct vehicle — see `.claude/rules/testing.md`.)*

## Design forks for review (Ian)

1. **Version floor (0,2,94)** — must equal the actual first-emitting release; re-confirm at release time if the number slips.
2. **Reconcile is write-forward only for now.** The initiator ships its delta to the holder; the *reverse* leg (initiator pulling the holder's delta to converge its own copy) is deferred to lazy host-on-read, consistent with F5. The spec calls the reconcile "bidirectional"; the reverse leg is a cheap, additive follow-up (`ProbeResponse.holder_summary` already carries what the initiator needs). Flagging in case you want it in this piece.
3. **Originator stores locally before probing** so it can summarize/delta by key and becomes a host (publisher = demand). This is a behavior change for the summary-first path only; the non-summary-first (old-target) path is byte-identical to today.

Refs #4642, spec step 3-bis.

[AI-assisted - Claude]