### PR TITLE
fix(hosting): rehydrate local-hosting interest on restart so cached contracts serve locally (#4780)

### DIFF
--- a/crates/core/src/client_events.rs
+++ b/crates/core/src/client_events.rs
@@ -161,6 +161,17 @@ async fn register_subscription_listener(
 /// near-miss floor. `local_satisfies_request` already guarantees valid state is
 /// present, so a phantom (interested-but-stateless, #4440) copy is excluded even
 /// though it can register interest via a downstream subscriber.
+///
+/// Do NOT re-add `is_hosting_contract` (the in-memory hosting-cache membership)
+/// as a serve term — see .claude/rules/hosting-invariants.md (invariant 1). A
+/// hosting-cache copy is NOT necessarily in the update mesh: on restart the
+/// cache is restored but the InterestManager is not, so `is_hosting_contract`
+/// can be true while the copy has no freshening path. Serving on it would
+/// re-introduce the #3698 stale-serve bug. The correct fix for restored copies
+/// is to rehydrate `has_local_interest` at startup
+/// (`OpManager::rehydrate_local_hosting_interest`, #4780), which registers the
+/// copy into anti-entropy so `has_local_interest` (term 3) is a true
+/// fresh-in-mesh signal — NOT to widen this gate.
 fn should_serve_local_copy(
     local_satisfies_request: bool,
     connection_count: usize,

--- a/crates/core/src/client_events.rs
+++ b/crates/core/src/client_events.rs
@@ -172,7 +172,12 @@ async fn register_subscription_listener(
 /// (`OpManager::rehydrate_local_hosting_interest`, #4780), which registers the
 /// copy into anti-entropy so `has_local_interest` (term 3) is a true
 /// fresh-in-mesh signal — NOT to widen this gate.
-fn should_serve_local_copy(
+// `pub(crate)` so the restart-rehydration regression test
+// (`node::op_state_manager::tests`) can assert the ACTUAL serve decision for a
+// restored contract, not just the `has_local_interest` input — guarding against
+// a future refactor that decouples the gate from `has_local_interest`. Pure fn,
+// no state, safe to expose in-crate.
+pub(crate) fn should_serve_local_copy(
     local_satisfies_request: bool,
     connection_count: usize,
     is_subscribed: bool,

--- a/crates/core/src/contract/handler.rs
+++ b/crates/core/src/contract/handler.rs
@@ -174,6 +174,23 @@ impl ContractHandler for NetworkContractHandler {
             .neighbor_hosting
             .initialize_from_hosting_cache(hosted_ids);
 
+        // #4780: also rehydrate InterestManager local-hosting for every restored
+        // hosted contract, so a client GET for a cached contract serves LOCALLY
+        // (serve-DURING gate) instead of routing to the network, and the copy
+        // re-joins InterestSync anti-entropy. The two restore steps above rebuild
+        // the hosting cache and the advertised-host set but NOT the
+        // InterestManager, which both the serve gate and the interest-sync
+        // heartbeat key on. State-gated inside the helper (register-after-state,
+        // #4782) so no phantom interested-but-stateless entry is created — the
+        // hosting storage handle is set above (`set_hosting_storage`), so the
+        // state-presence check is real here.
+        //
+        // Do NOT "fix" this instead by re-adding is_hosting_contract to the serve
+        // gate (`client_events::should_serve_local_copy`) — that would serve
+        // copies with no freshening path and re-introduce the #3698 stale-serve
+        // bug. See .claude/rules/hosting-invariants.md (invariant 1).
+        op_manager.rehydrate_local_hosting_interest();
+
         Ok(Self { executor, channel })
     }
 

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -552,6 +552,58 @@ impl OpManager {
         })
     }
 
+    /// Re-register local-hosting interest for every restored hosted contract
+    /// on restart (#4780).
+    ///
+    /// Startup restore repopulates the hosting cache
+    /// ([`Ring::load_hosting_cache`]) and the advertised-host set
+    /// ([`NeighborHostingManager::initialize_from_hosting_cache`]), but NOT the
+    /// [`InterestManager`](crate::ring::interest::InterestManager). Both the
+    /// client-GET serve gate (`client_events::should_serve_local_copy`, which
+    /// keys on `InterestManager::has_local_interest`) AND the InterestSync
+    /// anti-entropy heartbeat (`node::handle_interest_sync_message`, which keys
+    /// on `has_local_interest` / `get_matching_contracts` — i.e. the interest
+    /// hash index) read the InterestManager. So without this call a restored,
+    /// still-hosted contract silently fell out of BOTH local serving and
+    /// anti-entropy: after a restart with connections re-established (so the
+    /// serve gate's `connection_count == 0` escape hatch no longer applies) and
+    /// no live subscription, every subsequent client GET routed the whole
+    /// request through the network (slow), and the copy never re-joined the
+    /// update mesh. serve-DURING (`hosting-invariants.md` invariant 1) requires
+    /// the reverse: serve the local copy immediately and re-link it in the
+    /// background.
+    ///
+    /// Registering `hosting = true` (the same reason the GET/PUT host-formation
+    /// paths register on first cache) is exactly what restores both: the serve
+    /// gate answers locally, and the contract re-enters the interest index so
+    /// the ~5-min InterestSync heartbeat heals it and neighbors learn we
+    /// co-host it (live fan-out).
+    ///
+    /// Register-after-state (#4782): a restored key whose state is NOT on disk
+    /// is skipped, so we never create a phantom interested-but-stateless entry
+    /// (#4440). `Ring::contract_state_present` conservatively returns `true`
+    /// when the storage handle is unset, matching the summarize gate; at the
+    /// production call site (`contract::handler::build`) the handle is already
+    /// set, so this is a real state-store existence check.
+    ///
+    /// Returns the number of contracts for which interest was (re-)registered.
+    pub(crate) fn rehydrate_local_hosting_interest(&self) -> usize {
+        let mut rehydrated = 0usize;
+        for key in self.ring.hosting_contract_keys() {
+            if self.ring.contract_state_present(&key) {
+                self.interest_manager.register_local_hosting(&key);
+                rehydrated += 1;
+            }
+        }
+        if rehydrated > 0 {
+            tracing::info!(
+                rehydrated,
+                "Rehydrated local-hosting interest for restored contracts on restart (#4780)"
+            );
+        }
+        rehydrated
+    }
+
     /// Cloneable handle to the shutting-down flag. Used by
     /// `ShutdownHandle` to flip the gate before starting the drain
     /// wait. Callers checking the flag should use
@@ -4815,5 +4867,179 @@ mod tests {
         assert_eq!(counter.load(Ordering::Relaxed), 1);
         drop(g);
         assert_eq!(counter.load(Ordering::Relaxed), 0);
+    }
+
+    // ===== Restart serve-rehydration (#4780) =====
+
+    /// Build a contract key whose 32-byte instance id and code hash are both
+    /// derived from `seed`, so a `HostingMetadata { code_hash }` we persist under
+    /// `key.as_bytes()` reconstructs to the SAME key after restore.
+    #[cfg(feature = "redb")]
+    fn rehydrate_key(seed: u8) -> ContractKey {
+        ContractKey::from_id_and_code(
+            ContractInstanceId::new([seed; 32]),
+            freenet_stdlib::prelude::CodeHash::new([seed.wrapping_add(0x40); 32]),
+        )
+    }
+
+    /// #4780 regression: after a restart that restores the hosting cache and
+    /// re-establishes connections (so the serve gate's `connection_count == 0`
+    /// escape hatch does NOT apply) with no live subscription, a restored hosted
+    /// contract whose state is on disk must be SERVED LOCALLY and re-enrolled in
+    /// InterestSync anti-entropy — not routed through the network.
+    ///
+    /// Root cause: startup restore (`Ring::load_hosting_cache` +
+    /// `NeighborHostingManager::initialize_from_hosting_cache`) rebuilt the
+    /// hosting cache and the advertised-host set but NOT the `InterestManager`.
+    /// The serve gate (`client_events::should_serve_local_copy`) and the
+    /// interest-sync heartbeat (`node::handle_interest_sync_message`) both key on
+    /// `InterestManager::has_local_interest` / the interest hash index, so the
+    /// restored copy silently fell out of both. The fix rehydrates local-hosting
+    /// interest on restart (`OpManager::rehydrate_local_hosting_interest`).
+    ///
+    /// This drives the REAL restore path (`load_hosting_cache` against a real
+    /// redb store), then the REAL fix method. It also pins the
+    /// register-after-state gate (#4782): a restored metadata-only key with no
+    /// state on disk must NOT be registered (no phantom interested-but-stateless
+    /// entry, #4440).
+    ///
+    /// Red-without / green-with: neutering `rehydrate_local_hosting_interest` to
+    /// a no-op flips the post-restart `has_local_interest` / lookup_by_hash
+    /// assertions from true to false.
+    #[cfg(feature = "redb")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn restart_rehydrates_local_hosting_interest_so_cached_get_serves_locally() {
+        use crate::contract::storages::{HostingMetadata, ReDb};
+        use crate::ring::interest::contract_hash;
+        use freenet_stdlib::prelude::WrappedState;
+
+        let (op_manager, _guards) =
+            build_reroot_test_op_manager("restart-serve-rehydration-4780").await;
+        // Re-establish connectivity: connection_count > 0 means the serve gate's
+        // isolated-node escape hatch does NOT fire, so serving depends on
+        // has_local_interest — exactly the #4780 scenario.
+        seed_location_and_one_connection(&op_manager);
+        assert!(op_manager.ring.open_connections() > 0);
+
+        // A restored hosted contract WITH state on disk (must be re-served + re-
+        // enrolled), and a restored metadata-only contract with NO state (must be
+        // skipped by the register-after-state gate).
+        let present_key = rehydrate_key(0x11);
+        let absent_key = rehydrate_key(0x22);
+        let state = WrappedState::new(b"restored contract state".to_vec());
+
+        // --- Simulate the pre-restart on-disk store ---
+        let dir = tempfile::tempdir().expect("tempdir");
+        let storage: ReDb = ReDb::new(dir.path()).await.expect("open redb");
+        storage
+            .store_state_sync(&present_key, state.clone())
+            .expect("store state for present key");
+        let now_ms = 1_000u64;
+        storage
+            .store_hosting_metadata(
+                &present_key,
+                HostingMetadata::new(
+                    now_ms,
+                    0,
+                    state.as_ref().len() as u64,
+                    **present_key.code_hash(),
+                    true,
+                ),
+            )
+            .expect("store hosting metadata for present key");
+        // absent_key: hosting metadata only, NO state row on disk.
+        storage
+            .store_hosting_metadata(
+                &absent_key,
+                HostingMetadata::new(now_ms, 0, 0, **absent_key.code_hash(), false),
+            )
+            .expect("store hosting metadata for absent key");
+
+        // --- Restart restore path (mirrors contract::handler::build) ---
+        op_manager.ring.set_hosting_storage(storage.clone());
+        let restored = op_manager
+            .ring
+            .load_hosting_cache(&storage, |_id| None)
+            .expect("load_hosting_cache");
+        assert_eq!(
+            restored, 2,
+            "both metadata entries restore into the hosting cache"
+        );
+        assert!(op_manager.ring.is_hosting_contract(&present_key));
+        assert!(op_manager.ring.is_hosting_contract(&absent_key));
+        assert!(
+            op_manager.ring.contract_state_present(&present_key),
+            "present key must have on-disk state after restore",
+        );
+        assert!(
+            !op_manager.ring.contract_state_present(&absent_key),
+            "absent key must have NO on-disk state (register-after-state control)",
+        );
+
+        // --- Pre-fix state (the #4780 bug): restore did NOT touch the
+        // InterestManager, so the serve gate would route to the network ---
+        assert!(
+            !op_manager.interest_manager.has_local_interest(&present_key),
+            "BUG REPRO: restored hosted contract has no local interest after restore, \
+             so the serve gate (has_local_interest term) routes the GET to the network",
+        );
+        // Not subscribed (no live update stream) — the other serve-gate term.
+        assert!(!op_manager.ring.is_receiving_updates(&present_key));
+        assert!(
+            op_manager
+                .interest_manager
+                .lookup_by_hash(contract_hash(&present_key))
+                .is_empty(),
+            "BUG REPRO: restored contract is absent from the interest hash index, \
+             so it does not participate in InterestSync anti-entropy",
+        );
+
+        // --- Apply the fix ---
+        let rehydrated = op_manager.rehydrate_local_hosting_interest();
+        assert_eq!(
+            rehydrated, 1,
+            "only the state-present contract is re-registered; the stateless one is skipped",
+        );
+
+        // --- Post-fix: serve LOCALLY + re-enrolled in anti-entropy ---
+        assert!(
+            op_manager.interest_manager.has_local_interest(&present_key),
+            "FIX: restored hosted contract now has local interest → serve gate \
+             answers the GET from the local copy instead of routing to the network",
+        );
+        assert!(
+            op_manager
+                .interest_manager
+                .lookup_by_hash(contract_hash(&present_key))
+                .contains(&present_key),
+            "FIX: restored contract is back in the interest hash index → it re-joins \
+             the InterestSync anti-entropy heartbeat (node::handle_interest_sync_message)",
+        );
+
+        // Register-after-state gate: the stateless restored copy must NOT be
+        // registered (no phantom interested-but-stateless entry, #4440 / #4782).
+        assert!(
+            !op_manager.interest_manager.has_local_interest(&absent_key),
+            "register-after-state: a restored metadata-only copy with no on-disk \
+             state must NOT be registered as interested",
+        );
+    }
+
+    /// Wiring pin (#4780): `contract::handler::NetworkContractHandler::build`
+    /// MUST call `rehydrate_local_hosting_interest` after restoring the hosting
+    /// cache, or restored contracts silently stop serving locally / rejoining
+    /// anti-entropy. The behavioral test above proves the method WORKS; this pin
+    /// proves it is actually invoked at startup (the first `async fn build(` in
+    /// handler.rs is `NetworkContractHandler::build`).
+    #[test]
+    fn handler_build_rehydrates_local_hosting_interest_on_restart() {
+        let handler_src = include_str!("../contract/handler.rs");
+        let build_body = braced_block_after(handler_src, "async fn build(");
+        assert!(
+            build_body.contains("rehydrate_local_hosting_interest"),
+            "NetworkContractHandler::build must call rehydrate_local_hosting_interest \
+             after load_hosting_cache so restored hosted contracts serve locally and \
+             rejoin anti-entropy (#4780)",
+        );
     }
 }

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -581,10 +581,28 @@ impl OpManager {
     ///
     /// Register-after-state (#4782): a restored key whose state is NOT on disk
     /// is skipped, so we never create a phantom interested-but-stateless entry
-    /// (#4440). `Ring::contract_state_present` conservatively returns `true`
-    /// when the storage handle is unset, matching the summarize gate; at the
-    /// production call site (`contract::handler::build`) the handle is already
-    /// set, so this is a real state-store existence check.
+    /// (#4440).
+    ///
+    /// **Backend scope of the state gate.** `Ring::contract_state_present` is a
+    /// REAL state-store existence check only on the **redb** backend (the
+    /// production default): it does a cheap synchronous point lookup on the
+    /// state table. On the **sqlite** backend, and whenever the storage handle
+    /// is unset, it conservatively returns `true` — the same conservative shape
+    /// as the #4610 summarize gate and #4782 register-after-state. So on sqlite
+    /// a restored *metadata-only* key with no on-disk state WOULD be registered
+    /// here. That is:
+    /// - **pre-existing and shared** with the summarize gate, not introduced by
+    ///   this method;
+    /// - **moot in production**, which runs redb and sets the storage handle
+    ///   (`set_hosting_storage`) before this call, so the check is real; and
+    /// - **never a mis-serve**: the client-GET serve gate still requires
+    ///   `local_satisfies_request` (valid state actually present), so a
+    ///   stateless-but-interested entry can enroll in anti-entropy but can
+    ///   never cause a read to be answered from absent state.
+    ///
+    /// Tightening the shared `contract_state_present` gate to a real check on
+    /// sqlite is a whole-system change out of scope here (tracked separately);
+    /// do NOT special-case it in this method.
     ///
     /// Returns the number of contracts for which interest was (re-)registered.
     pub(crate) fn rehydrate_local_hosting_interest(&self) -> usize {
@@ -4904,11 +4922,12 @@ mod tests {
     /// entry, #4440).
     ///
     /// Red-without / green-with: neutering `rehydrate_local_hosting_interest` to
-    /// a no-op flips the post-restart `has_local_interest` / lookup_by_hash
-    /// assertions from true to false.
+    /// a no-op flips the post-restart real-serve-gate (`should_serve_local_copy`),
+    /// `has_local_interest`, and `lookup_by_hash` assertions from true to false.
     #[cfg(feature = "redb")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn restart_rehydrates_local_hosting_interest_so_cached_get_serves_locally() {
+        use crate::client_events::should_serve_local_copy;
         use crate::contract::storages::{HostingMetadata, ReDb};
         use crate::ring::interest::contract_hash;
         use freenet_stdlib::prelude::WrappedState;
@@ -4976,15 +4995,37 @@ mod tests {
             "absent key must have NO on-disk state (register-after-state control)",
         );
 
+        // The ACTUAL serve decision for a client GET of the present key, using
+        // the real production gate with the real inputs a restored contract
+        // presents: valid local state (`local_satisfies_request = true`),
+        // connections re-established, NOT subscribed, and whatever local
+        // interest the InterestManager currently holds. Asserting the real gate
+        // (not just the `has_local_interest` input) guards against a future
+        // refactor that decouples the serve decision from `has_local_interest`.
+        let serves_locally = |key: &ContractKey| {
+            should_serve_local_copy(
+                /* local_satisfies_request */ true,
+                op_manager.ring.open_connections(),
+                /* is_subscribed */ op_manager.ring.is_receiving_updates(key),
+                /* has_local_interest */
+                op_manager.interest_manager.has_local_interest(key),
+            )
+        };
+
         // --- Pre-fix state (the #4780 bug): restore did NOT touch the
-        // InterestManager, so the serve gate would route to the network ---
+        // InterestManager, so the serve gate routes to the network ---
         assert!(
             !op_manager.interest_manager.has_local_interest(&present_key),
-            "BUG REPRO: restored hosted contract has no local interest after restore, \
-             so the serve gate (has_local_interest term) routes the GET to the network",
+            "BUG REPRO: restored hosted contract has no local interest after restore",
         );
         // Not subscribed (no live update stream) — the other serve-gate term.
         assert!(!op_manager.ring.is_receiving_updates(&present_key));
+        assert!(
+            !serves_locally(&present_key),
+            "BUG REPRO: the real serve gate returns FALSE for the restored contract \
+             (connections up, not subscribed, no local interest) → the GET is routed \
+             to the network instead of served from the fresh local copy",
+        );
         assert!(
             op_manager
                 .interest_manager
@@ -5004,8 +5045,13 @@ mod tests {
         // --- Post-fix: serve LOCALLY + re-enrolled in anti-entropy ---
         assert!(
             op_manager.interest_manager.has_local_interest(&present_key),
-            "FIX: restored hosted contract now has local interest → serve gate \
-             answers the GET from the local copy instead of routing to the network",
+            "FIX: restored hosted contract now has local interest",
+        );
+        assert!(
+            serves_locally(&present_key),
+            "FIX: the real serve gate now returns TRUE for the restored contract → \
+             the GET is answered from the fresh local copy instead of routing to the \
+             network (serve-DURING)",
         );
         assert!(
             op_manager


### PR DESCRIPTION
## Problem

After a successful GET, restart, then GET again, the node stopped serving the contract from its local cache: it routed the whole request through the network (slow) and the restored copy never re-joined anti-entropy. Reported by a River user (Ivvor) with a code-level analysis; verified.

Root cause: serve-DURING (#4748) re-keyed the client-GET serve gate (`client_events::should_serve_local_copy`) and the InterestSync heartbeat onto `InterestManager::has_local_interest`. Startup restore (`Ring::load_hosting_cache` + `NeighborHostingManager::initialize_from_hosting_cache`) rebuilds the hosting cache and the advertised-host set but never rehydrates the InterestManager, and the only `register_local_hosting` callers (GET/PUT host-formation) fire on `access_result.is_new` — false for a contract already in the restored cache. So every post-restart GET saw `has_local_interest == false` and, with connections re-established and no live subscription, routed to the network while the copy stayed out of the interest hash index (no anti-entropy). Unchanged by #4782, which reworked the subscribe/hosting paths but not startup restore or the serve gate.

## Approach

On startup, after the existing hosting-cache / neighbor-hosting restore, re-register local-hosting interest for every restored hosted contract whose state is on disk (`OpManager::rehydrate_local_hosting_interest`). This makes the serve gate answer locally AND re-enrolls the copy in the interest hash index so the ~5-min InterestSync heartbeat heals it and neighbors learn we co-host it — the serve-DURING permitted transient in hosting-invariants invariant 1 (serve immediately, re-link in the background, never block the read).

Register-after-state (#4782): a restored metadata-only key with no on-disk state is skipped, so no phantom interested-but-stateless entry (#4440). The serve gate is deliberately NOT widened with `is_hosting_contract` — that would serve copies with no freshening path and re-introduce the #3698 stale-serve bug; guard comments added at both the gate and the restore site.

Touches hosting-invariants invariant 1 (a served copy is fresh) and preserves it by re-linking restored copies into anti-entropy rather than serving an unfreshened cache copy.

## Testing

- `restart_rehydrates_local_hosting_interest_so_cached_get_serves_locally` drives the real `load_hosting_cache` restore against a redb store, then the fix; asserts (via the real `should_serve_local_copy` gate) that the restored state-present copy is routed-to-network pre-fix and served-locally post-fix, and that it rejoins the interest hash index (anti-entropy), the stateless copy is skipped — all with `connection_count > 0` and no subscription. Verified red without the fix, green with it.
- `handler_build_rehydrates_local_hosting_interest_on_restart` — source-scrape pin that startup build calls the rehydration.

Closes #4780

[AI-assisted - Claude]
