### PR TITLE
feat(dashboard): surface disk usage on the demand-driven eviction panel

### DIFF
--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -1174,6 +1174,26 @@ pub struct HostingSnapshot {
     /// budget pressure is first). May be truncated by the renderer; the full
     /// count is `contract_count`.
     pub contracts: Vec<HostedContractEntry>,
+    /// Aggregate on-disk bytes used by persisted contract state
+    /// (`DiskUsageTracker::stats().state_bytes`, #4683). `None` until the
+    /// disk tracker is configured and seeded (early startup) — distinct from
+    /// `Some(0)`, which means seeded-and-empty.
+    pub disk_state_bytes: Option<u64>,
+    /// Aggregate on-disk bytes used by `*.wasm` code blobs. Same
+    /// seeded-gate semantics as `disk_state_bytes`.
+    pub disk_wasm_bytes: Option<u64>,
+    /// Aggregate on-disk bytes used by the wasmtime compile cache. Same
+    /// seeded-gate semantics as `disk_state_bytes`.
+    pub disk_compile_cache_bytes: Option<u64>,
+    /// Sum of `disk_state_bytes` + `disk_wasm_bytes` + `disk_compile_cache_bytes`
+    /// — the aggregate the disk budget bounds. Same seeded-gate semantics.
+    pub disk_total_bytes: Option<u64>,
+    /// The aggregate disk budget the admission gate checks projected writes
+    /// against (`HostingManager::disk_budget_bytes`, #4702). `None` while it
+    /// is still `u64::MAX` — i.e. before the first 60s recompute installs a
+    /// real value — so the panel can distinguish "not yet computed" from a
+    /// genuine (if enormous) budget.
+    pub disk_budget_bytes: Option<u64>,
 }
 
 /// One hosted contract's demand-driven eviction row for the dashboard.

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -3841,6 +3841,24 @@ impl Ring {
             })
             .collect();
 
