### PR TITLE
refactor(hosting): retire relay_put_replicate_forward (R3 piece E) — DO NOT MERGE, negative result

### DIFF
--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -1279,22 +1279,17 @@ where
                     "PUT relay: chain descended here and next hop moves away; finalizing here (#4363)"
                 );
                 // Finalize the operation at this closest-seen node (#4363
-                // placement) but STILL replicate the contract one hop onward so
-                // the UPDATE broadcast tree stays connected (#4509 convergence).
-                // See `relay_put_replicate_forward` for why both are required.
-                if let Some(next_addr) = peer.socket_addr() {
-                    relay_put_replicate_forward(
-                        op_manager,
-                        next_addr,
-                        key,
-                        contract.clone(),
-                        related_contracts.clone(),
-                        merged_value.clone(),
-                        htl,
-                        new_skip_list.clone(),
-                    )
-                    .await;
-                }
+                // placement). The contract is NOT replicated one hop PAST the
+                // terminus: a peer past the routing terminus has no demand for
+                // the contract, so it correctly should not host it — hosting is
+                // demand-driven, not holding-driven (see
+                // .claude/rules/hosting-invariants.md, invariant 2). A
+                // demand-having peer joins the contract's update mesh via its
+                // own subscribe-chain + live fan-out + anti-entropy; the old
+                // fire-and-forget past-terminus replication
+                // (`relay_put_replicate_forward`, #4509) is retired in R3
+                // piece E (do NOT re-add — the freshness mechanism now covers
+                // what it did).
                 let hop_count = op_manager.ring.max_hops_to_live.saturating_sub(htl);
                 return relay_put_finalize_local(
                     op_manager,
@@ -1998,104 +1993,6 @@ async fn relay_put_store_locally(
     Ok(merged_value)
 }
 
-/// Fire-and-forget a replication-only `PutMsg::Request` to `next_addr`
-/// when the #4363 terminus guard finalizes the operation locally.
-///
-/// # Why the guard must still replicate (issue #4509 convergence fix)
-///
-/// The terminus guard makes the *closest-seen* node the authoritative
-/// finalizer (it sends the upstream `PutMsg::Response`, so the originator's
-/// reply and `hop_count` reflect placement at the contract neighbourhood —
-/// the #4363 goal). But finalizing must NOT also stop the contract from
-/// replicating onward: this codebase forms the UPDATE broadcast tree along
-/// the PUT forward path (each relay `host_contract` + `announce_contract_hosted`
-/// in `relay_put_store_locally`). If the guard simply returns after the
-/// upstream Response, the next hop — and everything past it — never receives
-/// the contract, so a later UPDATE that the router fans out to one of those
-/// peers fails with `missing contract` and the network splits into divergent
-/// state groups (observed in `test_six_peer_contract_lifecycle`: contract on
-/// 4/6 peers, a 2/2 v20-vs-v30 split, node-2's updates reaching no one).
-///
-/// To keep placement (#4363) AND replication breadth (convergence), the guard
-/// finalizes locally *and* forwards a replication copy onward with a FRESH
-/// transaction so it does not collide with the upstream finalization waiter
-/// (the originator is already satisfied by this node's Response). The forward
-/// is fire-and-forget: no reply is awaited, and the downstream relay drives
-/// its own replication (including re-applying the same guard one hop deeper).
-/// The skip list — which already contains `upstream_addr` and `own_addr` —
-/// rides along unchanged, and HTL is decremented, so the replication copy is
-/// bounded and cannot loop back upstream. This is the "ensure terminated PUTs
-/// still replicate to the contract neighbourhood" resolution.
-#[allow(clippy::too_many_arguments)]
-async fn relay_put_replicate_forward(
-    op_manager: &OpManager,
-    next_addr: SocketAddr,
-    key: ContractKey,
-    contract: ContractContainer,
-    related_contracts: RelatedContracts<'static>,
-    merged_value: WrappedState,
-    htl: usize,
-    skip_list: HashSet<SocketAddr>,
-) {
-    // The replication copy is sent as a single `PutMsg::Request`. For a
-    // payload that would need streaming we skip the replication forward rather
-    // than re-implement the piped-stream upgrade here: the local store already
-    // placed the authoritative replica at this closest-seen node (#4363), and
-    // the convergence regression this restores (#4509) is on the small-state
-    // non-streaming path. A large-contract terminus is rare; skipping leaves
-    // placement correct and only forgoes the extra broadcast-path replica.
-    let payload = PutStreamingPayload {
-        contract: contract.clone(),
-        related_contracts: related_contracts.clone(),
-        value: merged_value.clone(),
-    };
-    let payload_size = bincode::serialized_size(&payload).unwrap_or(u64::MAX) as usize;
-    if crate::operations::should_use_streaming(op_manager.streaming_threshold, payload_size) {
-        tracing::debug!(
-            contract = %key,
-            target = %next_addr,
-            payload_size,
-            phase = "relay_put_terminus_replicate",
-            "PUT relay: terminus replication skipped for streaming-size payload (placement still correct)"
-        );
-        return;
-    }
-
-    // Fresh tx: the upstream Response under `incoming_tx` already satisfies
-    // the originator's waiter; reusing it would (a) make the downstream relay
-    // bubble a second Response back to a node with no waiter and (b) trip the
-    // per-node dedup gate on `incoming_tx`. A new transaction keeps the
-    // replication copy a clean, independent fire-and-forget op.
-    let replication_tx = Transaction::new::<PutMsg>();
-    let forward = NetMessage::from(PutMsg::Request {
-        id: replication_tx,
-        contract,
-        related_contracts,
-        value: merged_value,
-        htl: htl.saturating_sub(1),
-        skip_list,
-    });
-    let mut ctx = op_manager.op_ctx(replication_tx);
-    if let Err(err) = ctx.send_fire_and_forget(next_addr, forward).await {
-        tracing::debug!(
-            replication_tx = %replication_tx,
-            contract = %key,
-            target = %next_addr,
-            error = %err,
-            phase = "relay_put_terminus_replicate",
-            "PUT relay: terminus replication forward failed (best-effort)"
-        );
-    } else {
-        tracing::debug!(
-            replication_tx = %replication_tx,
-            contract = %key,
-            target = %next_addr,
-            phase = "relay_put_terminus_replicate",
-            "PUT relay: finalized locally but forwarded replication copy onward (#4509)"
-        );
-    }
-}
-
 /// Finalize at this node when there's no next hop. Emits `put_success`
 /// telemetry and sends `PutMsg::Response` upstream.
 ///
@@ -2580,13 +2477,12 @@ where
     // just stops piping the replica to a farther peer the contract
     // neighbourhood will never descend to. The away-move alone is not a
     // sufficient stop condition; see `put_routing_should_terminate`.
-    // When the terminus guard fires it drops `next_hop` (stops piping), but
-    // the contract must still replicate one hop onward to keep the UPDATE
-    // broadcast tree connected (#4509 convergence — see
-    // `relay_put_replicate_forward`). The streaming payload isn't assembled
-    // until step 5, so we remember the next-hop address here and forward a
-    // replication copy after the local store in step 6.
-    let mut terminus_replicate_to: Option<SocketAddr> = None;
+    // When the terminus guard fires it simply drops `next_hop` (stops piping)
+    // and finalizes locally. The contract is NOT replicated one hop PAST the
+    // terminus: a peer past the terminus has no demand for the contract and
+    // correctly should not host it (R3 piece E retired the past-terminus
+    // `relay_put_replicate_forward`, #4509; do NOT re-add — hosting is
+    // demand-driven, see .claude/rules/hosting-invariants.md invariant 2).
     let next_hop = match next_hop {
         Some(peer) => {
             let target = crate::ring::Location::from(&contract_key);
@@ -2612,7 +2508,8 @@ where
                     phase = "relay_put_streaming_terminus",
                     "PUT streaming relay: chain descended here and next hop moves away; finalizing here (#4363)"
                 );
-                terminus_replicate_to = peer.socket_addr();
+                // Drop the non-improving next hop and finalize locally
+                // (R3 piece E: no past-terminus replication).
                 None
             } else {
                 Some(peer)
@@ -2802,10 +2699,6 @@ where
     }
 
     // ── Step 6: Store contract locally (shared helper with slice A) ──────
-    // Clone the contract/related-contracts for a possible terminus replication
-    // forward (#4509) before the store consumes `related_contracts`.
-    let replicate_payload =
-        terminus_replicate_to.map(|addr| (addr, contract.clone(), related_contracts.clone()));
     // Originator-loopback client PUT → ClientLocal reserved lane (#4534).
     let store_priority = put_store_priority(op_manager, upstream_addr);
     let merged_value = relay_put_store_locally(
@@ -2820,23 +2713,10 @@ where
     )
     .await?;
 
-    // Terminus guard fired (#4363) on the streaming path: finalize here but
-    // still replicate the assembled contract one hop onward so the UPDATE
-    // broadcast tree stays connected (#4509). Mirrors the non-streaming guard
-    // branch; see `relay_put_replicate_forward`.
-    if let Some((next_addr, contract, related_contracts)) = replicate_payload {
-        relay_put_replicate_forward(
-            op_manager,
-            next_addr,
-            key,
-            contract,
-            related_contracts,
-            merged_value.clone(),
-            htl,
-            new_skip_list.clone(),
-        )
-        .await;
-    }
+    // Terminus guard fired (#4363) on the streaming path: finalize here and
+    // stop. R3 piece E retired the past-terminus replication forward — a peer
+    // past the terminus has no demand and correctly should not host the
+    // contract; demand-driven mesh join covers convergence.
 
     // ── Step 7: Await downstream reply (if piping), then bubble upstream ──
     //
@@ -4641,22 +4521,26 @@ mod tests {
         );
 
         // The guard must finalize locally on its terminus branch (so the
-        // closest-seen node is the authoritative finalizer, #4363) AND still
-        // replicate the contract one hop onward (so the UPDATE broadcast tree
-        // stays connected, #4509) — not just log, and not fall through to the
-        // forward. Both calls live in the terminus branch before the forward.
+        // closest-seen node is the authoritative finalizer, #4363) — not just
+        // log, and not fall through to the forward.
         let guard_region = &body[guard_pos..forward_pos];
         assert!(
             guard_region.contains("relay_put_finalize_local("),
             "the terminus branch MUST finalize locally via \
              relay_put_finalize_local, not fall through to the forward"
         );
+        // R3 piece E retired the past-terminus replication forward: the
+        // terminus branch finalizes locally WITHOUT replicating one hop past
+        // the terminus (a peer past the terminus has no demand and correctly
+        // should not host the contract — hosting-invariants invariant 2).
+        // Convergence is instead carried by the demand-driven mesh join
+        // (subscribe-chain + live fan-out + anti-entropy). Pin the function's
+        // absence so a future change can't silently re-introduce holding-driven
+        // placement.
         assert!(
-            guard_region.contains("relay_put_replicate_forward("),
-            "the terminus branch MUST still replicate the contract onward via \
-             relay_put_replicate_forward (#4509) — finalizing without \
-             replicating orphans the UPDATE broadcast path and splits the \
-             network into divergent state groups"
+            !src.contains("fn relay_put_replicate_forward"),
+            "relay_put_replicate_forward MUST stay removed (R3 piece E) — the \
+             past-terminus PUT replication is retired; do NOT re-add it"
         );
     }
 
