### PR TITLE
fix(transport): record failed transfers (transfers_failed had no writer)

### DIFF
--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -758,6 +758,41 @@ mod tests {
         assert!(html.contains("23</span>"), "slowdown count missing");
         assert!(html.contains("847"), "transfers completed missing");
         assert!(html.contains("3"), "transfers failed missing");
+        assert!(
+            html.contains("1.200s avg"),
+            "a real average must still render when transfers completed"
+        );
+    }
+
+    /// An all-failures window must NOT render an average.
+    ///
+    /// `avg_transfer_time_ms` is a sentinel 0 when nothing completed
+    /// (metrics.rs guards the division), so rendering it would claim a measured
+    /// "0.000s avg" for transfers that produced no timing at all. The window is
+    /// reachable only since #4827 gave `transfers_failed` a writer: before that
+    /// the counter was structurally 0, so this row required >=1 completion and
+    /// the average was always real. A 30s all-failures window is exactly the
+    /// sick-node case #4827 exists to surface, so the first thing it renders
+    /// must not be a fabricated timing.
+    #[test]
+    fn transfer_card_omits_avg_when_nothing_completed() {
+        let mut snap = base_snapshot();
+        snap.bytes_uploaded = 5000;
+        snap.open_connections = 1;
+        snap.transport_snapshot.transfers_completed = 0;
+        snap.transport_snapshot.transfers_failed = 3;
+        // The sentinel metrics.rs produces when transfers_completed == 0.
+        snap.transport_snapshot.avg_transfer_time_ms = 0;
+        let html = build_transfer_card(&Some(snap));
+
+        assert!(
+            html.contains("0 ok / 3 fail"),
+            "the failure row must still render — surfacing it is the point of #4827"
+        );
+        assert!(
+            !html.contains("avg)"),
+            "must not present the sentinel 0 as a measured average; got: {html}"
+        );
     }
 
     #[test]

--- a/crates/core/src/server/home_page/cards.rs
+++ b/crates/core/src/server/home_page/cards.rs
@@ -381,15 +381,31 @@ pub fn build_transfer_card(snap: &Option<network_status::NetworkStatusSnapshot>)
         String::new()
     };
 
+    // Only render the average when something actually completed.
+    // `avg_transfer_time_ms` is a sentinel 0 when `transfers_completed == 0`
+    // (metrics.rs guards the division), so an all-failures window would
+    // otherwise render "0 ok / 3 fail (0.000s avg)" — presenting the sentinel
+    // as a measured timing. That window became reachable when #4827 gave
+    // `transfers_failed` a writer: before that the counter was structurally 0,
+    // so this row only ever rendered with >=1 completion and the avg was always
+    // real.
+    let avg_str = if ts.transfers_completed > 0 {
+        format!(
+            r#" <span class="transfer-detail">({avg}s avg)</span>"#,
+            avg = format_args!("{:.3}", ts.avg_transfer_time_ms as f64 / 1000.0),
+        )
+    } else {
+        String::new()
+    };
+
     let xfer_str = if ts.transfers_completed > 0 || ts.transfers_failed > 0 {
         format!(
             r#"<div class="transfer-stat">
                 <span class="transfer-label">Transfers (avg time)</span>
-                <span class="transfer-value">{ok} ok / {fail} fail <span class="transfer-detail">({avg}s avg)</span></span>
+                <span class="transfer-value">{ok} ok / {fail} fail{avg_str}</span>
             </div>"#,
             ok = ts.transfers_completed,
             fail = ts.transfers_failed,
-            avg = format_args!("{:.3}", ts.avg_transfer_time_ms as f64 / 1000.0),
         )
     } else {
         String::new()

--- a/crates/core/src/transport/metrics.rs
+++ b/crates/core/src/transport/metrics.rs
@@ -245,6 +245,40 @@ impl TransportMetrics {
         }
     }
 
