### PR TITLE
fix(router): keep Renegade predictor training reachable at saturation

### DIFF
--- a/crates/core/src/router/routing_predictor.rs
+++ b/crates/core/src/router/routing_predictor.rs
@@ -112,7 +112,8 @@ struct PredictionStage {
     count: usize,
     /// Cached K from the last training. Used for immutable predictions.
     cached_k: usize,
-    /// Number of observations when last trained (for growth-based retraining).
+    /// Number of observations when last trained (base for the retraining
+    /// threshold; see `observations_since_train`). Zero means never trained.
     trained_at: usize,
     /// Observations added since the last training.
     ///
@@ -169,6 +170,16 @@ impl PredictionStage {
     }
 
     /// Trigger training (metric learning + K selection).
+    ///
+    /// `get_optimal_k()` early-returns unless renegade's cached K has been
+    /// invalidated, so this only does real work when there is real work to do.
+    /// At saturation eviction is what invalidates it, and eviction is several
+    /// times more frequent than training (every ~`max_observations / 10` adds
+    /// vs every ~`max_observations * 0.45`), so each training here genuinely
+    /// re-learns rather than no-op'ing. Do not "optimize" the eviction path into
+    /// preserving the cache without revisiting the retraining cadence: that
+    /// would turn these calls into early-returns and silently re-freeze K
+    /// (#4810).
     fn train(&mut self) {
         if self.model.len() >= MIN_OBSERVATIONS_FOR_TRAINING {
             self.cached_k = self.model.get_optimal_k();
@@ -954,6 +965,23 @@ mod tests {
             "Should evict, got {}",
             predictor.len()
         );
+
+        // #4810: this test drives the LIVE `record_at_time` path deep into
+        // saturation, so it is where the training freeze was observable — and
+        // it sat here green for the whole time the freeze existed, because it
+        // only ever asserted the eviction bound. `growth_based_retraining`
+        // watches training but never saturates; this one saturates but never
+        // watched training. Both halves were covered and never intersected,
+        // which is exactly how #4810 got past CI. Assert the intersection:
+        // training must still be keeping up at saturation. At max=100,
+        // trained_at settles in [90, 100], so the retrain threshold is at most
+        // 50 and the counter can never sit above it for long. Pre-fix this
+        // reads ~100 (frozen, counting up forever).
+        assert!(
+            predictor.failure_stage.observations_since_train <= 50,
+            "training froze at saturation (#4810): {} observations since last train",
+            predictor.failure_stage.observations_since_train,
+        );
     }
 
     #[test]
@@ -1001,6 +1029,15 @@ mod tests {
         // But the failure and response time stages should have the observation
         assert_eq!(predictor.stage_sizes().0, 1);
         assert_eq!(predictor.stage_sizes().1, 1);
+
+        // A rejected observation must not count toward retraining either: the
+        // increment sits after the `!is_finite()` early-return in `add()`, so a
+        // stage fed nothing but Inf never trains. Without this, moving the
+        // increment above the early-return would still pass the size asserts.
+        assert_eq!(
+            predictor.transfer_speed_stage.observations_since_train, 0,
+            "rejected Inf observation must not count toward retraining",
+        );
     }
 
     #[test]
@@ -1070,16 +1107,21 @@ mod tests {
             i += 1;
         }
 
-        // Guard against a vacuous test: assert we are genuinely in the state
-        // the old rule could never escape. If this fails, the test is no longer
-        // exercising #4810 and the count below proves nothing.
-        let n = stage.len();
+        // Guard against a vacuous test: assert we are genuinely in the state the
+        // old rule could never escape, or the count below proves nothing.
+        //
+        // This is the STRUCTURAL form from #4810 ("any trained_at > 3333 freezes,
+        // because trained_at * 1.5 > 5000 from there on"), scaled to this cap. It
+        // is phase-independent: `len()` oscillates in [90, 100] as eviction
+        // fires, so an instantaneous `len() < trained_at + trained_at/2` could be
+        // satisfied by a trough rather than by genuine unreachability. Comparing
+        // against `max_observations` instead holds at every point in the cycle.
         assert!(
-            n < stage.trained_at + stage.trained_at / 2,
-            "test precondition: expected to be in the frozen zone, \
-             but old rule is still satisfiable (n={}, trained_at={})",
-            n,
+            stage.trained_at + stage.trained_at / 2 > stage.max_observations,
+            "test precondition: expected the old rule to be unsatisfiable, but \
+             trained_at={} still allows it under cap {}",
             stage.trained_at,
+            stage.max_observations,
         );
 
         // Training must still fire over a further run of observations.
@@ -1091,10 +1133,22 @@ mod tests {
             i += 1;
         }
 
+        // Bounded on BOTH sides. The lower bound catches the freeze; the upper
+        // bound catches a fix that restores training by making it fire far too
+        // often (e.g. an escape hatch like `if n >= max_observations * 9 / 10 {
+        // return true }`, which would train on EVERY event — an O(n^2)
+        // `ensure_trained` per routing event at n~4500). The cadence is the whole
+        // reason this fix is cheap, so pin it.
+        //
+        // Deterministic: trained_at settles in [90, 100], so the threshold is
+        // 45-50 and 1000 observations yield 21 trainings. The band absorbs
+        // incidental drift without admitting either failure mode.
         assert!(
-            trainings > 0,
-            "training froze permanently at saturation (#4810): 0 trainings over \
-             1000 observations with trained_at={}, len={}",
+            (15..=25).contains(&trainings),
+            "expected ~21 trainings over 1000 observations at saturation, got {} \
+             (0 = frozen (#4810); >25 = retraining far too often) with \
+             trained_at={}, len={}",
+            trainings,
             stage.trained_at,
             stage.len(),
         );
@@ -1114,7 +1168,12 @@ mod tests {
             }
         }
 
-        // The exact 50%-growth ladder documented in #4810.
+        // The exact 50%-growth ladder documented in #4810. It is DERIVED, not
+        // magic: it starts at MIN_OBSERVATIONS_FOR_TRAINING (20) and each rung
+        // is `t + t / 2` (integer division). If you change either the constant
+        // or the 50% factor, recompute this vector from the new values rather
+        // than editing it to match whatever the test now prints — the point of
+        // the assertion is that the cadence is the one that was designed.
         assert_eq!(ladder, vec![20, 30, 45, 67, 100, 150, 225, 337, 505]);
     }
 

