### PR TITLE
fix(router): stop periodic refresh discarding relay-learned events

### DIFF
--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -1504,9 +1504,13 @@ impl Ring {
         self.event_register.register_events(events).await;
     }
 
-    /// Maximum number of route events to load from the AOF event log on startup
-    /// and during periodic refresh. Caps memory use while retaining enough history
-    /// for the isotonic estimators to converge.
+    /// Maximum number of route events to load from the AOF event log on startup.
+    /// Caps memory use while retaining enough history for the isotonic estimators
+    /// to converge.
+    ///
+    /// Startup only: since #4808 the periodic loop no longer reads the event log
+    /// (it refits in place from each estimator's own in-memory window), so this is
+    /// consulted exactly once per process.
     const ROUTER_HISTORY_LIMIT: usize = 10_000;
 
     async fn refresh_router<ER: NetEventRegister>(
@@ -7976,6 +7980,72 @@ mod refresh_router_tests {
             "the event log must be read exactly once (startup) and NEVER again: \
              the periodic rebuild from disk discarded every relay-recorded event \
              (#4808). Got {total_calls} reads across >5 ticks"
+        );
+    }
+
+    /// The loop must actually REFIT — nothing else pins the one line that makes
+    /// #4808's fix do anything in production.
+    ///
+    /// Without this, deleting `router.write().refit_stale_estimators()` from
+    /// `refresh_router` leaves every other guard green: the never-reloads test
+    /// still sees its timeout and its single read, and the health-gauge scrape
+    /// still counts its call sites. This also restores the positive liveness proof
+    /// the superseded transient-error test provided via `total_calls > 4` — a bare
+    /// timeout cannot distinguish a healthy loop from one deadlocked on
+    /// `router.write()` or never ticking at all.
+    #[tokio::test(start_paused = true)]
+    async fn refresh_router_loop_refits_stale_estimators() {
+        let router = Arc::new(RwLock::new(Router::new(&[])));
+
+        // Seed past the staleness trigger so a refit is owed. These go straight
+        // into the in-memory router, exactly as a relay hop's
+        // `record_relay_route_event` does.
+        {
+            let mut guard = router.write();
+            for _ in 0..120 {
+                guard.add_event(crate::router::RouteEvent {
+                    peer: PeerKeyLocation::random(),
+                    contract_location: Location::random(),
+                    outcome: crate::router::RouteOutcome::Success {
+                        time_to_response_start: Duration::from_millis(100),
+                        payload_size: 5000,
+                        payload_transfer_time: Duration::from_millis(50),
+                    },
+                    op_type: Some(crate::node::network_status::OpType::Get),
+                });
+            }
+            assert!(
+                guard.refit_stale_estimators() > 0,
+                "sanity: a freshly-seeded router owes a refit before the loop runs"
+            );
+            // Re-dirty it so the loop has work to do.
+            for _ in 0..120 {
+                guard.add_event(crate::router::RouteEvent {
+                    peer: PeerKeyLocation::random(),
+                    contract_location: Location::random(),
+                    outcome: crate::router::RouteOutcome::SuccessUntimed,
+                    op_type: Some(crate::node::network_status::OpType::Get),
+                });
+            }
+        }
+
+        tokio::time::timeout(
+            Duration::from_secs(60 * 40),
+            super::Ring::refresh_router(
+                router.clone(),
+                WarmStartRegister { events: vec![] },
+                CancellationToken::new(),
+            ),
+        )
+        .await
+        .ok(); // timeout expected — a healthy loop runs forever
+
+        assert_eq!(
+            router.write().refit_stale_estimators(),
+            0,
+            "the loop must have consumed the outstanding staleness; a non-zero \
+             count here means it never called refit_stale_estimators (or never \
+             ticked), leaving the model to drift exactly as it did before #4808"
         );
     }
 

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -1552,42 +1552,36 @@ impl Ring {
             {
                 return;
             }
-            let history = match register.get_router_events(Self::ROUTER_HISTORY_LIMIT).await {
-                Ok(h) => {
-                    // Health gauge (#4440): a successful read clears the
-                    // consecutive-failure run and stamps the last-success time so
-                    // a *persistently* failing refresh (silent since the #4438
-                    // non-fatal hotfix) becomes observable on the snapshot
-                    // cadence. The read succeeded regardless of whether the
-                    // history is empty, so record success here, not below.
-                    BACKGROUND_TASK_HEALTH.record_refresh_router_success();
-                    h
-                }
-                Err(error) => {
-                    // get_router_events errors are transient and recoverable —
-                    // e.g. file-descriptor exhaustion ("os error 24") when the
-                    // AOF segment file can't be opened during a connection-churn
-                    // spike. Router refresh is a best-effort optimization, so we
-                    // keep the existing in-memory router in place and retry on
-                    // the next interval rather than killing the node. (A genuine
-                    // panic inside this task is still caught by the
-                    // BackgroundTaskMonitor — only this expected, transient read
-                    // failure is swallowed here.)
-                    //
-                    // Health gauge (#4440): bump the consecutive-failure run so
-                    // the escalation #4438 deliberately left non-fatal is at
-                    // least visible in telemetry.
-                    BACKGROUND_TASK_HEALTH.record_refresh_router_failure();
-                    tracing::error!(
-                        error = %error,
-                        "Failed to refresh routing history from event log; \
-                         keeping existing router and retrying on next interval"
-                    );
-                    continue;
-                }
-            };
-            if !history.is_empty() {
-                *router.write() = Router::new(&history);
+            // Refit the isotonic estimators in place from their own in-memory
+            // raw points. Each estimator only refits once >10% of its window has
+            // turned over, so an idle router does no work here.
+            //
+            // This deliberately does NOT re-read the event log. Until #4808 this
+            // loop did `*router.write() = Router::new(&history)`, rebuilding the
+            // whole router from disk every 5 minutes. That was destructive:
+            // `operations::record_relay_route_event` feeds the in-memory router
+            // ONLY — it never persists — so every relay-recorded event was
+            // discarded on each rebuild, giving relay events a <=5 minute
+            // half-life and resetting the model faster than it could reach
+            // `MIN_EVENTS_FOR_PREDICTION`. Observed in production as a peer's
+            // event count collapsing 29 -> 2 within one 30s window, and
+            // fleet-wide as 271,518 events lost to resets against 261,710
+            // gained (net zero accumulation).
+            //
+            // Within a session the on-disk log is a strict SUBSET of what the
+            // live router already knows (same originator events, minus every
+            // relay event), so rebuilding from it could only ever lose
+            // information. The batch-accuracy benefit that motivated the rebuild
+            // is preserved — and made complete — by refitting from `raw_points`,
+            // which holds every observation regardless of origin.
+            //
+            // Health gauge (#4440): this now marks "the refit pass ran", which is
+            // still the liveness signal the gauge exists to provide. The former
+            // fallible log read is gone, so there is no failure arm to record.
+            let refit_count = router.write().refit_stale_estimators();
+            BACKGROUND_TASK_HEALTH.record_refresh_router_success();
+            if refit_count > 0 {
+                tracing::debug!(refit_count, "Refit stale isotonic estimators");
             }
         }
     }
@@ -6273,7 +6267,7 @@ mod background_task_health_tests {
     /// Asserting against the process-global `BACKGROUND_TASK_HEALTH` after
     /// running `refresh_router` would be racy (concurrent tests share the
     /// global), so this pins the call sites in source instead — three startup
-    /// records plus two in the loop = five total.
+    /// records plus one in the loop = four total.
     #[test]
     fn refresh_router_records_health_on_startup_and_in_loop() {
         let src = include_str!("ring.rs");
@@ -6291,18 +6285,24 @@ mod background_task_health_tests {
 
         let successes = body.matches(".record_refresh_router_success()").count();
         let failures = body.matches(".record_refresh_router_failure()").count();
-        // Startup: 2 Ok arms (success) + 1 Err arm (failure). Loop: 1 Ok
-        // (success) + 1 Err (failure). Total 3 success + 2 failure.
+        // Startup: 2 Ok arms (success) + 1 Err arm (failure). Loop: 1 success
+        // per refit pass. Total 3 success + 1 failure.
+        //
+        // The loop's failure arm went away with #4808: it existed only to report
+        // a failed periodic `get_router_events` read, and the loop no longer
+        // reads the log at all (it refits in place from the estimators' own
+        // raw points). The startup read is still fallible, so its Err arm — and
+        // the gauge's reason to exist — remain.
         assert_eq!(
             successes, 3,
             "refresh_router must record a success on both startup Ok arms and \
-             the loop Ok arm (got {successes}); a dropped startup record would \
-             mask a startup-only success in the health gauge"
+             the loop's refit pass (got {successes}); a dropped startup record \
+             would mask a startup-only success in the health gauge"
         );
         assert_eq!(
-            failures, 2,
-            "refresh_router must record a failure on both the startup Err arm \
-             and the loop Err arm (got {failures})"
+            failures, 1,
+            "refresh_router must record a failure on the startup Err arm (got \
+             {failures}); the loop has no fallible read since #4808"
         );
     }
 }
@@ -7927,54 +7927,55 @@ mod refresh_router_tests {
         }
     }
 
