### PR TITLE
fix(release-agent): poll River announce convergence verify instead of one read

### DIFF
--- a/scripts/release-agent/announce-to-river.sh
+++ b/scripts/release-agent/announce-to-river.sh
@@ -64,6 +64,19 @@ NODE_WAIT_INTERVAL="${NODE_WAIT_INTERVAL:-5}"
 # Bounds the legacy-generation walk a failing GET performs during the
 # down-window; the happy-path read is far faster. Overridable in tests.
 READ_PROBE_TIMEOUT="${READ_PROBE_TIMEOUT:-15}"
+# Post-send convergence verify budget. Cross-node UPDATE convergence is NOT
+# instant (measured ~6-7s on a healthy 0.2.96 network) and can be delayed
+# further when the announce runs concurrently with a gateway self-update that
+# briefly restarts the node. A SINGLE immediate re-read therefore false-negatives
+# a message that is still propagating — observed on the v0.2.96 release, where the
+# message DID land but the one-shot verify reported a "silent drop". So the verify
+# POLLS: re-read every VERIFY_INTERVAL up to VERIFY_ATTEMPTS times, succeeding on
+# the first match, declaring a drop only after the whole budget is exhausted. The
+# common case succeeds in the first 1-3 attempts (~seconds); the drop case waits
+# the full budget before reporting (harmless — the announce is fire-and-forget).
+# Overridable (e.g. VERIFY_ATTEMPTS=1 in tests for the single-shot cases).
+VERIFY_ATTEMPTS="${VERIFY_ATTEMPTS:-24}"
+VERIFY_INTERVAL="${VERIFY_INTERVAL:-5}"
 # Target release version this announcement is for, WITHOUT a leading `v`
 # (e.g. "0.2.90"). Plumbed end-to-end from release-announce.yml's `resolve`
 # job → the nova release-agent (ANNOUNCE_TARGET_VERSION env on the sudo
@@ -206,6 +219,25 @@ verify_converged() {
     local listing
     listing="$(read_room_messages)"
     grep -qF -- "$MESSAGE" <<<"$listing"
+}
+
+# Poll verify_converged until it succeeds or the VERIFY_ATTEMPTS budget is
+# exhausted, sleeping VERIFY_INTERVAL between reads. A single read false-negatives
+# a message that is still propagating (convergence is ~6-7s, and a concurrent
+# gateway restart can delay the first readable read further — see VERIFY_ATTEMPTS),
+# so the "silent drop" verdict must survive the whole budget, not one read.
+# Returns 0 as soon as the message is observed (leaving the winning attempt count
+# in the global VERIFY_ATTEMPT for the caller's log), 1 if it never converges.
+verify_converged_with_retry() {
+    for ((VERIFY_ATTEMPT = 1; VERIFY_ATTEMPT <= VERIFY_ATTEMPTS; VERIFY_ATTEMPT++)); do
+        if verify_converged; then
+            return 0
+        fi
+        if ((VERIFY_ATTEMPT < VERIFY_ATTEMPTS)); then
+            sleep "$VERIFY_INTERVAL"
+        fi
+    done
+    return 1
 }
 
 # Report the version of the locally running freenet node by parsing
@@ -490,10 +522,10 @@ if [[ -n "$SKIP_POST_VERIFY" ]]; then
     exit 0
 fi
 
-if verify_converged; then
-    log "OK (verified message present in room state)"
+if verify_converged_with_retry; then
+    log "OK (verified message present in room state after ${VERIFY_ATTEMPT} read attempt(s))"
     exit 0
 else
-    log "ERROR: riverctl reported success but the message did NOT converge into room state (silent drop)"
+    log "ERROR: riverctl reported success but the message did NOT converge into room state after ${VERIFY_ATTEMPTS} attempts over ~$((VERIFY_ATTEMPTS * VERIFY_INTERVAL))s of polling (silent drop)"
     exit 1
 fi

