### PR TITLE
feat(hosting): near-key replication prototype + convergence-vs-cost sweep (R&D — DO NOT MERGE)

### DIFF
--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -1177,6 +1177,7 @@ where
                         value,
                         htl,
                         skip_list,
+                        replication_budget,
                     } => {
                         if let Err(err) = put::op_ctx_task::start_relay_put(
                             op_manager.clone(),
@@ -1188,6 +1189,7 @@ where
                             *htl,
                             skip_list.clone(),
                             upstream_addr,
+                            *replication_budget,
                         )
                         .await
                         {
@@ -4765,6 +4767,7 @@ mod tests {
                 value: WrappedState::new(vec![1u8]),
                 htl: 5,
                 skip_list: std::collections::HashSet::new(),
+                replication_budget: 0,
             };
 
             let taken = put_branch_would_forward(&op, Some(&tx));

--- a/crates/core/src/operations/put.rs
+++ b/crates/core/src/operations/put.rs
@@ -298,6 +298,18 @@ mod messages {
             htl: usize,
             /// Addresses to skip when selecting next hop (prevents loops)
             skip_list: HashSet<std::net::SocketAddr>,
+            /// R&D PROTOTYPE — near-key replication (#4642 R3 piece E
+            /// alternative). Remaining near-key replication budget carried by a
+            /// SPREAD copy. `0` for a normal client/relay PUT — the routing
+            /// terminus mints `R_MAX` locally and begins the spread. `>0` only on
+            /// the fire-and-forget replication copies emitted by
+            /// `nearkey_replicate_spread`: the budget is spent 1-per-hop and is
+            /// locally CLAMPED to `R_MAX` on receipt (the DoS bound — an attacker
+            /// inflating this field is capped). `#[serde(default)]` for
+            /// source-level clarity; bincode is positional, so this rides after
+            /// `skip_list` and all sim peers run the same build.
+            #[serde(default)]
+            replication_budget: usize,
         },
         /// Response indicating the PUT completed. Routed hop-by-hop back to originator
         /// using each node's stored upstream_addr.
@@ -604,6 +616,7 @@ mod tests {
                     value: WrappedState::new(vec![]),
                     htl: 0,
                     skip_list: Default::default(),
+                    replication_budget: 0,
                 },
             ),
             (

--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -305,6 +305,12 @@ async fn drive_client_put_inner(
                     .get_own_addr()
                     .into_iter()
                     .collect::<HashSet<_>>(),
+                // R&D PROTOTYPE: a client's initial PUT carries NO replication
+                // budget. The budget is MINTED fresh (`R_MAX`) at the routing
+                // terminus; carrying it from the originator would make every
+                // relay hop short-circuit as a spread copy before the terminus
+                // is reached. See `nearkey_replicate_spread`.
+                replication_budget: 0,
             })
         }
 
@@ -830,6 +836,10 @@ pub(crate) async fn start_relay_put<CB>(
     htl: usize,
     skip_list: HashSet<SocketAddr>,
     upstream_addr: SocketAddr,
+    // R&D PROTOTYPE (near-key replication): remaining near-key replication
+    // budget carried by a spread copy; 0 for a normal PUT. See
+    // `nearkey_replicate_spread`.
+    replication_budget: usize,
 ) -> Result<(), OpError>
 where
     CB: NetworkBridge + Clone + Send + 'static,
@@ -882,6 +892,7 @@ where
         htl,
         skip_list,
         upstream_addr,
+        replication_budget,
     ));
     Ok(())
 }
@@ -916,6 +927,7 @@ async fn run_relay_put<CB>(
     htl: usize,
     skip_list: HashSet<SocketAddr>,
     upstream_addr: SocketAddr,
+    replication_budget: usize,
 ) where
     CB: NetworkBridge + Clone + Send + 'static,
 {
@@ -931,6 +943,7 @@ async fn run_relay_put<CB>(
         htl,
         skip_list,
         upstream_addr,
+        replication_budget,
     )
     .await;
 
@@ -1186,6 +1199,7 @@ async fn drive_relay_put<CB>(
     htl: usize,
     skip_list: HashSet<SocketAddr>,
     upstream_addr: SocketAddr,
+    incoming_replication_budget: usize,
 ) -> Result<(), OpError>
 where
     CB: NetworkBridge + Clone + Send + 'static,
@@ -1197,6 +1211,7 @@ where
         contract = %key,
         htl,
         %upstream_addr,
+        incoming_replication_budget,
         phase = "relay_put_request",
         "PUT relay: processing Request"
     );
@@ -1227,6 +1242,32 @@ where
     new_skip_list.insert(upstream_addr);
     if let Some(own_addr) = op_manager.ring.connection_manager.get_own_addr() {
         new_skip_list.insert(own_addr);
+    }
+
+    // ── R&D PROTOTYPE near-key replication: spread-copy short-circuit ───────
+    // A spread copy (`incoming_replication_budget > 0`) is a lateral,
+    // fire-and-forget replica already within the near-key band. It has stored
+    // locally (Step 1 above) and now RE-SPREADS its remaining budget to ITS own
+    // near-key neighbors, then returns. It must NOT (a) re-mint `R_MAX`
+    // (recursion would explode), (b) route onward toward the key (the spread is
+    // lateral, not descent), or (c) finalize/bubble a Response upstream (the
+    // spread copy rides a FRESH fire-and-forget tx with no waiter). The budget
+    // is clamped to `R_MAX` on receipt — this is the DoS bound (an attacker
+    // inflating the field is capped here). See `nearkey_replicate_spread`.
+    if incoming_replication_budget > 0 {
+        let budget = incoming_replication_budget.min(nearkey_r_max());
+        nearkey_replicate_spread(
+            op_manager,
+            key,
+            contract,
+            related_contracts,
+            merged_value,
+            htl,
+            new_skip_list,
+            budget,
+        )
+        .await;
+        return Ok(());
     }
 
     let next_hop = if htl > 0 {
@@ -1279,22 +1320,27 @@ where
                     "PUT relay: chain descended here and next hop moves away; finalizing here (#4363)"
                 );
                 // Finalize the operation at this closest-seen node (#4363
