### PR TITLE
feat(hosting): serve-DURING at the originator GET gate (#4642 R3 piece C)

### DIFF
--- a/crates/core/src/client_events.rs
+++ b/crates/core/src/client_events.rs
@@ -117,6 +117,45 @@ async fn register_subscription_listener(
     }
 }
 
+/// serve-DURING gate (#4642 R3 piece C — `hosting-invariants.md` invariant 1).
+///
+/// Decides whether a client GET is answered from this node's LOCAL copy
+/// immediately, or routed through the network. The originator serves its best
+/// local copy the instant it holds a FRESH one — it never blocks a read on a
+/// network round-trip to confirm freshness (serve-DURING).
+///
+/// Serve locally when we have valid local state (`local_satisfies_request`) AND
+/// any of:
+/// 1. **No connections** — an isolated node can only answer from local state.
+/// 2. **Actively receiving updates** (`is_subscribed`) — a network/client
+///    subscription keeps the copy fresh.
+/// 3. **Local interest** (`has_local_interest`) — this node is a fresh in-mesh
+///    HOST of the contract. `has_local_interest` is true for a demandless
+///    every-hop hosting copy (it registers `hosting = true` and joins the
+///    InterestSync anti-entropy heartbeat — #4744 piece B), a local-client-
+///    subscribed copy, or a copy with a downstream subscriber. This is the SAME
+///    predicate the TERMINUS serve gate uses (`check_local_with_interest_gate`
+///    → `InterestManager::has_local_interest`), so the originator no longer
+///    routes a whole GET for a copy it already holds fresh.
+///
+/// Term 3 REPLACES the pre-serve-DURING `is_hosting_contract &&
+/// has_local_client_access` gate, which served only copies the LOCAL user had
+/// touched and forced a demandless hosted copy to route the whole GET — the
+/// exact "goes dark on a read it could answer" gap serve-DURING closes.
+/// Freshness is NOT confirmed here; it rides on the anti-entropy mesh
+/// (invariant 1), and an isolated holder serves best-effort at the ~5-9%
+/// near-miss floor. `local_satisfies_request` already guarantees valid state is
+/// present, so a phantom (interested-but-stateless, #4440) copy is excluded even
+/// though it can register interest via a downstream subscriber.
+fn should_serve_local_copy(
+    local_satisfies_request: bool,
+    connection_count: usize,
+    is_subscribed: bool,
+    has_local_interest: bool,
+) -> bool {
+    local_satisfies_request && (connection_count == 0 || is_subscribed || has_local_interest)
+}
+
 /// Report an operation init failure to the client via the result router.
 async fn report_op_init_error(
     op_manager: &OpManager,
@@ -916,23 +955,31 @@ async fn process_open_request(
                             }
                         }
 
-                        // Serve from local cache only if the local user requested
-                        // this contract (not just relay-cached).
-                        let is_locally_hosted = full_key
+                        // serve-DURING (#4642 R3 piece C): serve immediately when
+                        // this node HAS LOCAL INTEREST in the contract — i.e. it is
+                        // a fresh in-mesh host. `has_local_interest` is true for a
+                        // demandless every-hop copy (registers `hosting = true`,
+                        // joins anti-entropy — #4744 piece B), a locally-subscribed
+                        // copy, or one with a downstream subscriber. This is the
+                        // SAME predicate the TERMINUS serve gate uses
+                        // (`check_local_with_interest_gate`), replacing the old
+                        // `has_local_client_access` gate that forced a demandless
+                        // hosted copy to route a whole GET through the network.
+                        let has_local_interest = full_key
                             .as_ref()
-                            .map(|k| {
-                                op_manager.ring.is_hosting_contract(k)
-                                    && op_manager.ring.has_local_client_access(k)
-                            })
+                            .map(|k| op_manager.interest_manager.has_local_interest(k))
                             .unwrap_or(false);
 
                         // Return local cache if we have valid state AND any of:
                         // 1. No connections (isolated node)
                         // 2. Actively subscribed (cache kept fresh via updates)
