### PR TITLE
feat(server): one-click data export to your own peer

### DIFF
--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -3707,6 +3707,80 @@ mod tests {
         assert!(clear < reload, "must clear the token before reloading");
     }
 
+    /// The hosted "Move to my peer" migration (#4592) must default to a
+    /// ONE-CLICK open against the user's local peer, keeping copy-the-URL only
+    /// as a SECONDARY fallback. Before this, the only affordance was a link the
+    /// user had to hand-copy and paste into another browser — friction for the
+    /// exact action we want them to take. This pins the whole primary/secondary
+    /// contract so a refactor can't silently regress it back to copy-only.
+    #[test]
+    fn hosted_bar_migration_defaults_to_one_click_open_4592() {
+        // (a) A PRIMARY "open on my peer" control that opens the peer import
+        // page in a new browsing context (so the hosted tab is left intact).
+        assert!(
+            HOSTED_BAR_HTML.contains("id=\"fnmigrateopen\""),
+            "hosted bar must expose a primary 'open on my peer' control (#4592)"
+        );
+        let open_idx = HOSTED_BAR_HTML
+            .find("id=\"fnmigrateopen\"")
+            .expect("primary open control present");
+        // The control is an anchor with target=_blank in the SAME element, so a
+        // plain click (or cmd/middle-click into another profile) opens the peer
+        // import page directly — the "direct link" the friction complaint asked
+        // for. Assert the target belongs to this control (nearby), not anywhere.
+        let target_idx = HOSTED_BAR_HTML
+            .find("target=\"_blank\"")
+            .expect("the primary open control must target a new browsing context");
+        assert!(
+            target_idx > open_idx && target_idx - open_idx < 120,
+            "target=_blank must be on the primary open control's own element"
+        );
+
+        // (b) The mint handler performs the one-click open: it opens a tab and
+        // navigates it to the freshly minted LOCAL peer import link, instead of
+        // only revealing a box to copy. Both the open and the loopback import
+        // path must be present in the migrate handler.
+        let mint = HOSTED_BAR_JS
+            .find("getElementById('fnmigrate')")
+            .expect("Move-to-my-peer button must have a click handler");
+        assert!(
+            HOSTED_BAR_JS[mint..].contains("window.open("),
+            "the migration default must open the peer import page directly \
+             (one-click), not merely surface a link to copy"
+        );
+        // Reverse-tabnabbing hardening: the freshly-opened tab must have its
+        // window.opener severed so the destination peer page can't navigate the
+        // hosted tab back to a spoofed origin. Set synchronously while the tab is
+        // still about:blank; it survives the later peerWin.location navigation.
+        assert!(
+            HOSTED_BAR_JS[mint..].contains("peerWin.opener = null"),
+            "the one-click open must sever window.opener to prevent \
+             reverse tabnabbing"
+        );
+        assert!(
+            HOSTED_BAR_JS.contains("/hosted/import?source="),
+            "the one-click open must target the local peer's import page"
+        );
+        // The handler sets the primary control's href too, so the fallback link
+        // (used when the pop-up is blocked) points at the same minted link.
+        assert!(
+            HOSTED_BAR_JS.contains("migrateOpen.href = link"),
+            "the primary open control's href must be set to the minted link"
+        );
+
+        // (c) Copy-the-URL remains available as the SECONDARY option (kept for a
+        // peer on a different computer/browser/profile) — never removed.
+        assert!(
+            HOSTED_BAR_HTML.contains("id=\"fnmigratecopy\"")
+                && HOSTED_BAR_HTML.contains("id=\"fnmigratelink\""),
+            "copy-the-URL must remain available as a secondary fallback"
+        );
+        assert!(
+            HOSTED_BAR_JS.contains("getElementById('fnmigratecopy')"),
+            "the secondary copy-link control must stay wired to clipboard copy"
+        );
+    }
+
     /// Non-hosted mode must NEVER reach the fail-closed path: the bridge is
     /// called with one argument, so `hostedMode` is undefined and the whole
     /// hostedNoToken branch is inert — the app loads and connects over http

--- a/crates/core/src/server/path_handlers/assets/hosted_bar.css
+++ b/crates/core/src/server/path_handlers/assets/hosted_bar.css
@@ -40,8 +40,11 @@ iframe {
   position: relative;
   flex: 0 0 auto;
 }
-#fnbar button {
+#fnbar button,
+#fnbar a.act {
+  display: inline-block;
   font: inherit;
+  text-decoration: none;
   color: #222;
   background: #fff;
   border: 1px solid #cfcfcf;
@@ -49,8 +52,21 @@ iframe {
   padding: 3px 10px;
   cursor: pointer;
 }
-#fnbar button:hover {
+#fnbar button:hover,
+#fnbar a.act:hover {
   border-color: #999;
