### PR TITLE
fix(contract): surface silently-dropped update notifications

### DIFF
--- a/crates/core/src/client_events.rs
+++ b/crates/core/src/client_events.rs
@@ -85,7 +85,7 @@ async fn register_subscription_listener(
             );
         });
     match register_listener {
-        Ok(ContractHandlerEvent::RegisterSubscriberListenerResponse) => {
+        Ok(ContractHandlerEvent::RegisterSubscriberListenerResponse { result: Ok(()) }) => {
             tracing::debug!(
                 client_id = %client_id,
                 contract = %instance_id,
@@ -103,6 +103,20 @@ async fn register_subscription_listener(
                 }
             }
             Ok(())
+        }
+        // #4681: registration was rejected (e.g. subscriber-limit reached).
+        // Forward the underlying RequestError so the client sees the real
+        // reason instead of a generic "unexpected op state".
+        Ok(ContractHandlerEvent::RegisterSubscriberListenerResponse { result: Err(e) }) => {
+            tracing::error!(
+                client_id = %client_id,
+                contract = %instance_id,
+                operation = operation_type,
+                error = %e,
+                phase = "registration_failed",
+                "Subscriber listener registration rejected"
+            );
+            Err(Error::Registration(e))
         }
         _ => {
             tracing::error!(
@@ -1276,7 +1290,9 @@ async fn process_open_request(
                                 );
                             });
                         match register_listener {
-                            Ok(ContractHandlerEvent::RegisterSubscriberListenerResponse) => {
+                            Ok(ContractHandlerEvent::RegisterSubscriberListenerResponse {
+                                result: Ok(()),
+                            }) => {
                                 tracing::debug!(
                                     client_id = %client_id,
                                     request_id = %request_id,
@@ -1295,6 +1311,23 @@ async fn process_open_request(
                                         op_manager.ring.register_events(Either::Left(event)).await;
                                     }
                                 }
+                            }
+                            // #4681: registration rejected (e.g. subscriber-limit
+                            // reached). Forward the underlying RequestError so the
+                            // client sees the real reason instead of a generic
+                            // "unexpected op state".
+                            Ok(ContractHandlerEvent::RegisterSubscriberListenerResponse {
+                                result: Err(e),
+                            }) => {
+                                tracing::error!(
+                                    client_id = %client_id,
+                                    request_id = %request_id,
+                                    contract = %key,
+                                    error = %e,
+                                    phase = "registration_failed",
+                                    "Subscriber listener registration rejected"
+                                );
+                                return Err(Error::Registration(e));
                             }
                             _ => {
                                 tracing::error!(

--- a/crates/core/src/client_events/error.rs
+++ b/crates/core/src/client_events/error.rs
@@ -1,10 +1,17 @@
 use crate::node::OpManager;
 use crate::operations::OpError;
+use freenet_stdlib::client_api::RequestError;
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum Error {
     #[error("Node not connected to network")]
     Disconnected,
+    /// Registration of a subscriber notifier was rejected (e.g. the
+    /// per-contract subscriber limit was reached). Carries the underlying
+    /// `RequestError` so the detail reaches the client instead of being
+    /// flattened into the generic `UnexpectedOpState` (#4681).
+    #[error("subscriber registration rejected: {0}")]
+    Registration(Box<RequestError>),
     #[error("Peer has not joined the network yet (no ring location established)")]
     PeerNotJoined,
     #[error("No ring connections found")]
@@ -44,4 +51,41 @@ pub(crate) fn ensure_peer_ready(op_manager: &OpManager) -> Result<std::net::Sock
         return Err(Error::PeerNotJoined);
     }
     Ok(op_manager.ring.connection_manager.peer_addr()?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use freenet_stdlib::client_api::ContractError as StdContractError;
+    use freenet_stdlib::prelude::{CodeHash, ContractInstanceId, ContractKey};
+
+    /// #4681 regression: a rejected subscriber registration must surface the
+    /// underlying `RequestError` detail to the client, not the generic
+    /// "unexpected op state" that the old fake-success path collapsed to. The
+    /// `client_event_handling` catch-all wraps the `Error`'s `Display` into the
+    /// client-facing `OperationError { cause }`, so the detail MUST appear in
+    /// the `Error::Registration` display.
+    #[test]
+    fn registration_error_display_carries_underlying_detail() {
+        let key = ContractKey::from_id_and_code(
+            ContractInstanceId::new([7u8; 32]),
+            CodeHash::new([0u8; 32]),
+        );
+        let inner = RequestError::ContractError(StdContractError::Subscribe {
+            key,
+            cause: "subscriber limit (100) reached for contract".into(),
+        });
+        let err = Error::Registration(Box::new(inner));
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("subscriber limit"),
+            "the registration error must carry the underlying cause, got: {rendered}"
+        );
+        // Must NOT collapse to the generic op-state message the old path used.
+        assert_ne!(
+            rendered,
+            Error::Op(OpError::UnexpectedOpState).to_string(),
+            "registration failure must not degrade to the generic UnexpectedOpState message"
+        );
+    }
 }

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -1893,7 +1893,7 @@ async fn send_queue_full_response(
         | ContractHandlerEvent::UpdateResponse { .. }
         | ContractHandlerEvent::UpdateNoChange { .. }
         | ContractHandlerEvent::RegisterSubscriberListener { .. }
-        | ContractHandlerEvent::RegisterSubscriberListenerResponse
+        | ContractHandlerEvent::RegisterSubscriberListenerResponse { .. }
         | ContractHandlerEvent::QuerySubscriptions { .. }
         | ContractHandlerEvent::QuerySubscriptionsResponse
         | ContractHandlerEvent::GetSummaryResponse { .. }
@@ -2510,12 +2510,17 @@ where
             summary,
             subscriber_listener,
         } => {
-            if let Err(err) = contract_handler.executor().register_contract_notifier(
+            // #4681: surface a registration failure to the client instead of
+            // returning a success response that client_events.rs would convert
+            // into a fake successful subscribe. The error rides back on the
+            // response variant so the subscribing client sees a real failure.
+            let result = contract_handler.executor().register_contract_notifier(
                 key,
                 client_id,
                 subscriber_listener,
                 summary,
-            ) {
+            );
+            if let Err(err) = &result {
                 tracing::warn!(
                     contract = %key,
                     client = %client_id,
@@ -2525,11 +2530,13 @@ where
                 );
             }
 
-            // FIXME: if there is an error send actually an error back
             // If the caller disconnected, just log and continue.
             if let Err(error) = contract_handler
                 .channel()
-                .send_to_sender(id, ContractHandlerEvent::RegisterSubscriberListenerResponse)
+                .send_to_sender(
+                    id,
+                    ContractHandlerEvent::RegisterSubscriberListenerResponse { result },
+                )
                 .await
             {
                 tracing::debug!(
@@ -2650,7 +2657,7 @@ where
         | ContractHandlerEvent::GetResponse { .. }
         | ContractHandlerEvent::UpdateResponse { .. }
         | ContractHandlerEvent::UpdateNoChange { .. }
-        | ContractHandlerEvent::RegisterSubscriberListenerResponse
+        | ContractHandlerEvent::RegisterSubscriberListenerResponse { .. }
         | ContractHandlerEvent::QuerySubscriptionsResponse
         | ContractHandlerEvent::GetSummaryResponse { .. }
         | ContractHandlerEvent::GetDeltaResponse { .. } => {
@@ -4745,5 +4752,75 @@ mod hol_4391_tests {
             result.is_err(),
             "no op_manager must surface MissingRelated, got {result:?}"
         );
+    }
+
+    /// Regression for #4681 (partial hardening): when `register_contract_notifier`
+    /// fails (here: the per-contract subscriber limit is exhausted), the
+    /// `RegisterSubscriberListener` handler MUST return a
+    /// `RegisterSubscriberListenerResponse { result: Err(_) }` so the subscribing
+    /// client sees a real failure. Before the fix the handler always returned a
+    /// success response, which `client_events.rs` converted into a fake
+    /// successful subscribe.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn register_subscriber_listener_surfaces_registration_failure() {
+        use crate::contract::executor::{ContractExecutor, MAX_SUBSCRIBERS_PER_CONTRACT};
+
+        let (send_halve, rcv_halve, _) = handler::contract_handler_channel();
+        let mut handler = MockWasmContractHandler::new_test(rcv_halve, None, "reg_fail_4681").await;
+
+        let instance_id = *make_contract(b"reg_fail_4681").key().id();
+
+        // Saturate the per-contract subscriber cap directly on the executor so
+        // the next registration through the handler event path is rejected.
+        for _ in 0..MAX_SUBSCRIBERS_PER_CONTRACT {
+            let (tx, _rx) = tokio::sync::mpsc::channel(64);
+            handler
+                .executor()
+                .register_contract_notifier(
+                    instance_id,
+                    crate::client_events::ClientId::next(),
+                    tx,
+                    None,
+                )
+                .expect("registration within limit should succeed");
+        }
+
+        // One more registration, driven through `handle_contract_event`, must
+        // fail — and that failure must ride back on the response variant.
+        let (tx, _rx) = tokio::sync::mpsc::channel(64);
+        let event = ContractHandlerEvent::RegisterSubscriberListener {
+            key: instance_id,
+            client_id: crate::client_events::ClientId::next(),
+            summary: None,
+            subscriber_listener: tx,
+        };
+        let send_fut = send_halve.send_to_handler(event);
+        let recv_fut = async {
+            let (id, received, _priority) = handler
+                .channel()
+                .recv_from_sender()
+                .await
+                .expect("handler channel should be open");
+            handle_contract_event(
+                &mut handler,
+                id,
+                received,
+                &user_input::AutoApprovePrompter,
+                None,
+            )
+            .await
+            .expect("dispatch must not error");
+        };
+        let (send_res, ()) = tokio::join!(send_fut, recv_fut);
+        match send_res.expect("must receive a response") {
+            ContractHandlerEvent::RegisterSubscriberListenerResponse { result } => {
+                assert!(
+                    result.is_err(),
+                    "a registration rejected by the subscriber limit must surface \
+                     an error to the client, not a fake success"
+                );
+            }
+            other => panic!("expected RegisterSubscriberListenerResponse, got {other}"),
+        }
     }
 }

--- a/crates/core/src/contract/executor/pool_tests/subscriber_limit_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/subscriber_limit_tests.rs
@@ -270,3 +270,244 @@ async fn test_reconnection_does_not_inflate_client_count() {
         receivers.push(rx);
     }
 }
+
+// =========================================================================
+// Observability: dropped notification to a registered subscriber (#4681)
+// =========================================================================
+
+/// Install a thread-local `tracing` subscriber that records every event as a
+/// `"<LEVEL> field=value ..."` string. Returns the captured-message buffer and
+/// the default-subscriber guard (drop it to detach the capture).
+#[cfg(feature = "trace")]
+fn install_log_capture() -> (
+    std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+    tracing::subscriber::DefaultGuard,
+) {
+    use std::sync::{Arc, Mutex};
+    use tracing_subscriber::Layer;
+    use tracing_subscriber::layer::SubscriberExt;
+
+    #[derive(Default, Clone)]
+    struct Capture(Arc<Mutex<Vec<String>>>);
+    impl<S: tracing::Subscriber> Layer<S> for Capture {
+        fn on_event(
+            &self,
+            event: &tracing::Event<'_>,
+            _ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            struct V(String);
+            impl tracing::field::Visit for V {
+                fn record_debug(
+                    &mut self,
+                    field: &tracing::field::Field,
+                    value: &dyn std::fmt::Debug,
+                ) {
+                    use std::fmt::Write;
+                    // Writing into a String is infallible; ignore the Result.
+                    write!(self.0, " {}={value:?}", field.name()).ok();
+                }
+            }
+            let mut v = V(String::new());
+            event.record(&mut v);
+            self.0
+                .lock()
+                .unwrap()
+                .push(format!("{}{}", event.metadata().level(), v.0));
+        }
+    }
+
+    let capture = Capture::default();
+    let messages = capture.0.clone();
+    let subscriber = tracing_subscriber::registry().with(capture);
+    let guard = tracing::subscriber::set_default(subscriber);
+    (messages, guard)
+}
+
+/// Regression for #4681 (partial hardening): a committed state install for a
+/// contract that has NO subscriber snapshot must emit an observable WARN
+/// (carrying the contract `instance_id`) instead of returning silently. The
+/// silent early-return was the observability gap that let a cross-node
+/// subscriber miss a committed `UpdateNotification` with nothing logged.
+///
+/// The mock executor has no shared storage, so this exercises the LOCAL-storage
+/// (`else`) branch — see the `_shared_*` tests below for the shared branch.
+#[cfg(feature = "trace")]
+#[tokio::test(flavor = "current_thread")]
+async fn send_update_notification_without_subscribers_emits_warn() {
+    let mut executor = create_executor().await;
+    let contract = test_contract(b"warn_no_subscribers_4681");
+    let key = contract.key();
+    let instance_id = *key.id();
+
+    let (messages, guard) = install_log_capture();
+
+    // Fresh install of a contract with NO registered subscribers hits the
+    // missing-snapshot path in `send_update_notification`.
+    executor
+        .upsert_contract_state(
+            key,
+            either::Either::Left(WrappedState::new(vec![1, 2, 3])),
+            RelatedContracts::default(),
+            Some(contract),
+        )
+        .await
+        .expect("store contract");
+
+    drop(guard);
+
+    let logs = messages.lock().unwrap();
+    let id_str = instance_id.to_string();
+    assert!(
+        logs.iter().any(|l| l.starts_with("WARN")
+            && l.contains("no subscriber snapshot")
+            && l.contains("local storage")
+            && l.contains(&id_str)),
+        "expected a local-storage WARN naming instance_id {id_str}; captured: {logs:?}"
+    );
+}
+
+/// Regression for #4681 (main revise item): the empty-but-present case. The
+/// channel-closed cleanup inside `send_update_notification` empties a
+/// subscriber vec in place (leaving `Some([])` in the map), so the NEXT
+/// committed update must still emit a WARN — an empty snapshot is as silent a
+/// drop as a missing one, and is the MORE diagnostic case (a subscriber was
+/// registered and lost). LOCAL-storage branch.
+#[cfg(feature = "trace")]
+#[tokio::test(flavor = "current_thread")]
+async fn send_update_notification_empty_local_snapshot_emits_warn() {
+    let mut executor = create_executor().await;
+    let contract = test_contract(b"warn_empty_local_4681");
+    let key = contract.key();
+    let instance_id = *key.id();
+
+    // Simulate the post-cleanup state: an entry that exists but whose
+    // subscriber vec has been emptied by the channel-closed `retain`. The
+    // matching (empty) `subscriber_summaries` entry mirrors the real cleanup,
+    // which retains the summaries map. (`pool_tests` is a descendant module of
+    // `executor`, so it may touch these private fields.)
+    executor
+        .update_notifications
+        .insert(instance_id, Vec::new());
+    executor
+        .subscriber_summaries
+        .insert(instance_id, std::collections::HashMap::new());
+
+    let (messages, guard) = install_log_capture();
+
+    // Fresh install still calls `send_update_notification`; it now finds a
+    // present-but-empty local snapshot.
+    executor
+        .upsert_contract_state(
+            key,
+            either::Either::Left(WrappedState::new(vec![9, 9, 9])),
+            RelatedContracts::default(),
+            Some(contract),
+        )
+        .await
+        .expect("store contract");
+
+    drop(guard);
+
+    let logs = messages.lock().unwrap();
+    let id_str = instance_id.to_string();
+    assert!(
+        logs.iter().any(|l| l.starts_with("WARN")
+            && l.contains("no subscriber snapshot")
+            && l.contains("local storage")
+            && l.contains(&id_str)),
+        "an empty (present) local snapshot must still WARN naming instance_id \
+         {id_str}; captured: {logs:?}"
+    );
+}
+
+/// Regression for #4681: the SHARED-storage branch — the exact path the issue
+/// cites (`shared_notifications.get(&instance_id) == None`). A committed update
+/// with no shared subscriber entry must emit a shared-storage WARN.
+#[cfg(feature = "trace")]
+#[tokio::test(flavor = "current_thread")]
+async fn send_update_notification_missing_shared_snapshot_emits_warn() {
+    let mut executor = create_executor().await;
+    // Attach empty shared storage so `send_update_notification` takes the
+    // shared branch instead of the local one.
+    executor.set_shared_notifications(
+        std::sync::Arc::new(dashmap::DashMap::new()),
+        std::sync::Arc::new(dashmap::DashMap::new()),
+        std::sync::Arc::new(dashmap::DashMap::new()),
+    );
+
+    let contract = test_contract(b"warn_missing_shared_4681");
+    let key = contract.key();
+    let instance_id = *key.id();
+
+    let (messages, guard) = install_log_capture();
+
+    executor
+        .upsert_contract_state(
+            key,
+            either::Either::Left(WrappedState::new(vec![1, 2, 3])),
+            RelatedContracts::default(),
+            Some(contract),
+        )
+        .await
+        .expect("store contract");
+
+    drop(guard);
+
+    let logs = messages.lock().unwrap();
+    let id_str = instance_id.to_string();
+    assert!(
+        logs.iter().any(|l| l.starts_with("WARN")
+            && l.contains("no subscriber snapshot")
+            && l.contains("shared storage")
+            && l.contains(&id_str)),
+        "expected a shared-storage WARN naming instance_id {id_str}; captured: {logs:?}"
+    );
+}
+
+/// Regression for #4681 (main revise item), SHARED-storage branch: a
+/// present-but-EMPTY shared subscriber vec (the state the in-place channel-
+/// closed `retain` leaves behind) must still emit a shared-storage WARN rather
+/// than snapshotting `Some([])` and returning silently.
+#[cfg(feature = "trace")]
+#[tokio::test(flavor = "current_thread")]
+async fn send_update_notification_empty_shared_snapshot_emits_warn() {
+    let mut executor = create_executor().await;
+    let shared_notifications = std::sync::Arc::new(dashmap::DashMap::new());
+    executor.set_shared_notifications(
+        shared_notifications.clone(),
+        std::sync::Arc::new(dashmap::DashMap::new()),
+        std::sync::Arc::new(dashmap::DashMap::new()),
+    );
+
+    let contract = test_contract(b"warn_empty_shared_4681");
+    let key = contract.key();
+    let instance_id = *key.id();
+
+    // Pre-seed a present-but-empty subscriber vec (post-`retain` state).
+    shared_notifications.insert(instance_id, Vec::new());
+
+    let (messages, guard) = install_log_capture();
+
+    executor
+        .upsert_contract_state(
+            key,
+            either::Either::Left(WrappedState::new(vec![7, 7, 7])),
+            RelatedContracts::default(),
+            Some(contract),
+        )
+        .await
+        .expect("store contract");
+
+    drop(guard);
+
+    let logs = messages.lock().unwrap();
+    let id_str = instance_id.to_string();
+    assert!(
+        logs.iter().any(|l| l.starts_with("WARN")
+            && l.contains("no subscriber snapshot")
+            && l.contains("shared storage")
+            && l.contains(&id_str)),
+        "an empty (present) shared snapshot must still WARN naming instance_id \
+         {id_str}; captured: {logs:?}"
+    );
+}

--- a/crates/core/src/contract/executor/runtime/executor_impl.rs
+++ b/crates/core/src/contract/executor/runtime/executor_impl.rs
@@ -2281,16 +2281,14 @@ where
                     }
                 }
             }
-        } else if self
+        } else if let Some(notifiers) = self
             .update_notifications
-            .get(&instance_id)
-            .is_some_and(|notifiers| !notifiers.is_empty())
+            .get_mut(&instance_id)
+            .filter(|notifiers| !notifiers.is_empty())
         {
             // #4681: only take the fan-out path when a LIVE subscriber remains.
             // A present-but-EMPTY entry (left by the channel-closed cleanup
-            // below) is routed to the `else` WARN, not silently skipped. The
-            // guard above proved the entry is non-empty, so re-borrow mutably.
-            let notifiers = self.update_notifications.get_mut(&instance_id).unwrap();
+            // below) is routed to the `else` WARN, not silently skipped.
             let summaries = self.subscriber_summaries.get_mut(&instance_id).unwrap();
 
             if notifiers.len() > super::FANOUT_WARNING_THRESHOLD {

--- a/crates/core/src/contract/executor/runtime/executor_impl.rs
+++ b/crates/core/src/contract/executor/runtime/executor_impl.rs
@@ -2153,10 +2153,28 @@ where
         ) {
             // Snapshot subscribers and release the DashMap read-lock before sending
             let notifiers_snapshot: Vec<(ClientId, mpsc::Sender<HostResult>)> =
-                match shared_notifications.get(&instance_id) {
-                    Some(notifiers) => notifiers.value().clone(),
-                    None => return Ok(()),
-                };
+                shared_notifications
+                    .get(&instance_id)
+                    .map_or_else(Vec::new, |notifiers| notifiers.value().clone());
+
+            // #4681: a committed update found no LIVE subscriber for this
+            // contract — either no map entry at all, OR an empty subscriber vec
+            // left behind by the channel-closed cleanup below (`retain` removes
+            // the last dead subscriber but leaves the emptied entry in the map,
+            // so the next committed update snapshots `Some([])`). Both cases are
+            // fully silent drops for a contract that may have had a registered
+            // subscriber, so surface them with a WARN (instance + total
+            // registered-contract count) instead of returning silently — a
+            // notification dropped for a registered subscriber is never invisible.
+            if notifiers_snapshot.is_empty() {
+                tracing::warn!(
+                    %instance_id,
+                    registered_contracts = shared_notifications.len(),
+                    "send_update_notification: no subscriber snapshot for contract \
+                     (shared storage); update notification not delivered"
+                );
+                return Ok(());
+            }
 
             let summaries_snapshot: HashMap<ClientId, Option<StateSummary<'static>>> =
                 shared_summaries
@@ -2263,7 +2281,16 @@ where
                     }
                 }
             }
