### PR TITLE
refactor(put): remove redundant relay_put_replicate_forward hop (#4509)

### DIFF
--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -1675,22 +1675,12 @@ where
                     "PUT relay: chain descended here and next hop moves away; finalizing here (#4363)"
                 );
                 // Finalize the operation at this closest-seen node (#4363
-                // placement) but STILL replicate the contract one hop onward so
-                // the UPDATE broadcast tree stays connected (#4509 convergence).
-                // See `relay_put_replicate_forward` for why both are required.
-                if let Some(next_addr) = peer.socket_addr() {
-                    relay_put_replicate_forward(
-                        op_manager,
-                        next_addr,
-                        key,
-                        contract.clone(),
-                        related_contracts.clone(),
-                        merged_value.clone(),
-                        htl,
-                        new_skip_list.clone(),
-                    )
-                    .await;
-                }
+                // placement). The contract is stored locally here; UPDATE
+                // convergence is carried by the demand-driven mesh
+                // (subscribe-chains + live fan-out + anti-entropy), so no
+                // extra replication hop past the terminus is needed. The old
+                // #4509 store-one-hop-onward copy was proven redundant by the
+                // #4752 honest convergence gate and removed.
                 let hop_count = op_manager.ring.max_hops_to_live.saturating_sub(htl);
                 return relay_put_finalize_local(
                     op_manager,
@@ -2394,104 +2384,6 @@ async fn relay_put_store_locally(
     Ok(merged_value)
 }
 
-/// Fire-and-forget a replication-only `PutMsg::Request` to `next_addr`
-/// when the #4363 terminus guard finalizes the operation locally.
-///
-/// # Why the guard must still replicate (issue #4509 convergence fix)
-///
-/// The terminus guard makes the *closest-seen* node the authoritative
-/// finalizer (it sends the upstream `PutMsg::Response`, so the originator's
-/// reply and `hop_count` reflect placement at the contract neighbourhood —
-/// the #4363 goal). But finalizing must NOT also stop the contract from
-/// replicating onward: this codebase forms the UPDATE broadcast tree along
-/// the PUT forward path (each relay `host_contract` + `announce_contract_hosted`
-/// in `relay_put_store_locally`). If the guard simply returns after the
-/// upstream Response, the next hop — and everything past it — never receives
-/// the contract, so a later UPDATE that the router fans out to one of those
-/// peers fails with `missing contract` and the network splits into divergent
-/// state groups (observed in `test_six_peer_contract_lifecycle`: contract on
-/// 4/6 peers, a 2/2 v20-vs-v30 split, node-2's updates reaching no one).
-///
-/// To keep placement (#4363) AND replication breadth (convergence), the guard
-/// finalizes locally *and* forwards a replication copy onward with a FRESH
-/// transaction so it does not collide with the upstream finalization waiter
-/// (the originator is already satisfied by this node's Response). The forward
-/// is fire-and-forget: no reply is awaited, and the downstream relay drives
-/// its own replication (including re-applying the same guard one hop deeper).
-/// The skip list — which already contains `upstream_addr` and `own_addr` —
-/// rides along unchanged, and HTL is decremented, so the replication copy is
-/// bounded and cannot loop back upstream. This is the "ensure terminated PUTs
-/// still replicate to the contract neighbourhood" resolution.
-#[allow(clippy::too_many_arguments)]
-async fn relay_put_replicate_forward(
-    op_manager: &OpManager,
-    next_addr: SocketAddr,
-    key: ContractKey,
-    contract: ContractContainer,
-    related_contracts: RelatedContracts<'static>,
-    merged_value: WrappedState,
-    htl: usize,
-    skip_list: HashSet<SocketAddr>,
-) {
-    // The replication copy is sent as a single `PutMsg::Request`. For a
-    // payload that would need streaming we skip the replication forward rather
-    // than re-implement the piped-stream upgrade here: the local store already
-    // placed the authoritative replica at this closest-seen node (#4363), and
-    // the convergence regression this restores (#4509) is on the small-state
-    // non-streaming path. A large-contract terminus is rare; skipping leaves
-    // placement correct and only forgoes the extra broadcast-path replica.
-    let payload = PutStreamingPayload {
-        contract: contract.clone(),
-        related_contracts: related_contracts.clone(),
-        value: merged_value.clone(),
-    };
-    let payload_size = bincode::serialized_size(&payload).unwrap_or(u64::MAX) as usize;
-    if crate::operations::should_use_streaming(op_manager.streaming_threshold, payload_size) {
-        tracing::debug!(
-            contract = %key,
-            target = %next_addr,
-            payload_size,
-            phase = "relay_put_terminus_replicate",
-            "PUT relay: terminus replication skipped for streaming-size payload (placement still correct)"
-        );
-        return;
-    }
-
-    // Fresh tx: the upstream Response under `incoming_tx` already satisfies
-    // the originator's waiter; reusing it would (a) make the downstream relay
-    // bubble a second Response back to a node with no waiter and (b) trip the
-    // per-node dedup gate on `incoming_tx`. A new transaction keeps the
-    // replication copy a clean, independent fire-and-forget op.
-    let replication_tx = Transaction::new::<PutMsg>();
-    let forward = NetMessage::from(PutMsg::Request {
-        id: replication_tx,
-        contract,
-        related_contracts,
-        value: merged_value,
-        htl: htl.saturating_sub(1),
-        skip_list,
-    });
-    let mut ctx = op_manager.op_ctx(replication_tx);
-    if let Err(err) = ctx.send_fire_and_forget(next_addr, forward).await {
-        tracing::debug!(
-            replication_tx = %replication_tx,
-            contract = %key,
-            target = %next_addr,
-            error = %err,
-            phase = "relay_put_terminus_replicate",
-            "PUT relay: terminus replication forward failed (best-effort)"
-        );
-    } else {
-        tracing::debug!(
-            replication_tx = %replication_tx,
-            contract = %key,
-            target = %next_addr,
-            phase = "relay_put_terminus_replicate",
-            "PUT relay: finalized locally but forwarded replication copy onward (#4509)"
-        );
-    }
-}
-
 /// Finalize at this node when there's no next hop. Emits `put_success`
 /// telemetry and sends `PutMsg::Response` upstream.
 ///
@@ -2976,13 +2868,11 @@ where
     // just stops piping the replica to a farther peer the contract
     // neighbourhood will never descend to. The away-move alone is not a
     // sufficient stop condition; see `put_routing_should_terminate`.
-    // When the terminus guard fires it drops `next_hop` (stops piping), but
-    // the contract must still replicate one hop onward to keep the UPDATE
-    // broadcast tree connected (#4509 convergence — see
-    // `relay_put_replicate_forward`). The streaming payload isn't assembled
-    // until step 5, so we remember the next-hop address here and forward a
-    // replication copy after the local store in step 6.
-    let mut terminus_replicate_to: Option<SocketAddr> = None;
+    // When the terminus guard fires it drops `next_hop` (stops piping). The
+    // contract is still assembled and stored locally here in steps 5/6, and
+    // UPDATE convergence is carried by the demand-driven mesh, so nothing is
+    // pushed past the terminus (the old #4509 one-hop-onward copy was proven
+    // redundant by the #4752 honest convergence gate and removed).
     let next_hop = match next_hop {
         Some(peer) => {
             let target = crate::ring::Location::from(&contract_key);
@@ -3008,7 +2898,6 @@ where
                     phase = "relay_put_streaming_terminus",
                     "PUT streaming relay: chain descended here and next hop moves away; finalizing here (#4363)"
                 );
-                terminus_replicate_to = peer.socket_addr();
                 None
             } else {
                 Some(peer)
@@ -3198,10 +3087,6 @@ where
     }
 
     // ── Step 6: Store contract locally (shared helper with slice A) ──────
-    // Clone the contract/related-contracts for a possible terminus replication
-    // forward (#4509) before the store consumes `related_contracts`.
-    let replicate_payload =
-        terminus_replicate_to.map(|addr| (addr, contract.clone(), related_contracts.clone()));
     // Originator-loopback client PUT → ClientLocal reserved lane (#4534).
     let store_priority = put_store_priority(op_manager, upstream_addr);
     let merged_value = relay_put_store_locally(
@@ -3215,24 +3100,6 @@ where
         store_priority,
     )
     .await?;
-
-    // Terminus guard fired (#4363) on the streaming path: finalize here but
-    // still replicate the assembled contract one hop onward so the UPDATE
-    // broadcast tree stays connected (#4509). Mirrors the non-streaming guard
-    // branch; see `relay_put_replicate_forward`.
-    if let Some((next_addr, contract, related_contracts)) = replicate_payload {
-        relay_put_replicate_forward(
-            op_manager,
-            next_addr,
-            key,
-            contract,
-            related_contracts,
-            merged_value.clone(),
-            htl,
-            new_skip_list.clone(),
-        )
-        .await;
-    }
 
     // ── Step 7: Await downstream reply (if piping), then bubble upstream ──
     //
@@ -5748,22 +5615,14 @@ mod tests {
         );
 
         // The guard must finalize locally on its terminus branch (so the
-        // closest-seen node is the authoritative finalizer, #4363) AND still
-        // replicate the contract one hop onward (so the UPDATE broadcast tree
-        // stays connected, #4509) — not just log, and not fall through to the
-        // forward. Both calls live in the terminus branch before the forward.
+        // closest-seen node is the authoritative finalizer, #4363) — not just
+        // log, and not fall through to the forward. The finalize call lives in
+        // the terminus branch before the forward.
         let guard_region = &body[guard_pos..forward_pos];
         assert!(
             guard_region.contains("relay_put_finalize_local("),
             "the terminus branch MUST finalize locally via \
              relay_put_finalize_local, not fall through to the forward"
-        );
-        assert!(
-            guard_region.contains("relay_put_replicate_forward("),
-            "the terminus branch MUST still replicate the contract onward via \
-             relay_put_replicate_forward (#4509) — finalizing without \
-             replicating orphans the UPDATE broadcast path and splits the \
-             network into divergent state groups"
         );
     }
 
