### PR TITLE
fix(hosting): size summarize cache to live hosted count to stop module thrash

### DIFF
--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -971,6 +971,16 @@ pub struct Executor<R = Runtime, S: StateStorage = Storage> {
     delegate_notification_tx: Option<DelegateNotificationSender>,
 }
 
+/// Summary/delta cache is sized to the live hosted-contract count (see
+/// `ensure_cache_covers_hosted_set`) so the ~5-min interest-heartbeat summarize
+/// never recompiles a cold module — coverage tied to the real count, not a
+/// contract-size assumption. MIN keeps small/mock nodes at the historical size;
+/// MAX bounds worst-case per-worker LRU-node overhead for pathologically tiny
+/// contracts (a byte-budget can hold far more small contracts than large ones).
+pub(crate) const SUMMARY_CACHE_MIN: usize = 1024;
+pub(crate) const SUMMARY_CACHE_MARGIN: usize = 256; // contracts hosted mid-cycle
+pub(crate) const SUMMARY_CACHE_MAX: usize = 65_536;
+
 impl<R, S> Executor<R, S>
 where
     S: StateStorage + Send + Sync + 'static,
@@ -1001,8 +1011,8 @@ where
             shared_summaries: None,
             shared_client_counts: None,
             recovery_guard: Arc::new(std::sync::Mutex::new(HashSet::new())),
-            summary_cache: LruCache::new(NonZeroUsize::new(1024).unwrap()),
-            delta_cache: LruCache::new(NonZeroUsize::new(1024).unwrap()),
+            summary_cache: LruCache::new(NonZeroUsize::new(SUMMARY_CACHE_MIN).unwrap()),
+            delta_cache: LruCache::new(NonZeroUsize::new(SUMMARY_CACHE_MIN).unwrap()),
             delegate_notification_tx: None,
         })
     }

--- a/crates/core/src/contract/executor/mock_wasm_runtime.rs
+++ b/crates/core/src/contract/executor/mock_wasm_runtime.rs
@@ -407,6 +407,35 @@ impl Executor<MockWasmRuntime, MockStateStorage> {
         Executor::new(state_store, || Ok(()), OperationMode::Local, runtime, None).await
     }
 
+    /// Like [`new_mock_wasm_uncached`](Self::new_mock_wasm_uncached) but also wires
+    /// a real `OpManager`, so `Ring::hosting_contracts_count()` reflects contracts
+    /// hosted via `op_manager.ring.host_contract(..)`. Used by the summary-cache
+    /// sizing test to prove `ensure_cache_covers_hosted_set` grows the caches to
+    /// the live hosted count (observable via `MockStateStorage::get_count`).
+    #[cfg(test)]
+    pub async fn new_mock_wasm_uncached_with_op_manager(
+        _identifier: &str,
+        shared_storage: MockStateStorage,
+        op_manager: std::sync::Arc<crate::node::OpManager>,
+    ) -> anyhow::Result<Self> {
+        let state_store = crate::wasm_runtime::StateStore::new_uncached(shared_storage);
+
+        let runtime = MockWasmRuntime {
+            contract_store: InMemoryContractStore::default(),
+            validate_overrides: HashMap::new(),
+            update_overrides: HashMap::new(),
+        };
+
+        Executor::new(
+            state_store,
+            || Ok(()),
+            OperationMode::Local,
+            runtime,
+            Some(op_manager),
+        )
+        .await
+    }
+
     /// Mutable access to the inner `MockWasmRuntime` so tests can install
     /// per-contract `validate_overrides` / `update_overrides` after the
     /// executor is wrapped in a handler. The `runtime` field is private to

--- a/crates/core/src/contract/executor/pool_tests/summarize_delta_cache_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/summarize_delta_cache_tests.rs
@@ -15,9 +15,13 @@
 
 use either::Either;
 use freenet_stdlib::prelude::*;
+use std::sync::Arc;
 
+use crate::config::ConfigArgs;
 use crate::contract::executor::mock_wasm_runtime::MockWasmRuntime;