+}
+/* Primary migration action: emphasis by contrast, not colour, so it reads as
+   the default in the bar's near-monochrome palette while copy-the-URL stays a
+   plain secondary button. */
+#fnbar a.act-primary {
+  color: #fff;
+  background: #333;
+  border-color: #333;
+}
+#fnbar a.act-primary:hover {
+  background: #222;
+  border-color: #222;
 }
 #fnpop {
   position: absolute;
@@ -142,13 +158,24 @@ iframe {
   #fnbar .nt {
     color: #88888c;
   }
-  #fnbar button {
+  #fnbar button,
+  #fnbar a.act {
     color: #e6e6e8;
     background: #2c2c2f;
     border-color: #46464a;
   }
-  #fnbar button:hover {
+  #fnbar button:hover,
+  #fnbar a.act:hover {
     border-color: #6a6a6e;
+  }
+  #fnbar a.act-primary {
+    color: #1c1c1e;
+    background: #e6e6e8;
+    border-color: #e6e6e8;
+  }
+  #fnbar a.act-primary:hover {
+    background: #f4f4f6;
+    border-color: #f4f4f6;
   }
   #fnpop {
     background: #252528;

--- a/crates/core/src/server/path_handlers/assets/hosted_bar.html
+++ b/crates/core/src/server/path_handlers/assets/hosted_bar.html
@@ -31,8 +31,21 @@
         </div>
         <div id="fnmigrateout" hidden>
           <p class="mhint">
-            Open this one-time link (it expires soon) in a browser on the
-            computer running your Freenet peer:
+            This opens a one-time confirmation page on the Freenet peer running
+            on this computer. It expires in a few minutes.
+          </p>
+          <div class="row">
+            <a
+              class="act act-primary"
+              id="fnmigrateopen"
+              target="_blank"
+              rel="noopener"
+              >Open on my peer</a
+            >
+          </div>
+          <p class="mhint">
+            Running your peer on a different computer or browser? Copy this link
+            and open it there instead:
           </p>
           <div class="row">
             <input id="fnmigratelink" type="text" readonly /><button

--- a/crates/core/src/server/path_handlers/assets/hosted_bar.js
+++ b/crates/core/src/server/path_handlers/assets/hosted_bar.js
@@ -117,11 +117,21 @@
 
   // "Move to my peer" — the zero-friction magic-link migration (#4592). Mints a
   // one-time pull token on this hosted node (authorized by the shell-only user
-  // token) and builds a link the user opens on their OWN peer, which then pulls
-  // the data over HTTPS and imports it. The durable access key never leaves this
-  // browser: the bundle is sealed under a fresh ephemeral key held server-side.
+  // token) and sends the user to the import confirmation page on their OWN peer,
+  // which then pulls the data over HTTPS and imports it. The durable access key
+  // never leaves this browser: the bundle is sealed under a fresh ephemeral key
+  // held server-side.
+  //
+  // The DEFAULT is one click: we navigate straight to the peer's import page
+  // (top-level navigation to the loopback peer is exempt from mixed-content and
+  // CORS, and that page still requires an explicit "Import" click, so there is
+  // no drive-by risk). Copy-the-URL stays as a SECONDARY option for a peer on a
+  // different computer/browser/profile. Not everyone's peer is on this machine,
+  // but making the common case one click is the whole point — "why create
+  // friction for a behavior we want the user to do?".
   var migrateOut = document.getElementById('fnmigrateout');
   var migrateLink = document.getElementById('fnmigratelink');
+  var migrateOpen = document.getElementById('fnmigrateopen');
   var migrateMsg = document.getElementById('fnmigratemsg');
   // Default local-peer web/ws-api port (the freenet config default, see
   // config.rs default_ws_api_port). Overriding a non-default local port is a
@@ -132,12 +142,36 @@
     if (migrateMsg) migrateMsg.textContent = m || '';
   }
 