+    /// Record a failed outbound transfer.
+    ///
+    /// The failure sibling of [`Self::record_transfer_completed`]. Together the
+    /// two count every outbound stream that resolves: `send_stream` /
+    /// `pipe_stream` either run to completion (completed) or return early from
+    /// one of their error sites (failed), never both.
+    ///
+    /// Call this once per failed stream, from the OUTBOUND-stream arms of
+    /// `PeerConnection::recv` — the place every outbound stream task's result
+    /// is observed. (`recv` also observes `inbound_stream_futures`; those are
+    /// not transfers this counter tracks.)
+    ///
+    /// It mirrors the `emit_transfer_failed` event for every stream whose
+    /// result is observed there, but the two are NOT unconditionally 1:1: the
+    /// event is emitted inside the stream task, while this counter increments
+    /// only at the observation site, so a task that panics or is orphaned by
+    /// connection teardown diverges. See the call sites in `peer_connection.rs`
+    /// for both gaps and for the classification rationale.
+    ///
+    /// Unlike the success path this records ONLY the counter: a failed transfer
+    /// has no meaningful duration, throughput, or payload size to aggregate,
+    /// and the bytes it did put on the wire are already counted at the socket
+    /// layer by `record_packet_sent`.
+    pub fn record_transfer_failed(&self) {
+        // Saturating, matching `record_transfer_completed` — a pinned u32::MAX
+        // is a better failure mode than wrapping to 0 and reporting a healthy
+        // node.
+        self.transfers_failed
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
+                Some(v.saturating_add(1))
+            })
+            .ok();
+    }
+
     /// Record the start of an outbound NAT traversal attempt.
     pub fn record_nat_traversal_attempt(&self) {
         self.nat_traversal_attempts.fetch_add(1, Ordering::Relaxed);
@@ -462,11 +496,12 @@ impl TransportMetrics {
     /// Read-only snapshot for the local dashboard. Does NOT reset counters
     /// (unlike `take_snapshot` which is consumed by the telemetry worker).
     ///
-    /// **Telemetry interaction**: `peak_throughput_bps`, `avg_cwnd_bytes`,
-    /// `avg_rtt_us`, and `slowdowns_triggered` are period accumulators that
-    /// `take_snapshot` resets every `transport_snapshot_interval_secs`
-    /// (default 30s).  Between resets these reflect recent activity; the
-    /// dashboard sees the current window, not a lifetime aggregate.
+    /// **Telemetry interaction**: `transfers_completed`, `transfers_failed`,
+    /// `peak_throughput_bps`, `avg_cwnd_bytes`, `avg_rtt_us`, and
+    /// `slowdowns_triggered` are period accumulators that `take_snapshot`
+    /// resets every `transport_snapshot_interval_secs` (default 30s).  Between
+    /// resets these reflect recent activity; the dashboard sees the current
+    /// window, not a lifetime aggregate.
     /// `cumulative_bytes_sent/received` are never reset and reflect totals.
     pub fn read_snapshot(&self) -> TransportSnapshot {
         let transfers_completed = self.transfers_completed.load(Ordering::Relaxed);
@@ -938,6 +973,45 @@ mod tests {
 
         // Counters reset after the snapshot: a subsequent snapshot with no new
         // activity is None.
+        assert!(metrics.take_snapshot().is_none());
+    }
+
+    /// Failed transfers count as snapshot activity in their own right: a period
+    /// whose ONLY activity is failures (a sick node whose every transfer dies,
+    /// with no completions and no RTT keep-alive samples) must still emit a
+    /// snapshot, otherwise `take_snapshot` returns `None`, the telemetry worker
+    /// uploads nothing, and the fail counter reads a permanent 0 — exactly the
+    /// #4827 symptom this fix exists to surface.
+    ///
+    /// The `&& transfers_failed == 0` conjunct in the no-activity gate was DEAD
+    /// until #4827 gave the counter a writer, so this is its first coverage.
+    /// Sibling pins: `test_snapshot_emitted_for_rtt_only_activity` (#4000) and
+    /// `test_snapshot_emitted_for_nat_only_activity`.
+    ///
+    /// Also the only coverage that a failure reaches `take_snapshot` at all —
+    /// the value telemetry actually uploads, distinct from the `read_snapshot`
+    /// the `peer_connection` wiring tests read.
+    #[test]
+    fn test_snapshot_emitted_for_failed_transfers_only() {
+        let metrics = TransportMetrics::new();
+
+        // No completions, no RTT samples, no NAT activity — only failures.
+        metrics.record_transfer_failed();
+        metrics.record_transfer_failed();
+        metrics.record_transfer_failed();
+
+        let snapshot = metrics
+            .take_snapshot()
+            .expect("failure-only activity must still produce a snapshot");
+        assert_eq!(snapshot.transfers_failed, 3);
+        assert_eq!(snapshot.transfers_completed, 0);
+        // No completion means no measured duration: the average is the sentinel
+        // 0, not a real timing. `cards.rs` must not render it as one.
+        assert_eq!(snapshot.avg_transfer_time_ms, 0);
+
+        // Counters reset after the snapshot: a subsequent snapshot with no new
+        // activity is None. Without the reset a single failure would re-emit a
+        // stale snapshot every period forever.
         assert!(metrics.take_snapshot().is_none());
     }
 

--- a/crates/core/src/transport/peer_connection.rs
+++ b/crates/core/src/transport/peer_connection.rs
@@ -1183,14 +1183,55 @@ impl<S: super::Socket, T: TimeSource> PeerConnection<S, T> {
                             // Report to global metrics for periodic telemetry snapshots
                             super::TRANSPORT_METRICS.record_transfer_completed(&stats);
                         }
+                        // Both Err arms count the transfer as failed (#4827).
+                        //
+                        // "Transient" here classifies CONNECTION liveness, not
+                        // the transfer's fate: it means "don't tear down the
+                        // connection", NOT "this transfer might still finish".
+                        // The stream task has already returned — this stream is
+                        // dead either way, so both arms are real transfer
+                        // failures. Instrumenting only the terminal arm would
+                        // leave the counter ~always 0 (every common failure —
+                        // cwnd-wait timeout, pipe stall, inbound-feed error,
+                        // socket send error — is transient), which is the bug
+                        // this fixes.
+                        //
+                        // Never counted twice for one stream: one spawned task
+                        // yields one result, `FuturesUnordered` yields that
+                        // result exactly once, and nothing awaits between the
+                        // yield and the increment. (Counted zero times in the
+                        // orphan case below, so this is an upper bound, not an
+                        // exact count.)
+                        //
+                        // Relation to the `emit_transfer_failed` event stream:
+                        // that event is emitted INSIDE the stream task, whereas
+                        // this counter increments only where the task's result
+                        // is observed. The two therefore agree 1:1 for every
+                        // stream whose result reaches this match — but not for:
+                        //  - A task that PANICS: the `?` above turns it into
+                        //    `TransportError::Other`, so it reaches neither arm
+                        //    and is missing from BOTH the counter and the event
+                        //    stream (symmetric).
+                        //  - A task ORPHANED at teardown: `Drop` does not abort
+                        //    or drain `outbound_stream_futures`, and dropping a
+                        //    `JoinHandle` detaches the task — it runs on and
+                        //    still emits its event, but no `recv()` remains to
+                        //    observe its result (ASYMMETRIC: the event fires,
+                        //    the counter does not). This concentrates at
+                        //    teardown, and `record_transfer_completed` above has
+                        //    the same gap.
                         Err(e) if e.is_transient_send_failure() => {
+                            super::TRANSPORT_METRICS.record_transfer_failed();
                             tracing::warn!(
                                 peer_addr = %self.remote_conn.remote_addr,
                                 error = %e,
                                 "Outbound stream send failed, operation layer will timeout and retry"
                             );
                         }
-                        Err(e) => return Err(e),
+                        Err(e) => {
+                            super::TRANSPORT_METRICS.record_transfer_failed();
+                            return Err(e);
+                        }
                     }
                 },
                 _ = timeout_check.tick() => {
@@ -3820,6 +3861,234 @@ mod tests {
         assert_eq!(
             target, remote_addr,
             "recovered send must be addressed to the connected peer"
+        );
+    }
+
+    /// Build a `PeerConnection` wired to a no-op socket, for tests that only
+    /// need to drive `recv()`'s outbound-stream arms.
+    ///
+    /// Uses `RealTime` deliberately: the recv loop's timers sleep on the
+    /// connection's `TimeSource`, and a mock clock whose `sleep` is a no-op
+    /// would spin those arms hot.
+    ///
+    /// The other arms DO fire within the bounded wait these tests use — only
+    /// `timeout_check` (5s) does not. `ack_interval` is picked by
+    /// `SimulationTransportOpt::is_enabled()` (false here), so `ack_check` and
+    /// `rate_update_check` tick at `ACK_CHECK_INTERVAL` (100ms) and the resend
+    /// arm first fires at 10ms, then every 2ms. They are harmless because they
+    /// are no-ops on an idle fixture: nothing was sent, so there is nothing to
+    /// resend and `ack_check` returns early on `receipts.is_empty()`. The
+    /// outbound-stream arm is the only one that observes anything — not the
+    /// only one that runs.
+    ///
+    /// Returns the inbound sender alongside the connection: it MUST be held
+    /// alive by the caller. Dropping it closes `inbound_packet_recv`, and the
+    /// recv loop treats a closed inbound channel as a dead connection and
+    /// returns immediately — before the outbound-stream arm is ever polled.
+    #[allow(clippy::type_complexity)]
+    fn test_conn_for_outbound_stream_arm(
+        remote_addr: SocketAddr,
+    ) -> (
+        PeerConnection<TestSocket, crate::simulation::RealTime>,
+        mpsc::Sender<PacketData<UnknownEncryption>>,
+    ) {
+        use crate::simulation::RealTime;
+        use crate::transport::crypto::TransportKeypair;
+
+        let time_source = RealTime::new();
+        let (inbound_tx, inbound_rx) = mpsc::channel(16);
+
+        let mut key = [0u8; 16];
+        crate::config::GlobalRng::fill_bytes(&mut key);
+        let cipher = Aes128Gcm::new(&key.into());
+        let keypair = TransportKeypair::new();
+
+        let sent_tracker = Arc::new(parking_lot::Mutex::new(
+            SentPacketTracker::new_with_time_source(time_source.clone()),
+        ));
+        let congestion_controller =
+            crate::transport::congestion_control::CongestionControlConfig::default()
+                .build_arc_with_time_source(time_source.clone());
+        let token_bucket = Arc::new(TokenBucket::new_with_time_source(
+            10_000,
+            10_000_000,
+            time_source.clone(),
+        ));
+        let socket = Arc::new(TestSocket::new(
+            mpsc::channel::<(SocketAddr, Arc<[u8]>)>(16).0,
+        ));
+        let rolling_rtt_stats = crate::transport::rolling_rtt_stats::RollingRttStatsHandle::new(
+            remote_addr,
+            time_source.clone(),
+        );
+
+        let conn = PeerConnection::new(RemoteConnection {
+            outbound_symmetric_key: cipher.clone(),
+            remote_addr,
+            sent_tracker,
+            last_packet_id: Arc::new(AtomicU32::new(0)),
+            inbound_packet_recv: inbound_rx,
+            inbound_symmetric_key: cipher,
+            inbound_symmetric_key_bytes: key,
+            my_address: None,
+            remote_protoc_version: None,
+            transport_secret_key: keypair.secret,
+            congestion_controller,
+            token_bucket,
+            socket,
+            global_bandwidth: None,
+            rolling_rtt_stats,
+            time_source,
+        });
+        (conn, inbound_tx)
+    }
+
+    /// Serializes the #4827 `transfers_failed` tests. `TRANSPORT_METRICS` is a
+    /// process-wide global and these tests assert an EXACT +1 delta, so they
+    /// must not observe each other's increment. An exact delta (rather than a
+    /// weaker `>=`) is what makes them fail on a double-count as well as on the
+    /// original never-counts bug.
+    ///
+    /// `tokio::sync::Mutex` (not `parking_lot`/`std`): the guard is held across
+    /// an `.await`, which `clippy::await_holding_lock` rightly rejects for a
+    /// sync guard.
+    static TRANSFERS_FAILED_TEST_LOCK: std::sync::LazyLock<tokio::sync::Mutex<()>> =
+        std::sync::LazyLock::new(|| tokio::sync::Mutex::new(()));
+
+    /// Regression test for #4827: a failed outbound stream must increment
+    /// `transfers_failed`.
+    ///
+    /// The bug: `transfers_failed` was declared, read, reset, rendered on the
+    /// dashboard, and uploaded to telemetry, but NOTHING ever incremented it —
+    /// it was structurally pinned at 0, so a node whose transfers were all
+    /// failing rendered as `N ok / 0 fail` and looked perfectly healthy.
+    ///
+    /// This drives the REAL `recv()` loop rather than calling
+    /// `record_transfer_failed` directly, because the bug was missing WIRING,
+    /// not a missing counter: a test that only exercised the metrics function
+    /// would pass even with both call sites deleted. The pre-existing tests
+    /// (`metrics.rs`) only assert the counter STAYS 0, which is exactly why CI
+    /// never caught this — do not copy that pattern.
+    ///
+    /// Both arms are covered because both are real transfer failures and both
+    /// emit `emit_transfer_failed`; see the call sites for why "transient"
+    /// classifies connection liveness, not the transfer's fate.
+    #[tokio::test]
+    async fn recv_records_transfer_failed_on_transient_stream_failure() {
+        let _guard = TRANSFERS_FAILED_TEST_LOCK.lock().await;
+        let remote_addr = SocketAddr::new(Ipv4Addr::new(10, 99, 99, 4).into(), 50004);
+        // `_inbound_tx` must stay alive: dropping it closes the inbound channel
+        // and recv() returns before the outbound-stream arm is polled.
+        let (mut conn, _inbound_tx) = test_conn_for_outbound_stream_arm(remote_addr);
+
+        let before = crate::transport::TRANSPORT_METRICS
+            .read_snapshot()
+            .transfers_failed;
+
+        // `OutboundStreamFailed` is what send_stream/pipe_stream's stream-scoped
+        // error sites return (cwnd-wait timeout, pipe inactivity stall,
+        // inbound-feed error) — the dominant outbound-stream failure by far. It
+        // is `is_transient_send_failure()`, so it takes the connection-survives
+        // arm.
+        let err = TransportError::OutboundStreamFailed(remote_addr);
+        assert!(
+            err.is_transient_send_failure(),
+            "test premise: OutboundStreamFailed must be classified transient, \
+             otherwise this test is silently exercising the other arm"
+        );
+        conn.outbound_stream_futures
+            .push(tokio::spawn(async move { Err(err) }));
+
+        // The transient arm logs and keeps looping, so recv() never returns
+        // here — the bounded wait is just an upper bound for giving up. The
+        // arm itself fires as soon as the future is ready.
+        let recv_result = tokio::time::timeout(Duration::from_millis(500), conn.recv()).await;
+        assert!(
+            recv_result.is_err(),
+            "a transient stream failure must NOT end recv() — the connection \
+             survives and only the stream fails (#4345)"
+        );
+
+        let after = crate::transport::TRANSPORT_METRICS
+            .read_snapshot()
+            .transfers_failed;
+        assert_eq!(
+            after,
+            before + 1,
+            "a transient outbound-stream failure must increment transfers_failed \
+             (#4827): the counter had no writer and was permanently 0"
+        );
+    }
+
+    /// Regression test for #4827, terminal arm — see
+    /// `recv_records_transfer_failed_on_transient_stream_failure`.
+    ///
+    /// A non-transient stream error tears the connection down. The transfer
+    /// still failed, and `emit_transfer_failed` still fired for it, so the
+    /// counter must move before the error propagates.
+    ///
+    /// Reachability note: from an outbound stream this arm is only reachable
+    /// via `TransportError::Serialization` — the sole non-transient error
+    /// `packet_sending` can produce (a bincode failure from
+    /// `try_serialize_msg_to_packet_data`); every other outbound-stream error
+    /// is `OutboundStreamFailed` or `SendFailed`, both transient. That is
+    /// exactly why instrumenting ONLY this arm would have left the counter
+    /// ~always 0 and not fixed #4827.
+    ///
+    /// The injected error is `ConnectionEstablishmentFailure` carrying a unique
+    /// sentinel `cause`, NOT `ConnectionClosed`: a closed inbound channel also
+    /// yields `ConnectionClosed` (see the `inbound.ok_or_else(..)` site in
+    /// `recv`), so asserting on that variant could pass for the wrong reason.
+    /// The sentinel proves the error came from OUR stream task. What the arm
+    /// actually keys off is the `!is_transient_send_failure()` predicate, which
+    /// the test asserts directly.
+    #[tokio::test]
+    async fn recv_records_transfer_failed_on_terminal_stream_failure() {
+        let _guard = TRANSFERS_FAILED_TEST_LOCK.lock().await;
+        let remote_addr = SocketAddr::new(Ipv4Addr::new(10, 99, 99, 5).into(), 50005);
+        // `_inbound_tx` must stay alive — see the transient test above.
+        let (mut conn, _inbound_tx) = test_conn_for_outbound_stream_arm(remote_addr);
+
+        let before = crate::transport::TRANSPORT_METRICS
+            .read_snapshot()
+            .transfers_failed;
+
+        const SENTINEL: &str = "4827-terminal-stream-failure-sentinel";
+        let err = TransportError::ConnectionEstablishmentFailure {
+            cause: SENTINEL.into(),
+        };
+        assert!(
+            !err.is_transient_send_failure(),
+            "test premise: the injected error must NOT be classified transient, \
+             otherwise this test is silently exercising the other arm"
+        );
+        conn.outbound_stream_futures
+            .push(tokio::spawn(async move { Err(err) }));
+
+        // The terminal arm returns the error, so recv() resolves on its own.
+        let recv_result = tokio::time::timeout(Duration::from_millis(500), conn.recv())
+            .await
+            .expect("recv() must return promptly on a terminal stream failure");
+        match recv_result {
+            Err(TransportError::ConnectionEstablishmentFailure { cause }) => assert_eq!(
+                cause, SENTINEL,
+                "the terminal arm must propagate OUR stream error unchanged"
+            ),
+            other => panic!(
+                "the terminal arm must propagate the injected stream error; a \
+                 different error means recv() bailed out somewhere else and the \
+                 outbound-stream arm was never reached. Got: {other:?}"
+            ),
+        }
+
+        let after = crate::transport::TRANSPORT_METRICS
+            .read_snapshot()
+            .transfers_failed;
+        assert_eq!(
+            after,
+            before + 1,
+            "a terminal outbound-stream failure must increment transfers_failed \
+             (#4827) before the error propagates"
         );
     }
 


### PR DESCRIPTION
## Problem

`TransportMetrics::transfers_failed` is declared, initialized, read, reset, rendered on the local peer dashboard, and uploaded to telemetry — but **nothing ever incremented it**. No `record_transfer_failed` existed anywhere in the crate, so the counter was structurally pinned at 0.

User-visible effect: the dashboard's Data Transfer row always read `N ok / 0 fail` (`server/home_page/cards.rs:384-391`), and `tracing/telemetry.rs:2009` uploaded `transfers_failed: 0` forever. **A node whose transfers were all failing looked perfectly healthy.**

Second-order effect: `transfers_failed` is an input to `take_snapshot`'s no-activity gate (`metrics.rs:596`). Being structurally 0 it contributed nothing, so a period whose only activity was *failed* transfers could emit no snapshot at all.

This was unfinished wiring rather than an unimplemented idea: the failure paths were already instrumented for the **event stream** (`emit_transfer_failed`, six call sites in `outbound_stream.rs`), and the counter's success sibling `record_transfer_completed` sits directly beside the failure arms.

## Solution

Add `record_transfer_failed()` next to `record_transfer_completed`, and call it from **both** outbound-stream failure arms in `PeerConnection::recv`.

### Judgment call: why both arms, not just the terminal one

The brief flagged a real risk — that counting the `is_transient_send_failure()` arm might inflate the metric or double-count a retried transfer. I traced the code, and it doesn't:

**"Transient" classifies CONNECTION liveness, not the transfer's fate.** Its own rustdoc (`transport.rs:368-387`) is explicit: it returns true for "a stream-scoped failure that must NOT kill the connection", where "a single stalled or failed stream **only fails that stream**, and the operation layer times out and **retries against another candidate**." The stream task has already returned — the transfer is dead in both arms. The arms differ only in whether the *connection* survives (#4345).

**No double-count, and it does not depend on retry behaviour.** One spawned task yields exactly one result; `FuturesUnordered` yields that result exactly once; there is no `.await` between the yield and the increment. One stream, one terminal outcome, counted once. (An earlier revision of this PR justified this via "a retry opens a new stream with a new `stream_id`". That reasoning was wrong for the dominant case — `MAX_PEER_ADVANCEMENTS_STREAMING = 0` (`put/op_ctx_task.rs:1067`, selected at `:444`), so streaming PUTs — exactly the payloads that produce outbound-stream failures — get **zero** op-layer advancements, and `get/op_ctx_task.rs:1851` notes GETs are never streaming today. The conclusion survives; the stated reason didn't, and has been replaced by the one-task-one-result argument above.)

### Emit-site census

The six `emit_transfer_failed` sites, and which arm their error return lands in:

| emit site | returns | `is_transient_send_failure()` | arm |
|---|---|---|---|
| 210 → 248 | `OutboundStreamFailed` (cwnd-wait timeout) | true | transient |
| 347 → 390 | `e` from `packet_sending` | see below | either |
| 550 → 572 | `OutboundStreamFailed` (pipe inactivity stall) | true | transient |
| 579 → 595 | `OutboundStreamFailed` (inbound-feed error) | true | transient |
| 651 → 672 | `OutboundStreamFailed` (cwnd-wait timeout) | true | transient |
| 743 → 774 | `e` from `packet_sending` | see below | either |

So: **four** `OutboundStreamFailed` sites, and **two** mid-send `packet_sending` sites. `packet_sending` returns `SendFailed` on socket error (transient), **or** propagates a bincode `Serialization` error from `try_serialize_msg_to_packet_data` via `?` (`peer_connection.rs:2242`) — and `Serialization` is *not* transient, so it reaches the terminal arm. Each mid-send site can therefore return either kind; both emit `emit_transfer_failed` before returning, regardless of which.

Every production error return in `send_stream`/`pipe_stream` emits the event, and they distribute across *both* arms. Counting only the transient arm would silently miss the serialization case; **counting only the terminal arm would have left the counter ~always 0 and not fixed this issue at all** — every common failure (cwnd-wait timeout, pipe stall, inbound-feed error, socket send error) is transient.

This census is deliberately kept here rather than inline in the code: it is cross-file bookkeeping that a 7th emit site would silently falsify, with nothing to pin it. The inline comment keeps only the why (the liveness-vs-fate distinction and the counted-once argument), which stays true regardless of site count.

### Where the counter and the event stream cannot agree

The counter is **not** unconditionally 1:1 with the event stream. `emit_transfer_failed` fires **inside** the stream task (`send_stream` spans `outbound_stream.rs:103-473`, `pipe_stream` `:485-841`); the counter increments only where the task's *result* is observed, in `recv()`. They agree 1:1 for every stream whose result reaches that match — with two known gaps:

- **Panic (symmetric).** A stream task that panics becomes a `JoinError` → `TransportError::Other` via the `?` on the join result, *before* the match. It reaches neither arm, so it is missing from **both** the counter and the event stream. The two still agree with each other; both under-count panics equally.

- **Teardown orphan (ASYMMETRIC).** `PeerConnection::drop` (`peer_connection.rs:308-333`) cancels `streaming_handles` and aborts `keep_alive_handle`, but does **not** abort or drain `outbound_stream_futures`. Dropping a `FuturesUnordered<JoinHandle<_>>` drops the `JoinHandle`s, which **detaches** the tasks (`GlobalExecutor::spawn` returns a real `tokio::task::JoinHandle`, `config.rs:2923-2925`). A detached `send_stream`/`pipe_stream` task that later fails still calls `emit_transfer_failed` from inside the task — but no `recv()` remains to observe its result, so the **event fires and the counter does not**. This concentrates at teardown: the terminal arm's `return Err(e)` ends `recv()`, the caller drops the connection, and sibling in-flight streams orphan — i.e. exactly when mass stream failures happen. `record_transfer_completed` has the same gap.

Both gaps are now documented at the call site and in the `record_transfer_failed` rustdoc. Closing them is out of scope here.

### Implementation notes

- Saturating increment (matching `record_transfer_completed`): a pinned `u32::MAX` is a better failure mode than wrapping to 0 and reporting a healthy node.
- Records **only** the counter, unlike the success path — a failed transfer has no meaningful duration/throughput to aggregate, and bytes already on the wire are counted at the socket layer by `record_packet_sent`.

### Third file: suppressing a now-reachable dishonest render

`server/home_page/cards.rs` gates the transfers row on `transfers_completed > 0 || transfers_failed > 0`. **The `|| transfers_failed > 0` half was dead code before this PR** — the row only ever rendered with >=1 completion, so its average was always real. Giving the counter a writer makes an all-failures window reachable, and it would render:

> `0 ok / 3 fail (0.000s avg)`

presenting the sentinel 0 from `metrics.rs`'s `if transfers_completed > 0 { … } else { 0 }` guard as a measured average. A 30s all-failures window is exactly the sick-node case this PR exists to surface, so the first thing it renders must not be a fabricated timing.

Fixed by suppressing the average span when `transfers_completed == 0`, following the file's existing idiom (`peak_tput`, `rtt_str`, `cwnd_str` all conditionally suppress). **Flagged explicitly as a third file in the diff**: it's in scope under the repo's finish-the-fix rule because *this PR* is what makes the branch reachable, but it is not part of the counter wiring itself.

## Testing

**Two regression tests that drive the real `recv()` loop**, one per arm.

This is deliberate: the bug was missing **wiring**, not a missing counter. A test that only called `record_transfer_failed` directly would pass with **both call sites deleted** — it would not have caught this. The pre-existing metrics tests (`metrics.rs:906`, `:933`) only assert the counter *stays* 0, which is precisely why CI never caught it; that pattern is not followed here.

Verified the full falsification cycle explicitly:

- **With the fix**: both tests pass.
- **Fix removed** (both `record_transfer_failed()` call sites deleted, tests untouched): both fail with `left: 0, right: 1` — reproducing the exact bug (counter permanently 0).
- **Fix restored**: both pass again.

Test design details:
- Each asserts an **exact** `before + 1` delta, not a weaker `>=`, so they fail on a double-count as well as on the original never-counts bug.
- Each asserts its **premise** (`is_transient_send_failure()` is/isn't true for the injected error), so a future reclassification cannot leave a test silently exercising the wrong arm and passing for the wrong reason.
- The terminal test injects `ConnectionEstablishmentFailure` with a unique sentinel rather than `ConnectionClosed`, because a closed inbound channel also yields `ConnectionClosed` — asserting on that variant could pass for the wrong reason. The sentinel proves the error came from our stream task.
- The tests serialize on a shared lock (`TRANSPORT_METRICS` is a process-wide global) so they can't observe each other's increment.

**Plus a pin test for the newly-live activity gate**: `test_snapshot_emitted_for_failed_transfers_only`. `take_snapshot`'s no-activity gate includes `&& transfers_failed == 0`, a conjunct that was **dead until this PR** (the counter was structurally 0) and is now live for the first time. Both its siblings have a dedicated pin test for exactly this branch (`test_snapshot_emitted_for_rtt_only_activity`, citing #4000, and `test_snapshot_emitted_for_nat_only_activity`) because dropping a gate conjunct silently discards a period's telemetry; there was no failures-only equivalent. Without it, someone "simplifying" the gate by dropping the conjunct would make a failures-only window return `None` → telemetry uploads nothing → the fail counter reads a permanent 0 again, i.e. the exact #4827 symptom with green CI.

Falsified the same way: removing `&& transfers_failed == 0` from the gate makes it fail with *"failure-only activity must still produce a snapshot"*; restored, it passes. It also closes `record_transfer_failed`'s previously-zero coverage in `metrics.rs` — that a failure surfaces through `take_snapshot()` (the value telemetry actually uploads, distinct from the `read_snapshot()` the `peer_connection` tests use) and that it resets afterwards.

**Plus a render test**: `transfer_card_omits_avg_when_nothing_completed` (and an added assertion to `transfer_card_renders_subsections_with_data` that a real average still renders). Falsified by forcing the avg span unconditionally, which makes it fail.

Also green: full `transport::` lib suite (685 passed), `server::home_page::` (121 passed), `cargo fmt`, and `cargo clippy -p freenet --lib -- -D warnings` clean.

## Review follow-ups applied

A four-reviewer pass found no blocking correctness findings; every finding was comment/doc accuracy or a test gap. All are addressed:

1. **The "1:1" claim was false** — disclosed the asymmetric teardown/detach gap alongside the panic gap, and scoped the claim to "every stream whose result is observed by `recv()`". Fixed at the call site, in the `record_transfer_failed` rustdoc, and here. (Mechanism independently re-verified against `Drop`, the `FuturesUnordered<JoinHandle>` field, and `GlobalExecutor::spawn`'s return type.)
2. **The "all six" enumeration miscounted** — it reached six by adding 4 *sites* + 2 *error kinds arising from those same 2 sites*. The inline census is removed (it's cross-file bookkeeping that would rot); the corrected census lives in this PR body.
3. **The retry premise was wrong for the dominant case** — replaced with the one-task-one-result guarantee, which is airtight and retry-independent.
4. **Missing pin test for the newly-live activity gate** — added, plus `record_transfer_failed`'s `take_snapshot`/reset coverage.
5. **Stale `read_snapshot` doc** — it omitted `transfers_completed`/`transfers_failed` from the period accumulators `take_snapshot` resets, implying they are not reset. Corrected.
6. **`metrics.rs` overstated "the single place every stream task's result is observed"** — `recv()` also observes `inbound_stream_futures`; scoped to *outbound*.
7. **Test-helper doc had a wrong causal model** — it claimed the timer arms are TimeSource-driven with first ticks "seconds away". Actually `ack_interval` is selected by `SimulationTransportOpt::is_enabled()`, giving `ACK_CHECK_INTERVAL` = 100ms; the resend arm fires at 10ms then every 2ms. Only `timeout_check` (5s) matched the claim. The tests pass for a different reason — those arms are no-ops on an idle fixture (`ack_check` returns early on `receipts.is_empty()`). Corrected to the real reason.
8. **This PR made a dishonest render reachable** — fixed in `cards.rs`; see "Third file" above.

## Scope

Strictly the `transfers_failed` counter, plus the `cards.rs` render branch this PR makes reachable (flagged above). The two related items in the issue — the `bytes_sent`/`bytes_received` asymmetry, and the 30s-reset row flicker (which needs a design call) — are deliberately **not** touched here.

Fixes #4827

[AI-assisted - Claude]