@@ -4698,19 +4582,20 @@ mod tests {
              locally"
         );
 
-        // The streaming guard records the dropped next hop in
-        // `terminus_replicate_to` and, after the local store, replicates the
-        // contract one hop onward via `relay_put_replicate_forward` (#4509) so
-        // the streaming path does not orphan the UPDATE broadcast tree either.
+        // R3 piece E retired the past-terminus replication forward on the
+        // streaming path too: the terminus branch drops `next_hop` and
+        // finalizes locally WITHOUT replicating one hop past the terminus.
+        // Pin the absence of both the plumbing var and the forward call so a
+        // future change can't silently re-introduce it.
         assert!(
-            body.contains("terminus_replicate_to"),
-            "streaming guard MUST record the dropped next hop in \
-             terminus_replicate_to for the #4509 replication forward"
+            !body.contains("terminus_replicate_to"),
+            "streaming terminus path MUST NOT re-introduce terminus_replicate_to \
+             (R3 piece E retired the past-terminus replication forward)"
         );
         assert!(
-            body.contains("relay_put_replicate_forward("),
-            "streaming terminus path MUST still replicate the contract onward \
-             via relay_put_replicate_forward (#4509)"
+            !body.contains("relay_put_replicate_forward("),
+            "streaming terminus path MUST NOT replicate one hop past the terminus \
+             (R3 piece E) — demand-driven mesh join covers convergence"
         );
     }
 