--- a/scripts/release-agent/announce-to-river.sh
+++ b/scripts/release-agent/announce-to-river.sh
@@ -77,13 +77,7 @@ READ_PROBE_TIMEOUT="${READ_PROBE_TIMEOUT:-15}"
 # Overridable (e.g. VERIFY_ATTEMPTS=1 in tests for the single-shot cases).
 VERIFY_ATTEMPTS="${VERIFY_ATTEMPTS:-24}"
 VERIFY_INTERVAL="${VERIFY_INTERVAL:-5}"
-# Guard the overrides: a non-numeric or absurd value (e.g. VERIFY_INTERVAL=inf)
-# would make `sleep` hang the retry loop forever, so the budget must be
-# wall-clock-bounded, not just attempt-bounded. Require plain non-negative
-# integers; fall back to the defaults otherwise. (ATTEMPTS must be >= 1 to run at
-# least one read; INTERVAL may be 0 — tests set it so, and 0 just polls tightly.)
-[[ "$VERIFY_ATTEMPTS" =~ ^[0-9]+$ ]] && (( VERIFY_ATTEMPTS >= 1 )) || VERIFY_ATTEMPTS=24
-[[ "$VERIFY_INTERVAL" =~ ^[0-9]+$ ]] || VERIFY_INTERVAL=5
+# Overrides are sanity-clamped just before use — see clamp_verify_budget().
 # Target release version this announcement is for, WITHOUT a leading `v`
 # (e.g. "0.2.90"). Plumbed end-to-end from release-announce.yml's `resolve`
 # job → the nova release-agent (ANNOUNCE_TARGET_VERSION env on the sudo
@@ -245,6 +239,17 @@ verify_converged_with_retry() {
         fi
     done
     return 1
+}
+
+# Sanity-clamp the VERIFY_ATTEMPTS/VERIFY_INTERVAL overrides. A non-numeric or
+# absurd value (e.g. VERIFY_INTERVAL=inf) would make `sleep` hang the retry loop
+# forever, leaving the budget only attempt-bounded, not wall-clock-bounded. Require
+# plain non-negative integers, falling back to the defaults otherwise (ATTEMPTS
+# must be >= 1 to run at least one read; INTERVAL may be 0 — 0 just polls tightly).
+clamp_verify_budget() {
+    [[ "$VERIFY_ATTEMPTS" =~ ^[0-9]+$ ]] && (( VERIFY_ATTEMPTS >= 1 )) || VERIFY_ATTEMPTS=24
+    [[ "$VERIFY_INTERVAL" =~ ^[0-9]+$ ]] || VERIFY_INTERVAL=5
+    return 0
 }
 
 # Report the version of the locally running freenet node by parsing
@@ -529,6 +534,7 @@ if [[ -n "$SKIP_POST_VERIFY" ]]; then
     exit 0
 fi
 
+clamp_verify_budget
 if verify_converged_with_retry; then
     log "OK (verified message present in room state after ${VERIFY_ATTEMPT} read attempt(s))"
     exit 0

--- a/scripts/release-agent/announce-to-river.sh
+++ b/scripts/release-agent/announce-to-river.sh
@@ -77,6 +77,13 @@ READ_PROBE_TIMEOUT="${READ_PROBE_TIMEOUT:-15}"
 # Overridable (e.g. VERIFY_ATTEMPTS=1 in tests for the single-shot cases).
 VERIFY_ATTEMPTS="${VERIFY_ATTEMPTS:-24}"
 VERIFY_INTERVAL="${VERIFY_INTERVAL:-5}"
+# Guard the overrides: a non-numeric or absurd value (e.g. VERIFY_INTERVAL=inf)
+# would make `sleep` hang the retry loop forever, so the budget must be
+# wall-clock-bounded, not just attempt-bounded. Require plain non-negative
+# integers; fall back to the defaults otherwise. (ATTEMPTS must be >= 1 to run at
+# least one read; INTERVAL may be 0 — tests set it so, and 0 just polls tightly.)
+[[ "$VERIFY_ATTEMPTS" =~ ^[0-9]+$ ]] && (( VERIFY_ATTEMPTS >= 1 )) || VERIFY_ATTEMPTS=24
+[[ "$VERIFY_INTERVAL" =~ ^[0-9]+$ ]] || VERIFY_INTERVAL=5
 # Target release version this announcement is for, WITHOUT a leading `v`
 # (e.g. "0.2.90"). Plumbed end-to-end from release-announce.yml's `resolve`
 # job → the nova release-agent (ANNOUNCE_TARGET_VERSION env on the sudo