-                // placement) but STILL replicate the contract one hop onward so
-                // the UPDATE broadcast tree stays connected (#4509 convergence).
-                // See `relay_put_replicate_forward` for why both are required.
-                if let Some(next_addr) = peer.socket_addr() {
-                    relay_put_replicate_forward(
-                        op_manager,
-                        next_addr,
-                        key,
-                        contract.clone(),
-                        related_contracts.clone(),
-                        merged_value.clone(),
-                        htl,
-                        new_skip_list.clone(),
-                    )
-                    .await;
-                }
+                // placement). R&D PROTOTYPE: instead of the single past-terminus
+                // hop the old `relay_put_replicate_forward` used to keep the
+                // UPDATE broadcast tree connected (#4509), MINT a fresh `R_MAX`
+                // budget and begin a BOUNDED near-key replication spread. The
+                // spread places up to `R_MAX` copies (INCLUDING this terminus)
+                // on a CONNECTED cluster of neighbors within band `D` of the
+                // key, so the multi-hop UPDATE tree is reconstructed robustly
+                // rather than by a single fragile hop. At `R_MAX = 2` this
+                // reduces to "terminus + nearest near-key neighbor", i.e. the
+                // retired single-hop behavior. See `nearkey_replicate_spread`.
+                nearkey_replicate_spread(
+                    op_manager,
+                    key,
+                    contract.clone(),
+                    related_contracts.clone(),
+                    merged_value.clone(),
+                    htl,
+                    new_skip_list.clone(),
+                    nearkey_r_max(),
+                )
+                .await;
                 let hop_count = op_manager.ring.max_hops_to_live.saturating_sub(htl);
                 return relay_put_finalize_local(
                     op_manager,
@@ -1560,6 +1606,10 @@ where
                 value: merged_value.clone(),
                 htl: new_htl,
                 skip_list: new_skip_list,
+                // Normal toward-key forward: a spread copy short-circuits before
+                // this point, so this is reached only for a non-spread PUT
+                // (`incoming_replication_budget == 0`). Carried for correctness.
+                replication_budget: incoming_replication_budget,
             });
             if let Err(err) = ctx.send_fire_and_forget(next_addr, forward).await {
                 tracing::warn!(
@@ -1674,6 +1724,8 @@ where
             value: merged_value,
             htl: new_htl,
             skip_list: new_skip_list,
+            // Normal toward-key forward (non-spread PUT only; see above).
+            replication_budget: incoming_replication_budget,
         });
         tokio::time::timeout(OPERATION_TTL, ctx.send_to_and_await(next_addr, forward)).await
     };
@@ -1998,52 +2050,114 @@ async fn relay_put_store_locally(
     Ok(merged_value)
 }
 
-/// Fire-and-forget a replication-only `PutMsg::Request` to `next_addr`
-/// when the #4363 terminus guard finalizes the operation locally.
+// ─────────────────────────────────────────────────────────────────────────
+// R&D PROTOTYPE — bounded near-key replication (#4642 R3 piece E alternative)
+// ─────────────────────────────────────────────────────────────────────────
+//
+// EXPERIMENTAL, DO NOT MERGE. This replaces the single past-terminus hop
+// (`relay_put_replicate_forward`, #4509) with a principled, bounded, local-
+// information-only near-key replication cluster, so Ian can pick the
+// parameters from convergence-vs-cost data.
+
+/// Default near-key replication factor `R_MAX` (total copies in the near-key
+/// cluster INCLUDING the terminus). `R_MAX = 2` reduces to the retired
+/// single-hop past-terminus behavior ("terminus + nearest near-key neighbor").
+/// Overridable at process start via `FREENET_NEARKEY_R_MAX` for the sweep.
+const NEARKEY_R_MAX_DEFAULT: usize = 2;
+
+/// Default near-key distance band `D` (ring distance in `[0, 0.5]`). A neighbor
+/// counts as "near-key" if its ring distance to the contract key is `<= D`.
+/// Governs how much of the cluster lands beyond the connectivity floor.
+/// Overridable at process start via `FREENET_NEARKEY_BAND_D`.
+const NEARKEY_BAND_D_DEFAULT: f64 = 0.30;
+
+/// Process-global `R_MAX`, read once from `FREENET_NEARKEY_R_MAX` (DoS clamp
+/// ceiling + terminus mint value). A single process runs one whole sim, so all
+/// sim peers share the same value; the sweep runs a fresh process per value.
+fn nearkey_r_max() -> usize {
+    use std::sync::OnceLock;
+    static R_MAX: OnceLock<usize> = OnceLock::new();
+    *R_MAX.get_or_init(|| {
+        std::env::var("FREENET_NEARKEY_R_MAX")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .filter(|&r| r >= 1)
+            .unwrap_or(NEARKEY_R_MAX_DEFAULT)
+    })
+}
+
+/// Process-global near-key band `D`, read once from `FREENET_NEARKEY_BAND_D`.
+fn nearkey_band_d() -> f64 {
+    use std::sync::OnceLock;
+    static BAND_D: OnceLock<f64> = OnceLock::new();
+    *BAND_D.get_or_init(|| {
+        std::env::var("FREENET_NEARKEY_BAND_D")
+            .ok()
+            .and_then(|v| v.parse::<f64>().ok())
+            .filter(|d| d.is_finite() && *d >= 0.0)
+            .unwrap_or(NEARKEY_BAND_D_DEFAULT)
+    })
+}
+
+/// Bounded near-key replication spread (R&D PROTOTYPE).
 ///
-/// # Why the guard must still replicate (issue #4509 convergence fix)
+/// # Why this replaces the single past-terminus hop (#4509)
 ///
-/// The terminus guard makes the *closest-seen* node the authoritative
-/// finalizer (it sends the upstream `PutMsg::Response`, so the originator's
-/// reply and `hop_count` reflect placement at the contract neighbourhood —
-/// the #4363 goal). But finalizing must NOT also stop the contract from
-/// replicating onward: this codebase forms the UPDATE broadcast tree along
-/// the PUT forward path (each relay `host_contract` + `announce_contract_hosted`
-/// in `relay_put_store_locally`). If the guard simply returns after the
-/// upstream Response, the next hop — and everything past it — never receives
-/// the contract, so a later UPDATE that the router fans out to one of those
-/// peers fails with `missing contract` and the network splits into divergent
-/// state groups (observed in `test_six_peer_contract_lifecycle`: contract on
-/// 4/6 peers, a 2/2 v20-vs-v30 split, node-2's updates reaching no one).
+/// The retired `relay_put_replicate_forward` fired ONE fire-and-forget copy one
+/// hop past the #4363 routing terminus purely to keep the multi-hop UPDATE
+/// broadcast tree connected: without it, a later UPDATE the router fans out to
+/// a peer past the terminus fails with `missing contract` and the network
+/// splits into divergent state groups (the #4509 v20-vs-v30 signature). Live
+/// fan-out alone does not heal this — it only reaches DIRECTLY-connected
+/// co-hosts and does not reconstruct the tree.
 ///