--- a/crates/core/tests/nat_subscription.rs
+++ b/crates/core/tests/nat_subscription.rs
@@ -69,12 +69,13 @@
 //! contract itself, so the only way it can hold the contract locally is to
 //! fetch it. It cannot rely on PUT replication: the originator PUT on
 //! `host-peer` finalizes at `host-peer` (already at the contract location) and
-//! replicates exactly **one hop** toward the contract neighbourhood
-//! (`relay_put_replicate_forward`, #4509), which lands on the *gateway* (closer
-//! to the contract than `nat-peer`) — not on `nat-peer`. So a bare SUBSCRIBE on
-//! `nat-peer` raced contract presence that, for the farthest peer, often never
-//! arrives at all; that is the flake tracked in #4524 (a "contract not cached
-//! locally" rejection ~7-9s in).
+//! only leaves copies on the hops along its route toward the contract
+//! neighbourhood — none of which is `nat-peer` (half a ring away, off that
+//! route). (The PUT no longer even replicates one hop PAST the terminus: R3
+//! piece E retired `relay_put_replicate_forward`, #4509.) So a bare SUBSCRIBE
+//! on `nat-peer` raced contract presence that, for the farthest peer, often
+//! never arrives at all; that is the flake tracked in #4524 (a "contract not
+//! cached locally" rejection ~7-9s in).
 //!
 //! The deterministic fix is to use the supported non-host path: `nat-peer`
 //! issues `GET` with `subscribe=true`. The GET routes *toward* the contract

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -6362,6 +6362,87 @@ fn verify_contract_propagation(
     peer_states
 }
 