--- a/crates/core/src/router/routing_predictor.rs
+++ b/crates/core/src/router/routing_predictor.rs
@@ -118,11 +118,12 @@ struct PredictionStage {
     /// Observations added since the last training.
     ///
     /// Retraining keys off this rather than off total-count growth
-    /// (`len() >= trained_at * 3 / 2`) because eviction pins `len()` below
-    /// `max_observations`. Once `trained_at * 3 / 2` exceeded the reachable
-    /// count, the total-count rule became unsatisfiable and training froze
-    /// permanently. No constant rescues that formulation — capping the growth
-    /// term just moves the rung at which it freezes. See #4810.
+    /// (`len() >= trained_at * 3 / 2`) because eviction pins `len()` at or below
+    /// `max_observations` (it reaches the cap exactly, then drops to 9/10 of it).
+    /// Once `trained_at * 3 / 2` exceeded that reachable count, the total-count
+    /// rule became unsatisfiable and training froze permanently. No constant
+    /// rescues that formulation — capping the growth term just moves the rung at
+    /// which it freezes. See #4810.
     observations_since_train: usize,
 }
 
@@ -161,11 +162,18 @@ impl PredictionStage {
         if self.trained_at == 0 {
             return true;
         }
-        // Below the observation cap nothing has been evicted, so
+        // BEFORE THE FIRST EVICTION nothing has been discarded, so
         // `observations_since_train == n - trained_at` and this is exactly the
-        // historical `n >= trained_at + trained_at / 2` rule. Above the cap the
-        // two diverge: `n` stops growing but new observations keep arriving, so
-        // only this form stays satisfiable. See #4810.
+        // historical `n >= trained_at + trained_at / 2` rule — the pre-eviction
+        // cadence is preserved bit-for-bit.
+        //
+        // The boundary is the first eviction, NOT the cap: once eviction starts,
+        // `n` is still below `max_observations` (it drops to 9/10 of it) but the
+        // two forms have already diverged, because evicted observations still
+        // count as "arrived". At trained_at=3829 with a 5000 cap, for instance,
+        // `observations_since_train` reads 1173 while `n - trained_at` is 672.
+        // That divergence is the fix: `n` stops growing but new observations keep
+        // arriving, so only this form stays satisfiable. See #4810.
         self.observations_since_train >= (self.trained_at / 2).max(1)
     }
 
