### PR TITLE
fix(hosting): shed subscribed contracts + tear down memory on eviction

### DIFF
--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -3150,13 +3150,16 @@ async fn get_contract_summary(
 /// on-disk store — which is the only signal that distinguishes a phantom from a
 /// contract we can really summarize:
 /// - Phantom contracts (the storm) have no stored state, so they are skipped.
-/// - An evicted-but-in-use contract keeps its state ON DISK
-///   (`evict_over_budget` PINS `subscriber_count >= 1` entries under normal
-///   `AtCapacity` pressure — only the deliberately-unwired OOM valve under
-///   `MemoryPressure::Overflow` can pierce that pin — and
-///   `reclaim_evicted_contract` only deletes state once NOT in use), so
-///   `contract_state_present` is true and it KEEPS summarizing — which is why
-///   the gate reads the state store, not the in-memory hosting cache.
+/// - A subscribed contract we hold keeps its state ON DISK: under normal
+///   `AtCapacity` pressure `evict_over_budget` orders it LAST (shed only as a
+///   last resort when nothing with fewer subscribers is eligible), so while any
+///   fewer-subscriber contract exists it is retained and `contract_state_present`
+///   stays true, and it KEEPS summarizing — which is why the gate reads the
+///   state store, not the in-memory hosting cache. In the all-subscribed
+///   last-resort extreme where it IS shed, `teardown_evicted_in_use_contract`
+///   clears its subscription state so `contract_in_use` is false and
+///   `reclaim_evicted_contract` deletes the disk state — at which point it is no
+///   longer held and correctly stops summarizing.
 /// - The moment a contract's state is fetched/stored it summarizes again — no
 ///   loss of proactive repair for any contract we genuinely hold.
 async fn summary_if_hosted_or_in_use(

--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -1192,10 +1192,10 @@ pub struct HostedContractEntry {
     /// Read accesses (GET/SUBSCRIBE) observed over this entry's residency.
     pub read_count: u32,
     /// Whether the over-budget sweep would actually consider this contract for
-    /// eviction: past its `min_ttl` age gate AND not pinned by demand
-    /// (`contract_in_use`). The renderer badges "next to evict" on the first
-    /// eligible row, NOT the raw lowest-keep-score row — a within-TTL or
-    /// in-use low-score contract is skipped by the real sweep, so badging it
+    /// eviction: NOT pinned by demand (`contract_in_use`). There is no longer a
+    /// `min_ttl` age gate (dropped 2026-07-08). The renderer badges "next to
+    /// evict" on the first eligible row, NOT the raw lowest-keep-score row — an
+    /// in-use low-score contract is ordered last by the real sweep, so badging it
     /// would mislead the operator.
     pub eviction_eligible: bool,
 }

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -1278,6 +1278,21 @@ async fn cache_contract_locally(
         op_manager.ring.mark_local_client_access(&key);
     }
 
+    // Sync the InterestManager for any subscribed contract the subscriber-primary
+    // eviction shed + tore down (#4642 invariant 3). Run BEFORE the
+    // `unregister_local_hosting` loop below so that call observes the now-zeroed
+    // subscriber counts and reports full interest loss (→ retraction via
+    // `removed_contracts`). Without this, ghost `interested_peers` /
+    // `peer_contracts` / `local_client_count` entries survive and mis-target
+    // UPDATE broadcasts / inflate upstream interest counts (PR #4734 Fix 1).
+    for teardown in &access_result.evicted_in_use_teardown {
+        op_manager.interest_manager.remove_evicted_in_use(
+            &teardown.key,
+            &teardown.downstream_peers,
+            teardown.local_client_count,
+        );
+    }
+
     let mut removed_contracts = Vec::new();
     for (evicted_key, expected_generation) in &access_result.evicted {
         if op_manager
@@ -4104,6 +4119,30 @@ mod tests {
              executor rejects the PutQuery. The legacy branch at \
              get.rs:2420-2435 continues these side effects on error; \
              the driver must match."
+        );
+    }
+
+    /// Pin (PR #4734 Fix 1): the GET eviction handler must sync the
+    /// InterestManager for any subscribed contract the subscriber-primary
+    /// eviction shed + tore down. `teardown_evicted_in_use_contract` clears the
+    /// hosting maps, but the InterestManager lives on `OpManager`, so a dropped
+    /// `remove_evicted_in_use` call leaves ghost `interested_peers` /
+    /// `peer_contracts` / `local_client_count` entries that mis-target UPDATE
+    /// broadcasts and do NOT self-heal. A refactor that drops the call must trip
+    /// this pin (the "manually-inlined side effect after a task-per-tx
+    /// migration" class — see .claude/rules/bug-prevention-patterns.md).
+    #[test]
+    fn cache_contract_locally_syncs_interest_on_subscribed_eviction() {
+        let src = production_source();
+        let body = extract_fn_body(src, "async fn cache_contract_locally(");
+        assert!(
+            body.contains("evicted_in_use_teardown"),
+            "GET eviction handler must consume access_result.evicted_in_use_teardown"
+        );
+        assert!(
+            body.contains("remove_evicted_in_use"),
+            "GET eviction handler must call interest_manager.remove_evicted_in_use \
+             to sync the InterestManager after a subscribed eviction"
         );
     }
 

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -1172,6 +1172,11 @@ fn synthetic_key(instance_id: &ContractInstanceId) -> ContractKey {
 ///    (i.e., `access_result.is_new && put_persisted`). NOT gated on
 ///    `is_client_requester`; legacy announces on any first-time relay
 ///    cache too (`get.rs:2278, 2370`).
+// NAMING LANDMINE: "cache"/"store" here means HOSTING, not a lesser cache tier. A
+// peer stores a contract because a GET routed through it, and a routed GET is a
+// demand signal, so the peer HOSTS the contract (WASM+state, kept fresh in the
+// update mesh) until LRU eviction. There is no cache tier. Slated to be renamed
+// hosting-* AFTER 0.2.94. See .claude/rules/hosting-invariants.md + epic #4642.
 async fn cache_contract_locally(
     op_manager: &OpManager,
     key: ContractKey,
@@ -2164,6 +2169,13 @@ async fn run_relay_get<CB>(
     }
 }
 
+// NAMING LANDMINE: "relay" is a fossil of the hollow-relay firefight (#3763).
+// Forwarding a GET does NOT make a peer a hollow relay; a routed GET is demand, so
+// the peer HOSTS the contract (routing and hosting co-occur; there is no
+// forward-without-hosting for GET/PUT). The only true hollow relay was the
+// standalone SUBSCRIBE hop, being retired (subscribe folds into GET/PUT). Slated for
+// removal/rename by piece D (chain peers become real hosts). Do not name new code
+// "relay". See .claude/rules/hosting-invariants.md terminology + epic #4642.
 #[allow(clippy::too_many_arguments)]
 async fn drive_relay_get<CB>(
     op_manager: &Arc<OpManager>,

--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -1168,6 +1168,13 @@ fn put_routing_should_terminate(
     descended_to_here && next_hop_moves_away
 }
 
+// NAMING LANDMINE: "relay" is a fossil of the hollow-relay firefight (#3763).
+// Forwarding a PUT does NOT make a peer a hollow relay; a routed PUT is demand, so
+// the peer HOSTS the contract (routing and hosting co-occur; there is no
+// forward-without-hosting for GET/PUT). The only true hollow relay was the
+// standalone SUBSCRIBE hop, being retired (subscribe folds into GET/PUT). Slated for
+// removal/rename by piece D (chain peers become real hosts). Do not name new code
+// "relay". See .claude/rules/hosting-invariants.md terminology + epic #4642.
 #[allow(clippy::too_many_arguments)]
 async fn drive_relay_put<CB>(
     op_manager: &Arc<OpManager>,
@@ -1195,6 +1202,10 @@ where
     );
 
     // ── Step 1: Store contract locally (all nodes cache) ────────────────────
+    // NAMING LANDMINE: "cache" here = HOSTING. Storing on a routed PUT is
+    // legitimate hosting (a routed PUT is demand), evictable under LRU, not a
+    // lesser cache tier. To be renamed hosting-* after 0.2.94.
+    // See .claude/rules/hosting-invariants.md + #4642.
     // Originator-loopback (a local client's own PUT, mapped to
     // upstream_addr=own_addr in dispatch) is ClientLocal so it lands in the
     // reserved fair-queue lane; a genuine relay store stays NetworkRelay (#4534).
@@ -1850,6 +1861,12 @@ fn put_store_priority(
     }
 }
 
+// NAMING LANDMINE: "store" (and the "relay_" prefix) here means HOSTING, not a
+// lesser cache tier or a hollow relay. A peer stores a contract because a PUT routed
+// through it, and a routed PUT is a demand signal, so the peer HOSTS the contract
+// (WASM+state, kept fresh in the update mesh) until LRU eviction. There is no cache
+// tier and no forward-without-hosting. Slated to be renamed hosting-* AFTER 0.2.94.
+// See .claude/rules/hosting-invariants.md terminology + epic #4642.
 #[allow(clippy::too_many_arguments)]
 async fn relay_put_store_locally(
     op_manager: &Arc<OpManager>,

--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -1913,10 +1913,27 @@ async fn relay_put_store_locally(
     };
 
     if !was_hosting {
-        let evicted = op_manager
-            .ring
-            .host_contract(key, value.size() as u64, crate::ring::AccessType::Put)
-            .evicted;
+        let access_result =
+            op_manager
+                .ring
+                .host_contract(key, value.size() as u64, crate::ring::AccessType::Put);
+        let evicted = access_result.evicted;
+
+        // Sync the InterestManager for any subscribed contract the
+        // subscriber-primary eviction shed + tore down (#4642 invariant 3). Run
+        // BEFORE the `unregister_local_hosting` loop below so that call observes
+        // the now-zeroed subscriber counts and reports full interest loss (→
+        // retraction via `removed_contracts`). Without this, ghost
+        // `interested_peers` / `peer_contracts` / `local_client_count` entries
+        // survive and mis-target UPDATE broadcasts / inflate upstream interest
+        // counts (PR #4734 Fix 1).
+        for teardown in &access_result.evicted_in_use_teardown {
+            op_manager.interest_manager.remove_evicted_in_use(
+                &teardown.key,
+                &teardown.downstream_peers,
+                teardown.local_client_count,
+            );
+        }
 
         crate::operations::announce_contract_hosted(op_manager, &key).await;
 
@@ -4556,6 +4573,20 @@ mod tests {
         assert!(
             helper_src.contains("announce_contract_hosted"),
             "helper MUST call announce_contract_hosted for first-time hosting"
+        );
+        // PR #4734 Fix 1: the eviction handler must sync the InterestManager for
+        // any subscribed contract the subscriber-primary eviction shed + tore
+        // down, or ghost interested_peers / peer_contracts / local_client_count
+        // entries survive (they mis-target UPDATE broadcasts and do NOT
+        // self-heal). A dropped call must trip this pin.
+        assert!(
+            helper_src.contains("evicted_in_use_teardown"),
+            "helper MUST consume access_result.evicted_in_use_teardown"
+        );
+        assert!(
+            helper_src.contains("remove_evicted_in_use"),
+            "helper MUST call interest_manager.remove_evicted_in_use to sync the \
+             InterestManager after a subscribed eviction"
         );
     }
 

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -2574,7 +2574,10 @@ impl Ring {
             }
 
             // Sweep expired entries from GET subscription cache
-            let expired = ring.sweep_expired_get_subscriptions();
+            let crate::ring::hosting::HostingSweepResult {
+                expired,
+                evicted_in_use_teardown,
+            } = ring.sweep_expired_get_subscriptions();
 
             // Do NOT early-continue when `expired` is empty: pending
             // reclamation retries below must run every cycle, otherwise
@@ -2631,6 +2634,22 @@ impl Ring {
                         op_manager,
                         key,
                         expected_generation,
+                    );
+                }
+            }
+
+            // Sync the `InterestManager` for any still-in-use victim the sweep
+            // shed as a last resort: `teardown_evicted_in_use_contract` cleared
+            // the hosting maps but the `InterestManager` lives on `OpManager`, so
+            // ghost `interested_peers` / `peer_contracts` / `local_client_count`
+            // entries survive unless we replay the same removals here (PR #4734
+            // Fix 1). No-op in the common zero-subscriber sweep.
+            if let Some(op_manager) = &op_manager {
+                for teardown in &evicted_in_use_teardown {
+                    op_manager.interest_manager.remove_evicted_in_use(
+                        &teardown.key,
+                        &teardown.downstream_peers,
+                        teardown.local_client_count,
                     );
                 }
             }
@@ -4115,22 +4134,22 @@ impl Ring {
 
     /// Sweep for expired entries in the hosting cache.
     ///
-    /// Returns `(ContractKey, write_generation)` pairs for contracts
-    /// evicted from this cache. Contracts with client subscriptions
-    /// (or downstream/network subscribers) are protected from eviction.
-    /// The generation snapshot is carried through `EvictContract` so the
-    /// deletion-time guard can detect a re-host race.
-    pub fn sweep_expired_hosting(&self) -> Vec<(ContractKey, u64)> {
+    /// Returns a [`HostingSweepResult`]: the `(ContractKey, write_generation)`
+    /// reclaim pairs plus, for any still-in-use victim shed as a last resort,
+    /// the subscription state torn down (so the caller can sync the
+    /// `InterestManager`). Under subscriber-primary ordering a contract with
+    /// subscribers is evicted LAST (shed only when nothing with fewer
+    /// subscribers is eligible). The generation snapshot is carried through
+    /// `EvictContract` so the deletion-time guard can detect a re-host race.
+    pub fn sweep_expired_hosting(&self) -> crate::ring::hosting::HostingSweepResult {
         self.hosting_manager.sweep_expired_hosting()
     }
 
     // ==================== Legacy GET Auto-Subscription (delegating to hosting cache) ====================
     /// Sweep for expired entries (delegated to hosting cache).
     ///
-    /// Returns `(ContractKey, write_generation)` pairs for contracts
-    /// evicted from the cache. Contracts with client subscriptions are
-    /// protected from eviction.
-    pub fn sweep_expired_get_subscriptions(&self) -> Vec<(ContractKey, u64)> {
+    /// Returns a [`HostingSweepResult`] (see [`Self::sweep_expired_hosting`]).
+    pub fn sweep_expired_get_subscriptions(&self) -> crate::ring::hosting::HostingSweepResult {
         // Delegate to hosting cache
         self.sweep_expired_hosting()
     }

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -2609,6 +2609,25 @@ impl Ring {
                 );
             }
 
+            // Sync the `InterestManager` for any still-in-use victim the sweep
+            // shed as a last resort: `teardown_evicted_in_use_contract` cleared
+            // the hosting maps but the `InterestManager` lives on `OpManager`, so
+            // ghost `interested_peers` / `peer_contracts` / `local_client_count`
+            // entries survive unless we replay the same removals here (PR #4734
+            // Fix 1). No-op in the common zero-subscriber sweep. Run BEFORE the
+            // `unregister_local_hosting` loop below so that call observes the
+            // now-zeroed subscriber counts and reports full interest loss (→
+            // retraction), mirroring the GET/PUT host-formation paths.
+            if let Some(op_manager) = &op_manager {
+                for teardown in &evicted_in_use_teardown {
+                    op_manager.interest_manager.remove_evicted_in_use(
+                        &teardown.key,
+                        &teardown.downstream_peers,
+                        teardown.local_client_count,
+                    );
+                }
+            }
+
             // Clean up local subscription state for each expired contract.
             // Note: under the subscriber-primary ordering (#4642, invariant 3) a
             // contract with subscribers is ordered LAST but NOT hard-pinned, so
@@ -2623,6 +2642,17 @@ impl Ring {
             // the eviction decision in `HostingCache::record_access` /
             // `sweep_expired`; it is re-checked at deletion time by
             // `RuntimePool::remove_contract` to close the re-host race.
+            //
+            // Also retract the local hosting advertisement for each evicted
+            // contract, mirroring the GET (`get/op_ctx_task.rs`) and PUT
+            // (`put/op_ctx_task.rs`) host-formation paths (PR #4734 Fix 1):
+            // clear `LocalInterest.hosting` via `unregister_local_hosting` and
+            // collect the contracts that thereby lose ALL interest so the
+            // neighbor advertisement can be retracted below. Without this an
+            // evicted contract keeps `hosting = true` and its advertisement
+            // lingers on neighbors — a stale-interest leak, now widened because
+            // subscribed contracts are sweep-evictable under invariant 3.
+            let mut removed_contracts = Vec::new();
             for (key, expected_generation) in expired {
                 ring.unsubscribe(&key);
                 tracing::info!(
@@ -2630,6 +2660,9 @@ impl Ring {
                     "Cleaned up expired hosting subscription from local state"
                 );
                 if let Some(op_manager) = &op_manager {
+                    if op_manager.interest_manager.unregister_local_hosting(&key) {
+                        removed_contracts.push(key);
+                    }
                     crate::operations::reclaim_evicted_contract(
                         op_manager,
                         key,
@@ -2638,20 +2671,17 @@ impl Ring {
                 }
             }
 
-            // Sync the `InterestManager` for any still-in-use victim the sweep
-            // shed as a last resort: `teardown_evicted_in_use_contract` cleared
-            // the hosting maps but the `InterestManager` lives on `OpManager`, so
-            // ghost `interested_peers` / `peer_contracts` / `local_client_count`
-            // entries survive unless we replay the same removals here (PR #4734
-            // Fix 1). No-op in the common zero-subscriber sweep.
+            // Retract neighbor advertisements for contracts that lost all local
+            // interest above. The sweep never ADDS interest, so `added` is always
+            // empty here (unlike the GET/PUT paths). `broadcast_change_interests`
+            // is a no-op when `removed_contracts` is empty (the common case).
             if let Some(op_manager) = &op_manager {
-                for teardown in &evicted_in_use_teardown {
-                    op_manager.interest_manager.remove_evicted_in_use(
-                        &teardown.key,
-                        &teardown.downstream_peers,
-                        teardown.local_client_count,
-                    );
-                }
+                crate::operations::broadcast_change_interests(
+                    op_manager,
+                    Vec::new(),
+                    removed_contracts,
+                )
+                .await;
             }
 
             // Retry pending reclamations queued by the two skip points
@@ -6311,6 +6341,63 @@ mod k_closest_source_tests {
              is_peer_ready in the routability mapping): k_closest falls back to \
              not-ready peers, so a not-ready closer neighbor is still a valid route \
              target and must keep this node from short-circuiting its renewal (#4440)."
+        );
+    }
+
+    /// PR #4734 Fix 1: the periodic hosting sweep must retract the local hosting
+    /// advertisement for every contract it evicts, exactly like the GET/PUT
+    /// host-formation paths (`cache_contract_locally` / the PUT relay store). An
+    /// evicted contract that keeps `LocalInterest.hosting = true` and does not
+    /// retract its neighbor advertisement is a stale-interest leak — now widened
+    /// because subscribed contracts are sweep-evictable under invariant 3.
+    ///
+    /// The GET/PUT pins (`cache_contract_locally_syncs_interest_on_subscribed_eviction`)
+    /// only cover `remove_evicted_in_use`; this pins the sweep's matching
+    /// `unregister_local_hosting` + `broadcast_change_interests` so a future refactor
+    /// can't silently drop the retraction from the maintenance path.
+    #[test]
+    fn sweep_retracts_hosting_interest_on_eviction() {
+        let src = production_source();
+        let body = extract_fn_body(
+            src,
+            "async fn sweep_get_subscription_cache(ring: Arc<Self>, interval_duration: Duration) {",
+        );
+        // Teardown of a still-in-use victim (subscribed contract shed as a last
+        // resort) must sync the InterestManager, matching GET/PUT.
+        assert!(
+            body.contains("remove_evicted_in_use"),
+            "sweep must call remove_evicted_in_use to sync the InterestManager for \
+             a subscribed contract it sheds (mirrors GET/PUT)."
+        );
+        // Every evicted contract must clear its local hosting flag …
+        assert!(
+            body.contains("unregister_local_hosting"),
+            "sweep must call unregister_local_hosting for each evicted contract so \
+             the evicted contract does not keep LocalInterest.hosting = true \
+             (PR #4734 Fix 1 — mirrors GET/PUT host-formation paths)."
+        );
+        // … and retract the neighbor advertisement for those that lost all interest.
+        assert!(
+            body.contains("broadcast_change_interests"),
+            "sweep must call broadcast_change_interests to retract neighbor \
+             advertisements for evicted contracts (PR #4734 Fix 1)."
+        );
+        // Ordering: the remove_evicted_in_use CALL must run BEFORE the
+        // unregister_local_hosting CALL so the latter observes zeroed subscriber
+        // counts and reports full interest loss (→ retraction), matching the
+        // GET/PUT comment discipline. Anchor on the call expressions (`.method(`),
+        // not the bare identifiers, so a prose mention in a leading comment (e.g.
+        // "Run BEFORE the `unregister_local_hosting` loop") can't fool the check.
+        let teardown_pos = body
+            .find("interest_manager.remove_evicted_in_use(")
+            .expect("remove_evicted_in_use call present");
+        let unregister_pos = body
+            .find("interest_manager.unregister_local_hosting(")
+            .expect("unregister_local_hosting call present");
+        assert!(
+            teardown_pos < unregister_pos,
+            "remove_evicted_in_use must precede unregister_local_hosting in the sweep \
+             so interest loss is reported against the already-zeroed subscriber counts."
         );
     }
 

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -1728,6 +1728,12 @@ impl Ring {
             // that shed a subscribed contract under genuine RAM overflow. Stays 0
             // until the Overflow trigger is wired (mechanism-only this release).
             snapshot.hosting_oom_valve_evictions_total = Some(hosting.oom_valve_evictions_total);
+            // Subscribed-eviction falsifier (#4642 subscriber-primary rework): the
+            // count of evictions that shed a SUBSCRIBED contract (the riskiest new
+            // behavior). Unlike the OOM-valve counter this can go nonzero as soon
+            // as the rework ships (AtCapacity now sheds subscribed as a last
+            // resort). Same periodic cadence.
+            snapshot.hosting_subscribed_evictions_total = Some(hosting.subscribed_evictions_total);
             // Local-client GET hit-rate (#4642 A3): served-locally vs routed to
             // the network. Driven by the real serve/forward decision in the
             // client GET handler, so it is read from the manager counters (not
@@ -2601,11 +2607,15 @@ impl Ring {
             }
 
             // Clean up local subscription state for each expired contract.
-            // Note: contracts with subscribers (client subscriptions or
-            // downstream subscribers) are PINNED from eviction by the
-            // subscriber_count closure in sweep_expired_hosting() under normal
-            // AtCapacity pressure; only the deliberately-unwired OOM valve
-            // (MemoryPressure::Overflow) can pierce that pin.
+            // Note: under the subscriber-primary ordering (#4642, invariant 3) a
+            // contract with subscribers is ordered LAST but NOT hard-pinned, so
+            // `sweep_expired_hosting()` CAN shed a still-in-use contract as a last
+            // resort — and when it does, it has already torn down that contract's
+            // subscription state (downstream + client subscriptions + upstream
+            // lease) so `contract_in_use` is false before we reclaim it. The
+            // `ring.unsubscribe(&key)` below is therefore a belt-and-suspenders
+            // no-op for those (its lease is already gone) and, for a
+            // zero-subscriber eviction, drops any lingering upstream lease.
             // The `expected_generation` snapshot is captured atomically with
             // the eviction decision in `HostingCache::record_access` /
             // `sweep_expired`; it is re-checked at deletion time by

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -978,9 +978,12 @@ impl HostingManager {
                 .find(|entry| *entry.key().id() == instance_id)
                 .map(|entry| *entry.key());
             if let Some(contract) = contract {
-                // Client disconnect may have just transitioned the contract
-                // to no-longer-in-use. Record abandonment so over-budget
-                // eviction targets it first.
+                // Client disconnect may have just transitioned the contract to
+                // no-longer-in-use. Record abandonment so over-budget eviction
+                // does NOT shed it for an old last-read accrued while it was
+                // subscribed: `record_abandonment` resets its recency to the
+                // current frontier at termination, so the formerly-subscribed
+                // contract sorts LAST (freshest recency) and survives longest.
                 self.maybe_record_abandonment(&contract);
                 affected_contracts.push(contract);
             }
@@ -1057,9 +1060,12 @@ impl HostingManager {
             // Remove the map entry if no peers remain
             self.downstream_subscribers
                 .remove_if(contract, |_, peers| peers.is_empty());
-            // If the contract has just transitioned to no-longer-in-use,
-            // mark it as recently abandoned so over-budget eviction
-            // targets it before older-but-still-active entries.
+            // If the contract has just transitioned to no-longer-in-use, record
+            // abandonment: `record_abandonment` resets its recency to the current
+            // frontier at termination, so the formerly-subscribed contract sorts
+            // LAST (freshest recency) under over-budget eviction and survives
+            // longest, rather than being shed for an old last-read accrued while
+            // it was subscribed.
             self.maybe_record_abandonment(contract);
         }
         removed
@@ -1356,8 +1362,13 @@ impl HostingManager {
     /// Hook called from every code path that removes an "in-use" signal
     /// (client subscription, downstream subscriber, or stale-expiry of
     /// either). If the contract has just transitioned to no-longer-in-use,
-    /// mark it as recently abandoned in the hosting cache so the next
-    /// over-budget sweep evicts it before older-but-still-active entries.
+    /// record abandonment in the hosting cache: `record_abandonment` resets the
+    /// entry's recency to the current frontier at termination, so under the next
+    /// over-budget sweep the formerly-subscribed contract sorts LAST (freshest
+    /// recency) and survives longest — it is NOT evicted first. This stops it
+    /// being shed for an old last-read it accrued while parked in the
+    /// subscription tier (see `record_abandonment` /
+    /// `record_abandonment_resets_recency_at_subscription_termination`).
     ///
     /// Idle persistence is preserved: this changes eviction *order*, not
     /// eviction *eligibility*. A contract with no budget pressure on it
@@ -1409,8 +1420,10 @@ impl HostingManager {
             };
             if became_empty {
                 // Lease expiry may have just transitioned the contract to
-                // no-longer-in-use — record abandonment so the next
-                // over-budget sweep targets it first.
+                // no-longer-in-use — record abandonment so the next over-budget
+                // sweep does NOT shed it for an old last-read: `record_abandonment`
+                // resets its recency to the current frontier at termination, so it
+                // sorts LAST (freshest recency) and survives longest.
                 self.maybe_record_abandonment(&key);
             }
         }

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -51,7 +51,7 @@ pub(crate) use cache::LEGACY_FLAT_HOSTING_BUDGET_BYTES;
 /// default is RAM-scaled (capability-relative, A2) rather than a flat constant.
 pub(crate) use cache::default_hosting_budget_bytes;
 pub use cache::{AccessType, EvictedInUseTeardown, RecordAccessResult};
-use cache::{DEFAULT_MIN_TTL, HostingCache, HostingCacheStats};
+use cache::{HostingCache, HostingCacheStats};
 /// Clamp bounds re-exported only for the config-default round-trip test, which
 /// asserts the resolved default lands within [MIN, MAX] without hardcoding the
 /// byte values. Gated to test builds so the re-export isn't an unused import
@@ -390,11 +390,7 @@ impl HostingManager {
         Self {
             active_subscriptions: DashMap::new(),
             client_subscriptions: DashMap::new(),
-            hosting_cache: RwLock::new(HostingCache::new(
-                budget_bytes,
-                DEFAULT_MIN_TTL,
-                time_source.clone(),
-            )),
+            hosting_cache: RwLock::new(HostingCache::new(budget_bytes, time_source.clone())),
             demand_estimator: RwLock::new(ProximityPrior::new()),
             own_location: RwLock::new(None),
             local_get_serves: AtomicU64::new(0),
@@ -1261,7 +1257,7 @@ impl HostingManager {
     /// The SPLIT genuine-demand counts pinning `contract`:
     /// `(local_client_subscriptions, downstream_subscribers)`. This is the
     /// subscriber-primary eviction key (#4642, Ian's confirmed ordering): the
-    /// cache orders victims ascending by `(local, downstream, last_get_seq, key)`,
+    /// cache orders victims ascending by `(local, downstream, recency_seq, key)`,
     /// so a contract THIS node's own client is subscribed to (local >= 1) is
     /// evicted LAST. Aligned with [`contract_in_use`](Self::contract_in_use) BY
     /// CONSTRUCTION — it counts the exact same two sources, so `local + downstream
@@ -1764,14 +1760,14 @@ impl HostingManager {
     }
 
     /// Whether the over-budget sweep would evict `score`'s contract in the
-    /// COMMON case — `past_min_ttl` (the TTL floor, precomputed by the cache) AND
-    /// NOT [`contract_in_use`](Self::contract_in_use).
+    /// COMMON case — NOT [`contract_in_use`](Self::contract_in_use).
     ///
     /// The dashboard uses this to badge the "next to evict" contract: the raw
-    /// lowest-keep-score row can be an entry the sweep would not pick first (still
-    /// within `min_ttl`, or ordered last because a local client / downstream
-    /// subscriber makes it in-use), so badging it unconditionally would mislabel a
-    /// still-wanted contract.
+    /// lowest-keep-score row can be an entry the sweep would not pick first
+    /// (ordered last because a local client / downstream subscriber makes it
+    /// in-use), so badging it unconditionally would mislabel a still-wanted
+    /// contract. There is no longer a `min_ttl` age gate (dropped 2026-07-08), so
+    /// eligibility reduces to "not in use".
     ///
     /// NOTE (subscriber-primary rework, #4642): under the split-ordering model an
     /// in-use contract is no longer hard-pinned — it is ordered LAST and IS shed
@@ -1787,7 +1783,7 @@ impl HostingManager {
     /// and `contract_in_use` reads only the subscription maps — never the
     /// hosting cache — so there is no lock held across this call.
     pub(crate) fn is_eviction_eligible(&self, score: &HostingContractScore) -> bool {
-        score.past_min_ttl && !self.contract_in_use(&score.key)
+        !self.contract_in_use(&score.key)
     }
 
     /// Check if we should continue hosting a contract.
@@ -1893,7 +1889,7 @@ impl HostingManager {
     ///
     /// Under normal (`AtCapacity`) pressure victims are chosen subscriber-primary
     /// (#4642, invariant 3): ascending `(local_subscription_count,
-    /// downstream_subscriber_count, last_get_seq, key)`, using the same split
+    /// downstream_subscriber_count, recency_seq, key)`, using the same split
     /// `local_and_downstream_counts` closure `record_contract_access` passes, so
     /// all eviction paths agree. A subscribed contract is ordered LAST and shed
     /// only as a last resort (when nothing with fewer subscribers is eligible and
@@ -1901,8 +1897,9 @@ impl HostingManager {
     /// shipped #4720 code. When such a still-in-use victim IS shed, its
     /// subscription state is torn down here (via `teardown_evicted_in_use_contract`)
     /// so `contract_in_use` is false before the caller reclaims it and the on-disk
-    /// state is actually freed. The `Overflow` pressure (which ALSO pierces
-    /// `min_ttl`) is intentionally unwired in production (see `cache::MemoryPressure`).
+    /// state is actually freed. The `Overflow` pressure (which ALSO pierces the
+    /// op-scoped backstop) is intentionally unwired in production (see
+    /// `cache::MemoryPressure`).
     /// Downstream subscriber leases are otherwise time-bounded: stale entries are
     /// removed by `expire_stale_downstream_subscribers()` (called periodically)
     /// after `SUBSCRIPTION_LEASE_DURATION` without renewal.
@@ -1915,7 +1912,7 @@ impl HostingManager {
     /// as a last resort, the subscription state torn down so the caller can sync
     /// the `InterestManager` (PR #4734 Fix 1).
     pub fn sweep_expired_hosting(&self) -> HostingSweepResult {
-        // AtCapacity: the Overflow `min_ttl`-pierce trigger is intentionally
+        // AtCapacity: the Overflow op-backstop-pierce trigger is intentionally
         // unwired in production (see cache::MemoryPressure). AtCapacity itself
         // CAN now shed a subscribed contract as a last resort — see below.
         let evicted = self.hosting_cache.write().sweep_expired(
@@ -3203,46 +3200,18 @@ mod tests {
         assert!(used.in_use, "a client subscription is real demand → in_use");
     }
 
-    /// `is_eviction_eligible` must combine BOTH halves of the
-    /// `evict_over_budget` skip filter — the cache's `past_min_ttl` age gate
-    /// AND `!contract_in_use` — so the dashboard's "next to evict" badge only
-    /// marks a contract the sweep would actually consider. A within-TTL OR an
-    /// in-use low-score contract must read as NOT eligible (the sweep skips it);
-    /// badging it would mislabel an eviction-exempt contract.
+    /// `is_eviction_eligible` gates the dashboard's "next to evict" badge on the
+    /// sweep skip filter, which since 2026-07-08 is `!contract_in_use` ONLY (the
+    /// `min_ttl` age gate was dropped — invariant 3). A freshly-accessed, not-in-
+    /// use contract is now eligible (the change: it is no longer protected by a
+    /// cold-start floor), while an in-use contract reads as NOT eligible so the
+    /// badge does not mislabel it.
     #[test]
     fn dashboard_is_eviction_eligible_matches_sweep_skip_filter() {
         let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
 
-        // Case 1 — default cache (DEFAULT_MIN_TTL): a freshly-accessed contract
-        // is within its TTL window → past_min_ttl false → NOT eligible even
-        // though nothing pins it.
-        let fresh = make_contract_key(1);
-        manager.record_contract_access(fresh, 100, AccessType::Get);
-        let scores = manager.dashboard_hosting_scores();
-        let fresh_score = scores
-            .iter()
-            .find(|s| s.key == fresh)
-            .expect("fresh contract present");
-        assert!(
-            !fresh_score.past_min_ttl,
-            "a freshly-accessed contract is within min_ttl"
-        );
-        assert!(
-            !manager.is_eviction_eligible(fresh_score),
-            "within-TTL contract is skipped by the sweep → not eligible"
-        );
-
-        // Case 2 — override with a ZERO-TTL cache so every entry is instantly
-        // past the TTL gate; eligibility is then decided solely by
-        // `contract_in_use`.
-        {
-            let mut cache = manager.hosting_cache.write();
-            *cache = cache::HostingCache::new(
-                10_000,
-                std::time::Duration::ZERO,
-                std::sync::Arc::new(crate::util::time_source::InstantTimeSrc::new()),
-            );
-        }
+        // A freshly-accessed contract with nothing pinning it is ELIGIBLE — there
+        // is no longer a `min_ttl` cold-start floor to protect it.
         let evictable = make_contract_key(2);
         let pinned = make_contract_key(3);
         manager.record_contract_access(evictable, 100, AccessType::Get);
@@ -3263,16 +3232,12 @@ mod tests {
             .find(|s| s.key == pinned)
             .expect("pinned contract present");
         assert!(
-            ev.past_min_ttl && pin.past_min_ttl,
-            "zero TTL → both entries are past the TTL gate"
-        );
-        assert!(
             manager.is_eviction_eligible(ev),
-            "past-TTL and not in use → eligible (the real next victim)"
+            "fresh and not in use → eligible (the real next victim; no TTL floor)"
         );
         assert!(
             !manager.is_eviction_eligible(pin),
-            "past-TTL but in use → NOT eligible (sweep skips it)"
+            "in use → NOT eligible (sweep skips it)"
         );
     }
 
@@ -4399,7 +4364,6 @@ mod tests {
             let mut cache = manager.hosting_cache.write();
             *cache = cache::HostingCache::new(
                 100,
-                std::time::Duration::ZERO,
                 std::sync::Arc::new(crate::util::time_source::InstantTimeSrc::new()),
             );
         }
@@ -4471,7 +4435,6 @@ mod tests {
             let mut cache = manager.hosting_cache.write();
             *cache = cache::HostingCache::new(
                 100,
-                std::time::Duration::ZERO,
                 std::sync::Arc::new(crate::util::time_source::InstantTimeSrc::new()),
             );
         }
@@ -4588,7 +4551,6 @@ mod tests {
             let mut cache = manager.hosting_cache.write();
             *cache = cache::HostingCache::new(
                 200, // room for ~2 contracts at 100 bytes
-                std::time::Duration::ZERO,
                 std::sync::Arc::new(crate::util::time_source::InstantTimeSrc::new()),
             );
         }
@@ -4655,7 +4617,6 @@ mod tests {
             let mut cache = manager.hosting_cache.write();
             *cache = cache::HostingCache::new(
                 200, // room for ~2 contracts at 100 bytes
-                std::time::Duration::ZERO,
                 std::sync::Arc::new(crate::util::time_source::InstantTimeSrc::new()),
             );
         }
@@ -4733,7 +4694,6 @@ mod tests {
             let mut cache = manager.hosting_cache.write();
             *cache = cache::HostingCache::new(
                 200,
-                std::time::Duration::ZERO,
                 std::sync::Arc::new(crate::util::time_source::InstantTimeSrc::new()),
             );
         }
@@ -4826,27 +4786,27 @@ mod tests {
     /// subscribed contracts last, interior peers would drop hosting → stop
     /// renewal → lose upstream subscription → downstream subscribers lose their feed.
     ///
-    /// This test operates at the HostingCache level with MockTimeSrc so we
-    /// can actually advance time past TTL and verify the ordering.
+    /// This test operates at the HostingCache level so it can seed both entries
+    /// and verify the subscriber-primary ordering directly.
     #[test]
     fn test_zero_sub_evicted_before_downstream_subscribed() {
         use crate::ring::hosting::cache::HostingCache;
         use crate::util::time_source::SharedMockTimeSource;
 
         let time = SharedMockTimeSource::new();
-        let min_ttl = Duration::from_secs(60);
-        // Budget of 150 bytes with 2x100-byte entries = over budget
-        let mut cache = HostingCache::new(150, min_ttl, time.clone());
+        // Seed both under a generous budget (no auto-evict; distinct recency), then
+        // tighten to 150 so 2x100-byte entries are over budget for the sweep. (No
+        // `min_ttl` floor since 2026-07-08, so record_access sheds to budget
+        // immediately — the "both resident over budget" state needs a budget shrink.)
+        let mut cache = HostingCache::new(100_000, time.clone());
 
         let subscribed = make_contract_key(1);
         let zero_sub = make_contract_key(2);
 
         cache.record_access(subscribed, 100, AccessType::Get, 0, |_| (0, 0));
         cache.record_access(zero_sub, 100, AccessType::Get, 0, |_| (0, 0));
+        cache.set_budget_for_test(150);
         assert_eq!(cache.current_bytes(), 200); // over budget
-
-        // Advance past TTL
-        time.advance_time(Duration::from_secs(61));
 
         // `subscribed` has a downstream subscriber; `zero_sub` has none. Under
         // subscriber-primary ordering the zero-subscriber one sheds first, and one
@@ -4863,44 +4823,37 @@ mod tests {
         );
         assert!(
             evicted.iter().any(|e| e.key == zero_sub),
-            "the zero-subscriber contract is evicted first when over budget + past TTL"
+            "the zero-subscriber contract is evicted first when over budget"
         );
         assert!(cache.contains(&subscribed));
     }
 
-    /// A hosted contract with NO subscribers and NO clients SHOULD be
-    /// evictable after TTL expires when the cache is over budget.
+    /// A hosted contract with NO subscribers and NO clients IS evictable when the
+    /// cache is over budget — there is no `min_ttl` floor (dropped 2026-07-08), so
+    /// the sweep sheds it immediately.
     ///
-    /// Uses HostingCache with MockTimeSrc for time advancement.
+    /// Uses HostingCache with MockTimeSrc.
     #[test]
     fn test_no_subscribers_allows_eviction() {
         use crate::ring::hosting::cache::HostingCache;
         use crate::util::time_source::SharedMockTimeSource;
 
         let time = SharedMockTimeSource::new();
-        let min_ttl = Duration::from_secs(60);
-        // Budget of 80 bytes, entry is 100 → over budget immediately
-        let mut cache = HostingCache::new(80, min_ttl, time.clone());
+        // Budget of 80 bytes, entry is 100 → over budget immediately.
+        let mut cache = HostingCache::new(80, time.clone());
 
         let contract = make_contract_key(100);
+        // The insert can't self-evict the just-inserted contract (op-scoped
+        // backstop), so it is resident but over budget.
         cache.record_access(contract, 100, AccessType::Get, 0, |_| (0, 0));
         assert!(cache.contains(&contract));
 
-        // Under TTL: should not be evicted even though over budget
-        let evicted = cache.sweep_expired(|_| (0, 0), cache::MemoryPressure::AtCapacity);
-        assert!(
-            evicted.is_empty(),
-            "Contract within TTL should not be evicted"
-        );
-
-        // Advance past TTL
-        time.advance_time(Duration::from_secs(61));
-
-        // Now should be evicted (over budget + past TTL + no subscribers)
+        // A sweep (no op-protected key) sheds the zero-subscriber contract at once
+        // — no TTL wait.
         let evicted = cache.sweep_expired(|_| (0, 0), cache::MemoryPressure::AtCapacity);
         assert!(
             evicted.iter().any(|e| e.key == contract),
-            "Contract past TTL with no subscribers should be evicted"
+            "an over-budget contract with no subscribers is evicted (no min_ttl floor)"
         );
         assert!(!cache.contains(&contract));
     }
@@ -5242,8 +5195,7 @@ mod tests {
         {
             let mut cache = manager.hosting_cache.write();
             *cache = cache::HostingCache::new(
-                200,                       // tiny budget: room for ~2 contracts at 100 bytes
-                std::time::Duration::ZERO, // no TTL protection
+                200, // tiny budget: room for ~2 contracts at 100 bytes
                 std::sync::Arc::new(crate::util::time_source::InstantTimeSrc::new()),
             );
         }

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -50,7 +50,7 @@ pub(crate) use cache::LEGACY_FLAT_HOSTING_BUDGET_BYTES;
 /// the operator-facing default and the in-code fallback can never drift. The
 /// default is RAM-scaled (capability-relative, A2) rather than a flat constant.
 pub(crate) use cache::default_hosting_budget_bytes;
-pub use cache::{AccessType, RecordAccessResult};
+pub use cache::{AccessType, EvictedInUseTeardown, RecordAccessResult};
 use cache::{DEFAULT_MIN_TTL, HostingCache, HostingCacheStats};
 /// Clamp bounds re-exported only for the config-default round-trip test, which
 /// asserts the resolved default lands within [MIN, MAX] without hardcoding the
@@ -166,6 +166,19 @@ pub struct SubscribeResult {
     pub is_new: bool,
     /// When the subscription will expire.
     pub expires_at: Instant,
+}
+
+/// Result of a hosting-cache over-budget/expiry sweep
+/// ([`HostingManager::sweep_expired_hosting`]).
+#[derive(Debug, Default)]
+pub struct HostingSweepResult {
+    /// `(ContractKey, write_generation)` pairs the caller reclaims from disk.
+    pub expired: Vec<(ContractKey, u64)>,
+    /// Subscription state torn down for any still-in-use victim shed as a last
+    /// resort, so the caller can replay the removals against the
+    /// `InterestManager` (PR #4734 Fix 1). Empty in the common (zero-subscriber)
+    /// sweep.
+    pub evicted_in_use_teardown: Vec<EvictedInUseTeardown>,
 }
 
 /// Lease-tracked active subscription state.
@@ -1301,14 +1314,33 @@ impl HostingManager {
     ///   contract; clearing `client_subscriptions` likewise stops section 2
     ///   (client-subscription re-subscribe) from re-driving it.
     ///
+    /// Returns the removed subscription state so the eviction CONSUMER can
+    /// replay the identical removals against the `InterestManager` (which lives
+    /// on `OpManager`, not here) via
+    /// [`InterestManager::remove_evicted_in_use`](crate::ring::interest::InterestManager::remove_evicted_in_use);
+    /// otherwise ghost `interested_peers` / `peer_contracts` /
+    /// `local_client_count` entries survive and mis-target UPDATE broadcasts /
+    /// inflate upstream interest counts (PR #4734 Fix 1). See
+    /// [`EvictedInUseTeardown`].
+    ///
     /// Idempotent and safe to call on an already-clean key (each removal is a
     /// no-op when absent).
-    fn teardown_evicted_in_use_contract(&self, key: &ContractKey) {
-        let had_downstream = self.downstream_subscribers.remove(key).is_some();
-        let had_client = self.client_subscriptions.remove(key.id()).is_some();
+    fn teardown_evicted_in_use_contract(&self, key: &ContractKey) -> EvictedInUseTeardown {
+        let downstream_peers: Vec<PeerKey> = self
+            .downstream_subscribers
+            .remove(key)
+            .map(|(_, peers)| peers.into_keys().collect())
+            .unwrap_or_default();
+        let local_client_count = self
+            .client_subscriptions
+            .remove(key.id())
+            .map(|(_, clients)| clients.len())
+            .unwrap_or(0);
         // Drop our own upstream lease too (same as the sweep loop's belt-and-
         // suspenders `ring.unsubscribe`), so renewal section 1 won't re-drive it.
         self.unsubscribe(key);
+        let had_downstream = !downstream_peers.is_empty();
+        let had_client = local_client_count > 0;
         if had_downstream || had_client {
             debug!(
                 contract = %key,
@@ -1317,6 +1349,11 @@ impl HostingManager {
                 "Tore down subscription state for a subscriber-primary eviction \
                  (#4642 invariant 3); disk reclamation can now proceed"
             );
+        }
+        EvictedInUseTeardown {
+            key: *key,
+            downstream_peers,
+            local_client_count,
         }
     }
 
@@ -1485,7 +1522,7 @@ impl HostingManager {
         // before the hosting-cache write lock is taken (no nested lock order).
         let (distance, predicted_demand) = self.distance_and_demand(&key);
 
-        let result = self.hosting_cache.write().record_access_with_demand(
+        let mut result = self.hosting_cache.write().record_access_with_demand(
             key,
             size_bytes,
             access_type,
@@ -1502,9 +1539,16 @@ impl HostingManager {
         // freed (the memory-teardown the shipped #4720 code was missing). The
         // cache write lock is already dropped; the teardown touches only the
         // subscription DashMaps + active_subscriptions, never the hosting cache.
-        for evicted_key in &result.evicted_in_use {
-            self.teardown_evicted_in_use_contract(evicted_key);
-        }
+        //
+        // Collect what each teardown removed so the CONSUMER can replay the same
+        // removals against the `InterestManager` (which lives on `OpManager`, not
+        // here) — otherwise ghost `interested_peers` / `peer_contracts` /
+        // `local_client_count` entries survive (PR #4734 Fix 1).
+        result.evicted_in_use_teardown = result
+            .evicted_in_use
+            .iter()
+            .map(|evicted_key| self.teardown_evicted_in_use_contract(evicted_key))
+            .collect();
 
         // Train the proximity prior from this peer's own observed read rate for
         // the accessed contract (only reads yield a sample; PUT is a seed). The
@@ -1864,11 +1908,13 @@ impl HostingManager {
     /// after `SUBSCRIPTION_LEASE_DURATION` without renewal.
     /// Automatically removes persisted metadata for expired contracts.
     ///
-    /// Returns `(ContractKey, write_generation)` pairs — the generation
-    /// captured atomically under the hosting-cache write lock travels with
-    /// the `EvictContract` event so the deletion-time guard can detect a
-    /// re-host race.
-    pub fn sweep_expired_hosting(&self) -> Vec<(ContractKey, u64)> {
+    /// Returns a [`HostingSweepResult`]: the `(ContractKey, write_generation)`
+    /// reclaim pairs — the generation captured atomically under the hosting-cache
+    /// write lock travels with the `EvictContract` event so the deletion-time
+    /// guard can detect a re-host race — plus, for any still-in-use victim shed
+    /// as a last resort, the subscription state torn down so the caller can sync
+    /// the `InterestManager` (PR #4734 Fix 1).
+    pub fn sweep_expired_hosting(&self) -> HostingSweepResult {
         // AtCapacity: the Overflow `min_ttl`-pierce trigger is intentionally
         // unwired in production (see cache::MemoryPressure). AtCapacity itself
         // CAN now shed a subscribed contract as a last resort — see below.
@@ -1882,11 +1928,14 @@ impl HostingManager {
         // checks it and the disk state is actually freed (the memory-teardown the
         // shipped #4720 code was missing). Then strip to the `(key, generation)`
         // reclaim list the caller (`ring.rs` maintenance loop) already consumes.
+        // Collect each teardown so the caller can replay the removals against the
+        // `InterestManager` (which lives on `OpManager`, not here).
+        let mut evicted_in_use_teardown = Vec::new();
         let expired: Vec<(ContractKey, u64)> = evicted
             .iter()
             .map(|e| {
                 if e.was_in_use {
-                    self.teardown_evicted_in_use_contract(&e.key);
+                    evicted_in_use_teardown.push(self.teardown_evicted_in_use_contract(&e.key));
                 }
                 (e.key, e.write_generation)
             })
@@ -1917,7 +1966,10 @@ impl HostingManager {
             }
         }
 
-        expired
+        HostingSweepResult {
+            expired,
+            evicted_in_use_teardown,
+        }
     }
 
     // =========================================================================
@@ -4777,7 +4829,7 @@ mod tests {
     /// This test operates at the HostingCache level with MockTimeSrc so we
     /// can actually advance time past TTL and verify the ordering.
     #[test]
-    fn test_downstream_subscribers_evicted_after_zero_sub() {
+    fn test_zero_sub_evicted_before_downstream_subscribed() {
         use crate::ring::hosting::cache::HostingCache;
         use crate::util::time_source::SharedMockTimeSource;
 

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -1245,17 +1245,20 @@ impl HostingManager {
         self.has_client_subscriptions(contract.id()) || self.has_downstream_subscribers(contract)
     }
 
-    /// Count of genuine demand pinning `contract`: local client subscriptions
-    /// PLUS downstream subscribers. This is the subscriber-primary eviction key
-    /// (#4642). Aligned with [`contract_in_use`](Self::contract_in_use) BY
-    /// CONSTRUCTION — it counts the exact same two sources, so
-    /// `subscriber_count(k) == 0` iff `!contract_in_use(k)`, keeping retention
-    /// and the collapse/renewal decision in agreement (per the piece-D source).
-    /// Counts ALL downstream entries (matching `has_downstream_subscribers`, no
-    /// lease filter) so the pin equals `contract_in_use` exactly; the periodic
+    /// The SPLIT genuine-demand counts pinning `contract`:
+    /// `(local_client_subscriptions, downstream_subscribers)`. This is the
+    /// subscriber-primary eviction key (#4642, Ian's confirmed ordering): the
+    /// cache orders victims ascending by `(local, downstream, last_get_seq, key)`,
+    /// so a contract THIS node's own client is subscribed to (local >= 1) is
+    /// evicted LAST. Aligned with [`contract_in_use`](Self::contract_in_use) BY
+    /// CONSTRUCTION — it counts the exact same two sources, so `local + downstream
+    /// == 0` iff `!contract_in_use(k)`, keeping retention and the collapse/renewal
+    /// decision in agreement (per the piece-D source). Counts ALL downstream
+    /// entries (no lease filter, matching `has_downstream_subscribers`) so the
+    /// count equals `contract_in_use` exactly; the periodic
     /// `expire_stale_downstream_subscribers` sweep keeps the map fresh.
-    pub(crate) fn subscriber_count(&self, contract: &ContractKey) -> usize {
-        let clients = self
+    pub(crate) fn local_and_downstream_counts(&self, contract: &ContractKey) -> (usize, usize) {
+        let local = self
             .client_subscriptions
             .get(contract.id())
             .map(|c| c.len())
@@ -1265,7 +1268,56 @@ impl HostingManager {
             .get(contract)
             .map(|peers| peers.len())
             .unwrap_or(0);
-        clients + downstream
+        (local, downstream)
+    }
+
+    /// Complete a subscriber-primary eviction that shed a still-in-use contract
+    /// (#4642, invariant 3): drop every subscription record that keeps
+    /// `contract_in_use(key)` true, so the disk-reclamation funnel
+    /// (`reclaim_evicted_contract` → `RuntimePool::remove_contract`) actually
+    /// frees the on-disk state instead of skipping it forever. Called ONLY for
+    /// the `evicted_in_use` subset (victims that were subscribed at eviction-
+    /// decision time), so a zero-subscriber eviction is untouched and — crucially
+    /// — a contract that gained a fresh subscriber AFTER it was evicted as
+    /// zero-subscriber is NOT torn down here (the re-host / re-subscribe guards in
+    /// `RuntimePool::remove_contract` handle that race).
+    ///
+    /// Clears, in order:
+    /// - `downstream_subscribers[key]` — the peer subscription leases. Downstream
+    ///   re-home, when demand persists, happens through the interest-gated
+    ///   renewal loop (ring-routed via `k_closest_potentially_hosting`), NOT from
+    ///   here — this PR builds no proactive re-home signal.
+    /// - `client_subscriptions[key.id()]` — local WebSocket client subscriptions.
+    ///   Under the fewest-`(local, downstream)` ordering a contract with LOCAL
+    ///   subscriptions is only ever a victim in the all-local-subscribed extreme
+    ///   (every eligible contract carries a local subscriber and the peer is still
+    ///   over budget), so this is a no-op in the common case and, in that extreme,
+    ///   silently STRANDS the local client. That is the accepted last-resort
+    ///   behavior — there is deliberately no client-notification surface (out of
+    ///   scope; see hosting-invariants invariant 3).
+    /// - the active upstream subscription lease (`unsubscribe`), so
+    ///   `contracts_needing_renewal` section 1 (active-subscription renewal, gated
+    ///   on `contract_in_use`) does not immediately re-drive the torn-down
+    ///   contract; clearing `client_subscriptions` likewise stops section 2
+    ///   (client-subscription re-subscribe) from re-driving it.
+    ///
+    /// Idempotent and safe to call on an already-clean key (each removal is a
+    /// no-op when absent).
+    fn teardown_evicted_in_use_contract(&self, key: &ContractKey) {
+        let had_downstream = self.downstream_subscribers.remove(key).is_some();
+        let had_client = self.client_subscriptions.remove(key.id()).is_some();
+        // Drop our own upstream lease too (same as the sweep loop's belt-and-
+        // suspenders `ring.unsubscribe`), so renewal section 1 won't re-drive it.
+        self.unsubscribe(key);
+        if had_downstream || had_client {
+            debug!(
+                contract = %key,
+                had_downstream,
+                had_client,
+                "Tore down subscription state for a subscriber-primary eviction \
+                 (#4642 invariant 3); disk reclamation can now proceed"
+            );
+        }
     }
 
     /// Hook called from every code path that removes an "in-use" signal
@@ -1439,8 +1491,20 @@ impl HostingManager {
             access_type,
             current_generation,
             predicted_demand,
-            |k: &ContractKey| self.subscriber_count(k),
+            |k: &ContractKey| self.local_and_downstream_counts(k),
         );
+
+        // Subscriber-primary eviction (#4642, invariant 3) can now shed a
+        // still-in-use contract as a last resort. For each such victim tear down
+        // its subscription state HERE — before the caller iterates `result.evicted`
+        // and calls `reclaim_evicted_contract` — so `contract_in_use` is already
+        // false when the reclaim gate checks it and the on-disk state is actually
+        // freed (the memory-teardown the shipped #4720 code was missing). The
+        // cache write lock is already dropped; the teardown touches only the
+        // subscription DashMaps + active_subscriptions, never the hosting cache.
+        for evicted_key in &result.evicted_in_use {
+            self.teardown_evicted_in_use_contract(evicted_key);
+        }
 
         // Train the proximity prior from this peer's own observed read rate for
         // the accessed contract (only reads yield a sample; PUT is a seed). The
@@ -1655,16 +1719,23 @@ impl HostingManager {
         self.hosting_cache.read().eviction_ordered_scores()
     }
 
-    /// Whether the over-budget sweep would currently CONSIDER `score`'s
-    /// contract for eviction — i.e. whether it passes the same per-contract
-    /// filter [`cache::HostingCache::evict_over_budget`] applies:
-    /// `past_min_ttl` (the TTL half, precomputed by the cache) AND NOT
-    /// [`contract_in_use`](Self::contract_in_use) (the `should_retain` half).
+    /// Whether the over-budget sweep would evict `score`'s contract in the
+    /// COMMON case — `past_min_ttl` (the TTL floor, precomputed by the cache) AND
+    /// NOT [`contract_in_use`](Self::contract_in_use).
     ///
-    /// The dashboard uses this to badge the true "next to evict" contract: the
-    /// raw lowest-keep-score row can be an entry the sweep would SKIP (still
-    /// within `min_ttl`, or pinned by a local client / downstream subscriber),
-    /// so badging it unconditionally mislabels an eviction-exempt contract.
+    /// The dashboard uses this to badge the "next to evict" contract: the raw
+    /// lowest-keep-score row can be an entry the sweep would not pick first (still
+    /// within `min_ttl`, or ordered last because a local client / downstream
+    /// subscriber makes it in-use), so badging it unconditionally would mislabel a
+    /// still-wanted contract.
+    ///
+    /// NOTE (subscriber-primary rework, #4642): under the split-ordering model an
+    /// in-use contract is no longer hard-pinned — it is ordered LAST and IS shed
+    /// as a last resort when nothing with fewer subscribers is eligible and the
+    /// peer is still over budget. This badge deliberately reflects the common,
+    /// non-last-resort case (in-use = not the next victim); it does not surface the
+    /// all-subscribed-extreme last-resort shed. A dashboard that wants to show the
+    /// true last-resort victim would drop the `!contract_in_use` term.
     ///
     /// Deadlock-safe by construction: `score` is already-collected owned data
     /// (the `hosting_cache` read guard was released when
@@ -1774,18 +1845,21 @@ impl HostingManager {
         }
     }
 
-    /// Sweep for expired entries in the hosting cache.
+    /// Sweep for over-budget entries in the hosting cache.
     ///
-    /// Under normal (`AtCapacity`) pressure a contract is PINNED — never evicted
-    /// — while `subscriber_count(key) >= 1`, i.e. it has client subscriptions OR
-    /// downstream subscribers (the two sources `contract_in_use` checks; note an
-    /// active *upstream* network subscription is deliberately NOT one of them —
-    /// see `contract_in_use`). This is the same `subscriber_count` closure
-    /// `record_contract_access` passes, so all eviction paths agree. Only the OOM
-    /// valve (`MemoryPressure::Overflow`) pierces this pin, and its trigger is
-    /// intentionally unwired in production (see `cache::MemoryPressure`), so
-    /// nothing sheds a subscribed contract in the field yet.
-    /// The downstream subscriber exemption is time-bounded: stale entries are
+    /// Under normal (`AtCapacity`) pressure victims are chosen subscriber-primary
+    /// (#4642, invariant 3): ascending `(local_subscription_count,
+    /// downstream_subscriber_count, last_get_seq, key)`, using the same split
+    /// `local_and_downstream_counts` closure `record_contract_access` passes, so
+    /// all eviction paths agree. A subscribed contract is ordered LAST and shed
+    /// only as a last resort (when nothing with fewer subscribers is eligible and
+    /// the peer is still over budget) — it is NOT hard-pinned, the change from the
+    /// shipped #4720 code. When such a still-in-use victim IS shed, its
+    /// subscription state is torn down here (via `teardown_evicted_in_use_contract`)
+    /// so `contract_in_use` is false before the caller reclaims it and the on-disk
+    /// state is actually freed. The `Overflow` pressure (which ALSO pierces
+    /// `min_ttl`) is intentionally unwired in production (see `cache::MemoryPressure`).
+    /// Downstream subscriber leases are otherwise time-bounded: stale entries are
     /// removed by `expire_stale_downstream_subscribers()` (called periodically)
     /// after `SUBSCRIPTION_LEASE_DURATION` without renewal.
     /// Automatically removes persisted metadata for expired contracts.
@@ -1795,13 +1869,28 @@ impl HostingManager {
     /// the `EvictContract` event so the deletion-time guard can detect a
     /// re-host race.
     pub fn sweep_expired_hosting(&self) -> Vec<(ContractKey, u64)> {
-        // AtCapacity: the OOM-valve Overflow trigger is intentionally unwired in
-        // production (see cache::MemoryPressure); nothing sheds a subscribed
-        // contract in the field yet.
-        let expired = self.hosting_cache.write().sweep_expired(
-            |key| self.subscriber_count(key),
+        // AtCapacity: the Overflow `min_ttl`-pierce trigger is intentionally
+        // unwired in production (see cache::MemoryPressure). AtCapacity itself
+        // CAN now shed a subscribed contract as a last resort — see below.
+        let evicted = self.hosting_cache.write().sweep_expired(
+            |key| self.local_and_downstream_counts(key),
             cache::MemoryPressure::AtCapacity,
         );
+
+        // Tear down subscription state for any still-in-use victim BEFORE the
+        // caller reclaims it, so `contract_in_use` is false when the reclaim gate
+        // checks it and the disk state is actually freed (the memory-teardown the
+        // shipped #4720 code was missing). Then strip to the `(key, generation)`
+        // reclaim list the caller (`ring.rs` maintenance loop) already consumes.
+        let expired: Vec<(ContractKey, u64)> = evicted
+            .iter()
+            .map(|e| {
+                if e.was_in_use {
+                    self.teardown_evicted_in_use_contract(&e.key);
+                }
+                (e.key, e.write_generation)
+            })
+            .collect();
 
         // Clean up persisted metadata for expired contracts
         if !expired.is_empty() {
@@ -4428,17 +4517,21 @@ mod tests {
         );
     }
 
-    /// `record_contract_access` must not evict an in-use contract when the
-    /// cache is over budget; once the in-use signal is removed the contract
-    /// becomes evictable. The in-use signal here is a local client
-    /// subscription — the time-bounded form `contract_in_use` actually
-    /// checks (see its rustdoc for why an upstream network subscription
-    /// alone is excluded).
+    /// `record_contract_access`: an in-use (locally-subscribed) contract is
+    /// ordered LAST, so while a zero-subscriber contract is available to shed it
+    /// is NOT the victim — the subscribed contract survives WITHOUT being torn
+    /// down. Once its subscription is removed it becomes an ordinary zero-
+    /// subscriber contract and is evicted normally. (The in-use signal here is a
+    /// local client subscription, the LAST-evicted dimension of the
+    /// subscriber-primary ordering; see `contract_in_use`'s rustdoc for why an
+    /// upstream network subscription alone is excluded.) The complementary
+    /// last-resort case — an in-use contract that IS shed and torn down — is
+    /// covered by `record_contract_access_sheds_and_tears_down_only_subscribed`.
     #[test]
-    fn test_record_contract_access_skips_in_use_contract() {
+    fn test_record_contract_access_orders_in_use_last() {
         let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         // Override with a tiny cache and ZERO TTL so every entry is instantly
-        // eviction-eligible — `contract_in_use` is then the only protection.
+        // eviction-eligible — ordering is then the only thing in play.
         {
             let mut cache = manager.hosting_cache.write();
             *cache = cache::HostingCache::new(
@@ -4460,30 +4553,182 @@ mod tests {
         manager.record_contract_access(in_use, 100, AccessType::Get);
         manager.record_contract_access(filler, 100, AccessType::Get);
 
-        // Inserting `trigger` puts the cache over budget. A naive LRU would
-        // evict `in_use` (oldest) — `contract_in_use` must protect it, so
-        // `filler` is evicted instead.
+        // Inserting `trigger` puts the cache over budget. A naive LRU would evict
+        // `in_use` (oldest) — but it is locally subscribed so it is ordered LAST,
+        // and one eviction of the zero-subscriber `filler` is enough.
         let result = manager.record_contract_access(trigger, 100, AccessType::Get);
         assert_eq!(
             result.evicted,
             vec![(filler, 0)],
-            "in-use (client-subscribed) contract must be skipped; the \
-             unprotected contract must be evicted instead"
+            "the zero-subscriber contract is shed; the locally-subscribed one is \
+             ordered last and survives"
+        );
+        assert!(
+            result.evicted_in_use.is_empty(),
+            "no in-use contract was shed, so nothing was torn down"
         );
         assert!(manager.is_hosting_contract(&in_use));
         assert!(!manager.is_hosting_contract(&filler));
+        // `in_use`'s subscription is intact — it was NOT torn down.
+        assert!(manager.contract_in_use(&in_use));
 
-        // Drop the client subscription: `in_use` is now evictable.
+        // Drop the client subscription: `in_use` is now an ordinary zero-
+        // subscriber contract.
         manager.remove_client_subscription(in_use.id(), client);
         assert!(!manager.contract_in_use(&in_use));
 
         let result = manager.record_contract_access(filler, 100, AccessType::Get);
         assert!(
             result.evicted.iter().any(|(k, _)| *k == in_use),
-            "once the subscription is removed the contract must become \
-             evictable when the cache is over budget"
+            "once the subscription is removed the contract is evicted normally \
+             when the cache is over budget"
         );
         assert!(!manager.is_hosting_contract(&in_use));
+    }
+
+    /// LOAD-BEARING (#4642, invariant 3): when the cache is over budget and EVERY
+    /// hosted contract is subscribed, `record_contract_access` sheds the fewest-
+    /// `(local, downstream)`-subscriber one AND tears down its subscription state
+    /// so `contract_in_use` flips to false — the memory-teardown the shipped
+    /// #4720 code was missing (there, the entry vanished from the cache but the
+    /// subscription lingered, so `reclaim_evicted_contract` skipped the disk
+    /// delete forever). Verifies fewest-downstream-first among equal-local
+    /// contracts, and that ONLY the shed contract is torn down.
+    #[test]
+    fn record_contract_access_sheds_and_tears_down_only_subscribed() {
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
+        // Tiny cache, ZERO TTL so every entry is instantly eligible (no min_ttl
+        // grace masking the shed).
+        {
+            let mut cache = manager.hosting_cache.write();
+            *cache = cache::HostingCache::new(
+                200, // room for ~2 contracts at 100 bytes
+                std::time::Duration::ZERO,
+                std::sync::Arc::new(crate::util::time_source::InstantTimeSrc::new()),
+            );
+        }
+
+        let few = make_contract_key(1); // 1 downstream subscriber — shed first
+        let many = make_contract_key(2); // 3 downstream subscribers — survives
+        let trigger = make_contract_key(3); // 2 downstream subscribers
+
+        // Every contract is subscribed (downstream peers); none is zero-subscriber.
+        let p_few = make_peer_key(10);
+        let p_many: Vec<_> = (0..3).map(|i| make_peer_key(20 + i)).collect();
+        let p_trigger: Vec<_> = (0..2).map(|i| make_peer_key(30 + i)).collect();
+        manager.add_downstream_subscriber(&few, p_few.clone());
+        for p in &p_many {
+            manager.add_downstream_subscriber(&many, p.clone());
+        }
+        for p in &p_trigger {
+            manager.add_downstream_subscriber(&trigger, p.clone());
+        }
+
+        manager.record_contract_access(few, 100, AccessType::Get);
+        manager.record_contract_access(many, 100, AccessType::Get);
+        assert!(manager.contract_in_use(&few));
+        assert!(manager.contract_in_use(&many));
+
+        // Insert `trigger` over budget. Nothing is zero-subscriber, so the fewest-
+        // downstream contract `few` (1 sub) is shed as the last resort ahead of
+        // `many` (3 subs).
+        let result = manager.record_contract_access(trigger, 100, AccessType::Get);
+        assert_eq!(
+            result.evicted,
+            vec![(few, 0)],
+            "with only subscribed contracts, the fewest-downstream one is shed"
+        );
+        assert_eq!(
+            result.evicted_in_use,
+            vec![few],
+            "the shed subscribed contract is reported for teardown"
+        );
+
+        // THE LOAD-BEARING ASSERTION: the shed contract's subscription state was
+        // torn down, so `contract_in_use` is now false and the reclaim gate
+        // (`reclaim_evicted_contract` / `RuntimePool::remove_contract`) will
+        // proceed to free the disk state instead of skipping it forever.
+        assert!(
+            !manager.contract_in_use(&few),
+            "the shed contract must be torn down so contract_in_use is false and \
+             disk reclamation proceeds (the memory-teardown #4720 lacked)"
+        );
+        assert!(!manager.has_downstream_subscribers(&few));
+        assert!(!manager.is_hosting_contract(&few));
+
+        // The surviving contract keeps its subscription intact — only the victim
+        // was torn down.
+        assert!(
+            manager.contract_in_use(&many),
+            "the surviving subscribed contract must NOT be torn down"
+        );
+        assert!(manager.has_downstream_subscribers(&many));
+        assert!(manager.is_hosting_contract(&many));
+    }
+
+    /// A torn-down subscriber-primary eviction must NOT be immediately re-driven
+    /// by `contracts_needing_renewal` (#4642 teardown correctness). In the all-
+    /// local-subscribed extreme the victim's client subscription AND its upstream
+    /// lease are cleared, so neither renewal section 1 (active-subscription, gated
+    /// on `contract_in_use`) nor section 2 (client-subscription re-subscribe)
+    /// re-selects it — otherwise the teardown would be undone one tick later and
+    /// the contract would re-fetch/re-host, defeating the eviction.
+    #[test]
+    fn torn_down_eviction_not_redriven_by_contracts_needing_renewal() {
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
+        // Tiny cache, ZERO TTL so every entry is instantly eligible.
+        {
+            let mut cache = manager.hosting_cache.write();
+            *cache = cache::HostingCache::new(
+                200,
+                std::time::Duration::ZERO,
+                std::sync::Arc::new(crate::util::time_source::InstantTimeSrc::new()),
+            );
+        }
+
+        let victim = make_contract_key(1);
+        let keep = make_contract_key(2);
+        let trigger = make_contract_key(3);
+
+        // The all-LOCAL extreme: every contract has a local client subscription
+        // AND an upstream subscription lease (so both renewal sections are live).
+        let client = crate::client_events::ClientId::next();
+        for k in [&victim, &keep, &trigger] {
+            manager.add_client_subscription(k.id(), client);
+            manager.subscribe(*k);
+        }
+
+        manager.record_contract_access(victim, 100, AccessType::Get);
+        manager.record_contract_access(keep, 100, AccessType::Get);
+        assert!(manager.contract_in_use(&victim));
+
+        // Insert `trigger` over budget. Every contract is locally subscribed
+        // (local = 1), so ties break by least-recent GET → `victim` (accessed
+        // first) is shed as the last resort and torn down.
+        let result = manager.record_contract_access(trigger, 100, AccessType::Get);
+        assert_eq!(
+            result.evicted_in_use,
+            vec![victim],
+            "the local victim is torn down"
+        );
+        assert!(
+            !manager.contract_in_use(&victim),
+            "victim's local subscription + lease were cleared"
+        );
+        assert!(
+            !manager.is_subscribed(&victim),
+            "victim's upstream lease was dropped"
+        );
+
+        // THE REGRESSION ASSERTION: renewal must not re-select the torn-down
+        // victim. The still-subscribed `keep` (and `trigger`) may appear, but
+        // `victim` must not — otherwise the next renewal tick would re-fetch it.
+        let renewal = manager.contracts_needing_renewal();
+        assert!(
+            !renewal.contains(&victim),
+            "a torn-down eviction must not be re-driven by contracts_needing_renewal, \
+             got {renewal:?}"
+        );
     }
 
     /// Removing from an untracked contract is a noop; other contracts unaffected.
@@ -4520,15 +4765,19 @@ mod tests {
         assert!(interest.remove_peer_interest(&contract, &peer));
     }
 
-    /// A hosted contract with downstream subscribers must NOT be evicted
-    /// from the hosting cache even after TTL expires and cache is over budget.
-    /// Without this, interior peers would drop hosting → stop renewal → lose
-    /// upstream subscription → downstream subscribers lose their feed.
+    /// A hosted contract with downstream subscribers is ordered LAST, so when a
+    /// zero-subscriber contract is available to shed it is NOT evicted (one
+    /// eviction of the zero-subscriber contract is enough to get back under
+    /// budget). This is the common case; it is NOT a hard pin — see
+    /// `evict_all_subscribed_sheds_fewest_as_last_resort` (cache tests) for the
+    /// last-resort shed when EVERY contract is subscribed. Without ordering
+    /// subscribed contracts last, interior peers would drop hosting → stop
+    /// renewal → lose upstream subscription → downstream subscribers lose their feed.
     ///
     /// This test operates at the HostingCache level with MockTimeSrc so we
-    /// can actually advance time past TTL and verify the retain predicate.
+    /// can actually advance time past TTL and verify the ordering.
     #[test]
-    fn test_downstream_subscribers_protect_from_eviction() {
+    fn test_downstream_subscribers_evicted_after_zero_sub() {
         use crate::ring::hosting::cache::HostingCache;
         use crate::util::time_source::SharedMockTimeSource;
 
@@ -4537,32 +4786,34 @@ mod tests {
         // Budget of 150 bytes with 2x100-byte entries = over budget
         let mut cache = HostingCache::new(150, min_ttl, time.clone());
 
-        let protected = make_contract_key(1);
-        let unprotected = make_contract_key(2);
+        let subscribed = make_contract_key(1);
+        let zero_sub = make_contract_key(2);
 
-        cache.record_access(protected, 100, AccessType::Get, 0, |_| 0);
-        cache.record_access(unprotected, 100, AccessType::Get, 0, |_| 0);
+        cache.record_access(subscribed, 100, AccessType::Get, 0, |_| (0, 0));
+        cache.record_access(zero_sub, 100, AccessType::Get, 0, |_| (0, 0));
         assert_eq!(cache.current_bytes(), 200); // over budget
 
         // Advance past TTL
         time.advance_time(Duration::from_secs(61));
 
-        // Sweep with predicate that protects the first contract
-        // (simulates has_downstream_subscribers returning true)
+        // `subscribed` has a downstream subscriber; `zero_sub` has none. Under
+        // subscriber-primary ordering the zero-subscriber one sheds first, and one
+        // eviction is enough — so the subscribed one survives (ordered last).
         let evicted = cache.sweep_expired(
-            |k| (*k == protected) as usize,
+            |k| (0, (*k == subscribed) as usize),
             cache::MemoryPressure::AtCapacity,
         );
 
         assert!(
-            !evicted.iter().any(|(k, _)| *k == protected),
-            "Contract with downstream subscribers must not be evicted"
+            !evicted.iter().any(|e| e.key == subscribed),
+            "the subscribed contract is ordered last; it survives while a \
+             zero-subscriber one can be shed"
         );
         assert!(
-            evicted.iter().any(|(k, _)| *k == unprotected),
-            "Unprotected contract should be evicted when over budget + past TTL"
+            evicted.iter().any(|e| e.key == zero_sub),
+            "the zero-subscriber contract is evicted first when over budget + past TTL"
         );
-        assert!(cache.contains(&protected));
+        assert!(cache.contains(&subscribed));
     }
 
     /// A hosted contract with NO subscribers and NO clients SHOULD be
@@ -4580,11 +4831,11 @@ mod tests {
         let mut cache = HostingCache::new(80, min_ttl, time.clone());
 
         let contract = make_contract_key(100);
-        cache.record_access(contract, 100, AccessType::Get, 0, |_| 0);
+        cache.record_access(contract, 100, AccessType::Get, 0, |_| (0, 0));
         assert!(cache.contains(&contract));
 
         // Under TTL: should not be evicted even though over budget
-        let evicted = cache.sweep_expired(|_| 0, cache::MemoryPressure::AtCapacity);
+        let evicted = cache.sweep_expired(|_| (0, 0), cache::MemoryPressure::AtCapacity);
         assert!(
             evicted.is_empty(),
             "Contract within TTL should not be evicted"
@@ -4593,10 +4844,10 @@ mod tests {
         // Advance past TTL
         time.advance_time(Duration::from_secs(61));
 
-        // Now should be evicted (over budget + past TTL + no retain predicate)
-        let evicted = cache.sweep_expired(|_| 0, cache::MemoryPressure::AtCapacity);
+        // Now should be evicted (over budget + past TTL + no subscribers)
+        let evicted = cache.sweep_expired(|_| (0, 0), cache::MemoryPressure::AtCapacity);
         assert!(
-            evicted.iter().any(|(k, _)| *k == contract),
+            evicted.iter().any(|e| e.key == contract),
             "Contract past TTL with no subscribers should be evicted"
         );
         assert!(!cache.contains(&contract));

--- a/crates/core/src/ring/hosting/admission.rs
+++ b/crates/core/src/ring/hosting/admission.rs
@@ -49,8 +49,8 @@
 //! delivered by routing, not by the admission/eviction decision (invariant 3).
 //!
 //! The `last_get_seq` recency tiebreak means the same thing on both sides: it is
-//! **real-GET-only** — stamped by a real GET, never by SUBSCRIBE, PUT, or
-//! subscription renewal — in both `cache.rs` (see `HostedContract::last_get_seq`)
+//! stamped by a real **GET or PUT** (genuine client access), never by SUBSCRIBE or
+//! subscription renewal — in both `cache.rs` (see `HostedContract::recency_seq`)
 //! and here, so the shared tiebreak is consistent.
 //!
 //! # The decision (spec "Admission & Shedding"; task 7-bis)
@@ -227,15 +227,15 @@ pub(crate) struct AdmissionIncumbent {
     /// `!contract_in_use`, so the in-use pin here matches the eviction pin.
     pub subscriber_count: usize,
 
-    /// Monotonic real-GET recency sequence for this contract: a smaller value is a
-    /// less-recent real GET. The recency tiebreak in `cache::victim_order`. It is
-    /// **real-GET-only** — stamped ONLY by a real GET, never by SUBSCRIBE, PUT, or
-    /// subscription renewal (so renewal traffic doesn't make every subscribed
+    /// Monotonic real-access recency sequence for this contract: a smaller value is
+    /// a less-recent access. The recency tiebreak in `cache::victim_order`. It is
+    /// stamped by a real **GET or PUT** (genuine client access), never by SUBSCRIBE
+    /// or subscription renewal (so renewal traffic doesn't make every subscribed
     /// contract look equally fresh) — matching `cache.rs`'s
-    /// `HostedContract::last_get_seq` semantics exactly, so the shared tiebreak
-    /// means the same thing on both sides. A never-GET-read entry (e.g. a fresh PUT
-    /// seed) carries `0` and is the least-recent, evicted first within its
-    /// subscriber class.
+    /// `HostedContract::recency_seq` semantics exactly, so the shared tiebreak
+    /// means the same thing on both sides. An entry created without a real GET or
+    /// PUT (e.g. a SUBSCRIBE-only entry) carries `0` and is the least-recent,
+    /// evicted first within its subscriber class.
     pub last_get_seq: u64,
 }
 

--- a/crates/core/src/ring/hosting/admission.rs
+++ b/crates/core/src/ring/hosting/admission.rs
@@ -469,7 +469,6 @@ mod tests {
     use crate::util::time_source::SharedMockTimeSource;
     use freenet_stdlib::prelude::{CodeHash, ContractInstanceId};
     use std::collections::HashMap;
-    use std::time::Duration;
 
     /// Deterministic distinct `ContractKey` from a seed byte (same construction
     /// as the `cache` module's tests).
@@ -1009,13 +1008,18 @@ mod tests {
     /// Build the shared 4-contract fixture: seeds 3 & 2 are zero-subscriber,
     /// seed 5 has 1 subscriber, seed 4 has 2. Inserts via GET in `[3, 2, 5, 4]`
     /// order so seed 3 is a strictly-less-recent GET than seed 2 (each GET stamps
-    /// an increasing `last_get_seq`), making the zero-subscriber tiebreak
+    /// an increasing `recency_seq`), making the zero-subscriber tiebreak
     /// deterministic and key-independent. Returns the populated cache, the
     /// subscriber-count map, and the admission-side view of the same set with
     /// each `last_get_seq` read back from the cache's actually-stamped value.
+    ///
+    /// All four are inserted under a GENEROUS budget so no insert auto-evicts (now
+    /// that `min_ttl` is gone, the insert path sheds down to budget immediately);
+    /// the caller-requested `budget` is then applied via `set_budget_for_test`, so
+    /// a subsequent sweep sees all four resident with their distinct recency and
+    /// sheds according to the tightened budget.
     fn cross_module_fixture(
         budget: u64,
-        ttl: Duration,
     ) -> (
         HostingCache<SharedMockTimeSource>,
         SharedMockTimeSource,
@@ -1035,19 +1039,21 @@ mod tests {
         let counts_of = |k: &ContractKey| (0usize, subs.get(k).copied().unwrap_or(0));
 
         let time = SharedMockTimeSource::new();
-        let mut cache = HostingCache::new(budget, ttl, time.clone());
+        // Seed under a generous budget so no insert auto-evicts, then tighten.
+        let mut cache = HostingCache::new(100_000, time.clone());
         for seed in [3u8, 2, 5, 4] {
             let key = make_key(seed);
             let r = cache.record_access(key, 100, AccessType::Get, 0, counts_of);
             assert!(r.is_new, "fixture keys must be distinct fresh inserts");
         }
+        cache.set_budget_for_test(budget);
 
         let hosted: Vec<AdmissionIncumbent> = subs
             .keys()
             .map(|k| AdmissionIncumbent {
                 key: *k,
                 subscriber_count: subs.get(k).copied().unwrap_or(0),
-                last_get_seq: cache.get(k).expect("inserted above").last_get_seq,
+                last_get_seq: cache.get(k).expect("inserted above").recency_seq,
             })
             .collect();
 
@@ -1057,10 +1063,10 @@ mod tests {
     #[test]
     fn admission_and_cache_agree_on_full_eviction_order() {
         // Budget 0 so an Overflow sweep sheds EVERY entry, exposing the full
-        // eviction order across all three ranking tiers. mock time never advances
-        // (age stays 0), so the AtCapacity eviction each insert triggers finds
-        // nothing past `min_ttl` and all four survive for the Overflow sweep.
-        let (mut cache, _time, subs, hosted) = cross_module_fixture(0, Duration::from_secs(3600));
+        // eviction order across all three ranking tiers. The fixture seeds all four
+        // under a generous budget then tightens to 0 (see `cross_module_fixture`),
+        // so all four are resident with distinct recency for the Overflow sweep.
+        let (mut cache, _time, subs, hosted) = cross_module_fixture(0);
         // Combined counts mapped to the downstream slot (local = 0), matching the
         // admission `victim_order` shim, so the two orderings stay comparable.
         let counts_of = |k: &ContractKey| (0usize, subs.get(k).copied().unwrap_or(0));
@@ -1102,19 +1108,17 @@ mod tests {
         // The displacement / AtCapacity path: a 1-subscriber newcomer, so
         // admission's displacement picker is eligible to evict the strictly-fewer
         // (zero-subscriber) incumbents, while the cache's AtCapacity sweep evicts
-        // only zero-subscriber, past-`min_ttl` entries. Both must pick seed 3.
-        let ttl = Duration::from_secs(60);
+        // the fewest-subscriber entries (no `min_ttl` gate). Both must pick seed 3.
         // Budget 350: three entries (300B) fit, four (400B) do not, so exactly
         // one entry is shed and the sweep's FRONT victim is observable.
-        let (mut cache, time, subs, hosted) = cross_module_fixture(350, ttl);
+        let (mut cache, _time, subs, hosted) = cross_module_fixture(350);
         // Combined counts mapped to the downstream slot (local = 0), matching the
         // admission `victim_order` shim.
         let counts_of = |k: &ContractKey| (0usize, subs.get(k).copied().unwrap_or(0));
 
-        // Age every entry past `min_ttl` so all become eligible; the zero-
-        // subscriber seeds 2 & 3 still sort ahead of the subscribed 4 & 5, so one
+        // No `min_ttl` gate (dropped 2026-07-08): every entry is eligible, so the
+        // zero-subscriber seeds 2 & 3 sort ahead of the subscribed 4 & 5 and one
         // zero-subscriber entry is the front victim (subscribed ordered last).
-        time.advance_time(ttl + Duration::from_secs(1));
 
         let admission_victim =
             pick_displacement_victim(&hosted, 1).expect("a zero-sub incumbent is displaceable");

--- a/crates/core/src/ring/hosting/admission.rs
+++ b/crates/core/src/ring/hosting/admission.rs
@@ -26,13 +26,20 @@
 //! Admission and the background over-budget eviction sweep are ONE demand-vs-
 //! capacity decision (invariant 3), so they MUST rank victims the same way. They
 //! do, by construction: both go through the single canonical
-//! [`cache::victim_order`], which orders victims ascending
-//! `(subscriber_count, last_get_seq, key_bytes)`. [`pick_displacement_victim`]
-//! and [`pick_oom_valve_victim`] call it directly — there is no second copy of
-//! the ordering to drift out of sync. The `admission_and_cache_agree_*` pin tests
-//! in this module assert admission's victim selection and `cache`'s over-budget
-//! eviction pick the SAME victim (and the same full eviction order) from a shared
-//! fixture, so a change to either side that broke the agreement fails CI.
+//! [`cache::victim_order`], which since the subscriber-primary rework (#4642)
+//! orders victims ascending
+//! `(local_subscription_count, downstream_subscriber_count, last_get_seq, key_bytes)`.
+//! This inert admission model tracks only a single COMBINED `subscriber_count`, so
+//! [`pick_displacement_victim`] and [`pick_oom_valve_victim`] call `victim_order`
+//! with that combined count in the DOWNSTREAM slot and the local slot held at 0 —
+//! `(0, n, seq, key)` compares exactly as the pre-split `(n, seq, key)` did, so no
+//! second copy of the ordering drifts out of sync. The `admission_and_cache_agree_*`
+//! pin tests in this module map their combined counts the same way and assert
+//! admission's victim selection and `cache`'s over-budget eviction pick the SAME
+//! victim (and the same full eviction order) from a shared fixture, so a change to
+//! either side that broke the agreement fails CI. (When admission is reconciled
+//! with the split model — or removed, per the demand-driven-hosting model that has
+//! no separate admission decision — this shim goes away.)
 //!
 //! The subscriber signal is a raw `usize` count (local client subs + downstream
 //! subs), NOT a distance-derived read-demand estimate and NOT ring distance. Both
@@ -415,9 +422,16 @@ fn pick_displacement_victim(
         .iter()
         .filter(|c| c.subscriber_count < candidate_subscriber_count)
         .min_by(|a, b| {
+            // The inert admission model (#4717) tracks only a single combined
+            // `subscriber_count`; the split `(local, downstream)` `victim_order`
+            // key degrades to ordering by that combined count when the first
+            // (local) slot is held at 0 — `(0, n, seq, key)` compares exactly as
+            // the old `(n, seq, key)` did. Shim kept until admission is reconciled
+            // with the split model (or removed per the demand-driven-hosting model,
+            // which has no separate admission decision).
             cache::victim_order(
-                (a.subscriber_count, a.last_get_seq, &a.key),
-                (b.subscriber_count, b.last_get_seq, &b.key),
+                (0, a.subscriber_count, a.last_get_seq, &a.key),
+                (0, b.subscriber_count, b.last_get_seq, &b.key),
             )
         })
         .map(|c| c.key)
@@ -438,9 +452,11 @@ fn pick_oom_valve_victim(hosted: &[AdmissionIncumbent]) -> Option<ContractKey> {
     hosted
         .iter()
         .min_by(|a, b| {
+            // See `pick_displacement_victim`: admission's inert combined-count
+            // model maps onto the split `victim_order` key with the local slot 0.
             cache::victim_order(
-                (a.subscriber_count, a.last_get_seq, &a.key),
-                (b.subscriber_count, b.last_get_seq, &b.key),
+                (0, a.subscriber_count, a.last_get_seq, &a.key),
+                (0, b.subscriber_count, b.last_get_seq, &b.key),
             )
         })
         .map(|c| c.key)
@@ -1012,13 +1028,17 @@ mod tests {
             (make_key(4), 2),
             (make_key(5), 1),
         ]);
-        let subs_of = |k: &ContractKey| subs.get(k).copied().unwrap_or(0);
+        // The cache orders by (local, downstream); admission's inert model tracks
+        // only a combined count. Map every combined count to the DOWNSTREAM slot
+        // (local = 0), exactly as admission's `victim_order` shim does, so the two
+        // orderings remain comparable.
+        let counts_of = |k: &ContractKey| (0usize, subs.get(k).copied().unwrap_or(0));
 
         let time = SharedMockTimeSource::new();
         let mut cache = HostingCache::new(budget, ttl, time.clone());
         for seed in [3u8, 2, 5, 4] {
             let key = make_key(seed);
-            let r = cache.record_access(key, 100, AccessType::Get, 0, &subs_of);
+            let r = cache.record_access(key, 100, AccessType::Get, 0, counts_of);
             assert!(r.is_new, "fixture keys must be distinct fresh inserts");
         }
 
@@ -1026,7 +1046,7 @@ mod tests {
             .keys()
             .map(|k| AdmissionIncumbent {
                 key: *k,
-                subscriber_count: subs_of(k),
+                subscriber_count: subs.get(k).copied().unwrap_or(0),
                 last_get_seq: cache.get(k).expect("inserted above").last_get_seq,
             })
             .collect();
@@ -1041,7 +1061,9 @@ mod tests {
         // (age stays 0), so the AtCapacity eviction each insert triggers finds
         // nothing past `min_ttl` and all four survive for the Overflow sweep.
         let (mut cache, _time, subs, hosted) = cross_module_fixture(0, Duration::from_secs(3600));
-        let subs_of = |k: &ContractKey| subs.get(k).copied().unwrap_or(0);
+        // Combined counts mapped to the downstream slot (local = 0), matching the
+        // admission `victim_order` shim, so the two orderings stay comparable.
+        let counts_of = |k: &ContractKey| (0usize, subs.get(k).copied().unwrap_or(0));
 
         // Admission's full order: repeatedly pick the OOM-valve victim (ranks
         // over ALL incumbents by `victim_order`) and remove it.
@@ -1055,9 +1077,9 @@ mod tests {
         // Cache's full order: Overflow sweep at budget 0 sheds all, fewest-
         // subscriber-then-least-recent-GET-first.
         let cache_order: Vec<ContractKey> = cache
-            .sweep_expired(&subs_of, CachePressure::Overflow)
+            .sweep_expired(counts_of, CachePressure::Overflow)
             .into_iter()
-            .map(|(k, _)| k)
+            .map(|e| e.key)
             .collect();
 
         assert_eq!(
@@ -1085,22 +1107,25 @@ mod tests {
         // Budget 350: three entries (300B) fit, four (400B) do not, so exactly
         // one entry is shed and the sweep's FRONT victim is observable.
         let (mut cache, time, subs, hosted) = cross_module_fixture(350, ttl);
-        let subs_of = |k: &ContractKey| subs.get(k).copied().unwrap_or(0);
+        // Combined counts mapped to the downstream slot (local = 0), matching the
+        // admission `victim_order` shim.
+        let counts_of = |k: &ContractKey| (0usize, subs.get(k).copied().unwrap_or(0));
 
-        // Age every entry past `min_ttl` so the AtCapacity zero-subscriber
-        // candidates become eligible (the subscribed seeds 4 & 5 stay pinned).
+        // Age every entry past `min_ttl` so all become eligible; the zero-
+        // subscriber seeds 2 & 3 still sort ahead of the subscribed 4 & 5, so one
+        // zero-subscriber entry is the front victim (subscribed ordered last).
         time.advance_time(ttl + Duration::from_secs(1));
 
         let admission_victim =
             pick_displacement_victim(&hosted, 1).expect("a zero-sub incumbent is displaceable");
 
-        let evicted = cache.sweep_expired(&subs_of, CachePressure::AtCapacity);
+        let evicted = cache.sweep_expired(counts_of, CachePressure::AtCapacity);
         assert_eq!(
             evicted.len(),
             1,
             "budget 350 sheds exactly one of four 100B entries"
         );
-        let cache_victim = evicted[0].0;
+        let cache_victim = evicted[0].key;
 
         assert_eq!(
             admission_victim, cache_victim,

--- a/crates/core/src/ring/hosting/cache.rs
+++ b/crates/core/src/ring/hosting/cache.rs
@@ -11,21 +11,26 @@
 //! 1. **Single source of truth**: All hosted contracts are tracked in one cache
 //! 2. **Subscriber-primary eviction** (freenet/freenet-core#4642, subscriber-
 //!    primary rework): when over budget the eviction victim is chosen by
-//!    ascending `(subscriber_count, last_get_seq, key_bytes)` — the
-//!    FEWEST-subscriber contract first, ties broken by least-recent **real GET
-//!    read**, then a deterministic key-byte tiebreak. `subscriber_count` is
-//!    supplied by the caller (`HostingManager`) via the same closure that used
-//!    to be `should_retain`; it is the count of genuine demand (local client
-//!    subscriptions + downstream subscribers) and is `0` exactly when the
-//!    contract is NOT `contract_in_use`. In NORMAL over-budget operation
-//!    ([`MemoryPressure::AtCapacity`]) any subscribed contract (count >= 1) is
-//!    PINNED — only zero-subscriber contracts are evicted, so among the
-//!    candidate set `subscriber_count` is always 0 and the order reduces to
-//!    least-recent-GET. The subscriber-count gradation only bites at ADMISSION
-//!    (a later PR) and under the OOM valve ([`MemoryPressure::Overflow`]), where
-//!    the pin is pierced and the fewest-subscriber contract is shed to survive
-//!    genuine RAM overflow. `min_ttl` is preserved as the cold-start grace floor
-//!    for fresh zero-subscriber contracts.
+//!    ascending `(local_subscription_count, downstream_subscriber_count,
+//!    last_get_seq, key_bytes)` — the FEWEST-subscriber contract first (local
+//!    subscriptions weighed ahead of downstream), ties broken by least-recent
+//!    **real GET read**, then a deterministic key-byte tiebreak. The split
+//!    `(local, downstream)` counts are supplied by the caller (`HostingManager`)
+//!    via the same closure that used to be `should_retain`; they count genuine
+//!    demand (local client subscriptions + downstream subscribers) and sum to
+//!    `0` exactly when the contract is NOT `contract_in_use`. Subscriber count
+//!    is the ORDERING, NOT a hard pin: under NORMAL over-budget operation
+//!    ([`MemoryPressure::AtCapacity`]) a subscribed contract is ordered LAST and
+//!    survives while any contract with fewer subscribers is eligible, but when
+//!    the peer is still over budget and nothing fewer-subscriber is eligible the
+//!    fewest-subscriber contract IS shed as a last resort — including a
+//!    subscribed one (its subscription state is then torn down; see
+//!    [`RecordAccessResult::evicted_in_use_teardown`]). This is the change from
+//!    the shipped #4720 code, which hard-pinned every subscribed contract. The
+//!    OOM valve ([`MemoryPressure::Overflow`], trigger unwired) adds only one
+//!    extra power on top: it ALSO pierces the `min_ttl` cold-start floor.
+//!    `min_ttl` is preserved as the cold-start grace floor for fresh
+//!    zero-subscriber contracts.
 //! 3. **Subscription renewal**: All hosted contracts get subscription renewal
 //! 4. **Access type tracking**: Records how contract was accessed (GET/PUT/SUBSCRIBE)
 //!
@@ -49,6 +54,7 @@ use std::time::Duration;
 use tokio::time::Instant;
 
 use super::demand::NEUTRAL_DEMAND;
+use crate::ring::interest::PeerKey;
 use crate::util::time_source::TimeSource;
 use crate::wasm_runtime::read_total_ram_bytes;
 
@@ -238,13 +244,13 @@ pub(crate) struct HostingContractScore {
     /// eviction recency tiebreak (subscriber-primary rework, #4642). The cache
     /// orders zero-subscriber eviction candidates ascending by this.
     pub last_get_seq: u64,
-    /// Whether this entry is past its `min_ttl` age gate — the TTL half of the
-    /// `evict_over_budget` eviction filter (`age >= min_ttl && !should_retain`).
-    /// This is the only half the cache can decide on its own; the
-    /// `!should_retain` (in-use) half is folded in by the `HostingManager`
-    /// layer via [`super::HostingManager::is_eviction_eligible`]. Used by the
-    /// dashboard so the "next to evict" badge only marks a contract the
-    /// over-budget sweep would actually consider — never one it would skip.
+    /// Whether this entry is past its `min_ttl` age gate. Under normal
+    /// (`AtCapacity`) pressure this is the WHOLE eviction-eligibility filter
+    /// (`age >= min_ttl`): subscriber count no longer gates eligibility — a
+    /// subscribed contract is still eligible, just ordered LAST, and shed only
+    /// as a last resort (the change from the shipped #4720 `!should_retain`
+    /// hard pin). Used by the dashboard so the "next to evict" badge marks
+    /// contracts the over-budget sweep would actually consider.
     pub past_min_ttl: bool,
 }
 
@@ -360,6 +366,18 @@ pub struct RecordAccessResult {
     /// the shipped #4720 code carried). Captured atomically with the
     /// eviction decision to avoid a racy post-hoc `contract_in_use` re-read.
     pub evicted_in_use: Vec<ContractKey>,
+    /// The subscription state that `HostingManager::teardown_evicted_in_use_contract`
+    /// actually removed for each [`Self::evicted_in_use`] victim (one entry per
+    /// key). Populated by the `HostingManager` AFTER `evicted_in_use` drives the
+    /// teardown (empty at the cache layer, which decides the eviction but does
+    /// not own the subscription maps or the peer identities). The eviction
+    /// CONSUMER replays these removals against the `InterestManager` (which
+    /// lives on `OpManager`, not `HostingManager`) via
+    /// [`InterestManager::remove_evicted_in_use`](crate::ring::interest::InterestManager::remove_evicted_in_use)
+    /// so no ghost `interested_peers` / `peer_contracts` / `local_client_count`
+    /// entry survives to mis-target UPDATE broadcasts or inflate upstream
+    /// interest counts (PR #4734 Fix 1).
+    pub evicted_in_use_teardown: Vec<EvictedInUseTeardown>,
     /// Observed read-rate training sample (reads/second) for the accessed
     /// contract, or `None` when no meaningful rate is available (a seed/PUT, a
     /// brand-new entry, or a read with zero residency). `HostingManager` pairs
@@ -367,6 +385,28 @@ pub struct RecordAccessResult {
     /// prior (`super::demand::ProximityPrior`). Purely a training signal — it
     /// never affects THIS access's `keep_score`.
     pub observed_read_rate: Option<f64>,
+}
+
+/// The subscription state `HostingManager::teardown_evicted_in_use_contract`
+/// removed from the hosting maps for a single subscriber-primary eviction that
+/// shed a still-in-use contract. Carries exactly what the eviction consumer
+/// needs to replay against the `InterestManager` (per-peer downstream removals +
+/// a per-contract local-client count) so the two managers stay in sync. See
+/// [`RecordAccessResult::evicted_in_use_teardown`] and
+/// [`InterestManager::remove_evicted_in_use`](crate::ring::interest::InterestManager::remove_evicted_in_use).
+#[derive(Debug, Clone)]
+pub struct EvictedInUseTeardown {
+    /// The evicted contract.
+    pub key: ContractKey,
+    /// Downstream peer leases removed from `downstream_subscribers[key]`. The
+    /// consumer replays `remove_peer_interest(&key, peer)` +
+    /// `remove_downstream_subscriber(&key)` per peer (the
+    /// `handle_unsubscribe_inbound` pair).
+    pub downstream_peers: Vec<PeerKey>,
+    /// Number of local WebSocket client subscriptions removed from
+    /// `client_subscriptions[key.id()]`. The consumer replays
+    /// `remove_local_client(&key)` once per client (the client-disconnect path).
+    pub local_client_count: usize,
 }
 
 /// A single contract evicted by the over-budget sweep, with the metadata the
@@ -764,6 +804,18 @@ impl<T: TimeSource> HostingCache<T> {
                 let (local, downstream) = subscriber_counts(key);
                 let eligible = match pressure {
                     MemoryPressure::AtCapacity => {
+                        // KNOWN OPEN ITEM (pending Ian's decision — do NOT change
+                        // this gate without it): `min_ttl` is applied BEFORE the
+                        // subscriber-primary ordering, so a fresh zero-subscriber
+                        // contract still inside `min_ttl` is INELIGIBLE and thus
+                        // outranks (survives over) an older LOCAL-subscribed
+                        // contract that is past `min_ttl` — the cold-start floor
+                        // wins over subscriber count in that corner. Whether
+                        // subscriber-primary should override `min_ttl` (evict the
+                        // fresh zero-sub contract to keep the local-subscribed one)
+                        // is undecided. See `.claude/rules/hosting-invariants.md`
+                        // (Resolved decisions: "`min_ttl` KEPT as the cold-start
+                        // floor").
                         let age = now.saturating_duration_since(entry.last_accessed);
                         age >= self.min_ttl
                     }
@@ -861,14 +913,19 @@ impl<T: TimeSource> HostingCache<T> {
     /// Eviction respects TTL: age-0 entries are not eligible for eviction
     /// while `min_ttl > 0` (the production default — i.e. the new entry
     /// just inserted by this call cannot be evicted by the same call).
-    /// It also honors `subscriber_count`: a contract with `subscriber_count(key)
-    /// >= 1` (an active client subscription or downstream subscriber) is PINNED
-    /// and never evicted under normal ([`MemoryPressure::AtCapacity`]) pressure,
-    /// even past TTL. Evicting an in-use contract would orphan its on-disk state
-    /// — the caller skips disk reclamation for it, but the contract is then gone
-    /// from the cache and never revisited. (Only the OOM valve, wired via
-    /// `sweep_expired` under [`MemoryPressure::Overflow`], may pierce this pin;
-    /// a fresh insert always uses `AtCapacity`.)
+    /// Subscriber count ORDERS victims, it does not pin them: a contract with
+    /// `subscriber_count(key) >= 1` (an active client subscription or downstream
+    /// subscriber) is evicted LAST and survives while any contract with fewer
+    /// subscribers is eligible, but when the cache is still over budget past TTL
+    /// and nothing fewer-subscriber is eligible, the fewest-subscriber contract
+    /// IS shed as a last resort — even a subscribed one. When that happens the
+    /// returned `EvictedContract::was_in_use` flag is set so the caller tears
+    /// down the subscription state and reclaims the on-disk state (see
+    /// `HostingManager::teardown_evicted_in_use_contract`). This is the change
+    /// from the shipped #4720 code, which hard-pinned subscribed contracts. The
+    /// OOM valve ([`MemoryPressure::Overflow`], trigger unwired) adds only one
+    /// extra power: it ALSO pierces `min_ttl`; a fresh insert always uses
+    /// `AtCapacity`.
     ///
     /// `write_generation` is the current state-write generation for this
     /// contract (from `HostingManager::state_generation`). It is stored on
@@ -988,6 +1045,9 @@ impl<T: TimeSource> HostingCache<T> {
                 is_new: false,
                 evicted: Vec::new(),
                 evicted_in_use: Vec::new(),
+                // Filled by `HostingManager::record_contract_access` after the
+                // teardown loop; empty here (refresh path evicts nothing).
+                evicted_in_use_teardown: Vec::new(),
                 observed_read_rate,
             }
         } else {
@@ -1042,7 +1102,10 @@ impl<T: TimeSource> HostingCache<T> {
                 is_new: true,
                 evicted,
                 evicted_in_use,
-                // Brand-new entry has zero residency -> no rate sample yet.
+                // Filled by `HostingManager::record_contract_access` from the
+                // teardown loop (this layer knows WHICH keys are in-use but not
+                // the peer identities / client counts the manager tears down).
+                evicted_in_use_teardown: Vec::new(),
                 observed_read_rate: None,
             }
         }
@@ -1833,7 +1896,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sweep_respects_should_retain() {
+    fn test_sweep_orders_subscribed_last() {
         let (mut cache, time) = make_cache(200, Duration::from_secs(60));
         let key1 = make_key(1);
         let key2 = make_key(2);
@@ -1862,11 +1925,13 @@ mod tests {
         assert_eq!(cache.current_bytes(), 200);
     }
 
-    /// `record_access` must honor `should_retain`: an over-budget, past-TTL
-    /// entry whose `should_retain` returns true is NOT evicted; an
-    /// unretained past-TTL entry IS evicted.
+    /// `record_access` orders subscribed contracts LAST: over budget past TTL,
+    /// the subscribed entry survives while a zero-subscriber past-TTL entry is
+    /// shed instead (one eviction is enough to get back under budget). It is NOT
+    /// a hard pin — see `evict_all_subscribed_sheds_fewest_as_last_resort` for
+    /// the last-resort shed when EVERY contract is subscribed.
     #[test]
-    fn test_record_access_respects_should_retain() {
+    fn test_record_access_orders_subscribed_last() {
         let (mut cache, time) = make_cache(200, Duration::from_secs(60));
         let retained = make_key(1);
         let evictable = make_key(2);

--- a/crates/core/src/ring/hosting/cache.rs
+++ b/crates/core/src/ring/hosting/cache.rs
@@ -199,6 +199,19 @@ pub(crate) struct HostingCacheStats {
     /// stays 0 in the field today; once the RSS trigger is plumbed, a nonzero
     /// differenced rate is the alarm that the node is shedding to avoid OOM.
     pub oom_valve_evictions_total: u64,
+    /// Monotonic count of over-budget evictions whose victim still had ≥1
+    /// subscriber (local client OR downstream peer) at eviction-decision time —
+    /// i.e. a SUBSCRIBED contract shed by the subscriber-primary ordering
+    /// (#4642, invariant 3). Counted by the captured `(local + downstream)`
+    /// count, regardless of pressure, so it covers BOTH the normal AtCapacity
+    /// last-resort shed (nothing zero-subscriber eligible) AND the Overflow
+    /// valve. This is the FIELD FALSIFIER for the single riskiest new behavior
+    /// in the subscriber-primary rework: shedding a subscribed contract. Unlike
+    /// [`Self::oom_valve_evictions_total`] (which stays 0 until the Overflow
+    /// trigger is wired), this can go nonzero the moment the eviction rework
+    /// ships, so a rising differenced rate here is the signal to check whether
+    /// budgets are too tight / demand is churning subscribed contracts.
+    pub subscribed_evictions_total: u64,
 }
 
 /// Per-contract Greedy-Dual priority row for the local-peer dashboard.
@@ -265,53 +278,57 @@ pub enum AccessType {
 
 /// Coarse memory-pressure state handed to the over-budget eviction sweep — the
 /// eviction half of invariant 3 ("admission and eviction are ONE demand-vs-
-/// capacity decision"). Mirrors the shape of the admission core's
-/// `MemoryPressure` (a later PR); kept minimal here because the eviction sweep
-/// only runs once the byte budget is already exceeded, so it only needs to
-/// distinguish "at capacity" from "genuine RAM overflow".
+/// capacity decision"). Kept minimal because the eviction sweep only runs once
+/// the byte budget is already exceeded, so it only needs to distinguish "at
+/// capacity" from "genuine RAM overflow".
 ///
-/// # The OOM-valve trigger is intentionally UNWIRED in production
+/// # There is ONE eviction ordering; the two variants only differ on `min_ttl`
 ///
-/// [`Self::Overflow`] is the ONLY value that lets eviction pierce the in-use
-/// pin (shed a subscribed contract). It is a genuine-RAM-overflow signal
-/// (RSS near the ceiling), which is NOT plumbed yet: production callers
-/// (`HostingManager::sweep_expired_hosting`, `record_contract_access`) pass
-/// [`Self::AtCapacity`] unconditionally, so **nothing can shed a subscribed
-/// contract in the field yet**. The valve MECHANISM lands + is unit-tested
-/// here; wiring the real RSS/A1-resource trigger is a deliberately separate,
-/// separately-validated step, because shedding a subscribed contract is the
-/// single riskiest new behavior in the subscriber-primary rework (#4642).
+/// Since the subscriber-primary eviction rework (#4642, Ian's confirmed model)
+/// BOTH variants shed the fewest-`(local, downstream)`-subscriber contract using
+/// the same [`victim_order`] — a subscribed contract is NOT hard-pinned under
+/// either. The only difference is eligibility:
+///
+/// - [`Self::AtCapacity`] evicts past-`min_ttl` entries (subscribed contracts
+///   ordered last, shed as a last resort). This is what production passes.
+/// - [`Self::Overflow`] ALSO pierces the `min_ttl` cold-start floor, so a node at
+///   genuine RAM-overflow can shed even fresh contracts to survive. This is "a
+///   corner of the same eviction, not a separate valve" (hosting-invariants
+///   Resolved decisions); it is NOT a second ranking.
+///
+/// The `Overflow` (min_ttl-pierce) TRIGGER is intentionally UNWIRED in
+/// production: it needs a genuine RSS/A1 resource signal, which is NOT plumbed.
+/// Production callers (`HostingManager::sweep_expired_hosting`,
+/// `record_contract_access`) pass [`Self::AtCapacity`] unconditionally. Note
+/// that — unlike the shipped #4720 code — AtCapacity CAN now shed a subscribed
+/// contract (as a last resort), so shedding subscribed contracts is live in the
+/// field; only the `min_ttl` PIERCE remains gated behind the unwired trigger.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MemoryPressure {
-    /// Over the byte budget but not at genuine RAM-overflow risk. Subscribed
-    /// contracts (subscriber_count >= 1) stay PINNED; only zero-subscriber
-    /// contracts past `min_ttl` are evicted, by least-recent real GET. This is
-    /// the value production always passes today (the Overflow trigger is
-    /// unwired — see the type docs).
+    /// Over the byte budget but not at genuine RAM-overflow risk. Past-`min_ttl`
+    /// entries are eligible; victims are chosen fewest-`(local, downstream)`-
+    /// subscriber first, so a subscribed contract is ordered LAST and shed only
+    /// as a last resort (when nothing with fewer subscribers is eligible and the
+    /// peer is still over budget). `min_ttl` still protects every fresh contract.
+    /// This is the value production always passes.
     AtCapacity,
-    /// Genuine RAM overflow: the OOM valve may shed the FEWEST-subscriber
-    /// contract, piercing the in-use pin AND bypassing `min_ttl`, to survive.
-    /// NOTHING produces this value in production yet.
+    /// Genuine RAM overflow: the same fewest-subscriber ordering, but ALSO
+    /// pierces the `min_ttl` cold-start floor so a fresh contract can be shed to
+    /// survive OOM. NOTHING produces this value in production yet.
     ///
-    /// `dead_code`-allowed in non-test builds ON PURPOSE: the OOM-valve trigger
-    /// (a genuine RSS/A1 resource signal) is intentionally unwired for this PR,
-    /// so only the valve-mechanism unit tests construct `Overflow`. Remove the
-    /// allow when the trigger is plumbed in a later, separately-validated step.
+    /// `dead_code`-allowed in non-test builds ON PURPOSE: the min_ttl-pierce
+    /// trigger (a genuine RSS/A1 resource signal) is intentionally unwired, so
+    /// only the mechanism unit tests construct `Overflow`. Remove the allow when
+    /// the trigger is plumbed in a later, separately-validated step.
     ///
-    /// OWED when the trigger is wired (NOT done here — the mechanism is
-    /// deliberately unwired this release):
-    /// 1. **Rank the valve by the LEASE-FILTERED downstream count**
-    ///    (`HostingManager::downstream_subscriber_peers`, which drops leases
-    ///    older than `SUBSCRIPTION_LEASE_DURATION`), NOT the unfiltered
-    ///    `subscriber_count` used for the normal-op pin. The unfiltered count
-    ///    includes stale-unswept leases, which is fine for the pin (it must equal
-    ///    `contract_in_use`) but would let the valve mis-rank "real demand" when
-    ///    it is actually shedding under overflow.
-    /// 2. **Clean up the shed contract's subscription state.** Valve-evicting a
-    ///    subscribed contract MUST also remove its `client_subscriptions` /
-    ///    `downstream_subscribers` entries, or `subscriber_count` immediately
-    ///    reports it in-use again and the eviction is undone in practice
-    ///    (the entry is gone from the cache but still pinned by phantom demand).
+    /// Subscription-state teardown for a shed subscribed contract is handled the
+    /// SAME way as the AtCapacity last-resort shed: the `was_in_use` flag on the
+    /// returned [`EvictedContract`] drives
+    /// `HostingManager::teardown_evicted_in_use_contract`, so a valve eviction is
+    /// not "undone in practice" by phantom demand. When the trigger is wired,
+    /// prefer ranking by the LEASE-FILTERED downstream count
+    /// (`HostingManager::downstream_subscriber_peers`) rather than the unfiltered
+    /// map length, so stale-unswept leases don't mis-rank real demand.
     #[cfg_attr(not(test), allow(dead_code))]
     Overflow,
 }
@@ -327,6 +344,22 @@ pub struct RecordAccessResult {
     /// deletion-time guard in `RuntimePool::remove_contract` can detect
     /// a re-host that occurred between eviction and disk reclamation.
     pub evicted: Vec<(ContractKey, u64)>,
+    /// Subset of [`Self::evicted`] whose victim still had ≥1 subscriber (a
+    /// local client subscription OR a downstream peer subscriber) at the
+    /// eviction-decision instant — i.e. `contract_in_use` was true for it.
+    ///
+    /// Under the subscriber-primary ordering (#4642, invariant 3) an
+    /// over-budget peer sheds the fewest-`(local, downstream)`-subscriber
+    /// contract, which — when nothing zero-subscriber is eligible — is a
+    /// SUBSCRIBED contract. The `HostingManager` MUST tear down that
+    /// contract's subscription state (see
+    /// `HostingManager::teardown_evicted_in_use_contract`) so
+    /// `contract_in_use` flips to false BEFORE `reclaim_evicted_contract`
+    /// runs; otherwise the reclaim gate skips the deletion forever and the
+    /// eviction frees the cache entry but not the on-disk state (the drift
+    /// the shipped #4720 code carried). Captured atomically with the
+    /// eviction decision to avoid a racy post-hoc `contract_in_use` re-read.
+    pub evicted_in_use: Vec<ContractKey>,
     /// Observed read-rate training sample (reads/second) for the accessed
     /// contract, or `None` when no meaningful rate is available (a seed/PUT, a
     /// brand-new entry, or a read with zero residency). `HostingManager` pairs
@@ -334,6 +367,25 @@ pub struct RecordAccessResult {
     /// prior (`super::demand::ProximityPrior`). Purely a training signal — it
     /// never affects THIS access's `keep_score`.
     pub observed_read_rate: Option<f64>,
+}
+
+/// A single contract evicted by the over-budget sweep, with the metadata the
+/// `HostingManager` needs to (a) drive disk reclamation and (b) — for a
+/// subscriber-primary eviction that shed a still-in-use contract — tear down
+/// the subscription state pinning it. See [`RecordAccessResult::evicted_in_use`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct EvictedContract {
+    /// The evicted contract's key.
+    pub key: ContractKey,
+    /// State-write generation snapshot captured atomically with the eviction
+    /// decision; carried through `EvictContract` for the deletion-time re-host
+    /// guard in `RuntimePool::remove_contract`.
+    pub write_generation: u64,
+    /// `true` iff the victim had ≥1 subscriber (local client OR downstream peer)
+    /// at eviction-decision time — the flag the manager keys its subscription
+    /// teardown on. Zero-subscriber evictions leave this `false` (nothing to
+    /// tear down; `contract_in_use` is already false for them).
+    pub was_in_use: bool,
 }
 
 /// Metadata about a hosted contract.
@@ -539,41 +591,61 @@ pub struct HostingCache<T: TimeSource> {
     /// and, once the RSS trigger is plumbed, becomes the alarm for how often the
     /// node is shedding to avoid OOM.
     oom_valve_evictions_total: u64,
+    /// Monotonic count of over-budget evictions whose victim was SUBSCRIBED
+    /// (`local + downstream >= 1`) at eviction-decision time — the field
+    /// falsifier for shedding a subscribed contract. Counted by the captured
+    /// subscriber count regardless of pressure (covers the normal AtCapacity
+    /// last-resort shed AND the Overflow valve). See
+    /// [`HostingCacheStats::subscribed_evictions_total`].
+    subscribed_evictions_total: u64,
     /// Time source for testability
     time_source: T,
 }
 
 /// The canonical eviction **victim ordering** (subscriber-primary, #4642).
 ///
-/// Given the three ranking components of two hosted-contract candidates —
-/// `subscriber_count`, `last_get_seq`, and the `ContractKey` — returns the
-/// [`Ordering`](std::cmp::Ordering) that sorts them ascending by
-/// `(subscriber_count, last_get_seq, key_bytes)`:
+/// Given the four ranking components of two hosted-contract candidates —
+/// `local_subscription_count`, `downstream_subscriber_count`, `last_get_seq`,
+/// and the `ContractKey` — returns the [`Ordering`](std::cmp::Ordering) that
+/// sorts them ascending by
+/// `(local_subscription_count, downstream_subscriber_count, last_get_seq, key_bytes)`:
 ///
-/// 1. fewest **subscribers** first (subscribed contracts are the last to be
-///    shed — genuine demand pins them),
-/// 2. ties broken by least-recent real **GET** (`last_get_seq`, a recency
-///    tiebreak — NOT the primary key),
-/// 3. then contract-key bytes as a final deterministic tiebreak.
+/// 1. fewest **local client subscriptions** first — a contract THIS node's own
+///    client is subscribed to is evicted LAST (Ian's confirmed ordering, #4642);
+/// 2. then fewest **downstream subscribers** (forwarded demand);
+/// 3. then least-recent real **GET** (`last_get_seq`, a recency tiebreak — NOT a
+///    primary key; subscription-renewal traffic must not refresh it);
+/// 4. then contract-key bytes as a final deterministic tiebreak.
 ///
-/// The candidate that sorts FIRST under this order is the one evicted first.
+/// The candidate that sorts FIRST under this order is the one evicted first. A
+/// locally-subscribed contract is ordered LAST but NOT absolutely pinned: in the
+/// extreme where every eligible contract carries a local subscription and the
+/// peer is still over budget, the least-recently-read local one IS the victim
+/// (accepted last resort — see [`HostingCache::evict_over_budget`] and
+/// hosting-invariants invariant 3).
 ///
 /// This is the single reusable entry point for eviction ranking:
-/// [`HostingCache::evict_over_budget`] sorts victims with it, and admission
-/// (#4717) plus any future disk-driven eviction (#4700's disk-eviction floor)
-/// MUST reuse it rather than forking a byte-only or distance-based order. Do
-/// NOT re-add distance to this key — its causal pull on demand already flows
-/// through `subscriber_count` via keyward routing gravity, and byte-only /
-/// distance-based eviction are the anti-patterns the hosting-invariants rule
-/// exists to keep out (see `.claude/rules/hosting-invariants.md`).
+/// [`HostingCache::evict_over_budget`] sorts victims with it. Do NOT re-add
+/// distance to this key — its causal pull on demand already flows through the
+/// subscriber counts via keyward routing gravity, and byte-only / distance-based
+/// eviction are the anti-patterns the hosting-invariants rule exists to keep out
+/// (see `.claude/rules/hosting-invariants.md`).
+///
+/// The inert admission core (#4717, not wired to production) reuses this ordering
+/// with `local_subscription_count` held at 0 — its model tracks only a single
+/// combined `subscriber_count`, and `(0, n, seq, key)` ordering reduces exactly
+/// to ordering by that combined count. That shim keeps ONE canonical ordering
+/// until admission is reconciled with the split model (or removed per the
+/// demand-driven-hosting model, which has no separate admission decision).
 pub(crate) fn victim_order(
-    a: (usize, u64, &ContractKey),
-    b: (usize, u64, &ContractKey),
+    a: (usize, usize, u64, &ContractKey),
+    b: (usize, usize, u64, &ContractKey),
 ) -> std::cmp::Ordering {
-    let (a_subs, a_seq, a_key) = a;
-    let (b_subs, b_seq, b_key) = b;
-    a_subs
-        .cmp(&b_subs)
+    let (a_local, a_down, a_seq, a_key) = a;
+    let (b_local, b_down, b_seq, b_key) = b;
+    a_local
+        .cmp(&b_local)
+        .then_with(|| a_down.cmp(&b_down))
         .then_with(|| a_seq.cmp(&b_seq))
         .then_with(|| a_key.as_bytes().cmp(b_key.as_bytes()))
 }
@@ -593,6 +665,7 @@ impl<T: TimeSource> HostingCache<T> {
             evicted_unread_total: 0,
             evicted_unread_age_secs_sum: 0,
             oom_valve_evictions_total: 0,
+            subscribed_evictions_total: 0,
             time_source,
         }
     }
@@ -605,46 +678,59 @@ impl<T: TimeSource> HostingCache<T> {
     }
 
     /// Evict contracts while the cache is over budget, choosing victims
-    /// **subscriber-primary**: ascending `(subscriber_count, last_get_seq,
-    /// key_bytes)` — fewest subscribers first, then least-recent real GET, then
-    /// a deterministic key-byte tiebreak (#4642 subscriber-primary rework).
+    /// **subscriber-primary**: ascending `(local_subscription_count,
+    /// downstream_subscriber_count, last_get_seq, key_bytes)` — fewest LOCAL
+    /// client subscriptions first, then fewest downstream subscribers, then
+    /// least-recent real GET, then a deterministic key-byte tiebreak (#4642
+    /// subscriber-primary rework; Ian's confirmed ordering).
     ///
-    /// `subscriber_count(key)` is the caller's genuine-demand count (local
-    /// client subscriptions + downstream subscribers); it is `0` exactly when
-    /// the contract is NOT `contract_in_use`. Candidate eligibility depends on
-    /// `pressure`:
+    /// `subscriber_counts(key)` is the caller's genuine-demand split
+    /// `(local_client_subscriptions, downstream_subscribers)`; their sum is `0`
+    /// exactly when the contract is NOT `contract_in_use`. Candidate eligibility
+    /// depends on `pressure`:
     ///
-    /// - [`MemoryPressure::AtCapacity`] (the production value today): an entry
-    ///   is eligible iff `age >= min_ttl` AND `subscriber_count(key) == 0`.
-    ///   Subscribed contracts are PINNED and never evicted; the `min_ttl` floor
-    ///   gives fresh zero-subscriber contracts cold-start grace. Among the
-    ///   eligible (all zero-subscriber) entries the order reduces to least-
-    ///   recent real GET.
-    /// - [`MemoryPressure::Overflow`] (the OOM valve — trigger UNWIRED in
-    ///   production, see [`MemoryPressure`]): ALL entries are eligible; the pin
-    ///   and `min_ttl` are BOTH pierced, and the fewest-subscriber (then least-
-    ///   recent-GET) contract is shed to survive genuine RAM overflow. Shedding
-    ///   a subscribed contract increments [`Self::oom_valve_evictions_total`].
+    /// - [`MemoryPressure::AtCapacity`] (the production value): an entry is
+    ///   eligible iff `age >= min_ttl`. Subscriber count is NOT a filter — it is
+    ///   the ORDERING. A subscribed contract is therefore ordered LAST (behind
+    ///   every zero-subscriber candidate) but is NOT hard-pinned: when nothing
+    ///   with fewer subscribers is eligible and the peer is still over budget,
+    ///   the fewest-`(local, downstream)` subscribed contract IS evicted (the
+    ///   accepted last resort). The `min_ttl` floor still gives every fresh
+    ///   contract cold-start grace. This is the change from the shipped #4720
+    ///   code, which hard-filtered `subs == 0` (a hard pin) and so could never
+    ///   shed a subscribed contract in the field.
+    /// - [`MemoryPressure::Overflow`] (genuine-RAM-overflow corner — trigger
+    ///   UNWIRED in production, see [`MemoryPressure`]): ALL entries are
+    ///   eligible; `min_ttl` is ALSO pierced (its only remaining special power
+    ///   now that AtCapacity already sheds subscribed contracts), so the
+    ///   fewest-subscriber contract is shed even within its cold-start floor to
+    ///   survive OOM. Not a separate ranking — the SAME `victim_order` — just a
+    ///   wider eligibility set (hosting-invariants: "a corner of the same
+    ///   eviction, not a separate valve").
+    ///
+    /// Any eviction whose victim was subscribed (`local + downstream >= 1` at
+    /// decision time) increments [`Self::subscribed_evictions_total`] (the field
+    /// falsifier) and is flagged `was_in_use` in the returned [`EvictedContract`]
+    /// so the manager tears down its subscription state. Overflow-pressure
+    /// evictions additionally increment [`Self::oom_valve_evictions_total`].
     ///
     /// Eviction stops as soon as `current_bytes <= budget_bytes`. Returns the
-    /// evicted `(key, write_generation)` pairs; the generation is captured
-    /// atomically under the cache's write lock so the `EvictContract`
-    /// deletion-time guard can detect a re-host that races with this eviction
-    /// (see `RuntimePool::remove_contract`).
+    /// evicted contracts; the generation is captured atomically under the cache's
+    /// write lock so the `EvictContract` deletion-time guard can detect a re-host
+    /// that races with this eviction (see `RuntimePool::remove_contract`).
     ///
     /// do NOT revert to byte-only / recency-only LRU as the PRIMARY key — see
     /// hosting-invariants (byte-only eviction anti-pattern). Subscriber count is
     /// the demand-authorization signal: a subscribed contract is real demand and
-    /// must be pinned in normal operation (only the OOM valve may pierce it).
-    /// Real-GET recency is a SECONDARY tiebreak among equal-subscriber
-    /// contracts, not the primary key.
+    /// is shed only as a last resort. Real-GET recency is a tiebreak among
+    /// equal-subscriber contracts, not the primary key.
     fn evict_over_budget<G>(
         &mut self,
-        subscriber_count: &G,
+        subscriber_counts: &G,
         pressure: MemoryPressure,
-    ) -> Vec<(ContractKey, u64)>
+    ) -> Vec<EvictedContract>
     where
-        G: Fn(&ContractKey) -> usize,
+        G: Fn(&ContractKey) -> (usize, usize),
     {
         if self.current_bytes <= self.budget_bytes {
             return Vec::new();
@@ -658,57 +744,67 @@ impl<T: TimeSource> HostingCache<T> {
         // and this only runs when actually over budget.
         //
         // Eligibility by pressure:
-        // - AtCapacity: past-TTL AND zero-subscriber (subscribed = pinned).
-        // - Overflow (OOM valve): every entry — pierce the in-use pin AND
-        //   bypass min_ttl to survive genuine RAM overflow.
+        // - AtCapacity: past-TTL only. Subscriber count is the ORDERING, not a
+        //   filter — a subscribed contract is ordered last but still eligible, so
+        //   it is shed as a last resort when nothing zero-subscriber is eligible.
+        // - Overflow (genuine-overflow corner): every entry — ALSO pierce
+        //   `min_ttl` to survive genuine RAM overflow.
         //
-        // `subscriber_count(key)` reads the unlocked subscription DashMaps, so it
-        // is evaluated EXACTLY ONCE per entry here and reused for both the filter
-        // decision and the sort key. Reading it twice (once to filter, once to
-        // build the sort key) would open a TOCTOU window: a subscription
-        // registered between the two reads could make an entry that passed the
-        // `== 0` AtCapacity filter carry `subs >= 1` in the sort key. (The valve
-        // counter is separately made airtight below by gating on `pressure`.)
-        let mut candidates: Vec<(ContractKey, usize, u64)> = self
+        // `subscriber_counts(key)` reads the unlocked subscription DashMaps, so
+        // it is evaluated EXACTLY ONCE per entry here and reused for both the
+        // eligibility (min_ttl) decision and the (local, downstream) sort key.
+        // Evaluating it once also fixes the captured `was_in_use` flag atomically
+        // with the decision, so the manager's teardown targets exactly the
+        // contracts this sweep decided to shed while in use (no racy post-hoc
+        // `contract_in_use` re-read).
+        let mut candidates: Vec<(ContractKey, usize, usize, u64)> = self
             .contracts
             .iter()
             .filter_map(|(key, entry)| {
-                let subs = subscriber_count(key);
+                let (local, downstream) = subscriber_counts(key);
                 let eligible = match pressure {
                     MemoryPressure::AtCapacity => {
                         let age = now.saturating_duration_since(entry.last_accessed);
-                        age >= self.min_ttl && subs == 0
+                        age >= self.min_ttl
                     }
                     MemoryPressure::Overflow => true,
                 };
-                eligible.then_some((*key, subs, entry.last_get_seq))
+                eligible.then_some((*key, local, downstream, entry.last_get_seq))
             })
             .collect();
 
-        // Ascending by subscriber_count (fewest first), then by last_get_seq
-        // (least-recently real-GET first), then by contract-key bytes as a final
-        // deterministic tiebreak. Under AtCapacity every candidate has
-        // subscriber_count == 0, so the order reduces to real-GET recency.
-        // `victim_order` is the canonical ranking — admission and any future
-        // disk-driven eviction must reuse it rather than fork their own.
-        candidates.sort_by(|a, b| victim_order((a.1, a.2, &a.0), (b.1, b.2, &b.0)));
+        // Ascending by local subscriptions (fewest first), then downstream
+        // subscribers, then last_get_seq (least-recently real-GET first), then
+        // contract-key bytes as a final deterministic tiebreak. `victim_order`
+        // is the canonical ranking (Ian's confirmed ordering, #4642).
+        candidates.sort_by(|a, b| victim_order((a.1, a.2, a.3, &a.0), (b.1, b.2, b.3, &b.0)));
 
         let mut evicted = Vec::new();
-        for (key, _subs, _) in candidates {
+        for (key, local, downstream, _seq) in candidates {
             if self.current_bytes <= self.budget_bytes {
                 break; // back under budget, stop evicting
             }
             if let Some(entry) = self.contracts.remove(&key) {
+                let was_in_use = local + downstream > 0;
                 self.current_bytes = self.current_bytes.saturating_sub(entry.size_bytes);
                 self.budget_evictions_total = self.budget_evictions_total.saturating_add(1);
-                // Count OOM-valve evictions by PRESSURE, not by the entry's
-                // subscriber count. Gating on `pressure == Overflow` is airtight:
-                // it cannot be perturbed by a concurrent subscription change, so
-                // the "stays 0 in the field while the Overflow trigger is unwired"
-                // guarantee holds by construction. (Under Overflow the sweep sheds
-                // fewest-subscriber-first, so these evictions MAY be subscribed
-                // contracts — the valve piercing the in-use pin — which is exactly
-                // the riskiest behavior this counter exists to surface.)
+                // Field falsifier for the single riskiest new behavior: shedding a
+                // subscribed contract. Counted by the captured subscriber split
+                // (not by pressure), so it covers the normal AtCapacity last-resort
+                // shed AND the Overflow valve. The `was_in_use` flag on the
+                // returned tuple drives the manager's subscription teardown.
+                if was_in_use {
+                    self.subscribed_evictions_total =
+                        self.subscribed_evictions_total.saturating_add(1);
+                }
+                // Count OOM-valve evictions by PRESSURE (any eviction under
+                // Overflow), not by the victim's subscriber count. Gating on
+                // `pressure == Overflow` is airtight: it cannot be perturbed by a
+                // concurrent subscription change, so the "stays 0 in the field
+                // while the Overflow trigger is unwired" guarantee holds by
+                // construction. (Overflow's only remaining special power is
+                // piercing `min_ttl`; AtCapacity already sheds subscribed
+                // contracts, tracked by `subscribed_evictions_total` above.)
                 if matches!(pressure, MemoryPressure::Overflow) {
                     self.oom_valve_evictions_total =
                         self.oom_valve_evictions_total.saturating_add(1);
@@ -739,7 +835,11 @@ impl<T: TimeSource> HostingCache<T> {
                 if entry.keep_score > self.eviction_floor {
                     self.eviction_floor = entry.keep_score;
                 }
-                evicted.push((key, entry.write_generation));
+                evicted.push(EvictedContract {
+                    key,
+                    write_generation: entry.write_generation,
+                    was_in_use,
+                });
             }
         }
 
@@ -787,10 +887,10 @@ impl<T: TimeSource> HostingCache<T> {
         size_bytes: u64,
         access_type: AccessType,
         write_generation: u64,
-        subscriber_count: G,
+        subscriber_counts: G,
     ) -> RecordAccessResult
     where
-        G: Fn(&ContractKey) -> usize,
+        G: Fn(&ContractKey) -> (usize, usize),
     {
         // Neutral demand: the demoted proximity-prior term (telemetry only). The
         // eviction order is subscriber-primary + real-GET recency regardless.
@@ -803,7 +903,7 @@ impl<T: TimeSource> HostingCache<T> {
             access_type,
             write_generation,
             NEUTRAL_DEMAND,
-            subscriber_count,
+            subscriber_counts,
         )
     }
 
@@ -833,10 +933,10 @@ impl<T: TimeSource> HostingCache<T> {
         access_type: AccessType,
         write_generation: u64,
         predicted_demand: f64,
-        subscriber_count: G,
+        subscriber_counts: G,
     ) -> RecordAccessResult
     where
-        G: Fn(&ContractKey) -> usize,
+        G: Fn(&ContractKey) -> (usize, usize),
     {
         let now = self.time_source.now();
         let seq = self.next_seq();
@@ -887,6 +987,7 @@ impl<T: TimeSource> HostingCache<T> {
             RecordAccessResult {
                 is_new: false,
                 evicted: Vec::new(),
+                evicted_in_use: Vec::new(),
                 observed_read_rate,
             }
         } else {
@@ -919,12 +1020,28 @@ impl<T: TimeSource> HostingCache<T> {
             self.current_bytes = self.current_bytes.saturating_add(size_bytes);
 
             // A fresh insert always evicts under AtCapacity: an insert never
-            // constitutes genuine RAM overflow, so it must not pierce the pin.
-            let evicted = self.evict_over_budget(&subscriber_count, MemoryPressure::AtCapacity);
+            // constitutes genuine RAM overflow, so it must not pierce `min_ttl`.
+            let evicted = self.evict_over_budget(&subscriber_counts, MemoryPressure::AtCapacity);
+
+            // Split into the (key, generation) reclaim list (unchanged external
+            // contract) and the in-use subset the manager must tear down. Under
+            // the subscriber-primary ordering a fresh insert CAN now shed a
+            // subscribed contract as a last resort, so `evicted_in_use` is no
+            // longer always empty here.
+            let evicted_in_use: Vec<ContractKey> = evicted
+                .iter()
+                .filter(|e| e.was_in_use)
+                .map(|e| e.key)
+                .collect();
+            let evicted = evicted
+                .into_iter()
+                .map(|e| (e.key, e.write_generation))
+                .collect();
 
             RecordAccessResult {
                 is_new: true,
                 evicted,
+                evicted_in_use,
                 // Brand-new entry has zero residency -> no rate sample yet.
                 observed_read_rate: None,
             }
@@ -1141,6 +1258,7 @@ impl<T: TimeSource> HostingCache<T> {
             current_bytes: self.current_bytes,
             contract_count: self.contracts.len() as u64,
             budget_evictions_total: self.budget_evictions_total,
+            subscribed_evictions_total: self.subscribed_evictions_total,
             evictions_of_recently_read_total: self.evictions_of_recently_read_total,
             evicted_unread_total: self.evicted_unread_total,
             evicted_unread_age_secs_sum: self.evicted_unread_age_secs_sum,
@@ -1218,32 +1336,35 @@ impl<T: TimeSource> HostingCache<T> {
     /// [`MemoryPressure`].
     ///
     /// Only evicts when `current_bytes > budget_bytes`. Victims are chosen
-    /// subscriber-primary — ascending `(subscriber_count, last_get_seq, key)` —
+    /// subscriber-primary — ascending
+    /// `(local_subscription_count, downstream_subscriber_count, last_get_seq, key)` —
     /// with eligibility governed by `pressure`:
-    /// - [`MemoryPressure::AtCapacity`]: past-TTL, zero-subscriber entries only
-    ///   (subscribed contracts pinned). This is the production value today.
-    /// - [`MemoryPressure::Overflow`]: the OOM valve — pierces the pin and
-    ///   `min_ttl` to shed the fewest-subscriber contract. The trigger is
-    ///   UNWIRED in production (see [`MemoryPressure`]).
+    /// - [`MemoryPressure::AtCapacity`] (production): past-TTL entries. Subscriber
+    ///   count is the ORDERING, not a filter — a subscribed contract is ordered
+    ///   last but shed as a last resort when nothing zero-subscriber is eligible.
+    /// - [`MemoryPressure::Overflow`]: the genuine-overflow corner — ALSO pierces
+    ///   `min_ttl`. The trigger is UNWIRED in production (see [`MemoryPressure`]).
     ///
-    /// `subscriber_count(key)` is the caller's genuine-demand count (client
-    /// subscriptions + downstream subscribers), `0` iff not `contract_in_use`.
+    /// `subscriber_counts(key)` is the caller's genuine-demand split
+    /// `(local_client_subscriptions, downstream_subscribers)`; their sum is `0`
+    /// iff not `contract_in_use`.
     ///
-    /// Returns `(ContractKey, write_generation)` pairs for evicted contracts;
-    /// the generation snapshot is carried through `EvictContract` so the
-    /// deletion-time guard can detect a re-host race.
+    /// Returns [`EvictedContract`]s: each carries the write-generation snapshot
+    /// (carried through `EvictContract` for the deletion-time re-host guard) and
+    /// the `was_in_use` flag the manager keys its subscription teardown on.
     pub fn sweep_expired<G>(
         &mut self,
-        subscriber_count: G,
+        subscriber_counts: G,
         pressure: MemoryPressure,
-    ) -> Vec<(ContractKey, u64)>
+    ) -> Vec<EvictedContract>
     where
-        G: Fn(&ContractKey) -> usize,
+        G: Fn(&ContractKey) -> (usize, usize),
     {
         // Over-budget eviction logic is shared with `record_access` via
         // `evict_over_budget`: it returns early when under budget, then evicts
-        // subscriber-primary (fewest-subscriber, then least-recent real GET).
-        self.evict_over_budget(&subscriber_count, pressure)
+        // subscriber-primary (fewest local, then fewest downstream, then
+        // least-recent real GET).
+        self.evict_over_budget(&subscriber_counts, pressure)
     }
 
     /// Load a contract entry from persisted data during startup, using an
@@ -1421,29 +1542,49 @@ mod tests {
         (cache, time_source)
     }
 
+    /// Project the `(key, write_generation)` reclaim pairs out of a
+    /// `sweep_expired` result so the ordering/eviction assertions can compare
+    /// against a plain `Vec<(ContractKey, u64)>` (the `was_in_use` flag is
+    /// asserted separately where it matters).
+    fn evicted_pairs(evicted: &[EvictedContract]) -> Vec<(ContractKey, u64)> {
+        evicted
+            .iter()
+            .map(|e| (e.key, e.write_generation))
+            .collect()
+    }
+
     #[test]
-    fn victim_order_is_subscriber_then_get_recency_then_key() {
+    fn victim_order_is_local_then_downstream_then_get_recency_then_key() {
         use std::cmp::Ordering;
         let k1 = make_key(1);
         let k2 = make_key(2);
 
-        // 1. Fewer subscribers ranks FIRST (evicted first), even against a
-        //    more-recent GET and a smaller key on the other side.
+        // 1. Fewer LOCAL client subscriptions ranks FIRST (evicted first), even
+        //    against MORE downstream subscribers, a more-recent GET, and a smaller
+        //    key on the other side. A locally-subscribed contract is evicted LAST.
         assert_eq!(
-            victim_order((0, 999, &k2), (1, 0, &k1)),
+            victim_order((0, 99, 999, &k2), (1, 0, 0, &k1)),
             Ordering::Less,
-            "fewer subscribers must rank ahead of a more-recent GET / smaller key"
+            "fewer local subscriptions must rank ahead of everything else"
         );
 
-        // 2. Equal subscribers: least-recent real GET (smaller last_get_seq)
-        //    ranks first.
+        // 2. Equal local count: fewer DOWNSTREAM subscribers ranks first, even
+        //    against a more-recent GET / smaller key on the other side.
         assert_eq!(
-            victim_order((2, 5, &k1), (2, 6, &k2)),
+            victim_order((1, 0, 999, &k2), (1, 3, 0, &k1)),
             Ordering::Less,
-            "with equal subscribers, least-recent GET ranks first"
+            "with equal local count, fewer downstream subscribers ranks first"
         );
 
-        // 3. Equal subscribers AND GET recency: smaller key bytes break the tie
+        // 3. Equal local AND downstream: least-recent real GET (smaller
+        //    last_get_seq) ranks first.
+        assert_eq!(
+            victim_order((2, 2, 5, &k1), (2, 2, 6, &k2)),
+            Ordering::Less,
+            "with equal subscriber counts, least-recent GET ranks first"
+        );
+
+        // 4. Equal subscribers AND GET recency: smaller key bytes break the tie
         //    deterministically.
         let (small, large) = if k1.as_bytes() < k2.as_bytes() {
             (&k1, &k2)
@@ -1451,13 +1592,16 @@ mod tests {
             (&k2, &k1)
         };
         assert_eq!(
-            victim_order((3, 7, small), (3, 7, large)),
+            victim_order((3, 1, 7, small), (3, 1, 7, large)),
             Ordering::Less,
-            "equal subscribers + GET recency fall back to key-byte order"
+            "equal subscriber counts + GET recency fall back to key-byte order"
         );
 
         // Reflexive: identical ranking components compare Equal.
-        assert_eq!(victim_order((1, 1, &k1), (1, 1, &k1)), Ordering::Equal);
+        assert_eq!(
+            victim_order((1, 1, 1, &k1), (1, 1, 1, &k1)),
+            Ordering::Equal
+        );
     }
 
     #[test]
@@ -1474,7 +1618,7 @@ mod tests {
         let (mut cache, _) = make_cache(1000, Duration::from_secs(60));
         let key = make_key(1);
 
-        let result = cache.record_access(key, 100, AccessType::Get, 0, |_| 0);
+        let result = cache.record_access(key, 100, AccessType::Get, 0, |_| (0, 0));
 
         assert!(result.is_new);
         assert!(result.evicted.is_empty());
@@ -1493,12 +1637,12 @@ mod tests {
         let key = make_key(1);
 
         // First access
-        cache.record_access(key, 100, AccessType::Get, 0, |_| 0);
+        cache.record_access(key, 100, AccessType::Get, 0, |_| (0, 0));
         let first_access = cache.get(&key).unwrap().last_accessed;
 
         // Advance time and access again
         time.advance_time(Duration::from_secs(10));
-        cache.record_access(key, 100, AccessType::Put, 0, |_| 0);
+        cache.record_access(key, 100, AccessType::Put, 0, |_| (0, 0));
 
         // Should still be one contract, but updated
         assert_eq!(cache.len(), 1);
@@ -1518,15 +1662,15 @@ mod tests {
         let key3 = make_key(3);
 
         // Add two entries
-        cache.record_access(key1, 100, AccessType::Get, 0, |_| 0);
-        cache.record_access(key2, 100, AccessType::Get, 0, |_| 0);
+        cache.record_access(key1, 100, AccessType::Get, 0, |_| (0, 0));
+        cache.record_access(key2, 100, AccessType::Get, 0, |_| (0, 0));
         assert_eq!(cache.current_bytes(), 200);
 
         // Advance time by 30 seconds (under TTL)
         time.advance_time(Duration::from_secs(30));
 
         // Add third entry - should NOT evict because all entries under TTL
-        let result = cache.record_access(key3, 100, AccessType::Get, 0, |_| 0);
+        let result = cache.record_access(key3, 100, AccessType::Get, 0, |_| (0, 0));
         assert!(
             result.evicted.is_empty(),
             "Should not evict entries under TTL"
@@ -1550,14 +1694,14 @@ mod tests {
         let key3 = make_key(3);
 
         // Add two entries
-        cache.record_access(key1, 100, AccessType::Get, 0, |_| 0);
-        cache.record_access(key2, 100, AccessType::Get, 0, |_| 0);
+        cache.record_access(key1, 100, AccessType::Get, 0, |_| (0, 0));
+        cache.record_access(key2, 100, AccessType::Get, 0, |_| (0, 0));
 
         // Advance time past TTL
         time.advance_time(Duration::from_secs(61));
 
         // Add third entry - should evict key1 (oldest)
-        let result = cache.record_access(key3, 100, AccessType::Get, 0, |_| 0);
+        let result = cache.record_access(key3, 100, AccessType::Get, 0, |_| (0, 0));
         assert!(result.is_new);
         assert_eq!(result.evicted, vec![(key1, 0)]);
         assert_eq!(cache.len(), 2);
@@ -1574,12 +1718,12 @@ mod tests {
         let key3 = make_key(3);
 
         // Add two contracts
-        cache.record_access(key1, 100, AccessType::Get, 0, |_| 0);
-        cache.record_access(key2, 100, AccessType::Get, 0, |_| 0);
+        cache.record_access(key1, 100, AccessType::Get, 0, |_| (0, 0));
+        cache.record_access(key2, 100, AccessType::Get, 0, |_| (0, 0));
 
         // GET key1 again - a real GET refreshes the eviction recency position,
         // so it becomes the LAST eviction candidate; key2 is now first.
-        cache.record_access(key1, 100, AccessType::Get, 0, |_| 0);
+        cache.record_access(key1, 100, AccessType::Get, 0, |_| (0, 0));
 
         // Eviction order (least-worthy first) should now be [key2, key1]
         let order = cache.keys_eviction_order();
@@ -1587,7 +1731,7 @@ mod tests {
 
         // Advance past TTL and add key3 - should evict key2 (now oldest)
         time.advance_time(Duration::from_secs(61));
-        let result = cache.record_access(key3, 100, AccessType::Get, 0, |_| 0);
+        let result = cache.record_access(key3, 100, AccessType::Get, 0, |_| (0, 0));
 
         assert_eq!(result.evicted, vec![(key2, 0)]);
         assert!(cache.contains(&key1));
@@ -1603,8 +1747,8 @@ mod tests {
         let key3 = make_key(3);
 
         // Add two entries
-        cache.record_access(key1, 100, AccessType::Get, 0, |_| 0);
-        cache.record_access(key2, 100, AccessType::Get, 0, |_| 0);
+        cache.record_access(key1, 100, AccessType::Get, 0, |_| (0, 0));
+        cache.record_access(key2, 100, AccessType::Get, 0, |_| (0, 0));
 
         // Advance time by 50 seconds
         time.advance_time(Duration::from_secs(50));
@@ -1616,7 +1760,7 @@ mod tests {
         time.advance_time(Duration::from_secs(15));
 
         // Add key3 - should evict key2 (past TTL), NOT key1 (recently touched)
-        let result = cache.record_access(key3, 100, AccessType::Get, 0, |_| 0);
+        let result = cache.record_access(key3, 100, AccessType::Get, 0, |_| (0, 0));
 
         assert_eq!(
             result.evicted,
@@ -1640,16 +1784,16 @@ mod tests {
         let large = make_key(4);
 
         // Add three small contracts
-        cache.record_access(small1, 100, AccessType::Get, 0, |_| 0);
-        cache.record_access(small2, 100, AccessType::Get, 0, |_| 0);
-        cache.record_access(small3, 100, AccessType::Get, 0, |_| 0);
+        cache.record_access(small1, 100, AccessType::Get, 0, |_| (0, 0));
+        cache.record_access(small2, 100, AccessType::Get, 0, |_| (0, 0));
+        cache.record_access(small3, 100, AccessType::Get, 0, |_| (0, 0));
         assert_eq!(cache.current_bytes(), 300);
 
         // Advance past TTL
         time.advance_time(Duration::from_secs(61));
 
         // Add one large contract - should evict two small ones
-        let result = cache.record_access(large, 200, AccessType::Put, 0, |_| 0);
+        let result = cache.record_access(large, 200, AccessType::Put, 0, |_| (0, 0));
 
         assert_eq!(result.evicted.len(), 2);
         assert_eq!(result.evicted[0], (small1, 0)); // Oldest first
@@ -1668,14 +1812,14 @@ mod tests {
         let key3 = make_key(3);
 
         // Add three entries (exceeds budget)
-        cache.record_access(key1, 100, AccessType::Get, 0, |_| 0);
-        cache.record_access(key2, 100, AccessType::Get, 0, |_| 0);
-        cache.record_access(key3, 100, AccessType::Get, 0, |_| 0);
+        cache.record_access(key1, 100, AccessType::Get, 0, |_| (0, 0));
+        cache.record_access(key2, 100, AccessType::Get, 0, |_| (0, 0));
+        cache.record_access(key3, 100, AccessType::Get, 0, |_| (0, 0));
         assert_eq!(cache.len(), 3);
         assert_eq!(cache.current_bytes(), 300);
 
         // Sweep immediately - nothing should be evicted (all under TTL)
-        let evicted = cache.sweep_expired(|_| 0, MemoryPressure::AtCapacity);
+        let evicted = cache.sweep_expired(|_| (0, 0), MemoryPressure::AtCapacity);
         assert!(evicted.is_empty());
         assert_eq!(cache.len(), 3);
 
@@ -1683,8 +1827,8 @@ mod tests {
         time.advance_time(Duration::from_secs(61));
 
         // Sweep should evict oldest entry to get back under budget
-        let evicted = cache.sweep_expired(|_| 0, MemoryPressure::AtCapacity);
-        assert_eq!(evicted, vec![(key1, 0)]);
+        let evicted = cache.sweep_expired(|_| (0, 0), MemoryPressure::AtCapacity);
+        assert_eq!(evicted_pairs(&evicted), vec![(key1, 0)]);
         assert_eq!(cache.current_bytes(), 200);
     }
 
@@ -1696,18 +1840,22 @@ mod tests {
         let key3 = make_key(3);
 
         // Add three entries (exceeds budget)
-        cache.record_access(key1, 100, AccessType::Get, 0, |_| 0);
-        cache.record_access(key2, 100, AccessType::Get, 0, |_| 0);
-        cache.record_access(key3, 100, AccessType::Get, 0, |_| 0);
+        cache.record_access(key1, 100, AccessType::Get, 0, |_| (0, 0));
+        cache.record_access(key2, 100, AccessType::Get, 0, |_| (0, 0));
+        cache.record_access(key3, 100, AccessType::Get, 0, |_| (0, 0));
 
         // Advance past TTL
         time.advance_time(Duration::from_secs(61));
 
-        // Sweep with predicate that retains key1
-        let evicted = cache.sweep_expired(|k| (*k == key1) as usize, MemoryPressure::AtCapacity);
+        // Sweep with a subscriber count that makes key1 subscribed (downstream).
+        // Under subscriber-primary ordering it sorts LAST, so the zero-subscriber
+        // key2 is shed first — one eviction is enough to get back under budget, so
+        // key1 survives (ordered last, not hard-pinned).
+        let evicted =
+            cache.sweep_expired(|k| (0, (*k == key1) as usize), MemoryPressure::AtCapacity);
 
-        // key1 should be retained, key2 evicted to get under budget
-        assert_eq!(evicted, vec![(key2, 0)]);
+        // key1 (subscribed) survives, key2 (zero-subscriber) evicted to get under budget
+        assert_eq!(evicted_pairs(&evicted), vec![(key2, 0)]);
         assert!(cache.contains(&key1));
         assert!(!cache.contains(&key2));
         assert!(cache.contains(&key3));
@@ -1725,29 +1873,31 @@ mod tests {
         let trigger = make_key(3);
 
         // Fill the cache: `retained` (oldest) then `evictable`.
-        cache.record_access(retained, 100, AccessType::Get, 0, |_| 0);
-        cache.record_access(evictable, 100, AccessType::Get, 0, |_| 0);
+        cache.record_access(retained, 100, AccessType::Get, 0, |_| (0, 0));
+        cache.record_access(evictable, 100, AccessType::Get, 0, |_| (0, 0));
         assert_eq!(cache.current_bytes(), 200);
 
         // Advance past TTL so both existing entries are eviction-eligible.
         time.advance_time(Duration::from_secs(61));
 
         // Insert a third entry, over budget. `retained` is the oldest, so a
-        // naive LRU eviction would drop it first — but `should_retain`
-        // protects it, so `evictable` (next oldest) must be evicted instead.
+        // naive LRU eviction would drop it first — but it is subscribed
+        // (downstream), so under subscriber-primary ordering it sorts LAST and the
+        // zero-subscriber `evictable` is shed first. One eviction is enough, so
+        // `retained` survives (ordered last, not hard-pinned).
         let result = cache.record_access(trigger, 100, AccessType::Get, 0, |k| {
-            (*k == retained) as usize
+            (0, (*k == retained) as usize)
         });
 
         assert_eq!(
             result.evicted,
             vec![(evictable, 0)],
-            "in-use (retained) contract must be skipped; the unretained \
+            "the subscribed contract is ordered last; the zero-subscriber \
              past-TTL contract must be evicted instead"
         );
         assert!(
             cache.contains(&retained),
-            "retained contract must survive even past TTL and over budget"
+            "subscribed contract survives while a zero-subscriber one can be shed"
         );
         assert!(!cache.contains(&evictable));
         assert!(cache.contains(&trigger));
@@ -1762,13 +1912,13 @@ mod tests {
         let first = make_key(1);
         let second = make_key(2);
 
-        cache.record_access(first, 100, AccessType::Get, 0, |_| 0);
+        cache.record_access(first, 100, AccessType::Get, 0, |_| (0, 0));
         time.advance_time(Duration::from_secs(61));
 
         // Inserting `second` puts the cache over budget; `first` is past TTL
         // and unretained so it is evicted, but the just-inserted `second`
         // (age 0) must survive.
-        let result = cache.record_access(second, 100, AccessType::Get, 0, |_| 0);
+        let result = cache.record_access(second, 100, AccessType::Get, 0, |_| (0, 0));
         assert_eq!(result.evicted, vec![(first, 0)]);
         assert!(cache.contains(&second));
         assert!(!cache.contains(&first));
@@ -1793,13 +1943,13 @@ mod tests {
         let key = make_key(1);
 
         // Test each access type is recorded correctly
-        cache.record_access(key, 100, AccessType::Get, 0, |_| 0);
+        cache.record_access(key, 100, AccessType::Get, 0, |_| (0, 0));
         assert_eq!(cache.get(&key).unwrap().access_type, AccessType::Get);
 
-        cache.record_access(key, 100, AccessType::Put, 0, |_| 0);
+        cache.record_access(key, 100, AccessType::Put, 0, |_| (0, 0));
         assert_eq!(cache.get(&key).unwrap().access_type, AccessType::Put);
 
-        cache.record_access(key, 100, AccessType::Subscribe, 0, |_| 0);
+        cache.record_access(key, 100, AccessType::Subscribe, 0, |_| (0, 0));
         assert_eq!(cache.get(&key).unwrap().access_type, AccessType::Subscribe);
     }
 
@@ -1809,17 +1959,17 @@ mod tests {
         let key = make_key(1);
 
         // Add contract with initial size
-        cache.record_access(key, 100, AccessType::Get, 0, |_| 0);
+        cache.record_access(key, 100, AccessType::Get, 0, |_| (0, 0));
         assert_eq!(cache.current_bytes(), 100);
         assert_eq!(cache.get(&key).unwrap().size_bytes, 100);
 
         // Contract state grows
-        cache.record_access(key, 200, AccessType::Put, 0, |_| 0);
+        cache.record_access(key, 200, AccessType::Put, 0, |_| (0, 0));
         assert_eq!(cache.current_bytes(), 200);
         assert_eq!(cache.get(&key).unwrap().size_bytes, 200);
 
         // Contract state shrinks
-        cache.record_access(key, 150, AccessType::Put, 0, |_| 0);
+        cache.record_access(key, 150, AccessType::Put, 0, |_| (0, 0));
         assert_eq!(cache.current_bytes(), 150);
         assert_eq!(cache.get(&key).unwrap().size_bytes, 150);
     }
@@ -1835,9 +1985,9 @@ mod tests {
         let key2 = make_key(2);
         let key3 = make_key(3);
 
-        cache.record_access(key1, 100, AccessType::Get, 0, |_| 0);
-        cache.record_access(key2, 100, AccessType::Put, 0, |_| 0);
-        cache.record_access(key3, 100, AccessType::Subscribe, 0, |_| 0);
+        cache.record_access(key1, 100, AccessType::Get, 0, |_| (0, 0));
+        cache.record_access(key2, 100, AccessType::Put, 0, |_| (0, 0));
+        cache.record_access(key3, 100, AccessType::Subscribe, 0, |_| (0, 0));
 
         let keys: Vec<ContractKey> = cache.iter().collect();
         assert_eq!(keys.len(), 3);
@@ -1867,7 +2017,7 @@ mod tests {
             100,
             AccessType::Get,
             captured_generation,
-            |_| 0,
+            |_| (0, 0),
         );
         assert!(first.evicted.is_empty(), "first insert evicts nothing");
         assert_eq!(
@@ -1888,7 +2038,7 @@ mod tests {
             100,
             AccessType::Get,
             999, // trigger's own generation is irrelevant to the eviction
-            |_| 0,
+            |_| (0, 0),
         );
         assert_eq!(
             result.evicted,
@@ -1910,13 +2060,13 @@ mod tests {
         let (mut cache, _) = make_cache(1000, Duration::from_secs(60));
         let key = make_key(7);
 
-        cache.record_access(key, 100, AccessType::Get, 1, |_| 0);
+        cache.record_access(key, 100, AccessType::Get, 1, |_| (0, 0));
         assert_eq!(cache.get(&key).unwrap().write_generation, 1);
 
         // Refresh with a higher generation (simulates a state write that
         // bumped the generation between the original insert and a later
         // GET/PUT/SUBSCRIBE re-access).
-        cache.record_access(key, 100, AccessType::Put, 5, |_| 0);
+        cache.record_access(key, 100, AccessType::Put, 5, |_| (0, 0));
         assert_eq!(
             cache.get(&key).unwrap().write_generation,
             5,
@@ -1933,7 +2083,7 @@ mod tests {
         let (mut cache, time) = make_cache(10000, Duration::from_secs(60));
         let key = make_key(1);
 
-        cache.record_access(key, 100, AccessType::Get, 0, |_| 0);
+        cache.record_access(key, 100, AccessType::Get, 0, |_| (0, 0));
         cache.mark_local_client_access(&key);
 
         // Immediately after marking: recent access is true
@@ -1974,9 +2124,9 @@ mod tests {
         let key1 = make_key(1);
         let key2 = make_key(2);
         let key3 = make_key(3);
-        cache.record_access(key1, 111, AccessType::Get, 0, |_| 0);
-        cache.record_access(key2, 222, AccessType::Get, 0, |_| 0);
-        cache.record_access(key3, 333, AccessType::Get, 0, |_| 0);
+        cache.record_access(key1, 111, AccessType::Get, 0, |_| (0, 0));
+        cache.record_access(key2, 222, AccessType::Get, 0, |_| (0, 0));
+        cache.record_access(key3, 333, AccessType::Get, 0, |_| (0, 0));
 
         let scores = cache.eviction_ordered_scores();
         let score_keys: Vec<_> = scores.iter().map(|s| s.key).collect();
@@ -2011,7 +2161,7 @@ mod tests {
         let min_ttl = Duration::from_secs(60);
         let (mut cache, time_source) = make_cache(10_000, min_ttl);
         let key = make_key(1);
-        cache.record_access(key, 111, AccessType::Get, 0, |_| 0);
+        cache.record_access(key, 111, AccessType::Get, 0, |_| (0, 0));
 
         let before = cache.eviction_ordered_scores();
         assert!(
@@ -2044,9 +2194,9 @@ mod tests {
 
         // Equal (neutral) demand -> equal keep_score; eviction order is by
         // access sequence: key1, key2, key3.
-        cache.record_access(key1, 100, AccessType::Get, 0, |_| 0);
-        cache.record_access(key2, 100, AccessType::Get, 0, |_| 0);
-        cache.record_access(key3, 100, AccessType::Get, 0, |_| 0);
+        cache.record_access(key1, 100, AccessType::Get, 0, |_| (0, 0));
+        cache.record_access(key2, 100, AccessType::Get, 0, |_| (0, 0));
+        cache.record_access(key3, 100, AccessType::Get, 0, |_| (0, 0));
         assert_eq!(cache.keys_eviction_order(), vec![key1, key2, key3]);
 
         // Abandon key3 — the most recently used — and its keep_score drops to
@@ -2071,7 +2221,7 @@ mod tests {
     fn test_record_abandonment_is_idempotent() {
         let (mut cache, time) = make_cache(1000, Duration::from_secs(60));
         let key = make_key(1);
-        cache.record_access(key, 100, AccessType::Get, 0, |_| 0);
+        cache.record_access(key, 100, AccessType::Get, 0, |_| (0, 0));
 
         cache.record_abandonment(&key);
         let first = cache.get(&key).unwrap().abandoned_at;
@@ -2100,13 +2250,13 @@ mod tests {
     fn test_record_access_clears_abandoned_marker() {
         let (mut cache, _) = make_cache(1000, Duration::from_secs(60));
         let key = make_key(1);
-        cache.record_access(key, 100, AccessType::Get, 0, |_| 0);
+        cache.record_access(key, 100, AccessType::Get, 0, |_| (0, 0));
         cache.record_abandonment(&key);
         assert!(cache.get(&key).unwrap().abandoned_at.is_some());
 
         // Fresh access — a re-subscribe or re-GET — clears the marker
         // and returns the entry to the LRU tail.
-        cache.record_access(key, 100, AccessType::Get, 0, |_| 0);
+        cache.record_access(key, 100, AccessType::Get, 0, |_| (0, 0));
         assert!(
             cache.get(&key).unwrap().abandoned_at.is_none(),
             "record_access must clear abandoned_at"
@@ -2117,7 +2267,7 @@ mod tests {
     fn test_touch_clears_abandoned_marker() {
         let (mut cache, _) = make_cache(1000, Duration::from_secs(60));
         let key = make_key(1);
-        cache.record_access(key, 100, AccessType::Get, 0, |_| 0);
+        cache.record_access(key, 100, AccessType::Get, 0, |_| (0, 0));
         cache.record_abandonment(&key);
 
         cache.touch(&key);
@@ -2144,8 +2294,8 @@ mod tests {
         let key2 = make_key(2);
         let key3 = make_key(3);
 
-        cache.record_access(key1, 100, AccessType::Get, 0, |_| 0);
-        cache.record_access(key2, 100, AccessType::Get, 0, |_| 0);
+        cache.record_access(key1, 100, AccessType::Get, 0, |_| (0, 0));
+        cache.record_access(key2, 100, AccessType::Get, 0, |_| (0, 0));
 
         // key2 is abandoned (latest in use, just lost its subscribers).
         cache.record_abandonment(&key2);
@@ -2156,7 +2306,7 @@ mod tests {
         // Insert key3: now over budget, must evict one. The abandoned
         // bucket means key2 goes first, even though key1 is the older
         // entry by `last_accessed`.
-        let result = cache.record_access(key3, 100, AccessType::Get, 0, |_| 0);
+        let result = cache.record_access(key3, 100, AccessType::Get, 0, |_| (0, 0));
         assert!(result.is_new);
         assert_eq!(
             result.evicted,
@@ -2178,15 +2328,15 @@ mod tests {
         let key1 = make_key(1);
         let key2 = make_key(2);
 
-        cache.record_access(key1, 100, AccessType::Get, 0, |_| 0);
-        cache.record_access(key2, 100, AccessType::Get, 0, |_| 0);
+        cache.record_access(key1, 100, AccessType::Get, 0, |_| (0, 0));
+        cache.record_access(key2, 100, AccessType::Get, 0, |_| (0, 0));
 
         cache.record_abandonment(&key2);
         time.advance_time(Duration::from_secs(3600));
 
         // No budget pressure → sweep_expired evicts nothing, abandoned
         // or otherwise.
-        let evicted = cache.sweep_expired(|_| 0, MemoryPressure::AtCapacity);
+        let evicted = cache.sweep_expired(|_| (0, 0), MemoryPressure::AtCapacity);
         assert!(evicted.is_empty(), "no pressure → no eviction");
         assert!(cache.contains(&key1));
         assert!(cache.contains(&key2));
@@ -2264,12 +2414,12 @@ mod tests {
         let key2 = make_key(2);
         let key3 = make_key(3);
 
-        cache.record_access(key1, 100, AccessType::Get, 0, |_| 0);
-        cache.record_access(key2, 100, AccessType::Get, 0, |_| 0);
+        cache.record_access(key1, 100, AccessType::Get, 0, |_| (0, 0));
+        cache.record_access(key2, 100, AccessType::Get, 0, |_| (0, 0));
         assert_eq!(cache.stats().budget_evictions_total, 0);
 
         // Over budget but every entry is under TTL: no budget eviction yet.
-        cache.record_access(key3, 100, AccessType::Get, 0, |_| 0);
+        cache.record_access(key3, 100, AccessType::Get, 0, |_| (0, 0));
         assert_eq!(
             cache.stats().budget_evictions_total,
             0,
@@ -2278,7 +2428,7 @@ mod tests {
 
         // Past TTL: a sweep now evicts the single over-budget entry.
         time.advance_time(Duration::from_secs(61));
-        let evicted = cache.sweep_expired(|_| 0, MemoryPressure::AtCapacity);
+        let evicted = cache.sweep_expired(|_| (0, 0), MemoryPressure::AtCapacity);
         assert_eq!(
             evicted.len(),
             1,
@@ -2291,7 +2441,7 @@ mod tests {
         assert_eq!(stats.budget_bytes, 200);
 
         // No pressure now (at budget): the counter is unchanged.
-        let evicted = cache.sweep_expired(|_| 0, MemoryPressure::AtCapacity);
+        let evicted = cache.sweep_expired(|_| (0, 0), MemoryPressure::AtCapacity);
         assert!(evicted.is_empty(), "at budget -> no further eviction");
         assert_eq!(
             cache.stats().budget_evictions_total,
@@ -2314,13 +2464,13 @@ mod tests {
         let key3 = make_key(3);
 
         // Seed key1 via PUT (read_count == 0 — an unread seed).
-        cache.record_access(key1, 100, AccessType::Put, 0, |_| 0);
+        cache.record_access(key1, 100, AccessType::Put, 0, |_| (0, 0));
         assert_eq!(cache.stats().evicted_unread_total, 0);
 
         // Past TTL, insert key2 (also a seed). key1 is evicted: never read, so
         // it counts as an unread-seed eviction and its age (~61s) is recorded.
         time.advance_time(Duration::from_secs(61));
-        let result = cache.record_access(key2, 100, AccessType::Put, 0, |_| 0);
+        let result = cache.record_access(key2, 100, AccessType::Put, 0, |_| (0, 0));
         assert_eq!(result.evicted, vec![(key1, 0)]);
         let stats = cache.stats();
         assert_eq!(stats.budget_evictions_total, 1);
@@ -2331,13 +2481,13 @@ mod tests {
         );
 
         // Read key2 once (GET) so read_count == 1 — no longer an unread seed.
-        cache.record_access(key2, 100, AccessType::Get, 0, |_| 0);
+        cache.record_access(key2, 100, AccessType::Get, 0, |_| (0, 0));
 
         // Past TTL, insert key3 to evict key2. key2 was read once, so it is
         // neither an unread seed nor a recently-read (>=2) victim: the unread
         // counter and age sum both hold.
         time.advance_time(Duration::from_secs(61));
-        let result = cache.record_access(key3, 100, AccessType::Get, 0, |_| 0);
+        let result = cache.record_access(key3, 100, AccessType::Get, 0, |_| (0, 0));
         assert_eq!(result.evicted, vec![(key2, 0)]);
         let stats = cache.stats();
         assert_eq!(stats.budget_evictions_total, 2);
@@ -2377,7 +2527,7 @@ mod tests {
         // Advance past min_ttl so the reloaded entry is eviction-eligible, then a
         // fresh insert pushes over budget and sheds it (the post-load burst).
         time.advance_time(Duration::from_secs(61));
-        let result = cache.record_access(key2, 100, AccessType::Get, 0, |_| 0);
+        let result = cache.record_access(key2, 100, AccessType::Get, 0, |_| (0, 0));
         assert_eq!(
             result.evicted,
             vec![(key1, 0)],
@@ -2439,7 +2589,7 @@ mod tests {
 
         // A real GET after restart re-stamps it to a genuine (nonzero) value,
         // lifting it out of the never-GET-read front of the eviction order.
-        cache.record_access(put_seed, 100, AccessType::Get, 0, |_| 0);
+        cache.record_access(put_seed, 100, AccessType::Get, 0, |_| (0, 0));
         assert!(
             cache.get(&put_seed).unwrap().last_get_seq > 0,
             "a real GET after restart must re-stamp last_get_seq to a real value"
@@ -2458,13 +2608,13 @@ mod tests {
         let key = make_key(1);
 
         // Insert at floor 0 with demand 3.0 -> keep_score 3.0.
-        cache.record_access_with_demand(key, 100, AccessType::Get, 0, 3.0, |_| 0);
+        cache.record_access_with_demand(key, 100, AccessType::Get, 0, 3.0, |_| (0, 0));
         assert_eq!(cache.get(&key).unwrap().keep_score, 3.0);
         assert_eq!(cache.get(&key).unwrap().predicted_demand, 3.0);
         assert_eq!(cache.get(&key).unwrap().read_count, 1);
 
         // A read with a new demand estimate refreshes keep_score = floor + demand.
-        cache.record_access_with_demand(key, 100, AccessType::Get, 0, 5.0, |_| 0);
+        cache.record_access_with_demand(key, 100, AccessType::Get, 0, 5.0, |_| (0, 0));
         assert_eq!(cache.get(&key).unwrap().keep_score, 5.0);
         assert_eq!(cache.get(&key).unwrap().read_count, 2);
     }
@@ -2485,15 +2635,16 @@ mod tests {
 
         // `high` inserted first (older) with strong demand; `low` inserted after
         // with weak demand. A recency-only (LRU) policy would evict `high`.
-        cache.record_access_with_demand(high, 100, AccessType::Get, 0, 10.0, |_| 0);
-        cache.record_access_with_demand(low, 100, AccessType::Get, 0, 1.0, |_| 0);
+        cache.record_access_with_demand(high, 100, AccessType::Get, 0, 10.0, |_| (0, 0));
+        cache.record_access_with_demand(low, 100, AccessType::Get, 0, 1.0, |_| (0, 0));
         assert_eq!(cache.current_bytes(), 200);
 
         time.advance_time(Duration::from_secs(61));
 
         // Over-budget insert must evict the LOWEST keep_score (`low`), not the
         // oldest (`high`).
-        let result = cache.record_access_with_demand(trigger, 100, AccessType::Get, 0, 1.0, |_| 0);
+        let result =
+            cache.record_access_with_demand(trigger, 100, AccessType::Get, 0, 1.0, |_| (0, 0));
         assert_eq!(
             result.evicted,
             vec![(low, 0)],
@@ -2538,8 +2689,8 @@ mod tests {
         let trigger = make_key(3);
 
         // Insert both cold (zero samples), scored only by the distance prior.
-        cache.record_access_with_demand(near, 100, AccessType::Get, 0, near_demand, |_| 0);
-        cache.record_access_with_demand(far, 100, AccessType::Get, 0, far_demand, |_| 0);
+        cache.record_access_with_demand(near, 100, AccessType::Get, 0, near_demand, |_| (0, 0));
+        cache.record_access_with_demand(far, 100, AccessType::Get, 0, far_demand, |_| (0, 0));
         assert_eq!(cache.current_bytes(), 200);
         assert!(
             cache.get(&near).unwrap().keep_score > cache.get(&far).unwrap().keep_score,
@@ -2556,7 +2707,7 @@ mod tests {
             AccessType::Get,
             0,
             NEUTRAL_DEMAND,
-            |_| 0,
+            |_| (0, 0),
         );
         assert_eq!(
             result.evicted,
@@ -2608,7 +2759,7 @@ mod tests {
 
         // Seed the room with strong demand, then read it repeatedly (simulating
         // recurring GETs). These reads are the room's LAST accesses.
-        cache.record_access_with_demand(room, 100, AccessType::Get, 0, 10.0, |_| 0);
+        cache.record_access_with_demand(room, 100, AccessType::Get, 0, 10.0, |_| (0, 0));
         for _ in 0..3 {
             time.advance_time(Duration::from_secs(5));
             cache.touch(&room);
@@ -2617,7 +2768,7 @@ mod tests {
         // Junk arrives AFTER the room's last read, so junk is the more-recently-
         // accessed entry — and carries weak demand.
         time.advance_time(Duration::from_secs(5));
-        cache.record_access_with_demand(junk, 100, AccessType::Get, 0, 1.0, |_| 0);
+        cache.record_access_with_demand(junk, 100, AccessType::Get, 0, 1.0, |_| (0, 0));
 
         // Advance so BOTH are past TTL and eviction-eligible; the room, last read
         // 5s before junk, is the least-recently-accessed of the two.
@@ -2642,7 +2793,8 @@ mod tests {
         // Over-budget insert: the fuel gauge evicts the lowest keep_score (junk).
         // Byte-LRU-with-TTL would instead evict the room (the oldest past-TTL
         // entry) — so this assertion is what fails under a recency-only policy.
-        let result = cache.record_access_with_demand(trigger, 100, AccessType::Get, 0, 1.0, |_| 0);
+        let result =
+            cache.record_access_with_demand(trigger, 100, AccessType::Get, 0, 1.0, |_| (0, 0));
         assert_eq!(
             result.evicted,
             vec![(junk, 0)],
@@ -2673,10 +2825,10 @@ mod tests {
         // Insert a demand-7 contract, let it age, then evict it via an
         // over-budget insert; the floor must climb to 7.
         let a = make_key(1);
-        cache.record_access_with_demand(a, 100, AccessType::Get, 0, 7.0, |_| 0);
+        cache.record_access_with_demand(a, 100, AccessType::Get, 0, 7.0, |_| (0, 0));
         time.advance_time(Duration::from_secs(61));
         let b = make_key(2);
-        let r = cache.record_access_with_demand(b, 100, AccessType::Get, 0, 2.0, |_| 0);
+        let r = cache.record_access_with_demand(b, 100, AccessType::Get, 0, 2.0, |_| (0, 0));
         assert_eq!(r.evicted, vec![(a, 0)]);
         assert_eq!(
             cache.eviction_floor(),
@@ -2688,7 +2840,7 @@ mod tests {
         // lower-scored victim must not drop the floor below 7.
         time.advance_time(Duration::from_secs(61));
         let c = make_key(3);
-        let r = cache.record_access_with_demand(c, 100, AccessType::Get, 0, 1.0, |_| 0);
+        let r = cache.record_access_with_demand(c, 100, AccessType::Get, 0, 1.0, |_| (0, 0));
         assert_eq!(r.evicted, vec![(b, 0)], "b (keep_score 2) evicts");
         assert_eq!(
             cache.eviction_floor(),
@@ -2706,14 +2858,14 @@ mod tests {
         let key = make_key(1);
 
         // Seed via PUT: keep_score = floor(0) + demand, read_count 0.
-        cache.record_access_with_demand(key, 100, AccessType::Put, 0, 2.0, |_| 0);
+        cache.record_access_with_demand(key, 100, AccessType::Put, 0, 2.0, |_| (0, 0));
         assert_eq!(cache.get(&key).unwrap().read_count, 0, "PUT is not a read");
         let seed_score = cache.get(&key).unwrap().keep_score;
         assert_eq!(seed_score, 2.0);
 
         // Manually raise the floor by evicting something else would be indirect;
         // instead assert that a re-PUT does NOT refresh keep_score or read_count.
-        cache.record_access_with_demand(key, 100, AccessType::Put, 0, 9.0, |_| 0);
+        cache.record_access_with_demand(key, 100, AccessType::Put, 0, 9.0, |_| (0, 0));
         assert_eq!(
             cache.get(&key).unwrap().read_count,
             0,
@@ -2726,7 +2878,7 @@ mod tests {
         );
 
         // A GET, by contrast, IS read-demand and refreshes both.
-        cache.record_access_with_demand(key, 100, AccessType::Get, 0, 9.0, |_| 0);
+        cache.record_access_with_demand(key, 100, AccessType::Get, 0, 9.0, |_| (0, 0));
         assert_eq!(cache.get(&key).unwrap().read_count, 1);
         assert_eq!(cache.get(&key).unwrap().keep_score, 9.0);
     }
@@ -2739,12 +2891,12 @@ mod tests {
 
         // A contract read twice (repeat demand), then forced out by junk.
         let read_twice = make_key(1);
-        cache.record_access(read_twice, 100, AccessType::Get, 0, |_| 0);
+        cache.record_access(read_twice, 100, AccessType::Get, 0, |_| (0, 0));
         cache.touch(&read_twice); // second read -> read_count 2
         time.advance_time(Duration::from_secs(61));
         // Evict it by inserting a higher-demand junk (so read_twice is the victim).
         let junk = make_key(2);
-        let r = cache.record_access_with_demand(junk, 100, AccessType::Get, 0, 5.0, |_| 0);
+        let r = cache.record_access_with_demand(junk, 100, AccessType::Get, 0, 5.0, |_| (0, 0));
         assert_eq!(r.evicted, vec![(read_twice, 0)]);
         assert_eq!(
             cache.stats().evictions_of_recently_read_total,
@@ -2756,7 +2908,7 @@ mod tests {
         time.advance_time(Duration::from_secs(61));
         let seed = make_key(3);
         // junk currently has demand 5 (>seed's), so make the new one higher.
-        let r = cache.record_access_with_demand(seed, 100, AccessType::Get, 0, 9.0, |_| 0);
+        let r = cache.record_access_with_demand(seed, 100, AccessType::Get, 0, 9.0, |_| (0, 0));
         assert_eq!(r.evicted, vec![(junk, 0)], "junk (read once) evicts");
         assert_eq!(
             cache.stats().evictions_of_recently_read_total,
@@ -2765,61 +2917,72 @@ mod tests {
         );
     }
 
-    /// A subscribed (retained) contract is exempt from eviction even when its
-    /// `keep_score` is the lowest and it is past TTL — the pin dominates demand
-    /// ordering.
+    /// A subscribed contract is ordered LAST, so when only ONE eviction is needed
+    /// to get back under budget a zero-subscriber contract is shed and the
+    /// subscribed one survives — even though its `keep_score` is the lowest and it
+    /// is past TTL. (Subscriber-primary ordering dominates demand ordering; the
+    /// subscribed contract is NOT hard-pinned — see
+    /// `evict_all_subscribed_sheds_fewest_as_last_resort` for the last-resort shed.)
     #[test]
-    fn subscribe_pin_exempts_lowest_score_from_eviction() {
+    fn subscribed_contract_ordered_last_survives_while_zero_sub_evicted() {
         let (mut cache, time) = make_cache(200, Duration::from_secs(60));
-        let pinned = make_key(1); // lowest demand, but subscribed
+        let subscribed = make_key(1); // lowest demand, but subscribed
         let other = make_key(2);
         let trigger = make_key(3);
 
-        cache.record_access_with_demand(pinned, 100, AccessType::Get, 0, 0.1, |_| 0);
-        cache.record_access_with_demand(other, 100, AccessType::Get, 0, 5.0, |_| 0);
+        cache.record_access_with_demand(subscribed, 100, AccessType::Get, 0, 0.1, |_| (0, 0));
+        cache.record_access_with_demand(other, 100, AccessType::Get, 0, 5.0, |_| (0, 0));
         time.advance_time(Duration::from_secs(61));
 
-        // Over budget: `pinned` has the lowest keep_score and would evict first,
-        // but should_retain protects it, so `other` is evicted instead.
+        // Over budget by one entry: `subscribed` has the lowest keep_score and a
+        // naive demand order would evict it first, but it is downstream-subscribed
+        // so it sorts LAST — the zero-subscriber `other` is shed instead.
         let result = cache.record_access_with_demand(trigger, 100, AccessType::Get, 0, 5.0, |k| {
-            (*k == pinned) as usize
+            (0, (*k == subscribed) as usize)
         });
         assert_eq!(
             result.evicted,
             vec![(other, 0)],
-            "an active subscription pins the contract even at the lowest keep_score"
+            "the subscribed contract is ordered last; the zero-subscriber one sheds"
         );
-        assert!(cache.contains(&pinned));
+        assert_eq!(
+            result.evicted_in_use,
+            Vec::<ContractKey>::new(),
+            "no in-use contract was shed here, so nothing needs subscription teardown"
+        );
+        assert!(cache.contains(&subscribed));
         assert!(!cache.contains(&other));
     }
 
     // --- Subscriber-primary eviction (#4642, PR-1) ---
 
-    /// Under normal (AtCapacity) over-budget pressure a subscribed contract is
-    /// PINNED and only the zero-subscriber contract is evicted.
+    /// Under normal (AtCapacity) over-budget pressure the zero-subscriber contract
+    /// is shed before the subscribed one (subscriber-primary ordering). The
+    /// subscribed contract is ordered LAST, not hard-pinned.
     #[test]
-    fn evict_normal_pins_subscribed_drops_zero_sub() {
+    fn evict_normal_drops_zero_sub_before_subscribed() {
         let (mut cache, time) = make_cache(200, Duration::from_secs(60));
         let a = make_key(1);
         let b = make_key(2);
         let c = make_key(3);
 
-        // A is subscribed (pinned); B is zero-subscriber.
-        let subs = |k: &ContractKey| usize::from(*k == a);
+        // A is subscribed (downstream); B is zero-subscriber.
+        let subs = |k: &ContractKey| (0, usize::from(*k == a));
         cache.record_access(a, 100, AccessType::Get, 0, subs);
         cache.record_access(b, 100, AccessType::Get, 0, subs);
         assert_eq!(cache.current_bytes(), 200);
 
-        // Past TTL, insert C over budget. Under AtCapacity, A (subscribed) is
-        // pinned and B (zero-subscriber, past TTL) is the only eligible victim.
+        // Past TTL, insert C over budget. Both A and B are eligible (past TTL),
+        // but B (zero-subscriber) sorts ahead of A (subscribed), so B is the
+        // victim and one eviction is enough — A survives, ordered last.
         time.advance_time(Duration::from_secs(61));
         let result = cache.record_access(c, 100, AccessType::Get, 0, subs);
         assert_eq!(
             result.evicted,
             vec![(b, 0)],
-            "a subscribed contract is pinned; only the zero-subscriber one is evicted"
+            "the zero-subscriber contract sheds before the subscribed one"
         );
-        assert!(cache.contains(&a), "subscribed A stays pinned");
+        assert!(cache.contains(&a), "subscribed A survives (ordered last)");
         assert!(cache.contains(&c));
         assert!(!cache.contains(&b));
     }
@@ -2836,17 +2999,17 @@ mod tests {
         let d = make_key(4);
 
         // last_get order A < B < C.
-        cache.record_access(a, 100, AccessType::Get, 0, |_| 0);
-        cache.record_access(b, 100, AccessType::Get, 0, |_| 0);
-        cache.record_access(c, 100, AccessType::Get, 0, |_| 0);
+        cache.record_access(a, 100, AccessType::Get, 0, |_| (0, 0));
+        cache.record_access(b, 100, AccessType::Get, 0, |_| (0, 0));
+        cache.record_access(c, 100, AccessType::Get, 0, |_| (0, 0));
 
         // A SUBSCRIBE on A and a PUT on B must NOT refresh their real-GET
         // recency, so A stays the least-recently-GET entry.
-        cache.record_access(a, 100, AccessType::Subscribe, 0, |_| 0);
-        cache.record_access(b, 100, AccessType::Put, 0, |_| 0);
+        cache.record_access(a, 100, AccessType::Subscribe, 0, |_| (0, 0));
+        cache.record_access(b, 100, AccessType::Put, 0, |_| (0, 0));
 
         time.advance_time(Duration::from_secs(61));
-        let result = cache.record_access(d, 100, AccessType::Get, 0, |_| 0);
+        let result = cache.record_access(d, 100, AccessType::Get, 0, |_| (0, 0));
         assert_eq!(
             result.evicted,
             vec![(a, 0)],
@@ -2868,15 +3031,15 @@ mod tests {
         let c = make_key(3);
         let d = make_key(4);
 
-        cache.record_access(a, 100, AccessType::Get, 0, |_| 0);
-        cache.record_access(b, 100, AccessType::Get, 0, |_| 0);
-        cache.record_access(c, 100, AccessType::Get, 0, |_| 0);
+        cache.record_access(a, 100, AccessType::Get, 0, |_| (0, 0));
+        cache.record_access(b, 100, AccessType::Get, 0, |_| (0, 0));
+        cache.record_access(c, 100, AccessType::Get, 0, |_| (0, 0));
 
         // A real GET on A makes A the newest, leaving B least-recently-GET.
-        cache.record_access(a, 100, AccessType::Get, 0, |_| 0);
+        cache.record_access(a, 100, AccessType::Get, 0, |_| (0, 0));
 
         time.advance_time(Duration::from_secs(61));
-        let result = cache.record_access(d, 100, AccessType::Get, 0, |_| 0);
+        let result = cache.record_access(d, 100, AccessType::Get, 0, |_| (0, 0));
         assert_eq!(
             result.evicted,
             vec![(b, 0)],
@@ -2888,43 +3051,53 @@ mod tests {
         assert!(cache.contains(&d));
     }
 
-    /// The OOM valve (Overflow) pierces the in-use pin and sheds the
-    /// FEWEST-subscriber contract first, bumping the valve counter.
+    /// The Overflow corner ALSO pierces the `min_ttl` cold-start floor (its only
+    /// remaining special power) and sheds the FEWEST-subscriber contract first,
+    /// bumping both the OOM-valve counter and the subscribed-eviction counter.
     #[test]
-    fn oom_valve_sheds_fewest_subscriber_piercing_pin() {
+    fn oom_valve_sheds_fewest_subscriber_piercing_min_ttl() {
         let (mut cache, _time) = make_cache(100, Duration::from_secs(60));
         let a = make_key(1);
         let b = make_key(2);
 
-        // A has more subscribers than B; both are subscribed (pinned under
-        // AtCapacity).
-        let subs = |k: &ContractKey| if *k == a { 2 } else { 1 };
+        // A has more downstream subscribers than B; both are subscribed and fresh
+        // (within min_ttl — no time advance).
+        let subs = |k: &ContractKey| if *k == a { (0, 2) } else { (0, 1) };
         cache.record_access(a, 100, AccessType::Get, 0, subs);
-        // Inserting B pushes over budget, but under AtCapacity both are pinned
-        // (subscriber_count >= 1) and B is age-0, so nothing is evicted.
+        // Inserting B pushes over budget, but both are age-0 (within min_ttl), so
+        // under AtCapacity cold-start grace keeps them — nothing is evicted.
         let insert = cache.record_access(b, 100, AccessType::Get, 0, subs);
         assert!(
             insert.evicted.is_empty(),
-            "AtCapacity pins both subscribed contracts"
+            "within min_ttl, cold-start grace protects both fresh contracts"
         );
         assert!(cache.contains(&a));
         assert!(cache.contains(&b));
         assert_eq!(cache.current_bytes(), 200, "200 bytes over the 100 budget");
 
-        // The OOM valve pierces the pin and sheds the FEWEST-subscriber contract
-        // (B, 1 sub) before A (2 subs), bumping the valve counter.
+        // The Overflow corner pierces min_ttl AND sheds the FEWEST-subscriber
+        // contract (B, 1 sub) before A (2 subs), bumping both counters.
         let evicted = cache.sweep_expired(subs, MemoryPressure::Overflow);
         assert_eq!(
-            evicted,
+            evicted_pairs(&evicted),
             vec![(b, 0)],
             "fewest-subscriber contract sheds first"
+        );
+        assert!(
+            evicted.iter().all(|e| e.was_in_use),
+            "the shed contract was subscribed, so it is flagged in-use for teardown"
         );
         assert!(cache.contains(&a), "the more-subscribed contract survives");
         assert!(!cache.contains(&b));
         assert_eq!(cache.stats().oom_valve_evictions_total, 1);
+        assert_eq!(
+            cache.stats().subscribed_evictions_total,
+            1,
+            "shedding a subscribed contract bumps the subscribed-eviction falsifier"
+        );
     }
 
-    /// With equal subscriber counts, the OOM valve tiebreaks by least-recent
+    /// With equal subscriber counts, the Overflow corner tiebreaks by least-recent
     /// real GET.
     #[test]
     fn oom_valve_equal_subscribers_sheds_least_recent_get() {
@@ -2933,13 +3106,13 @@ mod tests {
         let b = make_key(2);
 
         // Equal subscriber counts: the tiebreak is least-recent real GET.
-        cache.record_access(a, 100, AccessType::Get, 0, |_| 1);
-        cache.record_access(b, 100, AccessType::Get, 0, |_| 1);
+        cache.record_access(a, 100, AccessType::Get, 0, |_| (0, 1));
+        cache.record_access(b, 100, AccessType::Get, 0, |_| (0, 1));
         assert_eq!(cache.current_bytes(), 200);
 
-        let evicted = cache.sweep_expired(|_| 1, MemoryPressure::Overflow);
+        let evicted = cache.sweep_expired(|_| (0, 1), MemoryPressure::Overflow);
         assert_eq!(
-            evicted,
+            evicted_pairs(&evicted),
             vec![(a, 0)],
             "with equal subscribers, the least-recently-GET contract (A) sheds"
         );
@@ -2948,23 +3121,33 @@ mod tests {
         assert_eq!(cache.stats().oom_valve_evictions_total, 1);
     }
 
-    /// A normal AtCapacity eviction of a zero-subscriber contract must NOT
-    /// touch the OOM-valve counter (that counter is only for pierced pins).
+    /// A normal AtCapacity eviction of a zero-subscriber contract must NOT touch
+    /// EITHER the OOM-valve counter (Overflow-pressure only) or the
+    /// subscribed-eviction counter (in-use victims only).
     #[test]
     fn oom_valve_counter_zero_under_normal_atcapacity() {
         let (mut cache, time) = make_cache(100, Duration::from_secs(60));
         let a = make_key(1);
         let b = make_key(2);
 
-        cache.record_access(a, 100, AccessType::Get, 0, |_| 0);
+        cache.record_access(a, 100, AccessType::Get, 0, |_| (0, 0));
         time.advance_time(Duration::from_secs(61));
         // Normal AtCapacity eviction of a zero-subscriber, past-TTL contract.
-        let result = cache.record_access(b, 100, AccessType::Get, 0, |_| 0);
+        let result = cache.record_access(b, 100, AccessType::Get, 0, |_| (0, 0));
         assert_eq!(result.evicted, vec![(a, 0)]);
+        assert!(
+            result.evicted_in_use.is_empty(),
+            "a zero-subscriber eviction needs no subscription teardown"
+        );
         assert_eq!(
             cache.stats().oom_valve_evictions_total,
             0,
             "a normal zero-subscriber eviction must not touch the OOM-valve counter"
+        );
+        assert_eq!(
+            cache.stats().subscribed_evictions_total,
+            0,
+            "a zero-subscriber eviction must not touch the subscribed-eviction counter"
         );
     }
 
@@ -2977,10 +3160,10 @@ mod tests {
         let other = make_key(2);
 
         // A fresh PUT seed (never GET-read, zero-subscriber, read_count 0).
-        cache.record_access(seed, 100, AccessType::Put, 0, |_| 0);
+        cache.record_access(seed, 100, AccessType::Put, 0, |_| (0, 0));
         // Inserting `other` pushes over budget, but the seed is age-0 / within
         // min_ttl, so cold-start grace keeps it: nothing is evicted.
-        let result = cache.record_access(other, 100, AccessType::Get, 0, |_| 0);
+        let result = cache.record_access(other, 100, AccessType::Get, 0, |_| (0, 0));
         assert!(
             result.evicted.is_empty(),
             "a fresh unread zero-subscriber seed is not evicted within min_ttl even over budget"
@@ -2990,11 +3173,72 @@ mod tests {
 
         // Past min_ttl the unread seed becomes eligible and sheds under budget.
         time.advance_time(Duration::from_secs(61));
-        let evicted = cache.sweep_expired(|_| 0, MemoryPressure::AtCapacity);
+        let evicted = cache.sweep_expired(|_| (0, 0), MemoryPressure::AtCapacity);
         assert!(
-            evicted.iter().any(|(k, _)| *k == seed),
+            evicted.iter().any(|e| e.key == seed),
             "past min_ttl the unread seed is evicted"
         );
         assert!(!cache.contains(&seed));
+    }
+
+    /// LAST RESORT (Ian's confirmed ordering, #4642): when EVERY eligible contract
+    /// is subscribed and the peer is still over budget, the fewest-`(local,
+    /// downstream)`-subscriber one IS shed under normal AtCapacity pressure (no
+    /// hard pin), and is flagged `was_in_use` so the manager tears down its
+    /// subscription state. Also checks fewest-LOCAL-first: a downstream-only
+    /// contract is shed before a local-client one.
+    #[test]
+    fn evict_all_subscribed_sheds_fewest_as_last_resort() {
+        let (mut cache, time) = make_cache(200, Duration::from_secs(60));
+        let local_sub = make_key(1); // (local=1, downstream=0) — evicted LAST
+        let downstream_sub = make_key(2); // (local=0, downstream=5) — evicted first
+        let trigger = make_key(3);
+
+        // Every contract is subscribed; NONE is zero-subscriber.
+        let subs = |k: &ContractKey| {
+            if *k == local_sub {
+                (1, 0)
+            } else if *k == downstream_sub {
+                (0, 5)
+            } else {
+                (0, 1) // trigger: one downstream subscriber
+            }
+        };
+        cache.record_access(local_sub, 100, AccessType::Get, 0, subs);
+        cache.record_access(downstream_sub, 100, AccessType::Get, 0, subs);
+        assert_eq!(cache.current_bytes(), 200);
+
+        // Age both past min_ttl so they are eligible, then insert `trigger` over
+        // budget. Nothing is zero-subscriber, so the fewest-`(local, downstream)`
+        // contract — `downstream_sub` (0, 5) sorts ahead of `local_sub` (1, 0) —
+        // is shed as the last resort, NOT hard-pinned.
+        time.advance_time(Duration::from_secs(61));
+        let result = cache.record_access(trigger, 100, AccessType::Get, 0, subs);
+        assert_eq!(
+            result.evicted,
+            vec![(downstream_sub, 0)],
+            "with only subscribed contracts, the fewest-LOCAL (then fewest-\
+             downstream) one is shed — the local-client contract is evicted last"
+        );
+        assert_eq!(
+            result.evicted_in_use,
+            vec![downstream_sub],
+            "the shed subscribed contract is flagged in-use for teardown"
+        );
+        assert!(
+            cache.contains(&local_sub),
+            "the local-client contract survives (ordered last)"
+        );
+        assert!(!cache.contains(&downstream_sub));
+        assert_eq!(
+            cache.stats().subscribed_evictions_total,
+            1,
+            "shedding a subscribed contract bumps the falsifier under AtCapacity"
+        );
+        assert_eq!(
+            cache.stats().oom_valve_evictions_total,
+            0,
+            "AtCapacity last-resort shed is NOT an OOM-valve eviction"
+        );
     }
 }

--- a/crates/core/src/ring/hosting/cache.rs
+++ b/crates/core/src/ring/hosting/cache.rs
@@ -12,9 +12,10 @@
 //! 2. **Subscriber-primary eviction** (freenet/freenet-core#4642, subscriber-
 //!    primary rework): when over budget the eviction victim is chosen by
 //!    ascending `(local_subscription_count, downstream_subscriber_count,
-//!    last_get_seq, key_bytes)` — the FEWEST-subscriber contract first (local
+//!    recency_seq, key_bytes)` — the FEWEST-subscriber contract first (local
 //!    subscriptions weighed ahead of downstream), ties broken by least-recent
-//!    **real GET read**, then a deterministic key-byte tiebreak. The split
+//!    **real GET or PUT access** (`recency_seq`), then a deterministic key-byte
+//!    tiebreak. The split
 //!    `(local, downstream)` counts are supplied by the caller (`HostingManager`)
 //!    via the same closure that used to be `should_retain`; they count genuine
 //!    demand (local client subscriptions + downstream subscribers) and sum to
@@ -26,13 +27,20 @@
 //!    fewest-subscriber contract IS shed as a last resort — including a
 //!    subscribed one (its subscription state is then torn down; see
 //!    [`RecordAccessResult::evicted_in_use_teardown`]). This is the change from
-//!    the shipped #4720 code, which hard-pinned every subscribed contract. The
-//!    OOM valve ([`MemoryPressure::Overflow`], trigger unwired) adds only one
-//!    extra power on top: it ALSO pierces the `min_ttl` cold-start floor.
-//!    `min_ttl` is preserved as the cold-start grace floor for fresh
-//!    zero-subscriber contracts.
+//!    the shipped #4720 code, which hard-pinned every subscribed contract. There
+//!    is **no `min_ttl` cold-start floor** (dropped 2026-07-08): a real GET or
+//!    PUT resets an entry's `recency_seq`, so a freshly-accessed contract is
+//!    protected simply by being the most-recently-accessed under the recency
+//!    ordering, and a fresh PUT protects itself at PUT time without waiting for a
+//!    first read. The OOM valve ([`MemoryPressure::Overflow`], trigger unwired)
+//!    now differs from `AtCapacity` only in that it pierces the op-scoped backstop
+//!    (evicting even a contract with an in-flight op) to survive genuine RAM
+//!    overflow.
 //! 3. **Subscription renewal**: All hosted contracts get subscription renewal
-//! 4. **Access type tracking**: Records how contract was accessed (GET/PUT/SUBSCRIBE)
+//! 4. **Access type tracking**: Records how contract was accessed (GET/PUT/SUBSCRIBE).
+//!    A real GET or PUT (genuine client access) resets `recency_seq`; SUBSCRIBE
+//!    and automatic subscription-renewal traffic do NOT, so renewal cannot keep a
+//!    contract artificially fresh (invariant 3, decision 2026-07-08).
 //!
 //! ## Demoted (telemetry-only) demand machinery
 //!
@@ -43,7 +51,7 @@
 //! displayed) for telemetry continuity this release, and are scheduled for
 //! deletion in a follow-up once the subscriber-primary policy is field-
 //! validated. Eviction reads NONE of them; it orders by subscriber count and
-//! real-GET recency (see principle 2). `predicted_demand` is still supplied by
+//! real GET/PUT recency (see principle 2). `predicted_demand` is still supplied by
 //! the caller (`HostingManager`, which owns the proximity-prior estimator and
 //! the peer's own ring location — see [`super::demand`]) purely so the
 //! estimator keeps training and the dashboard column stays populated.
@@ -240,29 +248,12 @@ pub(crate) struct HostingContractScore {
     pub size_bytes: u64,
     /// Read accesses (GET/SUBSCRIBE) observed over this entry's residency.
     pub read_count: u32,
-    /// Monotonic access sequence at the entry's most recent real GET — the
-    /// eviction recency tiebreak (subscriber-primary rework, #4642). The cache
-    /// orders zero-subscriber eviction candidates ascending by this.
-    pub last_get_seq: u64,
-    /// Whether this entry is past its `min_ttl` age gate. Under normal
-    /// (`AtCapacity`) pressure this is the WHOLE eviction-eligibility filter
-    /// (`age >= min_ttl`): subscriber count no longer gates eligibility — a
-    /// subscribed contract is still eligible, just ordered LAST, and shed only
-    /// as a last resort (the change from the shipped #4720 `!should_retain`
-    /// hard pin). Used by the dashboard so the "next to evict" badge marks
-    /// contracts the over-budget sweep would actually consider.
-    pub past_min_ttl: bool,
+    /// Monotonic access sequence at the entry's most recent real GET or PUT
+    /// (genuine client access) — the eviction recency tiebreak (subscriber-
+    /// primary rework, #4642). The cache orders zero-subscriber eviction
+    /// candidates ascending by this. SUBSCRIBE / renewal traffic does NOT bump it.
+    pub recency_seq: u64,
 }
-
-/// Multiplier for TTL relative to subscription renewal interval.
-/// Gives this many renewal attempts before eviction if renewals keep failing.
-pub const TTL_RENEWAL_MULTIPLIER: u32 = 4;
-
-/// Default minimum TTL before a hosted contract can be evicted.
-/// Computed as TTL_RENEWAL_MULTIPLIER × SUBSCRIPTION_RENEWAL_INTERVAL.
-pub const DEFAULT_MIN_TTL: Duration = Duration::from_secs(
-    super::SUBSCRIPTION_RENEWAL_INTERVAL.as_secs() * TTL_RENEWAL_MULTIPLIER as u64,
-);
 
 /// Type of access that adds/refreshes a contract in the hosting cache.
 ///
@@ -288,41 +279,43 @@ pub enum AccessType {
 /// the byte budget is already exceeded, so it only needs to distinguish "at
 /// capacity" from "genuine RAM overflow".
 ///
-/// # There is ONE eviction ordering; the two variants only differ on `min_ttl`
+/// # There is ONE eviction ordering; the two variants only differ on the op-scoped backstop
 ///
 /// Since the subscriber-primary eviction rework (#4642, Ian's confirmed model)
 /// BOTH variants shed the fewest-`(local, downstream)`-subscriber contract using
 /// the same [`victim_order`] — a subscribed contract is NOT hard-pinned under
-/// either. The only difference is eligibility:
+/// either, and there is no `min_ttl` cold-start floor (dropped 2026-07-08). The
+/// only difference is the op-scoped backstop:
 ///
-/// - [`Self::AtCapacity`] evicts past-`min_ttl` entries (subscribed contracts
-///   ordered last, shed as a last resort). This is what production passes.
-/// - [`Self::Overflow`] ALSO pierces the `min_ttl` cold-start floor, so a node at
-///   genuine RAM-overflow can shed even fresh contracts to survive. This is "a
-///   corner of the same eviction, not a separate valve" (hosting-invariants
-///   Resolved decisions); it is NOT a second ranking.
+/// - [`Self::AtCapacity`] never evicts the `protected` key (the contract whose
+///   in-flight access triggered this sweep — the op-scoped backstop guard;
+///   invariant 3, decision 2026-07-08). This is what production passes.
+/// - [`Self::Overflow`] pierces that backstop, so a node at genuine RAM-overflow
+///   can shed even a contract with an in-flight op to survive. This is "a corner
+///   of the same eviction, not a separate valve" (hosting-invariants Resolved
+///   decisions); it is NOT a second ranking.
 ///
-/// The `Overflow` (min_ttl-pierce) TRIGGER is intentionally UNWIRED in
+/// The `Overflow` (backstop-pierce) TRIGGER is intentionally UNWIRED in
 /// production: it needs a genuine RSS/A1 resource signal, which is NOT plumbed.
 /// Production callers (`HostingManager::sweep_expired_hosting`,
 /// `record_contract_access`) pass [`Self::AtCapacity`] unconditionally. Note
 /// that — unlike the shipped #4720 code — AtCapacity CAN now shed a subscribed
 /// contract (as a last resort), so shedding subscribed contracts is live in the
-/// field; only the `min_ttl` PIERCE remains gated behind the unwired trigger.
+/// field; only the op-backstop PIERCE remains gated behind the unwired trigger.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MemoryPressure {
-    /// Over the byte budget but not at genuine RAM-overflow risk. Past-`min_ttl`
-    /// entries are eligible; victims are chosen fewest-`(local, downstream)`-
-    /// subscriber first, so a subscribed contract is ordered LAST and shed only
-    /// as a last resort (when nothing with fewer subscribers is eligible and the
-    /// peer is still over budget). `min_ttl` still protects every fresh contract.
-    /// This is the value production always passes.
+    /// Over the byte budget but not at genuine RAM-overflow risk. Every entry is
+    /// eligible EXCEPT the op-scoped `protected` key; victims are chosen fewest-
+    /// `(local, downstream)`-subscriber first, so a subscribed contract is ordered
+    /// LAST and shed only as a last resort (when nothing with fewer subscribers is
+    /// eligible and the peer is still over budget). This is the value production
+    /// always passes.
     AtCapacity,
     /// Genuine RAM overflow: the same fewest-subscriber ordering, but ALSO
-    /// pierces the `min_ttl` cold-start floor so a fresh contract can be shed to
-    /// survive OOM. NOTHING produces this value in production yet.
+    /// pierces the op-scoped backstop so a contract with an in-flight op can be
+    /// shed to survive OOM. NOTHING produces this value in production yet.
     ///
-    /// `dead_code`-allowed in non-test builds ON PURPOSE: the min_ttl-pierce
+    /// `dead_code`-allowed in non-test builds ON PURPOSE: the backstop-pierce
     /// trigger (a genuine RSS/A1 resource signal) is intentionally unwired, so
     /// only the mechanism unit tests construct `Overflow`. Remove the allow when
     /// the trigger is plumbed in a later, separately-validated step.
@@ -433,36 +426,44 @@ pub(crate) struct EvictedContract {
 pub struct HostedContract {
     /// Size of the contract state in bytes
     pub size_bytes: u64,
-    /// Last time this contract was accessed (via GET/PUT/SUBSCRIBE). Drives the
-    /// TTL gate (an entry is not eviction-eligible until `min_ttl` since this).
+    /// Last time this contract was accessed (via GET/PUT/SUBSCRIBE). Used as the
+    /// restart-reload recency tiebreak (`finalize_loading`) and to age-gate local-
+    /// client renewal; it no longer gates eviction eligibility (the `min_ttl` floor
+    /// was dropped 2026-07-08 — see [`Self::recency_seq`]).
     pub last_accessed: Instant,
     /// Monotonic access sequence number stamped on every access (insert / read /
     /// seed / touch).
     ///
     /// UNUSED, pending deletion: it was the old eviction tiebreak, which the
-    /// subscriber-primary rework (#4642) replaced with [`Self::last_get_seq`]
+    /// subscriber-primary rework (#4642) replaced with [`Self::recency_seq`]
     /// (real-GET recency). No production reader remains (only a `#[cfg(test)]`
     /// assertion via the `get()` accessor keeps it from tripping dead-code). It
     /// is still maintained here to avoid churning the write sites in this PR;
     /// slated for removal with the rest of the demoted machinery once
     /// subscriber-primary is field-validated. Do NOT add new readers.
     pub last_access_seq: u64,
-    /// Monotonic access sequence at this entry's most recent **real GET read**
-    /// — the eviction recency tiebreak (subscriber-primary rework, #4642).
+    /// Monotonic access sequence at this entry's most recent **real GET or PUT
+    /// access** (genuine client access) — the eviction recency tiebreak among
+    /// equal-`(local, downstream)`-subscriber candidates (subscriber-primary
+    /// rework, #4642; GET-or-PUT extension 2026-07-08).
     ///
-    /// Stamped (to the shared `access_seq` value) ONLY by an `AccessType::Get`
-    /// access and by `touch_with_demand` (a local-cache GET serve). It is
-    /// deliberately NOT bumped by PUT (a seed/write, not a read), by SUBSCRIBE
-    /// (a subscription, not a read), by subscription RENEWAL traffic, or by a
-    /// restart reload — so that "recently GET-read" means exactly that. Without
-    /// this Get-only key, renewal traffic on every subscribed contract would
-    /// keep them all equally "fresh" and the tiebreak would be useless.
+    /// Stamped (to the shared `access_seq` value) by an `AccessType::Get` or
+    /// `AccessType::Put` access, by `touch_with_demand` (a local-cache GET serve),
+    /// and — reset to the current frontier — at subscription TERMINATION
+    /// (`record_abandonment`, so a formerly-subscribed contract is not instantly
+    /// evicted for an old last-read accrued while it sat in the subscription tier).
+    /// It is deliberately NOT bumped by SUBSCRIBE (a subscription, not a read/
+    /// write), by subscription RENEWAL traffic, or by a restart reload — so that
+    /// "recently accessed by a client" means exactly that. Without excluding
+    /// renewal traffic, every subscribed contract would stay equally "fresh" and
+    /// the tiebreak would be useless.
     ///
-    /// A never-GET-read entry (e.g. a fresh PUT seed) has `last_get_seq == 0`,
-    /// so among zero-subscriber candidates it sorts to evict first once past
-    /// `min_ttl` — the intended "unread seeds evaporate" behavior, with the
-    /// `min_ttl` floor giving it cold-start grace to be found first.
-    pub last_get_seq: u64,
+    /// A never-accessed entry (a fresh SUBSCRIBE-only seed, or a restart-reloaded
+    /// entry) has `recency_seq == 0`, so among zero-subscriber candidates it sorts
+    /// to evict first. A fresh PUT resets `recency_seq` at PUT time, so it is
+    /// protected by being the most-recently-accessed without any `min_ttl` floor
+    /// (dropped 2026-07-08).
+    pub recency_seq: u64,
     /// Demand-ordered (Greedy-Dual) priority: `eviction_floor + predicted_demand` captured at the
     /// last read-demand refresh (or at insert). The over-budget walk evicts the
     /// entry with the lowest `keep_score` (ties broken by `last_accessed`). A
@@ -565,17 +566,18 @@ pub struct HostedContract {
     pub abandoned_at: Option<Instant>,
 }
 
-/// Unified hosting cache that combines byte-budget LRU with TTL protection.
+/// Unified hosting cache with a byte-budget and subscriber-primary eviction.
 ///
 /// This cache maintains contracts that this peer is "hosting" - keeping available
 /// for the network. The cache has:
 /// - Byte budget: Large contracts consume more budget. The budget is measured
 ///   in tracked contract **state** bytes only; WASM code blobs and database
 ///   overhead are not counted against it.
-/// - TTL protection: Contracts can't be evicted until min_ttl has passed
-/// - Demand-ordered eviction (Greedy-Dual): when over budget the
-///   contract with the lowest `keep_score` is evicted first (ties broken by
-///   least-recently-read), NOT purely the oldest. See the module docs.
+/// - Subscriber-primary eviction: when over budget the victim is chosen by
+///   ascending `(local_subscription_count, downstream_subscriber_count,
+///   recency_seq, key_bytes)` (see [`victim_order`] and the module docs). There
+///   is no `min_ttl` cold-start floor (dropped 2026-07-08); a fresh contract is
+///   protected by being the most-recently-accessed under the recency ordering.
 ///
 /// # Subscription Renewal
 ///
@@ -586,11 +588,9 @@ pub struct HostingCache<T: TimeSource> {
     budget_bytes: u64,
     /// Current total bytes used
     current_bytes: u64,
-    /// Minimum time since last access before eviction is allowed
-    min_ttl: Duration,
     /// Contract metadata indexed by key. Eviction order is derived from each
-    /// entry's `keep_score` (then `last_accessed`), not from a separate LRU
-    /// list, so there is no second structure to keep in sync.
+    /// entry's subscriber counts + `recency_seq` (via [`victim_order`]), not from
+    /// a separate LRU list, so there is no second structure to keep in sync.
     contracts: HashMap<ContractKey, HostedContract>,
     /// Monotonic access counter. Incremented on every access (insert / read /
     /// seed / touch) and stamped onto the entry's `last_access_seq`, giving an
@@ -645,15 +645,15 @@ pub struct HostingCache<T: TimeSource> {
 /// The canonical eviction **victim ordering** (subscriber-primary, #4642).
 ///
 /// Given the four ranking components of two hosted-contract candidates —
-/// `local_subscription_count`, `downstream_subscriber_count`, `last_get_seq`,
+/// `local_subscription_count`, `downstream_subscriber_count`, `recency_seq`,
 /// and the `ContractKey` — returns the [`Ordering`](std::cmp::Ordering) that
 /// sorts them ascending by
-/// `(local_subscription_count, downstream_subscriber_count, last_get_seq, key_bytes)`:
+/// `(local_subscription_count, downstream_subscriber_count, recency_seq, key_bytes)`:
 ///
 /// 1. fewest **local client subscriptions** first — a contract THIS node's own
 ///    client is subscribed to is evicted LAST (Ian's confirmed ordering, #4642);
 /// 2. then fewest **downstream subscribers** (forwarded demand);
-/// 3. then least-recent real **GET** (`last_get_seq`, a recency tiebreak — NOT a
+/// 3. then least-recent real **GET** (`recency_seq`, a recency tiebreak — NOT a
 ///    primary key; subscription-renewal traffic must not refresh it);
 /// 4. then contract-key bytes as a final deterministic tiebreak.
 ///
@@ -691,12 +691,11 @@ pub(crate) fn victim_order(
 }
 
 impl<T: TimeSource> HostingCache<T> {
-    /// Create a new hosting cache with the given byte budget and TTL.
-    pub fn new(budget_bytes: u64, min_ttl: Duration, time_source: T) -> Self {
+    /// Create a new hosting cache with the given byte budget.
+    pub fn new(budget_bytes: u64, time_source: T) -> Self {
         Self {
             budget_bytes,
             current_bytes: 0,
-            min_ttl,
             contracts: HashMap::new(),
             access_seq: 0,
             eviction_floor: 0.0,
@@ -719,31 +718,36 @@ impl<T: TimeSource> HostingCache<T> {
 
     /// Evict contracts while the cache is over budget, choosing victims
     /// **subscriber-primary**: ascending `(local_subscription_count,
-    /// downstream_subscriber_count, last_get_seq, key_bytes)` — fewest LOCAL
+    /// downstream_subscriber_count, recency_seq, key_bytes)` — fewest LOCAL
     /// client subscriptions first, then fewest downstream subscribers, then
     /// least-recent real GET, then a deterministic key-byte tiebreak (#4642
     /// subscriber-primary rework; Ian's confirmed ordering).
     ///
     /// `subscriber_counts(key)` is the caller's genuine-demand split
     /// `(local_client_subscriptions, downstream_subscribers)`; their sum is `0`
-    /// exactly when the contract is NOT `contract_in_use`. Candidate eligibility
-    /// depends on `pressure`:
+    /// exactly when the contract is NOT `contract_in_use`. There is NO `min_ttl`
+    /// cold-start floor (dropped 2026-07-08); every entry is eligible, with a
+    /// single op-scoped exception governed by `pressure`:
     ///
-    /// - [`MemoryPressure::AtCapacity`] (the production value): an entry is
-    ///   eligible iff `age >= min_ttl`. Subscriber count is NOT a filter — it is
-    ///   the ORDERING. A subscribed contract is therefore ordered LAST (behind
-    ///   every zero-subscriber candidate) but is NOT hard-pinned: when nothing
-    ///   with fewer subscribers is eligible and the peer is still over budget,
-    ///   the fewest-`(local, downstream)` subscribed contract IS evicted (the
-    ///   accepted last resort). The `min_ttl` floor still gives every fresh
-    ///   contract cold-start grace. This is the change from the shipped #4720
-    ///   code, which hard-filtered `subs == 0` (a hard pin) and so could never
-    ///   shed a subscribed contract in the field.
+    /// - [`MemoryPressure::AtCapacity`] (the production value): every entry is
+    ///   eligible EXCEPT `protected` — the op-scoped backstop guard. `protected`
+    ///   is the contract whose in-flight access triggered this sweep (the just-
+    ///   inserted key on the `record_access` path). Skipping it replaces the old
+    ///   `min_ttl` age-0 guarantee that "the entry a call just inserted cannot be
+    ///   evicted by that same call", so `host_contract` still guarantees the
+    ///   contract is hosted on return. It is a backstop, not a pin: the just-
+    ///   accessed key also has the highest `recency_seq`, so `victim_order` already
+    ///   sorts it LAST — the skip only bites on an already-broken peer (invariant
+    ///   3, decision 2026-07-08). Subscriber count is NOT a filter — it is the
+    ///   ORDERING. A subscribed contract is ordered LAST but is NOT hard-pinned:
+    ///   when nothing with fewer subscribers is eligible and the peer is still over
+    ///   budget, the fewest-`(local, downstream)` subscribed contract IS evicted
+    ///   (the accepted last resort). This is the change from the shipped #4720
+    ///   code, which hard-filtered `subs == 0` (a hard pin).
     /// - [`MemoryPressure::Overflow`] (genuine-RAM-overflow corner — trigger
-    ///   UNWIRED in production, see [`MemoryPressure`]): ALL entries are
-    ///   eligible; `min_ttl` is ALSO pierced (its only remaining special power
-    ///   now that AtCapacity already sheds subscribed contracts), so the
-    ///   fewest-subscriber contract is shed even within its cold-start floor to
+    ///   UNWIRED in production, see [`MemoryPressure`]): ALL entries are eligible,
+    ///   INCLUDING `protected` (the op-scoped backstop is pierced), so the
+    ///   fewest-subscriber contract is shed even out from under an in-flight op to
     ///   survive OOM. Not a separate ranking — the SAME `victim_order` — just a
     ///   wider eligibility set (hosting-invariants: "a corner of the same
     ///   eviction, not a separate valve").
@@ -762,12 +766,13 @@ impl<T: TimeSource> HostingCache<T> {
     /// do NOT revert to byte-only / recency-only LRU as the PRIMARY key — see
     /// hosting-invariants (byte-only eviction anti-pattern). Subscriber count is
     /// the demand-authorization signal: a subscribed contract is real demand and
-    /// is shed only as a last resort. Real-GET recency is a tiebreak among
+    /// is shed only as a last resort. Real GET/PUT recency is a tiebreak among
     /// equal-subscriber contracts, not the primary key.
     fn evict_over_budget<G>(
         &mut self,
         subscriber_counts: &G,
         pressure: MemoryPressure,
+        protected: Option<&ContractKey>,
     ) -> Vec<EvictedContract>
     where
         G: Fn(&ContractKey) -> (usize, usize),
@@ -776,61 +781,53 @@ impl<T: TimeSource> HostingCache<T> {
             return Vec::new();
         }
 
-        let now = self.time_source.now();
-
         // Collect eviction-eligible entries with their ordering keys, then evict
         // lowest-priority first until back under budget. O(n log n) per
         // over-budget event; n is the hosted-contract count (hundreds to ~1k),
         // and this only runs when actually over budget.
         //
-        // Eligibility by pressure:
-        // - AtCapacity: past-TTL only. Subscriber count is the ORDERING, not a
-        //   filter — a subscribed contract is ordered last but still eligible, so
-        //   it is shed as a last resort when nothing zero-subscriber is eligible.
-        // - Overflow (genuine-overflow corner): every entry — ALSO pierce
-        //   `min_ttl` to survive genuine RAM overflow.
+        // Eligibility (no `min_ttl` floor since 2026-07-08 — every entry is
+        // eligible) with one op-scoped exception:
+        // - AtCapacity: skip the `protected` key (the op-scoped backstop guard).
+        //   Subscriber count is the ORDERING, not a filter — a subscribed contract
+        //   is ordered last but still eligible, so it is shed as a last resort when
+        //   nothing zero-subscriber is eligible.
+        // - Overflow (genuine-overflow corner): every entry, INCLUDING protected —
+        //   pierce the op backstop to survive genuine RAM overflow.
         //
         // `subscriber_counts(key)` reads the unlocked subscription DashMaps, so
-        // it is evaluated EXACTLY ONCE per entry here and reused for both the
-        // eligibility (min_ttl) decision and the (local, downstream) sort key.
-        // Evaluating it once also fixes the captured `was_in_use` flag atomically
-        // with the decision, so the manager's teardown targets exactly the
-        // contracts this sweep decided to shed while in use (no racy post-hoc
-        // `contract_in_use` re-read).
+        // it is evaluated EXACTLY ONCE per entry here and reused for the (local,
+        // downstream) sort key. Evaluating it once also fixes the captured
+        // `was_in_use` flag atomically with the decision, so the manager's teardown
+        // targets exactly the contracts this sweep decided to shed while in use (no
+        // racy post-hoc `contract_in_use` re-read).
         let mut candidates: Vec<(ContractKey, usize, usize, u64)> = self
             .contracts
             .iter()
             .filter_map(|(key, entry)| {
-                let (local, downstream) = subscriber_counts(key);
                 let eligible = match pressure {
-                    MemoryPressure::AtCapacity => {
-                        // KNOWN OPEN ITEM (pending Ian's decision — do NOT change
-                        // this gate without it): `min_ttl` is applied BEFORE the
-                        // subscriber-primary ordering, so a fresh zero-subscriber
-                        // contract still inside `min_ttl` is INELIGIBLE and thus
-                        // outranks (survives over) an older LOCAL-subscribed
-                        // contract that is past `min_ttl` — the cold-start floor
-                        // wins over subscriber count in that corner. Whether
-                        // subscriber-primary should override `min_ttl` (evict the
-                        // fresh zero-sub contract to keep the local-subscribed one)
-                        // is undecided. See `.claude/rules/hosting-invariants.md`
-                        // (Resolved decisions: "`min_ttl` KEPT as the cold-start
-                        // floor").
-                        let age = now.saturating_duration_since(entry.last_accessed);
-                        age >= self.min_ttl
-                    }
+                    // Op-scoped backstop: never evict the contract whose in-flight
+                    // access triggered this sweep. Only trips on an already-broken
+                    // peer because `protected` also has the highest recency_seq.
+                    MemoryPressure::AtCapacity => protected != Some(key),
                     MemoryPressure::Overflow => true,
                 };
-                eligible.then_some((*key, local, downstream, entry.last_get_seq))
+                if !eligible {
+                    return None;
+                }
+                let (local, downstream) = subscriber_counts(key);
+                Some((*key, local, downstream, entry.recency_seq))
             })
             .collect();
 
         // Ascending by local subscriptions (fewest first), then downstream
-        // subscribers, then last_get_seq (least-recently real-GET first), then
+        // subscribers, then recency_seq (least-recently real-GET first), then
         // contract-key bytes as a final deterministic tiebreak. `victim_order`
         // is the canonical ranking (Ian's confirmed ordering, #4642).
         candidates.sort_by(|a, b| victim_order((a.1, a.2, a.3, &a.0), (b.1, b.2, b.3, &b.0)));
 
+        // Only used by the unread-seed age falsifier below.
+        let now = self.time_source.now();
         let mut evicted = Vec::new();
         for (key, local, downstream, _seq) in candidates {
             if self.current_bytes <= self.budget_bytes {
@@ -855,8 +852,8 @@ impl<T: TimeSource> HostingCache<T> {
                 // concurrent subscription change, so the "stays 0 in the field
                 // while the Overflow trigger is unwired" guarantee holds by
                 // construction. (Overflow's only remaining special power is
-                // piercing `min_ttl`; AtCapacity already sheds subscribed
-                // contracts, tracked by `subscribed_evictions_total` above.)
+                // piercing the op-scoped backstop; AtCapacity already sheds
+                // subscribed contracts, tracked by `subscribed_evictions_total`.)
                 if matches!(pressure, MemoryPressure::Overflow) {
                     self.oom_valve_evictions_total =
                         self.oom_valve_evictions_total.saturating_add(1);
@@ -895,6 +892,36 @@ impl<T: TimeSource> HostingCache<T> {
             }
         }
 
+        // Op-scoped backstop tripwire (invariant 3, decision 2026-07-08): under
+        // AtCapacity we refused to evict `protected` (the op-scoped guard). If that
+        // refusal leaves us still over budget with `protected` still resident, the
+        // peer is in the corner the invariant calls out — a recency-reset contract
+        // we would otherwise have to evict mid-op. On a healthy peer this never
+        // fires: `protected` sorts LAST by recency, so everything else evicts first
+        // and clears the budget before we would reach it. It CAN fire on an already-
+        // over-capacity peer (e.g. a just-inserted contract larger than the whole
+        // budget); genuine RAM overflow arrives as `Overflow`, which pierces the
+        // backstop. Not a `debug_assert!`: the "contract larger than budget" corner
+        // is legitimate (the old `min_ttl` age-0 gate left the same state silently),
+        // so we surface it as a warning rather than panicking debug builds.
+        if self.current_bytes > self.budget_bytes {
+            if let Some(protected_key) = protected {
+                if matches!(pressure, MemoryPressure::AtCapacity)
+                    && self.contracts.contains_key(protected_key)
+                {
+                    tracing::warn!(
+                        contract = %protected_key,
+                        current_bytes = self.current_bytes,
+                        budget_bytes = self.budget_bytes,
+                        over_by = self.current_bytes - self.budget_bytes,
+                        "op-scoped backstop kept an in-flight contract while still over \
+                         budget (pathological — a genuine RAM-overflow signal would pierce \
+                         this via Overflow)",
+                    );
+                }
+            }
+        }
+
         evicted
     }
 
@@ -910,22 +937,23 @@ impl<T: TimeSource> HostingCache<T> {
     ///   the cache's write lock so the `EvictContract` deletion-time guard
     ///   can detect a re-host that occurred after this call returned.
     ///
-    /// Eviction respects TTL: age-0 entries are not eligible for eviction
-    /// while `min_ttl > 0` (the production default — i.e. the new entry
-    /// just inserted by this call cannot be evicted by the same call).
+    /// The entry this call just inserted is passed to `evict_over_budget` as the
+    /// op-scoped `protected` key, so it can never be evicted by the same call
+    /// (replacing the old `min_ttl` age-0 guarantee, now that `min_ttl` is gone).
+    /// It also carries the highest `recency_seq`, so it sorts LAST regardless.
     /// Subscriber count ORDERS victims, it does not pin them: a contract with
     /// `subscriber_count(key) >= 1` (an active client subscription or downstream
     /// subscriber) is evicted LAST and survives while any contract with fewer
-    /// subscribers is eligible, but when the cache is still over budget past TTL
-    /// and nothing fewer-subscriber is eligible, the fewest-subscriber contract
-    /// IS shed as a last resort — even a subscribed one. When that happens the
-    /// returned `EvictedContract::was_in_use` flag is set so the caller tears
-    /// down the subscription state and reclaims the on-disk state (see
+    /// subscribers is eligible, but when the cache is still over budget and nothing
+    /// fewer-subscriber is eligible, the fewest-subscriber contract IS shed as a
+    /// last resort — even a subscribed one. When that happens the returned
+    /// `EvictedContract::was_in_use` flag is set so the caller tears down the
+    /// subscription state and reclaims the on-disk state (see
     /// `HostingManager::teardown_evicted_in_use_contract`). This is the change
     /// from the shipped #4720 code, which hard-pinned subscribed contracts. The
     /// OOM valve ([`MemoryPressure::Overflow`], trigger unwired) adds only one
-    /// extra power: it ALSO pierces `min_ttl`; a fresh insert always uses
-    /// `AtCapacity`.
+    /// extra power: it ALSO pierces the op-scoped backstop; a fresh insert always
+    /// uses `AtCapacity`.
     ///
     /// `write_generation` is the current state-write generation for this
     /// contract (from `HostingManager::state_generation`). It is stored on
@@ -970,19 +998,20 @@ impl<T: TimeSource> HostingCache<T> {
     /// Semantics by access kind:
     /// - **New entry (any kind):** inserted with the caller's `predicted_demand`
     ///   (telemetry). A GET/SUBSCRIBE counts as one read (`read_count = 1`); a
-    ///   PUT is a SEED (`read_count = 0`). Only a GET stamps `last_get_seq` (the
-    ///   eviction recency key); a PUT/SUBSCRIBE leaves it at 0.
-    /// - **Existing entry, GET (real read):** stamp `last_get_seq` to the
+    ///   PUT is a SEED (`read_count = 0`). A GET or PUT (genuine client access)
+    ///   stamps `recency_seq`; a SUBSCRIBE-only seed leaves it at 0.
+    /// - **Existing entry, GET (real read):** stamp `recency_seq` to the
     ///   current frontier (this is the eviction recency refresh), bump
     ///   `read_count`, clear any abandonment, refresh the telemetry
     ///   `keep_score`. Returns an `observed_read_rate` training sample.
     /// - **Existing entry, SUBSCRIBE:** counts as a read for `read_count` /
-    ///   telemetry, but does NOT stamp `last_get_seq` — a subscription is not a
-    ///   GET, so it must not refresh eviction recency (renewal traffic would
+    ///   telemetry, but does NOT stamp `recency_seq` — a subscription is not a
+    ///   GET/PUT, so it must not refresh eviction recency (renewal traffic would
     ///   otherwise keep every subscribed contract equally fresh).
     /// - **Existing entry, PUT (seed only):** refresh recency-of-access/size/
-    ///   generation and the stored `predicted_demand`, but no read count, no
-    ///   `last_get_seq` stamp, no `keep_score` refresh.
+    ///   generation, the stored `predicted_demand`, AND `recency_seq` (a PUT is
+    ///   genuine client access — invariant 3, decision 2026-07-08), but no read
+    ///   count and no `keep_score` refresh (a PUT is a write, not a read).
     pub fn record_access_with_demand<G>(
         &mut self,
         key: ContractKey,
@@ -998,9 +1027,10 @@ impl<T: TimeSource> HostingCache<T> {
         let now = self.time_source.now();
         let seq = self.next_seq();
         let is_read = matches!(access_type, AccessType::Get | AccessType::Subscribe);
-        // Only a real GET refreshes the eviction recency key. SUBSCRIBE and PUT
-        // do not, so renewal/subscription traffic can't keep a contract fresh.
-        let is_get = matches!(access_type, AccessType::Get);
+        // A real GET or PUT (genuine client access) refreshes the eviction recency
+        // key (invariant 3, decision 2026-07-08). SUBSCRIBE / renewal traffic does
+        // NOT, so it can't keep a contract artificially fresh.
+        let resets_recency = matches!(access_type, AccessType::Get | AccessType::Put);
 
         if let Some(existing) = self.contracts.get_mut(&key) {
             // Already cached - update size if changed
@@ -1023,9 +1053,10 @@ impl<T: TimeSource> HostingCache<T> {
             // (which has no estimator access) refreshes against the latest prior.
             existing.predicted_demand = predicted_demand;
 
-            // A real GET refreshes the eviction recency key.
-            if is_get {
-                existing.last_get_seq = seq;
+            // A real GET or PUT refreshes the eviction recency key (a PUT is
+            // genuine client access; SUBSCRIBE/renewal does not).
+            if resets_recency {
+                existing.recency_seq = seq;
             }
 
             let observed_read_rate = if is_read {
@@ -1036,8 +1067,9 @@ impl<T: TimeSource> HostingCache<T> {
                 existing.keep_score = self.eviction_floor + predicted_demand;
                 Self::rate_sample(existing.read_count, now, existing.inserted_at)
             } else {
-                // Seed (PUT) on an existing entry: no read count, no recency
-                // refresh, no telemetry keep_score refresh.
+                // Seed (PUT) on an existing entry: recency already refreshed above
+                // (genuine client access), but no read count and no telemetry
+                // keep_score refresh (a PUT is a write, not a read).
                 None
             };
 
@@ -1052,17 +1084,19 @@ impl<T: TimeSource> HostingCache<T> {
             }
         } else {
             // Not cached - insert the new entry first, then evict over-budget
-            // entries. The new entry is age-0 so the eviction walk's
-            // past-TTL check guarantees it is never evicted by this call
-            // (under AtCapacity, which a fresh insert always uses).
+            // entries. The new entry is passed to `evict_over_budget` as the
+            // op-scoped `protected` key, so it is never evicted by this call
+            // (under AtCapacity, which a fresh insert always uses) — the backstop
+            // that replaces the old `min_ttl` age-0 guarantee.
             let contract = HostedContract {
                 size_bytes,
                 last_accessed: now,
                 last_access_seq: seq,
-                // Only a real GET seeds the eviction recency key; a fresh PUT
-                // seed / SUBSCRIBE starts at 0 (never GET-read), so once past
-                // min_ttl it sorts to evict first among zero-subscriber entries.
-                last_get_seq: if is_get { seq } else { 0 },
+                // A real GET or PUT (genuine client access) seeds the eviction
+                // recency key at the current frontier; a SUBSCRIBE-only seed starts
+                // at 0 (never client-accessed), so it sorts to evict first among
+                // zero-subscriber entries.
+                recency_seq: if resets_recency { seq } else { 0 },
                 keep_score: self.eviction_floor + predicted_demand,
                 predicted_demand,
                 read_count: if is_read { 1 } else { 0 },
@@ -1080,8 +1114,11 @@ impl<T: TimeSource> HostingCache<T> {
             self.current_bytes = self.current_bytes.saturating_add(size_bytes);
 
             // A fresh insert always evicts under AtCapacity: an insert never
-            // constitutes genuine RAM overflow, so it must not pierce `min_ttl`.
-            let evicted = self.evict_over_budget(&subscriber_counts, MemoryPressure::AtCapacity);
+            // constitutes genuine RAM overflow, so it must not pierce the op-scoped
+            // backstop. The just-inserted `key` is the `protected` key, so this
+            // call can never evict the contract it just added.
+            let evicted =
+                self.evict_over_budget(&subscriber_counts, MemoryPressure::AtCapacity, Some(&key));
 
             // Split into the (key, generation) reclaim list (unchanged external
             // contract) and the in-use subset the manager must tear down. Under
@@ -1192,7 +1229,7 @@ impl<T: TimeSource> HostingCache<T> {
             existing.last_access_seq = seq;
             // A touch is a local-cache GET serve — a real GET read, so it
             // refreshes the eviction recency key (unlike SUBSCRIBE/PUT/renewal).
-            existing.last_get_seq = seq;
+            existing.recency_seq = seq;
             existing.read_count = existing.read_count.saturating_add(1);
             // A fresh touch is evidence of demand — clear any abandoned marker,
             // refresh the stored demand estimate to the caller's freshly-derived
@@ -1218,39 +1255,64 @@ impl<T: TimeSource> HostingCache<T> {
         self.touch_with_demand(key, stored)
     }
 
-    /// Mark `key` as recently abandoned and strip its demand credit so it is the
-    /// first candidate for eviction under budget pressure.
+    /// Mark `key` as recently abandoned and **reset its recency clock** as the
+    /// contract enters the zero-subscriber tier.
     ///
     /// Called by `HostingManager` when a contract transitions from "in
     /// use" (has subscribers / clients / downstream peers) to "no longer
     /// in use" — the moment its `contract_in_use` predicate flips from
-    /// `true` to `false`. The entry's `keep_score` is dropped to the current
-    /// `eviction_floor` (zero demand credit), so among the credited band it
-    /// sorts first: a still-active entry keeps `floor + demand`, and since the
-    /// proximity prior (`predict`) is strictly positive it sorts strictly above
-    /// the abandoned entry at the floor. The TTL gate in `evict_over_budget`
-    /// still applies: an abandoned entry within
-    /// `min_ttl` of its last access is not yet eligible.
+    /// `true` to `false`, i.e. subscription TERMINATION.
     ///
-    /// No-op when `key` is absent (already evicted). Idempotent: calling
-    /// it on an already-abandoned entry leaves the existing marker (and
-    /// its earlier timestamp) intact, which is the right behavior — the
-    /// first abandonment is what we want to time from.
+    /// # Recency reset at termination (invariant 3, decision 2026-07-08)
     ///
-    /// Network forgetfulness is explicitly preserved: this method does
-    /// **not** evict the contract or shorten its TTL. It only changes the
-    /// eviction *priority* used when the cache is genuinely over budget. A
-    /// contract that's abandoned but under budget pressure stays cached.
+    /// While a contract is subscribed its eviction rank is dominated by its
+    /// `(local, downstream)` subscriber counts, and its `recency_seq` (a GET/PUT
+    /// tiebreak) is NOT refreshed by subscription-renewal traffic. So the moment
+    /// the last subscription terminates and the contract drops into the zero-
+    /// subscriber tier, its `recency_seq` could be arbitrarily stale (an old read
+    /// from before it was subscribed), which would make it the instant eviction
+    /// victim. To avoid that, termination resets `recency_seq` to the current
+    /// frontier — the recency clock "starts" at termination, so a formerly-
+    /// subscribed contract competes on equal footing with freshly-accessed
+    /// zero-subscriber copies rather than being punished for an old last-read it
+    /// accrued while parked in the subscription tier.
+    ///
+    /// The demoted telemetry `keep_score` is also dropped to the current
+    /// `eviction_floor`; that field no longer drives eviction (see the module
+    /// docs) and is retained only for the dashboard.
+    ///
+    /// No-op when `key` is absent (already evicted). Idempotent: only the FIRST
+    /// abandonment (the actual termination) resets recency / marks the timestamp;
+    /// a repeat call on an already-abandoned entry leaves it intact. A later
+    /// re-subscription clears `abandoned_at` (via `record_access` / `touch`), so a
+    /// second termination resets recency again — the correct behavior.
+    ///
+    /// Network forgetfulness is explicitly preserved: this method does **not**
+    /// evict the contract. It only re-times the eviction *priority* used when the
+    /// cache is genuinely over budget. A contract that's abandoned but under
+    /// budget pressure stays cached.
     pub fn record_abandonment(&mut self, key: &ContractKey) {
         let floor = self.eviction_floor;
+        // Only the first abandonment (the termination transition) acts. Decide
+        // before taking the &mut borrow so we can allocate a fresh recency seq.
+        let is_termination = self
+            .contracts
+            .get(key)
+            .is_some_and(|e| e.abandoned_at.is_none());
+        if !is_termination {
+            return;
+        }
+        let seq = self.next_seq();
+        let now = self.time_source.now();
         if let Some(existing) = self.contracts.get_mut(key) {
-            if existing.abandoned_at.is_none() {
-                existing.abandoned_at = Some(self.time_source.now());
-                // Strip demand credit: drop keep_score to the frontier so the
-                // next over-budget walk evaluates this entry before any
-                // still-credited (floor + demand) entry.
-                existing.keep_score = floor;
-            }
+            existing.abandoned_at = Some(now);
+            // Reset the recency clock at termination (see the doc above) so the
+            // formerly-subscribed contract is not instantly evicted for an old
+            // last-read accrued while it sat in the subscription tier.
+            existing.recency_seq = seq;
+            // Strip demand credit (demoted telemetry only): drop keep_score to
+            // the frontier.
+            existing.keep_score = floor;
         }
     }
 
@@ -1313,6 +1375,18 @@ impl<T: TimeSource> HostingCache<T> {
         self.budget_bytes
     }
 
+    /// Test-only: shrink/grow the byte budget after construction WITHOUT running
+    /// eviction. Lets a test seed several entries at a generous budget (so they
+    /// get distinct `recency_seq` without the insert path auto-evicting), then
+    /// tighten the budget and observe a subsequent sweep. Needed since dropping
+    /// `min_ttl` (2026-07-08) means the insert path now sheds down to budget
+    /// immediately, so "sit over budget with everything present" is only
+    /// reachable by growing the resident set under a large budget then shrinking.
+    #[cfg(test)]
+    pub fn set_budget_for_test(&mut self, budget_bytes: u64) {
+        self.budget_bytes = budget_bytes;
+    }
+
     /// Snapshot the cache's aggregate resource gauges under a single read for
     /// per-node telemetry. See [`HostingCacheStats`].
     pub fn stats(&self) -> HostingCacheStats {
@@ -1330,7 +1404,7 @@ impl<T: TimeSource> HostingCache<T> {
     }
 
     /// Per-contract rows for the local dashboard, in the cache-side EVICTION
-    /// order: ascending `(last_get_seq, key)` — least-recent real GET first, the
+    /// order: ascending `(recency_seq, key)` — least-recent real GET/PUT first, the
     /// same order [`Self::keys_eviction_order`] uses. This reflects the order
     /// among the ZERO-subscriber candidate set the over-budget sweep would evict
     /// under `AtCapacity` (the production pressure); the subscriber-count pin is
@@ -1339,10 +1413,6 @@ impl<T: TimeSource> HostingCache<T> {
     /// still carry the demoted telemetry score fields (`keep_score`,
     /// `predicted_demand`) the dashboard renders.
     pub(crate) fn eviction_ordered_scores(&self) -> Vec<HostingContractScore> {
-        // `past_min_ttl` mirrors the `age >= self.min_ttl` term of the
-        // `evict_over_budget` AtCapacity filter so the dashboard reflects real
-        // sweep behavior (see `past_min_ttl` doc).
-        let now = self.time_source.now();
         let mut rows: Vec<HostingContractScore> = self
             .contracts
             .iter()
@@ -1352,20 +1422,19 @@ impl<T: TimeSource> HostingCache<T> {
                 predicted_demand: v.predicted_demand,
                 size_bytes: v.size_bytes,
                 read_count: v.read_count,
-                last_get_seq: v.last_get_seq,
-                past_min_ttl: now.saturating_duration_since(v.last_accessed) >= self.min_ttl,
+                recency_seq: v.recency_seq,
             })
             .collect();
         rows.sort_by(|a, b| {
-            a.last_get_seq
-                .cmp(&b.last_get_seq)
+            a.recency_seq
+                .cmp(&b.recency_seq)
                 .then_with(|| a.key.as_bytes().cmp(b.key.as_bytes()))
         });
         rows
     }
 
     /// Get all hosted contract keys in the cache-side EVICTION order — ascending
-    /// `(last_get_seq, key)`, i.e. the least-recently real-GET-read contract
+    /// `(recency_seq, key)`, i.e. the least-recently real-GET-read contract
     /// first. This is the order among the zero-subscriber candidate set under
     /// `AtCapacity`; the subscriber-count primary key and pin are applied by the
     /// caller (`HostingManager`), which the cache cannot see here.
@@ -1374,7 +1443,7 @@ impl<T: TimeSource> HostingCache<T> {
         let mut entries: Vec<_> = self
             .contracts
             .iter()
-            .map(|(k, v)| (*k, v.last_get_seq))
+            .map(|(k, v)| (*k, v.recency_seq))
             .collect();
         entries.sort_by(|a, b| {
             a.1.cmp(&b.1)
@@ -1400,13 +1469,19 @@ impl<T: TimeSource> HostingCache<T> {
     ///
     /// Only evicts when `current_bytes > budget_bytes`. Victims are chosen
     /// subscriber-primary — ascending
-    /// `(local_subscription_count, downstream_subscriber_count, last_get_seq, key)` —
+    /// `(local_subscription_count, downstream_subscriber_count, recency_seq, key)` —
     /// with eligibility governed by `pressure`:
-    /// - [`MemoryPressure::AtCapacity`] (production): past-TTL entries. Subscriber
-    ///   count is the ORDERING, not a filter — a subscribed contract is ordered
-    ///   last but shed as a last resort when nothing zero-subscriber is eligible.
+    /// - [`MemoryPressure::AtCapacity`] (production): every entry is eligible (no
+    ///   `min_ttl` floor). Subscriber count is the ORDERING, not a filter — a
+    ///   subscribed contract is ordered last but shed as a last resort when nothing
+    ///   zero-subscriber is eligible.
     /// - [`MemoryPressure::Overflow`]: the genuine-overflow corner — ALSO pierces
-    ///   `min_ttl`. The trigger is UNWIRED in production (see [`MemoryPressure`]).
+    ///   the op-scoped backstop. The trigger is UNWIRED in production (see
+    ///   [`MemoryPressure`]).
+    ///
+    /// The periodic sweep has no single triggering access, so it passes NO
+    /// op-scoped `protected` key: in-flight-op contracts are protected only by
+    /// their fresh `recency_seq` (they sort last), not by a per-sweep skip.
     ///
     /// `subscriber_counts(key)` is the caller's genuine-demand split
     /// `(local_client_subscriptions, downstream_subscribers)`; their sum is `0`
@@ -1426,8 +1501,8 @@ impl<T: TimeSource> HostingCache<T> {
         // Over-budget eviction logic is shared with `record_access` via
         // `evict_over_budget`: it returns early when under budget, then evicts
         // subscriber-primary (fewest local, then fewest downstream, then
-        // least-recent real GET).
-        self.evict_over_budget(&subscriber_counts, pressure)
+        // least-recent real GET/PUT). No `protected` key on the periodic sweep.
+        self.evict_over_budget(&subscriber_counts, pressure, None)
     }
 
     /// Load a contract entry from persisted data during startup, using an
@@ -1490,7 +1565,7 @@ impl<T: TimeSource> HostingCache<T> {
             // demand (a never-read PUT seed out-surviving a genuinely GET-read
             // entry). A live GET after restart re-stamps it to a true value. See
             // `finalize_loading`.
-            last_get_seq: 0,
+            recency_seq: 0,
             // Loaded entries start at the caller-supplied cold demand (the
             // distance prior when this peer's location is known at load, else
             // neutral). The first live read re-scores against the current prior.
@@ -1554,12 +1629,12 @@ impl<T: TimeSource> HostingCache<T> {
     /// access counter past the assigned range so subsequent live accesses keep
     /// sorting after loaded entries.
     ///
-    /// It deliberately does NOT stamp `last_get_seq` (the eviction recency key):
+    /// It deliberately does NOT stamp `recency_seq` (the eviction recency key):
     /// persistence records only a generic LAST-ACCESS time, which does not
-    /// distinguish a real GET from a PUT/SUBSCRIBE, so stamping `last_get_seq`
+    /// distinguish a real GET from a PUT/SUBSCRIBE, so stamping `recency_seq`
     /// from it would FABRICATE real-GET recency — a never-GET-read PUT seed
     /// persisted just before restart would then out-survive an entry that had
-    /// genuine GET demand. Instead every reloaded entry keeps `last_get_seq == 0`
+    /// genuine GET demand. Instead every reloaded entry keeps `recency_seq == 0`
     /// (treated as "never GET-read since restart"); a live GET after restart
     /// re-stamps it to a real value. Reloaded entries therefore tie at the front
     /// of the eviction order (0), broken by key bytes, until a real GET lifts
@@ -1596,12 +1671,9 @@ mod tests {
         )
     }
 
-    fn make_cache(
-        budget: u64,
-        min_ttl: Duration,
-    ) -> (HostingCache<SharedMockTimeSource>, SharedMockTimeSource) {
+    fn make_cache(budget: u64) -> (HostingCache<SharedMockTimeSource>, SharedMockTimeSource) {
         let time_source = SharedMockTimeSource::new();
-        let cache = HostingCache::new(budget, min_ttl, time_source.clone());
+        let cache = HostingCache::new(budget, time_source.clone());
         (cache, time_source)
     }
 
@@ -1640,7 +1712,7 @@ mod tests {
         );
 
         // 3. Equal local AND downstream: least-recent real GET (smaller
-        //    last_get_seq) ranks first.
+        //    recency_seq) ranks first.
         assert_eq!(
             victim_order((2, 2, 5, &k1), (2, 2, 6, &k2)),
             Ordering::Less,
@@ -1669,7 +1741,7 @@ mod tests {
 
     #[test]
     fn test_empty_cache() {
-        let (cache, _) = make_cache(1000, Duration::from_secs(60));
+        let (cache, _) = make_cache(1000);
         assert!(cache.is_empty());
         assert_eq!(cache.len(), 0);
         assert_eq!(cache.current_bytes(), 0);
@@ -1678,7 +1750,7 @@ mod tests {
 
     #[test]
     fn test_add_single_contract() {
-        let (mut cache, _) = make_cache(1000, Duration::from_secs(60));
+        let (mut cache, _) = make_cache(1000);
         let key = make_key(1);
 
         let result = cache.record_access(key, 100, AccessType::Get, 0, |_| (0, 0));
@@ -1696,7 +1768,7 @@ mod tests {
 
     #[test]
     fn test_refresh_existing_contract() {
-        let (mut cache, time) = make_cache(1000, Duration::from_secs(60));
+        let (mut cache, time) = make_cache(1000);
         let key = make_key(1);
 
         // First access
@@ -1716,54 +1788,26 @@ mod tests {
         assert!(info.last_accessed > first_access);
     }
 
+    /// Over budget, eviction happens IMMEDIATELY — there is no `min_ttl` floor
+    /// (dropped 2026-07-08). Adding a third entry that pushes over budget sheds the
+    /// least-recently-accessed entry at once; the just-inserted entry is protected.
+    /// (The former `test_lru_eviction_respects_ttl` / `test_lru_eviction_after_ttl`
+    /// pair, which asserted min_ttl grace then post-TTL eviction, was collapsed into
+    /// this single no-floor pin.)
     #[test]
-    fn test_lru_eviction_respects_ttl() {
-        // Cache with max 200 bytes, 60 second TTL
-        let (mut cache, time) = make_cache(200, Duration::from_secs(60));
+    fn test_over_budget_evicts_least_recent_no_min_ttl_floor() {
+        // Cache with max 200 bytes.
+        let (mut cache, _time) = make_cache(200);
         let key1 = make_key(1);
         let key2 = make_key(2);
         let key3 = make_key(3);
 
-        // Add two entries
+        // Add two entries (fits exactly, no eviction).
         cache.record_access(key1, 100, AccessType::Get, 0, |_| (0, 0));
         cache.record_access(key2, 100, AccessType::Get, 0, |_| (0, 0));
         assert_eq!(cache.current_bytes(), 200);
 
-        // Advance time by 30 seconds (under TTL)
-        time.advance_time(Duration::from_secs(30));
-
-        // Add third entry - should NOT evict because all entries under TTL
-        let result = cache.record_access(key3, 100, AccessType::Get, 0, |_| (0, 0));
-        assert!(
-            result.evicted.is_empty(),
-            "Should not evict entries under TTL"
-        );
-        assert_eq!(
-            cache.len(),
-            3,
-            "Cache should exceed budget when all under TTL"
-        );
-        assert!(cache.contains(&key1));
-        assert!(cache.contains(&key2));
-        assert!(cache.contains(&key3));
-    }
-
-    #[test]
-    fn test_lru_eviction_after_ttl() {
-        // Cache with max 200 bytes, 60 second TTL
-        let (mut cache, time) = make_cache(200, Duration::from_secs(60));
-        let key1 = make_key(1);
-        let key2 = make_key(2);
-        let key3 = make_key(3);
-
-        // Add two entries
-        cache.record_access(key1, 100, AccessType::Get, 0, |_| (0, 0));
-        cache.record_access(key2, 100, AccessType::Get, 0, |_| (0, 0));
-
-        // Advance time past TTL
-        time.advance_time(Duration::from_secs(61));
-
-        // Add third entry - should evict key1 (oldest)
+        // Add third entry - immediately evicts key1 (oldest); no TTL wait.
         let result = cache.record_access(key3, 100, AccessType::Get, 0, |_| (0, 0));
         assert!(result.is_new);
         assert_eq!(result.evicted, vec![(key1, 0)]);
@@ -1775,7 +1819,7 @@ mod tests {
 
     #[test]
     fn test_access_refreshes_lru_position() {
-        let (mut cache, time) = make_cache(200, Duration::from_secs(60));
+        let (mut cache, time) = make_cache(200);
         let key1 = make_key(1);
         let key2 = make_key(2);
         let key3 = make_key(3);
@@ -1804,7 +1848,7 @@ mod tests {
 
     #[test]
     fn test_touch_refreshes_ttl() {
-        let (mut cache, time) = make_cache(200, Duration::from_secs(60));
+        let (mut cache, time) = make_cache(200);
         let key1 = make_key(1);
         let key2 = make_key(2);
         let key3 = make_key(3);
@@ -1839,7 +1883,7 @@ mod tests {
 
     #[test]
     fn test_large_contract_evicts_multiple() {
-        let (mut cache, time) = make_cache(300, Duration::from_secs(60));
+        let (mut cache, time) = make_cache(300);
 
         let small1 = make_key(1);
         let small2 = make_key(2);
@@ -1869,27 +1913,24 @@ mod tests {
 
     #[test]
     fn test_sweep_expired() {
-        let (mut cache, time) = make_cache(200, Duration::from_secs(60));
+        // Seed three entries under a generous budget (no auto-evict), then tighten
+        // so the cache sits over budget for the sweep. (There is no `min_ttl` floor
+        // since 2026-07-08, so record_access sheds to budget immediately — the
+        // "3 resident over budget" state is only reachable via a budget shrink.)
+        let (mut cache, _time) = make_cache(100_000);
         let key1 = make_key(1);
         let key2 = make_key(2);
         let key3 = make_key(3);
 
-        // Add three entries (exceeds budget)
-        cache.record_access(key1, 100, AccessType::Get, 0, |_| (0, 0));
+        cache.record_access(key1, 100, AccessType::Get, 0, |_| (0, 0)); // recency: oldest
         cache.record_access(key2, 100, AccessType::Get, 0, |_| (0, 0));
         cache.record_access(key3, 100, AccessType::Get, 0, |_| (0, 0));
+        cache.set_budget_for_test(200);
         assert_eq!(cache.len(), 3);
         assert_eq!(cache.current_bytes(), 300);
 
-        // Sweep immediately - nothing should be evicted (all under TTL)
-        let evicted = cache.sweep_expired(|_| (0, 0), MemoryPressure::AtCapacity);
-        assert!(evicted.is_empty());
-        assert_eq!(cache.len(), 3);
-
-        // Advance past TTL
-        time.advance_time(Duration::from_secs(61));
-
-        // Sweep should evict oldest entry to get back under budget
+        // Sweep evicts the least-recently-accessed entry (key1) to get back under
+        // budget.
         let evicted = cache.sweep_expired(|_| (0, 0), MemoryPressure::AtCapacity);
         assert_eq!(evicted_pairs(&evicted), vec![(key1, 0)]);
         assert_eq!(cache.current_bytes(), 200);
@@ -1897,18 +1938,17 @@ mod tests {
 
     #[test]
     fn test_sweep_orders_subscribed_last() {
-        let (mut cache, time) = make_cache(200, Duration::from_secs(60));
+        // Seed three entries under a generous budget (distinct recency), then
+        // tighten so the sweep runs over budget.
+        let (mut cache, _time) = make_cache(100_000);
         let key1 = make_key(1);
         let key2 = make_key(2);
         let key3 = make_key(3);
 
-        // Add three entries (exceeds budget)
         cache.record_access(key1, 100, AccessType::Get, 0, |_| (0, 0));
         cache.record_access(key2, 100, AccessType::Get, 0, |_| (0, 0));
         cache.record_access(key3, 100, AccessType::Get, 0, |_| (0, 0));
-
-        // Advance past TTL
-        time.advance_time(Duration::from_secs(61));
+        cache.set_budget_for_test(200);
 
         // Sweep with a subscriber count that makes key1 subscribed (downstream).
         // Under subscriber-primary ordering it sorts LAST, so the zero-subscriber
@@ -1932,7 +1972,7 @@ mod tests {
     /// the last-resort shed when EVERY contract is subscribed.
     #[test]
     fn test_record_access_orders_subscribed_last() {
-        let (mut cache, time) = make_cache(200, Duration::from_secs(60));
+        let (mut cache, time) = make_cache(200);
         let retained = make_key(1);
         let evictable = make_key(2);
         let trigger = make_key(3);
@@ -1968,21 +2008,22 @@ mod tests {
         assert!(cache.contains(&trigger));
     }
 
-    /// The contract inserted by `record_access` is age-0, so while
-    /// `min_ttl > 0` (the production default) it is never evicted by the
-    /// same call even when the insert pushes over budget.
+    /// The contract inserted by `record_access` is the op-scoped `protected` key,
+    /// so it is never evicted by the same call even when the insert pushes over
+    /// budget — the backstop that replaces the old `min_ttl` age-0 guarantee (now
+    /// that `min_ttl` is dropped, 2026-07-08). It is also the most-recently-
+    /// accessed, so it sorts last regardless.
     #[test]
     fn test_record_access_never_evicts_the_new_entry() {
-        let (mut cache, time) = make_cache(100, Duration::from_secs(60));
+        let (mut cache, _time) = make_cache(100);
         let first = make_key(1);
         let second = make_key(2);
 
         cache.record_access(first, 100, AccessType::Get, 0, |_| (0, 0));
-        time.advance_time(Duration::from_secs(61));
 
-        // Inserting `second` puts the cache over budget; `first` is past TTL
-        // and unretained so it is evicted, but the just-inserted `second`
-        // (age 0) must survive.
+        // Inserting `second` puts the cache over budget; `first` (older, zero-
+        // subscriber) is evicted, but the just-inserted `second` (the op-protected
+        // key) must survive.
         let result = cache.record_access(second, 100, AccessType::Get, 0, |_| (0, 0));
         assert_eq!(result.evicted, vec![(first, 0)]);
         assert!(cache.contains(&second));
@@ -1991,7 +2032,7 @@ mod tests {
 
     #[test]
     fn test_touch_non_existent_is_no_op() {
-        let (mut cache, _) = make_cache(1000, Duration::from_secs(60));
+        let (mut cache, _) = make_cache(1000);
         let key = make_key(1);
 
         // Touch a key that doesn't exist
@@ -2004,7 +2045,7 @@ mod tests {
 
     #[test]
     fn test_access_types() {
-        let (mut cache, _) = make_cache(1000, Duration::from_secs(60));
+        let (mut cache, _) = make_cache(1000);
         let key = make_key(1);
 
         // Test each access type is recorded correctly
@@ -2020,7 +2061,7 @@ mod tests {
 
     #[test]
     fn test_contract_size_change() {
-        let (mut cache, _) = make_cache(1000, Duration::from_secs(60));
+        let (mut cache, _) = make_cache(1000);
         let key = make_key(1);
 
         // Add contract with initial size
@@ -2041,7 +2082,7 @@ mod tests {
 
     #[test]
     fn test_iter_returns_all_hosted_keys() {
-        let (mut cache, _) = make_cache(1000, Duration::from_secs(60));
+        let (mut cache, _) = make_cache(1000);
 
         // Empty cache yields no keys
         assert_eq!(cache.iter().count(), 0);
@@ -2071,7 +2112,7 @@ mod tests {
     /// Regression test for PR #4212 review round C.
     #[test]
     fn test_record_access_carries_write_generation_through_eviction() {
-        let (mut cache, time) = make_cache(100, Duration::from_secs(60));
+        let (mut cache, time) = make_cache(100);
         let evicted_key = make_key(1);
         let trigger_key = make_key(2);
 
@@ -2122,7 +2163,7 @@ mod tests {
     /// captures the correct generation snapshot.
     #[test]
     fn test_record_access_refresh_updates_write_generation() {
-        let (mut cache, _) = make_cache(1000, Duration::from_secs(60));
+        let (mut cache, _) = make_cache(1000);
         let key = make_key(7);
 
         cache.record_access(key, 100, AccessType::Get, 1, |_| (0, 0));
@@ -2145,7 +2186,7 @@ mod tests {
     #[test]
     fn test_local_client_access_age_gate_expiry() {
         let lease = Duration::from_secs(480); // SUBSCRIPTION_LEASE_DURATION
-        let (mut cache, time) = make_cache(10000, Duration::from_secs(60));
+        let (mut cache, time) = make_cache(10000);
         let key = make_key(1);
 
         cache.record_access(key, 100, AccessType::Get, 0, |_| (0, 0));
@@ -2185,7 +2226,7 @@ mod tests {
         // The dashboard reads `eviction_ordered_scores` (production) to render
         // piece A's demand-driven eviction. It must yield the same order as the
         // test-only `keys_eviction_order` and carry each entry's score fields.
-        let (mut cache, _) = make_cache(10_000, Duration::from_secs(60));
+        let (mut cache, _) = make_cache(10_000);
         let key1 = make_key(1);
         let key2 = make_key(2);
         let key3 = make_key(3);
@@ -2206,42 +2247,15 @@ mod tests {
             assert_eq!(s.size_bytes, entry.size_bytes);
             assert_eq!(s.read_count, entry.read_count);
             assert_eq!(s.predicted_demand, entry.predicted_demand);
-            assert_eq!(s.last_get_seq, entry.last_get_seq);
-            // Just accessed with a 60s min_ttl → not yet past the TTL gate.
-            assert!(
-                !s.past_min_ttl,
-                "a freshly-accessed entry is within min_ttl, so it is not \
-                 eviction-eligible yet"
-            );
+            assert_eq!(s.recency_seq, entry.recency_seq);
         }
     }
 
-    #[test]
-    fn eviction_ordered_scores_flags_past_min_ttl_after_ttl_elapses() {
-        // `past_min_ttl` must mirror the `age >= min_ttl` term of the
-        // `evict_over_budget` filter: false while within the TTL window, true
-        // once the entry has aged past it. This is the cache half of the
-        // dashboard "next to evict" eligibility (the in-use half is folded in
-        // by `HostingManager::is_eviction_eligible`).
-        let min_ttl = Duration::from_secs(60);
-        let (mut cache, time_source) = make_cache(10_000, min_ttl);
-        let key = make_key(1);
-        cache.record_access(key, 111, AccessType::Get, 0, |_| (0, 0));
-
-        let before = cache.eviction_ordered_scores();
-        assert!(
-            !before[0].past_min_ttl,
-            "within min_ttl → not past the TTL gate"
-        );
-
-        // Age the entry past min_ttl.
-        time_source.advance_time(min_ttl + Duration::from_secs(1));
-        let after = cache.eviction_ordered_scores();
-        assert!(
-            after[0].past_min_ttl,
-            "past min_ttl → now eligible for the TTL gate"
-        );
-    }
+    // The former `eviction_ordered_scores_flags_past_min_ttl_after_ttl_elapses`
+    // test was DELETED: it exercised the `past_min_ttl` age gate, which no longer
+    // exists (the `min_ttl` cold-start floor was dropped 2026-07-08 — invariant 3).
+    // Dashboard eviction-eligibility is now "not in use" only; that half is
+    // covered by `HostingManager::is_eviction_eligible` tests in hosting.rs.
 
     // --- Recently-abandoned priority (demand-credit strip) ---
 
@@ -2252,7 +2266,7 @@ mod tests {
     #[ignore]
     #[test]
     fn test_record_abandonment_moves_entry_to_eviction_front() {
-        let (mut cache, _) = make_cache(1000, Duration::from_secs(60));
+        let (mut cache, _) = make_cache(1000);
         let key1 = make_key(1);
         let key2 = make_key(2);
         let key3 = make_key(3);
@@ -2282,9 +2296,51 @@ mod tests {
         );
     }
 
+    /// Decision 3 (invariant 3, 2026-07-08): the recency clock starts at
+    /// subscription TERMINATION. `record_abandonment` (the termination hook) resets
+    /// the contract's `recency_seq` to the current frontier, so a formerly-
+    /// subscribed contract is NOT instantly evicted for an old last-read it accrued
+    /// while parked in the subscription tier. Here `subscribed` has the OLDEST GET
+    /// recency, but after termination it becomes the newest and survives; the
+    /// genuinely-oldest zero-subscriber contract is the victim instead.
+    #[test]
+    fn record_abandonment_resets_recency_at_subscription_termination() {
+        let (mut cache, _time) = make_cache(300); // 3x100-byte entries fit
+        let subscribed = make_key(1);
+        let older = make_key(2);
+        let newer = make_key(3);
+        let trigger = make_key(4);
+
+        // Recency order after the GETs: subscribed < older < newer.
+        cache.record_access(subscribed, 100, AccessType::Get, 0, |_| (0, 0));
+        cache.record_access(older, 100, AccessType::Get, 0, |_| (0, 0));
+        cache.record_access(newer, 100, AccessType::Get, 0, |_| (0, 0));
+
+        // The subscription on `subscribed` terminates → recency reset to newest.
+        cache.record_abandonment(&subscribed);
+        assert!(
+            cache.get(&subscribed).unwrap().recency_seq > cache.get(&newer).unwrap().recency_seq,
+            "termination must reset recency to the frontier (newer than everything else)"
+        );
+
+        // Insert `trigger` over budget: the victim is the genuinely least-recent
+        // zero-subscriber contract (`older`), NOT the formerly-subscribed one.
+        let result = cache.record_access(trigger, 100, AccessType::Get, 0, |_| (0, 0));
+        assert_eq!(
+            result.evicted,
+            vec![(older, 0)],
+            "the least-recent zero-subscriber contract is shed; termination protected `subscribed`"
+        );
+        assert!(
+            cache.contains(&subscribed),
+            "the formerly-subscribed contract survived: termination reset its recency"
+        );
+        assert!(!cache.contains(&older));
+    }
+
     #[test]
     fn test_record_abandonment_is_idempotent() {
-        let (mut cache, time) = make_cache(1000, Duration::from_secs(60));
+        let (mut cache, time) = make_cache(1000);
         let key = make_key(1);
         cache.record_access(key, 100, AccessType::Get, 0, |_| (0, 0));
 
@@ -2303,7 +2359,7 @@ mod tests {
 
     #[test]
     fn test_record_abandonment_missing_key_is_noop() {
-        let (mut cache, _) = make_cache(1000, Duration::from_secs(60));
+        let (mut cache, _) = make_cache(1000);
         let key = make_key(42);
         // Should not panic, should not insert anything.
         cache.record_abandonment(&key);
@@ -2313,7 +2369,7 @@ mod tests {
 
     #[test]
     fn test_record_access_clears_abandoned_marker() {
-        let (mut cache, _) = make_cache(1000, Duration::from_secs(60));
+        let (mut cache, _) = make_cache(1000);
         let key = make_key(1);
         cache.record_access(key, 100, AccessType::Get, 0, |_| (0, 0));
         cache.record_abandonment(&key);
@@ -2330,7 +2386,7 @@ mod tests {
 
     #[test]
     fn test_touch_clears_abandoned_marker() {
-        let (mut cache, _) = make_cache(1000, Duration::from_secs(60));
+        let (mut cache, _) = make_cache(1000);
         let key = make_key(1);
         cache.record_access(key, 100, AccessType::Get, 0, |_| (0, 0));
         cache.record_abandonment(&key);
@@ -2354,7 +2410,7 @@ mod tests {
         // are past TTL. Without the abandonment bump key1 (oldest)
         // evicts; with the bump key2 (abandoned-and-bumped) evicts
         // even though key1 is older.
-        let (mut cache, time) = make_cache(200, Duration::from_secs(60));
+        let (mut cache, time) = make_cache(200);
         let key1 = make_key(1);
         let key2 = make_key(2);
         let key3 = make_key(3);
@@ -2389,7 +2445,7 @@ mod tests {
         // Abandoning an entry MUST NOT evict it — the network's
         // persistence-beyond-active-demand property only yields to
         // disk pressure, never to abandonment alone.
-        let (mut cache, time) = make_cache(1000, Duration::from_secs(60));
+        let (mut cache, time) = make_cache(1000);
         let key1 = make_key(1);
         let key2 = make_key(2);
 
@@ -2469,38 +2525,37 @@ mod tests {
     }
 
     /// The budget-triggered eviction counter increments once per over-budget
-    /// eviction and is surfaced via `stats()`; a TTL-protected or no-pressure
-    /// cache leaves it untouched. This is the telemetry A2 ships to observe its
-    /// own eviction rate.
+    /// eviction and is surfaced via `stats()`; a no-pressure (under-budget) cache
+    /// leaves it untouched. This is the telemetry A2 ships to observe its own
+    /// eviction rate. (There is no `min_ttl` floor since 2026-07-08, so an over-
+    /// budget insert evicts — and counts — immediately.)
     #[test]
     fn test_budget_eviction_counter_tracks_over_budget_evictions() {
-        let (mut cache, time) = make_cache(200, Duration::from_secs(60));
+        let (mut cache, _time) = make_cache(200);
         let key1 = make_key(1);
         let key2 = make_key(2);
         let key3 = make_key(3);
+        let key4 = make_key(4);
 
+        // Under budget: no eviction, counter untouched.
         cache.record_access(key1, 100, AccessType::Get, 0, |_| (0, 0));
         cache.record_access(key2, 100, AccessType::Get, 0, |_| (0, 0));
         assert_eq!(cache.stats().budget_evictions_total, 0);
 
-        // Over budget but every entry is under TTL: no budget eviction yet.
-        cache.record_access(key3, 100, AccessType::Get, 0, |_| (0, 0));
+        // Over budget: the insert immediately sheds the oldest (key1) → counter 1.
+        let result = cache.record_access(key3, 100, AccessType::Get, 0, |_| (0, 0));
+        assert_eq!(result.evicted, vec![(key1, 0)]);
         assert_eq!(
             cache.stats().budget_evictions_total,
-            0,
-            "TTL-protected entries must not count as budget evictions"
+            1,
+            "an over-budget insert counts one budget eviction (no min_ttl grace)"
         );
 
-        // Past TTL: a sweep now evicts the single over-budget entry.
-        time.advance_time(Duration::from_secs(61));
-        let evicted = cache.sweep_expired(|_| (0, 0), MemoryPressure::AtCapacity);
-        assert_eq!(
-            evicted.len(),
-            1,
-            "one 100-byte entry brings 300 back to 200"
-        );
+        // A further over-budget insert sheds key2 → counter 2.
+        let result = cache.record_access(key4, 100, AccessType::Get, 0, |_| (0, 0));
+        assert_eq!(result.evicted, vec![(key2, 0)]);
         let stats = cache.stats();
-        assert_eq!(stats.budget_evictions_total, 1);
+        assert_eq!(stats.budget_evictions_total, 2);
         assert_eq!(stats.current_bytes, 200);
         assert_eq!(stats.contract_count, 2);
         assert_eq!(stats.budget_bytes, 200);
@@ -2510,7 +2565,7 @@ mod tests {
         assert!(evicted.is_empty(), "at budget -> no further eviction");
         assert_eq!(
             cache.stats().budget_evictions_total,
-            1,
+            2,
             "counter must not advance with no budget pressure"
         );
     }
@@ -2523,7 +2578,7 @@ mod tests {
     fn test_evicted_unread_counts_only_never_read_seeds() {
         // Budget 100 bytes: only one 100-byte entry fits, so each insert past
         // TTL evicts the resident one.
-        let (mut cache, time) = make_cache(100, Duration::from_secs(60));
+        let (mut cache, time) = make_cache(100);
         let key1 = make_key(1);
         let key2 = make_key(2);
         let key3 = make_key(3);
@@ -2576,22 +2631,22 @@ mod tests {
     #[test]
     fn test_reloaded_entry_eviction_does_not_count_as_unread_seed() {
         // Budget 100 bytes: one 100-byte entry fits.
-        let (mut cache, time) = make_cache(100, Duration::from_secs(60));
+        let (mut cache, _time) = make_cache(100);
         let key1 = make_key(1);
         let key2 = make_key(2);
 
         // Reload key1 from persistence with read_count 0 — the exact shape of a
         // long-hosted entry after a restart resets its counters. (A PUT was its
         // last pre-restart access, so access_type == Put, proving the counter
-        // cannot key on access_type instead of the explicit marker.)
+        // cannot key on access_type instead of the explicit marker.) A reloaded
+        // entry has recency_seq 0, so it is the first eviction candidate.
         cache.load_persisted_entry(key1, 100, AccessType::Put, Duration::from_secs(1), false);
         cache.finalize_loading();
         assert!(cache.contains(&key1));
         assert_eq!(cache.stats().evicted_unread_total, 0);
 
-        // Advance past min_ttl so the reloaded entry is eviction-eligible, then a
-        // fresh insert pushes over budget and sheds it (the post-load burst).
-        time.advance_time(Duration::from_secs(61));
+        // A fresh insert (key2, the op-protected key) pushes over budget and sheds
+        // the reloaded key1 (the post-load burst) — no `min_ttl` wait needed.
         let result = cache.record_access(key2, 100, AccessType::Get, 0, |_| (0, 0));
         assert_eq!(
             result.evicted,
@@ -2611,20 +2666,20 @@ mod tests {
     }
 
     /// Restart must NOT fabricate real-GET recency (#4642 review fix): a reloaded
-    /// entry keeps `last_get_seq == 0` regardless of its persisted access type,
+    /// entry keeps `recency_seq == 0` regardless of its persisted access type,
     /// because persistence records only a generic last-ACCESS time and cannot
-    /// distinguish a real GET from a PUT/SUBSCRIBE. Stamping `last_get_seq` from
+    /// distinguish a real GET from a PUT/SUBSCRIBE. Stamping `recency_seq` from
     /// last-access order would let a never-GET-read PUT seed out-survive an entry
     /// with genuine GET demand after a restart.
     #[test]
     fn reloaded_entry_has_zero_get_recency_regardless_of_access_type() {
-        let (mut cache, _) = make_cache(10_000, Duration::from_secs(60));
+        let (mut cache, _) = make_cache(10_000);
         let put_seed = make_key(1);
         let subscribed = make_key(2);
 
         // Both reloaded from persistence with different pre-restart access types
         // and different persisted recency (so finalize_loading's last_access_seq
-        // ordering differs) — neither may fabricate a nonzero last_get_seq.
+        // ordering differs) — neither may fabricate a nonzero recency_seq.
         cache.load_persisted_entry(
             put_seed,
             100,
@@ -2642,22 +2697,22 @@ mod tests {
         cache.finalize_loading();
 
         assert_eq!(
-            cache.get(&put_seed).unwrap().last_get_seq,
+            cache.get(&put_seed).unwrap().recency_seq,
             0,
-            "a reloaded PUT entry must have last_get_seq == 0 (never GET-read since restart)"
+            "a reloaded PUT entry must have recency_seq == 0 (never GET-read since restart)"
         );
         assert_eq!(
-            cache.get(&subscribed).unwrap().last_get_seq,
+            cache.get(&subscribed).unwrap().recency_seq,
             0,
-            "a reloaded SUBSCRIBE entry must also have last_get_seq == 0"
+            "a reloaded SUBSCRIBE entry must also have recency_seq == 0"
         );
 
         // A real GET after restart re-stamps it to a genuine (nonzero) value,
         // lifting it out of the never-GET-read front of the eviction order.
         cache.record_access(put_seed, 100, AccessType::Get, 0, |_| (0, 0));
         assert!(
-            cache.get(&put_seed).unwrap().last_get_seq > 0,
-            "a real GET after restart must re-stamp last_get_seq to a real value"
+            cache.get(&put_seed).unwrap().recency_seq > 0,
+            "a real GET after restart must re-stamp recency_seq to a real value"
         );
     }
 
@@ -2669,7 +2724,7 @@ mod tests {
     /// stays put.
     #[test]
     fn fuel_gauge_keep_score_set_on_insert_and_refreshed_on_read() {
-        let (mut cache, _) = make_cache(10_000, Duration::from_secs(60));
+        let (mut cache, _) = make_cache(10_000);
         let key = make_key(1);
 
         // Insert at floor 0 with demand 3.0 -> keep_score 3.0.
@@ -2693,7 +2748,7 @@ mod tests {
     #[ignore]
     #[test]
     fn fuel_gauge_evicts_lowest_demand_not_lru() {
-        let (mut cache, time) = make_cache(200, Duration::from_secs(60));
+        let (mut cache, time) = make_cache(200);
         let high = make_key(1);
         let low = make_key(2);
         let trigger = make_key(3);
@@ -2748,7 +2803,7 @@ mod tests {
         );
 
         // Budget for exactly two 100-byte contracts.
-        let (mut cache, time) = make_cache(200, Duration::from_secs(60));
+        let (mut cache, time) = make_cache(200);
         let near = make_key(1);
         let far = make_key(2);
         let trigger = make_key(3);
@@ -2817,7 +2872,7 @@ mod tests {
     #[test]
     fn fuel_gauge_keeps_repeatedly_read_contract_over_junk() {
         // Budget for two 100-byte contracts.
-        let (mut cache, time) = make_cache(200, Duration::from_secs(60));
+        let (mut cache, time) = make_cache(200);
         let room = make_key(1); // the "River room": repeatedly read, high demand
         let junk = make_key(2); // never re-read, low demand, inserted LATER
         let trigger = make_key(3);
@@ -2884,7 +2939,7 @@ mod tests {
     /// and never decreases (Greedy-Dual aging).
     #[test]
     fn eviction_floor_ratchets_up_on_eviction() {
-        let (mut cache, time) = make_cache(100, Duration::from_secs(60));
+        let (mut cache, time) = make_cache(100);
         assert_eq!(cache.eviction_floor(), 0.0);
 
         // Insert a demand-7 contract, let it age, then evict it via an
@@ -2919,7 +2974,7 @@ mod tests {
     /// contract cannot outrank a repeatedly-GET one.
     #[test]
     fn put_seeds_but_earns_no_read_demand_credit() {
-        let (mut cache, _) = make_cache(10_000, Duration::from_secs(60));
+        let (mut cache, _) = make_cache(10_000);
         let key = make_key(1);
 
         // Seed via PUT: keep_score = floor(0) + demand, read_count 0.
@@ -2952,7 +3007,7 @@ mod tests {
     /// repeat demand (`read_count >= 2`), not one-off seeds.
     #[test]
     fn evictions_of_recently_read_counts_only_repeat_demand() {
-        let (mut cache, time) = make_cache(100, Duration::from_secs(60));
+        let (mut cache, time) = make_cache(100);
 
         // A contract read twice (repeat demand), then forced out by junk.
         let read_twice = make_key(1);
@@ -2990,7 +3045,7 @@ mod tests {
     /// `evict_all_subscribed_sheds_fewest_as_last_resort` for the last-resort shed.)
     #[test]
     fn subscribed_contract_ordered_last_survives_while_zero_sub_evicted() {
-        let (mut cache, time) = make_cache(200, Duration::from_secs(60));
+        let (mut cache, time) = make_cache(200);
         let subscribed = make_key(1); // lowest demand, but subscribed
         let other = make_key(2);
         let trigger = make_key(3);
@@ -3026,7 +3081,7 @@ mod tests {
     /// subscribed contract is ordered LAST, not hard-pinned.
     #[test]
     fn evict_normal_drops_zero_sub_before_subscribed() {
-        let (mut cache, time) = make_cache(200, Duration::from_secs(60));
+        let (mut cache, time) = make_cache(200);
         let a = make_key(1);
         let b = make_key(2);
         let c = make_key(3);
@@ -3052,36 +3107,39 @@ mod tests {
         assert!(!cache.contains(&b));
     }
 
-    /// Neither SUBSCRIBE nor PUT refreshes the eviction recency key, so a
-    /// contract subscribed/re-PUT after its last GET stays the least-recent
-    /// real-GET entry and is evicted first.
+    /// A real GET OR PUT (genuine client access) refreshes the eviction recency
+    /// key (invariant 3, decision 2026-07-08); SUBSCRIBE / renewal does NOT. This
+    /// discriminates both facts at once: `a` is re-PUT (must float to newest, so
+    /// it survives) while `b` is only re-SUBSCRIBEd (must stay stale, so it is the
+    /// victim). Without the PUT-refresh, `a` (the oldest GET) would be the victim
+    /// instead — so this fails under a GET-only recency rule.
     #[test]
-    fn real_get_refreshes_recency_subscribe_and_put_do_not() {
-        let (mut cache, time) = make_cache(300, Duration::from_secs(60));
+    fn real_get_and_put_refresh_recency_subscribe_does_not() {
+        let (mut cache, _time) = make_cache(300);
         let a = make_key(1);
         let b = make_key(2);
         let c = make_key(3);
         let d = make_key(4);
 
-        // last_get order A < B < C.
+        // Recency order after the initial GETs: A < B < C (A oldest).
         cache.record_access(a, 100, AccessType::Get, 0, |_| (0, 0));
         cache.record_access(b, 100, AccessType::Get, 0, |_| (0, 0));
         cache.record_access(c, 100, AccessType::Get, 0, |_| (0, 0));
 
-        // A SUBSCRIBE on A and a PUT on B must NOT refresh their real-GET
-        // recency, so A stays the least-recently-GET entry.
-        cache.record_access(a, 100, AccessType::Subscribe, 0, |_| (0, 0));
-        cache.record_access(b, 100, AccessType::Put, 0, |_| (0, 0));
+        // A PUT on A refreshes A's recency (genuine client access) → A becomes
+        // NEWEST. A SUBSCRIBE on B must NOT refresh B → B stays at its GET recency,
+        // so B is now the least-recently-accessed entry.
+        cache.record_access(a, 100, AccessType::Put, 0, |_| (0, 0));
+        cache.record_access(b, 100, AccessType::Subscribe, 0, |_| (0, 0));
 
-        time.advance_time(Duration::from_secs(61));
         let result = cache.record_access(d, 100, AccessType::Get, 0, |_| (0, 0));
         assert_eq!(
             result.evicted,
-            vec![(a, 0)],
-            "A is evicted: SUBSCRIBE/PUT did not refresh its real-GET recency"
+            vec![(b, 0)],
+            "B is evicted: SUBSCRIBE did not refresh recency, but A's PUT did (A survives)"
         );
-        assert!(!cache.contains(&a));
-        assert!(cache.contains(&b));
+        assert!(cache.contains(&a), "A survives: its PUT refreshed recency");
+        assert!(!cache.contains(&b));
         assert!(cache.contains(&c));
         assert!(cache.contains(&d));
     }
@@ -3090,7 +3148,7 @@ mod tests {
     /// the newest position so a different (now least-recent) entry evicts.
     #[test]
     fn real_get_refreshes_recency() {
-        let (mut cache, time) = make_cache(300, Duration::from_secs(60));
+        let (mut cache, time) = make_cache(300);
         let a = make_key(1);
         let b = make_key(2);
         let c = make_key(3);
@@ -3116,32 +3174,31 @@ mod tests {
         assert!(cache.contains(&d));
     }
 
-    /// The Overflow corner ALSO pierces the `min_ttl` cold-start floor (its only
-    /// remaining special power) and sheds the FEWEST-subscriber contract first,
-    /// bumping both the OOM-valve counter and the subscribed-eviction counter.
+    /// The Overflow-pressure sweep sheds the FEWEST-subscriber contract first and
+    /// bumps both the OOM-valve counter and the subscribed-eviction counter. (With
+    /// `min_ttl` dropped 2026-07-08 there is no cold-start floor to pierce;
+    /// Overflow's only remaining distinct power is piercing the op-scoped backstop,
+    /// which a periodic sweep never sets — so here it behaves like AtCapacity
+    /// except for the OOM-valve counter.)
     #[test]
-    fn oom_valve_sheds_fewest_subscriber_piercing_min_ttl() {
-        let (mut cache, _time) = make_cache(100, Duration::from_secs(60));
+    fn oom_valve_sheds_fewest_subscriber() {
+        // Seed under a generous budget so the inserts don't auto-evict, then
+        // tighten so both are resident and over budget for the sweep.
+        let (mut cache, _time) = make_cache(100_000);
         let a = make_key(1);
         let b = make_key(2);
 
-        // A has more downstream subscribers than B; both are subscribed and fresh
-        // (within min_ttl — no time advance).
+        // A has more downstream subscribers than B; both are subscribed.
         let subs = |k: &ContractKey| if *k == a { (0, 2) } else { (0, 1) };
         cache.record_access(a, 100, AccessType::Get, 0, subs);
-        // Inserting B pushes over budget, but both are age-0 (within min_ttl), so
-        // under AtCapacity cold-start grace keeps them — nothing is evicted.
-        let insert = cache.record_access(b, 100, AccessType::Get, 0, subs);
-        assert!(
-            insert.evicted.is_empty(),
-            "within min_ttl, cold-start grace protects both fresh contracts"
-        );
+        cache.record_access(b, 100, AccessType::Get, 0, subs);
+        cache.set_budget_for_test(100);
         assert!(cache.contains(&a));
         assert!(cache.contains(&b));
         assert_eq!(cache.current_bytes(), 200, "200 bytes over the 100 budget");
 
-        // The Overflow corner pierces min_ttl AND sheds the FEWEST-subscriber
-        // contract (B, 1 sub) before A (2 subs), bumping both counters.
+        // The Overflow sweep sheds the FEWEST-subscriber contract (B, 1 sub) before
+        // A (2 subs), bumping both counters.
         let evicted = cache.sweep_expired(subs, MemoryPressure::Overflow);
         assert_eq!(
             evicted_pairs(&evicted),
@@ -3162,24 +3219,26 @@ mod tests {
         );
     }
 
-    /// With equal subscriber counts, the Overflow corner tiebreaks by least-recent
-    /// real GET.
+    /// With equal subscriber counts, the Overflow sweep tiebreaks by least-recent
+    /// real GET/PUT.
     #[test]
     fn oom_valve_equal_subscribers_sheds_least_recent_get() {
-        let (mut cache, _time) = make_cache(100, Duration::from_secs(60));
+        // Seed under a generous budget (distinct recency: A older than B), then
+        // tighten so both are resident and over budget for the sweep.
+        let (mut cache, _time) = make_cache(100_000);
         let a = make_key(1);
         let b = make_key(2);
 
-        // Equal subscriber counts: the tiebreak is least-recent real GET.
-        cache.record_access(a, 100, AccessType::Get, 0, |_| (0, 1));
-        cache.record_access(b, 100, AccessType::Get, 0, |_| (0, 1));
+        cache.record_access(a, 100, AccessType::Get, 0, |_| (0, 1)); // recency: A older
+        cache.record_access(b, 100, AccessType::Get, 0, |_| (0, 1)); // recency: B newer
+        cache.set_budget_for_test(100);
         assert_eq!(cache.current_bytes(), 200);
 
         let evicted = cache.sweep_expired(|_| (0, 1), MemoryPressure::Overflow);
         assert_eq!(
             evicted_pairs(&evicted),
             vec![(a, 0)],
-            "with equal subscribers, the least-recently-GET contract (A) sheds"
+            "with equal subscribers, the least-recently-accessed contract (A) sheds"
         );
         assert!(!cache.contains(&a));
         assert!(cache.contains(&b));
@@ -3191,13 +3250,13 @@ mod tests {
     /// subscribed-eviction counter (in-use victims only).
     #[test]
     fn oom_valve_counter_zero_under_normal_atcapacity() {
-        let (mut cache, time) = make_cache(100, Duration::from_secs(60));
+        let (mut cache, _time) = make_cache(100);
         let a = make_key(1);
         let b = make_key(2);
 
         cache.record_access(a, 100, AccessType::Get, 0, |_| (0, 0));
-        time.advance_time(Duration::from_secs(61));
-        // Normal AtCapacity eviction of a zero-subscriber, past-TTL contract.
+        // Inserting B (the op-protected key) over budget evicts the older, zero-
+        // subscriber A under AtCapacity — no `min_ttl` wait needed.
         let result = cache.record_access(b, 100, AccessType::Get, 0, |_| (0, 0));
         assert_eq!(result.evicted, vec![(a, 0)]);
         assert!(
@@ -3216,34 +3275,34 @@ mod tests {
         );
     }
 
-    /// Cold-start grace: a fresh, never-read zero-subscriber PUT seed survives
-    /// over-budget pressure within min_ttl, then becomes evictable past it.
+    /// A fresh PUT resets `recency_seq` (invariant 3, decision 2026-07-08), so it
+    /// is protected by being the most-recently-accessed — NO `min_ttl` floor
+    /// needed. It out-survives an OLDER contract and is never evicted by its own
+    /// insert (the op-scoped backstop). This is what `min_ttl`'s cold-start grace
+    /// used to provide, now delivered by recency instead.
     #[test]
-    fn cold_start_grace_fresh_unread_seed_survives_min_ttl() {
-        let (mut cache, time) = make_cache(100, Duration::from_secs(60));
-        let seed = make_key(1);
-        let other = make_key(2);
+    fn fresh_put_protected_by_recency_not_min_ttl() {
+        let (mut cache, _time) = make_cache(100);
+        let old = make_key(1);
+        let seed = make_key(2);
 
-        // A fresh PUT seed (never GET-read, zero-subscriber, read_count 0).
-        cache.record_access(seed, 100, AccessType::Put, 0, |_| (0, 0));
-        // Inserting `other` pushes over budget, but the seed is age-0 / within
-        // min_ttl, so cold-start grace keeps it: nothing is evicted.
-        let result = cache.record_access(other, 100, AccessType::Get, 0, |_| (0, 0));
-        assert!(
-            result.evicted.is_empty(),
-            "a fresh unread zero-subscriber seed is not evicted within min_ttl even over budget"
-        );
-        assert!(cache.contains(&seed));
-        assert!(cache.contains(&other));
+        // An older GET, then a fresh zero-subscriber PUT seed. Budget fits one.
+        cache.record_access(old, 100, AccessType::Get, 0, |_| (0, 0)); // recency: older
+        let result = cache.record_access(seed, 100, AccessType::Put, 0, |_| (0, 0));
 
-        // Past min_ttl the unread seed becomes eligible and sheds under budget.
-        time.advance_time(Duration::from_secs(61));
-        let evicted = cache.sweep_expired(|_| (0, 0), MemoryPressure::AtCapacity);
-        assert!(
-            evicted.iter().any(|e| e.key == seed),
-            "past min_ttl the unread seed is evicted"
+        // The fresh PUT seed (newest recency + op-protected) survives; the OLDER
+        // contract is shed. Under a GET-only recency rule the seed would have
+        // recency 0 and be the victim instead — so this pins the PUT-refresh.
+        assert_eq!(
+            result.evicted,
+            vec![(old, 0)],
+            "the fresh PUT out-survives the older contract by recency"
         );
-        assert!(!cache.contains(&seed));
+        assert!(
+            cache.contains(&seed),
+            "a fresh PUT is protected by its recency + the op-scoped backstop"
+        );
+        assert!(!cache.contains(&old));
     }
 
     /// LAST RESORT (Ian's confirmed ordering, #4642): when EVERY eligible contract
@@ -3254,7 +3313,7 @@ mod tests {
     /// contract is shed before a local-client one.
     #[test]
     fn evict_all_subscribed_sheds_fewest_as_last_resort() {
-        let (mut cache, time) = make_cache(200, Duration::from_secs(60));
+        let (mut cache, time) = make_cache(200);
         let local_sub = make_key(1); // (local=1, downstream=0) — evicted LAST
         let downstream_sub = make_key(2); // (local=0, downstream=5) — evicted first
         let trigger = make_key(3);

--- a/crates/core/src/ring/hosting/cache.rs
+++ b/crates/core/src/ring/hosting/cache.rs
@@ -56,6 +56,15 @@
 //! the peer's own ring location — see [`super::demand`]) purely so the
 //! estimator keeps training and the dashboard column stays populated.
 
+// NAMING LANDMINE: "cache" throughout this module means HOSTING, not a lesser
+// cache tier. A peer stores a contract because a GET or PUT routed through it, and
+// a routed GET/PUT is a demand signal, so the peer HOSTS the contract (holds
+// WASM+state, kept fresh in the update mesh) until LRU eviction. There is no cache
+// tier. This naming confuses humans and LLMs; slated to be renamed to hosting-* in
+// a follow-up refactor AFTER 0.2.94 (deferred to avoid conflicting with the
+// in-flight eviction rewrite of this file). See .claude/rules/hosting-invariants.md
+// terminology + epic #4642.
+
 use freenet_stdlib::prelude::ContractKey;
 use std::collections::HashMap;
 use std::time::Duration;
@@ -583,6 +592,10 @@ pub struct HostedContract {
 ///
 /// ALL contracts in this cache should have their subscriptions renewed automatically.
 /// This is the key fix for the bug where GET-triggered subscriptions weren't being renewed.
+// NAMING LANDMINE: "cache" here = HOSTING, not a lesser tier. Entries are contracts
+// this peer HOSTS (WASM+state, kept fresh in the update mesh) because a GET/PUT
+// routed through it, and a routed GET/PUT is demand. No cache tier exists; to be
+// renamed hosting-* after 0.2.94. See .claude/rules/hosting-invariants.md + #4642.
 pub struct HostingCache<T: TimeSource> {
     /// Maximum bytes to use for cached contracts
     budget_bytes: u64,

--- a/crates/core/src/ring/hosting/cache.rs
+++ b/crates/core/src/ring/hosting/cache.rs
@@ -809,6 +809,18 @@ impl<T: TimeSource> HostingCache<T> {
                     // Op-scoped backstop: never evict the contract whose in-flight
                     // access triggered this sweep. Only trips on an already-broken
                     // peer because `protected` also has the highest recency_seq.
+                    //
+                    // KNOWN invariant-3 divergence (tracked in #4735, deferred): in
+                    // the corner where the cache is at budget and EVERY incumbent is
+                    // subscribed, excluding a zero-subscriber `protected` newcomer
+                    // from the candidate set forces the victim to be a subscribed
+                    // incumbent — the INVERSE of invariant 3's emergent refusal,
+                    // which says the fewest-subscriber contract (the newcomer) is the
+                    // one that should be refused, never displacing a 2+-subscriber
+                    // incumbent. The correct fix needs `host_contract` to signal
+                    // "served but not retained" so a zero-subscriber op doesn't have
+                    // to be protected here; until then this is left as-is (comment
+                    // only, no behavior change) — see #4735.
                     MemoryPressure::AtCapacity => protected != Some(key),
                     MemoryPressure::Overflow => true,
                 };
@@ -1117,6 +1129,15 @@ impl<T: TimeSource> HostingCache<T> {
             // constitutes genuine RAM overflow, so it must not pierce the op-scoped
             // backstop. The just-inserted `key` is the `protected` key, so this
             // call can never evict the contract it just added.
+            //
+            // KNOWN invariant-3 divergence (tracked in #4735, deferred): passing the
+            // zero-subscriber newcomer as `protected` means that, when the cache is
+            // at budget and every incumbent is subscribed, admitting this newcomer
+            // sheds a subscribed incumbent — the inverse of invariant 3's emergent
+            // refusal (the fewest-subscriber contract, i.e. the newcomer, should be
+            // the one refused). The proper fix needs `host_contract` to distinguish
+            // "served but not retained"; comment-only for now — see the matching note
+            // on the `protected` skip in `evict_over_budget`.
             let evicted =
                 self.evict_over_budget(&subscriber_counts, MemoryPressure::AtCapacity, Some(&key));
 

--- a/crates/core/src/ring/hosting/demand.rs
+++ b/crates/core/src/ring/hosting/demand.rs
@@ -180,28 +180,27 @@ impl ProximityPrior {
     /// strictly positive: `g0 > 0` and `fit >= 0`, and `w(n) > 0`, so the blend
     /// `w*g0 + (1-w)*fit >= w*g0 > 0`.
     ///
-    /// # Accepted tradeoff (A3 intermediate)
+    /// # Demoted to telemetry (subscriber-primary rework, #4642)
     ///
-    /// At cold start (and for a low-traffic peer whose observed rates stay
-    /// `<< NEUTRAL_DEMAND`; see the module docs) eviction ordering is effectively
-    /// **distance-only** — demand-blind, because the per-contract observed-read-
-    /// rate signal (A4) is deferred. Concretely: a FAR contract that is actually
-    /// GET-hot can be out-scored, and once past `min_ttl` evicted, in favor of an
-    /// unread NEAR contract that merely sits closer to this peer's key. This is
-    /// the spec-accepted intermediate state, not a bug:
+    /// This predicted demand NO LONGER feeds eviction. Under the subscriber-primary
+    /// model (`.claude/rules/hosting-invariants.md`, invariant 3) eviction orders
+    /// victims ascending by `(subscriber_count, real-GET/PUT recency, key_bytes)` —
+    /// fewest subscribers first, then least-recent genuine client access (a real
+    /// GET or PUT, not SUBSCRIBE or subscription renewal), then a deterministic
+    /// key-byte tiebreak. Ring **distance is not an eviction input**: its causal
+    /// pull on demand already flows through subscriber count via keyward routing
+    /// gravity (counting both would double-count), and locality is delivered by
+    /// routing, not by the eviction decision.
     ///
-    /// - It is **bounded by `min_ttl`** — the anti-thrash retention floor kept
-    ///   deliberately per the hosting design (`hosting-invariants.md`, invariant
-    ///   3 / #4441): nothing evicts a contract within `min_ttl` of its last read,
-    ///   so a genuinely hot far contract keeps being refreshed and survives.
-    /// - It is **fully resolved when A4 lands** (per-contract own-observed-rate
-    ///   blend) together with in-flight op-pinning, at which point real read
-    ///   demand overrides the distance prior for any contract with evidence.
-    ///
-    /// The design contract for this piece is exactly "distance prior + `min_ttl`
-    /// until A4" (`.claude/rules/hosting-invariants.md`, piece A / #4642). Do NOT
-    /// try to close the gap here by reaching for a per-contract counter — that is
-    /// A4's job and belongs with its telemetry and op-pinning.
+    /// `predict()` (and the whole distance-prior estimator) is therefore retained
+    /// for **telemetry only** — it backs the demoted `predicted_demand` /
+    /// `keep_score` dashboard signal (see [`super::cache`]) and drives no retention
+    /// decision. The `min_ttl` cold-start floor that once bounded a distance-only
+    /// ordering was **dropped entirely** (2026-07-08): a fresh zero-subscriber
+    /// PUT/GET is now protected by being the most-recently-accessed, not by an age
+    /// floor. Do NOT re-wire this estimate back into the eviction sort — the whole
+    /// demand machinery is scheduled for deletion once subscriber-primary is
+    /// field-validated.
     pub(crate) fn predict(&self, distance: f64) -> f64 {
         if !distance.is_finite() {
             return NEUTRAL_DEMAND;

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -781,6 +781,43 @@ impl<T: TimeSource + Sync> InterestManager<T> {
         }
     }
 
+    /// Mirror a subscriber-primary eviction that tore down a still-in-use
+    /// contract's hosting subscription state (#4642 invariant 3, PR #4734).
+    ///
+    /// The `InterestManager` lives on `OpManager`, NOT on `HostingManager`, so
+    /// when `HostingManager::teardown_evicted_in_use_contract` clears the
+    /// hosting maps (`downstream_subscribers` + `client_subscriptions`) the
+    /// eviction CONSUMER must replay the identical removals here or ghost
+    /// `interested_peers` / `peer_contracts` / `local_client_count` entries
+    /// survive. Those ghosts are load-bearing — they drive UPDATE broadcast
+    /// targeting (`get_interested_peers`) and upstream interest counts — and do
+    /// NOT self-heal, because the reconcilers iterate the very hosting maps the
+    /// teardown just emptied.
+    ///
+    /// Mirrors, exactly:
+    /// - `handle_unsubscribe_inbound` per downstream peer: `remove_peer_interest`
+    ///   (clears `interested_peers` / `peer_contracts`) + `remove_downstream_subscriber`
+    ///   (decrements the local `downstream_subscriber_count`).
+    /// - the client-disconnect path per local client: `remove_local_client`
+    ///   (decrements `local_client_count`).
+    ///
+    /// Idempotent and safe on an already-clean contract (each removal is a
+    /// no-op when absent).
+    pub fn remove_evicted_in_use(
+        &self,
+        contract: &ContractKey,
+        downstream_peers: &[PeerKey],
+        local_client_count: usize,
+    ) {
+        for peer in downstream_peers {
+            self.remove_peer_interest(contract, peer);
+            self.remove_downstream_subscriber(contract);
+        }
+        for _ in 0..local_client_count {
+            self.remove_local_client(contract);
+        }
+    }
+
     /// Get or create local interest entry, returning mutable reference.
     pub fn with_local_interest<F, R>(&self, contract: &ContractKey, f: F) -> R
     where
@@ -1289,6 +1326,89 @@ mod tests {
 
         // Remove again returns false
         assert!(!manager.remove_peer_interest(&contract, &peer));
+    }
+
+    /// Regression for the InterestManager desync on subscribed eviction
+    /// (PR #4734 Fix 1). When a subscriber-primary eviction shed + tore down a
+    /// still-in-use contract, the hosting maps are cleared by
+    /// `HostingManager::teardown_evicted_in_use_contract`, but the
+    /// InterestManager lives on `OpManager` and must be synced separately by the
+    /// consumer via `remove_evicted_in_use`. Before this fix, ghost
+    /// `interested_peers` / `peer_contracts` / `local_client_count` entries
+    /// survived (they drive UPDATE broadcast targeting + upstream interest
+    /// counts) and did NOT self-heal. Assert every map is ZERO afterward — the
+    /// gap the HostingManager-level `torn_down_...` test did not cover.
+    #[test]
+    fn remove_evicted_in_use_clears_all_interest_maps() {
+        let (manager, _time) = make_manager();
+        let contract = make_contract_key(1);
+        let downstream_a = make_peer_key(1);
+        let downstream_b = make_peer_key(2);
+
+        // Mirror the real add path: per downstream peer,
+        // register_peer_interest (interested_peers/peer_contracts) +
+        // add_downstream_subscriber (downstream_subscriber_count). Plus two
+        // local client subscriptions (local_client_count).
+        manager.register_peer_interest(&contract, downstream_a.clone(), None, false);
+        manager.add_downstream_subscriber(&contract);
+        manager.register_peer_interest(&contract, downstream_b.clone(), None, false);
+        manager.add_downstream_subscriber(&contract);
+        manager.add_local_client(&contract);
+        manager.add_local_client(&contract);
+
+        // Sanity: interest present in all three maps before teardown.
+        assert_eq!(manager.get_interested_peers(&contract).len(), 2);
+        assert!(!manager.get_contracts_for_peer(&downstream_a).is_empty());
+        assert!(!manager.get_contracts_for_peer(&downstream_b).is_empty());
+        manager.with_local_interest(&contract, |li| {
+            assert_eq!(li.local_client_count, 2);
+            assert_eq!(li.downstream_subscriber_count, 2);
+        });
+
+        // Replay the hosting teardown against the InterestManager exactly as the
+        // eviction consumers do.
+        manager.remove_evicted_in_use(&contract, &[downstream_a.clone(), downstream_b.clone()], 2);
+
+        // interested_peers / peer_contracts / local_client_count all ZERO — no
+        // ghost survives to mis-target UPDATE broadcasts or inflate counts.
+        assert!(
+            manager.get_interested_peers(&contract).is_empty(),
+            "interested_peers must be cleared for the evicted contract"
+        );
+        assert!(
+            manager.get_contracts_for_peer(&downstream_a).is_empty(),
+            "peer_contracts[downstream_a] must be cleared"
+        );
+        assert!(
+            manager.get_contracts_for_peer(&downstream_b).is_empty(),
+            "peer_contracts[downstream_b] must be cleared"
+        );
+        // has_local_interest reads via `.get` (no entry re-creation), so a false
+        // result proves the local_interests entry — local_client_count and
+        // downstream_subscriber_count — is fully gone.
+        assert!(
+            !manager.has_local_interest(&contract),
+            "no local interest (client or downstream count) may remain"
+        );
+        let stats = manager.stats();
+        assert_eq!(
+            stats.total_contracts, 0,
+            "no contract may retain interested peers"
+        );
+        assert_eq!(stats.total_peer_interests, 0);
+        assert_eq!(
+            stats.local_interests, 0,
+            "no local_interests entry may survive"
+        );
+        assert_eq!(
+            stats.hash_index_size, 0,
+            "the contract hash index must be cleaned up once no interest remains"
+        );
+
+        // Idempotent: replaying on an already-clean contract is a no-op.
+        manager.remove_evicted_in_use(&contract, &[downstream_a], 1);
+        assert_eq!(manager.stats().total_contracts, 0);
+        assert_eq!(manager.stats().local_interests, 0);
     }
 
     #[test]

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -254,6 +254,17 @@ pub(crate) struct RouterSnapshotInfo {
     /// avoid OOM. Populated by `Ring` on the snapshot cadence. `None` until the
     /// ring is built. Per-node aggregate scalar.
     pub hosting_oom_valve_evictions_total: Option<u64>,
+    /// Subscribed-eviction falsifier (subscriber-primary hosting rework, #4642):
+    /// monotonic count of over-budget evictions whose victim was SUBSCRIBED
+    /// (`local + downstream >= 1`) at eviction-decision time. Unlike
+    /// `hosting_oom_valve_evictions_total` (which stays 0 until the unwired
+    /// Overflow trigger lands), this can go nonzero the moment the eviction rework
+    /// ships — it is the field signal for the single riskiest new behavior,
+    /// shedding a subscribed contract as a last resort. A rising differenced rate
+    /// means budgets are too tight or demand is churning subscribed contracts.
+    /// Populated by `Ring` on the snapshot cadence. `None` until the ring is
+    /// built. Per-node aggregate scalar.
+    pub hosting_subscribed_evictions_total: Option<u64>,
     /// Terminal advertisement-consult counters (hosting redesign piece C,
     /// #4646; exported to central telemetry per #4658), populated by `Ring`
     /// from the per-node `network_status` singleton on the snapshot cadence.
@@ -1259,6 +1270,7 @@ impl Router {
             hosting_disk_compile_cache_bytes: None,
             hosting_disk_total_bytes: None,
             hosting_oom_valve_evictions_total: None,
+            hosting_subscribed_evictions_total: None,
             // Terminal advertisement-consult counters (piece C, #4646),
             // populated by Ring from the network_status singleton on the
             // snapshot cadence (#4658).

--- a/crates/core/src/server/home_page/cards.rs
+++ b/crates/core/src/server/home_page/cards.rs
@@ -1151,13 +1151,14 @@ pub fn build_hosting_card(snap: &Option<network_status::NetworkStatusSnapshot>) 
     // keep-score first); show at most MAX_ROWS. The tile carries the full count.
     //
     // The "next to evict" badge marks the first EVICTION-ELIGIBLE row, not
-    // simply the lowest keep-score row: the over-budget sweep SKIPS contracts
-    // that are within `min_ttl` or still in use (`should_retain`), so the
-    // lowest-score row may be one the cache would never actually evict. Badging
-    // it would mislabel an eviction-exempt contract — exactly the "dashboard
-    // misleads the operator" problem this card exists to fix. When nothing is
-    // currently eligible (every hosted contract is within-TTL / in use), no row
-    // is badged.
+    // simply the lowest keep-score row. A contract within `min_ttl` is not yet
+    // eligible, and one still in use (a local client / downstream subscriber) is
+    // ordered LAST by the subscriber-primary sweep — shed only as a last resort
+    // when nothing with fewer subscribers is eligible — so it is not the common-
+    // case next victim. `is_eviction_eligible` reflects that (past `min_ttl` AND
+    // not in use), so the badge never mislabels a contract the sweep would
+    // ordinarily keep. When nothing is currently eligible (every hosted contract
+    // is within-TTL / in use), no row is badged.
     const MAX_ROWS: usize = 20;
     let next_victim_idx = h.contracts.iter().position(|c| c.eviction_eligible);
     let mut rows = String::new();

--- a/crates/core/src/server/home_page/cards.rs
+++ b/crates/core/src/server/home_page/cards.rs
@@ -1151,20 +1151,19 @@ pub fn build_hosting_card(snap: &Option<network_status::NetworkStatusSnapshot>) 
     // keep-score first); show at most MAX_ROWS. The tile carries the full count.
     //
     // The "next to evict" badge marks the first EVICTION-ELIGIBLE row, not
-    // simply the lowest keep-score row. A contract within `min_ttl` is not yet
-    // eligible, and one still in use (a local client / downstream subscriber) is
-    // ordered LAST by the subscriber-primary sweep — shed only as a last resort
-    // when nothing with fewer subscribers is eligible — so it is not the common-
-    // case next victim. `is_eviction_eligible` reflects that (past `min_ttl` AND
-    // not in use), so the badge never mislabels a contract the sweep would
-    // ordinarily keep. When nothing is currently eligible (every hosted contract
-    // is within-TTL / in use), no row is badged.
+    // simply the lowest keep-score row. A contract still in use (a local client /
+    // downstream subscriber) is ordered LAST by the subscriber-primary sweep —
+    // shed only as a last resort when nothing with fewer subscribers is eligible —
+    // so it is not the common-case next victim. `is_eviction_eligible` reflects
+    // that (not in use; there is no longer a `min_ttl` age gate), so the badge
+    // never mislabels a contract the sweep would ordinarily keep. When nothing is
+    // currently eligible (every hosted contract is in use), no row is badged.
     const MAX_ROWS: usize = 20;
     let next_victim_idx = h.contracts.iter().position(|c| c.eviction_eligible);
     let mut rows = String::new();
     for (i, c) in h.contracts.iter().take(MAX_ROWS).enumerate() {
         let next_badge = if Some(i) == next_victim_idx {
-            r#" <span class="hz-badge hz-next" title="Lowest keep-score among eviction-eligible contracts (past min-TTL and not in use) — the over-budget sweep would evict this one first.">next to evict</span>"#
+            r#" <span class="hz-badge hz-next" title="Lowest keep-score among eviction-eligible contracts (not in use) — the over-budget sweep would evict this one first.">next to evict</span>"#
         } else {
             ""
         };

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -2231,6 +2231,17 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                     "hosting_oom_valve_evictions_total".to_string(),
                     serde_json::json!(snapshot.hosting_oom_valve_evictions_total),
                 );
+                // Subscribed-eviction falsifier (#4642 subscriber-primary rework):
+                // count of evictions that shed a SUBSCRIBED contract. Same
+                // hand-mirrored footgun — invisible to the collector unless added
+                // here. Unlike the OOM-valve gauge this can go nonzero as soon as
+                // the rework ships (AtCapacity now sheds subscribed as a last
+                // resort). Pinned by
+                // `router_snapshot_json_includes_subscribed_evictions_gauge`.
+                obj.insert(
+                    "hosting_subscribed_evictions_total".to_string(),
+                    serde_json::json!(snapshot.hosting_subscribed_evictions_total),
+                );
                 // Terminal advertisement-consult counters (hosting redesign
                 // piece C, #4646; exported per #4658). Same hand-mirrored
                 // footgun as the gauges above: a new `RouterSnapshotInfo` field
@@ -2664,6 +2675,26 @@ mod tests {
         assert_eq!(
             json["hosting_oom_valve_evictions_total"], 359,
             "hosting_oom_valve_evictions_total must reach the OTLP body"
+        );
+    }
+
+    /// Pin: the subscribed-eviction falsifier gauge (#4642 subscriber-primary
+    /// rework) must reach the hand-mirrored OTLP body. This counts evictions that
+    /// shed a SUBSCRIBED contract as a last resort — unlike the OOM-valve gauge it
+    /// can go nonzero the moment the rework ships (AtCapacity now sheds subscribed
+    /// contracts), so a silent drop would blind central telemetry to the single
+    /// riskiest new hosting behavior exactly when it first fires.
+    #[test]
+    fn router_snapshot_json_includes_subscribed_evictions_gauge() {
+        use arbitrary::{Arbitrary, Unstructured};
+        let mut u = Unstructured::new(&[0u8; 4096]);
+        let mut info = crate::router::RouterSnapshotInfo::arbitrary(&mut u)
+            .expect("construct RouterSnapshotInfo for test");
+        info.hosting_subscribed_evictions_total = Some(287);
+        let json = event_kind_to_json(&EventKind::RouterSnapshot(Box::new(info)));
+        assert_eq!(
+            json["hosting_subscribed_evictions_total"], 287,
+            "hosting_subscribed_evictions_total must reach the OTLP body"
         );
     }
 

--- a/crates/core/src/wasm_runtime/secrets_store/store.rs
+++ b/crates/core/src/wasm_runtime/secrets_store/store.rs
@@ -2443,7 +2443,6 @@ mod test {
     use super::super::sweep::{
         // Private helpers exposed pub(super) for this test module
         LAST_SEEN_FILE,
-        SweepOutcome,
         enumerate_marked_users,
         read_user_last_seen,
         reclaim_inactive_users,

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -12424,151 +12424,177 @@ fn test_advance_hosting_clock_without_control_is_graceful_noop() {
 /// DEMANDED contract SURVIVES a clock jump — a no-op injection would pass that
 /// too).
 ///
-/// A gateway hosts several UNDEMANDED (`subscribe=false`, cache-only) contracts
-/// under a 1-byte hosting budget, so the cache is permanently over budget and
-/// eviction is gated SOLELY by the TTL clock. Eviction of a past-TTL entry runs
-/// on the next cache access; a trailing PUT provides that access
-/// deterministically (no dependence on background-sweep timing). We run the SAME
-/// scenario twice, differing ONLY in how far the injected clock is advanced
-/// before that trailing access:
-///   * control: advance 1 min  (< DEFAULT_MIN_TTL = 8 min) → NO eviction
-///   * test:    advance 10 min (> DEFAULT_MIN_TTL)         → eviction
+/// # Why this no longer tests undemanded eviction
 ///
-/// If the clock injection were broken (an `AdvanceHostingClock` that never
-/// reaches the `HostingManager`'s cache), both runs would behave identically and
-/// the `test_count < control_count` assertion would fail — which is exactly the
-/// regression this test exists to catch.
+/// The original version discriminated on the `min_ttl` cold-start grace: an
+/// UNDEMANDED (zero-subscriber) contract under a 1-byte budget was TTL-protected
+/// for 8 min, then evictable. `min_ttl` was DROPPED (invariant 3, 2026-07-08 —
+/// PR #4734): an undemanded contract over budget is now evicted IMMEDIATELY
+/// regardless of the clock, so undemanded eviction is no longer clock-gated and
+/// can no longer discriminate on the clock. (Eviction of a *subscribed* contract
+/// whose lease lapsed is also not a usable discriminator: `record_abandonment`
+/// resets its recency to the frontier at lease termination, so the formerly-
+/// subscribed contract sorts LAST and is the one that survives budget pressure —
+/// the opposite of what "lease lapse → evicted" would need. And a hosted copy
+/// under no budget pressure stays cached regardless of the clock.)
+///
+/// # What is still clock-gated: subscription lease expiry
+///
+/// The remaining time-based behavior driven by the injected clock in the
+/// `HostingManager` is SUBSCRIPTION LEASE expiry. A lease lapses only once the
+/// injected clock crosses `SUBSCRIPTION_LEASE_DURATION` (8 min); the periodic
+/// expiry sweeps (`expire_stale_subscriptions`, `expire_stale_downstream_subscribers`)
+/// read `time_source.now()` for the lease age. So we run the SAME scenario twice,
+/// differing ONLY in how far the injected clock is advanced after the demand
+/// source is gone:
+///   * control: advance 1 min  (< SUBSCRIPTION_LEASE_DURATION = 8 min) → lease survives
+///   * test:    advance 20 min (> SUBSCRIPTION_LEASE_DURATION)         → lease lapses
+///
+/// A gateway hosts + announces a contract and a node subscribes to it, forming a
+/// real subscription (leases on both peers). The subscriber is then SILENTLY
+/// crashed (`CrashNode`): a silent crash sends no `Unsubscribe` (so the leases are
+/// NOT torn down immediately — that is what a clean `Disconnect` would do) and
+/// stops the subscriber renewing (so nothing refreshes the leases). The leases can
+/// therefore lapse ONLY via the injected clock crossing the 8-minute duration.
+///
+/// If the clock injection were broken (an `AdvanceHostingClock` that never reaches
+/// the `HostingManager`), the leases would either both survive (with the crash
+/// stopping renewal) or, absent the injected advance, never lapse within the
+/// virtual settle window (120s ≪ 8 min) — either way both runs would show the same
+/// surviving subscription set and the `test < control` assertion would fail, which
+/// is exactly the regression this test exists to catch.
 #[test]
-fn test_injected_hosting_clock_drives_undemanded_eviction() {
+fn test_injected_hosting_clock_drives_subscription_lease_lapse() {
     use freenet::dev_tool::{NodeLabel, ScheduledOperation, SimOperation};
 
-    // DEFAULT_MIN_TTL = TTL_RENEWAL_MULTIPLIER (4) × SUBSCRIPTION_RENEWAL_INTERVAL
-    // (120s) = 480s (8 min). One advance stays under it, the other crosses it.
-    const SUB_TTL_ADVANCE: Duration = Duration::from_secs(60); // 1 min  < 8 min
-    const SUPER_TTL_ADVANCE: Duration = Duration::from_secs(10 * 60); // 10 min > 8 min
+    // SUBSCRIPTION_LEASE_DURATION = LEASE_RENEWAL_MULTIPLIER (4) ×
+    // SUBSCRIPTION_RENEWAL_INTERVAL (120s) = 480s (8 min). One advance stays
+    // under it, the other crosses it.
+    const SUB_LEASE_ADVANCE: Duration = Duration::from_secs(60); // 1 min  < 8 min
+    const SUPER_LEASE_ADVANCE: Duration = Duration::from_secs(20 * 60); // 20 min > 8 min
 
-    // Seeds of the undemanded contracts the gateway hosts (cache-only). A
-    // distinct trigger contract is PUT AFTER the advance to force a cache access.
-    const UNDEMANDED_SEEDS: [u8; 3] = [41, 42, 43];
-    const TRIGGER_SEED: u8 = 44;
-
-    // Runs the scenario with a given clock advance; returns the gateway's final
-    // hosting count and whether each undemanded contract is still hosted.
-    let run = |network: &str, seed: u64, advance: Duration| -> (usize, [bool; 3]) {
+    // Runs the scenario with a given clock advance; returns how many peers still
+    // hold the contract in `active_subscriptions` network-wide, plus the crashed-
+    // packet count (a discriminating signal that the scripted crash took effect).
+    let run = |network: &str, seed: u64, advance: Duration| -> (usize, u64) {
         setup_deterministic_state(seed);
         let rt = create_runtime();
         let gateway = NodeLabel::gateway(network, 0);
-
-        let undemanded: Vec<_> = UNDEMANDED_SEEDS
-            .iter()
-            .map(|s| SimOperation::create_test_contract(*s))
-            .collect();
-        let undemanded_keys: Vec<_> = undemanded.iter().map(|c| c.key()).collect();
-        let trigger = SimOperation::create_test_contract(TRIGGER_SEED);
+        let subscriber = NodeLabel::node(network, 1);
+        let contract = SimOperation::create_test_contract(51);
+        let contract_id = *contract.key().id();
 
         let sim = rt.block_on(async {
-            let mut sim = SimNetwork::new(network, 1, 2, 7, 3, 10, 2, seed).await;
-            // Piece A: inject the controllable clock (TTL under test control) and
-            // a 1-byte budget so ANY hosted contract is over budget — eviction is
-            // then gated purely by the TTL clock this test advances.
+            let mut sim = SimNetwork::new(network, 1, 3, 7, 3, 10, 2, seed).await;
+            // Piece A: inject the controllable hosting clock so lease expiry is
+            // under test control (advanced deterministically, without running
+            // minutes of virtual time).
             sim.enable_hosting_time_control();
-            sim.with_hosting_budget(1);
             sim
         });
 
-        let mut operations = Vec::new();
-        // The gateway hosts each undemanded contract (host-on-PUT); with
-        // subscribe=false there is no client subscription, so it is cache-only
-        // (evictable) rather than demand-pinned.
-        for (c, s) in undemanded.iter().zip(UNDEMANDED_SEEDS.iter()) {
-            operations.push(ScheduledOperation::new(
+        let ops = vec![
+            // Gateway hosts + announces the contract so the subscriber can reach it.
+            ScheduledOperation::new(
                 gateway.clone(),
                 SimOperation::Put {
-                    contract: c.clone(),
-                    state: SimOperation::create_test_state(*s),
+                    contract: contract.clone(),
+                    state: SimOperation::create_test_state(51),
                     subscribe: false,
                 },
-            ));
-        }
-        // Jump the injected clock deterministically (no virtual minutes elapse).
-        operations.push(ScheduledOperation::new(
-            gateway.clone(),
-            SimOperation::AdvanceHostingClock { duration: advance },
-        ));
-        // Trailing PUT: a fresh cache access that runs `evict_over_budget`. In
-        // the super-TTL run the undemanded entries are now past TTL and are
-        // evicted; in the sub-TTL run they are still TTL-protected. The trigger
-        // itself is freshly inserted (age 0) and cannot be evicted by its own
-        // access, so it survives in both runs.
-        operations.push(ScheduledOperation::new(
-            gateway.clone(),
-            SimOperation::Put {
-                contract: trigger.clone(),
-                state: SimOperation::create_test_state(TRIGGER_SEED),
-                subscribe: false,
-            },
-        ));
+            ),
+            // A node subscribes → forms a real subscription lease (timestamp read
+            // from the injected hosting clock) on the subscriber and the gateway.
+            ScheduledOperation::new(subscriber.clone(), SimOperation::Subscribe { contract_id }),
+            // Silent crash: the subscriber sends NO Unsubscribe (so the leases are
+            // not torn down immediately) and stops renewing (so nothing refreshes
+            // them). The leases can now lapse ONLY via the injected clock crossing
+            // SUBSCRIPTION_LEASE_DURATION — see the doc comment.
+            ScheduledOperation::new(subscriber.clone(), SimOperation::CrashNode),
+            // The ONLY thing that differs between the two runs.
+            ScheduledOperation::new(
+                gateway.clone(),
+                SimOperation::AdvanceHostingClock { duration: advance },
+            ),
+        ];
 
+        // Generous settle (120s ≈ 4 renewal/expiry cycles at 30s each) so the
+        // expiry sweeps run against the advanced clock before the final snapshot.
         let result = sim.run_controlled_simulation(
             seed,
-            operations,
+            ops,
+            Duration::from_secs(300),
             Duration::from_secs(120),
-            Duration::from_secs(20),
         );
         assert!(
             result.turmoil_result.is_ok(),
             "controlled simulation should complete: {:?}",
             result.turmoil_result.err()
         );
-        let flags = [
-            result.is_node_hosting(&gateway, &undemanded_keys[0]),
-            result.is_node_hosting(&gateway, &undemanded_keys[1]),
-            result.is_node_hosting(&gateway, &undemanded_keys[2]),
-        ];
-        (result.node_hosting_count(&gateway), flags)
+
+        let subscribed_peers = result
+            .topology_snapshots
+            .iter()
+            .filter(|s| s.active_subscription_keys.contains(&contract_id))
+            .count();
+        (subscribed_peers, result.crash_packets_dropped())
     };
 
     const SEED: u64 = 0x4642_A003_CAFE;
-    let (control_count, control_flags) = run("clock-evict-control", SEED, SUB_TTL_ADVANCE);
-    let (test_count, test_flags) = run("clock-evict-test", SEED, SUPER_TTL_ADVANCE);
+    let (control_count, control_dropped) = run("clock-lease-control", SEED, SUB_LEASE_ADVANCE);
+    let (test_count, test_dropped) = run("clock-lease-test", SEED, SUPER_LEASE_ADVANCE);
 
     tracing::info!(
         control_count,
         test_count,
-        ?control_flags,
-        ?test_flags,
-        "injected-clock eviction: control (sub-TTL advance) vs test (super-TTL advance)"
+        control_dropped,
+        test_dropped,
+        "injected-clock lease lapse: control (sub-lease advance) vs test (super-lease advance)"
     );
 
-    // Sanity: host-on-PUT actually hosted the undemanded contracts (otherwise the
-    // comparison below would be vacuous). All three present in the control run.
+    // Sanity: the scripted crash actually took effect in BOTH runs (it is what
+    // stops renewal so the lease can lapse purely via the clock). `> 0` holds only
+    // if the crash really blocked the subscriber's packets.
     assert!(
-        control_flags.iter().all(|&h| h),
-        "sub-TTL advance ({}s < 8min): all undemanded contracts must still be hosted \
-         — they are over budget but TTL-protected, so eviction must NOT fire; got {:?}",
-        SUB_TTL_ADVANCE.as_secs(),
-        control_flags
+        control_dropped > 0 && test_dropped > 0,
+        "scripted CrashNode must drop packets in both runs (control={control_dropped}, \
+         test={test_dropped}); 0 means the crash was a silent no-op and renewal would \
+         keep refreshing the lease"
     );
 
-    // After crossing DEFAULT_MIN_TTL: the SAME undemanded contracts ARE evicted.
+    // Sanity: the subscription genuinely FORMED and SURVIVED the sub-lease advance
+    // (otherwise the comparison below would be vacuous). At least the gateway still
+    // holds the contract in active_subscriptions 1 minute in.
     assert!(
-        test_flags.iter().all(|&h| !h),
-        "super-TTL advance ({}s > 8min): all undemanded contracts must be evicted \
-         once the injected clock crosses DEFAULT_MIN_TTL; got {:?}",
-        SUPER_TTL_ADVANCE.as_secs(),
-        test_flags
+        control_count >= 1,
+        "sub-lease advance ({}s < 8min): the subscription must still be held by at least \
+         one peer — the lease is younger than SUBSCRIPTION_LEASE_DURATION, so it must NOT \
+         lapse; got {control_count} subscribed peer(s)",
+        SUB_LEASE_ADVANCE.as_secs(),
+    );
+
+    // After crossing SUBSCRIPTION_LEASE_DURATION: with no renewal source, EVERY
+    // lease lapses, so no peer holds the contract in active_subscriptions.
+    assert_eq!(
+        test_count,
+        0,
+        "super-lease advance ({}s > 8min): every subscription lease must lapse once the \
+         injected clock crosses SUBSCRIPTION_LEASE_DURATION (nothing renews it after the \
+         crash); got {test_count} peer(s) still subscribed",
+        SUPER_LEASE_ADVANCE.as_secs(),
     );
 
     // The discriminating comparison: the ONLY difference between the two runs is
-    // how far the injected clock advanced. Strictly fewer contracts surviving the
-    // super-TTL run can happen ONLY if `AdvanceHostingClock` actually reached the
-    // `HostingManager`'s cache. A no-op injection would make the runs identical.
+    // how far the injected clock advanced. Strictly fewer subscribed peers in the
+    // super-lease run can happen ONLY if `AdvanceHostingClock` actually reached the
+    // `HostingManager` and drove lease expiry. A no-op injection would make the two
+    // runs identical (the crash stops renewal in both), so the counts would match.
     assert!(
         test_count < control_count,
-        "the super-TTL run must host strictly fewer contracts than the sub-TTL run \
-         (control={control_count}, test={test_count}); equal counts mean the injected \
-         clock never reached the hosting cache (silent no-op — the regression this \
-         test guards against)"
+        "the super-lease run must leave strictly fewer subscribed peers than the sub-lease \
+         run (control={control_count}, test={test_count}); equal counts mean the injected \
+         clock never reached the HostingManager (silent no-op — the regression this test \
+         guards against)"
     );
 }
 


### PR DESCRIPTION
## Problem

The shipped subscriber-primary eviction (#4720, 0.2.93) **hard-pins any subscribed contract**: `evict_over_budget` filters candidates to `subs == 0` under `AtCapacity` (the only pressure production passes), so a peer that is over budget with only subscribed contracts cannot shed anything and the memory bound stops being real. It also lumps local-client and downstream subscribers into one `subscriber_count`, so it cannot express Ian's confirmed ordering (local-subscribed evicted **last**). And it has **no memory-teardown**: even the (unwired) OOM valve would drop the cache entry but leave the subscription state, so `contract_in_use` stays true and `reclaim_evicted_contract` skips the disk delete forever — the entry vanishes but memory never frees.

## Approach

Ian's confirmed model: eviction is ONE ordering, victim ascending by `(local_subscription_count, downstream_subscriber_count, real-GET recency, key bytes)`. Local-subscribed is evicted **last** but **not** hard-pinned; in the all-subscribed extreme the fewest-subscriber contract **is** shed. `min_ttl` stays the cold-start floor. No separate OOM valve, no admission gate, no hard pin.

- **`victim_order` / `evict_over_budget`** (`cache.rs`): split the combined count into the two dimensions; drop the `subs == 0` `AtCapacity` filter (eligibility is now just `age >= min_ttl`); return `EvictedContract` carrying a `was_in_use` flag captured **atomically** with the decision. `Overflow` is kept only as the `min_ttl`-pierce corner of the SAME ordering (not a separate valve), trigger still unwired.
- **In-use teardown** (`hosting.rs`): `record_contract_access` and `sweep_expired_hosting` call `teardown_evicted_in_use_contract` for each `was_in_use` victim — clearing downstream subscribers, client subscriptions (only non-empty in the all-local last resort; strands the client, **accepted** last-resort), and the upstream lease — so `contract_in_use` is false **before** the caller reclaims and the disk state actually frees. Driven by the atomic flag, not a racy post-hoc `contract_in_use` re-read, so a contract that gained a subscriber *after* a zero-sub eviction is left alone (the re-host / re-subscribe guards in `RuntimePool::remove_contract` handle that race). Downstream re-home rides the existing interest-gated renewal loop — **no new signal built** (out of scope).
- **`subscribed_evictions_total`** falsifier counter wired to `RouterSnapshot` / OTLP telemetry: the OOM-valve counter stays 0 until its trigger is wired, so shedding subscribed contracts (which is now live under `AtCapacity`) would otherwise be invisible in the field.
- **`admission`** (#4717, inert / not wired to production) reuses `victim_order` via a `local = 0` shim — its model tracks only a combined count, and `(0, n, seq, key)` orders identically to the old `(n, seq, key)`, so its pin tests still pass unchanged.

## Testing

Every behavioral change has a regression test (this is a `fix:` PR, CI requires new test functions):

- **Load-bearing:** `record_contract_access_sheds_and_tears_down_only_subscribed` — over budget with ONLY subscribed contracts sheds the fewest-`(local, downstream)` one AND asserts `contract_in_use` flips false (so reclaim proceeds and memory frees), while only the victim is torn down.
- `evict_all_subscribed_sheds_fewest_as_last_resort` — fewest-local then fewest-downstream; local-client contract evicted last; `subscribed_evictions_total` bumped, `oom_valve` untouched.
- `torn_down_eviction_not_redriven_by_contracts_needing_renewal` — the torn-down victim is not re-selected by renewal section 1/2.
- `router_snapshot_json_includes_subscribed_evictions_gauge` — falsifier reaches the OTLP body.
- Updated the #4720 hard-pin tests to the new model (subscribed = ordered last, not pinned), e.g. `victim_order_is_local_then_downstream_then_get_recency_then_key`, `evict_normal_drops_zero_sub_before_subscribed`, `test_downstream_subscribers_evicted_after_zero_sub`, `test_record_contract_access_orders_in_use_last`, `oom_valve_sheds_fewest_subscriber_piercing_min_ttl`.

Local verification green: `cargo build -p freenet`, `cargo clippy --locked -p freenet -- -D warnings`, `cargo fmt --check`, `cargo test -p freenet --lib` (3822 passed, 0 failed).

## Status

Part of the **0.2.94** demand-driven-hosting bundle. **DRAFT — do not merge.** High-risk hosting / OOM-safety surface: needs full multi-model review + Ian sign-off first. A prior scope trace confirmed this piece is flip-independent and buildable now.

Refs #4642

[AI-assisted - Claude]