+        // Aggregate on-disk usage (#4683) + the disk budget the admission gate
+        // checks against (#4702), for the same "measuring…" pre-seed gate the
+        // `hosting_disk_*` telemetry gauges use (see the population above at
+        // the `RouterSnapshot` disk-usage block): `None` until the tracker is
+        // seeded, so an unseeded tracker is distinguishable from genuine zero
+        // usage.
+        let disk = self.hosting_manager.disk_usage_stats();
+        let disk_state_bytes = disk.map(|d| d.state_bytes);
+        let disk_wasm_bytes = disk.map(|d| d.wasm_bytes);
+        let disk_compile_cache_bytes = disk.map(|d| d.compile_cache_bytes);
+        let disk_total_bytes = disk.map(|d| d.total_bytes);
+        // `disk_budget_bytes` starts at `u64::MAX` until the first 60s
+        // recompute installs a real value (see `HostingManager::
+        // recompute_effective_budget`); surface that as `None` rather than an
+        // astronomical byte count.
+        let raw_disk_budget = self.hosting_manager.disk_budget_bytes();
+        let disk_budget_bytes = (raw_disk_budget != u64::MAX).then_some(raw_disk_budget);
+
         ns::HostingSnapshot {
             budget_bytes: stats.budget_bytes,
             used_bytes: stats.current_bytes,
@@ -3848,6 +3866,11 @@ impl Ring {
             budget_evictions_total: stats.budget_evictions_total,
             evictions_of_recently_read_total: stats.evictions_of_recently_read_total,
             contracts,
+            disk_state_bytes,
+            disk_wasm_bytes,
+            disk_compile_cache_bytes,
+            disk_total_bytes,
+            disk_budget_bytes,
         }
     }
 

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -639,7 +639,12 @@ impl HostingManager {
 
     /// The current aggregate disk budget the admission gate checks against
     /// (#4683). `u64::MAX` until the first 60s recompute installs a real value.
-    #[cfg(test)]
+    ///
+    /// Also read by the dashboard's "Demand-driven eviction" panel
+    /// (`Ring::dashboard_hosting_snapshot`, follow-up to #4683/#4702) to
+    /// surface disk usage next to the RAM budget: `u64::MAX` maps to `None`
+    /// there so an unseeded/not-yet-recomputed budget reads as "measuring…"
+    /// instead of a nonsensical astronomical byte count.
     pub(crate) fn disk_budget_bytes(&self) -> u64 {
         self.disk_budget_bytes.load(Ordering::Relaxed)
     }
@@ -5855,6 +5860,90 @@ mod tests {
             manager
                 .admit_state_write(&make_contract_key(1), u64::MAX / 2)
                 .is_ok()
+        );
+    }
+
+    // --- Dashboard disk-usage panel population (follow-up to #4683/#4702) ----
+    //
+    // `Ring::dashboard_hosting_snapshot` maps `disk_usage_stats()` and
+    // `disk_budget_bytes()` straight into `HostingSnapshot`'s `Option<u64>`
+    // disk fields (`None` while unseeded / not yet recomputed). These tests
+    // exercise the two `HostingManager` accessors the mapping reads, so a
+    // regression in the seeded/unseeded gate is caught at the source rather
+    // than only through the heavier `Ring`-level plumbing.
+
+    /// No tracker configured at all (mirrors a node with hosting disabled or
+    /// very early startup before `configure_disk_tracker` runs): both
+    /// accessors report the "not yet meaningful" values the dashboard maps to
+    /// `None` — `disk_usage_stats()` is `None` and `disk_budget_bytes()` is
+    /// `u64::MAX`.
+    #[test]
+    fn dashboard_disk_fields_absent_without_tracker() {
+        let manager = HostingManager::new(1024 * 1024 * 1024);
+        assert!(
+            manager.disk_usage_stats().is_none(),
+            "no tracker configured → disk_usage_stats must be None"
+        );
+        assert_eq!(
+            manager.disk_budget_bytes(),
+            u64::MAX,
+            "no recompute has run → disk_budget_bytes stays u64::MAX"
+        );
+    }
+
+    /// Tracker configured but not yet seeded (the window between
+    /// `configure_disk_tracker` and the first successful `seed`): still
+    /// `None` / `u64::MAX` — an in-flight seed must not leak a
+    /// zero-initialized (misleadingly "empty") snapshot to the dashboard.
+    #[test]
+    fn dashboard_disk_fields_absent_while_unseeded() {
+        let manager = HostingManager::new(1024 * 1024 * 1024);
+        manager.configure_disk_tracker(
+            std::path::PathBuf::from("/nonexistent/contracts"),
+            std::path::PathBuf::from("/nonexistent/cache"),
+        );
+        assert!(
+            manager.disk_usage_stats().is_none(),
+            "configured-but-unseeded tracker → disk_usage_stats must stay None"
+        );
+        assert_eq!(manager.disk_budget_bytes(), u64::MAX);
+    }
+
+    /// Once seeded, `disk_usage_stats()` reports `Some` with the exact
+    /// component breakdown (state/wasm/compile-cache/total) the dashboard
+    /// renders. `disk_budget_bytes()` stays `u64::MAX` (→ `None`-mapped)
+    /// until `recompute_effective_budget` has ALSO run — seeding alone does
+    /// not install a budget.
+    #[test]
+    fn dashboard_disk_usage_populated_after_seed_budget_after_recompute() {
+        const MIB: u64 = 1024 * 1024;
+        let manager = HostingManager::new(64 * 1024 * MIB);
+        manager.seed_disk_tracker_for_test([
+            (make_contract_key(1), 100 * MIB),
+            (make_contract_key(2), 50 * MIB),
+        ]);
+
+        let stats = manager
+            .disk_usage_stats()
+            .expect("seeded tracker → Some usage stats");
+        assert_eq!(stats.state_bytes, 150 * MIB);
+        assert_eq!(stats.total_bytes, 150 * MIB);
+        // Seeding alone (no recompute) leaves the budget unset.
+        assert_eq!(
+            manager.disk_budget_bytes(),
+            u64::MAX,
+            "budget stays u64::MAX until recompute_effective_budget runs"
+        );
+
+        manager.configure_disk_budget(0.5, DEFAULT_MAX_HOSTING_DISK_BYTES);
+        manager
+            .recompute_effective_budget(150 * MIB)
+            .expect("seeded → recompute installs a budget");
+        let budget = manager.disk_budget_bytes();
+        assert_ne!(
+            budget,
+            u64::MAX,
+            "after recompute the dashboard must see a real (non-MAX) budget"
         );
     }
 

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -2155,6 +2155,7 @@ mod tests {
                     eviction_eligible: false,
                 },
             ],