@@ -516,7 +524,14 @@ impl RoutingPredictor {
             }
         }
 
-        // Train based on data growth (not at fixed counts)
+        // Retrain on observation turnover (not at fixed counts).
+        //
+        // Note the ordering: `add()` above evicts inline, so by the time
+        // `should_train()` runs, a stage that just hit `max_observations + 1` has
+        // already been trimmed to 9/10 of the cap. The largest `len()` any
+        // `should_train()` can observe is therefore exactly `max_observations` —
+        // which is why a rule keyed off total count is unsatisfiable past a
+        // point, and why this one is keyed off turnover instead (#4810).
         if !self.batch_mode {
             if self.failure_stage.should_train() {
                 self.failure_stage.train();
@@ -1116,6 +1131,13 @@ mod tests {
         // fires, so an instantaneous `len() < trained_at + trained_at/2` could be
         // satisfied by a trough rather than by genuine unreachability. Comparing
         // against `max_observations` instead holds at every point in the cycle.
+        //
+        // Concretely, why the instantaneous form is not enough: change the cap
+        // above to 100_000 and the warmup ends at len=1000, trained_at=757. The
+        // instantaneous check passes (1000 < 1135) even though the old rule is
+        // nowhere near frozen — 1135 is perfectly reachable under that cap — so
+        // the test would pass while proving nothing. The structural check
+        // correctly fails there (1135 is not > 100_000).
         assert!(
             stage.trained_at + stage.trained_at / 2 > stage.max_observations,
             "test precondition: expected the old rule to be unsatisfiable, but \

--- a/crates/core/src/router/routing_predictor.rs
+++ b/crates/core/src/router/routing_predictor.rs
@@ -114,6 +114,15 @@ struct PredictionStage {
     cached_k: usize,
     /// Number of observations when last trained (for growth-based retraining).
     trained_at: usize,
+    /// Observations added since the last training.
+    ///
+    /// Retraining keys off this rather than off total-count growth
+    /// (`len() >= trained_at * 3 / 2`) because eviction pins `len()` below
+    /// `max_observations`. Once `trained_at * 3 / 2` exceeded the reachable
+    /// count, the total-count rule became unsatisfiable and training froze
+    /// permanently. No constant rescues that formulation — capping the growth
+    /// term just moves the rung at which it freezes. See #4810.
+    observations_since_train: usize,
 }
 
 impl PredictionStage {
@@ -124,6 +133,7 @@ impl PredictionStage {
             count: 0,
             cached_k: DEFAULT_K,
             trained_at: 0,
+            observations_since_train: 0,
         }
     }
 
@@ -134,12 +144,14 @@ impl PredictionStage {
         }
         self.model.add(obs, output);
         self.count += 1;
+        self.observations_since_train += 1;
         if self.count > self.max_observations {
             self.evict_oldest();
         }
     }
 
-    /// Check if training should happen based on data growth (50% since last train).
+    /// Check if training should happen: 50% of the last-trained size worth of
+    /// fresh observations has arrived since the last training.
     fn should_train(&self) -> bool {
         let n = self.model.len();
         if n < MIN_OBSERVATIONS_FOR_TRAINING {
@@ -148,8 +160,12 @@ impl PredictionStage {
         if self.trained_at == 0 {
             return true;
         }
-        // Retrain when data has grown 50% since last training
-        n >= self.trained_at + self.trained_at / 2
+        // Below the observation cap nothing has been evicted, so
+        // `observations_since_train == n - trained_at` and this is exactly the
+        // historical `n >= trained_at + trained_at / 2` rule. Above the cap the
+        // two diverge: `n` stops growing but new observations keep arriving, so
+        // only this form stays satisfiable. See #4810.
+        self.observations_since_train >= (self.trained_at / 2).max(1)
     }
 
     /// Trigger training (metric learning + K selection).
@@ -157,6 +173,7 @@ impl PredictionStage {
         if self.model.len() >= MIN_OBSERVATIONS_FOR_TRAINING {
             self.cached_k = self.model.get_optimal_k();
             self.trained_at = self.model.len();
+            self.observations_since_train = 0;
         }
     }
 
@@ -195,6 +212,9 @@ impl PredictionStage {
             }
         });
         self.count = self.model.len();
+        // Deliberately does NOT touch `observations_since_train`: eviction must
+        // not erase the record that new data has arrived, or retraining would
+        // freeze again at saturation (#4810).
     }
 }
 
@@ -1005,6 +1025,97 @@ mod tests {
             "Should have retrained, trained_at={}",
             predictor.failure_stage.trained_at,
         );
+    }
+
+    fn stage_obs(i: usize) -> RoutingObservation {
+        RoutingObservation {
+            peer_id: (i % 7) as f64,
+            contract_location: (i % 100) as f64 / 100.0,
+            distance: (i % 50) as f64 / 100.0,
+            time: i as f64 * 0.01,
+        }
+    }
+
+    /// Drive a stage exactly the way the live `record_at_time` path does:
+    /// add the observation (which may evict), then train if due.
+    /// Returns true if training fired.
+    fn add_then_maybe_train(stage: &mut PredictionStage, i: usize) -> bool {
+        stage.add(stage_obs(i), (i % 2) as f64);
+        if stage.should_train() {
+            stage.train();
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Regression test for #4810: training must stay reachable once the stage
+    /// saturates its observation cap.
+    ///
+    /// The old rule (`n >= trained_at + trained_at / 2`) compares against the
+    /// TOTAL observation count, which eviction pins below `max_observations`.
+    /// Once `trained_at * 3 / 2` exceeds the reachable count, the condition is
+    /// unsatisfiable and training never fires again.
+    #[test]
+    fn regression_training_reachable_after_saturation() {
+        // Small cap so saturation is reached quickly. Ladder is 20 → 30 → 45 →
+        // 67 → 100, and at trained_at=100 the old rule needs n >= 150, which a
+        // 100-observation cap can never reach.
+        let mut stage = PredictionStage::new(100);
+        let mut i = 0;
+
+        // Warm up well past saturation.
+        for _ in 0..1_000 {
+            add_then_maybe_train(&mut stage, i);
+            i += 1;
+        }
+
+        // Guard against a vacuous test: assert we are genuinely in the state
+        // the old rule could never escape. If this fails, the test is no longer
+        // exercising #4810 and the count below proves nothing.
+        let n = stage.len();
+        assert!(
+            n < stage.trained_at + stage.trained_at / 2,
+            "test precondition: expected to be in the frozen zone, \
+             but old rule is still satisfiable (n={}, trained_at={})",
+            n,
+            stage.trained_at,
+        );
+
+        // Training must still fire over a further run of observations.
+        let mut trainings = 0;
+        for _ in 0..1_000 {
+            if add_then_maybe_train(&mut stage, i) {
+                trainings += 1;
+            }
+            i += 1;
+        }
+
+        assert!(
+            trainings > 0,
+            "training froze permanently at saturation (#4810): 0 trainings over \
+             1000 observations with trained_at={}, len={}",
+            stage.trained_at,
+            stage.len(),
+        );
+    }
+
+    /// Pins the pre-saturation retraining cadence from #4810 so the fix for the
+    /// frozen-at-saturation case does not perturb the 50%-growth ladder.
+    #[test]
+    fn pre_saturation_training_cadence_unchanged() {
+        // Cap far above the observations added, so nothing is ever evicted.
+        let mut stage = PredictionStage::new(100_000);
+        let mut ladder = Vec::new();
+
+        for i in 0..600 {
+            if add_then_maybe_train(&mut stage, i) {
+                ladder.push(stage.trained_at);
+            }
+        }
+
+        // The exact 50%-growth ladder documented in #4810.
+        assert_eq!(ladder, vec![20, 30, 45, 67, 100, 150, 225, 337, 505]);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`PredictionStage::should_train()` freezes permanently on a busy router, and the consequences are worse than "K stops updating" — see **Impact** below.

Training triggers on **total-count** growth (`n >= trained_at + trained_at / 2`), but `evict_oldest()` pins `n` below `max_observations`. Once `trained_at * 3 / 2` exceeds the reachable count, the condition is unsatisfiable forever.

The reachable ceiling is **5000**, not 5001: `add()` increments `count` and evicts inline when `count > max_observations`, and `record_at_time()` calls `should_train()` only *after* `add()` returns. So a stage that hits 5001 has already been trimmed to 4500 by the time the check runs. The largest `n` `should_train()` can ever observe is 5000.

Simulating the ladder against that ceiling:

| Rule | Ladder tail | Freezes at | Needs | Reachable |
|---|---|---|---|---|
| Current (`trained_at/2`) | …1702, 2553, **3829** | 3829 | n >= 5743 | 5000 |
| `min(trained_at/2, MAX/4)` | …1702, 2553, **3803** | 3803 | n >= 5053 | 5000 |
| `min(trained_at/2, MAX/10)` | … | 4635 | n >= 5135 | 5000 |

The current-rule ladder reproduces the one in #4810 exactly, which independently validates the model of the code.

**The issue's first suggested fix does not work.** Capping the growth term (`min(trained_at/2, RENEGADE_MAX_OBSERVATIONS/4)`) still freezes — at `trained_at=3803` instead of 3829. It moves the rung rather than removing it.

Stated precisely: any delta that is a **positive constant or a positive function of `trained_at`** eventually freezes, because `n` stops growing at the cap while `trained_at` does not. The technical exception is a delta shrinking toward zero as `trained_at` approaches the cap, but that isn't a real option — it degenerates into training on every observation at saturation. So the issue's *second* option (trigger on observations since last training) is the one that works.

### Impact: worse than "degraded prediction quality"

**This revises the severity note in #4810** ("the frozen model still *predicts*; it just stops re-tuning K and the metric"). Verified in `renegade-ml-0.3.3/src/lib.rs`:

- `retain()` — which `evict_oldest()` calls — ends in `self.invalidate()` (:190).
- `invalidate()` nulls `optimal_k`, `learned_metric`, `kernel_bandwidth`, `vp_index`, and zeroes `vp_built_at` (:199-205).
- `add()`'s incremental VP-tree rebuild is gated on `vp_built_at > 0` (:144) — just zeroed — so it can never restore it. `rebuild_vp_tree()` is private (:208), and `predict()` takes `&self`.

So **the first eviction after the freeze permanently destroys the learned metric and the VP index**, and nothing can rebuild them. Every subsequent `predict()` degrades to a brute-force scan of ~4500-5000 points using the unweighted distance fallback — across 3 stages, per candidate peer, per routing decision. Predictions get **worse AND materially more expensive**, not merely stale.

### Reachability

The freeze is live, not batch-only: `record_at_time()` calls `should_train()` on every non-batch record. It was masked until issue #4808 was fixed, because `Ring::refresh_router` rebuilt the whole Router every 5 minutes, constructing a fresh predictor and re-running the batch path. That fix landed as **PR #4809** (merge commit `2c677810`), whose diff touches only `ring.rs`, `router.rs`, and `isotonic_estimator.rs` — `routing_predictor.rs` is not in it. So this is pre-existing and latent; #4809 just removes the accidental workaround. (#4810's own text attributes the diff to #4808, which is the issue rather than the PR.)

## Solution

Track `observations_since_train`, incremented in `add()` (after the non-finite early-return, so rejected outputs don't count) and reset in `train()`. `evict_oldest()` deliberately does **not** touch it — resetting there would erase the "new data arrived" signal and re-freeze training. That's called out in a comment, along with a `#4810` cite on the field, so it doesn't get "simplified" back into the frozen form.

```rust
self.observations_since_train >= (self.trained_at / 2).max(1)
```

**Pre-eviction cadence is bit-for-bit unchanged.** Before the first eviction nothing has been discarded, so `observations_since_train == n - trained_at`, making `n - trained_at >= trained_at/2` exactly the old `n >= trained_at + trained_at/2`. Only the frozen-at-saturation case changes.

The boundary is the **first eviction, not the cap**. Once eviction starts, `n` is still below `max_observations` (it drops to 9/10 of it) but the two forms have already diverged, because evicted observations still count as having arrived — at `trained_at=3829` under a 5000 cap, `observations_since_train` reads 1173 while `n - trained_at` is 672. That divergence is exactly the fix.

**At saturation, retraining resumes every 2250-2500 observations.** `train()` reads the post-eviction length, and `evict_oldest()` trims *to* `max_observations * 9 / 10 = 4500` and never below, so `trained_at` settles in `[4500, 5000]` and the threshold in `[2250, 2500]`. That 4500 floor also rules out a cadence collapse: a lower `trained_at` would mean a lower threshold would mean more frequent training, and the floor blocks that regress.

**Why that cadence is affordable** — the argument is internal to the design, so it holds at any event rate: the old ladder's last two rungs were 2553 → 3829, only **1276 apart**. The design was already training ~2x *more* often than the post-fix 2250-2500 steady state, immediately before it froze. The restored cadence is strictly gentler than what was already accepted.

Each retrain does real work rather than no-op'ing: `get_optimal_k()` → `ensure_trained()` early-returns on `optimal_k.is_some()` (:366-368), and at saturation eviction invalidates the cache every ~`max_observations/10` adds versus training every ~`max_observations*0.45` — roughly 4.1x more often at `max=100`, 4.5x at `max=5000`. That ratio is near-scale-invariant, which is also why the tests' `max=100` is a faithful scale model.

## Testing

Test-first per `.claude/rules/testing.md` — written before the fix, observed failing, then passing.

Isolated by reverting **only** the `should_train()` rule while keeping the counter, so the evidence attributes to the fix itself and not to the new field:

**Before**:
```
test sliding_window_eviction ... FAILED
  training froze at saturation (#4810): 100 observations since last train
test regression_training_reachable_after_saturation ... FAILED
  expected ~21 trainings over 1000 observations at saturation, got 0
  (0 = frozen (#4810); >25 = retraining far too often) with trained_at=100, len=97
test result: FAILED. 12 passed; 2 failed
```

**After**:
```
test result: ok. 14 passed; 0 failed
```

### Closing the CI gap

Per `.claude/rules/pr-quality.md` ("a bug that made it past CI is also a bug in CI — close the gap in the same PR"): `sliding_window_eviction` drives the **live** `record_at_time` path to saturation and **sat green through the entire life of this bug**, because it only asserted the eviction bound. `growth_based_retraining` watches training but never saturates. Both halves were covered and never intersected — that is precisely how #4810 got past CI. It now also asserts the intersection (`observations_since_train <= 50`), which reads 100 pre-fix.

### Tests

1. **`regression_training_reachable_after_saturation`** — bounded on **both** sides (`15..=25`, deterministically 21). The lower bound catches the freeze; the upper bound catches a fix that restores training by firing far too often (e.g. an escape hatch like `if n >= max_observations * 9 / 10 { return true }`, which passes `> 0` while training on every event), and catches "trains once then re-freezes".

   Its vacuity guard is **structural** — `trained_at + trained_at/2 > max_observations`, the form #4810 itself states. An instantaneous `len() < trained_at + trained_at/2` could be satisfied by a trough in the [90,100] eviction cycle rather than by genuine unreachability; comparing against the cap holds at every phase.

2. **`pre_saturation_training_cadence_unchanged`** — pins the exact ladder (`[20, 30, 45, 67, 100, 150, 225, 337, 505]`) with eviction disabled, with a comment on its derivation from `MIN_OBSERVATIONS_FOR_TRAINING` so the constant gets recomputed rather than the vector edited to match.

3. **`inf_output_rejected`** — now pins that a rejected `Inf` doesn't count toward retraining, so moving the increment above the early-return fails.

Both new tests drive the stage exactly as the live path does (add, then train if due), so the eviction-before-check ordering that produces the 5000 ceiling is genuinely exercised.

## Follow-up

The VP-tree remains absent ~80% of the time at saturation even post-fix (eviction invalidates every ~501 adds; training rebuilds every ~2250-2500). Fixing that needs an upstream `renegade-ml` change — `retain()` invalidates unconditionally and `rebuild_vp_tree()` is private. Filed as #4817, which also records that `renegade-ml` has the identical #4810 freeze internally (currently masked, because `retain()` zeroes its `computed_at` first). Out of scope here.

Closes #4810

[AI-assisted - Claude]

