### PR TITLE
feat(telemetry): wire nearest-neighbor ring-lattice gauges into central telemetry

### DIFF
--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -1641,6 +1641,26 @@ impl Ring {
             snapshot.open_fds = open_fds;
             snapshot.fd_soft_limit = fd_soft_limit;
 
+            // Nearest-neighbor ring-lattice completeness + probe health (#4760),
+            // mirrored from the home-page ring-stats provider (see
+            // `node/p2p_impl.rs`) onto the central-telemetry snapshot cadence so
+            // the lattice fix's network-wide impact — fraction of peers holding
+            // both immediate-neighbor edges, median edge distances, probe success
+            // rate — is a one-line query over central telemetry as 0.2.96 rolls
+            // out (#4642). Same calls, same `None`/`0` semantics as the home page:
+            // a distance is `None` when that side is unheld or own location is
+            // unknown; the probe counters are `0` before any probe fires.
+            let cm = &ring.connection_manager;
+            let lattice_successor = cm.nearest_lattice_neighbor_dist(true);
+            let lattice_predecessor = cm.nearest_lattice_neighbor_dist(false);
+            let (lattice_probes_issued, lattice_probe_improvements) = cm.lattice_probe_stats();
+            snapshot.lattice_has_successor = Some(lattice_successor.is_some());
+            snapshot.lattice_has_predecessor = Some(lattice_predecessor.is_some());
+            snapshot.lattice_successor_distance = lattice_successor;
+            snapshot.lattice_predecessor_distance = lattice_predecessor;
+            snapshot.lattice_probes_issued = Some(lattice_probes_issued);
+            snapshot.lattice_probe_improvements = Some(lattice_probe_improvements);
+
             // Compiled-WASM module-cache occupancy + eviction gauges (#4440),
             // read from the per-node `Arc` the caches publish into (they live
             // behind the contract-handler channel, unreachable from here; the

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -448,6 +448,32 @@ pub(crate) struct RouterSnapshotInfo {
     /// Monotonic lifetime total; trends how much renewal traffic the
     /// root-satisfied path removes. `None` until the snapshot task populates it.
     pub renewal_terminus_satisfied: Option<u64>,
+    /// Nearest-neighbor ring-lattice completeness + probe health (#4760),
+    /// populated by `Ring` on the snapshot cadence from the same
+    /// `connection_manager` queries the home-page ring-stats provider uses. They
+    /// make the #4760 lattice fix's impact measurable NETWORK-WIDE (the home page
+    /// only shows the local peer): the fraction of peers holding BOTH immediate
+    /// ring-neighbor edges, the median held-edge distances, and the route-to-self
+    /// probe success rate, all as one-line queries over central telemetry.
+    /// `lattice_has_successor` / `_predecessor` are whether this peer currently
+    /// HOLDS its closest-higher / closest-lower connected ring neighbor (a peer
+    /// with both `true` has a complete both-sides lattice; the collector
+    /// aggregates the fraction). The `_distance` fields are the ring distance to
+    /// each held edge, `None` when that side is unheld (or own location is
+    /// unknown). `lattice_probes_issued` / `_probe_improvements` are the
+    /// route-to-self discovery-health counters (monotonic lifetime totals,
+    /// differenced by the collector); they are counted INDEPENDENTLY (an
+    /// improvement lands a few ticks after the probe), so the ratio is a
+    /// convergence-health gauge, not a strict per-probe rate. `None` until the
+    /// snapshot task populates them (i.e. always populated in production). Read
+    /// from the live connection set + probe counters — no mirrored counter to
+    /// rot. See #4642.
+    pub lattice_has_successor: Option<bool>,
+    pub lattice_has_predecessor: Option<bool>,
+    pub lattice_successor_distance: Option<f64>,
+    pub lattice_predecessor_distance: Option<f64>,
+    pub lattice_probes_issued: Option<u64>,
+    pub lattice_probe_improvements: Option<u64>,
     /// Per-operation-type estimator curves, keyed by op type name (e.g., "GET").
     pub per_op_curves: HashMap<String, PerOpCurves>,
     /// Renegade predictor diagnostics. These (and `renegade_accuracy_pairs`) are
@@ -1343,6 +1369,14 @@ impl Router {
             subscribe_hint_acted_succeeded: None,
             subscribe_hint_acted_failed: None,
             renewal_terminus_satisfied: None,
+            // Nearest-neighbor ring-lattice gauges populated by Ring on the
+            // snapshot cadence (#4760 / #4642).
+            lattice_has_successor: None,
+            lattice_has_predecessor: None,
+            lattice_successor_distance: None,
+            lattice_predecessor_distance: None,
+            lattice_probes_issued: None,
+            lattice_probe_improvements: None,
             // Renegade predictor diagnostics
             renegade_failure_events: self.renegade_predictor.len(),
             renegade_response_time_events: self.renegade_predictor.stage_sizes().1,

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -2119,6 +2119,36 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                     "subscribe_hint_acted_failed".to_string(),
                     serde_json::json!(snapshot.subscribe_hint_acted_failed),
                 );
+                // Nearest-neighbor ring-lattice completeness + probe health
+                // (#4760 / #4642). Same hand-mirroring footgun as the placement
+                // gauges above — a new `RouterSnapshotInfo` field is invisible to
+                // the collector unless added here. Pinned by
+                // `router_snapshot_json_includes_placement_gauges`. `Option`
+                // fields emit `null` when unset, matching hosted_key_distance_*.
+                obj.insert(
+                    "lattice_has_successor".to_string(),
+                    serde_json::json!(snapshot.lattice_has_successor),
+                );
+                obj.insert(
+                    "lattice_has_predecessor".to_string(),
+                    serde_json::json!(snapshot.lattice_has_predecessor),
+                );
+                obj.insert(
+                    "lattice_successor_distance".to_string(),
+                    serde_json::json!(snapshot.lattice_successor_distance),
+                );
+                obj.insert(
+                    "lattice_predecessor_distance".to_string(),
+                    serde_json::json!(snapshot.lattice_predecessor_distance),
+                );
+                obj.insert(
+                    "lattice_probes_issued".to_string(),
+                    serde_json::json!(snapshot.lattice_probes_issued),
+                );
+                obj.insert(
+                    "lattice_probe_improvements".to_string(),
+                    serde_json::json!(snapshot.lattice_probe_improvements),
+                );
                 // Interest-weighted (two-tier) module-cache SHADOW gauges
                 // (#4441/#4534). Inserted here (not as inline `json!` keys) to
                 // keep the macro under its recursion limit, same as the
@@ -2905,6 +2935,14 @@ mod tests {
         info.subscribe_hint_refused_cache = Some(24);
         info.subscribe_hint_acted_succeeded = Some(25);
         info.subscribe_hint_acted_failed = Some(26);
+        // Nearest-neighbor ring-lattice gauges (#4760 / #4642): successor held,
+        // predecessor unheld, so the two boolean states are both exercised.
+        info.lattice_has_successor = Some(true);
+        info.lattice_has_predecessor = Some(false);
+        info.lattice_successor_distance = Some(0.05);
+        info.lattice_predecessor_distance = Some(0.07);
+        info.lattice_probes_issued = Some(31);
+        info.lattice_probe_improvements = Some(17);
         let json = event_kind_to_json(&EventKind::RouterSnapshot(Box::new(info)));
         for (key, want) in [
             ("hosted_contracts_count", 5u64),
@@ -2918,6 +2956,8 @@ mod tests {
             ("subscribe_hint_refused_cache", 24),
             ("subscribe_hint_acted_succeeded", 25),
             ("subscribe_hint_acted_failed", 26),
+            ("lattice_probes_issued", 31),
+            ("lattice_probe_improvements", 17),
         ] {
             assert_eq!(json[key], want, "{key} must reach the OTLP body");
         }
@@ -2927,9 +2967,21 @@ mod tests {
             ("hosted_key_distance_min", 0.0),
             ("hosted_key_distance_mean", 0.15),
             ("hosted_key_distance_frac_within_0_1", 0.6),
+            ("lattice_successor_distance", 0.05),
+            ("lattice_predecessor_distance", 0.07),
         ] {
             assert_eq!(json[key], want, "{key} must reach the OTLP body");
         }
+        // Boolean lattice completeness flags reach the body with both states
+        // distinguishable from `null` (unpopulated).
+        assert_eq!(
+            json["lattice_has_successor"], true,
+            "lattice_has_successor must reach the OTLP body"
+        );
+        assert_eq!(
+            json["lattice_has_predecessor"], false,
+            "lattice_has_predecessor must reach the OTLP body"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The six nearest-neighbor ring-lattice metrics from the #4760 lattice fix are computed on every peer but only feed that peer's LOCAL home page (`RingStatsSnapshot`, rendered per-request). There is no way to measure the fix's impact NETWORK-WIDE. As 0.2.96 rolls out we want to answer, as a one-line query over central telemetry:

- what fraction of peers hold BOTH immediate ring-neighbor edges (a complete both-sides lattice),
- the median held-edge distances (successor / predecessor), and
- the route-to-self probe success rate.

None of that is currently reachable centrally.

## Solution

Additive / observability-only. Extend the existing periodic per-peer `RouterSnapshot` central event — it already fires on a cadence and carries `peer_id`, so aggregation needs no new plumbing — with the same six gauges, following the existing placement-gauge pattern exactly (no behavior change). Per CONTRIBUTING this needs no prior issue.

The six metrics:
- `lattice_has_successor`, `lattice_has_predecessor` (`Option<bool>`)
- `lattice_successor_distance`, `lattice_predecessor_distance` (`Option<f64>`)
- `lattice_probes_issued`, `lattice_probe_improvements` (`Option<u64>`)

Changes:
1. **`crates/core/src/router.rs`** — added the six `Option` fields to `RouterSnapshotInfo`, grouped with the placement-quality gauges for greppability (all `None` in the default constructor, populated by `Ring` — same convention as `open_fds` / `hosted_key_distance_median`).
2. **`crates/core/src/ring.rs`** (`emit_router_snapshot_telemetry`, right after the fd gauges) — populate them via the SAME `connection_manager` calls the home-page provider uses: `nearest_lattice_neighbor_dist(true)` (successor) / `(false)` (predecessor) and `lattice_probe_stats()`. Identical `None`/`0` semantics: a distance is `None` when that side is unheld or own location is unknown; probe counters are `0` before any probe fires.
3. **`crates/core/src/tracing/telemetry.rs`** — mirror the six fields into the hand-written OTLP `json!` body next to `hosted_key_distance_*`. `Option` fields emit `null` when unset, matching the existing distance gauges.

Field names are snake_case and `lattice_`-prefixed for greppability.

## Testing

Extended the pin test `router_snapshot_json_includes_placement_gauges` to assert all six new fields reach the OTLP body — with `lattice_has_successor = Some(true)` and `lattice_has_predecessor = Some(false)` so both boolean states are exercised and shown distinguishable from `null`.

- `cargo fmt` clean
- `cargo clippy --locked -p freenet -- -D warnings` clean
- all 14 `router_snapshot` lib tests pass (`cargo test -p freenet --lib router_snapshot`)

Refs #4760, #4642

[AI-assisted - Claude]