+            ..Default::default()
         };
         let html = build_hosting_card(&Some(snap));
         assert!(
@@ -2221,6 +2222,7 @@ mod tests {
                 // Higher score, but actually eligible → this is the real victim.
                 mk_hosted_entry("EVICTABLE", 2.0, true),
             ],
+            ..Default::default()
         };
         let html = build_hosting_card(&Some(snap));
         let pinned_idx = html.find("PINNED_FULL").expect("pinned row present");
@@ -2256,6 +2258,7 @@ mod tests {
                 mk_hosted_entry("A", 0.10, false),
                 mk_hosted_entry("B", 2.0, false),
             ],
+            ..Default::default()
         };
         let html = build_hosting_card(&Some(snap));
         assert!(
@@ -2265,6 +2268,97 @@ mod tests {
         assert!(
             !html.contains("next to evict"),
             "no row may be badged when nothing is eviction-eligible — got:\n{html}"
+        );
+    }
+
+    // ─── Disk-usage tiles (follow-up to #4683/#4702) ────────────────
+
+    #[test]
+    fn hosting_card_disk_tiles_show_measuring_before_seed() {
+        use crate::node::network_status::HostingSnapshot;
+        // Disk fields default to `None` (tracker not yet seeded / budget not
+        // yet recomputed). The panel must render "measuring…" rather than a
+        // bogus 0 B or an astronomical u64::MAX byte count.
+        let mut snap = base_snapshot();
+        snap.hosting = HostingSnapshot {
+            budget_bytes: 256 * 1024 * 1024,
+            used_bytes: 64 * 1024 * 1024,
+            contract_count: 1,
+            budget_evictions_total: 0,
+            evictions_of_recently_read_total: 0,
+            contracts: vec![mk_hosted_entry("A", 1.0, false)],
+            disk_state_bytes: None,
+            disk_wasm_bytes: None,
+            disk_compile_cache_bytes: None,
+            disk_total_bytes: None,
+            disk_budget_bytes: None,
+        };
+        let html = build_hosting_card(&Some(snap));
+        assert!(
+            html.contains("Disk used"),
+            "disk-used tile label present — got:\n{html}"
+        );
+        assert!(
+            html.contains("Disk budget"),
+            "disk-budget tile label present — got:\n{html}"
+        );
+        assert!(
+            html.contains("Disk headroom"),
+            "disk-headroom tile label present — got:\n{html}"
+        );
+        let measuring_count = html.matches("measuring…").count();
+        assert_eq!(
+            measuring_count, 3,
+            "all three disk tiles must show 'measuring…' pre-seed — got:\n{html}"
+        );
+        assert!(
+            !html.contains("18446744073709551615"),
+            "u64::MAX must never leak into the rendered disk budget — got:\n{html}"
+        );
+    }
+
+    #[test]
+    fn hosting_card_disk_tiles_render_seeded_values() {
+        use crate::node::network_status::HostingSnapshot;
+        let mut snap = base_snapshot();
+        snap.hosting = HostingSnapshot {
+            budget_bytes: 256 * 1024 * 1024,
+            used_bytes: 64 * 1024 * 1024,
+            contract_count: 1,
+            budget_evictions_total: 0,
+            evictions_of_recently_read_total: 0,
+            contracts: vec![mk_hosted_entry("A", 1.0, false)],
+            disk_state_bytes: Some(100 * 1024 * 1024),
+            disk_wasm_bytes: Some(20 * 1024 * 1024),
+            disk_compile_cache_bytes: Some(5 * 1024 * 1024),
+            disk_total_bytes: Some(125 * 1024 * 1024),
+            disk_budget_bytes: Some(500 * 1024 * 1024),
+        };
+        let html = build_hosting_card(&Some(snap));
+        assert!(
+            !html.contains("measuring…"),
+            "seeded snapshot must not show 'measuring…' — got:\n{html}"
+        );
+        assert!(
+            html.contains("125.0 MB"),
+            "disk-used total tile — got:\n{html}"
+        );
+        assert!(html.contains("500.0 MB"), "disk-budget tile — got:\n{html}");
+        // Headroom = budget(500) - used(125) = 375 MB.
+        assert!(
+            html.contains("375.0 MB"),
+            "disk-headroom tile (budget - used) — got:\n{html}"
+        );
+        // Breakdown surfaced in the title tooltip.
+        assert!(
+            html.contains("State: 100.0 MB")
+                && html.contains("WASM: 20.0 MB")
+                && html.contains("Compile cache: 5.0 MB"),
+            "per-component breakdown in tooltip — got:\n{html}"
+        );
+        assert!(
+            html.contains("min(RAM budget, disk budget)"),
+            "explanatory paragraph must mention the #4702 min(ram, disk) eviction floor — got:\n{html}"
         );
     }
 

--- a/crates/core/src/server/home_page/cards.rs
+++ b/crates/core/src/server/home_page/cards.rs
@@ -1190,10 +1190,40 @@ pub fn build_hosting_card(snap: &Option<network_status::NetworkStatusSnapshot>) 
         String::new()
     };
 
