### PR TITLE
refactor: validate contracts from the in-hand container, skip store→fetch (#2216)

### DIFF
--- a/crates/core/src/contract/executor/runtime/contract_ops.rs
+++ b/crates/core/src/contract/executor/runtime/contract_ops.rs
@@ -61,9 +61,18 @@ impl Executor<Runtime> {
                 }
             };
 
-            // Validate before persisting (fetch related contracts from network if needed)
+            // Validate before persisting (fetch related contracts from network if needed).
+            // This is an existing-contract merge, not a fresh store — we don't
+            // have a `ContractContainer` in hand, so fall back to the
+            // fetch-from-store path (`None`).
             let validate_result = self
-                .fetch_related_for_validation_network(&key, &params, &new_state, &related_contracts)
+                .fetch_related_for_validation_network(
+                    &key,
+                    &params,
+                    &new_state,
+                    &related_contracts,
+                    None,
+                )
                 .await?;
             if validate_result != ValidateResult::Valid {
                 return Err(Self::validation_error_put(key, validate_result));
@@ -279,12 +288,15 @@ impl Executor<Runtime> {
         };
 
         // Validate before persisting or broadcasting (fetch related contracts from network if needed).
+        // This is an UPDATE on an already-hosted contract, not a fresh store —
+        // no `ContractContainer` in hand, so fall back to fetch-from-store (`None`).
         let result = self
             .fetch_related_for_validation_network(
                 &key,
                 parameters,
                 &new_state,
                 &RelatedContracts::default(),
+                None,
             )
             .await?;
 
@@ -367,6 +379,11 @@ impl Executor<Runtime> {
             }
         }
 
+        // Keep a cheap (Arc-backed) clone in hand so validation below can use
+        // it directly instead of re-fetching from `contract_store` on a
+        // module-cache miss (issue #2216: avoids the store→fetch round-trip).
+        let contract_for_validation = contract.clone();
+
         // Store contract code in runtime store
         self.runtime
             .contract_store