-        } else if let Some(notifiers) = self.update_notifications.get_mut(&instance_id) {
+        } else if self
+            .update_notifications
+            .get(&instance_id)
+            .is_some_and(|notifiers| !notifiers.is_empty())
+        {
+            // #4681: only take the fan-out path when a LIVE subscriber remains.
+            // A present-but-EMPTY entry (left by the channel-closed cleanup
+            // below) is routed to the `else` WARN, not silently skipped. The
+            // guard above proved the entry is non-empty, so re-borrow mutably.
+            let notifiers = self.update_notifications.get_mut(&instance_id).unwrap();
             let summaries = self.subscriber_summaries.get_mut(&instance_id).unwrap();
 
             if notifiers.len() > super::FANOUT_WARNING_THRESHOLD {
@@ -2348,6 +2375,18 @@ where
                     }
                 }
             }
+        } else {
+            // #4681: mirror the shared-storage observability for the local
+            // (non-pool) executor — a committed update with no LIVE subscriber
+            // for this contract (no map entry at all, OR an empty subscriber vec
+            // left behind by the channel-closed cleanup above) must not vanish
+            // silently.
+            tracing::warn!(
+                %instance_id,
+                registered_contracts = self.update_notifications.len(),
+                "send_update_notification: no subscriber snapshot for contract \
+                 (local storage); update notification not delivered"
+            );
         }
         Ok(())
     }