-use crate::contract::executor::{ContractExecutor, Executor};
+use crate::contract::executor::{ContractExecutor, Executor, OperationMode};
+use crate::node::OpManager;
+use crate::ring::AccessType;
 use crate::wasm_runtime::MockStateStorage;
 
 use super::super::mock_runtime::test::create_test_contract as test_contract;
@@ -373,4 +377,133 @@ async fn summarize_with_cold_caches_recomputes_correctly() {
         blake3::hash(state.as_ref()).as_bytes(),
         "cold-cache executor must recompute the correct summary from disk"
     );
+}
+
+// =========================================================================
+// CACHE SIZING (coverage is driven by the live hosted COUNT, not a fixed cap)
+// =========================================================================
+
+/// Build a real `OpManager` backed by a temp-dir `Config` so
+/// `Ring::hosting_contracts_count()` reflects contracts hosted via
+/// `op_manager.ring.host_contract(..)`. Mirrors
+/// `disk_budget_gate_tests::build_op_manager`; the returned guard bundle keeps the
+/// channel receivers + task monitor alive for the whole test (dropping them
+/// mid-run would tear down the OpManager's channels).
+async fn build_op_manager(id: &str) -> (Arc<OpManager>, Box<dyn std::any::Any>) {
+    let config_args = ConfigArgs {
+        id: Some(id.to_string()),
+        mode: Some(OperationMode::Local),
+        ..Default::default()
+    };
+    let node_config =
+        crate::node::NodeConfig::new(config_args.build().await.expect("build Config"))
+            .await
+            .expect("build NodeConfig");
+
+    let (notification_rx, notification_tx) = crate::node::event_loop_notification_channel();
+    let (ops_ch_channel, ch_channel, wait_for_event) = crate::contract::contract_handler_channel();
+    let connection_manager = crate::ring::ConnectionManager::new(&node_config);
+    let (result_router_tx, result_router_rx) = tokio::sync::mpsc::channel(100);
+    let task_monitor = crate::node::background_task_monitor::BackgroundTaskMonitor::new();
+
+    let op_manager = Arc::new(
+        OpManager::new(
+            notification_tx,
+            ops_ch_channel,
+            &node_config,
+            crate::tracing::DynamicRegister::new(vec![]),
+            connection_manager,
+            result_router_tx,
+            &task_monitor,
+        )
+        .expect("build OpManager"),
+    );
+    op_manager.ring.attach_op_manager(&op_manager);
+
+    let guards: Box<dyn std::any::Any> = Box::new((
+        notification_rx,
+        ch_channel,
+        wait_for_event,
+        result_router_rx,
+        task_monitor,
+    ));
+    (op_manager, guards)
+}
+
+/// The summary cache must cover the node's live hosted-contract COUNT, not sit at
+/// a fixed capacity. This proves it by count, not by a magic threshold: for
+/// several hosted-set sizes (including well past the historical 1024 cap),
+/// summarizing the whole hosted set twice must reload state ZERO times on the
+/// second pass — which only holds if the cache grew to cover every hosted
+/// contract. Under the old fixed 1024-entry cap the 3000/5000 cases would evict
+/// the earliest keys and reload (and thus recompile a cold module) on pass 2:
+/// exactly the interest-heartbeat thrash this fix removes. Uses an uncached
+/// `StateStore` so every reload is observable via `MockStateStorage::get_count`.
+#[tokio::test(flavor = "current_thread")]
+async fn summary_cache_covers_live_hosted_count_not_fixed_cap() {
+    for n in [1024usize, 3000, 5000] {
+        let storage = MockStateStorage::new();
+        let (op_manager, _guards) = build_op_manager(&format!("cache_cover_{n}")).await;
+        let mut exec = Executor::new_mock_wasm_uncached_with_op_manager(
+            "cache_cover",
+            storage.clone(),
+            op_manager.clone(),
+        )
+        .await
+        .expect("create uncached executor with op_manager");
+
+        // Store N distinct contracts+states and host each one, driving
+        // `hosting_contracts_count()` to exactly N.
+        let mut keys = Vec::with_capacity(n);
+        for i in 0..n {
+            let contract = test_contract(format!("cache_cover_{n}_{i}").as_bytes());
+            let key = contract.key();
+            let state = WrappedState::new(vec![(i & 0xff) as u8, (i >> 8) as u8, 1, 2, 3]);
+            exec.upsert_contract_state(
+                key,
+                Either::Left(state.clone()),
+                RelatedContracts::default(),
+                Some(contract.clone()),
+            )
+            .await
+            .expect("PUT");
+            op_manager
+                .ring
+                .host_contract(key, state.as_ref().len() as u64, AccessType::Get);
+            keys.push(key);
+        }
+        assert_eq!(
+            op_manager.ring.hosting_contracts_count(),
+            n,
+            "all {n} contracts must be hosted (this count is what drives cache sizing)"
+        );
+
+        // Pass 1: cold summarize of every hosted contract. The first call resizes
+        // the cache to cover the live hosted count; all N summaries then fill it.
+        for key in &keys {
+            let _ = exec
+                .summarize_contract_state(*key)
+                .await
+                .expect("summarize pass 1");
+        }
+        let gets_after_pass1 = storage.get_count();
+
+        // Pass 2: summarize every hosted contract again, all unchanged. If the
+        // cache covers the whole hosted set, every summary hits the fast path and
+        // reloads NOTHING. A fixed cap < N would have evicted the earliest keys,
+        // forcing reloads here (get_count would climb).
+        for key in &keys {
+            let _ = exec
+                .summarize_contract_state(*key)
+                .await
+                .expect("summarize pass 2");
+        }
+        assert_eq!(
+            storage.get_count(),
+            gets_after_pass1,
+            "pass 2 reloaded state for hosted_count={n}: the summary cache must be sized \
+             to the live hosted count so no cold-module recompute happens on the interest \
+             heartbeat (a fixed cap < N evicts and reloads)"
+        );
+    }
 }