@@ -408,7 +425,13 @@ impl Executor<Runtime> {
         //   - Excessive fan-out (max 10 related contracts per request)
         // See MAX_RELATED_CONTRACTS_PER_REQUEST and RELATED_FETCH_TIMEOUT constants.
         let result = self
-            .fetch_related_for_validation_network(&key, &params, &state, &related_contracts)
+            .fetch_related_for_validation_network(
+                &key,
+                &params,
+                &state,
+                &related_contracts,
+                Some(&contract_for_validation),
+            )
             .await
             .inspect_err(|_| {
                 if let Err(e) = self.runtime.contract_store.remove_contract(&key) {
@@ -601,17 +624,31 @@ impl Executor<Runtime> {
     /// `local_state_or_from_network` helper directly and several PUT call
     /// sites already wire through it; collapsing the two would touch more
     /// surface area than the bug fix needs.
+    ///
+    /// `already_fetched_contract`: when the caller already holds the
+    /// `ContractContainer` being validated (e.g. `verify_and_store_contract`,
+    /// which just handed it to `contract_store.store_contract`), pass it here
+    /// so a module-cache miss compiles directly from it instead of re-fetching
+    /// the same bytes from `contract_store` (issue #2216). `None` for callers
+    /// that don't have it in hand — behaves exactly as before.
     async fn fetch_related_for_validation_network(
         &mut self,
         key: &ContractKey,
         params: &Parameters<'_>,
         state: &WrappedState,
         initial_related: &RelatedContracts<'_>,
+        already_fetched_contract: Option<&ContractContainer>,
     ) -> Result<ValidateResult, ExecutorError> {
-        let result = self
-            .runtime
-            .validate_state(key, params, state, initial_related)
-            .map_err(|e| ExecutorError::execution(e, None))?;
+        let result = match already_fetched_contract {
+            Some(contract) => self
+                .runtime
+                .validate_state_with_contract(key, params, state, initial_related, contract)
+                .map_err(|e| ExecutorError::execution(e, None))?,
+            None => self
+                .runtime
+                .validate_state(key, params, state, initial_related)
+                .map_err(|e| ExecutorError::execution(e, None))?,
+        };
 
         let requested_ids = match result {
             ValidateResult::Valid | ValidateResult::Invalid => return Ok(result),
@@ -711,10 +748,16 @@ impl Executor<Runtime> {
         }
 
         let populated_related = RelatedContracts::from(related_map);
-        let retry_result = self
-            .runtime
-            .validate_state(key, params, state, &populated_related)
-            .map_err(|e| ExecutorError::execution(e, None))?;
+        let retry_result = match already_fetched_contract {
+            Some(contract) => self
+                .runtime
+                .validate_state_with_contract(key, params, state, &populated_related, contract)
+                .map_err(|e| ExecutorError::execution(e, None))?,
+            None => self
+                .runtime
+                .validate_state(key, params, state, &populated_related)
+                .map_err(|e| ExecutorError::execution(e, None))?,
+        };
 
         if let ValidateResult::RequestRelated(_) = &retry_result {
             return Err(ExecutorError::request(StdContractError::Put {

--- a/crates/core/src/wasm_runtime/contract.rs
+++ b/crates/core/src/wasm_runtime/contract.rs
@@ -1,5 +1,6 @@
 use super::engine::{WasmEngine, WasmError};
 use super::native_api::CONTRACT_IO;
+use super::runtime::RunningInstance;
 use super::{ContractExecError, RuntimeResult};
 use freenet_stdlib::prelude::{
     CodeHash, ContractContainer, ContractInstanceId, ContractInterfaceResult, ContractKey,
@@ -97,16 +98,18 @@ impl Drop for ContractIoGuard {
     }
 }
 
-impl ContractRuntimeInterface for super::Runtime {
-    fn validate_state(
+impl super::Runtime {
+    /// Shared body of `validate_state`, parameterized over the already-running
+    /// WASM instance (obtained by the caller via either `prepare_contract_call`
+    /// or `prepare_contract_call_with_contract`). See [`Self::validate_state_with_contract`]
+    /// for why the latter exists.
+    fn run_validate_state(
         &mut self,
-        key: &ContractKey,
+        mut running: RunningInstance,
         parameters: &Parameters<'_>,
         state: &WrappedState,
         related: &RelatedContracts<'_>,
     ) -> RuntimeResult<ValidateResult> {
-        let req_bytes = parameters.size() + state.size();
-        let mut running = self.prepare_contract_call(key, parameters, req_bytes)?;
         let _io_guard = ContractIoGuard::new(running.id);
 
         let result = (|| -> RuntimeResult<ValidateResult> {
@@ -141,6 +144,44 @@ impl ContractRuntimeInterface for super::Runtime {
 
         self.drop_running_instance(&mut running);
         result
+    }
+
+    /// Like [`ContractRuntimeInterface::validate_state`], but takes the
+    /// contract the caller already has in hand and passes it through to the
+    /// module-compile path instead of re-fetching it from `contract_store`.
+    ///
+    /// Closes the store→fetch round-trip in `verify_and_store_contract`
+    /// (issue #2216): that path calls `contract_store.store_contract(contract)`
+    /// and then immediately needed to validate the state, which — on the
+    /// (guaranteed, for a never-before-seen contract) module-cache miss —
+    /// used to re-fetch the very same bytes from `contract_store` just to
+    /// compile them.
+    pub(crate) fn validate_state_with_contract(
+        &mut self,
+        key: &ContractKey,
+        parameters: &Parameters<'_>,
+        state: &WrappedState,
+        related: &RelatedContracts<'_>,
+        contract: &ContractContainer,
+    ) -> RuntimeResult<ValidateResult> {
+        let req_bytes = parameters.size() + state.size();
+        let running =
+            self.prepare_contract_call_with_contract(key, parameters, req_bytes, contract)?;
+        self.run_validate_state(running, parameters, state, related)
+    }
+}
+
+impl ContractRuntimeInterface for super::Runtime {
+    fn validate_state(
+        &mut self,
+        key: &ContractKey,
+        parameters: &Parameters<'_>,
+        state: &WrappedState,
+        related: &RelatedContracts<'_>,
+    ) -> RuntimeResult<ValidateResult> {
+        let req_bytes = parameters.size() + state.size();
+        let running = self.prepare_contract_call(key, parameters, req_bytes)?;
+        self.run_validate_state(running, parameters, state, related)
     }
 
     fn update_state(

--- a/crates/core/src/wasm_runtime/runtime.rs
+++ b/crates/core/src/wasm_runtime/runtime.rs
@@ -643,6 +643,41 @@ impl Runtime {
         parameters: &Parameters,
         req_bytes: usize,
     ) -> RuntimeResult<RunningInstance> {
+        self.prepare_contract_call_inner(key, parameters, req_bytes, None)
+    }
+
+    /// Like [`Self::prepare_contract_call`], but lets the caller supply the
+    /// contract it already has in hand (`already_fetched`) to use on a
+    /// module-cache miss, instead of re-fetching it from `contract_store`.
+    ///
+    /// This closes the store→fetch round-trip described in issue #2216:
+    /// `verify_and_store_contract` hands a freshly-received `ContractContainer`
+    /// to `contract_store.store_contract`, then immediately needed the same
+    /// bytes again to compile the module on the (guaranteed, for a brand-new
+    /// contract) cache miss. Passing the contract through means that path
+    /// never re-reads what it just wrote.
+    ///
+    /// When `already_fetched` is `None` this is behaviorally identical to
+    /// `prepare_contract_call` (used by every call site that doesn't already
+    /// hold the contract, e.g. `update_state`/`summarize_state` on a contract
+    /// that's merely being re-validated).
+    pub(super) fn prepare_contract_call_with_contract(
+        &mut self,
+        key: &ContractKey,
+        parameters: &Parameters,
+        req_bytes: usize,
+        already_fetched: &ContractContainer,
+    ) -> RuntimeResult<RunningInstance> {
+        self.prepare_contract_call_inner(key, parameters, req_bytes, Some(already_fetched))
+    }
+
+    fn prepare_contract_call_inner(
+        &mut self,
+        key: &ContractKey,
+        parameters: &Parameters,
+        req_bytes: usize,
+        already_fetched: Option<&ContractContainer>,
+    ) -> RuntimeResult<RunningInstance> {
         // Check shared cache first. The lock is held only for the duration of
         // the lookup + Module clone (an Arc bump) and is ALWAYS dropped before
         // the compile below — never held across the blocking compile.
@@ -652,24 +687,35 @@ impl Runtime {
             module
         } else {
             tracing::info!(contract = %key, "Module cache miss — compiling");
-            // Cache miss — fetch the code and compile with the lock released so
-            // the (potentially multi-hundred-millisecond) Cranelift compile
+            // Cache miss — obtain the code and compile with the lock released
+            // so the (potentially multi-hundred-millisecond) Cranelift compile
             // never blocks other executors waiting on the shared cache. When
             // `offload_compilation` is set, `engine.compile` further offloads
             // the compile to a blocking thread so it does not pin the
             // single-threaded contract-handling loop (issue #4441).
-            let contract = self
-                .contract_store
-                .fetch_contract(key, parameters)
-                .ok_or_else(|| {
-                    tracing::error!(
-                        contract = %key,
-                        key_code_hash = ?key.code_hash(),
-                        phase = "prepare_contract_call_failed",
-                        "Contract not found in store during WASM execution"
-                    );
-                    RuntimeInnerError::ContractNotFound(*key)
-                })?;
+            //
+            // Prefer the caller-supplied contract (already in hand — no need
+            // to round-trip through `contract_store`); fall back to fetching
+            // from the store for callers that don't have it (issue #2216).
+            let owned_contract;
+            let contract = match already_fetched {
+                Some(contract) => contract,
+                None => {
+                    owned_contract = self
+                        .contract_store
+                        .fetch_contract(key, parameters)
+                        .ok_or_else(|| {
+                            tracing::error!(
+                                contract = %key,
+                                key_code_hash = ?key.code_hash(),
+                                phase = "prepare_contract_call_failed",
+                                "Contract not found in store during WASM execution"
+                            );
+                            RuntimeInnerError::ContractNotFound(*key)
+                        })?;
+                    &owned_contract
+                }
+            };
             let code = match contract {
                 ContractContainer::Wasm(ContractWasmAPIVersion::V1(contract_v1)) => {
                     contract_v1.code().data().to_vec()

--- a/crates/core/src/wasm_runtime/tests/contract.rs
+++ b/crates/core/src/wasm_runtime/tests/contract.rs
@@ -37,6 +37,94 @@ async fn validate_state() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+/// Regression test for issue #2216: `validate_state_with_contract` must
+/// compile and validate directly from the caller-supplied `ContractContainer`
+/// WITHOUT needing the contract to already be resolvable via
+/// `contract_store.fetch_contract` — i.e. it must not depend on the
+/// store→fetch round-trip `verify_and_store_contract` used to require.
+///
+/// This is proven by deliberately NOT storing the contract in `contract_store`
+/// (unlike `setup_test_contract`, which always does) before calling
+/// `validate_state_with_contract`: if the method secretly still needed
+/// `contract_store.fetch_contract` on the module-cache miss, this would fail
+/// with `ContractNotFound` instead of validating successfully.
+#[tokio::test(flavor = "multi_thread")]
+async fn validate_state_with_contract_does_not_require_prior_store()
+-> Result<(), Box<dyn std::error::Error>> {
+    use std::sync::Arc;
+
+    use freenet_stdlib::prelude::{
+        ContractCode, ContractContainer, ContractWasmAPIVersion, WrappedContract,
+    };
+
+    use crate::contract::storages::Storage;
+    use crate::util::tests::get_temp_dir;
+
+    let temp_dir = get_temp_dir();
+    let module_bytes = crate::wasm_runtime::tests::get_test_module(TEST_CONTRACT_1)?;
+    let contract_bytes =
+        WrappedContract::new(Arc::new(ContractCode::from(module_bytes)), vec![].into());
+    let contract = ContractContainer::Wasm(ContractWasmAPIVersion::V1(contract_bytes));
+    let contract_key = contract.key();
+    let params = Parameters::from([].as_ref());
+
+    let storage = Storage::new(temp_dir.path()).await?;
+    // Deliberately empty: the contract is NEVER stored here.
+    let contract_store = super::super::ContractStore::new(
+        temp_dir.path().join("contract"),
+        10_000,
+        storage.clone(),
+    )?;
+    let delegate_store = super::super::DelegateStore::new(
+        temp_dir.path().join("delegate"),
+        10_000,
+        storage.clone(),
+    )?;
+    let secrets_store = super::super::SecretsStore::new(
+        temp_dir.path().join("secrets"),
+        Default::default(),
+        storage,
+    )?;
+    let mut runtime = Runtime::build(contract_store, delegate_store, secrets_store, false).unwrap();
+
+    // Sanity check: fetch_contract genuinely misses (proves the round-trip
+    // this test guards against would fail if it were still required).
+    assert!(
+        runtime
+            .contract_store
+            .fetch_contract(&contract_key, &params)
+            .is_none(),
+        "test setup invariant: the contract must NOT be in contract_store yet"
+    );
+
+    let is_valid = runtime.validate_state_with_contract(
+        &contract_key,
+        &params,
+        &WrappedState::new(vec![1, 2, 3, 4]),
+        &Default::default(),
+        &contract,
+    )?;
+    assert_eq!(
+        is_valid,
+        ValidateResult::Valid,
+        "validate_state_with_contract must validate directly from the \
+         supplied ContractContainer, without needing it in contract_store"
+    );
+
+    // The invalid-state branch must behave identically to `validate_state`.
+    let not_valid = runtime.validate_state_with_contract(
+        &contract_key,
+        &params,
+        &WrappedState::new(vec![1, 0, 0, 1]),
+        &Default::default(),
+        &contract,
+    )?;
+    assert!(matches!(not_valid, ValidateResult::RequestRelated(_)));
+
+    std::mem::drop(temp_dir);
+    Ok(())
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn update_state() -> Result<(), Box<dyn std::error::Error>> {
     let TestSetup {


### PR DESCRIPTION
## Problem

`verify_and_store_contract()` (`crates/core/src/contract/executor/runtime/contract_ops.rs`) receives a freshly-put `ContractContainer`, stores it into `contract_store`, and then validates the state. Validation compiles the WASM module via `Runtime::validate_state` → `prepare_contract_call`, which — on a module-cache miss (guaranteed the first time a brand-new contract is PUT) — re-fetches the exact same contract bytes from `contract_store` just to compile them. We already had the bytes in hand a few lines above; this is a redundant store→fetch round-trip, as described in #2216.

The issue's own line references were stale (the executor was refactored into `crates/core/src/contract/executor/runtime/` modules, and #4702's disk-budget admission gate touched `verify_and_store_contract` further), so this PR re-locates the current code before changing it. It also investigates and rules out the issue's cited *root cause*: sibling issue #2215's `stretto` cache `wait()` (needed because stretto's cache insert was eventually-consistent) is gone — PR #3471 replaced `stretto` with `moka` (synchronous insert/get), so that specific eventual-consistency hazard no longer exists. The architectural round-trip itself, however, was still present, which is what this PR removes.

## Solution

- Added `Runtime::prepare_contract_call_with_contract` (and a shared `prepare_contract_call_inner`) that, on a module-cache miss, compiles directly from a caller-supplied `ContractContainer` instead of calling `contract_store.fetch_contract`. `prepare_contract_call` keeps its original behavior (`None` case) for every other caller.
- Added `Runtime::validate_state_with_contract`, mirroring `ContractRuntimeInterface::validate_state` but routed through the new `prepare_contract_call_with_contract`. The two share a `run_validate_state` body so there's no duplicated WASM-call logic.
- `verify_and_store_contract` now keeps a cheap `Arc`-backed `.clone()` of the contract it already received, and threads it through `fetch_related_for_validation_network` (which now takes `already_fetched_contract: Option<&ContractContainer>`) into `validate_state_with_contract` — both the initial validate call and the depth=1 retry-after-`RequestRelated` call.
- The other two call sites of `fetch_related_for_validation_network` (`perform_contract_put`'s existing-contract merge path, and `get_updated_state`'s post-update validation) don't have a fresh `ContractContainer` in hand — they pass `None` and are unchanged in behavior.
- Scope: only `verify_and_store_contract` — the function #2216 names — was touched. The generic, cross-runtime `bridged_upsert_contract_state` PUT path (`executor_impl.rs`, used by both `Executor<Runtime>` and `Executor<MockWasmRuntime>`) has the same shape of round-trip but is a separate, generic path; changing it would mean adding this method to the `ContractRuntimeInterface` trait (touching the mock runtime too) — out of scope for this one-function fix.
- All existing disk-budget admission-gate ordering and `remove_contract` / `record_wasm_removed` rollback semantics in `verify_and_store_contract` are untouched; only the validation call itself was rerouted.

## Testing

- New regression test `wasm_runtime::tests::contract::validate_state_with_contract_does_not_require_prior_store`: builds a real (compiled) test contract, deliberately does **not** store it in `contract_store`, and calls `validate_state_with_contract` directly — proving it validates from the supplied container without needing the store round-trip. Asserts both the `Valid` and `RequestRelated` (invalid-state) branches match `validate_state`'s existing behavior.
  - Verified the test fails to compile without the new API (temporarily reverted the runtime/contract.rs changes) and fails at runtime with `ContractNotFound` when the pass-through is defeated (temporarily forced `prepare_contract_call_with_contract` to ignore the supplied contract) — confirming the test actually exercises the fix.
- `cargo fmt` — clean.
- `cargo clippy -p freenet -- -D warnings` — clean.
- `cargo test -p freenet --lib` — 3862 passed, 25 ignored, only the 2 pre-existing macOS-only `wasm_runtime::migration_tests` failures (confirmed identical on the unmodified base branch — case-sensitivity artifact, unrelated to this change).

## Fixes

Closes #2216

https://claude.ai/code/session_01DR69yFsB57UFRTMrHGG5nx