-/// To keep placement (#4363) AND replication breadth (convergence), the guard
-/// finalizes locally *and* forwards a replication copy onward with a FRESH
-/// transaction so it does not collide with the upstream finalization waiter
-/// (the originator is already satisfied by this node's Response). The forward
-/// is fire-and-forget: no reply is awaited, and the downstream relay drives
-/// its own replication (including re-applying the same guard one hop deeper).
-/// The skip list — which already contains `upstream_addr` and `own_addr` —
-/// rides along unchanged, and HTL is decremented, so the replication copy is
-/// bounded and cannot loop back upstream. This is the "ensure terminated PUTs
-/// still replicate to the contract neighbourhood" resolution.
+/// This spread generalizes that single hop into a BOUNDED, CONNECTED near-key
+/// cluster. Local information only:
+///
+/// 1. The caller has already stored locally, so this node is copy #1. We spend
+///    1 of `budget` on self; `remaining = budget - 1`.
+/// 2. We enumerate our own connected neighbors, keep those within band `D` of
+///    the key (a LOCAL distance check), and — as a CONNECTIVITY FLOOR — always
+///    keep the single nearest-to-key neighbor even if band `D` excluded it, so
+///    the terminus never no-ops and the tree stays connected. (At `R_MAX = 2`
+///    this floor alone reproduces the retired single-hop replica.)
+/// 3. We split `remaining` across those targets (evenly, each `>= 1`) and send
+///    each a fire-and-forget replication `PutMsg::Request` carrying its
+///    sub-budget. The recipient stores, spends 1, and RE-SPREADS the rest to
+///    ITS near-key neighbors — until budget hits 0 or no near-key neighbor
+///    remains.
+///
+/// Because every copy lands at a DIRECT NEIGHBOR of an existing copy, the
+/// result is a connected co-host cluster near the key — exactly the property
+/// convergence needs, now robust to any single peer rather than one fragile
+/// hop. Bounding: the budget strictly decreases by `>= 1` per spread hop
+/// (total copies `<= budget <= R_MAX`); HTL is decremented too; and the skip
+/// list (which already contains `upstream_addr`, `own_addr`, and — added here
+/// — the sibling targets) prevents loops and sibling double-cover. The `R_MAX`
+/// clamp on receipt (`drive_relay_put`) is the DoS bound.
 #[allow(clippy::too_many_arguments)]