+    // On-disk usage tiles (#4683/#4702 follow-up): `None` renders "measuring…"
+    // so an unseeded disk tracker (early startup) is visually distinct from
+    // genuine zero usage, mirroring the `hosting_disk_*` telemetry gate.
+    const MEASURING: &str = "measuring…";
+    let disk_used_value = match h.disk_total_bytes {
+        Some(total) => format_bytes(total),
+        None => MEASURING.to_string(),
+    };
+    let disk_breakdown_title = match (
+        h.disk_state_bytes,
+        h.disk_wasm_bytes,
+        h.disk_compile_cache_bytes,
+    ) {
+        (Some(state), Some(wasm), Some(cache)) => format!(
+            "State: {state} · WASM: {wasm} · Compile cache: {cache}",
+            state = format_bytes(state),
+            wasm = format_bytes(wasm),
+            cache = format_bytes(cache),
+        ),
+        _ => "Disk tracker not yet seeded".to_string(),
+    };
+    let disk_budget_value = match h.disk_budget_bytes {
+        Some(budget) => format_bytes(budget),
+        None => MEASURING.to_string(),
+    };
+    let disk_headroom_value = match (h.disk_total_bytes, h.disk_budget_bytes) {
+        (Some(used), Some(budget)) => format_bytes(budget.saturating_sub(used)),
+        _ => MEASURING.to_string(),
+    };
+
     format!(
         r##"<div class="card">
             <div class="card-header"><h2>Demand-driven eviction</h2><span class="g-mode g-mode-enforce">piece A</span></div>
-            <p class="empty" style="margin: 0.2rem 0.9rem 0.4rem; font-size: 0.82rem; color: var(--text-muted, #888);">Retention is demand-driven: contracts with the lowest predicted read-demand (keep-score) are evicted first when over the RAM budget.</p>
+            <p class="empty" style="margin: 0.2rem 0.9rem 0.4rem; font-size: 0.82rem; color: var(--text-muted, #888);">Retention is demand-driven: contracts with the lowest predicted read-demand (keep-score) are evicted first when over budget. Since #4702 the eviction floor is min(RAM budget, disk budget) — either resource running low can trigger eviction.</p>
             <div class="g-verdict-row">
                 <div class="g-norms">
                     <div class="g-norm"><div class="g-norm-label">RAM used</div><div class="g-norm-value">{used} / {budget} ({pct:.0}%)</div></div>
@@ -1201,6 +1231,13 @@ pub fn build_hosting_card(snap: &Option<network_status::NetworkStatusSnapshot>) 
                     <div class="g-norm"><div class="g-norm-label">Hosted</div><div class="g-norm-value">{count}</div></div>
                     <div class="g-norm"><div class="g-norm-label">Budget evictions</div><div class="g-norm-value">{budget_evictions}</div></div>
                     <div class="g-norm"><div class="g-norm-label">Evicted w/ demand</div><div class="g-norm-value">{recently_read}</div></div>
+                </div>
+            </div>
+            <div class="g-verdict-row">
+                <div class="g-norms">
+                    <div class="g-norm" title="{disk_breakdown_title}"><div class="g-norm-label">Disk used</div><div class="g-norm-value">{disk_used}</div></div>
+                    <div class="g-norm"><div class="g-norm-label">Disk budget</div><div class="g-norm-value">{disk_budget}</div></div>
+                    <div class="g-norm"><div class="g-norm-label">Disk headroom</div><div class="g-norm-value">{disk_headroom}</div></div>
                 </div>
             </div>
             <div class="table-wrap">
@@ -1218,6 +1255,10 @@ pub fn build_hosting_card(snap: &Option<network_status::NetworkStatusSnapshot>) 
         count = h.contract_count,
         budget_evictions = h.budget_evictions_total,
         recently_read = recently_read_value,
+        disk_breakdown_title = html_escape(&disk_breakdown_title),
+        disk_used = disk_used_value,
+        disk_budget = disk_budget_value,
+        disk_headroom = disk_headroom_value,
         rows = rows,
         footer = footer,
     )


