### PR TITLE
refactor(update): remove redundant Source-2 interest fan-out (#4642 step 9)

### DIFF
--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -1803,8 +1803,10 @@ where
                     // now a `neighbors_with_contract` broadcast target. If a
                     // fresh-contract PUT gave up with no targets and is stashed,
                     // flush it here — this is the proximity first-viable-target
-                    // signal, distinct from the interest-manager (Source 2)
-                    // signals. Must run BEFORE the receiving-updates/downstream
+                    // signal, distinct from the interest-registration flush sites
+                    // (`register_peer_interest`; the Source-2 live fan-out arm
+                    // itself was removed in #4642 step 9). Must run BEFORE the
+                    // receiving-updates/downstream
                     // gate below, which `continue`s for exactly the
                     // locally-hosted-only fresh-PUT case this fix targets.
                     op_manager.flush_pending_broadcast_on_interest(&key).await;

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -5054,9 +5054,13 @@ mod tests {
 
     /// #4359 trigger-completeness pin (MUST-FIX 1). The deferred broadcast only
     /// drains when a viable target appears, signalled by
-    /// `flush_pending_broadcast_on_interest`. The interest-manager (Source 2)
-    /// path makes a peer a target via `register_peer_interest`; EVERY such call
-    /// site that can be the first viable target for a never-seen id must flush.
+    /// `flush_pending_broadcast_on_interest`. Since #4642 step 9 an interest-only
+    /// peer is no longer itself a broadcast target (the Source-2 live fan-out arm
+    /// was removed), but interest registration typically coincides with the
+    /// peer's advertisement, so every `register_peer_interest` call site keeps
+    /// flushing as the eager wakeup for the Source-1 target that lands alongside
+    /// it. EVERY such call site that can be the first viable target for a
+    /// never-seen id must flush.
     ///
     /// Rather than trusting a static allow-list of files (the brittle shape the
     /// re-review flagged — a NEW production `register_peer_interest` added in

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -2939,11 +2939,12 @@ mod tests {
     ///    advertisement) case; under the old two-source model it WOULD be a
     ///    target via Source 2, and after step 9 it must not be.
     /// 2. An advertised co-host (Source 1) is still INCLUDED.
-    /// 3. The anti-entropy heal restores the lagged peer: once its advertisement
-    ///    arrives — exactly what the periodic InterestSync
-    ///    `HostingStateRequest`/`HostingStateResponse` reconciliation delivers,
-    ///    a `HostingAnnounce { is_response: true }` (`ring.rs::interest_heartbeat`,
-    ///    #4722) — it becomes a broadcast target.
+    /// 3. The advertisement-reconciliation heal restores the lagged peer: once
+    ///    our view of it includes the contract it becomes a broadcast target. The
+    ///    periodic interest heartbeat sends each neighbor a `HostingStateRequest`;
+    ///    the neighbor replies with a `HostingStateResponse` snapshot of its
+    ///    hosted set, which we full-replace into our Source-1 view
+    ///    (`ring.rs::interest_heartbeat`, #4722).
     ///
     /// This is the unit-level counterpart of the lagged-advertisement
     /// convergence simulation: removing Source-2 is safe precisely because a
@@ -3034,16 +3035,16 @@ mod tests {
             "interest_found is vestigial after Source-2 removal and must report 0"
         );
 
-        // THE HEAL: B's advertisement arrives. This mirrors the periodic
-        // InterestSync anti-entropy `HostingStateResponse` reconciliation
-        // (`ring.rs::interest_heartbeat`, #4722), which re-pulls a neighbor's
-        // hosted set as a `HostingAnnounce { is_response: true }`.
+        // THE HEAL: the periodic interest heartbeat re-pulls B's hosted set. We
+        // send B a `HostingStateRequest`; B replies with a `HostingStateResponse`
+        // snapshot of what it hosts, which we full-replace into our view of B
+        // (`ring.rs::interest_heartbeat`, #4722). That is what moves B into
+        // Source-1. (An advertised co-host may also announce proactively via
+        // `HostingAnnounce`; either path lands B in the proximity cache.)
         op_manager.neighbor_hosting.handle_message(
             kp_b.public(),
-            crate::message::NeighborHostingMessage::HostingAnnounce {
-                added: vec![cid],
-                removed: vec![],
-                is_response: true,
+            crate::message::NeighborHostingMessage::HostingStateResponse {
+                contracts: vec![cid],
             },
         );
 

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -789,29 +789,37 @@ impl OpManager {
     ///
     /// ## Trigger completeness (issue #4359 re-review, MUST-FIX 1)
     ///
-    /// `get_broadcast_targets_update` resolves targets from two sources, so the
-    /// *first viable target* for a cold id can appear via either. This method is
-    /// invoked from every site that makes a peer a target for the first time:
+    /// Since #4642 step 9, `get_broadcast_targets_update` resolves targets from
+    /// a SINGLE source — the proximity cache of advertised co-hosts (Source 1).
+    /// The *first viable target* for a cold id therefore appears when a
+    /// connected neighbor newly announces it hosts one of our contracts:
     ///
-    /// * **Source 2 — interest manager** (`register_peer_interest` is_new):
+    /// * **Source 1 — proximity cache** (`neighbors_with_contract`):
+    ///   - `node.rs` NeighborHosting overlap path, when a neighbor newly
+    ///     announces hosting one of our contracts (the neighbor just became a
+    ///     `neighbors_with_contract` target) — live, or reconciled by the
+    ///     ~5-min InterestSync anti-entropy heartbeat
+    ///     (`ring.rs::interest_heartbeat`, #4722).
+    ///
+    /// The interest-registration flush sites remain wired even though an
+    /// interest-only peer is no longer a broadcast target (Source 2 was removed
+    /// in #4642 step 9): a flush that finds no Source-1 target simply re-stashes
+    /// or lets the entry expire — harmless and cheap, and it keeps the eager
+    /// #4359 wakeup for the case where an interest registration coincides with
+    /// the peer's advertisement. Those sites are (`register_peer_interest`
+    /// is_new):
     ///   - `subscribe::register_downstream_subscriber` (downstream subscriber)
     ///   - `subscribe::finalize_originator_subscribe` (originator upstream)
     ///   - `get::op_ctx_task` remote GET `subscribe=false` (requester interest)
     ///   - `node.rs` Interests / Summaries interest-sync handlers
-    /// * **Source 1 — proximity cache** (`neighbors_with_contract`):
-    ///   - `node.rs` NeighborHosting overlap path, when a neighbor newly
-    ///     announces hosting one of our contracts (the neighbor just became a
-    ///     `neighbors_with_contract` target).
     ///
     /// That set is the complete first-viable-target signal: a never-seen id can
-    /// only gain a broadcast target by a peer expressing interest (Source 2) or
-    /// by a connected neighbor announcing it hosts the id (Source 1), and each
-    /// such transition routes through one of the sites above. The give-up path
-    /// itself also re-checks targets immediately after stashing
-    /// (`pending_broadcast_stash_recheck`) to close the stash-after-flush race.
-    /// A grep pin test (`pending_broadcast_flush_wired_at_all_interest_sites`)
-    /// guards against a future `register_peer_interest` call site forgetting the
-    /// flush.
+    /// only gain a broadcast target by a connected neighbor announcing it hosts
+    /// the id (Source 1). The give-up path itself also re-checks targets
+    /// immediately after stashing (`pending_broadcast_stash_recheck`) to close
+    /// the stash-after-flush race. A grep pin test
+    /// (`pending_broadcast_flush_wired_at_all_interest_sites`) guards against a
+    /// future `register_peer_interest` call site forgetting the flush.
     ///
     /// Best-effort via [`Self::try_notify_node_event`]: if the channel is full
     /// the state is re-stashed for the next signal. No-op (no read, no emit)
@@ -2919,6 +2927,141 @@ mod tests {
             },
         );
         op_manager.neighbor_hosting.contracts_for_peer(hub)
+    }
+
+    /// Safety proof for #4642 step 9 (remove the Source-2 interest fan-out arm
+    /// from live UPDATE propagation). At the `get_broadcast_targets_update`
+    /// boundary this asserts the properties the removal must preserve:
+    ///
+    /// 1. An interest-only peer — registered in the interest manager but NOT
+    ///    advertising via the advertisement layer — is EXCLUDED from broadcast
+    ///    targets. This is the interest-but-not-yet-advertised (lagged
+    ///    advertisement) case; under the old two-source model it WOULD be a
+    ///    target via Source 2, and after step 9 it must not be.
+    /// 2. An advertised co-host (Source 1) is still INCLUDED.
+    /// 3. The anti-entropy heal restores the lagged peer: once its advertisement
+    ///    arrives — exactly what the periodic InterestSync
+    ///    `HostingStateRequest`/`HostingStateResponse` reconciliation delivers,
+    ///    a `HostingAnnounce { is_response: true }` (`ring.rs::interest_heartbeat`,
+    ///    #4722) — it becomes a broadcast target.
+    ///
+    /// This is the unit-level counterpart of the lagged-advertisement
+    /// convergence simulation: removing Source-2 is safe precisely because a
+    /// peer that is interested-but-not-yet-advertised is reached once its
+    /// advertisement lands in Source-1, live or via anti-entropy. See
+    /// `.claude/rules/hosting-invariants.md` invariant 1 and
+    /// `docs/design/demand-driven-hosting.md`.
+    #[tokio::test(flavor = "current_thread")]
+    async fn broadcast_targets_are_advertised_cohosts_only_and_heal_via_advertisement() {
+        use crate::ring::interest::PeerKey;
+
+        let (op_manager, _guards) =
+            build_reroot_test_op_manager("broadcast-targets-source1-only").await;
+
+        // Own address. The UPDATE sender is a DIFFERENT peer, so the self/sender
+        // echo-skip never applies to A or B below.
+        let self_addr: std::net::SocketAddr = "127.0.0.1:12000".parse().unwrap();
+        op_manager.ring.connection_manager.set_own_addr(self_addr);
+        let sender_addr: std::net::SocketAddr = "127.0.0.1:20000".parse().unwrap();
+
+        let key = reroot_contract_key(0x5A);
+        let cid = *key.id();
+
+        // Peer A: a connected, ADVERTISED co-host (Source 1).
+        let kp_a = crate::transport::TransportKeypair::new();
+        let addr_a: std::net::SocketAddr = "127.0.0.1:20001".parse().unwrap();
+        assert!(op_manager.ring.connection_manager.add_connection(
+            crate::ring::Location::new(0.3),
+            addr_a,
+            kp_a.public().clone(),
+            false,
+        ));
+        op_manager.neighbor_hosting.handle_message(
+            kp_a.public(),
+            crate::message::NeighborHostingMessage::HostingAnnounce {
+                added: vec![cid],
+                removed: vec![],
+                is_response: false,
+            },
+        );
+
+        // Peer B: a connected peer that has registered INTEREST but has NOT yet
+        // advertised (the lagged-advertisement case). It is a valid, resolvable
+        // connection, so its exclusion below is due to the Source-2 removal, not
+        // an unresolvable peer.
+        let kp_b = crate::transport::TransportKeypair::new();
+        let addr_b: std::net::SocketAddr = "127.0.0.1:20002".parse().unwrap();
+        assert!(op_manager.ring.connection_manager.add_connection(
+            crate::ring::Location::new(0.6),
+            addr_b,
+            kp_b.public().clone(),
+            false,
+        ));
+        assert!(
+            op_manager.interest_manager.register_peer_interest(
+                &key,
+                PeerKey(kp_b.public().clone()),
+                None,
+                false,
+            ),
+            "interest registration should succeed"
+        );
+
+        // BEFORE the heal: only the advertised co-host A is a target.
+        let before = op_manager.get_broadcast_targets_update(&key, &sender_addr);
+        let before_addrs: std::collections::HashSet<std::net::SocketAddr> = before
+            .targets
+            .iter()
+            .filter_map(|p| p.socket_addr())
+            .collect();
+        assert!(
+            before_addrs.contains(&addr_a),
+            "advertised co-host (Source 1) must be a broadcast target; got {before_addrs:?}"
+        );
+        assert!(
+            !before_addrs.contains(&addr_b),
+            "interest-only peer (former Source 2) must NOT be a broadcast target after \
+             #4642 step 9; got {before_addrs:?}"
+        );
+        assert_eq!(
+            before.targets.len(),
+            1,
+            "exactly one target (A) before heal"
+        );
+        assert_eq!(before.proximity_found, 1);
+        assert_eq!(
+            before.interest_found, 0,
+            "interest_found is vestigial after Source-2 removal and must report 0"
+        );
+
+        // THE HEAL: B's advertisement arrives. This mirrors the periodic
+        // InterestSync anti-entropy `HostingStateResponse` reconciliation
+        // (`ring.rs::interest_heartbeat`, #4722), which re-pulls a neighbor's
+        // hosted set as a `HostingAnnounce { is_response: true }`.
+        op_manager.neighbor_hosting.handle_message(
+            kp_b.public(),
+            crate::message::NeighborHostingMessage::HostingAnnounce {
+                added: vec![cid],
+                removed: vec![],
+                is_response: true,
+            },
+        );
+
+        // AFTER the heal: B is now an advertised co-host and IS a target.
+        let after = op_manager.get_broadcast_targets_update(&key, &sender_addr);
+        let after_addrs: std::collections::HashSet<std::net::SocketAddr> = after
+            .targets
+            .iter()
+            .filter_map(|p| p.socket_addr())
+            .collect();
+        assert!(
+            after_addrs.contains(&addr_a) && after_addrs.contains(&addr_b),
+            "after the advertisement heals, BOTH co-hosts must be broadcast targets; \
+             got {after_addrs:?}"
+        );
+        assert_eq!(after.targets.len(), 2, "both A and B after heal");
+        assert_eq!(after.proximity_found, 2);
+        assert_eq!(after.interest_found, 0);
     }
 
     /// THE re-root-storm falsifier (#4642 piece F, the load-bearing test). Drop a

--- a/crates/core/src/node/testing_impl/in_memory.rs
+++ b/crates/core/src/node/testing_impl/in_memory.rs
@@ -592,13 +592,15 @@ async fn append_contracts(
 ///
 /// It deliberately does NOT pre-register the subscriber's interest/subscription
 /// for any contract. Broadcast fan-out (`get_broadcast_targets_update`)
-/// enumerates the interest manager + proximity cache, not the raw connection
-/// set — and those are populated organically when each subscriber runs its real
-/// `Subscribe` operation, which now routes directly to the gateway over the
-/// injected connection (`subscribe.rs` calls `register_peer_interest` /
-/// `add_downstream_subscriber` on the host as it processes the inbound
-/// subscribe). So the scenario keeps using the genuine subscribe + interest +
-/// broadcast machinery; the ONLY thing replaced is the CONNECT handshake.
+/// enumerates the proximity cache of advertised co-hosts (Source 1; the
+/// interest-manager Source-2 arm was removed in #4642 step 9), not the raw
+/// connection set — and that is populated organically when each subscriber runs
+/// its real `Subscribe` operation, which now routes directly to the gateway
+/// over the injected connection (`subscribe.rs` calls `register_peer_interest` /
+/// `add_downstream_subscriber` and `announce_contract_hosted` on the host as it
+/// processes the inbound subscribe). So the scenario keeps using the genuine
+/// subscribe + advertisement + broadcast machinery; the ONLY thing replaced is
+/// the CONNECT handshake.
 ///
 /// `was_reserved: false` is correct because no reservation was ever made for
 /// these synthetic connections. A peer that the cap rejects (over

--- a/crates/core/src/operations/subscribe.rs
+++ b/crates/core/src/operations/subscribe.rs
@@ -799,6 +799,105 @@ pub(crate) async fn handle_unsubscribe_inbound(
 #[cfg(test)]
 mod tests;
 
+/// Source-scrape pins for the subscribe-seeds-state-via-GET invariant.
+///
+/// This is the load-bearing property that makes removing the Source-2
+/// (interest-manager) live-update fan-out safe (#4642 step 9, see
+/// `operations/update.rs::get_broadcast_targets_update`). Because
+/// `finalize_originator_subscribe` awaits `fetch_contract_if_missing` (which
+/// drives a sub-op GET) BEFORE it advertises hosting or returns subscribe
+/// success, a genuine subscriber pulls current state (including any
+/// already-committed UPDATE) via its OWN GET and never persists in the
+/// "interested but no local state" condition. That is why it is safe for live
+/// UPDATE fan-out to target advertised co-hosts only: a real subscriber has
+/// state and advertises, so it is a Source-1 target and has a non-empty summary.
+///
+/// If a future change let a peer register as a subscriber WITHOUT that seeding
+/// GET, a no-state subscriber relying on live fan-out would reappear and the
+/// Source-2 removal WOULD drop its first update. These pins fail loudly if the
+/// seed-GET is dropped, made fire-and-forget, or reordered after the advertise.
+#[cfg(test)]
+mod source_pin_tests {
+    /// Extract the balanced-brace body of the named `async fn` from this file.
+    /// The needle is composed at runtime so the pin does not match itself.
+    fn extract_fn_body(fn_name: &str) -> &'static str {
+        let src = include_str!("subscribe.rs");
+        let head = ["async fn ", fn_name, "("].concat();
+        let start = src
+            .find(&head)
+            .unwrap_or_else(|| panic!("`async fn {fn_name}(` must exist in subscribe.rs"));
+        let body_open = src[start..].find('{').map(|off| start + off).unwrap();
+        let mut depth: i32 = 0;
+        let mut end = body_open;
+        for (i, ch) in src[body_open..].char_indices() {
+            match ch {
+                '{' => depth += 1,
+                '}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        end = body_open + i + 1;
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        &src[start..end]
+    }
+
+    #[test]
+    fn subscribe_seeds_state_via_get_before_finalize() {
+        let body = extract_fn_body("finalize_originator_subscribe");
+
+        // (1) The seed-GET call is present at all.
+        let fetch_idx = body.find("fetch_contract_if_missing(").expect(
+            "#4642 step 9 safety: `finalize_originator_subscribe` MUST call \
+             `fetch_contract_if_missing` to seed baseline state via GET before \
+             finalizing. Without it, a peer can become a subscriber with no local \
+             state and rely on a live UPDATE fan-out that Source-2 removal deleted.",
+        );
+
+        // Match the CALL (`announce_contract_hosted(`), not the several prose
+        // mentions of the name in comments above it.
+        let announce_idx = body.find("announce_contract_hosted(").expect(
+            "`finalize_originator_subscribe` should still advertise hosting via \
+             `announce_contract_hosted`.",
+        );
+
+        // (2) The seed-GET precedes the advertise (seed BEFORE announce): a peer
+        // must not advertise itself as a host before it has pulled state.
+        assert!(
+            fetch_idx < announce_idx,
+            "#4642 step 9 safety: `fetch_contract_if_missing` (seed state via GET) \
+             must run BEFORE `announce_contract_hosted` in \
+             `finalize_originator_subscribe`. Advertising before seeding would make \
+             the peer a Source-1 target with no state.",
+        );
+
+        // (3) It is AWAITED (not fire-and-forget): the fetch result must gate the
+        // subsequent finalize steps, so a `.await` must appear between the call
+        // and the advertise.
+        assert!(
+            body[fetch_idx..announce_idx].contains(".await"),
+            "#4642 step 9 safety: the `fetch_contract_if_missing` seed-GET must be \
+             AWAITED before finalizing. A fire-and-forget fetch would let the \
+             subscription complete before state lands, reintroducing the no-state \
+             subscriber that live fan-out no longer covers.",
+        );
+
+        // (4) The fetch genuinely drives a GET (not merely a local cache peek), so
+        // committed-but-not-yet-seen state is actually pulled in.
+        let fetch_body = extract_fn_body("fetch_contract_if_missing");
+        assert!(
+            fetch_body.contains("start_sub_op_get")
+                || fetch_body.contains("start_targeted_sub_op_get"),
+            "#4642 step 9 safety: `fetch_contract_if_missing` must drive a sub-op \
+             GET (`start_sub_op_get` / `start_targeted_sub_op_get`) so a subscriber \
+             pulls current state, including any already-committed UPDATE.",
+        );
+    }
+}
+
 /// Task-per-transaction SUBSCRIBE drivers.
 pub(crate) mod op_ctx_task;
 

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -119,6 +119,11 @@ pub(crate) struct BroadcastTargetResult {
     pub targets: Vec<PeerKeyLocation>,
     pub proximity_found: usize,
     pub proximity_resolve_failed: usize,
+    /// Interest-manager (Source-2) fan-out was removed in #4642 step 9, so
+    /// these are always 0. They are retained for telemetry-schema continuity:
+    /// the #4281 propagation-stats window (`propagation_stats.rs`) and the
+    /// #3046 broadcast-delivery event (`tracing::register`) still carry them.
+    /// See `get_broadcast_targets_update`'s rustdoc.
     pub interest_found: usize,
     pub interest_resolve_failed: usize,
     pub skipped_self: usize,
@@ -269,12 +274,30 @@ impl OpManager {
 
     /// Resolve the set of peers to broadcast a state update to.
     ///
-    /// Combines the proximity neighbor cache (peers who announced they seed
-    /// the contract) with the interest manager (peers who expressed interest
-    /// via the protocol). Skips the sender (to avoid echo) and this node
-    /// (unless we are the local originator). Returns skip-reason counters
-    /// alongside the resolved targets for broadcast delivery diagnostics
-    /// (issue #3046).
+    /// Targets are the advertised co-hosts from the proximity neighbor cache
+    /// (peers who announced, via the advertisement layer, that they host this
+    /// contract). Skips the sender (to avoid echo) and this node (unless we are
+    /// the local originator). Returns skip-reason counters alongside the
+    /// resolved targets for broadcast delivery diagnostics (issue #3046).
+    ///
+    /// ## Source-1-only live fan-out (#4642 step 9)
+    ///
+    /// This previously unioned a second source — the interest manager's
+    /// `get_interested_peers` (peers who registered interest via the protocol).
+    /// That arm was removed. Under the demand-driven hosting model every co-host
+    /// advertises (so it is already a Source-1 target), and any transient gap
+    /// between "interested" and "advertised" is closed by the periodic
+    /// InterestSync anti-entropy heartbeat (~5 min), which re-pulls each
+    /// neighbor's hosted-contract set via `HostingStateRequest`
+    /// (`ring.rs::interest_heartbeat`, #4722). Live fan-out is therefore
+    /// advertised-co-hosts-only; anti-entropy is the healing backstop. See
+    /// `.claude/rules/hosting-invariants.md` invariant 1 and
+    /// `docs/design/demand-driven-hosting.md`.
+    ///
+    /// `InterestManager` itself is retained — it still drives proactive summary
+    /// notifications (`send_proactive_summary_notification`), interest-heartbeat
+    /// TTL refresh, and eviction demand-counting. Only the *state fan-out* arm
+    /// was removed here.
     pub(crate) fn get_broadcast_targets_update(
         &self,
         key: &ContractKey,
@@ -287,11 +310,13 @@ impl OpManager {
 
         let mut targets: HashSet<PeerKeyLocation> = HashSet::new();
         let mut proximity_resolve_failed: usize = 0;
-        let mut interest_resolve_failed: usize = 0;
         let mut skipped_self: usize = 0;
         let mut skipped_sender: usize = 0;
 
-        // Source 1: Proximity cache (peers who announced they seed this contract)
+        // Source 1 (the ONLY live fan-out source): the proximity cache of
+        // advertised co-hosts — peers who announced they host this contract via
+        // the advertisement layer. The former interest-manager arm (Source 2)
+        // was removed in #4642 step 9; see this function's rustdoc.
         let proximity_pub_keys = self.neighbor_hosting.neighbors_with_contract(key);
         let proximity_found = proximity_pub_keys.len();
 
@@ -320,43 +345,12 @@ impl OpManager {
             }
         }
 
-        // Source 2: Interest manager (peers who expressed interest via protocol)
-        let interested_peers = self.interest_manager.get_interested_peers(key);
-        let interest_found = interested_peers.len();
-
-        for (peer_key, _interest) in interested_peers {
-            if let Some(pkl) = self
-                .ring
-                .connection_manager
-                .get_peer_by_pub_key(&peer_key.0)
-            {
-                if let Some(pkl_addr) = pkl.socket_addr() {
-                    if &pkl_addr == sender && !is_local_update_initiator {
-                        skipped_sender += 1;
-                        continue;
-                    }
-                    if !is_local_update_initiator && self_addr.as_ref() == Some(&pkl_addr) {
-                        skipped_self += 1;
-                        continue;
-                    }
-                }
-                targets.insert(pkl);
-            } else {
-                interest_resolve_failed += 1;
-                // Counter (interest_resolve_failed) feeds the aggregate
-                // logged below — at INFO when targets were found,
-                // promoted to WARN when ALL targets failed to resolve
-                // (worst case, NO_TARGETS branch). Per-peer-miss DEBUG
-                // avoids the hundreds-per-hour spam on hot contracts.
-                tracing::debug!(
-                    contract = %format!("{:.8}", key),
-                    interest_peer = %peer_key.0,
-                    is_local = is_local_update_initiator,
-                    phase = "target_lookup_failed",
-                    "Interest manager peer not found in connection manager"
-                );
-            }
-        }
+        // Source 2 (interest manager) REMOVED in #4642 step 9. Do NOT re-add a
+        // fan-out arm here that unions `interest_manager.get_interested_peers`:
+        // an interest-only peer that has not yet advertised is reached by the
+        // anti-entropy heartbeat (which re-pulls its hosted set into Source-1),
+        // not by live fan-out. See this function's rustdoc and
+        // `.claude/rules/hosting-invariants.md` invariant 1.
 
         let mut result: Vec<PeerKeyLocation> = targets.into_iter().collect();
         result.sort();
@@ -373,7 +367,6 @@ impl OpManager {
                     .join(","),
                 count = result.len(),
                 proximity_sources = proximity_found,
-                interest_sources = interest_found,
                 phase = "broadcast",
                 "UPDATE_PROPAGATION"
             );
@@ -385,14 +378,13 @@ impl OpManager {
             // WARN in p2p_protoc.rs (grep for
             // "BROADCAST_NO_TARGETS: no targets found after"); the
             // per-attempt detail belongs in metrics/structured counters
-            // (interest_resolve_failed). Issue #4251 re-review M2.
+            // (proximity_resolve_failed). Issue #4251 re-review M2.
             tracing::debug!(
                 contract = %format!("{:.8}", key),
                 peer_addr = %sender,
                 self_addr = ?self_addr.map(|a| format!("{:.8}", a)),
                 proximity_sources = proximity_found,
-                interest_sources = interest_found,
-                interest_resolve_failed,
+                proximity_resolve_failed,
                 phase = "warning",
                 "UPDATE_PROPAGATION: NO_TARGETS - update will not propagate further"
             );
@@ -402,8 +394,10 @@ impl OpManager {
             targets: result,
             proximity_found,
             proximity_resolve_failed,
-            interest_found,
-            interest_resolve_failed,
+            // Source-2 interest fan-out removed in #4642 step 9; kept at 0 for
+            // telemetry-schema continuity (see the struct's field docs).
+            interest_found: 0,
+            interest_resolve_failed: 0,
             skipped_self,
             skipped_sender,
         }

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -282,22 +282,42 @@ impl OpManager {
     ///
     /// ## Source-1-only live fan-out (#4642 step 9)
     ///
-    /// This previously unioned a second source — the interest manager's
+    /// This previously unioned a second source: the interest manager's
     /// `get_interested_peers` (peers who registered interest via the protocol).
-    /// That arm was removed. Under the demand-driven hosting model every co-host
-    /// advertises (so it is already a Source-1 target), and any transient gap
-    /// between "interested" and "advertised" is closed by the periodic
-    /// InterestSync anti-entropy heartbeat (~5 min), which re-pulls each
-    /// neighbor's hosted-contract set via `HostingStateRequest`
-    /// (`ring.rs::interest_heartbeat`, #4722). Live fan-out is therefore
-    /// advertised-co-hosts-only; anti-entropy is the healing backstop. See
+    /// That arm was removed. Live fan-out is now advertised-co-hosts-only.
+    ///
+    /// Removing it does NOT drop a subscriber's update, because a genuine
+    /// subscriber never persists in the "interested but no local state" condition
+    /// that arm used to cover:
+    ///
+    /// 1. A subscriber seeds its own baseline state via its subscribe-GET before
+    ///    the subscription is finalized. `finalize_originator_subscribe`
+    ///    (`subscribe.rs`) awaits `fetch_contract_if_missing` (which drives a
+    ///    sub-op GET) and only returns success once current state, including any
+    ///    already-committed UPDATE, is stored locally. So no real subscriber is
+    ///    left relying on a live fan-out for its first copy of the state. Pinned
+    ///    by `subscribe_seeds_state_via_get_before_finalize` (`subscribe.rs`).
+    /// 2. Once it holds state it advertises (`announce_contract_hosted`), which
+    ///    makes it a Source-1 target for later live fan-out AND gives it a
+    ///    non-empty state summary. From then on the summary-based InterestSync
+    ///    anti-entropy (`node.rs` Summaries -> `SyncStateToPeer`) and the
+    ///    advertisement-reconciliation exchange keep it fresh if it ever misses a
+    ///    live update: the ~5-min `ring.rs::interest_heartbeat` sends each
+    ///    neighbor a `HostingStateRequest`, the neighbor replies with a
+    ///    `HostingStateResponse` snapshot of its hosted set, and we full-replace
+    ///    that into our Source-1 view (#4722).
+    ///
+    /// The summary-based anti-entropy path deliberately does NOT heal a peer with
+    /// no state: a `None` summary is skipped by the `zip` staleness gate in
+    /// `node.rs`. That is exactly why the subscribe-GET seeding in (1), not the
+    /// heartbeat, is the load-bearing safety property. See
     /// `.claude/rules/hosting-invariants.md` invariant 1 and
     /// `docs/design/demand-driven-hosting.md`.
     ///
-    /// `InterestManager` itself is retained — it still drives proactive summary
+    /// `InterestManager` itself is retained: it still drives proactive summary
     /// notifications (`send_proactive_summary_notification`), interest-heartbeat
-    /// TTL refresh, and eviction demand-counting. Only the *state fan-out* arm
-    /// was removed here.
+    /// TTL refresh, and eviction demand-counting. Only the state fan-out arm was
+    /// removed here.
     pub(crate) fn get_broadcast_targets_update(
         &self,
         key: &ContractKey,
@@ -346,10 +366,11 @@ impl OpManager {
         }
 
         // Source 2 (interest manager) REMOVED in #4642 step 9. Do NOT re-add a
-        // fan-out arm here that unions `interest_manager.get_interested_peers`:
-        // an interest-only peer that has not yet advertised is reached by the
-        // anti-entropy heartbeat (which re-pulls its hosted set into Source-1),
-        // not by live fan-out. See this function's rustdoc and
+        // fan-out arm here that unions `interest_manager.get_interested_peers`.
+        // A genuine subscriber does not stay "interested but stateless": it seeds
+        // baseline state via its own subscribe-GET before finalizing
+        // (`finalize_originator_subscribe`), then advertises and becomes a
+        // Source-1 target. See this function's rustdoc and
         // `.claude/rules/hosting-invariants.md` invariant 1.
 
         let mut result: Vec<PeerKeyLocation> = targets.into_iter().collect();

--- a/crates/core/src/operations/update/pending_broadcast.rs
+++ b/crates/core/src/operations/update/pending_broadcast.rs
@@ -23,23 +23,34 @@
 //!
 //! ## First-viable-target signal set (issue #4359 re-review, MUST-FIX 1)
 //!
-//! `get_broadcast_targets_update` resolves targets from two sources, so the
-//! flush must fire from BOTH:
+//! Since #4642 step 9, `get_broadcast_targets_update` resolves targets from a
+//! SINGLE source — the proximity cache of advertised co-hosts (Source 1). So
+//! the meaningful flush signal is:
 //!
-//! * **Source 2 — interest manager**: every `register_peer_interest` call that
-//!   returns "new" (downstream subscriber, originator upstream, GET-piggyback,
-//!   remote GET `subscribe=false`, and the Interests/ChangeInterests sync
-//!   handlers) calls [`OpManager::flush_pending_broadcast_on_interest`].
 //! * **Source 1 — proximity cache**: when a neighbor newly announces it hosts a
 //!   contract we also host (`NeighborHosting` overlap path), it becomes a
-//!   `neighbors_with_contract` target and the same flush fires.
+//!   `neighbors_with_contract` target and the flush fires, re-emitting the
+//!   stashed broadcast so it now reaches the freshly-advertised co-host.
+//!
+//! The interest-triggered flush call sites
+//! ([`OpManager::flush_pending_broadcast_on_interest`], invoked from every
+//! `register_peer_interest` that returns "new" — downstream subscriber,
+//! originator upstream, GET-piggyback, remote GET `subscribe=false`, and the
+//! Interests/ChangeInterests sync handlers) are LEFT IN PLACE but are now only
+//! an eager nudge: an interested-but-not-yet-advertised peer is NOT a broadcast
+//! target anymore (Source 2 was removed), so such a flush re-emits, finds no
+//! target, and simply re-stashes (or lets the entry expire at its TTL). It is
+//! harmless and cheap; a re-emit only actually propagates once the peer
+//! advertises (Source 1) — live, or reconciled by the anti-entropy heartbeat.
 //!
 //! That set is complete: a never-seen id can only gain a broadcast target by a
-//! peer expressing interest (Source 2) or a connected neighbor announcing it
-//! hosts the id (Source 1). The give-up path additionally re-checks targets
-//! immediately after stashing to close the stash-after-flush lost-wakeup race.
-//! The flush re-reads the *current* local state (not the stale give-up-time
-//! bytes) so a newer locally-applied UPDATE is never clobbered.
+//! connected neighbor advertising it hosts the id (Source 1), whether that
+//! advertisement arrives live or is reconciled by the ~5-min InterestSync
+//! anti-entropy heartbeat (`ring.rs::interest_heartbeat`, #4722). The give-up
+//! path additionally re-checks targets immediately after stashing to close the
+//! stash-after-flush lost-wakeup race. The flush re-reads the *current* local
+//! state (not the stale give-up-time bytes) so a newer locally-applied UPDATE
+//! is never clobbered.
 //!
 //! ## Bounding (per `.claude/rules/code-style.md` per-key-collection rule and
 //! the AGENTS.md "cleanup exemptions must be time-bounded" rule)

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -14120,6 +14120,261 @@ fn test_piece_b_anti_entropy_heals_demandless_copy() {
     freenet::dev_tool::clear_crdt_contracts();
 }
 
+/// Safety proof for #4642 step 9: removing the Source-2 (interest-manager)
+/// fan-out arm from live UPDATE propagation is safe because Source-1 (advertised
+/// co-hosts) delivers the live update to the mesh, and the InterestSync
+/// anti-entropy heartbeat is the backstop for a subscriber that missed the live
+/// fan-out (e.g. one whose advertisement lagged, or that was briefly
+/// unreachable).
+///
+/// The interest manager (Source 2) used to be resolved as broadcast targets for
+/// exactly the peers that register interest — i.e. SUBSCRIBERS. So the on-point
+/// end-to-end demonstration is that a SUBSCRIBED mesh member still converges
+/// with Source-2 gone:
+///
+/// * **Positive control (Source-1 live fan-out, no Source-2):** the reachable
+///   mesh subscribers receive the committed UPDATE and end fresh. Their only
+///   route to the live update is Source-1 (advertised co-hosts) — Source-2 is
+///   removed — so this asserts advertised-co-host fan-out alone delivers it.
+/// * **Backstop (anti-entropy heals the missed peer):** one mesh subscriber is
+///   crash-isolated across the UPDATE (the harness has no per-message-type loss
+///   knob, so a crash across the update is the deterministic proxy for "did not
+///   receive the live fan-out"), then recovered. With no NEW update after
+///   recovery, nothing re-pushes v2 via Source-1; only the periodic InterestSync
+///   anti-entropy exchange (`ring.rs::interest_heartbeat`, #4722) can bring it
+///   current. It MUST heal to v2 within the heartbeat window.
+///
+/// This is the end-to-end counterpart of the unit test
+/// `broadcast_targets_are_advertised_cohosts_only_and_heal_via_advertisement`
+/// (op_state_manager.rs), which pins the same guarantee at the
+/// `get_broadcast_targets_update` boundary. See
+/// `.claude/rules/hosting-invariants.md` invariant 1 and
+/// `docs/design/demand-driven-hosting.md`.
+#[test_log::test]
+fn test_step9_source2_removal_subscriber_heals_via_anti_entropy() {
+    use freenet::dev_tool::{Location, NodeLabel, ScheduledOperation, SimNetwork, SimOperation};
+
+    const SEED: u64 = 0x4642_0009_5AFE; // step-9, "SAFE"
+    const NETWORK_NAME: &str = "step9-source2-removal-heal";
+    const NUM_NODES: usize = 8;
+
+    setup_deterministic_state(SEED);
+
+    let contract = SimOperation::create_test_contract(0x59);
+    let contract_id = *contract.key().id();
+    let contract_key = contract.key();
+    let key_loc = Location::from(&contract_key).as_f64();
+    // CRDT-versioned states so the higher VERSION deterministically wins the
+    // anti-entropy merge (mirrors test_piece_b's rationale): v2 wins, and a
+    // stale copy pushing v1 back is a no-op.
+    freenet::dev_tool::register_crdt_contract(contract_id);
+    let state_v1 = SimOperation::create_crdt_state(1, 0x11);
+    let state_v2 = SimOperation::create_crdt_state(2, 0x22);
+
+    let wrap = |x: f64| x.rem_euclid(1.0);
+    let node_locations: Vec<f64> = (0..NUM_NODES)
+        .map(|i| wrap(key_loc + i as f64 / NUM_NODES as f64))
+        .collect();
+
+    let rt = create_runtime();
+    let sim = rt.block_on(async {
+        SimNetwork::new_with_node_locations(
+            NETWORK_NAME,
+            1,
+            NUM_NODES,
+            10,
+            7,
+            8,
+            3,
+            SEED,
+            &node_locations,
+        )
+        .await
+    });
+
+    let locs = sim.get_peer_locations();
+    let ranked = nodes_by_distance_to_key(&locs, NUM_NODES, key_loc);
+    let host_no = ranked[0]; // nearest the key: source of truth
+    let mesh_control_nos = [ranked[1], ranked[2]]; // subscribed, stay reachable (positive control)
+    let isolated_no = ranked[3]; // subscribed, crash-isolated across the UPDATE then RECOVERED
+
+    let host = NodeLabel::node(NETWORK_NAME, host_no);
+    let mesh_control: Vec<NodeLabel> = mesh_control_nos
+        .iter()
+        .map(|n| NodeLabel::node(NETWORK_NAME, *n))
+        .collect();
+    let isolated = NodeLabel::node(NETWORK_NAME, isolated_no);
+
+    tracing::info!(
+        key_loc,
+        host = host_no,
+        mesh_control = ?mesh_control_nos,
+        isolated = isolated_no,
+        "step-9 Source-2-removal heal: roles by ring distance to key"
+    );
+
+    let mut operations = Vec::new();
+    // 0. Source of truth near the key.
+    operations.push(ScheduledOperation::new(
+        host.clone(),
+        SimOperation::SeedHostedContract {
+            contract: contract.clone(),
+            state: state_v1.clone(),
+        },
+    ));
+    // 1. Reachable mesh: GET-with-subscribe joins the update mesh (positive
+    //    control that Source-1 live fan-out delivers the UPDATE, no Source-2).
+    for m in &mesh_control {
+        operations.push(ScheduledOperation::new(
+            m.clone(),
+            SimOperation::Get {
+                contract_id,
+                return_contract_code: true,
+                subscribe: true,
+            },
+        ));
+    }
+    // 2. Isolated mesh member: also GET-with-subscribe, so it is a genuine
+    //    subscriber (the exact peer class the removed Source-2 arm used to serve).
+    operations.push(ScheduledOperation::new(
+        isolated.clone(),
+        SimOperation::Get {
+            contract_id,
+            return_contract_code: true,
+            subscribe: true,
+        },
+    ));
+    // 3. Crash-isolate the ISOLATED subscriber BEFORE the UPDATE so it misses the
+    //    live fan-out — the deterministic proxy for "not reached by Source-1".
+    operations.push(ScheduledOperation::new(
+        isolated.clone(),
+        SimOperation::CrashNode,
+    ));
+    // 4. UPDATE to v2: host + reachable mesh refresh; the isolated copy misses it.
+    operations.push(ScheduledOperation::new(
+        host.clone(),
+        SimOperation::Update {
+            key: contract_key,
+            data: state_v2.clone(),
+        },
+    ));
+    // 5. RECOVER the ISOLATED subscriber: messages flow again, but there is no
+    //    NEW update, so Source-1 does not re-push v2 — only anti-entropy can
+    //    bring it current.
+    operations.push(ScheduledOperation::new(
+        isolated.clone(),
+        SimOperation::RecoverNode,
+    ));
+
+    let logs_handle = sim.event_logs_handle();
+    // Post-op wait must exceed one interest-heartbeat interval (300 s) plus the
+    // per-peer spread + push round-trip, so the periodic InterestSync exchange
+    // fires at least once after recovery. Turmoil virtual time makes this cheap.
+    let result = sim.run_controlled_simulation(
+        SEED,
+        operations,
+        Duration::from_secs(720),
+        Duration::from_secs(680),
+    );
+    assert!(
+        result.turmoil_result.is_ok(),
+        "step-9 heal sim failed: {:?}",
+        result.turmoil_result.err()
+    );
+
+    let logs = rt.block_on(async { logs_handle.lock().await.clone() });
+    let metrics = compute_piece_e_metrics(&result, &logs, &contract_key, &host, &[], &mesh_control);
+
+    let v1_hash = freenet::tracing::state_hash_short(&freenet_stdlib::prelude::WrappedState::new(
+        state_v1.clone(),
+    ));
+    let v2_hash = freenet::tracing::state_hash_short(&freenet_stdlib::prelude::WrappedState::new(
+        state_v2.clone(),
+    ));
+    let hash_of = |label: &NodeLabel| -> Option<String> {
+        result
+            .node_storages
+            .get(label)
+            .and_then(|s| s.get_stored_state(&contract_key))
+            .map(|ws| freenet::tracing::state_hash_short(&ws))
+    };
+    let host_current = hash_of(&host);
+    let isolated_hash = hash_of(&isolated);
+    let isolated_hosting = result.is_node_hosting(&isolated, &contract_key);
+
+    tracing::info!(target: "step9_heal",
+        "===== STEP-9 SOURCE-2-REMOVAL HEAL (seed=0x{SEED:X}) =====");
+    tracing::info!(target: "step9_heal", "  v1={v1_hash} v2={v2_hash} host_current={host_current:?}");
+    tracing::info!(target: "step9_heal",
+        "  ISOLATED subscriber: hash={isolated_hash:?} hosting={isolated_hosting} (recovered; must HEAL to v2)");
+    tracing::info!(target: "step9_heal",
+        "  mesh subscribers fresh (Source-1 live fan-out): {}/{}",
+        metrics.subscribers_fresh, metrics.subscribers_total);
+    tracing::info!(target: "step9_heal",
+        "  crash packets dropped (isolation took effect): {}", result.crash_packets_dropped());
+    tracing::info!(target: "step9_heal", "===== END =====");
+
+    // --- Assertions ---
+    // (1) The UPDATE is a real state change.
+    assert_ne!(
+        v1_hash, v2_hash,
+        "v1 and v2 must differ — the UPDATE must be a real state change"
+    );
+    // (2) The UPDATE applied at HOST (defines "current" = v2).
+    assert_eq!(
+        host_current.as_deref(),
+        Some(v2_hash.as_str()),
+        "UPDATE must apply at HOST (host_current should equal v2)"
+    );
+    // (3) POSITIVE CONTROL: the reachable mesh subscribers received the live
+    //     UPDATE and ended fresh. Their ONLY route to the live update is Source-1
+    //     (advertised co-hosts) — Source-2 was removed in step 9 — so this
+    //     asserts advertised-co-host fan-out alone delivers a committed UPDATE.
+    assert!(
+        metrics.subscribers_total >= 2,
+        "test wiring: expected >=2 reachable mesh subscribers, got {}",
+        metrics.subscribers_total
+    );
+    assert_eq!(
+        metrics.subscribers_fresh, metrics.subscribers_total,
+        "reachable mesh subscribers must all be fresh via Source-1 live fan-out \
+         ({}/{}) — a stale subscriber means advertised-co-host fan-out failed to \
+         deliver the UPDATE without Source-2",
+        metrics.subscribers_fresh, metrics.subscribers_total
+    );
+    // (4) The isolation genuinely took effect — the isolated subscriber provably
+    //     missed the live fan-out.
+    assert!(
+        result.crash_packets_dropped() > 0,
+        "crash-isolation had no effect (no packets dropped) — the subscriber did \
+         not miss the update, so the heal below would not exercise anti-entropy"
+    );
+    // (5) The isolated node is a genuine hosting subscriber.
+    assert!(
+        isolated_hosting,
+        "isolated node must host the contract (it GET-subscribed), got hosting=false"
+    );
+    // (6) PRIMARY (step 9 safety): the recovered subscriber HEALED to the current
+    //     state via the anti-entropy backstop. With Source-2 removed and no new
+    //     update after recovery, this is the ONLY mechanism that can bring a
+    //     subscriber that missed the live fan-out current. If this FAILS,
+    //     removing Source-2 dropped an update the backstop did not recover.
+    assert_eq!(
+        isolated_hash.as_deref(),
+        Some(v2_hash.as_str()),
+        "STEP-9: the recovered subscriber MUST heal to v2 via anti-entropy \
+         (isolated_hash={isolated_hash:?}, v2={v2_hash}, host_current={host_current:?})"
+    );
+    assert_eq!(
+        isolated_hash.as_deref(),
+        host_current.as_deref(),
+        "STEP-9: the recovered subscriber MUST converge with the source of truth"
+    );
+
+    // Avoid leaking the CRDT registration into other tests sharing this process.
+    freenet::dev_tool::clear_crdt_contracts();
+}
+
 // =============================================================================
 // Summary-first PUT (#4642 step 3-bis) — behavioral simulation tests
 // =============================================================================


### PR DESCRIPTION
## Problem

Live UPDATE fan-out resolved broadcast targets from **two** sources, unioned in
`get_broadcast_targets_update` (`crates/core/src/operations/update.rs`):

- **Source 1** — `neighbor_hosting.neighbors_with_contract(key)`: advertised
  co-hosts (peers that announced, via the advertisement layer, that they host
  the contract).
- **Source 2** — `interest_manager.get_interested_peers(key)`: peers that
  registered interest via the protocol.

Under the demand-driven hosting model (`.claude/rules/hosting-invariants.md`
invariant 1, `docs/design/demand-driven-hosting.md`), live fan-out is defined as
**Source-1 only**, with the periodic InterestSync **anti-entropy heartbeat** as
the healing backstop. Source 2 is redundant: every co-host advertises (so it is
already a Source-1 target), and any transient gap between "interested" and
"advertised" is closed by the ~5-min heartbeat, which re-pulls each neighbor's
hosted-contract set via `HostingStateRequest` (`ring.rs::interest_heartbeat`,
#4722). This is R4 step 9 of the demand-driven hosting epic (#4642).

## Approach

Remove **only** the Source-2 fan-out arm from `get_broadcast_targets_update`;
keep Source-1. This is narrowly the *state fan-out* arm:

- `InterestManager` and `get_interested_peers` are **retained** — other live
  consumers stay wired: `send_proactive_summary_notification` (proactive summary
  fan-out), the interest-heartbeat TTL refresh, and eviction demand-counting.
- The `#4359` fresh-PUT deferred-broadcast flush call sites are **left intact**.
  An interest-triggered flush that now finds no Source-1 target simply
  re-stashes or lets the entry expire at its TTL — harmless and cheap. The
  meaningful flush signal is now Source-1 (a neighbor advertising, live or
  reconciled by anti-entropy). Module/dispatch docs updated to say so
  (`pending_broadcast.rs`, `op_state_manager.rs::flush_pending_broadcast_on_interest`).
- No wire change: `BroadcastStateChange` is an internal `NodeEvent`, so **no
  version gate** is needed.
- The `interest_found` / `interest_resolve_failed` fields on
  `BroadcastTargetResult` are kept (now always 0) for telemetry-schema
  continuity — the #4281 propagation-stats window and the #3046 delivery event
  still carry them. A follow-up cleanup can retire the vestigial fields.

## Testing

The safety proof is that a subscriber not reached by live Source-1 fan-out still
converges via the anti-entropy backstop.

- **Simulation (the safety proof)**:
  `test_step9_source2_removal_subscriber_heals_via_anti_entropy`
  (`simulation_integration.rs`). A subscribed mesh commits an UPDATE; the
  reachable mesh subscribers end fresh via **Source-1 live fan-out alone**
  (positive control — their only route to the live update is advertised-co-host
  fan-out, Source-2 being gone). One mesh subscriber is crash-isolated across
  the UPDATE (the harness has no per-message-type loss knob, so a crash across
  the update is the deterministic proxy for "did not receive the live fan-out"),
  then recovered; with no new update after recovery, only the anti-entropy
  heartbeat can bring it current, and it MUST heal to v2 within the heartbeat
  window. Modeled on the proven `test_piece_b_anti_entropy_heals_demandless_copy`
  (720 s / 680 s virtual time).
- **Unit (the boundary proof)**:
  `broadcast_targets_are_advertised_cohosts_only_and_heal_via_advertisement`
  (`op_state_manager.rs`). At the `get_broadcast_targets_update` boundary:
  (1) an interest-only peer (registered but not yet advertised — the lagged case)
  is EXCLUDED; (2) an advertised co-host IS included; (3) the anti-entropy heal
  (a `HostingAnnounce { is_response: true }`, exactly what the heartbeat's
  `HostingStateResponse` reconciliation delivers) makes the lagged peer a target.
- **Regression**: the #4359 pending-broadcast flush tests and the existing
  `test_subscription_broadcast_propagation` / `test_piece_b` sims remain green
  (Source-1 path and anti-entropy backstop both intact).

## Precondition

Depends on R1 advertisement-layer reliability (#4722) — the anti-entropy
`HostingStateRequest`/`HostingStateResponse` reconciliation that backstops this
removal — which is live and field-validated since 0.2.94.

## Review / merge

- **Full-tier multi-model review required** (UPDATE broadcast path — the
  #3791 fan-out / #4145/#4231 backpressure incident family).
- **Merge HELD** pending review AND the findability-investigation verdict for
  the epic. Do not auto-merge.

Part of #4642 (R4 step 9).

[AI-assisted - Claude]