+  function buildMigrateLink(pt) {
+    return (
+      'http://127.0.0.1:' +
+      LOCAL_PEER_PORT +
+      '/hosted/import?source=' +
+      encodeURIComponent(window.location.origin) +
+      '&pt=' +
+      encodeURIComponent(pt)
+    );
+  }
+
   document.getElementById('fnmigrate').addEventListener('click', function () {
     var t =
       typeof __freenet_user_token !== 'undefined' ? __freenet_user_token : null;
     if (!t) {
       setOk('No key on this connection');
       return;
+    }
+    // Open the destination tab SYNCHRONOUSLY inside the click gesture so the
+    // popup isn't blocked, then point it at the link once minted. (window.open
+    // after the async mint resolves would be treated as programmatic and
+    // blocked.) If the browser still blocks it, peerWin is null and the
+    // revealed "Open on my peer" link is a direct one-click fallback.
+    var peerWin = null;
+    try {
+      peerWin = window.open('', '_blank');
+      // sever reverse-tabnabbing back-ref; persists across the later navigation
+      if (peerWin) peerWin.opener = null;
+    } catch (e) {
+      peerWin = null;
     }
     setMigrateMsg('Preparing your one-time migration link...');
     fetch('/v1/hosted/migrate/mint', {
@@ -155,18 +189,26 @@
         if (!pt) {
           throw new Error('no token');
         }
-        var link =
-          'http://127.0.0.1:' +
-          LOCAL_PEER_PORT +
-          '/hosted/import?source=' +
-          encodeURIComponent(window.location.origin) +
-          '&pt=' +
-          encodeURIComponent(pt);
+        var link = buildMigrateLink(pt);
         if (migrateLink) migrateLink.value = link;
+        if (migrateOpen) migrateOpen.href = link;
         if (migrateOut) migrateOut.hidden = false;
-        setMigrateMsg('One-time link ready. It expires in a few minutes.');
+        if (peerWin && !peerWin.closed) {
+          // One click: send the tab we opened to the peer's import page.
+          peerWin.location = link;
+          setMigrateMsg(
+            "Opening the import page on your peer. Didn't open? Use " +
+              '"Open on my peer" below.',
+          );
+        } else {
+          setMigrateMsg('One-time link ready. Click "Open on my peer".');
+        }
       })
       .catch(function (e) {
+        // Don't strand a blank tab if minting failed.
+        if (peerWin && !peerWin.closed) {
+          peerWin.close();
+        }
         setMigrateMsg('Could not prepare a link (' + e.message + ')');
       });
   });


### PR DESCRIPTION
## Problem

On the hosted demo (try.freenet.org), a user who runs their own Freenet peer
can migrate their private data from the hosted node into their own peer via the
Account popover's **Your own peer → Move to my peer** action (the magic-link
migration, #4592). Until now, clicking "Move to my peer" only *revealed a
one-time link the user had to hand-copy and paste* into a browser on the machine
running their peer. That is friction for the exact action we want people to take
("hosted means not private; export to your own peer for real privacy").

## Solution

Make the **default one click**, keep copy-the-URL as a labelled secondary
option. Clicking "Move to my peer" now:

1. Opens a tab **synchronously inside the click gesture** (so the pop-up isn't
   blocked), then
2. mints the one-time pull token and **points that tab straight at the peer's
   import confirmation page** (`http://127.0.0.1:7509/hosted/import?...`).

The revealed panel now leads with a primary **"Open on my peer"** link (a real
`<a target="_blank" rel="noopener">`, so it also survives a blocked pop-up and
supports cmd/middle-click into another profile), and keeps the **Copy link**
input + button underneath, framed for "a peer on a different computer or
browser".

### Why one-click is safe here (no CORS / mixed-content blocker)

- The link is a **top-level navigation** to the user's **loopback** peer.
  Top-level navigations aren't subject to mixed-content blocking, and
  `http://127.0.0.1` is a *potentially-trustworthy* origin, so an `https://`
  hosted page can navigate to it. This is not a CORS/`fetch` request.
- The destination `/hosted/import` page **does not auto-import** — it requires
  an explicit "Import my data" click and ships `frame-ancestors 'none'` +
  `COOP: same-origin`. So a mere navigation to the link cannot import anything;
  there is no drive-by/CSRF risk introduced by opening it automatically.
- `window.open('', '_blank')` is opened in the gesture and only navigated once
  the token is minted (a programmatic `window.open` *after* the async mint would
  be pop-up-blocked); if the browser still blocks it, `peerWin` is null and the
  primary "Open on my peer" link is the direct one-click fallback.

### Scope

Only the **hosted-bar UI assets** change (`hosted_bar.{html,js,css}`) plus one
grep regression test. The migration **mint / pull / pull-import endpoints and
their crypto + gating are untouched** — this is presentation only.

### Known tradeoff (for reviewer judgement)

If the user's peer is on a *different* machine, the auto-opened tab will show a
"can't reach 127.0.0.1" error; they then use the Copy-link secondary path. This
is the deliberate cost of making the common (same-machine) case one click. Easy
to downgrade to a two-click "reveal then Open" flow if preferred.

## Testing

- **New regression test** `hosted_bar_migration_defaults_to_one_click_open_4592`
  (in `path_handlers.rs`) pins the primary/secondary contract: a primary
  `#fnmigrateopen` `target="_blank"` control exists, the mint handler opens a tab
  and navigates it to the local `/hosted/import` link (not merely a copy box),
  and the copy-link control stays wired — so a refactor can't silently regress
  to copy-only.
- `cargo fmt` clean; **Prettier `--check` + ESLint** (the `lint-assets`
  workflow) pass on the changed JS/CSS/HTML.
- Not yet exercised in a live browser end-to-end; the one-click mechanism is
  argued from the platform rules above and the unchanged, explicit-click import
  page. Worth a manual smoke on try.freenet.org before merge.

Refs #4592

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JPWBra4TVGs4MCpbnkVQEg
