### PR TITLE
perf(telemetry): roll up always-on shadow floor-analysis events

### DIFF
--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -177,15 +177,17 @@ const MAX_EVENTS_PER_SECOND: usize = 10;
 ///
 /// Shadow telemetry is admitted under this sub-budget, carved out of the
 /// aggregate [`MAX_EVENTS_PER_SECOND`] cap, so that always-on background
-/// emitters cannot starve operational telemetry (#4380). With the current
-/// always-on baseline of 3 shadow events/sec (`shadow_rtt_aggregate` +
-/// `shadow_rate_demand` + `shadow_outbound_class`), rising to 5/sec on a
-/// gateway that also enables reference-ping and iface-tx, a cap of 4 admits
-/// the always-on set while still reserving at least
-/// `MAX_EVENTS_PER_SECOND - MAX_SHADOW_EVENTS_PER_SECOND` (= 6) slots/sec for
-/// operational events even when shadow demand spikes (e.g. Phase 2 adds the
-/// shadow controller decision log). Shadow events still also count against the
-/// aggregate cap.
+/// emitters cannot starve operational telemetry (#4380). Each shadow stream
+/// (`shadow_rtt_aggregate`, `shadow_rate_demand`, `shadow_outbound_class`,
+/// plus `shadow_reference_ping` / `shadow_iface_tx` on opted-in gateways)
+/// samples at 1 Hz but only emits one rolled-up event per
+/// `transport::shadow_stats::SHADOW_ROLLUP_WINDOW_SECS`, so the steady-state
+/// shadow rate is now well below 1 event/sec. The cap is kept at 4 so a
+/// transient burst (window boundaries aligning, or Phase 2 adding a shadow
+/// controller decision log) still yields to operational telemetry, always
+/// reserving at least `MAX_EVENTS_PER_SECOND - MAX_SHADOW_EVENTS_PER_SECOND`
+/// (= 6) slots/sec for operational events. Shadow events still also count
+/// against the aggregate cap.
 const MAX_SHADOW_EVENTS_PER_SECOND: usize = 4;
 
 /// Initial backoff duration on failure

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -8,7 +8,7 @@
 //! - Exponential backoff on connection failures (1s → 2s → 4s → ... → 5min max)
 //! - Event batching (send every 10 seconds or when buffer reaches 100 events)
 //! - Rate limiting (max 10 events/second aggregate), with a separate shadow
-//!   sub-budget (max 4/second) so always-on low-priority shadow telemetry
+//!   sub-budget (max 6/second) so always-on low-priority shadow telemetry
 //!   cannot starve operational telemetry (#4380)
 //! - Priority-based dropping when buffer is full
 //!
@@ -177,18 +177,26 @@ const MAX_EVENTS_PER_SECOND: usize = 10;
 ///
 /// Shadow telemetry is admitted under this sub-budget, carved out of the
 /// aggregate [`MAX_EVENTS_PER_SECOND`] cap, so that always-on background
-/// emitters cannot starve operational telemetry (#4380). Each shadow stream
-/// (`shadow_rtt_aggregate`, `shadow_rate_demand`, `shadow_outbound_class`,
-/// plus `shadow_reference_ping` / `shadow_iface_tx` on opted-in gateways)
-/// samples at 1 Hz but only emits one rolled-up event per
+/// emitters cannot starve operational telemetry (#4380). There are five shadow
+/// streams — `shadow_rtt_aggregate`, `shadow_rate_demand`,
+/// `shadow_outbound_class` (always-on) plus `shadow_reference_ping` /
+/// `shadow_iface_tx` (opt-in on gateways). Each samples at 1 Hz but only emits
+/// one rolled-up event per
 /// `transport::shadow_stats::SHADOW_ROLLUP_WINDOW_SECS`, so the steady-state
-/// shadow rate is now well below 1 event/sec. The cap is kept at 4 so a
-/// transient burst (window boundaries aligning, or Phase 2 adding a shadow
-/// controller decision log) still yields to operational telemetry, always
-/// reserving at least `MAX_EVENTS_PER_SECOND - MAX_SHADOW_EVENTS_PER_SECOND`
-/// (= 6) slots/sec for operational events. Shadow events still also count
-/// against the aggregate cap.
-const MAX_SHADOW_EVENTS_PER_SECOND: usize = 4;
+/// shadow rate is well below 1 event/sec.
+///
+/// The catch: all five aggregator tickers start at node startup and share the
+/// same window length, so their emit ticks ALIGN on the same second every
+/// window — five rollups contend for the sub-budget simultaneously. The cap is
+/// therefore set to 6, one slot above the five aligned rollups, so no window's
+/// rollup is ever dropped for lack of a shadow slot (at a cap of 4 the fifth
+/// aligned rollup was deterministically dropped every window). This still
+/// reserves `MAX_EVENTS_PER_SECOND - MAX_SHADOW_EVENTS_PER_SECOND` (= 4)
+/// slots/sec for operational telemetry, and leaves one slot of headroom for a
+/// sixth stream (e.g. Phase 2 adding a shadow controller decision log). Shadow
+/// events still also count against the aggregate cap, so under genuine
+/// operational load they continue to yield.
+const MAX_SHADOW_EVENTS_PER_SECOND: usize = 6;
 
 /// Initial backoff duration on failure
 const INITIAL_BACKOFF_MS: u64 = 1000;
