### PR TITLE
fix(server): transfer Uint8Array WS frames zero-copy across the OOPIF

### DIFF
--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -3730,6 +3730,40 @@ mod tests {
         );
     }
 
+    // Regression guard for the OOPIF zero-copy send() fix. wasm-bindgen hands
+    // send() a Uint8Array, which is NOT `instanceof ArrayBuffer`; the pre-fix
+    // code therefore left the postMessage transfer list empty and every
+    // outbound WS frame was structured-clone COPIED across the process
+    // boundary (a ~2.7 s main-thread CPU burst on tab-focus flush). The fix
+    // transfers the backing buffer for ArrayBuffer *views* too, copying the
+    // view out via `.slice()` first so it never detaches WASM linear memory.
+    // The behavioural coverage is in tests/playwright/tests/websocket-shim.spec.ts
+    // (a real browser asserting the actual transfer list); this content guard
+    // runs in the default CI job and fails fast if the JS is reverted.
+    #[test]
+    fn shim_js_transfers_array_buffer_views_zero_copy() {
+        // The old, buggy one-liner must be gone.
+        assert!(
+            !WEBSOCKET_SHIM_JS.contains("data instanceof ArrayBuffer ? [data] : []"),
+            "shim send() must not use the copy-everything transfer check (OOPIF copy regression)"
+        );
+        // Views (Uint8Array) must be recognised and their buffer transferred.
+        assert!(
+            WEBSOCKET_SHIM_JS.contains("ArrayBuffer.isView(data)"),
+            "shim send() must transfer ArrayBuffer views zero-copy"
+        );
+        // The view must be copied out (.slice()) before transfer so WASM
+        // linear memory is never detached.
+        assert!(
+            WEBSOCKET_SHIM_JS.contains("data.slice()"),
+            "shim send() must copy the view out before transferring its buffer"
+        );
+        assert!(
+            WEBSOCKET_SHIM_JS.contains("transfer = [copy.buffer]"),
+            "shim send() must transfer the copied buffer, not the shared/WASM one"
+        );
+    }
+
     #[test]
     fn get_path_v1() {
         let req_path = "/v1/contract/HjpgVdSziPUmxFoBgTdMkQ8xiwhXdv1qn5ouQvSaApzD/state.html";

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -3735,11 +3735,13 @@ mod tests {
     // code therefore left the postMessage transfer list empty and every
     // outbound WS frame was structured-clone COPIED across the process
     // boundary (a ~2.7 s main-thread CPU burst on tab-focus flush). The fix
-    // transfers the backing buffer for ArrayBuffer *views* too, copying the
-    // view out via `.slice()` first so it never detaches WASM linear memory.
-    // The behavioural coverage is in tests/playwright/tests/websocket-shim.spec.ts
-    // (a real browser asserting the actual transfer list); this content guard
-    // runs in the default CI job and fails fast if the JS is reverted.
+    // transfers the backing buffer for ArrayBuffer *views* too, copying exactly
+    // the view window off `data.buffer` first (works for TypedArrays AND a
+    // DataView, which has no `.slice()`) so it never detaches WASM linear
+    // memory. The behavioural coverage is in
+    // tests/playwright/tests/websocket-shim.spec.ts (a real browser asserting
+    // the actual transfer list); this content guard runs in the default CI job
+    // and fails fast if the JS is reverted.
     #[test]
     fn shim_js_transfers_array_buffer_views_zero_copy() {
         // The old, buggy one-liner must be gone.
@@ -3747,20 +3749,26 @@ mod tests {
             !WEBSOCKET_SHIM_JS.contains("data instanceof ArrayBuffer ? [data] : []"),
             "shim send() must not use the copy-everything transfer check (OOPIF copy regression)"
         );
-        // Views (Uint8Array) must be recognised and their buffer transferred.
+        // Views (Uint8Array / DataView) must be recognised and their buffer
+        // transferred.
         assert!(
             WEBSOCKET_SHIM_JS.contains("ArrayBuffer.isView(data)"),
             "shim send() must transfer ArrayBuffer views zero-copy"
         );
-        // The view must be copied out (.slice()) before transfer so WASM
-        // linear memory is never detached.
+        // The view window must be copied off data.buffer (NOT data.slice(),
+        // which a DataView lacks) before transfer, so WASM linear memory is
+        // never detached.
         assert!(
-            WEBSOCKET_SHIM_JS.contains("data.slice()"),
-            "shim send() must copy the view out before transferring its buffer"
+            WEBSOCKET_SHIM_JS.contains("data.buffer.slice("),
+            "shim send() must copy the view window off data.buffer (handles DataView too)"
         );
         assert!(
-            WEBSOCKET_SHIM_JS.contains("transfer = [copy.buffer]"),
-            "shim send() must transfer the copied buffer, not the shared/WASM one"
+            !WEBSOCKET_SHIM_JS.contains("data.slice()"),
+            "shim send() must not call data.slice() (a DataView has no .slice())"
+        );
+        assert!(
+            WEBSOCKET_SHIM_JS.contains("transfer = [buf]"),
+            "shim send() must transfer the freshly copied buffer, not the shared/WASM one"
         );
     }
 

--- a/crates/core/src/server/path_handlers/assets/websocket_shim.js
+++ b/crates/core/src/server/path_handlers/assets/websocket_shim.js
@@ -35,13 +35,23 @@
   FreenetWebSocket.prototype.send = function (data) {
     if (this.readyState !== 1)
       throw new DOMException('WebSocket is not open', 'InvalidStateError');
-    var transfer = data instanceof ArrayBuffer ? [data] : [];
+    var payload = data;
+    var transfer = [];
+    if (data instanceof ArrayBuffer) {
+      transfer = [data];
+    } else if (ArrayBuffer.isView(data)) {
+      // wasm-bindgen hands us a Uint8Array that may be a view into WASM linear
+      // memory; copy it out so we can transfer ownership without detaching that.
+      var copy = data.slice();
+      payload = copy;
+      transfer = [copy.buffer];
+    }
     window.parent.postMessage(
       {
         __freenet_ws__: true,
         type: 'send',
         id: this._id,
-        data: data,
+        data: payload,
       },
       '*',
       transfer,

--- a/crates/core/src/server/path_handlers/assets/websocket_shim.js
+++ b/crates/core/src/server/path_handlers/assets/websocket_shim.js
@@ -41,10 +41,15 @@
       transfer = [data];
     } else if (ArrayBuffer.isView(data)) {
       // wasm-bindgen hands us a Uint8Array that may be a view into WASM linear
-      // memory; copy it out so we can transfer ownership without detaching that.
-      var copy = data.slice();
-      payload = copy;
-      transfer = [copy.buffer];
+      // memory; copy exactly this view's window into a fresh buffer so we can
+      // transfer ownership without detaching that. Use data.buffer.slice (not
+      // data.slice) so a DataView — which has no .slice — is handled too.
+      var buf = data.buffer.slice(
+        data.byteOffset,
+        data.byteOffset + data.byteLength,
+      );
+      payload = new Uint8Array(buf);
+      transfer = [buf];
     }
     window.parent.postMessage(
       {

--- a/crates/core/tests/playwright/tests/websocket-shim.spec.ts
+++ b/crates/core/tests/playwright/tests/websocket-shim.spec.ts
@@ -1,0 +1,210 @@
+import { test, expect } from "@playwright/test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// Regression tests for the outbound send() path of the injected WebSocket shim
+// (crates/core/src/server/path_handlers/assets/websocket_shim.js).
+//
+// Bug (fixed here): the sandboxed webapp (River) runs in a separate OS process
+// (an OOPIF). wasm-bindgen hands `send()` a `Uint8Array`, which is NOT
+// `instanceof ArrayBuffer`, so the pre-fix code left the postMessage transfer
+// list EMPTY and every outbound WS frame was structured-clone COPIED across the
+// process boundary instead of transferred zero-copy. On tab-focus the webapp
+// flushes ~15 queued frames (~740 KB) at once and each copy reallocated under
+// ArrayBuffer GC pressure -> a ~2.7 s main-thread CPU burst (spun the laptop
+// fan). A live CDP A/B patch proved the shell handler self-time dropped
+// 2.73 s -> 0.00 s with identical bytes still reaching the node.
+//
+// The fix transfers the backing buffer for ArrayBuffer VIEWS too. Because the
+// Uint8Array may be a view into WASM linear memory (transferring
+// `memory.buffer` would detach ALL of WASM memory and crash the app), it copies
+// the view out once in-process via `.slice()` and transfers that copy's buffer.
+//
+// These tests load the real shim JS in a headless Chromium, stub
+// `window.parent.postMessage` (top-level page, so `window.parent === window`)
+// to capture the exact transfer list the shim passes, and assert the transfer
+// semantics per payload type. The stub deliberately does NOT forward to the
+// real postMessage, so the buffers are never actually detached and the
+// delivered bytes remain readable for assertion.
+//
+// This spec needs a browser but NOT a running node, so unlike shell.spec.ts it
+// does not require FREENET_SHELL_URL. It still runs inside the dedicated
+// playwright-shell.yml CI job (which invokes `npx playwright test`).
+
+const shimSource = readFileSync(
+  join(
+    __dirname,
+    "..",
+    "..",
+    "..",
+    "src",
+    "server",
+    "path_handlers",
+    "assets",
+    "websocket_shim.js",
+  ),
+  "utf8",
+);
+
+type SendProbe = {
+  transferLen: number;
+  transfer0IsArrayBuffer: boolean;
+  transfer0ByteLength: number | null;
+  dataBytes: number[];
+  dataBufferIsTransferred: boolean;
+};
+
+type Probes = {
+  uint8: SendProbe;
+  subarrayView: SendProbe & { sharedBufferByteLength: number };
+  arraybuffer: SendProbe & { dataIsTransfer0: boolean };
+  string: SendProbe & { dataEquals: boolean };
+};
+
+test("send() transfers ArrayBuffer views zero-copy without detaching WASM memory", async ({
+  page,
+}) => {
+  await page.goto("about:blank");
+
+  const probes = (await page.evaluate((src: string) => {
+    // Capture every outbound `send` frame plus the transfer list the shim
+    // passed. window.parent === window for a top-level page, so overriding
+    // window.postMessage intercepts window.parent.postMessage. We do NOT call
+    // through to the native postMessage: that keeps the buffers un-detached so
+    // the delivered bytes stay readable below.
+    const sends: Array<{ message: { data: unknown }; transfer: Transferable[] }> = [];
+    (window as unknown as { postMessage: unknown }).postMessage = function (
+      message: { __freenet_ws__?: boolean; type?: string; data: unknown },
+      _targetOrigin: string,
+      transfer?: Transferable[],
+    ) {
+      if (message && message.__freenet_ws__ && message.type === "send") {
+        sends.push({ message, transfer: transfer || [] });
+      }
+    };
+
+    // Load the real shim (an IIFE that installs window.WebSocket). Indirect
+    // eval runs it in global scope.
+    (0, eval)(src);
+
+    const WS = (window as unknown as { WebSocket: new (url: string) => any }).WebSocket;
+
+    function capture(payload: unknown): {
+      message: { data: unknown };
+      transfer: Transferable[];
+    } {
+      const ws = new WS("ws://test.invalid");
+      ws.readyState = 1; // shim's send() throws unless OPEN; no real handshake here.
+      sends.length = 0;
+      ws.send(payload);
+      return sends[sends.length - 1];
+    }
+
+    function toBytes(data: unknown): number[] {
+      if (data instanceof ArrayBuffer) return Array.from(new Uint8Array(data));
+      if (ArrayBuffer.isView(data)) {
+        const v = data as ArrayBufferView;
+        return Array.from(
+          new Uint8Array(v.buffer, v.byteOffset, v.byteLength),
+        );
+      }
+      return [];
+    }
+
+    function probe(s: { message: { data: unknown }; transfer: Transferable[] }): {
+      transferLen: number;
+      transfer0IsArrayBuffer: boolean;
+      transfer0ByteLength: number | null;
+      dataBytes: number[];
+      dataBufferIsTransferred: boolean;
+    } {
+      const data = s.message.data;
+      const t0 = s.transfer[0];
+      const dataBuffer = ArrayBuffer.isView(data)
+        ? (data as ArrayBufferView).buffer
+        : data instanceof ArrayBuffer
+          ? data
+          : null;
+      return {
+        transferLen: s.transfer.length,
+        transfer0IsArrayBuffer: t0 instanceof ArrayBuffer,
+        transfer0ByteLength: t0 instanceof ArrayBuffer ? t0.byteLength : null,
+        dataBytes: toBytes(data),
+        dataBufferIsTransferred: dataBuffer !== null && dataBuffer === t0,
+      };
+    }
+
+    // 1) Plain Uint8Array (the wasm-bindgen case that regressed).
+    const uint8 = probe(capture(new Uint8Array([1, 2, 3])));
+
+    // 2) Uint8Array that is a SUBARRAY view over a larger buffer (models a view
+    // into WASM linear memory). The fix must transfer a fresh 3-byte copy, NOT
+    // the shared 6-byte backing buffer.
+    const shared = new Uint8Array([0, 1, 2, 3, 4, 5]);
+    const view = shared.subarray(1, 4); // [1,2,3], byteOffset 1 over a 6-byte buffer
+    const sub = capture(view);
+    const subProbe = probe(sub);
+    const subarrayView = {
+      ...subProbe,
+      sharedBufferByteLength: shared.buffer.byteLength,
+      // The transferred buffer must be distinct from the shared backing buffer.
+      transfer0IsSharedBuffer: sub.transfer[0] === shared.buffer,
+    };
+
+    // 3) A real ArrayBuffer still transfers itself (unchanged behaviour).
+    const ab = new Uint8Array([9, 9]).buffer;
+    const abSend = capture(ab);
+    const arraybuffer = {
+      ...probe(abSend),
+      dataIsTransfer0: abSend.message.data === abSend.transfer[0],
+    };
+
+    // 4) A string transfers nothing (strings cannot be transferred).
+    const strSend = capture("hello");
+    const string = {
+      ...probe(strSend),
+      dataEquals: strSend.message.data === "hello",
+    };
+
+    return { uint8, subarrayView, arraybuffer, string };
+  }, shimSource)) as unknown as Probes & {
+    subarrayView: { transfer0IsSharedBuffer: boolean };
+  };
+
+  // 1) Uint8Array: backing buffer MUST be in the transfer list (the fix). The
+  // pre-fix code left transfer empty -> these assertions fail without the fix.
+  expect(
+    probes.uint8.transferLen,
+    "Uint8Array send must transfer its backing buffer (regression: empty transfer list -> cross-process COPY)",
+  ).toBe(1);
+  expect(probes.uint8.transfer0IsArrayBuffer).toBe(true);
+  expect(probes.uint8.transfer0ByteLength).toBe(3);
+  // Bytes must be preserved through the copy-out.
+  expect(probes.uint8.dataBytes).toEqual([1, 2, 3]);
+  // The delivered payload's backing buffer is exactly the transferred buffer.
+  expect(probes.uint8.dataBufferIsTransferred).toBe(true);
+
+  // 2) Subarray view: transfer a fresh 3-byte copy, never the shared 6-byte
+  // buffer (transferring WASM linear memory would detach ALL of it).
+  expect(probes.subarrayView.transferLen).toBe(1);
+  expect(probes.subarrayView.transfer0ByteLength).toBe(3);
+  expect(probes.subarrayView.dataBytes).toEqual([1, 2, 3]);
+  expect(
+    probes.subarrayView.transfer0IsSharedBuffer,
+    "must NOT transfer the shared/WASM-memory backing buffer",
+  ).toBe(false);
+  expect(
+    probes.subarrayView.sharedBufferByteLength,
+    "shared backing buffer must remain intact (not detached)",
+  ).toBe(6);
+
+  // 3) ArrayBuffer: unchanged — transfers itself.
+  expect(probes.arraybuffer.transferLen).toBe(1);
+  expect(probes.arraybuffer.transfer0IsArrayBuffer).toBe(true);
+  expect(probes.arraybuffer.dataIsTransfer0).toBe(true);
+  expect(probes.arraybuffer.dataBytes).toEqual([9, 9]);
+
+  // 4) String: transfers nothing.
+  expect(probes.string.transferLen).toBe(0);
+  expect(probes.string.dataEquals).toBe(true);
+});

--- a/crates/core/tests/playwright/tests/websocket-shim.spec.ts
+++ b/crates/core/tests/playwright/tests/websocket-shim.spec.ts
@@ -57,6 +57,11 @@ type SendProbe = {
 type Probes = {
   uint8: SendProbe;
   subarrayView: SendProbe & { sharedBufferByteLength: number };
+  dataView: SendProbe & {
+    threw: boolean;
+    callerBufferByteLength: number;
+    transfer0IsCallerBuffer: boolean;
+  };
   arraybuffer: SendProbe & { dataIsTransfer0: boolean };
   string: SendProbe & { dataEquals: boolean };
 };
@@ -151,6 +156,36 @@ test("send() transfers ArrayBuffer views zero-copy without detaching WASM memory
       transfer0IsSharedBuffer: sub.transfer[0] === shared.buffer,
     };
 
+    // 2b) A DataView is ALSO an ArrayBuffer view, but unlike a TypedArray it has
+    // no `.slice()`. Copying the window off `data.buffer` (not `data.slice()`)
+    // must handle it WITHOUT throwing, transferring a fresh copy of exactly the
+    // view window and never the caller's buffer.
+    const dvBuf = new Uint8Array([10, 20, 30, 40]).buffer; // 4-byte buffer
+    const dv = new DataView(dvBuf, 1, 2); // window [20,30], byteOffset 1, length 2
+    let dvThrew = false;
+    let dvSend: { message: { data: unknown }; transfer: Transferable[] } | null =
+      null;
+    try {
+      dvSend = capture(dv);
+    } catch (_e) {
+      dvThrew = true;
+    }
+    const dvProbe = dvSend
+      ? probe(dvSend)
+      : {
+          transferLen: 0,
+          transfer0IsArrayBuffer: false,
+          transfer0ByteLength: null as number | null,
+          dataBytes: [] as number[],
+          dataBufferIsTransferred: false,
+        };
+    const dataView = {
+      ...dvProbe,
+      threw: dvThrew,
+      callerBufferByteLength: dvBuf.byteLength,
+      transfer0IsCallerBuffer: dvSend ? dvSend.transfer[0] === dvBuf : false,
+    };
+
     // 3) A real ArrayBuffer still transfers itself (unchanged behaviour).
     const ab = new Uint8Array([9, 9]).buffer;
     const abSend = capture(ab);
@@ -166,7 +201,7 @@ test("send() transfers ArrayBuffer views zero-copy without detaching WASM memory
       dataEquals: strSend.message.data === "hello",
     };
 
-    return { uint8, subarrayView, arraybuffer, string };
+    return { uint8, subarrayView, dataView, arraybuffer, string };
   }, shimSource)) as unknown as Probes & {
     subarrayView: { transfer0IsSharedBuffer: boolean };
   };
@@ -197,6 +232,26 @@ test("send() transfers ArrayBuffer views zero-copy without detaching WASM memory
     probes.subarrayView.sharedBufferByteLength,
     "shared backing buffer must remain intact (not detached)",
   ).toBe(6);
+
+  // 2b) DataView: must not throw (a DataView has no `.slice()`), and must
+  // transfer a fresh 2-byte copy of exactly the view window, never the caller's
+  // buffer, with bytes preserved.
+  expect(
+    probes.dataView.threw,
+    "send(DataView) must not throw (DataView has no .slice())",
+  ).toBe(false);
+  expect(probes.dataView.transferLen).toBe(1);
+  expect(probes.dataView.transfer0IsArrayBuffer).toBe(true);
+  expect(probes.dataView.transfer0ByteLength).toBe(2);
+  expect(probes.dataView.dataBytes).toEqual([20, 30]);
+  expect(
+    probes.dataView.transfer0IsCallerBuffer,
+    "must NOT transfer the caller's backing buffer",
+  ).toBe(false);
+  expect(
+    probes.dataView.callerBufferByteLength,
+    "caller's backing buffer must remain intact (not detached)",
+  ).toBe(4);
 
   // 3) ArrayBuffer: unchanged — transfers itself.
   expect(probes.arraybuffer.transferLen).toBe(1);


### PR DESCRIPTION
## Problem

The sandboxed webapp (River) runs in a separate OS process (an OOPIF). The injected WebSocket shim's `send()` (`crates/core/src/server/path_handlers/assets/websocket_shim.js`) is handed a **`Uint8Array`** by wasm-bindgen. A `Uint8Array` is NOT `instanceof ArrayBuffer`, so the pre-fix code:

```js
var transfer = data instanceof ArrayBuffer ? [data] : [];
```

left the `postMessage` transfer list **empty**, and every outbound WS frame was **structured-clone COPIED** across the process boundary instead of transferred zero-copy.

On tab-focus (after the tab was hidden and outbound frames queued up), River flushes ~15 frames / ~740 KB at once; each copy reallocates under ArrayBuffer GC pressure (~87 ms each) → a **~2.7 s main-thread CPU burst** (spins the laptop fan).

This was proven with a live CDP A/B patch: the shell handler self-time dropped **2.73 s → 0.00 s** with identical bytes still reaching the node (15 msgs / 738253 bytes, 0 errors).

## Solution

Transfer the backing buffer for ArrayBuffer **views** too. Because the `Uint8Array` may be a view into WASM linear memory (transferring `memory.buffer` would detach **all** of WASM memory and crash the app), copy it out once in-process via `.slice()` and transfer that fresh copy's buffer:

```js
var payload = data;
var transfer = [];
if (data instanceof ArrayBuffer) {
  transfer = [data];
} else if (ArrayBuffer.isView(data)) {
  var copy = data.slice();
  payload = copy;
  transfer = [copy.buffer];
}
```

String/Blob payloads keep an empty transfer list — correct, they can't be transferred.

### Inbound path — checked, no change needed

`shell_bridge.js` (~line 640) uses `e.data instanceof ArrayBuffer ? [e.data] : []` for the node→iframe direction. That is already correct because line 633 sets `ws.binaryType = 'arraybuffer'`, so `e.data` is always a real `ArrayBuffer`. Noted here so a reviewer knows it was considered.

## Testing

**Behavioural regression test** — new Playwright spec `crates/core/tests/playwright/tests/websocket-shim.spec.ts`. There is no JS-unit harness in the repo (no jest/vitest), and adding one would be disproportionate; the existing Playwright package (`@playwright/test` + chromium) is the lightest mechanism that runs the **real** shim in a real browser with true `ArrayBuffer`/transfer semantics. Unlike `shell.spec.ts` it needs a browser but **not** a running node, so it does not require `FREENET_SHELL_URL`; it still runs inside the `playwright-shell.yml` CI job (which invokes `npx playwright test`).

It loads the real shim, stubs `window.parent.postMessage` (top-level page, so `window.parent === window`) to capture the exact transfer list — deliberately **not** forwarding to native `postMessage`, so buffers stay un-detached and delivered bytes remain readable — and asserts:

1. **`send(new Uint8Array([1,2,3]))`** → transfer list has one element, an `ArrayBuffer`; delivered bytes are `[1,2,3]`; the payload's backing buffer **is** the transferred buffer.
2. **Subarray view** over a larger buffer → transfers a fresh **3-byte** copy, never the shared 6-byte backing buffer (models not detaching WASM linear memory); shared buffer stays intact.
3. **ArrayBuffer** → still transfers itself (unchanged).
4. **String** → transfers nothing.

Verified this spec **FAILS against the old code** (empty transfer list → `transferLen` 0, received where 1 expected) and **PASSES with the fix**.

Run:
```bash
cd crates/core/tests/playwright
npm ci
npx playwright test websocket-shim
```

**Content guard** — `shim_js_transfers_array_buffer_views_zero_copy` in `path_handlers.rs` (alongside the existing `shim_js_validates_message_source`) runs in the **default** Rust CI job. The Playwright job is opt-in (`FREENET_PLAYWRIGHT=1`) and path-filtered, so this guard is a fast, always-on fail-if-reverted check. It passes with the fix; it inverts against the old JS (which contains the removed `data instanceof ArrayBuffer ? [data] : []` and lacks `ArrayBuffer.isView(data)`).

`lint-assets` (Prettier `--check` + ESLint over the served assets) passes on the edited shim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AI-assisted - Claude]