--- a/scripts/release-agent/announce-to-river_test.sh
+++ b/scripts/release-agent/announce-to-river_test.sh
@@ -442,6 +442,51 @@ rc=0
 verify_converged || rc=$?
 check "verify_converged() matches messages with regex/dash metacharacters literally" "$rc" "0"
 
+# ── verify_converged_with_retry() ────────────────────────────────────
+#
+# The post-send verify must POLL, not read once: cross-node UPDATE convergence
+# is ~6-7s and a concurrent gateway restart can delay the first readable read
+# further, so a single immediate read false-negatives a message that DID land
+# (the v0.2.96 "silent drop" that was actually converged). This wrapper re-reads
+# up to VERIFY_ATTEMPTS times and only declares a drop after the budget.
+#
+# Extracted verbatim (depends on verify_converged, extracted above). The stubs
+# key on the loop's VERIFY_ATTEMPT global — read-only in the command-substitution
+# subshell, so no counter file needed. VERIFY_INTERVAL=0 keeps the tests instant.
+# shellcheck disable=SC2317  # stubs are called indirectly via eval'd functions
+eval "$(awk '/^verify_converged_with_retry\(\) \{/,/^}/' "$ANNOUNCE_SH")"
+VERIFY_INTERVAL=0
+
+MESSAGE="Freenet v0.2.96 released: https://example/v0.2.96"
+
+# Present immediately: succeeds on attempt 1.
+VERIFY_ATTEMPTS=5
+read_room_messages() { echo "[t - Room Owner]: $MESSAGE"; }
+rc=0; verify_converged_with_retry || rc=$?
+check "verify_converged_with_retry() returns 0 when present on the first read" "$rc" "0"
+check "verify_converged_with_retry() records attempt 1 when present immediately" "$VERIFY_ATTEMPT" "1"
+
+# THE FIX: still propagating on the first two reads, converges on attempt 3 —
+# a single-shot verify would have wrongly reported a silent drop here.
+VERIFY_ATTEMPTS=5
+read_room_messages() {
+    if ((VERIFY_ATTEMPT >= 3)); then
+        echo "[t - Room Owner]: $MESSAGE"
+    else
+        echo "[t]: still propagating, message not converged yet"
+    fi
+}
+rc=0; verify_converged_with_retry || rc=$?
+check "verify_converged_with_retry() converges after transient misses (no false silent-drop)" "$rc" "0"
+check "verify_converged_with_retry() succeeds on the attempt the message first appears" "$VERIFY_ATTEMPT" "3"
+
+# Genuine silent drop: never converges within the budget → still fails, so a
+# real drop is not masked by the retry.
+VERIFY_ATTEMPTS=4
+read_room_messages() { echo "[t]: unrelated chatter only, message never lands"; }
+rc=0; verify_converged_with_retry || rc=$?
+check "verify_converged_with_retry() returns nonzero when the message never converges (real drop)" "$rc" "1"
+
 # ── send_message_checked() exit-code preservation ────────────────────
 #
 # Regression for the Codex finding: the success path originally used