@@ -5803,21 +5662,6 @@ mod tests {
              derived (i.e. before the piped-forward decision), so a \
              non-improving next hop is dropped and the driver finalizes \
              locally"
-        );
-
-        // The streaming guard records the dropped next hop in
-        // `terminus_replicate_to` and, after the local store, replicates the
-        // contract one hop onward via `relay_put_replicate_forward` (#4509) so
-        // the streaming path does not orphan the UPDATE broadcast tree either.
-        assert!(
-            body.contains("terminus_replicate_to"),
-            "streaming guard MUST record the dropped next hop in \
-             terminus_replicate_to for the #4509 replication forward"
-        );
-        assert!(
-            body.contains("relay_put_replicate_forward("),
-            "streaming terminus path MUST still replicate the contract onward \
-             via relay_put_replicate_forward (#4509)"
         );
     }
 

--- a/crates/core/tests/nat_subscription.rs
+++ b/crates/core/tests/nat_subscription.rs
@@ -69,12 +69,11 @@
 //! contract itself, so the only way it can hold the contract locally is to
 //! fetch it. It cannot rely on PUT replication: the originator PUT on
 //! `host-peer` finalizes at `host-peer` (already at the contract location) and
-//! replicates exactly **one hop** toward the contract neighbourhood
-//! (`relay_put_replicate_forward`, #4509), which lands on the *gateway* (closer
-//! to the contract than `nat-peer`) — not on `nat-peer`. So a bare SUBSCRIBE on
-//! `nat-peer` raced contract presence that, for the farthest peer, often never
-//! arrives at all; that is the flake tracked in #4524 (a "contract not cached
-//! locally" rejection ~7-9s in).
+//! is not pushed onward to `nat-peer` (the PUT places copies along its routed
+//! path toward the contract, none of which is the far-side `nat-peer`). So a
+//! bare SUBSCRIBE on `nat-peer` raced contract presence that, for the farthest
+//! peer, often never arrives at all; that is the flake tracked in #4524 (a
+//! "contract not cached locally" rejection ~7-9s in).
 //!
 //! The deterministic fix is to use the supported non-host path: `nat-peer`
 //! issues `GET` with `subscribe=true`. The GET routes *toward* the contract
