### PR TITLE
feat(telemetry): isolate large-transfer, NAT, and routing failure modes

### DIFF
--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -411,13 +411,21 @@ pub struct TerminalConsultStats {
 #[derive(Default)]
 pub struct StreamAbortStats {
     /// Receiver aborts: no fragment arrived within the inactivity window.
+    /// Recorded in transport `StreamHandle::assemble`, so this AGGREGATES across
+    /// GET + PUT + UPDATE inbound streams (any op that assembles a streamed
+    /// transfer), not GET fetches alone.
     pub recv_inactivity: u64,
     /// Receiver aborts: stream cancelled / connection closed mid-transfer.
+    /// Like `recv_inactivity`, recorded in transport `StreamHandle::assemble`
+    /// and therefore AGGREGATED across GET + PUT + UPDATE inbound streams.
     pub recv_cancelled: u64,
     /// Receiver aborts: no inbound stream was ever claimed (claim timed out).
+    /// GET-fetch-only: recorded in the GET originator's
+    /// `assemble_and_cache_stream`, so PUT/UPDATE streams are not included.
     pub recv_claim_timeout: u64,
     /// Receiver aborts: bytes fully received but payload failed to deserialize
     /// or was structurally invalid (key mismatch / missing state).
+    /// GET-fetch-only, same site as `recv_claim_timeout`.
     pub recv_deserialize: u64,
     /// Sender aborts: cwnd-wait timed out (ACKs stopped arriving) — the stream
     /// was failed rather than blocking the connection forever.
@@ -1011,7 +1019,13 @@ pub fn record_relayed_subscribe() {
     }
 }
 
-/// Record that this node relayed (forwarded one hop) an UPDATE request.
+/// Record that this node relayed (forwarded one hop) an UPDATE *request*
+/// toward the contract key. Counts both `UpdateMsg::RequestUpdate` and its
+/// large-payload variant `RequestUpdateStreaming` (the same logical relayed
+/// request). Does NOT count `BroadcastTo` / `BroadcastToStreaming`: those are
+/// update-mesh fan-out to interested co-hosts, not a request relayed one hop
+/// toward the key, and counting them would conflate relay volume with fan-out
+/// volume (one update -> N broadcasts).
 pub fn record_relayed_update() {
     if let Some(status) = NETWORK_STATUS.get() {
         if let Ok(mut s) = status.write() {

--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -218,6 +218,12 @@ pub struct NetworkStatus {
     pub nat_stats: NatStats,
     /// Terminal advertisement-consult counters (hosting redesign piece C).
     pub terminal_consult_stats: TerminalConsultStats,
+    /// Streamed-transfer abort counters (large-contract failure isolation).
+    pub stream_abort_stats: StreamAbortStats,
+    /// Relayed-operation counters (routing/hosting attribution).
+    pub relayed_op_stats: RelayedOpStats,
+    /// Connect-event emission counters (firehose-retirement precursor).
+    pub connect_emit_stats: ConnectEmitStats,
     /// Computed-upstream vs. stored-`is_upstream`-flag divergence counters
     /// (hosting redesign piece D, #4642 / #4671).
     pub upstream_divergence_stats: UpstreamDivergenceStats,
@@ -391,6 +397,85 @@ pub struct TerminalConsultStats {
     pub still_not_found: u64,
 }
 
+/// Streamed-transfer (> 64 KB `streaming_threshold`) abort counters, aggregated
+/// per-node so the large-contract failure class (~50% of large fetches were
+/// failing) is legible in central telemetry WITHOUT a per-fragment or
+/// per-transfer event stream. Recorded at the receiver stream-assembly abort
+/// sites (transport `StreamHandle::assemble` for inactivity/cancelled; the GET
+/// originator's `assemble_and_cache_stream` for claim-timeout/deserialize) and
+/// the sender cwnd-wait abort site; read into `RouterSnapshotInfo` on the
+/// existing snapshot cadence. All monotonic lifetime totals (the collector
+/// differences them across the cadence). The `frac_*` fields are a
+/// fragment-progress histogram bumped ONCE per receiver abort, bucketing how far
+/// the transfer got before dying — the WHERE signal.
+#[derive(Default)]
+pub struct StreamAbortStats {
+    /// Receiver aborts: no fragment arrived within the inactivity window.
+    pub recv_inactivity: u64,
+    /// Receiver aborts: stream cancelled / connection closed mid-transfer.
+    pub recv_cancelled: u64,
+    /// Receiver aborts: no inbound stream was ever claimed (claim timed out).
+    pub recv_claim_timeout: u64,
+    /// Receiver aborts: bytes fully received but payload failed to deserialize
+    /// or was structurally invalid (key mismatch / missing state).
+    pub recv_deserialize: u64,
+    /// Sender aborts: cwnd-wait timed out (ACKs stopped arriving) — the stream
+    /// was failed rather than blocking the connection forever.
+    pub send_cwnd: u64,
+    /// Fragment-progress histogram, one bump per receiver abort: 0% received.
+    pub frac_0: u64,
+    /// Fragment-progress histogram: 100% received but still aborted (payload /
+    /// deserialize failure after full receipt).
+    pub frac_1: u64,
+    /// Fragment-progress histogram: (0%, 50%) received.
+    pub frac_lt50: u64,
+    /// Fragment-progress histogram: [50%, 90%) received.
+    pub frac_50_90: u64,
+    /// Fragment-progress histogram: [90%, 100%) received.
+    pub frac_ge90: u64,
+}
+
+/// Immutable copy of [`StreamAbortStats`] returned by [`stream_abort_counts`]
+/// for the `Ring` snapshot task to mirror onto `RouterSnapshotInfo`.
+#[derive(Clone, Copy, Default)]
+pub struct StreamAbortSnapshot {
+    pub recv_inactivity: u64,
+    pub recv_cancelled: u64,
+    pub recv_claim_timeout: u64,
+    pub recv_deserialize: u64,
+    pub send_cwnd: u64,
+    pub frac_0: u64,
+    pub frac_1: u64,
+    pub frac_lt50: u64,
+    pub frac_50_90: u64,
+    pub frac_ge90: u64,
+}
+
+/// Count of operations this node RELAYED (forwarded a request one hop toward its
+/// key, as a routing intermediary — not the client originator). One increment
+/// per relay-driver entry. Per-node monotonic totals for routing/hosting
+/// attribution on the snapshot cadence; the collector differences them to see
+/// how much traffic a peer relays vs. originates.
+#[derive(Default)]
+pub struct RelayedOpStats {
+    pub gets: u64,
+    pub puts: u64,
+    pub subscribes: u64,
+    pub updates: u64,
+}
+
+/// Count of connect telemetry events this node EMITTED to the collector, added
+/// so the per-event `connect_connected` / `connect_rejected` firehose (~92k
+/// events / 18 min) can eventually be replaced by these aggregate snapshot
+/// counters. The per-event emission is NOT retired yet — a downstream dashboard
+/// likely still consumes the per-event stream — see the `TODO(follow-up)` at the
+/// increment site. Per-node monotonic totals.
+#[derive(Default)]
+pub struct ConnectEmitStats {
+    pub accepts_emitted: u64,
+    pub rejects_emitted: u64,
+}
+
 /// A connected peer with metadata.
 pub struct ConnectedPeer {
     pub address: SocketAddr,
@@ -551,6 +636,9 @@ pub fn init(listening_port: u16, gateway_addrs: HashSet<SocketAddr>, version: St
         op_stats: OperationStats::default(),
         nat_stats: NatStats::default(),
         terminal_consult_stats: TerminalConsultStats::default(),
+        stream_abort_stats: StreamAbortStats::default(),
+        relayed_op_stats: RelayedOpStats::default(),
+        connect_emit_stats: ConnectEmitStats::default(),
         upstream_divergence_stats: UpstreamDivergenceStats::default(),
         reconcile_shadow_collapse: ReconcileShadowStats::default(),
         reconcile_shadow_renewal: ReconcileShadowStats::default(),
@@ -786,6 +874,202 @@ pub fn terminal_consult_counts() -> Option<(u64, u64, u64, u64)> {
     let s = status.read().ok()?;
     let c = &s.terminal_consult_stats;
     Some((c.attempts, c.hits, c.resolved_found, c.still_not_found))
+}
+
+/// Bump the fragment-progress histogram bucket for one receiver abort.
+/// `received`/`total` come from the stream handle; `None` (no handle, e.g. a
+/// claim timeout) counts as 0% (`frac_0`).
+fn bump_stream_frac(stats: &mut StreamAbortStats, received: Option<u32>, total: Option<u32>) {
+    match (received, total) {
+        (Some(r), Some(t)) if t > 0 => {
+            if r == 0 {
+                stats.frac_0 = stats.frac_0.saturating_add(1);
+            } else if r >= t {
+                stats.frac_1 = stats.frac_1.saturating_add(1);
+            } else {
+                // Integer-only bucketing avoids float rounding at the edges.
+                let pct = (r as u64) * 100 / (t as u64);
+                if pct < 50 {
+                    stats.frac_lt50 = stats.frac_lt50.saturating_add(1);
+                } else if pct < 90 {
+                    stats.frac_50_90 = stats.frac_50_90.saturating_add(1);
+                } else {
+                    stats.frac_ge90 = stats.frac_ge90.saturating_add(1);
+                }
+            }
+        }
+        // No usable fragment counts (claim timeout, or total unknown): treat as
+        // zero progress so every abort lands in exactly one bucket.
+        _ => stats.frac_0 = stats.frac_0.saturating_add(1),
+    }
+}
+
+/// Record a receiver stream-assembly abort: no fragment arrived within the
+/// inactivity window. Called from the transport `StreamHandle::assemble` site
+/// (covers both the GET originator and relay receive paths).
+pub fn record_stream_recv_abort_inactivity(received: Option<u32>, total: Option<u32>) {
+    if let Some(status) = NETWORK_STATUS.get() {
+        if let Ok(mut s) = status.write() {
+            s.stream_abort_stats.recv_inactivity =
+                s.stream_abort_stats.recv_inactivity.saturating_add(1);
+            bump_stream_frac(&mut s.stream_abort_stats, received, total);
+        }
+    }
+}
+
+/// Record a receiver stream-assembly abort: the stream was cancelled or the
+/// connection closed mid-transfer.
+pub fn record_stream_recv_abort_cancelled(received: Option<u32>, total: Option<u32>) {
+    if let Some(status) = NETWORK_STATUS.get() {
+        if let Ok(mut s) = status.write() {
+            s.stream_abort_stats.recv_cancelled =
+                s.stream_abort_stats.recv_cancelled.saturating_add(1);
+            bump_stream_frac(&mut s.stream_abort_stats, received, total);
+        }
+    }
+}
+
+/// Record a receiver stream abort: no inbound stream was ever claimed (the
+/// claim timed out); zero fragments observed.
+pub fn record_stream_recv_abort_claim_timeout() {
+    if let Some(status) = NETWORK_STATUS.get() {
+        if let Ok(mut s) = status.write() {
+            s.stream_abort_stats.recv_claim_timeout =
+                s.stream_abort_stats.recv_claim_timeout.saturating_add(1);
+            bump_stream_frac(&mut s.stream_abort_stats, None, None);
+        }
+    }
+}
+
+/// Record a receiver stream abort: all bytes arrived but the payload failed to
+/// deserialize or was structurally invalid (key mismatch / missing state).
+pub fn record_stream_recv_abort_deserialize(received: Option<u32>, total: Option<u32>) {
+    if let Some(status) = NETWORK_STATUS.get() {
+        if let Ok(mut s) = status.write() {
+            s.stream_abort_stats.recv_deserialize =
+                s.stream_abort_stats.recv_deserialize.saturating_add(1);
+            bump_stream_frac(&mut s.stream_abort_stats, received, total);
+        }
+    }
+}
+
+/// Record a sender stream abort: cwnd-wait timed out (ACKs stopped arriving) and
+/// the stream was failed rather than blocking the connection.
+pub fn record_stream_send_abort_cwnd() {
+    if let Some(status) = NETWORK_STATUS.get() {
+        if let Ok(mut s) = status.write() {
+            s.stream_abort_stats.send_cwnd = s.stream_abort_stats.send_cwnd.saturating_add(1);
+        }
+    }
+}
+
+/// Read the current streamed-transfer abort counters for export to the
+/// `router_snapshot` telemetry event. `None` before the singleton is
+/// initialized (i.e. always populated in production snapshots).
+pub fn stream_abort_counts() -> Option<StreamAbortSnapshot> {
+    let status = NETWORK_STATUS.get()?;
+    let s = status.read().ok()?;
+    let a = &s.stream_abort_stats;
+    Some(StreamAbortSnapshot {
+        recv_inactivity: a.recv_inactivity,
+        recv_cancelled: a.recv_cancelled,
+        recv_claim_timeout: a.recv_claim_timeout,
+        recv_deserialize: a.recv_deserialize,
+        send_cwnd: a.send_cwnd,
+        frac_0: a.frac_0,
+        frac_1: a.frac_1,
+        frac_lt50: a.frac_lt50,
+        frac_50_90: a.frac_50_90,
+        frac_ge90: a.frac_ge90,
+    })
+}
+
+/// Record that this node relayed (forwarded one hop) a GET request.
+pub fn record_relayed_get() {
+    if let Some(status) = NETWORK_STATUS.get() {
+        if let Ok(mut s) = status.write() {
+            s.relayed_op_stats.gets = s.relayed_op_stats.gets.saturating_add(1);
+        }
+    }
+}
+
+/// Record that this node relayed (forwarded one hop) a PUT request.
+pub fn record_relayed_put() {
+    if let Some(status) = NETWORK_STATUS.get() {
+        if let Ok(mut s) = status.write() {
+            s.relayed_op_stats.puts = s.relayed_op_stats.puts.saturating_add(1);
+        }
+    }
+}
+
+/// Record that this node relayed (forwarded one hop) a SUBSCRIBE request.
+pub fn record_relayed_subscribe() {
+    if let Some(status) = NETWORK_STATUS.get() {
+        if let Ok(mut s) = status.write() {
+            s.relayed_op_stats.subscribes = s.relayed_op_stats.subscribes.saturating_add(1);
+        }
+    }
+}
+
+/// Record that this node relayed (forwarded one hop) an UPDATE request.
+pub fn record_relayed_update() {
+    if let Some(status) = NETWORK_STATUS.get() {
+        if let Ok(mut s) = status.write() {
+            s.relayed_op_stats.updates = s.relayed_op_stats.updates.saturating_add(1);
+        }
+    }
+}
+
+/// Read the current relayed-operation counters for export to `router_snapshot`.
+/// Returns `(gets, puts, subscribes, updates)` or `None` before the singleton
+/// is initialized.
+pub fn relayed_op_counts() -> Option<(u64, u64, u64, u64)> {
+    let status = NETWORK_STATUS.get()?;
+    let s = status.read().ok()?;
+    let r = &s.relayed_op_stats;
+    Some((r.gets, r.puts, r.subscribes, r.updates))
+}
+
+/// Record that a `connect_connected` telemetry event was emitted to the
+/// collector (aggregate precursor to retiring the per-event firehose).
+pub fn record_connect_accept_emitted() {
+    if let Some(status) = NETWORK_STATUS.get() {
+        if let Ok(mut s) = status.write() {
+            s.connect_emit_stats.accepts_emitted =
+                s.connect_emit_stats.accepts_emitted.saturating_add(1);
+        }
+    }
+}
+
+/// Record that a `connect_rejected` telemetry event was emitted to the
+/// collector (aggregate precursor to retiring the per-event firehose).
+pub fn record_connect_reject_emitted() {
+    if let Some(status) = NETWORK_STATUS.get() {
+        if let Ok(mut s) = status.write() {
+            s.connect_emit_stats.rejects_emitted =
+                s.connect_emit_stats.rejects_emitted.saturating_add(1);
+        }
+    }
+}
+
+/// Read the current connect-event emission counters for export to
+/// `router_snapshot`. Returns `(accepts_emitted, rejects_emitted)` or `None`
+/// before the singleton is initialized.
+pub fn connect_emit_counts() -> Option<(u64, u64)> {
+    let status = NETWORK_STATUS.get()?;
+    let s = status.read().ok()?;
+    let c = &s.connect_emit_stats;
+    Some((c.accepts_emitted, c.rejects_emitted))
+}
+
+/// Count of this node's active connections that are to gateways (the
+/// NAT-stranded fingerprint — a peer stuck on gateways only). Read from the
+/// authoritative tracked `connected_peers` list. `None` before the singleton is
+/// initialized.
+pub fn connections_to_gateways() -> Option<u64> {
+    let status = NETWORK_STATUS.get()?;
+    let s = status.read().ok()?;
+    Some(s.connected_peers.iter().filter(|p| p.is_gateway).count() as u64)
 }
 
 /// Record one computed-upstream vs. stored-`is_upstream`-flag comparison

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -55,8 +55,9 @@ use crate::operations::VisitedPeers;
 use crate::operations::bootstrap::bootstrap_gateway_target;
 use crate::ring::{Location, PeerKeyLocation};
 use crate::router::{RouteEvent, RouteOutcome};
-use crate::tracing::GetTerminalOutcome;
+use crate::tracing::{GetTerminalOutcome, StreamAbortCause};
 use crate::transport::peer_connection::StreamId;
+use crate::transport::peer_connection::streaming::StreamError;
 
 use super::{GetMsg, GetMsgResult, GetStreamingPayload};
 use crate::operations::orphan_streams::{OrphanStreamError, STREAM_CLAIM_TIMEOUT};
@@ -284,6 +285,9 @@ async fn emit_get_terminal_event(
     is_sub_op: bool,
     attempts: usize,
     hop_count: Option<usize>,
+    fragments_received: Option<u32>,
+    total_fragments: Option<u32>,
+    stream_abort_cause: Option<StreamAbortCause>,
 ) {
     if let Some(log_event) = crate::tracing::NetEventLog::get_terminal(
         &tx,
@@ -295,6 +299,9 @@ async fn emit_get_terminal_event(
         is_sub_op,
         attempts,
         hop_count,
+        fragments_received,
+        total_fragments,
+        stream_abort_cause,
     ) {
         op_manager
             .ring
@@ -330,6 +337,9 @@ pub(crate) async fn emit_local_get_terminal_event(
         false, // a real client GET, not a sub-op
         0,     // local hit: no network request was sent
         None,  // no hop count for a local hit
+        None,  // no stream: fragment/abort fields are streaming-only
+        None,
+        None,
     )
     .await;
 }
@@ -650,6 +660,13 @@ async fn drive_client_get_inner(
             let outcome = done_terminal_outcome(host_result.is_ok());
             let is_sub_op = client_tx.is_sub_operation();
             let attempts = driver.requests_sent;
+            // Streamed-transfer failure-isolation fields (Group B). Populated by
+            // the assembly wrapper on both the streaming success and failure
+            // paths; `None` on non-streaming terminals. `abort_cause` is `Some`
+            // only when a streaming assembly actually failed.
+            let stream_fragments_received = streaming_assembly.fragments_received;
+            let stream_total_fragments = streaming_assembly.total_fragments;
+            let stream_abort_cause = streaming_assembly.abort_cause;
 
             // For a BLOCKING subscribe hand-off the client result is not
             // delivered until `maybe_subscribe_child`'s inline await
@@ -672,6 +689,9 @@ async fn drive_client_get_inner(
                     is_sub_op,
                     attempts,
                     hop_count,
+                    stream_fragments_received,
+                    stream_total_fragments,
+                    stream_abort_cause,
                 )
                 .await;
             }
@@ -704,6 +724,9 @@ async fn drive_client_get_inner(
                     is_sub_op,
                     attempts,
                     hop_count,
+                    stream_fragments_received,
+                    stream_total_fragments,
+                    stream_abort_cause,
                 )
                 .await;
             }
@@ -739,6 +762,9 @@ async fn drive_client_get_inner(
                 false,
                 client_tx.is_sub_operation(),
                 driver.requests_sent,
+                None,
+                None, // no streaming header ever seen on the exhausted path
+                None,
                 None,
             )
             .await;
@@ -1009,6 +1035,33 @@ struct AssemblyOutcome {
     /// Threaded into the synthesized client error so the failure is
     /// diagnosable instead of the generic store-lookup message.
     error: Option<String>,
+    /// Fragments received / expected on the last streaming attempt (success or
+    /// failure), read from the stream handle and threaded into the terminal
+    /// telemetry event so WHERE a large fetch died is legible. `None` when the
+    /// terminal was not `Streaming`, or on the claim-timeout path (no handle).
+    fragments_received: Option<u32>,
+    total_fragments: Option<u32>,
+    /// Classified cause of a streaming assembly failure; `None` on success.
+    abort_cause: Option<StreamAbortCause>,
+}
+
+/// Fragment progress from a streaming GET assembly attempt (#4345 telemetry),
+/// threaded into the terminal event on the SUCCESS path.
+#[derive(Default, Clone, Copy)]
+struct StreamProgress {
+    fragments_received: Option<u32>,
+    total_fragments: Option<u32>,
+}
+
+/// Structured streaming-assembly failure (#4345 telemetry). `message` is the
+/// human-readable cause kept for the existing client-error synthesis
+/// (`synthesized_get_error_cause`); `cause` + fragment counts feed the terminal
+/// telemetry event so analysts can see WHERE a large fetch died.
+struct AssemblyFailure {
+    message: String,
+    cause: StreamAbortCause,
+    fragments_received: Option<u32>,
+    total_fragments: Option<u32>,
 }
 
 /// Drive the shared GET retry loop, treating stream-assembly failure
@@ -1135,9 +1188,12 @@ async fn drive_get_with_assembly_retry(
         match assemble_and_cache_stream(op_manager, peer_addr, stream_id, key, includes_contract)
             .await
         {
-            Ok(()) => {
+            Ok(progress) => {
                 assembly.transfer_duration = Some(stream_start.elapsed());
                 assembly.error = None;
+                assembly.fragments_received = progress.fragments_received;
+                assembly.total_fragments = progress.total_fragments;
+                assembly.abort_cause = None;
                 break result;
             }
             Err(e) => {
@@ -1145,11 +1201,18 @@ async fn drive_get_with_assembly_retry(
                 // `current_target` — the routing penalty must land on
                 // the candidate whose header never became a stream.
                 let failed_target = driver.current_target.clone();
+                // Capture the structured progress/cause for the terminal
+                // telemetry event BEFORE `e.message` is moved into
+                // `assembly.error`, so the emitted `get_terminal` carries WHERE
+                // this attempt died even after the string is consumed.
+                assembly.fragments_received = e.fragments_received;
+                assembly.total_fragments = e.total_fragments;
+                assembly.abort_cause = Some(e.cause);
                 match driver.advance() {
                     AdvanceOutcome::Next => {
                         tracing::warn!(
                             %key,
-                            error = %e,
+                            error = %e.message,
                             retries = driver.retries,
                             "get: stream assembly failed; \
                              retrying against next candidate (#4345)"
@@ -1169,7 +1232,7 @@ async fn drive_get_with_assembly_retry(
                         #[cfg(any(test, feature = "testing"))]
                         assembly_fault_injection::ASSEMBLY_RETRY_COUNT
                             .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-                        assembly.error = Some(e);
+                        assembly.error = Some(e.message);
                         // Remember the header so a later wire
                         // exhaustion converts back to Done(Streaming)
                         // instead of surfacing a false NotFound.
@@ -1180,11 +1243,11 @@ async fn drive_get_with_assembly_retry(
                     AdvanceOutcome::Exhausted => {
                         tracing::warn!(
                             %key,
-                            error = %e,
+                            error = %e.message,
                             "get: stream assembly failed and retry budget \
                              exhausted — state will not be cached locally"
                         );
-                        assembly.error = Some(e);
+                        assembly.error = Some(e.message);
                         break result;
                     }
                 }
@@ -1606,13 +1669,19 @@ async fn assemble_and_cache_stream(
     stream_id: StreamId,
     expected_key: ContractKey,
     includes_contract: bool,
-) -> Result<(), String> {
+) -> Result<StreamProgress, AssemblyFailure> {
     // Test-only deterministic fault injection (#4345). Returning before
-    // the claim mirrors the production failure (the inbound stream is
-    // left orphaned for GC), so the retry path is exercised end-to-end.
+    // the claim mirrors the production claim-timeout failure (the inbound
+    // stream is left orphaned for GC), so the retry path is exercised
+    // end-to-end; classify it as ClaimTimeout for the terminal event.
     #[cfg(any(test, feature = "testing"))]
     if assembly_fault_injection::consume(&expected_key) {
-        return Err("injected stream assembly failure (assembly_fault_injection test hook)".into());
+        return Err(AssemblyFailure {
+            message: "injected stream assembly failure (assembly_fault_injection test hook)".into(),
+            cause: StreamAbortCause::ClaimTimeout,
+            fragments_received: None,
+            total_fragments: None,
+        });
     }
 
     let handle = match op_manager
@@ -1627,28 +1696,95 @@ async fn assemble_and_cache_stream(
                 %stream_id,
                 "stream already claimed (dedup)"
             );
-            return Ok(());
+            return Ok(StreamProgress::default());
         }
-        Err(e) => return Err(format!("claim_or_wait: {e}")),
+        Err(e) => {
+            // No inbound stream was ever claimed — zero fragments observed.
+            // Recorded here (not at the transport `StreamHandle::assemble`
+            // site) because this failure is owned by the claim layer, which
+            // never reaches `assemble`.
+            crate::node::network_status::record_stream_recv_abort_claim_timeout();
+            return Err(AssemblyFailure {
+                message: format!("claim_or_wait: {e}"),
+                cause: StreamAbortCause::ClaimTimeout,
+                fragments_received: None,
+                total_fragments: None,
+            });
+        }
     };
 
-    let bytes = handle
-        .assemble()
-        .await
-        .map_err(|e| format!("stream assembly: {e}"))?;
+    let bytes = match handle.assemble().await {
+        Ok(b) => b,
+        Err(e) => {
+            // Read fragment counts BEFORE building the error (the WHERE
+            // signal). The inactivity / cancelled AGGREGATE counters are
+            // recorded by the transport `StreamHandle::assemble` site itself
+            // (which also covers relay receive paths), so they are NOT
+            // re-recorded here — only the per-op terminal-event cause is
+            // classified from the `StreamError` variant.
+            let fragments_received = Some(handle.received_fragments() as u32);
+            let total_fragments = Some(handle.total_fragments() as u32);
+            let cause = match e {
+                StreamError::InactivityTimeout => StreamAbortCause::InactivityTimeout,
+                StreamError::Cancelled | StreamError::NotFound => StreamAbortCause::Cancelled,
+                StreamError::InvalidFragment { .. } => StreamAbortCause::PayloadInvalid,
+            };
+            return Err(AssemblyFailure {
+                message: format!("stream assembly: {e}"),
+                cause,
+                fragments_received,
+                total_fragments,
+            });
+        }
+    };
 
-    let payload: GetStreamingPayload =
-        bincode::deserialize(&bytes).map_err(|e| format!("deserialize: {e}"))?;
+    // Assembly succeeded: every expected fragment is present.
+    let fragments_received = Some(handle.received_fragments() as u32);
+    let total_fragments = Some(handle.total_fragments() as u32);
+
+    let payload: GetStreamingPayload = match bincode::deserialize(&bytes) {
+        Ok(p) => p,
+        Err(e) => {
+            crate::node::network_status::record_stream_recv_abort_deserialize(
+                fragments_received,
+                total_fragments,
+            );
+            return Err(AssemblyFailure {
+                message: format!("deserialize: {e}"),
+                cause: StreamAbortCause::Deserialize,
+                fragments_received,
+                total_fragments,
+            });
+        }
+    };
 
     if payload.key != expected_key {
-        return Err(format!(
-            "stream key mismatch: expected {expected_key}, got {}",
-            payload.key
-        ));
+        crate::node::network_status::record_stream_recv_abort_deserialize(
+            fragments_received,
+            total_fragments,
+        );
+        return Err(AssemblyFailure {
+            message: format!(
+                "stream key mismatch: expected {expected_key}, got {}",
+                payload.key
+            ),
+            cause: StreamAbortCause::PayloadInvalid,
+            fragments_received,
+            total_fragments,
+        });
     }
 
     let Some(state) = payload.value.state else {
-        return Err("stream payload has no state".into());
+        crate::node::network_status::record_stream_recv_abort_deserialize(
+            fragments_received,
+            total_fragments,
+        );
+        return Err(AssemblyFailure {
+            message: "stream payload has no state".into(),
+            cause: StreamAbortCause::PayloadInvalid,
+            fragments_received,
+            total_fragments,
+        });
     };
 
     let contract = if includes_contract {
@@ -1663,7 +1799,10 @@ async fn assemble_and_cache_stream(
     // false`; this path is the originator, which IS the client requester, so
     // the sticky `local_client_access` flag applies here.
     cache_contract_locally(op_manager, payload.key, state, contract, true).await;
-    Ok(())
+    Ok(StreamProgress {
+        fragments_received,
+        total_fragments,
+    })
 }
 
 /// Re-query the local store for the contract key, used on the
@@ -2163,6 +2302,9 @@ async fn drive_sub_op_get(
                 true,
                 driver.requests_sent,
                 hop_count,
+                streaming_assembly.fragments_received,
+                streaming_assembly.total_fragments,
+                streaming_assembly.abort_cause,
             )
             .await;
             result
@@ -2177,6 +2319,9 @@ async fn drive_sub_op_get(
                 false,
                 true,
                 driver.requests_sent,
+                None,
+                None, // no streaming header ever seen on the exhausted path
+                None,
                 None,
             )
             .await;
@@ -2313,6 +2458,10 @@ where
         );
         return Ok(());
     }
+
+    // Routing/hosting attribution (Group C): count this as a genuine relayed
+    // GET (past the dedup gate — a deduped duplicate is not a relay).
+    crate::node::network_status::record_relayed_get();
 
     tracing::debug!(
         tx = %incoming_tx,

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -1134,8 +1134,13 @@ async fn drive_get_with_assembly_retry(
                 // so any earlier assembly failure is moot — clear the
                 // remembered error or an unrelated store-lookup miss
                 // (eviction race) would be mislabeled as an assembly
-                // failure by the caller's error synthesis.
-                assembly.error = None;
+                // failure by the caller's error synthesis. A prior failed
+                // streaming attempt may ALSO have set `fragments_received` /
+                // `total_fragments` / `abort_cause`; leaving them set would make
+                // the caller emit a `streamed=false` terminal event carrying
+                // another attempt's fragment counts + abort cause. Reset the
+                // whole outcome so no stale stream field survives.
+                assembly = AssemblyOutcome::default();
                 break result;
             }
             RetryLoopOutcome::Exhausted(cause) => {
@@ -1176,11 +1181,20 @@ async fn drive_get_with_assembly_retry(
                 "get: current_target has no socket_addr; \
                  cannot claim orphan stream"
             );
-            assembly.error = Some(
-                "selected target has no socket address; \
-                 cannot claim the response stream"
-                    .to_string(),
-            );
+            // Reset the whole assembly outcome (not just `error`): a prior
+            // failed streaming attempt may have left `fragments_received` /
+            // `total_fragments` / `abort_cause` set, and those belong to that
+            // attempt, not to this routing failure. Keep only the error string
+            // so the terminal event does not report another attempt's fragment
+            // progress or stream-abort cause.
+            assembly = AssemblyOutcome {
+                error: Some(
+                    "selected target has no socket address; \
+                     cannot claim the response stream"
+                        .to_string(),
+                ),
+                ..Default::default()
+            };
             break result;
         };
 
@@ -2460,8 +2474,16 @@ where
     }
 
     // Routing/hosting attribution (Group C): count this as a genuine relayed
-    // GET (past the dedup gate — a deduped duplicate is not a relay).
-    crate::node::network_status::record_relayed_get();
+    // GET (past the dedup gate — a deduped duplicate is not a relay). Exclude
+    // the originator-loopback case: node.rs maps a client-originated GET
+    // (`source_addr=None`) to `upstream_addr=own_addr` and drives it through
+    // this same entry, so counting it would inflate `relayed_gets_total` with
+    // the node's OWN originations rather than genuine downstream forwards.
+    let originator_loopback =
+        Some(upstream_addr) == op_manager.ring.connection_manager.get_own_addr();
+    if !originator_loopback {
+        crate::node::network_status::record_relayed_get();
+    }
 
     tracing::debug!(
         tx = %incoming_tx,
@@ -4755,6 +4777,26 @@ mod tests {
             i += 1;
         }
         panic!("unterminated fn body for {signature_prefix}");
+    }
+
+    /// Pin (telemetry accuracy): `start_relay_get` must gate
+    /// `record_relayed_get` on `!originator_loopback`. node.rs maps a
+    /// client-originated GET (`source_addr=None`) to `upstream_addr=own_addr`
+    /// and drives it through this same entry, so counting the loopback edge
+    /// would inflate `relayed_gets_total` with the node's own originations.
+    #[test]
+    fn start_relay_get_excludes_originator_loopback_from_relayed_counter() {
+        let src = production_source();
+        let body = extract_fn_body(src, "pub(crate) async fn start_relay_get<CB>(");
+        assert!(
+            body.contains("record_relayed_get()"),
+            "start_relay_get must record the relayed GET counter"
+        );
+        assert!(
+            body.contains("if !originator_loopback"),
+            "record_relayed_get must be gated on !originator_loopback so the \
+             node's own originated GET (loopback) is not counted as a relay"
+        );
     }
 
     /// Bug #3 reproduction: the legacy Response{Found} branch at

--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -1253,6 +1253,10 @@ where
         return Ok(());
     }
 
+    // Routing/hosting attribution (Group C): count this as a genuine relayed
+    // PUT (past the dedup gate — a deduped duplicate is not a relay).
+    crate::node::network_status::record_relayed_put();
+
     tracing::debug!(
         tx = %incoming_tx,
         contract = %contract.key(),

--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -1254,8 +1254,16 @@ where
     }
 
     // Routing/hosting attribution (Group C): count this as a genuine relayed
-    // PUT (past the dedup gate — a deduped duplicate is not a relay).
-    crate::node::network_status::record_relayed_put();
+    // PUT (past the dedup gate — a deduped duplicate is not a relay). Exclude
+    // the originator-loopback case: node.rs maps a client-originated PUT
+    // (`source_addr=None`) to `upstream_addr=own_addr` and drives it here, so
+    // counting it would inflate `relayed_puts_total` with the node's OWN
+    // originations rather than genuine downstream forwards.
+    let originator_loopback =
+        Some(upstream_addr) == op_manager.ring.connection_manager.get_own_addr();
+    if !originator_loopback {
+        crate::node::network_status::record_relayed_put();
+    }
 
     tracing::debug!(
         tx = %incoming_tx,
@@ -2918,6 +2926,18 @@ where
         // rejected duplicate would tell the upstream that the
         // contract stored when it did not.
         return Ok(());
+    }
+
+    // Routing/hosting attribution (Group C): count this as a genuine relayed
+    // PUT, mirroring `start_relay_put`. A direct `PutMsg::RequestStreaming`
+    // (or a `PutMsg::Request` that upgrades to streaming on forward) dispatches
+    // here, so without this the largest PUT relays were undercounted. Exclude
+    // the originator-loopback case (own streaming PUT mapped to
+    // `upstream_addr=own_addr`), consistent with the non-streaming path.
+    let originator_loopback =
+        Some(upstream_addr) == op_manager.ring.connection_manager.get_own_addr();
+    if !originator_loopback {
+        crate::node::network_status::record_relayed_put();
     }
 
     tracing::debug!(
@@ -4677,6 +4697,30 @@ mod tests {
             i += 1;
         }
         panic!("unterminated fn body for {signature_prefix}");
+    }
+
+    /// Pin (telemetry accuracy): BOTH relay PUT entry points must record
+    /// `record_relayed_put` gated on `!originator_loopback`. The streaming
+    /// entry must record at all; a direct `RequestStreaming` would otherwise
+    /// be undercounted. Loopback = node.rs mapping a client PUT's
+    /// `source_addr=None` to `upstream_addr=own_addr`.
+    #[test]
+    fn relay_put_entries_gate_relayed_counter_on_loopback() {
+        let src = production_source();
+        for sig in [
+            "pub(crate) async fn start_relay_put<CB>(",
+            "pub(crate) async fn start_relay_put_streaming<CB>(",
+        ] {
+            let body = extract_fn_body(src, sig);
+            assert!(
+                body.contains("record_relayed_put()"),
+                "{sig} must record the relayed PUT counter"
+            );
+            assert!(
+                body.contains("if !originator_loopback"),
+                "{sig} must gate record_relayed_put on !originator_loopback"
+            );
+        }
     }
 
     /// Source-grep pin (#4361 / #4365): both relay PUT drivers must

--- a/crates/core/src/operations/subscribe/op_ctx_task.rs
+++ b/crates/core/src/operations/subscribe/op_ctx_task.rs
@@ -1509,10 +1509,6 @@ pub(crate) async fn start_relay_subscribe(
         return Ok(());
     }
 
-    // Routing/hosting attribution (Group C): count this as a genuine relayed
-    // SUBSCRIBE (past the dedup gate — a deduped duplicate is not a relay).
-    crate::node::network_status::record_relayed_subscribe();
-
     // Construct the guard IMMEDIATELY after `insert` so a panic in any
     // intervening work (fmt-allocating logs, future OOM) cannot leak
     // the dedup-set entry. The guard's Drop clears the entry; without
@@ -1524,6 +1520,19 @@ pub(crate) async fn start_relay_subscribe(
         op_manager: op_manager.clone(),
         incoming_tx,
     };
+
+    // Routing/hosting attribution (Group C): count this as a genuine relayed
+    // SUBSCRIBE (past the dedup gate — a deduped duplicate is not a relay).
+    // Recorded AFTER the inflight guard so the guard sits immediately after the
+    // dedup insert (the #3932 leak-safety invariant). Exclude the
+    // originator-loopback case: node.rs maps a client-originated SUBSCRIBE
+    // (`source_addr=None`) to `upstream_addr=own_addr` and drives it here, so
+    // counting it would inflate `relayed_subscribes_total` with own subscribes.
+    let originator_loopback =
+        Some(upstream_addr) == op_manager.ring.connection_manager.get_own_addr();
+    if !originator_loopback {
+        crate::node::network_status::record_relayed_subscribe();
+    }
 
     tracing::debug!(
         tx = %incoming_tx,
@@ -3848,6 +3857,32 @@ mod tests {
             i += 1;
         }
         panic!("unterminated fn body for {signature_prefix}");
+    }
+
+    /// Pin (telemetry accuracy + #3932 ordering): `start_relay_subscribe`
+    /// must record `record_relayed_subscribe` AFTER the inflight guard (so the
+    /// guard sits immediately after the dedup insert) and gate it on
+    /// `!originator_loopback` (a client-originated SUBSCRIBE is mapped to
+    /// `upstream_addr=own_addr` and would otherwise be counted as a relay).
+    #[test]
+    fn start_relay_subscribe_records_after_guard_and_excludes_loopback() {
+        let full = include_str!("op_ctx_task.rs");
+        let src = production_source(full);
+        let body = extract_fn_body(src, "pub(crate) async fn start_relay_subscribe(");
+        let guard_pos = body
+            .find("let guard = RelaySubscribeInflightGuard {")
+            .expect("guard construction must exist");
+        let record_pos = body
+            .find("record_relayed_subscribe()")
+            .expect("must record the relayed SUBSCRIBE counter");
+        assert!(
+            record_pos > guard_pos,
+            "record_relayed_subscribe must come AFTER the inflight guard (#3932)"
+        );
+        assert!(
+            body.contains("if !originator_loopback"),
+            "record_relayed_subscribe must be gated on !originator_loopback"
+        );
     }
 
     // ---- #3808: inter-attempt retry pacing (jitter + delay) ----

--- a/crates/core/src/operations/subscribe/op_ctx_task.rs
+++ b/crates/core/src/operations/subscribe/op_ctx_task.rs
@@ -1509,6 +1509,10 @@ pub(crate) async fn start_relay_subscribe(
         return Ok(());
     }
 
+    // Routing/hosting attribution (Group C): count this as a genuine relayed
+    // SUBSCRIBE (past the dedup gate — a deduped duplicate is not a relay).
+    crate::node::network_status::record_relayed_subscribe();
+
     // Construct the guard IMMEDIATELY after `insert` so a panic in any
     // intervening work (fmt-allocating logs, future OOM) cannot leak
     // the dedup-set entry. The guard's Drop clears the entry; without

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -702,6 +702,11 @@ pub(crate) async fn start_relay_broadcast_to(
         return Ok(());
     }
 
+    // NOT counted in `relayed_updates_total`: BroadcastTo is update-mesh
+    // fan-out to interested co-hosts, not a relayed UPDATE *request* toward the
+    // key. Counting fan-out here would conflate relay volume with fan-out
+    // volume (one update -> N broadcasts). See `record_relayed_update` doc.
+
     tracing::debug!(
         tx = %incoming_tx,
         %key,
@@ -1364,6 +1369,15 @@ pub(crate) async fn start_relay_request_update_streaming(
         return Ok(());
     }
 
+    // Routing/hosting attribution (Group C): count this as a genuine relayed
+    // UPDATE, mirroring the non-streaming `start_relay_request_update`.
+    // `relayed_updates_total` counts relayed UPDATE *requests* toward the key;
+    // `RequestUpdateStreaming` is the large-payload variant of that request, so
+    // it is counted. No loopback exclusion: UPDATE relay drivers run only for
+    // `source_addr.is_some()` (an internal/loopback UPDATE is dropped in
+    // node.rs and never reaches this driver).
+    crate::node::network_status::record_relayed_update();
+
     tracing::debug!(
         tx = %incoming_tx,
         %key,
@@ -1418,6 +1432,9 @@ pub(crate) async fn start_relay_broadcast_to_streaming(
         );
         return Ok(());
     }
+
+    // NOT counted in `relayed_updates_total` (see `start_relay_broadcast_to`):
+    // BroadcastToStreaming is update-mesh fan-out, not a relayed request.
 
     tracing::debug!(
         tx = %incoming_tx,
@@ -2968,5 +2985,35 @@ mod tests {
             i += 1;
         }
         panic!("unterminated fn body for {signature_prefix}");
+    }
+
+    /// Pin (telemetry accuracy / scope): `relayed_updates_total` counts
+    /// relayed UPDATE *requests* only. Both request entries record
+    /// `record_relayed_update`; the broadcast fan-out entries must NOT (they
+    /// are update-mesh fan-out, not a relayed request — counting them would
+    /// conflate relay volume with fan-out volume).
+    #[test]
+    fn relayed_update_counter_scope_requests_only() {
+        let full = include_str!("op_ctx_task.rs");
+        let src = production_source(full);
+        for sig in [
+            "pub(crate) async fn start_relay_request_update(",
+            "pub(crate) async fn start_relay_request_update_streaming(",
+        ] {
+            assert!(
+                extract_fn_body(src, sig).contains("record_relayed_update()"),
+                "{sig} must record the relayed UPDATE request counter"
+            );
+        }
+        for sig in [
+            "pub(crate) async fn start_relay_broadcast_to(",
+            "pub(crate) async fn start_relay_broadcast_to_streaming(",
+        ] {
+            assert!(
+                !extract_fn_body(src, sig).contains("record_relayed_update()"),
+                "{sig} must NOT record relayed_updates_total (fan-out, not a \
+                 relayed request)"
+            );
+        }
     }
 }

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -635,6 +635,10 @@ pub(crate) async fn start_relay_request_update(
         return Ok(());
     }
 
+    // Routing/hosting attribution (Group C): count this as a genuine relayed
+    // UPDATE (past the dedup gate — a deduped duplicate is not a relay).
+    crate::node::network_status::record_relayed_update();
+
     tracing::debug!(
         tx = %incoming_tx,
         %key,

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -1767,6 +1767,53 @@ impl Ring {
                 snapshot.terminal_consult_still_not_found = Some(still_not_found);
             }
 
+            // Streamed-transfer abort counters (Group B): isolate the
+            // large-contract failure class on the existing snapshot cadence.
+            // Same hand-mirror footgun as the counters above — a new
+            // `RouterSnapshotInfo` field is invisible to the collector unless
+            // added here AND in `event_kind_to_json` (pinned by
+            // `router_snapshot_json_includes_stream_abort_counters`). Read from
+            // the per-node network_status singleton where the abort sites record
+            // them; `None` only before the singleton is initialized.
+            if let Some(a) = crate::node::network_status::stream_abort_counts() {
+                snapshot.stream_recv_aborts_inactivity_total = Some(a.recv_inactivity);
+                snapshot.stream_recv_aborts_cancelled_total = Some(a.recv_cancelled);
+                snapshot.stream_recv_aborts_claim_timeout_total = Some(a.recv_claim_timeout);
+                snapshot.stream_recv_aborts_deserialize_total = Some(a.recv_deserialize);
+                snapshot.stream_send_aborts_cwnd_total = Some(a.send_cwnd);
+                snapshot.stream_recv_abort_frac_0 = Some(a.frac_0);
+                snapshot.stream_recv_abort_frac_1 = Some(a.frac_1);
+                snapshot.stream_recv_abort_frac_lt50 = Some(a.frac_lt50);
+                snapshot.stream_recv_abort_frac_50_90 = Some(a.frac_50_90);
+                snapshot.stream_recv_abort_frac_ge90 = Some(a.frac_ge90);
+            }
+
+            // Routing/hosting attribution (Group C): current connection gauges
+            // from `connection_manager` plus relayed-op counters and the
+            // gateway-connection gauge from the network_status singleton. Same
+            // hand-mirror footgun — pinned by
+            // `router_snapshot_json_includes_routing_attribution_counters`.
+            snapshot.ring_connections = Some(cm.connection_count() as u64);
+            snapshot.transient_connections = Some(cm.transient_count() as u64);
+            snapshot.connections_to_gateways =
+                crate::node::network_status::connections_to_gateways();
+            if let Some((gets, puts, subscribes, updates)) =
+                crate::node::network_status::relayed_op_counts()
+            {
+                snapshot.relayed_gets_total = Some(gets);
+                snapshot.relayed_puts_total = Some(puts);
+                snapshot.relayed_subscribes_total = Some(subscribes);
+                snapshot.relayed_updates_total = Some(updates);
+            }
+
+            // Connect-event emission counters (firehose-retirement precursor).
+            // Additive aggregate for a future net-negative retirement of the
+            // per-event `connect_connected` / `connect_rejected` firehose.
+            if let Some((accepts, rejects)) = crate::node::network_status::connect_emit_counts() {
+                snapshot.connect_accepts_emitted = Some(accepts);
+                snapshot.connect_rejects_emitted = Some(rejects);
+            }
+
             // Computed-upstream vs. stored-`is_upstream`-flag divergence counters
             // (#4642 piece D / #4671). Recorded at `send_unsubscribe_upstream`
             // where the stored flag is still consulted; exported here so the

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -484,6 +484,49 @@ pub(crate) struct RouterSnapshotInfo {
     pub lattice_predecessor_distance: Option<f64>,
     pub lattice_probes_issued: Option<u64>,
     pub lattice_probe_improvements: Option<u64>,
+    /// Streamed-transfer (> 64 KB) abort counters, populated by `Ring` from the
+    /// per-node `network_status` singleton on the snapshot cadence. They isolate
+    /// the large-contract failure class (~50% of large fetches were failing)
+    /// WITHOUT a per-fragment/per-transfer event stream: five monotonic cause
+    /// totals (receiver inactivity / cancelled / claim-timeout / deserialize;
+    /// sender cwnd) plus a fragment-progress histogram (`*_frac_*`, one bump per
+    /// receiver abort) showing HOW FAR transfers got before dying. All monotonic
+    /// lifetime totals the collector differences across the cadence. `None`
+    /// until the ring's snapshot task populates them.
+    pub stream_recv_aborts_inactivity_total: Option<u64>,
+    pub stream_recv_aborts_cancelled_total: Option<u64>,
+    pub stream_recv_aborts_claim_timeout_total: Option<u64>,
+    pub stream_recv_aborts_deserialize_total: Option<u64>,
+    pub stream_send_aborts_cwnd_total: Option<u64>,
+    pub stream_recv_abort_frac_0: Option<u64>,
+    pub stream_recv_abort_frac_1: Option<u64>,
+    pub stream_recv_abort_frac_lt50: Option<u64>,
+    pub stream_recv_abort_frac_50_90: Option<u64>,
+    pub stream_recv_abort_frac_ge90: Option<u64>,
+    /// Routing/hosting attribution gauges + counters, populated by `Ring` on the
+    /// snapshot cadence. `ring_connections` / `transient_connections` are current
+    /// gauges (live + transient connection counts from `connection_manager`);
+    /// `connections_to_gateways` is how many of this node's active connections go
+    /// to gateways (the NAT-stranded fingerprint — a peer stuck on gateways only).
+    /// `relayed_*_total` are monotonic counts of operations this node RELAYED
+    /// (forwarded one hop as a routing intermediary, not as originator), one
+    /// increment per relay-driver entry. `None` until the ring's snapshot task
+    /// populates them.
+    pub ring_connections: Option<u64>,
+    pub transient_connections: Option<u64>,
+    pub connections_to_gateways: Option<u64>,
+    pub relayed_gets_total: Option<u64>,
+    pub relayed_puts_total: Option<u64>,
+    pub relayed_subscribes_total: Option<u64>,
+    pub relayed_updates_total: Option<u64>,
+    /// Connect-event emission counters (aggregate precursor to retiring the
+    /// per-event `connect_connected` / `connect_rejected` firehose), populated by
+    /// `Ring` on the snapshot cadence. The per-event emission is NOT retired yet
+    /// (a downstream dashboard likely still consumes it — see the increment-site
+    /// TODO); these additive counters make a future retirement net-negative.
+    /// Monotonic lifetime totals. `None` until the ring's snapshot task populates.
+    pub connect_accepts_emitted: Option<u64>,
+    pub connect_rejects_emitted: Option<u64>,
     /// Per-operation-type estimator curves, keyed by op type name (e.g., "GET").
     pub per_op_curves: HashMap<String, PerOpCurves>,
     /// Renegade predictor diagnostics. These (and `renegade_accuracy_pairs`) are
@@ -1388,6 +1431,31 @@ impl Router {
             lattice_predecessor_distance: None,
             lattice_probes_issued: None,
             lattice_probe_improvements: None,
+            // Streamed-transfer abort counters, populated by Ring from the
+            // network_status singleton on the snapshot cadence (Group B).
+            stream_recv_aborts_inactivity_total: None,
+            stream_recv_aborts_cancelled_total: None,
+            stream_recv_aborts_claim_timeout_total: None,
+            stream_recv_aborts_deserialize_total: None,
+            stream_send_aborts_cwnd_total: None,
+            stream_recv_abort_frac_0: None,
+            stream_recv_abort_frac_1: None,
+            stream_recv_abort_frac_lt50: None,
+            stream_recv_abort_frac_50_90: None,
+            stream_recv_abort_frac_ge90: None,
+            // Routing/hosting attribution, populated by Ring on the snapshot
+            // cadence (Group C).
+            ring_connections: None,
+            transient_connections: None,
+            connections_to_gateways: None,
+            relayed_gets_total: None,
+            relayed_puts_total: None,
+            relayed_subscribes_total: None,
+            relayed_updates_total: None,
+            // Connect-event emission counters, populated by Ring on the snapshot
+            // cadence (firehose-retirement precursor).
+            connect_accepts_emitted: None,
+            connect_rejects_emitted: None,
             // Renegade predictor diagnostics
             renegade_failure_events: self.renegade_predictor.len(),
             renegade_response_time_events: self.renegade_predictor.stage_sizes().1,

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -490,9 +490,13 @@ pub(crate) struct RouterSnapshotInfo {
     /// WITHOUT a per-fragment/per-transfer event stream: five monotonic cause
     /// totals (receiver inactivity / cancelled / claim-timeout / deserialize;
     /// sender cwnd) plus a fragment-progress histogram (`*_frac_*`, one bump per
-    /// receiver abort) showing HOW FAR transfers got before dying. All monotonic
-    /// lifetime totals the collector differences across the cadence. `None`
-    /// until the ring's snapshot task populates them.
+    /// receiver abort) showing HOW FAR transfers got before dying. Scope differs
+    /// by cause: `*_inactivity_total` / `*_cancelled_total` are recorded in
+    /// transport `StreamHandle::assemble` and AGGREGATE across GET + PUT + UPDATE
+    /// inbound streams, while `*_claim_timeout_total` / `*_deserialize_total` are
+    /// GET-fetch-only (the GET originator's `assemble_and_cache_stream`). All
+    /// monotonic lifetime totals the collector differences across the cadence.
+    /// `None` until the ring's snapshot task populates them.
     pub stream_recv_aborts_inactivity_total: Option<u64>,
     pub stream_recv_aborts_cancelled_total: Option<u64>,
     pub stream_recv_aborts_claim_timeout_total: Option<u64>,

--- a/crates/core/src/tracing.rs
+++ b/crates/core/src/tracing.rs
@@ -96,7 +96,8 @@ pub(crate) use register::{
 pub use register::{EventFlushHandle, NetLogMessage};
 // NEW_RECORDS_TS is needed by metrics_client's opentelemetry_tracer
 pub(crate) use event_kind::{
-    ConnectEvent, GetEvent, GetTerminalOutcome, PutEvent, SubscribeEvent, UpdateEvent,
+    ConnectEvent, GetEvent, GetTerminalOutcome, PutEvent, StreamAbortCause, SubscribeEvent,
+    UpdateEvent,
 };
 pub use event_kind::{
     ConnectionType, DisconnectReason, EventKind, HostingStoppedReason, InterestSyncEvent,

--- a/crates/core/src/tracing/event_kind.rs
+++ b/crates/core/src/tracing/event_kind.rs
@@ -1118,6 +1118,43 @@ impl GetTerminalOutcome {
     }
 }
 
+/// Why a streamed (> 64 KB `streaming_threshold`) GET transfer aborted before
+/// its state could be assembled and cached. Telemetry-only; carried on
+/// [`GetEvent::ClientTerminal`] so analysts can see WHERE large fetches fail
+/// (~50% of large fetches were failing with only a stringified cause). `None`
+/// on success and on non-streaming terminals.
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
+#[cfg_attr(test, derive(arbitrary::Arbitrary))]
+pub(crate) enum StreamAbortCause {
+    /// No inbound stream was ever claimed (claim timed out / errored); zero
+    /// fragments observed.
+    ClaimTimeout,
+    /// A claimed stream stalled — no fragment arrived within the inactivity
+    /// window.
+    InactivityTimeout,
+    /// The stream was cancelled / the connection closed mid-transfer.
+    Cancelled,
+    /// All fragments arrived but the assembled bytes failed to deserialize into
+    /// a GET streaming payload.
+    Deserialize,
+    /// The assembled payload was structurally invalid (key mismatch, missing
+    /// state, or a bad fragment reported by the transport).
+    PayloadInvalid,
+}
+
+impl StreamAbortCause {
+    /// Stable snake_case string for the OTLP/json export.
+    pub(crate) fn as_str(&self) -> &'static str {
+        match self {
+            StreamAbortCause::ClaimTimeout => "claim_timeout",
+            StreamAbortCause::InactivityTimeout => "inactivity_timeout",
+            StreamAbortCause::Cancelled => "cancelled",
+            StreamAbortCause::Deserialize => "deserialize",
+            StreamAbortCause::PayloadInvalid => "payload_invalid",
+        }
+    }
+}
+
 /// GET operation events for tracking the lifecycle of contract retrieval.
 ///
 /// Similar to `PutEvent`, this enum captures the full sequence of a Get operation:
@@ -1268,6 +1305,20 @@ pub(crate) enum GetEvent {
         attempts: usize,
         /// Forward-path hop count when carried by the terminal reply.
         hop_count: Option<usize>,
+        /// Fragments received on the streaming path. `None` for non-streaming
+        /// terminals and where no stream was ever claimed. On the streaming
+        /// SUCCESS path it is the total fragments received; on the streaming
+        /// FAILURE path it is the last assembly attempt's count. Isolates WHERE
+        /// a large fetch died (paired with `total_fragments`).
+        fragments_received: Option<u32>,
+        /// Total fragments the streamed payload expected. `None` for
+        /// non-streaming terminals or when no stream was ever claimed.
+        total_fragments: Option<u32>,
+        /// Why a streamed GET aborted; `None` on success and on non-streaming
+        /// terminals. Streaming outcomes flow EXCLUSIVELY through this event
+        /// (the inline `GetSuccess`/`GetFailure` paths miss them — see #4796),
+        /// so this is the only terminal that can carry the abort cause.
+        stream_abort_cause: Option<StreamAbortCause>,
         /// Time elapsed since operation started (milliseconds).
         elapsed_ms: u64,
         timestamp: u64,

--- a/crates/core/src/tracing/register.rs
+++ b/crates/core/src/tracing/register.rs
@@ -540,6 +540,9 @@ impl<'a> NetEventLog<'a> {
         is_sub_op: bool,
         attempts: usize,
         hop_count: Option<usize>,
+        fragments_received: Option<u32>,
+        total_fragments: Option<u32>,
+        stream_abort_cause: Option<super::StreamAbortCause>,
     ) -> Option<Self> {
         let peer_id = Self::get_own_peer_id(ring)?;
         let own_loc = ring.connection_manager.own_location();
@@ -556,6 +559,9 @@ impl<'a> NetEventLog<'a> {
                 is_sub_op,
                 attempts,
                 hop_count,
+                fragments_received,
+                total_fragments,
+                stream_abort_cause,
                 elapsed_ms: tx.elapsed().as_millis() as u64,
                 timestamp: chrono::Utc::now().timestamp() as u64,
             }),
@@ -2193,6 +2199,9 @@ mod span_completed_tests {
                 is_sub_op: false,
                 attempts: 1,
                 hop_count: None,
+                fragments_received: None,
+                total_fragments: None,
+                stream_abort_cause: None,
                 elapsed_ms: 0,
                 timestamp: 0,
             }));

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -444,11 +444,33 @@ impl NetEventRegister for TelemetryReporter {
     ) -> BoxFuture<'a, ()> {
         async move {
             for log_msg in NetLogMessage::to_log_message(logs) {
+                let event_type = event_kind_to_string(&log_msg.kind);
+                // Aggregate connect-emission counts onto the periodic
+                // RouterSnapshot (`connect_accepts_emitted`/`_rejects_emitted`).
+                // This is the exact point the per-event `connect_connected` /
+                // `connect_rejected` firehose (~92k events / 18 min) is emitted
+                // to the collector.
+                //
+                // TODO(follow-up): retire per-event connect_rejected/
+                // connect_connected once the dashboard reads the snapshot
+                // counters — deferred because an external dashboard likely still
+                // consumes the per-event stream (topology / rejection panels).
+                // Retiring here (skip the two variants) would make net telemetry
+                // volume NEGATIVE.
+                match event_type.as_str() {
+                    "connect_connected" => {
+                        crate::node::network_status::record_connect_accept_emitted()
+                    }
+                    "connect_rejected" => {
+                        crate::node::network_status::record_connect_reject_emitted()
+                    }
+                    _ => {}
+                }
                 let event = TelemetryEvent {
                     timestamp: current_timestamp_ms(),
                     peer_id: log_msg.peer_id.to_string(),
                     transaction_id: log_msg.tx.to_string(),
-                    event_type: event_kind_to_string(&log_msg.kind),
+                    event_type,
                     event_data: event_kind_to_json(&log_msg.kind),
                     priority: EventPriority::Operational,
                 };
@@ -1426,6 +1448,9 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                     is_sub_op,
                     attempts,
                     hop_count,
+                    fragments_received,
+                    total_fragments,
+                    stream_abort_cause,
                     elapsed_ms,
                     timestamp,
                 } => {
@@ -1444,6 +1469,19 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                     });
                     if let Some(k) = key {
                         json["key"] = serde_json::Value::String(k.to_string());
+                    }
+                    // Streamed-transfer failure-isolation fields (Group B): only
+                    // present on the streaming path, so emit them only when set
+                    // to keep the common non-streaming terminal lean.
+                    if let Some(fr) = fragments_received {
+                        json["fragments_received"] = serde_json::json!(fr);
+                    }
+                    if let Some(tf) = total_fragments {
+                        json["total_fragments"] = serde_json::json!(tf);
+                    }
+                    if let Some(cause) = stream_abort_cause {
+                        json["stream_abort_cause"] =
+                            serde_json::Value::String(cause.as_str().to_string());
                     }
                     json
                 }
@@ -2348,6 +2386,69 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                     "terminal_consult_still_not_found".to_string(),
                     serde_json::json!(snapshot.terminal_consult_still_not_found),
                 );
+                // Streamed-transfer abort counters (Group B), routing/hosting
+                // attribution (Group C), and connect-emit counters — same
+                // hand-mirror footgun: a new `RouterSnapshotInfo` field is
+                // invisible to the collector unless added here. All `Option<u64>`
+                // so one loop suffices. Pinned by
+                // `router_snapshot_json_includes_stream_abort_counters` /
+                // `_routing_attribution_counters` / `_connect_emit_counters`.
+                for (key, value) in [
+                    (
+                        "stream_recv_aborts_inactivity_total",
+                        snapshot.stream_recv_aborts_inactivity_total,
+                    ),
+                    (
+                        "stream_recv_aborts_cancelled_total",
+                        snapshot.stream_recv_aborts_cancelled_total,
+                    ),
+                    (
+                        "stream_recv_aborts_claim_timeout_total",
+                        snapshot.stream_recv_aborts_claim_timeout_total,
+                    ),
+                    (
+                        "stream_recv_aborts_deserialize_total",
+                        snapshot.stream_recv_aborts_deserialize_total,
+                    ),
+                    (
+                        "stream_send_aborts_cwnd_total",
+                        snapshot.stream_send_aborts_cwnd_total,
+                    ),
+                    (
+                        "stream_recv_abort_frac_0",
+                        snapshot.stream_recv_abort_frac_0,
+                    ),
+                    (
+                        "stream_recv_abort_frac_1",
+                        snapshot.stream_recv_abort_frac_1,
+                    ),
+                    (
+                        "stream_recv_abort_frac_lt50",
+                        snapshot.stream_recv_abort_frac_lt50,
+                    ),
+                    (
+                        "stream_recv_abort_frac_50_90",
+                        snapshot.stream_recv_abort_frac_50_90,
+                    ),
+                    (
+                        "stream_recv_abort_frac_ge90",
+                        snapshot.stream_recv_abort_frac_ge90,
+                    ),
+                    ("ring_connections", snapshot.ring_connections),
+                    ("transient_connections", snapshot.transient_connections),
+                    ("connections_to_gateways", snapshot.connections_to_gateways),
+                    ("relayed_gets_total", snapshot.relayed_gets_total),
+                    ("relayed_puts_total", snapshot.relayed_puts_total),
+                    (
+                        "relayed_subscribes_total",
+                        snapshot.relayed_subscribes_total,
+                    ),
+                    ("relayed_updates_total", snapshot.relayed_updates_total),
+                    ("connect_accepts_emitted", snapshot.connect_accepts_emitted),
+                    ("connect_rejects_emitted", snapshot.connect_rejects_emitted),
+                ] {
+                    obj.insert(key.to_string(), serde_json::json!(value));
+                }
                 // Computed-upstream vs. stored-flag divergence counters (piece D,
                 // #4642 / #4671) — same hand-mirror footgun: a new
                 // `RouterSnapshotInfo` field is invisible to the collector unless
@@ -2827,6 +2928,87 @@ mod tests {
         ] {
             assert_eq!(json[key], want, "{key} must reach the OTLP body");
         }
+    }
+
+    /// Pin: the streamed-transfer abort counters (Group B) must reach the
+    /// hand-mirrored OTLP body — same footgun as the counters above. These are
+    /// the large-contract failure-isolation signal; a silent drop re-blinds
+    /// central telemetry to WHERE large fetches fail.
+    #[test]
+    fn router_snapshot_json_includes_stream_abort_counters() {
+        use arbitrary::{Arbitrary, Unstructured};
+        let mut u = Unstructured::new(&[0u8; 4096]);
+        let mut info = crate::router::RouterSnapshotInfo::arbitrary(&mut u)
+            .expect("construct RouterSnapshotInfo for test");
+        info.stream_recv_aborts_inactivity_total = Some(11);
+        info.stream_recv_aborts_cancelled_total = Some(12);
+        info.stream_recv_aborts_claim_timeout_total = Some(13);
+        info.stream_recv_aborts_deserialize_total = Some(14);
+        info.stream_send_aborts_cwnd_total = Some(15);
+        info.stream_recv_abort_frac_0 = Some(1);
+        info.stream_recv_abort_frac_1 = Some(2);
+        info.stream_recv_abort_frac_lt50 = Some(3);
+        info.stream_recv_abort_frac_50_90 = Some(4);
+        info.stream_recv_abort_frac_ge90 = Some(5);
+        let json = event_kind_to_json(&EventKind::RouterSnapshot(Box::new(info)));
+        for (key, want) in [
+            ("stream_recv_aborts_inactivity_total", 11),
+            ("stream_recv_aborts_cancelled_total", 12),
+            ("stream_recv_aborts_claim_timeout_total", 13),
+            ("stream_recv_aborts_deserialize_total", 14),
+            ("stream_send_aborts_cwnd_total", 15),
+            ("stream_recv_abort_frac_0", 1),
+            ("stream_recv_abort_frac_1", 2),
+            ("stream_recv_abort_frac_lt50", 3),
+            ("stream_recv_abort_frac_50_90", 4),
+            ("stream_recv_abort_frac_ge90", 5),
+        ] {
+            assert_eq!(json[key], want, "{key} must reach the OTLP body");
+        }
+    }
+
+    /// Pin: the routing/hosting attribution gauges + counters (Group C) must
+    /// reach the hand-mirrored OTLP body.
+    #[test]
+    fn router_snapshot_json_includes_routing_attribution_counters() {
+        use arbitrary::{Arbitrary, Unstructured};
+        let mut u = Unstructured::new(&[0u8; 4096]);
+        let mut info = crate::router::RouterSnapshotInfo::arbitrary(&mut u)
+            .expect("construct RouterSnapshotInfo for test");
+        info.ring_connections = Some(21);
+        info.transient_connections = Some(22);
+        info.connections_to_gateways = Some(23);
+        info.relayed_gets_total = Some(24);
+        info.relayed_puts_total = Some(25);
+        info.relayed_subscribes_total = Some(26);
+        info.relayed_updates_total = Some(27);
+        let json = event_kind_to_json(&EventKind::RouterSnapshot(Box::new(info)));
+        for (key, want) in [
+            ("ring_connections", 21),
+            ("transient_connections", 22),
+            ("connections_to_gateways", 23),
+            ("relayed_gets_total", 24),
+            ("relayed_puts_total", 25),
+            ("relayed_subscribes_total", 26),
+            ("relayed_updates_total", 27),
+        ] {
+            assert_eq!(json[key], want, "{key} must reach the OTLP body");
+        }
+    }
+
+    /// Pin: the connect-emission counters (firehose-retirement precursor) must
+    /// reach the hand-mirrored OTLP body.
+    #[test]
+    fn router_snapshot_json_includes_connect_emit_counters() {
+        use arbitrary::{Arbitrary, Unstructured};
+        let mut u = Unstructured::new(&[0u8; 4096]);
+        let mut info = crate::router::RouterSnapshotInfo::arbitrary(&mut u)
+            .expect("construct RouterSnapshotInfo for test");
+        info.connect_accepts_emitted = Some(41);
+        info.connect_rejects_emitted = Some(42);
+        let json = event_kind_to_json(&EventKind::RouterSnapshot(Box::new(info)));
+        assert_eq!(json["connect_accepts_emitted"], 41);
+        assert_eq!(json["connect_rejects_emitted"], 42);
     }
 
     /// Pin: the computed-upstream vs. stored-flag divergence counters (piece D,
@@ -3570,6 +3752,9 @@ mod tests {
             is_sub_op: false,
             attempts: 2,
             hop_count: Some(3),
+            fragments_received: Some(8),
+            total_fragments: Some(8),
+            stream_abort_cause: None,
             elapsed_ms: 1234,
             timestamp: 99999,
         });
@@ -3590,6 +3775,51 @@ mod tests {
         assert_eq!(json["elapsed_ms"], 1234);
         assert_eq!(json["timestamp"], 99999);
         assert!(json["key"].is_string());
+        // Streaming success carries fragment counts and NO abort cause.
+        assert_eq!(json["fragments_received"], 8);
+        assert_eq!(json["total_fragments"], 8);
+        assert!(json.get("stream_abort_cause").is_none());
+    }
+
+    /// A streamed GET FAILURE carries the classified abort cause and the
+    /// fragment progress of the last assembly attempt — the WHERE signal that
+    /// isolates the large-contract failure class (Group B). Streaming outcomes
+    /// flow exclusively through `ClientTerminal`, so this is the only terminal
+    /// event that can carry them.
+    #[test]
+    fn test_event_kind_to_json_get_terminal_streaming_failure_abort_cause() {
+        use crate::message::Transaction;
+        use crate::ring::PeerKeyLocation;
+        use crate::tracing::{GetEvent, GetTerminalOutcome, StreamAbortCause};
+        use freenet_stdlib::prelude::ContractInstanceId;
+
+        let tx = Transaction::new::<crate::operations::get::GetMsg>();
+        let instance_id = ContractInstanceId::new([4u8; 32]);
+
+        let event = EventKind::Get(GetEvent::ClientTerminal {
+            id: tx,
+            requester: PeerKeyLocation::random(),
+            instance_id,
+            key: None,
+            outcome: GetTerminalOutcome::TimeoutExhausted,
+            streamed: true,
+            is_sub_op: false,
+            attempts: 3,
+            hop_count: None,
+            fragments_received: Some(3),
+            total_fragments: Some(10),
+            stream_abort_cause: Some(StreamAbortCause::InactivityTimeout),
+            elapsed_ms: 4321,
+            timestamp: 7,
+        });
+
+        assert_eq!(event_kind_to_string(&event), "get_terminal");
+        let json = event_kind_to_json(&event);
+        assert_eq!(json["outcome"], "timeout_exhausted");
+        assert_eq!(json["streamed"], true);
+        assert_eq!(json["fragments_received"], 3);
+        assert_eq!(json["total_fragments"], 10);
+        assert_eq!(json["stream_abort_cause"], "inactivity_timeout");
     }
 
     /// A timeout-exhausted client GET now emits a `get_terminal` event with
@@ -3616,6 +3846,9 @@ mod tests {
             is_sub_op: false,
             attempts: 3,
             hop_count: None,
+            fragments_received: None,
+            total_fragments: None,
+            stream_abort_cause: None,
             elapsed_ms: 60000,
             timestamp: 1,
         });
@@ -3627,6 +3860,10 @@ mod tests {
         // No key and no hop_count on the timeout path — both serialize null.
         assert!(json["key"].is_null());
         assert!(json["hop_count"].is_null());
+        // Non-streaming terminal omits the streaming-only fields entirely.
+        assert!(json.get("fragments_received").is_none());
+        assert!(json.get("total_fragments").is_none());
+        assert!(json.get("stream_abort_cause").is_none());
     }
 
     /// A local-cache-hit client GET emits a `ClientTerminal` with
@@ -3656,6 +3893,9 @@ mod tests {
             is_sub_op: false,
             attempts: 0,
             hop_count: None,
+            fragments_received: None,
+            total_fragments: None,
+            stream_abort_cause: None,
             elapsed_ms: 1,
             timestamp: 1,
         });

--- a/crates/core/src/transport/connection_handler.rs
+++ b/crates/core/src/transport/connection_handler.rs
@@ -1670,6 +1670,8 @@ impl<S: Socket, T: TimeSource> UdpPacketsListener<S, T> {
                                 inbound_remote_connection.inbound_packet_sender,
                             ) {
                                 tracing::info!(peer_addr = %remote_addr, "NAT traversal connection established");
+                                crate::transport::TRANSPORT_METRICS
+                                    .record_nat_traversal_established();
                                 if result_sender.send(Ok(outbound_remote_conn)).is_err() {
                                     tracing::debug!(peer_addr = %remote_addr, "NAT traversal result receiver already dropped");
                                 }
@@ -1682,9 +1684,13 @@ impl<S: Socket, T: TimeSource> UdpPacketsListener<S, T> {
                             match &error {
                                 TransportError::ProtocolVersionMismatch { .. } => {
                                     tracing::warn!(%error);
+                                    crate::transport::TRANSPORT_METRICS
+                                        .record_nat_traversal_failed_version();
                                 }
                                 TransportError::ChannelClosed | TransportError::ConnectionClosed(_) | TransportError::ConnectionEstablishmentFailure { .. } | TransportError::SendFailed(..) | TransportError::OutboundStreamFailed(_) | TransportError::IO(_) | TransportError::Other(_) | TransportError::PubKeyDecryptionError(_) | TransportError::Serialization(_) => {
                                     tracing::error!(error = %error, peer_addr = %remote_addr, "Failed NAT traversal");
+                                    crate::transport::TRANSPORT_METRICS
+                                        .record_nat_traversal_failed_error();
                                 }
                             }
                             self.expected_non_gateway.remove(&remote_addr.ip());
@@ -1724,6 +1730,7 @@ impl<S: Socket, T: TimeSource> UdpPacketsListener<S, T> {
                     }
 
                     tracing::info!(peer_addr = %remote_addr, "Starting NAT traversal");
+                    crate::transport::TRANSPORT_METRICS.record_nat_traversal_attempt();
                     let (ongoing_connection, packets_sender) = self.traverse_nat(remote_addr, remote_public_key.clone());
 
                     if !self.connections.start_nat_traversal(remote_addr, packets_sender, open_connection) {

--- a/crates/core/src/transport/connection_handler.rs
+++ b/crates/core/src/transport/connection_handler.rs
@@ -1730,12 +1730,22 @@ impl<S: Socket, T: TimeSource> UdpPacketsListener<S, T> {
                     }
 
                     tracing::info!(peer_addr = %remote_addr, "Starting NAT traversal");
-                    crate::transport::TRANSPORT_METRICS.record_nat_traversal_attempt();
                     let (ongoing_connection, packets_sender) = self.traverse_nat(remote_addr, remote_public_key.clone());
 
                     if !self.connections.start_nat_traversal(remote_addr, packets_sender, open_connection) {
+                        // Rejected AFTER the `has_nat_traversal` guard above: a
+                        // gateway handshake is in progress, or the peer is in its
+                        // recently-closed grace period. No task is spawned and no
+                        // established/failed outcome will fire, so counting this
+                        // as an attempt would inflate the `nat_traversal_attempts`
+                        // denominator and skew the hole-punch success rate.
                         continue;
                     }
+
+                    // Admitted: a traversal task is now spawned and will emit
+                    // exactly one established/failed outcome. Count the attempt
+                    // here so the denominator matches the outcomes.
+                    crate::transport::TRANSPORT_METRICS.record_nat_traversal_attempt();
 
                     self.expected_non_gateway.insert(remote_addr.ip());
                     let task = GlobalExecutor::spawn(ongoing_connection

--- a/crates/core/src/transport/metrics.rs
+++ b/crates/core/src/transport/metrics.rs
@@ -88,6 +88,18 @@ pub struct TransportMetrics {
     // Slowdowns during period
     slowdowns_triggered: AtomicU32,
 
+    // NAT hole-punch traversal counters (reset each snapshot).
+    /// Outbound NAT traversal attempts started during the period.
+    nat_traversal_attempts: AtomicU32,
+    /// NAT traversal attempts that established a connection during the period.
+    nat_traversal_established: AtomicU32,
+    /// NAT traversal attempts that failed for a non-version reason during the
+    /// period (unreachable / symmetric-NAT / generic transport error bucket).
+    nat_traversal_failed_error: AtomicU32,
+    /// NAT traversal attempts that failed due to a protocol version mismatch
+    /// during the period.
+    nat_traversal_failed_version: AtomicU32,
+
     // Per-peer wire-byte stats (bounded to MAX_TRACKED_PEERS entries).
     //
     // Receive side is metered post-authentication in
@@ -158,6 +170,10 @@ impl TransportMetrics {
             cwnd_sum: AtomicU64::new(0),
             cwnd_samples: AtomicU32::new(0),
             slowdowns_triggered: AtomicU32::new(0),
+            nat_traversal_attempts: AtomicU32::new(0),
+            nat_traversal_established: AtomicU32::new(0),
+            nat_traversal_failed_error: AtomicU32::new(0),
+            nat_traversal_failed_version: AtomicU32::new(0),
             min_rtt_us: AtomicU64::new(u64::MAX),
             max_rtt_us: AtomicU64::new(0),
             rtt_sum_us: AtomicU64::new(0),
@@ -227,6 +243,31 @@ impl TransportMetrics {
         if rtt_us > 0 {
             self.record_rtt_sample(rtt_us);
         }
+    }
+
+    /// Record the start of an outbound NAT traversal attempt.
+    pub fn record_nat_traversal_attempt(&self) {
+        self.nat_traversal_attempts.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record a NAT traversal attempt that established a connection.
+    pub fn record_nat_traversal_established(&self) {
+        self.nat_traversal_established
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record a NAT traversal attempt that failed for a non-version reason
+    /// (unreachable / symmetric-NAT / generic transport error).
+    pub fn record_nat_traversal_failed_error(&self) {
+        self.nat_traversal_failed_error
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record a NAT traversal attempt that failed due to a protocol version
+    /// mismatch.
+    pub fn record_nat_traversal_failed_version(&self) {
+        self.nat_traversal_failed_version
+            .fetch_add(1, Ordering::Relaxed);
     }
 
     /// Record a cwnd sample (called periodically or on transfer completion).
@@ -437,6 +478,11 @@ impl TransportMetrics {
         let cwnd_sum = self.cwnd_sum.load(Ordering::Relaxed);
         let cwnd_samples = self.cwnd_samples.load(Ordering::Relaxed);
         let slowdowns_triggered = self.slowdowns_triggered.load(Ordering::Relaxed);
+        let nat_traversal_attempts = self.nat_traversal_attempts.load(Ordering::Relaxed);
+        let nat_traversal_established = self.nat_traversal_established.load(Ordering::Relaxed);
+        let nat_traversal_failed_error = self.nat_traversal_failed_error.load(Ordering::Relaxed);
+        let nat_traversal_failed_version =
+            self.nat_traversal_failed_version.load(Ordering::Relaxed);
         let min_rtt_us = self.min_rtt_us.load(Ordering::Relaxed);
         let max_rtt_us = self.max_rtt_us.load(Ordering::Relaxed);
         let rtt_sum_us = self.rtt_sum_us.load(Ordering::Relaxed);
@@ -476,6 +522,10 @@ impl TransportMetrics {
                 min_cwnd_bytes
             },
             slowdowns_triggered,
+            nat_traversal_attempts,
+            nat_traversal_established,
+            nat_traversal_failed_error,
+            nat_traversal_failed_version,
             avg_rtt_us,
             min_rtt_us: if min_rtt_us == u64::MAX {
                 0
@@ -506,6 +556,13 @@ impl TransportMetrics {
         // Read and reset counters
         let transfers_completed = self.transfers_completed.swap(0, Ordering::Relaxed);
         let transfers_failed = self.transfers_failed.swap(0, Ordering::Relaxed);
+        // NAT hole-punch counters mirror transfers_*: swapped-to-reset at the
+        // top and treated as activity inputs to the snapshot gate below.
+        let nat_traversal_attempts = self.nat_traversal_attempts.swap(0, Ordering::Relaxed);
+        let nat_traversal_established = self.nat_traversal_established.swap(0, Ordering::Relaxed);
+        let nat_traversal_failed_error = self.nat_traversal_failed_error.swap(0, Ordering::Relaxed);
+        let nat_traversal_failed_version =
+            self.nat_traversal_failed_version.swap(0, Ordering::Relaxed);
         // RTT samples count as activity in their own right: quiet connections
         // that only exchange keep-alive ping/pong traffic record RTT samples
         // but complete no transfers (#4000). Gating snapshot emission solely on
@@ -522,8 +579,24 @@ impl TransportMetrics {
         // avg/min/max = 0 next tick.
         let rtt_samples_pending = self.rtt_samples.load(Ordering::Relaxed);
 
+        // NAT traversal attempts/outcomes count as activity in their own
+        // right: a period whose only event is a NAT hole-punch (e.g. a failed
+        // traversal on a bootstrapping node with no other connections, hence no
+        // RTT keep-alive samples) must still emit a snapshot — otherwise the NAT
+        // visibility counters would be silently dropped, the exact
+        // under-counting this feature exists to fix. The counters were already
+        // swap-consumed above, so this is a pure gate check on the swapped values.
+        let nat_activity = nat_traversal_attempts != 0
+            || nat_traversal_established != 0
+            || nat_traversal_failed_error != 0
+            || nat_traversal_failed_version != 0;
+
         // No activity = no snapshot
-        if transfers_completed == 0 && transfers_failed == 0 && rtt_samples_pending == 0 {
+        if transfers_completed == 0
+            && transfers_failed == 0
+            && rtt_samples_pending == 0
+            && !nat_activity
+        {
             // Still reset other counters to prevent stale data. The RTT
             // accumulators (`rtt_samples`, `rtt_sum_us`, `min_rtt_us`,
             // `max_rtt_us`) are deliberately left untouched: they are only ever
@@ -595,6 +668,10 @@ impl TransportMetrics {
                 min_cwnd_bytes
             },
             slowdowns_triggered,
+            nat_traversal_attempts,
+            nat_traversal_established,
+            nat_traversal_failed_error,
+            nat_traversal_failed_version,
             avg_rtt_us,
             min_rtt_us: if min_rtt_us == u64::MAX {
                 0
@@ -639,6 +716,16 @@ pub struct TransportSnapshot {
     pub min_cwnd_bytes: u32,
     /// Number of LEDBAT slowdowns triggered.
     pub slowdowns_triggered: u32,
+    /// Outbound NAT traversal attempts started during the period.
+    pub nat_traversal_attempts: u32,
+    /// NAT traversal attempts that established a connection during the period.
+    pub nat_traversal_established: u32,
+    /// NAT traversal attempts that failed for a non-version reason during the
+    /// period (unreachable / symmetric-NAT / generic transport error).
+    pub nat_traversal_failed_error: u32,
+    /// NAT traversal attempts that failed due to a protocol version mismatch
+    /// during the period.
+    pub nat_traversal_failed_version: u32,
     /// Average RTT in microseconds (0 if no samples).
     pub avg_rtt_us: u64,
     /// Minimum RTT in microseconds (0 if no samples recorded).
@@ -823,6 +910,57 @@ mod tests {
 
         // Counters reset: a subsequent snapshot with no new activity is None.
         assert!(metrics.take_snapshot().is_none());
+    }
+
+    /// NAT hole-punch counters are period accumulators that also count as
+    /// snapshot activity: a period whose only event is a NAT traversal (e.g. a
+    /// failed hole-punch on a bootstrapping node with no transfers and no RTT
+    /// keep-alive samples) must still emit a snapshot, otherwise the NAT
+    /// visibility counters would be silently dropped by the no-activity gate.
+    #[test]
+    fn test_snapshot_emitted_for_nat_only_activity() {
+        let metrics = TransportMetrics::new();
+
+        metrics.record_nat_traversal_attempt();
+        metrics.record_nat_traversal_established();
+        metrics.record_nat_traversal_failed_error();
+        metrics.record_nat_traversal_failed_version();
+
+        let snapshot = metrics
+            .take_snapshot()
+            .expect("NAT-only activity must still produce a snapshot");
+        assert_eq!(snapshot.transfers_completed, 0);
+        assert_eq!(snapshot.transfers_failed, 0);
+        assert_eq!(snapshot.nat_traversal_attempts, 1);
+        assert_eq!(snapshot.nat_traversal_established, 1);
+        assert_eq!(snapshot.nat_traversal_failed_error, 1);
+        assert_eq!(snapshot.nat_traversal_failed_version, 1);
+
+        // Counters reset after the snapshot: a subsequent snapshot with no new
+        // activity is None.
+        assert!(metrics.take_snapshot().is_none());
+    }
+
+    /// `read_snapshot` (non-resetting dashboard read) reflects the NAT counters
+    /// without consuming them, so a following `take_snapshot` still sees them.
+    #[test]
+    fn read_snapshot_reflects_nat_counters() {
+        let metrics = TransportMetrics::new();
+        metrics.record_nat_traversal_attempt();
+        metrics.record_nat_traversal_attempt();
+        metrics.record_nat_traversal_failed_version();
+
+        let snap = metrics.read_snapshot();
+        assert_eq!(snap.nat_traversal_attempts, 2);
+        assert_eq!(snap.nat_traversal_failed_version, 1);
+        assert_eq!(snap.nat_traversal_established, 0);
+        assert_eq!(snap.nat_traversal_failed_error, 0);
+
+        // read_snapshot must NOT reset — take_snapshot still sees the counts.
+        let taken = metrics
+            .take_snapshot()
+            .expect("counts still present after a non-resetting read");
+        assert_eq!(taken.nat_traversal_attempts, 2);
     }
 
     #[test]

--- a/crates/core/src/transport/peer_connection/outbound_stream.rs
+++ b/crates/core/src/transport/peer_connection/outbound_stream.rs
@@ -219,6 +219,10 @@ pub(super) async fn send_stream<S: super::super::Socket, T: TimeSource>(
                     elapsed.as_millis() as u64,
                     TransferDirection::Send,
                 );
+                // Aggregate sender-abort counter (Group B telemetry): the
+                // cwnd-wait timed out (ACKs stopped arriving) and this stream is
+                // being failed. Bucketed once here, never per-fragment.
+                crate::node::network_status::record_stream_send_abort_cwnd();
                 // Fail only this stream, not the connection (#4345). A cwnd-wait
                 // timeout means ACKs stopped arriving for this transfer; tearing
                 // down the whole connection would kill every other operation

--- a/crates/core/src/transport/peer_connection/streaming.rs
+++ b/crates/core/src/transport/peer_connection/streaming.rs
@@ -365,6 +365,14 @@ impl StreamHandle {
         loop {
             // Check cancelled state
             if self.sync.read().cancelled {
+                // Aggregate receiver-abort counter (Group B telemetry). Recorded
+                // here so BOTH the GET originator and relay receive paths are
+                // covered; the GET originator classifies the per-op cause from
+                // the returned `StreamError` without re-recording this counter.
+                crate::node::network_status::record_stream_recv_abort_cancelled(
+                    Some(self.buffer.inserted_count() as u32),
+                    Some(self.buffer.total_fragments() as u32),
+                );
                 return Err(StreamError::Cancelled);
             }
 
@@ -398,6 +406,10 @@ impl StreamHandle {
                     // Re-check before declaring timeout — a fragment may have arrived
                     // in the race window between is_complete()/listen() above (TOCTOU).
                     if self.sync.read().cancelled {
+                        crate::node::network_status::record_stream_recv_abort_cancelled(
+                            Some(self.buffer.inserted_count() as u32),
+                            Some(self.buffer.total_fragments() as u32),
+                        );
                         return Err(StreamError::Cancelled);
                     }
                     if let Some(data) = self.buffer.assemble() {
@@ -410,6 +422,10 @@ impl StreamHandle {
                         total_fragments = self.buffer.total_fragments(),
                         timeout_secs = STREAM_INACTIVITY_TIMEOUT.as_secs(),
                         "Stream assembly timed out — no fragments received within inactivity window"
+                    );
+                    crate::node::network_status::record_stream_recv_abort_inactivity(
+                        Some(self.buffer.inserted_count() as u32),
+                        Some(self.buffer.total_fragments() as u32),
                     );
                     return Err(StreamError::InactivityTimeout);
                 }


### PR DESCRIPTION
Draft. Telemetry-only change to isolate three network failure classes, designed to be budget-safe (aggregate counters on EXISTING periodic snapshots, no new event types).

## Problem
Three failure classes are hard to diagnose from central telemetry today:

1. **Large streamed-transfer failures (highest value).** ~50% of large (> 64 KB streaming) GET fetches were failing, but the receiver stringified the stream-assembly error and discarded fragment counts — so we couldn't see WHERE they died (stream never claimed? stalled mid-stream? deserialize?).
2. **NAT hole-punch traversal has ZERO telemetry** — only file logs. Symmetric-NAT / stranded-peer failures are invisible.
3. **Routing/hosting attribution missing** — how many ops a peer relays vs originates, and its connection counts, weren't on the snapshot.

## Approach

### Group B — streamed-transfer failure isolation
- Extend the authoritative `get_terminal` event (`GetEvent::ClientTerminal` — the terminal that captures streaming outcomes since #4796; the inline `GetSuccess`/`GetFailure` paths MISS streaming) with `fragments_received`, `total_fragments`, and a new telemetry-only `StreamAbortCause` enum `{ClaimTimeout, InactivityTimeout, Cancelled, Deserialize, PayloadInvalid}`.
  - **Note / deviation from the brief:** the brief named `GetFailure`/`GetSuccess`, but those predate #4796 and structurally cannot observe streaming outcomes. `ClientTerminal` (the OTLP `get_terminal` event) is where streaming terminals actually flow, so the fields land there — which is what makes them populated at all.
- Populated by returning a structured `AssemblyFailure { message, cause, fragments_received, total_fragments }` from `assemble_and_cache_stream` (reading the stream handle's fragment counts before the error is built; `None` on the no-handle claim-timeout path). The existing human-readable error-string threading is preserved.
- **Aggregate abort counters** on the periodic RouterSnapshot: five monotonic cause totals + a five-bucket fragment-progress histogram (one bump per receiver abort — **never per-fragment**). Incremented at the receiver (`StreamHandle::assemble` inactivity/cancelled, which also covers relay receive paths; `assemble_and_cache_stream` claim-timeout/deserialize) and sender (`outbound_stream` cwnd-wait) abort sites.

### Group D — NAT hole-punch visibility
- Four monotonic counters on the EXISTING `TransportSnapshot` (`nat_traversal_attempts`, `_established`, `_failed_error`, `_failed_version`), incremented at the four outcome sites in `connection_handler.rs`.
- `connections_to_gateways` gauge on the RouterSnapshot — the NAT-stranded fingerprint.

### Group C — routing/hosting attribution
- `ring_connections` / `transient_connections` gauges + `relayed_{gets,puts,subscribes,updates}_total` counters (incremented once per genuine relay, past each `start_relay_*` dedup gate). Speculative hosting-add attribution intentionally skipped.

### Connect firehose — DEFERRED (additive counters only)
The per-event `connect_connected`/`connect_rejected` stream is a ~92k-events / 18-min firehose that these snapshot counters could replace for a net-**negative** volume change. An in-repo investigation found nothing in-repo critically depends on it, **but the external nova dashboard very likely consumes it** (topology / rejection-rate panels), which we can't see from here. So retirement is **deferred**: this PR only adds `connect_accepts_emitted`/`connect_rejects_emitted` on the snapshot (incremented in the OTLP reporter — the exact point a future retirement would filter) with a `TODO(follow-up)` to retire the per-event stream once the dashboard reads the counters.

## Volume (Ian's hard constraint)
Additive-only; **NO new event types** — the new fields ride EXISTING periodic snapshots:
- RouterSnapshot: every **5 min** (~0.2 emits/min/peer), 19 new `Option<u64>` fields.
- TransportSnapshot: every **30s** (~2/min/peer), 4 new `u32` fields.
- `get_terminal`: 3 fields, only on streaming terminals (~226/hr network-wide), emitted only when set.

Net added ≈ **well under ~0.5 KB/min per peer** (dominated by the 5-min RouterSnapshot fields), i.e. a few tens of KB/min network-wide — no increase in event COUNT, just marginally larger existing payloads. For comparison, the deferred connect firehose is ~5,000 events/min (~2 MB/min) network-wide, so a future retirement would make this change strongly net-negative. **Confirmed small (additive) / net-negative (once the firehose is retired).**

## Testing
- New pin tests: `router_snapshot_json_includes_stream_abort_counters`, `_routing_attribution_counters`, `_connect_emit_counters`, `test_event_kind_to_json_get_terminal_streaming_failure_abort_cause`, plus updated `get_terminal` json tests and Group D's `test_snapshot_emitted_for_nat_only_activity` / `read_snapshot_reflects_nat_counters`.
- Existing assembly-retry / streaming-terminal pin tests still pass.
- `cargo fmt` + `cargo clippy -p freenet --lib -- -D warnings` clean; targeted `cargo test -p freenet --lib` green (50 passed, 0 failed, 1 pre-existing ignore).

## Commits
- `feat(telemetry): add NAT hole-punch traversal counters (Group D)` — transport-only, cleanly separable.
- `feat(telemetry): isolate large streamed-transfer and routing failures` — Groups B + C + firehose-deferral counters, coupled through the shared `RouterSnapshotInfo` hand-mirror (which is why B and C aren't split into independently-compiling commits).

[AI-assisted - Claude]