+/// Ground-truth STATE-convergence assertion for the demand-driven hosting
+/// convergence gate (#4642 R3 piece E — retiring `relay_put_replicate_forward`).
+///
+/// Reads each node's ACTUAL final stored state for `key` directly from its
+/// `MockStateStorage` (NOT log-scraped) and asserts:
+///   1. at least `min_holders` non-excluded nodes hold the contract (presence),
+///   2. every holder holds byte-identical state (`unique hashes == 1`), and
+///   3. that single converged hash equals `expected_hash`.
+///
+/// This is strictly stronger than a presence / ≥N-peers check, which passes
+/// vacuously for the #4509 failure class two different ways:
+///   * a v20-vs-v30 STATE SPLIT — holders "present" on ≥4 peers but at
+///     divergent versions (caught by check 2), and
+///   * convergence at a STALE value — every holder agreeing on the initial
+///     PUT state because no UPDATE propagated (all agree, but on the wrong
+///     hash; caught by check 3).
+///
+/// `exclude` drops nodes that are intentionally partitioned/crashed and hence
+/// legitimately frozen at a pre-crash state (their stale copy must not count
+/// against convergence). Returns the surviving holder→hash map for logging.
+fn assert_state_convergence(
+    result: &freenet::dev_tool::ControlledSimulationResult,
+    key: &freenet_stdlib::prelude::ContractKey,
+    min_holders: usize,
+    expected_hash: &str,
+    exclude: &[freenet::dev_tool::NodeLabel],
+) -> BTreeMap<freenet::dev_tool::NodeLabel, String> {
+    let holders: BTreeMap<freenet::dev_tool::NodeLabel, String> = result
+        .node_storages
+        .iter()
+        .filter_map(|(label, storage)| {
+            if exclude.contains(label) {
+                return None;
+            }
+            storage
+                .get_stored_state(key)
+                .map(|ws| (label.clone(), freenet::tracing::state_hash_full(&ws)))
+        })
+        .collect();
+
+    let unique: std::collections::HashSet<&String> = holders.values().collect();
+    tracing::info!(
+        "state-convergence check for {:?}: {} holder(s) (need >= {}), {} unique hash(es), \
+         expected {}: {:?}",
+        key,
+        holders.len(),
+        min_holders,
+        unique.len(),
+        expected_hash,
+        holders,
+    );
+
+    assert!(
+        holders.len() >= min_holders,
+        "contract {:?} held by only {} node(s), expected >= {}. Holders: {:?}",
+        key,
+        holders.len(),
+        min_holders,
+        holders,
+    );
+    assert_eq!(
+        unique.len(),
+        1,
+        "contract {:?} STATE SPLIT: {} distinct final-state hashes across {} holders \
+         (the #4509 divergence class a presence check misses). Holders: {:?}",
+        key,
+        unique.len(),
+        holders.len(),
+        holders,
+    );
+    let converged = holders.values().next().expect("holders is non-empty");
+    assert_eq!(
+        converged, expected_hash,
+        "contract {:?} converged at {} but expected the final-update hash {} — all holders \
+         AGREE but on a STALE value, i.e. the UPDATE never propagated (vacuous convergence)",
+        key, converged, expected_hash,
+    );
+
+    holders
+}
+
 /// Six-peer multi-contract lifecycle test — direct replacement for River's
 /// six-peer regression test.
 ///