@@ -427,9 +426,9 @@ async fn test_nat_peer_remote_subscription_receives_update(ctx: &mut TestContext
     // NAT peer fetches the contract (with BLOCKING auto-subscribe) instead of
     // issuing a bare SUBSCRIBE. A bare `Subscribe` would be rejected "contract
     // WASM not cached locally" because nat-peer is the provable non-host and
-    // does not reliably receive the contract via PUT replication (the PUT
-    // replicates one hop toward the contract neighbourhood — onto the closer
-    // gateway, not nat-peer). `GET` routes *toward* the contract, so it reliably
+    // does not receive the contract via PUT replication (the PUT places copies
+    // along its routed path toward the contract, not on the far-side nat-peer).
+    // `GET` routes *toward* the contract, so it reliably
     // resolves on gateway/host-peer, fetches and caches the body on nat-peer,
     // and the GET driver registers the subscription through the SAME relay path:
     // the wire `SubscribeMsg::Request` carries no address, so each hop

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -14583,3 +14583,316 @@ fn test_summary_first_put_reverse_delta_converges_originator() {
     // Avoid leaking the CRDT registration into other tests sharing this process.
     freenet::dev_tool::clear_crdt_contracts();
 }
+
+// =============================================================================
+// Honest PUT-mesh UPDATE-convergence gate (#4509 removal regression proof)
+// =============================================================================
+//
+// Proves that removing the past-#4363-terminus PUT replication hop
+// (`relay_put_replicate_forward`, #4509) does NOT regress UPDATE convergence.
+// This is the mergeable, ASSERTING CI form of the #4752 honest gate. The R&D
+// measurement branch `rnd/honest-convergence-gate` ran 15 seeds control-vs-
+// removal (the removal expressed as a runtime kill-switch) and found removal
+// converges identically (15/15, incl. under a mid-mesh crash). That harness is
+// a `#[ignore]` measurement and cannot merge; this is its distilled gate,
+// stripped of the env kill-switch / hop-toggle scaffolding — the hop is now
+// DELETED, so the gate runs against the real code and asserts convergence.
+//
+// Why the pre-existing convergence sims did not already cover the removal:
+//   - `test_pr2763_crdt_convergence_with_resync` and `test_crdt_convergence`
+//     subscribe via a BARE `SimOperation::Subscribe`, which the node rejects
+//     until the WASM is cached locally, so a subscriber only joins when the PUT
+//     physically reached it — the test then measured PUT *reach*, not mesh
+//     *convergence* (the exact confound #4752 identified; removing the hop
+//     shortens PUT reach by one hop, which is why one of those tests is the most
+//     sensitive to this change).
+//   - `test_partition_heal_convergence` / `test_crash_recover_convergence` are
+//     random-op fuzz + anomaly reports that only LOG, never hard-assert
+//     convergence.
+//   - `test_piece_e_unsubscribed_stale_serve_gate` IS honest (GET-with-subscribe
+//     mesh, asserts convergence) but SEEDS the contract locally
+//     (`SeedHostedContract`), so it never exercises the PUT-routing path the
+//     deleted hop sat on.
+// This gate closes that gap: it PUT-routes the contract through a 16-peer
+// network, forms the mesh via GET-with-subscribe, VERIFIES every survivor is
+// `node_is_receiving_updates` before measuring, then asserts ground-truth STATE
+// convergence to the final update (v50) — in a steady and a mid-mesh-crash
+// (churn) variant.
+
+/// Per-seed outcome of one honest PUT-mesh convergence run. All counts are over
+/// the intended subscribers (excluding a crashed node in the churn variant).
+#[derive(Debug, Clone, Copy)]
+struct HonestConvergenceOutcome {
+    /// Intended mesh subscribers considered (16 steady, 15 with churn).
+    intended: usize,
+    /// Intended subscribers that ended `node_is_receiving_updates` (REAL mesh
+    /// members — a live network/client subscription, not a mere cache copy).
+    mesh_members: usize,
+    /// Mesh members that also hold stored state for the key.
+    mesh_holders: usize,
+    /// Distinct final-state hashes across mesh holders (1 == converged shape).
+    unique_hashes: usize,
+    /// Mesh holders whose final state equals the v50 final update.
+    at_final: usize,
+    /// The controlled sim completed without a turmoil error.
+    turmoil_ok: bool,
+    /// Packets dropped by the scripted crash (>0 proves churn took effect).
+    crash_dropped: u64,
+}
+
+impl HonestConvergenceOutcome {
+    /// The mesh formed well enough for the convergence measurement to be
+    /// meaningful (>= 75% of intended subscribers actually receiving updates).
+    /// This is the honest guard against the bare-SUBSCRIBE confound: a run whose
+    /// subscribers never joined the mesh fails HERE, before convergence is read.
+    fn mesh_formed(&self) -> bool {
+        self.turmoil_ok && self.mesh_members * 4 >= self.intended * 3
+    }
+
+    /// The update mesh FULLY converged: mesh formed, every mesh member holds
+    /// state, all byte-identical, all equal to the v50 final update.
+    fn converged(&self) -> bool {
+        self.mesh_formed()
+            && self.mesh_members > 0
+            && self.mesh_holders == self.mesh_members
+            && self.unique_hashes == 1
+            && self.at_final == self.mesh_holders
+    }
+}
+
+/// Run one honest PUT-mesh convergence seed. `churn` crashes a mid-mesh node
+/// partway through the update sequence (its frozen copy is excluded from the
+/// convergence accounting). Returns the measured outcome; never panics on a
+/// convergence failure so the caller can render a full diagnostic.
+fn honest_put_mesh_convergence_seed(seed: u64, churn: bool) -> HonestConvergenceOutcome {
+    use freenet::dev_tool::{
+        NodeLabel, ScheduledOperation, SimNetwork, SimOperation, register_crdt_contract,
+    };
+
+    // 2 gateways + 14 nodes = 16 peers. Regular nodes are numbered starting at
+    // the gateway count, so labels are node(N_GW..N_GW+N_NODES).
+    const N_GW: usize = 2;
+    const N_NODES: usize = 14;
+    const CRASH_IDX: usize = N_GW + N_NODES / 2; // node(9) — a mid-mesh subscriber
+
+    setup_deterministic_state(seed);
+    let network = format!(
+        "honest-conv-{}{seed:x}",
+        if churn { "churn-" } else { "steady-" }
+    );
+
+    let seed_byte = 0x7Eu8;
+    let contract = SimOperation::create_test_contract(seed_byte);
+    let contract_id = *contract.key().id();
+    let contract_key = contract.key();
+    register_crdt_contract(contract_id);
+
+    let gw0 = NodeLabel::gateway(&network, 0);
+    let gw1 = NodeLabel::gateway(&network, 1);
+
+    // Intended mesh: gw0 (subscribes via PUT), then gw1 + node(2..=15) via
+    // GET-with-subscribe.
+    let mut intended: Vec<NodeLabel> = vec![gw0.clone(), gw1.clone()];
+    for n in N_GW..(N_GW + N_NODES) {
+        intended.push(NodeLabel::node(&network, n));
+    }
+
+    let crashed: Option<NodeLabel> = churn.then(|| NodeLabel::node(&network, CRASH_IDX));
+
+    // Update sources at varied ring positions (none is the crashed node), so the
+    // multi-hop broadcast tree is genuinely exercised. LWW-by-version: v50 wins.
+    let src_v20 = NodeLabel::node(&network, N_GW + 2); // node(4)
+    let src_v30 = NodeLabel::node(&network, N_GW + N_NODES - 1); // node(15), far side
+    let src_v40 = NodeLabel::node(&network, N_GW + N_NODES / 3 + 1); // node(6)
+
+    let rt = create_runtime();
+    let sim = rt.block_on(async {
+        // ring_max_htl=10, rnd_if_htl_above=5, max_connections=10, min_connections=3.
+        SimNetwork::new(&network, N_GW, N_NODES, 10, 5, 10, 3, seed).await
+    });
+
+    let mut operations = Vec::new();
+    // 1. gw0 PUTs with subscribe=true (root of the mesh, holds v1). This is a
+    //    ROUTED PUT — it exercises the #4363 terminus path the deleted #4509 hop
+    //    sat on, which is exactly why this gate (not the seed-based piece-E test)
+    //    is the removal's regression proof.
+    operations.push(ScheduledOperation::new(
+        gw0.clone(),
+        SimOperation::Put {
+            contract: contract.clone(),
+            state: SimOperation::create_crdt_state(1, seed_byte),
+            subscribe: true,
+        },
+    ));
+    // 2. Every other intended peer GET-with-subscribe: fetch+cache the WASM/state
+    //    AND register the subscription, genuinely joining the update mesh (a bare
+    //    Subscribe would be rejected until the WASM is cached — the #4752 confound).
+    for label in intended.iter().skip(1) {
+        operations.push(ScheduledOperation::new(
+            label.clone(),
+            SimOperation::Get {
+                contract_id,
+                return_contract_code: true,
+                subscribe: true,
+            },
+        ));
+    }
+    // 3. Early updates every subscriber should get before any crash.
+    operations.push(ScheduledOperation::new(
+        gw0.clone(),
+        SimOperation::Update {
+            key: contract_key,
+            data: SimOperation::create_crdt_state(10, seed_byte),
+        },
+    ));
+    operations.push(ScheduledOperation::new(
+        src_v20,
+        SimOperation::Update {
+            key: contract_key,
+            data: SimOperation::create_crdt_state(20, seed_byte),
+        },
+    ));
+    // 4. Crash a mid-mesh subscriber (churn variant only).
+    if let Some(ref c) = crashed {
+        operations.push(ScheduledOperation::new(c.clone(), SimOperation::CrashNode));
+    }
+    // 5. Later updates from multiple sources — survivors must still converge on
+    //    the final value (v50) through the multi-hop tree, without the crashed
+    //    relay and without the deleted past-terminus forward.
+    operations.push(ScheduledOperation::new(
+        src_v30,
+        SimOperation::Update {
+            key: contract_key,
+            data: SimOperation::create_crdt_state(30, seed_byte),
+        },
+    ));
+    operations.push(ScheduledOperation::new(
+        src_v40,
+        SimOperation::Update {
+            key: contract_key,
+            data: SimOperation::create_crdt_state(40, seed_byte),
+        },
+    ));
+    operations.push(ScheduledOperation::new(
+        gw1.clone(),
+        SimOperation::Update {
+            key: contract_key,
+            data: SimOperation::create_crdt_state(50, seed_byte),
+        },
+    ));
+
+    let result = sim.run_controlled_simulation(
+        seed,
+        operations,
+        Duration::from_secs(240),
+        Duration::from_secs(120),
+    );
+
+    // Accounting: consider intended subscribers minus the crashed node (its
+    // pre-crash frozen copy must not count for OR against convergence).
+    let considered: Vec<&NodeLabel> = intended
+        .iter()
+        .filter(|l| Some(*l) != crashed.as_ref())
+        .collect();
+
+    let expected = freenet::tracing::state_hash_full(&freenet_stdlib::prelude::WrappedState::new(
+        SimOperation::create_crdt_state(50, seed_byte),
+    ));
+
+    let mut mesh_members = 0usize;
+    let mut hashes: Vec<String> = Vec::new();
+    for label in &considered {
+        // node_is_receiving_updates == a live network/client subscription (REAL
+        // mesh membership), NOT a mere cache copy: this is the honest gate.
+        if result.node_is_receiving_updates(label, &contract_key) {
+            mesh_members += 1;
+            if let Some(ws) = result
+                .node_storages
+                .get(*label)
+                .and_then(|s| s.get_stored_state(&contract_key))
+            {
+                hashes.push(freenet::tracing::state_hash_full(&ws));
+            }
+        }
+    }
+    let mesh_holders = hashes.len();
+    let unique_hashes = hashes.iter().collect::<HashSet<&String>>().len();
+    let at_final = hashes.iter().filter(|h| **h == expected).count();
+
+    let outcome = HonestConvergenceOutcome {
+        intended: considered.len(),
+        mesh_members,
+        mesh_holders,
+        unique_hashes,
+        at_final,
+        turmoil_ok: result.turmoil_result.is_ok(),
+        crash_dropped: result.crash_packets_dropped(),
+    };
+
+    freenet::dev_tool::clear_crdt_contracts();
+    outcome
+}
+
+/// Assert one honest PUT-mesh convergence seed: the mesh must form (honest
+/// membership, guarding the bare-SUBSCRIBE confound), churn must have bitten
+/// (churn variant), and the surviving mesh must FULLY converge to v50 — the
+/// property removing the #4509 hop is claimed not to regress.
+fn assert_honest_put_mesh_convergence(seed: u64, churn: bool) {
+    let o = honest_put_mesh_convergence_seed(seed, churn);
+    let variant = if churn { "churn" } else { "steady" };
+    assert!(
+        o.turmoil_ok,
+        "[{variant} seed=0x{seed:X}] controlled sim did not complete"
+    );
+    if churn {
+        assert!(
+            o.crash_dropped > 0,
+            "[{variant} seed=0x{seed:X}] scripted CrashNode dropped no packets — \
+             churn had no effect, so a 'converged' result would be vacuous"
+        );
+    }
+    assert!(
+        o.mesh_formed(),
+        "[{variant} seed=0x{seed:X}] mesh did not form: only {}/{} intended \
+         subscribers are receiving updates (need >= 75%). Convergence is not \
+         measurable until the mesh forms — this guards the bare-SUBSCRIBE confound",
+        o.mesh_members,
+        o.intended
+    );
+    assert!(
+        o.converged(),
+        "[{variant} seed=0x{seed:X}] UPDATE mesh did NOT converge to v50 without \
+         the #4509 hop: mesh_members={} holders={} unique_hashes={} at_v50={} \
+         (require holders==members, unique==1, at_v50==holders)",
+        o.mesh_members,
+        o.mesh_holders,
+        o.unique_hashes,
+        o.at_final
+    );
+}
+
+/// A couple of fixed seeds (a CI-weighted subset of the R&D sweep's 15), each a
+/// distinct topology. Two seeds × two variants (steady + churn) exercise four
+/// broadcast trees at 16 peers — enough to catch a convergence regression
+/// without the full validation sweep's wall-clock cost. Each seed is ~60s at 16
+/// peers, so keep this small; the R&D branch runs the full 15-seed sweep.
+const HONEST_CONVERGENCE_SEEDS: [u64; 2] = [0x4642_E5B0_0001, 0x4642_E5B0_0002];
+
+/// Honest PUT-mesh UPDATE-convergence gate — STEADY (no churn). Regression proof
+/// that deleting `relay_put_replicate_forward` (#4509) preserves convergence.
+#[test_log::test]
+fn honest_put_mesh_convergence_steady() {
+    for &seed in &HONEST_CONVERGENCE_SEEDS {
+        assert_honest_put_mesh_convergence(seed, false);
+    }
+}
+
+/// Honest PUT-mesh UPDATE-convergence gate — CHURN (crash a mid-mesh subscriber
+/// mid-run). Proves survivors still converge to v50 without the #4509 hop even
+/// when a mid-mesh relay drops out.
+#[test_log::test]
+fn honest_put_mesh_convergence_churn() {
+    for &seed in &HONEST_CONVERGENCE_SEEDS {
+        assert_honest_put_mesh_convergence(seed, true);
+    }
+}


### PR DESCRIPTION
## Problem

The #4363 greedy-routing terminus guard finalizes a PUT at the closest-seen node, then fire-and-forgets one **extra replication copy one hop past the terminus** (`relay_put_replicate_forward`, added for #4509). That extra copy is a durable-regardless-of-demand remnant: it places a copy on a peer with no demand for the contract, purely to widen PUT physical reach. It is exactly the "durable-regardless-of-demand hosting" anti-pattern the demand-driven-hosting redesign (#4642) is removing.

The #4752 honest UPDATE-mesh convergence gate proved the hop is redundant: 16 peers, subscribers using GET-with-subscribe so they **actually join the mesh** (verified via `is_receiving_updates`), ground-truth STATE convergence, 15 seeds, steady + churn. Removal converges **15/15 — identical to keeping the hop**, including under a mid-mesh crash. The demand-driven mesh (subscribe-chains + live fan-out + anti-entropy, all shipped in 0.2.94) already carries UPDATE convergence; the hop is not load-bearing.

The earlier "removal re-opens the #4509 divergent-state split" belief was a test artifact: the #4749 six-peer gate used **bare** `SUBSCRIBE`, which the node rejects when the WASM isn't cached locally, so its subscribers never joined the mesh — it measured PUT *physical reach* (which the hop extends by one), not mesh *convergence*.

## Approach

Delete the function, both call sites, its dead plumbing, and correct the now-false #4509 documentation. Rely on a committed honest convergence gate (below) plus the #4752 R&D proof.

Removed:
- `async fn relay_put_replicate_forward` and its #4509 doc block
- the non-streaming terminus call site
- the streaming path's `terminus_replicate_to` plumbing + Step 6 call site
- the now-false #4509 "must still replicate / divergent-state split" claims in the two terminus-guard pin tests — the #4363 **guard-order and finalize-local assertions are kept intact**
- stale #4509 narrative references naming the deleted function in `tests/nat_subscription.rs`

No wire-format change.

## Testing

- `cargo build`, `cargo fmt`, `cargo clippy -p freenet -- -D warnings` all clean (no dead-code warnings from the removal).
- Put unit tests: **101 passed**, including the two edited terminus-guard pin tests.

**Committed regression proof — honest PUT-mesh convergence gate** (`honest_put_mesh_convergence_{steady,churn}` in `tests/simulation_integration.rs`). Because the #4752 honest gate lives only on the unmergeable `rnd/honest-convergence-gate` R&D branch (env kill-switch, `#[ignore]` measurement), this PR ports a mergeable, **asserting** distillation of it, stripped of the scaffolding (the hop is deleted, so it runs against the real code):

- PUT-routes the contract through a 16-peer network (2 gw + 14 nodes) — exercising the exact #4363 terminus path the deleted hop sat on.
- Forms the mesh via **GET-with-subscribe** (subscribers genuinely join; a bare `SUBSCRIBE` is rejected until the WASM is cached — the #4752 confound).
- **Verifies every survivor is `node_is_receiving_updates`** (real network/client subscription, not a mere cache copy) *before* measuring — a run whose mesh didn't form fails there.
- Asserts ground-truth **STATE convergence** to the final update (v50): all mesh members hold state, byte-identical, all == v50.
- **Steady + churn** (mid-mesh subscriber crash) variants; CI-weighted to 2 seeds each (~2 min/variant). Passes on this branch (hop deleted): all mesh members converge to v50 in every run.

Audit of why the pre-existing convergence sims did **not** already cover the removal (which is why the new gate was needed):

| Test | Mesh formation | Convergence assertion | Honest for this removal? |
|---|---|---|---|
| `test_pr2763_crdt_convergence_with_resync` | bare `SUBSCRIBE` | asserts | No — bare-SUBSCRIBE confound (measures PUT reach) |
| `test_crdt_convergence` (44 cases) | `TestConfig::medium` fuzz, mixed | asserts | No — fuzz + bare SUBSCRIBE |
| `test_partition_heal_convergence` | random-op fuzz | only logs anomalies | No — no hard convergence assert |
| `test_crash_recover_convergence` | random-op fuzz | only logs anomalies | No — no hard convergence assert |
| `test_piece_e_unsubscribed_stale_serve_gate` | GET-with-subscribe | asserts mesh converges | Honest, but **seeds** the contract (`SeedHostedContract`), never PUT-routes |

Other removal-relevant sim tests pass without the hop: `test_piece_e_unsubscribed_stale_serve_gate` (anti-entropy heals a demandless copy — the safety net), `test_summary_first_put_*`, `test_terminal_advertisement_consult_closes_subscribe_dead_end`, `test_concurrent_updates_convergence`, `test_partition_heal_convergence`, `test_crash_recover_convergence`, `test_pr2763_crdt_convergence_with_resync`. `test_crdt_convergence` (44 cases): 4/4 dedicated batch reruns pass 44/44; one earlier mixed-batch run had a single transient `case_07` divergence that did not reproduce in isolation or on reruns (that suite is bare-SUBSCRIBE, with a known parallel-load noise floor).

**Merge held pending v0.2.95 field-validation.** Per the hosting redesign ordering, the demand gauge (subscriber-primary eviction, shipped 0.2.94) must be field-validated before this durable-copy removal lands.

Closes #4509
Refs #4752 (honest convergence gate), #4642 (demand-driven hosting epic)

[AI-assisted - Claude]
