### PR TITLE
fix(ring): repair or drop phantom in-use contracts (#4612)

### DIFF
--- a/.claude/rules/ring.md
+++ b/.claude/rules/ring.md
@@ -237,6 +237,18 @@ WHEN summarizing contracts in the InterestSync heartbeat handlers
     state store so an evicted-but-on-disk contract (state present, not in the
     hosting cache, still in_use) keeps summarizing — keying on is_hosting_contract
     there would wrongly drop it.
+  → #4612 (root fix for the phantoms the #4610 gate only filters): the 30s
+    recovery loop reconciles the downstream-driven in-use set against the
+    state store (HostingManager::reconcile_phantom_in_use). A contract in_use
+    via downstream subscribers with NO stored state gets a bounded one-shot
+    repair fetch (sub-op GET; ≤ MAX_PHANTOM_REPAIRS_PER_INTERVAL per tick,
+    one per contract per OPERATION_TTL cooldown); after
+    MAX_PHANTOM_REPAIR_ATTEMPTS failures its downstream registration is
+    DROPPED (drop_phantom_downstream + symmetric interest decrement +
+    reconcile_wants_collapse), never kept as a persistent stateless "host".
+    Do NOT instead skip register_downstream_subscriber on a stateless relay:
+    the downstream map is load-bearing for UPDATE forwarding through relay
+    chains — the fix is repair-or-drop, not never-register.
 ```
 
 ### Cleanup Exemptions Must Be Time-Bounded

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -2014,6 +2014,16 @@ impl Ring {
     /// if the network can't absorb this many.
     const MAX_RECOVERY_ATTEMPTS_PER_INTERVAL: usize = 10;
 
+    /// Maximum phantom repair fetches (#4612) spawned per recovery tick.
+    ///
+    /// Bounds the producer (the #4440/#4610 lesson: never an unbounded
+    /// producer feeding the shared serial paths): at 30s intervals this is at
+    /// most 8 sub-op GETs/minute network-wide fetch pressure from phantom
+    /// repair, regardless of how many phantoms the relay path accumulated.
+    /// Per-contract pacing/giving-up lives in
+    /// `HostingManager::reconcile_phantom_in_use` (cooldown + max attempts).
+    const MAX_PHANTOM_REPAIRS_PER_INTERVAL: usize = 4;
+
     /// Skip renewal cycle when channel remaining capacity falls below this
     /// fraction of max (i.e. channel is more than 50% full).
     const RENEWAL_DEFER_CAPACITY_FRACTION: usize = 2; // channel_max / 2
@@ -2233,6 +2243,69 @@ impl Ring {
             if ring.open_connections() == 0 {
                 tracing::debug!("Skipping subscription renewal: no ring connections");
                 continue;
+            }
+
+            // Phantom in-use reconciliation (#4612): enforce `in-use ⇒
+            // has-state`. The transit-relay SUBSCRIBE path registers
+            // downstream subscribers without ever fetching the contract's
+            // state, leaving this node advertised as a "host" it cannot be
+            // (GET dead-ends #4404; summarize storm #4610 before the #4611
+            // gate). Repair each phantom with a bounded one-shot sub-op GET;
+            // after MAX_PHANTOM_REPAIR_ATTEMPTS failures drop the phantom
+            // registration instead of keeping it forever. Runs after the
+            // connection gate: the repair fetch needs peers to route through,
+            // and a disconnected node must not burn its bounded attempts on
+            // fetches that are doomed locally.
+            let repairs = ring.reconcile_phantom_in_use(Self::MAX_PHANTOM_REPAIRS_PER_INTERVAL);
+            if !repairs.is_empty()
+                && let Some(op_manager) = ring.upgrade_op_manager()
+            {
+                for repair in repairs {
+                    match repair {
+                        crate::ring::hosting::PhantomRepair::Fetch(key) => {
+                            tracing::info!(
+                                contract = %key,
+                                "phantom in-use contract (no stored state): \
+                                 starting one-shot repair fetch"
+                            );
+                            // Fire-and-forget: the side effect (contract +
+                            // state cached locally) is what restores the
+                            // invariant; the next 30s pass observes the store.
+                            let _ = crate::operations::get::op_ctx_task::start_sub_op_get(
+                                &op_manager,
+                                *key.id(),
+                                true,
+                            );
+                        }
+                        crate::ring::hosting::PhantomRepair::Drop(key) => {
+                            let removed = ring.drop_phantom_downstream(&key);
+                            tracing::warn!(
+                                contract = %key,
+                                removed_subscribers = removed,
+                                "phantom in-use contract unrepairable: dropping \
+                                 downstream registration (peers re-root via \
+                                 their own lease renewal)"
+                            );
+                            // Mirror the stale-lease expiry handling above:
+                            // decrement interest symmetrically, then collapse
+                            // upstream if no interest remains.
+                            for _ in 0..removed {
+                                op_manager
+                                    .interest_manager
+                                    .remove_downstream_subscriber(&key);
+                            }
+                            if op_manager.reconcile_wants_collapse(
+                                &key,
+                                crate::node::network_status::ReconcileShadowSite::Collapse,
+                            ) {
+                                let op_mgr = op_manager.clone();
+                                GlobalExecutor::spawn(async move {
+                                    op_mgr.send_unsubscribe_upstream(&key).await;
+                                });
+                            }
+                        }
+                    }
+                }
             }
 
             // Get contracts that need subscription renewal (have client subscriptions)
@@ -3676,6 +3749,24 @@ impl Ring {
 
     pub fn expire_stale_downstream_subscribers(&self) -> Vec<(ContractKey, usize)> {
         self.hosting_manager.expire_stale_downstream_subscribers()
+    }
+
+    /// Reconcile downstream-driven in-use contracts against the state store
+    /// (#4612): emit repair fetches for phantoms (in-use, stateless) and
+    /// drops for unrepairable ones. See
+    /// `HostingManager::reconcile_phantom_in_use`.
+    pub(crate) fn reconcile_phantom_in_use(
+        &self,
+        max_fetches: usize,
+    ) -> Vec<crate::ring::hosting::PhantomRepair> {
+        self.hosting_manager.reconcile_phantom_in_use(max_fetches)
+    }
+
+    /// Drop the downstream registration of an unrepairable phantom contract,
+    /// returning the number of removed subscriber entries. See
+    /// `HostingManager::drop_phantom_downstream`.
+    pub(crate) fn drop_phantom_downstream(&self, key: &ContractKey) -> usize {
+        self.hosting_manager.drop_phantom_downstream(key)
     }
 
     pub fn should_unsubscribe_upstream(&self, contract: &ContractKey) -> bool {

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -113,9 +113,43 @@ const MAX_SUBSCRIPTION_BACKOFF_ENTRIES: usize = 4096;
 /// Prevents network-level subscription amplification attacks.
 const MAX_DOWNSTREAM_SUBSCRIBERS_PER_CONTRACT: usize = 512;
 
+/// Maximum one-shot repair-fetch attempts for a phantom in-use contract
+/// (`contract_in_use` via downstream subscribers, but NO stored state — the
+/// #4612 transit-relay leak) before the phantom registration is dropped
+/// rather than kept as a persistent stateless "host".
+const MAX_PHANTOM_REPAIR_ATTEMPTS: u32 = 3;
+
+/// Minimum spacing between repair-fetch attempts for the same phantom
+/// contract. Derived from [`crate::config::OPERATION_TTL`] (the sub-op GET's
+/// own per-attempt ceiling) so a retry is never issued while the previous
+/// fire-and-forget fetch could still be in flight.
+const PHANTOM_REPAIR_COOLDOWN: Duration = crate::config::OPERATION_TTL;
+
 // =============================================================================
 // Result Types
 // =============================================================================
+
+/// Per-contract repair-fetch attempt tracking for phantom in-use contracts.
+/// See [`HostingManager::reconcile_phantom_in_use`].
+#[derive(Debug, Clone, Copy)]
+struct PhantomRepairEntry {
+    attempts: u32,
+    last_attempt: Instant,
+}
+
+/// Action emitted by [`HostingManager::reconcile_phantom_in_use`] for one
+/// phantom (in-use, stateless) contract. The driver in
+/// `Ring::recover_orphaned_subscriptions` applies it: `Fetch` spawns a
+/// fire-and-forget sub-op GET (`start_sub_op_get`); `Drop` removes the
+/// phantom registration via [`HostingManager::drop_phantom_downstream`] and
+/// decrements the interest manager.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PhantomRepair {
+    /// Launch a one-shot state repair fetch for the contract.
+    Fetch(ContractKey),
+    /// Repair attempts exhausted — drop the phantom downstream registration.
+    Drop(ContractKey),
+}
 
 /// Result of adding a client subscription.
 #[derive(Debug)]
@@ -364,6 +398,16 @@ pub(crate) struct HostingManager {
     /// without re-entering the `HostingManager` borrow.
     pending_reclamation: std::sync::Arc<DashMap<ContractKey, u64>>,
 
+    /// Repair-fetch attempt tracking for phantom in-use contracts (#4612):
+    /// contract is `contract_in_use` via downstream subscribers but holds NO
+    /// stored state (the transit-relay leak). Keyed per contract with the
+    /// attempt count and the time of the last attempt; entries are removed as
+    /// soon as state appears (repair succeeded) or when the phantom is
+    /// dropped after [`MAX_PHANTOM_REPAIR_ATTEMPTS`]. Level-triggered against
+    /// the state store by [`Self::reconcile_phantom_in_use`], so the map is
+    /// bounded by the number of concurrently-phantom contracts.
+    phantom_repair: DashMap<ContractKey, PhantomRepairEntry>,
+
     /// Aggregate on-disk usage accounting (#4683): hosted state + WASM blobs +
     /// wasmtime compile cache. `None` until [`Self::configure_disk_tracker`]
     /// installs it with the node's real paths (done once at startup alongside
@@ -439,6 +483,7 @@ impl HostingManager {
             storage: RwLock::new(None),
             state_generation: DashMap::new(),
             pending_reclamation: std::sync::Arc::new(DashMap::new()),
+            phantom_repair: DashMap::new(),
             disk_tracker: RwLock::new(None),
             ram_budget_bytes: AtomicU64::new(budget_bytes),
             disk_pct_bits: AtomicU64::new(DEFAULT_HOSTING_DISK_PCT.to_bits()),
@@ -1651,6 +1696,120 @@ impl HostingManager {
             return false;
         }
         !self.has_downstream_subscribers(contract)
+    }
+
+    /// Reconcile the downstream-driven in-use set against the state store
+    /// (#4612 root fix, option b): enforce `in-use ⇒ has-state` as a repaired
+    /// invariant rather than a persistent violation.
+    ///
+    /// The transit-relay SUBSCRIBE path registers downstream subscribers on a
+    /// node that never fetched the contract's state (update forwarding needs
+    /// the registration, so it cannot simply be skipped — see
+    /// `register_downstream_subscriber`). That makes `contract_in_use` true
+    /// with nothing on disk: a "phantom host" that is advertised to neighbors
+    /// (GET dead-ends, #4404) and — before the #4610/#4611 gate — stormed the
+    /// summarize loop. This sweep turns each phantom into one of:
+    ///
+    /// - [`PhantomRepair::Fetch`]: launch a one-shot sub-op GET so the state
+    ///   is actually fetched/stored and the node becomes a real host. Bounded
+    ///   by `max_fetches` per sweep, [`PHANTOM_REPAIR_COOLDOWN`] between
+    ///   attempts per contract (never overlapping an in-flight fetch), and
+    ///   [`MAX_PHANTOM_REPAIR_ATTEMPTS`] total (bound the producer — the
+    ///   #4440/#4610 storms both came from unbounded producers).
+    /// - [`PhantomRepair::Drop`]: attempts exhausted and state still absent —
+    ///   the contract is unretrievable from here; drop the downstream
+    ///   registration (via [`Self::drop_phantom_downstream`]) so the phantom
+    ///   does not persist. The downstream peers' own lease renewal re-roots
+    ///   them through a path that can actually serve the contract.
+    ///
+    /// Decisions are level-triggered against the state store: a contract
+    /// whose state appears (this sweep's fetch, an inbound UPDATE auto-fetch,
+    /// a PUT...) has its tracking cleared on the next pass, whatever wrote it.
+    /// Contracts with a subscription request in flight are skipped — that
+    /// flow fetches the contract itself. Client-subscription-only phantoms
+    /// are not scanned: `client_subscriptions` is keyed by instance id (no
+    /// key index exists) and an active client subscribe already fetches
+    /// state; the dominant phantom source is the relay's downstream map.
+    ///
+    /// Conservative by construction: `contract_state_present` returns `true`
+    /// on the sqlite backend, pre-`set_storage`, and on store errors, so no
+    /// phantom is flagged (and nothing is fetched or dropped) unless a real
+    /// redb store answered "absent".
+    pub(crate) fn reconcile_phantom_in_use(&self, max_fetches: usize) -> Vec<PhantomRepair> {
+        let now = self.time_source.now();
+        let mut actions = Vec::new();
+        let mut fetches = 0usize;
+
+        let keys: Vec<ContractKey> = self
+            .downstream_subscribers
+            .iter()
+            .map(|entry| *entry.key())
+            .collect();
+
+        for key in keys {
+            if self.contract_state_present(&key) {
+                // Invariant holds (or repair succeeded) — clear any tracking.
+                self.phantom_repair.remove(&key);
+                continue;
+            }
+            if self.pending_subscription_requests.contains(&key) {
+                continue;
+            }
+
+            use dashmap::mapref::entry::Entry;
+            match self.phantom_repair.entry(key) {
+                Entry::Occupied(mut e) => {
+                    let entry = e.get_mut();
+                    if now.duration_since(entry.last_attempt) < PHANTOM_REPAIR_COOLDOWN {
+                        continue;
+                    }
+                    if entry.attempts >= MAX_PHANTOM_REPAIR_ATTEMPTS {
+                        e.remove();
+                        actions.push(PhantomRepair::Drop(key));
+                    } else if fetches < max_fetches {
+                        entry.attempts += 1;
+                        entry.last_attempt = now;
+                        fetches += 1;
+                        actions.push(PhantomRepair::Fetch(key));
+                    }
+                }
+                Entry::Vacant(slot) => {
+                    if fetches < max_fetches {
+                        slot.insert(PhantomRepairEntry {
+                            attempts: 1,
+                            last_attempt: now,
+                        });
+                        fetches += 1;
+                        actions.push(PhantomRepair::Fetch(key));
+                    }
+                }
+            }
+        }
+
+        actions
+    }
+
+    /// Drop the downstream-subscriber registration for an unrepairable
+    /// phantom contract (state fetch failed [`MAX_PHANTOM_REPAIR_ATTEMPTS`]
+    /// times). Returns the number of removed subscriber entries so the caller
+    /// can decrement the interest manager symmetrically (one
+    /// `remove_downstream_subscriber` per entry, mirroring the
+    /// `expire_stale_downstream_subscribers` handling in
+    /// `recover_orphaned_subscriptions`).
+    pub(crate) fn drop_phantom_downstream(&self, key: &ContractKey) -> usize {
+        let removed = self
+            .downstream_subscribers
+            .remove(key)
+            .map(|(_, peers)| peers.len())
+            .unwrap_or(0);
+        if removed > 0 {
+            // Same as lease expiry: the contract may have just transitioned to
+            // no-longer-in-use — reset recency so the next over-budget sweep
+            // does not shed it for an old last-read.
+            self.maybe_record_abandonment(key);
+        }
+        self.phantom_repair.remove(key);
+        removed
     }
 
     // =========================================================================
@@ -4598,6 +4757,162 @@ mod tests {
     // would never run: the sqlite backend does not compile on main (unrelated
     // pre-existing errors, e.g. missing `get_user_secrets_index`) and there is
     // no sqlite CI lane, so such a test would be unverifiable dead code.
+
+    /// Behavioural regression for #4612 (phantom-hosting root cause): the
+    /// reconcile sweep must enforce `in-use ⇒ has-state` as a REPAIRED
+    /// invariant — a downstream-registered contract with no stored state gets
+    /// a bounded one-shot fetch per cooldown window, and after
+    /// `MAX_PHANTOM_REPAIR_ATTEMPTS` failures a `Drop` so the phantom does
+    /// not persist. Covers all four transitions through a real redb store and
+    /// the injected clock:
+    ///   - phantom (downstream, stateless) → `Fetch`, exactly once per
+    ///     cooldown window (a retry never overlaps the in-flight fetch);
+    ///   - attempts exhausted → `Drop`, and applying it via
+    ///     `drop_phantom_downstream` clears `contract_in_use`;
+    ///   - repair success (state appears between passes, whatever wrote it)
+    ///     → tracking cleared, no further fetches, contract keeps its
+    ///     downstream subscribers;
+    ///   - a stateful in-use contract is never flagged.
+    #[cfg(feature = "redb")]
+    #[tokio::test]
+    async fn phantom_in_use_reconcile_fetch_then_drop_4612() {
+        use freenet_stdlib::prelude::WrappedState;
+
+        let clock = crate::util::time_source::SharedMockTimeSource::new();
+        let manager = HostingManager::with_time_source(
+            DEFAULT_HOSTING_BUDGET_BYTES,
+            std::sync::Arc::new(clock.clone()),
+        );
+
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let storage = crate::contract::storages::ReDb::new(temp_dir.path())
+            .await
+            .unwrap();
+        // Keep a handle to write state mid-test (repair-success case).
+        let store_handle = storage.clone();
+
+        let peer = make_peer_key(7);
+
+        // Phantom: relay-registered downstream subscriber, state never fetched.
+        let phantom = make_contract_key(70);
+        manager.add_downstream_subscriber(&phantom, peer.clone());
+
+        // Stateful in-use contract: must never be flagged.
+        let stateful = make_contract_key(71);
+        storage
+            .store_state_sync(&stateful, WrappedState::new(vec![1, 2, 3]))
+            .unwrap();
+        manager.add_downstream_subscriber(&stateful, peer.clone());
+
+        manager.set_storage(storage);
+
+        assert!(
+            manager.contract_in_use(&phantom) && !manager.contract_state_present(&phantom),
+            "phantom precondition: in-use with no stored state (#4612)"
+        );
+
+        // Attempt 1, then nothing until the cooldown elapses.
+        assert_eq!(
+            manager.reconcile_phantom_in_use(8),
+            vec![PhantomRepair::Fetch(phantom)],
+            "a phantom gets a repair fetch; the stateful contract is not flagged"
+        );
+        assert!(
+            manager.reconcile_phantom_in_use(8).is_empty(),
+            "within the cooldown no second fetch is issued (never overlap the \
+             in-flight sub-op GET)"
+        );
+
+        // Attempts 2 and 3, one per cooldown window.
+        for attempt in 2..=MAX_PHANTOM_REPAIR_ATTEMPTS {
+            clock.advance_time(PHANTOM_REPAIR_COOLDOWN + Duration::from_secs(1));
+            assert_eq!(
+                manager.reconcile_phantom_in_use(8),
+                vec![PhantomRepair::Fetch(phantom)],
+                "attempt {attempt} fires after the cooldown"
+            );
+        }
+
+        // Attempts exhausted → Drop; applying it removes the phantom's
+        // downstream registration and with it `contract_in_use`.
+        clock.advance_time(PHANTOM_REPAIR_COOLDOWN + Duration::from_secs(1));
+        assert_eq!(
+            manager.reconcile_phantom_in_use(8),
+            vec![PhantomRepair::Drop(phantom)],
+            "after MAX_PHANTOM_REPAIR_ATTEMPTS failed fetches the phantom is dropped, \
+             not kept as a persistent stateless host"
+        );
+        assert_eq!(manager.drop_phantom_downstream(&phantom), 1);
+        assert!(
+            !manager.contract_in_use(&phantom),
+            "dropping the phantom clears contract_in_use — the #4612 invariant"
+        );
+        assert!(manager.reconcile_phantom_in_use(8).is_empty());
+
+        // Repair-success path: state appears (here via a direct store write,
+        // in production via the sub-op GET / an UPDATE auto-fetch / a PUT)
+        // after the first attempt → tracking cleared, no more fetches, and
+        // the contract keeps its downstream subscribers.
+        let repaired = make_contract_key(72);
+        manager.add_downstream_subscriber(&repaired, peer.clone());
+        assert_eq!(
+            manager.reconcile_phantom_in_use(8),
+            vec![PhantomRepair::Fetch(repaired)]
+        );
+        store_handle
+            .store_state_sync(&repaired, WrappedState::new(vec![9, 9]))
+            .unwrap();
+        clock.advance_time(PHANTOM_REPAIR_COOLDOWN + Duration::from_secs(1));
+        assert!(
+            manager.reconcile_phantom_in_use(8).is_empty(),
+            "once state is present the contract is no longer a phantom"
+        );
+        assert!(
+            manager.contract_in_use(&repaired),
+            "a repaired contract keeps its downstream subscribers (now a real host)"
+        );
+
+        // The stateful contract was never touched throughout.
+        assert!(manager.contract_in_use(&stateful));
+    }
+
+    /// #4612 producer bound: `max_fetches` caps the fetches emitted per sweep
+    /// (the #4440/#4610 lesson — never an unbounded producer). Contracts left
+    /// over are NOT counted as attempts and get picked up by a later sweep.
+    #[cfg(feature = "redb")]
+    #[tokio::test]
+    async fn phantom_reconcile_bounds_fetches_per_sweep_4612() {
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let storage = crate::contract::storages::ReDb::new(temp_dir.path())
+            .await
+            .unwrap();
+        manager.set_storage(storage);
+
+        let peer = make_peer_key(9);
+        for i in 0..5u8 {
+            manager.add_downstream_subscriber(&make_contract_key(100 + i), peer.clone());
+        }
+
+        let first = manager.reconcile_phantom_in_use(2);
+        assert_eq!(first.len(), 2, "sweep emits at most max_fetches fetches");
+        // The remaining phantoms are untracked (no attempt burned) and the
+        // next sweep picks them up immediately — no cooldown applies to a
+        // contract that never got its fetch.
+        let second = manager.reconcile_phantom_in_use(8);
+        assert_eq!(
+            second.len(),
+            3,
+            "later sweeps pick up the leftover phantoms without burning attempts"
+        );
+        assert!(
+            first
+                .iter()
+                .chain(second.iter())
+                .all(|a| matches!(a, PhantomRepair::Fetch(_))),
+            "all emitted actions are fetches on the first pass over fresh phantoms"
+        );
+    }
 
     /// Generation flow through `HostingManager`: bumping the state
     /// generation BEFORE `record_contract_access` makes the captured


### PR DESCRIPTION
## Problem

A node can be marked `contract_in_use` for a contract it has no state for. The dominant source is the SUBSCRIBE transit-relay path: on a relayed `Subscribed` reply the relay registers the downstream subscriber, which flips `contract_in_use = has_downstream_subscribers = true` on a node that never fetched the contract's state.

These "phantom hosts" caused:

- The #4610 summarize storm. The #4611 `contract_state_present` gate stops the storm but only filters the symptom — the phantom itself persists.
- GET dead-ends (#4404): the node is advertised as interested/in-use for a contract it cannot serve.

## Solution

Implements option (b) from #4612: reconcile the downstream-driven in-use set against the state store, making `in-use ⇒ has-state` a repaired invariant instead of a persistent violation.

`HostingManager::reconcile_phantom_in_use` runs every 30s from the existing recovery loop (`Ring::recover_orphaned_subscriptions`), after the lease-expiry sweep and the zero-connections gate. For each contract with downstream subscribers but no stored state it emits one of two actions:

- **`Fetch`** — a fire-and-forget sub-op GET (`start_sub_op_get` with contract code) so the state is actually fetched and stored; the node becomes a real host. Bounded: at most `MAX_PHANTOM_REPAIRS_PER_INTERVAL` (4) fetches per tick, one attempt per contract per `OPERATION_TTL` (60s) cooldown so a retry never overlaps an in-flight fetch, and `MAX_PHANTOM_REPAIR_ATTEMPTS` (3) attempts total.
- **`Drop`** — attempts exhausted and state still absent: the downstream registration is removed (`drop_phantom_downstream`), the interest manager is decremented symmetrically, and upstream is collapsed via `reconcile_wants_collapse` + unsubscribe — mirroring the existing stale-lease expiry handling. Downstream peers re-route through their own lease renewal (2 min interval), the same recovery contract lease expiry already relies on.

Design notes:

- **Repair-or-drop, not never-register.** Option (a) (skip `register_downstream_subscriber` on a stateless relay) was rejected: the downstream map is load-bearing for UPDATE forwarding through relay chains. Documented in `.claude/rules/ring.md`.
- **Level-triggered, not edge-triggered.** Decisions are made against the state store each sweep, not at subscribe arrival. Phantoms that self-heal (UPDATE auto-fetch, an in-flight subscription — skipped via `pending_subscription_requests` — a PUT) never consume repair budget, and the producer stays bounded regardless of subscribe traffic (the #4440/#4610 lesson).
- **Conservative by construction.** `contract_state_present` returns `true` on the sqlite backend, before `set_storage`, and on store errors — nothing is fetched or dropped unless a real redb store answered "absent". On sqlite the sweep is a safe no-op (same limitation as the #4611 gate).
- The bounded attempts satisfy the time-bounded cleanup-exemption rule: a phantom is resolved (repaired or dropped) in ~2.5–3.5 min, well within one subscription lease (8 min).

## Testing

Two regression tests in `ring/hosting.rs` (redb + injected mock clock, no network):

- `phantom_in_use_reconcile_fetch_then_drop_4612` — covers all four transitions: phantom → `Fetch` exactly once per cooldown window; attempts exhausted → `Drop`, and applying it clears `contract_in_use`; repair success (state appears between passes) → tracking cleared, downstream subscribers kept; a stateful in-use contract is never flagged.
- `phantom_reconcile_bounds_fetches_per_sweep_4612` — `max_fetches` caps fetches per sweep; leftover phantoms are picked up by later sweeps without burning attempts.

## Fixes

Closes #4612. Root fix for the phantoms behind #4610 (complements the #4611 gate, which remains as the symptom filter). Refs #4404.