--- a/crates/core/src/contract/executor/runtime/executor_impl.rs
+++ b/crates/core/src/contract/executor/runtime/executor_impl.rs
@@ -15,6 +15,36 @@ where
     S: crate::wasm_runtime::StateStorage + Send + Sync + 'static,
     <S as crate::wasm_runtime::StateStorage>::Error: Into<anyhow::Error>,
 {
+    /// Grow the summary/delta caches to cover the node's live hosted-contract count
+    /// before a summarize/delta computation, so the interest-heartbeat's full hosted
+    /// working set stays cached across cycles (no cold-module recompile). Tied to the
+    /// real count via `Ring::hosting_contracts_count()`, clamped [MIN, MAX]. O(1) when
+    /// already sized (the common case after warm-up): a count read + a compare.
+    /// `lru::resize` grows lazily (no preallocation), so memory tracks actual entries.
+    fn ensure_cache_covers_hosted_set(&mut self) {
+        use crate::contract::executor::{
+            SUMMARY_CACHE_MARGIN, SUMMARY_CACHE_MAX, SUMMARY_CACHE_MIN,
+        };
+        use std::num::NonZeroUsize;
+
+        let Some(om) = self.op_manager.as_ref() else {
+            return;
+        };
+        let hosted = om.ring.hosting_contracts_count();
+        let needed = hosted
+            .saturating_add(SUMMARY_CACHE_MARGIN)
+            .clamp(SUMMARY_CACHE_MIN, SUMMARY_CACHE_MAX)
+            .next_power_of_two()
+            .min(SUMMARY_CACHE_MAX);
+        if needed > self.summary_cache.cap().get() {
+            self.summary_cache
+                .resize(NonZeroUsize::new(needed).unwrap());
+        }
+        if needed > self.delta_cache.cap().get() {
+            self.delta_cache.resize(NonZeroUsize::new(needed).unwrap());
+        }
+    }
+
     pub(in crate::contract::executor) fn bridged_lookup_key(
         &self,
         instance_id: &ContractInstanceId,
@@ -1164,6 +1194,10 @@ where
         &mut self,
         key: ContractKey,
     ) -> Result<StateSummary<'static>, ExecutorError> {
+        // Size the caches to the live hosted set before any lookup/insert, so the
+        // interest-heartbeat's full working set stays cached across cycles.
+        self.ensure_cache_covers_hosted_set();
+
         // Fast path (the hot path on a busy node — tens/sec over MB-scale
         // states): if the state store holds a cheap change-detector hash for
         // this contract's CURRENT state AND we already have a summary cached
@@ -1243,6 +1277,10 @@ where
         key: ContractKey,
         their_summary: StateSummary<'static>,
     ) -> Result<StateDelta<'static>, ExecutorError> {