### PR DESCRIPTION
## Problem

The #4683/#4702 disk-budget series added a `DiskUsageTracker`
(`crates/core/src/ring/hosting/disk_usage.rs`), an aggregate disk budget
(`HostingManager::disk_budget_bytes`, starts at `u64::MAX` until the
first 60s recompute), and `hosting_disk_*` telemetry gauges on
`RouterSnapshotInfo` (`crates/core/src/ring.rs`). None of that reached
the node's own home-page dashboard: `build_hosting_card` reads
`HostingSnapshot` (`crates/core/src/node/network_status.rs`), which had
zero disk fields. A local operator looking at the "Demand-driven
eviction" panel only ever saw RAM usage, even though disk can now be
the binding constraint — since #4702 the eviction floor is
`min(RAM budget, disk budget)`.

## Solution

- Added `disk_state_bytes`, `disk_wasm_bytes`, `disk_compile_cache_bytes`,
  `disk_total_bytes`, and `disk_budget_bytes` (all `Option<u64>`) to
  `HostingSnapshot`.
- Populated them in `Ring::dashboard_hosting_snapshot` from
  `HostingManager::disk_usage_stats()` (the same `DiskUsageTracker`
  snapshot the `hosting_disk_*` telemetry gauges already read) and
  `HostingManager::disk_budget_bytes()`. `disk_budget_bytes()` was
  `#[cfg(test)]`-only; widened to a normal `pub(crate)` accessor so the
  dashboard can read it.
- Rendered a second tile row in `build_hosting_card`: "Disk used" (with
  a state/WASM/compile-cache breakdown in the tile's title tooltip),
  "Disk budget", "Disk headroom". Reused the existing `g-norm` tile
  markup and `format_bytes`. Values render `measuring…` before the
  tracker is seeded / the budget is recomputed, so that state is
  visually distinct from genuine zero usage — and `u64::MAX` (the
  budget's pre-recompute sentinel) never leaks into the UI as a byte
  count. Updated the card's explanatory paragraph to mention the
  `min(RAM, disk)` eviction floor introduced in #4702.
- Display-only: no new gate/tracking logic, no admission/eviction
  behavior change.

## Testing

- `crates/core/src/ring/hosting.rs`: three new unit tests exercising the
  exact two `HostingManager` accessors the dashboard mapping reads —
  `dashboard_disk_fields_absent_without_tracker`,
  `dashboard_disk_fields_absent_while_unseeded`, and
  `dashboard_disk_usage_populated_after_seed_budget_after_recompute`
  (seeded-usage-populated-but-budget-still-MAX vs.
  budget-installed-after-recompute).
- `crates/core/src/server/home_page.rs`: two new render tests —
  `hosting_card_disk_tiles_show_measuring_before_seed` (all three disk
  tiles show `measuring…`, `u64::MAX` never rendered) and
  `hosting_card_disk_tiles_render_seeded_values` (byte totals, budget,
  headroom, and the per-component tooltip breakdown all render
  correctly, and the new `min(RAM budget, disk budget)` sentence is
  present).
- Updated the three pre-existing `HostingSnapshot` struct-literal test
  fixtures in `home_page.rs` with `..Default::default()` for the new
  fields.
- `cargo fmt`, `cargo clippy -p freenet -- -D warnings` (lib target)
  clean. `cargo test -p freenet --lib`: 3841 passed, 0 new failures —
  the only 2 failures are the pre-existing macOS-only
  `wasm_runtime::migration_tests` (unrelated, known-ignorable).

## Fixes

Follow-up to the #4683 disk-budget series (merged via 5939214d7 and
30db9d70e / #4702).

https://claude.ai/code/session_01DR69yFsB57UFRTMrHGG5nx