### PR TITLE
fix: de-globalize per-node delegate state (node-wedging underflow + #4813 test race)

### DIFF
--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -88,7 +88,8 @@ pub(crate) const MAX_DELEGATE_CREATIONS_PER_CALL: u32 = 8;
 
 /// Maximum total delegates that can be created via the create_delegate host function
 /// across the lifetime of this node. Prevents unbounded memory growth in the
-/// delegate store and secret store. Enforced via `CREATED_DELEGATES_COUNT` atomic counter.
+/// delegate store and secret store. Enforced via the per-node
+/// `wasm_runtime::SharedDelegateCounter` the runtime carries.
 pub(crate) const MAX_CREATED_DELEGATES_PER_NODE: usize = 1024;
 
 pub(crate) type DelegateNotificationSender = mpsc::Sender<DelegateNotification>;

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -428,6 +428,8 @@ impl Executor<Runtime> {
         contract_modules: SharedModuleCache<ContractKey>,
         delegate_modules: SharedModuleCache<DelegateKey>,
         delegate_contexts: crate::wasm_runtime::DelegateContextCache,
+        created_delegates_count: crate::wasm_runtime::SharedDelegateCounter,
+        inherited_origins: crate::wasm_runtime::SharedInheritedOrigins,
         shared_backend: Option<BackendEngine>,
         shared_contract_index: SharedContractIndex,
     ) -> anyhow::Result<Self> {
@@ -467,6 +469,8 @@ impl Executor<Runtime> {
             contract_modules,
             delegate_modules,
             delegate_contexts,
+            created_delegates_count,
+            inherited_origins,
             shared_backend.unwrap_or_else(|| {
                 // First executor — create a fresh backend engine; RuntimePool
                 // will extract and share it with subsequent executors.

--- a/crates/core/src/contract/executor/runtime/delegates.rs
+++ b/crates/core/src/contract/executor/runtime/delegates.rs
@@ -259,9 +259,8 @@ impl Executor<Runtime> {
 ///    deliberately replaces (not composes with) any inherited WebApp origin.
 /// 2. `origin_contract` — set when a contract-backed web app dispatched
 ///    this request via the WebSocket API.
-/// 3. `DELEGATE_INHERITED_ORIGINS[delegate_key]` — set when a parent
-///    delegate created this delegate via `create_delegate`, inheriting its
-///    WebApp attestation.
+/// 3. `inherited_origins[delegate_key]` — set when a parent delegate created
+///    this delegate via `create_delegate`, inheriting its WebApp attestation.
 ///
 /// Extracted as a free function so the precedence rules can be unit-tested
 /// directly without standing up a full `Executor`. `inherited_origins` is the

--- a/crates/core/src/contract/executor/runtime/delegates.rs
+++ b/crates/core/src/contract/executor/runtime/delegates.rs
@@ -172,19 +172,14 @@ impl Executor<Runtime> {
                 });
 
                 // Clean up delegate creation tracking to prevent unbounded growth
-                crate::wasm_runtime::DELEGATE_INHERITED_ORIGINS.remove(&key);
+                self.runtime.inherited_origins.remove(&key);
 
-                // Decrement the global created-delegates counter so the slot can be reused.
-                // Only decrement if count > 0 to avoid underflow for delegates not created
-                // via the host function (e.g., registered directly by apps).
-                {
-                    use std::sync::atomic::Ordering;
-                    let count = &crate::wasm_runtime::CREATED_DELEGATES_COUNT;
-                    let prev = count.load(Ordering::Relaxed);
-                    if prev > 0 {
-                        count.fetch_sub(1, Ordering::Relaxed);
-                    }
-                }
+                // Release this node's created-delegate slot so it can be reused.
+                // Saturates at zero: delegates registered directly by apps were
+                // never counted. See `release_created_delegate_slot`.
+                crate::wasm_runtime::release_created_delegate_slot(
+                    &self.runtime.created_delegates_count,
+                );
 
                 match self.runtime.unregister_delegate(&key) {
                     Ok(_) => Ok(HostResponse::Ok),
@@ -204,7 +199,12 @@ impl Executor<Runtime> {
                 inbound,
                 params,
             } => {
-                let origin = resolve_message_origin(caller_delegate, origin_contract, &key);
+                let origin = resolve_message_origin(
+                    &self.runtime.inherited_origins,
+                    caller_delegate,
+                    origin_contract,
+                    &key,
+                );
                 match self.runtime.inbound_app_message(
                     &key,
                     &params,
@@ -264,8 +264,11 @@ impl Executor<Runtime> {
 ///    WebApp attestation.
 ///
 /// Extracted as a free function so the precedence rules can be unit-tested
-/// directly without standing up a full `Executor`.
+/// directly without standing up a full `Executor`. `inherited_origins` is the
+/// node's attestation map, passed in rather than reached for globally so a
+/// test's map is its own (#4813).
 fn resolve_message_origin(
+    inherited_origins: &crate::wasm_runtime::SharedInheritedOrigins,
     caller_delegate: Option<&DelegateKey>,
     origin_contract: Option<&ContractInstanceId>,
     delegate_key: &DelegateKey,
@@ -279,7 +282,7 @@ fn resolve_message_origin(
         // inbound_app_message instead, so a child that only ever gets messages
         // from other delegates (those don't reach this branch) still counts as
         // active and isn't dropped.
-        crate::wasm_runtime::DELEGATE_INHERITED_ORIGINS
+        inherited_origins
             .get(delegate_key)
             .and_then(|entry| entry.origins.first().copied().map(MessageOrigin::WebApp))
     }
@@ -294,6 +297,17 @@ mod resolve_message_origin_tests {
         DelegateKey::new([seed; 32], CodeHash::new([seed; 32]))
     }
 
+    /// A fresh attestation map, standing in for one node's.
+    ///
+    /// Each test gets its own, so no test can see another's entries. These
+    /// tests used to share one process-global map, which forced them to pick
+    /// collision-avoiding keys and to hand back their entries before asserting
+    /// (so a panic wouldn't leak into a sibling). Neither dance is needed now,
+    /// and both are gone. See #4813.
+    fn origins() -> crate::wasm_runtime::SharedInheritedOrigins {
+        crate::wasm_runtime::new_inherited_origins()
+    }
+
     /// Caller delegate identity wins over a concurrently-supplied WebApp
     /// contract (regression for issue #3860 precedence rule).
     #[test]
@@ -302,7 +316,8 @@ mod resolve_message_origin_tests {
         let recipient = dkey(0xB2);
         let app_contract = ContractInstanceId::new([0xC3; 32]);
 
-        let origin = resolve_message_origin(Some(&caller), Some(&app_contract), &recipient);
+        let origin =
+            resolve_message_origin(&origins(), Some(&caller), Some(&app_contract), &recipient);
 
         match origin {
             Some(MessageOrigin::Delegate(k)) => assert_eq!(k, caller),
@@ -310,15 +325,14 @@ mod resolve_message_origin_tests {
         }
     }
 
-    /// With only `origin_contract` set, the receiver sees `WebApp(..)` —
-    /// the historical behavior for web-app-driven dispatch must be
-    /// preserved.
+    /// With only `origin_contract` set, the receiver sees `WebApp(..)` — the
+    /// historical behavior for web-app-driven dispatch must be preserved.
     #[test]
     fn origin_contract_alone_yields_webapp() {
         let recipient = dkey(0xB2);
         let app_contract = ContractInstanceId::new([0xC3; 32]);
 
-        let origin = resolve_message_origin(None, Some(&app_contract), &recipient);
+        let origin = resolve_message_origin(&origins(), None, Some(&app_contract), &recipient);
 
         match origin {
             Some(MessageOrigin::WebApp(id)) => assert_eq!(id, app_contract),
@@ -326,44 +340,35 @@ mod resolve_message_origin_tests {
         }
     }
 
-    /// With neither argument set and no inherited origin in the static
-    /// map, the receiver sees `None` (matches pre-#3860 behavior for
-    /// orphaned dispatches and the fall-through case for unrelated
-    /// recipients in tests).
+    /// With neither argument set and no inherited origin in the node's map, the
+    /// receiver sees `None` (matches pre-#3860 behavior for orphaned dispatches
+    /// and the fall-through case for unrelated recipients).
     #[test]
     fn no_arguments_and_no_inherited_yields_none() {
-        // Pick a recipient key with no entry in DELEGATE_INHERITED_ORIGINS.
-        // Using a randomized seed avoids collision with anything another
-        // test populated in the same process.
         let recipient = dkey(0xEE);
-        crate::wasm_runtime::DELEGATE_INHERITED_ORIGINS.remove(&recipient);
 
-        let origin = resolve_message_origin(None, None, &recipient);
+        let origin = resolve_message_origin(&origins(), None, None, &recipient);
         assert!(origin.is_none(), "Expected None, got {origin:?}");
     }
 
-    /// Caller delegate identity also wins over an inherited WebApp origin
-    /// in `DELEGATE_INHERITED_ORIGINS`. This documents the deliberate
-    /// "inter-delegate calls revoke inherited contract access" semantics
-    /// from the `MessageOrigin::Delegate` rustdoc.
+    /// Caller delegate identity also wins over an inherited WebApp origin. This
+    /// documents the deliberate "inter-delegate calls revoke inherited contract
+    /// access" semantics from the `MessageOrigin::Delegate` rustdoc.
     #[test]
     fn caller_delegate_overrides_inherited_origin() {
         let caller = dkey(0xA1);
         let recipient = dkey(0xB3);
         let inherited_contract = ContractInstanceId::new([0xDD; 32]);
+        let origins = origins();
 
-        // Plant an inherited WebApp origin for the recipient so the
-        // fallback branch would have something to return.
-        crate::wasm_runtime::DELEGATE_INHERITED_ORIGINS.insert(
+        // Plant an inherited WebApp origin for the recipient so the fallback
+        // branch would have something to return.
+        origins.insert(
             recipient.clone(),
             crate::wasm_runtime::InheritedOriginsEntry::new(vec![inherited_contract]),
         );
 
-        let origin = resolve_message_origin(Some(&caller), None, &recipient);
-
-        // Cleanup before assertions so a panic doesn't leak state into
-        // sibling tests sharing the same process.
-        crate::wasm_runtime::DELEGATE_INHERITED_ORIGINS.remove(&recipient);
+        let origin = resolve_message_origin(&origins, Some(&caller), None, &recipient);
 
         match origin {
             Some(MessageOrigin::Delegate(k)) => assert_eq!(k, caller),
@@ -377,21 +382,56 @@ mod resolve_message_origin_tests {
     /// `no_arguments_and_no_inherited_yields_none`.
     #[test]
     fn inherited_origin_fallback_yields_webapp() {
-        use crate::wasm_runtime::{DELEGATE_INHERITED_ORIGINS, InheritedOriginsEntry};
+        use crate::wasm_runtime::InheritedOriginsEntry;
 
         let recipient = dkey(0xC5);
         let contract = ContractInstanceId::new([0xC6; 32]);
-        DELEGATE_INHERITED_ORIGINS.insert(
+        let origins = origins();
+        origins.insert(
             recipient.clone(),
             InheritedOriginsEntry::new(vec![contract]),
         );
 
-        let origin = resolve_message_origin(None, None, &recipient);
-        DELEGATE_INHERITED_ORIGINS.remove(&recipient);
+        let origin = resolve_message_origin(&origins, None, None, &recipient);
 
         assert!(
             matches!(origin, Some(MessageOrigin::WebApp(c)) if c == contract),
             "fallback must yield the inherited WebApp origin, got {origin:?}"
+        );
+    }
+
+    /// Two nodes' attestation maps are independent (#4813).
+    ///
+    /// A `DelegateKey` is derived from the delegate's code and params, so two
+    /// nodes running the same delegate collide on the key by construction.
+    /// While this map was a `static`, that collision meant one node's inherited
+    /// origin resolved as another's — and this map decides which contract a
+    /// delegate message is attributed to, hence what it may access.
+    #[test]
+    fn inherited_origin_does_not_leak_across_nodes() {
+        use crate::wasm_runtime::InheritedOriginsEntry;
+
+        // The same delegate key on both nodes, as identical code+params gives.
+        let recipient = dkey(0xC5);
+        let contract = ContractInstanceId::new([0xC6; 32]);
+
+        let node_a = origins();
+        let node_b = origins();
+        node_a.insert(
+            recipient.clone(),
+            InheritedOriginsEntry::new(vec![contract]),
+        );
+
+        assert!(
+            matches!(
+                resolve_message_origin(&node_a, None, None, &recipient),
+                Some(MessageOrigin::WebApp(c)) if c == contract
+            ),
+            "node A resolves its own inherited origin"
+        );
+        assert!(
+            resolve_message_origin(&node_b, None, None, &recipient).is_none(),
+            "node B must NOT resolve node A's inherited origin for the same key"
         );
     }
 }

--- a/crates/core/src/contract/executor/runtime/pool.rs
+++ b/crates/core/src/contract/executor/runtime/pool.rs
@@ -82,6 +82,16 @@ pub struct RuntimePool {
     shared_delegate_modules: SharedModuleCache<DelegateKey>,
     /// Shared per-delegate `ctx.write()` cache (see `DelegateContextCache`).
     shared_delegate_contexts: crate::wasm_runtime::DelegateContextCache,
+    /// This node's created-delegate count, shared by every executor so
+    /// `MAX_CREATED_DELEGATES_PER_NODE` is enforced per node rather than per
+    /// executor. Pool-owned so a replacement executor inherits the live count
+    /// instead of resetting it to zero. See `SharedDelegateCounter`.
+    shared_delegate_counter: crate::wasm_runtime::SharedDelegateCounter,
+    /// This node's child-delegate attestation map, shared by every executor so
+    /// a child created via one executor is attributed the same origins when a
+    /// message reaches it via another. Pool-owned so a replacement executor
+    /// inherits the live map. See `SharedInheritedOrigins`.
+    shared_inherited_origins: crate::wasm_runtime::SharedInheritedOrigins,
     /// Shared backend engine used by all executors.
     ///
     /// All executors MUST share the same backend engine because compiled modules
@@ -380,6 +390,14 @@ impl RuntimePool {
         // Shared delegate-context cache so a prompt round-trip routed to a
         // different pool executor still finds its `ctx.write()` blob.
         let shared_delegate_contexts = crate::wasm_runtime::new_delegate_context_cache();
+        // One created-delegate count for this node, shared by every executor:
+        // the limit it enforces is per node, so a delegate created via one
+        // executor must draw down the same budget every other executor checks.
+        let shared_delegate_counter = crate::wasm_runtime::new_delegate_counter();
+        // One attestation map for this node, shared by every executor: a child
+        // delegate created via one executor must resolve to the same inherited
+        // origins when a later message reaches it via a different one.
+        let shared_inherited_origins = crate::wasm_runtime::new_inherited_origins();
 
         // Create shared recovery guard for corrupted-state self-healing.
         // All pool executors share this so recovery tracking is consistent.
@@ -402,6 +420,8 @@ impl RuntimePool {
             shared_contract_modules.clone(),
             shared_delegate_modules.clone(),
             shared_delegate_contexts.clone(),
+            shared_delegate_counter.clone(),
+            shared_inherited_origins.clone(),
             None, // No shared backend yet — this executor creates the engine
             shared_contract_index.clone(),
         )
@@ -424,6 +444,8 @@ impl RuntimePool {
                 shared_contract_modules.clone(),
                 shared_delegate_modules.clone(),
                 shared_delegate_contexts.clone(),
+                shared_delegate_counter.clone(),
+                shared_inherited_origins.clone(),
                 Some(shared_backend_engine.clone()),
                 shared_contract_index.clone(),
             )
@@ -491,6 +513,8 @@ impl RuntimePool {
             shared_contract_index,
             shared_delegate_modules,
             shared_delegate_contexts,
+            shared_delegate_counter,
+            shared_inherited_origins,
             shared_backend_engine,
             shared_recovery_guard,
             delegate_notification_tx,
@@ -673,6 +697,8 @@ impl RuntimePool {
             self.shared_contract_modules.clone(),
             self.shared_delegate_modules.clone(),
             self.shared_delegate_contexts.clone(),
+            self.shared_delegate_counter.clone(),
+            self.shared_inherited_origins.clone(),
             Some(self.shared_backend_engine.clone()),
             self.shared_contract_index.clone(),
         )

--- a/crates/core/src/wasm_runtime.rs
+++ b/crates/core/src/wasm_runtime.rs
@@ -39,8 +39,9 @@ pub(crate) use module_cache::{
     MAX_DEFAULT_MODULE_CACHE_BUDGET_BYTES, MIN_DEFAULT_MODULE_CACHE_BUDGET_BYTES,
 };
 pub(crate) use native_api::{
-    CREATED_DELEGATES_COUNT, DELEGATE_INHERITED_ORIGINS, DELEGATE_SUBSCRIPTIONS,
-    DelegateContextCache, new_delegate_context_cache,
+    DELEGATE_SUBSCRIPTIONS, DelegateContextCache, SharedDelegateCounter, SharedInheritedOrigins,
+    new_delegate_context_cache, new_delegate_counter, new_inherited_origins,
+    release_created_delegate_slot,
 };
 // Only constructed by name in test code (e.g. resolve_message_origin tests);
 // production read/write paths access the entry through the DashMap without

--- a/crates/core/src/wasm_runtime/delegate/execution.rs
+++ b/crates/core/src/wasm_runtime/delegate/execution.rs
@@ -146,6 +146,12 @@ impl Runtime {
                 // delegate cannot mutate or forge it. `None` outside hosted
                 // mode keeps secret ops on `SecretScope::Local`.
                 user_context.cloned(),
+                // This node's created-delegate count, enforcing
+                // MAX_CREATED_DELEGATES_PER_NODE across the pool's executors.
+                self.created_delegates_count.clone(),
+                // This node's attestation map, which a creation by an attested
+                // parent extends with the child's inherited origins.
+                self.inherited_origins.clone(),
             )
         };
 

--- a/crates/core/src/wasm_runtime/delegate/interface.rs
+++ b/crates/core/src/wasm_runtime/delegate/interface.rs
@@ -70,8 +70,8 @@ impl DelegateRuntimeInterface for Runtime {
         // Keep the inherited-origins map tidy. Mark this delegate as just-used
         // so the cleanup keeps its entry, then drop entries for delegates that
         // have gone unused long enough. See `InheritedOriginsEntry`.
-        native_api::touch_inherited_origin(delegate_key);
-        native_api::prune_expired_inherited_origins();
+        native_api::touch_inherited_origin(&self.inherited_origins, delegate_key);
+        native_api::prune_expired_inherited_origins(&self.inherited_origins);
         let mut context: Vec<u8> = self
             .delegate_contexts
             .get(delegate_key)

--- a/crates/core/src/wasm_runtime/delegate/test.rs
+++ b/crates/core/src/wasm_runtime/delegate/test.rs
@@ -1118,11 +1118,14 @@ fn inbound_app_message_wires_inherited_origins_ttl_in_order() {
         .rsplit("fn inbound_app_message(")
         .next()
         .expect("inbound_app_message impl must exist");
+    // Anchor on the call, not its arguments: the map these take is injected
+    // state now (#4813), and pinning the argument list would have failed that
+    // refactor for no reason. What must not regress is that both run, in order.
     let touch = body
-        .find("touch_inherited_origin(delegate_key)")
+        .find("touch_inherited_origin(")
         .expect("inbound_app_message must refresh inherited-origin liveness (touch)");
     let prune = body
-        .find("prune_expired_inherited_origins()")
+        .find("prune_expired_inherited_origins(")
         .expect("inbound_app_message must run the inherited-origins TTL sweep (prune)");
     assert!(
         touch < prune,

--- a/crates/core/src/wasm_runtime/delegate_api.rs
+++ b/crates/core/src/wasm_runtime/delegate_api.rs
@@ -1497,14 +1497,14 @@ mod tests {
     /// two tests from colliding on a key; what makes them independent is that
     /// each node's map is its own.
     ///
-    /// It is also the production-facing half. Both the count and the attestation
-    /// map are per-*node* state, but a `static` made them process-wide, so every
-    /// node sharing a process (the simulation runner) pooled them:
-    /// `MAX_CREATED_DELEGATES_PER_NODE` became one budget drawn down by all
-    /// peers, and — since a DelegateKey is derived from code and params, so peers
-    /// running the same delegate collide by construction — one peer's inherited
-    /// origin was visible as another's. The latter decides what a delegate may
-    /// access.
+    /// It pins the scoping itself, which is a test-isolation property, not a
+    /// production one. Both the count and the attestation map are per-*node*
+    /// state that a `static` made process-wide. No production configuration is
+    /// affected: a node is a process (one `RuntimePool` per node), and the
+    /// simulation runner cannot create delegates at all (`MockWasmRuntime`'s
+    /// `execute_delegate_request` returns "delegates not supported"). So the
+    /// only context where per-node and per-process ever diverged is this test
+    /// suite — which is exactly the flake in #4813.
     #[tokio::test]
     async fn test_delegate_node_state_is_per_node_not_per_process() {
         use std::sync::atomic::Ordering;

--- a/crates/core/src/wasm_runtime/delegate_api.rs
+++ b/crates/core/src/wasm_runtime/delegate_api.rs
@@ -1527,9 +1527,9 @@ mod tests {
             .unwrap();
 
         // Node B creates from the same code and params, so it derives the SAME
-        // key — the collision is real and is what the `static` map turned into a
-        // cross-node (and cross-test) leak. Isolation comes from the map, not
-        // from the keys differing.
+        // key. The collision is real and unavoidable; what keeps the two envs
+        // independent is that each owns its map. Isolation comes from the map,
+        // not from the keys differing.
         let b_child_key = env_b
             .create_delegate_sync(&minimal_delegate_wasm(), &[1], [0u8; 32], [0u8; 24])
             .unwrap();

--- a/crates/core/src/wasm_runtime/delegate_api.rs
+++ b/crates/core/src/wasm_runtime/delegate_api.rs
@@ -1598,8 +1598,10 @@ mod tests {
     /// A barrier lines the racers up on the same slot, and the round repeats,
     /// because a wrap is a race and one round proves little. Verified to have
     /// teeth rather than assumed: against the `load`-then-`fetch_sub` this
-    /// replaced it fails on every run (5/5, immediately), with more than one
-    /// racer claiming the slot and the count wrapping past zero.
+    /// replaced it fails immediately on every run (6/6 at this round count),
+    /// with more than one racer claiming the slot and the count wrapping past
+    /// zero. 200 rounds is deliberate — it is the smallest count still verified
+    /// to catch that, since this suite does not need 16k more OS threads.
     #[test]
     fn test_release_created_delegate_slot_concurrent_releases_do_not_wrap() {
         use super::super::native_api::{new_delegate_counter, release_created_delegate_slot};
@@ -1608,7 +1610,7 @@ mod tests {
 
         const RACERS: usize = 8;
 
-        for _ in 0..2_000 {
+        for _ in 0..200 {
             let counter = new_delegate_counter();
             counter.store(1, Ordering::Relaxed);
             // Release the racers together, so they contend for the ONE occupied

--- a/crates/core/src/wasm_runtime/delegate_api.rs
+++ b/crates/core/src/wasm_runtime/delegate_api.rs
@@ -321,6 +321,14 @@ mod tests {
         delegate_store: super::super::delegate_store::DelegateStore,
         secret_store: SecretsStore,
         db: Storage,
+        /// This env's own per-node delegate state, standing in for what a real
+        /// node's `Runtime` owns. Private to this `TestEnv`, so a test
+        /// asserting on either one cannot observe another test's delegate
+        /// creations — the coupling that made
+        /// `test_create_delegate_non_attested_still_counts_toward_node_limit`
+        /// flaky under a parallel suite run (#4813).
+        created_delegates_count: super::super::native_api::SharedDelegateCounter,
+        inherited_origins: super::super::native_api::SharedInheritedOrigins,
     }
 
     impl TestEnv {
@@ -345,6 +353,8 @@ mod tests {
                 delegate_store,
                 secret_store,
                 db,
+                created_delegates_count: super::super::native_api::new_delegate_counter(),
+                inherited_origins: super::super::native_api::new_inherited_origins(),
             }
         }
 
@@ -397,6 +407,8 @@ mod tests {
                     depth,
                     vec![],
                     None,
+                    self.created_delegates_count.clone(),
+                    self.inherited_origins.clone(),
                 )
             }
         }
@@ -425,6 +437,8 @@ mod tests {
                     0,
                     vec![],
                     None,
+                    self.created_delegates_count.clone(),
+                    self.inherited_origins.clone(),
                 )
             }
         }
@@ -456,6 +470,8 @@ mod tests {
                     0,
                     vec![],
                     None,
+                    self.created_delegates_count.clone(),
+                    self.inherited_origins.clone(),
                 )
             }
         }
@@ -484,6 +500,8 @@ mod tests {
                     0,
                     attestations,
                     None,
+                    self.created_delegates_count.clone(),
+                    self.inherited_origins.clone(),
                 )
             }
         }
@@ -579,6 +597,8 @@ mod tests {
                 0,
                 vec![],
                 None,
+                env_holder.created_delegates_count.clone(),
+                env_holder.inherited_origins.clone(),
             )
         };
 
@@ -662,6 +682,8 @@ mod tests {
                 0,
                 vec![],
                 None,
+                env_holder.created_delegates_count.clone(),
+                env_holder.inherited_origins.clone(),
             )
         };
 
@@ -691,6 +713,8 @@ mod tests {
                 0,
                 vec![],
                 None,
+                env_holder.created_delegates_count.clone(),
+                env_holder.inherited_origins.clone(),
             )
         };
 
@@ -1387,12 +1411,11 @@ mod tests {
         assert_eq!(env.creations_this_call.get(), 2);
     }
 
-    /// Child delegate inherits parent's attested contracts in DELEGATE_INHERITED_ORIGINS.
+    /// Child delegate inherits parent's attested contracts.
     #[tokio::test]
     async fn test_create_delegate_inherits_attestations() {
-        use super::super::native_api::DELEGATE_INHERITED_ORIGINS;
-
         let mut env_holder = TestEnv::new().await;
+        let origins = env_holder.inherited_origins.clone();
 
         let contract_id = ContractInstanceId::new([42u8; 32]);
         // SAFETY: env_holder is alive for the duration of this test
@@ -1406,27 +1429,35 @@ mod tests {
             .unwrap();
 
         // Verify the child inherited the parent's attestation
-        let inherited = DELEGATE_INHERITED_ORIGINS.get(&child_key);
+        let inherited = origins.get(&child_key);
         assert!(
             inherited.is_some(),
             "child should have inherited attestations"
         );
         assert_eq!(inherited.unwrap().value().origins, vec![contract_id]);
 
-        // Cleanup
-        DELEGATE_INHERITED_ORIGINS.remove(&child_key);
+        // No cleanup: the map is this env's own and dies with `env_holder`.
+        // It used to be a process-global that this test had to hand back,
+        // and the window before it did was the #4813 flake.
     }
 
-    /// Child created by non-attested parent does NOT appear in DELEGATE_INHERITED_ORIGINS
-    /// but still counts toward the per-node limit via CREATED_DELEGATES_COUNT.
+    /// Child created by non-attested parent gets no attestation entry, but
+    /// still counts toward the per-node limit.
+    ///
+    /// Both halves read this env's own state, so neither can be moved by a
+    /// concurrent test (#4813). Note the params (`&[1]`) match those in
+    /// `test_create_delegate_inherits_attestations`, so both derive the SAME
+    /// child_key — when the attestation map was a process-global, that sibling's
+    /// entry was visible here under that shared key and failed the `is_none()`
+    /// assertion below. The keys still collide; the maps no longer do.
     #[tokio::test]
     async fn test_create_delegate_non_attested_still_counts_toward_node_limit() {
-        use super::super::native_api::{CREATED_DELEGATES_COUNT, DELEGATE_INHERITED_ORIGINS};
         use std::sync::atomic::Ordering;
 
         let mut env_holder = TestEnv::new().await;
-
-        let before = CREATED_DELEGATES_COUNT.load(Ordering::Relaxed);
+        let counter = env_holder.created_delegates_count.clone();
+        let origins = env_holder.inherited_origins.clone();
+        assert_eq!(counter.load(Ordering::Relaxed), 0, "fresh env starts at 0");
 
         // SAFETY: env_holder is alive for the duration of this test
         let env = unsafe { env_holder.make_env() }; // no attestations
@@ -1440,19 +1471,176 @@ mod tests {
 
         // Should NOT be in inherited attestations (parent had none)
         assert!(
-            DELEGATE_INHERITED_ORIGINS.get(&child_key).is_none(),
+            origins.get(&child_key).is_none(),
             "non-attested parent should not create attestation entry"
         );
 
-        // But SHOULD have incremented the global counter
-        let after = CREATED_DELEGATES_COUNT.load(Ordering::Relaxed);
-        assert!(
-            after > before,
-            "global counter should increment for all creations (before={before}, after={after})"
+        // But SHOULD have counted toward the node limit. An exact count is
+        // assertable now that the counter is this env's own; the old
+        // `after > before` was a workaround for a count anything could move.
+        assert_eq!(
+            counter.load(Ordering::Relaxed),
+            1,
+            "creation by a non-attested parent must still count toward the node limit"
         );
 
-        // Cleanup
-        CREATED_DELEGATES_COUNT.fetch_sub(1, Ordering::Relaxed);
+        // No cleanup: both live in `env_holder` and die with it.
+    }
+
+    /// A node's delegate state is per node, not per process (#4813).
+    ///
+    /// This is the property that makes the two tests above deterministic. Both
+    /// create a delegate from the same WASM with params `&[1]`, so both derive
+    /// the SAME child_key — one asserting an attestation entry EXISTS under it,
+    /// the other asserting it does NOT. While the map was a `static`, those two
+    /// assertions raced on one entry, which is the flake in #4813. Nothing stops
+    /// two tests from colliding on a key; what makes them independent is that
+    /// each node's map is its own.
+    ///
+    /// It is also the production-facing half. Both the count and the attestation
+    /// map are per-*node* state, but a `static` made them process-wide, so every
+    /// node sharing a process (the simulation runner) pooled them:
+    /// `MAX_CREATED_DELEGATES_PER_NODE` became one budget drawn down by all
+    /// peers, and — since a DelegateKey is derived from code and params, so peers
+    /// running the same delegate collide by construction — one peer's inherited
+    /// origin was visible as another's. The latter decides what a delegate may
+    /// access.
+    #[tokio::test]
+    async fn test_delegate_node_state_is_per_node_not_per_process() {
+        use std::sync::atomic::Ordering;
+
+        // Two envs stand in for two nodes in one process.
+        let mut node_a = TestEnv::new().await;
+        let mut node_b = TestEnv::new().await;
+
+        let a_counter = node_a.created_delegates_count.clone();
+        let b_counter = node_b.created_delegates_count.clone();
+        let b_origins = node_b.inherited_origins.clone();
+
+        let contract_id = ContractInstanceId::new([42u8; 32]);
+        // SAFETY: both holders are alive for the duration of this test
+        let env_a = unsafe { node_a.make_env_with_attestations(vec![contract_id]) };
+        // SAFETY: node_b is alive for the duration of this test
+        let env_b = unsafe { node_b.make_env() }; // no attestations
+        let child_key = env_a
+            .create_delegate_sync(&minimal_delegate_wasm(), &[1], [0u8; 32], [0u8; 24])
+            .unwrap();
+
+        // Node B creates from the same code and params, so it derives the SAME
+        // key — the collision is real and is what the `static` map turned into a
+        // cross-node (and cross-test) leak. Isolation comes from the map, not
+        // from the keys differing.
+        let b_child_key = env_b
+            .create_delegate_sync(&minimal_delegate_wasm(), &[1], [0u8; 32], [0u8; 24])
+            .unwrap();
+        assert_eq!(
+            child_key, b_child_key,
+            "identical code+params must still collide on the key"
+        );
+
+        assert_eq!(
+            a_counter.load(Ordering::Relaxed),
+            1,
+            "the creating node counts its own delegate"
+        );
+        assert_eq!(
+            b_counter.load(Ordering::Relaxed),
+            1,
+            "node B counts only its own creation, not node A's"
+        );
+        assert!(
+            b_origins.get(&child_key).is_none(),
+            "node A's attestation must not be visible to node B under the shared \
+             key — this map decides which contract a delegate message is \
+             attributed to, hence what that delegate may access"
+        );
+    }
+
+    /// Releasing a slot saturates at zero rather than wrapping.
+    ///
+    /// A delegate registered directly by an app was never counted, so an
+    /// unregister can legitimately arrive with the count already at zero.
+    #[test]
+    fn test_release_created_delegate_slot_saturates_at_zero() {
+        use super::super::native_api::{new_delegate_counter, release_created_delegate_slot};
+        use std::sync::atomic::Ordering;
+
+        let counter = new_delegate_counter();
+        assert!(
+            !release_created_delegate_slot(&counter),
+            "releasing an already-empty count releases nothing"
+        );
+        assert_eq!(
+            counter.load(Ordering::Relaxed),
+            0,
+            "releasing an already-empty count must stay at 0, not wrap to usize::MAX"
+        );
+
+        counter.fetch_add(1, Ordering::Relaxed);
+        assert!(
+            release_created_delegate_slot(&counter),
+            "the one occupied slot is released"
+        );
+        assert!(
+            !release_created_delegate_slot(&counter),
+            "a second release finds nothing left"
+        );
+        assert_eq!(counter.load(Ordering::Relaxed), 0, "one release per slot");
+    }
+
+    /// Concurrent releases at count == 1 cannot wrap the count.
+    ///
+    /// Pool executors share one node's counter, so two unregisters can land
+    /// together. A `load`-then-`fetch_sub` pair (what this replaced) would let
+    /// both observe `1` and both subtract, wrapping to `usize::MAX` —
+    /// permanently above `MAX_CREATED_DELEGATES_PER_NODE`, which would wedge the
+    /// node into rejecting every later delegate creation.
+    /// A barrier lines the racers up on the same slot, and the round repeats,
+    /// because a wrap is a race and one round proves little. Verified to have
+    /// teeth rather than assumed: against the `load`-then-`fetch_sub` this
+    /// replaced it fails on every run (5/5, immediately), with more than one
+    /// racer claiming the slot and the count wrapping past zero.
+    #[test]
+    fn test_release_created_delegate_slot_concurrent_releases_do_not_wrap() {
+        use super::super::native_api::{new_delegate_counter, release_created_delegate_slot};
+        use std::sync::atomic::Ordering;
+        use std::sync::{Arc, Barrier};
+
+        const RACERS: usize = 8;
+
+        for _ in 0..2_000 {
+            let counter = new_delegate_counter();
+            counter.store(1, Ordering::Relaxed);
+            // Release the racers together, so they contend for the ONE occupied
+            // slot rather than arriving spread out and finding it already empty.
+            let barrier = Arc::new(Barrier::new(RACERS));
+
+            let threads: Vec<_> = (0..RACERS)
+                .map(|_| {
+                    let counter = counter.clone();
+                    let barrier = barrier.clone();
+                    std::thread::spawn(move || {
+                        barrier.wait();
+                        release_created_delegate_slot(&counter)
+                    })
+                })
+                .collect();
+            let released = threads
+                .into_iter()
+                .map(|t| t.join().unwrap())
+                .filter(|&released| released)
+                .count();
+
+            assert_eq!(
+                counter.load(Ordering::Relaxed),
+                0,
+                "concurrent releases must saturate at 0, never wrap"
+            );
+            assert_eq!(
+                released, 1,
+                "exactly one racer may claim the single occupied slot"
+            );
+        }
     }
 
     // These tests check the eviction rule directly. They build a small map by
@@ -1640,38 +1828,38 @@ mod tests {
     /// Runs the real `prune_expired_inherited_origins` / `touch_inherited_origin`
     /// (the functions production calls; the other tests use the `_at` variants
     /// with a hand-picked time). Checks that touching a delegate with no entry
-    /// does not create one, and that a fresh entry is kept. Uses its own keys so
-    /// it can't disturb other tests that share the global map.
+    /// does not create one, and that a fresh entry is kept. Operates on its own
+    /// map, so its keys are its own business — it used to need distinct keys to
+    /// avoid disturbing tests sharing the global map.
     #[test]
-    fn test_global_inherited_origin_wrappers_smoke() {
+    fn test_inherited_origin_wrappers_smoke() {
         use super::super::native_api::{
-            DELEGATE_INHERITED_ORIGINS, InheritedOriginsEntry, prune_expired_inherited_origins,
+            InheritedOriginsEntry, new_inherited_origins, prune_expired_inherited_origins,
             touch_inherited_origin,
         };
         use freenet_stdlib::prelude::CodeHash;
 
+        let origins = new_inherited_origins();
         let child = DelegateKey::new([0x7b; 32], CodeHash::new([0x7b; 32]));
         let absent = DelegateKey::new([0x7c; 32], CodeHash::new([0x7c; 32]));
-        DELEGATE_INHERITED_ORIGINS.insert(
+        origins.insert(
             child.clone(),
             InheritedOriginsEntry::new(vec![ContractInstanceId::new([0x7d; 32])]),
         );
 
         // touch must NOT create an entry for a delegate with no inherited origin.
-        touch_inherited_origin(&absent);
+        touch_inherited_origin(&origins, &absent);
         assert!(
-            !DELEGATE_INHERITED_ORIGINS.contains_key(&absent),
+            !origins.contains_key(&absent),
             "touch must be a no-op (never insert) for a key with no entry"
         );
 
-        // touch refreshes an existing entry; the global sweep keeps it fresh.
-        touch_inherited_origin(&child);
-        prune_expired_inherited_origins();
+        // touch refreshes an existing entry; the sweep keeps it fresh.
+        touch_inherited_origin(&origins, &child);
+        prune_expired_inherited_origins(&origins);
         assert!(
-            DELEGATE_INHERITED_ORIGINS.contains_key(&child),
-            "global prune must keep a freshly-touched entry"
+            origins.contains_key(&child),
+            "prune must keep a freshly-touched entry"
         );
-
-        DELEGATE_INHERITED_ORIGINS.remove(&child);
     }
 }

--- a/crates/core/src/wasm_runtime/native_api.rs
+++ b/crates/core/src/wasm_runtime/native_api.rs
@@ -663,6 +663,25 @@ impl DelegateCallEnv {
         }
 
         // Check per-node creation limit (counts ALL created delegates, not just origin)
+        //
+        // Deliberately check-then-act, unlike the decrement in
+        // `release_created_delegate_slot`, which is one atomic `fetch_update`.
+        // The asymmetry is intentional, not an oversight: the two sides have
+        // very different failure modes when a race is lost.
+        //
+        // Here, concurrent creators can all pass this check and each `fetch_add`
+        // below, overshooting by at most one per creator — bounded by the pool's
+        // executor count, against a limit of 1024, and it drains back as slots
+        // are released. On the decrement, a lost race instead wraps the count
+        // past zero to `usize::MAX`: permanently over the limit, wedging the node
+        // into rejecting every later creation. Bounded overshoot versus permanent
+        // wedge is why that side is CAS'd and this one is not.
+        //
+        // Reserving the slot here would mean releasing it again on each of the
+        // three fallible paths between this check and the `fetch_add` (oversized
+        // WASM, and the two store failures). Worth doing, but it reworks the
+        // error paths of a limit-enforcing function and belongs in its own
+        // change.
         if self.created_delegates_count.load(Ordering::Relaxed) >= MAX_CREATED_DELEGATES_PER_NODE {
             return Err(DelegateCreateError::NodeLimitExceeded);
         }

--- a/crates/core/src/wasm_runtime/native_api.rs
+++ b/crates/core/src/wasm_runtime/native_api.rs
@@ -165,9 +165,27 @@ pub(crate) const DELEGATE_INHERITED_ORIGINS_MAX_AGE: std::time::Duration =
 /// When a delegate with an origin contract creates a child, the child inherits
 /// the same origin so it can interact with the same app context.
 /// DelegateKey (child) → inherited origins + TTL metadata.
-pub(crate) static DELEGATE_INHERITED_ORIGINS: LazyLock<
-    DashMap<DelegateKey, InheritedOriginsEntry>,
-> = LazyLock::new(DashMap::default);
+///
+/// This is injected state, not a process-global: `Runtime` owns one and
+/// `RuntimePool` clones the `Arc` into every executor, so a node's executors
+/// share one map while separate nodes in the same process each get their own.
+///
+/// Per-node is the correct scope because this map is an **authorization**
+/// input — `resolve_message_origin` reads it to decide which contract a
+/// delegate message is attributed to, which in turn decides what that delegate
+/// may access. A `static` made it process-wide, so every node sharing a process
+/// (the simulation runner) pooled its attestations into one map. A `DelegateKey`
+/// is derived from the delegate's code and params, so two nodes running the same
+/// delegate code necessarily collide on the key — one node's inherited origin
+/// was visible as another's. It also made the map's contents depend on whatever
+/// else shared the process, which is what made
+/// `test_create_delegate_non_attested_still_counts_toward_node_limit` flaky
+/// (#4813).
+pub(crate) type SharedInheritedOrigins = Arc<DashMap<DelegateKey, InheritedOriginsEntry>>;
+
+pub(crate) fn new_inherited_origins() -> SharedInheritedOrigins {
+    Arc::new(DashMap::default())
+}
 
 /// Drop entries idle past `..._TTL` or older than `..._MAX_AGE`, measured
 /// against `now`. Kept separate from `prune_expired_inherited_origins` so tests
@@ -184,10 +202,10 @@ pub(crate) fn prune_inherited_origins_at(
     });
 }
 
-/// Sweep the global map. Called amortised from `inbound_app_message` (no
+/// Sweep this node's map. Called amortised from `inbound_app_message` (no
 /// background task). O(n) per call, but n ≤ `MAX_CREATED_DELEGATES_PER_NODE`.
-pub(crate) fn prune_expired_inherited_origins() {
-    prune_inherited_origins_at(&DELEGATE_INHERITED_ORIGINS, tokio::time::Instant::now());
+pub(crate) fn prune_expired_inherited_origins(map: &SharedInheritedOrigins) {
+    prune_inherited_origins_at(map, tokio::time::Instant::now());
 }
 
 /// Set one delegate's `last_access` to `now`, if it has an entry. Kept separate
@@ -208,18 +226,49 @@ pub(crate) fn touch_inherited_origin_at(
 /// calls that never read the inherited origin — so any still-alive child keeps
 /// its origin. No-op if the delegate has no entry; still bounded by the MAX_AGE
 /// cap.
-pub(crate) fn touch_inherited_origin(delegate_key: &DelegateKey) {
-    touch_inherited_origin_at(
-        &DELEGATE_INHERITED_ORIGINS,
-        delegate_key,
-        tokio::time::Instant::now(),
-    );
+pub(crate) fn touch_inherited_origin(map: &SharedInheritedOrigins, delegate_key: &DelegateKey) {
+    touch_inherited_origin_at(map, delegate_key, tokio::time::Instant::now());
 }
 
-/// Global counter of all delegates created via the `create_delegate` host function.
-/// Used to enforce `MAX_CREATED_DELEGATES_PER_NODE` regardless of attestation status.
-/// Decremented on `UnregisterDelegate` to allow reuse of slots.
-pub(crate) static CREATED_DELEGATES_COUNT: AtomicUsize = AtomicUsize::new(0);
+/// Per-node counter of all delegates created via the `create_delegate` host
+/// function. Used to enforce `MAX_CREATED_DELEGATES_PER_NODE` regardless of
+/// attestation status. Decremented on `UnregisterDelegate` to allow reuse of
+/// slots.
+///
+/// This is injected state, not a process-global: `Runtime` owns one and
+/// `RuntimePool` clones the `Arc` into every executor, so the executors of a
+/// single node share one count while separate nodes in the same process (the
+/// simulation runner, and the test suite) each get their own. A `static` here
+/// would make the "per-node" limit a per-*process* limit — every simulated peer
+/// would draw down one shared budget of `MAX_CREATED_DELEGATES_PER_NODE`, and
+/// concurrent tests would observe each other's creations.
+pub(crate) type SharedDelegateCounter = Arc<AtomicUsize>;
+
+pub(crate) fn new_delegate_counter() -> SharedDelegateCounter {
+    Arc::new(AtomicUsize::new(0))
+}
+
+/// Release one slot from a node's created-delegate count, saturating at zero.
+///
+/// Saturating rather than wrapping is required: not every unregistered delegate
+/// was created via the `create_delegate` host function (an app can register one
+/// directly), so the count can legitimately already be zero here.
+///
+/// The load and the subtract are one atomic step. A `load`-then-`fetch_sub`
+/// pair is not equivalent: two concurrent unregisters (pool executors share
+/// this counter) could both observe `1` and both subtract, wrapping the count
+/// to `usize::MAX` — which reads as permanently over
+/// `MAX_CREATED_DELEGATES_PER_NODE` and would wedge the node into rejecting
+/// every subsequent delegate creation.
+/// Returns whether a slot was actually released — `false` means the count was
+/// already zero.
+pub(crate) fn release_created_delegate_slot(counter: &SharedDelegateCounter) -> bool {
+    counter
+        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |prev| {
+            prev.checked_sub(1)
+        })
+        .is_ok()
+}
 
 // Thread-local tracking of the currently-executing delegate instance ID.
 // Set before a WASM process() call, cleared after. This allows the new
@@ -412,6 +461,13 @@ pub(super) struct DelegateCallEnv {
     pub(super) creations_this_call: std::cell::Cell<u32>,
     /// Origin contract IDs for this delegate (from parent or direct registration).
     origin_contracts: Vec<ContractInstanceId>,
+    /// The owning node's created-delegate count, enforcing
+    /// `MAX_CREATED_DELEGATES_PER_NODE`. See [`SharedDelegateCounter`].
+    created_delegates_count: SharedDelegateCounter,
+    /// The owning node's child-delegate attestation map, which a successful
+    /// creation extends when the parent has origins. See
+    /// [`SharedInheritedOrigins`].
+    inherited_origins: SharedInheritedOrigins,
 }
 
 // SAFETY: DelegateCallEnv is only inserted into DELEGATE_ENV immediately before
@@ -479,6 +535,8 @@ impl DelegateCallEnv {
         creation_depth: u32,
         origin_contracts: Vec<ContractInstanceId>,
         user_context: Option<UserSecretContext>,
+        created_delegates_count: SharedDelegateCounter,
+        inherited_origins: SharedInheritedOrigins,
     ) -> Self {
         Self {
             context,
@@ -493,6 +551,8 @@ impl DelegateCallEnv {
             creation_depth,
             creations_this_call: std::cell::Cell::new(0),
             origin_contracts,
+            created_delegates_count,
+            inherited_origins,
         }
     }
 
@@ -594,7 +654,7 @@ impl DelegateCallEnv {
         }
 
         // Check per-node creation limit (counts ALL created delegates, not just origin)
-        if CREATED_DELEGATES_COUNT.load(Ordering::Relaxed) >= MAX_CREATED_DELEGATES_PER_NODE {
+        if self.created_delegates_count.load(Ordering::Relaxed) >= MAX_CREATED_DELEGATES_PER_NODE {
             return Err(DelegateCreateError::NodeLimitExceeded);
         }
 
@@ -634,11 +694,11 @@ impl DelegateCallEnv {
 
         // Increment per-call counter and global node counter
         self.creations_this_call.set(current + 1);
-        CREATED_DELEGATES_COUNT.fetch_add(1, Ordering::Relaxed);
+        self.created_delegates_count.fetch_add(1, Ordering::Relaxed);
 
         // Propagate app attestation to child
         if !self.origin_contracts.is_empty() {
-            DELEGATE_INHERITED_ORIGINS.insert(
+            self.inherited_origins.insert(
                 child_key.clone(),
                 InheritedOriginsEntry::new(self.origin_contracts.clone()),
             );

--- a/crates/core/src/wasm_runtime/native_api.rs
+++ b/crates/core/src/wasm_runtime/native_api.rs
@@ -173,12 +173,18 @@ pub(crate) const DELEGATE_INHERITED_ORIGINS_MAX_AGE: std::time::Duration =
 /// Per-node is the correct scope because this map is an **authorization**
 /// input — `resolve_message_origin` reads it to decide which contract a
 /// delegate message is attributed to, which in turn decides what that delegate
-/// may access. A `static` made it process-wide, so every node sharing a process
-/// (the simulation runner) pooled its attestations into one map. A `DelegateKey`
-/// is derived from the delegate's code and params, so two nodes running the same
-/// delegate code necessarily collide on the key — one node's inherited origin
-/// was visible as another's. It also made the map's contents depend on whatever
-/// else shared the process, which is what made
+/// may access. A `DelegateKey` is derived from the delegate's code and params,
+/// so two nodes running the same delegate code necessarily collide on the key;
+/// under a `static`, one node's attestations would be visible as another's.
+///
+/// No production configuration reaches that: a node is a process (one
+/// `RuntimePool` per node), and the simulation runner cannot create delegates
+/// at all — it uses `MockWasmRuntime`, whose `execute_delegate_request` returns
+/// "delegates not supported". The scope is per-node because that is what this
+/// state is, not because a live cross-node leak depended on it.
+///
+/// What the `static` did cause is test flakiness: it made the map's contents
+/// depend on whatever else shared the process, which is what made
 /// `test_create_delegate_non_attested_still_counts_toward_node_limit` flaky
 /// (#4813).
 pub(crate) type SharedInheritedOrigins = Arc<DashMap<DelegateKey, InheritedOriginsEntry>>;
@@ -237,11 +243,14 @@ pub(crate) fn touch_inherited_origin(map: &SharedInheritedOrigins, delegate_key:
 ///
 /// This is injected state, not a process-global: `Runtime` owns one and
 /// `RuntimePool` clones the `Arc` into every executor, so the executors of a
-/// single node share one count while separate nodes in the same process (the
-/// simulation runner, and the test suite) each get their own. A `static` here
-/// would make the "per-node" limit a per-*process* limit — every simulated peer
-/// would draw down one shared budget of `MAX_CREATED_DELEGATES_PER_NODE`, and
-/// concurrent tests would observe each other's creations.
+/// single node share one count while separate nodes in the same process (today,
+/// only the test suite) each get their own. A `static` here would make the
+/// "per-node" limit a per-*process* limit, so concurrent tests observed each
+/// other's creations.
+///
+/// In production the two coincide — a node is a process — so this scoping is a
+/// no-op there; it is the correct shape for per-node state rather than a fix for
+/// a live production limit bug.
 pub(crate) type SharedDelegateCounter = Arc<AtomicUsize>;
 
 pub(crate) fn new_delegate_counter() -> SharedDelegateCounter {

--- a/crates/core/src/wasm_runtime/native_api.rs
+++ b/crates/core/src/wasm_runtime/native_api.rs
@@ -111,8 +111,8 @@ pub(crate) fn prune_expired_contexts(cache: &DelegateContextCache) {
     cache.retain(|_, entry| now.duration_since(entry.last_write) < DELEGATE_CONTEXT_TTL);
 }
 
-/// One entry in [`DELEGATE_INHERITED_ORIGINS`]: a child delegate's inherited
-/// contracts plus TTL metadata.
+/// One entry in a node's [`SharedInheritedOrigins`]: a child delegate's
+/// inherited contracts plus TTL metadata.
 ///
 /// Why a TTL: the map is cleaned only on `UnregisterDelegate`, which children
 /// created via `create_delegate` rarely receive — they are spawned inside the

--- a/crates/core/src/wasm_runtime/runtime.rs
+++ b/crates/core/src/wasm_runtime/runtime.rs
@@ -274,6 +274,16 @@ pub struct Runtime {
     /// executors so a prompt round-trip routed to a different `Runtime` still
     /// sees the pending state. See `native_api::DelegateContextCache`.
     pub(super) delegate_contexts: super::native_api::DelegateContextCache,
+    /// This node's count of delegates created via the `create_delegate` host
+    /// function, enforcing `MAX_CREATED_DELEGATES_PER_NODE`. Shared across the
+    /// pool's executors (so the limit is per node, not per executor) and NOT
+    /// across nodes. See `native_api::SharedDelegateCounter`.
+    pub(crate) created_delegates_count: super::native_api::SharedDelegateCounter,
+    /// This node's child-delegate attestation map (child `DelegateKey` → the
+    /// origins it inherited from its parent). Shared across the pool's
+    /// executors and NOT across nodes — it is an authorization input, see
+    /// `native_api::SharedInheritedOrigins`.
+    pub(crate) inherited_origins: super::native_api::SharedInheritedOrigins,
 
     /// Local contract storage.
     pub(crate) contract_store: ContractStore,
@@ -428,6 +438,8 @@ impl Runtime {
             contract_store,
             delegate_modules: Arc::new(Mutex::new(ModuleCache::new(budget))),
             delegate_contexts: super::native_api::new_delegate_context_cache(),
+            created_delegates_count: super::native_api::new_delegate_counter(),
+            inherited_origins: super::native_api::new_inherited_origins(),
             state_store_db: None,
             state_write_callback: None,
             state_admit_callback: None,
@@ -475,6 +487,8 @@ impl Runtime {
         contract_modules: SharedModuleCache<ContractKey>,
         delegate_modules: SharedModuleCache<DelegateKey>,
         delegate_contexts: super::native_api::DelegateContextCache,
+        created_delegates_count: super::native_api::SharedDelegateCounter,
+        inherited_origins: super::native_api::SharedInheritedOrigins,
         shared_backend: BackendEngine,
         config: &RuntimeConfig,
     ) -> RuntimeResult<Self> {
@@ -493,6 +507,8 @@ impl Runtime {
             contract_store,
             delegate_modules,
             delegate_contexts,
+            created_delegates_count,
+            inherited_origins,
             state_store_db: None,
             state_write_callback: None,
             state_admit_callback: None,


### PR DESCRIPTION
De-globalize per-node delegate state, fixing a latent node-wedging underflow and the #4813 test-isolation race.

## Problem

### 1. The flaky test — and the issue's diagnosis is wrong

`test_create_delegate_non_attested_still_counts_toward_node_limit` is flaky under a full-suite run: green alone, red occasionally in parallel.

**#4813's diagnosed mechanism is not reachable, and following it could not have fixed the flake.** The issue blames a sibling's `fetch_sub(1)` on `CREATED_DELEGATES_COUNT` landing inside the test's read-modify-read window, making `after == before`. But only two sites decrement that counter: this test's own cleanup (which runs *after* its assert), and the executor's `UnregisterDelegate` handler — and **no test in the lib binary drives that handler** (the only references are production paths, a WebSocket *encoding* test, and doc comments; the `crates/core/tests/*` integration tests that register delegates are separate binaries and cannot touch this process's global). With no concurrent decrement, `before = load(); create(+1); after = load()` makes `after > before` unfailable.

**The real cause is the test's *first* assertion.** `test_create_delegate_inherits_attestations` (`delegate_api.rs:1429`) and this test (`:1470`) both create a delegate from `minimal_delegate_wasm()` with params `&[1]`. A `DelegateKey` is derived from code and params, so both derive the **same** key (`G6it92bA2oAG1bVFPLEDav6hZvspQcFs9FiudvE89JWg` — verified). The attested test inserts that key into the process-global `DELEGATE_INHERITED_ORIGINS` and removes it only at the end; this test asserts `.get(&child_key).is_none()`. That window is *wider* than the counter's. Run in parallel, this test's check lands inside it and fails with `non-attested parent should not create attestation entry`.

Reproduced deterministically against pristine `main` (see Testing).

### 2. A latent node-wedging underflow (real, reachable on main today)

The counter's decrement was `load` then `if prev > 0 { fetch_sub }`. **Two concurrent unregisters at `count == 1` both observe 1 and both subtract, wrapping to `usize::MAX`** — permanently above `MAX_CREATED_DELEGATES_PER_NODE`, so the node rejects *every subsequent delegate creation, forever*. Reachable on main: pool executors share the counter and handle unregisters concurrently.

## Solution

Scope both globals to the node that owns them — the issue's own **option 2**, and `code-style.md`'s preference for injected state over globals (the `ModuleCacheMetrics` precedent, #4543). `Runtime` owns an `Arc` of each; `RuntimePool` clones them into every executor; tests get a `TestEnv`-private instance.

`release_created_delegate_slot` (`native_api.rs`) replaces the check-then-act decrement with one atomic `fetch_update` + `checked_sub`, fixing the underflow above.

**Why option 2, not option 1 (observe your own delta):** option 1 cannot fix this bug. The failing assertion is about the **absence** of an entry in a shared map, under a key another test legitimately owns. There is no way to phrase that against a global without depending on what else is running. Scoping the map is *the* fix, not a rider. For the counter, the payoff is concrete: the test now owns its counter, asserts it starts at 0, and asserts an **exact count of 1** — where the old `after > before` was a workaround for a count anything could move.

**Production semantics are unchanged.** The limit stays per-node: pool-owned (`pool.rs:89`, created once at `:396`), all three `from_config_with_shared_modules` sites clone the same `Arc`, and `create_replacement_executor` (`pool.rs:693`) passes it too — without that, a post-panic replacement would return with a fresh zeroed budget. `Executor`/`Runtime` are not `Clone`; pool checkout moves out and back, so no reset or double-count. A node is a process (one `RuntimePool` per node), so per-node and per-process coincide and the scoping is a no-op in production. Independently confirmed by Codex and by an adversarial reviewer tracing ownership.

**This does not fix a cross-node production bug, and an earlier revision of this PR wrongly claimed it did.** I had asserted a cross-node authorization leak "in the simulation runner". That is false — @sanity corrected it in 80aa0c51 (thank you). The simulation runner cannot exercise delegates at all: it uses `MockWasmRuntime`, whose `execute_delegate_request` returns `"delegates not supported in MockWasmRuntime"`, so no simulated peer ever constructs a `Runtime`. **The only context where per-node and per-process ever diverged is the unit suite** — which is #4813 restated. The rustdoc now says only that. I should have traced the claim to a reachable path before writing it into permanent docs.

### Scope: why 11 files

One logical change — "this state is per-node, so give it to the node" — and each file is load-bearing for threading it, not cleanup riding along:

| File | Why it must change |
|---|---|
| `native_api.rs` | Owns both globals; defines the `Shared*` aliases; `create_delegate_sync` reads/writes both. The fix's core. |
| `runtime.rs` | `Runtime` is the owner; the field has to live somewhere per-node. |
| `delegate/execution.rs` | The **only** production site constructing `DelegateCallEnv` — must pass both through. |
| `delegate/interface.rs` | Calls `touch_/prune_expired_inherited_origins`, which no longer reach for a global. |
| `pool.rs` | Creates each once per node and clones into every executor **and replacements** — this is what keeps the limit per-node. |
| `executor/runtime.rs` | `from_config_with_shared_modules` is the pool→`Runtime` seam the `Arc`s travel through. |
| `executor/runtime/delegates.rs` | Decrements the counter and removes from the map on unregister; `resolve_message_origin` reads the map. |
| `executor.rs` | One doc line naming the now-removed global. |
| `delegate_api.rs` | The tests themselves (the fix's point) + `TestEnv`. |
| `delegate/test.rs` | A source-scrape pin test anchored on the exact old call text. |

## Testing

**The flake, reproduced deterministically against pristine `main`** — a test performing the exact interleaving (attested sibling mid-flight, then the flaky test's body):

```
panicked at delegate_api.rs:1425: non-attested parent should not create attestation entry
test result: FAILED. 0 passed; 1 failed
```

The same test passes on this branch, with `assert_eq!(child_key, sibling_key)` confirming the keys **still collide** — isolation comes from the maps, not from keys differing. Its permanent form is `test_delegate_node_state_is_per_node_not_per_process`.

Every new test was verified to have teeth, not assumed:

- `test_delegate_node_state_is_per_node_not_per_process` — two envs as two nodes; same key, node B's count untouched, node A's attestation invisible to B. Fails under emulated process-global semantics (`left: 2, right: 1` — a concurrent sibling's creation landing on the shared counter).
- `inherited_origin_does_not_leak_across_nodes` — same isolation at the `resolve_message_origin` boundary.
- `test_release_created_delegate_slot_{saturates_at_zero,concurrent_releases_do_not_wrap}` — the underflow. The concurrent one uses a barrier and **fails 6/6 immediately against the old `load`-then-`fetch_sub`** (count wraps past zero; >1 racer claims the slot), passing in 0.04s on the fix. An earlier unsynchronized version of this test *passed* against the buggy code — it was strengthened until it actually failed, then tuned down to the smallest round count (200) still verified to catch it.

Existing tests updated, not weakened: the flaky test now asserts an exact count instead of `after > before`.

Runs on this branch (real output):

- `cargo test -p freenet --lib delegate` — 136 passed, **8/8 consecutive runs clean**
- `cargo test -p freenet --lib` — **4000 passed, 0 failed**, three times (incl. final HEAD)
- `cargo test -p freenet --test hosted_mode_{isolation,export,import,migrate}` — 3/7/6/4 passed (these exercise delegate registration and attestation)
- `cargo clippy --locked -- -D warnings` (CI's exact command) — **exit 0**; `cargo fmt --check` clean
- `grep -rn "CREATED_DELEGATES_COUNT" crates/` — **empty**

**Honest caveats:**

- **I did not catch the flake by chance under a natural parallel run** — it is rare, and I did not try to force the original timing. The evidence is the deterministic interleaving above plus the structural argument (the assertions now read state nothing else can reach), which I consider stronger than a lucky red run.
- **The increment is still check-then-act** (`native_api.rs:666` `load >= MAX`, `:706` `fetch_add`) while the decrement is now CAS'd. Deliberate, and documented in-place: a lost race there overshoots by at most one per concurrent creator against a limit of 1024 and drains back, whereas the decrement's lost race wedges the node permanently. Reserving at the check means releasing on three fallible paths before the `fetch_add` — worth doing, in its own change. Pre-existing either way.
- **`DELEGATE_SUBSCRIPTIONS`** (`native_api.rs:40`) is the same shape and my own argument applies verbatim. Not implicated in this flake and a bigger change (its sites span `contract.rs`'s registration path), so deferred rather than ridden along: **#4826**.
- `cargo clippy -p freenet --all-targets --all-features` reports one error at `contract_store.rs:1230`. **Pre-existing on `main`**, in a file this PR does not touch, and not a CI blocker (CI runs `cargo clippy --locked` without `--all-targets`, so test code isn't linted). Left alone to keep this diff scoped.
- The pin test `inbound_app_message_wires_inherited_origins_ttl_in_order` anchored on exact old call text and would have failed this refactor. Re-anchored on the call, not its arguments, per `bug-prevention-patterns.md`'s "anchor on the API surface". It still pins that both calls run, in order.

Closes #4813

[AI-assisted - Claude]