-    /// Regression test: a transient `get_router_events` error inside the
-    /// periodic refresh loop must NOT terminate the task (which, as a monitored
-    /// background task, would be node-fatal and crash-loop the gateway).
+    /// Regression for #4808, and the successor to the old
+    /// `refresh_router_survives_transient_get_router_events_error`.
     ///
-    /// The mock fails the startup load plus the first few periodic ticks, then
-    /// succeeds. We assert the loop kept polling past the errors (call count >
-    /// the number of injected failures) AND eventually recovered by loading the
-    /// history — both impossible if the error arm had `return`ed.
+    /// Two invariants, both of which the pre-#4808 loop violated:
+    ///
+    /// 1. **The periodic loop must NEVER re-read the event log.** It used to,
+    ///    doing `*router.write() = Router::new(&history)` every 5 minutes.
+    ///    Relay hops never persist (`operations::record_relay_route_event` feeds
+    ///    the in-memory router only), so each rebuild silently discarded every
+    ///    relay-learned event — resetting the model faster than it could reach
+    ///    `MIN_EVENTS_FOR_PREDICTION`. The log is a strict SUBSET of what the
+    ///    live router knows, so reloading it can only lose information. Asserting
+    ///    the read happens exactly ONCE (the startup load) is the tripwire: if
+    ///    anyone re-introduces a periodic disk rebuild, this fails.
+    /// 2. **A transient read error must not terminate the task** — as a monitored
+    ///    background task, returning would be node-fatal and crash-loop the
+    ///    gateway. The mock fails the startup read; the loop must still run.
     #[tokio::test(start_paused = true)]