+        // Size the caches to the live hosted set before any lookup/insert, so the
+        // interest-heartbeat's full working set stays cached across cycles.
+        self.ensure_cache_covers_hosted_set();
+
         // Hash the peer's summary up front — it's a small digest, so this is
         // cheap (unlike the full state). Only the STATE component of the cache
         // key gets the cheap change-detector treatment below.


### PR DESCRIPTION
## Problem

Gateways thrash the compiled-WASM module cache. The ~5-min InterestSync
heartbeat runs WASM `summarize` for every hosted contract, but the
per-executor `summary_cache` / `delta_cache` (`lru::LruCache`) were seeded
at a flat **1024** entries. On a gateway hosting ~2600 contracts, ~1576
keys per cycle miss the cache and recompile a cold module every cycle.

The flat 1024 was a magic number unrelated to the working set it must
cover, so coverage silently degraded as the hosted set grew.

## Approach

Tie the cache size to the **real** working set rather than a guess.
Before a summarize/delta computation, `ensure_cache_covers_hosted_set`
grows the caches to the node's live hosted-contract count
(`Ring::hosting_contracts_count()`, a node-tracked metric) plus a small
mid-cycle margin, rounded up to a power of two and clamped to
`[SUMMARY_CACHE_MIN, SUMMARY_CACHE_MAX]`.

- **Guaranteed coverage for any count** — not for one assumed count, and
  not via a contract-size/byte-budget proxy (which was PR #4794's earlier
  `clamp(budget / 128 KiB, ...)` divisor approach; this count-tied resize
  replaces it).
- **O(1) once warmed** — a count read + a compare; the resize only fires
  when the hosted set actually grew past the current capacity.
- **Lazy memory** — `lru::resize` grows with no preallocation, so resident
  memory tracks the actual entry count, not the capacity.
- **`SUMMARY_CACHE_MIN` (1024)** keeps small/mock nodes at the historical
  size. **`SUMMARY_CACHE_MAX` (65536)** bounds worst-case per-worker
  LRU-node overhead for pathologically tiny contracts (a byte budget can
  hold far more small contracts than large ones); `.next_power_of_two()`
  can round above MAX, hence the trailing `.min(MAX)`.

**Delta-cache caveat:** the delta cache key includes a per-peer summary
hash, so during fan-out it can hold more than one entry per contract.
Sizing it to the hosted count is a strict improvement and removes the
size assumption, but is count-scaled best-effort rather than a
per-subscriber guarantee. Summary-cache coverage is exact.

Built off current `origin/main` (flat `LruCache::new(1024)`), not #4794's
branch.

## Testing

New test `summary_cache_covers_live_hosted_count_not_fixed_cap` proves
coverage is driven by the **count**, not a threshold. For `N` in
`{1024, 3000, 5000}` it stores N distinct contracts+states against an
**uncached** state store and hosts each (driving
`hosting_contracts_count() == N`), then summarizes the whole hosted set
twice. The second pass must reload state **zero** times — observable via
`MockStateStorage::get_count` — which only holds if the cache grew to
cover every hosted contract. Under the old fixed 1024 cap the 3000/5000
cases would evict the earliest keys and reload (recompiling a cold
module) on pass 2.

`cargo test -p freenet --lib contract::executor::pool_tests::summarize_delta_cache_tests`
→ 7 passed / 0 failed. `cargo clippy -p freenet --lib -- -D warnings` clean.

Refs #4642 (demand-driven hosting epic).

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0199hK8Vdn5DAWcXJsxZHk8H
