### PR TITLE
feat(dashboard): surface connection state in the browser tab title

### DIFF
--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -22,7 +22,7 @@ use cards::{
     build_ban_list_card, build_contracts_card, build_governance_card, build_hosting_card,
     build_ops_card, build_peers_card, build_status_card, build_transfer_card,
 };
-use favicon::build_favicon_data_uri;
+use favicon::{build_dashboard_title, build_favicon_data_uri};
 use peer_detail::peer_detail_html;
 
 /// Freenet rabbit silhouette SVG path, derived from freenet_logo.svg.
@@ -112,6 +112,7 @@ fn homepage_html() -> String {
     };
 
     let favicon = build_favicon_data_uri(&snap);
+    let title = build_dashboard_title(&snap);
 
     let status_card = build_status_card(&snap);
     let peers_card = build_peers_card(&snap);
@@ -160,6 +161,7 @@ fn homepage_html() -> String {
         CSS = CSS,
         JS = JS,
         favicon = favicon,
+        title = html_escape(&title),
         version = html_escape(version),
         // Asset version = the build that compiled THIS served page. Baked in at
         // compile time so the JS can compare it against the live runtime version
@@ -196,7 +198,7 @@ mod tests {
         build_regression_chart, build_reliability_chart, build_renegade_accuracy_panel,
         failure_chart_y_max, fmt_prediction_prob, fmt_prediction_speed, fmt_prediction_time,
     };
-    use super::favicon::build_favicon_data_uri;
+    use super::favicon::{build_dashboard_title, build_favicon_data_uri};
     use super::peer_detail::peer_detail_html;
     use crate::node::network_status::{
         FailureSnapshot, HealthLevel, NatStatsSnapshot, NetworkStatusSnapshot, OpStatsSnapshot,
@@ -796,12 +798,102 @@ mod tests {
         );
     }
 
+    // ── Tab title surfaces connection state + count (#3509) ────────────────
+
     #[test]
-    fn title_is_fn_peer() {
+    fn title_shows_trying_to_connect_when_no_snapshot() {
+        // Before the first `network_status` snapshot exists (node mid-startup)
+        // the title must fall back to the "trying to connect" indicator, not
+        // crash or render a stale placeholder.
+        assert_eq!(build_dashboard_title(&None), "\u{26A1} Dashboard");
+    }
+
+    #[test]
+    fn title_shows_connection_count_when_connected() {
+        let mut snap = base_snapshot();
+        snap.open_connections = 4;
+        assert_eq!(
+            build_dashboard_title(&Some(snap)),
+            "(4) Dashboard",
+            "connected state must show the open connection count"
+        );
+    }
+
+    #[test]
+    fn title_shows_connection_count_boundary_one() {
+        // Boundary: exactly one connection still uses the count form, not a
+        // singular/plural variant — the format is purely numeric.
+        let mut snap = base_snapshot();
+        snap.open_connections = 1;
+        assert_eq!(build_dashboard_title(&Some(snap)), "(1) Dashboard");
+    }
+
+    #[test]
+    fn title_shows_trouble_icon_on_health_trouble() {
+        let mut snap = base_snapshot();
+        snap.health = HealthLevel::Trouble;
+        snap.open_connections = 0;
+        assert_eq!(
+            build_dashboard_title(&Some(snap)),
+            "\u{26A0} Dashboard",
+            "HealthLevel::Trouble must surface the warning icon"
+        );
+    }
+
+    #[test]
+    fn title_shows_trouble_icon_on_nat_failure() {
+        // Even without HealthLevel::Trouble, an all-failed NAT traversal
+        // history is a major connectivity error worth the same icon (mirrors
+        // the favicon's dark-red NAT-failure precedence).
+        let mut snap = base_snapshot();
+        snap.nat_stats.attempts = 5;
+        snap.nat_stats.successes = 0;
+        snap.open_connections = 0;
+        assert_eq!(build_dashboard_title(&Some(snap)), "\u{26A0} Dashboard");
+    }
+
+    #[test]
+    fn title_shows_connecting_icon_by_default() {
+        // Default base_snapshot(): HealthLevel::Connecting, zero connections,
+        // no NAT attempts yet — the "still trying" fallback.
+        let snap = base_snapshot();
+        assert_eq!(build_dashboard_title(&Some(snap)), "\u{26A1} Dashboard");
+    }
+
+    #[test]
+    fn title_connected_overrides_trouble_and_nat_failure() {
+        // Connection count takes top priority even if failures/NAT problems
+        // are still present in the snapshot (mirrors the favicon: "connected
+        // wins" over lingering failure signals from before the connection
+        // was established).
+        let mut snap = base_snapshot();
+        snap.open_connections = 2;
+        snap.health = HealthLevel::Trouble;
+        snap.nat_stats.attempts = 5;
+        snap.nat_stats.successes = 0;
+        assert_eq!(build_dashboard_title(&Some(snap)), "(2) Dashboard");
+    }
+
+    #[test]
+    fn homepage_renders_dynamic_title() {
+        // The rendered page must carry the derived title, not a static
+        // placeholder — the JS refresh path re-reads it from `doc.title`.
         let html = homepage_html();
         assert!(
-            html.contains("<title>FN Peer</title>"),
-            "dashboard title must be 'FN Peer' — do not rename without updating this test"
+            html.contains("<title>\u{26A1} Dashboard</title>"),
+            "no snapshot exists in the unit-test process, so the homepage \
+             must render the 'trying to connect' title, got: {html}"
+        );
+    }
+
+    #[test]
+    fn js_syncs_title_on_refresh() {
+        // Source-scrape guard: the auto-refresh handler must copy the
+        // fetched document's title onto the live page so a backgrounded tab
+        // reflects the current connection state without a full reload.
+        assert!(
+            JS.contains("document.title = doc.title"),
+            "JS auto-refresh must sync document.title from the refreshed page"
         );
     }
 

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -853,6 +853,25 @@ mod tests {
     }
 
     #[test]
+    fn title_shows_warning_icon_on_connection_failures() {
+        // Mirrors the favicon's red case (build_favicon_data_uri's
+        // `!s.failures.is_empty()` branch): a node can accumulate gateway
+        // connection failures (e.g. Timeout) within the first 60s while
+        // health == Connecting and nat_stats.attempts == 0 — no NAT history
+        // yet, so this must not fall through to the default "connecting"
+        // icon. Previously the title omitted this branch entirely and
+        // showed the ⚡ default here, disagreeing with the favicon's red
+        // "connection issues" icon for the same snapshot.
+        let mut snap = base_snapshot();
+        snap.open_connections = 0;
+        snap.failures.push(FailureSnapshot {
+            address: "1.2.3.4:1234".parse().unwrap(),
+            reason_html: "Timeout".to_string(),
+        });
+        assert_eq!(build_dashboard_title(&Some(snap)), "\u{26A0} Dashboard");
+    }
+
+    #[test]
     fn title_shows_connecting_icon_by_default() {
         // Default base_snapshot(): HealthLevel::Connecting, zero connections,
         // no NAT attempts yet — the "still trying" fallback.
@@ -872,6 +891,22 @@ mod tests {
         snap.nat_stats.attempts = 5;
         snap.nat_stats.successes = 0;
         assert_eq!(build_dashboard_title(&Some(snap)), "(2) Dashboard");
+    }
+
+    #[test]
+    fn title_connected_overrides_failures() {
+        // Same "connected wins" precedence as
+        // title_connected_overrides_trouble_and_nat_failure, but exercised
+        // against a bare `failures` signal with no Trouble/NAT-failure
+        // present — connected must still win (mirrors
+        // favicon_connected_overrides_failures).
+        let mut snap = base_snapshot();
+        snap.open_connections = 3;
+        snap.failures.push(FailureSnapshot {
+            address: "1.2.3.4:1234".parse().unwrap(),
+            reason_html: "Timeout".to_string(),
+        });
+        assert_eq!(build_dashboard_title(&Some(snap)), "(3) Dashboard");
     }
 
     #[test]

--- a/crates/core/src/server/home_page/assets/dashboard.js
+++ b/crates/core/src/server/home_page/assets/dashboard.js
@@ -613,6 +613,9 @@ document.addEventListener('DOMContentLoaded', function () {
         var newMain = doc.querySelector('main');
         var oldMain = document.querySelector('main');
         if (newMain && oldMain) oldMain.innerHTML = newMain.innerHTML;
+        /* Update the tab title (connection state + count, #3509) so a
+           backgrounded tab still surfaces the current status at a glance. */
+        if (doc.title) document.title = doc.title;
         /* Update header elements (outside <main>) */
         var newUp = doc.querySelector('.uptime');
         var oldUp = document.querySelector('.uptime');

--- a/crates/core/src/server/home_page/assets/home.html
+++ b/crates/core/src/server/home_page/assets/home.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>FN Peer</title>
+    <title>{title}</title>
     <link rel="icon" type="image/svg+xml" href="{favicon}">
     <style>{CSS}</style>
     <script>{JS}</script>

--- a/crates/core/src/server/home_page/favicon.rs
+++ b/crates/core/src/server/home_page/favicon.rs
@@ -30,3 +30,29 @@ pub fn build_favicon_data_uri(snap: &Option<network_status::NetworkStatusSnapsho
         color = color,
     )
 }
+
+/// Build the browser tab `<title>` text, surfacing connection state at a
+/// glance (#3509) so the operator can tell the node's status from a
+/// background tab without switching to it.
+///
+/// Derived from the same snapshot fields as [`build_favicon_data_uri`] — no
+/// new state is invented at render time. Priority mirrors the favicon:
+/// 1. `(N) Dashboard` — connected (any open connections; matches the
+///    favicon's "connected wins" precedence over lingering failures/NAT
+///    issues from before the connection was established).
+/// 2. `⚠ Dashboard` — unable to connect / major error (`HealthLevel::Trouble`,
+///    or NAT traversal has failed every attempt).
+/// 3. `⚡ Dashboard` — trying to connect (no snapshot yet, or still
+///    connecting/degraded with zero open connections).
+pub fn build_dashboard_title(snap: &Option<network_status::NetworkStatusSnapshot>) -> String {
+    match snap {
+        Some(s) if s.open_connections > 0 => format!("({}) Dashboard", s.open_connections),
+        Some(s)
+            if s.health == network_status::HealthLevel::Trouble
+                || (s.nat_stats.attempts > 0 && s.nat_stats.successes == 0) =>
+        {
+            "\u{26A0} Dashboard".to_string()
+        }
+        _ => "\u{26A1} Dashboard".to_string(),
+    }
+}

--- a/crates/core/src/server/home_page/favicon.rs
+++ b/crates/core/src/server/home_page/favicon.rs
@@ -41,9 +41,13 @@ pub fn build_favicon_data_uri(snap: &Option<network_status::NetworkStatusSnapsho
 ///    favicon's "connected wins" precedence over lingering failures/NAT
 ///    issues from before the connection was established).
 /// 2. `⚠ Dashboard` — unable to connect / major error (`HealthLevel::Trouble`,
-///    or NAT traversal has failed every attempt).
-/// 3. `⚡ Dashboard` — trying to connect (no snapshot yet, or still
-///    connecting/degraded with zero open connections).
+///    or NAT traversal has failed every attempt — the favicon's dark-red
+///    case).
+/// 3. `⚠ Dashboard` — connection failures present (the favicon's red case,
+///    e.g. gateway timeouts) even without a NAT-all-failed history or
+///    `HealthLevel::Trouble`.
+/// 4. `⚡ Dashboard` — trying to connect (no snapshot yet, or still
+///    connecting/degraded with zero open connections and no failures).
 pub fn build_dashboard_title(snap: &Option<network_status::NetworkStatusSnapshot>) -> String {
     match snap {
         Some(s) if s.open_connections > 0 => format!("({}) Dashboard", s.open_connections),
@@ -53,6 +57,7 @@ pub fn build_dashboard_title(snap: &Option<network_status::NetworkStatusSnapshot
         {
             "\u{26A0} Dashboard".to_string()
         }
+        Some(s) if !s.failures.is_empty() => "\u{26A0} Dashboard".to_string(),
         _ => "\u{26A1} Dashboard".to_string(),
     }
 }


### PR DESCRIPTION
## Problem

The local node dashboard is often left open in a background tab. There is
no way to tell whether the node is connected, and to how many peers,
without switching to that tab and reading the page — the browser tab
`<title>` is a static `"FN Peer"` regardless of connection state
(crates/core/src/server/home_page.rs).

## Solution

Derive the tab `<title>` from the same `network_status` snapshot the
favicon (`build_favicon_data_uri`) already uses — no new state is
invented at render time:

- `(N) Dashboard` — connected, `N` = `open_connections` (any open
  connection; mirrors the favicon's "connected wins" precedence).
- `⚠ Dashboard` — unable to connect / major error: `HealthLevel::Trouble`,
  or NAT traversal has failed every attempt.
- `⚡ Dashboard` — trying to connect: no snapshot yet, or still
  connecting/degraded with zero open connections.

This is a sensible subset of the icon set proposed in #3509 (which lists
several more transient/momentary variants like "new peer connected" toasts)
— the two states an operator most needs while a tab is backgrounded:
"am I connected, and to how many peers" and "is something wrong".

New `build_dashboard_title` helper lives next to `build_favicon_data_uri`
in `favicon.rs` since both derive from the same snapshot fields. The
5-second dashboard auto-refresh (`dashboard.js`) already fetches the full
page and swaps `<main>`'s content; it now also copies the fetched
document's `<title>` onto the live page, so the tab title stays current
without a full reload.

## Testing

- Unit tests in `home_page.rs` cover `build_dashboard_title`'s priority
  order and boundary cases: no snapshot, zero/one/N connections,
  `HealthLevel::Trouble`, NAT-failure-only (no `Trouble`), default
  "connecting" fallback, and connected-overrides-trouble-and-nat-failure.
- `homepage_renders_dynamic_title` pins that the rendered page actually
  carries the derived title (replaces the old static `title_is_fn_peer`
  pin).
- `js_syncs_title_on_refresh` source-scrapes `dashboard.js` to guard the
  auto-refresh title-sync wiring.
- Gate: `cargo fmt`, `cargo clippy -p freenet -- -D warnings` (clean),
  `cargo test -p freenet --lib` (3869 passed, 25 ignored, 2 pre-existing
  `wasm_runtime::migration_tests` failures on macOS — known-ignorable
  case-sensitivity issue unrelated to this change).

## Fixes

Closes #3509

https://claude.ai/code/session_01DR69yFsB57UFRTMrHGG5nx