### PR TITLE
perf(hosting): size summary/delta caches to hosted-set scale to stop anti-entropy re-summarize thrash

### DIFF
--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -925,10 +925,19 @@ pub(crate) type SummaryCache = MokaCache<ContractKey, (u64, StateSummary<'static
 /// Value cached per `(contract, state-hash, peer-summary-hash)` for the
 /// `get_contract_state_delta` fast path. Shared across pool executors like
 /// [`SummaryCache`].
+///
+/// Unlike [`SummaryCache`] this is BYTE-bounded, not entry-bounded: a
+/// `StateDelta` is variable and can be large (up to `MAX_STATE_SIZE` = 50 MiB —
+/// a contract may legitimately return its full state as a delta), and the key's
+/// cardinality (one entry per distinct peer-summary per contract) exceeds the
+/// contract count, so an entry-count cap reused from the tiny-summary cache could
+/// pin multi-GB of RAM (the #4565 OOM class). See [`build_delta_cache`] /
+/// [`delta_cache_capacity_bytes`].
 pub(crate) type DeltaCache = MokaCache<(ContractKey, u64, u64), StateDelta<'static>>;
 
-/// Conservative per-contract on-disk state floor used to size the summarize/delta
-/// fast-path caches from the node's hosting byte budget.
+/// Conservative per-contract on-disk state floor used to size the SUMMARY
+/// fast-path cache (entry-count) from the node's hosting byte budget. The delta
+/// cache is byte-bounded separately (see [`delta_cache_capacity_bytes`]).
 ///
 /// Chosen well BELOW the ~400 KiB average contract-state size observed on
 /// production gateways (a 1 GiB hosting budget held ~2616 contracts) so the
@@ -943,22 +952,23 @@ pub(crate) type DeltaCache = MokaCache<(ContractKey, u64, u64), StateDelta<'stat
 /// at the 1 GiB budget.
 const SUMMARIZE_CACHE_STATE_FLOOR_BYTES: u64 = 128 * 1024;
 
-/// Floor for the derived summarize/delta cache size: the historical fixed cap
+/// Floor for the derived SUMMARY cache entry-count: the historical fixed cap
 /// (1024). A host at the 128 MiB minimum hosting budget lands exactly here, so
 /// the change is a pure "larger budgets get a proportionally larger cache" —
 /// small/standalone hosts are unaffected.
 const SUMMARIZE_CACHE_MIN_CAPACITY: u64 = 1024;
 
-/// Sanity ceiling for the derived summarize/delta cache size.
+/// Sanity ceiling for the derived SUMMARY cache entry-count.
 ///
-/// Mirrors `StateStore::STATE_HASH_CACHE_CAPACITY` (100_000): the cheap
-/// change-detector that ALSO gates the fast path caps at 100k entries, so a
-/// larger summary/delta cache could never raise the hit rate (a summary miss on
-/// the detector's evicted key falls to the slow path regardless). Also bounds
-/// worst-case cache RAM if an operator sets an extreme `max-hosting-storage`.
-const SUMMARIZE_CACHE_MAX_CAPACITY: u64 = 100_000;
+/// Pinned to `STATE_HASH_CACHE_CAPACITY` (100_000) rather than a duplicated
+/// literal (the "manually-mirrored value that rots" pattern): the cheap
+/// change-detector that ALSO gates the fast path caps at that many entries, so a
+/// larger summary cache could never raise the hit rate (a summary miss on the
+/// detector's evicted key falls to the slow path regardless). Also bounds
+/// worst-case summary-cache RAM if an operator sets an extreme `max-hosting-storage`.
+const SUMMARIZE_CACHE_MAX_CAPACITY: u64 = crate::wasm_runtime::STATE_HASH_CACHE_CAPACITY;
 
-/// Derive the summarize/delta fast-path cache entry-count from the node's hosting
+/// Derive the SUMMARY fast-path cache entry-count from the node's hosting
 /// byte budget (`Config::max_hosting_storage`), so the ~5-min InterestSync
 /// anti-entropy re-summarize of the WHOLE hosted set hits the fast path (reuses
 /// the cached summary, skipping the WASM `summarize_state` and its possible module
@@ -972,19 +982,81 @@ const SUMMARIZE_CACHE_MAX_CAPACITY: u64 = 100_000;
 ///
 /// At the default RAM-scaled hosting budgets (`clamp(total_ram/8, 128 MiB, 1 GiB)`):
 /// 128 MiB budget → 1024 entries, 1 GiB budget → 8192 entries.
+///
+/// FUTURE: this sizes from the byte budget as a proxy for the hosted-set size. A
+/// more direct sizing would read the live hosted-contract count and size the
+/// cache from it, which would self-correct under-coverage on small-contract
+/// nodes (where `budget / SUMMARIZE_CACHE_STATE_FLOOR_BYTES` under-covers the real
+/// hosted count). Not done here — the summarize slow-path telemetry counter
+/// (`network_status::record_summarize_slow_path`) is the pragmatic detector for
+/// that under-coverage; size-from-count is the follow-up if it shows up.
 pub(crate) fn summarize_cache_capacity(hosting_budget_bytes: u64) -> u64 {
     (hosting_budget_bytes / SUMMARIZE_CACHE_STATE_FLOOR_BYTES)
         .clamp(SUMMARIZE_CACHE_MIN_CAPACITY, SUMMARIZE_CACHE_MAX_CAPACITY)
 }
 
-/// Build a [`SummaryCache`] bounded to `capacity` entries.
+/// Build a [`SummaryCache`] bounded to `capacity` ENTRIES. Summaries are tiny (a
+/// version number or small digest, ~1 KiB each), so entry-count sizing is an
+/// adequate RAM proxy here; the delta cache is byte-bounded instead
+/// ([`build_delta_cache`]).
 pub(crate) fn build_summary_cache(capacity: u64) -> SummaryCache {
     MokaCache::builder().max_capacity(capacity).build()
 }
 
-/// Build a [`DeltaCache`] bounded to `capacity` entries.
-pub(crate) fn build_delta_cache(capacity: u64) -> DeltaCache {
-    MokaCache::builder().max_capacity(capacity).build()
+/// Divisor applied to the hosting byte budget to derive the delta cache's BYTE
+/// budget: the delta cache gets `Config::max_hosting_storage / this` bytes.
+///
+/// The delta cache is a pure performance cache (a miss recomputes the delta via
+/// WASM — never a correctness issue), so it deserves only a modest slice of RAM.
+/// Its working set is bounded by live fan-out (per-subscriber delta computation),
+/// NOT by the whole hosted set, so it does not need to scale with the ~5-min
+/// anti-entropy re-summarize the way the summary cache does.
+const DELTA_CACHE_BUDGET_DIVISOR: u64 = 16;
+
+/// Floor for the delta cache byte budget (8 MiB). A host at the 128 MiB minimum
+/// hosting budget lands here (128 MiB / 16 = 8 MiB). At the observed ~400 KiB
+/// average delta this holds ~20 deltas — enough for a small node's fan-out.
+const DELTA_CACHE_MIN_BYTES: u64 = 8 * 1024 * 1024;
+
+/// Ceiling for the delta cache byte budget (64 MiB) — the HARD worst-case RAM for
+/// this cache regardless of operator `max-hosting-storage`, since moka evicts by
+/// the per-entry byte weight (below) to keep total weight under this cap. A
+/// gateway at the 1 GiB default hosting budget lands here (1 GiB / 16 = 64 MiB).
+const DELTA_CACHE_MAX_BYTES: u64 = 64 * 1024 * 1024;
+
+/// Derive the delta fast-path cache's BYTE budget from the node's hosting byte
+/// budget: `clamp(hosting_budget / DELTA_CACHE_BUDGET_DIVISOR,
+/// DELTA_CACHE_MIN_BYTES, DELTA_CACHE_MAX_BYTES)`.
+///
+/// Byte-bounded (not entry-counted) because a `StateDelta` is variable and can be
+/// large (up to `MAX_STATE_SIZE` = 50 MiB), and the delta key's cardinality
+/// exceeds the contract count, so an entry-count cap could pin multi-GB of RAM
+/// (#4565 OOM class). At the default budgets: 128 MiB hosting budget → 8 MiB delta
+/// cache, 1 GiB → 64 MiB. Worst-case delta-cache RAM is `DELTA_CACHE_MAX_BYTES`
+/// (64 MiB). NOTE: an individual delta whose byte length exceeds the derived
+/// budget (e.g. a >8 MiB delta on a small 128 MiB-budget node) simply is not
+/// cached and falls to the slow path — correctness is unaffected.
+pub(crate) fn delta_cache_capacity_bytes(hosting_budget_bytes: u64) -> u64 {
+    (hosting_budget_bytes / DELTA_CACHE_BUDGET_DIVISOR)
+        .clamp(DELTA_CACHE_MIN_BYTES, DELTA_CACHE_MAX_BYTES)
+}
+
+/// Build a [`DeltaCache`] bounded to `capacity_bytes` BYTES (NOT entries).
+///
+/// The weigher is the delta's byte length, so moka's size-aware eviction keeps
+/// the cache's total held bytes under `capacity_bytes` — the hard RAM bound that
+/// entry-count sizing could not provide for a variable-size, high-cardinality
+/// value (see [`delta_cache_capacity_bytes`]). Saturates the weight to `u32::MAX`
+/// on the (impossible, `MAX_STATE_SIZE` = 50 MiB) overflow, as moka recommends.
+pub(crate) fn build_delta_cache(capacity_bytes: u64) -> DeltaCache {
+    MokaCache::builder()
+        .max_capacity(capacity_bytes)
+        .weigher(
+            |_key: &(ContractKey, u64, u64), delta: &StateDelta<'static>| -> u32 {
+                u32::try_from(delta.as_ref().len()).unwrap_or(u32::MAX)
+            },
+        )
+        .build()
 }
 
 /// Consumers of the executor are required to poll for new changes in order to be notified
@@ -1084,7 +1156,7 @@ where
             // via `set_summarize_caches`, so pool executors don't each hold a full
             // copy of the hosted set's summaries.
             summary_cache: build_summary_cache(SUMMARIZE_CACHE_MIN_CAPACITY),
-            delta_cache: build_delta_cache(SUMMARIZE_CACHE_MIN_CAPACITY),
+            delta_cache: build_delta_cache(DELTA_CACHE_MIN_BYTES),
             delegate_notification_tx: None,
         })
     }

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -5,7 +5,6 @@
 use std::collections::{HashMap, HashSet};
 use std::fmt::Display;
 use std::future::Future;