@@ -6471,14 +6552,228 @@ fn test_six_peer_contract_lifecycle() {
         result.turmoil_result.err()
     );
 
-    // Verify both contracts propagated to at least 4 of 6 peers
+    // Verify both contracts propagated to at least 4 of 6 peers (log-scraped
+    // presence + agreement).
     let states_a = verify_contract_propagation(&rt, &logs_handle, contract_a_key, 4);
     let states_b = verify_contract_propagation(&rt, &logs_handle, contract_b_key, 4);
 
+    // STRENGTHENED convergence gate (#4642 R3 piece E, retiring
+    // `relay_put_replicate_forward`): assert STATE convergence from
+    // ground-truth final storage — every holder ends at the SAME hash AND that
+    // hash is the final-update (v50) value. This is the load-bearing assertion
+    // for the removal: the #4509 failure was a v20-vs-v30 state split that a
+    // ≥4/6 presence check passes vacuously. The last write in this scenario is
+    // node 2's v50 update (versions 10/20/30 from gw0, then 40/50 from node 2),
+    // and the CRDT LWW-by-version merge (data is version-independent) must
+    // converge every holder to create_crdt_state(50, seed).
+    let expected_a = freenet::tracing::state_hash_full(
+        &freenet_stdlib::prelude::WrappedState::new(SimOperation::create_crdt_state(50, 0xA1u8)),
+    );
+    let expected_b = freenet::tracing::state_hash_full(
+        &freenet_stdlib::prelude::WrappedState::new(SimOperation::create_crdt_state(50, 0xB2u8)),
+    );
+    let converged_a = assert_state_convergence(&result, &contract_a_key, 4, &expected_a, &[]);
+    let converged_b = assert_state_convergence(&result, &contract_b_key, 4, &expected_b, &[]);
+
     tracing::info!(
-        "test_six_peer_contract_lifecycle PASSED: contract_a on {} peers, contract_b on {} peers",
+        "test_six_peer_contract_lifecycle PASSED: contract_a converged on {} holders at v50, \
+         contract_b on {} holders at v50 (log-scraped presence: a={}, b={})",
+        converged_a.len(),
+        converged_b.len(),
         states_a.len(),
-        states_b.len()
+        states_b.len(),
+    );
+}
+
+/// No-subscriber convergence variant for retiring `relay_put_replicate_forward`
+/// (#4642 R3 piece E). A contract is PUT withOUT subscribe and NEVER
+/// subscribed, then UPDATEd once. Each hop the PUT routed through left a
+/// demandless every-hop copy (the every-hop store, live since v0.2.93); those
+/// copies are advertised co-hosts, so live fan-out (no interest check) must
+/// carry the UPDATE to all of them. Retiring the past-terminus replication
+/// forward only drops the copy ONE hop PAST the routing terminus — which has
+/// no demand and correctly should not host — so every ON-path copy must still
+/// converge on the updated state.
+///
+/// The teeth are in `assert_state_convergence`: no holder may be stranded at
+/// the initial PUT state (that is a split — check 2), and the converged value
+/// must be the UPDATE (v50), not the PUT (v1) — check 3. `min_holders = 1` is
+/// deliberately weak on presence (a zero-subscriber copy is a legitimate
+/// eviction candidate, so the surviving holder count is not pinned); the
+/// discriminating assertion is that whatever copies survive are FRESH.
+#[test_log::test]
+fn test_put_no_subscriber_update_convergence() {
+    use freenet::dev_tool::{NodeLabel, ScheduledOperation, SimOperation, register_crdt_contract};
+
+    const SEED: u64 = 0x4642_E5B0_0001;
+    const NETWORK_NAME: &str = "piece-e-no-subscriber";
+
+    GlobalTestMetrics::reset();
+    setup_deterministic_state(SEED);
+
+    let rt = create_runtime();
+    let sim = rt.block_on(async { SimNetwork::new(NETWORK_NAME, 2, 4, 10, 5, 15, 3, SEED).await });
+
+    let seed_byte = 0xC3u8;
+    let contract = SimOperation::create_test_contract(seed_byte);
+    let contract_id = *contract.key().id();
+    let contract_key = contract.key();
+    register_crdt_contract(contract_id);
+
+    let operations = vec![
+        // Gateway 0 PUTs withOUT subscribe — zero client demand network-wide.
+        ScheduledOperation::new(
+            NodeLabel::gateway(NETWORK_NAME, 0),
+            SimOperation::Put {
+                contract: contract.clone(),
+                state: SimOperation::create_crdt_state(1, seed_byte),
+                subscribe: false,
+            },
+        ),
+        // Gateway 0 UPDATEs to v50. With no subscribers, the only way the
+        // forward-path demandless copies can learn v50 is live fan-out to
+        // advertised co-hosts.
+        ScheduledOperation::new(
+            NodeLabel::gateway(NETWORK_NAME, 0),
+            SimOperation::Update {
+                key: contract_key,
+                data: SimOperation::create_crdt_state(50, seed_byte),
+            },
+        ),
+    ];
+
+    let result = sim.run_controlled_simulation(
+        SEED,
+        operations,
+        Duration::from_secs(180),
+        Duration::from_secs(60),
+    );
+    assert!(
+        result.turmoil_result.is_ok(),
+        "no-subscriber convergence sim failed: {:?}",
+        result.turmoil_result.err()
+    );
+
+    let expected = freenet::tracing::state_hash_full(&freenet_stdlib::prelude::WrappedState::new(
+        SimOperation::create_crdt_state(50, seed_byte),
+    ));
+    // Every holder that exists must have received the UPDATE via live fan-out —
+    // none stranded at the initial PUT state, and the converged value is v50.
+    let holders = assert_state_convergence(&result, &contract_key, 1, &expected, &[]);
+    tracing::info!(
+        "test_put_no_subscriber_update_convergence PASSED: {} demandless holder(s) all at v50 \
+         (no on-path copy stranded at the initial PUT state)",
+        holders.len(),
+    );
+}
+
+/// Churn convergence variant for retiring `relay_put_replicate_forward`
+/// (#4642 R3 piece E). Same subscribed lifecycle as the six-peer test, but a
+/// mid-chain subscriber is CRASHED partway through the UPDATE sequence. The
+/// surviving subscribed holders must still converge on the final state — i.e.
+/// the demand-driven update mesh (subscribe-chain + live fan-out +
+/// anti-entropy) keeps the network convergent across churn WITHOUT the retired
+/// past-terminus PUT replication.
+///
+/// NOTE: this asserts convergence among SURVIVORS. It does not require the
+/// crashed node's chain to be re-rooted onto a new upstream — the prompt
+/// event-driven re-subscribe that would do that is a separate change not on
+/// `main` (see `test_scripted_node_crash_mid_run`). The crashed node's own
+/// (frozen, pre-crash) copy is excluded from the convergence check.
+#[test_log::test]
+fn test_put_replicate_forward_removal_churn_convergence() {
+    use freenet::dev_tool::{NodeLabel, ScheduledOperation, SimOperation, register_crdt_contract};
+
+    const SEED: u64 = 0x4642_E0C0_0001;
+    const NETWORK_NAME: &str = "piece-e-churn";
+
+    GlobalTestMetrics::reset();
+    setup_deterministic_state(SEED);
+
+    let rt = create_runtime();
+    let sim = rt.block_on(async { SimNetwork::new(NETWORK_NAME, 2, 4, 10, 5, 15, 3, SEED).await });
+
+    let seed_byte = 0xD4u8;
+    let contract = SimOperation::create_test_contract(seed_byte);
+    let contract_id = *contract.key().id();
+    let contract_key = contract.key();
+    register_crdt_contract(contract_id);
+
+    // Crash a mid-chain subscriber (node 3) partway through the updates.
+    let crashed = NodeLabel::node(NETWORK_NAME, 3);
+
+    let mut operations = vec![
+        // Gateway 0 PUTs with subscribe=true.
+        ScheduledOperation::new(
+            NodeLabel::gateway(NETWORK_NAME, 0),
+            SimOperation::Put {
+                contract: contract.clone(),
+                state: SimOperation::create_crdt_state(1, seed_byte),
+                subscribe: true,
+            },
+        ),
+    ];
+    // gateway 1 + nodes 2..=5 subscribe.
+    operations.push(ScheduledOperation::new(
+        NodeLabel::gateway(NETWORK_NAME, 1),
+        SimOperation::Subscribe { contract_id },
+    ));
+    for i in 2..=5 {
+        operations.push(ScheduledOperation::new(
+            NodeLabel::node(NETWORK_NAME, i),
+            SimOperation::Subscribe { contract_id },
+        ));
+    }
+    // Two early updates every subscriber should get before the crash.
+    for v in [10u64, 20] {
+        operations.push(ScheduledOperation::new(
+            NodeLabel::gateway(NETWORK_NAME, 0),
+            SimOperation::Update {
+                key: contract_key,
+                data: SimOperation::create_crdt_state(v, seed_byte),
+            },
+        ));
+    }
+    // Crash node 3 mid-lifecycle.
+    operations.push(ScheduledOperation::new(
+        crashed.clone(),
+        SimOperation::CrashNode,
+    ));
+    // Later updates (from node 2) the SURVIVORS must still converge on
+    // (final = v50), driven through the mesh without the crashed relay.
+    for v in [30u64, 40, 50] {
+        operations.push(ScheduledOperation::new(
+            NodeLabel::node(NETWORK_NAME, 2),
+            SimOperation::Update {
+                key: contract_key,
+                data: SimOperation::create_crdt_state(v, seed_byte),
+            },
+        ));
+    }
+
+    let result = sim.run_controlled_simulation(
+        SEED,
+        operations,
+        Duration::from_secs(240),
+        Duration::from_secs(90),
+    );
+    assert!(
+        result.turmoil_result.is_ok(),
+        "churn convergence sim failed: {:?}",
+        result.turmoil_result.err()
+    );
+
+    let expected = freenet::tracing::state_hash_full(&freenet_stdlib::prelude::WrappedState::new(
+        SimOperation::create_crdt_state(50, seed_byte),
+    ));
+    // Survivors (all holders except the crashed node) must converge at v50.
+    let holders =
+        assert_state_convergence(&result, &contract_key, 3, &expected, &[crashed.clone()]);
+    tracing::info!(
+        "test_put_replicate_forward_removal_churn_convergence PASSED: {} surviving holders \
+         converged at v50 after mid-run crash of {:?}",
+        holders.len(),
+        crashed,
     );
 }
 


