### PR TITLE
fix(fdev): add configurable response timeout with distinct exit code

### DIFF
--- a/crates/fdev/src/commands.rs
+++ b/crates/fdev/src/commands.rs
@@ -16,11 +16,69 @@ use crate::config::{BaseConfig, GetConfig, PutConfig, SubscribeConfig, UpdateCon
 
 mod v1;
 
-/// Timeout for waiting for server responses.
+/// Default timeout for waiting for server responses.
 /// Contract operations (especially updates with large state) may take time to process
 /// and propagate through the network. Network publish operations may require forwarding
 /// through multiple hops, so we use a generous timeout.
-pub(crate) const RESPONSE_TIMEOUT: Duration = Duration::from_secs(300);
+pub(crate) const DEFAULT_RESPONSE_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// Environment variable that overrides the default response timeout (in seconds).
+/// A `--timeout` CLI flag, when present, takes precedence over this variable.
+/// See issue #4102.
+pub(crate) const RESPONSE_TIMEOUT_ENV: &str = "FDEV_RESPONSE_TIMEOUT";
+
+/// Error returned when the node did not deliver a response within the configured
+/// timeout window. The operation may still have succeeded on the node/network —
+/// see issue #4102. `fdev` maps this to a distinct process exit code (3) so that
+/// release automation can verify out-of-band before treating it as a hard failure.
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "Timeout waiting for server response for {target} after {} seconds.\n\
+     The operation may have succeeded on the network - verify out-of-band \
+     (e.g. fetch the contract over the HTTP API) before treating this as a \
+     failure. Increase the wait with --timeout <seconds> or the \
+     FDEV_RESPONSE_TIMEOUT env var. See issue #4102.",
+    .timeout.as_secs()
+)]
+pub(crate) struct ResponseTimeout {
+    /// Human-readable description of what was awaited, e.g. "contract <key>".
+    pub(crate) target: String,
+    /// The timeout window that elapsed.
+    pub(crate) timeout: Duration,
+}
+
+/// Resolve the response timeout with precedence: explicit `--timeout` flag >
+/// `FDEV_RESPONSE_TIMEOUT` env var > [`DEFAULT_RESPONSE_TIMEOUT`].
+///
+/// A zero or non-numeric value — from either the flag or the env var — is
+/// ignored (falls back to the default) so neither a malformed environment nor
+/// an explicit `--timeout 0` ever silently disables the wait (which would
+/// produce an immediate timeout without the request ever being awaited).
+/// See issue #4102.
+pub(crate) fn resolve_response_timeout(cli: Option<u64>) -> Duration {
+    resolve_response_timeout_from(cli, std::env::var(RESPONSE_TIMEOUT_ENV).ok())
+}
+
+/// Pure inner form of [`resolve_response_timeout`], parameterized on the env
+/// value so it can be unit-tested without mutating the process environment.
+fn resolve_response_timeout_from(cli: Option<u64>, env: Option<String>) -> Duration {
+    // `--timeout 0` is treated the same as `FDEV_RESPONSE_TIMEOUT=0`: ignored,
+    // so a zero never disables the wait and produces a spurious "may have
+    // succeeded" timeout before anything is awaited. See issue #4102.
+    if let Some(secs) = cli {
+        if secs > 0 {
+            return Duration::from_secs(secs);
+        }
+    }
+    if let Some(raw) = env {
+        if let Ok(secs) = raw.trim().parse::<u64>() {
+            if secs > 0 {
+                return Duration::from_secs(secs);
+            }
+        }
+    }
+    DEFAULT_RESPONSE_TIMEOUT
+}
 
 #[derive(Debug, Clone, clap::Subcommand)]
 pub(crate) enum PutType {
@@ -215,13 +273,14 @@ async fn put_contract(
     execute_command(request, &mut client).await?;
 
     // Wait for server response before closing connection (with timeout)
+    let timeout = resolve_response_timeout(config.timeout);
     tracing::info!(
         %key,
         "Request submitted, waiting for network response (timeout: {}s)...",
-        RESPONSE_TIMEOUT.as_secs()
+        timeout.as_secs()
     );
 
-    let result = match tokio::time::timeout(RESPONSE_TIMEOUT, client.recv()).await {
+    let result = match tokio::time::timeout(timeout, client.recv()).await {
         Ok(Ok(HostResponse::ContractResponse(ContractResponse::PutResponse {
             key: response_key,
         }))) => {
@@ -241,14 +300,11 @@ async fn put_contract(
         }
         Ok(Ok(other)) => Err(anyhow::anyhow!("Unexpected response type: {:?}", other)),
         Ok(Err(e)) => Err(anyhow::anyhow!("Failed to receive response: {e}")),
-        Err(_) => Err(anyhow::anyhow!(
-            "Timeout waiting for server response for contract {key} after {} seconds.\n\
-             The operation may have succeeded on the network - check server logs.\n\
-             If this timeout is consistently too short, consider:\n\
-             - Network latency between you and the gateway\n\
-             - Contract size and propagation time through the network",
-            RESPONSE_TIMEOUT.as_secs()
-        )),
+        Err(_) => Err(ResponseTimeout {
+            target: format!("contract {key}"),
+            timeout,
+        }
+        .into()),
     };
 
     // Always gracefully close the WebSocket connection, even on timeout/error
@@ -304,28 +360,25 @@ async fn put_delegate(
     execute_command(request, &mut client).await?;
 
     // Wait for server response before closing connection (with timeout)
+    let timeout = resolve_response_timeout(config.timeout);
     tracing::info!(
         delegate = %delegate_key.encode(),
         "Request submitted, waiting for network response (timeout: {}s)...",
-        RESPONSE_TIMEOUT.as_secs()
+        timeout.as_secs()
     );
 
-    let result = match tokio::time::timeout(RESPONSE_TIMEOUT, client.recv()).await {
+    let result = match tokio::time::timeout(timeout, client.recv()).await {
         Ok(Ok(HostResponse::DelegateResponse { key, values })) => {
             tracing::info!(%key, response_count = values.len(), "Delegate registered successfully");
             Ok(())
         }
         Ok(Ok(other)) => Err(anyhow::anyhow!("Unexpected response type: {:?}", other)),
         Ok(Err(e)) => Err(anyhow::anyhow!("Failed to receive response: {e}")),
-        Err(_) => Err(anyhow::anyhow!(
-            "Timeout waiting for server response for delegate {} after {} seconds.\n\
-             The operation may have succeeded on the network - check server logs.\n\
-             If this timeout is consistently too short, consider:\n\
-             - Network latency between you and the gateway\n\
-             - Delegate size and propagation time through the network",
-            delegate_key.encode(),
-            RESPONSE_TIMEOUT.as_secs()
-        )),
+        Err(_) => Err(ResponseTimeout {
+            target: format!("delegate {}", delegate_key.encode()),
+            timeout,
+        }
+        .into()),
     };
 
     // Always gracefully close the WebSocket connection, even on timeout/error
@@ -377,13 +430,14 @@ pub async fn update(config: UpdateConfig, other: BaseConfig) -> anyhow::Result<(
     execute_command(request, &mut client).await?;
 
     // Wait for server response before closing connection (with timeout)
+    let timeout = resolve_response_timeout(config.timeout);
     tracing::info!(
         %key,
         "Request submitted, waiting for network response (timeout: {}s)...",
-        RESPONSE_TIMEOUT.as_secs()
+        timeout.as_secs()
     );
 
-    let result = match tokio::time::timeout(RESPONSE_TIMEOUT, client.recv()).await {
+    let result = match tokio::time::timeout(timeout, client.recv()).await {
         Ok(Ok(HostResponse::ContractResponse(ContractResponse::UpdateResponse {
             key: response_key,
             summary,
@@ -396,14 +450,11 @@ pub async fn update(config: UpdateConfig, other: BaseConfig) -> anyhow::Result<(
         }
         Ok(Ok(other)) => Err(anyhow::anyhow!("Unexpected response type: {:?}", other)),
         Ok(Err(e)) => Err(anyhow::anyhow!("Failed to receive response: {e}")),
-        Err(_) => Err(anyhow::anyhow!(
-            "Timeout waiting for server response for contract {key} after {} seconds.\n\
-             The operation may have succeeded on the network - check server logs.\n\
-             If this timeout is consistently too short, consider:\n\
-             - Network latency between you and the gateway\n\
-             - State delta size and propagation time through the network",
-            RESPONSE_TIMEOUT.as_secs()
-        )),
+        Err(_) => Err(ResponseTimeout {
+            target: format!("contract {key}"),
+            timeout,
+        }
+        .into()),
     };
 
     // Always gracefully close the WebSocket connection, even on timeout/error
@@ -427,7 +478,8 @@ pub async fn get(config: GetConfig, other: BaseConfig) -> anyhow::Result<()> {
     let mut client = start_api_client(other).await?;
     execute_command(request, &mut client).await?;
 
-    let result = match tokio::time::timeout(RESPONSE_TIMEOUT, client.recv()).await {
+    let timeout = resolve_response_timeout(config.timeout);
+    let result = match tokio::time::timeout(timeout, client.recv()).await {
         Ok(Ok(HostResponse::ContractResponse(ContractResponse::GetResponse {
             key: response_key,
             state,
@@ -453,10 +505,11 @@ pub async fn get(config: GetConfig, other: BaseConfig) -> anyhow::Result<()> {
         }
         Ok(Ok(other)) => Err(anyhow::anyhow!("Unexpected response type: {:?}", other)),
         Ok(Err(e)) => Err(anyhow::anyhow!("Failed to receive response: {e}")),
-        Err(_) => Err(anyhow::anyhow!(
-            "Timeout waiting for get response for contract {key} after {} seconds",
-            RESPONSE_TIMEOUT.as_secs()
-        )),
+        Err(_) => Err(ResponseTimeout {
+            target: format!("contract {key}"),
+            timeout,
+        }
+        .into()),
     };
 
     close_api_client(&mut client).await;
@@ -477,7 +530,8 @@ pub async fn subscribe(config: SubscribeConfig, other: BaseConfig) -> anyhow::Re
     execute_command(request, &mut client).await?;
 
     // Wait for initial subscribe confirmation
-    match tokio::time::timeout(RESPONSE_TIMEOUT, client.recv()).await {
+    let timeout = resolve_response_timeout(config.timeout);
+    match tokio::time::timeout(timeout, client.recv()).await {
         Ok(Ok(HostResponse::ContractResponse(ContractResponse::SubscribeResponse {
             key: response_key,
             subscribed: true,
@@ -507,10 +561,11 @@ pub async fn subscribe(config: SubscribeConfig, other: BaseConfig) -> anyhow::Re
         }
         Err(_) => {
             close_api_client(&mut client).await;
-            return Err(anyhow::anyhow!(
-                "Timeout waiting for subscribe response after {} seconds",
-                RESPONSE_TIMEOUT.as_secs()
-            ));
+            return Err(ResponseTimeout {
+                target: format!("contract {key} (subscribe)"),
+                timeout,
+            }
+            .into());
         }
     }
 
@@ -777,5 +832,104 @@ mod tests {
         assert!(matches!(wrapped, UpdateData::Delta(_)));
         assert_eq!(extract_update_bytes(&wrapped), bytes.as_slice());
         assert_eq!(describe_update_variant(&wrapped), "delta");
+    }
+
+    // ---------------------------------------------------------------
+    // #4102: configurable response timeout + distinguishable timeout
+    // error. These reference `resolve_response_timeout_from` and
+    // `ResponseTimeout`, which do not exist on pre-fix code.
+    // ---------------------------------------------------------------
+
+    /// Explicit `--timeout` flag wins over env var and default.
+    #[test]
+    fn timeout_flag_takes_precedence() {
+        let d = resolve_response_timeout_from(Some(600), Some("90".to_string()));
+        assert_eq!(d, Duration::from_secs(600));
+        // Even a garbage env value is irrelevant when the flag is set.
+        let d = resolve_response_timeout_from(Some(600), Some("not-a-number".to_string()));
+        assert_eq!(d, Duration::from_secs(600));
+    }
+
+    /// #4102: `--timeout 0` is rejected the same way `FDEV_RESPONSE_TIMEOUT=0`
+    /// is — it must NOT be honored as an immediate timeout (which would emit a
+    /// spurious "may have succeeded" before the request is ever awaited).
+    /// A zero flag falls back to the env var, and to the default when the env
+    /// is also unset/zero.
+    #[test]
+    fn timeout_flag_zero_falls_back() {
+        // Zero flag, no env → default.
+        assert_eq!(
+            resolve_response_timeout_from(Some(0), None),
+            DEFAULT_RESPONSE_TIMEOUT
+        );
+        // Zero flag, zero env → still the default (never disabled).
+        assert_eq!(
+            resolve_response_timeout_from(Some(0), Some("0".to_string())),
+            DEFAULT_RESPONSE_TIMEOUT
+        );
+        // Zero flag defers to a valid env value rather than short-circuiting.
+        assert_eq!(
+            resolve_response_timeout_from(Some(0), Some("90".to_string())),
+            Duration::from_secs(90)
+        );
+    }
+
+    /// Env var is used when no flag is given.
+    #[test]
+    fn timeout_env_used_when_no_flag() {
+        let d = resolve_response_timeout_from(None, Some("90".to_string()));
+        assert_eq!(d, Duration::from_secs(90));
+        // Surrounding whitespace is tolerated.
+        let d = resolve_response_timeout_from(None, Some("  120 ".to_string()));
+        assert_eq!(d, Duration::from_secs(120));
+    }
+
+    /// Neither flag nor env → the 300s default.
+    #[test]
+    fn timeout_defaults_when_absent() {
+        let d = resolve_response_timeout_from(None, None);
+        assert_eq!(d, DEFAULT_RESPONSE_TIMEOUT);
+        assert_eq!(d, Duration::from_secs(300));
+    }
+
+    /// A zero or non-numeric env value is rejected and falls back to the
+    /// default rather than silently disabling the wait.
+    #[test]
+    fn timeout_env_zero_or_garbage_falls_back_to_default() {
+        assert_eq!(
+            resolve_response_timeout_from(None, Some("0".to_string())),
+            DEFAULT_RESPONSE_TIMEOUT
+        );
+        assert_eq!(
+            resolve_response_timeout_from(None, Some("not-a-number".to_string())),
+            DEFAULT_RESPONSE_TIMEOUT
+        );
+        assert_eq!(
+            resolve_response_timeout_from(None, Some(String::new())),
+            DEFAULT_RESPONSE_TIMEOUT
+        );
+    }
+
+    /// The timeout error survives conversion into `anyhow::Error` and can be
+    /// downcast back to `ResponseTimeout`, so `main` can map it to a distinct
+    /// exit code. The "may have succeeded" wording is preserved for humans.
+    #[test]
+    fn response_timeout_downcasts_through_anyhow() {
+        let err: anyhow::Error = ResponseTimeout {
+            target: "contract ABC".to_string(),
+            timeout: Duration::from_secs(300),
+        }
+        .into();
+        let downcast = err.downcast_ref::<ResponseTimeout>();
+        assert!(
+            downcast.is_some(),
+            "timeout error must remain downcastable to ResponseTimeout"
+        );
+        assert_eq!(downcast.unwrap().timeout, Duration::from_secs(300));
+        assert!(err.to_string().contains("may have succeeded"));
+
+        // A different error type must NOT downcast to ResponseTimeout.
+        let other: anyhow::Error = anyhow::anyhow!("some other failure");
+        assert!(other.downcast_ref::<ResponseTimeout>().is_none());
     }
 }

--- a/crates/fdev/src/config.rs
+++ b/crates/fdev/src/config.rs
@@ -121,6 +121,11 @@ pub struct GetConfig {
     /// Write the state to a file instead of stdout.
     #[arg(short, long)]
     pub(crate) output: Option<PathBuf>,
+    /// Maximum seconds to wait for the node's response before giving up.
+    /// Takes precedence over the `FDEV_RESPONSE_TIMEOUT` env var; when neither
+    /// is set the default of 300s applies. See issue #4102.
+    #[arg(long)]
+    pub(crate) timeout: Option<u64>,
 }
 
 /// Subscribes to a contract and streams update notifications until interrupted.
@@ -131,6 +136,11 @@ pub struct SubscribeConfig {
     /// Write each update to a file (overwritten on each update) instead of stdout.
     #[arg(short, long)]
     pub(crate) output: Option<PathBuf>,
+    /// Maximum seconds to wait for the node's initial subscribe confirmation
+    /// before giving up. Takes precedence over the `FDEV_RESPONSE_TIMEOUT` env
+    /// var; when neither is set the default of 300s applies. See issue #4102.
+    #[arg(long)]
+    pub(crate) timeout: Option<u64>,
 }
 
 /// Updates a contract in the network.
@@ -151,6 +161,11 @@ pub struct UpdateConfig {
     /// contract's `update_state` only accepts full-state replacements.
     #[arg(long)]
     pub(crate) as_state: bool,
+    /// Maximum seconds to wait for the node's response before giving up.
+    /// Takes precedence over the `FDEV_RESPONSE_TIMEOUT` env var; when neither
+    /// is set the default of 300s applies. See issue #4102.
+    #[arg(long)]
+    pub(crate) timeout: Option<u64>,
 }
 
 /// Publishes a new contract or delegate to the network.
@@ -173,6 +188,12 @@ pub struct PutConfig {
     /// Flag that indicates if the node should subscribe to the contract.
     #[arg(long)]
     pub(crate) subscribe: bool,
+
+    /// Maximum seconds to wait for the node's response before giving up.
+    /// Takes precedence over the `FDEV_RESPONSE_TIMEOUT` env var; when neither
+    /// is set the default of 300s applies. See issue #4102.
+    #[arg(long)]
+    pub(crate) timeout: Option<u64>,
 }
 
 /// Builds and packages a contract or delegate.
@@ -328,5 +349,175 @@ mod tests {
             result.is_err(),
             "fdev execute update with a third positional arg should fail after #4088 removal"
         );
+    }
+
+    // -----------------------------------------------------------------
+    // #4102: `--timeout <seconds>` on publish / execute {put,get,update}.
+    // These parse assertions fail to COMPILE on pre-fix code because the
+    // `timeout` field does not exist on the config structs yet.
+    // -----------------------------------------------------------------
+
+    use super::{NodeCommand, SubCommand};
+    use crate::commands::PutType;
+
+    #[test]
+    fn publish_accepts_timeout_flag() {
+        let config = Config::try_parse_from([
+            "fdev",
+            "publish",
+            "--code",
+            "contract.wasm",
+            "--timeout",
+            "600",
+            "contract",
+        ])
+        .expect("publish --timeout 600 should parse");
+        match config.sub_command {
+            SubCommand::Publish(put) => {
+                assert_eq!(put.timeout, Some(600));
+                assert!(matches!(put.package_type, PutType::Contract(_)));
+            }
+            _ => panic!("expected Publish subcommand"),
+        }
+    }
+
+    #[test]
+    fn publish_timeout_defaults_to_none_when_omitted() {
+        let config =
+            Config::try_parse_from(["fdev", "publish", "--code", "contract.wasm", "contract"])
+                .expect("publish without --timeout should parse");
+        match config.sub_command {
+            SubCommand::Publish(put) => assert_eq!(put.timeout, None),
+            _ => panic!("expected Publish subcommand"),
+        }
+    }
+
+    #[test]
+    fn execute_put_accepts_timeout_flag() {
+        let config = Config::try_parse_from([
+            "fdev",
+            "execute",
+            "put",
+            "--code",
+            "contract.wasm",
+            "--timeout",
+            "45",
+            "contract",
+        ])
+        .expect("execute put --timeout 45 should parse");
+        match config.sub_command {
+            SubCommand::Execute(run) => match run.command {
+                NodeCommand::Put(put) => assert_eq!(put.timeout, Some(45)),
+                _ => panic!("expected Put command"),
+            },
+            _ => panic!("expected Execute subcommand"),
+        }
+    }
+
+    #[test]
+    fn execute_get_accepts_timeout_flag() {
+        let config = Config::try_parse_from([
+            "fdev",
+            "execute",
+            "get",
+            "SomeBase58ContractKey",
+            "--timeout",
+            "42",
+        ])
+        .expect("execute get --timeout 42 should parse");
+        match config.sub_command {
+            SubCommand::Execute(run) => match run.command {
+                NodeCommand::Get(get) => assert_eq!(get.timeout, Some(42)),
+                _ => panic!("expected Get command"),
+            },
+            _ => panic!("expected Execute subcommand"),
+        }
+    }
+
+    #[test]
+    fn execute_update_accepts_timeout_flag() {
+        let config = Config::try_parse_from([
+            "fdev",
+            "execute",
+            "update",
+            "SomeBase58ContractKey",
+            "/tmp/delta.bin",
+            "--timeout",
+            "42",
+        ])
+        .expect("execute update --timeout 42 should parse");
+        match config.sub_command {
+            SubCommand::Execute(run) => match run.command {
+                NodeCommand::Update(update) => assert_eq!(update.timeout, Some(42)),
+                _ => panic!("expected Update command"),
+            },
+            _ => panic!("expected Execute subcommand"),
+        }
+    }
+
+    #[test]
+    fn execute_subscribe_accepts_timeout_flag() {
+        let config = Config::try_parse_from([
+            "fdev",
+            "execute",
+            "subscribe",
+            "SomeBase58ContractKey",
+            "--timeout",
+            "42",
+        ])
+        .expect("execute subscribe --timeout 42 should parse");
+        match config.sub_command {
+            SubCommand::Execute(run) => match run.command {
+                NodeCommand::Subscribe(subscribe) => assert_eq!(subscribe.timeout, Some(42)),
+                _ => panic!("expected Subscribe command"),
+            },
+            _ => panic!("expected Execute subcommand"),
+        }
+    }
+
+    #[test]
+    fn website_publish_accepts_timeout_flag() {
+        use crate::website::WebsiteCommand;
+        let config = Config::try_parse_from([
+            "fdev",
+            "website",
+            "publish",
+            "/tmp/site",
+            "--key",
+            "my-site",
+            "--timeout",
+            "120",
+        ])
+        .expect("website publish --timeout 120 should parse");
+        match config.sub_command {
+            SubCommand::Website { command } => match command {
+                WebsiteCommand::Publish { timeout, .. } => assert_eq!(timeout, Some(120)),
+                _ => panic!("expected Publish website command"),
+            },
+            _ => panic!("expected Website subcommand"),
+        }
+    }
+
+    #[test]
+    fn website_update_accepts_timeout_flag() {
+        use crate::website::WebsiteCommand;
+        let config = Config::try_parse_from([
+            "fdev",
+            "website",
+            "update",
+            "/tmp/site",
+            "--key",
+            "my-site",
+            "--timeout",
+            "120",
+        ])
+        .expect("website update --timeout 120 should parse");
+        match config.sub_command {
+            SubCommand::Website { command } => match command {
+                WebsiteCommand::Update { timeout, .. } => assert_eq!(timeout, Some(120)),
+                _ => panic!("expected Update website command"),
+            },
+            _ => panic!("expected Website subcommand"),
+        }
     }
 }

--- a/crates/fdev/src/main.rs
+++ b/crates/fdev/src/main.rs
@@ -37,6 +37,30 @@ enum Error {
     CommandFailed(&'static str),
 }
 
+/// Process exit code for a response timeout (see [`commands::ResponseTimeout`]
+/// and issue #4102). Distinct from the generic failure code (1) so release
+/// automation can treat a timeout as "verify out-of-band before failing"
+/// rather than a hard failure.
+///
+/// Deliberately NOT `2`: clap emits exit code `2` for CLI usage errors
+/// (unknown flag, missing argument, etc.) from `Config::parse()` before any
+/// of our code runs. Reusing `2` would let a usage error — where nothing was
+/// ever sent to the node — masquerade as "submitted, may have succeeded",
+/// which is exactly the misclassification this distinct code exists to
+/// prevent. `3` is the first free code above clap's reserved range.
+const EXIT_RESPONSE_TIMEOUT: i32 = 3;
+
+/// Map a top-level error to the process exit code. A [`commands::ResponseTimeout`]
+/// (possibly wrapped by `anyhow`) maps to [`EXIT_RESPONSE_TIMEOUT`]; everything
+/// else maps to the generic failure code `1`.
+fn exit_code_for_error(err: &anyhow::Error) -> i32 {
+    if err.downcast_ref::<commands::ResponseTimeout>().is_some() {
+        EXIT_RESPONSE_TIMEOUT
+    } else {
+        1
+    }
+}
+
 fn main() -> anyhow::Result<()> {
     let config = Config::parse();
     if !config.sub_command.is_child() {
@@ -54,7 +78,7 @@ fn main() -> anyhow::Result<()> {
     let tokio_rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()?;
-    tokio_rt.block_on(async move {
+    let result = tokio_rt.block_on(async move {
         let cwd = std::env::current_dir()?;
         let r = match config.sub_command {
             SubCommand::WasmRuntime(local_node_config) => {
@@ -107,16 +131,82 @@ fn main() -> anyhow::Result<()> {
                     directory,
                     key,
                     contract_wasm,
-                } => website::publish(directory, key, contract_wasm, config.additional).await,
+                    timeout,
+                } => {
+                    website::publish(directory, key, contract_wasm, timeout, config.additional)
+                        .await
+                }
                 website::WebsiteCommand::Update {
                     directory,
                     key,
                     contract_wasm,
-                } => website::update(directory, key, contract_wasm, config.additional).await,
+                    timeout,
+                } => {
+                    website::update(directory, key, contract_wasm, timeout, config.additional).await
+                }
                 website::WebsiteCommand::List => website::list(),
             },
         };
         // todo: make all commands return concrete `thiserror` compatible errors so we can use anyhow
-        r.map_err(|e| anyhow::format_err!(e))
-    })
+        // Preserve the concrete `ResponseTimeout` type so main() can map it to a
+        // distinct exit code (#4102); re-wrap every other error as before.
+        r.map_err(|e| {
+            if e.downcast_ref::<commands::ResponseTimeout>().is_some() {
+                e
+            } else {
+                anyhow::format_err!(e)
+            }
+        })
+    });
+
+    // A response timeout exits with a distinct code (#4102) so release scripts
+    // can distinguish "timed out, may have succeeded" from a hard failure.
+    if let Err(err) = &result {
+        let code = exit_code_for_error(err);
+        if code != 1 {
+            eprintln!("Error: {err:#}");
+            std::process::exit(code);
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{EXIT_RESPONSE_TIMEOUT, exit_code_for_error};
+    use crate::commands::ResponseTimeout;
+    use std::time::Duration;
+
+    /// #4102: a response timeout maps to a distinct exit code so release
+    /// automation can verify out-of-band before treating it as a hard failure.
+    #[test]
+    fn response_timeout_maps_to_distinct_exit_code() {
+        let err: anyhow::Error = ResponseTimeout {
+            target: "contract ABC".to_string(),
+            timeout: Duration::from_secs(300),
+        }
+        .into();
+        assert_eq!(exit_code_for_error(&err), EXIT_RESPONSE_TIMEOUT);
+        assert_eq!(EXIT_RESPONSE_TIMEOUT, 3);
+    }
+
+    /// #4102: the timeout exit code must NOT collide with clap's usage-error
+    /// code (2). A release script treating exit 2 as "submitted, may have
+    /// succeeded" would otherwise misclassify a CLI usage error (unknown flag,
+    /// e.g. passing `--timeout` to an older fdev) where nothing was ever sent.
+    #[test]
+    fn timeout_exit_code_does_not_collide_with_clap_usage_error() {
+        const CLAP_USAGE_ERROR: i32 = 2;
+        assert_ne!(
+            EXIT_RESPONSE_TIMEOUT, CLAP_USAGE_ERROR,
+            "response-timeout exit code must not reuse clap's usage-error code"
+        );
+    }
+
+    /// Any other error keeps the generic failure code (1).
+    #[test]
+    fn other_errors_map_to_generic_failure_code() {
+        let err = anyhow::anyhow!("boom");
+        assert_eq!(exit_code_for_error(&err), 1);
+    }
 }

--- a/crates/fdev/src/website.rs
+++ b/crates/fdev/src/website.rs
@@ -15,7 +15,9 @@ use freenet_stdlib::prelude::*;
 use serde::{Deserialize, Serialize};
 use xz2::write::XzEncoder;
 
-use crate::commands::{RESPONSE_TIMEOUT, close_api_client, execute_command, start_api_client};
+use crate::commands::{
+    ResponseTimeout, close_api_client, execute_command, resolve_response_timeout, start_api_client,
+};
 use crate::config::BaseConfig;
 
 /// Pre-compiled website container contract WASM, embedded at build time.
@@ -56,6 +58,11 @@ pub enum WebsiteCommand {
         /// Path to a custom contract WASM file (uses built-in contract by default)
         #[arg(long)]
         contract_wasm: Option<PathBuf>,
+        /// Maximum seconds to wait for the node's response before giving up.
+        /// Takes precedence over the `FDEV_RESPONSE_TIMEOUT` env var; when
+        /// neither is set the default of 300s applies. See issue #4102.
+        #[arg(long)]
+        timeout: Option<u64>,
     },
     /// Update an existing website with new content (publishes with a higher version)
     Update {
@@ -67,6 +74,11 @@ pub enum WebsiteCommand {
         /// Path to a custom contract WASM file (uses built-in contract by default)
         #[arg(long)]
         contract_wasm: Option<PathBuf>,
+        /// Maximum seconds to wait for the node's response before giving up.
+        /// Takes precedence over the `FDEV_RESPONSE_TIMEOUT` env var; when
+        /// neither is set the default of 300s applies. See issue #4102.
+        #[arg(long)]
+        timeout: Option<u64>,
     },
     /// List all website signing keys
     List,
@@ -319,6 +331,7 @@ pub async fn publish(
     directory: PathBuf,
     key_name: String,
     contract_wasm: Option<PathBuf>,
+    timeout_secs: Option<u64>,
     base_config: BaseConfig,
 ) -> anyhow::Result<()> {
     let signing_key = read_signing_key(&key_name)?;
@@ -369,7 +382,8 @@ pub async fn publish(
     let mut client = start_api_client(base_config).await?;
     execute_command(request, &mut client).await?;
 
-    let result = match tokio::time::timeout(RESPONSE_TIMEOUT, client.recv()).await {
+    let timeout = resolve_response_timeout(timeout_secs);
+    let result = match tokio::time::timeout(timeout, client.recv()).await {
         Ok(Ok(HostResponse::ContractResponse(ContractResponse::PutResponse {
             key: response_key,
         }))) => {
@@ -387,10 +401,11 @@ pub async fn publish(
         }
         Ok(Ok(other)) => Err(anyhow::anyhow!("Unexpected response: {:?}", other)),
         Ok(Err(e)) => Err(anyhow::anyhow!("Failed to receive response: {e}")),
-        Err(_) => Err(anyhow::anyhow!(
-            "Timeout waiting for response after {} seconds. The operation may have succeeded.",
-            RESPONSE_TIMEOUT.as_secs()
-        )),
+        Err(_) => Err(ResponseTimeout {
+            target: format!("website contract {key}"),
+            timeout,
+        }
+        .into()),
     };
 
     close_api_client(&mut client).await;
@@ -401,12 +416,20 @@ pub async fn update(
     directory: PathBuf,
     key_name: String,
     contract_wasm: Option<PathBuf>,
+    timeout_secs: Option<u64>,
     base_config: BaseConfig,
 ) -> anyhow::Result<()> {
     // Update is the same as publish -- the node handles PUT vs UPDATE based on
     // whether the contract already exists. The contract's update_state validates
     // that the version is strictly increasing.
-    publish(directory, key_name, contract_wasm, base_config).await
+    publish(
+        directory,
+        key_name,
+        contract_wasm,
+        timeout_secs,
+        base_config,
+    )
+    .await
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Problem

`fdev publish` waited for the node's response with a hardcoded 300s timeout, then exited with a generic error — even when the server-side PUT had already succeeded (#4102). Users saw "timeout" for a publish that actually landed, and scripts had no way to distinguish "submitted, possibly succeeded" from a real failure, leading to unnecessary (and version-tie-prone) republish retries.

## Solution

- Make the response wait configurable via a `--timeout` flag on the publish/subscribe/website paths; `0` falls back to the default.
- Exit with a dedicated code (`3`) on response timeout so callers can distinguish "request submitted but response not observed in time" from real errors. Exit code 3 is deliberate: clap emits exit code 2 for CLI usage errors before any of this code runs, so reusing 2 would let a usage error masquerade as "may have succeeded".
- The timeout message now states that the operation may have completed server-side and suggests how to verify.

## Testing

New unit tests in `crates/fdev`: `timeout_exit_code_does_not_collide_with_clap_usage_error`, `timeout_flag_zero_falls_back`, `execute_subscribe_accepts_timeout_flag`, `website_publish_accepts_timeout_flag`, `website_update_accepts_timeout_flag`, plus the existing suite.

`cargo test -p fdev` (51 passed, 0 failed), `cargo fmt --check`, `cargo clippy -- -D warnings` all green.

## Fixes

Fixes #4102

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MNWiSYhzF68Dgfe5bbHEAC

---
_Generated by [Claude Code](https://claude.ai/code/session_01MNWiSYhzF68Dgfe5bbHEAC)_