-                        // 3. Locally hosted (subscription may be in progress)
-                        if local_satisfies_request
-                            && (connection_count == 0 || is_subscribed || is_locally_hosted)
-                        {
+                        // 3. We hold a fresh in-mesh copy (serve-DURING)
+                        if should_serve_local_copy(
+                            local_satisfies_request,
+                            connection_count,
+                            is_subscribed,
+                            has_local_interest,
+                        ) {
                             let full_key = full_key.unwrap();
                             let state = state.unwrap();
 
@@ -942,7 +989,7 @@ async fn process_open_request(
                                 peer = %peer_id,
                                 contract = %full_key,
                                 is_subscribed,
-                                is_locally_hosted,
+                                has_local_interest,
                                 connection_count,
                                 phase = "local_cache",
                                 "Returning locally cached contract state"
@@ -972,6 +1019,37 @@ async fn process_open_request(
                                         contract = %full_key,
                                         "GET with subscribe=true but no subscription_listener (expected for HTTP clients)"
                                     );
+                                }
+
+                                // serve-DURING (#4642 R3 piece C): a subscribe=true GET
+                                // served from a LOCAL copy did NOT route through the
+                                // network, which is where the subscribe normally rides
+                                // (`maybe_subscribe_child`, the sole GET subscribe
+                                // path). If we were not already receiving updates (a
+                                // demandless every-hop copy), establish the upstream
+                                // subscription in the BACKGROUND so the client gets
+                                // ongoing updates — never blocking the served read.
+                                //
+                                // A subscribe=FALSE read establishes NOTHING: no durable
+                                // demand is created, the demandless copy stays fresh via
+                                // anti-entropy and is NEVER re-rooted (re-root is
+                                // connection-drop-driven — P0 / #4642 piece F — and its
+                                // interest gate refuses a demandless copy), so a burst of
+                                // serve-DURING reads fans out ZERO re-links. This kick
+                                // fires only on an EXPLICIT client subscribe, and the
+                                // subscribe op is internally deduped + backoff-guarded, so
+                                // it cannot become a read storm. Gated on `!is_subscribed`
+                                // to avoid a redundant subscribe when an upstream already
+                                // exists.
+                                if !is_subscribed {
+                                    get::op_ctx_task::maybe_subscribe_child(
+                                        &op_manager,
+                                        crate::message::Transaction::new::<get::GetMsg>(),
+                                        full_key,
+                                        true,  // subscribe
+                                        false, // blocking_subscribe: never block the served read
+                                    )
+                                    .await;
                                 }
                             }
 
@@ -1681,3 +1759,84 @@ async fn process_open_request(
 use tokio::sync::mpsc;
 // Re-export Arc for use in this module
 use std::sync::Arc;
+
+#[cfg(test)]
+mod serve_during_gate_tests {
+    use super::should_serve_local_copy;
+
+    // Ring distinctions used below (from `LocalInterest::is_interested` +
+    // `is_receiving_updates`): a demandless every-hop hosting copy has
+    // `has_local_interest = true` (hosting flag) but `is_subscribed = false`.
+
+    /// serve-DURING falsifier (#4642 R3 piece C): a DEMANDLESS but interested
+    /// hosted copy — `has_local_interest = true`, `is_subscribed = false` — on a
+    /// node WITH connections MUST be served locally. Before serve-DURING the
+    /// third gate term was `is_hosting_contract && has_local_client_access`,
+    /// which is `false` for a demandless copy (no local client ever touched it),
+    /// so the whole GET was routed through the network — the "goes dark on a read
+    /// it could answer" gap. This asserts the flipped behavior; it fails against
+    /// the pre-serve-DURING client-access gate.
+    #[test]
+    fn demandless_interested_copy_serves_locally_with_connections() {
+        assert!(
+            should_serve_local_copy(
+                /* local_satisfies_request */ true, /* connection_count       */ 8,
+                /* is_subscribed           */ false, /* has_local_interest      */ true,
+            ),
+            "a demandless-but-interested hosted copy must serve locally (serve-DURING), \
+             not route through the network"
+        );
+    }
+
+    /// A copy with NO local interest and NO subscription on a connected node must
+    /// still route (we have no fresh in-mesh copy to serve). Guards against
+    /// over-broadening the gate to serve any stored bytes regardless of mesh
+    /// membership (which would re-introduce stale-serve, invariant 1).
+    #[test]
+    fn uninterested_copy_forwards_with_connections() {
+        assert!(
+            !should_serve_local_copy(
+                /* local_satisfies_request */ true, /* connection_count       */ 8,
+                /* is_subscribed           */ false, /* has_local_interest      */ false,
+            ),
+            "a stored copy with no local interest and no subscription must route \
+             (serve-DURING serves only a fresh in-mesh copy)"
+        );
+    }
+
+    /// Never serve when local state does not satisfy the request, regardless of
+    /// interest/subscription/connectivity.
+    #[test]
+    fn missing_local_state_never_serves() {
+        for is_subscribed in [false, true] {
+            for has_local_interest in [false, true] {
+                for connection_count in [0usize, 8] {
+                    assert!(
+                        !should_serve_local_copy(
+                            /* local_satisfies_request */ false,
+                            connection_count,
+                            is_subscribed,
+                            has_local_interest,
+                        ),
+                        "must not serve without valid local state \
+                         (is_subscribed={is_subscribed}, \
+                         has_local_interest={has_local_interest}, \
+                         connection_count={connection_count})"
+                    );
+                }
+            }
+        }
+    }
+
+    /// The three pre-existing serve reasons are preserved: isolated node
+    /// (no connections), active subscription, and the new local-interest term.
+    #[test]
+    fn each_serve_reason_holds_independently() {
+        // Isolated node: serves purely on zero connections.
+        assert!(should_serve_local_copy(true, 0, false, false));
+        // Actively receiving updates.
+        assert!(should_serve_local_copy(true, 8, true, false));
+        // Fresh in-mesh host (serve-DURING).
+        assert!(should_serve_local_copy(true, 8, false, true));
+    }
+}

--- a/crates/core/src/client_events.rs
+++ b/crates/core/src/client_events.rs
@@ -1027,8 +1027,24 @@ async fn process_open_request(
                                 // (`maybe_subscribe_child`, the sole GET subscribe
                                 // path). If we were not already receiving updates (a
                                 // demandless every-hop copy), establish the upstream
-                                // subscription in the BACKGROUND so the client gets
-                                // ongoing updates — never blocking the served read.
+                                // subscription so the client gets ongoing updates. The
+                                // state itself was already served from the LOCAL copy
+                                // above (serve-DURING) regardless of the flag — only the
+                                // subscribe-registration wait differs here.
+                                //
+                                // `blocking_subscribe` is the client's real wire-API flag
+                                // and is LOAD-BEARING (#4524): when `true`, the served read
+                                // is held until the upstream subscription is registered, so
+                                // the client cannot see the `GetResponse` before its
+                                // downstream-subscriber chain exists (else an UPDATE sent
+                                // immediately after the response would race registration and
+                                // be missed — the exact bug #4524 fixed). Hardcoding `false`
+                                // here would silently downgrade an explicit
+                                // `blocking_subscribe=true` GET to fire-and-forget the moment
+                                // serve-DURING fires — a regression vs the network path,
+                                // which passes the real flag. When `false`, the subscribe is
+                                // spawned in the background and the served read returns
+                                // immediately.
                                 //
                                 // A subscribe=FALSE read establishes NOTHING: no durable
                                 // demand is created, the demandless copy stays fresh via
@@ -1036,18 +1052,19 @@ async fn process_open_request(
                                 // connection-drop-driven — P0 / #4642 piece F — and its
                                 // interest gate refuses a demandless copy), so a burst of
                                 // serve-DURING reads fans out ZERO re-links. This kick
-                                // fires only on an EXPLICIT client subscribe, and the
-                                // subscribe op is internally deduped + backoff-guarded, so
-                                // it cannot become a read storm. Gated on `!is_subscribed`
-                                // to avoid a redundant subscribe when an upstream already
-                                // exists.
+                                // fires only on an EXPLICIT client subscribe — the
+                                // client-subscribe origination path has no per-contract
+                                // dedup, so re-link volume is bounded by explicit client
+                                // subscribes plus the `!is_subscribed` gate (which skips a
+                                // redundant subscribe when an upstream already exists), not
+                                // by internal dedup. It therefore cannot become a read storm.
                                 if !is_subscribed {
                                     get::op_ctx_task::maybe_subscribe_child(
                                         &op_manager,
                                         crate::message::Transaction::new::<get::GetMsg>(),
                                         full_key,
-                                        true,  // subscribe
-                                        false, // blocking_subscribe: never block the served read
+                                        true,               // subscribe
+                                        blocking_subscribe, // honor the client's #4524 flag
                                     )
                                     .await;
                                 }
@@ -1838,5 +1855,57 @@ mod serve_during_gate_tests {
         assert!(should_serve_local_copy(true, 8, true, false));
         // Fresh in-mesh host (serve-DURING).
         assert!(should_serve_local_copy(true, 8, false, true));
+    }
+
+    /// #4524 regression guard (source-scrape): the serve-DURING subscribe kick
+    /// MUST forward the client's real `blocking_subscribe` flag to
+    /// `maybe_subscribe_child`, NOT a hardcoded `false`.
+    ///
+    /// `blocking_subscribe` is load-bearing (#4524): when `true` the served read
+    /// must be held until the upstream subscription is registered, so the client
+    /// cannot see the `GetResponse` before its downstream-subscriber chain exists
+    /// (else an UPDATE sent immediately after the response races registration and
+    /// is missed). Hardcoding `false` here silently downgrades an explicit
+    /// `blocking_subscribe=true` GET to fire-and-forget the moment serve-DURING
+    /// fires — a regression vs the network path, which passes the real flag.
+    ///
+    /// This deterministically FAILS on the pre-fix code (the fifth positional
+    /// arg was `false`) and PASSES once the real flag is forwarded. It mirrors
+    /// the codebase's source-scrape pin idiom (e.g.
+    /// `maybe_subscribe_child_short_circuits_on_false` in get/op_ctx_task.rs).
+    #[test]
+    fn serve_during_kick_forwards_real_blocking_subscribe_flag() {
+        const SOURCE: &str = include_str!("client_events.rs");
+        let call_start = SOURCE
+            .find("get::op_ctx_task::maybe_subscribe_child(")
+            .expect("serve-DURING kick must call maybe_subscribe_child");
+        // Slice the call up to its terminating `.await`.
+        let call_tail = &SOURCE[call_start..];
+        let call_end = call_tail
+            .find(".await")
+            .expect("maybe_subscribe_child call must be awaited");
+        let call = &call_tail[..call_end];
+
+        // Strip line comments so the pre-fix comment ("// blocking_subscribe:
+        // never block the served read") cannot mask the hardcoded `false`.
+        let args_only: String = call
+            .lines()
+            .map(|line| line.split("//").next().unwrap_or(""))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(
+            args_only.contains("blocking_subscribe"),
+            "serve-DURING kick must forward the client's real `blocking_subscribe` \
+             flag to maybe_subscribe_child (#4524), not a hardcoded value. \
+             Call args: {args_only:?}"
+        );
+        assert!(
+            !args_only.contains("false"),
+            "serve-DURING kick must NOT pass a hardcoded `false` for \
+             blocking_subscribe — that silently downgrades an explicit \
+             blocking_subscribe=true GET to fire-and-forget (#4524 regression). \
+             Call args: {args_only:?}"
+        );
     }
 }

--- a/crates/core/src/node/testing_impl.rs
+++ b/crates/core/src/node/testing_impl.rs
@@ -196,6 +196,29 @@ pub enum SimOperation {
         /// Initial state bytes
         state: Vec<u8>,
     },
+    /// Seed a **demandless every-hop copy** into a node's local store: state
+    /// present, `is_hosting_contract` true, `has_local_interest` true, but NO
+    /// subscription (`is_receiving_updates` false) and NO prior local client
+    /// access.
+    ///
+    /// This is the state a production every-hop GET/PUT store leaves on a RELAY
+    /// hop (`get`/`put` `op_ctx_task` call `register_local_hosting` without
+    /// `ring.subscribe` and, on a non-originator hop, without
+    /// `mark_local_client_access`). Unlike
+    /// [`SeedHostedContract`](Self::SeedHostedContract) — which registers an
+    /// active subscription, so the pre-serve-DURING gate already served it — a
+    /// demandless copy is exactly what the pre-serve-DURING originator gate
+    /// (`is_hosting && has_local_client_access`) would REFUSE to serve, forcing
+    /// a whole GET through the network for a copy the node already held fresh.
+    /// Use this to exercise serve-DURING (#4642 R3 piece C): a connected node
+    /// holding a demandless copy must answer a GET from its local copy instead
+    /// of going dark on the network.
+    SeedDemandlessCopy {
+        /// The contract container (code + parameters)
+        contract: ContractContainer,
+        /// Initial state bytes
+        state: Vec<u8>,
+    },
     /// Simulate a client disconnecting from this node.
     ///
     /// Emits `ClientRequest::Disconnect` through the same
@@ -362,6 +385,12 @@ impl SimOperation {
             SimOperation::SeedHostedContract { .. } => {
                 panic!(
                     "SeedHostedContract is not a client request — it must be handled \
+                     by run_controlled_simulation before event dispatch"
+                )
+            }
+            SimOperation::SeedDemandlessCopy { .. } => {
+                panic!(
+                    "SeedDemandlessCopy is not a client request — it must be handled \
                      by run_controlled_simulation before event dispatch"
                 )
             }
@@ -561,6 +590,49 @@ impl ControlledSimulationResult {
     /// its Ring). Handy for iterating per-node assertions.
     pub fn captured_node_labels(&self) -> Vec<NodeLabel> {
         self.node_rings.keys().cloned().collect()
+    }
+
+    /// Number of open ring connections `label`'s node held at the end of the run.
+    /// Returns 0 if the node never published its Ring. Used by the serve-DURING
+    /// falsifier to confirm the serving node was CONNECTED (so a local serve is
+    /// attributable to serve-DURING interest, not the isolated-node fallback).
+    pub fn node_open_connections(&self, label: &NodeLabel) -> usize {
+        self.node_rings
+            .get(label)
+            .map(|ring| ring.open_connections())
+            .unwrap_or(0)
+    }
+
+    /// Whether `label`'s node was actively receiving updates for `key` (has a
+    /// live network/client subscription keeping the copy fresh) at the end of the
+    /// run. Returns `false` if the node never published its Ring. The serve-DURING
+    /// falsifier asserts this is `false` for a demandless copy, so the local serve
+    /// is attributable to `has_local_interest`, not an active subscription.
+    pub fn node_is_receiving_updates(&self, label: &NodeLabel, key: &ContractKey) -> bool {
+        self.node_rings
+            .get(label)
+            .is_some_and(|ring| ring.is_receiving_updates(key))
+    }
+
+    /// Number of client GETs `label`'s node answered from local hosted state (A3
+    /// serve-DURING hit counter). Returns 0 if the node never published its Ring.
+    /// See [`Ring::local_get_serves`](crate::ring::Ring::local_get_serves).
+    pub fn node_local_get_serves(&self, label: &NodeLabel) -> u64 {
+        self.node_rings
+            .get(label)
+            .map(|ring| ring.local_get_serves())
+            .unwrap_or(0)
+    }
+
+    /// Number of client GETs `label`'s node routed to the network (A3 forward/miss
+    /// counter). Returns 0 if the node never published its Ring. The serve-DURING
+    /// falsifier asserts this stays 0 for a demandless-copy GET (never went dark).
+    /// See [`Ring::local_get_forwards`](crate::ring::Ring::local_get_forwards).
+    pub fn node_local_get_forwards(&self, label: &NodeLabel) -> u64 {
+        self.node_rings
+            .get(label)
+            .map(|ring| ring.local_get_forwards())
+            .unwrap_or(0)
     }
 
     /// Subscription-renewal metrics for the peer at `addr` (captured before the
@@ -951,11 +1023,39 @@ type DefaultRegistry = CombinedRegister<2>;
 #[cfg(not(feature = "trace-ot"))]
 type DefaultRegistry = TestEventListener;
 
+/// How a startup-seeded contract is registered on its owning node.
+///
+/// Threads the distinction between the two seed primitives from
+/// `run_controlled_simulation` down into [`in_memory::append_contracts`], which
+/// runs at node startup. Both store the state locally with no network
+/// propagation; they differ ONLY in the hosting/demand bookkeeping they install,
+/// which is exactly what the serve-DURING gate keys on.
+///
+/// The variants are only ever constructed by `run_controlled_simulation`
+/// (`#[cfg(any(test, feature = "testing"))]`), but `testing_impl` itself compiles
+/// in every build (e.g. `trace-ot`), where `append_contracts` still matches on
+/// this enum. So in a non-testing build the variants are legitimately never
+/// constructed — allow dead_code there, keeping the lint live under testing.
+#[cfg_attr(not(any(test, feature = "testing")), allow(dead_code))]
+#[derive(Clone, Copy, Debug)]
+pub(super) enum SeedMode {
+    /// Genuine host WITH an active subscription (`SeedHostedContract`):
+    /// `host_contract` + `ring.subscribe`, so `is_receiving_updates` is true.
+    Subscribed,
+    /// Demandless every-hop copy (`SeedDemandlessCopy`): `host_contract` +
+    /// `register_local_hosting` (interest `hosting = true`), with NO subscription
+    /// and NO prior local client access. This is the exact state a production
+    /// every-hop GET/PUT store leaves on a RELAY hop (`is_hosting_contract` and
+    /// `has_local_interest` true, `is_receiving_updates` false), which the
+    /// serve-DURING originator gate (#4642 R3 piece C) must serve locally.
+    Demandless,
+}
+
 pub(super) struct Builder<ER> {
     pub config: NodeConfig,
     contract_handler_name: String,
     event_register: ER,
-    contracts: Vec<(ContractContainer, WrappedState, bool)>,
+    contracts: Vec<(ContractContainer, WrappedState, SeedMode)>,
     contract_subscribers: HashMap<ContractKey, Vec<PeerKeyLocation>>,
     /// Pre-formed ring connections injected at node startup, bypassing the
     /// organic CONNECT handshake. Each entry is a peer this node should already
@@ -4230,6 +4330,11 @@ impl SimNetwork {
         // nodes are drained into Turmoil host closures) so startup
         // `append_contracts` registers genuine hosting + subscription.
         let mut seed_hosted_ops: Vec<(NodeLabel, ContractContainer, Vec<u8>)> = Vec::new();
+        // SeedDemandlessCopy operations: like seed_hosted_ops, but injected with
+        // `SeedMode::Demandless` so `append_contracts` registers a demandless
+        // every-hop copy (hosting + local interest, NO subscription) rather than
+        // a subscribed host. See serve-DURING (#4642 R3 piece C).
+        let mut seed_demandless_ops: Vec<(NodeLabel, ContractContainer, Vec<u8>)> = Vec::new();
         let mut event_ops: Vec<ScheduledOperation> = Vec::new();
         for scheduled_op in operations {
             match scheduled_op.operation {
@@ -4244,6 +4349,12 @@ impl SimNetwork {
                     ref state,
                 } => {
                     seed_hosted_ops.push((scheduled_op.node, contract.clone(), state.clone()));
+                }
+                SimOperation::SeedDemandlessCopy {
+                    ref contract,
+                    ref state,
+                } => {
+                    seed_demandless_ops.push((scheduled_op.node, contract.clone(), state.clone()));
                 }
                 SimOperation::Put { .. }
                 | SimOperation::Get { .. }
@@ -4280,11 +4391,38 @@ impl SimNetwork {
                         .find(|(_, cfg)| cfg.label == target_label)
                         .map(|(node, _)| &mut node.contracts)
                 })
-                .map(|contracts| contracts.push((contract, wrapped, true)))
+                .map(|contracts| contracts.push((contract, wrapped, SeedMode::Subscribed)))
                 .is_some();
             assert!(
                 injected,
                 "SeedHostedContract: node {target_label:?} not found among gateways/nodes"
+            );
+        }
+
+        // Inject SeedDemandlessCopy contracts with `SeedMode::Demandless`. Same
+        // injection point as the hosted seed above, but startup
+        // `append_contracts` installs a demandless every-hop copy (hosting +
+        // local interest, no subscription, no local client access) — the state a
+        // production every-hop store leaves on a relay hop, which serve-DURING
+        // (#4642 R3 piece C) must serve locally.
+        for (target_label, contract, state) in seed_demandless_ops {
+            let wrapped = WrappedState::new(state);
+            let injected = self
+                .nodes
+                .iter_mut()
+                .find(|(_, label)| *label == target_label)
+                .map(|(node, _)| &mut node.contracts)
+                .or_else(|| {
+                    self.gateways
+                        .iter_mut()
+                        .find(|(_, cfg)| cfg.label == target_label)
+                        .map(|(node, _)| &mut node.contracts)
+                })
+                .map(|contracts| contracts.push((contract, wrapped, SeedMode::Demandless)))
+                .is_some();
+            assert!(
+                injected,
+                "SeedDemandlessCopy: node {target_label:?} not found among gateways/nodes"
             );
         }
 
@@ -4349,9 +4487,12 @@ impl SimNetwork {
                 }
                 // Seed ops were split out before the numbering loop (see the
                 // separation match above), so they never reach here.
-                SimOperation::SeedContract { .. } | SimOperation::SeedHostedContract { .. } => {
+                SimOperation::SeedContract { .. }
+                | SimOperation::SeedHostedContract { .. }
+                | SimOperation::SeedDemandlessCopy { .. } => {
                     unreachable!(
-                        "SeedContract/SeedHostedContract are separated out before numbering"
+                        "SeedContract/SeedHostedContract/SeedDemandlessCopy are separated out \
+                         before numbering"
                     )
                 }
             }

--- a/crates/core/src/node/testing_impl/in_memory.rs
+++ b/crates/core/src/node/testing_impl/in_memory.rs
@@ -479,12 +479,12 @@ impl<ER> Builder<ER> {
 /// Append contracts to the op_manager before starting the event loop.
 async fn append_contracts(
     op_manager: &Arc<OpManager>,
-    contracts: Vec<(ContractContainer, WrappedState, bool)>,
+    contracts: Vec<(ContractContainer, WrappedState, super::SeedMode)>,
     _contract_subscribers: HashMap<ContractKey, Vec<PeerKeyLocation>>,
     advertise_seeded_hosts: bool,
 ) -> anyhow::Result<()> {
     use crate::contract::ContractHandlerEvent;
-    for (contract, state, subscription) in contracts {
+    for (contract, state, mode) in contracts {
         let key: ContractKey = contract.key();
         let state_size = state.size() as u64;
         op_manager
@@ -496,35 +496,61 @@ async fn append_contracts(
             })
             .await?;
         tracing::debug!(
-            "Appended contract {} to peer {}",
+            "Appended contract {} to peer {} (mode {:?})",
             key,
-            op_manager.ring.connection_manager.get_own_addr().unwrap()
+            op_manager.ring.connection_manager.get_own_addr().unwrap(),
+            mode,
         );
-        if subscription {
-            op_manager
-                .ring
-                .host_contract(key, state_size, crate::ring::AccessType::Put);
-            // In the new lease-based model, register an active subscription
-            op_manager.ring.subscribe(key);
-            // OPT-IN (default off): register the contract in the
-            // neighbor-hosting advertised set so the connection-established
-            // HostingStateResponse exchange advertises it to neighbors.
-            //
-            // Without this, a startup-hosted contract (SeedHostedContract)
-            // leaves `my_contracts` empty and neighbors never learn this node
-            // hosts it. That matches the harness's historical behavior, so it
-            // stays the default — existing tests (e.g. the migration dead-end
-            // controls) rely on a seeded host NOT advertising, which keeps a
-            // key-routed GET dead-ending. A test that needs the seeded host to
-            // genuinely advertise (so the terminal advertisement consult can
-            // reach it) opts in via
-            // `SimNetwork::enable_seeded_host_advertisements`.
-            //
-            // The returned announcement is dropped because the node has no ring
-            // connections yet at startup (the exchange runs later, on
-            // connection-established).
-            if advertise_seeded_hosts {
-                let _ = op_manager.neighbor_hosting.on_contract_hosted(&key);
+        match mode {
+            super::SeedMode::Subscribed => {
+                op_manager
+                    .ring
+                    .host_contract(key, state_size, crate::ring::AccessType::Put);
+                // In the new lease-based model, register an active subscription
+                op_manager.ring.subscribe(key);
+                // OPT-IN (default off): register the contract in the
+                // neighbor-hosting advertised set so the connection-established
+                // HostingStateResponse exchange advertises it to neighbors.
+                //
+                // Without this, a startup-hosted contract (SeedHostedContract)
+                // leaves `my_contracts` empty and neighbors never learn this node
+                // hosts it. That matches the harness's historical behavior, so it
+                // stays the default — existing tests (e.g. the migration dead-end
+                // controls) rely on a seeded host NOT advertising, which keeps a
+                // key-routed GET dead-ending. A test that needs the seeded host to
+                // genuinely advertise (so the terminal advertisement consult can
+                // reach it) opts in via
+                // `SimNetwork::enable_seeded_host_advertisements`.
+                //
+                // The returned announcement is dropped because the node has no ring
+                // connections yet at startup (the exchange runs later, on
+                // connection-established).
+                if advertise_seeded_hosts {
+                    let _ = op_manager.neighbor_hosting.on_contract_hosted(&key);
+                }
+            }
+            super::SeedMode::Demandless => {
+                // Demandless every-hop copy (serve-DURING, #4642 R3 piece C).
+                // Install EXACTLY the state a production every-hop GET/PUT store
+                // leaves on a RELAY hop: the hosting-cache entry
+                // (`host_contract`, AccessType::Get — this is a stored copy, not
+                // a client-originated access) plus `register_local_hosting`,
+                // which sets the interest `hosting = true` flag so
+                // `has_local_interest` is true. Deliberately NO `ring.subscribe`
+                // (so `is_receiving_updates` stays false — this is a demandless,
+                // non-subscribed copy) and NO `mark_local_client_access` (no local
+                // client ever touched it). This is the state the pre-serve-DURING
+                // originator gate would NOT serve (its third term was
+                // `is_hosting && has_local_client_access`), forcing a whole GET
+                // through the network for a copy the node already held fresh.
+                op_manager
+                    .ring
+                    .host_contract(key, state_size, crate::ring::AccessType::Get);
+                let _ = op_manager.interest_manager.register_local_hosting(&key);
+                // Advertisement is a separate concern from the local serve gate
+                // (which keys on `has_local_interest`, a purely local signal), so
+                // a demandless copy is not advertised even under the opt-in — it
+                // matches the default "seeded host does not advertise" behavior.
             }
         }
         // Note: contract_subscribers is ignored in the new model.

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -1575,7 +1575,7 @@ fn advance_to_next_peer(
 ///
 /// For `blocking_subscribe = true`, awaits the subscribe driver inline.
 /// For `blocking_subscribe = false`, spawns a fire-and-forget task.
-async fn maybe_subscribe_child(
+pub(crate) async fn maybe_subscribe_child(
     op_manager: &Arc<OpManager>,
     client_tx: Transaction,
     key: ContractKey,

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -2933,6 +2933,24 @@ impl Ring {
         self.hosting_manager.record_local_get_forward();
     }
 
+    /// Number of client GETs this node answered from local hosted state (A3
+    /// serve-DURING hit counter). Read accessor for the counter incremented by
+    /// [`Self::record_get_served_locally`]; used by the serve-DURING sim
+    /// falsifier to assert a demandless-copy GET was served locally, not routed.
+    #[cfg(any(test, feature = "testing"))]
+    pub fn local_get_serves(&self) -> u64 {
+        self.hosting_manager.local_get_serves()
+    }
+
+    /// Number of client GETs this node routed to the network (A3 forward/miss
+    /// counter). Read accessor for the counter incremented by
+    /// [`Self::record_get_forwarded`]; the serve-DURING falsifier asserts this
+    /// stays `0` for a demandless-copy GET (the node never went dark).
+    #[cfg(any(test, feature = "testing"))]
+    pub fn local_get_forwards(&self) -> u64 {
+        self.hosting_manager.local_get_forwards()
+    }
+
     /// Whether this node is hosting this contract (has it in cache).
     #[inline]
     pub fn is_hosting_contract(&self, key: &ContractKey) -> bool {

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -4350,10 +4350,13 @@ impl Ring {
         self.hosting_manager.mark_local_client_access(key)
     }
 
-    /// Check if a contract was accessed by a local client.
-    pub fn has_local_client_access(&self, key: &ContractKey) -> bool {
-        self.hosting_manager.has_local_client_access(key)
-    }
+    // NOTE: `has_local_client_access` (the plain, non-recency variant) had its
+    // only production caller removed by serve-DURING (#4642 R3 piece C): the
+    // originator GET gate now serves on `interest_manager.has_local_interest`
+    // (a fresh in-mesh copy) rather than on whether the LOCAL user had touched
+    // the contract. The flag is still maintained (`mark_local_client_access`)
+    // and read via the recency variant below; the plain read accessor survives
+    // only on `HostingManager` for its unit tests.
 
     /// Whether a local client GET/PUT touched this contract within the renewal age
     /// gate (`SUBSCRIPTION_LEASE_DURATION`) — the read/PUT demand signal the

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -2075,6 +2075,13 @@ impl HostingManager {
     }
 
     /// Check if a contract was accessed by a local client.
+    ///
+    /// Test-only since serve-DURING (#4642 R3 piece C) removed the production
+    /// caller (the originator GET gate). The underlying flag is still maintained
+    /// (`mark_local_client_access`) and consulted via the recency variant
+    /// (`has_recent_local_client_access`), which the reconcile renewal path uses;
+    /// this plain accessor survives only for the hosting unit tests.
+    #[cfg(test)]
     pub fn has_local_client_access(&self, key: &ContractKey) -> bool {
         self.hosting_cache.read().has_local_client_access(key)
     }

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -11011,6 +11011,142 @@ fn test_contract_migrates_to_close_cluster_resolving_get_dead_end() {
     );
 }
 
+/// serve-DURING e2e falsifier (#4642 R3 piece C): a CONNECTED node holding a
+/// DEMANDLESS every-hop copy answers a client GET from its LOCAL copy instead of
+/// routing the whole request through the network ("never dark on a read it could
+/// answer").
+///
+/// The node is seeded with `SeedDemandlessCopy`, which installs exactly the state
+/// a production every-hop GET/PUT store leaves on a relay hop: state present,
+/// `is_hosting_contract` true, `has_local_interest` true (interest `hosting`
+/// flag), but NO subscription (`is_receiving_updates` false) and NO prior local
+/// client access. That is the copy the PRE-serve-DURING originator gate
+/// (`is_hosting && has_local_client_access`) would REFUSE to serve — on `main`
+/// this GET forwards to the network. With serve-DURING (this branch) the gate's
+/// third term is `has_local_interest`, so the GET is served locally.
+///
+/// The falsifier reads the A3 hit/miss counters directly: a local serve
+/// increments `local_get_serves` (via `record_get_served_locally`) and a
+/// network forward increments `local_get_forwards` (via `record_get_forwarded`)
+/// — the two are mutually exclusive on the client GET path, so `serves >= 1 AND
+/// forwards == 0` proves the node never went dark. The node is asserted CONNECTED
+/// first, so the local serve is attributable to serve-DURING interest and NOT to
+/// the isolated-node (`connection_count == 0`) fallback.
+#[test_log::test]
+fn test_serve_during_demandless_copy_served_locally_never_dark() {
+    use freenet::dev_tool::{NodeLabel, ScheduledOperation, SimNetwork, SimOperation};
+
+    const SEED: u64 = 0x5E27_D021_0001;
+    const NETWORK_NAME: &str = "serve-during-never-dark";
+    setup_deterministic_state(SEED);
+
+    let contract = SimOperation::create_test_contract(0x5D);
+    let contract_id = *contract.key().id();
+    let contract_key = contract.key();
+
+    let rt = create_runtime();
+    let sim = rt.block_on(async {
+        SimNetwork::new(
+            NETWORK_NAME,
+            1, // 1 gateway
+            3, // 3 regular nodes (node-1 holds the demandless copy)
+            7, // ring_max_htl
+            3, // rnd_if_htl_above
+            5, // max_connections
+            2, // min_connections
+            SEED,
+        )
+        .await
+    });
+
+    // node-1 is the demandless-copy holder + the GET requester.
+    let holder = NodeLabel::node(NETWORK_NAME, 1);
+
+    let operations = vec![
+        // Seed a DEMANDLESS every-hop copy on node-1 (hosting + local interest,
+        // NO subscription, NO local client access). No network propagation.
+        ScheduledOperation::new(
+            holder.clone(),
+            SimOperation::SeedDemandlessCopy {
+                contract: contract.clone(),
+                state: vec![7, 7, 7, 7],
+            },
+        ),
+        // node-1 GETs the contract it already holds demandlessly. subscribe=false
+        // so this is a pure read (serve-DURING must serve it locally; a
+        // subscribe=false read establishes nothing).
+        ScheduledOperation::new(
+            holder.clone(),
+            SimOperation::Get {
+                contract_id,
+                return_contract_code: false,
+                subscribe: false,
+            },
+        ),
+    ];
+
+    let result = sim.run_controlled_simulation(
+        SEED,
+        operations,
+        Duration::from_secs(120),
+        Duration::from_secs(30),
+    );
+    assert!(
+        result.turmoil_result.is_ok(),
+        "simulation failed: {:?}",
+        result.turmoil_result.err()
+    );
+
+    // Precondition 1: node-1 is CONNECTED. Without this a local serve could be
+    // the isolated-node (`connection_count == 0`) fallback rather than
+    // serve-DURING, and the test would not exercise the piece-C gate.
+    let connections = result.node_open_connections(&holder);
+    assert!(
+        connections >= 1,
+        "node-1 must be connected for the serve to be attributable to \
+         serve-DURING interest (open_connections={connections})"
+    );
+
+    // Precondition 2: node-1 hosts the demandless copy.
+    assert!(
+        result.is_node_hosting(&holder, &contract_key),
+        "node-1 must hold the seeded demandless copy"
+    );
+
+    // Precondition 3: node-1 is NOT receiving updates (no subscription) — this is
+    // a demandless copy, so a local serve is attributable to `has_local_interest`
+    // and not to an active subscription keeping the copy fresh.
+    assert!(
+        !result.node_is_receiving_updates(&holder, &contract_key),
+        "the seeded copy must be DEMANDLESS (not subscribed) — otherwise the serve \
+         would be attributable to the subscription term, not serve-DURING"
+    );
+
+    // CORE FALSIFIER: the demandless-copy GET was served LOCALLY and the node
+    // never went dark. On `main` (pre-serve-DURING) this GET forwards, so
+    // `local_get_forwards` would be >= 1 and `local_get_serves` == 0.
+    let serves = result.node_local_get_serves(&holder);
+    let forwards = result.node_local_get_forwards(&holder);
+    assert_eq!(
+        forwards, 0,
+        "serve-DURING regression: a demandless-copy GET was ROUTED to the network \
+         (local_get_forwards={forwards}, local_get_serves={serves}) — the node went \
+         dark on a read it could answer locally"
+    );
+    assert!(
+        serves >= 1,
+        "serve-DURING: the demandless-copy GET must be answered from the local copy \
+         (local_get_serves={serves}, local_get_forwards={forwards})"
+    );
+
+    tracing::info!(
+        connections,
+        serves,
+        forwards,
+        "serve-DURING: demandless-copy GET served locally (never dark)"
+    );
+}
+
 /// Negative control for `test_contract_migrates_to_close_cluster_resolving_get_dead_end`.
 ///
 /// IDENTICAL scenario, but WITHOUT `enable_placement_migration()` — so the


### PR DESCRIPTION
> **Stacked on #4745 (R3 P0, connection-drop prompt re-root).** Base branch is `worktree-r3-p0-reroot`; review the serve-DURING commits on top of P0. Do NOT merge until #4745 merges and this is rebased onto main. Build-ahead draft.

## Problem

The **originator** GET gate (`client_events.rs`) served a local copy only when `is_subscribed` OR `is_hosting_contract && has_local_client_access`. A purely **demandless** every-hop hosting copy (hosted, no local client access, no subscription) therefore **routed the whole GET through the network** even though the node already held a fresh copy — it "went dark" on a read it could answer locally.

The **terminus** serve gate already serves such a copy immediately (`check_local_with_interest_gate` → `InterestManager::has_local_interest`), so the originator was the sole remaining gap. Routing a GET for a copy you already hold fresh violates `hosting-invariants.md` **invariant 1 (serve-DURING)**: "a peer serves its best local copy immediately and re-links in the background; it never blocks a read to confirm freshness."

## Approach

Align the **originator** gate with the **terminus** gate: serve immediately when the node has **local interest** (`interest_manager.has_local_interest`) — true for a demandless every-hop copy (registers `hosting = true`, joins the InterestSync anti-entropy heartbeat; **#4744 piece B** proves anti-entropy keeps demandless copies fresh-in-mesh), a locally-subscribed copy, or one with a downstream subscriber. This replaces the old `has_local_client_access` term — the copies the *local* user had touched, the exact condition serve-DURING relaxes. `local_satisfies_request` still guarantees state is present, so a phantom (interested-but-stateless, #4440) copy is excluded. **No `GetResponse` freshness flag** is added (invariant 1 forbids it); freshness rides on the anti-entropy mesh.

### Re-link semantics (spec step 3 / Re-rooting)

- **`subscribe=false` read:** serve, establish **nothing**. No durable demand; the demandless copy stays fresh via anti-entropy and is **never re-rooted** (re-root is connection-drop-driven — P0/#4745 — and its interest gate refuses a demandless copy). A burst of serve-DURING reads fans out **zero** re-links (storm-safe by construction — the third falsifier).
- **`subscribe=true` read:** serve the state immediately from the local copy, then — if not already receiving updates — establish the upstream subscription via `maybe_subscribe_child` (the sole GET subscribe path, now `pub(crate)`). Without this, a locally-served subscribe=true GET would bypass the network route where the subscribe normally rides, so the client would not get ongoing updates. This kick fires only on an **explicit client subscribe** and is gated on `!is_subscribed`; the client-subscribe origination path has no per-contract dedup, so re-link volume is **bounded by explicit client subscribes** (plus the `!is_subscribed` gate), not by internal dedup → it cannot become a read storm.

### `blocking_subscribe` correctness (#4524) — fixed this revision

The serve-DURING kick now forwards the client's **real `blocking_subscribe`** flag to `maybe_subscribe_child`, not a hardcoded `false`. `blocking_subscribe` is load-bearing for #4524: when `true`, the served read is held until the upstream subscription is registered, so the client cannot see the `GetResponse` before its downstream-subscriber chain exists (else an UPDATE sent immediately after the response races registration and is missed). The served **state** still comes from the local copy in both flag cases (serve-DURING); only the subscribe-registration wait differs. The earlier revision hardcoded `false`, which silently downgraded an explicit `blocking_subscribe=true` GET to fire-and-forget the moment serve-DURING fired — a regression vs the network path (which passes the real flag).

The serve decision is extracted into a pure `should_serve_local_copy` helper so the gate logic is unit-testable. `Ring::has_local_client_access` (its sole production caller removed) is deleted; the `HostingManager` accessor is `#[cfg(test)]`-gated. The flag itself is still maintained (`mark_local_client_access`) and read via the recency variant used by reconcile renewal.

## Testing

Unit falsifiers on `should_serve_local_copy`:

- **`demandless_interested_copy_serves_locally_with_connections`** — the serve-DURING falsifier: a demandless-but-interested copy (`has_local_interest=true`, `is_subscribed=false`) on a **connected** node serves locally. Before serve-DURING the third gate term was `is_hosting && has_local_client_access` = `false` for a demandless copy → the GET was forwarded; this pins the flipped behavior.
- **`uninterested_copy_forwards_with_connections`** — a stored copy with no interest and no subscription still routes (guards against over-broadening to serve stale bytes, invariant 1).
- `missing_local_state_never_serves`, `each_serve_reason_holds_independently`.

### End-to-end + regression coverage (this revision)

- **`SeedDemandlessCopy` sim primitive** — seeds a DEMANDLESS every-hop copy (hosting + local interest, **no** subscription, **no** prior local client access): exactly the state a production every-hop GET/PUT store leaves on a relay hop. `SeedHostedContract` seeds a *subscribed* copy (which the pre-serve-DURING gate already served), so it could not express this case. Implemented by threading a `SeedMode` enum through the startup `append_contracts` path.
- **`test_serve_during_demandless_copy_served_locally_never_dark`** (e2e) — a CONNECTED node holding a demandless copy answers a client `GET(subscribe=false)` from its LOCAL copy: asserts the A3 counters `local_get_serves >= 1` **and** `local_get_forwards == 0` (the two are mutually exclusive on the client GET path, so this proves the node never went dark). On `main` this GET forwards. Deterministic; verified across repeated runs.
- **`serve_during_kick_forwards_real_blocking_subscribe_flag`** (source-scrape pin) — the #4524 regression guard: asserts the serve-DURING kick forwards the real `blocking_subscribe` flag, not a hardcoded `false`. Deterministically **FAILS on the pre-fix code** and **PASSES after the fix** (verified by reverting the one-liner).

### Behavioral `blocking_subscribe` e2e — harness limitation (documented, not shipped as a flaky test)

The `blocking`-vs-`non-blocking` distinction is purely **temporal**: does the upstream subscribe register *before* or *after* the `GetResponse` is delivered (a sub-second ordering). It has no end-state difference — both paths have the subscription registered and any later UPDATE delivered. The deterministic Turmoil controlled-sim cannot observe this ordering: its inter-op dispatch gap (3 virtual seconds) is far larger than the subscribe-registration window, so any UPDATE scheduled after the GET finds the subscription already registered in *both* paths. A real-node `#[freenet_test]` (à la `nat_subscription.rs`) *can* exhibit the race, but only non-deterministically in the fail-pre direction (real wall-clock; the fire-and-forget subscribe sometimes wins), so it cannot serve as a reliable regression guard without being flaky ("flaky tests are broken tests"). The exact regression is instead pinned deterministically by the source-scrape test above; the **network-path** #4524 blocking behavior remains covered by `nat_subscription.rs`.

`cargo fmt` + `cargo check` + `cargo clippy --locked -- -D warnings` (and the `trace-ot` variant) clean; the unit falsifiers, the new e2e sim, and the source-scrape pin pass.

## Note for the P0 (#4745) owner

The `ci: fix pre-existing doc_lazy_continuation clippy error in reconcile.rs` commit fixes a **pre-existing** clippy failure on the P0 base — a piece-F module doc line wrapping to `+ jittered)` that markdown reads as a bullet — which currently fails `cargo clippy --locked -- -D warnings` (the exact CI invocation) for the whole stack. Split out so it can be dropped if #4745 fixes it at the source.

Refs #4642, #4524

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0199hK8Vdn5DAWcXJsxZHk8H

[AI-assisted - Claude]