@@ -3519,6 +3527,36 @@ mod tests {
         assert_eq!(
             admitted, MAX_SHADOW_EVENTS_PER_SECOND,
             "shadow events must be capped at the sub-budget within a window"
+        );
+    }
+
+    #[test]
+    fn test_all_aligned_shadow_rollups_are_admitted() {
+        // Regression: the five shadow streams (shadow_rtt_aggregate,
+        // shadow_rate_demand, shadow_outbound_class, shadow_reference_ping,
+        // shadow_iface_tx) each emit one rollup per SHADOW_ROLLUP_WINDOW_SECS.
+        // Their aggregator tickers all start at node startup and share the same
+        // window length, so their emit ticks align on the same second every
+        // window. The shadow sub-budget must admit all five in that one second,
+        // or a full 30 s rollup is deterministically dropped every window. A
+        // cap of 4 dropped the fifth; the cap must fit all five with headroom.
+        const SHADOW_STREAMS: usize = 5;
+        const {
+            assert!(
+                MAX_SHADOW_EVENTS_PER_SECOND > SHADOW_STREAMS,
+                "shadow sub-budget must fit all five aligned rollups with headroom"
+            );
+        }
+
+        let mut worker = rate_limit_test_worker();
+        let now = Instant::now();
+
+        // All five rollups arrive in the same aligned second (no operational
+        // load competing for the aggregate cap).
+        let admitted = admit_n(&mut worker, EventPriority::Shadow, SHADOW_STREAMS, now);
+        assert_eq!(
+            admitted, SHADOW_STREAMS,
+            "all five aligned shadow rollups must be admitted; none dropped"
         );
     }
 

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -718,7 +718,7 @@ impl TelemetryWorker {
     ///   [`MAX_EVENTS_PER_SECOND`] — unchanged from the pre-#4380 behavior.
     /// - `Shadow` events are admitted only while BOTH the shadow sub-budget
     ///   ([`MAX_SHADOW_EVENTS_PER_SECOND`]) AND the aggregate cap have room.
-    ///   Because the sub-budget (4) is strictly below the aggregate cap (10),
+    ///   Because the sub-budget (6) is strictly below the aggregate cap (10),
     ///   shadow events can occupy at most `MAX_SHADOW_EVENTS_PER_SECOND` of
     ///   the slots, always leaving
     ///   `MAX_EVENTS_PER_SECOND - MAX_SHADOW_EVENTS_PER_SECOND` for

--- a/crates/core/src/transport.rs
+++ b/crates/core/src/transport.rs
@@ -209,6 +209,7 @@ pub(crate) mod reference_ping;
 pub(crate) mod rolling_rtt_stats;
 pub(crate) mod shadow_demand;
 pub(crate) mod shadow_iface_tx;
+pub(crate) mod shadow_stats;
 
 // Type alias for the in-crate concrete `Socket` impl so callers in
 // this crate can obtain a real UDP socket via a stable alias. The

--- a/crates/core/src/transport/reference_ping.rs
+++ b/crates/core/src/transport/reference_ping.rs
@@ -209,7 +209,14 @@ struct RefPingSample {
 /// Windowed rollup accumulator for the `shadow_reference_ping` stream.
 #[derive(Default)]
 struct RefPingWindow {
+    /// Total 1 Hz ticks elapsed (including warmup/failed-probe ticks that had
+    /// no usable snapshot), used only to decide when the window closes.
     ticks: u32,
+    /// Ticks that contributed a real measurement (the rolling snapshot had
+    /// data). This is the honest denominator for the summary stats and the
+    /// value reported as `samples`; a window of pure warmup/failed probes has
+    /// `samples == 0` and is not emitted.
+    samples: u32,
     baseline_min_us: WindowedStat,
     recent_median_us: WindowedStat,
     inflation_us: WindowedStat,
@@ -218,13 +225,20 @@ struct RefPingWindow {
 }
 
 impl RefPingWindow {
-    fn record(&mut self, sample: RefPingSample) {
+    /// Count the tick toward window closing; fold a measurement only when the
+    /// tick actually produced a snapshot (`Some`). Warmup and all-failed ticks
+    /// (`None`) advance `ticks` but not `samples`, so they never dilute the
+    /// summary stats or inflate the reported `samples` count.
+    fn record(&mut self, sample: Option<RefPingSample>) {
         self.ticks += 1;
-        self.baseline_min_us.record_opt(sample.baseline_min_us);
-        self.recent_median_us.record_opt(sample.recent_median_us);
-        self.inflation_us.record_opt(sample.inflation_us);
-        self.baseline_samples.record(sample.baseline_samples);
-        self.recent_samples.record(sample.recent_samples);
+        if let Some(sample) = sample {
+            self.samples += 1;
+            self.baseline_min_us.record_opt(sample.baseline_min_us);
+            self.recent_median_us.record_opt(sample.recent_median_us);
+            self.inflation_us.record_opt(sample.inflation_us);
+            self.baseline_samples.record(sample.baseline_samples);
+            self.recent_samples.record(sample.recent_samples);
+        }
     }
 
     fn is_full(&self) -> bool {
@@ -232,62 +246,70 @@ impl RefPingWindow {
     }
 }
 
-/// Read one rolling snapshot of the reference-path RTT stats.
-fn sample_reference_ping(stats: &RollingRttStats<RealTime>) -> RefPingSample {
-    match stats.snapshot() {
-        Some(s) => RefPingSample {
-            baseline_min_us: s.baseline_min.map(|d| d.as_micros() as u64),
-            recent_median_us: s.recent_median.map(|d| d.as_micros() as u64),
-            inflation_us: s.inflation.map(|d| d.as_micros() as u64),
-            baseline_samples: s.baseline_samples as u64,
-            recent_samples: s.recent_samples as u64,
-        },
-        None => RefPingSample {
-            baseline_min_us: None,
-            recent_median_us: None,
-            inflation_us: None,
-            baseline_samples: 0,
-            recent_samples: 0,
-        },
-    }
+/// Read one rolling snapshot of the reference-path RTT stats. Returns `None`
+/// when the snapshot has no data (warmup before the first successful probe, or
+/// every retained sample decayed past the baseline window) — that tick is not
+/// a valid measurement and must not be counted in the rollup's `samples`.
+fn sample_reference_ping(stats: &RollingRttStats<RealTime>) -> Option<RefPingSample> {
+    let s = stats.snapshot()?;
+    Some(RefPingSample {
+        baseline_min_us: s.baseline_min.map(|d| d.as_micros() as u64),
+        recent_median_us: s.recent_median.map(|d| d.as_micros() as u64),
+        inflation_us: s.inflation.map(|d| d.as_micros() as u64),
+        baseline_samples: s.baseline_samples as u64,
+        recent_samples: s.recent_samples as u64,
+    })
 }
 
-/// Emit one `shadow_reference_ping` rollup. Each latency field keeps the
-/// window mean under its original name; `inflation_us_p50` / `inflation_us_max`
-/// (and `recent_median_us_max`) are the additive distribution fields the #4074
-/// reference-path analysis consumes to separate local-uplink contention from
-/// overlay queueing.
+/// Emit one `shadow_reference_ping` rollup. Skips emission entirely when the
+/// window had zero valid measurements (all ticks were warmup/failed probes), so
+/// the collector never sees null stats dressed up with a nonzero `samples`.
+/// Each latency field keeps the window mean under its original name;
+/// `inflation_us_p50` / `inflation_us_max` (and `recent_median_us_max`) are the
+/// additive distribution fields the #4074 reference-path analysis consumes to
+/// separate local-uplink contention from overlay queueing.
 fn emit_reference_ping_rollup(local_peer_id: &str, target: SocketAddr, window: &RefPingWindow) {
-    let baseline_min_us = window.baseline_min_us.mean();
-    let recent_median_us = window.recent_median_us.mean();
-    let inflation_us = window.inflation_us.mean();
-
+    if window.samples == 0 {
+        return;
+    }
+    // Record the Option<u64> means directly (NOT via `?`): tracing renders a
+    // `Some(n)` as the bare number and omits the field for `None`, matching the
+    // OTLP number-or-null. `?` would emit the literal `Some(n)` and break
+    // structured local-log parsers.
     tracing::debug!(
         target: "freenet::transport::reference_ping",
         %target,
-        ?baseline_min_us,
-        ?recent_median_us,
-        ?inflation_us,
+        baseline_min_us = window.baseline_min_us.mean(),
+        recent_median_us = window.recent_median_us.mean(),
+        inflation_us = window.inflation_us.mean(),
         window_secs = SHADOW_ROLLUP_WINDOW_SECS,
         "shadow_reference_ping"
     );
     crate::tracing::telemetry::send_standalone_shadow_event_with_peer_id(
         "shadow_reference_ping",
         local_peer_id,
-        serde_json::json!({
-            "target": target.to_string(),
-            "baseline_min_us": baseline_min_us,
-            "recent_median_us": recent_median_us,
-            "recent_median_us_max": window.recent_median_us.max(),
-            "inflation_us": inflation_us,
-            "inflation_us_p50": window.inflation_us.p50(),
-            "inflation_us_max": window.inflation_us.max(),
-            "baseline_samples": window.baseline_samples.mean(),
-            "recent_samples": window.recent_samples.mean(),
-            "window_secs": SHADOW_ROLLUP_WINDOW_SECS,
-            "samples": window.ticks,
-        }),
+        reference_ping_rollup_json(target, window),
     );
+}
+
+/// Build the `shadow_reference_ping` rollup JSON. Pure so the schema (compat
+/// field = window mean, additive distribution fields, and `samples` = count of
+/// VALID measurements, not elapsed ticks) is unit-testable without the
+/// telemetry sender.
+fn reference_ping_rollup_json(target: SocketAddr, window: &RefPingWindow) -> serde_json::Value {
+    serde_json::json!({
+        "target": target.to_string(),
+        "baseline_min_us": window.baseline_min_us.mean(),
+        "recent_median_us": window.recent_median_us.mean(),
+        "recent_median_us_max": window.recent_median_us.max(),
+        "inflation_us": window.inflation_us.mean(),
+        "inflation_us_p50": window.inflation_us.p50(),
+        "inflation_us_max": window.inflation_us.max(),
+        "baseline_samples": window.baseline_samples.mean(),
+        "recent_samples": window.recent_samples.mean(),
+        "window_secs": SHADOW_ROLLUP_WINDOW_SECS,
+        "samples": window.samples,
+    })
 }
 
 /// Build a minimal DNS query packet for `name` of type A, class IN.
@@ -343,6 +365,66 @@ fn is_matching_dns_response(buf: &[u8], expected_id: u16) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_target() -> SocketAddr {
+        "1.1.1.1:53".parse().unwrap()
+    }
+
+    fn measured_sample(inflation_us: Option<u64>) -> RefPingSample {
+        RefPingSample {
+            baseline_min_us: Some(1_000),
+            recent_median_us: inflation_us.map(|i| 1_000 + i),
+            inflation_us,
+            baseline_samples: 5,
+            recent_samples: 3,
+        }
+    }
+
+    #[test]
+    fn rollup_samples_count_valid_measurements_not_ticks() {
+        // Regression: `samples` used to report the raw tick count, so a window
+        // of warmup/failed probes (no usable snapshot) emitted null stats with
+        // samples == 30. `samples` must instead count only ticks that produced
+        // a real measurement.
+        let mut window = RefPingWindow::default();
+        // Two warmup ticks: snapshot was None, no measurement.
+        window.record(None);
+        window.record(None);
+        // One tick where inflation had not converged yet (Some sample, but the
+        // inflation field is None) — still a valid measurement.
+        window.record(Some(measured_sample(None)));
+        // One fully-measured tick.
+        window.record(Some(measured_sample(Some(200))));
+
+        assert_eq!(window.ticks, 4, "all ticks advance the window clock");
+        assert_eq!(window.samples, 2, "only measured ticks count as samples");
+
+        let json = reference_ping_rollup_json(test_target(), &window);
+        // `samples` reflects valid measurements, not the 4 elapsed ticks.
+        assert_eq!(json["samples"], 2);
+        // baseline_min was present on both measured ticks → mean over 2 samples.
+        assert_eq!(json["baseline_min_us"], 1_000);
+        // inflation was present on exactly one measured tick → stats over that
+        // one valid value only, never diluted by the None ticks.
+        assert_eq!(json["inflation_us"], 200);
+        assert_eq!(json["inflation_us_p50"], 200);
+        assert_eq!(json["inflation_us_max"], 200);
+    }
+
+    #[test]
+    fn rollup_is_skipped_when_no_valid_measurements() {
+        // A whole window of warmup/failed probes must not be emitted at all:
+        // `samples == 0` is the emit guard in `emit_reference_ping_rollup`.
+        let mut window = RefPingWindow::default();
+        for _ in 0..SHADOW_ROLLUP_WINDOW_SECS {
+            window.record(None);
+        }
+        assert_eq!(window.ticks, SHADOW_ROLLUP_WINDOW_SECS);
+        assert_eq!(
+            window.samples, 0,
+            "no measured tick means the rollup is skipped (samples == 0)"
+        );
+    }
 
     #[test]
     fn dns_query_header_is_well_formed() {

--- a/crates/core/src/transport/reference_ping.rs
+++ b/crates/core/src/transport/reference_ping.rs
@@ -144,13 +144,37 @@ async fn run_probe_loop(local_peer_id: String, target: SocketAddr, socket: Defau
                 // would poison the baseline.
             }
         }
-        // Sample the rolling snapshot every second, but emit one OTLP rollup
-        // per SHADOW_ROLLUP_WINDOW_SECS to keep central telemetry volume down.
-        window.record(sample_reference_ping(&stats));
+        // Fold a measurement into the window only when THIS tick's probe
+        // actually succeeded. A failed probe advances the window clock but
+        // contributes no sample — even though `stats.snapshot()` is still
+        // `Some` (the rolling history stays non-empty for up to the baseline
+        // window after any earlier success). Counting that stale snapshot was
+        // the finding #2 bug: a 30 s window of all-failed probes would emit
+        // `samples: 30` with stale RTT stats. Emit one OTLP rollup per
+        // SHADOW_ROLLUP_WINDOW_SECS to keep central telemetry volume down.
+        window.record(sample_for_outcome(&outcome, &stats));
         if window.is_full() {
             emit_reference_ping_rollup(&local_peer_id, target, &window);
             window = RefPingWindow::default();
         }
+    }
+}
+
+/// The window contribution for one probe tick: the current rolling snapshot
+/// when THIS tick produced a fresh RTT sample, otherwise `None`.
+///
+/// A failed probe (`NoResponse` / `SendError`) yields `None` even when
+/// `stats.snapshot()` would return `Some` from earlier successes still inside
+/// the baseline window — a stale snapshot is not a fresh measurement and must
+/// not increment `samples` or fold into the window stats (finding #2). Pulled
+/// out of the probe loop so the fresh-vs-stale gate is unit-testable.
+fn sample_for_outcome(
+    outcome: &ProbeOutcome,
+    stats: &RollingRttStats<RealTime>,
+) -> Option<RefPingSample> {
+    match outcome {
+        ProbeOutcome::Sample(_) => sample_reference_ping(stats),
+        ProbeOutcome::NoResponse | ProbeOutcome::SendError => None,
     }
 }
 
@@ -209,13 +233,16 @@ struct RefPingSample {
 /// Windowed rollup accumulator for the `shadow_reference_ping` stream.
 #[derive(Default)]
 struct RefPingWindow {
-    /// Total 1 Hz ticks elapsed (including warmup/failed-probe ticks that had
-    /// no usable snapshot), used only to decide when the window closes.
+    /// Total 1 Hz ticks elapsed (including warmup/failed-probe ticks that
+    /// produced no fresh measurement), used only to decide when the window
+    /// closes.
     ticks: u32,
-    /// Ticks that contributed a real measurement (the rolling snapshot had
-    /// data). This is the honest denominator for the summary stats and the
-    /// value reported as `samples`; a window of pure warmup/failed probes has
-    /// `samples == 0` and is not emitted.
+    /// Ticks whose probe succeeded THIS tick (a fresh RTT measurement). This is
+    /// the honest denominator for the summary stats and the value reported as
+    /// `samples`; a window of pure warmup/failed probes has `samples == 0` and
+    /// is not emitted. It counts fresh probes, not merely ticks where the
+    /// rolling snapshot was non-empty (which stays `Some` on failed ticks after
+    /// any earlier success).
     samples: u32,
     baseline_min_us: WindowedStat,
     recent_median_us: WindowedStat,
@@ -226,9 +253,10 @@ struct RefPingWindow {
 
 impl RefPingWindow {
     /// Count the tick toward window closing; fold a measurement only when the
-    /// tick actually produced a snapshot (`Some`). Warmup and all-failed ticks
-    /// (`None`) advance `ticks` but not `samples`, so they never dilute the
-    /// summary stats or inflate the reported `samples` count.
+    /// caller passes `Some` (this tick's probe produced a fresh sample —
+    /// see [`sample_for_outcome`]). A `None` tick (warmup or failed probe)
+    /// advances `ticks` but not `samples`, so it never dilutes the summary
+    /// stats or inflates the reported `samples` count.
     fn record(&mut self, sample: Option<RefPingSample>) {
         self.ticks += 1;
         if let Some(sample) = sample {
@@ -248,8 +276,11 @@ impl RefPingWindow {
 
 /// Read one rolling snapshot of the reference-path RTT stats. Returns `None`
 /// when the snapshot has no data (warmup before the first successful probe, or
-/// every retained sample decayed past the baseline window) — that tick is not
-/// a valid measurement and must not be counted in the rollup's `samples`.
+/// every retained sample decayed past the baseline window).
+///
+/// Called by [`sample_for_outcome`] only on a fresh-probe tick, so on the live
+/// path a returned `None` here is the warmup case; the failed-probe stale-
+/// snapshot case is filtered earlier by [`sample_for_outcome`].
 fn sample_reference_ping(stats: &RollingRttStats<RealTime>) -> Option<RefPingSample> {
     let s = stats.snapshot()?;
     Some(RefPingSample {
@@ -424,6 +455,47 @@ mod tests {
             window.samples, 0,
             "no measured tick means the rollup is skipped (samples == 0)"
         );
+    }
+
+    #[tokio::test]
+    async fn failed_probe_after_success_does_not_count_as_sample() {
+        // Production-path regression (finding #2, second round): a failed probe
+        // that lands AFTER an earlier success leaves the rolling history
+        // non-empty, so `stats.snapshot()` (hence `sample_reference_ping`) still
+        // returns `Some(stale)`. The window must NOT count that as a sample —
+        // otherwise a 30 s window of all-failed probes emits `samples: 30` with
+        // stale RTT stats. `sample_for_outcome` is the gate: only a fresh
+        // `Sample` outcome this tick folds a measurement.
+        let stats = RollingRttStats::new(RealTime::new());
+        // An earlier successful probe leaves the rolling history non-empty.
+        stats.record(Duration::from_millis(20));
+        assert!(
+            sample_reference_ping(&stats).is_some(),
+            "precondition: the rolling snapshot is non-empty after a success, \
+             so a naive `record(sample_reference_ping(..))` would wrongly count \
+             a failed tick"
+        );
+
+        let mut window = RefPingWindow::default();
+
+        // A failed probe THIS tick — snapshot is Some(stale) but it must not
+        // count.
+        window.record(sample_for_outcome(&ProbeOutcome::NoResponse, &stats));
+        window.record(sample_for_outcome(&ProbeOutcome::SendError, &stats));
+        assert_eq!(window.ticks, 2, "failed ticks still advance the clock");
+        assert_eq!(
+            window.samples, 0,
+            "a failed probe must not increment samples even when the rolling \
+             history is non-empty from an earlier success"
+        );
+
+        // A fresh successful probe THIS tick does count.
+        window.record(sample_for_outcome(
+            &ProbeOutcome::Sample(Duration::from_millis(25)),
+            &stats,
+        ));
+        assert_eq!(window.ticks, 3);
+        assert_eq!(window.samples, 1, "a fresh successful probe counts");
     }
 
     #[test]

--- a/crates/core/src/transport/reference_ping.rs
+++ b/crates/core/src/transport/reference_ping.rs
@@ -44,6 +44,7 @@ use crate::config::GlobalRng;
 use crate::simulation::RealTime;
 use crate::transport::DefaultSocket;
 use crate::transport::rolling_rtt_stats::RollingRttStats;
+use crate::transport::shadow_stats::{SHADOW_ROLLUP_WINDOW_SECS, WindowedStat};
 
 /// Default reference target (Cloudflare public DNS over UDP).
 ///
@@ -131,6 +132,7 @@ async fn run_probe_loop(local_peer_id: String, target: SocketAddr, socket: Defau
     // align with the rest of the node clock.
     ticker.tick().await;
 
+    let mut window = RefPingWindow::default();
     loop {
         ticker.tick().await;
         let outcome = probe_once(&socket, target).await;
@@ -142,7 +144,13 @@ async fn run_probe_loop(local_peer_id: String, target: SocketAddr, socket: Defau
                 // would poison the baseline.
             }
         }
-        emit_snapshot(&local_peer_id, target, &stats);
+        // Sample the rolling snapshot every second, but emit one OTLP rollup
+        // per SHADOW_ROLLUP_WINDOW_SECS to keep central telemetry volume down.
+        window.record(sample_reference_ping(&stats));
+        if window.is_full() {
+            emit_reference_ping_rollup(&local_peer_id, target, &window);
+            window = RefPingWindow::default();
+        }
     }
 }
 
@@ -189,28 +197,78 @@ async fn probe_once(socket: &DefaultSocket, target: SocketAddr) -> ProbeOutcome 
     }
 }
 
-fn emit_snapshot(local_peer_id: &str, target: SocketAddr, stats: &RollingRttStats<RealTime>) {
-    let snapshot = stats.snapshot();
-    let (baseline_min_us, recent_median_us, inflation_us, baseline_samples, recent_samples) =
-        match snapshot {
-            Some(s) => (
-                s.baseline_min.map(|d| d.as_micros() as u64),
-                s.recent_median.map(|d| d.as_micros() as u64),
-                s.inflation.map(|d| d.as_micros() as u64),
-                s.baseline_samples as u64,
-                s.recent_samples as u64,
-            ),
-            None => (None, None, None, 0, 0),
-        };
+/// One 1 Hz sample of the reference-path rolling snapshot.
+struct RefPingSample {
+    baseline_min_us: Option<u64>,
+    recent_median_us: Option<u64>,
+    inflation_us: Option<u64>,
+    baseline_samples: u64,
+    recent_samples: u64,
+}
+
+/// Windowed rollup accumulator for the `shadow_reference_ping` stream.
+#[derive(Default)]
+struct RefPingWindow {
+    ticks: u32,
+    baseline_min_us: WindowedStat,
+    recent_median_us: WindowedStat,
+    inflation_us: WindowedStat,
+    baseline_samples: WindowedStat,
+    recent_samples: WindowedStat,
+}
+
+impl RefPingWindow {
+    fn record(&mut self, sample: RefPingSample) {
+        self.ticks += 1;
+        self.baseline_min_us.record_opt(sample.baseline_min_us);
+        self.recent_median_us.record_opt(sample.recent_median_us);
+        self.inflation_us.record_opt(sample.inflation_us);
+        self.baseline_samples.record(sample.baseline_samples);
+        self.recent_samples.record(sample.recent_samples);
+    }
+
+    fn is_full(&self) -> bool {
+        self.ticks >= SHADOW_ROLLUP_WINDOW_SECS
+    }
+}
+
+/// Read one rolling snapshot of the reference-path RTT stats.
+fn sample_reference_ping(stats: &RollingRttStats<RealTime>) -> RefPingSample {
+    match stats.snapshot() {
+        Some(s) => RefPingSample {
+            baseline_min_us: s.baseline_min.map(|d| d.as_micros() as u64),
+            recent_median_us: s.recent_median.map(|d| d.as_micros() as u64),
+            inflation_us: s.inflation.map(|d| d.as_micros() as u64),
+            baseline_samples: s.baseline_samples as u64,
+            recent_samples: s.recent_samples as u64,
+        },
+        None => RefPingSample {
+            baseline_min_us: None,
+            recent_median_us: None,
+            inflation_us: None,
+            baseline_samples: 0,
+            recent_samples: 0,
+        },
+    }
+}
+
+/// Emit one `shadow_reference_ping` rollup. Each latency field keeps the
+/// window mean under its original name; `inflation_us_p50` / `inflation_us_max`
+/// (and `recent_median_us_max`) are the additive distribution fields the #4074
+/// reference-path analysis consumes to separate local-uplink contention from
+/// overlay queueing.
+fn emit_reference_ping_rollup(local_peer_id: &str, target: SocketAddr, window: &RefPingWindow) {
+    let baseline_min_us = window.baseline_min_us.mean();
+    let recent_median_us = window.recent_median_us.mean();
+    let inflation_us = window.inflation_us.mean();
 
     tracing::debug!(
         target: "freenet::transport::reference_ping",
         %target,
-        baseline_min_us,
-        recent_median_us,
-        inflation_us,
-        baseline_samples,
-        recent_samples,
+        ?baseline_min_us,
+        ?recent_median_us,
+        ?inflation_us,
+        window_secs = SHADOW_ROLLUP_WINDOW_SECS,
         "shadow_reference_ping"
     );
     crate::tracing::telemetry::send_standalone_shadow_event_with_peer_id(
@@ -220,9 +278,14 @@ fn emit_snapshot(local_peer_id: &str, target: SocketAddr, stats: &RollingRttStat
             "target": target.to_string(),
             "baseline_min_us": baseline_min_us,
             "recent_median_us": recent_median_us,
+            "recent_median_us_max": window.recent_median_us.max(),
             "inflation_us": inflation_us,
-            "baseline_samples": baseline_samples,
-            "recent_samples": recent_samples,
+            "inflation_us_p50": window.inflation_us.p50(),
+            "inflation_us_max": window.inflation_us.max(),
+            "baseline_samples": window.baseline_samples.mean(),
+            "recent_samples": window.recent_samples.mean(),
+            "window_secs": SHADOW_ROLLUP_WINDOW_SECS,
+            "samples": window.ticks,
         }),
     );
 }

--- a/crates/core/src/transport/rolling_rtt_stats.rs
+++ b/crates/core/src/transport/rolling_rtt_stats.rs
@@ -335,30 +335,6 @@ pub(crate) fn spawn_aggregator(
     monitor.register("shadow_rtt_aggregator", handle);
 }
 
-/// Emit one tracing event summarising the current cross-connection
-/// state. The local file-log mirror is at `debug`. In debug builds
-/// this is visible via `RUST_LOG=…=debug`; in release builds the
-/// `release_max_level_info` feature in `crates/core/Cargo.toml`
-/// compiles DEBUG events out entirely — `RUST_LOG` alone cannot
-/// revive them without a rebuild. This is intentional: the local
-/// mirror at INFO was the third-largest contributor to the
-/// #4251 / #4272 log-volume regression at ~3,600 lines/hour per
-/// node. Production telemetry reaches the OTLP collector via the
-/// `send_standalone_shadow_event_with_peer_id` call below, which is
-/// independent of the tracing level, so the dashboard's 1 Hz feed
-/// survives.
-///
-/// `send_standalone_shadow_event_with_peer_id` pushes a structured
-/// event through the global telemetry sender
-/// (`crate::tracing::telemetry::send_standalone_shadow_event_with_peer_id`)
-/// so it reaches the central OTLP collector (per the `NetEventLog`
-/// path that `TelemetryReporter` consumes). Without that, the
-/// aggregate would land only in per-node file logs and the 2-4 week
-/// observation the RFC calls for would require manual log scraping.
-/// The `local_peer_id` argument is attached as an OTLP attribute so
-/// the collector can disaggregate per reporting node. The shadow
-/// variant tags the event as low-priority so it yields to operational
-/// telemetry under the rate-limiter sub-budget (#4380).
 /// One 1 Hz sample of the cross-connection RTT aggregate.
 struct RttSample {
     active_peers: u64,
@@ -434,6 +410,15 @@ fn sample_aggregate() -> Option<RttSample> {
 /// and `*_max` (worst-second inflation) are the additive distribution fields
 /// the #4074 floor analysis consumes. `active_peers` / `peers_with_recent`
 /// carry the window mean.
+///
+/// The local `tracing::debug!` mirror stays at DEBUG on purpose: at INFO it was
+/// the third-largest contributor to the #4251 / #4272 log-volume regression
+/// (~3,600 lines/hour per node), and `release_max_level_info` compiles DEBUG
+/// out of release builds entirely. The OTLP path below
+/// (`send_standalone_shadow_event_with_peer_id`) is independent of the tracing
+/// level, so the central-collector feed survives regardless; `local_peer_id`
+/// rides as an OTLP attribute so the collector can disaggregate per node, and
+/// the shadow variant tags the event low-priority (#4380).
 fn emit_aggregate_rollup(local_peer_id: &str, window: &RttWindow) {
     if window.samples == 0 {
         return;

--- a/crates/core/src/transport/rolling_rtt_stats.rs
+++ b/crates/core/src/transport/rolling_rtt_stats.rs
@@ -424,11 +424,16 @@ fn emit_aggregate_rollup(local_peer_id: &str, window: &RttWindow) {
         return;
     }
     let payload = aggregate_rollup_json(window);
+    // Record the Option<u64> means directly (NOT via `?`): tracing's
+    // `Value for Option<T>` renders `Some(6)` as the bare number `6` and omits
+    // the field for `None`, matching the OTLP path's number-or-null. The `?`
+    // Debug sigil would instead emit the literal `Some(6)`, which breaks
+    // structured local-log parsers.
     tracing::debug!(
         target: "freenet::transport::shadow_rtt",
-        active_peers = ?window.active_peers.mean(),
-        peers_with_recent = ?window.peers_with_recent.mean(),
-        median_inflation_us = ?window.median_inflation_us.mean(),
+        active_peers = window.active_peers.mean(),
+        peers_with_recent = window.peers_with_recent.mean(),
+        median_inflation_us = window.median_inflation_us.mean(),
         window_secs = SHADOW_ROLLUP_WINDOW_SECS,
         "shadow_rtt_aggregate"
     );
@@ -448,6 +453,14 @@ fn emit_aggregate_rollup(local_peer_id: &str, window: &RttWindow) {
 /// Build the `shadow_rtt_aggregate` rollup JSON. Pure so the schema (compat
 /// field = window mean, additive `*_p50` / `*_max` distribution fields) is
 /// unit-testable without the telemetry sender.
+///
+/// Design note (#4314): the per-tick `median_inflation_us` samples are
+/// intentionally rolled up here into the window mean / p50 / max — the central
+/// collector receives one summary per window, not the raw 1 Hz series. The
+/// stubbed #4314 controller-replay would want the per-tick RTT series, but it
+/// is deferred, and when it lands it will use its own dedicated opt-in per-tick
+/// capture path rather than reviving the raw stream through this central
+/// rollup. Do NOT re-expand this into a per-tick emitter to serve #4314.
 fn aggregate_rollup_json(window: &RttWindow) -> serde_json::Value {
     serde_json::json!({
         "active_peers": window.active_peers.mean(),
@@ -822,7 +835,8 @@ mod tests {
         assert_eq!(json["active_peers"], 6);
         assert_eq!(json["peers_with_recent"], 4);
         assert_eq!(json["median_inflation_us"], 200);
-        // Additive distribution fields (lower-median of [100,300] = 300).
+        // Additive distribution fields (upper-middle median of [100,300] =
+        // sorted[len/2] = sorted[1] = 300).
         assert_eq!(json["median_inflation_us_p50"], 300);
         assert_eq!(json["median_inflation_us_max"], 300);
         assert_eq!(json["window_secs"], SHADOW_ROLLUP_WINDOW_SECS);

--- a/crates/core/src/transport/rolling_rtt_stats.rs
+++ b/crates/core/src/transport/rolling_rtt_stats.rs
@@ -26,6 +26,7 @@ use std::time::Duration;
 
 use dashmap::DashMap;
 
+use super::shadow_stats::{SHADOW_ROLLUP_WINDOW_SECS, WindowedStat};
 use crate::simulation::TimeSource;
 
 /// Baseline window for the rolling minimum RTT. The RFC uses 5 min as a
@@ -314,9 +315,21 @@ pub(crate) fn spawn_aggregator(
         // sample to report.
         ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
         ticker.tick().await;
+        let mut window = RttWindow::default();
         loop {
             ticker.tick().await;
-            emit_aggregate_snapshot(&local_peer_id);
+            // Sample the cross-connection signal at 1 Hz (also emits the
+            // local-only per-peer TRACE mirror), but only push a sample when
+            // the node actually has peers — preserving the original
+            // "no peers → no signal" semantic across the rollup window.
+            if let Some(sample) = sample_aggregate() {
+                window.record(sample);
+            }
+            window.ticks += 1;
+            if window.ticks >= SHADOW_ROLLUP_WINDOW_SECS {
+                emit_aggregate_rollup(&local_peer_id, &window);
+                window = RttWindow::default();
+            }
         }
     });
     monitor.register("shadow_rtt_aggregator", handle);
@@ -346,11 +359,45 @@ pub(crate) fn spawn_aggregator(
 /// the collector can disaggregate per reporting node. The shadow
 /// variant tags the event as low-priority so it yields to operational
 /// telemetry under the rate-limiter sub-budget (#4380).
-fn emit_aggregate_snapshot(local_peer_id: &str) {
+/// One 1 Hz sample of the cross-connection RTT aggregate.
+struct RttSample {
+    active_peers: u64,
+    peers_with_recent: u64,
+    median_inflation_us: Option<u64>,
+}
+
+/// Windowed rollup accumulator for the `shadow_rtt_aggregate` stream.
+#[derive(Default)]
+struct RttWindow {
+    /// Total 1 Hz ticks elapsed in this window (including no-peer ticks),
+    /// used only to decide when the [`SHADOW_ROLLUP_WINDOW_SECS`] window closes.
+    ticks: u32,
+    /// Ticks that actually contributed a sample (node had ≥1 peer).
+    samples: u32,
+    active_peers: WindowedStat,
+    peers_with_recent: WindowedStat,
+    median_inflation_us: WindowedStat,
+}
+
+impl RttWindow {
+    fn record(&mut self, sample: RttSample) {
+        self.samples += 1;
+        self.active_peers.record(sample.active_peers);
+        self.peers_with_recent.record(sample.peers_with_recent);
+        self.median_inflation_us
+            .record_opt(sample.median_inflation_us);
+    }
+}
+
+/// Take one 1 Hz sample of the cross-connection RTT signal, emitting the
+/// local-only per-peer TRACE mirror as a side effect. Returns `None` when the
+/// node has no peers (nothing to report), preserving the original semantic
+/// that an isolated node emits no `shadow_rtt_aggregate` telemetry.
+fn sample_aggregate() -> Option<RttSample> {
     let snap = registry_snapshot();
     let active_peers = snap.len();
     if active_peers == 0 {
-        return;
+        return None;
     }
     let peers_with_recent = snap
         .iter()
@@ -371,11 +418,33 @@ fn emit_aggregate_snapshot(local_peer_id: &str) {
             "shadow_rtt_per_peer"
         );
     }
+    Some(RttSample {
+        active_peers: active_peers as u64,
+        peers_with_recent: peers_with_recent as u64,
+        median_inflation_us,
+    })
+}
+
+/// Emit one `shadow_rtt_aggregate` rollup covering the closed window. Skips
+/// emission entirely when the node had no peers for the whole window (no
+/// samples), mirroring the original per-tick short-circuit.
+///
+/// `median_inflation_us` keeps the window mean under its original name (the
+/// value existing consumers read); `*_p50` (median of the per-second medians)
+/// and `*_max` (worst-second inflation) are the additive distribution fields
+/// the #4074 floor analysis consumes. `active_peers` / `peers_with_recent`
+/// carry the window mean.
+fn emit_aggregate_rollup(local_peer_id: &str, window: &RttWindow) {
+    if window.samples == 0 {
+        return;
+    }
+    let payload = aggregate_rollup_json(window);
     tracing::debug!(
         target: "freenet::transport::shadow_rtt",
-        active_peers,
-        peers_with_recent,
-        median_inflation_us,
+        active_peers = ?window.active_peers.mean(),
+        peers_with_recent = ?window.peers_with_recent.mean(),
+        median_inflation_us = ?window.median_inflation_us.mean(),
+        window_secs = SHADOW_ROLLUP_WINDOW_SECS,
         "shadow_rtt_aggregate"
     );
     // Mirror the aggregate to the central OTLP collector tagged with
@@ -387,12 +456,23 @@ fn emit_aggregate_snapshot(local_peer_id: &str) {
     crate::tracing::telemetry::send_standalone_shadow_event_with_peer_id(
         "shadow_rtt_aggregate",
         local_peer_id,
-        serde_json::json!({
-            "active_peers": active_peers,
-            "peers_with_recent": peers_with_recent,
-            "median_inflation_us": median_inflation_us,
-        }),
+        payload,
     );
+}
+
+/// Build the `shadow_rtt_aggregate` rollup JSON. Pure so the schema (compat
+/// field = window mean, additive `*_p50` / `*_max` distribution fields) is
+/// unit-testable without the telemetry sender.
+fn aggregate_rollup_json(window: &RttWindow) -> serde_json::Value {
+    serde_json::json!({
+        "active_peers": window.active_peers.mean(),
+        "peers_with_recent": window.peers_with_recent.mean(),
+        "median_inflation_us": window.median_inflation_us.mean(),
+        "median_inflation_us_p50": window.median_inflation_us.p50(),
+        "median_inflation_us_max": window.median_inflation_us.max(),
+        "window_secs": SHADOW_ROLLUP_WINDOW_SECS,
+        "samples": window.samples,
+    })
 }
 
 #[cfg(test)]
@@ -739,13 +819,58 @@ mod tests {
         assert_eq!(snap.recent_median, Some(dur_ms(60)));
     }
 
-    /// `spawn_aggregator` must produce a task that emits the
-    /// `shadow_rtt_aggregate` event on its 1Hz cadence and survives
-    /// across multiple ticks. Uses paused tokio time so the test is
-    /// deterministic and finishes in microseconds. A regression that
-    /// (a) returns before spawning, (b) panics inside the loop, or
-    /// (c) breaks the OTLP `send_standalone_event` mirror by holding
-    /// it inside a blocking call would be caught here.
+    #[test]
+    fn aggregate_rollup_json_keeps_median_field_and_adds_distribution() {
+        let mut window = RttWindow::default();
+        window.record(RttSample {
+            active_peers: 5,
+            peers_with_recent: 3,
+            median_inflation_us: Some(100),
+        });
+        window.record(RttSample {
+            active_peers: 7,
+            peers_with_recent: 5,
+            median_inflation_us: Some(300),
+        });
+        let json = aggregate_rollup_json(&window);
+        // Compat: original fields carry the window MEAN.
+        assert_eq!(json["active_peers"], 6);
+        assert_eq!(json["peers_with_recent"], 4);
+        assert_eq!(json["median_inflation_us"], 200);
+        // Additive distribution fields (lower-median of [100,300] = 300).
+        assert_eq!(json["median_inflation_us_p50"], 300);
+        assert_eq!(json["median_inflation_us_max"], 300);
+        assert_eq!(json["window_secs"], SHADOW_ROLLUP_WINDOW_SECS);
+        assert_eq!(json["samples"], 2);
+    }
+
+    #[test]
+    fn aggregate_rollup_json_median_is_null_when_never_measured() {
+        // A window where every tick had peers but no inflation sample yet:
+        // the median field (and its distribution companions) must stay null,
+        // exactly as the pre-rollup emitter reported a null median.
+        let mut window = RttWindow::default();
+        window.record(RttSample {
+            active_peers: 2,
+            peers_with_recent: 0,
+            median_inflation_us: None,
+        });
+        let json = aggregate_rollup_json(&window);
+        assert_eq!(json["active_peers"], 2);
+        assert!(json["median_inflation_us"].is_null());
+        assert!(json["median_inflation_us_p50"].is_null());
+        assert!(json["median_inflation_us_max"].is_null());
+        assert_eq!(json["samples"], 1);
+    }
+
+    /// `spawn_aggregator` must produce a task that samples the
+    /// `shadow_rtt_aggregate` signal on its 1Hz cadence (emitting a rollup
+    /// once per `SHADOW_ROLLUP_WINDOW_SECS`) and survives across multiple
+    /// ticks. Uses paused tokio time so the test is deterministic and
+    /// finishes in microseconds. A regression that (a) returns before
+    /// spawning, (b) panics inside the loop, or (c) breaks the OTLP
+    /// `send_standalone_event` mirror by holding it inside a blocking call
+    /// would be caught here.
     #[tokio::test(start_paused = true)]
     async fn aggregator_emits_periodically() {
         use crate::node::background_task_monitor::BackgroundTaskMonitor;
@@ -753,7 +878,7 @@ mod tests {
         let monitor = BackgroundTaskMonitor::new();
         spawn_aggregator("test-peer".to_string(), &monitor);
 
-        // Register a peer so emit_aggregate_snapshot has something to
+        // Register a peer so sample_aggregate has something to
         // report (active_peers == 0 short-circuits).
         let ts = VirtualTime::new();
         let addr = unique_addr(40, 50400);

--- a/crates/core/src/transport/rolling_rtt_stats.rs
+++ b/crates/core/src/transport/rolling_rtt_stats.rs
@@ -884,8 +884,11 @@ mod tests {
         let h = RollingRttStatsHandle::new(addr, ts.clone());
         h.record(dur_ms(50));
 
-        // Advance well past two full intervals; the first tick is
-        // skipped, the next two should emit.
+        // Advance a few 1 Hz sample intervals (the first tick is skipped).
+        // No rollup is emitted here — a rollup needs SHADOW_ROLLUP_WINDOW_SECS
+        // (30) samples; this test only exercises the sample loop and asserts
+        // the task survives across ticks. The full sample→emit→reset cycle is
+        // covered by `aggregator_survives_full_window_cycle`.
         tokio::time::advance(AGGREGATOR_INTERVAL * 3 + Duration::from_millis(100)).await;
         // Yield so the spawned task runs.
         tokio::task::yield_now().await;
@@ -903,6 +906,48 @@ mod tests {
         );
 
         drop(h);
+    }
+
+    /// Drive the aggregator through a FULL rollup window so the live
+    /// record → `is_full` → emit → reset cycle actually executes (the shorter
+    /// `aggregator_emits_periodically` stops well before the window closes).
+    /// The OTLP send is a no-op in unit tests (no `TELEMETRY_SENDER` registered),
+    /// so this asserts the cycle runs and the task survives the window boundary
+    /// + reset without panicking, rather than inspecting output. The emit-skip
+    /// branch (`emit_aggregate_rollup` returns early when `window.samples == 0`)
+    /// is pinned deterministically at the window level by the identical guard in
+    /// `reference_ping::tests::rollup_is_skipped_when_no_valid_measurements`;
+    /// this test does not register a peer, so on an unpolluted process-global
+    /// registry it also takes that skip branch, but the survival assertion holds
+    /// regardless of concurrent tests' registry state.
+    #[tokio::test(start_paused = true)]
+    async fn aggregator_survives_full_window_cycle() {
+        use crate::node::background_task_monitor::BackgroundTaskMonitor;
+
+        let monitor = BackgroundTaskMonitor::new();
+        spawn_aggregator("test-peer".to_string(), &monitor);
+
+        // Advance past a full window plus a few samples into the next one, so
+        // the loop hits `is_full`, emits (skipped: no samples), resets, and
+        // keeps going. Yield repeatedly so the spawned task drains every
+        // past-due tick.
+        tokio::time::advance(
+            AGGREGATOR_INTERVAL * (SHADOW_ROLLUP_WINDOW_SECS + 3) + Duration::from_millis(100),
+        )
+        .await;
+        for _ in 0..5 {
+            tokio::task::yield_now().await;
+        }
+
+        let exit = monitor.wait_for_any_exit();
+        tokio::pin!(exit);
+        let still_running = tokio::time::timeout(Duration::from_millis(50), &mut exit)
+            .await
+            .is_err();
+        assert!(
+            still_running,
+            "aggregator must survive a full window emit+reset cycle"
+        );
     }
 
     /// Source-level pin for the `"shadow_rtt_aggregate"` local file-log

--- a/crates/core/src/transport/shadow_demand.rs
+++ b/crates/core/src/transport/shadow_demand.rs
@@ -66,14 +66,16 @@
 //!
 //! ## Telemetry budget
 //!
-//! These two always-on emitters plus the Phase 1 RTT aggregator put three
-//! 1 Hz shadow events (and, on a gateway with reference-ping and iface-tx
-//! enabled, up to five) into an OTLP pipe rate-limited at 10 events/sec
-//! with no priority ordering (`tracing/telemetry.rs`). On a busy gateway
-//! some events — shadow or operational — may be dropped within a 1 s
-//! window. Acceptable as a statistical tradeoff for shadow telemetry; a
-//! shadow-event priority / sub-budget should land before Phase 2 adds
-//! more always-on streams (tracked separately).
+//! These two always-on emitters plus the Phase 1 RTT aggregator sample at
+//! 1 Hz but emit only one rolled-up event each per
+//! [`super::shadow_stats::SHADOW_ROLLUP_WINDOW_SECS`] (see `shadow_stats.rs`);
+//! the per-window `min`/`max`/`mean` preserve the offline floor-analysis
+//! distribution while cutting the central-collector record count by that
+//! factor. Every production peer reports to the central collector by default,
+//! so the raw 1 Hz stream was ~56% of all central telemetry volume — the
+//! rollup is what reclaims it. Shadow events are also admitted under the
+//! low-priority sub-budget (#4380) so they yield to operational telemetry
+//! under load (`tracing/telemetry.rs`).
 //!
 //! ## Process-wide, single-node-per-process
 //!
@@ -90,6 +92,7 @@ use std::sync::{Arc, OnceLock, Weak};
 use std::time::Duration;
 
 use super::global_bandwidth::GlobalBandwidthManager;
+use super::shadow_stats::{SHADOW_ROLLUP_WINDOW_SECS, WindowedStat};
 use super::symmetric_message::SymmetricMessagePayload;
 use crate::node::background_task_monitor::BackgroundTaskMonitor;
 use crate::transport::TRANSPORT_METRICS;
@@ -263,19 +266,83 @@ fn active_connections() -> usize {
     super::rolling_rtt_stats::SHADOW_RTT_REGISTRY.len()
 }
 
-/// 1 Hz cadence, matching the Phase 1/1.5 aggregators so all shadow
-/// streams align at the collector.
+/// 1 Hz sampling cadence, matching the Phase 1/1.5 aggregators so all shadow
+/// streams align at the collector. The aggregator samples the cheap
+/// process-global signals at this cadence but only *emits* one OTLP rollup per
+/// [`SHADOW_ROLLUP_WINDOW_SECS`] samples (see `shadow_stats.rs`).
 const AGGREGATOR_INTERVAL: Duration = Duration::from_secs(1);
+
+/// One 1 Hz sample of the demand signals, taken at tick time.
+struct DemandSample {
+    sent_bytes: u64,
+    active_connections: u64,
+    broadcast_queue_depth: u64,
+    global_total_limit_bytes: Option<u64>,
+    global_per_connection_rate_bytes: Option<u64>,
+    global_active_connections: Option<u64>,
+}
+
+/// Take one demand sample: the interval throughput delta plus the current
+/// gauges. Reads atomics + the (weak) bandwidth handle only — safe on any task.
+fn demand_sample(sent_bytes: u64) -> DemandSample {
+    let gbm = global_bandwidth();
+    DemandSample {
+        sent_bytes,
+        active_connections: active_connections() as u64,
+        broadcast_queue_depth: BROADCAST_QUEUE_DEPTH.load(Ordering::Relaxed) as u64,
+        global_total_limit_bytes: gbm.as_ref().map(|m| m.total_limit() as u64),
+        global_per_connection_rate_bytes: gbm
+            .as_ref()
+            .map(|m| m.current_per_connection_rate() as u64),
+        global_active_connections: gbm.as_ref().map(|m| m.connection_count() as u64),
+    }
+}
+
+/// Windowed rollup accumulator for the `shadow_rate_demand` stream. Folds up to
+/// [`SHADOW_ROLLUP_WINDOW_SECS`] one-second samples, then emits one summary
+/// event and resets.
+#[derive(Default)]
+struct DemandWindow {
+    samples: u32,
+    sent_bytes: WindowedStat,
+    active_connections: WindowedStat,
+    broadcast_queue_depth: WindowedStat,
+    global_total_limit_bytes: WindowedStat,
+    global_per_connection_rate_bytes: WindowedStat,
+    global_active_connections: WindowedStat,
+}
+
+impl DemandWindow {
+    fn record(&mut self, sample: DemandSample) {
+        self.samples += 1;
+        self.sent_bytes.record(sample.sent_bytes);
+        self.active_connections.record(sample.active_connections);
+        self.broadcast_queue_depth
+            .record(sample.broadcast_queue_depth);
+        self.global_total_limit_bytes
+            .record_opt(sample.global_total_limit_bytes);
+        self.global_per_connection_rate_bytes
+            .record_opt(sample.global_per_connection_rate_bytes);
+        self.global_active_connections
+            .record_opt(sample.global_active_connections);
+    }
+
+    fn is_full(&self) -> bool {
+        self.samples >= SHADOW_ROLLUP_WINDOW_SECS
+    }
+}
 
 /// Spawn the `shadow_rate_demand` aggregator and register it with the
 /// `BackgroundTaskMonitor`. Always-on (cheap: atomic loads + one OTLP
-/// event per second), like the RTT aggregator. Call once at node startup.
+/// rollup per [`SHADOW_ROLLUP_WINDOW_SECS`]), like the RTT aggregator. Call
+/// once at node startup.
 ///
 /// Emits achieved outbound throughput (a faithful proxy for offered
 /// demand, since the transport never drops outbound — it sleeps on the
 /// token bucket / cwnd instead, which surfaces as broadcast-queue depth),
 /// the active-connection count, the broadcast-queue depth, and the
-/// global-pool rate `R` when available.
+/// global-pool rate `R` when available — each as a per-window mean plus the
+/// distribution fields the #4074 floor analysis consumes.
 pub(crate) fn spawn_demand_aggregator(local_peer_id: String, monitor: &BackgroundTaskMonitor) {
     let handle = tokio::spawn(async move {
         let mut ticker = tokio::time::interval(AGGREGATOR_INTERVAL);
@@ -284,67 +351,107 @@ pub(crate) fn spawn_demand_aggregator(local_peer_id: String, monitor: &Backgroun
         // the loop is aligned to the cadence.
         ticker.tick().await;
         let mut prev_sent = TRANSPORT_METRICS.cumulative_bytes_sent();
+        let mut window = DemandWindow::default();
         loop {
             ticker.tick().await;
             let now_sent = TRANSPORT_METRICS.cumulative_bytes_sent();
             let sent_delta = now_sent.saturating_sub(prev_sent);
             prev_sent = now_sent;
-            emit_demand_snapshot(&local_peer_id, sent_delta);
+            window.record(demand_sample(sent_delta));
+            if window.is_full() {
+                emit_demand_rollup(&local_peer_id, &window);
+                window = DemandWindow::default();
+            }
         }
     });
     monitor.register("shadow_demand_aggregator", handle);
 }
 
-/// Emit one `shadow_rate_demand` event. See the module-level rustdoc for
+/// Emit one `shadow_rate_demand` rollup. See the module-level rustdoc for
 /// why the OTLP send is independent of the `tracing::debug!` level: the
 /// local mirror is at DEBUG (compiled out of release builds via
 /// `release_max_level_info`), while `send_standalone_shadow_event_with_peer_id`
 /// reaches the collector regardless of log level (tagged low-priority so it
 /// yields to operational telemetry under the rate-limiter sub-budget, #4380).
-fn emit_demand_snapshot(local_peer_id: &str, sent_bytes_last_interval: u64) {
-    let active_connections = active_connections();
-    let broadcast_queue_depth = BROADCAST_QUEUE_DEPTH.load(Ordering::Relaxed);
-    let gbm = global_bandwidth();
-    let global_total_limit_bytes = gbm.as_ref().map(|m| m.total_limit() as u64);
-    let global_per_connection_rate_bytes =
-        gbm.as_ref().map(|m| m.current_per_connection_rate() as u64);
-    let global_active_connections = gbm.as_ref().map(|m| m.connection_count() as u64);
-
+///
+/// Each original field name carries the window **mean** in its original unit
+/// (a per-second rate stays a per-second rate — the mean of the one-second
+/// deltas is the average bytes/sec over the window), so existing consumers of
+/// the flat field keep working. `*_max` (the busiest second's demand /
+/// deepest backlog) and `window_secs` / `samples` are additive.
+fn emit_demand_rollup(local_peer_id: &str, window: &DemandWindow) {
+    let payload = demand_rollup_json(window);
     tracing::debug!(
         target: "freenet::transport::shadow_demand",
-        sent_bytes_last_interval,
-        active_connections,
-        broadcast_queue_depth,
-        global_total_limit_bytes,
-        global_per_connection_rate_bytes,
+        sent_bytes_per_sec = ?window.sent_bytes.mean(),
+        active_connections = ?window.active_connections.mean(),
+        broadcast_queue_depth = ?window.broadcast_queue_depth.mean(),
+        window_secs = SHADOW_ROLLUP_WINDOW_SECS,
         "shadow_rate_demand"
     );
     crate::tracing::telemetry::send_standalone_shadow_event_with_peer_id(
         "shadow_rate_demand",
         local_peer_id,
-        serde_json::json!({
-            // Achieved wire throughput over the last interval (~1 s). A
-            // proxy for offered demand; true offered>granted backlog shows
-            // up as broadcast_queue_depth and (Phase 2) token-bucket debt.
-            "sent_bytes_per_sec": sent_bytes_last_interval,
-            "active_connections": active_connections,
-            "broadcast_queue_depth": broadcast_queue_depth,
-            // Effective aggregate rate R — present only in global-pool
-            // mode (total_bandwidth_limit configured). Null under the
-            // default per-connection FixedRate mode, where the effective
-            // per-connection R is the FixedRate default constant.
-            "global_total_limit_bytes": global_total_limit_bytes,
-            "global_per_connection_rate_bytes": global_per_connection_rate_bytes,
-            "global_active_connections": global_active_connections,
-        }),
+        payload,
     );
+}
+
+/// Build the `shadow_rate_demand` rollup JSON. Pure so the schema (compat
+/// field = window mean, additive distribution fields) is unit-testable without
+/// the telemetry sender.
+fn demand_rollup_json(window: &DemandWindow) -> serde_json::Value {
+    serde_json::json!({
+        // Achieved wire throughput, averaged over the rollup window. A
+        // proxy for offered demand; true offered>granted backlog shows
+        // up as broadcast_queue_depth and (Phase 2) token-bucket debt.
+        "sent_bytes_per_sec": window.sent_bytes.mean(),
+        "sent_bytes_per_sec_min": window.sent_bytes.min(),
+        "sent_bytes_per_sec_max": window.sent_bytes.max(),
+        "active_connections": window.active_connections.mean(),
+        "broadcast_queue_depth": window.broadcast_queue_depth.mean(),
+        // Peak backlog in the window — the value the floor analysis cares
+        // about, since a single congested second is where demand exceeds R.
+        "broadcast_queue_depth_max": window.broadcast_queue_depth.max(),
+        // Effective aggregate rate R — present only in global-pool
+        // mode (total_bandwidth_limit configured). Null under the
+        // default per-connection FixedRate mode, where the effective
+        // per-connection R is the FixedRate default constant.
+        "global_total_limit_bytes": window.global_total_limit_bytes.mean(),
+        "global_per_connection_rate_bytes": window.global_per_connection_rate_bytes.mean(),
+        "global_active_connections": window.global_active_connections.mean(),
+        "window_secs": SHADOW_ROLLUP_WINDOW_SECS,
+        "samples": window.samples,
+    })
+}
+
+/// Windowed rollup accumulator for the `shadow_outbound_class` stream.
+#[derive(Default)]
+struct ClassWindow {
+    samples: u32,
+    must_flow_bytes: WindowedStat,
+    short_bytes: WindowedStat,
+    bulk_bytes: WindowedStat,
+}
+
+impl ClassWindow {
+    fn record(&mut self, must_flow: u64, short: u64, bulk: u64) {
+        self.samples += 1;
+        self.must_flow_bytes.record(must_flow);
+        self.short_bytes.record(short);
+        self.bulk_bytes.record(bulk);
+    }
+
+    fn is_full(&self) -> bool {
+        self.samples >= SHADOW_ROLLUP_WINDOW_SECS
+    }
 }
 
 /// Spawn the `shadow_outbound_class` aggregator and register it with the
 /// `BackgroundTaskMonitor`. Always-on, like the demand aggregator. Reports
-/// the per-interval must-flow / short / bulk byte split that feeds both
-/// floor bounds (lower bound = must-flow rate when not bulk-transferring;
-/// upper bound combines with the OS counter).
+/// the must-flow / short / bulk byte split that feeds both floor bounds
+/// (lower bound = must-flow rate when not bulk-transferring; upper bound
+/// combines with the OS counter), sampled at 1 Hz and emitted as one rollup
+/// per [`SHADOW_ROLLUP_WINDOW_SECS`].
 pub(crate) fn spawn_outbound_class_aggregator(
     local_peer_id: String,
     monitor: &BackgroundTaskMonitor,
@@ -354,39 +461,59 @@ pub(crate) fn spawn_outbound_class_aggregator(
         ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
         ticker.tick().await;
         let mut prev = snapshot_outbound();
+        let mut window = ClassWindow::default();
         loop {
             ticker.tick().await;
             let now = snapshot_outbound();
             let (must_flow, short, bulk) = outbound_delta(prev, now);
             prev = now;
-            emit_class_snapshot(&local_peer_id, must_flow, short, bulk);
+            window.record(must_flow, short, bulk);
+            if window.is_full() {
+                emit_class_rollup(&local_peer_id, &window);
+                window = ClassWindow::default();
+            }
         }
     });
     monitor.register("shadow_outbound_class_aggregator", handle);
 }
 
-fn emit_class_snapshot(
-    local_peer_id: &str,
-    must_flow_bytes: u64,
-    short_bytes: u64,
-    bulk_bytes: u64,
-) {
+/// Emit one `shadow_outbound_class` rollup. Each original field carries the
+/// window mean per-second rate; `*_min` (the must-flow floor, i.e. the least
+/// the class ever pushed in a second) and `*_max` (the burst peak) are the
+/// additive distribution fields the #4074 floor bounds consume directly.
+fn emit_class_rollup(local_peer_id: &str, window: &ClassWindow) {
+    let payload = class_rollup_json(window);
     tracing::debug!(
         target: "freenet::transport::shadow_demand",
-        must_flow_bytes,
-        short_bytes,
-        bulk_bytes,
+        must_flow_bytes = ?window.must_flow_bytes.mean(),
+        short_bytes = ?window.short_bytes.mean(),
+        bulk_bytes = ?window.bulk_bytes.mean(),
+        window_secs = SHADOW_ROLLUP_WINDOW_SECS,
         "shadow_outbound_class"
     );
     crate::tracing::telemetry::send_standalone_shadow_event_with_peer_id(
         "shadow_outbound_class",
         local_peer_id,
-        serde_json::json!({
-            "must_flow_bytes_per_sec": must_flow_bytes,
-            "short_message_bytes_per_sec": short_bytes,
-            "bulk_bytes_per_sec": bulk_bytes,
-        }),
+        payload,
     );
+}
+
+/// Build the `shadow_outbound_class` rollup JSON. Pure so the schema is
+/// unit-testable without the telemetry sender.
+fn class_rollup_json(window: &ClassWindow) -> serde_json::Value {
+    serde_json::json!({
+        "must_flow_bytes_per_sec": window.must_flow_bytes.mean(),
+        "must_flow_bytes_per_sec_min": window.must_flow_bytes.min(),
+        "must_flow_bytes_per_sec_max": window.must_flow_bytes.max(),
+        "short_message_bytes_per_sec": window.short_bytes.mean(),
+        "short_message_bytes_per_sec_min": window.short_bytes.min(),
+        "short_message_bytes_per_sec_max": window.short_bytes.max(),
+        "bulk_bytes_per_sec": window.bulk_bytes.mean(),
+        "bulk_bytes_per_sec_min": window.bulk_bytes.min(),
+        "bulk_bytes_per_sec_max": window.bulk_bytes.max(),
+        "window_secs": SHADOW_ROLLUP_WINDOW_SECS,
+        "samples": window.samples,
+    })
 }
 
 #[cfg(test)]
@@ -502,6 +629,58 @@ mod tests {
         assert_eq!(BROADCAST_QUEUE_DEPTH.load(Ordering::Relaxed), 42);
         record_broadcast_queue_depth(0);
         assert_eq!(BROADCAST_QUEUE_DEPTH.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn demand_rollup_json_keeps_mean_under_original_names_and_adds_distribution() {
+        let mut window = DemandWindow::default();
+        window.record(DemandSample {
+            sent_bytes: 100,
+            active_connections: 4,
+            broadcast_queue_depth: 0,
+            global_total_limit_bytes: None,
+            global_per_connection_rate_bytes: None,
+            global_active_connections: None,
+        });
+        window.record(DemandSample {
+            sent_bytes: 300,
+            active_connections: 6,
+            broadcast_queue_depth: 10,
+            global_total_limit_bytes: None,
+            global_per_connection_rate_bytes: None,
+            global_active_connections: None,
+        });
+        let json = demand_rollup_json(&window);
+        // Compat: the original flat field carries the window MEAN rate.
+        assert_eq!(json["sent_bytes_per_sec"], 200);
+        // Additive distribution fields.
+        assert_eq!(json["sent_bytes_per_sec_min"], 100);
+        assert_eq!(json["sent_bytes_per_sec_max"], 300);
+        assert_eq!(json["active_connections"], 5);
+        assert_eq!(json["broadcast_queue_depth"], 5);
+        assert_eq!(json["broadcast_queue_depth_max"], 10);
+        // FixedRate mode: no global-pool R, so these stay null (unchanged).
+        assert!(json["global_total_limit_bytes"].is_null());
+        assert!(json["global_per_connection_rate_bytes"].is_null());
+        assert_eq!(json["window_secs"], SHADOW_ROLLUP_WINDOW_SECS);
+        assert_eq!(json["samples"], 2);
+    }
+
+    #[test]
+    fn class_rollup_json_keeps_mean_under_original_names_and_adds_distribution() {
+        let mut window = ClassWindow::default();
+        window.record(10, 20, 1000);
+        window.record(30, 20, 3000);
+        let json = class_rollup_json(&window);
+        assert_eq!(json["must_flow_bytes_per_sec"], 20);
+        assert_eq!(json["must_flow_bytes_per_sec_min"], 10);
+        assert_eq!(json["must_flow_bytes_per_sec_max"], 30);
+        assert_eq!(json["short_message_bytes_per_sec"], 20);
+        assert_eq!(json["bulk_bytes_per_sec"], 2000);
+        assert_eq!(json["bulk_bytes_per_sec_min"], 1000);
+        assert_eq!(json["bulk_bytes_per_sec_max"], 3000);
+        assert_eq!(json["window_secs"], SHADOW_ROLLUP_WINDOW_SECS);
+        assert_eq!(json["samples"], 2);
     }
 
     /// `spawn_demand_aggregator` must produce a task that survives across

--- a/crates/core/src/transport/shadow_demand.rs
+++ b/crates/core/src/transport/shadow_demand.rs
@@ -377,15 +377,20 @@ pub(crate) fn spawn_demand_aggregator(local_peer_id: String, monitor: &Backgroun
 /// Each original field name carries the window **mean** in its original unit
 /// (a per-second rate stays a per-second rate — the mean of the one-second
 /// deltas is the average bytes/sec over the window), so existing consumers of
-/// the flat field keep working. `*_max` (the busiest second's demand /
-/// deepest backlog) and `window_secs` / `samples` are additive.
+/// the flat field keep working. `*_min` / `*_p50` / `*_max` (the byte-rate
+/// distribution — `p50` is a more robust central-tendency signal than `mean`
+/// for a bursty rate) and `window_secs` / `samples` are additive.
 fn emit_demand_rollup(local_peer_id: &str, window: &DemandWindow) {
     let payload = demand_rollup_json(window);
+    // Record the Option<u64> means directly (NOT via `?`): tracing renders a
+    // `Some(n)` as the bare number and omits the field for `None`, matching the
+    // OTLP number-or-null. `?` would emit the literal `Some(n)` and break
+    // structured local-log parsers.
     tracing::debug!(
         target: "freenet::transport::shadow_demand",
-        sent_bytes_per_sec = ?window.sent_bytes.mean(),
-        active_connections = ?window.active_connections.mean(),
-        broadcast_queue_depth = ?window.broadcast_queue_depth.mean(),
+        sent_bytes_per_sec = window.sent_bytes.mean(),
+        active_connections = window.active_connections.mean(),
+        broadcast_queue_depth = window.broadcast_queue_depth.mean(),
         window_secs = SHADOW_ROLLUP_WINDOW_SECS,
         "shadow_rate_demand"
     );
@@ -406,6 +411,7 @@ fn demand_rollup_json(window: &DemandWindow) -> serde_json::Value {
         // up as broadcast_queue_depth and (Phase 2) token-bucket debt.
         "sent_bytes_per_sec": window.sent_bytes.mean(),
         "sent_bytes_per_sec_min": window.sent_bytes.min(),
+        "sent_bytes_per_sec_p50": window.sent_bytes.p50(),
         "sent_bytes_per_sec_max": window.sent_bytes.max(),
         "active_connections": window.active_connections.mean(),
         "broadcast_queue_depth": window.broadcast_queue_depth.mean(),
@@ -479,15 +485,19 @@ pub(crate) fn spawn_outbound_class_aggregator(
 
 /// Emit one `shadow_outbound_class` rollup. Each original field carries the
 /// window mean per-second rate; `*_min` (the must-flow floor, i.e. the least
-/// the class ever pushed in a second) and `*_max` (the burst peak) are the
-/// additive distribution fields the #4074 floor bounds consume directly.
+/// the class ever pushed in a second), `*_p50` (robust central tendency for a
+/// bursty rate) and `*_max` (the burst peak) are the additive distribution
+/// fields the #4074 floor bounds consume directly.
 fn emit_class_rollup(local_peer_id: &str, window: &ClassWindow) {
     let payload = class_rollup_json(window);
+    // Record the Option<u64> means directly (NOT via `?`): see the
+    // `emit_demand_rollup` note — bare Option renders as the number-or-null
+    // form the OTLP path uses; `?` would emit `Some(n)` and break parsers.
     tracing::debug!(
         target: "freenet::transport::shadow_demand",
-        must_flow_bytes = ?window.must_flow_bytes.mean(),
-        short_bytes = ?window.short_bytes.mean(),
-        bulk_bytes = ?window.bulk_bytes.mean(),
+        must_flow_bytes = window.must_flow_bytes.mean(),
+        short_bytes = window.short_bytes.mean(),
+        bulk_bytes = window.bulk_bytes.mean(),
         window_secs = SHADOW_ROLLUP_WINDOW_SECS,
         "shadow_outbound_class"
     );
@@ -504,12 +514,15 @@ fn class_rollup_json(window: &ClassWindow) -> serde_json::Value {
     serde_json::json!({
         "must_flow_bytes_per_sec": window.must_flow_bytes.mean(),
         "must_flow_bytes_per_sec_min": window.must_flow_bytes.min(),
+        "must_flow_bytes_per_sec_p50": window.must_flow_bytes.p50(),
         "must_flow_bytes_per_sec_max": window.must_flow_bytes.max(),
         "short_message_bytes_per_sec": window.short_bytes.mean(),
         "short_message_bytes_per_sec_min": window.short_bytes.min(),
+        "short_message_bytes_per_sec_p50": window.short_bytes.p50(),
         "short_message_bytes_per_sec_max": window.short_bytes.max(),
         "bulk_bytes_per_sec": window.bulk_bytes.mean(),
         "bulk_bytes_per_sec_min": window.bulk_bytes.min(),
+        "bulk_bytes_per_sec_p50": window.bulk_bytes.p50(),
         "bulk_bytes_per_sec_max": window.bulk_bytes.max(),
         "window_secs": SHADOW_ROLLUP_WINDOW_SECS,
         "samples": window.samples,
@@ -655,6 +668,8 @@ mod tests {
         assert_eq!(json["sent_bytes_per_sec"], 200);
         // Additive distribution fields.
         assert_eq!(json["sent_bytes_per_sec_min"], 100);
+        // Upper-middle median of [100,300] = sorted[len/2] = sorted[1] = 300.
+        assert_eq!(json["sent_bytes_per_sec_p50"], 300);
         assert_eq!(json["sent_bytes_per_sec_max"], 300);
         assert_eq!(json["active_connections"], 5);
         assert_eq!(json["broadcast_queue_depth"], 5);
@@ -674,10 +689,16 @@ mod tests {
         let json = class_rollup_json(&window);
         assert_eq!(json["must_flow_bytes_per_sec"], 20);
         assert_eq!(json["must_flow_bytes_per_sec_min"], 10);
+        // Upper-middle median of [10,30] = sorted[1] = 30.
+        assert_eq!(json["must_flow_bytes_per_sec_p50"], 30);
         assert_eq!(json["must_flow_bytes_per_sec_max"], 30);
         assert_eq!(json["short_message_bytes_per_sec"], 20);
+        // Both samples are 20, so every summary stat is 20.
+        assert_eq!(json["short_message_bytes_per_sec_p50"], 20);
         assert_eq!(json["bulk_bytes_per_sec"], 2000);
         assert_eq!(json["bulk_bytes_per_sec_min"], 1000);
+        // Upper-middle median of [1000,3000] = sorted[1] = 3000.
+        assert_eq!(json["bulk_bytes_per_sec_p50"], 3000);
         assert_eq!(json["bulk_bytes_per_sec_max"], 3000);
         assert_eq!(json["window_secs"], SHADOW_ROLLUP_WINDOW_SECS);
         assert_eq!(json["samples"], 2);

--- a/crates/core/src/transport/shadow_iface_tx.rs
+++ b/crates/core/src/transport/shadow_iface_tx.rs
@@ -49,6 +49,7 @@
 use std::time::Duration;
 
 use crate::node::background_task_monitor::BackgroundTaskMonitor;
+use crate::simulation::{RealTime, TimeSource};
 use crate::transport::TRANSPORT_METRICS;
 use crate::transport::shadow_stats::{SHADOW_ROLLUP_WINDOW_SECS, WindowedStat};
 
@@ -76,34 +77,42 @@ pub(crate) fn spawn_iface_tx_monitor(local_peer_id: String, monitor: &Background
         // the cadence. `prev_total` and `prev_own` are sampled together so
         // their deltas cover the same window.
         ticker.tick().await;
+        // Monotonic clock (tokio-backed, so it advances with paused time in
+        // tests and reflects true wall-clock — including executor stalls — in
+        // production). The elapsed interval used to normalize a delta to a
+        // per-second rate MUST come from this clock, NOT a tick counter: under
+        // `MissedTickBehavior::Delay` a stalled executor makes one `tick()`
+        // span several wall-clock seconds, so a tick counter would divide by
+        // too few seconds and still fake a burst.
+        let time = RealTime::new();
         let mut prev_total = read_total_tx_bytes().await;
         let mut prev_own = TRANSPORT_METRICS.cumulative_bytes_sent();
-        // Seconds elapsed since the baseline (`prev_*`) was last taken. Ticks
-        // whose `/proc/net/dev` read fails do NOT advance the baseline, so a
-        // gap of failed reads makes the next successful interval span several
-        // seconds. Dividing the delta by this interval normalizes it back to a
-        // per-second rate, so a bridged gap is not misreported as a single
-        // one-second burst.
-        let mut secs_since_baseline: u64 = 0;
+        // Wall-clock nanos when the baseline (`prev_*`) was last taken. A failed
+        // `/proc/net/dev` read does NOT advance the baseline, so a gap of failed
+        // reads (or a stall) makes the next successful interval span several
+        // seconds; dividing the delta by the real elapsed interval normalizes
+        // it back to a per-second rate rather than a single one-second burst.
+        let mut baseline_at_nanos = time.now_nanos();
         let mut window = IfaceWindow::default();
 
         loop {
             ticker.tick().await;
-            secs_since_baseline += 1;
             let now_total = read_total_tx_bytes().await;
             let now_own = TRANSPORT_METRICS.cumulative_bytes_sent();
+            let now_nanos = time.now_nanos();
 
             if let (Some(prev), Some(now)) = (prev_total, now_total) {
                 // Bytes over the (possibly multi-second) interval, divided down
                 // to a per-second rate. Both counters share the same interval,
                 // so `op` stays consistent.
+                let interval_secs = elapsed_secs(baseline_at_nanos, now_nanos);
                 let total_delta = now.saturating_sub(prev);
                 let own_delta = now_own.saturating_sub(prev_own);
                 let op_delta = iface_op(total_delta, own_delta);
                 window.record(
-                    per_sec(total_delta, secs_since_baseline),
-                    per_sec(own_delta, secs_since_baseline),
-                    per_sec(op_delta, secs_since_baseline),
+                    per_sec(total_delta, interval_secs),
+                    per_sec(own_delta, interval_secs),
+                    per_sec(op_delta, interval_secs),
                 );
             }
             window.ticks += 1;
@@ -118,7 +127,7 @@ pub(crate) fn spawn_iface_tx_monitor(local_peer_id: String, monitor: &Background
             if now_total.is_some() {
                 prev_total = now_total;
                 prev_own = now_own;
-                secs_since_baseline = 0;
+                baseline_at_nanos = now_nanos;
             }
         }
     });
@@ -207,14 +216,32 @@ fn iface_op(total_delta: u64, own_delta: u64) -> u64 {
 /// Normalize an interval byte delta to a per-second rate.
 ///
 /// A failed `/proc/net/dev` read does not advance the baseline, so after a gap
-/// of `k` consecutive failed reads the next successful interval spans `k + 1`
-/// seconds. Dividing the delta by that elapsed interval keeps the recorded
-/// value a true per-second rate: without it, a whole multi-second byte count
-/// would be folded into a single one-second sample and reported as a fake burst
-/// (inflating both the window mean and its `max`). `interval_secs` is clamped
-/// to at least 1 to avoid a divide-by-zero on the normal every-second path.
+/// of failed reads (or an executor stall) the next successful interval spans
+/// several seconds. Dividing the delta by that elapsed interval keeps the
+/// recorded value a true per-second rate: without it, a whole multi-second byte
+/// count would be folded into a single one-second sample and reported as a fake
+/// burst (inflating both the window mean and its `max`). `interval_secs` is
+/// clamped to at least 1 to avoid a divide-by-zero on the normal every-second
+/// path (and when [`elapsed_secs`] rounds a sub-second interval to 0).
 fn per_sec(delta: u64, interval_secs: u64) -> u64 {
     delta / interval_secs.max(1)
+}
+
+/// Whole seconds elapsed between two monotonic-clock nanosecond readings,
+/// rounded to nearest.
+///
+/// This is the interval [`per_sec`] divides by. It is derived from the
+/// [`TimeSource`] clock, NOT the tick count, on purpose: under
+/// `MissedTickBehavior::Delay` a stalled executor can make one ticker `tick()`
+/// span several wall-clock seconds, so a tick counter would report `1` and
+/// [`per_sec`] would divide by too few seconds — still faking a burst. The
+/// monotonic clock reflects the true elapsed interval, so the stall normalizes
+/// correctly. A sub-second interval rounds to 0; `per_sec`'s `.max(1)` then
+/// treats it as one second.
+fn elapsed_secs(baseline_nanos: u64, now_nanos: u64) -> u64 {
+    let elapsed = now_nanos.saturating_sub(baseline_nanos);
+    // Round to nearest second (add half a second before the integer divide).
+    (elapsed + 500_000_000) / 1_000_000_000
 }
 
 /// Emit one `shadow_iface_tx` rollup covering the closed window. Skips
@@ -350,6 +377,30 @@ mod tests {
         assert_eq!(per_sec(300_000, 30), 10_000);
         // Divide-by-zero guard (interval clamped to >= 1).
         assert_eq!(per_sec(500, 0), 500);
+    }
+
+    #[test]
+    fn elapsed_secs_uses_wall_clock_not_tick_count() {
+        // Normal ~1 s interval.
+        assert_eq!(elapsed_secs(0, 1_000_000_000), 1);
+        // Executor stall: one tick spanning ~5 wall-clock seconds must yield 5,
+        // NOT 1 (which a tick counter would give), so per_sec divides correctly
+        // and a 5 s byte delta is not reported as a single 1 s burst.
+        assert_eq!(elapsed_secs(0, 5_000_000_000), 5);
+        let stalled_delta = 500_000u64; // ~5 s of bytes
+        assert_eq!(
+            per_sec(stalled_delta, elapsed_secs(0, 5_000_000_000)),
+            100_000,
+            "a 5 s stall normalizes to the real per-second rate, not a 5x burst"
+        );
+        // A 30 s bridged gap (baseline offset to prove it is a difference).
+        assert_eq!(elapsed_secs(1_000_000_000, 31_000_000_000), 30);
+        // Rounds to nearest second.
+        assert_eq!(elapsed_secs(0, 1_400_000_000), 1);
+        assert_eq!(elapsed_secs(0, 1_600_000_000), 2);
+        // Sub-second rounds to 0; per_sec's .max(1) then treats it as 1 s.
+        assert_eq!(elapsed_secs(0, 200_000_000), 0);
+        assert_eq!(per_sec(500, elapsed_secs(0, 200_000_000)), 500);
     }
 
     #[test]

--- a/crates/core/src/transport/shadow_iface_tx.rs
+++ b/crates/core/src/transport/shadow_iface_tx.rs
@@ -50,6 +50,7 @@ use std::time::Duration;
 
 use crate::node::background_task_monitor::BackgroundTaskMonitor;
 use crate::transport::TRANSPORT_METRICS;
+use crate::transport::shadow_stats::{SHADOW_ROLLUP_WINDOW_SECS, WindowedStat};
 
 /// 1 Hz cadence, matching the other shadow aggregators so the streams
 /// align at the collector.
@@ -77,6 +78,7 @@ pub(crate) fn spawn_iface_tx_monitor(local_peer_id: String, monitor: &Background
         ticker.tick().await;
         let mut prev_total = read_total_tx_bytes().await;
         let mut prev_own = TRANSPORT_METRICS.cumulative_bytes_sent();
+        let mut window = IfaceWindow::default();
 
         loop {
             ticker.tick().await;
@@ -87,7 +89,12 @@ pub(crate) fn spawn_iface_tx_monitor(local_peer_id: String, monitor: &Background
                 let total_delta = now.saturating_sub(prev);
                 let own_delta = now_own.saturating_sub(prev_own);
                 let op_delta = iface_op(total_delta, own_delta);
-                emit_iface_snapshot(&local_peer_id, total_delta, own_delta, op_delta);
+                window.record(total_delta, own_delta, op_delta);
+            }
+            window.ticks += 1;
+            if window.ticks >= SHADOW_ROLLUP_WINDOW_SECS {
+                emit_iface_rollup(&local_peer_id, &window);
+                window = IfaceWindow::default();
             }
             // Advance the baseline only on a successful read so that a
             // failed tick is bridged (the next success measures over the
@@ -100,6 +107,28 @@ pub(crate) fn spawn_iface_tx_monitor(local_peer_id: String, monitor: &Background
         }
     });
     monitor.register("shadow_iface_tx_monitor", handle);
+}
+
+/// Windowed rollup accumulator for the `shadow_iface_tx` stream.
+#[derive(Default)]
+struct IfaceWindow {
+    /// Total 1 Hz ticks in this window (including failed reads), used only to
+    /// close the [`SHADOW_ROLLUP_WINDOW_SECS`] window.
+    ticks: u32,
+    /// Ticks that produced a sample (a successful `/proc/net/dev` read).
+    samples: u32,
+    total_tx_bytes: WindowedStat,
+    own_tx_bytes: WindowedStat,
+    op_tx_bytes: WindowedStat,
+}
+
+impl IfaceWindow {
+    fn record(&mut self, total: u64, own: u64, op: u64) {
+        self.samples += 1;
+        self.total_tx_bytes.record(total);
+        self.own_tx_bytes.record(own);
+        self.op_tx_bytes.record(op);
+    }
 }
 
 /// Read `/proc/net/dev` and sum `tx_bytes` across non-loopback
@@ -159,17 +188,26 @@ fn iface_op(total_delta: u64, own_delta: u64) -> u64 {
     total_delta.saturating_sub(own_delta)
 }
 
-fn emit_iface_snapshot(
-    local_peer_id: &str,
-    total_tx_bytes: u64,
-    own_tx_bytes: u64,
-    op_tx_bytes: u64,
-) {
+/// Emit one `shadow_iface_tx` rollup covering the closed window. Skips
+/// emission when no `/proc/net/dev` read succeeded in the whole window
+/// (mirroring the original per-tick "omit on failed read"). Each field keeps
+/// the window mean per-second rate under its original name; `*_max` (the
+/// busiest second's transmit / competing-traffic peak) is the additive
+/// distribution field the #4074 saturation-attribution analysis consumes.
+fn emit_iface_rollup(local_peer_id: &str, window: &IfaceWindow) {
+    if window.samples == 0 {
+        return;
+    }
+    let total_tx_bytes = window.total_tx_bytes.mean();
+    let own_tx_bytes = window.own_tx_bytes.mean();
+    let op_tx_bytes = window.op_tx_bytes.mean();
+
     tracing::debug!(
         target: "freenet::transport::shadow_iface_tx",
-        total_tx_bytes,
-        own_tx_bytes,
-        op_tx_bytes,
+        ?total_tx_bytes,
+        ?own_tx_bytes,
+        ?op_tx_bytes,
+        window_secs = SHADOW_ROLLUP_WINDOW_SECS,
         "shadow_iface_tx"
     );
     crate::tracing::telemetry::send_standalone_shadow_event_with_peer_id(
@@ -177,8 +215,13 @@ fn emit_iface_snapshot(
         local_peer_id,
         serde_json::json!({
             "total_tx_bytes_per_sec": total_tx_bytes,
+            "total_tx_bytes_per_sec_max": window.total_tx_bytes.max(),
             "freenet_own_tx_bytes_per_sec": own_tx_bytes,
+            "freenet_own_tx_bytes_per_sec_max": window.own_tx_bytes.max(),
             "op_tx_bytes_per_sec": op_tx_bytes,
+            "op_tx_bytes_per_sec_max": window.op_tx_bytes.max(),
+            "window_secs": SHADOW_ROLLUP_WINDOW_SECS,
+            "samples": window.samples,
         }),
     );
 }

--- a/crates/core/src/transport/shadow_iface_tx.rs
+++ b/crates/core/src/transport/shadow_iface_tx.rs
@@ -78,18 +78,33 @@ pub(crate) fn spawn_iface_tx_monitor(local_peer_id: String, monitor: &Background
         ticker.tick().await;
         let mut prev_total = read_total_tx_bytes().await;
         let mut prev_own = TRANSPORT_METRICS.cumulative_bytes_sent();
+        // Seconds elapsed since the baseline (`prev_*`) was last taken. Ticks
+        // whose `/proc/net/dev` read fails do NOT advance the baseline, so a
+        // gap of failed reads makes the next successful interval span several
+        // seconds. Dividing the delta by this interval normalizes it back to a
+        // per-second rate, so a bridged gap is not misreported as a single
+        // one-second burst.
+        let mut secs_since_baseline: u64 = 0;
         let mut window = IfaceWindow::default();
 
         loop {
             ticker.tick().await;
+            secs_since_baseline += 1;
             let now_total = read_total_tx_bytes().await;
             let now_own = TRANSPORT_METRICS.cumulative_bytes_sent();
 
             if let (Some(prev), Some(now)) = (prev_total, now_total) {
+                // Bytes over the (possibly multi-second) interval, divided down
+                // to a per-second rate. Both counters share the same interval,
+                // so `op` stays consistent.
                 let total_delta = now.saturating_sub(prev);
                 let own_delta = now_own.saturating_sub(prev_own);
                 let op_delta = iface_op(total_delta, own_delta);
-                window.record(total_delta, own_delta, op_delta);
+                window.record(
+                    per_sec(total_delta, secs_since_baseline),
+                    per_sec(own_delta, secs_since_baseline),
+                    per_sec(op_delta, secs_since_baseline),
+                );
             }
             window.ticks += 1;
             if window.ticks >= SHADOW_ROLLUP_WINDOW_SECS {
@@ -103,6 +118,7 @@ pub(crate) fn spawn_iface_tx_monitor(local_peer_id: String, monitor: &Background
             if now_total.is_some() {
                 prev_total = now_total;
                 prev_own = now_own;
+                secs_since_baseline = 0;
             }
         }
     });
@@ -188,42 +204,66 @@ fn iface_op(total_delta: u64, own_delta: u64) -> u64 {
     total_delta.saturating_sub(own_delta)
 }
 
+/// Normalize an interval byte delta to a per-second rate.
+///
+/// A failed `/proc/net/dev` read does not advance the baseline, so after a gap
+/// of `k` consecutive failed reads the next successful interval spans `k + 1`
+/// seconds. Dividing the delta by that elapsed interval keeps the recorded
+/// value a true per-second rate: without it, a whole multi-second byte count
+/// would be folded into a single one-second sample and reported as a fake burst
+/// (inflating both the window mean and its `max`). `interval_secs` is clamped
+/// to at least 1 to avoid a divide-by-zero on the normal every-second path.
+fn per_sec(delta: u64, interval_secs: u64) -> u64 {
+    delta / interval_secs.max(1)
+}
+
 /// Emit one `shadow_iface_tx` rollup covering the closed window. Skips
 /// emission when no `/proc/net/dev` read succeeded in the whole window
 /// (mirroring the original per-tick "omit on failed read"). Each field keeps
-/// the window mean per-second rate under its original name; `*_max` (the
-/// busiest second's transmit / competing-traffic peak) is the additive
-/// distribution field the #4074 saturation-attribution analysis consumes.
+/// the window mean per-second rate under its original name; `*_p50` (robust
+/// central tendency for a bursty rate) and `*_max` (the busiest second's
+/// transmit / competing-traffic peak) are the additive distribution fields the
+/// #4074 saturation-attribution analysis consumes.
 fn emit_iface_rollup(local_peer_id: &str, window: &IfaceWindow) {
     if window.samples == 0 {
         return;
     }
-    let total_tx_bytes = window.total_tx_bytes.mean();
-    let own_tx_bytes = window.own_tx_bytes.mean();
-    let op_tx_bytes = window.op_tx_bytes.mean();
-
+    // Record the Option<u64> means directly (NOT via `?`): tracing renders a
+    // `Some(n)` as the bare number and omits the field for `None`, matching the
+    // OTLP number-or-null. `?` would emit the literal `Some(n)` and break
+    // structured local-log parsers.
     tracing::debug!(
         target: "freenet::transport::shadow_iface_tx",
-        ?total_tx_bytes,
-        ?own_tx_bytes,
-        ?op_tx_bytes,
+        total_tx_bytes = window.total_tx_bytes.mean(),
+        own_tx_bytes = window.own_tx_bytes.mean(),
+        op_tx_bytes = window.op_tx_bytes.mean(),
         window_secs = SHADOW_ROLLUP_WINDOW_SECS,
         "shadow_iface_tx"
     );
     crate::tracing::telemetry::send_standalone_shadow_event_with_peer_id(
         "shadow_iface_tx",
         local_peer_id,
-        serde_json::json!({
-            "total_tx_bytes_per_sec": total_tx_bytes,
-            "total_tx_bytes_per_sec_max": window.total_tx_bytes.max(),
-            "freenet_own_tx_bytes_per_sec": own_tx_bytes,
-            "freenet_own_tx_bytes_per_sec_max": window.own_tx_bytes.max(),
-            "op_tx_bytes_per_sec": op_tx_bytes,
-            "op_tx_bytes_per_sec_max": window.op_tx_bytes.max(),
-            "window_secs": SHADOW_ROLLUP_WINDOW_SECS,
-            "samples": window.samples,
-        }),
+        iface_rollup_json(window),
     );
+}
+
+/// Build the `shadow_iface_tx` rollup JSON. Pure so the schema (compat field =
+/// window mean per-second rate, additive `*_p50` / `*_max` distribution fields)
+/// is unit-testable without the telemetry sender.
+fn iface_rollup_json(window: &IfaceWindow) -> serde_json::Value {
+    serde_json::json!({
+        "total_tx_bytes_per_sec": window.total_tx_bytes.mean(),
+        "total_tx_bytes_per_sec_p50": window.total_tx_bytes.p50(),
+        "total_tx_bytes_per_sec_max": window.total_tx_bytes.max(),
+        "freenet_own_tx_bytes_per_sec": window.own_tx_bytes.mean(),
+        "freenet_own_tx_bytes_per_sec_p50": window.own_tx_bytes.p50(),
+        "freenet_own_tx_bytes_per_sec_max": window.own_tx_bytes.max(),
+        "op_tx_bytes_per_sec": window.op_tx_bytes.mean(),
+        "op_tx_bytes_per_sec_p50": window.op_tx_bytes.p50(),
+        "op_tx_bytes_per_sec_max": window.op_tx_bytes.max(),
+        "window_secs": SHADOW_ROLLUP_WINDOW_SECS,
+        "samples": window.samples,
+    })
 }
 
 #[cfg(test)]
@@ -298,6 +338,60 @@ mod tests {
         // The skewed-window case the module rustdoc promises to handle:
         // own > total must clamp op to 0, never wrap.
         assert_eq!(iface_op(1_000, 4_000), 0);
+    }
+
+    #[test]
+    fn per_sec_normalizes_bridged_gap_to_a_rate() {
+        // Normal every-second path: delta is already a per-second rate.
+        assert_eq!(per_sec(9_000, 1), 9_000);
+        // A gap: 29 failed reads then one success bridges a 30 s interval, so
+        // the 30 s byte count must be divided back to a per-second rate rather
+        // than recorded as a single one-second burst.
+        assert_eq!(per_sec(300_000, 30), 10_000);
+        // Divide-by-zero guard (interval clamped to >= 1).
+        assert_eq!(per_sec(500, 0), 500);
+    }
+
+    #[test]
+    fn bridged_gap_does_not_fake_a_burst_in_the_rollup() {
+        // Regression: before the per-second normalization, a window with 29
+        // failed reads and one success recorded the whole ~30 s byte count as a
+        // single 1 s sample, so mean == max == the full multi-second burst.
+        // With normalization the single bridged sample is a true per-second
+        // rate, so no fake burst appears.
+        let mut window = IfaceWindow::default();
+        // 29 failed reads contribute no sample but count as elapsed ticks.
+        for _ in 0..29 {
+            window.ticks += 1;
+        }
+        // One success bridging a 30 s interval carrying 300_000 total bytes.
+        let interval = 30u64;
+        window.record(per_sec(300_000, interval), per_sec(60_000, interval), 0);
+        window.ticks += 1;
+
+        let json = iface_rollup_json(&window);
+        // 300_000 / 30 = 10_000 bytes/sec, NOT the raw 300_000 burst.
+        assert_eq!(json["total_tx_bytes_per_sec"], 10_000);
+        assert_eq!(json["total_tx_bytes_per_sec_max"], 10_000);
+        assert_eq!(json["freenet_own_tx_bytes_per_sec"], 2_000);
+        // Only the one successful read counts as a sample; the 29 gaps do not.
+        assert_eq!(json["samples"], 1);
+        assert_eq!(json["window_secs"], SHADOW_ROLLUP_WINDOW_SECS);
+    }
+
+    #[test]
+    fn iface_rollup_json_includes_p50_for_byte_rates() {
+        let mut window = IfaceWindow::default();
+        window.record(10_000, 4_000, 6_000);
+        window.record(30_000, 4_000, 26_000);
+        window.ticks += 2;
+        let json = iface_rollup_json(&window);
+        assert_eq!(json["total_tx_bytes_per_sec"], 20_000); // mean
+        // Upper-middle median of [10_000, 30_000] = sorted[1] = 30_000.
+        assert_eq!(json["total_tx_bytes_per_sec_p50"], 30_000);
+        assert_eq!(json["total_tx_bytes_per_sec_max"], 30_000);
+        assert_eq!(json["op_tx_bytes_per_sec_p50"], 26_000);
+        assert_eq!(json["samples"], 2);
     }
 
     /// `spawn_iface_tx_monitor` must keep its task alive across ticks even

--- a/crates/core/src/transport/shadow_stats.rs
+++ b/crates/core/src/transport/shadow_stats.rs
@@ -14,10 +14,11 @@
 //! floor bounds), not any real-time controller — nothing reads them back on
 //! the production data path. An offline distribution does not need every raw
 //! 1 Hz sample transmitted individually: the node can fold a window of samples
-//! into one rollup carrying the summary statistics (`mean` / `min` / `max`,
-//! plus `p50` for the latency streams) and emit that once per window. The
-//! window's `max`/`p50` preserve the burst peak and the median that the floor
-//! analysis actually consumes, while the record count drops by
+//! into one rollup carrying the summary statistics (`mean` / `min` / `max` /
+//! `p50`) and emit that once per window. The window's `max`/`p50` preserve the
+//! burst peak and the median that the floor analysis actually consumes (`p50`
+//! is a more robust central-tendency signal than `mean` for the bursty,
+//! skewed byte-rate streams), while the record count drops by
 //! [`SHADOW_ROLLUP_WINDOW_SECS`]x on the shadow slice.
 //!
 //! Backwards compatibility: each rollup keeps every original top-level field
@@ -86,7 +87,8 @@ impl WindowedStat {
         self.samples.iter().copied().max()
     }
 
-    /// Arithmetic mean, rounded to the nearest integer, or `None`.
+    /// Arithmetic mean, floored to an integer (integer division truncates
+    /// toward zero), or `None`.
     ///
     /// Summed in `u128` so a full window of large `u64` byte counters cannot
     /// overflow before the divide.
@@ -98,11 +100,14 @@ impl WindowedStat {
         Some((sum / self.samples.len() as u128) as u64)
     }
 
-    /// Median (lower-median for an even sample count), or `None`.
+    /// Median (upper-middle value for an even sample count), or `None`.
     ///
-    /// Matches the lower-median convention the existing per-connection RTT
-    /// aggregate uses (`rolling_rtt_stats::cross_connection_median_inflation`)
-    /// so the two medians stay directly comparable in the offline analysis.
+    /// For an even sample count this returns `sorted[len / 2]`, the
+    /// upper-middle of the two central values. Matches the upper-middle-median
+    /// convention the existing per-connection RTT aggregate uses
+    /// (`rolling_rtt_stats::cross_connection_median_inflation`, and the recent
+    /// median in `RollingRttStats::snapshot`) so the two medians stay directly
+    /// comparable in the offline analysis.
     pub(crate) fn p50(&self) -> Option<u64> {
         if self.samples.is_empty() {
             return None;
@@ -166,12 +171,13 @@ mod tests {
     }
 
     #[test]
-    fn p50_uses_lower_median_for_even_counts() {
+    fn p50_uses_upper_middle_median_for_even_counts() {
         let mut stat = WindowedStat::default();
         for v in [1u64, 2, 3, 4] {
             stat.record(v);
         }
-        // sorted [1,2,3,4], len/2 == 2 → 3 (lower-median convention).
+        // sorted [1,2,3,4], len/2 == 2 → 3 (upper-middle of the two central
+        // values 2 and 3; matches the RTT aggregate's median convention).
         assert_eq!(stat.p50(), Some(3));
     }
 }

--- a/crates/core/src/transport/shadow_stats.rs
+++ b/crates/core/src/transport/shadow_stats.rs
@@ -1,0 +1,177 @@
+//! Node-side windowed rollup for the always-on #4074 "shadow" floor-analysis
+//! telemetry (`shadow_rtt_aggregate`, `shadow_rate_demand`,
+//! `shadow_outbound_class`, `shadow_reference_ping`, `shadow_iface_tx`).
+//!
+//! ## Why this exists
+//!
+//! Each shadow aggregator samples a cheap process-global signal once per
+//! second and used to emit one OTLP event *per sample*. Every production peer
+//! reports to the central collector (nova) by default, so the three always-on
+//! streams alone put `3 events/sec × fleet` into the collector — measured at
+//! ~56% of all central telemetry volume (the top three event types by count).
+//!
+//! The per-second samples feed an **offline** distribution analysis (#4074
+//! floor bounds), not any real-time controller — nothing reads them back on
+//! the production data path. An offline distribution does not need every raw
+//! 1 Hz sample transmitted individually: the node can fold a window of samples
+//! into one rollup carrying the summary statistics (`mean` / `min` / `max`,
+//! plus `p50` for the latency streams) and emit that once per window. The
+//! window's `max`/`p50` preserve the burst peak and the median that the floor
+//! analysis actually consumes, while the record count drops by
+//! [`SHADOW_ROLLUP_WINDOW_SECS`]x on the shadow slice.
+//!
+//! Backwards compatibility: each rollup keeps every original top-level field
+//! name, now carrying the window **mean** in the same unit (a per-second rate
+//! stays a per-second rate; a gauge stays that gauge, window-averaged), so any
+//! existing consumer that reads the flat field keeps working. The distribution
+//! fields (`*_min` / `*_max` / `*_p50`, `window_secs`, `samples`) are purely
+//! additive.
+
+/// Number of 1 Hz shadow samples folded into a single rollup emission.
+///
+/// All shadow aggregators tick at 1 Hz, so this is both the sample count per
+/// rollup and the wall-clock window in seconds. Raising it cuts central
+/// telemetry volume proportionally (30 → one shadow record per stream per 30 s,
+/// i.e. a 30x reduction on the shadow slice) at the cost of coarser temporal
+/// resolution; the per-window `min`/`max`/`p50` keep the in-window distribution
+/// regardless, so the floor analysis loses no statistical signal — only the
+/// ability to place an event to the exact second, which the 2–4 week
+/// observation horizon does not need.
+///
+/// 30 s keeps two rollups per minute (ample for the diurnal/contention
+/// patterns the analysis looks for) while capturing essentially the whole
+/// ~56% shadow volume prize.
+pub(crate) const SHADOW_ROLLUP_WINDOW_SECS: u32 = 30;
+
+/// Accumulates the `u64` samples of one metric over a rollup window and
+/// computes summary statistics. Cheap: a `Vec` of at most
+/// [`SHADOW_ROLLUP_WINDOW_SECS`] entries, reset after each emission.
+///
+/// `Option` samples (a metric that is absent on some ticks, e.g.
+/// `median_inflation_us` before enough RTT samples exist) are folded via
+/// [`WindowedStat::record_opt`], which skips `None` so the stats reflect only
+/// the ticks where the metric was actually measured.
+#[derive(Default)]
+pub(crate) struct WindowedStat {
+    samples: Vec<u64>,
+}
+
+impl WindowedStat {
+    /// Fold one sample into the window.
+    pub(crate) fn record(&mut self, value: u64) {
+        self.samples.push(value);
+    }
+
+    /// Fold an optional sample, skipping `None` (an unmeasured tick).
+    pub(crate) fn record_opt(&mut self, value: Option<u64>) {
+        if let Some(value) = value {
+            self.samples.push(value);
+        }
+    }
+
+    /// Number of measured samples in the window. Test-only: production paths
+    /// track their own tick/sample counters on the per-stream window struct.
+    #[cfg(test)]
+    pub(crate) fn count(&self) -> usize {
+        self.samples.len()
+    }
+
+    /// Smallest sample, or `None` if no sample was measured this window.
+    pub(crate) fn min(&self) -> Option<u64> {
+        self.samples.iter().copied().min()
+    }
+
+    /// Largest sample (the in-window burst peak), or `None`.
+    pub(crate) fn max(&self) -> Option<u64> {
+        self.samples.iter().copied().max()
+    }
+
+    /// Arithmetic mean, rounded to the nearest integer, or `None`.
+    ///
+    /// Summed in `u128` so a full window of large `u64` byte counters cannot
+    /// overflow before the divide.
+    pub(crate) fn mean(&self) -> Option<u64> {
+        if self.samples.is_empty() {
+            return None;
+        }
+        let sum: u128 = self.samples.iter().map(|&v| v as u128).sum();
+        Some((sum / self.samples.len() as u128) as u64)
+    }
+
+    /// Median (lower-median for an even sample count), or `None`.
+    ///
+    /// Matches the lower-median convention the existing per-connection RTT
+    /// aggregate uses (`rolling_rtt_stats::cross_connection_median_inflation`)
+    /// so the two medians stay directly comparable in the offline analysis.
+    pub(crate) fn p50(&self) -> Option<u64> {
+        if self.samples.is_empty() {
+            return None;
+        }
+        let mut sorted = self.samples.clone();
+        sorted.sort_unstable();
+        Some(sorted[sorted.len() / 2])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_stat_yields_none() {
+        let stat = WindowedStat::default();
+        assert_eq!(stat.count(), 0);
+        assert_eq!(stat.min(), None);
+        assert_eq!(stat.max(), None);
+        assert_eq!(stat.mean(), None);
+        assert_eq!(stat.p50(), None);
+    }
+
+    #[test]
+    fn record_opt_skips_none_samples() {
+        let mut stat = WindowedStat::default();
+        stat.record_opt(None);
+        stat.record_opt(Some(10));
+        stat.record_opt(None);
+        stat.record_opt(Some(20));
+        // Only the two measured ticks count.
+        assert_eq!(stat.count(), 2);
+        assert_eq!(stat.min(), Some(10));
+        assert_eq!(stat.max(), Some(20));
+        assert_eq!(stat.mean(), Some(15));
+    }
+
+    #[test]
+    fn summary_stats_over_a_window() {
+        let mut stat = WindowedStat::default();
+        for v in [5u64, 1, 9, 3, 7] {
+            stat.record(v);
+        }
+        assert_eq!(stat.count(), 5);
+        assert_eq!(stat.min(), Some(1));
+        assert_eq!(stat.max(), Some(9));
+        assert_eq!(stat.mean(), Some(5)); // (5+1+9+3+7)/5 = 25/5
+        assert_eq!(stat.p50(), Some(5)); // sorted [1,3,5,7,9], index 2
+    }
+
+    #[test]
+    fn mean_rounds_down_and_cannot_overflow() {
+        let mut stat = WindowedStat::default();
+        // A full 30 s window of the largest plausible per-second byte counter.
+        for _ in 0..SHADOW_ROLLUP_WINDOW_SECS {
+            stat.record(u64::MAX);
+        }
+        // u128 accumulation keeps this exact rather than overflowing.
+        assert_eq!(stat.mean(), Some(u64::MAX));
+    }
+
+    #[test]
+    fn p50_uses_lower_median_for_even_counts() {
+        let mut stat = WindowedStat::default();
+        for v in [1u64, 2, 3, 4] {
+            stat.record(v);
+        }
+        // sorted [1,2,3,4], len/2 == 2 → 3 (lower-median convention).
+        assert_eq!(stat.p50(), Some(3));
+    }
+}


### PR DESCRIPTION
## Problem

The central OTLP telemetry collector ingests ~56-70 GB/day from ~518 reporting
peers. The three **always-on** #4074 "shadow" floor-analysis streams dominate:

| event | share of central volume | cadence |
|---|---|---|
| `shadow_outbound_class` | ~22% | 1 Hz per peer |
| `shadow_rate_demand` | ~22% | 1 Hz per peer |
| `shadow_rtt_aggregate` | ~21% | 1 Hz per peer |

Together **~56-65% of all central telemetry volume** (measured live on the
collector). The two opt-in gateway streams (`shadow_reference_ping`,
`shadow_iface_tx`) emit at the same 1 Hz cadence.

These events feed an **offline** distribution analysis (#4074 outer-loop
rate-controller floor bounds) over a 2-4 week horizon. They are pure
observation: nothing reads them on the production data path, no dashboard or
collector script consumes them at per-event granularity, and #4074 needs the
RTT-inflation / rate **distribution**, not per-second samples. (Verified by
sweeping the repo, the nova dashboard `/var/www/freenet-dashboard`, and the
collector scripts — no consumer reads any shadow field at per-event
granularity; the only shaped consumer, the `replay-harness` OTLP path, is an
un-wired stub, #4314.)

## Approach

Sample each shadow stream at 1 Hz exactly as before, but **emit one rolled-up
event per `SHADOW_ROLLUP_WINDOW_SECS` (= 30 s)** instead of one event per
second. A new `transport::shadow_stats::WindowedStat` accumulates the
per-second samples over the window and computes `mean` / `min` / `max` / `p50`.

Each rollup event:

- **keeps every original flat field name**, now carrying the window **mean** in
  the same unit — a per-second rate stays a per-second rate (the mean of the
  one-second deltas is the average bytes/sec over the window), a gauge stays
  that gauge window-averaged. So any consumer that reads the flat field is
  byte-compatible and nothing downstream breaks.
- **adds distribution fields** — `*_min` / `*_max` (and `*_p50` for the
  latency/inflation streams) where analytically load-bearing — plus
  `window_secs` and `samples`, all purely additive.

Why aggregation over dropping/sampling: the offline floor analysis loses **no
statistical signal**. The window `max` preserves the burst peak (the congested
second where demand exceeds R — exactly what the floor bound cares about),
`min` preserves the must-flow floor, and `p50` preserves the median the RTT
analysis consumes. The only thing lost is the ability to place an event to the
exact second, which the 2-4 week observation horizon does not need.

**Volume reduction:** ~29/30 of the shadow records are eliminated — the shadow
slice drops from ~56-65% of central volume to ~2%, i.e. **roughly half of ALL
central telemetry volume removed**, with the analytical signal preserved.

The rate-limiter shadow sub-budget (`MAX_SHADOW_EVENTS_PER_SECOND`, #4380) is
kept as-is; steady-state shadow rate is now well under 1 event/sec so it never
approaches the cap.

## What was PRESERVED untouched (epic-validation signal)

None of the demand-driven-hosting epic (#4642) validation events were touched.
The change is confined to `crates/core/src/transport/{shadow_stats,
shadow_demand,rolling_rtt_stats,reference_ping,shadow_iface_tx}.rs` and one doc
comment in `tracing/telemetry.rs`. Explicitly NOT changed:

- `connect_connected`, `connect_request_sent`, `connect_request_received`,
  `connect_rejected` (connect success/reject rates, route-to-self lattice
  probes, nearest-neighbor distance reconstruction)
- `router_snapshot`, `subscription_health_snapshot`,
  `subscription_root_detected`
- `update_broadcast_received` / `update_broadcast_applied` (UPDATE convergence)
- `transfer_started` / `transfer_completed` and all other `transfer_*`
- `resource_utilization`, `transport_snapshot`, and every operational net-event

Only the five `shadow_*` floor-analysis streams changed, and each keeps its
original field names (window mean) plus additive distribution fields.

## Testing

- New `WindowedStat` unit tests: empty stat, `record_opt` skips `None`,
  mean/min/max/p50 over a window, `u128` mean cannot overflow, lower-median
  convention.
- New schema pin tests for the three always-on rollup JSON builders
  (`demand_rollup_json`, `class_rollup_json`, `aggregate_rollup_json`)
  asserting the compat field = window mean, the additive distribution fields,
  `window_secs`/`samples`, and null-when-never-measured for the Option latency
  field.
- Existing aggregator survival tests still pass; the `shadow_rtt_aggregate`
  DEBUG local-mirror source-scrape pin test
  (`shadow_rtt_aggregate_logs_at_debug_pin_test`) still passes (the DEBUG
  mirror is retained on the rollup path).
- `cargo fmt`, `cargo clippy -p freenet --lib -- -D warnings` clean.

Related: #4074 (the floor-analysis work these streams feed), #4380 (shadow
sub-budget).

[AI-assisted - Claude]