-use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -19,7 +18,7 @@ use freenet_stdlib::client_api::{
     RequestError,
 };
 use freenet_stdlib::prelude::*;
-use lru::LruCache;
+use moka::sync::Cache as MokaCache;
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 
@@ -916,6 +915,78 @@ type SharedSummaries =
 // Per-client subscription counts for O(1) limit enforcement (used by RuntimePool).
 type SharedClientCounts = Arc<dashmap::DashMap<ClientId, usize>>;
 
+/// Value cached per contract for the `summarize_contract_state` fast path: the
+/// state-hash the summary was computed against, plus the summary itself. moka is
+/// internally `Arc`, so cloning the cache (into every pool executor) shares one
+/// backing store — the summaries are held once, not once per executor. See
+/// [`summarize_cache_capacity`] and [`Executor::set_summarize_caches`].
+pub(crate) type SummaryCache = MokaCache<ContractKey, (u64, StateSummary<'static>)>;
+
+/// Value cached per `(contract, state-hash, peer-summary-hash)` for the
+/// `get_contract_state_delta` fast path. Shared across pool executors like
+/// [`SummaryCache`].
+pub(crate) type DeltaCache = MokaCache<(ContractKey, u64, u64), StateDelta<'static>>;
+
+/// Conservative per-contract on-disk state floor used to size the summarize/delta
+/// fast-path caches from the node's hosting byte budget.
+///
+/// Chosen well BELOW the ~400 KiB average contract-state size observed on
+/// production gateways (a 1 GiB hosting budget held ~2616 contracts) so the
+/// derived entry count comfortably EXCEEDS the real hosted set (headroom for a
+/// larger-than-average hosted set and for smaller-than-average contracts), while
+/// still reducing to the historical fixed 1024-entry cap at the 128 MiB minimum
+/// hosting budget so small hosts see no behavior change (128 MiB / 128 KiB =
+/// 1024). A smaller floor would only add cheap headroom (summaries are tiny — the
+/// website/UI-container summary is a serialized version number, a River room
+/// summary a small digest — so an entry costs ~1 KiB, not the ~1.4 MiB of a
+/// compiled module), but 128 KiB already gives ~3x headroom over the observed set
+/// at the 1 GiB budget.
+const SUMMARIZE_CACHE_STATE_FLOOR_BYTES: u64 = 128 * 1024;
+
+/// Floor for the derived summarize/delta cache size: the historical fixed cap
+/// (1024). A host at the 128 MiB minimum hosting budget lands exactly here, so
+/// the change is a pure "larger budgets get a proportionally larger cache" —
+/// small/standalone hosts are unaffected.
+const SUMMARIZE_CACHE_MIN_CAPACITY: u64 = 1024;
+
+/// Sanity ceiling for the derived summarize/delta cache size.
+///
+/// Mirrors `StateStore::STATE_HASH_CACHE_CAPACITY` (100_000): the cheap
+/// change-detector that ALSO gates the fast path caps at 100k entries, so a
+/// larger summary/delta cache could never raise the hit rate (a summary miss on
+/// the detector's evicted key falls to the slow path regardless). Also bounds
+/// worst-case cache RAM if an operator sets an extreme `max-hosting-storage`.
+const SUMMARIZE_CACHE_MAX_CAPACITY: u64 = 100_000;
+
+/// Derive the summarize/delta fast-path cache entry-count from the node's hosting
+/// byte budget (`Config::max_hosting_storage`), so the ~5-min InterestSync
+/// anti-entropy re-summarize of the WHOLE hosted set hits the fast path (reuses
+/// the cached summary, skipping the WASM `summarize_state` and its possible module
+/// recompile) instead of thrashing a fixed 1024-entry cache the moment the hosted
+/// set exceeds it. Under 0.2.98 every-hop hosting a gateway hosts thousands of
+/// contracts, so the fixed 1024 cap turned the heartbeat into a re-summarization
+/// storm (~250x the summarize rate, tens of module recompiles/sec).
+///
+/// `count = clamp(hosting_budget_bytes / SUMMARIZE_CACHE_STATE_FLOOR_BYTES,
+///                SUMMARIZE_CACHE_MIN_CAPACITY, SUMMARIZE_CACHE_MAX_CAPACITY)`.
+///
+/// At the default RAM-scaled hosting budgets (`clamp(total_ram/8, 128 MiB, 1 GiB)`):
+/// 128 MiB budget → 1024 entries, 1 GiB budget → 8192 entries.
+pub(crate) fn summarize_cache_capacity(hosting_budget_bytes: u64) -> u64 {
+    (hosting_budget_bytes / SUMMARIZE_CACHE_STATE_FLOOR_BYTES)
+        .clamp(SUMMARIZE_CACHE_MIN_CAPACITY, SUMMARIZE_CACHE_MAX_CAPACITY)
+}
+
+/// Build a [`SummaryCache`] bounded to `capacity` entries.
+pub(crate) fn build_summary_cache(capacity: u64) -> SummaryCache {
+    MokaCache::builder().max_capacity(capacity).build()
+}
+
+/// Build a [`DeltaCache`] bounded to `capacity` entries.
+pub(crate) fn build_delta_cache(capacity: u64) -> DeltaCache {
+    MokaCache::builder().max_capacity(capacity).build()
+}
+
 /// Consumers of the executor are required to poll for new changes in order to be notified
 /// of changes or can alternatively use the notification channel.
 ///
@@ -957,14 +1028,21 @@ pub struct Executor<R = Runtime, S: StateStorage = Storage> {
     pub(crate) recovery_guard: CorruptedStateRecoveryGuard,
 
     /// Cache of contract summaries keyed by ContractKey, storing (state_hash, summary).
-    /// Avoids redundant WASM instantiations during the 5-minute interest heartbeat
+    /// Avoids redundant WASM instantiations during the ~5-minute interest heartbeat
     /// which calls summarize_state() for every matching contract.
-    /// LRU-bounded to prevent unbounded growth on gateways that see many contracts over time.
-    summary_cache: LruCache<ContractKey, (u64, StateSummary<'static>)>,
+    ///
+    /// Bounded to cover the hosted set (see [`summarize_cache_capacity`]) so that
+    /// heartbeat re-summarize hits the fast path at every-hop-hosting scale
+    /// instead of thrashing. In a pool this is a clone of ONE shared moka cache
+    /// (injected via [`Self::set_summarize_caches`]), so the summaries are held
+    /// once for the whole pool rather than once per executor; standalone executors
+    /// get a private min-sized cache.
+    summary_cache: SummaryCache,
 
     /// Cache of delta results keyed by (ContractKey, state_hash, their_summary_hash).
-    /// Avoids redundant WASM instantiations for get_state_delta() calls.
-    delta_cache: LruCache<(ContractKey, u64, u64), StateDelta<'static>>,
+    /// Avoids redundant WASM instantiations for get_state_delta() calls. Shared and
+    /// bounded like [`Self::summary_cache`].
+    delta_cache: DeltaCache,
 
     /// Channel to send delegate notifications when subscribed contracts change state.
     /// Set when running in a pool via `set_delegate_notification_tx()`.
@@ -1001,8 +1079,12 @@ where
             shared_summaries: None,
             shared_client_counts: None,
             recovery_guard: Arc::new(std::sync::Mutex::new(HashSet::new())),
-            summary_cache: LruCache::new(NonZeroUsize::new(1024).unwrap()),
-            delta_cache: LruCache::new(NonZeroUsize::new(1024).unwrap()),
+            // Standalone executors get a private, minimum-sized cache. The pool
+            // replaces these with clones of one hosting-budget-sized shared cache
+            // via `set_summarize_caches`, so pool executors don't each hold a full
+            // copy of the hosted set's summaries.
+            summary_cache: build_summary_cache(SUMMARIZE_CACHE_MIN_CAPACITY),
+            delta_cache: build_delta_cache(SUMMARIZE_CACHE_MIN_CAPACITY),
             delegate_notification_tx: None,
         })
     }
@@ -1029,6 +1111,26 @@ where
         self.shared_notifications = Some(notifications);
         self.shared_summaries = Some(summaries);
         self.shared_client_counts = Some(client_counts);
+    }
+
+    /// Replace this executor's private summarize/delta fast-path caches with
+    /// pool-shared, hosting-budget-sized caches.
+    ///
+    /// Called by `RuntimePool::new` for every executor with clones of ONE moka
+    /// cache pair sized via [`summarize_cache_capacity`]. Because the
+    /// "first available" checkout scatters summarize/delta calls across executors,
+    /// per-executor caches fragment the hit rate AND duplicate the hosted set's
+    /// summaries N times in RAM; one shared cache sized to the hosted set fixes
+    /// both, so the ~5-min anti-entropy re-summarize hits the fast path (skips the
+    /// WASM summarize and its possible module recompile) across the whole pool.
+    /// moka is internally `Arc`, so the clones share one backing store.
+    pub(crate) fn set_summarize_caches(
+        &mut self,
+        summary_cache: SummaryCache,
+        delta_cache: DeltaCache,
+    ) {
+        self.summary_cache = summary_cache;
+        self.delta_cache = delta_cache;
     }
 
     /// Set a shared recovery guard for pool-based operation.
