### PR TITLE
fix(update): reap stale proximity-cache neighbor on failed resolve

### DIFF
--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -3062,6 +3062,100 @@ mod tests {
         );
     }
 
+    // ===== Stale proximity-cache reap (#4756) =====
+
+    /// Regression test for #4756: a proximity-cache entry for a neighbor that
+    /// disconnected (no longer in the connection manager) MUST be reaped the
+    /// first time `get_broadcast_targets_update` fails to resolve it —
+    /// otherwise it logs at WARN and re-fires on EVERY subsequent UPDATE
+    /// forever (the unbounded log-spam failure mode reported on the 0.2.95
+    /// soak).
+    #[tokio::test(flavor = "current_thread")]
+    async fn get_broadcast_targets_reaps_stale_proximity_neighbor() {
+        let (op_manager, _guards) = build_reroot_test_op_manager("reap-stale-proximity").await;
+        seed_location_and_one_connection(&op_manager);
+
+        let key = reroot_contract_key(7);
+        // A hub announced it co-hosts this contract, but it is NOT in the
+        // connection manager — reproducing the post-disconnect stale state
+        // where the ring pruned the connection (keyed by addr) but the
+        // proximity entry (keyed by pub_key) leaked.
+        let hub = crate::transport::TransportKeypair::new().public().clone();
+        register_hub_cohosting(&op_manager, &hub, &[*key.id()]);
+        assert_eq!(
+            op_manager.neighbor_hosting.neighbors_with_contract(&key),
+            vec![hub.clone()],
+            "precondition: the stale proximity entry is present"
+        );
+
+        let sender: std::net::SocketAddr = "127.0.0.1:40000".parse().unwrap();
+
+        // First lookup: the stale neighbor fails to resolve (counted once) AND
+        // is reaped so it cannot spam future UPDATEs.
+        let first = op_manager.get_broadcast_targets_update(&key, &sender);
+        assert_eq!(
+            first.proximity_resolve_failed, 1,
+            "the stale neighbor must be counted as one resolve failure"
+        );
+        assert!(
+            op_manager
+                .neighbor_hosting
+                .neighbors_with_contract(&key)
+                .is_empty(),
+            "the stale proximity entry must be reaped on the first failed resolve (#4756)"
+        );
+
+        // Second lookup: the entry is gone, so there is no repeat failure — the
+        // bug's failure mode is that this stays 1 (WARN spam) forever.
+        let second = op_manager.get_broadcast_targets_update(&key, &sender);
+        assert_eq!(
+            second.proximity_resolve_failed, 0,
+            "a reaped entry must not re-fire on the next UPDATE (no repeat spam)"
+        );
+    }
+
+    /// Companion to #4756: a proximity neighbor that IS still connected must be
+    /// resolved as a broadcast target and NOT reaped by the self-healing path.
+    #[tokio::test(flavor = "current_thread")]
+    async fn get_broadcast_targets_keeps_connected_proximity_neighbor() {
+        let (op_manager, _guards) = build_reroot_test_op_manager("keep-connected-proximity").await;
+        seed_location_and_one_connection(&op_manager);
+
+        let key = reroot_contract_key(8);
+        // A connected neighbor: present in BOTH the connection manager and the
+        // proximity cache.
+        let peer_kp = crate::transport::TransportKeypair::new();
+        let peer_pub = peer_kp.public().clone();
+        let peer_addr: std::net::SocketAddr = "127.0.0.1:45678".parse().unwrap();
+        assert!(op_manager.ring.connection_manager.add_connection(
+            crate::ring::Location::new(0.5),
+            peer_addr,
+            peer_pub.clone(),
+            false,
+        ));
+        register_hub_cohosting(&op_manager, &peer_pub, &[*key.id()]);
+
+        let sender: std::net::SocketAddr = "127.0.0.1:40001".parse().unwrap();
+        let result = op_manager.get_broadcast_targets_update(&key, &sender);
+
+        assert_eq!(
+            result.proximity_resolve_failed, 0,
+            "a connected neighbor must resolve, not fail"
+        );
+        assert!(
+            result
+                .targets
+                .iter()
+                .any(|t| t.socket_addr() == Some(peer_addr)),
+            "the connected neighbor must be included as a broadcast target"
+        );
+        assert_eq!(
+            op_manager.neighbor_hosting.neighbors_with_contract(&key),
+            vec![peer_pub.clone()],
+            "a connected neighbor must NOT be reaped"
+        );
+    }
+
     #[tokio::test]
     async fn notify_timeout_succeeds_when_receiver_alive() {
         let (receiver, notifier) = event_loop_notification_channel();

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -310,12 +310,26 @@ impl OpManager {
                 targets.insert(pkl);
             } else {
                 proximity_resolve_failed += 1;
-                tracing::warn!(
+                // Stale proximity-cache entry (#4756): the neighbor announced it
+                // seeds this contract but is no longer in the connection manager.
+                // Disconnect teardown prunes the ring connection (keyed by addr)
+                // but several paths leave this proximity entry (keyed by pub_key)
+                // behind; with no TTL it would WARN on every UPDATE forever.
+                // Self-heal at the detection point: reap the disconnected
+                // neighbor's proximity state so it fires at most once and then
+                // disappears. A reconnecting peer re-announces via the on-connect
+                // HostingStateRequest exchange and the periodic full-set
+                // re-request, so no fan-out is permanently lost. Demote the
+                // per-miss log to DEBUG (mirroring the interest arm below); the
+                // aggregate counter (proximity_resolve_failed) still feeds the
+                // summary log.
+                self.neighbor_hosting.on_peer_disconnected(&pub_key);
+                tracing::debug!(
                     contract = %format!("{:.8}", key),
                     proximity_neighbor = %pub_key,
                     is_local = is_local_update_initiator,
                     phase = "target_lookup_failed",
-                    "Proximity cache neighbor not found in connection manager"
+                    "Proximity cache neighbor not found in connection manager; reaped stale entry"
                 );
             }
         }


### PR DESCRIPTION
## Problem

A co-host neighbor's proximity-cache entry (`NeighborHostingManager::neighbor_contracts`, keyed by `TransportPublicKey`) can outlive the ring connection (#4756): disconnect cleanup is keyed by pub_key while `Ring::prune_connection` is keyed by socket addr, and several teardown paths pass a placeholder (own) pub_key to `on_ring_connection_lost` or skip it entirely. The map has no TTL, so a leaked entry made `get_broadcast_targets_update` WARN on every UPDATE for that contract, forever — the unbounded WARN spam in the issue.

## Solution

Make the lookup self-healing at the detection point: when a proximity neighbor's pub_key no longer resolves in the connection manager, remove its proximity-cache entry and demote the per-miss log to `debug` (keeping the aggregate `proximity_resolve_failed` counter) — mirroring the interest-manager arm directly below, which was already demoted for exactly this spam class. A stale entry now fires at most once and disappears. Reconnecting peers repopulate via the on-connect `HostingStateRequest` exchange and the periodic full-set re-request, so no fan-out is permanently lost.

The deeper own-pub_key-placeholder teardown holes are deliberately out of scope (one logical change); they can be filed separately.

## Testing

- Regression test: a stale co-host entry (registered in the proximity cache, absent from the connection manager — the exact post-disconnect state) is reaped on first `get_broadcast_targets_update` and does not fire again. Fails without the fix (the failure mode is the counter incrementing on every lookup forever).
- Negative test: a connected neighbor resolves as a broadcast target and is NOT reaped.
- `cargo test -p freenet --lib -- get_broadcast_targets_update neighbor_hosting` (24 passed); workspace `clippy -- -D warnings` and `fmt --check` green.

## Fixes

Fixes #4756

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MNWiSYhzF68Dgfe5bbHEAC

---
_Generated by [Claude Code](https://claude.ai/code/session_01MNWiSYhzF68Dgfe5bbHEAC)_