### PR DESCRIPTION
> **DO NOT MERGE — NEGATIVE RESULT.** This is a build-ahead experiment for #4642 R3 piece E. It removes `relay_put_replicate_forward` and adds a strengthened convergence gate to test whether the demand-driven freshness mechanism covers what that hop did. **It does not.** CI is (correctly) red: the strengthened gate catches that the removal reintroduces the #4509 convergence split. Kept as a draft so the finding + the reusable convergence gate are reviewable. Needs a decision from @sanity.

## Problem

`relay_put_replicate_forward` (`put/op_ctx_task.rs`) fires a fire-and-forget full-state PUT one hop past the #4363 routing terminus, purely to keep the UPDATE broadcast tree connected (#4509). R3 piece E wants to retire it: in the *target* model a demand-having peer joins the update mesh via its own subscribe-chain + live fan-out + anti-entropy, and a peer past the terminus with no demand correctly should not host the contract (hosting is demand-driven, `hosting-invariants` invariant 2).

The removal was **ship-gated on a strengthened convergence sim-check** that GATES it. This PR builds the removal + the gate and runs the gate. **The gate fails.**

## What this changes

- **Remove** `relay_put_replicate_forward`, both call sites (non-streaming + streaming), the streaming `terminus_replicate_to` / `replicate_payload` plumbing that only served it, and flip the two source-scrape pin tests (`drive_relay_put_applies_terminus_guard_before_forwarding`, `drive_relay_put_streaming_applies_terminus_guard_before_next_hop`) to assert the function stays **absent**.
- **Strengthen** `test_six_peer_contract_lifecycle`: new `assert_state_convergence` reads each node's **ground-truth** final state from `MockStateStorage` (not log-scraped) and asserts (1) ≥N holders, (2) all holders byte-identical, and (3) the converged hash equals the **final-update (v50)** value — catching both a v20/v30 split and the subtler "all agree on a stale value" vacuous pass.
- **Add** two variants: `test_put_no_subscriber_update_convergence` (PUT unsubscribed + UPDATE) and `test_put_replicate_forward_removal_churn_convergence` (crash a mid-chain subscriber mid-lifecycle).

