### PR TITLE
fix(telemetry): capture client-visible GET outcomes incl. streaming successes

### DIFF
--- a/crates/core/src/client_events.rs
+++ b/crates/core/src/client_events.rs
@@ -879,6 +879,16 @@ async fn process_open_request(
                                             phase = "local_cache_pre_join",
                                             "Serving locally cached contract state before network join"
                                         );
+                                        // Local-cache hit bypasses start_client_get, so
+                                        // emit the client-terminal event here (attempts=0
+                                        // marks a local hit) to keep the findability
+                                        // metric covering ALL client GET successes.
+                                        get::op_ctx_task::emit_local_get_terminal_event(
+                                            &op_manager,
+                                            key,
+                                            full_key,
+                                        )
+                                        .await;
                                         return Ok(Some(Either::Left(QueryResult::GetResult {
                                             key: full_key,
                                             state,
@@ -1100,6 +1110,16 @@ async fn process_open_request(
                                 }
                             }
 
+                            // Local-cache hit (serve-DURING / subscribed) bypasses
+                            // start_client_get, so emit the client-terminal event
+                            // here (attempts=0 marks a local hit) to keep the
+                            // findability metric covering ALL client GET successes.
+                            get::op_ctx_task::emit_local_get_terminal_event(
+                                &op_manager,
+                                key,
+                                full_key,
+                            )
+                            .await;
                             return Ok(Some(Either::Left(QueryResult::GetResult {
                                 key: full_key,
                                 state,

--- a/crates/core/src/node/testing_impl.rs
+++ b/crates/core/src/node/testing_impl.rs
@@ -3858,10 +3858,16 @@ impl SimNetwork {
                         GetEvent::Request { .. } => summary.get.requested += 1,
                         GetEvent::GetSuccess { .. } => summary.get.succeeded += 1,
                         GetEvent::GetFailure { .. } => summary.get.failed += 1,
+                        // ClientTerminal is emitted IN ADDITION to
+                        // GetSuccess / GetNotFound (once per client op from
+                        // the driver), so counting it here would double-count
+                        // the sim summary; the GetSuccess arm above already
+                        // tallies succeeded.
                         GetEvent::GetNotFound { .. }
                         | GetEvent::ResponseSent { .. }
                         | GetEvent::ForwardingAckSent { .. }
-                        | GetEvent::ForwardingAckReceived { .. } => {}
+                        | GetEvent::ForwardingAckReceived { .. }
+                        | GetEvent::ClientTerminal { .. } => {}
                     }
                 }
                 // Subscribe operations

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -303,6 +303,37 @@ async fn emit_get_terminal_event(
     }
 }
 
+/// Emit a `ClientTerminal` event for a client GET satisfied from a LOCAL
+/// copy (the pre-join cache return, or a serve-DURING / subscribed
+/// local-cache hit in `client_events.rs`) without routing through the
+/// network — those paths never call [`start_client_get`], so the driver's
+/// terminal event never fires for them.
+///
+/// `attempts = 0` is the convention marking a local hit (a networked GET
+/// always sends >= 1 request, so `attempts >= 1`), letting analysts split
+/// "all client GET successes" from "network GET findability" without a new
+/// field. Keeps the client-visible findability metric covering ALL client
+/// GET successes — gateways serve many local hits, which would otherwise
+/// bias the number toward network misses.
+pub(crate) async fn emit_local_get_terminal_event(
+    op_manager: &OpManager,
+    instance_id: ContractInstanceId,
+    key: ContractKey,
+) {
+    emit_get_terminal_event(
+        op_manager,
+        Transaction::new::<GetMsg>(),
+        instance_id,
+        Some(key),
+        GetTerminalOutcome::Success,
+        false, // not streamed
+        false, // a real client GET, not a sub-op
+        0,     // local hit: no network request was sent
+        None,  // no hop count for a local hit
+    )
+    .await;
+}
+
 async fn drive_client_get(
     op_manager: Arc<OpManager>,
     client_tx: Transaction,
@@ -390,6 +421,7 @@ async fn drive_client_get_inner(
         request_sent_at: None,
         response_received_at: None,
         saw_not_found: false,
+        requests_sent: 0,
     };
 
     let (loop_result, streaming_assembly) = drive_get_with_assembly_retry(
@@ -615,18 +647,34 @@ async fn drive_client_get_inner(
                 Terminal::InlineFound { hop_count, .. } => Some(*hop_count),
                 Terminal::Streaming { .. } | Terminal::LocalCompletion => None,
             };
-            emit_get_terminal_event(
-                op_manager,
-                client_tx,
-                instance_id,
-                Some(reply_key),
-                done_terminal_outcome(host_result.is_ok()),
-                streamed,
-                client_tx.is_sub_operation(),
-                driver.retries + 1,
-                hop_count,
-            )
-            .await;
+            let outcome = done_terminal_outcome(host_result.is_ok());
+            let is_sub_op = client_tx.is_sub_operation();
+            let attempts = driver.requests_sent;
+
+            // For a BLOCKING subscribe hand-off the client result is not
+            // delivered until `maybe_subscribe_child`'s inline await
+            // completes, so emit the terminal event AFTER it — otherwise
+            // `elapsed_ms` would exclude the subscribe wait the client
+            // actually experiences, and a cancellation during that wait would
+            // record a success for a response never delivered. The
+            // non-blocking / no-subscribe hand-off returns immediately
+            // (fire-and-forget spawn or no-op), so its emit stays BEFORE the
+            // hand-off, unchanged. Exactly one of the two guarded emits runs.
+            let blocking_hand_off = subscribe && blocking_subscribe;
+            if !blocking_hand_off {
+                emit_get_terminal_event(
+                    op_manager,
+                    client_tx,
+                    instance_id,
+                    Some(reply_key),
+                    outcome,
+                    streamed,
+                    is_sub_op,
+                    attempts,
+                    hop_count,
+                )
+                .await;
+            }
 
             // Explicit-subscribe hand-off. Mirrors PUT 3a's
             // `maybe_subscribe_child` — subscribe is never handled in
@@ -644,6 +692,21 @@ async fn drive_client_get_inner(
                 blocking_subscribe,
             )
             .await;
+
+            if blocking_hand_off {
+                emit_get_terminal_event(
+                    op_manager,
+                    client_tx,
+                    instance_id,
+                    Some(reply_key),
+                    outcome,
+                    streamed,
+                    is_sub_op,
+                    attempts,
+                    hop_count,
+                )
+                .await;
+            }
 
             Ok(DriverOutcome::Publish(host_result))
         }
@@ -675,7 +738,7 @@ async fn drive_client_get_inner(
                 exhausted_terminal_outcome(driver.saw_not_found),
                 false,
                 client_tx.is_sub_operation(),
-                driver.retries + 1,
+                driver.requests_sent,
                 None,
             )
             .await;
@@ -719,6 +782,13 @@ struct GetRetryDriver<'a> {
     /// the `RetryLoopOutcome::Exhausted` string does not carry that
     /// structural distinction.
     saw_not_found: bool,
+    /// Count of GET requests actually SENT for this client op, incremented
+    /// once per `build_request`. This is the `attempts` reported by the
+    /// terminal-telemetry event — NOT `retries`, which `advance_to_next_peer`
+    /// increments BEFORE its candidate lookup and so overcounts by one on
+    /// exhaustion (a one-candidate/isolated search that sent a single
+    /// request would otherwise report 2).
+    requests_sent: usize,
 }
 
 /// Terminal value for the GET driver.
@@ -875,6 +945,9 @@ impl RetryDriver for GetRetryDriver<'_> {
         // is read after the retry loop returns to compute
         // `time_to_response_start` for routing-prediction telemetry.
         self.request_sent_at = Some(tokio::time::Instant::now());
+        // Count actual requests sent (once per attempt) for the terminal
+        // event's `attempts` field — the accurate "requests sent" measure.
+        self.requests_sent += 1;
         NetMessage::from(GetMsg::Request {
             id: attempt_tx,
             instance_id: self.instance_id,
@@ -1991,6 +2064,7 @@ async fn drive_sub_op_get(
         request_sent_at: None,
         response_received_at: None,
         saw_not_found: false,
+        requests_sent: 0,
     };
 
     let (loop_result, streaming_assembly) = drive_get_with_assembly_retry(
@@ -2087,7 +2161,7 @@ async fn drive_sub_op_get(
                 done_terminal_outcome(matches!(result, SubOpGetOutcome::Found(_))),
                 streamed,
                 true,
-                driver.retries + 1,
+                driver.requests_sent,
                 hop_count,
             )
             .await;
@@ -2102,7 +2176,7 @@ async fn drive_sub_op_get(
                 exhausted_terminal_outcome(driver.saw_not_found),
                 false,
                 true,
-                driver.retries + 1,
+                driver.requests_sent,
                 None,
             )
             .await;
@@ -4343,9 +4417,16 @@ mod tests {
         let inner_body = extract_fn_body(src, "async fn drive_client_get_inner(");
         let emits = inner_body.matches("emit_get_terminal_event(").count();
         assert_eq!(
-            emits, 2,
-            "drive_client_get_inner must emit exactly one terminal event on \
-             each of the Done and Exhausted arms (found {emits})"
+            emits, 3,
+            "drive_client_get_inner must have three static emit sites: the \
+             Done arm's mutually-exclusive blocking/non-blocking pair (exactly \
+             one runs per op) plus the Exhausted arm (found {emits})"
+        );
+        assert!(
+            inner_body.contains("let blocking_hand_off = subscribe && blocking_subscribe;"),
+            "Done arm must gate the terminal-event emit on blocking_hand_off so a \
+             blocking subscribe hand-off emits AFTER the inline subscribe wait \
+             (so elapsed_ms includes the wait and a cancellation records no success)"
         );
         assert!(
             inner_body.contains("done_terminal_outcome(host_result.is_ok())"),
@@ -4399,6 +4480,70 @@ mod tests {
             "sub-op terminal events must pass is_sub_op=true explicitly, not \
              derive it from tx.is_sub_operation() — the sub-op tx has no \
              parent, so is_sub_operation() would wrongly report false."
+        );
+    }
+
+    /// `attempts` must reflect requests actually SENT (`driver.requests_sent`,
+    /// incremented once per `build_request`), NOT `driver.retries` — which
+    /// `advance_to_next_peer` bumps BEFORE its candidate lookup and so
+    /// overcounts by one on exhaustion (an isolated one-candidate search that
+    /// sent a single request would otherwise report 2). Source-scrape pin.
+    #[test]
+    fn get_terminal_attempts_counts_requests_sent_not_retries() {
+        let src = production_source();
+        let build_body =
+            extract_fn_body(src, "fn build_request(&mut self, attempt_tx: Transaction)");
+        assert!(
+            build_body.contains("self.requests_sent += 1;"),
+            "build_request must increment requests_sent once per request sent"
+        );
+        assert!(
+            !src.contains("driver.retries + 1"),
+            "terminal-event attempts must come from driver.requests_sent, not \
+             driver.retries + 1 (retries overcounts by one on exhaustion)"
+        );
+        // attempts is wired from requests_sent (1 client-Done local + the 3
+        // direct emit-site args = 4 occurrences of `driver.requests_sent`).
+        let count = src.matches("driver.requests_sent").count();
+        assert_eq!(
+            count, 4,
+            "the four driver terminal-event attempts values must all come from \
+             driver.requests_sent (found {count})"
+        );
+    }
+
+    /// The two local-serve GET paths in `client_events.rs` (pre-join cache
+    /// and serve-DURING / subscribed local hit) bypass `start_client_get`, so
+    /// they must emit a client-terminal event directly — otherwise the client
+    /// findability metric omits every local hit (gateways serve many), biasing
+    /// it toward network misses. Source-scrape pin.
+    #[test]
+    fn client_events_local_get_paths_emit_terminal_event() {
+        const CLIENT_EVENTS: &str = include_str!("../../client_events.rs");
+        let count = CLIENT_EVENTS
+            .matches("emit_local_get_terminal_event(")
+            .count();
+        assert_eq!(
+            count, 2,
+            "both local-serve GET paths (pre-join + serve-DURING) must call \
+             emit_local_get_terminal_event (found {count})"
+        );
+    }
+
+    /// The local-hit helper marks a client-visible LOCAL success:
+    /// `outcome=Success`, `attempts=0` (the local-hit convention), not
+    /// streamed, not a sub-op. Source-scrape pin.
+    #[test]
+    fn emit_local_get_terminal_event_marks_local_hit() {
+        let src = production_source();
+        let body = extract_fn_body(src, "pub(crate) async fn emit_local_get_terminal_event(");
+        assert!(
+            body.contains("GetTerminalOutcome::Success"),
+            "a local-cache hit is a client-visible success"
+        );
+        assert!(
+            body.contains("no network request was sent"),
+            "local hit must pass attempts=0 (documented convention)"
         );
     }
 

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -55,6 +55,7 @@ use crate::operations::VisitedPeers;
 use crate::operations::bootstrap::bootstrap_gateway_target;
 use crate::ring::{Location, PeerKeyLocation};
 use crate::router::{RouteEvent, RouteOutcome};
+use crate::tracing::GetTerminalOutcome;
 use crate::transport::peer_connection::StreamId;
 
 use super::{GetMsg, GetMsgResult, GetStreamingPayload};
@@ -235,6 +236,73 @@ enum DriverOutcome {
     InfrastructureError(OpError),
 }
 
+/// Map a GET that reached a terminal reply to its client-visible outcome.
+///
+/// `host_ok` is whether state was actually delivered to the client. A
+/// terminal header that then failed local assembly / store re-query (e.g.
+/// streaming assembly exhausting its retry budget, #4345) delivered
+/// nothing, so it is reported as `TimeoutExhausted` — the `streamed` flag
+/// on the emitted event distinguishes a streaming-delivery exhaustion from
+/// a routing timeout.
+fn done_terminal_outcome(host_ok: bool) -> GetTerminalOutcome {
+    if host_ok {
+        GetTerminalOutcome::Success
+    } else {
+        GetTerminalOutcome::TimeoutExhausted
+    }
+}
+
+/// Map a GET whose retry loop exhausted (no terminal reply reached) to its
+/// client-visible outcome: a definitive NotFound from at least one
+/// reachable peer is `NotFound`; otherwise the budget was burned by
+/// timeouts / unroutable attempts (`TimeoutExhausted`).
+fn exhausted_terminal_outcome(saw_not_found: bool) -> GetTerminalOutcome {
+    if saw_not_found {
+        GetTerminalOutcome::NotFound
+    } else {
+        GetTerminalOutcome::TimeoutExhausted
+    }
+}
+
+/// Emit the authoritative client-visible GET terminal telemetry event
+/// (exactly one per client GET op, one per sub-op GET) via the same
+/// `register_events` path the driver already uses for `RouteEvent`.
+///
+/// `is_sub_op` is passed EXPLICITLY by the caller rather than derived from
+/// `tx.is_sub_operation()`: the sub-op GET drivers construct their tx via
+/// `Transaction::new` (not `new_child_of`), so `is_sub_operation()` alone
+/// under-reports them. Callers OR-in `tx.is_sub_operation()` so a client tx
+/// that is itself a child is still flagged.
+#[allow(clippy::too_many_arguments)]
+async fn emit_get_terminal_event(
+    op_manager: &OpManager,
+    tx: Transaction,
+    instance_id: ContractInstanceId,
+    key: Option<ContractKey>,
+    outcome: GetTerminalOutcome,
+    streamed: bool,
+    is_sub_op: bool,
+    attempts: usize,
+    hop_count: Option<usize>,
+) {
+    if let Some(log_event) = crate::tracing::NetEventLog::get_terminal(
+        &tx,
+        &op_manager.ring,
+        instance_id,
+        key,
+        outcome,
+        streamed,
+        is_sub_op,
+        attempts,
+        hop_count,
+    ) {
+        op_manager
+            .ring
+            .register_events(either::Either::Left(log_event))
+            .await;
+    }
+}
+
 async fn drive_client_get(
     op_manager: Arc<OpManager>,
     client_tx: Transaction,
@@ -321,6 +389,7 @@ async fn drive_client_get_inner(
         attempt_visited: VisitedPeers::new(&client_tx),
         request_sent_at: None,
         response_received_at: None,
+        saw_not_found: false,
     };
 
     let (loop_result, streaming_assembly) = drive_get_with_assembly_retry(
@@ -536,6 +605,29 @@ async fn drive_client_get_inner(
                 host_result.is_ok(),
             );
 
+            // Authoritative client-visible terminal event (issue: streaming
+            // GETs emit no `get_success`). Captures streaming (> 64 KB)
+            // successes the inline `register.rs` path misses because they
+            // arrive as `ResponseStreaming`. `streamed` is true only for the
+            // streaming terminal; `hop_count` is carried only by InlineFound.
+            let streamed = matches!(terminal, Terminal::Streaming { .. });
+            let hop_count = match &terminal {
+                Terminal::InlineFound { hop_count, .. } => Some(*hop_count),
+                Terminal::Streaming { .. } | Terminal::LocalCompletion => None,
+            };
+            emit_get_terminal_event(
+                op_manager,
+                client_tx,
+                instance_id,
+                Some(reply_key),
+                done_terminal_outcome(host_result.is_ok()),
+                streamed,
+                client_tx.is_sub_operation(),
+                driver.retries + 1,
+                hop_count,
+            )
+            .await;
+
             // Explicit-subscribe hand-off. Mirrors PUT 3a's
             // `maybe_subscribe_child` — subscribe is never handled in
             // the terminal-result construction to avoid double-subscribe
@@ -571,6 +663,22 @@ async fn drive_client_get_inner(
                 %cause,
                 "GET client: retry loop exhausted — returning NotFound to client"
             );
+            // Terminal event for the previously-silent exhaustion path
+            // (only a `tracing::info!` fired before). `not_found` vs
+            // `timeout_exhausted` is distinguished by whether any reachable
+            // peer answered NotFound (`driver.saw_not_found`).
+            emit_get_terminal_event(
+                op_manager,
+                client_tx,
+                instance_id,
+                None,
+                exhausted_terminal_outcome(driver.saw_not_found),
+                false,
+                client_tx.is_sub_operation(),
+                driver.retries + 1,
+                None,
+            )
+            .await;
             Ok(DriverOutcome::Publish(Ok(HostResponse::ContractResponse(
                 freenet_stdlib::client_api::ContractResponse::NotFound { instance_id },
             ))))
@@ -603,6 +711,14 @@ struct GetRetryDriver<'a> {
     /// outcomes (Retry / Unexpected) leave it untouched and the next
     /// `build_request` overwrites `request_sent_at`.
     response_received_at: Option<tokio::time::Instant>,
+    /// Set once any attempt classified a reply as a definitive
+    /// `GetMsg::Response{NotFound}`. Used by the terminal-telemetry event
+    /// to distinguish a genuine `not_found` (a reachable peer answered
+    /// NotFound) from a `timeout_exhausted` (the budget was burned by
+    /// timeouts / unroutable attempts) when the retry loop exhausts —
+    /// the `RetryLoopOutcome::Exhausted` string does not carry that
+    /// structural distinction.
+    saw_not_found: bool,
 }
 
 /// Terminal value for the GET driver.
@@ -775,6 +891,15 @@ impl RetryDriver for GetRetryDriver<'_> {
             // Only capture on Terminal so non-terminal Retry/Unexpected
             // outcomes leave the field as None until a terminal arrives.
             self.response_received_at = Some(tokio::time::Instant::now());
+        }
+        // GET's ONLY source of `AttemptOutcome::Retry` is a
+        // `GetMsg::Response{NotFound}` (see the free `classify` fn — the
+        // NotFound arm is the sole `Retry` producer). Record it so the
+        // terminal-telemetry event can report `not_found` vs
+        // `timeout_exhausted` on exhaustion. If a future non-NotFound Retry
+        // source is added to `classify`, this must be narrowed accordingly.
+        if matches!(outcome, AttemptOutcome::Retry) {
+            self.saw_not_found = true;
         }
         outcome
     }
@@ -1865,6 +1990,7 @@ async fn drive_sub_op_get(
         attempt_visited: VisitedPeers::new(&tx),
         request_sent_at: None,
         response_received_at: None,
+        saw_not_found: false,
     };
 
     let (loop_result, streaming_assembly) = drive_get_with_assembly_retry(
@@ -1909,6 +2035,18 @@ async fn drive_sub_op_get(
                 Terminal::LocalCompletion => {}
             }
 
+            // Capture telemetry fields from the terminal before the store
+            // re-query consumes ownership below.
+            let terminal_key = match &terminal {
+                Terminal::InlineFound { key, .. } | Terminal::Streaming { key, .. } => Some(*key),
+                Terminal::LocalCompletion => None,
+            };
+            let streamed = matches!(terminal, Terminal::Streaming { .. });
+            let hop_count = match &terminal {
+                Terminal::InlineFound { hop_count, .. } => Some(*hop_count),
+                Terminal::Streaming { .. } | Terminal::LocalCompletion => None,
+            };
+
             // Resolve a GetResult by re-querying the local store. Mirrors
             // `build_host_response` but returns the raw `GetResult` shape
             // instead of a HostResponse.
@@ -1918,7 +2056,7 @@ async fn drive_sub_op_get(
                     return_contract_code,
                 })
                 .await;
-            match lookup {
+            let result = match lookup {
                 Ok(ContractHandlerEvent::GetResponse {
                     key: Some(_),
                     response:
@@ -1937,9 +2075,39 @@ async fn drive_sub_op_get(
                     &instance_id,
                     streaming_assembly.error.as_deref(),
                 )),
-            }
+            };
+            // Sub-op GET terminal event: `is_sub_op = true` so analysts can
+            // exclude repair / renewal / related fetches from
+            // client-findability metrics.
+            emit_get_terminal_event(
+                op_manager,
+                tx,
+                instance_id,
+                terminal_key,
+                done_terminal_outcome(matches!(result, SubOpGetOutcome::Found(_))),
+                streamed,
+                true,
+                driver.retries + 1,
+                hop_count,
+            )
+            .await;
+            result
         }
-        RetryLoopOutcome::Exhausted(cause) => SubOpGetOutcome::NotFound(cause),
+        RetryLoopOutcome::Exhausted(cause) => {
+            emit_get_terminal_event(
+                op_manager,
+                tx,
+                instance_id,
+                None,
+                exhausted_terminal_outcome(driver.saw_not_found),
+                false,
+                true,
+                driver.retries + 1,
+                None,
+            )
+            .await;
+            SubOpGetOutcome::NotFound(cause)
+        }
         RetryLoopOutcome::Unexpected => SubOpGetOutcome::Infra(OpError::UnexpectedOpState),
         RetryLoopOutcome::InfraError(err) => SubOpGetOutcome::Infra(err),
     }
@@ -4131,6 +4299,106 @@ mod tests {
             !arm_body.contains("routing_finished("),
             "Exhausted arm must NOT call routing_finished — no wire success \
              attribution is appropriate for a peer set that returned NotFound."
+        );
+    }
+
+    /// The pure outcome-mapping functions the terminal arms use.
+    #[test]
+    fn get_terminal_outcome_mappings() {
+        // Done arm: state delivered => Success. A located-but-undelivered
+        // terminal (e.g. streaming assembly exhausted its retry budget,
+        // #4345) delivered nothing => TimeoutExhausted (the `streamed` flag
+        // on the event distinguishes it from a routing timeout).
+        assert_eq!(done_terminal_outcome(true), GetTerminalOutcome::Success);
+        assert_eq!(
+            done_terminal_outcome(false),
+            GetTerminalOutcome::TimeoutExhausted
+        );
+        // Exhausted arm: a reachable peer answered NotFound => NotFound;
+        // otherwise the budget was burned by timeouts / unroutable attempts.
+        assert_eq!(
+            exhausted_terminal_outcome(true),
+            GetTerminalOutcome::NotFound
+        );
+        assert_eq!(
+            exhausted_terminal_outcome(false),
+            GetTerminalOutcome::TimeoutExhausted
+        );
+        // Stable OTLP `outcome` strings.
+        assert_eq!(GetTerminalOutcome::Success.as_str(), "success");
+        assert_eq!(GetTerminalOutcome::NotFound.as_str(), "not_found");
+        assert_eq!(
+            GetTerminalOutcome::TimeoutExhausted.as_str(),
+            "timeout_exhausted"
+        );
+    }
+
+    /// The client GET driver must emit exactly ONE terminal telemetry event
+    /// on EACH terminal arm (Done + Exhausted), tag `is_sub_op` from the tx
+    /// (never a hardcoded true on the client path), and map the outcome via
+    /// the pure helpers. Source-scrape pin.
+    #[test]
+    fn client_get_emits_terminal_event_on_both_arms() {
+        let src = production_source();
+        let inner_body = extract_fn_body(src, "async fn drive_client_get_inner(");
+        let emits = inner_body.matches("emit_get_terminal_event(").count();
+        assert_eq!(
+            emits, 2,
+            "drive_client_get_inner must emit exactly one terminal event on \
+             each of the Done and Exhausted arms (found {emits})"
+        );
+        assert!(
+            inner_body.contains("done_terminal_outcome(host_result.is_ok())"),
+            "Done arm must map its outcome via done_terminal_outcome(host_result.is_ok())"
+        );
+        assert!(
+            inner_body.contains("exhausted_terminal_outcome(driver.saw_not_found)"),
+            "Exhausted arm must map its outcome via \
+             exhausted_terminal_outcome(driver.saw_not_found)"
+        );
+        assert!(
+            inner_body.contains("client_tx.is_sub_operation()"),
+            "client GET terminal events must tag is_sub_op from \
+             client_tx.is_sub_operation(), not a hardcoded value"
+        );
+    }
+
+    /// Core-bug regression guard: a streaming (> 64 KB) GET success must be
+    /// tagged `streamed=true`. The Done arm derives `streamed` from whether
+    /// the terminal was `Terminal::Streaming` (delivered as
+    /// `ResponseStreaming`, the class of success the inline `GetSuccess`
+    /// path could not observe).
+    #[test]
+    fn client_get_terminal_marks_streaming_success() {
+        let src = production_source();
+        let inner_body = extract_fn_body(src, "async fn drive_client_get_inner(");
+        assert!(
+            inner_body.contains("let streamed = matches!(terminal, Terminal::Streaming { .. });"),
+            "Done arm must set `streamed` true for the Streaming terminal so \
+             streaming (>64KB) successes are measurable."
+        );
+    }
+
+    /// Sub-op GETs (phantom-repair, renewal, related-fetch) construct their
+    /// tx via `Transaction::new` (parent = None), so `is_sub_operation()`
+    /// under-reports them. The sub-op driver must emit a terminal event on
+    /// both arms and tag `is_sub_op` EXPLICITLY (not derive it from the tx),
+    /// so client-findability metrics can exclude these. Source-scrape pin.
+    #[test]
+    fn sub_op_get_tags_terminal_event_explicitly() {
+        let src = production_source();
+        let body = extract_fn_body(src, "async fn drive_sub_op_get(");
+        let emits = body.matches("emit_get_terminal_event(").count();
+        assert_eq!(
+            emits, 2,
+            "drive_sub_op_get must emit a terminal event on each of the Done \
+             and Exhausted arms (found {emits})"
+        );
+        assert!(
+            !body.contains("is_sub_operation()"),
+            "sub-op terminal events must pass is_sub_op=true explicitly, not \
+             derive it from tx.is_sub_operation() — the sub-op tx has no \
+             parent, so is_sub_operation() would wrongly report false."
         );
     }
 

--- a/crates/core/src/tracing.rs
+++ b/crates/core/src/tracing.rs
@@ -95,7 +95,9 @@ pub(crate) use register::{
 // (used by external crates, e.g. crates/core/tests), so they must stay `pub`.
 pub use register::{EventFlushHandle, NetLogMessage};
 // NEW_RECORDS_TS is needed by metrics_client's opentelemetry_tracer
-pub(crate) use event_kind::{ConnectEvent, GetEvent, PutEvent, SubscribeEvent, UpdateEvent};
+pub(crate) use event_kind::{
+    ConnectEvent, GetEvent, GetTerminalOutcome, PutEvent, SubscribeEvent, UpdateEvent,
+};
 pub use event_kind::{
     ConnectionType, DisconnectReason, EventKind, HostingStoppedReason, InterestSyncEvent,
     OperationFailure, PeerLifecycleEvent, TransferDirection, TransferEvent,

--- a/crates/core/src/tracing/event_kind.rs
+++ b/crates/core/src/tracing/event_kind.rs
@@ -1259,7 +1259,12 @@ pub(crate) enum GetEvent {
         /// Sub-operation GET (phantom-repair, renewal, related-fetch);
         /// excluded from client-findability metrics.
         is_sub_op: bool,
-        /// Peer attempts made before this terminal outcome (1 = first peer).
+        /// GET requests actually SENT before this terminal outcome. `1` means
+        /// the first peer answered; `0` is the convention for a LOCAL-cache
+        /// hit that never routed to the network (see
+        /// `emit_local_get_terminal_event`), letting analysts split "all
+        /// client GET successes" (`attempts >= 0`) from "network GET
+        /// findability" (`attempts >= 1`).
         attempts: usize,
         /// Forward-path hop count when carried by the terminal reply.
         hop_count: Option<usize>,

--- a/crates/core/src/tracing/event_kind.rs
+++ b/crates/core/src/tracing/event_kind.rs
@@ -1091,6 +1091,33 @@ impl UpdateEvent {
     }
 }
 
+/// Client-visible outcome of a completed GET operation, carried by
+/// [`GetEvent::ClientTerminal`].
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
+#[cfg_attr(test, derive(arbitrary::Arbitrary))]
+pub(crate) enum GetTerminalOutcome {
+    /// State was delivered to the client.
+    Success,
+    /// At least one reachable peer returned a definitive NotFound — the
+    /// contract was not located in the network.
+    NotFound,
+    /// The retry budget was exhausted by timeouts / unroutable attempts
+    /// without a definitive NotFound. Previously this returned NotFound to
+    /// the client with NO telemetry event at all.
+    TimeoutExhausted,
+}
+
+impl GetTerminalOutcome {
+    /// Stable string form used in the OTLP `outcome` field.
+    pub(crate) fn as_str(&self) -> &'static str {
+        match self {
+            GetTerminalOutcome::Success => "success",
+            GetTerminalOutcome::NotFound => "not_found",
+            GetTerminalOutcome::TimeoutExhausted => "timeout_exhausted",
+        }
+    }
+}
+
 /// GET operation events for tracking the lifecycle of contract retrieval.
 ///
 /// Similar to `PutEvent`, this enum captures the full sequence of a Get operation:
@@ -1203,15 +1230,54 @@ pub(crate) enum GetEvent {
         elapsed_ms: u64,
         timestamp: u64,
     },
+    /// Authoritative client-visible terminal outcome of a GET operation,
+    /// emitted exactly ONCE per client GET op (and once per sub-op GET,
+    /// tagged `is_sub_op`) from the originator / sub-op driver at completion.
+    ///
+    /// Unlike [`GetEvent::GetSuccess`] — which `register.rs` synthesizes
+    /// inline from a `GetMsg::Response{Found}` header and therefore MISSES
+    /// every streaming (> 64 KB `streaming_threshold`) success delivered as
+    /// `GetMsg::ResponseStreaming` (which falls through to `_ => Ignored`) —
+    /// this fires from the driver's terminal arm, so it captures ALL
+    /// client-visible outcomes including streaming successes. It is the
+    /// authoritative findability signal; `is_sub_op = true` marks
+    /// repair / renewal / related sub-op GETs so analysts can exclude them
+    /// from client-findability metrics.
+    ClientTerminal {
+        id: Transaction,
+        requester: PeerKeyLocation,
+        instance_id: ContractInstanceId,
+        /// Full contract key on the success path; `None` for
+        /// not-found / timeout-exhausted (the key is only known once a
+        /// terminal Found / streaming reply arrives).
+        key: Option<ContractKey>,
+        outcome: GetTerminalOutcome,
+        /// Payload delivered via `ResponseStreaming` (> 64 KB) rather than
+        /// inline — the class of success the inline `GetSuccess` path
+        /// could not observe.
+        streamed: bool,
+        /// Sub-operation GET (phantom-repair, renewal, related-fetch);
+        /// excluded from client-findability metrics.
+        is_sub_op: bool,
+        /// Peer attempts made before this terminal outcome (1 = first peer).
+        attempts: usize,
+        /// Forward-path hop count when carried by the terminal reply.
+        hop_count: Option<usize>,
+        /// Time elapsed since operation started (milliseconds).
+        elapsed_ms: u64,
+        timestamp: u64,
+    },
 }
 
 impl GetEvent {
     /// Returns the contract key for this event if available.
-    /// Only GetSuccess and ResponseSent may have the full key; other variants have instance_id.
+    /// Only GetSuccess, ResponseSent, and ClientTerminal may have the full
+    /// key; other variants have instance_id.
     fn contract_key(&self) -> Option<ContractKey> {
         match self {
             GetEvent::GetSuccess { key, .. } => Some(*key),
             GetEvent::ResponseSent { key, .. } => *key,
+            GetEvent::ClientTerminal { key, .. } => *key,
             GetEvent::Request { .. }
             | GetEvent::GetNotFound { .. }
             | GetEvent::GetFailure { .. }

--- a/crates/core/src/tracing/metrics_client.rs
+++ b/crates/core/src/tracing/metrics_client.rs
@@ -509,10 +509,15 @@ mod opentelemetry_tracer {
                         }
                     }
                     std::collections::hash_map::Entry::Vacant(empty) => {
-                        let span = empty.insert(OTSpan::new(log.tx));
-                        // does not make much sense to treat a single isolated event as a span,
-                        // so just ignore those in case they were to happen
+                        // A terminal event arriving with NO existing span is an
+                        // isolated event — e.g. the tx's span was already
+                        // completed+removed by an earlier terminal (GetSuccess),
+                        // and this is a second terminal (ClientTerminal). Do NOT
+                        // insert a span for it: inserting-and-not-removing leaks
+                        // an empty OTSpan until GC. Only start a span for a
+                        // non-terminal first event.
                         if !span_completed {
+                            let span = empty.insert(OTSpan::new(log.tx));
                             span.add_log(&log);
                         }
                     }
@@ -533,10 +538,15 @@ mod opentelemetry_tracer {
                         }
                     }
                     dashmap::mapref::entry::Entry::Vacant(empty) => {
-                        let mut span = empty.insert(OTSpan::new(log.tx));
-                        // does not make much sense to treat a single isolated event as a span,
-                        // so just ignore those in case they were to happen
+                        // A terminal event arriving with NO existing span is an
+                        // isolated event — e.g. the tx's span was already
+                        // completed+removed by an earlier terminal (GetSuccess),
+                        // and this is a second terminal (ClientTerminal). Do NOT
+                        // insert a span for it: inserting-and-not-removing leaks
+                        // an empty OTSpan until GC. Only start a span for a
+                        // non-terminal first event.
                         if !span_completed {
+                            let mut span = empty.insert(OTSpan::new(log.tx));
                             span.add_log(&log);
                         }
                     }

--- a/crates/core/src/tracing/register.rs
+++ b/crates/core/src/tracing/register.rs
@@ -524,6 +524,44 @@ impl<'a> NetEventLog<'a> {
         })
     }
 
+    /// Create the authoritative client-visible GET terminal event (see
+    /// [`GetEvent::ClientTerminal`]). Emitted once per client GET op (and
+    /// once per sub-op GET, tagged) from the driver so streaming (> 64 KB)
+    /// successes — invisible to the inline `GetSuccess` path — are
+    /// measurable.
+    #[allow(clippy::too_many_arguments)]
+    pub fn get_terminal(
+        tx: &'a Transaction,
+        ring: &'a Ring,
+        instance_id: ContractInstanceId,
+        key: Option<ContractKey>,
+        outcome: GetTerminalOutcome,
+        streamed: bool,
+        is_sub_op: bool,
+        attempts: usize,
+        hop_count: Option<usize>,
+    ) -> Option<Self> {
+        let peer_id = Self::get_own_peer_id(ring)?;
+        let own_loc = ring.connection_manager.own_location();
+        Some(NetEventLog {
+            tx,
+            peer_id,
+            kind: EventKind::Get(GetEvent::ClientTerminal {
+                id: *tx,
+                requester: own_loc,
+                instance_id,
+                key,
+                outcome,
+                streamed,
+                is_sub_op,
+                attempts,
+                hop_count,
+                elapsed_ms: tx.elapsed().as_millis() as u64,
+                timestamp: chrono::Utc::now().timestamp() as u64,
+            }),
+        })
+    }
+
     /// Create a ForwardingAck sent event.
     pub fn get_forwarding_ack_sent(
         tx: &'a Transaction,

--- a/crates/core/src/tracing/register.rs
+++ b/crates/core/src/tracing/register.rs
@@ -1604,7 +1604,11 @@ impl NetLogMessage {
             EventKind::Connect(_) => false,
             EventKind::Put(PutEvent::PutSuccess { .. }) => true,
             EventKind::Put(_) => false,
-            EventKind::Get(GetEvent::GetSuccess { .. } | GetEvent::GetNotFound { .. }) => true,
+            EventKind::Get(
+                GetEvent::GetSuccess { .. }
+                | GetEvent::GetNotFound { .. }
+                | GetEvent::ClientTerminal { .. },
+            ) => true,
             EventKind::Get(_) => false,
             EventKind::Subscribe(
                 SubscribeEvent::SubscribeSuccess { .. }
@@ -2162,6 +2166,41 @@ mod span_completed_tests {
             failure.span_completed(),
             "UpdateFailure must close its span"
         );
+    }
+
+    // ClientTerminal is the authoritative client-visible GET terminal event.
+    // It MUST close its span: for an inline success, `GetSuccess` already
+    // removed the span, so a ClientTerminal not treated as completing would be
+    // re-inserted as a fresh non-terminal span and leak (paired with the
+    // metrics_client `process_log` Vacant-branch guard). For a streaming
+    // success (no `GetSuccess` ever fired) it is the sole terminal and closes
+    // the span outright.
+    #[test]
+    fn client_terminal_event_completes_span() {
+        let tx = Transaction::new::<crate::operations::get::GetMsg>();
+        for outcome in [
+            GetTerminalOutcome::Success,
+            GetTerminalOutcome::NotFound,
+            GetTerminalOutcome::TimeoutExhausted,
+        ] {
+            let ev = msg(EventKind::Get(GetEvent::ClientTerminal {
+                id: tx,
+                requester: PeerKeyLocation::random(),
+                instance_id: ContractInstanceId::new([3u8; 32]),
+                key: Some(contract_key()),
+                outcome,
+                streamed: false,
+                is_sub_op: false,
+                attempts: 1,
+                hop_count: None,
+                elapsed_ms: 0,
+                timestamp: 0,
+            }));
+            assert!(
+                ev.span_completed(),
+                "ClientTerminal ({outcome:?}) must close its span"
+            );
+        }
     }
 
     // A non-terminal UPDATE event must NOT close the span — guards against

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -3629,6 +3629,46 @@ mod tests {
         assert!(json["hop_count"].is_null());
     }
 
+    /// A local-cache-hit client GET emits a `ClientTerminal` with
+    /// `attempts=0` (the local-hit convention) so the findability metric
+    /// covers ALL client GET successes — gateways serve many local hits,
+    /// which would otherwise bias the number toward network misses.
+    #[test]
+    fn test_event_kind_to_json_get_terminal_local_hit() {
+        use crate::message::Transaction;
+        use crate::ring::PeerKeyLocation;
+        use crate::tracing::{GetEvent, GetTerminalOutcome};
+        use freenet_stdlib::prelude::{CodeHash, ContractInstanceId, ContractKey};
+
+        let tx = Transaction::new::<crate::operations::get::GetMsg>();
+        let key = ContractKey::from_id_and_code(
+            ContractInstanceId::new([1u8; 32]),
+            CodeHash::new([2u8; 32]),
+        );
+
+        let event = EventKind::Get(GetEvent::ClientTerminal {
+            id: tx,
+            requester: PeerKeyLocation::random(),
+            instance_id: ContractInstanceId::new([1u8; 32]),
+            key: Some(key),
+            outcome: GetTerminalOutcome::Success,
+            streamed: false,
+            is_sub_op: false,
+            attempts: 0,
+            hop_count: None,
+            elapsed_ms: 1,
+            timestamp: 1,
+        });
+
+        assert_eq!(event_kind_to_string(&event), "get_terminal");
+        let json = event_kind_to_json(&event);
+        assert_eq!(json["outcome"], "success");
+        assert_eq!(json["attempts"], 0);
+        assert_eq!(json["streamed"], false);
+        assert_eq!(json["is_sub_op"], false);
+        assert!(json["key"].is_string());
+    }
+
     // ----- #4380: shadow sub-budget rate limiting -----
 
     /// Build a worker purely to exercise the admission policy. The endpoint

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -937,6 +937,7 @@ fn event_kind_to_string(kind: &EventKind) -> String {
                 GetEvent::ResponseSent { .. } => "get_response_sent".to_string(),
                 GetEvent::ForwardingAckSent { .. } => "get_forwarding_ack_sent".to_string(),
                 GetEvent::ForwardingAckReceived { .. } => "get_forwarding_ack_received".to_string(),
+                GetEvent::ClientTerminal { .. } => "get_terminal".to_string(),
             }
         }
         EventKind::Subscribe(subscribe_event) => {
@@ -1414,6 +1415,37 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                         "elapsed_ms": elapsed_ms,
                         "timestamp": timestamp,
                     })
+                }
+                GetEvent::ClientTerminal {
+                    id,
+                    requester,
+                    instance_id,
+                    key,
+                    outcome,
+                    streamed,
+                    is_sub_op,
+                    attempts,
+                    hop_count,
+                    elapsed_ms,
+                    timestamp,
+                } => {
+                    let mut json = serde_json::json!({
+                        "type": "get_terminal",
+                        "id": id.to_string(),
+                        "requester": requester.to_string(),
+                        "instance_id": instance_id.to_string(),
+                        "outcome": outcome.as_str(),
+                        "streamed": streamed,
+                        "is_sub_op": is_sub_op,
+                        "attempts": attempts,
+                        "hop_count": hop_count,
+                        "elapsed_ms": elapsed_ms,
+                        "timestamp": timestamp,
+                    });
+                    if let Some(k) = key {
+                        json["key"] = serde_json::Value::String(k.to_string());
+                    }
+                    json
                 }
             }
         }
@@ -3505,6 +3537,96 @@ mod tests {
         assert_eq!(json["reason"], "htl_exhausted");
         assert_eq!(json["elapsed_ms"], 1234);
         assert_eq!(json["timestamp"], 99999);
+    }
+
+    /// Core-bug regression guard: a streaming (> 64 KB) GET success must
+    /// reach the OTLP body as `get_terminal` with `outcome=success` and
+    /// `streamed=true`. This is the exact event the inline `get_success`
+    /// path drops (streaming replies arrive as `ResponseStreaming`, which
+    /// `register.rs` maps to `Ignored`), so without this the findability of
+    /// River rooms / UI-container contracts (all > 64 KB) is unmeasurable.
+    #[test]
+    fn test_event_kind_to_json_get_terminal_streaming_success() {
+        use crate::message::Transaction;
+        use crate::ring::PeerKeyLocation;
+        use crate::tracing::{GetEvent, GetTerminalOutcome};
+        use freenet_stdlib::prelude::{CodeHash, ContractInstanceId, ContractKey};
+
+        let tx = Transaction::new::<crate::operations::get::GetMsg>();
+        let requester = PeerKeyLocation::random();
+        let key = ContractKey::from_id_and_code(
+            ContractInstanceId::new([1u8; 32]),
+            CodeHash::new([2u8; 32]),
+        );
+        let instance_id = ContractInstanceId::new([9u8; 32]);
+
+        let event = EventKind::Get(GetEvent::ClientTerminal {
+            id: tx,
+            requester: requester.clone(),
+            instance_id,
+            key: Some(key),
+            outcome: GetTerminalOutcome::Success,
+            streamed: true,
+            is_sub_op: false,
+            attempts: 2,
+            hop_count: Some(3),
+            elapsed_ms: 1234,
+            timestamp: 99999,
+        });
+
+        // Metric name the central collector segments on.
+        assert_eq!(event_kind_to_string(&event), "get_terminal");
+
+        let json = event_kind_to_json(&event);
+        assert_eq!(json["type"], "get_terminal");
+        assert_eq!(json["id"], tx.to_string());
+        assert_eq!(json["requester"], requester.to_string());
+        assert_eq!(json["instance_id"], instance_id.to_string());
+        assert_eq!(json["outcome"], "success");
+        assert_eq!(json["streamed"], true);
+        assert_eq!(json["is_sub_op"], false);
+        assert_eq!(json["attempts"], 2);
+        assert_eq!(json["hop_count"], 3);
+        assert_eq!(json["elapsed_ms"], 1234);
+        assert_eq!(json["timestamp"], 99999);
+        assert!(json["key"].is_string());
+    }
+
+    /// A timeout-exhausted client GET now emits a `get_terminal` event with
+    /// `outcome=timeout_exhausted` (previously this path returned NotFound
+    /// to the client with NO telemetry event at all). No key on this path.
+    #[test]
+    fn test_event_kind_to_json_get_terminal_timeout_exhausted() {
+        use crate::message::Transaction;
+        use crate::ring::PeerKeyLocation;
+        use crate::tracing::{GetEvent, GetTerminalOutcome};
+        use freenet_stdlib::prelude::ContractInstanceId;
+
+        let tx = Transaction::new::<crate::operations::get::GetMsg>();
+        let requester = PeerKeyLocation::random();
+        let instance_id = ContractInstanceId::new([7u8; 32]);
+
+        let event = EventKind::Get(GetEvent::ClientTerminal {
+            id: tx,
+            requester,
+            instance_id,
+            key: None,
+            outcome: GetTerminalOutcome::TimeoutExhausted,
+            streamed: false,
+            is_sub_op: false,
+            attempts: 3,
+            hop_count: None,
+            elapsed_ms: 60000,
+            timestamp: 1,
+        });
+
+        assert_eq!(event_kind_to_string(&event), "get_terminal");
+        let json = event_kind_to_json(&event);
+        assert_eq!(json["outcome"], "timeout_exhausted");
+        assert_eq!(json["streamed"], false);
+        // No key and no hop_count on the timeout path — both serialize null.
+        assert!(json["key"].is_null());
+        assert!(json["hop_count"].is_null());
     }
 
     // ----- #4380: shadow sub-budget rate limiting -----


### PR DESCRIPTION
## Problem

`get_success` telemetry is synthesized ONLY from an inline
`GetMsg::Response{result: Found, value.state.is_some()}` in
`crates/core/src/tracing/register.rs`. Any GET whose payload exceeds the
64 KB `streaming_threshold` (default 65536) is delivered as
`GetMsg::ResponseStreaming`, which falls through to `_ => EventKind::Ignored`.

River rooms and UI-container contracts are all > 64 KB, so **their
successful GETs emit NO telemetry event at all** — the network's
findability is unmeasurable for exactly the contracts that matter.

Two secondary gaps:
- **Pure timeout-exhaustion** returned `NotFound` to the client with NO
  event (only a `tracing::info!`).
- **Sub-operation GETs** (phantom-repair, renewal, related-fetch) could
  not be distinguished from real client GETs, so they polluted any
  findability metric derived from GET events.

## Approach

Emit **exactly ONE** client-visible terminal event per client GET op from
the **originator / sub-op driver's terminal arms** (`drive_client_get_inner`
and `drive_sub_op_get` in `operations/get/op_ctx_task.rs`), which see the
true client outcome regardless of inline-vs-streaming delivery. Because it
fires at driver completion, it captures the streaming successes the inline
`register.rs` path drops — that is the core fix.

New `GetEvent::ClientTerminal` fields:
- `outcome`: `success` | `not_found` | `timeout_exhausted`
- `streamed: bool` (payload arrived via `ResponseStreaming`)
- `is_sub_op: bool`
- `attempts`, `hop_count` (when carried by the terminal reply), `key`

**Volume-conscious (explicit constraint — do not overwhelm the telemetry
server).** This is ONE event per client GET op — far FEWER than the
existing per-hop `get_request` / `get_not_found` events (which fire at
every hop). Net volume rises by ~1 event per client GET op (+1 per sub-op
GET); client GET ops are far fewer than total GET hops, so total volume
does not materially rise. **No per-hop or per-attempt events were added.**

**`is_sub_op` tagging** is passed EXPLICITLY by each driver rather than
derived solely from `tx.is_sub_operation()`: the sub-op GET drivers
construct their tx via `Transaction::new` (no parent), so
`is_sub_operation()` alone would wrongly report `false` for them. The
client driver tags from `client_tx.is_sub_operation()`; the sub-op driver
tags `true`.

**not_found vs timeout_exhausted** is distinguished by a new
`GetRetryDriver.saw_not_found` flag (GET's only `AttemptOutcome::Retry`
source is a `NotFound` reply) — no change to the shared retry loop.

This unblocks measuring the network's real findability, including for the
> 64 KB contracts that today are completely invisible.

### Note on the #4658 consult-counter export

The task also asked to export the terminal-consult counters
(`terminal_consult_attempts` / `hits` / `resolved_found` /
`still_not_found`). Verified this is **already complete in main**: the
fields exist in `RouterSnapshotInfo`, are populated in `ring.rs`, mirrored
in the OTLP JSON, and pinned by
`router_snapshot_json_includes_terminal_consult_counters`. No change
needed; the pin test stays green.

## Testing

- Pure outcome-mapping unit test (`done_terminal_outcome` /
  `exhausted_terminal_outcome`, all cases + stable OTLP `outcome` strings)
- Source-scrape pins: both client arms and both sub-op arms emit exactly
  once; client tags `is_sub_op` from the tx; sub-op tags it explicitly;
  the streaming Done arm sets `streamed=true`
- Telemetry JSON round-trip tests: a streaming (> 64 KB) success serializes
  to `get_terminal` / `outcome=success` / `streamed=true` (the core-bug
  regression guard); a timeout-exhausted GET serializes to
  `outcome=timeout_exhausted` with no key
- `cargo fmt` + `cargo clippy -p freenet -- -D warnings` clean; the
  `tracing`, `operations::get`, and `network_status` suites are green
  (217 passed, 0 failed)

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0199hK8Vdn5DAWcXJsxZHk8H