### PR TITLE
test(hosting): honest UPDATE-mesh convergence gate — relay_put_replicate_forward is NOT load-bearing (R&D, DO NOT MERGE)

### DIFF
--- a/crates/core/src/node/testing_impl.rs
+++ b/crates/core/src/node/testing_impl.rs
@@ -487,6 +487,22 @@ impl ControlledSimulationResult {
             .is_some_and(|ring| ring.is_hosting_contract(key))
     }
 
+    /// Whether `label`'s node was actually in the UPDATE MESH for `key` at the
+    /// end of the run — i.e. `Ring::is_receiving_updates` (an active network
+    /// subscription OR a local client subscription), NOT merely holding a cache
+    /// copy. This is the honest mesh-membership signal the convergence gate uses
+    /// to VERIFY the mesh formed before it trusts a convergence measurement:
+    /// `is_hosting_contract()` is true for a demandless cache copy that is not
+    /// kept fresh, so it is NOT a valid mesh-membership check (see
+    /// `hosting-invariants` — only `is_receiving_updates()` guarantees a fresh,
+    /// update-carrying copy). Returns `false` if the node never published its
+    /// Ring.
+    pub fn is_node_receiving_updates(&self, label: &NodeLabel, key: &ContractKey) -> bool {
+        self.node_rings
+            .get(label)
+            .is_some_and(|ring| ring.is_receiving_updates(key))
+    }
+
     /// Number of contracts `label`'s node held in its hosting cache at the end
     /// of the run (its "cache size"). Returns 0 if the node never published its
     /// Ring. See [`Ring::hosting_contracts_count`](crate::ring::Ring::hosting_contracts_count).

--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -1283,17 +1283,22 @@ where
                 // the UPDATE broadcast tree stays connected (#4509 convergence).
                 // See `relay_put_replicate_forward` for why both are required.
                 if let Some(next_addr) = peer.socket_addr() {
-                    relay_put_replicate_forward(
-                        op_manager,
-                        next_addr,
-                        key,
-                        contract.clone(),
-                        related_contracts.clone(),
-                        merged_value.clone(),
-                        htl,
-                        new_skip_list.clone(),
-                    )
-                    .await;
+                    // R&D gate (NOT FOR MERGE): env kill-switch so the honest
+                    // convergence gate can measure control vs. removal in one
+                    // binary. Unset env == pristine main.
+                    if !replicate_forward_disabled() {
+                        relay_put_replicate_forward(
+                            op_manager,
+                            next_addr,
+                            key,
+                            contract.clone(),
+                            related_contracts.clone(),
+                            merged_value.clone(),
+                            htl,
+                            new_skip_list.clone(),
+                        )
+                        .await;
+                    }
                 }
                 let hop_count = op_manager.ring.max_hops_to_live.saturating_sub(htl);
                 return relay_put_finalize_local(
@@ -1996,6 +2001,28 @@ async fn relay_put_store_locally(
     );
 
     Ok(merged_value)
+}
+
+/// R&D MEASUREMENT GATE (NOT FOR MERGE) — runtime kill-switch for
+/// `relay_put_replicate_forward` (#4509), used by the honest convergence gate
+/// (`simulation_integration.rs::honest_convergence_*`) to measure control vs.
+/// removal in the SAME binary with IDENTICAL scheduling.
+///
+/// When `FREENET_DISABLE_REPLICATE_FORWARD` is set in the environment, the two
+/// terminus call sites skip the past-terminus replication forward entirely.
+/// With the flag UNSET the behavior is byte-for-byte the pristine `origin/main`
+/// path (`if !false { forward }` == `forward`), so the control config is a
+/// faithful `main`. With the flag SET the forward never fires, which is
+/// behaviorally identical to deleting the hop + both call sites (the "removal"
+/// config #4749 built by editing the source).
+///
+/// Read once per process via `OnceLock`, so the config is fixed for a whole
+/// multi-seed sweep and can be swept by launching the test binary twice with
+/// different env. DELETE this and inline the call once the design decision is
+/// made.
+fn replicate_forward_disabled() -> bool {
+    static DISABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *DISABLED.get_or_init(|| std::env::var("FREENET_DISABLE_REPLICATE_FORWARD").is_ok())
 }
 
 /// Fire-and-forget a replication-only `PutMsg::Request` to `next_addr`
