### PR TITLE
fix(operations): record PUT/GET/UPDATE op_stats counters (#4828)

### DIFF
--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -750,14 +750,36 @@ pub fn record_peer_disconnected(addr: SocketAddr) {
 /// the matching outcome. Forgetting a call site silently rots the
 /// counter (issue #4009 / #4010 prior incidents). Current writers:
 ///
-/// - `node.rs::report_result` for legacy state-machine ops (PUT/GET/
-///   UPDATE/SUBSCRIBE that still flow through `OpManager.ops.*`).
-/// - `operations/get/op_ctx_task.rs` `Done` arm (client-initiated GET).
-/// - `operations/put/op_ctx_task.rs` `Done` arm (client-initiated PUT).
+/// - `operations/get/op_ctx_task.rs` `Done` arm (client-initiated GET;
+///   success flag from `host_result.is_ok()`), its `Exhausted` arm
+///   (records a failure — exhaustion publishes `NotFound`, having
+///   delivered no state), AND `deliver_outcome`'s `InfrastructureError`
+///   arm (records a failure — the `Unexpected`/`InfraError` terminal
+///   outcomes publish a synthesized client `Err`). GET cannot fold the
+///   success/exhaustion arms into an outcome-shape classifier the way
+///   PUT/UPDATE do: a dead-end publishes `Ok(HostResponse::…NotFound)`,
+///   so `matches!(Publish(Ok(_)))` would score it as a success (#4828).
+/// - `operations/put/op_ctx_task.rs::deliver_outcome` (client-initiated
+///   PUT; covers all `DriverOutcome` variants).
 /// - `operations/subscribe/op_ctx_task.rs::deliver_outcome` (client-
 ///   initiated SUBSCRIBE; covers all `DriverOutcome` variants).
 /// - `operations/update/op_ctx_task.rs::deliver_outcome` (client-
 ///   initiated UPDATE; covers all `DriverOutcome` variants).
+///
+/// `node.rs::report_result` is NOT a writer: the legacy `OpEnum` /
+/// mediator path is gone (see `crates/core/CLAUDE.md`), every op runs a
+/// task-per-tx driver, and its `Ok` branch has nothing left to report.
+/// It was listed here until #4828 — a stale entry on the very doc this
+/// section points auditors at.
+///
+/// Prefer the `deliver_outcome` funnel shape where the driver's outcome
+/// type can express failure: it is the one that did NOT rot. Recording
+/// in individual driver arms is how #4828 regrew #4009/#4010 on PUT —
+/// the success arms carried a hardcoded `true` and every failure arm was
+/// simply forgotten, making `op_stats.puts.1` unreachable. Each op's
+/// call site is pinned by a source-scrape test in its `op_ctx_task.rs`
+/// test module; those pins are the CI gate against the next migration
+/// silently dropping the call.
 ///
 /// Internal-only operations are intentionally NOT recorded; counting
 /// them would inflate the user-facing counter with background traffic
@@ -798,7 +820,30 @@ pub fn record_op_result(op_type: OpType, success: bool) {
     }
 }
 
-/// Record a broadcast update received via subscription streaming.
+/// Record a broadcast update that was received and actually changed local
+/// state.
+///
+/// # Required call sites
+///
+/// Manually-mirrored counter. BOTH broadcast-apply drivers in
+/// `operations/update/op_ctx_task.rs` must call this, each after its
+/// `if !changed` early-return (a no-op re-broadcast is not a received
+/// update):
+///
+/// - `drive_relay_broadcast_to` (`BroadcastTo` — every payload BELOW
+///   `streaming_threshold`, i.e. the ordinary small-delta case).
+/// - `drive_relay_broadcast_to_streaming` (`BroadcastToStreaming` —
+///   payloads at/above the threshold, default 64 KB).
+///
+/// Until #4828 only the streaming twin recorded, so ordinary small deltas
+/// — the normal River case — were invisible and an actively-receiving
+/// subscriber showed 0 (`server/home_page/cards.rs` renders
+/// `updates_received` as the ONLY UPDATE number for subscriber nodes).
+/// Pinned by `both_broadcast_drivers_record_update_received`.
+///
+/// Distinct from [`record_relayed_update`], which counts relayed UPDATE
+/// *requests* toward the key (`relayed_op_stats`) and deliberately does
+/// NOT count broadcast fan-out.
 pub fn record_update_received() {
     if let Some(status) = NETWORK_STATUS.get() {
         if let Ok(mut s) = status.write() {

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -768,6 +768,24 @@ async fn drive_client_get_inner(
                 None,
             )
             .await;
+            // Dashboard op_stats GET counter (issue #4828). Exhaustion
+            // delivered no state to the client, so it is a FAILED GET —
+            // record it explicitly as such. Before #4828 this arm recorded
+            // nothing, so a GET dead-end (the dominant production
+            // `not_found` mode) incremented NEITHER `gets.0` nor `gets.1`
+            // and the ops card showed an idle-looking node while every GET
+            // failed.
+            //
+            // This must stay an explicit `false` rather than moving to a
+            // `deliver_outcome` funnel the way PUT/UPDATE do: the arm
+            // publishes `Ok(HostResponse::…NotFound)` so that clients can
+            // distinguish "contract genuinely absent" from "operation
+            // failed", which means a `matches!(Publish(Ok(_)))` classifier
+            // would score a dead-end as a SUCCESS.
+            crate::node::network_status::record_op_result(
+                crate::node::network_status::OpType::Get,
+                false,
+            );
             Ok(DriverOutcome::Publish(Ok(HostResponse::ContractResponse(
                 freenet_stdlib::client_api::ContractResponse::NotFound { instance_id },
             ))))
@@ -1993,6 +2011,26 @@ fn deliver_outcome(op_manager: &OpManager, client_tx: Transaction, outcome: Driv
                 tx = %client_tx,
                 error = %err,
                 "get: infrastructure error; publishing synthesized client error"
+            );
+            // Dashboard op_stats GET counter (issue #4828). An
+            // infrastructure error (the `Unexpected` / `InfraError`
+            // terminal outcomes, mapped to `InfrastructureError` in
+            // `drive_client_get`) publishes a synthesized client error
+            // below, so it is a terminal client-visible FAILED GET and
+            // must increment `op_stats.gets.1`. Before #4828 this path
+            // recorded nothing — the same silent-counter-rot bug class the
+            // rest of this PR fixes, left open for the one GET failure arm
+            // that does not surface through `Done`/`Exhausted`.
+            //
+            // This is the ONLY site that observes these outcomes: the
+            // `Unexpected`/`InfraError` arms return `Err` from
+            // `drive_client_get_inner`, which `drive_client_get` maps to
+            // `InfrastructureError` and delivers to the client here. The
+            // `Done` and `Exhausted` arms record in the driver and return
+            // `Publish`, so they never reach this arm — no double count.
+            crate::node::network_status::record_op_result(
+                crate::node::network_status::OpType::Get,
+                false,
             );
             let synthesized: HostResult = Err(ErrorKind::OperationError {
                 cause: format!("GET failed: {err}").into(),
@@ -4963,6 +5001,145 @@ mod tests {
              `true`. The success flag must track `host_result.is_ok()` so \
              telemetry does not diverge from the client-visible outcome. \
              Call window: {call_window}"
+        );
+    }
+
+    /// Issue #4828: the `Exhausted` arm publishes `NotFound` to the
+    /// client — the contract was never delivered — but before #4828 it
+    /// called `record_op_result` nowhere at all, so a GET dead-end
+    /// incremented NEITHER `op_stats.gets.0` nor `.1`. GET dead-ends are
+    /// the dominant production `not_found` mode, so the ops card showed
+    /// an idle-looking node while every GET failed.
+    ///
+    /// Note GET cannot use PUT/UPDATE's `deliver_outcome` funnel shape:
+    /// exhaustion publishes `Ok(HostResponse::…NotFound)`, so a
+    /// `matches!(Publish(Ok(_)))` classifier would score a dead-end as a
+    /// SUCCESS. The arm must therefore record `false` explicitly, which
+    /// is what this pin enforces.
+    #[test]
+    fn exhausted_arm_records_get_failure() {
+        const SOURCE: &str = include_str!("op_ctx_task.rs");
+        let prod = production_source();
+        // Isolate the Exhausted arm: from its match pattern to the start
+        // of the following `Unexpected` arm.
+        let arm_start = prod
+            .find("RetryLoopOutcome::Exhausted(cause) => {")
+            .expect("Exhausted arm must exist");
+        let arm_end = prod[arm_start..]
+            .find("RetryLoopOutcome::Unexpected")
+            .expect("Unexpected arm must follow Exhausted");
+        let arm = &prod[arm_start..arm_start + arm_end];
+
+        assert!(
+            arm.contains("record_op_result"),
+            "the GET Exhausted arm must call record_op_result — it \
+             publishes NotFound to the client, so the op_stats.gets \
+             counter must see it. Without this a GET dead-end increments \
+             neither ok nor fail and the node looks idle. Issue #4828."
+        );
+        assert!(
+            arm.contains("OpType::Get"),
+            "record_op_result in the Exhausted arm must be passed OpType::Get."
+        );
+        // Exhaustion delivered no state, so it must be recorded as a
+        // FAILURE. `true` here would be the mirror-image of the #4828 PUT
+        // bug (successes counted, failures invisible).
+        let call_pos = arm
+            .find("record_op_result")
+            .expect("record_op_result must be called in the Exhausted arm");
+        let tail = &arm[call_pos..];
+        let call_window = &tail[..tail.len().min(200)];
+        assert!(
+            call_window.contains("false,"),
+            "the GET Exhausted arm must record a FAILURE (`false`) — it \
+             publishes NotFound, having delivered no state to the client. \
+             Issue #4828. Call window: {call_window}"
+        );
+        // Guard the pin itself: `production_source` must actually be
+        // trimming the test module, or this test could match its own text.
+        assert!(
+            prod.len() < SOURCE.len(),
+            "production_source must trim the test module"
+        );
+    }
+
+    /// Issue #4828: the `Unexpected` / `InfraError` terminal outcomes
+    /// return `Err` from `drive_client_get_inner`, are mapped to
+    /// `DriverOutcome::InfrastructureError` in `drive_client_get`, and
+    /// publish a synthesized client error in `deliver_outcome`'s
+    /// `InfrastructureError` arm — a terminal client-visible FAILED GET.
+    /// Before #4828 that arm recorded no `op_stats.gets` counter, so this
+    /// GET failure path silently rotted the counter, the same bug class
+    /// this PR fixes (Codex + Claude Rule Review both flagged it). Unlike
+    /// the `Exhausted` arm (which publishes `Ok(NotFound)`), the failure
+    /// classification here is unambiguous: an `InfrastructureError` always
+    /// publishes a client `Err`, so this arm records `false`.
+    ///
+    /// No double count: the `Done` and `Exhausted` arms record in the
+    /// driver and return `DriverOutcome::Publish`, so they reach
+    /// `deliver_outcome`'s `Publish` arm, never this one.
+    #[test]
+    fn infra_error_arm_records_get_failure() {
+        const SOURCE: &str = include_str!("op_ctx_task.rs");
+        let prod = production_source();
+        let body = extract_fn_body(prod, "fn deliver_outcome(");
+        // Isolate the InfrastructureError arm within deliver_outcome.
+        let arm_start = body
+            .find("DriverOutcome::InfrastructureError(err) => {")
+            .expect("deliver_outcome must have an InfrastructureError arm");
+        let arm = &body[arm_start..];
+
+        assert!(
+            arm.contains("record_op_result"),
+            "deliver_outcome's InfrastructureError arm must call \
+             record_op_result — it publishes a synthesized client error, so \
+             this terminal GET failure must increment op_stats.gets. Without \
+             it the Unexpected/InfraError GET failure path silently rots the \
+             counter. Issue #4828."
+        );
+        assert!(
+            arm.contains("OpType::Get"),
+            "record_op_result in the InfrastructureError arm must be passed \
+             OpType::Get."
+        );
+        // Infrastructure errors publish a client `Err`, so they are an
+        // unambiguous FAILURE and must record `false`.
+        let call_pos = arm
+            .find("record_op_result")
+            .expect("record_op_result must be called in the InfraError arm");
+        let tail = &arm[call_pos..];
+        let call_window = &tail[..tail.len().min(200)];
+        assert!(
+            call_window.contains("false,"),
+            "deliver_outcome's InfrastructureError arm must record a FAILURE \
+             (`false`) — it publishes a synthesized client error, delivering \
+             no state. Issue #4828. Call window: {call_window}"
+        );
+        // Exact-once: a second record_op_result in this arm would
+        // double-count every infrastructure-error GET. Pin the count so a
+        // future edit that adds a stray call fails CI.
+        assert_eq!(
+            arm.matches("record_op_result(").count(),
+            1,
+            "deliver_outcome's InfrastructureError arm must record exactly \
+             once — a duplicate would double-count op_stats.gets. Issue #4828."
+        );
+        // And the Publish arm (which the Done/Exhausted driver arms reach,
+        // since they return DriverOutcome::Publish) must record NOTHING here
+        // — those arms already record in the driver, so recording again in
+        // deliver_outcome's Publish arm would double-count them.
+        let publish_region = &body[..arm_start];
+        assert!(
+            !publish_region.contains("record_op_result"),
+            "deliver_outcome's Publish arm must NOT call record_op_result — \
+             the Done/Exhausted arms already record in the driver and return \
+             Publish, so recording here too would double-count. Issue #4828."
+        );
+        // Guard the pin itself: `production_source` must actually be
+        // trimming the test module, or this test could match its own text.
+        assert!(
+            prod.len() < SOURCE.len(),
+            "production_source must trim the test module"
         );
     }
 

--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -282,10 +282,6 @@ async fn drive_client_put_inner(
                 // (reverse-leg convergence) is a deliberate follow-up, not
                 // required for this PUT to report success correctly.
                 op_manager.completed(client_tx);
-                crate::node::network_status::record_op_result(
-                    crate::node::network_status::OpType::Put,
-                    true,
-                );
                 super::finalize_put_at_originator(
                     op_manager,
                     client_tx,
@@ -508,10 +504,6 @@ async fn drive_client_put_inner(
                     .await;
             }
             op_manager.ring.routing_finished(route_event);
-            crate::node::network_status::record_op_result(
-                crate::node::network_status::OpType::Put,
-                true,
-            );
 
             // Telemetry only — subscribe=false to avoid double-subscribe.
             //
@@ -1137,7 +1129,46 @@ async fn maybe_subscribe_child(
 
 // --- Outcome delivery ---
 
+/// Dashboard op_stats success classifier (issue #4828). Extracted so the
+/// success/failure mapping per `DriverOutcome` variant has direct unit
+/// coverage; `deliver_outcome` itself takes an `OpManager` which is
+/// expensive to construct in tests. Mirrors UPDATE's
+/// `classify_update_outcome_for_op_stats` (#4010).
+fn classify_put_outcome_for_op_stats(outcome: &DriverOutcome) -> bool {
+    matches!(outcome, DriverOutcome::Publish(Ok(_)))
+}
+
 fn deliver_outcome(op_manager: &OpManager, client_tx: Transaction, outcome: DriverOutcome) {
+    // Dashboard op_stats PUT counter (issue #4828). The legacy
+    // `report_result` recording path is bypassed for driver terminal
+    // replies (see `node::record_op_result` rustdoc), so every terminal
+    // outcome must be recorded here.
+    //
+    // Recording here rather than in the driver's arms is load-bearing:
+    // `run_client_put` -> `drive_client_put` -> `drive_client_put_inner`
+    // is the only call chain, so this single funnel sees EVERY terminal
+    // outcome. The pre-#4828 code recorded a hardcoded `true` in the two
+    // success arms instead, which left the `Done((Err(..), _))` #4111
+    // bypass, `Exhausted`, and `InfrastructureError` paths recording
+    // nothing at all — so `op_stats.puts.1` (the red "fail" number on the
+    // ops card) was structurally unreachable. Do NOT re-inline this into
+    // a driver arm; that is exactly how #4009/#4010 regrew here.
+    //
+    // Sub-operation gate: defensive. Today PUT has no sub-operation entry
+    // points (`Transaction::new_child_of` is only ever used to spawn
+    // SUBSCRIBE children), so `client_tx.is_sub_operation()` is always
+    // false on this path. The explicit gate matches UPDATE's and
+    // SUBSCRIBE's pattern so a future change that routes a sub-op tx
+    // through `run_client_put` doesn't silently start inflating the
+    // user-facing dashboard counter.
+    if !client_tx.is_sub_operation() {
+        let success = classify_put_outcome_for_op_stats(&outcome);
+        crate::node::network_status::record_op_result(
+            crate::node::network_status::OpType::Put,
+            success,
+        );
+    }
+
     match outcome {
         DriverOutcome::Publish(result) => {
             op_manager.send_client_result(client_tx, result);
@@ -4697,6 +4728,115 @@ mod tests {
             i += 1;
         }
         panic!("unterminated fn body for {signature_prefix}");
+    }
+
+    /// Issue #4828 (same class as #4009 / #4010): `deliver_outcome` is the
+    /// single funnel every client PUT terminal outcome passes through
+    /// (`run_client_put` -> `drive_client_put` -> `drive_client_put_inner`
+    /// is the only call chain), so it MUST record the dashboard
+    /// `op_stats.puts` counter there. Recording in the driver's success
+    /// arms instead — which is what this file did before #4828 — left
+    /// every failure arm (`Done((Err(..), _))` #4111 bypass,
+    /// `Exhausted`, and the `InfrastructureError` synthesis) recording
+    /// nothing, so `op_stats.puts.1` (the red "fail" number on the ops
+    /// card) was structurally stuck at 0.
+    ///
+    /// Mirrors UPDATE's `deliver_outcome_records_update_op_result`, the
+    /// #4010 fix shape that did NOT rot.
+    #[test]
+    fn deliver_outcome_records_put_op_result() {
+        let prod = production_source();
+        let body = extract_fn_body(prod, "fn deliver_outcome(");
+
+        assert!(
+            body.contains("record_op_result"),
+            "deliver_outcome must call record_op_result so the dashboard \
+             PUT counter advances on EVERY driver terminal outcome — \
+             including the failure arms. Issue #4828."
+        );
+        assert!(
+            body.contains("OpType::Put"),
+            "record_op_result inside deliver_outcome must be passed \
+             OpType::Put (not Get/Update/Subscribe)."
+        );
+        // The success flag must be DERIVED from the outcome. An
+        // unconditional `true` is the #4828 bug — it is what made
+        // `op_stats.puts.1` unreachable. Mirrors the assertion text of
+        // GET's `record_op_result_reflects_host_result_outcome`.
+        let call_pos = body
+            .find("record_op_result")
+            .expect("record_op_result must be called in deliver_outcome");
+        let tail = &body[call_pos..];
+        let call_window = &tail[..tail.len().min(200)];
+        assert!(
+            !call_window.contains("true,"),
+            "record_op_result in deliver_outcome is passed an unconditional \
+             `true`. The success flag must be derived from the outcome via \
+             `classify_put_outcome_for_op_stats` so a failing PUT increments \
+             op_stats.puts.1. Issue #4828. Call window: {call_window}"
+        );
+        assert!(
+            body.contains("!client_tx.is_sub_operation()"),
+            "deliver_outcome must gate record_op_result on \
+             `!client_tx.is_sub_operation()` (note the leading `!`) for \
+             parity with SUBSCRIBE / UPDATE; defensive against a future \
+             change that routes a sub-op tx through run_client_put and \
+             silently inflates the user-facing dashboard counter."
+        );
+    }
+
+    /// Issue #4828: the PUT driver must NOT record `op_stats` itself.
+    /// `deliver_outcome` owns the counter for every terminal outcome; a
+    /// `record_op_result` re-inlined into a driver arm double-counts that
+    /// arm (and is how the pre-#4828 code came to record only successes).
+    /// This is the counterpart pin to `deliver_outcome_records_put_op_result`.
+    #[test]
+    fn put_driver_must_not_record_op_result_directly() {
+        let prod = production_source();
+        let body = extract_fn_body(prod, "async fn drive_client_put_inner(");
+
+        assert!(
+            !body.contains("record_op_result"),
+            "drive_client_put_inner must NOT call record_op_result — \
+             `deliver_outcome` is the single recording funnel for the PUT \
+             op_stats counter. Re-inlining the call into a driver arm \
+             double-counts that arm and re-opens #4828 (only the arms that \
+             remember to call it get counted)."
+        );
+    }
+
+    /// Issue #4828: pure-function coverage of every `DriverOutcome`
+    /// variant, pinning the success/failure mapping against an
+    /// accidental `success: !success` flip. Mirrors UPDATE's
+    /// `classify_update_outcome_covers_all_variants` (#4010).
+    #[test]
+    fn classify_put_outcome_covers_all_variants() {
+        use freenet_stdlib::prelude::{CodeHash, ContractInstanceId, ContractKey};
+
+        let key = ContractKey::from_id_and_code(
+            ContractInstanceId::new([7u8; 32]),
+            CodeHash::new([8u8; 32]),
+        );
+        let publish_ok = DriverOutcome::Publish(Ok(HostResponse::ContractResponse(
+            ContractResponse::PutResponse { key },
+        )));
+        let publish_err = DriverOutcome::Publish(Err(ErrorKind::OperationError {
+            cause: "synthetic".into(),
+        }
+        .into()));
+        let infra = DriverOutcome::InfrastructureError(OpError::UnexpectedOpState);
+
+        assert!(classify_put_outcome_for_op_stats(&publish_ok));
+        assert!(
+            !classify_put_outcome_for_op_stats(&publish_err),
+            "a published client error is a FAILED PUT — it must increment \
+             op_stats.puts.1. Issue #4828."
+        );
+        assert!(
+            !classify_put_outcome_for_op_stats(&infra),
+            "an infrastructure error publishes a synthesized client error, \
+             so it is a FAILED PUT. Issue #4828."
+        );
     }
 
     /// Pin (telemetry accuracy): BOTH relay PUT entry points must record

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -1340,6 +1340,19 @@ async fn drive_relay_broadcast_to(
         return Ok(());
     }
 
+    // Dashboard `updates_received` counter (issue #4828). Mirrors the
+    // streaming twin `drive_relay_broadcast_to_streaming`, and must stay
+    // in both: `broadcast_queue.rs` only picks the streaming variant above
+    // `streaming_threshold` (default 64 KB), so this non-streaming path
+    // carries every ordinary small delta — the normal River case. Before
+    // #4828 only the streaming twin recorded, so an actively-receiving
+    // subscriber displayed 0 (`cards.rs` renders `updates_received` as the
+    // ONLY UPDATE number for subscriber nodes).
+    //
+    // Placed after the `!changed` guard, matching the streaming twin: a
+    // broadcast that mutated nothing is not a received update.
+    crate::node::network_status::record_update_received();
+
     tracing::debug!(
         "UPDATE relay: contract {} @ {:?} updated via BroadcastTo",
         key,
@@ -3385,6 +3398,113 @@ mod tests {
             i += 1;
         }
         panic!("unterminated fn body for {signature_prefix}");
+    }
+
+    /// Issue #4828: `record_update_received` must be recorded by BOTH
+    /// broadcast-apply paths, not just the streaming one. Before #4828 the
+    /// sole call site in the crate sat in the streaming path, but
+    /// `broadcast_queue.rs` only picks the streaming variant above
+    /// `streaming_threshold` (default 64 KB), so ordinary small deltas —
+    /// the normal River case — were invisible. `cards.rs` renders
+    /// `updates_received` as the ONLY UPDATE number for subscriber nodes,
+    /// so an actively-receiving subscriber displayed 0.
+    ///
+    /// Both paths must record AFTER their `if !changed` early-return, so
+    /// the counter tracks updates that actually mutated local state rather
+    /// than no-op re-broadcasts. The streaming path applies via the
+    /// extracted `apply_streaming_broadcast` helper (#4857), so its record
+    /// lives there and the streaming driver must delegate to it — pinned
+    /// below so the delegation cannot silently break the streaming record.
+    #[test]
+    fn both_broadcast_drivers_record_update_received() {
+        let full = include_str!("op_ctx_task.rs");
+        let src = production_source(full);
+        // Each broadcast path maps to the function that owns its `!changed`
+        // guard and its record call: the non-streaming driver records
+        // inline, the streaming driver records via `apply_streaming_broadcast`.
+        for sig in [
+            "async fn drive_relay_broadcast_to(",
+            "async fn apply_streaming_broadcast(",
+        ] {
+            let body = extract_fn_body(src, sig);
+            // Exactly once: a second call double-counts every changed
+            // broadcast on this path; zero calls rots the counter.
+            let record_calls = body.matches("record_update_received()").count();
+            assert_eq!(
+                record_calls, 1,
+                "{sig} must call record_update_received() EXACTLY once — \
+                 `updates_received` is the only UPDATE number the dashboard \
+                 shows for subscriber nodes, and broadcast_queue.rs picks the \
+                 NON-streaming variant for every payload under \
+                 streaming_threshold (64 KB), i.e. the normal small-delta \
+                 case. Found {record_calls}. Issue #4828."
+            );
+            // Must sit AFTER the entire `if !changed { ... }` guard block —
+            // not merely after some `return` inside it, which a nested
+            // early-return could fake. Brace-match the guard block and
+            // require the record after its closing `}`, so no in-block path
+            // can record a no-op re-broadcast as a received update.
+            let changed_guard = body
+                .find("if !changed {")
+                .unwrap_or_else(|| panic!("{sig} must keep its `if !changed` early-return"));
+            let guard_open = changed_guard
+                + body[changed_guard..]
+                    .find('{')
+                    .expect("the `!changed` guard must have an opening brace");
+            let guard_end = {
+                let bytes = body.as_bytes();
+                let mut depth = 0i32;
+                let mut end = None;
+                for (i, &b) in bytes.iter().enumerate().skip(guard_open) {
+                    match b {
+                        b'{' => depth += 1,
+                        b'}' => {
+                            depth -= 1;
+                            if depth == 0 {
+                                end = Some(i);
+                                break;
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+                end.expect("the `!changed` guard block must have a matching closing brace")
+            };
+            let record_pos = body
+                .find("record_update_received()")
+                .expect("checked above");
+            assert!(
+                record_pos > guard_end,
+                "{sig} must call record_update_received() AFTER the entire \
+                 `if !changed` guard block (past its closing brace), so no \
+                 in-block early-return path can record on a no-op broadcast. \
+                 Issue #4828."
+            );
+        }
+        // The streaming driver records via the extracted helper (#4857), so
+        // it must delegate to apply_streaming_broadcast EXACTLY once and must
+        // NOT record directly — zero delegations means the streaming path
+        // never records (counter rots for large payloads); a direct call or a
+        // second delegation would double-count.
+        let streaming_driver = extract_fn_body(src, "async fn drive_relay_broadcast_to_streaming(");
+        let delegations = streaming_driver
+            .matches("apply_streaming_broadcast(")
+            .count();
+        assert_eq!(
+            delegations, 1,
+            "drive_relay_broadcast_to_streaming must delegate to \
+             apply_streaming_broadcast EXACTLY once (found {delegations}); \
+             that helper owns the streaming record_update_received() call \
+             (#4857). Zero means the streaming path never records; two would \
+             double-count. Issue #4828."
+        );
+        assert!(
+            !streaming_driver.contains("record_update_received()"),
+            "drive_relay_broadcast_to_streaming must NOT call \
+             record_update_received() directly — the record lives in \
+             apply_streaming_broadcast (#4857). A direct call here would \
+             double-count the streaming path. Issue #4828."
+        );
     }
 
     /// Pin (telemetry accuracy / scope): `relayed_updates_total` counts


### PR DESCRIPTION
## Problem

The dashboard Operations card showed three `op_stats` counters that made a broken node look idle or healthy. All three are the **#4009/#4010 bug class** documented in `.claude/rules/bug-prevention-patterns.md` ("manually-mirrored telemetry counters / dashboard providers") **regrown**: #4010 was fixed only for UPDATE and SUBSCRIBE — which now record every terminal outcome via `deliver_outcome` and carry source-scrape pin tests — while PUT and GET drifted back to the same defect.

**1. PUT failure counter structurally stuck at 0.** The only two `record_op_result` calls in the PUT driver sat in its *success* arms, both passing a hardcoded `true`. Every failure arm recorded nothing: the `Done((Err(cause), _))` #4111 bypass, `Exhausted(cause)`, and the `InfrastructureError` synthesis. So `op_stats.puts.1` — the red "fail" number at `server/home_page/cards.rs` — was **unreachable**: a node failing every PUT displayed zero failures.

**2. GET exhaustion recorded as neither success nor failure.** The `Exhausted` arm publishes `ContractResponse::NotFound` and emits a terminal event, but never called `record_op_result`; only the `Done` arm did. GET dead-ends are the dominant production `not_found` mode, so the ops card showed an idle-looking node while every GET failed.

**3. `updates_received` only counted streaming (>=64KB) broadcasts.** The sole `record_update_received()` call site in the crate was inside `drive_relay_broadcast_to_streaming`. The non-streaming twin `drive_relay_broadcast_to` runs the identical apply-then-`if !changed` sequence but never recorded. `broadcast_queue.rs` picks the non-streaming variant below `streaming_threshold` (default 64KB), so ordinary small deltas — the normal River case — were invisible, and `cards.rs` renders `updates_received` as the **only** UPDATE number for subscriber nodes.

## Solution

**PUT** — move recording out of the driver arms into `deliver_outcome`, with a `classify_put_outcome_for_op_stats` classifier. `run_client_put` -> `drive_client_put` -> `drive_client_put_inner` is the only call chain and `deliver_outcome` is called unconditionally on its result, so this single funnel sees *every* terminal outcome. This is UPDATE's #4010 fix shape — the one that did **not** rot. Gated on `!client_tx.is_sub_operation()` for parity with UPDATE/SUBSCRIBE (defensive; PUT has no sub-op entry points today).

**GET** — record an explicit `false` in the `Exhausted` arm. GET deliberately keeps arm-based recording rather than adopting the funnel: exhaustion publishes `Ok(HostResponse::…NotFound)` so that clients can distinguish "contract absent" from "operation failed", which means a `matches!(Publish(Ok(_)))` classifier would score a dead-end as a **success**.

**UPDATE** — record in `drive_relay_broadcast_to` too, after its `!changed` guard (matching the streaming twin: a broadcast that mutated nothing is not a received update). Note `drive_relay_broadcast_to` already called `record_relayed_update()`, but that feeds a different counter (`relayed_op_stats`), not the ops card.

**Pin tests close the CI gap** that let #4010 regrow here — each fix carries a source-scrape pin so a future migration that drops the call fails CI, per `bug-prevention-patterns.md`.

**Stale rustdoc** on `network_status::record_op_result` fixed: it named `node.rs::report_result` as a writer for "legacy state-machine ops that still flow through OpManager.ops.*", but that function contains no `record_op_result` call and the legacy mediator path is gone (see `crates/core/CLAUDE.md`). This is the doc `bug-prevention-patterns.md` points auditors at, so its staleness misled the next audit. The "Current writers" list now matches the five real production call sites exactly.

## Testing

Regression test written first, verified failing, then fixed, then verified passing — **fail-then-pass observed for all three defects**. The unfixed state was reproduced faithfully by splicing origin/main's production code (everything before `#[cfg(test)]`) with the new test module, which landed the bug on the exact reported lines.

Pin tests added:

| Test | Guards |
|---|---|
| `put::…::deliver_outcome_records_put_op_result` | `deliver_outcome` calls `record_op_result` with `OpType::Put`, a **derived** (not hardcoded `true`) success flag, and the sub-op gate |
| `put::…::put_driver_must_not_record_op_result_directly` | driver must not re-inline the call (double-count / partial-arm regression) |
| `put::…::classify_put_outcome_covers_all_variants` | pure-function coverage of every `DriverOutcome` variant |
| `get::…::exhausted_arm_records_get_failure` | Exhausted arm records `OpType::Get` with `false` |
| `update::…::both_broadcast_drivers_record_update_received` | **both** broadcast drivers record, each after its `!changed` guard |

Against the unfixed code all four source-scrape pins fail with their intended diagnostics; `classify_put_outcome_covers_all_variants` fails to compile (it covers the new classifier). With the fix, all 5 pass.

- `cargo test -p freenet --lib -- operations::put::op_ctx_task operations::get::op_ctx_task operations::update::op_ctx_task node::network_status` — **229 passed, 0 failed**
- `cargo fmt --check` clean
- `cargo clippy -p freenet --lib -- -D warnings` clean

Scope is limited to these three counters plus the rustdoc; SUBSCRIBE/CONNECT, the cards, and #4829/#4830 are untouched.

Fixes #4828

[AI-assisted - Claude]