## Result (deterministic, `--features simulation_tests,testing`)

| Scenario | With `replicate_forward` (control) | Without it (this PR) |
|---|---|---|
| six-peer subscribed lifecycle | **PASS 3/3** | **FAIL 3/3** — 2/2 split: 2 peers @ **v20**, 2 peers @ **v30**; node-2's v40/v50 reached no one |
| churn (crash mid-chain subscriber) | n/a | **FAIL** — only 2 survivors hold it, both frozen @ **v20**; post-crash updates reached no survivor |
| no-subscriber (2-node reachable mesh) | n/a | PASS — live fan-out reaches the one directly-connected demandless copy, but does not exercise the multi-hop tree that fragments |

The six-peer failure is the **exact #4509 signature** the removed hop's own doc comment described: "contract on 4/6 peers, a 2/2 v20-vs-v30 split, node-2's updates reaching no one." The anti-entropy + live-fan-out mechanisms currently on `main` (interest-sync #3226/#2789/#4475, reconcile P6 #4725) do **not** heal it within the sim budget (240s sim + 90s post-op wait).

## Conclusion

The freshness mechanism does **not** fully cover `relay_put_replicate_forward`. **E cannot ship on this tree.** Options for @sanity:
1. Keep `relay_put_replicate_forward` until the freshness/re-root layer demonstrably covers multi-hop tree connectivity (then re-run this gate).
2. Land only the strengthened convergence gate (independently valuable — it PASSES on `main` with the hop present and would guard any future removal), and defer the removal.

The strengthened `assert_state_convergence` gate is the reusable artifact here regardless of the removal's fate.

Relates to #4642.

[AI-assisted - Claude]