@@ -2825,17 +2852,21 @@ where
     // broadcast tree stays connected (#4509). Mirrors the non-streaming guard
     // branch; see `relay_put_replicate_forward`.
     if let Some((next_addr, contract, related_contracts)) = replicate_payload {
-        relay_put_replicate_forward(
-            op_manager,
-            next_addr,
-            key,
-            contract,
-            related_contracts,
-            merged_value.clone(),
-            htl,
-            new_skip_list.clone(),
-        )
-        .await;
+        // R&D gate (NOT FOR MERGE): env kill-switch (see the non-streaming site
+        // above). Unset env == pristine main.
+        if !replicate_forward_disabled() {
+            relay_put_replicate_forward(
+                op_manager,
+                next_addr,
+                key,
+                contract,
+                related_contracts,
+                merged_value.clone(),
+                htl,
+                new_skip_list.clone(),
+            )
+            .await;
+        }
     }
 
     // ── Step 7: Await downstream reply (if piping), then bubble upstream ──

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -13711,3 +13711,388 @@ fn test_piece_e_unsubscribed_stale_serve_gate() {
     // Avoid leaking the CRDT registration into other tests sharing this process.
     freenet::dev_tool::clear_crdt_contracts();
 }
+
+// =============================================================================
+// HONEST UPDATE-MESH CONVERGENCE GATE (R&D MEASUREMENT — NOT FOR MERGE)
+// (demand-driven-hosting redesign; epic freenet/freenet-core#4642, piece E;
+//  supersedes the CONFOUNDED convergence gates in PR #4749 / #4750)
+// =============================================================================
+//
+// PURPOSE
+// -------
+// Decide, rigorously, whether removing `relay_put_replicate_forward` (the single
+// past-#4363-terminus PUT replication hop, added for #4509) actually regresses
+// UPDATE convergence on current `origin/main`.
+//
+// WHY THE EXISTING GATES (#4749/#4750) WERE UNRELIABLE
+// ----------------------------------------------------
+// Their six-peer "convergence" tests had subscribers issue a BARE
+// `SimOperation::Subscribe`, which the node REJECTS unless the contract WASM is
+// already cached locally ("Rejecting SUBSCRIBE: contract WASM not cached
+// locally", `client_events.rs`). So those subscribers NEVER joined the update
+// mesh (never became `is_receiving_updates`); the test measured how far the PUT
+// physically reached, NOT whether the update mesh converges. At 6 peers the
+// signal was also scheduling-noise-dominated.
+//
+// THE HONEST GATE (this module)
+// -----------------------------
+//   1. Subscribers REALLY join the mesh: they use GET-with-subscribe
+//      (`SimOperation::Get { subscribe: true }`), which fetches+caches the WASM
+//      and state and registers the subscription (`maybe_subscribe_child` ->
+//      `run_client_subscribe` -> downstream-subscriber edge). We then VERIFY
+//      the mesh formed via `ControlledSimulationResult::is_node_receiving_updates`
+//      (an active network OR local client subscription — NOT a mere cache copy)
+//      before trusting any convergence number. A run whose mesh did not form is
+//      reported INVALID, not "not converged".
+//   2. Larger network: 2 gateways + 14 nodes = 16 peers (proven scale; cf.
+//      `test_max_downstream_limit_reached`, `test_thundering_herd_connect_storm`),
+//      so scheduling noise does not dominate.
+//   3. Ground-truth STATE convergence: read each mesh member's final
+//      `MockStateStorage` and require all mesh holders byte-identical AND equal
+//      to the final update (v50) — catches both a version SPLIT (unique>1) and a
+//      vacuous "all agree on a stale value" (at_final<holders). Higher CRDT
+//      version always wins, so the converged value is deterministic = v50.
+//   4. Multi-seed (>=15): report the convergence RATE per config, aggregated,
+//      not a single-seed pass/fail.
+//   5. Several updates from MULTIPLE sources at varied ring positions, so the
+//      multi-hop broadcast tree is actually exercised.
+//
+// CONTROL vs REMOVAL, in ONE binary
+// ---------------------------------
+// The removal is expressed as a process-wide runtime kill-switch,
+// `FREENET_DISABLE_REPLICATE_FORWARD` (read once in
+// `put/op_ctx_task.rs::replicate_forward_disabled`). UNSET == pristine `main`
+// (the forward fires). SET == the forward never fires, behaviorally identical to
+// deleting the hop + both call sites (what #4749 did by editing source). Running
+// both configs from the SAME binary with IDENTICAL scheduling removes the
+// rebuild/scheduling confounds.
+//
+// These are `#[ignore]` MEASUREMENT harnesses (like #4750), not CI gates: they
+// PRINT per-seed + aggregate `HONEST_CONVERGE` lines and assert only that every
+// sim ran. The verdict comes from diffing the printed control vs removal
+// summaries. Run with:
+//   cargo test -p freenet --features simulation_tests,testing --test \
+//     simulation_integration -- --ignored --nocapture honest_convergence
+// and with `FREENET_DISABLE_REPLICATE_FORWARD=1` for the removal config.
+
+/// Per-seed outcome of one honest-convergence run. All counts are over the
+/// INTENDED subscribers (excluding a crashed node in the churn variant).
+#[derive(Debug, Clone, Copy)]
+struct HonestConvergenceOutcome {
+    /// Intended mesh subscribers considered this run (16, or 15 with churn).
+    intended: usize,
+    /// Intended subscribers that ended `is_receiving_updates` (REAL mesh members).
+    mesh_members: usize,
+    /// Mesh members that also hold stored state for the key.
+    mesh_holders: usize,
+    /// Distinct final-state hashes across mesh holders (1 == converged shape).
+    unique_hashes: usize,
+    /// Mesh holders whose final state equals the v50 final update.
+    at_final: usize,
+    /// The controlled sim completed without a turmoil error.
+    turmoil_ok: bool,
+    /// Packets dropped by the scripted crash (>0 proves churn took effect).
+    crash_dropped: u64,
+}
+
+impl HonestConvergenceOutcome {
+    /// The mesh formed well enough for the convergence measurement to be
+    /// meaningful (>= 75% of intended subscribers actually receiving updates).
+    fn mesh_formed(&self) -> bool {
+        self.turmoil_ok && self.mesh_members * 4 >= self.intended * 3
+    }
+
+    /// The update mesh FULLY converged: mesh formed, every mesh member holds
+    /// state, all byte-identical, all equal to the v50 final update.
+    fn converged(&self) -> bool {
+        self.mesh_formed()
+            && self.mesh_members > 0
+            && self.mesh_holders == self.mesh_members
+            && self.unique_hashes == 1
+            && self.at_final == self.mesh_holders
+    }
+}
+
+/// Run one honest-convergence seed. `churn` crashes a mid-mesh node partway
+/// through the update sequence (its frozen copy is excluded from the mesh /
+/// convergence accounting). Returns the measured outcome; never panics on a
+/// convergence failure (that IS the measurement).
+fn honest_convergence_seed(seed: u64, churn: bool) -> HonestConvergenceOutcome {
+    use freenet::dev_tool::{
+        NodeLabel, ScheduledOperation, SimNetwork, SimOperation, register_crdt_contract,
+    };
+
+    // 2 gateways + 14 nodes = 16 peers. Node labels are node(N_GW..N_GW+N_NODES)
+    // (regular nodes are numbered starting at the gateway count — using node(0..)
+    // would target nonexistent labels that are silently skipped).
+    const N_GW: usize = 2;
+    const N_NODES: usize = 14;
+    const CRASH_IDX: usize = N_GW + N_NODES / 2; // node(9) — a mid-mesh subscriber
+
+    setup_deterministic_state(seed);
+    // Config tag makes the per-node on-disk config dir (`/tmp/freenet-{label}`)
+    // UNIQUE per config, so the control and removal runs of the same test/seed
+    // can execute CONCURRENTLY without racing on an identical dir path (the tag
+    // does not feed the sim RNG, so it is behavior-neutral for the measurement).
+    let cfg_tag = if std::env::var("FREENET_DISABLE_REPLICATE_FORWARD").is_ok() {
+        "rm"
+    } else {
+        "ctl"
+    };
+    let network = format!(
+        "honest-conv-{}{cfg_tag}-{seed:x}",
+        if churn { "churn-" } else { "steady-" }
+    );
+
+    let seed_byte = 0x7Eu8;
+    let contract = SimOperation::create_test_contract(seed_byte);
+    let contract_id = *contract.key().id();
+    let contract_key = contract.key();
+    register_crdt_contract(contract_id);
+
+    let gw0 = NodeLabel::gateway(&network, 0);
+    let gw1 = NodeLabel::gateway(&network, 1);
+
+    // Intended mesh: gw0 (subscribes via PUT), then gw1 + node(2..=15) via
+    // GET-with-subscribe.
+    let mut intended: Vec<NodeLabel> = vec![gw0.clone(), gw1.clone()];
+    for n in N_GW..(N_GW + N_NODES) {
+        intended.push(NodeLabel::node(&network, n));
+    }
+
+    let crashed: Option<NodeLabel> = churn.then(|| NodeLabel::node(&network, CRASH_IDX));
+
+    // Update sources at varied ring positions (none is the crashed node), so the
+    // multi-hop broadcast tree is genuinely exercised. LWW-by-version: v50 wins.
+    let src_v20 = NodeLabel::node(&network, N_GW + 2); // node(4)
+    let src_v30 = NodeLabel::node(&network, N_GW + N_NODES - 1); // node(15), far side
+    let src_v40 = NodeLabel::node(&network, N_GW + N_NODES / 3 + 1); // node(6)
+
+    let rt = create_runtime();
+    let sim = rt.block_on(async {
+        // ring_max_htl=10, rnd_if_htl_above=5, max_connections=10, min_connections=3.
+        SimNetwork::new(&network, N_GW, N_NODES, 10, 5, 10, 3, seed).await
+    });
+
+    let mut operations = Vec::new();
+    // 1. gw0 PUTs with subscribe=true (root of the mesh, holds v1).
+    operations.push(ScheduledOperation::new(
+        gw0.clone(),
+        SimOperation::Put {
+            contract: contract.clone(),
+            state: SimOperation::create_crdt_state(1, seed_byte),
+            subscribe: true,
+        },
+    ));
+    // 2. Every other intended peer GET-with-subscribe: fetch+cache the WASM/state
+    //    AND register the subscription, genuinely joining the update mesh.
+    for label in intended.iter().skip(1) {
+        operations.push(ScheduledOperation::new(
+            label.clone(),
+            SimOperation::Get {
+                contract_id,
+                return_contract_code: true,
+                subscribe: true,
+            },
+        ));
+    }
+    // 3. Early updates every subscriber should get before any crash.
+    operations.push(ScheduledOperation::new(
+        gw0.clone(),
+        SimOperation::Update {
+            key: contract_key,
+            data: SimOperation::create_crdt_state(10, seed_byte),
+        },
+    ));
+    operations.push(ScheduledOperation::new(
+        src_v20,
+        SimOperation::Update {
+            key: contract_key,
+            data: SimOperation::create_crdt_state(20, seed_byte),
+        },
+    ));
+    // 4. Crash a mid-mesh subscriber (churn variant only).
+    if let Some(ref c) = crashed {
+        operations.push(ScheduledOperation::new(c.clone(), SimOperation::CrashNode));
+    }
+    // 5. Later updates from multiple sources — survivors must still converge on
+    //    the final value (v50) through the multi-hop tree, without the crashed
+    //    relay and (in the removal config) without the past-terminus forward.
+    operations.push(ScheduledOperation::new(
+        src_v30,
+        SimOperation::Update {
+            key: contract_key,
+            data: SimOperation::create_crdt_state(30, seed_byte),
+        },
+    ));
+    operations.push(ScheduledOperation::new(
+        src_v40,
+        SimOperation::Update {
+            key: contract_key,
+            data: SimOperation::create_crdt_state(40, seed_byte),
+        },
+    ));
+    operations.push(ScheduledOperation::new(
+        gw1.clone(),
+        SimOperation::Update {
+            key: contract_key,
+            data: SimOperation::create_crdt_state(50, seed_byte),
+        },
+    ));
+
+    let result = sim.run_controlled_simulation(
+        seed,
+        operations,
+        Duration::from_secs(240),
+        Duration::from_secs(120),
+    );
+
+    // Accounting: consider intended subscribers minus the crashed node (its
+    // pre-crash frozen copy must not count for OR against convergence).
+    let considered: Vec<&NodeLabel> = intended
+        .iter()
+        .filter(|l| Some(*l) != crashed.as_ref())
+        .collect();
+
+    let expected = freenet::tracing::state_hash_full(&freenet_stdlib::prelude::WrappedState::new(
+        SimOperation::create_crdt_state(50, seed_byte),
+    ));
+
+    let mut mesh_members = 0usize;
+    let mut hashes: Vec<String> = Vec::new();
+    for label in &considered {
+        if result.is_node_receiving_updates(label, &contract_key) {
+            mesh_members += 1;
+            if let Some(ws) = result
+                .node_storages
+                .get(*label)
+                .and_then(|s| s.get_stored_state(&contract_key))
+            {
+                hashes.push(freenet::tracing::state_hash_full(&ws));
+            }
+        }
+    }
+    let mesh_holders = hashes.len();
+    let unique_hashes = hashes.iter().collect::<HashSet<&String>>().len();
+    let at_final = hashes.iter().filter(|h| **h == expected).count();
+
+    let outcome = HonestConvergenceOutcome {
+        intended: considered.len(),
+        mesh_members,
+        mesh_holders,
+        unique_hashes,
+        at_final,
+        turmoil_ok: result.turmoil_result.is_ok(),
+        crash_dropped: result.crash_packets_dropped(),
+    };
+
+    freenet::dev_tool::clear_crdt_contracts();
+    outcome
+}
+
+/// The 15 fixed seeds for the honest-convergence sweep (diverse topologies).
+const HONEST_SEEDS: [u64; 15] = [
+    0x4642_E5B0_0001,
+    0x4642_E5B0_0002,
+    0x4642_E5B0_0003,
+    0x4642_E5B0_0005,
+    0x4642_E5B0_0007,
+    0x4642_E5B0_000B,
+    0x4642_E5B0_000D,
+    0x4642_E5B0_0011,
+    0x4642_E5B0_0013,
+    0x4642_E5B0_0017,
+    0x4642_E5B0_001D,
+    0x4642_E5B0_001F,
+    0x4642_E5B0_0025,
+    0x4642_E5B0_0029,
+    0x4642_E5B0_002B,
+];
+
+/// Aggregate a multi-seed honest-convergence sweep and PRINT the result. `label`
+/// names the config (e.g. "steady/control"). Returns nothing — this is a
+/// measurement, not a gate.
+fn run_honest_convergence_sweep(label: &str, churn: bool) {
+    let seeds: usize = std::env::var("FREENET_HONEST_SEEDS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(HONEST_SEEDS.len())
+        .min(HONEST_SEEDS.len());
+    let disabled = std::env::var("FREENET_DISABLE_REPLICATE_FORWARD").is_ok();
+    let config = if disabled { "REMOVAL" } else { "control" };
+
+    tracing::info!(target: "honest_converge",
+        "===== HONEST CONVERGENCE SWEEP [{label}] config={config} (replicate_forward {}) \
+         seeds={seeds} net=2gw+14node =====",
+        if disabled { "DISABLED" } else { "present" });
+
+    let mut mesh_formed_ct = 0usize;
+    let mut converged_ct = 0usize;
+    let mut total_crash = 0u64;
+    let mut mesh_sizes: Vec<usize> = Vec::new();
+
+    for &seed in HONEST_SEEDS.iter().take(seeds) {
+        let o = honest_convergence_seed(seed, churn);
+        assert!(
+            o.turmoil_ok,
+            "seed={seed:x} [{label}]: controlled sim did not complete"
+        );
+        if o.mesh_formed() {
+            mesh_formed_ct += 1;
+        }
+        if o.converged() {
+            converged_ct += 1;
+        }
+        total_crash += o.crash_dropped;
+        mesh_sizes.push(o.mesh_members);
+        tracing::info!(target: "honest_converge",
+            "  seed=0x{seed:X} [{label}/{config}]: mesh={}/{} formed={} \
+             holders={} unique={} at_v50={} converged={} crash_drop={}",
+            o.mesh_members, o.intended, o.mesh_formed(),
+            o.mesh_holders, o.unique_hashes, o.at_final, o.converged(), o.crash_dropped);
+    }
+
+    let n = seeds.max(1);
+    let mean_mesh = mesh_sizes.iter().sum::<usize>() as f64 / n as f64;
+    let mesh_rate = mesh_formed_ct as f64 / n as f64;
+    // Convergence rate among the runs whose mesh actually formed (the honest
+    // denominator), plus the overall rate for reference.
+    let conv_rate_valid = if mesh_formed_ct == 0 {
+        f64::NAN
+    } else {
+        converged_ct as f64 / mesh_formed_ct as f64
+    };
+    let conv_rate_all = converged_ct as f64 / n as f64;
+
+    // Single greppable summary line per config.
+    tracing::info!(target: "honest_converge",
+        "HONEST_CONVERGE label={label} config={config} seeds={seeds} \
+         mesh_formed={mesh_formed_ct}/{seeds} ({mesh_rate:.2}) mean_mesh={mean_mesh:.1} \
+         converged_of_formed={converged_ct}/{mesh_formed_ct} ({conv_rate_valid:.2}) \
+         converged_overall={converged_ct}/{seeds} ({conv_rate_all:.2}) crash_drops={total_crash}");
+    tracing::info!(target: "honest_converge", "===== END HONEST CONVERGENCE SWEEP [{label}] =====");
+
+    if churn {
+        assert!(
+            total_crash > 0,
+            "[{label}]: scripted CrashNode dropped no packets across any seed — churn had no effect"
+        );
+    }
+}
+
+/// Honest convergence gate — STEADY (no churn). Run once with
+/// `FREENET_DISABLE_REPLICATE_FORWARD` unset (control) and once set (removal),
+/// then diff the printed `HONEST_CONVERGE` lines.
+#[ignore = "R&D measurement harness (not a CI gate); run with --ignored --nocapture"]
+#[test_log::test]
+fn honest_convergence_gate_steady() {
+    run_honest_convergence_sweep("steady", false);
+}
+
+/// Honest convergence gate — CHURN (crash a mid-mesh subscriber mid-run). Same
+/// control-vs-removal protocol as the steady gate.
+#[ignore = "R&D measurement harness (not a CI gate); run with --ignored --nocapture"]
+#[test_log::test]
+fn honest_convergence_gate_churn() {
+    run_honest_convergence_sweep("churn", true);
+}


### PR DESCRIPTION
> **R&D MEASUREMENT — DO NOT MERGE.** Build-ahead experiment for the epic (#4642). Decides whether removing `relay_put_replicate_forward` (#4509) actually regresses UPDATE convergence on current `main`, using an HONEST convergence gate that fixes the confound in draft PRs #4749 and #4750. Kept as a draft for the reusable gate + the numbers.

## Problem

Draft PR #4749 concluded that removing `relay_put_replicate_forward` reintroduces the #4509 convergence split, and #4750 built a near-key replication mechanism to replace it. But **both of their six-peer convergence tests were confounded**: the subscribers issued a bare `SUBSCRIBE`, which the node REJECTS unless the contract WASM is already cached locally (`"Rejecting SUBSCRIBE: contract WASM not cached locally"`, `client_events.rs`). So those subscribers never joined the update mesh (`is_receiving_updates` never became true) — the tests measured how far the PUT physically reached, NOT whether the update mesh converges. At six peers the signal was also scheduling-noise-dominated. #4750 explicitly flagged this and asked for a rebuilt gate.

## The honest gate

`honest_convergence_gate_{steady,churn}` in `simulation_integration.rs`:

1. **Subscribers really join the mesh** — GET-with-subscribe (`SimOperation::Get { subscribe: true }`) fetches+caches the WASM/state AND registers the subscription (`maybe_subscribe_child` → `run_client_subscribe` → downstream-subscriber edge). The gate then **verifies** the mesh formed via the new `ControlledSimulationResult::is_node_receiving_updates` (an active network OR local client subscription, NOT a mere cache copy) before trusting any convergence number. A run whose mesh did not form is reported INVALID, not "not converged".
2. **Larger network** — 2 gateways + 14 nodes = 16 peers.
3. **Ground-truth STATE convergence** — read each mesh member's final `MockStateStorage`; require all mesh holders byte-identical AND equal to the final update (v50). Catches a version SPLIT (unique>1) and a vacuous "all agree on a stale value" (at_final<holders). CRDT is higher-version-wins, so the converged value is deterministic.
4. **Multi-seed (15)** — report the convergence RATE per config, aggregated.
5. **Several updates from multiple sources** at varied ring positions, so the multi-hop broadcast tree is exercised.

Control vs removal run in the **same binary** with identical scheduling, toggled by the `FREENET_DISABLE_REPLICATE_FORWARD` env kill-switch (`put/op_ctx_task.rs::replicate_forward_disabled`): unset == pristine `main` (`if !false { forward }`), set == the forward never fires (behaviorally identical to deleting the hop + both call sites). The `#[ignore]` harnesses PRINT `HONEST_CONVERGE` summaries; they are measurement tools, not CI gates.

## Results (15 seeds each, deterministic, `simulation_tests,testing`)

| Config | mesh formed (subscribers actually `is_receiving_updates`) | mean mesh | STATE convergence (all mesh holders byte-identical @ v50) |
|---|---|---|---|
| **steady, control** (`replicate_forward` present = main) | 15/15 (1.00) | 16.0 / 16 | **15/15 (1.00)** |
| **steady, REMOVAL** (`replicate_forward` disabled) | 15/15 (1.00) | 16.0 / 16 | **15/15 (1.00)** |
| **churn, control** (crash a mid-mesh subscriber; ~650 pkts dropped/seed) | 15/15 (1.00) | 15.0 / 15 | **15/15 (1.00)** |
| **churn, REMOVAL** | 15/15 (1.00) | 15.0 / 15 | **15/15 (1.00)** |

Every seed in every config: the mesh fully formed (all 16 / 15 intended subscribers genuinely `is_receiving_updates`), zero state splits (`unique_hashes == 1`), every mesh holder at the final update `v50`, `converged = true`. Churn `crash_drops` totalled 9745 (control) / 9846 (removal) across the 15 churn seeds, confirming the scripted crash actually blocked traffic — the survivors still converged.

## Verdict

**Removing `relay_put_replicate_forward` does NOT regress UPDATE convergence on current `main`.** With a REAL mesh (subscribers actually receiving updates, verified — not the confounded bare-SUBSCRIBE proxy), control and removal converge **identically at 100%**, in both the steady and churn variants. `relay_put_replicate_forward` is therefore **not load-bearing for convergence on current `main`**: the update mesh is held together by the subscribe chains + live fan-out + anti-entropy (#4725 P6, #4734, interest-sync), not by the past-terminus PUT replication hop.

The #4749 "removal breaks convergence" result was a **test artifact** of its confounded six-peer gate: its bare-`SUBSCRIBE` subscribers were rejected for want of a locally-cached WASM, so they never joined the mesh — the split it saw was PUT physical reach shrinking by one hop, not the update mesh fragmenting. #4750 already suspected this (its snags 2 & 3) and asked for exactly this rebuilt gate.

### Recommendation

- **Delete `relay_put_replicate_forward`** (both call sites + the streaming `terminus_replicate_to` / `replicate_payload` plumbing) as #4749 proposed — but land it against THIS honest gate (flip these harnesses to hard asserts, or keep them as measurement), not #4749's confounded one.
- **The near-key replication cluster (#4750) is not justified by a convergence need** on current `main`. Its one genuine signal was churn-robustness at ~full replication in a 6-peer net; this 16-peer honest gate shows the demand-driven mesh already converges 100% under a mid-mesh crash WITHOUT any past-terminus replication, so there is no convergence gap for near-key replication to close here.
- Findability (can a distant GET still locate a contract after the every-hop durable copy is removed) is a **separate** property, already measured by the existing `test_piece_e_findability_sparse_ring_gate`; this gate is scoped to UPDATE-mesh convergence only and does not speak to findability.

Caveat on scope: this measures small-state (non-streaming) contracts, matching the retired hop's own documented scope (it skips streaming-size payloads). The mesh here is bootstrapped by explicit GET-with-subscribe; a pure cache-only holder past the terminus with no demand is (correctly) not a mesh member and is out of scope by design (hosting-invariants: hosting is demand-driven).

## Testing

- `honest_convergence_gate_steady` / `honest_convergence_gate_churn` (`#[ignore]`), run with
  `FREENET_DISABLE_REPLICATE_FORWARD=1` for the removal config.
- The env kill-switch preserves the two source-scrape pin tests
  (`drive_relay_put_applies_terminus_guard_before_forwarding`,
  `drive_relay_put_streaming_applies_terminus_guard_before_next_hop`) — the call text is retained,
  only wrapped in the runtime branch.
- `cargo fmt` / `check` / `clippy` clean.

Relates to #4642. Supersedes the convergence-gate portions of #4749 and #4750.

[AI-assisted - Claude]