-async fn relay_put_replicate_forward(
+async fn nearkey_replicate_spread(
     op_manager: &OpManager,
-    next_addr: SocketAddr,
     key: ContractKey,
     contract: ContractContainer,
     related_contracts: RelatedContracts<'static>,
     merged_value: WrappedState,
     htl: usize,
+    // Already contains `upstream_addr` + `own_addr`.
     skip_list: HashSet<SocketAddr>,
+    // Total near-key copies INCLUDING this node (already clamped to `R_MAX`).
+    budget: usize,
 ) {
-    // The replication copy is sent as a single `PutMsg::Request`. For a
-    // payload that would need streaming we skip the replication forward rather
-    // than re-implement the piped-stream upgrade here: the local store already
-    // placed the authoritative replica at this closest-seen node (#4363), and
-    // the convergence regression this restores (#4509) is on the small-state
-    // non-streaming path. A large-contract terminus is rare; skipping leaves
-    // placement correct and only forgoes the extra broadcast-path replica.
+    // Self is copy #1 (stored by the caller). Spend it.
+    let remaining = budget.saturating_sub(1);
+    if remaining == 0 || htl == 0 {
+        return;
+    }
+
+    // Streaming-size payloads: skip (parity with the retired single-hop
+    // forward, which also skipped streaming; the convergence regression is on
+    // the small-state non-streaming path, and re-implementing the piped-stream
+    // upgrade here is out of scope for the prototype).
     let payload = PutStreamingPayload {
         contract: contract.clone(),
         related_contracts: related_contracts.clone(),
@@ -2053,46 +2167,116 @@ async fn relay_put_replicate_forward(
     if crate::operations::should_use_streaming(op_manager.streaming_threshold, payload_size) {
         tracing::debug!(
             contract = %key,
-            target = %next_addr,
             payload_size,
-            phase = "relay_put_terminus_replicate",
-            "PUT relay: terminus replication skipped for streaming-size payload (placement still correct)"
+            phase = "nearkey_replicate_spread",
+            "PUT near-key spread skipped for streaming-size payload (placement still correct)"
         );
         return;
     }
 
-    // Fresh tx: the upstream Response under `incoming_tx` already satisfies
-    // the originator's waiter; reusing it would (a) make the downstream relay
-    // bubble a second Response back to a node with no waiter and (b) trip the
-    // per-node dedup gate on `incoming_tx`. A new transaction keeps the
-    // replication copy a clean, independent fire-and-forget op.
-    let replication_tx = Transaction::new::<PutMsg>();
-    let forward = NetMessage::from(PutMsg::Request {
-        id: replication_tx,
-        contract,
-        related_contracts,
-        value: merged_value,
-        htl: htl.saturating_sub(1),
-        skip_list,
+    // Local-only near-key neighbor selection. Enumerate our connections, drop
+    // skip-listed / transient ones, and rank by ring distance to the key.
+    let band = nearkey_band_d();
+    let target_loc = crate::ring::Location::from(&key);
+    let connections = op_manager
+        .ring
+        .connection_manager
+        .get_connections_by_location();
+    let mut candidates: Vec<(SocketAddr, f64)> = Vec::new();
+    for conns in connections.values() {
+        for conn in conns {
+            let Some(addr) = conn.location.socket_addr() else {
+                continue;
+            };
+            if skip_list.contains(&addr) {
+                continue;
+            }
+            if op_manager.ring.connection_manager.is_transient(addr) {
+                continue;
+            }
+            let Some(loc) = conn.location.location() else {
+                continue;
+            };
+            let dist = target_loc.distance(loc).as_f64();
+            candidates.push((addr, dist));
+        }
+    }
+    if candidates.is_empty() {
+        return;
+    }
+    // Deterministic: nearest-to-key first, addr as tiebreak.
+    candidates.sort_by(|a, b| {
+        a.1.partial_cmp(&b.1)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then(a.0.cmp(&b.0))
     });
-    let mut ctx = op_manager.op_ctx(replication_tx);
-    if let Err(err) = ctx.send_fire_and_forget(next_addr, forward).await {
-        tracing::debug!(
-            replication_tx = %replication_tx,
-            contract = %key,
-            target = %next_addr,
-            error = %err,
-            phase = "relay_put_terminus_replicate",
-            "PUT relay: terminus replication forward failed (best-effort)"
-        );
-    } else {
-        tracing::debug!(
-            replication_tx = %replication_tx,
-            contract = %key,
-            target = %next_addr,
-            phase = "relay_put_terminus_replicate",
-            "PUT relay: finalized locally but forwarded replication copy onward (#4509)"
-        );
+
+    // Band filter, with the connectivity floor (always keep the nearest).
+    let mut near: Vec<(SocketAddr, f64)> = candidates
+        .iter()
+        .copied()
+        .filter(|(_, d)| *d <= band)
+        .collect();
+    if near.is_empty() {
+        near.push(candidates[0]);
+    }
+
+    let n_targets = near.len().min(remaining);
+    if n_targets == 0 {
+        return;
+    }
+    let targets: Vec<SocketAddr> = near.iter().take(n_targets).map(|(a, _)| *a).collect();
+
+    // Even budget split (each target gets >= 1 since n_targets <= remaining).
+    let base = remaining / n_targets;
+    let extra = remaining % n_targets;
+
+    // Sibling skip: each spread copy skips self + all sibling targets so the
+    // cluster does not double-cover the same neighbors.
+    let mut sibling_skip = skip_list.clone();
+    for t in &targets {
+        sibling_skip.insert(*t);
+    }
+    if let Some(own) = op_manager.ring.connection_manager.get_own_addr() {
+        sibling_skip.insert(own);
+    }
+
+    for (i, target) in targets.iter().enumerate() {
+        let sub_budget = base + if i < extra { 1 } else { 0 };
+        // Fresh tx: the replication copy is a clean fire-and-forget op with no
+        // waiter (the terminus already satisfied the originator via its
+        // Response), so it cannot collide with any upstream finalization.
+        let replication_tx = Transaction::new::<PutMsg>();
+        let forward = NetMessage::from(PutMsg::Request {
+            id: replication_tx,
+            contract: contract.clone(),
+            related_contracts: related_contracts.clone(),
+            value: merged_value.clone(),
+            htl: htl.saturating_sub(1),
+            skip_list: sibling_skip.clone(),
+            replication_budget: sub_budget,
+        });
+        let mut ctx = op_manager.op_ctx(replication_tx);
+        if let Err(err) = ctx.send_fire_and_forget(*target, forward).await {
+            tracing::debug!(
+                replication_tx = %replication_tx,
+                contract = %key,
+                target = %target,
+                sub_budget,
+                error = %err,
+                phase = "nearkey_replicate_spread",
+                "PUT near-key spread copy send failed (best-effort)"
+            );
+        } else {
+            tracing::debug!(
+                replication_tx = %replication_tx,
+                contract = %key,
+                target = %target,
+                sub_budget,
+                phase = "nearkey_replicate_spread",
+                "PUT near-key spread copy sent"
+            );
+        }
     }
 }
 
@@ -2580,13 +2764,13 @@ where
     // just stops piping the replica to a farther peer the contract
     // neighbourhood will never descend to. The away-move alone is not a
     // sufficient stop condition; see `put_routing_should_terminate`.
-    // When the terminus guard fires it drops `next_hop` (stops piping), but
-    // the contract must still replicate one hop onward to keep the UPDATE
-    // broadcast tree connected (#4509 convergence — see
-    // `relay_put_replicate_forward`). The streaming payload isn't assembled
-    // until step 5, so we remember the next-hop address here and forward a
-    // replication copy after the local store in step 6.
-    let mut terminus_replicate_to: Option<SocketAddr> = None;
+    // When the terminus guard fires it drops `next_hop` (stops piping). R&D
+    // PROTOTYPE: to keep the UPDATE broadcast tree connected (#4509) we run the
+    // bounded near-key replication spread after the local store (step 6),
+    // minting a fresh `R_MAX` budget — the same spread the non-streaming
+    // terminus uses. The streaming payload isn't assembled until step 5, so we
+    // just remember THAT the terminus fired here and spread after the store.
+    let mut terminus_finalized_here = false;
     let next_hop = match next_hop {
         Some(peer) => {
             let target = crate::ring::Location::from(&contract_key);
@@ -2612,7 +2796,7 @@ where
                     phase = "relay_put_streaming_terminus",
                     "PUT streaming relay: chain descended here and next hop moves away; finalizing here (#4363)"
                 );
-                terminus_replicate_to = peer.socket_addr();
+                terminus_finalized_here = true;
                 None
             } else {
                 Some(peer)
@@ -2802,10 +2986,13 @@ where
     }
 
     // ── Step 6: Store contract locally (shared helper with slice A) ──────
-    // Clone the contract/related-contracts for a possible terminus replication
-    // forward (#4509) before the store consumes `related_contracts`.
-    let replicate_payload =
-        terminus_replicate_to.map(|addr| (addr, contract.clone(), related_contracts.clone()));
+    // R&D PROTOTYPE: clone the contract/related-contracts for a possible
+    // near-key replication spread before the store consumes them.
+    let spread_payload = if terminus_finalized_here {
+        Some((contract.clone(), related_contracts.clone()))
+    } else {
+        None
+    };
     // Originator-loopback client PUT → ClientLocal reserved lane (#4534).
     let store_priority = put_store_priority(op_manager, upstream_addr);
     let merged_value = relay_put_store_locally(
@@ -2820,20 +3007,20 @@ where
     )
     .await?;
 
-    // Terminus guard fired (#4363) on the streaming path: finalize here but
-    // still replicate the assembled contract one hop onward so the UPDATE
-    // broadcast tree stays connected (#4509). Mirrors the non-streaming guard
-    // branch; see `relay_put_replicate_forward`.
-    if let Some((next_addr, contract, related_contracts)) = replicate_payload {
-        relay_put_replicate_forward(
+    // Terminus guard fired (#4363) on the streaming path: finalize here and run
+    // the bounded near-key replication spread so the UPDATE broadcast tree
+    // stays connected (#4509). Mirrors the non-streaming terminus branch; mints
+    // a fresh `R_MAX` budget. See `nearkey_replicate_spread`.
+    if let Some((contract, related_contracts)) = spread_payload {
+        nearkey_replicate_spread(
             op_manager,
-            next_addr,
             key,
             contract,
             related_contracts,
             merged_value.clone(),
             htl,
             new_skip_list.clone(),
+            nearkey_r_max(),
         )
         .await;
     }
@@ -4180,6 +4367,7 @@ mod tests {
             value: WrappedState::new(vec![1u8]),
             htl: 5,
             skip_list: HashSet::new(),
+            replication_budget: 0,
         }));
         assert!(matches!(
             classify_reply(&msg),
@@ -4642,7 +4830,7 @@ mod tests {
 
         // The guard must finalize locally on its terminus branch (so the
         // closest-seen node is the authoritative finalizer, #4363) AND still
-        // replicate the contract one hop onward (so the UPDATE broadcast tree
+        // replicate the contract near the key (so the UPDATE broadcast tree
         // stays connected, #4509) — not just log, and not fall through to the
         // forward. Both calls live in the terminus branch before the forward.
         let guard_region = &body[guard_pos..forward_pos];
@@ -4651,12 +4839,16 @@ mod tests {
             "the terminus branch MUST finalize locally via \
              relay_put_finalize_local, not fall through to the forward"
         );
+        // R&D PROTOTYPE: the single past-terminus hop (relay_put_replicate_forward)
+        // is replaced by the bounded near-key replication spread. Pin that the
+        // terminus branch begins the spread so a future change can't silently
+        // drop the #4509 convergence safeguard.
         assert!(
-            guard_region.contains("relay_put_replicate_forward("),
-            "the terminus branch MUST still replicate the contract onward via \
-             relay_put_replicate_forward (#4509) — finalizing without \
-             replicating orphans the UPDATE broadcast path and splits the \
-             network into divergent state groups"
+            guard_region.contains("nearkey_replicate_spread("),
+            "the terminus branch MUST begin the bounded near-key replication \
+             spread (nearkey_replicate_spread, #4509 convergence) — finalizing \
+             without replicating orphans the UPDATE broadcast path and splits \
+             the network into divergent state groups"
         );
     }
 
@@ -4698,19 +4890,20 @@ mod tests {
              locally"
         );
 
-        // The streaming guard records the dropped next hop in
-        // `terminus_replicate_to` and, after the local store, replicates the
-        // contract one hop onward via `relay_put_replicate_forward` (#4509) so
-        // the streaming path does not orphan the UPDATE broadcast tree either.
+        // R&D PROTOTYPE: the streaming guard records THAT the terminus fired
+        // (`terminus_finalized_here`) and, after the local store, runs the
+        // bounded near-key replication spread (`nearkey_replicate_spread`,
+        // #4509) so the streaming path does not orphan the UPDATE broadcast
+        // tree either.
         assert!(
-            body.contains("terminus_replicate_to"),
-            "streaming guard MUST record the dropped next hop in \
-             terminus_replicate_to for the #4509 replication forward"
+            body.contains("terminus_finalized_here"),
+            "streaming guard MUST record that the terminus fired in \
+             terminus_finalized_here for the #4509 near-key spread"
         );
         assert!(
-            body.contains("relay_put_replicate_forward("),
-            "streaming terminus path MUST still replicate the contract onward \
-             via relay_put_replicate_forward (#4509)"
+            body.contains("nearkey_replicate_spread("),
+            "streaming terminus path MUST run the bounded near-key replication \
+             spread (nearkey_replicate_spread, #4509)"
         );
     }
 

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -13711,3 +13711,424 @@ fn test_piece_e_unsubscribed_stale_serve_gate() {
     // Avoid leaking the CRDT registration into other tests sharing this process.
     freenet::dev_tool::clear_crdt_contracts();
 }
+
+// ═════════════════════════════════════════════════════════════════════════
+// R&D PROTOTYPE — bounded near-key replication: convergence-vs-cost measurement
+// (#4642 R3 piece E alternative — DO NOT MERGE).
+//
+// These tests port the strengthened STATE-convergence gate from draft PR #4749
+// and run it against the bounded near-key replication spread that replaces the
+// single past-terminus hop (`nearkey_replicate_spread` in put/op_ctx_task.rs).
+//
+// The near-key replication factor R_MAX and band D are read at process start
+// from `FREENET_NEARKEY_R_MAX` / `FREENET_NEARKEY_BAND_D`, so the sweep runs
+// one process per value:
+//
+//   for r in 1 2 3 4 5 6 7 8; do
+//     FREENET_NEARKEY_R_MAX=$r cargo test -p freenet \
+//       --features simulation_tests,testing --test simulation_integration \
+//       nearkey_ -- --ignored --nocapture --test-threads=1 ;
+//   done
+//
+// (The tests are #[ignore] by default — they are a measurement harness, not a
+// CI regression gate — so `--ignored` is required to run them. Optionally set
+// FREENET_NEARKEY_SEED to vary the RNG seed and FREENET_NEARKEY_BAND_D for the
+// near-key band. R_MAX=1 is the negative control: no spread = removal.)
+//
+// Every convergence assertion is preceded by a greppable measurement line
+//   NEARKEY_MEASURE ...
+// (emitted via `nearkey_measure_and_log`) so a FAILING R_MAX still yields its
+// cost numbers (copies placed) for the curve.
+// ═════════════════════════════════════════════════════════════════════════
+
+/// Optional per-run seed override so the sweep can also vary the RNG seed
+/// (`FREENET_NEARKEY_SEED`) to test whether a convergence outcome is robust or
+/// seed-marginal. Falls back to the test's baked-in constant.
+fn nearkey_seed(default: u64) -> u64 {
+    std::env::var("FREENET_NEARKEY_SEED")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(default)
+}
+
+/// Config the sweep is running under, for the measurement log line. Defaults
+/// MUST match `NEARKEY_R_MAX_DEFAULT` / `NEARKEY_BAND_D_DEFAULT` in
+/// put/op_ctx_task.rs.
+fn nearkey_cfg() -> (usize, f64) {
+    let r = std::env::var("FREENET_NEARKEY_R_MAX")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|&r| r >= 1)
+        .unwrap_or(2);
+    let d = std::env::var("FREENET_NEARKEY_BAND_D")
+        .ok()
+        .and_then(|v| v.parse::<f64>().ok())
+        .filter(|d: &f64| d.is_finite() && *d >= 0.0)
+        .unwrap_or(0.30);
+    (r, d)
+}
+
+/// Ground-truth holder→hash map read directly from each node's MockStateStorage
+/// (NOT log-scraped). `exclude` drops intentionally-crashed nodes whose frozen
+/// pre-crash copy must not count against convergence.
+fn nearkey_holder_hashes(
+    result: &freenet::dev_tool::ControlledSimulationResult,
+    key: &freenet_stdlib::prelude::ContractKey,
+    exclude: &[freenet::dev_tool::NodeLabel],
+) -> BTreeMap<freenet::dev_tool::NodeLabel, String> {
+    result
+        .node_storages
+        .iter()
+        .filter_map(|(label, storage)| {
+            if exclude.contains(label) {
+                return None;
+            }
+            storage
+                .get_stored_state(key)
+                .map(|ws| (label.clone(), freenet::tracing::state_hash_full(&ws)))
+        })
+        .collect()
+}
+
+/// Emit the greppable measurement line and return `(copies, unique_hashes,
+/// converged_at_expected)`. Called BEFORE any convergence assertion so the
+/// sweep captures cost even for a failing R_MAX.
+fn nearkey_measure_and_log(
+    test: &str,
+    scenario: &str,
+    result: &freenet::dev_tool::ControlledSimulationResult,
+    key: &freenet_stdlib::prelude::ContractKey,
+    expected_hash: &str,
+    exclude: &[freenet::dev_tool::NodeLabel],
+) -> (usize, usize, bool) {
+    let (r_max, band_d) = nearkey_cfg();
+    let holders = nearkey_holder_hashes(result, key, exclude);
+    let unique: std::collections::HashSet<&String> = holders.values().collect();
+    let converged =
+        unique.len() == 1 && holders.values().next() == Some(&expected_hash.to_string());
+    // Single greppable line for the sweep harness.
+    tracing::info!(
+        "NEARKEY_MEASURE test={} scenario={} r_max={} band_d={} copies={} unique_hashes={} converged={}",
+        test,
+        scenario,
+        r_max,
+        band_d,
+        holders.len(),
+        unique.len(),
+        converged,
+    );
+    tracing::info!("NEARKEY_MEASURE_DETAIL test={} holders={:?}", test, holders);
+    (holders.len(), unique.len(), converged)
+}
+
+/// Strengthened STATE-convergence assertion (ported from draft PR #4749):
+///   1. at least `min_holders` non-excluded nodes hold the contract,
+///   2. every holder holds byte-identical state (no v20-vs-v30 split), and
+///   3. that converged hash equals `expected_hash` (not a vacuous stale value).
+fn nearkey_assert_state_convergence(
+    result: &freenet::dev_tool::ControlledSimulationResult,
+    key: &freenet_stdlib::prelude::ContractKey,
+    min_holders: usize,
+    expected_hash: &str,
+    exclude: &[freenet::dev_tool::NodeLabel],
+) -> BTreeMap<freenet::dev_tool::NodeLabel, String> {
+    let holders = nearkey_holder_hashes(result, key, exclude);
+    let unique: std::collections::HashSet<&String> = holders.values().collect();
+    assert!(
+        holders.len() >= min_holders,
+        "contract {:?} held by only {} node(s), expected >= {}. Holders: {:?}",
+        key,
+        holders.len(),
+        min_holders,
+        holders,
+    );
+    assert_eq!(
+        unique.len(),
+        1,
+        "contract {:?} STATE SPLIT: {} distinct final-state hashes across {} holders \
+         (the #4509 divergence class a presence check misses). Holders: {:?}",
+        key,
+        unique.len(),
+        holders.len(),
+        holders,
+    );
+    let converged = holders.values().next().expect("holders is non-empty");
+    assert_eq!(
+        converged, expected_hash,
+        "contract {:?} converged at {} but expected the final-update hash {} — all holders \
+         AGREE but on a STALE value, i.e. the UPDATE never propagated (vacuous convergence)",
+        key, converged, expected_hash,
+    );
+    holders
+}
+
+/// PROTOTYPE convergence gate — subscribed six-peer lifecycle. Identical
+/// scenario to `test_six_peer_contract_lifecycle` but with the strengthened
+/// ground-truth v50 state-convergence gate. This is the load-bearing test: the
+/// #4509 removal regressed it into a v20-vs-v30 split (draft PR #4749); the
+/// near-key spread must heal it.
+// R&D PROTOTYPE measurement harness (not a CI regression gate). Pass/fail is
+// parametrized by FREENET_NEARKEY_R_MAX, and the subscribed gate is confounded
+// by bare-SUBSCRIBE-requires-local-cache (see report). Ignored by default; run
+// explicitly via the FREENET_NEARKEY_R_MAX sweep documented above.
+#[ignore = "R&D near-key-replication measurement harness; run via FREENET_NEARKEY_R_MAX sweep"]
+#[test_log::test]
+fn nearkey_six_peer_state_convergence() {
+    use freenet::dev_tool::{NodeLabel, ScheduledOperation, SimOperation, register_crdt_contract};
+
+    const SEED: u64 = 0x4642_E560_0001;
+    const NETWORK_NAME: &str = "nearkey-six-peer";
+    let seed = nearkey_seed(SEED);
+
+    GlobalTestMetrics::reset();
+    setup_deterministic_state(seed);
+
+    let rt = create_runtime();
+    let sim = rt.block_on(async { SimNetwork::new(NETWORK_NAME, 2, 4, 10, 5, 15, 3, seed).await });
+
+    let seed_byte = 0xA1u8;
+    let contract = SimOperation::create_test_contract(seed_byte);
+    let contract_id = *contract.key().id();
+    let contract_key = contract.key();
+    register_crdt_contract(contract_id);
+
+    let mut operations = vec![ScheduledOperation::new(
+        NodeLabel::gateway(NETWORK_NAME, 0),
+        SimOperation::Put {
+            contract: contract.clone(),
+            state: SimOperation::create_crdt_state(1, seed_byte),
+            subscribe: true,
+        },
+    )];
+    operations.push(ScheduledOperation::new(
+        NodeLabel::gateway(NETWORK_NAME, 1),
+        SimOperation::Subscribe { contract_id },
+    ));
+    for i in 2..=5 {
+        operations.push(ScheduledOperation::new(
+            NodeLabel::node(NETWORK_NAME, i),
+            SimOperation::Subscribe { contract_id },
+        ));
+    }
+    // gw0 updates 10/20/30, then node 2 updates 40/50 (final = v50).
+    for v in [10u64, 20, 30] {
+        operations.push(ScheduledOperation::new(
+            NodeLabel::gateway(NETWORK_NAME, 0),
+            SimOperation::Update {
+                key: contract_key,
+                data: SimOperation::create_crdt_state(v, seed_byte),
+            },
+        ));
+    }
+    for v in [40u64, 50] {
+        operations.push(ScheduledOperation::new(
+            NodeLabel::node(NETWORK_NAME, 2),
+            SimOperation::Update {
+                key: contract_key,
+                data: SimOperation::create_crdt_state(v, seed_byte),
+            },
+        ));
+    }
+
+    let result = sim.run_controlled_simulation(
+        seed,
+        operations,
+        Duration::from_secs(240),
+        Duration::from_secs(90),
+    );
+    assert!(
+        result.turmoil_result.is_ok(),
+        "six-peer convergence sim failed: {:?}",
+        result.turmoil_result.err()
+    );
+
+    let expected = freenet::tracing::state_hash_full(&freenet_stdlib::prelude::WrappedState::new(
+        SimOperation::create_crdt_state(50, seed_byte),
+    ));
+    nearkey_measure_and_log(
+        "nearkey_six_peer_state_convergence",
+        "subscribed",
+        &result,
+        &contract_key,
+        &expected,
+        &[],
+    );
+    nearkey_assert_state_convergence(&result, &contract_key, 4, &expected, &[]);
+    freenet::dev_tool::clear_crdt_contracts();
+}
+
+/// PROTOTYPE cost + convergence gate — PUT withOUT subscribe, then one UPDATE.
+/// No client demand network-wide, so the only copies are the every-hop store
+/// copies + the near-key spread copies. This is the CLEAN cost measurement:
+/// `copies` in the NEARKEY_MEASURE line is the per-PUT replication cost. The
+/// convergence teeth: no surviving copy may be stranded at the PUT (v1) state.
+// R&D PROTOTYPE measurement harness (not a CI regression gate). Cleanest cost
+// signal: copies placed per PUT. Ignored by default; run via the sweep.
+#[ignore = "R&D near-key-replication measurement harness; run via FREENET_NEARKEY_R_MAX sweep"]
+#[test_log::test]
+fn nearkey_put_no_subscriber_convergence() {
+    use freenet::dev_tool::{NodeLabel, ScheduledOperation, SimOperation, register_crdt_contract};
+
+    const SEED: u64 = 0x4642_E5B0_0001;
+    const NETWORK_NAME: &str = "nearkey-no-sub";
+    let seed = nearkey_seed(SEED);
+
+    GlobalTestMetrics::reset();
+    setup_deterministic_state(seed);
+
+    let rt = create_runtime();
+    let sim = rt.block_on(async { SimNetwork::new(NETWORK_NAME, 2, 4, 10, 5, 15, 3, seed).await });
+
+    let seed_byte = 0xC3u8;
+    let contract = SimOperation::create_test_contract(seed_byte);
+    let contract_id = *contract.key().id();
+    let contract_key = contract.key();
+    register_crdt_contract(contract_id);
+
+    let operations = vec![
+        ScheduledOperation::new(
+            NodeLabel::gateway(NETWORK_NAME, 0),
+            SimOperation::Put {
+                contract: contract.clone(),
+                state: SimOperation::create_crdt_state(1, seed_byte),
+                subscribe: false,
+            },
+        ),
+        ScheduledOperation::new(
+            NodeLabel::gateway(NETWORK_NAME, 0),
+            SimOperation::Update {
+                key: contract_key,
+                data: SimOperation::create_crdt_state(50, seed_byte),
+            },
+        ),
+    ];
+
+    let result = sim.run_controlled_simulation(
+        seed,
+        operations,
+        Duration::from_secs(180),
+        Duration::from_secs(60),
+    );
+    assert!(
+        result.turmoil_result.is_ok(),
+        "no-subscriber convergence sim failed: {:?}",
+        result.turmoil_result.err()
+    );
+
+    let expected = freenet::tracing::state_hash_full(&freenet_stdlib::prelude::WrappedState::new(
+        SimOperation::create_crdt_state(50, seed_byte),
+    ));
+    nearkey_measure_and_log(
+        "nearkey_put_no_subscriber_convergence",
+        "no_subscriber",
+        &result,
+        &contract_key,
+        &expected,
+        &[],
+    );
+    nearkey_assert_state_convergence(&result, &contract_key, 1, &expected, &[]);
+    freenet::dev_tool::clear_crdt_contracts();
+}
+
+/// PROTOTYPE convergence-under-churn gate — subscribed lifecycle with a
+/// mid-chain subscriber crashed partway through the UPDATE sequence. Survivors
+/// must still converge on v50 via the near-key cluster + update mesh WITHOUT the
+/// retired past-terminus hop. The crashed node's frozen copy is excluded.
+// R&D PROTOTYPE measurement harness (not a CI regression gate). Churn signal:
+// R_MAX needed for survivors to converge. Ignored by default; run via the sweep.
+#[ignore = "R&D near-key-replication measurement harness; run via FREENET_NEARKEY_R_MAX sweep"]
+#[test_log::test]
+fn nearkey_churn_convergence() {
+    use freenet::dev_tool::{NodeLabel, ScheduledOperation, SimOperation, register_crdt_contract};
+
+    const SEED: u64 = 0x4642_E0C0_0001;
+    const NETWORK_NAME: &str = "nearkey-churn";
+    let seed = nearkey_seed(SEED);
+
+    GlobalTestMetrics::reset();
+    setup_deterministic_state(seed);
+
+    let rt = create_runtime();
+    let sim = rt.block_on(async { SimNetwork::new(NETWORK_NAME, 2, 4, 10, 5, 15, 3, seed).await });
+
+    let seed_byte = 0xD4u8;
+    let contract = SimOperation::create_test_contract(seed_byte);
+    let contract_id = *contract.key().id();
+    let contract_key = contract.key();
+    register_crdt_contract(contract_id);
+
+    let crashed = NodeLabel::node(NETWORK_NAME, 3);
+
+    let mut operations = vec![ScheduledOperation::new(
+        NodeLabel::gateway(NETWORK_NAME, 0),
+        SimOperation::Put {
+            contract: contract.clone(),
+            state: SimOperation::create_crdt_state(1, seed_byte),
+            subscribe: true,
+        },
+    )];
+    operations.push(ScheduledOperation::new(
+        NodeLabel::gateway(NETWORK_NAME, 1),
+        SimOperation::Subscribe { contract_id },
+    ));
+    for i in 2..=5 {
+        operations.push(ScheduledOperation::new(
+            NodeLabel::node(NETWORK_NAME, i),
+            SimOperation::Subscribe { contract_id },
+        ));
+    }
+    for v in [10u64, 20] {
+        operations.push(ScheduledOperation::new(
+            NodeLabel::gateway(NETWORK_NAME, 0),
+            SimOperation::Update {
+                key: contract_key,
+                data: SimOperation::create_crdt_state(v, seed_byte),
+            },
+        ));
+    }
+    operations.push(ScheduledOperation::new(
+        crashed.clone(),
+        SimOperation::CrashNode,
+    ));
+    for v in [30u64, 40, 50] {
+        operations.push(ScheduledOperation::new(
+            NodeLabel::node(NETWORK_NAME, 2),
+            SimOperation::Update {
+                key: contract_key,
+                data: SimOperation::create_crdt_state(v, seed_byte),
+            },
+        ));
+    }
+
+    let result = sim.run_controlled_simulation(
+        seed,
+        operations,
+        Duration::from_secs(240),
+        Duration::from_secs(90),
+    );
+    assert!(
+        result.turmoil_result.is_ok(),
+        "churn convergence sim failed: {:?}",
+        result.turmoil_result.err()
+    );
+
+    let expected = freenet::tracing::state_hash_full(&freenet_stdlib::prelude::WrappedState::new(
+        SimOperation::create_crdt_state(50, seed_byte),
+    ));
+    nearkey_measure_and_log(
+        "nearkey_churn_convergence",
+        "churn",
+        &result,
+        &contract_key,
+        &expected,
+        std::slice::from_ref(&crashed),
+    );
+    nearkey_assert_state_convergence(
+        &result,
+        &contract_key,
+        3,
+        &expected,
+        std::slice::from_ref(&crashed),
+    );
+    freenet::dev_tool::clear_crdt_contracts();
+}


### PR DESCRIPTION
> **R&D PROTOTYPE — DO NOT MERGE.** Build-ahead experiment for the epic (#4642), exploring an ALTERNATIVE to draft PR #4749. Replaces the single past-terminus replication hop (`relay_put_replicate_forward`, #4509) with a principled, bounded, near-key replication cluster, and produces convergence-vs-cost numbers so the parameters can be chosen from data. Kept as a draft for the mechanism + the numbers. The mechanism-level pin tests pass; the measurement tests are `#[ignore]` (a parametrized harness, not a CI gate).

## Problem

Removing `relay_put_replicate_forward` deterministically reintroduced the #4509 convergence split on PR #4749's base: the past-terminus copy keeps the multi-hop UPDATE broadcast tree connected, and live-fan-out alone (which only reaches directly-connected co-hosts) does not reconstruct it. The direction was: replace the single fragile hop with a small **bounded near-key replication cluster** that forms a *connected* cluster near the key — decentralized, local-info-only, DoS-bounded.

## Approach (the prototype)

`nearkey_replicate_spread` (`put/op_ctx_task.rs`) replaces the single hop:

1. The routing terminus (a local fact: no neighbor closer to the key than self) MINTS a replication budget `R_MAX` and stores (copy #1).
2. It hands the remaining budget to its neighbors **within a ring-distance band `D` of the key** (a local check), split evenly. As a **connectivity floor** it always keeps the single nearest-to-key neighbor, so the terminus never no-ops and the tree stays connected. At `R_MAX = 2` this reduces to "terminus + nearest near-key neighbor" — i.e. the retired single-hop behavior.
3. Each recipient stores, spends 1, and RE-SPREADS the remainder to ITS near-key neighbors (carried in a new `replication_budget` field on `PutMsg::Request`), until budget hits 0. Because every copy lands at a DIRECT NEIGHBOR of an existing copy, the cluster is connected by construction.
4. **DoS bound:** the budget is locally CLAMPED to `R_MAX` on receipt; HTL is decremented; the skip list carries siblings so the cluster cannot loop or double-cover.

`R_MAX` and `D` are read from `FREENET_NEARKEY_R_MAX` / `FREENET_NEARKEY_BAND_D` at process start so a single test binary can be swept.

## Measurement

Ported the strengthened ground-truth STATE-convergence gate from #4749 (`nearkey_assert_state_convergence`: reads each node's final `MockStateStorage`, asserts ≥N holders + byte-identical + equals the final-update v50 hash), across three scenarios (subscribed six-peer, PUT-no-subscriber+UPDATE, mid-chain-subscriber crash), swept `R_MAX` 1→8 (R_MAX=1 = no spread = the removal negative control) and across seeds. A greppable `NEARKEY_MEASURE` line records copies + convergence for every run, including failures.

### Cost (deterministic, clean)

Copies placed per PUT = **`min(R_MAX + 1, N)`** — zero variance across seeds. `R_MAX=2` places exactly the same 2-copy footprint as the retired single hop. Update-fanout and memory scale linearly with copies (~1 MB resident/contract per the cost model).

### Convergence (single-seed sweep, default seed)

| R_MAX | subscribed (min 4) | no-subscriber (min 1) | churn (min 3) |
|---|---|---|---|
| 1 (removal) | 6 copies, converge | 2, converge | 2, **split** |
| 2 | 3, **fail** | 3, converge | 2, **split** |
| 3 | 4, converge | 4, converge | 3, **split** |
| 4 | 5, converge | 5, converge | 4, **split** |
| 5 | 5, converge | 6, converge | 4, **split** |
| 6 | 6, converge | 6, converge | 5, converge |
| 7 | 6, converge | 6, converge | 5, converge |

### The snags (why this does NOT cleanly replace `relay_put_replicate_forward`)

1. **The 6-peer convergence gate is scheduling-noise-dominated.** The negative control (R_MAX=1 ≈ removal) converges on some seeds and not others for ALL three scenarios (subscribed baseline holder count ranges 2→6 across seeds; churn converges at R_MAX=1 on some seeds and not the default). Single-seed sweeps are not reliable, so **this data cannot recommend an `R_MAX`**. The clean signal is cost, not convergence.

2. **The subscribed gate is confounded.** The test's subscribers issue a BARE `SUBSCRIBE`, which is rejected unless the contract is ALREADY cached locally (`"Rejecting SUBSCRIBE: contract WASM not cached locally"`). So the subscribed holder count measures "did a PUT copy reach this node before its subscribe fired," not update-mesh convergence. With the spread active, PUT-copy distribution is regularized to exactly the near-key cluster (`R_MAX+1`) deterministically — so the subscribed metric primarily reflects PUT-copy-vs-subscribe timing, not the mechanism's convergence effect. This confound also affects #4749's gate.

3. **The removal is NOT deterministically broken on current main.** Unlike PR #4749's older base, R_MAX=1 (removal) converges the subscribed six-peer on the default seed here. The newer reconcile/anti-entropy work merged since #4749's base (#4725 P6 flip, #4734) appears to cover the subscribed multi-hop case — so the premise that `relay_put_replicate_forward` is still needed should be re-verified before either removing OR replacing it.

4. **The one real signal is churn robustness — but it needs ~full replication at this scale.** Crashing a mid-chain subscriber strands its downstream chain. Across 5 seeds, R_MAX=6 converged the survivors **5/5** vs R_MAX=1 (removal) **3/5** — so higher R_MAX genuinely improves churn-convergence robustness. But R_MAX=6 in a 6-peer network is essentially "replicate to everyone," so the 6-peer test cannot distinguish "needs a small bounded R_MAX" from "needs R_MAX ≈ N". This is exactly the question a larger network would answer, and it's the strongest reason to re-run at scale before deciding. (The underlying crashed-subscriber gap is also addressable directly by event-driven re-subscribe / re-root — piece F — which is orthogonal to PUT-time replication.)

## Recommendation

**This data does not yet justify adopting near-key replication — but the churn-robustness signal is worth pursuing at scale.** The mechanism is sound and cheap (deterministic bounded cost, `R_MAX=2` = the status quo), the one genuine benefit (churn robustness, 5/5 vs 3/5) needs a bigger network to tell whether a *small bounded* R_MAX suffices, and the specific regression it targets may already be covered on current main. Before any parameter call:
- Rebuild the convergence gate to use **GET-with-subscribe** (not bare SUBSCRIBE) and a **larger, multi-contract** network with **multi-seed aggregation**, to get a signal that isn't dominated by PUT-reach timing and scheduling noise.
- Re-verify whether `relay_put_replicate_forward` removal actually regresses on current main (rebase #4749's exact removal) before deciding it needs replacing at all.
- Treat the churn/re-root gap as piece F (subscribe-chain repair), separately.

## Design decisions I had to make (flagged)

- **Budget minted at the terminus, not carried from the client.** Carrying `R` from the originator would make every relay hop short-circuit as a spread copy before the terminus. The DoS clamp is still demonstrable (spread copies carry `replication_budget`, clamped on receipt).
- **`R_MAX` counts the terminus** (cluster size incl. self); default 2 (= status quo). `D` default 0.30 ring distance; the connectivity floor makes the mechanism robust to `D` being too small.
- **Step 4 (near-key eviction keep-priority) NOT implemented.** It would reintroduce distance into the eviction ranking, which **contradicts settled hosting-invariant 3** (distance was removed from eviction, demoted to telemetry, 2026-07-08). It is also not needed for the convergence measurement. Implementing it needs an explicit design decision — flagged, not silently added.
- **Streaming-size payloads are skipped** in the spread (parity with the retired hop; the sim exercises the small-state non-streaming path).

## Testing

- `nearkey_replicate_spread` replaces `relay_put_replicate_forward` at both terminus call sites (non-streaming + streaming). The two source-scrape pin tests are updated to assert the spread is present (71/71 `op_ctx_task::tests` pass).
- Three `#[ignore]` measurement harnesses added (subscribed / no-subscriber / churn), parametrized by `FREENET_NEARKEY_R_MAX` / `_SEED` / `_BAND_D`. Run with `-- --ignored`.
- `cargo fmt` / `check` / `clippy` clean.

Relates to #4642.

[AI-assisted - Claude]