--- a/crates/core/src/contract/fair_queue.rs
+++ b/crates/core/src/contract/fair_queue.rs
@@ -471,7 +471,7 @@ fn extract_contract_id(event: &ContractHandlerEvent) -> Option<ContractInstanceI
         | ContractHandlerEvent::GetResponse { .. }
         | ContractHandlerEvent::UpdateResponse { .. }
         | ContractHandlerEvent::UpdateNoChange { .. }
-        | ContractHandlerEvent::RegisterSubscriberListenerResponse
+        | ContractHandlerEvent::RegisterSubscriberListenerResponse { .. }
         | ContractHandlerEvent::QuerySubscriptions { .. }
         | ContractHandlerEvent::QuerySubscriptionsResponse
         | ContractHandlerEvent::GetSummaryResponse { .. }
@@ -1143,7 +1143,7 @@ mod tests {
             ),
             (
                 "RegisterSubscriberListenerResponse",
-                ContractHandlerEvent::RegisterSubscriberListenerResponse,
+                ContractHandlerEvent::RegisterSubscriberListenerResponse { result: Ok(()) },
             ),
             (
                 "QuerySubscriptionsResponse",

--- a/crates/core/src/contract/handler.rs
+++ b/crates/core/src/contract/handler.rs
@@ -17,7 +17,7 @@ use std::time::Duration;
 
 use futures::Stream;
 
-use freenet_stdlib::client_api::DelegateRequest;
+use freenet_stdlib::client_api::{DelegateRequest, RequestError};
 use freenet_stdlib::prelude::*;
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
@@ -896,7 +896,13 @@ pub(crate) enum ContractHandlerEvent {
         summary: Option<StateSummary<'static>>,
         subscriber_listener: mpsc::Sender<HostResult>,
     },
-    RegisterSubscriberListenerResponse,
+    RegisterSubscriberListenerResponse {
+        /// `Ok(())` when the subscriber notifier was registered, `Err` when
+        /// registration was rejected (e.g. subscriber-limit exceeded). Carrying
+        /// the result lets the client-facing caller surface a real failure
+        /// instead of a fake successful subscribe (#4681).
+        result: Result<(), Box<RequestError>>,
+    },
     #[allow(dead_code)]
     QuerySubscriptions {
         callback: tokio::sync::mpsc::Sender<QueryResult>,
@@ -1033,9 +1039,10 @@ impl std::fmt::Display for ContractHandlerEvent {
                     "register subscriber listener {{ {key}, client_id: {client_id} }}",
                 )
             }
-            ContractHandlerEvent::RegisterSubscriberListenerResponse => {
-                write!(f, "register subscriber listener response")
-            }
+            ContractHandlerEvent::RegisterSubscriberListenerResponse { result } => match result {
+                Ok(()) => write!(f, "register subscriber listener response"),
+                Err(e) => write!(f, "register subscriber listener failed {{ {e} }}"),
+            },
             ContractHandlerEvent::QuerySubscriptions { .. } => {
                 write!(f, "query subscriptions")
             }

--- a/crates/core/src/operations.rs
+++ b/crates/core/src/operations.rs
@@ -655,7 +655,7 @@ pub(crate) async fn has_contract(
         | crate::contract::ContractHandlerEvent::UpdateResponse { .. }
         | crate::contract::ContractHandlerEvent::UpdateNoChange { .. }
         | crate::contract::ContractHandlerEvent::RegisterSubscriberListener { .. }
-        | crate::contract::ContractHandlerEvent::RegisterSubscriberListenerResponse
+        | crate::contract::ContractHandlerEvent::RegisterSubscriberListenerResponse { .. }
         | crate::contract::ContractHandlerEvent::QuerySubscriptions { .. }
         | crate::contract::ContractHandlerEvent::QuerySubscriptionsResponse
         | crate::contract::ContractHandlerEvent::GetSummaryQuery { .. }

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -645,7 +645,7 @@ pub(crate) async fn update_contract(
                             | ContractHandlerEvent::UpdateResponse { .. }
                             | ContractHandlerEvent::UpdateNoChange { .. }
                             | ContractHandlerEvent::RegisterSubscriberListener { .. }
-                            | ContractHandlerEvent::RegisterSubscriberListenerResponse
+                            | ContractHandlerEvent::RegisterSubscriberListenerResponse { .. }
                             | ContractHandlerEvent::QuerySubscriptions { .. }
                             | ContractHandlerEvent::QuerySubscriptionsResponse
                             | ContractHandlerEvent::GetSummaryQuery { .. }


### PR DESCRIPTION
## Problem

This is the **observability/error-propagation slice** that #4681 requests as a first step — the underlying delivery race is intentionally untouched (it needs failing-run logs to disambiguate, per the issue).

Two silent-failure paths made a dropped `UpdateNotification` to a registered local subscriber invisible:

1. `send_update_notification` returned `Ok(())` with zero logging when the subscriber snapshot was missing — and also when present but **empty**, a reachable state because the channel-closed `retain()` cleanup leaves an empty vec entry in the map (only `RuntimePool::remove_client` prunes empties).
2. A `register_contract_notifier` failure was masked (the long-standing `FIXME` in `contract.rs`): the handler returned a success `RegisterSubscriberListenerResponse`, which the client-events layer converted into a fake successful subscribe.

## Solution

- Both branches (shared and local storage) of `send_update_notification` now WARN with the contract instance id and registered count before returning, treating missing and empty snapshots uniformly.
- Registration failures flow through a new `Error::Registration(Box<RequestError>)` variant with explicit `result: Err(e)` handling at both `client_events.rs` consumers, so the client receives the real reason (e.g. subscriber limit) via the existing `ErrorKind::OperationError` path instead of a generic error.

Reviewer note: the WARN fires on the commit path for contracts with zero local subscribers (common on relays/gateways). Left unconditional per the issue's explicit request for a WARN; a follow-up could rate-limit it if it proves noisy (cf. #4238).

## Testing

- Four snapshot regression tests (missing/empty × shared/local); the two empty-snapshot tests were verified to FAIL without the fix.
- Handler failure-path regression test (mutation-verified: fails if the handler reverts to unconditional success) plus an error-detail forwarding unit test.
- `cargo test -p freenet --lib` targeted suites: 12 passed; workspace `clippy -- -D warnings` and `fmt --check` green.

## Fixes

Refs #4681 (partial — observability slice only; the delivery-race root cause remains open and needs log-based disambiguation first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MNWiSYhzF68Dgfe5bbHEAC

---
_Generated by [Claude Code](https://claude.ai/code/session_01MNWiSYhzF68Dgfe5bbHEAC)_