### PR TITLE
refactor(router): refit isotonic estimators in add_event, not on a periodic tick

### DIFF
--- a/crates/core/src/operations/connect.rs
+++ b/crates/core/src/operations/connect.rs
@@ -2128,6 +2128,42 @@ mod tests {
         estimator.record(&peer, Location::new(0.25), true);
     }
 
+    /// REGRESSION (#4811, gap 1): this estimator must get the batch-accuracy
+    /// refit like every other isotonic estimator in the tree.
+    ///
+    /// It never did. The refit was driven by `Router::refit_stale_estimators`,
+    /// reachable only from `Ring::refit_router_periodically`'s tick, and this
+    /// estimator lives OUTSIDE `Router` — behind its own `Arc<RwLock<..>>` on
+    /// `ConnectOp` — so the tick could not see it. Its incremental
+    /// pool-adjacent-violators fit therefore drifted from the batch fit forever,
+    /// with nothing to repair it, while `estimate()` kept biasing live CONNECT
+    /// forwarding off the drifted curve. Review noted its Bernoulli 0/1 outcomes
+    /// pool heavily, making it plausibly the worst drift case in the tree.
+    ///
+    /// Moving the trigger into `IsotonicEstimator::add_event` fixes it with no
+    /// wiring at all: `record` already funnels into `add_event`, so the estimator
+    /// now refits itself regardless of who owns it. That is the whole point of
+    /// the #4811 direction, and this is its pin — it fails against `main`, where
+    /// no amount of `record`ing ever refits this estimator.
+    #[test]
+    fn forward_estimator_refits_itself_despite_living_outside_router() {
+        let mut estimator = ConnectForwardEstimator::new();
+
+        // Well past the 10% turnover trigger. Distinct peers and desired
+        // locations, mixed Bernoulli outcomes — i.e. what `record` actually sees.
+        for i in 0..120u16 {
+            let peer = make_peer(3000 + i);
+            estimator.record(&peer, Location::new(f64::from(i % 50) / 100.0), i % 3 == 0);
+        }
+
+        assert!(
+            !estimator.estimator.is_stale_for_test(),
+            "ConnectForwardEstimator must not be left owing a refit: it is \
+             unreachable from Router, so if add_event does not refit it inline, \
+             nothing ever will and its curve drifts unrepaired forever (#4811)"
+        );
+    }
+
     #[test]
     fn expired_forward_attempts_are_cleared() {
         let mut op = ConnectOp::new_joiner(

--- a/crates/core/src/operations/connect.rs
+++ b/crates/core/src/operations/connect.rs
@@ -2134,17 +2134,35 @@ mod tests {
     /// It never did. The refit was driven by `Router::refit_stale_estimators`,
     /// reachable only from `Ring::refit_router_periodically`'s tick, and this
     /// estimator lives OUTSIDE `Router` — behind its own `Arc<RwLock<..>>` on
-    /// `ConnectOp` — so the tick could not see it. Its incremental
-    /// pool-adjacent-violators fit therefore drifted from the batch fit forever,
-    /// with nothing to repair it, while `estimate()` kept biasing live CONNECT
-    /// forwarding off the drifted curve. Review noted its Bernoulli 0/1 outcomes
-    /// pool heavily, making it plausibly the worst drift case in the tree.
+    /// **`OpManager`** (`node/op_state_manager.rs`, built once in `OpManager::new`),
+    /// so the tick could not see it. Note the owner: `ConnectOp` below is only a
+    /// `#[cfg(test)]` fixture. In production this estimator is **node-lifetime**,
+    /// which is what turns the missing refit from a nuisance into a leak.
     ///
-    /// Moving the trigger into `IsotonicEstimator::add_event` fixes it with no
+    /// Two consequences, both fixed by refitting on the write path:
+    ///
+    /// 1. **Drift, unrepaired forever.** The incremental pool-adjacent-violators
+    ///    fit is an approximation of a batch PAV pass, so its curve drifted with
+    ///    nothing to correct it, while `estimate()` kept biasing live CONNECT
+    ///    forwarding off the drifted curve. Its Bernoulli 0/1 outcomes pool
+    ///    heavily, making it plausibly the worst drift case in the tree.
+    /// 2. **An unbounded, remote-peer-keyed map.** `peer_adjustments` only ever
+    ///    INSERTS on the incremental path (`add_event`); the ONLY thing that
+    ///    prunes it to the current window is a refit (see `IsotonicEstimator::fit`).
+    ///    `raw_events` is capped at `MAX_REGRESSION_POINTS`, but with no refit the
+    ///    map was not capped by anything: it grew one entry per distinct peer ever
+    ///    seen in CONNECT forwarding, for the node's whole life — the exact hazard
+    ///    `.claude/rules/code-style.md` bans, driven by remote peers. It also made
+    ///    the `connect_forward_estimator.read().clone()` calls on the CONNECT path
+    ///    (`connect/op_ctx_task.rs`) monotonically more expensive with uptime,
+    ///    since the clone copies that map.
+    ///
+    /// Moving the trigger into `IsotonicEstimator::add_event` fixes both with no
     /// wiring at all: `record` already funnels into `add_event`, so the estimator
-    /// now refits itself regardless of who owns it. That is the whole point of
-    /// the #4811 direction, and this is its pin — it fails against `main`, where
-    /// no amount of `record`ing ever refits this estimator.
+    /// now refits itself regardless of who owns it, which bounds `peer_adjustments`
+    /// to the window (plus at most one refit interval of new peers). That is the
+    /// whole point of the #4811 direction, and this is its pin — it fails against
+    /// `main`, where no amount of `record`ing ever refits this estimator.
     #[test]
     fn forward_estimator_refits_itself_despite_living_outside_router() {
         let mut estimator = ConnectForwardEstimator::new();
@@ -2161,6 +2179,58 @@ mod tests {
             "ConnectForwardEstimator must not be left owing a refit: it is \
              unreachable from Router, so if add_event does not refit it inline, \
              nothing ever will and its curve drifts unrepaired forever (#4811)"
+        );
+    }
+
+    /// REGRESSION (#4811, gap 1 — the consequence that actually bites): the
+    /// refit is the ONLY thing that bounds this estimator's `peer_adjustments`.
+    ///
+    /// `IsotonicEstimator::add_event` only ever INSERTS into `peer_adjustments`;
+    /// nothing evicts from it. `raw_events` is capped at `MAX_REGRESSION_POINTS`,
+    /// but the map is pruned to the current window only by a refit
+    /// (`IsotonicEstimator::fit` rebuilds it from `raw_events`). Because nothing
+    /// refit THIS estimator, and because it hangs off `OpManager` and so lives as
+    /// long as the node, the map grew one entry per distinct peer ever seen in
+    /// CONNECT forwarding, forever — an unbounded collection keyed by remote
+    /// peers, which `.claude/rules/code-style.md` bans outright. It also made the
+    /// `connect_forward_estimator.read().clone()` calls on the CONNECT path
+    /// (`connect/op_ctx_task.rs`) grow more expensive with uptime.
+    ///
+    /// Feeding many more DISTINCT peers than the window can hold is the shape of
+    /// the leak: a long-lived node forwards CONNECTs to far more peers than fit
+    /// in 500 events. Against `main` this map would hold every one of them.
+    #[test]
+    fn forward_estimator_bounds_peer_adjustments_to_its_window() {
+        let mut estimator = ConnectForwardEstimator::new();
+
+        // Far more DISTINCT peers than the event window can hold, which is the
+        // shape of the leak: a long-lived node forwards CONNECTs to far more
+        // peers than fit in one window. Asserted as a RATIO rather than against
+        // `MAX_REGRESSION_POINTS` — that constant is private to the estimator's
+        // module, and a ratio does not rot if the window is ever resized.
+        let distinct_peers: usize = 2000;
+        for i in 0..distinct_peers {
+            let peer = make_peer(10_000 + u16::try_from(i).expect("port fits u16"));
+            estimator.record(&peer, Location::new((i % 50) as f64 / 100.0), i % 3 == 0);
+        }
+
+        let adjustments = estimator.estimator.peer_adjustments.len();
+        assert!(
+            adjustments < distinct_peers / 2,
+            "peer_adjustments must stay bounded by the event window, not by how \
+             many peers this node has ever forwarded to. The refit is the only \
+             thing that prunes this map, and the estimator is node-lifetime, so \
+             without an inline refit it retains every peer ever seen: got \
+             {adjustments} entries after {distinct_peers} distinct peers — on \
+             `main` this is {distinct_peers} (#4811)"
+        );
+        // Guard against passing for the wrong reason: an estimator that recorded
+        // nothing, or one that pruned everything, would also be "bounded".
+        assert!(
+            adjustments > 100,
+            "sanity: the estimator must still hold a full window's worth of peers \
+             (got {adjustments}); a near-empty map would satisfy the bound above \
+             while meaning the estimator had stopped tracking anything"
         );
     }
 

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -5,7 +5,7 @@
 
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::net::SocketAddr;
-use std::sync::{Arc, Weak, atomic::AtomicU64};
+use std::sync::{Arc, Weak};
 use std::time::Duration;
 // Intentional wall-clock type for suspend/resume detection in
 // `connection_maintenance`. See `classify_suspend_jump` for why the DST
@@ -505,22 +505,53 @@ impl Ring {
         };
 
         // Single shutdown signal for every long-lived background task spawned
-        // below. Created up front so `refit_router_periodically` (spawned before
-        // the `Ring` struct literal exists) shares the same token that gets moved
-        // into the struct. See issue #4278.
+        // below, moved into the struct literal at the end. See issue #4278.
         let shutdown = CancellationToken::new();
 
-        // Starts cold and learns from this session only — there is no warm start
-        // from the event log (see `refit_router_periodically`).
+        // The router starts COLD and learns purely from this session's
+        // observations. There is deliberately no warm start from the on-disk
+        // event log, and the reader that used to attempt one was deleted in the
+        // #4808 follow-up (#4812). Three reasons it is not worth resurrecting:
+        //
+        // 1. It effectively never fired in production. The restore read filtered
+        //    records to `record_ts >= NEW_RECORDS_TS`. `NEW_RECORDS_TS` is a
+        //    *process-global* `OnceLock` (`tracing::register`), stamped
+        //    `SystemTime::now()` at the FIRST event-register construction in the
+        //    process — `EventRegister::new`, or `OTEventRegister::new` under
+        //    `trace-ot`. A production node builds its register (`node.rs`) before
+        //    it can write a single route event and before `OpManager::new` ->
+        //    `Ring::new` ran, so the cutoff was always >= that process's start and
+        //    every prior-session record was discarded. Dead since #3672
+        //    (2026-03-27).
+        //
+        //    The invariant is "effectively never in production", NOT "structurally
+        //    unreachable" — do not tighten this claim. Two ways the branch can be
+        //    reached: both sides truncate to whole seconds, so a prior-session
+        //    record written in the same wall-clock second as the stamp passes; and
+        //    an in-process multi-node test that shares one `data_dir` (see
+        //    `tests/in_process_restart.rs`) makes the second node's `get_or_init` a
+        //    no-op, so it would read the first node's records. Neither happens on a
+        //    real node. Corroborated in production: across 8 gateway startups
+        //    captured in vega's retained logs, the INFO "Restored routing history
+        //    from event log" line and its WARN error arm each appear ZERO times,
+        //    while ~141k other INFO lines from `freenet::ring` are captured — i.e.
+        //    the read always returned `Ok(empty)`, exactly as the filter predicts.
+        // 2. Half of the state is meaningless across a restart anyway. The
+        //    per-peer `peer_adjustments` are keyed to a neighbour set that CONNECT
+        //    rebuilds differently on every start.
+        // 3. A partial restore is what caused #4808. Reloading a log that holds
+        //    only originator events (relay hops never persist) discards everything
+        //    the live router learned by relaying.
+        //
+        // The cost of starting cold is bounded: post-#4809 a peer reaches
+        // `MIN_EVENTS_FOR_PREDICTION` in a few hours at observed event rates.
+        //
+        // The estimators keep themselves batch-accurate: `IsotonicEstimator::add_event`
+        // refits inline once its window has turned over (#4811). There is no periodic
+        // refit task — `refit_router_periodically` was deleted with this change,
+        // because polling was the only thing it did.
         let router = Arc::new(RwLock::new(Router::new(&[])));
         crate::node::network_status::set_router(router.clone());
-        task_monitor.register(
-            "refit_router_periodically",
-            GlobalExecutor::spawn(Self::refit_router_periodically(
-                router.clone(),
-                shutdown.clone(),
-            )),
-        );
 
         // Interval for topology snapshot registration (1 second in test mode)
         // Registers subscription topology with the global registry for validation
@@ -1505,94 +1536,6 @@ impl Ring {
         self.event_register.register_events(events).await;
     }
 
-    /// Periodically refit the router's isotonic estimators in place, from their
-    /// own in-memory raw events. Never reads the event log — see the loop body.
-    ///
-    /// The node starts with a cold router (`Router::new(&[])`) and learns purely
-    /// from this session's observations. There is deliberately no warm start from
-    /// the on-disk event log, and the reader that used to attempt one was deleted
-    /// (#4808 follow-up). Three reasons it is not worth resurrecting:
-    ///
-    /// 1. **It effectively never fired in production.** The restore read filtered
-    ///    records to `record_ts >= NEW_RECORDS_TS`. `NEW_RECORDS_TS` is a
-    ///    *process-global* `OnceLock` (`tracing::register`), stamped
-    ///    `SystemTime::now()` at the FIRST event-register construction in the
-    ///    process — `EventRegister::new`, or `OTEventRegister::new` under
-    ///    `trace-ot`. A production node builds its register (`node.rs`) before it
-    ///    can write a single route event and before `OpManager::new` -> `Ring::new`
-    ///    spawns this task, so the cutoff was always >= that process's start and
-    ///    every prior-session record was discarded. Dead since #3672 (2026-03-27).
-    ///
-    ///    Note the invariant is "effectively never in production", NOT "structurally
-    ///    unreachable" — do not tighten this claim. Two ways the branch can be
-    ///    reached: both sides truncate to whole seconds, so a prior-session record
-    ///    written in the same wall-clock second as the stamp passes; and an
-    ///    in-process multi-node test that shares one `data_dir` (see
-    ///    `tests/in_process_restart.rs`) makes the second node's `get_or_init` a
-    ///    no-op, so it would read the first node's records. Neither happens on a
-    ///    real node. Corroborated in production: across 8 gateway startups captured
-    ///    in vega's retained logs, the INFO "Restored routing history from event
-    ///    log" line and its WARN error arm each appear ZERO times, while ~141k
-    ///    other INFO lines from `freenet::ring` are captured — i.e. the read always
-    ///    returned `Ok(empty)`, exactly as the filter predicts.
-    /// 2. **Half of the state is meaningless across a restart anyway.** The
-    ///    per-peer `peer_adjustments` are keyed to a neighbour set that CONNECT
-    ///    rebuilds differently on every start.
-    /// 3. **A partial restore is what caused #4808.** Reloading a log that holds
-    ///    only originator events (relay hops never persist) discards everything
-    ///    the live router learned by relaying.
-    ///
-    /// The cost of starting cold is bounded: post-#4809 a peer reaches
-    /// `MIN_EVENTS_FOR_PREDICTION` in a few hours at observed event rates.
-    async fn refit_router_periodically(router: Arc<RwLock<Router>>, shutdown: CancellationToken) {
-        let mut interval = tokio::time::interval(Duration::from_secs(60 * 5));
-        interval.tick().await;
-        loop {
-            if sleep_or_shutdown(&shutdown, async {
-                interval.tick().await;
-            })
-            .await
-            {
-                return;
-            }
-            // Refit the isotonic estimators in place from their own in-memory
-            // raw events. Each estimator only refits once >10% of its window has
-            // turned over, so an idle router does no work here.
-            //
-            // This deliberately does NOT re-read the event log. Until #4808 this
-            // loop did `*router.write() = Router::new(&history)`, rebuilding the
-            // whole router from disk every 5 minutes. That was destructive:
-            // `operations::record_relay_route_event` feeds the in-memory router
-            // ONLY — it never persists — so every relay-recorded event was
-            // discarded on each rebuild, giving relay events a <=5 minute
-            // half-life and resetting the model faster than it could reach
-            // `MIN_EVENTS_FOR_PREDICTION`. Observed in production as a peer's
-            // event count collapsing 29 -> 2 within one 30s window, and
-            // fleet-wide as 271,518 events lost to resets against 261,710
-            // gained (net zero accumulation).
-            //
-            // Within a session the on-disk log is a strict SUBSET of what the
-            // live router already knows (same originator events, minus every
-            // relay event), so rebuilding from it could only ever lose
-            // information. The batch-accuracy benefit that motivated the rebuild
-            // is preserved — and made complete — by refitting from `raw_events`,
-            // which holds every observation regardless of origin.
-            //
-            // Liveness (#4440): the task now has no fallible step, so there is no
-            // failure arm to record (the `consecutive_failures` gauge went with the
-            // startup read that was its only failure source). The success stamp
-            // stays as a pure heartbeat: `BackgroundTaskMonitor` only watches for
-            // task *death*, so a loop that is alive but starved — deadlocked on
-            // `router.write()`, or never scheduled — is invisible to it and shows
-            // up only as a rising `last_success_age_secs`.
-            let refit_count = router.write().refit_stale_estimators();
-            BACKGROUND_TASK_HEALTH.record_refit_router_success();
-            if refit_count > 0 {
-                tracing::debug!(refit_count, "Refit stale isotonic estimators");
-            }
-        }
-    }
-
     /// Periodically emit a router model snapshot as an EventKind::RouterSnapshot event.
     ///
     /// This captures the isotonic regression curves and model state, including the
@@ -1935,14 +1878,6 @@ impl Ring {
             snapshot.broadcast_stream_failures_last_snapshot =
                 Some(broadcast_stream_failures_delta);
 
-            // Liveness heartbeat (#4440) for the periodic refit task. The
-            // `BackgroundTaskMonitor` catches it dying; this catches it being
-            // alive but starved. Its companion `consecutive_failures` gauge went
-            // with the startup restore that was its only failure source (#4808
-            // follow-up).
-            let refit_router_age = BACKGROUND_TASK_HEALTH.refit_router_last_success_age_secs();
-            snapshot.refresh_router_last_success_age_secs = refit_router_age;
-
             // Placement-quality gauge (#4404 follow-up): host-to-hosted-key
             // ring-distance distribution. If the SubscribeHint placement
             // migration is working, hosting drifts toward each contract's key,
@@ -2012,7 +1947,6 @@ impl Ring {
                 broadcast_stream_attempts_total = bs.streaming_attempts_total,
                 broadcast_stream_failures_total = bs.streaming_failures_total,
                 broadcast_stream_failures_last_snapshot = broadcast_stream_failures_delta,
-                refresh_router_last_success_age_secs = ?refit_router_age,
                 hosted_contracts_count = ?snapshot.hosted_contracts_count,
                 hosted_key_distance_median = ?snapshot.hosted_key_distance_median,
                 hosted_key_distance_p90 = ?snapshot.hosted_key_distance_p90,
@@ -6028,103 +5962,6 @@ fn window_delta(current_total: u64, prev_total: &mut u64) -> u64 {
     delta
 }
 
-/// Process-global liveness heartbeat for the periodic router-refit task (#4440).
-///
-/// The [`BackgroundTaskMonitor`](crate::node::background_task_monitor) watches
-/// monitored tasks for *death* only. A task that is alive but starved — blocked
-/// forever on `router.write()`, or simply never scheduled — looks identical to a
-/// healthy one from the monitor's perspective. This records the time of the last
-/// completed pass so the snapshot task can emit a `last_success_age` gauge on the
-/// existing `router_snapshot` cadence, turning "alive but doing nothing" into a
-/// visible, rising number (partially addresses #4440 item (a)).
-///
-/// The task *publishes* (`record_refit_router_success`) and the `Ring` snapshot
-/// task *reads*, mirroring `BROADCAST_STREAM_METRICS` (and the module-cache
-/// metrics, which were a sibling process-global until #4488 threaded them as a
-/// per-node `Arc`).
-///
-/// This used to also carry a `consecutive_failures` counter per task. That gauge
-/// was removed in the #4808 follow-up: it existed to surface a *non-fatal*
-/// `get_router_events` read failure (#4438 made the read non-fatal, which made a
-/// persistent failure silent), and deleting the startup restore removed the last
-/// fallible call in the task. With no failure source left, the counter was pinned
-/// at 0 forever. What remains is a pure heartbeat, so there is deliberately no
-/// failure arm to record.
-///
-/// Per-node meaning holds only in single-node-per-process production. In a
-/// multi-node simulation every node's refit task shares this process-global, so
-/// the snapshot reads the aggregate (last-write-wins across nodes) — the same
-/// caveat that drove #4488 for the module-cache metrics.
-static BACKGROUND_TASK_HEALTH: std::sync::LazyLock<BackgroundTaskHealth> =
-    std::sync::LazyLock::new(BackgroundTaskHealth::new);
-
-/// Monotonic process clock for the background-task health gauge. `tokio::time`
-/// so the age respects `start_paused(true)` virtual time under simulation
-/// (a `std::time::Instant` would advance in real wall-clock and break
-/// deterministic tests). Sampled at publish time and at snapshot read time; the
-/// age is the difference, so the absolute epoch is irrelevant.
-static BACKGROUND_TASK_HEALTH_EPOCH: std::sync::LazyLock<Instant> =
-    std::sync::LazyLock::new(Instant::now);
-
-/// Liveness heartbeat for one monitored background task. See
-/// [`BACKGROUND_TASK_HEALTH`].
-struct TaskHealth {
-    /// Millis-since-[`BACKGROUND_TASK_HEALTH_EPOCH`] of the last completed pass,
-    /// or [`NO_SUCCESS`](Self::NO_SUCCESS) if the task has never completed one.
-    last_success_millis: AtomicU64,
-}
-
-impl TaskHealth {
-    /// Sentinel for "no completed pass yet". `u64::MAX` millis is ~584 million
-    /// years of uptime, so it can never collide with a real elapsed value.
-    const NO_SUCCESS: u64 = u64::MAX;
-
-    const fn new() -> Self {
-        Self {
-            last_success_millis: AtomicU64::new(Self::NO_SUCCESS),
-        }
-    }
-}
-
-/// Per-task background-task health, currently just the router-refit task. See
-/// [`BACKGROUND_TASK_HEALTH`].
-struct BackgroundTaskHealth {
-    refit_router: TaskHealth,
-}
-
-impl BackgroundTaskHealth {
-    fn new() -> Self {
-        Self {
-            refit_router: TaskHealth::new(),
-        }
-    }
-
-    /// Record a completed pass of `Ring::refit_router_periodically`: stamp the
-    /// last-success time. Cheap `Relaxed` atomic.
-    fn record_refit_router_success(&self) {
-        let elapsed_millis = BACKGROUND_TASK_HEALTH_EPOCH.elapsed().as_millis() as u64;
-        self.refit_router
-            .last_success_millis
-            .store(elapsed_millis, std::sync::atomic::Ordering::Relaxed);
-    }
-
-    /// Seconds since the refit task's last completed pass, or `None` if it has
-    /// never completed one.
-    fn refit_router_last_success_age_secs(&self) -> Option<u64> {
-        let last_success_millis = self
-            .refit_router
-            .last_success_millis
-            .load(std::sync::atomic::Ordering::Relaxed);
-        if last_success_millis == TaskHealth::NO_SUCCESS {
-            return None;
-        }
-        // saturating: if the clock and the stored stamp disagree (they
-        // shouldn't — same monotonic source), never underflow to a huge age.
-        let now_millis = BACKGROUND_TASK_HEALTH_EPOCH.elapsed().as_millis() as u64;
-        Some(now_millis.saturating_sub(last_success_millis) / 1_000)
-    }
-}
-
 /// Best-effort snapshot of this process's open file-descriptor count and the
 /// `RLIMIT_NOFILE` soft limit, for the node-health telemetry gauges (#4440).
 ///
@@ -6184,59 +6021,6 @@ fn read_fd_soft_limit() -> Option<u64> {
 #[cfg(not(unix))]
 fn read_fd_soft_limit() -> Option<u64> {
     None
-}
-
-#[cfg(test)]
-mod background_task_health_tests {
-    //! Validates the background-task liveness heartbeat (#4440): a task that has
-    //! never completed a pass must report `None` age (not a bogus zero), and once
-    //! it has, the age must track time since that pass. Tests a LOCAL
-    //! `BackgroundTaskHealth` so they never touch the shared process-global.
-
-    use super::BackgroundTaskHealth;
-
-    /// Before any completed pass, the age is `None` (the `NO_SUCCESS` sentinel),
-    /// not a misleading age of 0 — which would read as "just ran" on a task that
-    /// has never run at all.
-    #[tokio::test(start_paused = true)]
-    async fn never_succeeded_reports_none_age() {
-        let h = BackgroundTaskHealth::new();
-        assert_eq!(
-            h.refit_router_last_success_age_secs(),
-            None,
-            "no completed pass yet => None age, never a bogus 0"
-        );
-    }
-
-    /// A completed pass stamps the time; the age starts at ~0 and grows with
-    /// virtual time. This is the whole point of the gauge: a loop that stops
-    /// refitting but stays alive shows up as a climbing age, which is invisible to
-    /// the `BackgroundTaskMonitor` death-watch.
-    #[tokio::test(start_paused = true)]
-    async fn success_stamps_age_which_grows_with_time() {
-        let h = BackgroundTaskHealth::new();
-        h.record_refit_router_success();
-        assert_eq!(
-            h.refit_router_last_success_age_secs(),
-            Some(0),
-            "age is ~0 immediately after a completed pass"
-        );
-
-        tokio::time::advance(std::time::Duration::from_secs(90)).await;
-        assert_eq!(
-            h.refit_router_last_success_age_secs(),
-            Some(90),
-            "age grows with time since the last completed pass"
-        );
-
-        // A later pass re-stamps, resetting the age.
-        h.record_refit_router_success();
-        assert_eq!(
-            h.refit_router_last_success_age_secs(),
-            Some(0),
-            "a fresh pass resets the age"
-        );
-    }
 }
 
 #[cfg(test)]
@@ -7709,118 +7493,6 @@ mod op_manager_state_tests {
             "Detached maintenance task must park, not exit: a clean return \
              would trip BackgroundTaskMonitor::wait_for_any_exit and crash \
              the node (#3308 / #4292)"
-        );
-    }
-}
-
-#[cfg(test)]
-mod refit_router_tests {
-    use std::sync::Arc;
-    use std::time::Duration;
-
-    use parking_lot::RwLock;
-    use tokio_util::sync::CancellationToken;
-
-    use crate::ring::PeerKeyLocation;
-    use crate::ring::location::Location;
-    use crate::router::Router;
-
-    /// The loop must actually REFIT — nothing else pins the one line that makes
-    /// #4808's fix do anything in production.
-    ///
-    /// Without this, deleting `router.write().refit_stale_estimators()` from
-    /// `refit_router_periodically` leaves every other guard green: the shutdown
-    /// test still returns promptly, and "the loop never reads the log" is a
-    /// compile-time property that holds trivially for a loop that does nothing.
-    /// This is also the only positive liveness proof in the module — a bare
-    /// timeout cannot distinguish a healthy loop from one deadlocked on
-    /// `router.write()` or never ticking at all.
-    ///
-    /// Ported unchanged from `refresh_router_loop_refits_stale_estimators` (added
-    /// in the #4809 review); the only edit is dropping the event-register argument,
-    /// which `refit_router_periodically` no longer takes.
-    #[tokio::test(start_paused = true)]
-    async fn refit_router_periodically_refits_stale_estimators() {
-        let router = Arc::new(RwLock::new(Router::new(&[])));
-
-        // Seed past the staleness trigger so a refit is owed. These go straight
-        // into the in-memory router, exactly as a relay hop's
-        // `record_relay_route_event` does.
-        {
-            let mut guard = router.write();
-            for _ in 0..120 {
-                guard.add_event(crate::router::RouteEvent {
-                    peer: PeerKeyLocation::random(),
-                    contract_location: Location::random(),
-                    outcome: crate::router::RouteOutcome::Success {
-                        time_to_response_start: Duration::from_millis(100),
-                        payload_size: 5000,
-                        payload_transfer_time: Duration::from_millis(50),
-                    },
-                    op_type: Some(crate::node::network_status::OpType::Get),
-                });
-            }
-            assert!(
-                guard.refit_stale_estimators() > 0,
-                "sanity: a freshly-seeded router owes a refit before the loop runs"
-            );
-            // Re-dirty it so the loop has work to do.
-            for _ in 0..120 {
-                guard.add_event(crate::router::RouteEvent {
-                    peer: PeerKeyLocation::random(),
-                    contract_location: Location::random(),
-                    outcome: crate::router::RouteOutcome::SuccessUntimed,
-                    op_type: Some(crate::node::network_status::OpType::Get),
-                });
-            }
-        }
-
-        tokio::time::timeout(
-            Duration::from_secs(60 * 40),
-            super::Ring::refit_router_periodically(router.clone(), CancellationToken::new()),
-        )
-        .await
-        .ok(); // timeout expected — a healthy loop runs forever
-
-        assert_eq!(
-            router.write().refit_stale_estimators(),
-            0,
-            "the loop must have consumed the outstanding staleness; a non-zero \
-             count here means it never called refit_stale_estimators (or never \
-             ticked), leaving the model to drift exactly as it did before #4808"
-        );
-    }
-
-    /// Regression for #4278: the periodic loop ticks every 5 minutes. With the
-    /// shutdown token cancelled, the task must return *promptly* (well within one
-    /// tick) rather than parking on the 5-minute `interval.tick()`. Before the fix
-    /// there was no token to race against, so the only way out of the loop was the
-    /// 5-minute tick — a shutdown would hang for up to that long.
-    ///
-    /// Uses `start_paused`: virtual time only advances when every task is idle, so
-    /// if the loop were genuinely blocked on the 5-minute tick this `timeout` would
-    /// *fire* (the test would fail on the `expect`). The fix makes the future
-    /// resolve at t≈0 because the token is already cancelled.
-    #[tokio::test(start_paused = true)]
-    async fn refit_router_periodically_returns_promptly_on_shutdown() {
-        let router = Arc::new(RwLock::new(Router::new(&[])));
-
-        let shutdown = CancellationToken::new();
-        // Cancel before we even start: the very first interruptible `.await`
-        // (the 5-minute periodic tick) must observe the cancellation and bail.
-        shutdown.cancel();
-
-        // 1s of *virtual* time is generous; a working loop returns at t≈0,
-        // a broken (uninterruptible) one would block until the 5-minute tick
-        // and trip this timeout.
-        tokio::time::timeout(
-            Duration::from_secs(1),
-            super::Ring::refit_router_periodically(router.clone(), shutdown),
-        )
-        .await
-        .expect(
-            "refit_router_periodically must return promptly once the shutdown token \
-             is cancelled",
         );
     }
 }

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -3964,7 +3964,8 @@ mod tests {
 
     /// Regression test for crash: "user-provided comparison function does not
     /// correctly implement a total order" — originally observed in the periodic
-    /// router-refresh task (now `Ring::refit_router_periodically`).
+    /// router-refresh task (`Ring::refit_router_periodically`, since deleted in
+    /// #4811; the refit now runs inline in `IsotonicEstimator::add_event`).
     ///
     /// When `mean_transfer_size` has no samples (count=0), `compute()` returns
     /// NaN (0.0/0.0). If `xfer_speed` is also 0, the division NaN/0.0 stays NaN.

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -1604,7 +1604,17 @@ mod tests {
 
     #[test]
     fn add_event_preserves_relay_recorded_events() {
-        // REGRESSION (#4808). The periodic router refresh used to rebuild the whole
+        // SCOPE, honestly: this guards the refit's NO-DATA-LOSS property, not the
+        // refit TRIGGER. It stays green if the `refit_if_stale()` call is deleted
+        // from `add_event` (no refit, nothing lost), so it is not the #4811 guard —
+        // `add_event_leaves_no_estimator_stale` is. And because `len()` derives
+        // from `raw_events` and `refit` rebuilds from exactly that, preservation is
+        // close to structural: it can only fail if a refit corrupts the window.
+        // Carried forward cheaply, the same caveat #4809 recorded for its
+        // predecessor (`refit_stale_estimators_preserves_relay_recorded_events`).
+        // Cheap, not evidence.
+        //
+        // #4808 CONTEXT. The periodic router refresh used to rebuild the whole
         // router from the on-disk event log:
         //
         //     if !history.is_empty() { *router.write() = Router::new(&history); }

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -405,31 +405,6 @@ pub(crate) struct RouterSnapshotInfo {
     pub broadcast_stream_attempts_total: Option<u64>,
     pub broadcast_stream_failures_total: Option<u64>,
     pub broadcast_stream_failures_last_snapshot: Option<u64>,
-    /// Liveness heartbeat for the periodic router-refit task (#4440), populated
-    /// by `Ring` from the process-global `BACKGROUND_TASK_HEALTH` that task
-    /// publishes into. Seconds since its last completed pass, or `None` until the
-    /// first one.
-    ///
-    /// This is the LAST survivor of the #4440 background-task health gauges, and
-    /// it is a pure liveness signal — expect < ~300s on a healthy node. It is
-    /// worth keeping because `BackgroundTaskMonitor` only watches for task
-    /// *death*: a task that is alive but starved — deadlocked on `router.write()`,
-    /// or never scheduled — is invisible to the monitor and shows up here as a
-    /// rising age.
-    ///
-    /// The companion `consecutive_failures` gauge was removed in the #4808
-    /// follow-up. It was added because `refresh_router`'s transient
-    /// `get_router_events` errors were made non-fatal by the v0.2.74 #4438 hotfix,
-    /// leaving a persistently-failing refresh silent. Deleting the startup restore
-    /// removed the last fallible call in the task, so the counter had no remaining
-    /// failure source and was structurally pinned at 0 forever.
-    ///
-    /// The field name still says `refresh_router` though the task is now
-    /// `Ring::refit_router_periodically`. That is deliberate: this name is an OTLP
-    /// key, and renaming it would silently break the existing metric series and
-    /// any dashboard panel querying it. Renaming the key is a separate, riskier
-    /// change than the code rename that prompted it.
-    pub refresh_router_last_success_age_secs: Option<u64>,
     /// Placement-quality gauges (#4404 follow-up), populated by `Ring` on the
     /// snapshot cadence from the contracts this node hosts. They make the
     /// effect of the SubscribeHint placement migration observable: the migration
@@ -979,47 +954,6 @@ impl Router {
         }
     }
 
-    /// Refit every isotonic estimator whose data window has turned over enough to
-    /// warrant it (see [`IsotonicEstimator::refit_if_stale`]), returning how many
-    /// were refit.
-    ///
-    /// `add_event` maintains each fit incrementally, which is an approximation of
-    /// the batch pool-adjacent-violators result. This restores the exact fit
-    /// without discarding anything: it rebuilds from each estimator's own
-    /// in-memory `raw_points`, which already holds every observation the router
-    /// has seen — originator and relay hop alike.
-    ///
-    /// This REPLACES the previous approach of rebuilding the whole `Router` from
-    /// the on-disk event log, which lost every relay-recorded event because
-    /// `operations::record_relay_route_event` never persists (issue #4808).
-    pub(crate) fn refit_stale_estimators(&mut self) -> usize {
-        let mut refit_count = 0;
-
-        for estimator in [
-            &mut self.response_start_time_estimator,
-            &mut self.transfer_rate_estimator,
-            &mut self.failure_estimator,
-        ] {
-            if estimator.refit_if_stale() {
-                refit_count += 1;
-            }
-        }
-
-        for per_op in [
-            &mut self.per_op_failure,
-            &mut self.per_op_response_time,
-            &mut self.per_op_transfer_rate,
-        ] {
-            for estimator in per_op.values_mut() {
-                if estimator.refit_if_stale() {
-                    refit_count += 1;
-                }
-            }
-        }
-
-        refit_count
-    }
-
     fn select_closest_peers<'a>(
         &self,
         peers: impl IntoIterator<Item = &'a PeerKeyLocation>,
@@ -1463,7 +1397,6 @@ impl Router {
             broadcast_stream_attempts_total: None,
             broadcast_stream_failures_total: None,
             broadcast_stream_failures_last_snapshot: None,
-            refresh_router_last_success_age_secs: None,
             // Placement-quality + placement-migration gauges populated by Ring on
             // the snapshot cadence (#4404 follow-up).
             hosted_contracts_count: None,
@@ -1670,7 +1603,7 @@ mod tests {
     }
 
     #[test]
-    fn refit_stale_estimators_preserves_relay_recorded_events() {
+    fn add_event_preserves_relay_recorded_events() {
         // REGRESSION (#4808). The periodic router refresh used to rebuild the whole
         // router from the on-disk event log:
         //
@@ -1682,48 +1615,80 @@ mod tests {
         // single 30s window, and prediction could never latch because the model was
         // reset faster than it reached MIN_EVENTS_FOR_PREDICTION.
         //
-        // The refresh now refits in place from each estimator's own `raw_points`.
-        // This test pins the invariant that made the old code wrong: a refresh pass
-        // must never lose an observation the router already has.
+        // The refit now happens inside `add_event`, rebuilding in place from each
+        // estimator's own `raw_events` (#4811). This pins the invariant that made
+        // the old code wrong: refitting must never lose an observation the router
+        // already has. It is fed exclusively through the relay path, which is the
+        // one the old rebuild could not see.
         let mut router = Router::new(&[]);
         add_relay_recorded_successes(&mut router, 120);
 
-        let events_before = router.failure_estimator.len();
-        assert!(
-            router.has_sufficient_routing_events(),
-            "sanity: 120 relay events must clear the prediction gate before the refit"
-        );
-
-        let refit_count = router.refit_stale_estimators();
-        assert!(
-            refit_count > 0,
-            "120 events into a fresh router is well past the staleness trigger"
-        );
-
         assert_eq!(
             router.failure_estimator.len(),
-            events_before,
-            "a refresh pass must preserve relay-recorded events, not discard them"
+            120,
+            "the refits performed inside add_event must preserve relay-recorded \
+             events, not discard them"
         );
         assert!(
             router.has_sufficient_routing_events(),
-            "prediction must stay active across a refresh; the old rebuild switched \
+            "prediction must stay active across the refits; the old rebuild switched \
              it off by resetting the model to the on-disk (originator-only) subset"
         );
     }
 
+    /// The #4811 replacement for `refit_router_periodically_refits_stale_estimators`
+    /// (itself the port of #4809's `refresh_router_loop_refits_stale_estimators`).
+    ///
+    /// That guard pinned the ONE line that made #4809's fix do anything: the loop
+    /// calling `refit_stale_estimators`. Both the loop and that method are gone —
+    /// `add_event` now evaluates the trigger itself — so the guarantee is pinned
+    /// here against the mechanism that replaced them, in the same terms: after
+    /// feeding the router, NO estimator may be left owing a refit.
+    ///
+    /// It is the same assertion the loop test made (`refit_stale_estimators() == 0`
+    /// afterwards, i.e. "the outstanding staleness was consumed"), just without a
+    /// poller to consume it. Mutation-verified: deleting the `refit_if_stale()`
+    /// call from `IsotonicEstimator::add_event` fails this test.
     #[test]
-    fn refit_stale_estimators_is_idempotent_and_cheap_when_idle() {
-        // An idle router must do no refit work: the trigger is data turnover, not
-        // wall-clock, so a quiet node's 5-minute tick is a no-op.
+    fn add_event_leaves_no_estimator_stale() {
         let mut router = Router::new(&[]);
+
+        // Straight into the in-memory router, exactly as a relay hop's
+        // `record_relay_route_event` does — far past the staleness trigger.
         add_relay_recorded_successes(&mut router, 120);
-        assert!(router.refit_stale_estimators() > 0, "first pass refits");
-        assert_eq!(
-            router.refit_stale_estimators(),
-            0,
-            "a second pass with no new events must refit nothing"
+
+        let stale: Vec<&str> = [
+            ("response_start_time", &router.response_start_time_estimator),
+            ("transfer_rate", &router.transfer_rate_estimator),
+            ("failure", &router.failure_estimator),
+        ]
+        .into_iter()
+        .filter(|(_, est)| est.is_stale_for_test())
+        .map(|(name, _)| name)
+        .collect();
+        assert!(
+            stale.is_empty(),
+            "add_event must leave no global estimator owing a refit; {stale:?} are \
+             stale, so the model drifts exactly as it did before #4808"
         );
+
+        for (label, per_op) in [
+            ("per_op_failure", &router.per_op_failure),
+            ("per_op_response_time", &router.per_op_response_time),
+            ("per_op_transfer_rate", &router.per_op_transfer_rate),
+        ] {
+            assert!(
+                !per_op.is_empty(),
+                "sanity: {label} must have been populated by the seeded events, \
+                 or this guard is vacuous"
+            );
+            for (op_type, est) in per_op {
+                assert!(
+                    !est.is_stale_for_test(),
+                    "{label}[{op_type:?}] left stale by add_event"
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/core/src/router/isotonic_estimator.rs
+++ b/crates/core/src/router/isotonic_estimator.rs
@@ -418,11 +418,22 @@ impl IsotonicEstimator {
     /// conclusion it supported survives the correction, because what lands on the
     /// hot path is the amortised few µs, not the whole fit.
     ///
-    /// It takes no locks and does no I/O — it is pure computation over `self` —
-    /// so it cannot deadlock or re-enter a caller that already holds one
-    /// (`Router::add_event` is called under `ring.router.write()`;
-    /// `ConnectForwardEstimator::record` under its own `RwLock`). It only extends
-    /// a critical section the caller already holds.
+    /// LOCK SAFETY. The fit itself takes no locks and does no I/O — it is pure
+    /// computation over `self` — so it cannot deadlock or re-enter a caller that
+    /// already holds one (`Router::add_event` is called under
+    /// `ring.router.write()`; `ConnectForwardEstimator::record` under its own
+    /// `RwLock`). It only extends a critical section the caller already holds.
+    ///
+    /// Precisely: that "no locks" claim covers `fit`, not every line reachable
+    /// from the refit. `refit`'s error arm calls `tracing::warn!`, and in release
+    /// builds the per-callsite rate limiter (`util/rate_limit_layer.rs`) does a
+    /// DashMap lookup, whose shard guard is a real `parking_lot` lock (it is
+    /// compiled out under `cfg(test)`, so no test would surface it). That is not
+    /// a deadlock risk — nothing reachable from that shard guard takes
+    /// `ring.router` or `connect_forward_estimator` back, so there is no cycle —
+    /// and it is inert today because the error arm is unreachable (see `refit`).
+    /// Anyone making that arm reachable must re-check this paragraph, not just
+    /// the retry cadence noted there.
     pub fn add_event(&mut self, event: IsotonicEvent) {
         self.add_event_incremental(event);
 

--- a/crates/core/src/router/isotonic_estimator.rs
+++ b/crates/core/src/router/isotonic_estimator.rs
@@ -30,6 +30,20 @@ const MAX_REGRESSION_POINTS: usize = 500;
 /// worst. (That stayed a documentation caveat rather than a live fault only
 /// because ~10 events/min is ~40x the observed production median of ~14-16
 /// events/hour.)
+///
+/// A SLOW estimator loses nothing by the move, which is worth stating because the
+/// opposite is the natural guess. The old tick did not refit on a timer: it called
+/// `refit_stale_estimators` -> `refit_if_stale`, which returns early unless
+/// `refit_due()` — THIS predicate — already holds. So the tick was a poll of the
+/// same condition, and an estimator that had not earned turnover was skipped by it
+/// exactly as it is skipped now. The trigger condition is unchanged; only the
+/// latency between earning a refit and performing it changed, from "up to 5
+/// minutes" to zero. Nothing that used to be refit no longer is.
+///
+/// That the timer was never the real trigger is also why dropping it costs no
+/// accuracy: drift is produced by `add_event`'s incremental fitting, so an
+/// estimator receiving no events is not drifting, and refitting it on a timer
+/// would rebuild an identical fit from identical data.
 const REFIT_STALENESS_PERCENT: usize = 10;
 
 /// EWMA smoothing factor for per-peer adjustments.

--- a/crates/core/src/router/isotonic_estimator.rs
+++ b/crates/core/src/router/isotonic_estimator.rs
@@ -399,11 +399,20 @@ impl IsotonicEstimator {
     /// COST. The refit is amortised over the events that earn it: one O(n log n)
     /// batch fit per ~51 events on a saturated window, on a path that already
     /// pays O(k log k) twice per call (`add_points` and `remove_points` each
-    /// clone, sort, and re-run PAV). It takes no locks and does no I/O — it is
-    /// pure computation over `self` — so it cannot deadlock or re-enter a caller
-    /// that already holds one (`Router::add_event` is called under
-    /// `ring.router.write()`; `ConnectForwardEstimator::record` under its own
-    /// `RwLock`). It only extends a critical section the caller already holds.
+    /// clone, sort, and re-run PAV). Measured on this estimator at a saturated
+    /// 500-point window (release build, 20-50 distinct peers — a realistic
+    /// neighbour set): one refit costs ~150µs, `add_event` costs ~39µs without it,
+    /// and the amortised overhead is ~1.5-5.7µs/event, i.e. **+4-14% on a call
+    /// that was already the expensive part**. Note #4808's oft-quoted "~27µs per
+    /// saturated refit" does not reproduce — it is ~5x optimistic — but the
+    /// conclusion it supported survives the correction, because what lands on the
+    /// hot path is the amortised few µs, not the whole fit.
+    ///
+    /// It takes no locks and does no I/O — it is pure computation over `self` —
+    /// so it cannot deadlock or re-enter a caller that already holds one
+    /// (`Router::add_event` is called under `ring.router.write()`;
+    /// `ConnectForwardEstimator::record` under its own `RwLock`). It only extends
+    /// a critical section the caller already holds.
     pub fn add_event(&mut self, event: IsotonicEvent) {
         self.add_event_incremental(event);
 

--- a/crates/core/src/router/isotonic_estimator.rs
+++ b/crates/core/src/router/isotonic_estimator.rs
@@ -360,7 +360,17 @@ impl IsotonicEstimator {
                 // drifted regression beats a panicking node.
                 //
                 // `events_since_refit` is deliberately NOT reset, so the next
-                // poll retries rather than waiting for another full turnover.
+                // `add_event` retries rather than waiting for another full
+                // turnover. Note the cadence that implies now that the refit is
+                // on the write path: a PERSISTENTLY failing fit retries (and
+                // warns) on every subsequent event, not every 5 minutes as under
+                // the old polled task. That is acceptable only because this arm
+                // is unreachable in practice — `NegativePointWithIntersectOrigin`
+                // requires `intersect_origin: true` and both constructors pass
+                // `false`. If a reachable error variant is ever added here, reset
+                // the counter or rate-limit the warn before doing so; otherwise
+                // this becomes a ~150us refit attempt plus a log line per event
+                // on the relay hot path.
                 tracing::warn!(
                     %error,
                     events = self.raw_events.len(),

--- a/crates/core/src/router/isotonic_estimator.rs
+++ b/crates/core/src/router/isotonic_estimator.rs
@@ -20,13 +20,16 @@ const MAX_REGRESSION_POINTS: usize = 500;
 /// small, rare enough that the O(n log n) refit amortises to a handful of
 /// operations per event.
 ///
-/// NOTE: this bounds only how *often* a refit is EARNED. The realised cadence is
-/// `min(caller's poll interval, this)` — `refit_if_stale` does nothing until
-/// someone calls it, and today the only caller is
-/// `Ring::refit_router_periodically`'s 5-minute tick. Above ~10 events/min the
-/// tick binds instead and a window can
-/// turn over entirely between refits. That is far above the observed production
-/// median (~14-16 events/hour), where turnover always binds first.
+/// This is the WHOLE cadence, not a lower bound on it. [`IsotonicEstimator::add_event`]
+/// evaluates the trigger inline, and it is the only writer of both
+/// `events_since_refit` and `raw_events`, so a refit happens on the very event
+/// that earns it. Until #4811 the trigger was instead polled by
+/// `Ring::refit_router_periodically`'s 5-minute tick, making the realised cadence
+/// `min(5 minutes, this)`: above ~10 events/min the tick bound instead, and a
+/// window could turn over entirely between refits — precisely where drift is
+/// worst. (That stayed a documentation caveat rather than a live fault only
+/// because ~10 events/min is ~40x the observed production median of ~14-16
+/// events/hour.)
 const REFIT_STALENESS_PERCENT: usize = 10;
 
 /// EWMA smoothing factor for per-peer adjustments.
@@ -297,11 +300,29 @@ impl IsotonicEstimator {
     ///
     /// Rebuilds BOTH halves of the estimator — see [`Self::fit`] for why the
     /// global curve and the per-peer adjustments cannot be refit independently.
-    pub fn refit_if_stale(&mut self) -> bool {
+    ///
+    /// Called from [`Self::add_event`] only. It is deliberately NOT public: a
+    /// caller polling it could never observe a stale estimator, because
+    /// `add_event` clears staleness before it returns (see there for why the
+    /// check belongs on the write path).
+    fn refit_if_stale(&mut self) -> bool {
         if !self.refit_due() {
             return false;
         }
         self.refit()
+    }
+
+    /// Test-only view of [`Self::refit_due`], for guards in other modules
+    /// (`router`, `operations::connect`) that pin the #4811 invariant: once
+    /// [`Self::add_event`] returns, the estimator is never left stale.
+    ///
+    /// Reading the predicate rather than counting refits is deliberate — it
+    /// asserts the property that matters (no outstanding staleness) rather than
+    /// the mechanism, and it fails loudly if the `refit_if_stale` call in
+    /// `add_event` is ever dropped.
+    #[cfg(test)]
+    pub(crate) fn is_stale_for_test(&self) -> bool {
+        self.refit_due()
     }
 
     /// Whether enough of the window has turned over to justify a refit.
@@ -350,8 +371,60 @@ impl IsotonicEstimator {
         }
     }
 
-    /// Adds a new event to the estimator.
+    /// Adds a new event to the estimator, refitting it if this event pushes the
+    /// window past the staleness threshold ([`Self::refit_if_stale`]).
+    ///
+    /// WHY THE REFIT LIVES HERE (#4811). This method is the sole writer of both
+    /// inputs to the staleness trigger — `events_since_refit` and `raw_events` —
+    /// so it is the only moment staleness can change. Evaluating the trigger here
+    /// therefore catches every transition into staleness at the instant it
+    /// happens, and makes "the estimator is never stale once `add_event` returns"
+    /// an invariant rather than something a poller converges on.
+    ///
+    /// Until #4811 the trigger was polled by `Ring::refit_router_periodically`'s
+    /// 5-minute tick instead. That was a pull where a push is natural, and it
+    /// paid for the privilege three times over:
+    ///
+    /// - It could only ever refit LATER than this does, never sooner, so it
+    ///   widened the drift window it existed to close (see
+    ///   [`REFIT_STALENESS_PERCENT`]).
+    /// - It could only refit estimators reachable from `Router`, so
+    ///   `operations::connect::ConnectForwardEstimator` — which lives outside
+    ///   `Router`, behind its own lock — silently drifted forever. Refitting on
+    ///   the write path fixes that with no wiring: every estimator refits itself,
+    ///   whoever owns it.
+    /// - It kept a `task_monitor`-registered (hence node-fatal) task alive to
+    ///   poll an in-memory counter.
+    ///
+    /// COST. The refit is amortised over the events that earn it: one O(n log n)
+    /// batch fit per ~51 events on a saturated window, on a path that already
+    /// pays O(k log k) twice per call (`add_points` and `remove_points` each
+    /// clone, sort, and re-run PAV). It takes no locks and does no I/O — it is
+    /// pure computation over `self` — so it cannot deadlock or re-enter a caller
+    /// that already holds one (`Router::add_event` is called under
+    /// `ring.router.write()`; `ConnectForwardEstimator::record` under its own
+    /// `RwLock`). It only extends a critical section the caller already holds.
     pub fn add_event(&mut self, event: IsotonicEvent) {
+        self.add_event_incremental(event);
+
+        // Restore the exact batch fit once this event has turned over enough of
+        // the window. Runs last so the incremental state above is complete and
+        // correct on the ~50/51 events that do not earn a refit; on the one that
+        // does, `refit` rebuilds both halves from `raw_events` and supersedes it.
+        self.refit_if_stale();
+    }
+
+    /// The incremental half of [`Self::add_event`]: extend the window by one
+    /// event and patch the existing fit in place, WITHOUT considering a refit.
+    ///
+    /// Split out because this is the half that DRIFTS. Keeping it callable on its
+    /// own is what lets `incremental_fit_drifts_from_batch_and_refit_repairs_it`
+    /// and `refit_prunes_peers_that_fell_out_of_the_window` build a genuinely
+    /// refit-free fit to measure against a batch build — the tripwire that
+    /// justifies the refit existing at all, and the proof that pruning is needed.
+    /// Through `add_event` they no longer can: it repairs the drift as it goes,
+    /// which is the entire point of #4811.
+    fn add_event_incremental(&mut self, event: IsotonicEvent) {
         let route_distance = event.route_distance();
         let point = Point::new(route_distance.as_f64(), event.result);
 
@@ -1134,8 +1207,13 @@ mod tests {
     /// the boundary is the smallest k with `100k > 10(100 + k)`, i.e. k > 11.11 —
     /// k = 12 fires, k = 11 does not. Pinning BOTH sides matters: bracketing only
     /// 10 and 20 leaves `>` vs `>=` (and several off-by-ones) undetected.
+    ///
+    /// This side pins the HOLD-OFF: `add_event` must not refit eagerly. Since
+    /// #4811 the trigger is evaluated inside `add_event`, so an over-eager trigger
+    /// would refit on the relay hot path every time, which is exactly the cost the
+    /// amortisation argument rules out.
     #[test]
-    fn refit_if_stale_holds_off_just_below_the_turnover_boundary() {
+    fn add_event_holds_off_just_below_the_turnover_boundary() {
         let mut estimator = IsotonicEstimator::new(positive_events(100), EstimatorType::Positive);
         assert_eq!(estimator.events_since_refit, 0, "constructor starts fresh");
 
@@ -1143,47 +1221,66 @@ mod tests {
             estimator.add_event(event);
         }
         assert!(
-            !estimator.refit_if_stale(),
+            !estimator.is_stale_for_test(),
             "11 new events over a 111-event window is 9.9% — under the trigger"
         );
         assert_eq!(
             estimator.events_since_refit, 11,
-            "a held-off refit must not clear the counter, or turnover never accumulates"
+            "a held-off refit must not clear the counter, or turnover never \
+             accumulates — 11 adds must still be pending, un-refit"
         );
     }
 
+    /// The firing side of the boundary above, and the core #4811 pin: the 12th
+    /// `add_event` — the one that earns the refit — performs it ITSELF, with no
+    /// poller involved.
+    ///
+    /// Before #4811 this could only be observed by a caller polling
+    /// `refit_if_stale()`, and the refit landed whenever that caller next ran
+    /// (`Ring::refit_router_periodically`'s 5-minute tick). Now it is synchronous
+    /// with the event that earns it: `events_since_refit` is back to 0 by the time
+    /// `add_event` returns. Mutation check: deleting the `refit_if_stale()` call
+    /// from `add_event` leaves the counter at 12 and fails both assertions.
     #[test]
-    fn refit_if_stale_fires_at_the_turnover_boundary() {
+    fn add_event_refits_inline_at_the_turnover_boundary() {
         let mut estimator = IsotonicEstimator::new(positive_events(100), EstimatorType::Positive);
-        for event in positive_events(12) {
+        for event in positive_events(11) {
             estimator.add_event(event);
         }
-        assert!(
-            estimator.refit_if_stale(),
-            "12 new events over a 112-event window is 10.7% — past the trigger"
+        assert_eq!(
+            estimator.events_since_refit, 11,
+            "sanity: 11 adds are pending and un-refit (see the hold-off guard)"
         );
+
+        // The 12th add crosses 12*100 > 112*10 and must refit on the spot.
+        estimator.add_event(positive_events(1).pop().expect("one event"));
+
         assert_eq!(
             estimator.events_since_refit, 0,
-            "a completed refit resets the turnover counter"
+            "the add that earns the refit must perform it inline, resetting the \
+             turnover counter before it returns (#4811)"
         );
         assert!(
-            !estimator.refit_if_stale(),
-            "an immediate second call has no new data and must not refit"
+            !estimator.is_stale_for_test(),
+            "an estimator must never be left stale once add_event returns"
         );
     }
 
     #[test]
-    fn refit_if_stale_fires_at_exactly_min_points() {
+    fn add_event_refits_inline_at_exactly_min_points() {
         // Pins the `< MIN_POINTS_FOR_REGRESSION` guard's boundary: one fewer must
-        // hold off (covered above), exactly MIN must be allowed through.
+        // hold off (covered by `add_event_never_refits_below_min_points`), exactly
+        // MIN must be allowed through — and, since #4811, by `add_event` itself.
         let mut estimator = IsotonicEstimator::new(std::iter::empty(), EstimatorType::Positive);
         for event in positive_events(MIN_POINTS_FOR_REGRESSION) {
             estimator.add_event(event);
         }
-        assert!(
-            estimator.refit_if_stale(),
-            "at exactly MIN_POINTS_FOR_REGRESSION the guard must allow a refit"
+        assert_eq!(
+            estimator.events_since_refit, 0,
+            "at exactly MIN_POINTS_FOR_REGRESSION the guard must allow the refit, \
+             and add_event must have performed it"
         );
+        assert!(!estimator.is_stale_for_test());
     }
 
     #[test]
@@ -1239,11 +1336,16 @@ mod tests {
         let mut estimator = IsotonicEstimator::new(std::iter::empty(), EstimatorType::Positive);
 
         // Fill the window, then push it fully over with a disjoint peer set.
+        //
+        // Deliberately via `add_event_incremental`, NOT `add_event`: since #4811
+        // `add_event` refits inline, and a refit is precisely what prunes the map.
+        // Feeding through `add_event` would prune as it went and destroy this
+        // test's premise — the unbounded growth it exists to demonstrate.
         for event in positive_events(MAX_REGRESSION_POINTS) {
-            estimator.add_event(event);
+            estimator.add_event_incremental(event);
         }
         for event in positive_events(MAX_REGRESSION_POINTS) {
-            estimator.add_event(event);
+            estimator.add_event_incremental(event);
         }
         assert_eq!(
             estimator.raw_events.len(),
@@ -1268,35 +1370,52 @@ mod tests {
     }
 
     #[test]
-    fn refit_if_stale_is_noop_below_min_points() {
+    fn add_event_never_refits_below_min_points() {
         // Under MIN_POINTS_FOR_REGRESSION the regression refuses to estimate at
-        // all, so refitting buys nothing and must not thrash.
+        // all, so refitting buys nothing and must not thrash. Every one of these
+        // adds is past the turnover percentage (k*100 > k*10 for any k >= 1), so
+        // only the MIN_POINTS guard holds them off — which makes this the guard's
+        // real pin now that `add_event` evaluates the trigger on every call.
         let mut estimator = IsotonicEstimator::new(std::iter::empty(), EstimatorType::Positive);
         for event in positive_events(MIN_POINTS_FOR_REGRESSION - 1) {
             estimator.add_event(event);
         }
-        assert!(!estimator.refit_if_stale());
+        assert!(!estimator.is_stale_for_test());
+        assert_eq!(
+            estimator.events_since_refit,
+            MIN_POINTS_FOR_REGRESSION - 1,
+            "below MIN_POINTS_FOR_REGRESSION no refit may run, so the turnover \
+             counter must still be carrying every add"
+        );
     }
 
     #[test]
-    fn refit_preserves_every_observation() {
+    fn add_event_preserves_every_observation_across_its_inline_refits() {
         // The regression this guards: a refit must never DISCARD data. The bug it
         // replaces rebuilt the router from an on-disk log that lacked relay
         // events, so the model shrank on every pass (#4808).
+        //
+        // Since #4811 the refits happen inside these `add_event` calls (50 adds
+        // over a 200-event seed crosses the trigger twice), so this now pins the
+        // no-loss property across the real, inline mechanism rather than across a
+        // hand-invoked one.
         let mut estimator = IsotonicEstimator::new(positive_events(200), EstimatorType::Positive);
         let before = estimator.len();
 
         for event in positive_events(50) {
             estimator.add_event(event);
         }
-        let after_adds = estimator.len();
-        assert!(after_adds > before, "sanity: adds grow the model");
 
-        assert!(estimator.refit_if_stale(), "50/250 is past the trigger");
         assert_eq!(
             estimator.len(),
-            after_adds,
-            "refit must preserve the observation count exactly, not shrink it"
+            before + 50,
+            "add_event must preserve every observation across the refits it \
+             performs, not shrink the model"
+        );
+        assert_eq!(
+            estimator.raw_events.len(),
+            250,
+            "the refit rebuilds from raw_events; it must not disturb the window"
         );
     }
 
@@ -1334,9 +1453,14 @@ mod tests {
             })
             .collect();
 
+        // Fed through `add_event_incremental`, NOT `add_event`: since #4811 the
+        // latter refits inline, so it cannot produce the un-repaired fit this test
+        // needs to measure drift against. That is the fix working, not a reason to
+        // weaken the tripwire — the incremental path is still what runs between
+        // refits, and it is still what drifts.
         let mut incremental = IsotonicEstimator::new(std::iter::empty(), EstimatorType::Positive);
         for event in events.iter().cloned() {
-            incremental.add_event(event);
+            incremental.add_event_incremental(event);
         }
 
         // The batch reference: exactly what the estimator's own constructor builds

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -2120,7 +2120,6 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                 "broadcast_stream_attempts_total": snapshot.broadcast_stream_attempts_total,
                 "broadcast_stream_failures_total": snapshot.broadcast_stream_failures_total,
                 "broadcast_stream_failures_last_snapshot": snapshot.broadcast_stream_failures_last_snapshot,
-                "refresh_router_last_success_age_secs": snapshot.refresh_router_last_success_age_secs,
                 "per_op_curves": snapshot.per_op_curves,
             });
             // Placement-quality + placement-migration gauges (#4404 follow-up).
@@ -3125,24 +3124,28 @@ mod tests {
         }
     }
 
-    /// Pin: the UPDATE-broadcast stream-assembly gauges and the background-task
-    /// liveness heartbeat (#4440) must also reach the hand-mirrored OTLP body —
-    /// same footgun as the fd / module-cache gauges above. The broadcast
-    /// stream-assembly failure rate is the signal that flagged the v0.2.73
-    /// incident, so a silent drop here would re-blind us to a re-enable going
-    /// wrong.
+    /// Pin: the UPDATE-broadcast stream-assembly gauges must also reach the
+    /// hand-mirrored OTLP body — same footgun as the fd / module-cache gauges
+    /// above. The broadcast stream-assembly failure rate is the signal that
+    /// flagged the v0.2.73 incident, so a silent drop here would re-blind us to a
+    /// re-enable going wrong.
     ///
-    /// This used to cover a second background-task gauge,
-    /// `refresh_router_consecutive_failures`. It was removed in the #4808
-    /// follow-up along with the startup routing-history restore: it existed to
-    /// surface a *non-fatal* `get_router_events` read failure, and deleting the
-    /// restore removed the last fallible call in the task, pinning the counter at
-    /// 0 forever. `refresh_router_last_success_age_secs` survives as a pure
-    /// liveness heartbeat and is still pinned here — the
-    /// `BackgroundTaskMonitor` only watches for task death, so this is the only
-    /// signal that would show the refit loop alive but starved.
+    /// This used to cover the #4440 background-task health gauges too. Both are
+    /// now gone, each with the thing it measured:
+    ///
+    /// - `refresh_router_consecutive_failures` went in the #4808 follow-up with
+    ///   the startup routing-history restore — the task's last fallible call, so
+    ///   the counter had no failure source left and was pinned at 0 forever.
+    /// - `refresh_router_last_success_age_secs` went in #4811 with
+    ///   `Ring::refit_router_periodically` itself. It was a liveness heartbeat for
+    ///   that loop, and only for it: it existed because `BackgroundTaskMonitor`
+    ///   watches for task *death* only, leaving "alive but starved" invisible.
+    ///   With the refit moved onto `IsotonicEstimator::add_event` there is no loop
+    ///   to starve — a stalled refit now means a stalled relay path, which is
+    ///   loudly visible in the operation telemetry rather than needing a
+    ///   dedicated gauge.
     #[test]
-    fn router_snapshot_json_includes_broadcast_and_bgtask_gauges() {
+    fn router_snapshot_json_includes_broadcast_gauges() {
         use arbitrary::{Arbitrary, Unstructured};
         let mut u = Unstructured::new(&[0u8; 4096]);
         let mut info = crate::router::RouterSnapshotInfo::arbitrary(&mut u)
@@ -3150,13 +3153,11 @@ mod tests {
         info.broadcast_stream_attempts_total = Some(37);
         info.broadcast_stream_failures_total = Some(41);
         info.broadcast_stream_failures_last_snapshot = Some(43);
-        info.refresh_router_last_success_age_secs = Some(47);
         let json = event_kind_to_json(&EventKind::RouterSnapshot(Box::new(info)));
         for (key, want) in [
             ("broadcast_stream_attempts_total", 37),
             ("broadcast_stream_failures_total", 41),
             ("broadcast_stream_failures_last_snapshot", 43),
-            ("refresh_router_last_success_age_secs", 47),
         ] {
             assert_eq!(json[key], want, "{key} must reach the OTLP body");
         }


### PR DESCRIPTION
> [!IMPORTANT]
> **Simulation CI is RED** on `test_get_retry_with_alternatives_sparse_topology`, and it needs a decision before this merges. It is **not** the refit: on otherwise-pristine `main`, deleting only this PR's 2-line `task_monitor.register(...)` reverses it, and refit cadence vs. outcome is non-monotonic (never → FAIL, every 5 min → PASS, every ~51 events → FAIL). The test is explicitly seed-coupled and its own doc calls this class of break "expected maintenance rather than a regression". Full bisect and options in [this comment](https://github.com/freenet/freenet-core/pull/4821#issuecomment-4986191456). I have deliberately **not** re-seeded it unilaterally.

## Problem

Two gaps left by #4808/#4809, both about where the isotonic refit is triggered from.

### 1. `ConnectForwardEstimator` never got the refit — and that leaks memory

`operations/connect.rs` wraps an `IsotonicEstimator`, feeds it via `record` → `add_event` on every forward attempt, and reads it via `estimate()` to bias **live CONNECT forwarding**. It lives behind its own `Arc<RwLock<..>>` on **`OpManager`** (`node/op_state_manager.rs:152`, built once at `:415`) — **outside** `Router` — so `Router::refit_stale_estimators`, reachable only from `Ring::refit_router_periodically`'s tick, could not see it.

Note the owner, because it is the whole point: `ConnectOp` is a `#[cfg(test)]` fixture. In production this estimator is **node-lifetime**. (The issue and an earlier revision of this description both said `ConnectOp`; review caught it.)

Two consequences, not one:

1. **Drift, unrepaired forever.** #4808's argument applies verbatim: `pav_regression`'s incremental `add_points`/`remove_points` approximate a batch PAV fit, so its curve drifted with nothing to repair it while `estimate()` kept biasing live CONNECT forwarding off it. Its Bernoulli 0/1 outcomes pool heavily, making it plausibly the worst drift case in the tree.
2. **An unbounded, remote-peer-keyed map — i.e. a slow leak.** `add_event` only ever INSERTS into `peer_adjustments`; the ONLY thing that prunes it to the current window is a refit (`fit` rebuilds it from `raw_events`). `raw_events` is capped at `MAX_REGRESSION_POINTS`, but with no refit ever reaching this estimator the map was capped by **nothing**: it grew one entry per distinct peer ever seen in CONNECT forwarding, for the life of the node. That is exactly the unbounded remote-driven collection `.claude/rules/code-style.md` bans. Secondary cost: `connect_forward_estimator.read().clone()` on the CONNECT path (`connect/op_ctx_task.rs:754/1026/1177`) copies that map, so the leak made those clones monotonically more expensive with uptime.

This PR bounds the map to the window (plus at most one refit interval of new peers). Pinned empirically by `forward_estimator_bounds_peer_adjustments_to_its_window`: feed 2000 distinct peers, assert the map stays well under that — against the unfixed path it retains **1993 of 2000**.

Not a regression (the pre-#4808 rebuild never touched this estimator either), but the tree had one isotonic estimator getting the correction and one silently not.

### 2. The refit was polled, not pushed

`add_event` is the **only** writer of both staleness inputs (`events_since_refit` and `raw_events`), so it is the only moment staleness can change. Polling for a condition only one function can create is a pull where a push is natural — and the poll paid for it three times over: it could only refit **later** than the event that earned it (widening the drift window it existed to close), it could only reach estimators owned by `Router` (gap 1), and it kept a `task_monitor`-registered — hence **node-fatal** — task alive to read an in-memory counter.

## Solution

Move the trigger into `IsotonicEstimator::add_event`. Gap 1 falls out for free with zero wiring: every estimator now refits itself, whoever owns it.

`add_event` splits into two named halves — `add_event_incremental` (patch the fit in place; the half that drifts) and the `refit_if_stale()` that repairs it. The split is load-bearing for testing, not cosmetic: see Testing.

**Lock safety.** The **fit** takes no locks and does no I/O — pure computation over `&mut self` — so it cannot deadlock or re-enter a caller already holding one (`Router::add_event` runs under `ring.router.write()`; `ConnectForwardEstimator::record` under its own `RwLock`). It only extends a critical section the caller already held, and is deterministic given `raw_events`.

Scoped precisely (via review): "no locks" covers `fit`, **not** every line reachable from the refit. `refit`'s error arm calls `tracing::warn!`, whose release-build per-callsite rate limiter does a DashMap lookup — a real `parking_lot` shard guard, compiled out under `cfg(test)`, so no test would surface it. Not a deadlock risk (nothing under that guard reaches back to `ring.router` or the connect estimator, so there is no cycle) and inert today because the arm is unreachable. Both facts are recorded on the code, along with the note that a persistently-failing fit would now retry per-event rather than per-5-minutes.

**The trigger strictly dominates the tick.** Staleness becomes true only inside `add_event`, and `add_event` clears it before returning, so there is no state the tick would have caught that this misses. "An estimator is never stale once `add_event` returns" becomes an invariant rather than something a poller converges on.

### `refit_router_periodically` is genuinely dead — evidence

Verified, not assumed. Post-#4812 the loop body did exactly three things:

1. `router.write().refit_stale_estimators()` — now self-driving.
2. `BACKGROUND_TASK_HEALTH.record_refit_router_success()` — its own heartbeat.
3. A `tracing::debug!`.

With (1) gone its only remaining work is proving *itself* alive, which is self-referential. So it goes, and with it `Router::refit_stale_estimators` (no callers) and the `BackgroundTaskHealth` facility (one field, one recorder, called only from the loop).

**On deleting `refresh_router_last_success_age_secs`:** #4812 kept this gauge deliberately, because `BackgroundTaskMonitor` catches task *death* only, while a loop alive-but-starved shows up solely as a rising age. That rationale was entirely about the loop. With no loop there is nothing to starve — a stalled refit now means a stalled relay path, loudly visible in operation telemetry. Checked for external consumers first: `grep -rn refresh_router` over `/var/www/freenet-dashboard/` returns nothing, and there are no other in-repo references. The alternative was emitting a permanently-null field named after a task that no longer exists.

`Ring::new`'s "why there is no warm start from the event log" rationale lived on the deleted loop's rustdoc; it is **relocated** to the cold-router site, not lost.

## Testing

`cargo test -p freenet --lib`: **3993 passed, 0 failed**. `cargo fmt` clean. `cargo clippy --locked -- -D warnings` and the `trace-ot` variant both clean (the CI invocations; `--all-targets --all-features` fails on `main` too, for unrelated pre-existing lints).

**Simulation: RED** — see the banner above and the linked comment. `test_get_routing_coverage_low_htl` (the non-seed-coupled cover for the same GET retry logic, named in the failing test's own doc) passes on this branch. `simulation_smoke` passes 21/21.

**#4809's pin is kept, not dropped.** `refit_router_periodically_refits_stale_estimators` (itself the port of `refresh_router_loop_refits_stale_estimators`) pinned the one line that made #4809's fix do anything. Both the loop and `refit_stale_estimators` are gone, so the guarantee is re-pinned against the replacement mechanism in the same terms — "no estimator is left owing a refit" — as `router::tests::add_event_leaves_no_estimator_stale`. It covers all three global estimators plus every per-op estimator, and asserts the per-op maps are non-empty first so it cannot go vacuous.

**Gap 1 is pinned twice**, both failing against the unfixed behaviour: `forward_estimator_refits_itself_despite_living_outside_router` (the refit happens at all) and `forward_estimator_bounds_peer_adjustments_to_its_window` (the leak is bounded — 1993/2000 retained without the fix).

**Slow-event-rate estimators: no gap, and the natural guess is inverted.** The old tick did not refit on a timer — it called `refit_stale_estimators` → `refit_if_stale`, which returns early unless `refit_due()` (the turnover predicate) already holds. The tick was a *poll of the same condition*, so an estimator that had not earned turnover was skipped by it exactly as it is skipped now. The trigger condition is unchanged; only the earn-to-perform latency changed, from ≤5 minutes to zero. Nothing that used to be refit no longer is. This is recorded on `REFIT_STALENESS_PERCENT` rather than pinned as a test, since it is an argument about the trigger rather than a behaviour.

**Mutation-verified.** Stubbing the `refit_if_stale()` call in `add_event` fails exactly the four guards that pin the trigger — `add_event_leaves_no_estimator_stale`, `add_event_refits_inline_at_the_turnover_boundary`, `add_event_refits_inline_at_exactly_min_points`, `forward_estimator_refits_itself_despite_living_outside_router` — while the seven other refit guards stay green (they pin the refit *mechanism*, unchanged). So the new guards are the only thing pinning the trigger, exactly as #4809's loop test was.

Boundary coverage per `.claude/rules/testing.md`: 11/12 either side of `REFIT_STALENESS_PERCENT` (the true boundary — bracketing 10/20 leaves `>` vs `>=` undetected), exactly `MIN_POINTS_FOR_REGRESSION`, one below, and repeated `add_event` calls.

**Two tests had to switch to `add_event_incremental`, and this deserves reviewer attention.** `incremental_fit_drifts_from_batch_and_refit_repairs_it` (the tripwire proving the refit is necessary) and `refit_prunes_peers_that_fell_out_of_the_window` both need a genuinely refit-free fit to measure against. Through `add_event` they no longer can — it repairs drift as it goes. Feeding them through `add_event` would have silently gutted both. That is why the incremental half is a named function.

**Honest labelling:** `add_event_preserves_relay_recorded_events` and `add_event_preserves_every_observation_across_its_inline_refits` stay green under the mutation above. They guard the refit's no-data-loss property, not the trigger, and preservation is close to structural — carried forward cheaply, the same caveat #4809 recorded for their predecessor. The load-bearing guards are the four listed above.

Two deleted tests have no equivalent because their subject is gone: `refit_router_periodically_returns_promptly_on_shutdown` (#4278 — a loop that no longer exists cannot fail to exit promptly) and the two `background_task_health_tests` (they construct `BackgroundTaskHealth` directly). `test-exempt` justification: [comment](https://github.com/freenet/freenet-core/pull/4821#issuecomment-4985681705).

## Performance — measured, and the issue's figure is wrong

The issue's cost argument rests on "a saturated 500-point refit is ~27µs" (from #4809). **That does not reproduce.** Release build, saturated 500-point window:

| distinct peers in window | one refit | `add_event` (incremental) | `add_event` (+ inline refit) | amortised overhead |
|---|---|---|---|---|
| 20 (realistic) | ~150µs | ~39µs | ~41µs | **~1.5µs/event (+4%)** |
| 50 (realistic) | ~150µs | ~39µs | ~45µs | **~5.7µs/event (+14%)** |
| 500 (worst case) | ~275-337µs | ~39µs | ~43µs | ~4µs/event (+10%) |

A refit is ~150µs, not ~27µs — roughly **5x** the quoted figure (it scales with distinct peers in the window, since `fit` rebuilds `peer_adjustments`, cloning a `PeerKeyLocation` per peer). **The conclusion survives**: what reaches the hot path is the amortised few µs, not the whole fit. The measured numbers are now in the rustdoc so ~27µs stops propagating.

**The "~15x smaller peak critical section" claim needs refining too.** `IsotonicEstimator::add_event` refits at most one estimator, but `Router::add_event` fans out to up to **6** (3 global + 3 per-op), and their counters genuinely align (`response_start_time` and `failure` are both fed on every `Success`, sharing a window length). Honest bound: ~6 refits per `router.write()` hold vs. the tick's 15 — roughly **2x smaller, not 15x**. Measured on `Router::add_event` at saturation (20 peers): p50 ~340µs → ~350µs, p99 ~750µs → ~1.1ms.

**Pre-existing finding, not from this PR:** the worst-case single `Router::add_event` is **~183ms**, unchanged with my refit removed. It is `RoutingPredictor::record` → `should_train()` → `train()` running inline under `router.write()` on the relay hot path. Distinct from #4810 (that is about the training *freezing*, not its cost). Filed as **#4822** rather than fixed here, since `routing_predictor.rs` has in-flight work. It does put this PR's +350µs p99 in perspective.

## Risk

Routing/topology is a Full-tier surface. Checked against `.claude/rules/ring.md` and `bug-prevention-patterns.md`: no `send().await` in an event loop, no new spawn, no bounded-channel interaction — this PR *removes* a `GlobalExecutor::spawn` + `task_monitor` registration and adds only pure computation. No wire-format change.

Unrelated pre-existing flake found while testing and filed as **#4819** (`test_set_own_addr_atomic_with_network_status` races unlocked `set_own_addr` writers in `op_state_manager` tests; 2-in-14 runs on pristine `main`, never in isolation).

Closes #4811

[AI-assisted - Claude]