--- a/scripts/release-agent/announce-to-river_test.sh
+++ b/scripts/release-agent/announce-to-river_test.sh
@@ -487,6 +487,31 @@ read_room_messages() { echo "[t]: unrelated chatter only, message never lands"; 
 rc=0; verify_converged_with_retry || rc=$?
 check "verify_converged_with_retry() returns nonzero when the message never converges (real drop)" "$rc" "1"
 
+# ── clamp_verify_budget() ────────────────────────────────────────────
+#
+# The env-override guard: a non-numeric or absurd VERIFY_INTERVAL/VERIFY_ATTEMPTS
+# (e.g. VERIFY_INTERVAL=inf) would hang `sleep` in the retry loop forever, so the
+# budget must be wall-clock-bounded. clamp_verify_budget rejects anything that is
+# not a plain non-negative integer (ATTEMPTS also must be >= 1) and falls back to
+# the defaults. Extracted verbatim.
+eval "$(awk '/^clamp_verify_budget\(\) \{/,/^}/' "$ANNOUNCE_SH")"
+
+VERIFY_ATTEMPTS=abc; VERIFY_INTERVAL=5; clamp_verify_budget
+check "clamp: non-numeric VERIFY_ATTEMPTS falls back to 24" "$VERIFY_ATTEMPTS" "24"
+
+VERIFY_ATTEMPTS=0; VERIFY_INTERVAL=5; clamp_verify_budget
+check "clamp: VERIFY_ATTEMPTS=0 (below min) falls back to 24" "$VERIFY_ATTEMPTS" "24"
+
+VERIFY_ATTEMPTS=24; VERIFY_INTERVAL=inf; clamp_verify_budget
+check "clamp: non-numeric VERIFY_INTERVAL (inf) falls back to 5" "$VERIFY_INTERVAL" "5"
+
+VERIFY_ATTEMPTS=10; VERIFY_INTERVAL=3; clamp_verify_budget
+check "clamp: valid VERIFY_ATTEMPTS is left unchanged" "$VERIFY_ATTEMPTS" "10"
+check "clamp: valid VERIFY_INTERVAL is left unchanged" "$VERIFY_INTERVAL" "3"
+
+VERIFY_ATTEMPTS=5; VERIFY_INTERVAL=0; clamp_verify_budget
+check "clamp: VERIFY_INTERVAL=0 is valid (tight poll) and preserved" "$VERIFY_INTERVAL" "0"
+
 # ── send_message_checked() exit-code preservation ────────────────────
 #
 # Regression for the Codex finding: the success path originally used


### PR DESCRIPTION
## Problem

The v0.2.96 release announcement to the Freenet Official River room was reported as a **silent drop** — "riverctl reported success but the message did NOT converge into room state" — even though the message **did** land (confirmed in the room).

Root cause: `announce-to-river.sh`'s post-send convergence check did a **single immediate** `riverctl message list` read and declared a drop on a miss, with no retry. But:
- Cross-node UPDATE convergence takes **~6-7s** on a healthy 0.2.96 network (measured: a message posted on the nova gateway became readable on an independent node in ~7s).
- The announce fires on `release.published` **concurrently** with `gateway-update.yml`, which restarts the local node (~90s down + re-subscribe lag).

So the one-shot read routinely fires before the message has propagated → false "silent drop" on every release, masking real success.

## Solution

Wrap the verify in a bounded retry, `verify_converged_with_retry`: re-read every `VERIFY_INTERVAL` up to `VERIFY_ATTEMPTS`, succeed on the first match, declare a drop only after the budget is exhausted. The common case still exits in the first 1-3 reads; a genuine drop is still detected (after the budget). Defaults give a ~120s budget; both are overridable (`VERIFY_ATTEMPTS=1` preserves single-shot behaviour for the existing `verify_converged` unit tests). The announce is fire-and-forget (the agent returns 202 early), so a longer worst-case verify blocks nothing.

`verify_converged` itself is unchanged (still capture-then-grep, its SIGPIPE-safety intact); only the call site now polls it.

## Testing

Adds 5 regression tests to `announce-to-river_test.sh`:
- converges on the first read (attempt 1),
- **converges after transient misses** (attempt 3) — the exact false-negative this fixes, which a single-shot verify would have reported as a drop,
- **genuine never-converges** → still returns failure (a real drop is not masked by the retry).

All existing tests pass; `shellcheck` clean.

Follow-up: the deployed copy on nova (`/usr/local/bin/announce-to-river.sh`) is redeployed from this source via `scripts/release-agent/install.sh` — needs redeploy before the next release for the fix to take effect.

[AI-assisted - Claude]