@@ -1160,6 +1262,64 @@ pub(crate) mod test_fixtures {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The hosting-budget → summarize/delta cache-size derivation. Pure and
+    /// deterministic (no machine RAM), so these pin the exact sizing the pool
+    /// applies at every-hop-hosting scale (the 0.2.98 re-summarization storm fix).
+    mod summarize_cache_sizing_tests {
+        use super::*;
+
+        #[test]
+        fn reduces_to_old_cap_at_min_budget() {
+            // 128 MiB minimum hosting budget → exactly the historical fixed 1024
+            // cap, so small / standalone hosts see no behavior change.
+            assert_eq!(summarize_cache_capacity(128 * 1024 * 1024), 1024);
+        }
+
+        #[test]
+        fn covers_hosted_set_at_default_gateway_budget() {
+            // 1 GiB budget (the gateway default) → 8192, comfortably above the
+            // ~2616 contracts a production gateway hosted when the storm appeared.
+            assert_eq!(summarize_cache_capacity(1024 * 1024 * 1024), 8192);
+        }
+
+        #[test]
+        fn clamps_to_floor_for_degenerate_budget() {
+            assert_eq!(summarize_cache_capacity(0), SUMMARIZE_CACHE_MIN_CAPACITY);
+            assert_eq!(summarize_cache_capacity(1), SUMMARIZE_CACHE_MIN_CAPACITY);
+        }
+
+        #[test]
+        fn clamps_to_ceiling_for_extreme_budget() {
+            // An extreme operator `max-hosting-storage` is bounded by the sanity
+            // ceiling so cache RAM stays bounded (and never exceeds the detector
+            // cap that also gates the fast path).
+            assert_eq!(
+                summarize_cache_capacity(u64::MAX),
+                SUMMARIZE_CACHE_MAX_CAPACITY
+            );
+            // The first budget that reaches the ceiling: MAX * floor bytes.
+            assert_eq!(
+                summarize_cache_capacity(
+                    SUMMARIZE_CACHE_MAX_CAPACITY * SUMMARIZE_CACHE_STATE_FLOOR_BYTES
+                ),
+                SUMMARIZE_CACHE_MAX_CAPACITY
+            );
+        }
+
+        #[test]
+        fn is_monotonic_nondecreasing_in_budget() {
+            let mut prev = 0;
+            for gib in [0u64, 1, 2, 4, 8, 16, 64] {
+                let cap = summarize_cache_capacity(gib * 1024 * 1024 * 1024);
+                assert!(
+                    cap >= prev,
+                    "capacity must not decrease as the budget grows"
+                );
+                prev = cap;
+            }
+        }
+    }
 
     mod executor_error_tests {
         use super::*;

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -1018,11 +1018,39 @@ const DELTA_CACHE_BUDGET_DIVISOR: u64 = 16;
 /// average delta this holds ~20 deltas — enough for a small node's fan-out.
 const DELTA_CACHE_MIN_BYTES: u64 = 8 * 1024 * 1024;
 
-/// Ceiling for the delta cache byte budget (64 MiB) — the HARD worst-case RAM for
-/// this cache regardless of operator `max-hosting-storage`, since moka evicts by
-/// the per-entry byte weight (below) to keep total weight under this cap. A
-/// gateway at the 1 GiB default hosting budget lands here (1 GiB / 16 = 64 MiB).
+/// Ceiling for the delta cache byte budget (64 MiB) — the HARD ceiling on the
+/// cache's total byte WEIGHT regardless of operator `max-hosting-storage`, since
+/// moka evicts by the per-entry byte weight (below) to keep total weight under
+/// this cap. A gateway at the 1 GiB default hosting budget lands here
+/// (1 GiB / 16 = 64 MiB). Resident RAM is a small multiple of this weight cap:
+/// small/empty deltas are floored to [`DELTA_ENTRY_OVERHEAD_FLOOR_BYTES`] so the
+/// entry count (and its uncounted per-entry structural overhead) is also bounded,
+/// giving a worst case of <= ~1.5x this cap (<= ~96 MiB).
 const DELTA_CACHE_MAX_BYTES: u64 = 64 * 1024 * 1024;
+
+/// Per-entry weight FLOOR for the delta cache (512 bytes).
+///
+/// moka evicts only when the cache's total WEIGHT exceeds its byte budget, and the
+/// raw weigher (a delta's byte length) reports ~0 for the empty/tiny deltas some
+/// contracts legitimately return — the website / UI-container contract returns an
+/// EMPTY delta once a peer is already current. A zero-weight entry can never raise
+/// the weighted size, so WITHOUT a floor such entries are NEVER evicted: every
+/// UPDATE mints a fresh `(key, state_hash, summary_hash)` cache key, and the entry
+/// count — plus its uncounted per-entry structural overhead (the key tuple, moka's
+/// `ValueEntry`, deque node and map slot, ~100-250 B each) — grows without bound.
+/// That reintroduces the #4565 OOM class this cache exists to close (the delta
+/// cache is byte-bounded precisely so a high-cardinality value can't pin RAM).
+///
+/// Flooring every entry's weight at 512 B (a) is >= the real per-entry structural
+/// overhead, so the counted weight is a true upper bound on held RAM (RAM ~=
+/// weight, not weight + uncounted overhead), and (b) caps the entry COUNT at
+/// `byte_budget / 512`: 16_384 entries at the 8 MiB minimum budget, 131_072 at the
+/// 64 MiB maximum — comparable in scale to the summary cache's 100_000-entry
+/// ceiling. Worst-case delta-cache RAM is then the byte budget (real delta bytes,
+/// since `weighted_size <= budget`) PLUS `entry_count * overhead` (<= the budget
+/// again when overhead <= floor) — i.e. <= ~1.5x the byte budget, NOT the naive
+/// "budget only" the un-floored weigher implied.
+pub(crate) const DELTA_ENTRY_OVERHEAD_FLOOR_BYTES: u32 = 512;
 
 /// Derive the delta fast-path cache's BYTE budget from the node's hosting byte
 /// budget: `clamp(hosting_budget / DELTA_CACHE_BUDGET_DIVISOR,
@@ -1032,10 +1060,13 @@ const DELTA_CACHE_MAX_BYTES: u64 = 64 * 1024 * 1024;
 /// large (up to `MAX_STATE_SIZE` = 50 MiB), and the delta key's cardinality
 /// exceeds the contract count, so an entry-count cap could pin multi-GB of RAM
 /// (#4565 OOM class). At the default budgets: 128 MiB hosting budget → 8 MiB delta
-/// cache, 1 GiB → 64 MiB. Worst-case delta-cache RAM is `DELTA_CACHE_MAX_BYTES`
-/// (64 MiB). NOTE: an individual delta whose byte length exceeds the derived
-/// budget (e.g. a >8 MiB delta on a small 128 MiB-budget node) simply is not
-/// cached and falls to the slow path — correctness is unaffected.
+/// cache, 1 GiB → 64 MiB. Worst-case delta-cache RAM is the byte budget PLUS the
+/// floored entry-count overhead — <= ~1.5x `DELTA_CACHE_MAX_BYTES` (<= ~96 MiB) —
+/// see [`DELTA_ENTRY_OVERHEAD_FLOOR_BYTES`]; the floor is what bounds the entry
+/// count for the empty/tiny deltas the raw byte weigher would leave uncapped.
+/// NOTE: an individual delta whose byte length exceeds the derived budget (e.g.
+/// an 8-plus-MiB delta on a small 128 MiB-budget node) simply is not cached and
+/// falls to the slow path — correctness is unaffected.
 pub(crate) fn delta_cache_capacity_bytes(hosting_budget_bytes: u64) -> u64 {
     (hosting_budget_bytes / DELTA_CACHE_BUDGET_DIVISOR)
         .clamp(DELTA_CACHE_MIN_BYTES, DELTA_CACHE_MAX_BYTES)
@@ -1043,17 +1074,30 @@ pub(crate) fn delta_cache_capacity_bytes(hosting_budget_bytes: u64) -> u64 {
 
 /// Build a [`DeltaCache`] bounded to `capacity_bytes` BYTES (NOT entries).
 ///
-/// The weigher is the delta's byte length, so moka's size-aware eviction keeps
-/// the cache's total held bytes under `capacity_bytes` — the hard RAM bound that
+/// The weigher is the delta's byte length FLOORED at
+/// [`DELTA_ENTRY_OVERHEAD_FLOOR_BYTES`], so moka's size-aware eviction keeps the
+/// cache's total held bytes under `capacity_bytes` — the hard RAM bound that
 /// entry-count sizing could not provide for a variable-size, high-cardinality
-/// value (see [`delta_cache_capacity_bytes`]). Saturates the weight to `u32::MAX`
-/// on the (impossible, `MAX_STATE_SIZE` = 50 MiB) overflow, as moka recommends.
+/// value (see [`delta_cache_capacity_bytes`]). The floor is load-bearing: an
+/// UNfloored byte weigher reports ~0 for the empty/tiny deltas some contracts
+/// return (the website / UI-container contract returns an EMPTY delta once a peer
+/// is current), and a zero-weight entry is never evicted, so the entry count would
+/// grow without bound (re-opening the #4565 OOM class). Flooring caps the entry
+/// count at `capacity_bytes / DELTA_ENTRY_OVERHEAD_FLOOR_BYTES`. Saturates the
+/// weight to `u32::MAX` on the (impossible, `MAX_STATE_SIZE` = 50 MiB) overflow, as
+/// moka recommends, before applying the floor.
 pub(crate) fn build_delta_cache(capacity_bytes: u64) -> DeltaCache {
     MokaCache::builder()
         .max_capacity(capacity_bytes)
         .weigher(
             |_key: &(ContractKey, u64, u64), delta: &StateDelta<'static>| -> u32 {
-                u32::try_from(delta.as_ref().len()).unwrap_or(u32::MAX)
+                // Floor every entry's weight so empty/tiny deltas still count
+                // toward eviction — without this an unbounded stream of distinct
+                // empty-delta keys is never evicted (#4565 OOM class). See
+                // DELTA_ENTRY_OVERHEAD_FLOOR_BYTES.
+                u32::try_from(delta.as_ref().len())
+                    .unwrap_or(u32::MAX)
+                    .max(DELTA_ENTRY_OVERHEAD_FLOOR_BYTES)
             },
         )
         .build()

--- a/crates/core/src/contract/executor/mock_wasm_runtime.rs
+++ b/crates/core/src/contract/executor/mock_wasm_runtime.rs
@@ -407,6 +407,24 @@ impl Executor<MockWasmRuntime, MockStateStorage> {
         Executor::new(state_store, || Ok(()), OperationMode::Local, runtime, None).await
     }
 
+    /// Like [`new_mock_wasm_uncached`](Self::new_mock_wasm_uncached) but takes a
+    /// PRE-BUILT `StateStore` so two executors can SHARE one (its change-detector
+    /// `state_hash_cache` and the backing storage clone together, moka is
+    /// internally `Arc`) — the way the production pool shares one cloned
+    /// `StateStore` across executors. Used by the cross-executor shared-cache test
+    /// to prove a summary computed on executor A is served fast-path on executor B.
+    #[cfg(test)]
+    pub async fn new_mock_wasm_uncached_with_state_store(
+        state_store: crate::wasm_runtime::StateStore<MockStateStorage>,
+    ) -> anyhow::Result<Self> {
+        let runtime = MockWasmRuntime {
+            contract_store: InMemoryContractStore::default(),
+            validate_overrides: HashMap::new(),
+            update_overrides: HashMap::new(),
+        };
+        Executor::new(state_store, || Ok(()), OperationMode::Local, runtime, None).await
+    }
+
     /// Mutable access to the inner `MockWasmRuntime` so tests can install
     /// per-contract `validate_overrides` / `update_overrides` after the
     /// executor is wrapped in a handler. The `runtime` field is private to

--- a/crates/core/src/contract/executor/pool_tests/summarize_delta_cache_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/summarize_delta_cache_tests.rs
@@ -334,7 +334,8 @@ async fn delta_unchanged_skips_state_load() {
 #[tokio::test(flavor = "current_thread")]
 async fn summarize_unchanged_hits_fast_path_beyond_old_1024_cap() {
     use crate::contract::executor::{
-        build_delta_cache, build_summary_cache, summarize_cache_capacity,
+        build_delta_cache, build_summary_cache, delta_cache_capacity_bytes,
+        summarize_cache_capacity,
     };
 
     let storage = MockStateStorage::new();
@@ -342,15 +343,19 @@ async fn summarize_unchanged_hits_fast_path_beyond_old_1024_cap() {
         .await
         .expect("create uncached executor");
 
-    // Size the caches from a 1 GiB hosting budget (the gateway default), which
-    // derives to 8192 entries — far above both the old 1024 cap and the warm set
-    // below. Injected via the SAME setter the pool uses in production.
+    // Size the SUMMARY cache from a 1 GiB hosting budget (the gateway default),
+    // which derives to 8192 entries — far above both the old 1024 cap and the warm
+    // set below. The delta cache is byte-sized from the same budget. Injected via
+    // the SAME setter the pool uses in production.
     let capacity = summarize_cache_capacity(1024 * 1024 * 1024);
     assert!(
         capacity > 1024,
         "the gateway-default hosting budget must derive a cache larger than the old fixed cap"
     );
-    exec.set_summarize_caches(build_summary_cache(capacity), build_delta_cache(capacity));
+    exec.set_summarize_caches(
+        build_summary_cache(capacity),
+        build_delta_cache(delta_cache_capacity_bytes(1024 * 1024 * 1024)),
+    );
 
     // Warm WELL past the old 1024 cap (but under the derived capacity, so nothing
     // is evicted). Each contract is PUT then summarized once (cold → slow path,
@@ -391,6 +396,199 @@ async fn summarize_unchanged_hits_fast_path_beyond_old_1024_cap() {
         gets_before,
         "re-summarizing the oldest of {WARM} hosted contracts (> old 1024 cap) must hit the \
          fast path (no reload, no WASM summarize) with the budget-sized cache"
+    );
+
+    // Freshness-after-resize: the larger cache must NOT weaken the staleness
+    // guarantee. UPDATE the oldest contract, then re-summarize — the result must
+    // reflect the NEW state (the detector invalidation forces a recompute), never
+    // the summary still cached in the (large) budget-sized cache.
+    let new_state = WrappedState::new(vec![0xAB, 0xCD, 0xEF, 0x01]);
+    exec.upsert_contract_state(
+        keys[0],
+        Either::Left(new_state.clone()),
+        RelatedContracts::default(),
+        None,
+    )
+    .await
+    .expect("UPDATE oldest");
+    let summary_after = exec
+        .summarize_contract_state(keys[0])
+        .await
+        .expect("re-summarize after update");
+    assert_eq!(
+        summary_after.as_ref(),
+        blake3::hash(new_state.as_ref()).as_bytes(),
+        "after an UPDATE the summary must reflect the NEW state, never the stale summary \
+         still held in the budget-sized cache (sizing must not weaken freshness)"
+    );
+}
+
+/// Cross-executor sharing (the CORE of the 0.2.98 fix): a summary computed on one
+/// pool executor must be served on the FAST path by another executor, because the
+/// pool injects ONE shared summary cache (+ shared change-detector via the shared
+/// `StateStore`) into every executor. The headline scale test uses a single
+/// executor, so it proves sizing but NOT this cross-executor sharing; this guards
+/// it behaviorally (dropping the injection is exercised by the control C).
+#[tokio::test(flavor = "current_thread")]
+async fn shared_summary_cache_serves_fast_path_across_executors() {
+    use crate::contract::executor::{
+        build_delta_cache, build_summary_cache, delta_cache_capacity_bytes,
+        summarize_cache_capacity,
+    };
+    use crate::wasm_runtime::StateStore;
+
+    // ONE shared uncached StateStore: its change-detector `state_hash_cache` and
+    // the backing storage clone together (moka is internally Arc), exactly like the
+    // production pool sharing one cloned StateStore across executors. Uncached so
+    // every state LOAD hits the backing storage and is observable via get_count.
+    let storage = MockStateStorage::new();
+    let state_store = StateStore::new_uncached(storage.clone());
+
+    // ONE shared summary/delta cache pair, injected into BOTH working executors —
+    // exactly what RuntimePool does.
+    let budget = 1024 * 1024 * 1024;
+    let shared_summary = build_summary_cache(summarize_cache_capacity(budget));
+    let shared_delta = build_delta_cache(delta_cache_capacity_bytes(budget));
+
+    let mut exec_a = Executor::new_mock_wasm_uncached_with_state_store(state_store.clone())
+        .await
+        .expect("executor A");
+    exec_a.set_summarize_caches(shared_summary.clone(), shared_delta.clone());
+    let mut exec_b = Executor::new_mock_wasm_uncached_with_state_store(state_store.clone())
+        .await
+        .expect("executor B");
+    exec_b.set_summarize_caches(shared_summary.clone(), shared_delta.clone());
+
+    // Control executor C: SAME shared StateStore (so the shared DETECTOR is warm)
+    // but a PRIVATE summary cache (it never gets set_summarize_caches) — models
+    // "dropped the shared injection".
+    let mut exec_c = Executor::new_mock_wasm_uncached_with_state_store(state_store.clone())
+        .await
+        .expect("executor C");
+
+    let contract = test_contract(b"cross-executor-share");
+    let key = contract.key();
+    let state = WrappedState::new(vec![3, 1, 4, 1, 5, 9]);
+
+    // A PUTs and summarizes K → populates the SHARED detector (cache_state_hash)
+    // AND the SHARED summary cache (keyed by state hash).
+    exec_a
+        .upsert_contract_state(
+            key,
+            Either::Left(state.clone()),
+            RelatedContracts::default(),
+            Some(contract),
+        )
+        .await
+        .expect("A PUT");
+    let _ = exec_a
+        .summarize_contract_state(key)
+        .await
+        .expect("A summarize");
+
+    // B has NEVER summarized K, but both halves of the fast path (detector via the
+    // shared StateStore, summary via the shared cache) are populated by A, so B
+    // serves it fast: no state reload (no get_count bump), no WASM summarize.
+    let gets_before_b = storage.get_count();
+    let summary_b = exec_b
+        .summarize_contract_state(key)
+        .await
+        .expect("B summarize");
+    assert_eq!(
+        storage.get_count(),
+        gets_before_b,
+        "executor B must serve K from the POOL-SHARED summary cache A populated (no state \
+         reload) — the cross-executor sharing the fix relies on"
+    );
+    assert_eq!(
+        summary_b.as_ref(),
+        blake3::hash(state.as_ref()).as_bytes(),
+        "the shared cached summary must be correct for K's state"
+    );
+
+    // Control: C shares the warm DETECTOR but has a PRIVATE summary cache, so its
+    // fast path misses on the summary half and MUST reload — proving it is the
+    // SHARED summary cache (not merely the shared detector) that lets B skip the
+    // load. This is exactly what dropping the injection into replacements/executors
+    // would cost.
+    let gets_before_c = storage.get_count();
+    let _ = exec_c
+        .summarize_contract_state(key)
+        .await
+        .expect("C summarize");
+    assert!(
+        storage.get_count() > gets_before_c,
+        "control: an executor WITHOUT the shared summary cache must reload the state (its \
+         private cache misses), proving the shared injection is load-bearing"
+    );
+}
+
+/// Delta sibling of `summarize_unchanged_hits_fast_path_beyond_old_1024_cap`: at a
+/// working set LARGER than the historical fixed 1024-ENTRY cap, re-computing an
+/// UNCHANGED delta must still hit the fast path. The delta cache is now
+/// BYTE-bounded, so 1500 tiny deltas (a few bytes each) all stay cached where the
+/// old entry cap would have evicted the earliest.
+#[tokio::test(flavor = "current_thread")]
+async fn delta_unchanged_hits_fast_path_beyond_old_1024_cap() {
+    use crate::contract::executor::{
+        build_delta_cache, build_summary_cache, delta_cache_capacity_bytes,
+        summarize_cache_capacity,
+    };
+
+    let storage = MockStateStorage::new();
+    let mut exec = Executor::new_mock_wasm_uncached("delta_scale", storage.clone())
+        .await
+        .expect("create uncached executor");
+
+    // Byte-sized delta cache from the 1 GiB gateway-default budget (64 MiB). The
+    // warm set below is 1500 TINY deltas (`MockWasmRuntime` returns the ~3-byte
+    // state as the delta), ~KB total, so the byte budget evicts nothing while the
+    // old fixed 1024-ENTRY cap would have evicted the earliest. A fixed peer summary
+    // keeps ONLY the state component of the delta cache key varying across
+    // contracts.
+    let budget = 1024 * 1024 * 1024;
+    exec.set_summarize_caches(
+        build_summary_cache(summarize_cache_capacity(budget)),
+        build_delta_cache(delta_cache_capacity_bytes(budget)),
+    );
+    let peer_summary = StateSummary::from(vec![9u8; 3]);
+
+    const WARM: usize = 1500;
+    let mut keys = Vec::with_capacity(WARM);
+    for i in 0..WARM {
+        let seed = format!("delta-scale-{i}");
+        let contract = test_contract(seed.as_bytes());
+        let key = contract.key();
+        keys.push(key);
+        let state = WrappedState::new(vec![(i & 0xff) as u8, (i >> 8) as u8, 3]);
+        exec.upsert_contract_state(
+            key,
+            Either::Left(state),
+            RelatedContracts::default(),
+            Some(contract),
+        )
+        .await
+        .expect("warm PUT");
+        let _ = exec
+            .get_contract_state_delta(key, peer_summary.clone())
+            .await
+            .expect("warm delta");
+    }
+
+    // Re-delta the FIRST (oldest) contract, unchanged state, same peer summary. With
+    // the old fixed 1024-ENTRY cache this entry would have been evicted by the 1500
+    // warm inserts, forcing a reload; the byte-bounded cache holds all 1500 tiny
+    // deltas, so no reload (no WASM get_state_delta) happens.
+    let gets_before = storage.get_count();
+    let _ = exec
+        .get_contract_state_delta(keys[0], peer_summary.clone())
+        .await
+        .expect("re-delta oldest");
+    assert_eq!(
+        storage.get_count(),
+        gets_before,
+        "re-delta of the oldest of {WARM} contracts (> old 1024 ENTRY cap) must hit the fast \
+         path (no reload) with the byte-bounded delta cache"
     );
 }
 

--- a/crates/core/src/contract/executor/pool_tests/summarize_delta_cache_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/summarize_delta_cache_tests.rs
@@ -592,6 +592,63 @@ async fn delta_unchanged_hits_fast_path_beyond_old_1024_cap() {
     );
 }
 
+/// REGRESSION (#4794 review): the byte weigher must FLOOR each entry's weight so
+/// empty/tiny deltas still count toward eviction. moka evicts only when total
+/// WEIGHT exceeds the byte budget, and a raw byte-length weigher reports 0 for the
+/// EMPTY deltas some contracts return (the website / UI-container contract). A
+/// stream of distinct empty-delta keys — one per UPDATE, since every UPDATE mints a
+/// fresh `(key, state_hash, summary_hash)` — would then NEVER be evicted and the
+/// entry count would grow unbounded, re-opening the #4565 OOM class this cache
+/// closes.
+///
+/// This inserts FAR more distinct EMPTY-delta keys than `budget / floor` and
+/// asserts the entry count stays bounded by that ratio. Without the floor every
+/// entry weighs 0, nothing is ever evicted, and `entry_count` equals the number
+/// inserted (here 2000, ~62x the bound) — so this test would fail.
+#[tokio::test(flavor = "current_thread")]
+async fn delta_cache_empty_deltas_stay_entry_bounded() {
+    use crate::contract::executor::{DELTA_ENTRY_OVERHEAD_FLOOR_BYTES, build_delta_cache};
+
+    // A deliberately tiny byte budget so the derived max entry count is small and
+    // easy to exceed: 32 * floor => at most 32 floored entries fit.
+    let floor = u64::from(DELTA_ENTRY_OVERHEAD_FLOOR_BYTES);
+    let max_entries = 32u64;
+    let capacity_bytes = max_entries * floor;
+    let cache = build_delta_cache(capacity_bytes);
+
+    // Insert MANY distinct keys, each with an EMPTY delta (byte length 0). Distinct
+    // ContractKeys model the per-UPDATE churn of `(key, state_hash, summary_hash)`
+    // cache keys the website contract produces with empty deltas.
+    const INSERTS: usize = 2000;
+    for i in 0..INSERTS {
+        let seed = format!("delta-floor-{i}");
+        let key = test_contract(seed.as_bytes()).key();
+        cache.insert((key, 0u64, 0u64), StateDelta::from(Vec::<u8>::new()));
+    }
+
+    // Force moka's pending eviction/housekeeping so the counts are settled.
+    cache.run_pending_tasks();
+
+    let entries = cache.entry_count();
+    let weighted = cache.weighted_size();
+    assert!(
+        entries <= max_entries,
+        "delta cache must stay entry-bounded: inserted {INSERTS} distinct EMPTY deltas into a \
+         {capacity_bytes}-byte cache (floor {floor} => max {max_entries} entries) but holds \
+         {entries} (weighted_size {weighted}). Without the per-entry weight floor every empty \
+         delta weighs 0, nothing is evicted, and this would equal {INSERTS} (#4565 OOM class)."
+    );
+    assert!(
+        weighted <= capacity_bytes,
+        "floored weighted_size ({weighted}) must stay within the byte budget ({capacity_bytes})"
+    );
+    // Sanity: the bound is FAR below the insert count (not merely equal to it).
+    assert!(
+        entries < INSERTS as u64,
+        "entry count ({entries}) must not grow with the {INSERTS} inserts"
+    );
+}
+
 // =========================================================================
 // EDGE CASES
 // =========================================================================

--- a/crates/core/src/contract/executor/pool_tests/summarize_delta_cache_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/summarize_delta_cache_tests.rs
@@ -314,6 +314,87 @@ async fn delta_unchanged_skips_state_load() {
 }
 
 // =========================================================================
+// SCALE (the 0.2.98 fix: cover the hosted set, not a fixed 1024)
+// =========================================================================
+
+/// At an every-hop-hosting hosted set LARGER than the historical fixed
+/// 1024-entry cap, re-summarizing an UNCHANGED contract must still hit the fast
+/// path (no state reload → no WASM `summarize_state` → no module recompile).
+///
+/// This is the regression guard for the 0.2.98 anti-entropy re-summarization
+/// storm. With the old fixed `LruCache::new(1024)`, warming > 1024 distinct
+/// contracts evicted the earliest summaries, so the ~5-min InterestSync
+/// heartbeat re-summarize of those contracts fell to the slow path (reload +
+/// WASM summarize + a possible module recompile) EVERY cycle. The cache is now
+/// sized from the hosting byte budget (`summarize_cache_capacity`), so the whole
+/// hosted set stays cached. `get_count` is the fast/slow-path discriminator: the
+/// slow path ALWAYS loads the state before it runs WASM, so "no additional load"
+/// proves "no WASM summarize" (uses an uncached `StateStore` so every load is
+/// observable).
+#[tokio::test(flavor = "current_thread")]
+async fn summarize_unchanged_hits_fast_path_beyond_old_1024_cap() {
+    use crate::contract::executor::{
+        build_delta_cache, build_summary_cache, summarize_cache_capacity,
+    };
+
+    let storage = MockStateStorage::new();
+    let mut exec = Executor::new_mock_wasm_uncached("summarize_scale", storage.clone())
+        .await
+        .expect("create uncached executor");
+
+    // Size the caches from a 1 GiB hosting budget (the gateway default), which
+    // derives to 8192 entries — far above both the old 1024 cap and the warm set
+    // below. Injected via the SAME setter the pool uses in production.
+    let capacity = summarize_cache_capacity(1024 * 1024 * 1024);
+    assert!(
+        capacity > 1024,
+        "the gateway-default hosting budget must derive a cache larger than the old fixed cap"
+    );
+    exec.set_summarize_caches(build_summary_cache(capacity), build_delta_cache(capacity));
+
+    // Warm WELL past the old 1024 cap (but under the derived capacity, so nothing
+    // is evicted). Each contract is PUT then summarized once (cold → slow path,
+    // populating both the detector and the summary cache).
+    const WARM: usize = 1500;
+    let mut keys = Vec::with_capacity(WARM);
+    for i in 0..WARM {
+        let seed = format!("summarize-scale-{i}");
+        let contract = test_contract(seed.as_bytes());
+        let key = contract.key();
+        keys.push(key);
+        let state = WrappedState::new(vec![(i & 0xff) as u8, (i >> 8) as u8, 7, 7]);
+        exec.upsert_contract_state(
+            key,
+            Either::Left(state),
+            RelatedContracts::default(),
+            Some(contract),
+        )
+        .await
+        .expect("warm PUT");
+        let _ = exec
+            .summarize_contract_state(key)
+            .await
+            .expect("warm summarize");
+    }
+
+    // Re-summarize the FIRST (oldest) contract on unchanged state. With the old
+    // fixed 1024-entry cache this key's summary would have been evicted by the
+    // 1500 warm inserts, forcing a reload; with the hosting-budget-sized cache it
+    // is still cached, so no reload (and no WASM summarize) happens.
+    let gets_before = storage.get_count();
+    let _ = exec
+        .summarize_contract_state(keys[0])
+        .await
+        .expect("re-summarize oldest");
+    assert_eq!(
+        storage.get_count(),
+        gets_before,
+        "re-summarizing the oldest of {WARM} hosted contracts (> old 1024 cap) must hit the \
+         fast path (no reload, no WASM summarize) with the budget-sized cache"
+    );
+}
+
+// =========================================================================
 // EDGE CASES
 // =========================================================================
 

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -1358,6 +1358,92 @@ mod executor_pin_tests {
         );
     }
 
+    /// Pin (bug-prevention: migration-wiring): the SUMMARIZE/DELTA fast-path caches
+    /// are shared ACROSS the pool — the actual fix for the 0.2.98 re-summarization
+    /// storm. `RuntimePool::new` must size them from the hosting budget and inject
+    /// them into every executor, AND `create_replacement_executor` must inject the
+    /// SAME shared caches into replacements — a replacement (built on a WASM-panic /
+    /// unhealthy executor) that fell back to the private min-sized cache would
+    /// reintroduce the storm on that executor and never self-heal. The headline
+    /// sizing test injects into a single executor, so it proves sizing but NOT this
+    /// shared-injection wiring; dropping either injection would not fail that test.
+    /// This source-scrape closes that gap.
+    #[test]
+    fn runtime_pool_injects_shared_summarize_caches_into_new_and_replacements() {
+        let src = include_str!("runtime/pool.rs");
+
+        let new_body = src
+            .split("pub async fn new(")
+            .nth(1)
+            .expect("RuntimePool::new must exist")
+            .split("\n    /// Get the current health status of the pool.")
+            .next()
+            .expect("end of RuntimePool::new");
+        assert!(
+            new_body.contains("summarize_cache_capacity(config.max_hosting_storage)"),
+            "RuntimePool::new must size the shared SUMMARY cache from the hosting budget"
+        );
+        assert!(
+            new_body.contains("delta_cache_capacity_bytes(config.max_hosting_storage)"),
+            "RuntimePool::new must BYTE-size the shared DELTA cache from the hosting budget"
+        );
+        assert!(
+            new_body.matches("set_summarize_caches(").count() >= 2,
+            "RuntimePool::new must inject the shared caches into BOTH the first executor \
+             and each subsequent pool executor"
+        );
+
+        let replacement_body = src
+            .split("async fn create_replacement_executor(")
+            .nth(1)
+            .expect("create_replacement_executor must exist")
+            .split("\n    /// Return an executor to the pool")
+            .next()
+            .expect("end of create_replacement_executor");
+        assert!(
+            replacement_body.contains("set_summarize_caches("),
+            "create_replacement_executor must inject the pool-shared summarize/delta caches \
+             into replacements, or a WASM-panic replacement reintroduces the 0.2.98 \
+             re-summarization storm and never self-heals"
+        );
+    }
+
+    /// Pin (hosting-cache-thrash / serialization invariant): the pool-SHARED
+    /// summarize/delta caches + the `state_hash_cache` change-detector are correct
+    /// ONLY because every summarize/delta read and every `cache_state_hash`
+    /// populate runs on the serialized contract loop (no write can interleave
+    /// between a slow-path load and its detector populate). The one thing that
+    /// holds a pool executor OFF that loop is the hosted-secret export
+    /// (`ExportJob::run` → `export_user_secrets`), so it MUST stay read-only w.r.t.
+    /// contract state: it must NOT call summarize / delta / `cache_state_hash`, or
+    /// an off-loop populate could certify the detector against a state a concurrent
+    /// on-loop write has changed — poisoning the fast path for the WHOLE pool. This
+    /// guards a future off-loop path from silently re-coupling to the cache
+    /// surface. Mirrors `export_job_run_offloads_blocking_work`; see the
+    /// SERIALIZATION INVARIANT comment in runtime/executor_impl.rs.
+    #[test]
+    fn off_loop_export_does_not_touch_summarize_delta_cache_surface() {
+        let src = include_str!("runtime/delegates.rs");
+        let body = src
+            .split("pub fn export_user_secrets(")
+            .nth(1)
+            .expect("export_user_secrets must exist")
+            .split("\n    /// Import delegate secrets")
+            .next()
+            .expect("end of export_user_secrets");
+        for forbidden in [
+            "summarize_contract_state",
+            "get_contract_state_delta",
+            "cache_state_hash",
+        ] {
+            assert!(
+                !body.contains(forbidden),
+                "off-loop export_user_secrets must not call {forbidden}: off-loop \
+                 cache/detector mutation would poison the pool-shared summarize/delta fast path"
+            );
+        }
+    }
+
     /// Pin (#2257): the `ContractRequest::Put` arm of `contract_requests`
     /// MUST reject debug-compiled WASM (`contains_debug_sections`) BEFORE
     /// delegating to `perform_contract_put`. This is the only debug-WASM

--- a/crates/core/src/contract/executor/runtime/executor_impl.rs
+++ b/crates/core/src/contract/executor/runtime/executor_impl.rs
@@ -1183,8 +1183,8 @@ where
         // populate the detector against a state a concurrent write has changed.
         if let Some(detector_hash) = self.state_store.cached_state_hash(&key) {
             if let Some((cached_hash, cached_summary)) = self.summary_cache.get(&key) {
-                if *cached_hash == detector_hash {
-                    return Ok(cached_summary.clone());
+                if cached_hash == detector_hash {
+                    return Ok(cached_summary);
                 }
             }
         }
@@ -1209,11 +1209,11 @@ where
         self.state_store.cache_state_hash(key, state_hash);
 
         // The summary may already be cached under this exact hash even when the
-        // detector was cold (the summary cache is per-executor; the detector is
-        // shared). Reuse it to skip the WASM call.
+        // detector was cold (e.g. after a restart or a detector eviction). Reuse it
+        // to skip the WASM call.
         if let Some((cached_hash, cached_summary)) = self.summary_cache.get(&key) {
-            if *cached_hash == state_hash {
-                return Ok(cached_summary.clone());
+            if cached_hash == state_hash {
+                return Ok(cached_summary);
             }
         }
 
@@ -1234,7 +1234,8 @@ where
             .summarize_state(&key, &params, &state)
             .map_err(|e| ExecutorError::execution(e, None))?;
 
-        self.summary_cache.put(key, (state_hash, summary.clone()));
+        self.summary_cache
+            .insert(key, (state_hash, summary.clone()));
         Ok(summary)
     }
 
@@ -1270,7 +1271,7 @@ where
         if let Some(detector_hash) = self.state_store.cached_state_hash(&key) {
             let cache_key = (key, detector_hash, summary_hash);
             if let Some(cached_delta) = self.delta_cache.get(&cache_key) {
-                return Ok(cached_delta.clone());
+                return Ok(cached_delta);
             }
         }
 
@@ -1294,7 +1295,7 @@ where
 
         let cache_key = (key, state_hash, summary_hash);
         if let Some(cached_delta) = self.delta_cache.get(&cache_key) {
-            return Ok(cached_delta.clone());
+            return Ok(cached_delta);
         }
 
         let params = self
@@ -1314,7 +1315,7 @@ where
             .get_state_delta(&key, &params, &state, &their_summary)
             .map_err(|e| ExecutorError::execution(e, None))?;
 
-        self.delta_cache.put(cache_key, delta.clone());
+        self.delta_cache.insert(cache_key, delta.clone());
         Ok(delta)
     }
 

--- a/crates/core/src/contract/executor/runtime/executor_impl.rs
+++ b/crates/core/src/contract/executor/runtime/executor_impl.rs
@@ -1180,7 +1180,10 @@ where
         // write can land between the slow path's state load and its detector
         // populate. Any off-loop work that holds an executor (e.g. the hosted
         // secret export) MUST stay read-only w.r.t. contract state, or it could
-        // populate the detector against a state a concurrent write has changed.
+        // populate the detector against a state a concurrent write has changed —
+        // and because the caches + detector are pool-SHARED, that poisons the fast
+        // path for the WHOLE pool, not just one executor. Guarded by the pin
+        // `off_loop_export_does_not_touch_summarize_delta_cache_surface`.
         if let Some(detector_hash) = self.state_store.cached_state_hash(&key) {
             if let Some((cached_hash, cached_summary)) = self.summary_cache.get(&key) {
                 if cached_hash == detector_hash {
@@ -1209,8 +1212,10 @@ where
         self.state_store.cache_state_hash(key, state_hash);
 
         // The summary may already be cached under this exact hash even when the
-        // detector was cold (e.g. after a restart or a detector eviction). Reuse it
-        // to skip the WASM call.
+        // detector was cold. The detector (`state_hash_cache`) and the summary
+        // cache are SEPARATE moka instances with independent eviction, so the
+        // detector can evict a key whose summary is still cached — reuse it to skip
+        // the WASM call. (A process restart clears BOTH, so it is not this case.)
         if let Some((cached_hash, cached_summary)) = self.summary_cache.get(&key) {
             if cached_hash == state_hash {
                 return Ok(cached_summary);
@@ -1228,6 +1233,15 @@ where
                     cause: "contract parameters not found".into(),
                 })
             })?;
+
+        // Slow-path detectability (telemetry): we are about to run the WASM
+        // `summarize_state`, the expensive path the hosting-budget-sized summary
+        // cache exists to avoid. Count it so a sustained-high slow-path rate — the
+        // re-summarization storm's fingerprint, and the under-coverage signal on a
+        // small-contract node — is visible in central telemetry (router_snapshot)
+        // instead of silent. No-op until the network_status singleton is inited
+        // (mock/unit tests), and only on the slow path so no fast-path contention.
+        crate::node::network_status::record_summarize_slow_path();
 
         let summary = self
             .runtime

--- a/crates/core/src/contract/executor/runtime/pool.rs
+++ b/crates/core/src/contract/executor/runtime/pool.rs
@@ -91,6 +91,19 @@ pub struct RuntimePool {
     shared_backend_engine: BackendEngine,
     /// Shared recovery guard for corrupted-state self-healing across all pool executors.
     shared_recovery_guard: super::CorruptedStateRecoveryGuard,
+    /// Pool-shared summarize fast-path cache (moka, internally `Arc`), sized ONCE
+    /// from the hosting byte budget in [`RuntimePool::new`]. Held as a field so
+    /// [`RuntimePool::create_replacement_executor`] injects the SAME shared cache
+    /// into every replacement (built on WASM-panic / unhealthy executor) — a
+    /// replacement that fell back to the private min-sized cache would reintroduce
+    /// the 0.2.98 re-summarization storm and never self-heal. See
+    /// `Executor::set_summarize_caches`.
+    shared_summary_cache: super::SummaryCache,
+    /// Pool-shared delta fast-path cache, sized from the hosting byte budget
+    /// (byte-bounded, see `contract::executor::delta_cache_capacity_bytes`).
+    /// Injected into every executor AND every replacement alongside
+    /// [`Self::shared_summary_cache`].
+    shared_delta_cache: super::DeltaCache,
     /// Sender for delegate notifications (cloned into each executor and replacements).
     delegate_notification_tx: super::DelegateNotificationSender,
     /// Receiver for delegate notifications (taken once by `contract_handling()`).
@@ -296,10 +309,17 @@ impl RuntimePool {
         // gets a clone of the SAME moka cache (moka is internally `Arc`), so one
         // copy of each summary is held for the whole pool — NOT one per executor,
         // and the "first available" checkout can no longer fragment the hit rate
-        // across executors. See `Executor::set_summarize_caches`.
-        let summarize_cache_capacity = super::summarize_cache_capacity(config.max_hosting_storage);
-        let shared_summary_cache = super::build_summary_cache(summarize_cache_capacity);
-        let shared_delta_cache = super::build_delta_cache(summarize_cache_capacity);
+        // across executors. The summary cache is entry-count sized (summaries are
+        // tiny); the delta cache is BYTE-bounded (deltas are variable and can be
+        // large — an entry-count cap could pin multi-GB, the #4565 OOM class). Both
+        // handles are STORED on the pool (below) so `create_replacement_executor`
+        // injects the SAME shared caches into replacements — a replacement that
+        // fell back to the private min cache would reintroduce the storm and never
+        // self-heal. See `Executor::set_summarize_caches`.
+        let summary_cache_capacity = super::summarize_cache_capacity(config.max_hosting_storage);
+        let shared_summary_cache = super::build_summary_cache(summary_cache_capacity);
+        let delta_cache_bytes = super::delta_cache_capacity_bytes(config.max_hosting_storage);
+        let shared_delta_cache = super::build_delta_cache(delta_cache_bytes);
 
         // Create delegate notification channel for subscription delivery
         let (delegate_notification_tx, delegate_notification_rx) =
@@ -510,6 +530,8 @@ impl RuntimePool {
             shared_delegate_contexts,
             shared_backend_engine,
             shared_recovery_guard,
+            shared_summary_cache,
+            shared_delta_cache,
             delegate_notification_tx,
             delegate_notification_rx: Some(delegate_notification_rx),
             in_flight_contracts: HashMap::new(),
@@ -700,6 +722,16 @@ impl RuntimePool {
             self.shared_notifications.clone(),
             self.shared_summaries.clone(),
             self.shared_client_counts.clone(),
+        );
+        // Inject the pool-shared summarize/delta fast-path caches (hosting-budget
+        // sized in `RuntimePool::new`) so a replacement — built on a WASM-panic /
+        // unhealthy executor — shares the SAME caches as the rest of the pool. A
+        // replacement left with the private min-sized cache from `Executor::new`
+        // would miss the fast path for the whole hosted set, reintroducing the
+        // 0.2.98 re-summarization storm on that executor and never self-healing.
+        executor.set_summarize_caches(
+            self.shared_summary_cache.clone(),
+            self.shared_delta_cache.clone(),
         );
         executor.set_recovery_guard(self.shared_recovery_guard.clone());
         executor.set_delegate_notification_tx(self.delegate_notification_tx.clone());

--- a/crates/core/src/contract/executor/runtime/pool.rs
+++ b/crates/core/src/contract/executor/runtime/pool.rs
@@ -287,6 +287,20 @@ impl RuntimePool {
         let shared_summaries: SharedSummaries = Arc::new(DashMap::new());
         let shared_client_counts: SharedClientCounts = Arc::new(DashMap::new());
 
+        // Shared summarize/delta fast-path caches, sized ONCE from the hosting
+        // byte budget (`Config::max_hosting_storage`) so the ~5-min InterestSync
+        // anti-entropy re-summarize of the whole hosted set hits the fast path
+        // (skips the WASM `summarize_state` + a possible module recompile) instead
+        // of thrashing a fixed 1024-entry cache once the hosted set exceeds it
+        // (the 0.2.98 every-hop-hosting re-summarization storm). Every executor
+        // gets a clone of the SAME moka cache (moka is internally `Arc`), so one
+        // copy of each summary is held for the whole pool — NOT one per executor,
+        // and the "first available" checkout can no longer fragment the hit rate
+        // across executors. See `Executor::set_summarize_caches`.
+        let summarize_cache_capacity = super::summarize_cache_capacity(config.max_hosting_storage);
+        let shared_summary_cache = super::build_summary_cache(summarize_cache_capacity);
+        let shared_delta_cache = super::build_delta_cache(summarize_cache_capacity);
+
         // Create delegate notification channel for subscription delivery
         let (delegate_notification_tx, delegate_notification_rx) =
             tokio::sync::mpsc::channel(super::DELEGATE_NOTIFICATION_CHANNEL_SIZE);
@@ -412,6 +426,8 @@ impl RuntimePool {
             shared_summaries.clone(),
             shared_client_counts.clone(),
         );
+        first_executor
+            .set_summarize_caches(shared_summary_cache.clone(), shared_delta_cache.clone());
         first_executor.set_recovery_guard(shared_recovery_guard.clone());
         first_executor.set_delegate_notification_tx(delegate_notification_tx.clone());
         runtimes.push(Some(first_executor));
@@ -435,6 +451,7 @@ impl RuntimePool {
                 shared_summaries.clone(),
                 shared_client_counts.clone(),
             );
+            executor.set_summarize_caches(shared_summary_cache.clone(), shared_delta_cache.clone());
             executor.set_recovery_guard(shared_recovery_guard.clone());
             executor.set_delegate_notification_tx(delegate_notification_tx.clone());
 

--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -239,6 +239,17 @@ pub struct NetworkStatus {
     pub reconcile_shadow_inbound_unsubscribe: ReconcileShadowStats,
     pub reconcile_shadow_connection_drop: ReconcileShadowStats,
     pub reconcile_shadow_host_formation: ReconcileShadowStats,
+    /// Monotonic count of summarize SLOW-PATH runs: a `summarize_contract_state`
+    /// call that missed the fast-path summary cache and actually ran the WASM
+    /// `summarize_state` (the expensive path the hosting-budget-sized summary
+    /// cache exists to avoid). The collector differences this across the snapshot
+    /// cadence to derive the slow-path RATE; a sustained-high rate is the
+    /// re-summarization storm's fingerprint (#4565 / 0.2.98) and, on a
+    /// small-contract node, the DETECTABLE signal that the byte-budget-derived
+    /// summary cache is under-covering the real hosted count (see
+    /// `contract::executor::summarize_cache_capacity`). Recorded only on the slow
+    /// path (already expensive), so it adds no hot fast-path lock contention.
+    pub summarize_slow_path_total: u64,
 }
 
 /// Per-node counters measuring how often the demand-driven-hosting **computed
@@ -557,6 +568,7 @@ pub fn init(listening_port: u16, gateway_addrs: HashSet<SocketAddr>, version: St
         reconcile_shadow_inbound_unsubscribe: ReconcileShadowStats::default(),
         reconcile_shadow_connection_drop: ReconcileShadowStats::default(),
         reconcile_shadow_host_formation: ReconcileShadowStats::default(),
+        summarize_slow_path_total: 0,
     };
     match NETWORK_STATUS.get() {
         // Already initialized: overwrite the existing tracker in place so
@@ -786,6 +798,30 @@ pub fn terminal_consult_counts() -> Option<(u64, u64, u64, u64)> {
     let s = status.read().ok()?;
     let c = &s.terminal_consult_stats;
     Some((c.attempts, c.hits, c.resolved_found, c.still_not_found))
+}
+
+/// Record one summarize SLOW-PATH run: a `summarize_contract_state` call that
+/// missed the fast-path summary cache and actually ran the WASM `summarize_state`
+/// (see `NetworkStatus::summarize_slow_path_total`). Called ONLY on the slow path
+/// (already expensive), so the process-global write lock adds no hot fast-path
+/// contention.
+pub fn record_summarize_slow_path() {
+    if let Some(status) = NETWORK_STATUS.get() {
+        if let Ok(mut s) = status.write() {
+            s.summarize_slow_path_total = s.summarize_slow_path_total.saturating_add(1);
+        }
+    }
+}
+
+/// Read the monotonic summarize slow-path counter for export to the
+/// `router_snapshot` telemetry event, or `None` before the `NETWORK_STATUS`
+/// singleton is initialized. `Ring` polls this on the snapshot cadence so the
+/// slow-path rate (the re-summarization-storm / cache-under-coverage signal) is
+/// legible in central telemetry, not just internally.
+pub fn summarize_slow_path_count() -> Option<u64> {
+    let status = NETWORK_STATUS.get()?;
+    let s = status.read().ok()?;
+    Some(s.summarize_slow_path_total)
 }
 
 /// Record one computed-upstream vs. stored-`is_upstream`-flag comparison

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -1767,6 +1767,17 @@ impl Ring {
                 snapshot.terminal_consult_still_not_found = Some(still_not_found);
             }
 
+            // Summarize slow-path counter (cache-thrash detectability, #4565 /
+            // 0.2.98). Read from the per-node network_status singleton where the
+            // executor slow path records it; the collector differences it to a
+            // rate so the re-summarization storm / cache under-coverage is legible
+            // in central telemetry, not just internally. Same hand-mirror footgun
+            // as the counters above — invisible to the collector unless added to
+            // `event_kind_to_json` too (pinned by
+            // `router_snapshot_json_includes_summarize_slow_path_counter`).
+            snapshot.summarize_slow_path_total =
+                crate::node::network_status::summarize_slow_path_count();
+
             // Computed-upstream vs. stored-`is_upstream`-flag divergence counters
             // (#4642 piece D / #4671). Recorded at `send_unsubscribe_upstream`
             // where the stored flag is still consulted; exported here so the

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -297,6 +297,15 @@ pub(crate) struct RouterSnapshotInfo {
     pub terminal_consult_hits: Option<u64>,
     pub terminal_consult_resolved_found: Option<u64>,
     pub terminal_consult_still_not_found: Option<u64>,
+    /// Monotonic count of summarize SLOW-PATH runs (a `summarize_contract_state`
+    /// that missed the fast-path summary cache and ran the WASM `summarize_state`).
+    /// Populated by `Ring` from the `network_status` singleton on the snapshot
+    /// cadence; the collector differences it to a rate. A sustained-high rate is
+    /// the re-summarization-storm fingerprint (#4565 / 0.2.98) and, on a
+    /// small-contract node, the DETECTABLE signal that the budget-derived summary
+    /// cache is under-covering the hosted set. `None` until the ring's snapshot
+    /// task populates it.
+    pub summarize_slow_path_total: Option<u64>,
     /// Computed-upstream vs. stored-`is_upstream`-flag divergence counters
     /// (hosting redesign piece D, #4642 / #4671). `comparisons` is the
     /// denominator (one per `send_unsubscribe_upstream`), `divergences` the times
@@ -1315,6 +1324,9 @@ impl Router {
             terminal_consult_hits: None,
             terminal_consult_resolved_found: None,
             terminal_consult_still_not_found: None,
+            // Summarize slow-path counter (cache-thrash detectability), populated
+            // by Ring from the network_status singleton on the snapshot cadence.
+            summarize_slow_path_total: None,
             // Computed-upstream vs. stored-flag divergence counters (piece D,
             // #4642 / #4671), populated by Ring from the network_status
             // singleton on the snapshot cadence.

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -2316,6 +2316,15 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                     "terminal_consult_still_not_found".to_string(),
                     serde_json::json!(snapshot.terminal_consult_still_not_found),
                 );
+                // Summarize slow-path counter (cache-thrash detectability, #4565 /
+                // 0.2.98) — same hand-mirror footgun: a new `RouterSnapshotInfo`
+                // field is invisible to the collector unless added here. This is
+                // the storm / cache-under-coverage rate signal. Pinned by
+                // `router_snapshot_json_includes_summarize_slow_path_counter`.
+                obj.insert(
+                    "summarize_slow_path_total".to_string(),
+                    serde_json::json!(snapshot.summarize_slow_path_total),
+                );
                 // Computed-upstream vs. stored-flag divergence counters (piece D,
                 // #4642 / #4671) — same hand-mirror footgun: a new
                 // `RouterSnapshotInfo` field is invisible to the collector unless
@@ -2795,6 +2804,25 @@ mod tests {
         ] {
             assert_eq!(json[key], want, "{key} must reach the OTLP body");
         }
+    }
+
+    /// Pin: the summarize slow-path counter (cache-thrash detectability, #4565 /
+    /// 0.2.98) must also reach the hand-mirrored OTLP body — same footgun as the
+    /// terminal-consult counters above. This is the storm / cache-under-coverage
+    /// rate signal; a silent drop would re-blind central telemetry to whether the
+    /// hosting-budget-sized summary cache is actually covering the hosted set.
+    #[test]
+    fn router_snapshot_json_includes_summarize_slow_path_counter() {
+        use arbitrary::{Arbitrary, Unstructured};
+        let mut u = Unstructured::new(&[0u8; 4096]);
+        let mut info = crate::router::RouterSnapshotInfo::arbitrary(&mut u)
+            .expect("construct RouterSnapshotInfo for test");
+        info.summarize_slow_path_total = Some(353);
+        let json = event_kind_to_json(&EventKind::RouterSnapshot(Box::new(info)));
+        assert_eq!(
+            json["summarize_slow_path_total"], 353,
+            "summarize_slow_path_total must reach the OTLP body"
+        );
     }
 
     /// Pin: the computed-upstream vs. stored-flag divergence counters (piece D,

--- a/crates/core/src/wasm_runtime.rs
+++ b/crates/core/src/wasm_runtime.rs
@@ -63,7 +63,9 @@ pub use state_store::StateStore;
 // `MAX_STATE_SIZE` is `pub` (not `pub(crate)`) so it can be re-exported from the
 // crate root as `dev_tool::MAX_CONTRACT_STATE_SIZE` for fdev's client-side check.
 pub use state_store::MAX_STATE_SIZE;
-pub(crate) use state_store::{StateStorage, StateStoreError, state_hash};
+pub(crate) use state_store::{
+    STATE_HASH_CACHE_CAPACITY, StateStorage, StateStoreError, state_hash,
+};
 
 /// Rename a code-hash-named WASM file from the legacy all-lowercase Base58
 /// name to the canonical mixed-case name (issue #4214).

--- a/crates/core/src/wasm_runtime/state_store.rs
+++ b/crates/core/src/wasm_runtime/state_store.rs
@@ -48,7 +48,12 @@ pub const MAX_STATE_SIZE: usize = 50 * 1024 * 1024; // 50 MiB
 /// only ~40 bytes (key + `u64`), so this ceiling is well under 5 MiB. A miss
 /// simply falls back to loading and hashing the state, so the cap only trades a
 /// little extra work for a hard memory ceiling — never correctness.
-const STATE_HASH_CACHE_CAPACITY: u64 = 100_000;
+///
+/// `pub(crate)` so the summarize/delta fast-path caches in `contract::executor`
+/// can pin their sanity ceiling to THIS value instead of duplicating the literal
+/// (a larger summary cache than the detector cannot raise the hit rate, since the
+/// detector gates the fast path). See `contract::executor::SUMMARIZE_CACHE_MAX_CAPACITY`.
+pub(crate) const STATE_HASH_CACHE_CAPACITY: u64 = 100_000;
 
 /// Hash a contract state's bytes into the `u64` change-detector key shared by
 /// the summarize and delta caches.


### PR DESCRIPTION
## Problem

0.2.98 every-hop hosting means each gateway hosts ~2600 contracts, and the ~5-min InterestSync anti-entropy re-summarizes the whole set. The summary/delta caches were **per-executor** `LruCache(1024)`, duplicated across up to 16 pool workers, so ~1600 contracts/cycle miss the cache → slow path (reload state + WASM `summarize_state` → module recompile). Measured on the prod gateways after 0.2.98: summarize calls ~250x (~2/min → 500-650/min), ~36 module recompiles/sec, 55-83% CPU on both gateways, and the fastest feedstock for the musl allocator high-water-mark (#4565).

## Approach

Replace the per-executor `LruCache`s with a single **pool-shared moka cache**, sized from the hosting byte budget (`Config::max_hosting_storage`):

```
count = clamp(hosting_budget_bytes / 128 KiB, 1024, 100_000)
```

At the default RAM-scaled budgets: 128 MiB budget → 1024, **1 GiB budget → 8192** (covers the observed ~2616 hosted with ~3× headroom). Freshness is **unchanged**: the fast path returns a cached summary only when the shared change-detector hash matches the cached hash, and the detector is invalidated on every write — sharing the cache adds no staleness because the (already-shared) detector is the gate. Net RAM is neutral-to-negative (one shared 8192-entry cache ≈ 25-50 MB vs the old N×1024 fragmented ≈ 52 MB at N=16) while covering 8× more contracts — the right direction for #4565.

The sizing constants (128 KiB state floor, 1024 min, 100k ceiling) are named + documented inline as the hosting-cost-model knobs.

## Testing

- `summarize_unchanged_hits_fast_path_beyond_old_1024_cap`: warms 1500 distinct contracts (> old 1024 cap), re-summarizes an unchanged one, asserts no state reload (fast path, hence no WASM summarize). **Verified it FAILS when the cache is undersized** (512 → panic).
- 5 sizing-derivation unit tests. 206 `contract::executor` + 32 `state_store` tests green; `cargo fmt` + `clippy -D warnings` clean.

Live validation (deploy → watch the gateway summarize rate + CPU drop) to follow after merge. No observable behavior change (freshness preserved); this is a non-overreaching perf improvement.

Relates to #4565 (musl HWM / jemalloc), #4754, #4741.

[AI-assisted - Claude]