-    async fn refresh_router_survives_transient_get_router_events_error() {
+    async fn refresh_router_never_reloads_from_disk_after_startup() {
         let events = make_route_events(100);
         let calls = Arc::new(AtomicUsize::new(0));
-        // Fail the startup load (call 0) and the first 3 periodic ticks
-        // (calls 1..=3), then succeed from call 4 onward.
+        // Fail the startup load only; nothing after it should read at all.
         let register = FlakyRegister {
             events: events.clone(),
-            fail_first: 4,
+            fail_first: 1,
             calls: calls.clone(),
         };
         let router = Arc::new(RwLock::new(Router::new(&[])));
 
-        // The periodic loop ticks every 5 minutes; under start_paused the
-        // timeout auto-advances virtual time, so ~40 min covers >5 ticks and
-        // lets the loop poll well past the injected failures and recover.
-        tokio::time::timeout(
+        // The loop ticks every 5 minutes; under start_paused the timeout
+        // auto-advances virtual time, so ~40 min covers >5 ticks.
+        let outcome = tokio::time::timeout(
             Duration::from_secs(60 * 40),
             super::Ring::refresh_router(router.clone(), register, CancellationToken::new()),
         )
-        .await
-        .ok(); // timeout is expected — the loop runs forever when healthy
+        .await;
 
-        // The loop must have kept polling past every injected failure rather
-        // than returning on the first Err.
-        let total_calls = calls.load(Ordering::SeqCst);
         assert!(
-            total_calls > 4,
-            "refresh loop should keep polling past transient errors, but only \
-             called get_router_events {total_calls} times (<= the 4 injected failures), \
-             implying it returned/died instead of retrying"
+            outcome.is_err(),
+            "refresh_router must keep looping (a timeout is the healthy outcome); \
+             it returned instead, which for a monitored task is node-fatal"
         );
 
-        // And it must have recovered: once get_router_events started succeeding,
-        // the router got populated from the historical events.
-        let snapshot = router.read().snapshot();
+        let total_calls = calls.load(Ordering::SeqCst);
         assert_eq!(
-            snapshot.success_events, 100,
-            "router should have recovered and loaded history after the transient \
-             errors cleared"
+            total_calls, 1,
+            "the event log must be read exactly once (startup) and NEVER again: \
+             the periodic rebuild from disk discarded every relay-recorded event \
+             (#4808). Got {total_calls} reads across >5 ticks"
         );
     }
 

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -917,6 +917,47 @@ impl Router {
         }
     }
 
+    /// Refit every isotonic estimator whose data window has turned over enough to
+    /// warrant it (see [`IsotonicEstimator::refit_if_stale`]), returning how many
+    /// were refit.
+    ///
+    /// `add_event` maintains each fit incrementally, which is an approximation of
+    /// the batch pool-adjacent-violators result. This restores the exact fit
+    /// without discarding anything: it rebuilds from each estimator's own
+    /// in-memory `raw_points`, which already holds every observation the router
+    /// has seen — originator and relay hop alike.
+    ///
+    /// This REPLACES the previous approach of rebuilding the whole `Router` from
+    /// the on-disk event log, which lost every relay-recorded event because
+    /// `operations::record_relay_route_event` never persists (issue #4808).
+    pub(crate) fn refit_stale_estimators(&mut self) -> usize {
+        let mut refit_count = 0;
+
+        for estimator in [
+            &mut self.response_start_time_estimator,
+            &mut self.transfer_rate_estimator,
+            &mut self.failure_estimator,
+        ] {
+            if estimator.refit_if_stale() {
+                refit_count += 1;
+            }
+        }
+
+        for per_op in [
+            &mut self.per_op_failure,
+            &mut self.per_op_response_time,
+            &mut self.per_op_transfer_rate,
+        ] {
+            for estimator in per_op.values_mut() {
+                if estimator.refit_if_stale() {
+                    refit_count += 1;
+                }
+            }
+        }
+
+        refit_count
+    }
+
     fn select_closest_peers<'a>(
         &self,
         peers: impl IntoIterator<Item = &'a PeerKeyLocation>,
@@ -1523,6 +1564,81 @@ mod tests {
     use crate::ring::Distance;
 
     use super::*;
+
+    /// Feed `count` timed GET successes straight into the in-memory router, which
+    /// is exactly what `operations::record_relay_route_event` does on a relay hop:
+    /// `add_event` only, never persisted to the event log.
+    fn add_relay_recorded_successes(router: &mut Router, count: usize) {
+        for _ in 0..count {
+            router.add_event(RouteEvent {
+                peer: PeerKeyLocation::random(),
+                contract_location: Location::random(),
+                outcome: RouteOutcome::Success {
+                    time_to_response_start: Duration::from_millis(100),
+                    payload_size: 5000,
+                    payload_transfer_time: Duration::from_millis(50),
+                },
+                op_type: Some(OpType::Get),
+            });
+        }
+    }
+
+    #[test]
+    fn refit_stale_estimators_preserves_relay_recorded_events() {
+        // REGRESSION (#4808). The periodic router refresh used to rebuild the whole
+        // router from the on-disk event log:
+        //
+        //     if !history.is_empty() { *router.write() = Router::new(&history); }
+        //
+        // Relay hops never persist (`record_relay_route_event` feeds the in-memory
+        // router only), so every relay-recorded event was silently discarded on
+        // each pass. In production a peer's event count collapsed 29 -> 2 inside a
+        // single 30s window, and prediction could never latch because the model was
+        // reset faster than it reached MIN_EVENTS_FOR_PREDICTION.
+        //
+        // The refresh now refits in place from each estimator's own `raw_points`.
+        // This test pins the invariant that made the old code wrong: a refresh pass
+        // must never lose an observation the router already has.
+        let mut router = Router::new(&[]);
+        add_relay_recorded_successes(&mut router, 120);
+
+        let events_before = router.failure_estimator.len();
+        assert!(
+            router.has_sufficient_routing_events(),
+            "sanity: 120 relay events must clear the prediction gate before the refit"
+        );
+
+        let refit_count = router.refit_stale_estimators();
+        assert!(
+            refit_count > 0,
+            "120 events into a fresh router is well past the staleness trigger"
+        );
+
+        assert_eq!(
+            router.failure_estimator.len(),
+            events_before,
+            "a refresh pass must preserve relay-recorded events, not discard them"
+        );
+        assert!(
+            router.has_sufficient_routing_events(),
+            "prediction must stay active across a refresh; the old rebuild switched \
+             it off by resetting the model to the on-disk (originator-only) subset"
+        );
+    }
+
+    #[test]
+    fn refit_stale_estimators_is_idempotent_and_cheap_when_idle() {
+        // An idle router must do no refit work: the trigger is data turnover, not
+        // wall-clock, so a quiet node's 5-minute tick is a no-op.
+        let mut router = Router::new(&[]);
+        add_relay_recorded_successes(&mut router, 120);
+        assert!(router.refit_stale_estimators() > 0, "first pass refits");
+        assert_eq!(
+            router.refit_stale_estimators(),
+            0,
+            "a second pass with no new events must refit nothing"
+        );
+    }
 
     #[test]
     fn estimators_use_intended_adjustment_modes() {

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -407,12 +407,22 @@ pub(crate) struct RouterSnapshotInfo {
     pub broadcast_stream_failures_last_snapshot: Option<u64>,
     /// Background-task health gauges (#4440), populated by `Ring` from the
     /// process-global `BACKGROUND_TASK_HEALTH` the monitored tasks publish into.
-    /// `refresh_router`'s transient `get_router_events` errors were made
-    /// non-fatal by the v0.2.74 #4438 hotfix, so a persistently-failing refresh
-    /// is now silent; these make it observable (partially addresses #4440 (a)).
     /// `last_success_age_secs` is seconds since the last successful run (`None`
     /// until the first success); `consecutive_failures` is the current run of
     /// failures since the last success.
+    ///
+    /// SEMANTICS CHANGED IN #4808 — read `consecutive_failures` with care. These
+    /// were added because `refresh_router`'s transient `get_router_events` errors
+    /// were made non-fatal by the v0.2.74 #4438 hotfix, leaving a persistently
+    /// failing refresh silent. The periodic loop no longer reads the event log at
+    /// all, so it has no fallible call and no failure arm: the only remaining
+    /// `record_refresh_router_failure` is the STARTUP read, and the first tick
+    /// (<=5 min later) unconditionally records a success, which clears the run.
+    /// `consecutive_failures` is therefore structurally 0 or 1, and 1 only within
+    /// the first tick — it can no longer report a persistent failure, because no
+    /// repeating fallible operation exists. Do NOT alert on it.
+    /// `last_success_age_secs` remains meaningful as a LIVENESS heartbeat: it
+    /// shows the refit pass is still ticking (expect < ~300s on a healthy node).
     pub refresh_router_last_success_age_secs: Option<u64>,
     pub refresh_router_consecutive_failures: Option<u64>,
     /// Placement-quality gauges (#4404 follow-up), populated by `Ring` on the

--- a/crates/core/src/router/isotonic_estimator.rs
+++ b/crates/core/src/router/isotonic_estimator.rs
@@ -10,6 +10,16 @@ const MIN_POINTS_FOR_REGRESSION: usize = 5;
 /// Once reached, each new point evicts the oldest via `remove_points`.
 const MAX_REGRESSION_POINTS: usize = 500;
 
+/// Fraction of the current window that must turn over before
+/// [`IsotonicEstimator::refit_if_stale`] rebuilds the fit: 1/10 = 10%.
+///
+/// Expressed as an integer ratio to keep the comparison exact. Chosen so a
+/// saturated window (`MAX_REGRESSION_POINTS`) refits once per 50 new points —
+/// frequent enough that incremental PAV drift stays small, rare enough that the
+/// O(n log n) refit is amortised to a handful of operations per event.
+const REFIT_STALENESS_NUMERATOR: usize = 1;
+const REFIT_STALENESS_DENOMINATOR: usize = 10;
+
 /// EWMA smoothing factor for per-peer adjustments.
 /// Alpha = 0.1 gives a half-life of ~6.6 events, meaning the influence of an
 /// observation drops below 50% after about 7 newer observations.
@@ -48,6 +58,15 @@ pub(crate) struct IsotonicEstimator {
     /// `MAX_REGRESSION_POINTS`, the oldest is evicted via `remove_points`.
     #[serde(skip)]
     raw_points: VecDeque<Point<f64>>,
+    /// Monotonic direction of the fit, retained so [`Self::refit_if_stale`] can
+    /// rebuild `global_regression` from `raw_points` the same way
+    /// [`Self::new_with_mode`] built it.
+    #[serde(skip)]
+    estimator_type: EstimatorType,
+    /// Points added via [`Self::add_event`] since the last refit. Drives the
+    /// staleness trigger; see [`Self::refit_if_stale`].
+    #[serde(skip)]
+    points_since_refit: usize,
 }
 
 /// How a per-peer adjustment combines with the global isotonic estimate.
@@ -209,6 +228,76 @@ impl IsotonicEstimator {
             peer_adjustments,
             adjustment_mode,
             raw_points: all_points,
+            estimator_type,
+            points_since_refit: 0,
+        }
+    }
+
+    /// Refit `global_regression` from scratch over `raw_points`, but only once
+    /// more than `REFIT_STALENESS_NUMERATOR/REFIT_STALENESS_DENOMINATOR` of the
+    /// window has turned over since the last refit. Returns whether a refit ran.
+    ///
+    /// WHY THIS EXISTS: `add_event` maintains the fit incrementally
+    /// (`add_points` / `remove_points`). Incremental pool-adjacent-violators
+    /// maintenance is an approximation — the pooled blocks it leaves depend on
+    /// insertion order, so the fit drifts from the one a batch PAV pass over the
+    /// same points would produce. Refitting restores the exact fit.
+    ///
+    /// It is deliberately driven by DATA TURNOVER rather than a timer: a refit
+    /// on an idle router is pure waste (nothing changed), while a busy router
+    /// earns one quickly. This also replaces the previous mechanism, which
+    /// rebuilt the whole `Router` from the on-disk event log every 5 minutes —
+    /// that log never receives relay-recorded events
+    /// (`operations::record_relay_route_event` feeds the in-memory router only),
+    /// so the rebuild silently discarded them and reset the model faster than it
+    /// could learn. `raw_points` is the complete corpus by construction: every
+    /// `add_event` lands here regardless of whether it came from an originator
+    /// or a relay hop. See issue #4808.
+    ///
+    /// Only `global_regression` is refit. `peer_adjustments` is an EWMA, which is
+    /// inherently incremental and has no batch-vs-online discrepancy to correct.
+    pub fn refit_if_stale(&mut self) -> bool {
+        if !self.refit_due() {
+            return false;
+        }
+        self.refit();
+        true
+    }
+
+    /// Whether enough of the window has turned over to justify a refit.
+    fn refit_due(&self) -> bool {
+        if self.raw_points.len() < MIN_POINTS_FOR_REGRESSION {
+            // Below this the regression refuses to estimate anyway
+            // (`estimate_retrieval_time`), so a refit buys nothing.
+            return false;
+        }
+        self.points_since_refit * REFIT_STALENESS_DENOMINATOR
+            > self.raw_points.len() * REFIT_STALENESS_NUMERATOR
+    }
+
+    /// Unconditionally rebuild `global_regression` from `raw_points`.
+    fn refit(&mut self) {
+        let points: Vec<Point<f64>> = self.raw_points.iter().cloned().collect();
+        let refitted = match self.estimator_type {
+            EstimatorType::Positive => IsotonicRegression::new_ascending(&points),
+            EstimatorType::Negative => IsotonicRegression::new_descending(&points),
+        };
+        match refitted {
+            Ok(regression) => {
+                self.global_regression = regression;
+                self.points_since_refit = 0;
+            }
+            Err(error) => {
+                // `new_ascending`/`new_descending` fail only on empty input, which
+                // `refit_due` already excludes. Keep the existing fit rather than
+                // panicking on the routing path if that ever changes: a slightly
+                // drifted regression is strictly better than a dead node.
+                tracing::warn!(
+                    %error,
+                    points = self.raw_points.len(),
+                    "Isotonic refit failed; keeping previous fit"
+                );
+            }
         }
     }
 
@@ -217,9 +306,12 @@ impl IsotonicEstimator {
         let route_distance = event.route_distance();
         let point = Point::new(route_distance.as_f64(), event.result);
 
-        // Add the new point to the regression and raw-point FIFO.
+        // Add the new point to the regression and raw-point FIFO. This keeps the
+        // fit usable immediately; `refit_if_stale` later restores the exact batch
+        // fit once enough of the window has turned over.
         self.global_regression.add_points(&[point]);
         self.raw_points.push_back(point);
+        self.points_since_refit += 1;
 
         // Evict the oldest point if the window is full.
         if self.raw_points.len() > MAX_REGRESSION_POINTS {
@@ -367,7 +459,7 @@ impl IsotonicEstimator {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum EstimatorType {
     /// Where the estimated value is expected to increase as distance increases
     Positive,
@@ -951,6 +1043,213 @@ mod tests {
             peer,
             contract_location,
             result,
+        }
+    }
+
+    /// Build `count` positive events with distinct random peers.
+    fn positive_events(count: usize) -> Vec<IsotonicEvent> {
+        (0..count)
+            .map(|_| simulate_positive_request(PeerKeyLocation::random(), Location::random()))
+            .collect()
+    }
+
+    #[test]
+    fn refit_if_stale_holds_off_below_ten_percent_turnover() {
+        // 100 points; 10 more is exactly 10%, which is NOT "more than 10%".
+        let mut estimator = IsotonicEstimator::new(positive_events(100), EstimatorType::Positive);
+        assert_eq!(estimator.points_since_refit, 0, "constructor starts fresh");
+
+        for event in positive_events(10) {
+            estimator.add_event(event);
+        }
+        assert!(
+            !estimator.refit_if_stale(),
+            "10 new points over a 110-point window is under the 10% trigger"
+        );
+        assert_eq!(
+            estimator.points_since_refit, 10,
+            "a held-off refit must not clear the counter, or turnover never accumulates"
+        );
+    }
+
+    #[test]
+    fn refit_if_stale_fires_once_turnover_exceeds_ten_percent() {
+        let mut estimator = IsotonicEstimator::new(positive_events(100), EstimatorType::Positive);
+        for event in positive_events(20) {
+            estimator.add_event(event);
+        }
+        assert!(
+            estimator.refit_if_stale(),
+            "20 new points over a 120-point window is past the 10% trigger"
+        );
+        assert_eq!(
+            estimator.points_since_refit, 0,
+            "a completed refit resets the turnover counter"
+        );
+        assert!(
+            !estimator.refit_if_stale(),
+            "an immediate second call has no new data and must not refit"
+        );
+    }
+
+    #[test]
+    fn refit_if_stale_is_noop_below_min_points() {
+        // Under MIN_POINTS_FOR_REGRESSION the regression refuses to estimate at
+        // all, so refitting buys nothing and must not thrash.
+        let mut estimator = IsotonicEstimator::new(std::iter::empty(), EstimatorType::Positive);
+        for event in positive_events(MIN_POINTS_FOR_REGRESSION - 1) {
+            estimator.add_event(event);
+        }
+        assert!(!estimator.refit_if_stale());
+    }
+
+    #[test]
+    fn refit_preserves_every_observation() {
+        // The regression this guards: a refit must never DISCARD data. The bug it
+        // replaces rebuilt the router from an on-disk log that lacked relay
+        // events, so the model shrank on every pass (#4808).
+        let mut estimator = IsotonicEstimator::new(positive_events(200), EstimatorType::Positive);
+        let before = estimator.len();
+
+        for event in positive_events(50) {
+            estimator.add_event(event);
+        }
+        let after_adds = estimator.len();
+        assert!(after_adds > before, "sanity: adds grow the model");
+
+        assert!(estimator.refit_if_stale(), "50/250 is past the trigger");
+        assert_eq!(
+            estimator.len(),
+            after_adds,
+            "refit must preserve the observation count exactly, not shrink it"
+        );
+    }
+
+    #[test]
+    fn refit_matches_a_batch_build_over_the_same_points() {
+        // The whole point of refitting: incremental add_points/remove_points is an
+        // approximation of batch PAV. After a refit the fit must equal what a
+        // fresh batch construction over the same window produces.
+        let seed = positive_events(120);
+        let mut incremental = IsotonicEstimator::new(std::iter::empty(), EstimatorType::Positive);
+        for event in seed.iter().cloned() {
+            incremental.add_event(event);
+        }
+        incremental.refit();
+
+        let batch = IsotonicEstimator::new(seed, EstimatorType::Positive);
+
+        // Compare the fitted curve at points spanning the distance domain.
+        for step in 0..=50 {
+            let x = step as f64 / 100.0; // ring distance ranges over [0.0, 0.5]
+            let refit_y = incremental.global_regression.interpolate(x);
+            let batch_y = batch.global_regression.interpolate(x);
+            match (refit_y, batch_y) {
+                (Some(a), Some(b)) => assert!(
+                    (a - b).abs() < 1e-9,
+                    "refit and batch fits diverge at x={x}: {a} vs {b}"
+                ),
+                (None, None) => {}
+                (a, b) => panic!("refit/batch disagree on estimability at x={x}: {a:?} vs {b:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn incremental_fit_drifts_from_batch_and_refit_repairs_it() {
+        // This test justifies the refit's existence, and is a tripwire: if
+        // `pav_regression` ever makes the incremental path exact, the first
+        // assertion fails and `refit_if_stale` can be deleted.
+        //
+        // Why drift happens (pav_regression 0.7.0):
+        //   - `add_points` re-runs `isotonic()` over `self.points`, which are the
+        //     already-POOLED blocks, not the raw inputs. Pooling is lossy, so the
+        //     result depends on insertion order.
+        //   - `remove_points` is explicitly approximate: it subtracts the evicted
+        //     point's influence from the CLOSEST aggregate by x, which need not be
+        //     the aggregate that point actually contributed to.
+        // Eviction is the worse of the two, so drive the window past
+        // MAX_REGRESSION_POINTS to exercise it — the steady state of a busy peer.
+        //
+        // Deterministic: fixed points, no RNG, no dependence on peer identity.
+        let peer = PeerKeyLocation::random();
+        let make = |x: f64, y: f64| IsotonicEvent {
+            peer: peer.clone(),
+            contract_location: Location::new(x),
+            result: y,
+        };
+
+        // Deliberately non-monotonic in y so PAV must pool, with enough points to
+        // force eviction of the oldest.
+        let events: Vec<IsotonicEvent> = (0..(MAX_REGRESSION_POINTS + 200))
+            .map(|i| {
+                let x = (i % 50) as f64 / 100.0; // spread over [0.0, 0.49]
+                let y = if i % 3 == 0 { 1.0 - x } else { x }; // violates monotonicity
+                make(x, y)
+            })
+            .collect();
+
+        let mut incremental = IsotonicEstimator::new(std::iter::empty(), EstimatorType::Positive);
+        for event in events.iter().cloned() {
+            incremental.add_event(event);
+        }
+
+        // The batch reference: exactly what the estimator's own constructor builds
+        // from the same windowed corpus.
+        let batch = IsotonicEstimator::new(events, EstimatorType::Positive);
+
+        let sample = |est: &IsotonicEstimator| -> Vec<f64> {
+            (0..=49)
+                .map(|s| {
+                    est.global_regression
+                        .interpolate(s as f64 / 100.0)
+                        .unwrap_or(f64::NAN)
+                })
+                .collect()
+        };
+
+        let drift: f64 = sample(&incremental)
+            .iter()
+            .zip(sample(&batch).iter())
+            .map(|(a, b)| (a - b).abs())
+            .sum();
+        assert!(
+            drift > 1e-9,
+            "expected the incremental fit to drift from batch (drift={drift}); if this \
+             now holds exactly, pav_regression became exact and refit_if_stale is dead code"
+        );
+
+        incremental.refit();
+        let repaired: f64 = sample(&incremental)
+            .iter()
+            .zip(sample(&batch).iter())
+            .map(|(a, b)| (a - b).abs())
+            .sum();
+        assert!(
+            repaired < 1e-9,
+            "refit must restore the exact batch fit (residual={repaired}, was {drift})"
+        );
+    }
+
+    #[test]
+    fn refit_respects_descending_estimator_direction() {
+        // A refit must rebuild with the SAME monotonic direction it was created
+        // with; rebuilding a Negative estimator as ascending would silently invert
+        // every transfer-rate estimate.
+        let events: Vec<IsotonicEvent> = (0..120)
+            .map(|_| simulate_negative_request(PeerKeyLocation::random(), Location::random()))
+            .collect();
+        let mut estimator = IsotonicEstimator::new(events, EstimatorType::Negative);
+        estimator.refit();
+
+        let near = estimator.global_regression.interpolate(0.05);
+        let far = estimator.global_regression.interpolate(0.45);
+        if let (Some(near), Some(far)) = (near, far) {
+            assert!(
+                near >= far,
+                "a descending fit must not increase with distance after refit \
+                 (near={near}, far={far})"
+            );
         }
     }
 

--- a/crates/core/src/router/isotonic_estimator.rs
+++ b/crates/core/src/router/isotonic_estimator.rs
@@ -10,15 +10,23 @@ const MIN_POINTS_FOR_REGRESSION: usize = 5;
 /// Once reached, each new point evicts the oldest via `remove_points`.
 const MAX_REGRESSION_POINTS: usize = 500;
 
-/// Fraction of the current window that must turn over before
-/// [`IsotonicEstimator::refit_if_stale`] rebuilds the fit: 1/10 = 10%.
+/// Percentage of the current window that must turn over before
+/// [`IsotonicEstimator::refit_if_stale`] rebuilds the fit.
 ///
-/// Expressed as an integer ratio to keep the comparison exact. Chosen so a
-/// saturated window (`MAX_REGRESSION_POINTS`) refits once per 50 new points —
-/// frequent enough that incremental PAV drift stays small, rare enough that the
-/// O(n log n) refit is amortised to a handful of operations per event.
-const REFIT_STALENESS_NUMERATOR: usize = 1;
-const REFIT_STALENESS_DENOMINATOR: usize = 10;
+/// Compared as `events_since_refit * 100 > len * REFIT_STALENESS_PERCENT` — a
+/// multiplication rather than a division, so the threshold is exact with no
+/// truncation. Over a saturated window (`MAX_REGRESSION_POINTS`) this earns a
+/// refit every 51st event: frequent enough that incremental PAV drift stays
+/// small, rare enough that the O(n log n) refit amortises to a handful of
+/// operations per event.
+///
+/// NOTE: this bounds only how *often* a refit is EARNED. The realised cadence is
+/// `min(caller's poll interval, this)` — `refit_if_stale` does nothing until
+/// someone calls it, and today the only caller is `Ring::refresh_router`'s
+/// 5-minute tick. Above ~10 events/min the tick binds instead and a window can
+/// turn over entirely between refits. That is far above the observed production
+/// median (~14-16 events/hour), where turnover always binds first.
+const REFIT_STALENESS_PERCENT: usize = 10;
 
 /// EWMA smoothing factor for per-peer adjustments.
 /// Alpha = 0.1 gives a half-life of ~6.6 events, meaning the influence of an
@@ -54,19 +62,25 @@ pub(crate) struct IsotonicEstimator {
     /// [`AdjustmentMode`].
     #[serde(skip)]
     adjustment_mode: AdjustmentMode,
-    /// Raw input points in insertion order. When len exceeds
+    /// Raw input events in insertion order. When len exceeds
     /// `MAX_REGRESSION_POINTS`, the oldest is evicted via `remove_points`.
+    ///
+    /// Retains the whole [`IsotonicEvent`], not just its `(distance, result)`
+    /// point, because [`Self::refit`] must rebuild `peer_adjustments` too — and
+    /// that needs peer identity. Keeping only points would make a refit a
+    /// PARTIAL rebuild: the global curve would move while every peer's EWMA
+    /// stayed anchored to the old curve, and evicted peers would never be
+    /// pruned from `peer_adjustments`.
     #[serde(skip)]
-    raw_points: VecDeque<Point<f64>>,
-    /// Monotonic direction of the fit, retained so [`Self::refit_if_stale`] can
-    /// rebuild `global_regression` from `raw_points` the same way
-    /// [`Self::new_with_mode`] built it.
+    raw_events: VecDeque<IsotonicEvent>,
+    /// Monotonic direction of the fit, retained so [`Self::refit`] can rebuild
+    /// the same way [`Self::new_with_mode`] built it.
     #[serde(skip)]
     estimator_type: EstimatorType,
-    /// Points added via [`Self::add_event`] since the last refit. Drives the
+    /// Events added via [`Self::add_event`] since the last refit. Drives the
     /// staleness trigger; see [`Self::refit_if_stale`].
     #[serde(skip)]
-    points_since_refit: usize,
+    events_since_refit: usize,
 }
 
 /// How a per-peer adjustment combines with the global isotonic estimate.
@@ -180,38 +194,71 @@ impl IsotonicEstimator {
             all_events.drain(..all_events.len() - MAX_REGRESSION_POINTS);
         }
 
-        let mut all_points = VecDeque::with_capacity(all_events.len());
-        let mut peer_events: HashMap<PeerKeyLocation, Vec<IsotonicEvent>> = HashMap::new();
+        let raw_events: VecDeque<IsotonicEvent> = all_events.into();
+        let (global_regression, peer_adjustments) =
+            Self::fit(&raw_events, estimator_type, adjustment_mode)
+                .expect("Failed to create isotonic regression");
 
-        for event in all_events {
-            let point = Point::new(event.route_distance().as_f64(), event.result);
-            all_points.push_back(point);
-            peer_events
-                .entry(event.peer.clone())
-                .or_default()
-                .push(event);
+        IsotonicEstimator {
+            global_regression,
+            peer_adjustments,
+            adjustment_mode,
+            raw_events,
+            estimator_type,
+            events_since_refit: 0,
         }
+    }
 
-        let points: Vec<Point<f64>> = all_points.iter().cloned().collect();
+    /// Fit `events` from scratch: the global isotonic regression, plus every
+    /// peer's adjustment re-anchored to that fit.
+    ///
+    /// Shared by [`Self::new_with_mode`] and [`Self::refit`] so that a refit is a
+    /// TRUE batch rebuild rather than a partial one. Both halves must be rebuilt
+    /// together: a peer's `Adjustment` is an EWMA of residuals measured AGAINST
+    /// the global curve (see [`AdjustmentMode::residual`]), so refitting the
+    /// curve without re-deriving the residuals would leave every peer corrected
+    /// relative to a curve that no longer exists. Rebuilding from `events` also
+    /// bounds `peer_adjustments` to peers present in the current window —
+    /// without that, the map would grow one entry per peer ever seen (an
+    /// unbounded per-key collection driven by remote peers) and a returning peer
+    /// would have its stale adjustment applied at full weight, since
+    /// `Adjustment::effective_count` has no time decay.
+    fn fit(
+        events: &VecDeque<IsotonicEvent>,
+        estimator_type: EstimatorType,
+        adjustment_mode: AdjustmentMode,
+    ) -> Result<
+        (
+            IsotonicRegression<f64>,
+            HashMap<PeerKeyLocation, Adjustment>,
+        ),
+        pav_regression::isotonic_regression::IsotonicRegressionError,
+    > {
+        let points: Vec<Point<f64>> = events
+            .iter()
+            .map(|event| Point::new(event.route_distance().as_f64(), event.result))
+            .collect();
+
         let global_regression = match estimator_type {
             EstimatorType::Positive => IsotonicRegression::new_ascending(&points),
             EstimatorType::Negative => IsotonicRegression::new_descending(&points),
-        }
-        .expect("Failed to create isotonic regression");
-
-        let global_regression_big_enough =
-            global_regression.len() >= Self::ADJUSTMENT_PRIOR_SIZE as usize;
+        }?;
 
         let mut peer_adjustments: HashMap<PeerKeyLocation, Adjustment> = HashMap::new();
 
-        if global_regression_big_enough {
-            for (peer_location, events) in peer_events.iter() {
+        if global_regression.len() >= Self::ADJUSTMENT_PRIOR_SIZE as usize {
+            let mut peer_events: HashMap<&PeerKeyLocation, Vec<&IsotonicEvent>> = HashMap::new();
+            for event in events {
+                peer_events.entry(&event.peer).or_default().push(event);
+            }
+
+            for (peer_location, peer_history) in peer_events {
                 let mut adjustment = Adjustment::new();
                 // Seed with ADJUSTMENT_PRIOR_SIZE phantom neutral observations
                 // so peers with few real observations are shrunk toward zero.
                 adjustment.effective_count = Self::ADJUSTMENT_PRIOR_SIZE as f64;
 
-                for event in events {
+                for event in peer_history {
                     let global_estimate = global_regression
                         .interpolate(event.route_distance().as_f64())
                         .expect("Regression should always produce an estimate");
@@ -223,14 +270,7 @@ impl IsotonicEstimator {
             }
         }
 
-        IsotonicEstimator {
-            global_regression,
-            peer_adjustments,
-            adjustment_mode,
-            raw_points: all_points,
-            estimator_type,
-            points_since_refit: 0,
-        }
+        Ok((global_regression, peer_adjustments))
     }
 
     /// Refit `global_regression` from scratch over `raw_points`, but only once
@@ -254,49 +294,57 @@ impl IsotonicEstimator {
     /// `add_event` lands here regardless of whether it came from an originator
     /// or a relay hop. See issue #4808.
     ///
-    /// Only `global_regression` is refit. `peer_adjustments` is an EWMA, which is
-    /// inherently incremental and has no batch-vs-online discrepancy to correct.
+    /// Rebuilds BOTH halves of the estimator — see [`Self::fit`] for why the
+    /// global curve and the per-peer adjustments cannot be refit independently.
     pub fn refit_if_stale(&mut self) -> bool {
         if !self.refit_due() {
             return false;
         }
-        self.refit();
-        true
+        self.refit()
     }
 
     /// Whether enough of the window has turned over to justify a refit.
     fn refit_due(&self) -> bool {
-        if self.raw_points.len() < MIN_POINTS_FOR_REGRESSION {
+        if self.raw_events.len() < MIN_POINTS_FOR_REGRESSION {
             // Below this the regression refuses to estimate anyway
             // (`estimate_retrieval_time`), so a refit buys nothing.
             return false;
         }
-        self.points_since_refit * REFIT_STALENESS_DENOMINATOR
-            > self.raw_points.len() * REFIT_STALENESS_NUMERATOR
+        self.events_since_refit * 100 > self.raw_events.len() * REFIT_STALENESS_PERCENT
     }
 
-    /// Unconditionally rebuild `global_regression` from `raw_points`.
-    fn refit(&mut self) {
-        let points: Vec<Point<f64>> = self.raw_points.iter().cloned().collect();
-        let refitted = match self.estimator_type {
-            EstimatorType::Positive => IsotonicRegression::new_ascending(&points),
-            EstimatorType::Negative => IsotonicRegression::new_descending(&points),
-        };
-        match refitted {
-            Ok(regression) => {
-                self.global_regression = regression;
-                self.points_since_refit = 0;
+    /// Unconditionally rebuild the estimator from `raw_events`. Returns whether
+    /// the rebuild succeeded.
+    ///
+    /// Equivalent to constructing a fresh estimator over the current window —
+    /// which is exactly what the pre-#4808 periodic `Router::new(&history)`
+    /// rebuild achieved, except that it read an on-disk log missing every
+    /// relay-recorded event, whereas `raw_events` is complete by construction.
+    fn refit(&mut self) -> bool {
+        match Self::fit(&self.raw_events, self.estimator_type, self.adjustment_mode) {
+            Ok((global_regression, peer_adjustments)) => {
+                self.global_regression = global_regression;
+                self.peer_adjustments = peer_adjustments;
+                self.events_since_refit = 0;
+                true
             }
             Err(error) => {
-                // `new_ascending`/`new_descending` fail only on empty input, which
-                // `refit_due` already excludes. Keep the existing fit rather than
-                // panicking on the routing path if that ever changes: a slightly
-                // drifted regression is strictly better than a dead node.
+                // Unreachable today: `new_ascending`/`new_descending` pass
+                // `intersect_origin: false`, and the sole error variant
+                // (`NegativePointWithIntersectOrigin`) is only produced when that
+                // flag is true. Empty input succeeds. Handled rather than
+                // `.expect()`-ed so that a future pav_regression change cannot
+                // turn a fit failure into a dead routing path — a slightly
+                // drifted regression beats a panicking node.
+                //
+                // `events_since_refit` is deliberately NOT reset, so the next
+                // poll retries rather than waiting for another full turnover.
                 tracing::warn!(
                     %error,
-                    points = self.raw_points.len(),
+                    events = self.raw_events.len(),
                     "Isotonic refit failed; keeping previous fit"
                 );
+                false
             }
         }
     }
@@ -306,17 +354,18 @@ impl IsotonicEstimator {
         let route_distance = event.route_distance();
         let point = Point::new(route_distance.as_f64(), event.result);
 
-        // Add the new point to the regression and raw-point FIFO. This keeps the
-        // fit usable immediately; `refit_if_stale` later restores the exact batch
-        // fit once enough of the window has turned over.
+        // Add the new point to the regression and the raw-event FIFO. This keeps
+        // the fit usable immediately; `refit_if_stale` later restores the exact
+        // batch fit once enough of the window has turned over.
         self.global_regression.add_points(&[point]);
-        self.raw_points.push_back(point);
-        self.points_since_refit += 1;
+        self.raw_events.push_back(event.clone());
+        self.events_since_refit += 1;
 
-        // Evict the oldest point if the window is full.
-        if self.raw_points.len() > MAX_REGRESSION_POINTS {
-            if let Some(oldest) = self.raw_points.pop_front() {
-                self.global_regression.remove_points(&[oldest]);
+        // Evict the oldest event if the window is full.
+        if self.raw_events.len() > MAX_REGRESSION_POINTS {
+            if let Some(oldest) = self.raw_events.pop_front() {
+                let oldest_point = Point::new(oldest.route_distance().as_f64(), oldest.result);
+                self.global_regression.remove_points(&[oldest_point]);
             }
         }
 
@@ -441,19 +490,23 @@ impl IsotonicEstimator {
     /// window). These are the actual events the isotonic fit is computed from, so
     /// the dashboard can show the scatter behind the curve. Empty when no data.
     pub(crate) fn sampled_raw_points(&self, max: usize) -> Vec<(f64, f64)> {
-        let n = self.raw_points.len();
+        let n = self.raw_events.len();
         if n == 0 || max == 0 {
             return Vec::new();
         }
         if n <= max {
-            return self.raw_points.iter().map(|p| (*p.x(), *p.y())).collect();
+            return self
+                .raw_events
+                .iter()
+                .map(|e| (e.route_distance().as_f64(), e.result))
+                .collect();
         }
         let stride = n as f64 / max as f64;
         (0..max)
             .map(|i| {
                 let idx = ((i as f64 * stride) as usize).min(n - 1);
-                let p = &self.raw_points[idx];
-                (*p.x(), *p.y())
+                let event = &self.raw_events[idx];
+                (event.route_distance().as_f64(), event.result)
             })
             .collect()
     }
@@ -925,9 +978,9 @@ mod tests {
         }
 
         assert!(
-            estimator.raw_points.len() <= MAX_REGRESSION_POINTS,
+            estimator.raw_events.len() <= MAX_REGRESSION_POINTS,
             "Raw points should be bounded, got {}",
-            estimator.raw_points.len()
+            estimator.raw_events.len()
         );
 
         let result = estimator.estimate_retrieval_time(&peer, contract);
@@ -1053,42 +1106,163 @@ mod tests {
             .collect()
     }
 
-    #[test]
-    fn refit_if_stale_holds_off_below_ten_percent_turnover() {
-        // 100 points; 10 more is exactly 10%, which is NOT "more than 10%".
-        let mut estimator = IsotonicEstimator::new(positive_events(100), EstimatorType::Positive);
-        assert_eq!(estimator.points_since_refit, 0, "constructor starts fresh");
+    /// An event whose `route_distance()` is EXACTLY `distance`, built by placing
+    /// the contract at ring offset `distance` from `peer`.
+    ///
+    /// A peer's location is derived from its address and cannot be set, and
+    /// `route_distance()` is `contract.distance(peer_location)`, which folds
+    /// `|a-b|` around 0.5. So a test that picks contract locations directly has no
+    /// control over the regression's x-axis — the random peer location turns it
+    /// into a tent transform of the intended value. Deriving the contract FROM the
+    /// peer inverts that: for `distance` in `[0.0, 0.5]`, `route_distance()` is
+    /// `distance` exactly, whatever the peer happens to be.
+    fn event_at_distance(peer: &PeerKeyLocation, distance: f64, result: f64) -> IsotonicEvent {
+        let peer_location = peer
+            .location()
+            .expect("PeerKeyLocation::random always yields a known address");
+        let contract_location = Location::new((peer_location.as_f64() + distance).rem_euclid(1.0));
+        IsotonicEvent {
+            peer: peer.clone(),
+            contract_location,
+            result,
+        }
+    }
 
-        for event in positive_events(10) {
+    /// The trigger is `events_since_refit * 100 > len * 10`, where `len` is the
+    /// window AFTER the adds. Seeded with 100, adding k gives len = 100 + k, so
+    /// the boundary is the smallest k with `100k > 10(100 + k)`, i.e. k > 11.11 —
+    /// k = 12 fires, k = 11 does not. Pinning BOTH sides matters: bracketing only
+    /// 10 and 20 leaves `>` vs `>=` (and several off-by-ones) undetected.
+    #[test]
+    fn refit_if_stale_holds_off_just_below_the_turnover_boundary() {
+        let mut estimator = IsotonicEstimator::new(positive_events(100), EstimatorType::Positive);
+        assert_eq!(estimator.events_since_refit, 0, "constructor starts fresh");
+
+        for event in positive_events(11) {
             estimator.add_event(event);
         }
         assert!(
             !estimator.refit_if_stale(),
-            "10 new points over a 110-point window is under the 10% trigger"
+            "11 new events over a 111-event window is 9.9% — under the trigger"
         );
         assert_eq!(
-            estimator.points_since_refit, 10,
+            estimator.events_since_refit, 11,
             "a held-off refit must not clear the counter, or turnover never accumulates"
         );
     }
 
     #[test]
-    fn refit_if_stale_fires_once_turnover_exceeds_ten_percent() {
+    fn refit_if_stale_fires_at_the_turnover_boundary() {
         let mut estimator = IsotonicEstimator::new(positive_events(100), EstimatorType::Positive);
-        for event in positive_events(20) {
+        for event in positive_events(12) {
             estimator.add_event(event);
         }
         assert!(
             estimator.refit_if_stale(),
-            "20 new points over a 120-point window is past the 10% trigger"
+            "12 new events over a 112-event window is 10.7% — past the trigger"
         );
         assert_eq!(
-            estimator.points_since_refit, 0,
+            estimator.events_since_refit, 0,
             "a completed refit resets the turnover counter"
         );
         assert!(
             !estimator.refit_if_stale(),
             "an immediate second call has no new data and must not refit"
+        );
+    }
+
+    #[test]
+    fn refit_if_stale_fires_at_exactly_min_points() {
+        // Pins the `< MIN_POINTS_FOR_REGRESSION` guard's boundary: one fewer must
+        // hold off (covered above), exactly MIN must be allowed through.
+        let mut estimator = IsotonicEstimator::new(std::iter::empty(), EstimatorType::Positive);
+        for event in positive_events(MIN_POINTS_FOR_REGRESSION) {
+            estimator.add_event(event);
+        }
+        assert!(
+            estimator.refit_if_stale(),
+            "at exactly MIN_POINTS_FOR_REGRESSION the guard must allow a refit"
+        );
+    }
+
+    #[test]
+    fn refit_rebuilds_peer_adjustments_against_the_new_curve() {
+        // A refit moves `global_regression`. Every `Adjustment` is an EWMA of
+        // residuals measured AGAINST that curve, so leaving them untouched would
+        // correct each peer relative to a curve that no longer exists. The batch
+        // constructor rebuilds both together; a refit must too.
+        //
+        // Pinned by equivalence: after a refit, the estimator must match a batch
+        // build over the same window in the thing routing actually consumes —
+        // `estimate_retrieval_time` — not merely in the global curve.
+        let seed = positive_events(150);
+
+        let mut incremental = IsotonicEstimator::new(std::iter::empty(), EstimatorType::Positive);
+        for event in seed.iter().cloned() {
+            incremental.add_event(event);
+        }
+        assert!(incremental.refit(), "refit must succeed");
+
+        let batch = IsotonicEstimator::new(seed.clone(), EstimatorType::Positive);
+
+        assert_eq!(
+            incremental.peer_adjustments.len(),
+            batch.peer_adjustments.len(),
+            "a refit must produce the same peer set as a batch build over the \
+             same window — otherwise peer_adjustments is not bounded by the window"
+        );
+
+        for event in &seed {
+            let refit_est =
+                incremental.estimate_retrieval_time(&event.peer, event.contract_location);
+            let batch_est = batch.estimate_retrieval_time(&event.peer, event.contract_location);
+            match (refit_est, batch_est) {
+                (Ok(a), Ok(b)) => assert!(
+                    (a - b).abs() < 1e-9,
+                    "refit and batch disagree on the peer-adjusted estimate: {a} vs {b}"
+                ),
+                (Err(_), Err(_)) => {}
+                (a, b) => panic!("refit/batch disagree on estimability: {a:?} vs {b:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn refit_prunes_peers_that_fell_out_of_the_window() {
+        // `raw_events` evicts at MAX_REGRESSION_POINTS, but `peer_adjustments`
+        // only ever inserts on the incremental path. Without a rebuild the map
+        // would grow one entry per peer EVER seen — an unbounded per-key
+        // collection driven by remote peers (see .claude/rules/code-style.md) —
+        // and a returning peer's stale adjustment would apply at full weight,
+        // since Adjustment::effective_count has no time decay.
+        let mut estimator = IsotonicEstimator::new(std::iter::empty(), EstimatorType::Positive);
+
+        // Fill the window, then push it fully over with a disjoint peer set.
+        for event in positive_events(MAX_REGRESSION_POINTS) {
+            estimator.add_event(event);
+        }
+        for event in positive_events(MAX_REGRESSION_POINTS) {
+            estimator.add_event(event);
+        }
+        assert_eq!(
+            estimator.raw_events.len(),
+            MAX_REGRESSION_POINTS,
+            "sanity: the event window stays capped"
+        );
+        assert!(
+            estimator.peer_adjustments.len() > MAX_REGRESSION_POINTS,
+            "sanity: the incremental path really does accumulate evicted peers \
+             (got {})",
+            estimator.peer_adjustments.len()
+        );
+
+        assert!(estimator.refit(), "refit must succeed");
+        assert!(
+            estimator.peer_adjustments.len() <= MAX_REGRESSION_POINTS,
+            "a refit must bound peer_adjustments to peers in the current window \
+             (got {} for a {}-event window)",
+            estimator.peer_adjustments.len(),
+            MAX_REGRESSION_POINTS
         );
     }
 
@@ -1126,36 +1300,6 @@ mod tests {
     }
 
     #[test]
-    fn refit_matches_a_batch_build_over_the_same_points() {
-        // The whole point of refitting: incremental add_points/remove_points is an
-        // approximation of batch PAV. After a refit the fit must equal what a
-        // fresh batch construction over the same window produces.
-        let seed = positive_events(120);
-        let mut incremental = IsotonicEstimator::new(std::iter::empty(), EstimatorType::Positive);
-        for event in seed.iter().cloned() {
-            incremental.add_event(event);
-        }
-        incremental.refit();
-
-        let batch = IsotonicEstimator::new(seed, EstimatorType::Positive);
-
-        // Compare the fitted curve at points spanning the distance domain.
-        for step in 0..=50 {
-            let x = step as f64 / 100.0; // ring distance ranges over [0.0, 0.5]
-            let refit_y = incremental.global_regression.interpolate(x);
-            let batch_y = batch.global_regression.interpolate(x);
-            match (refit_y, batch_y) {
-                (Some(a), Some(b)) => assert!(
-                    (a - b).abs() < 1e-9,
-                    "refit and batch fits diverge at x={x}: {a} vs {b}"
-                ),
-                (None, None) => {}
-                (a, b) => panic!("refit/batch disagree on estimability at x={x}: {a:?} vs {b:?}"),
-            }
-        }
-    }
-
-    #[test]
     fn incremental_fit_drifts_from_batch_and_refit_repairs_it() {
         // This test justifies the refit's existence, and is a tripwire: if
         // `pav_regression` ever makes the incremental path exact, the first
@@ -1171,13 +1315,13 @@ mod tests {
         // Eviction is the worse of the two, so drive the window past
         // MAX_REGRESSION_POINTS to exercise it — the steady state of a busy peer.
         //
-        // Deterministic: fixed points, no RNG, no dependence on peer identity.
+        // The regression's x-axis is controlled exactly via `event_at_distance`
+        // (see its docs): the contract is placed at ring offset x FROM the peer,
+        // so `route_distance() == x` whatever the random peer location is. Without
+        // that, `Location::distance`'s fold turns the intended geometry into a
+        // peer-dependent tent transform and the data below is not what it reads as.
         let peer = PeerKeyLocation::random();
-        let make = |x: f64, y: f64| IsotonicEvent {
-            peer: peer.clone(),
-            contract_location: Location::new(x),
-            result: y,
-        };
+        let make = |x: f64, y: f64| event_at_distance(&peer, x, y);
 
         // Deliberately non-monotonic in y so PAV must pool, with enough points to
         // force eviction of the oldest.
@@ -1234,23 +1378,47 @@ mod tests {
     #[test]
     fn refit_respects_descending_estimator_direction() {
         // A refit must rebuild with the SAME monotonic direction it was created
-        // with; rebuilding a Negative estimator as ascending would silently invert
-        // every transfer-rate estimate.
+        // with: rebuilding a Negative (transfer-rate) estimator as ascending would
+        // silently invert every estimate.
+        //
+        // NOTE ON THE ASSERTION. The obvious check — `near >= far` — is VACUOUS
+        // and was proven so in review: PAV over data that violates its assumed
+        // direction at every pair pools everything into ONE aggregate, i.e. a flat
+        // line, and a flat line satisfies `near >= far` by equality. Fitting these
+        // points ascending yields exactly that, so the weak assertion passes on
+        // the very bug it is meant to catch.
+        //
+        // So assert a STRICT decrease AND that the fit did not collapse to a
+        // single block. Both fail if the direction is wrong.
+        let peer = PeerKeyLocation::random();
         let events: Vec<IsotonicEvent> = (0..120)
-            .map(|_| simulate_negative_request(PeerKeyLocation::random(), Location::random()))
+            .map(|i| {
+                let x = (i % 40) as f64 / 100.0; // [0.0, 0.39]
+                event_at_distance(&peer, x, 1.0 - x) // strictly decreasing in distance
+            })
             .collect();
         let mut estimator = IsotonicEstimator::new(events, EstimatorType::Negative);
-        estimator.refit();
+        assert!(estimator.refit(), "refit must succeed");
 
-        let near = estimator.global_regression.interpolate(0.05);
-        let far = estimator.global_regression.interpolate(0.45);
-        if let (Some(near), Some(far)) = (near, far) {
-            assert!(
-                near >= far,
-                "a descending fit must not increase with distance after refit \
-                 (near={near}, far={far})"
-            );
-        }
+        let near = estimator
+            .global_regression
+            .interpolate(0.05)
+            .expect("fit must estimate within its data range");
+        let far = estimator
+            .global_regression
+            .interpolate(0.35)
+            .expect("fit must estimate within its data range");
+        assert!(
+            near > far + 1e-6,
+            "a descending fit must STRICTLY decrease with distance after refit \
+             (near={near}, far={far}); equality means PAV pooled everything into \
+             one flat aggregate, which is what fitting the wrong direction does"
+        );
+        assert!(
+            estimator.global_regression.get_points().len() > 1,
+            "the fit collapsed to a single aggregate — the hallmark of PAV run \
+             against its data's actual direction"
+        );
     }
 
     fn simulate_positive_request(


### PR DESCRIPTION
## Problem

Every peer's routing model is reset faster than it can learn. `prediction_active` is false on ~85% of the network, the per-peer routing charts sit empty, and the transfer-rate estimator on a typical peer has never held an observation.

The router is **not** starving for input — it learns at a healthy median of ~14-16 events/hour. It is being wiped.

`Ring::refresh_router` rebuilt the whole router from the on-disk event log every 5 minutes:

```rust
if !history.is_empty() { *router.write() = Router::new(&history); }
```

But `operations::record_relay_route_event` (`operations.rs:835-844`) feeds the **in-memory router only** — it never persists. So every route event from the ~17 forwarding-hop sites had a **<=5 minute half-life**, while only the 4 originator sites (which do call `NetEventLog::route_event`) survived a rebuild.

On a peer carrying other people's traffic — i.e. most peers, and precisely the ones doing the most routing — forwarding-hop events **are** the model. The rebuild reset it to the originator-only remnant.

The log's originator events are a subset of what the router has already been fed, so reloading it could only lose information: it would *add stale* originator events (older than the rolling window — exactly what the window exists to discard) while *dropping fresh* forwarding-hop events.

### Evidence

Live, on a production peer (`Global events`, 30s polling):

```
10:32:11 - 10:37:12   29   (stable)
10:37:42               2   <- 93% of the model destroyed
10:40:12               4   <- re-climbing
10:42:42              14
```

Fleet-wide (118,080 `router_snapshot` rows, 43h, public-IP peers):

- **261,710 events gained, 271,518 lost to resets (103.7%)** — net accumulation zero.
- 16.7% of transitions lose events; max single drop **495**.
- Median peer holds 5-7 events against `MIN_EVENTS_FOR_PREDICTION = 50`; only 11-16% ever latch prediction.

Below that gate the router uses #3398's untried-first fallback, which was designed as a *transient* bootstrap toward 50 events. Because the gate is unreachable, the network sits in it permanently.

## Approach

Keep the batch refit — it is a real **accuracy** mechanism, not a vestigial restore path — but give it the right corpus and the right trigger.

`IsotonicEstimator` already retains a FIFO of every observation in the window, populated by `add_event` regardless of origin. That is the complete corpus, in memory, by construction. Refit from it instead of rebuilding from disk.

The refit is genuinely necessary — `pav_regression`'s incremental path is approximate, and review measured the resulting drift at **3-6% of span (response time), 21% (failure estimator)** on realistic data:

- `add_points` re-runs `isotonic()` over `self.points`, the already-**pooled** blocks rather than raw inputs, so the fit depends on insertion order.
- `remove_points` is explicitly approximate: it subtracts an evicted point's influence from the **closest aggregate by x**, which need not be the aggregate it contributed to. Only begins once the window saturates — the steady state of a busy peer.

Refitting is driven by **data turnover (>10% of the window)** rather than a timer, so an idle router does no work. (Realised cadence is `min(poll interval, turnover)`; the 5-min tick only binds above ~10 events/min, ~40× the production median — documented on `REFIT_STALENESS_PERCENT`.)

**A refit rebuilds BOTH halves** — the global curve *and* every peer's adjustment, via logic shared with the constructor. They cannot be refit independently: an `Adjustment` is an EWMA of residuals measured *against* the global curve, so moving the curve alone leaves every peer corrected relative to one that no longer exists (measured at up to 0.198 absolute on a [0,1] failure probability). Rebuilding from the window also bounds `peer_adjustments` to peers currently in it — without which it would grow one entry per peer ever seen, an unbounded per-key collection driven by remote peers.

Measured cost: a saturated 500-point refit is **27.3µs**; all 15 estimators worst-case **~410µs**, once per 5 min — strictly cheaper than the old `Router::new` over up to 10,000 events under the same lock.

## Testing

**The regression guard is `refresh_router_never_reloads_from_disk_after_startup`** — it exercises the pre-existing `refresh_router` and genuinely fails against the old loop (which read the log every tick, so `total_calls` would be ~9, not 1). It supersedes `refresh_router_survives_transient_get_router_events_error`; see the review comment for why deletion beat `#[ignore]` there.

**`refresh_router_loop_refits_stale_estimators`** pins the loop→refit wiring — the one line that makes this fix do anything. Verified by mutation: stubbing the call fails only this test; the other five guards stay green.

**`refit_rebuilds_peer_adjustments_against_the_new_curve`** asserts a refit equals a batch build in `estimate_retrieval_time` — the value routing actually consumes, not merely the global curve. Plus `refit_prunes_peers_that_fell_out_of_the_window`.

**`incremental_fit_drifts_from_batch_and_refit_repairs_it`** proves the refit is *necessary* (drift exists) and *sufficient* (restores the exact batch fit). Doubles as a tripwire: if `pav_regression` ever becomes exact, it fails and `refit_if_stale` can be deleted.

**`refit_respects_descending_estimator_direction`** — rewritten after review proved the original vacuous (an ascending fit over decreasing data pools to a flat line, satisfying `near >= far` by equality). Now asserts a strict decrease plus a non-collapsed fit; verified by mutation.

Plus trigger boundaries at 11/12 (the true boundary — bracketing 10/20 left `>` vs `>=` undetected), `MIN_POINTS_FOR_REGRESSION`, count preservation, and idle no-op.

`refit_stale_estimators_preserves_relay_recorded_events` is a **sanity check, not a regression test** — `len()` is preserved by construction, so it cannot fail. Retained cheaply; not evidence.

**No simulation test**, deliberately: the sim harness's register returns `Ok(vec![])` unconditionally and the old code was guarded on `!history.is_empty()`, so the rebuild never fired in simulation and this bug is structurally unreproducible there. Such a test would be green on both `main` and this branch.

Full suite: **3,980 passed, 0 failed**. `cargo fmt` + `cargo clippy --locked -- -D warnings` clean.

## Post-deploy verification (no new instrumentation needed)

Re-run the issue's own `router_snapshot` query: `prediction_active` should climb 11-16% → ~85% over ~4h; snapshot-to-snapshot event losses should fall from 16.7% to ~0 except at restarts; `failure_events` should be monotonic within a session, saturating at 500.

## Out of scope (filed, not ignored)

- **#4810** — Renegade training can freeze once `trained_at > 3333`. Pre-existing; the 5-min rebuild was masking it.
- **#4811** — `ConnectForwardEstimator` is never refit (pre-existing), plus the case for moving the refit into `add_event`.
- **Startup restore** — untouched and separately dead (`aof.rs` filters route records to `record_ts >= new_records_ts`, stamped before `refresh_router` is spawned; never executed successfully since #3672, 2026-03-27). Stacked follow-up PR.

Fixes #4808

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVhia9PxdeD3TPTXQvRBx4