### PR TITLE
fix(hosted): route programmatic window.open through the shell to avoid new-tab dead-end (#4645)

### DIFF
--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -4364,10 +4364,12 @@ mod tests {
              fall back to native (#4645)"
         );
         // In-place navigation targets are not new-window requests -> native.
+        // Names are normalized (case-insensitive) before the reserved check.
         assert!(
-            override_block.contains("name === '_self'"),
-            "window.open override must leave _self/_parent/_top to native so \
-             in-place navigation isn't turned into a new tab (#4645)"
+            override_block.contains("targetName === '_self'")
+                && override_block.contains("String(name).toLowerCase()"),
+            "window.open override must leave _self/_parent/_top (case-insensitive) \
+             to native so in-place navigation isn't turned into a new tab (#4645)"
         );
         // Loopback targets must fall back to native: open_url refuses them, so
         // forwarding would silently drop the open on local nodes.

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -4502,15 +4502,15 @@ mod tests {
         );
     }
 
-    /// `URL.hostname` strips the brackets from IPv6 literals, so a URL
-    /// `http://[::1]/` parses with `hostname === '::1'` (no brackets), and
-    /// the previous comparison `h === '[::1]'` never matched. The IPv6
-    /// loopback was effectively unblocked. The relaxation in
-    /// freenet/river#231 (accepting http: in addition to https:) makes
-    /// the gap newly reachable for typical home services, so fix it
-    /// alongside the http: change.
+    /// WHATWG `URL.hostname` serializes an IPv6 literal WITH brackets, so
+    /// `new URL('http://[::1]/').hostname === '[::1]'`. The handler must
+    /// therefore STRIP the brackets before comparing against `::1`, or the
+    /// loopback refusal never matches and a forged link to the viewer's IPv6
+    /// loopback slips through. (An earlier version of this test and the code
+    /// comment both had the fact inverted — asserting hostname is bracket-LESS —
+    /// so the test passed while the IPv6 loopback was in fact unblocked. #4645.)
     #[test]
-    fn shell_open_url_handler_blocks_ipv6_loopback_without_brackets() {
+    fn shell_open_url_handler_blocks_ipv6_loopback() {
         let js = SHELL_BRIDGE_JS;
         let open_url_idx = js
             .find("msg.type === 'open_url'")
@@ -4522,19 +4522,18 @@ mod tests {
             .unwrap_or(rest.len());
         let block = &rest[..next_branch];
 
-        // The block list must compare against `::1` (no brackets), the
-        // form `URL.hostname` actually returns. The bracketed form is a
-        // dead arm.
+        // The handler must strip surrounding brackets from the hostname before
+        // the loopback comparison, so the serialized `[::1]` matches `::1`.
         assert!(
-            block.contains("'::1'"),
-            "open_url handler must block the IPv6 loopback hostname `::1` \
-             (no brackets — URL.hostname strips them); got block: {block}"
+            block.contains(r"replace(/^\[/"),
+            "open_url handler must strip the leading bracket from an IPv6 \
+             hostname before comparing, else `[::1]` never matches `::1` and \
+             IPv6 loopback is unblocked (#4645); got block: {block}"
         );
         assert!(
-            !block.contains("'[::1]'"),
-            "open_url handler must NOT compare against `[::1]` with \
-             brackets — that arm is dead because URL.hostname strips \
-             brackets from IPv6 literals; got block: {block}"
+            block.contains("'::1'"),
+            "open_url handler must compare the bracket-stripped hostname \
+             against `::1`; got block: {block}"
         );
     }
 

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -7,8 +7,11 @@
 //!         allow="clipboard-read; clipboard-write">`
 //! with an opaque origin that cannot access other contracts' data.
 //! Popups inherit the sandbox (no `allow-popups-to-escape-sandbox`); external links
-//! are opened via the `open_url` shell bridge message to avoid CORS issues. Sandbox content
-//! is protected from top-level access via Sec-Fetch-Dest checks in client_api.rs.
+//! are opened via the `open_url` shell bridge message to avoid CORS issues. The
+//! injected interceptor also overrides programmatic `window.open` in the iframe,
+//! routing http(s) opens through the same `open_url` bridge so a new tab gets the
+//! shell's real origin instead of a sandbox-inheriting opaque one (freenet-core#4645).
+//! Sandbox content is protected from top-level access via Sec-Fetch-Dest checks in client_api.rs.
 
 use std::{
     path::{Path, PathBuf},
@@ -1041,8 +1044,9 @@ async fn sandbox_content_body(
 
     // Inject the WebSocket shim and navigation interceptor before any other scripts.
     // The shim overrides window.WebSocket so that wasm-bindgen routes connections
-    // through the shell page's bridge. The interceptor catches <a> clicks and
-    // routes them through postMessage for multi-page navigation.
+    // through the shell page's bridge. The interceptor catches <a> clicks AND
+    // overrides programmatic window.open, routing both through postMessage for
+    // multi-page navigation without a sandbox-inheriting popup (#4645).
     let injected_scripts =
         format!("<script>{WEBSOCKET_SHIM_JS}</script><script>{NAVIGATION_INTERCEPTOR_JS}</script>");
     if let Some(pos) = body.find("</head>") {
@@ -1144,6 +1148,15 @@ const WEBSOCKET_SHIM_JS: &str = include_str!("path_handlers/assets/websocket_shi
 /// Same-origin links with an explicit non-`_self` target are left to the
 /// browser so webapps that legitimately want multi-tab navigation within
 /// their own contract still work.
+///
+/// The interceptor also overrides programmatic `window.open`: an app that opens
+/// a new tab from its own JS bypasses the click/auxclick listeners, and on a
+/// hosted node the resulting opaque-origin popup can't read the per-user access
+/// key and dead-ends (freenet-core#4645). http(s) new-window opens are forwarded
+/// through the same `open_url` bridge (real origin); `_self`/`_parent`/`_top`,
+/// non-http(s) schemes, and loopback targets (which `open_url` refuses) fall back
+/// to the native open. The returned WindowProxy is dropped (null), matching the
+/// shell's `noopener` open.
 const NAVIGATION_INTERCEPTOR_JS: &str =
     include_str!("path_handlers/assets/navigation_interceptor.js");
 
@@ -4293,15 +4306,20 @@ mod tests {
     /// `window.open` and route http(s) targets through the shell's `open_url`
     /// bridge (real origin), returning null.
     ///
-    /// Pin the contract so a future edit can't silently drop the override:
+    /// Pin the contract so a future edit can't silently drop the override or
+    /// regress the edge cases the review surfaced. Behavioral coverage lives in
+    /// `crates/core/tests/playwright/tests/window-open.spec.ts` (runs in CI via
+    /// playwright-shell.yml); these source pins are the cheap CI-required guard.
     ///   1. `window.open` is reassigned (the override exists).
     ///   2. The override forwards through the SAME `open_url` bridge as the
-    ///      cross-origin anchor path.
-    ///   3. Relative targets are resolved against `document.baseURI` so the
-    ///      shell receives an absolute URL (a bare relative string would make
-    ///      `new URL()` throw and the forward would be lost).
-    ///   4. Only http/https is forwarded; other schemes fall back to native so
-    ///      unrelated behavior (about:blank, blob:, javascript:) is unchanged.
+    ///      cross-origin anchor path, posting the RESOLVED ABSOLUTE url
+    ///      (`resolved.href`) — not the raw arg, which would drop relative opens.
+    ///   3. Targets are resolved against `document.baseURI` so the shell gets an
+    ///      absolute URL.
+    ///   4. Only http/https is forwarded; other schemes fall back to native.
+    ///   5. `_self`/`_parent`/`_top` (in-place navigation) fall back to native.
+    ///   6. Loopback targets fall back to native (open_url refuses them).
+    ///   7. The arg is coerced to a string so URL objects are forwarded.
     #[test]
     fn navigation_interceptor_overrides_window_open() {
         let js = NAVIGATION_INTERCEPTOR_JS;
@@ -4310,8 +4328,8 @@ mod tests {
             "interceptor must override window.open so programmatic opens don't \
              create a sandbox-inherited null-origin popup (#4645)"
         );
-        // The override must forward through the shell's open_url bridge, in the
-        // __freenet_shell__ namespace, exactly like the cross-origin anchor path.
+        // The override is the final construct in the IIFE, so slicing to EOF
+        // scopes assertions to it (nothing but the `})();` close follows).
         let open_fn_idx = js
             .find("window.open = function")
             .expect("window.open override present");
@@ -4324,11 +4342,19 @@ mod tests {
             override_block.contains("__freenet_shell__: true"),
             "window.open override must use the __freenet_shell__ namespace (#4645)"
         );
-        // Relative targets resolved against the iframe base, else new URL() throws.
+        // Must post the RESOLVED absolute URL, not the raw (possibly relative)
+        // arg — posting `url` raw would make open_url's `new URL(msg.url)` throw
+        // on a relative target and silently drop the open.
         assert!(
-            override_block.contains("new URL(url, document.baseURI)"),
-            "window.open override must resolve relative targets against \
-             document.baseURI so the shell gets an absolute URL (#4645)"
+            override_block.contains("url: resolved.href"),
+            "window.open override must post the resolved absolute URL \
+             (resolved.href), not the raw arg (#4645)"
+        );
+        // Resolve against the iframe base so relative targets become absolute.
+        assert!(
+            override_block.contains("document.baseURI"),
+            "window.open override must resolve targets against document.baseURI \
+             so the shell gets an absolute URL (#4645)"
         );
         // http(s)-only forward; everything else falls back to native open.
         assert!(
@@ -4337,10 +4363,41 @@ mod tests {
             "window.open override must only forward http(s); other schemes \
              fall back to native (#4645)"
         );
+        // In-place navigation targets are not new-window requests -> native.
+        assert!(
+            override_block.contains("name === '_self'"),
+            "window.open override must leave _self/_parent/_top to native so \
+             in-place navigation isn't turned into a new tab (#4645)"
+        );
+        // Loopback targets must fall back to native: open_url refuses them, so
+        // forwarding would silently drop the open on local nodes.
+        assert!(
+            override_block.contains("isLoopbackHost(resolved.hostname)"),
+            "window.open override must fall back to native for loopback hosts \
+             (open_url refuses them) so local-node opens aren't silently dropped (#4645)"
+        );
+        // Coerce the arg so window.open(new URL(...)) is forwarded, not sent to
+        // native (which would recreate the dead end).
+        assert!(
+            override_block.contains("String(url)"),
+            "window.open override must string-coerce the arg so URL objects are \
+             forwarded rather than dead-ended (#4645)"
+        );
+        // Non-forwarded cases delegate to the captured native window.open.
         assert!(
             override_block.contains("fallbackOpen"),
             "window.open override must fall back to native open for the \
              non-forwarded cases (#4645)"
+        );
+        // The forwarded case drops the WindowProxy (matches the shell's
+        // noopener open) and asks for a plain tab (shiftKey false).
+        assert!(
+            override_block.contains("shiftKey: false"),
+            "window.open override must request a plain tab (shiftKey false) (#4645)"
+        );
+        assert!(
+            override_block.contains("return null;"),
+            "window.open override must return null for the forwarded case (#4645)"
         );
     }
 

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -4385,6 +4385,13 @@ mod tests {
             "window.open override must string-coerce the arg so URL objects are \
              forwarded rather than dead-ended (#4645)"
         );
+        // Only the shell's DIRECT child forwards: a deeper descendant's parent
+        // is an app frame the shell never hears, so it must stay native.
+        assert!(
+            override_block.contains("window.parent !== window.top"),
+            "window.open override must only intercept the shell's direct child \
+             (window.parent === window.top), else nested-frame opens are lost (#4645)"
+        );
         // Non-forwarded cases delegate to the captured native window.open.
         assert!(
             override_block.contains("fallbackOpen"),

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -3472,6 +3472,21 @@ mod tests {
             SHELL_BRIDGE_JS.contains("Copy address"),
             "fail-closed page must offer a one-click copy of the address"
         );
+        // The recovery copy must be explicit that THIS tab is the one stuck and
+        // that reloading / retyping the URL here will keep failing — the exact
+        // confusion a user reported (the address bar shows the clean URL, so a
+        // reload looks like it should work but stays sandboxed). Steer them to a
+        // genuinely new top-level tab.
+        assert!(
+            SHELL_BRIDGE_JS.contains("brand-new"),
+            "recovery copy must tell the user to open a brand-new tab (a reload \
+             of this sandbox-inherited tab keeps failing) (#4645)"
+        );
+        assert!(
+            SHELL_BRIDGE_JS.contains("Reloading or editing the address in this tab will"),
+            "recovery copy must warn that reloading/editing the address in this \
+             same tab will not work (#4645)"
+        );
         // The three distinct causes (opaque-origin restricted tab, plain http,
         // storage disabled) get distinct headings so the guidance actually
         // matches the situation rather than blaming https/storage for all.
@@ -4263,6 +4278,69 @@ mod tests {
             js.contains("addEventListener('auxclick'"),
             "interceptor must register an auxclick listener so middle-click \
              on cross-origin links is also routed through open_url (#3853)"
+        );
+    }
+
+    /// Regression test for freenet/freenet-core#4645.
+    ///
+    /// Anchor clicks are intercepted, but an app that calls `window.open()`
+    /// from its own JS bypasses the click/auxclick listeners. In a sandboxed
+    /// iframe (opaque origin, no `allow-popups-to-escape-sandbox`) that popup
+    /// inherits the sandbox, gets a null origin, cannot read the per-user
+    /// access key, and dead-ends on the "Open this app in a normal tab"
+    /// per-user-isolation page — the exact symptom users hit when a hosted
+    /// app opens a new tab. The interceptor must therefore override
+    /// `window.open` and route http(s) targets through the shell's `open_url`
+    /// bridge (real origin), returning null.
+    ///
+    /// Pin the contract so a future edit can't silently drop the override:
+    ///   1. `window.open` is reassigned (the override exists).
+    ///   2. The override forwards through the SAME `open_url` bridge as the
+    ///      cross-origin anchor path.
+    ///   3. Relative targets are resolved against `document.baseURI` so the
+    ///      shell receives an absolute URL (a bare relative string would make
+    ///      `new URL()` throw and the forward would be lost).
+    ///   4. Only http/https is forwarded; other schemes fall back to native so
+    ///      unrelated behavior (about:blank, blob:, javascript:) is unchanged.
+    #[test]
+    fn navigation_interceptor_overrides_window_open() {
+        let js = NAVIGATION_INTERCEPTOR_JS;
+        assert!(
+            js.contains("window.open = function"),
+            "interceptor must override window.open so programmatic opens don't \
+             create a sandbox-inherited null-origin popup (#4645)"
+        );
+        // The override must forward through the shell's open_url bridge, in the
+        // __freenet_shell__ namespace, exactly like the cross-origin anchor path.
+        let open_fn_idx = js
+            .find("window.open = function")
+            .expect("window.open override present");
+        let override_block = &js[open_fn_idx..];
+        assert!(
+            override_block.contains("type: 'open_url'"),
+            "window.open override must forward through the open_url bridge (#4645)"
+        );
+        assert!(
+            override_block.contains("__freenet_shell__: true"),
+            "window.open override must use the __freenet_shell__ namespace (#4645)"
+        );
+        // Relative targets resolved against the iframe base, else new URL() throws.
+        assert!(
+            override_block.contains("new URL(url, document.baseURI)"),
+            "window.open override must resolve relative targets against \
+             document.baseURI so the shell gets an absolute URL (#4645)"
+        );
+        // http(s)-only forward; everything else falls back to native open.
+        assert!(
+            override_block.contains("resolved.protocol !== 'http:'")
+                && override_block.contains("resolved.protocol !== 'https:'"),
+            "window.open override must only forward http(s); other schemes \
+             fall back to native (#4645)"
+        );
+        assert!(
+            override_block.contains("fallbackOpen"),
+            "window.open override must fall back to native open for the \
+             non-forwarded cases (#4645)"
         );
     }
 

--- a/crates/core/src/server/path_handlers/assets/navigation_interceptor.js
+++ b/crates/core/src/server/path_handlers/assets/navigation_interceptor.js
@@ -193,9 +193,18 @@
     //   - Why string surgery, not URLSearchParams.delete(): delete() reserializes
     //     the whole query, form-encoding co-inherited params (`%20`->`+`,
     //     `~`->`%7E`); a raw-pair filter preserves the kept params' bytes.
-    var gatewayOrigin;
+    // Prefer the frame's real location for the gateway-origin check: location.href
+    // is the served URL and is NOT affected by a contract-declared <base href>,
+    // so a contract can't relabel an external destination as gateway-local to
+    // make us mutate its query. Fall back to document.baseURI only when location
+    // has no http(s) origin (e.g. an about:srcdoc test/dev context).
+    var gatewayOrigin = null;
     try {
-      gatewayOrigin = new URL(document.baseURI).origin;
+      var loc = new URL(location.href);
+      gatewayOrigin =
+        loc.protocol === 'http:' || loc.protocol === 'https:'
+          ? loc.origin
+          : new URL(document.baseURI).origin;
     } catch (err) {
       gatewayOrigin = null;
     }

--- a/crates/core/src/server/path_handlers/assets/navigation_interceptor.js
+++ b/crates/core/src/server/path_handlers/assets/navigation_interceptor.js
@@ -110,17 +110,27 @@
     return nativeWindowOpen ? nativeWindowOpen(url, name, features) : null;
   }
   // Kept in sync with the loopback block in shell_bridge.js's open_url handler:
-  // forward only what that handler will actually open.
+  // forward only what that handler will actually open. WHATWG `URL.hostname`
+  // serializes an IPv6 literal WITH brackets (`[::1]`), so strip them before
+  // comparing or `http://[::1]/` would slip past the loopback fallback.
   function isLoopbackHost(hostname) {
-    var h = hostname.toLowerCase();
+    var h = hostname.toLowerCase().replace(/^\[/, '').replace(/\]$/, '');
     return (
       h === 'localhost' || h === '127.0.0.1' || h === '::1' || h === '0.0.0.0'
     );
   }
   window.open = function (url, name, features) {
-    // Only intercept a genuinely nested context that has a shell to forward to.
-    // A top-level document (no distinct parent) keeps native behavior.
-    if (!window.parent || window.parent === window) {
+    // Only intercept when this frame is the shell's DIRECT child. A top-level
+    // document (parent === window) keeps native behavior; so does a DEEPER
+    // descendant (a contract that embeds another served page), whose parent is
+    // an app frame rather than the shell — forwarding open_url there would post
+    // to the app frame, which the shell never sees, silently losing the open.
+    // For the direct app frame, parent and top are both the shell.
+    if (
+      !window.parent ||
+      window.parent === window ||
+      window.parent !== window.top
+    ) {
       return fallbackOpen(url, name, features);
     }
     // In-place navigation targets are not new-window requests; leave to native.
@@ -160,12 +170,26 @@
     // `?__sandbox=1` and, opened top-level, serve raw sandbox content with no
     // shell wrapper. Stripping on the base leaves an ABSOLUTE external target
     // untouched (it ignores the base), so we never reserialize an external
-    // query string — mutating the resolved URL's query would turn `%20` into
-    // `+` and `~` into `%7E` and could break signed/opaque links.
+    // query string.
+    //
+    // Remove only the raw `__sandbox` pair by string surgery, NOT via
+    // URLSearchParams.delete(): delete() reserializes the WHOLE query, which
+    // form-encodes co-inherited params (`%20`->`+`, `~`->`%7E`) and could break
+    // a signed/opaque param the base carries alongside `__sandbox` (e.g. an
+    // invitation deep-link). Reassigning `.search` with the kept pairs preserves
+    // their bytes.
     var baseHref;
     try {
       var base = new URL(document.baseURI);
-      base.searchParams.delete('__sandbox');
+      if (base.search) {
+        var kept = base.search
+          .slice(1)
+          .split('&')
+          .filter(function (pair) {
+            return pair !== '__sandbox' && pair.slice(0, 10) !== '__sandbox=';
+          });
+        base.search = kept.join('&');
+      }
       baseHref = base.href;
     } catch (err) {
       baseHref = document.baseURI;

--- a/crates/core/src/server/path_handlers/assets/navigation_interceptor.js
+++ b/crates/core/src/server/path_handlers/assets/navigation_interceptor.js
@@ -124,7 +124,16 @@
       return fallbackOpen(url, name, features);
     }
     // In-place navigation targets are not new-window requests; leave to native.
-    if (name === '_self' || name === '_parent' || name === '_top') {
+    // The reserved keywords are ASCII case-insensitive natively, so normalize
+    // (coerce + lowercase) before comparing; window.open(url, '_SELF') must
+    // still navigate in place, not open a tab. `_blank`/custom names are new
+    // windows and stay intercepted.
+    var targetName = name == null ? '' : String(name).toLowerCase();
+    if (
+      targetName === '_self' ||
+      targetName === '_parent' ||
+      targetName === '_top'
+    ) {
       return fallbackOpen(url, name, features);
     }
     // A missing/empty target is native about:blank; keep it native so
@@ -144,12 +153,26 @@
     if (urlStr === '') {
       return fallbackOpen(url, name, features);
     }
+    // Resolve relative targets (e.g. window.open('page2')) against the iframe's
+    // base so the shell receives an absolute URL. Strip the internal `__sandbox`
+    // routing param from the BASE first, not the resolved URL: a hash-only or
+    // query-relative target (e.g. window.open('#x')) would otherwise inherit
+    // `?__sandbox=1` and, opened top-level, serve raw sandbox content with no
+    // shell wrapper. Stripping on the base leaves an ABSOLUTE external target
+    // untouched (it ignores the base), so we never reserialize an external
+    // query string — mutating the resolved URL's query would turn `%20` into
+    // `+` and `~` into `%7E` and could break signed/opaque links.
+    var baseHref;
+    try {
+      var base = new URL(document.baseURI);
+      base.searchParams.delete('__sandbox');
+      baseHref = base.href;
+    } catch (err) {
+      baseHref = document.baseURI;
+    }
     var resolved;
     try {
-      // Resolve relative targets (e.g. window.open('page2')) against the
-      // iframe's base so the shell receives an absolute URL; new URL() with a
-      // relative string and no base would throw.
-      resolved = new URL(urlStr, document.baseURI);
+      resolved = new URL(urlStr, baseHref);
     } catch (err) {
       return fallbackOpen(url, name, features);
     }
@@ -159,11 +182,6 @@
     if (isLoopbackHost(resolved.hostname)) {
       return fallbackOpen(url, name, features);
     }
-    // Strip the internal `__sandbox` routing param: a hash-only or query-
-    // relative target (e.g. window.open('#x')) inherits `?__sandbox=1` from the
-    // iframe's base, and opening THAT top-level would serve raw sandbox content
-    // with no shell wrapper. Removing it makes the shell serve the wrapper page.
-    resolved.searchParams.delete('__sandbox');
     window.parent.postMessage(
       {
         __freenet_shell__: true,

--- a/crates/core/src/server/path_handlers/assets/navigation_interceptor.js
+++ b/crates/core/src/server/path_handlers/assets/navigation_interceptor.js
@@ -81,18 +81,41 @@
   // real origin, so having IT open the URL (via the same `open_url` bridge the
   // cross-origin anchor path uses) yields a normal tab that works.
   //
-  // The returned WindowProxy is intentionally dropped (return null). A popup
-  // opened from here would be a DIFFERENT opaque origin than this document, so
-  // the opener could never script it across that boundary anyway; nothing is
-  // lost by not handing back a reference, and null matches the shell's
-  // `noopener` open. Non-http(s) targets (empty/about:blank, javascript:,
-  // blob:, data:) fall back to the native open so unrelated behavior is
-  // unchanged; `open_url`'s scheme allow-list is the security gate for the
-  // forwarded case, exactly as for anchor clicks.
+  // Behavior notes (this changes window.open semantics for contract apps, so be
+  // precise about what is and isn't forwarded):
+  //   - Only NEW-window requests are forwarded. `_self`/`_parent`/`_top` name
+  //     an EXISTING context (in-place navigation, no sandbox-inheriting popup),
+  //     so they stay native.
+  //   - The `name` (window name) and `features` (size/position) arguments are
+  //     dropped for a forwarded open: the shell always opens a fresh tab. Named
+  //     -window reuse and popup sizing don't survive; on a hosted node such a
+  //     popup was a dead sandboxed context anyway, so this is not a regression
+  //     there.
+  //   - The returned WindowProxy is dropped (return null). A popup opened from
+  //     here is a DIFFERENT opaque origin the opener could never script across
+  //     anyway, and null matches the shell's `noopener` open. Chained callers
+  //     (`window.open(url).focus()`) will throw on null — an accepted break, as
+  //     that popup was a dead end on a hosted node.
+  //   - Non-http(s) targets (empty/about:blank, javascript:, blob:, data:) and
+  //     URL objects/other args are handled below; `open_url`'s scheme allow-list
+  //     is the security gate for whatever IS forwarded, exactly as for anchors.
+  //   - Loopback targets (localhost/127.0.0.1/...) are NOT forwarded: the shell
+  //     `open_url` handler refuses them, so forwarding would silently drop the
+  //     open. We fall back to native there, preserving prior local-node behavior
+  //     (local nodes have no per-user dead-end to fix). Hosted nodes use a real
+  //     domain, so this never affects the case #4645 is about.
   var nativeWindowOpen =
     typeof window.open === 'function' ? window.open.bind(window) : null;
   function fallbackOpen(url, name, features) {
     return nativeWindowOpen ? nativeWindowOpen(url, name, features) : null;
+  }
+  // Kept in sync with the loopback block in shell_bridge.js's open_url handler:
+  // forward only what that handler will actually open.
+  function isLoopbackHost(hostname) {
+    var h = hostname.toLowerCase();
+    return (
+      h === 'localhost' || h === '127.0.0.1' || h === '::1' || h === '0.0.0.0'
+    );
   }
   window.open = function (url, name, features) {
     // Only intercept a genuinely nested context that has a shell to forward to.
@@ -100,7 +123,25 @@
     if (!window.parent || window.parent === window) {
       return fallbackOpen(url, name, features);
     }
-    if (typeof url !== 'string' || url === '') {
+    // In-place navigation targets are not new-window requests; leave to native.
+    if (name === '_self' || name === '_parent' || name === '_top') {
+      return fallbackOpen(url, name, features);
+    }
+    // A missing/empty target is native about:blank; keep it native so
+    // `var w = window.open(); w.document.write(...)` flows are unchanged.
+    if (url === undefined || url === null) {
+      return fallbackOpen(url, name, features);
+    }
+    // Coerce URL objects / other stringifiables the way the native API does,
+    // so window.open(new URL(...)) is forwarded rather than sent to native
+    // (which would recreate the sandbox-inherited dead end this patch prevents).
+    var urlStr;
+    try {
+      urlStr = String(url);
+    } catch (err) {
+      return fallbackOpen(url, name, features);
+    }
+    if (urlStr === '') {
       return fallbackOpen(url, name, features);
     }
     var resolved;
@@ -108,13 +149,21 @@
       // Resolve relative targets (e.g. window.open('page2')) against the
       // iframe's base so the shell receives an absolute URL; new URL() with a
       // relative string and no base would throw.
-      resolved = new URL(url, document.baseURI);
+      resolved = new URL(urlStr, document.baseURI);
     } catch (err) {
       return fallbackOpen(url, name, features);
     }
     if (resolved.protocol !== 'http:' && resolved.protocol !== 'https:') {
       return fallbackOpen(url, name, features);
     }
+    if (isLoopbackHost(resolved.hostname)) {
+      return fallbackOpen(url, name, features);
+    }
+    // Strip the internal `__sandbox` routing param: a hash-only or query-
+    // relative target (e.g. window.open('#x')) inherits `?__sandbox=1` from the
+    // iframe's base, and opening THAT top-level would serve raw sandbox content
+    // with no shell wrapper. Removing it makes the shell serve the wrapper page.
+    resolved.searchParams.delete('__sandbox');
     window.parent.postMessage(
       {
         __freenet_shell__: true,

--- a/crates/core/src/server/path_handlers/assets/navigation_interceptor.js
+++ b/crates/core/src/server/path_handlers/assets/navigation_interceptor.js
@@ -146,9 +146,11 @@
     ) {
       return fallbackOpen(url, name, features);
     }
-    // A missing/empty target is native about:blank; keep it native so
-    // `var w = window.open(); w.document.write(...)` flows are unchanged.
-    if (url === undefined || url === null) {
+    // An OMITTED target (window.open()) is native about:blank; keep it native so
+    // `var w = window.open(); w.document.write(...)` flows are unchanged. Explicit
+    // null is NOT omitted: native Web IDL coerces it to the string "null" (a
+    // relative URL), so let it fall through to the string coercion below.
+    if (url === undefined) {
       return fallbackOpen(url, name, features);
     }
     // Coerce URL objects / other stringifiables the way the native API does,
@@ -164,39 +166,10 @@
       return fallbackOpen(url, name, features);
     }
     // Resolve relative targets (e.g. window.open('page2')) against the iframe's
-    // base so the shell receives an absolute URL. Strip the internal `__sandbox`
-    // routing param from the BASE first, not the resolved URL: a hash-only or
-    // query-relative target (e.g. window.open('#x')) would otherwise inherit
-    // `?__sandbox=1` and, opened top-level, serve raw sandbox content with no
-    // shell wrapper. Stripping on the base leaves an ABSOLUTE external target
-    // untouched (it ignores the base), so we never reserialize an external
-    // query string.
-    //
-    // Remove only the raw `__sandbox` pair by string surgery, NOT via
-    // URLSearchParams.delete(): delete() reserializes the WHOLE query, which
-    // form-encodes co-inherited params (`%20`->`+`, `~`->`%7E`) and could break
-    // a signed/opaque param the base carries alongside `__sandbox` (e.g. an
-    // invitation deep-link). Reassigning `.search` with the kept pairs preserves
-    // their bytes.
-    var baseHref;
-    try {
-      var base = new URL(document.baseURI);
-      if (base.search) {
-        var kept = base.search
-          .slice(1)
-          .split('&')
-          .filter(function (pair) {
-            return pair !== '__sandbox' && pair.slice(0, 10) !== '__sandbox=';
-          });
-        base.search = kept.join('&');
-      }
-      baseHref = base.href;
-    } catch (err) {
-      baseHref = document.baseURI;
-    }
+    // base so the shell receives an absolute URL.
     var resolved;
     try {
-      resolved = new URL(urlStr, baseHref);
+      resolved = new URL(urlStr, document.baseURI);
     } catch (err) {
       return fallbackOpen(url, name, features);
     }
@@ -205,6 +178,35 @@
     }
     if (isLoopbackHost(resolved.hostname)) {
       return fallbackOpen(url, name, features);
+    }
+    // Strip the internal `__sandbox` routing param, but ONLY from a SAME-ORIGIN
+    // (this node's own) target, and ONLY the raw pair via string surgery.
+    //   - Why strip: `__sandbox=1` reaches the resolved URL both when a hash-only
+    //     / query-relative target (window.open('#x')) inherits it from the base
+    //     AND when an app duplicates its page (window.open(location.href), an
+    //     absolute same-origin URL). Opened top-level, the shell redirects
+    //     `?__sandbox=1` to the shell root, DROPPING the subpath and app params
+    //     (e.g. an invitation). Removing it opens the page the app intended.
+    //   - Why same-origin only: an ABSOLUTE EXTERNAL target is forwarded
+    //     byte-for-byte — its `__sandbox` (if any) is the destination's, not
+    //     ours, and reserializing its query could break signed/opaque links.
+    //   - Why string surgery, not URLSearchParams.delete(): delete() reserializes
+    //     the whole query, form-encoding co-inherited params (`%20`->`+`,
+    //     `~`->`%7E`); a raw-pair filter preserves the kept params' bytes.
+    var gatewayOrigin;
+    try {
+      gatewayOrigin = new URL(document.baseURI).origin;
+    } catch (err) {
+      gatewayOrigin = null;
+    }
+    if (gatewayOrigin && resolved.origin === gatewayOrigin && resolved.search) {
+      var kept = resolved.search
+        .slice(1)
+        .split('&')
+        .filter(function (pair) {
+          return pair !== '__sandbox' && pair.slice(0, 10) !== '__sandbox=';
+        });
+      resolved.search = kept.join('&');
     }
     window.parent.postMessage(
       {

--- a/crates/core/src/server/path_handlers/assets/navigation_interceptor.js
+++ b/crates/core/src/server/path_handlers/assets/navigation_interceptor.js
@@ -69,4 +69,63 @@
   document.addEventListener('click', handleAnchorClick, true);
   // Catch middle-click and other non-primary button activations.
   document.addEventListener('auxclick', handleAnchorClick, true);
+
+  // Route programmatic `window.open()` through the shell too, mirroring the
+  // anchor interceptor above. A sandboxed iframe has an opaque origin and no
+  // `allow-popups-to-escape-sandbox`, so a popup it opens DIRECTLY inherits the
+  // sandbox: null origin, no localStorage. On a hosted node that dead-ends on
+  // the "Open this app in a normal tab" per-user-isolation page, because the
+  // opaque-origin tab can't read the per-user access key (freenet-core#4645).
+  // The click/auxclick listeners already cover <a> activations, but an app that
+  // calls window.open() from its own JS bypasses them. The shell runs in the
+  // real origin, so having IT open the URL (via the same `open_url` bridge the
+  // cross-origin anchor path uses) yields a normal tab that works.
+  //
+  // The returned WindowProxy is intentionally dropped (return null). A popup
+  // opened from here would be a DIFFERENT opaque origin than this document, so
+  // the opener could never script it across that boundary anyway; nothing is
+  // lost by not handing back a reference, and null matches the shell's
+  // `noopener` open. Non-http(s) targets (empty/about:blank, javascript:,
+  // blob:, data:) fall back to the native open so unrelated behavior is
+  // unchanged; `open_url`'s scheme allow-list is the security gate for the
+  // forwarded case, exactly as for anchor clicks.
+  var nativeWindowOpen =
+    typeof window.open === 'function' ? window.open.bind(window) : null;
+  function fallbackOpen(url, name, features) {
+    return nativeWindowOpen ? nativeWindowOpen(url, name, features) : null;
+  }
+  window.open = function (url, name, features) {
+    // Only intercept a genuinely nested context that has a shell to forward to.
+    // A top-level document (no distinct parent) keeps native behavior.
+    if (!window.parent || window.parent === window) {
+      return fallbackOpen(url, name, features);
+    }
+    if (typeof url !== 'string' || url === '') {
+      return fallbackOpen(url, name, features);
+    }
+    var resolved;
+    try {
+      // Resolve relative targets (e.g. window.open('page2')) against the
+      // iframe's base so the shell receives an absolute URL; new URL() with a
+      // relative string and no base would throw.
+      resolved = new URL(url, document.baseURI);
+    } catch (err) {
+      return fallbackOpen(url, name, features);
+    }
+    if (resolved.protocol !== 'http:' && resolved.protocol !== 'https:') {
+      return fallbackOpen(url, name, features);
+    }
+    window.parent.postMessage(
+      {
+        __freenet_shell__: true,
+        type: 'open_url',
+        url: resolved.href,
+        // window.open is an explicit new-window request; the shell opens a
+        // fresh tab (shiftKey:false matches the plain-left-click default).
+        shiftKey: false,
+      },
+      '*',
+    );
+    return null;
+  };
 })();

--- a/crates/core/src/server/path_handlers/assets/shell_bridge.js
+++ b/crates/core/src/server/path_handlers/assets/shell_bridge.js
@@ -541,10 +541,14 @@ function freenetBridge(authToken, userToken, hostedMode) {
         try {
           var u = new URL(msg.url);
           if (u.protocol !== 'https:' && u.protocol !== 'http:') return;
-          // URL.hostname strips brackets from IPv6 literals, so a URL
-          // `http://[::1]/` parses with hostname `::1`, NOT `[::1]`.
-          // Compare against the bracket-less form.
-          var h = u.hostname.toLowerCase();
+          // WHATWG URL.hostname serializes an IPv6 literal WITH brackets, so
+          // `http://[::1]/` has hostname `[::1]`, NOT `::1`. Strip the brackets
+          // before comparing, or the `::1` arm never matches and a forged link
+          // to the viewer's IPv6 loopback slips past this refusal.
+          var h = u.hostname
+            .toLowerCase()
+            .replace(/^\[/, '')
+            .replace(/\]$/, '');
           if (
             h === 'localhost' ||
             h === '127.0.0.1' ||

--- a/crates/core/src/server/path_handlers/assets/shell_bridge.js
+++ b/crates/core/src/server/path_handlers/assets/shell_bridge.js
@@ -81,7 +81,10 @@ function freenetBridge(authToken, userToken, hostedMode) {
         '(for example via "open link in new tab", a middle-click, or a ' +
         'right-click menu). Tabs opened that way run in a restricted mode ' +
         'that can’t reach the access key this hosted node uses to keep ' +
-        'your data separate, so the app won’t load here.';
+        'your data separate, so the app won’t load here. The address in this ' +
+        'tab looks normal, so reloading or retyping it here seems like it ' +
+        'should work. It will not: this tab itself is the one stuck in ' +
+        'restricted mode. Open a brand-new tab to continue.';
     } else {
       h.textContent = 'Browser storage required';
       lead.textContent =
@@ -105,8 +108,9 @@ function freenetBridge(authToken, userToken, hostedMode) {
       var howto = document.createElement('p');
       howto.style.cssText = 'margin:0 0 0.5rem;';
       howto.textContent =
-        'To continue, open this address in a normal browser tab ' +
-        '(one you start yourself, e.g. Ctrl/Cmd+T, then paste):';
+        'Open a brand-new browser tab yourself (Ctrl/Cmd+T), then paste this ' +
+        'address into it. Reloading or editing the address in this tab will ' +
+        'not work:';
       inner.appendChild(howto);
       var row = document.createElement('div');
       row.style.cssText = 'display:flex;gap:0.5rem;flex-wrap:wrap;';

--- a/crates/core/src/server/path_handlers/assets/shell_bridge.js
+++ b/crates/core/src/server/path_handlers/assets/shell_bridge.js
@@ -510,9 +510,12 @@ function freenetBridge(authToken, userToken, hostedMode) {
           }
         } catch (e) {}
       } else if (msg.type === 'open_url' && typeof msg.url === 'string') {
-        // Open external URLs in a new tab. Popups from the sandboxed iframe
-        // inherit the opaque origin, breaking CORS on target sites. The shell
-        // opens the URL instead, giving proper origin. See issue #1499.
+        // Open a URL in a new tab. External links come here from the anchor
+        // interceptor; same-origin (in-app) URLs also arrive from the
+        // window.open override (#4645). Popups the sandboxed iframe opens
+        // itself inherit the opaque origin, breaking CORS on target sites and
+        // (hosted) losing the per-user key. The shell opens the URL instead,
+        // giving proper origin. See issue #1499.
         //
         // Security model: this scheme allow-list is the PRIMARY gate, not
         // defence in depth. A malicious contract iframe can postMessage

--- a/crates/core/tests/playwright/tests/window-open.spec.ts
+++ b/crates/core/tests/playwright/tests/window-open.spec.ts
@@ -1,0 +1,243 @@
+import { test, expect } from "@playwright/test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// Behavioral regression tests for the programmatic `window.open` override in
+// the injected navigation interceptor
+// (crates/core/src/server/path_handlers/assets/navigation_interceptor.js).
+//
+// Bug (freenet-core#4645): on a hosted node the contract app runs in a
+// sandboxed iframe with an opaque origin and no `allow-popups-to-escape-sandbox`.
+// A new tab the app opens with `window.open()` inherits that sandbox, gets a
+// null origin, can't read the per-user access key in localStorage, and dead-ends
+// on the "Open this app in a normal tab" page. The fix overrides `window.open`
+// inside the iframe so http(s) NEW-window opens are forwarded to the shell (via
+// the same `open_url` postMessage the anchor interceptor uses), which opens them
+// with the shell's real origin.
+//
+// These tests load the REAL interceptor asset inside a genuinely sandboxed
+// (opaque-origin) iframe — the override guards on `window.parent !== window`, so
+// a top-level eval (like websocket-shim.spec.ts uses) would just fall back to
+// native and prove nothing. The iframe posts back what it observed; the parent
+// collects the forwarded `open_url` messages plus the per-call return values and
+// the iframe's origin. No running node is required, so this runs inside
+// playwright-shell.yml like websocket-shim.spec.ts.
+
+const INTERCEPTOR = readFileSync(
+  join(
+    __dirname,
+    "..",
+    "..",
+    "..",
+    "src",
+    "server",
+    "path_handlers",
+    "assets",
+    "navigation_interceptor.js",
+  ),
+  "utf8",
+);
+
+type CallResult = { label: string; arg: string; ret: string };
+type Forwarded = { url: string; shiftKey: unknown };
+type Collected = {
+  forwarded: Forwarded[];
+  report: {
+    origin: string;
+    results: CallResult[];
+    nativeCalls: string[];
+    error?: string;
+  } | null;
+};
+
+// Build the sandboxed-iframe document: a spy standing in for the native
+// window.open (so fallbacks are observable without spawning real popups), then
+// the real interceptor (which binds the spy as its native fallback), then an
+// exercise script that calls the overridden window.open and reports back.
+function buildSrcdoc(baseHref: string, calls: Array<{ label: string; expr: string }>): string {
+  const exercise = calls
+    .map(
+      (c) =>
+        `tryOpen(${JSON.stringify(c.label)}, function () { return window.open(${c.expr}); });`,
+    )
+    .join("\n    ");
+  // NB: the interceptor asset contains no literal "</script>", so embedding it
+  // in an inner <script> is safe. srcdoc is passed to page.evaluate as a JS
+  // argument (not HTML-parsed by the parent), so the parent script is unaffected.
+  return `<!doctype html><html><head><base href="${baseHref}"></head><body>
+<script>
+  window.__nativeCalls = [];
+  window.open = function (u) { window.__nativeCalls.push(String(u)); return { __spy: true }; };
+</script>
+<script>${INTERCEPTOR}</script>
+<script>
+  try {
+    var results = [];
+    function tryOpen(label, fn) {
+      var r, err = null;
+      try { r = fn(); } catch (e) { err = String(e); }
+      results.push({
+        label: label,
+        arg: label,
+        ret: err ? ('THREW:' + err) : (r && r.__spy ? 'NATIVE_SPY' : (r === null ? 'null' : typeof r)),
+      });
+    }
+    ${exercise}
+    parent.postMessage({ __harness_report__: true, results: results, nativeCalls: window.__nativeCalls, origin: String(window.origin) }, '*');
+  } catch (e) {
+    parent.postMessage({ __harness_report__: true, error: String(e) }, '*');
+  }
+</script>
+</body></html>`;
+}
+
+async function runHarness(
+  page: import("@playwright/test").Page,
+  srcdoc: string,
+): Promise<Collected> {
+  await page.goto("about:blank");
+  await page.evaluate((srcdocArg: string) => {
+    (window as unknown as { __collected: Collected }).__collected = {
+      forwarded: [],
+      report: null,
+    };
+    window.addEventListener("message", (e: MessageEvent) => {
+      const m = e.data as Record<string, unknown>;
+      const c = (window as unknown as { __collected: Collected }).__collected;
+      if (m && m.__freenet_shell__ && m.type === "open_url") {
+        c.forwarded.push({ url: m.url as string, shiftKey: m.shiftKey });
+      }
+      if (m && m.__harness_report__) {
+        c.report = m as unknown as Collected["report"];
+      }
+    });
+    const f = document.createElement("iframe");
+    f.setAttribute("sandbox", "allow-scripts allow-popups");
+    f.srcdoc = srcdocArg;
+    document.body.appendChild(f);
+  }, srcdoc);
+
+  await page
+    .waitForFunction(
+      () => (window as unknown as { __collected: Collected }).__collected.report !== null,
+      { timeout: 5000 },
+    )
+    .catch(() => {});
+  return page.evaluate(
+    () => (window as unknown as { __collected: Collected }).__collected,
+  );
+}
+
+const BASE = "https://node.example/v1/contract/web/KEY/?__sandbox=1";
+
+test("forwards http(s) new-window opens to the shell as an absolute URL, returning null", async ({
+  page,
+}) => {
+  const collected = await runHarness(
+    page,
+    buildSrcdoc(BASE, [
+      { label: "relative", expr: "'page2/sub#frag'" },
+      { label: "absolute-https", expr: "'https://example.com/x?q=1'" },
+      { label: "absolute-http", expr: "'http://example.org/y'" },
+      { label: "url-object", expr: "new URL('https://obj.example/u')" },
+    ]),
+  );
+  const report = collected.report!;
+  expect(report.error).toBeUndefined();
+  // The iframe is genuinely sandboxed (opaque origin) — the exact failing
+  // condition #4645 is about.
+  expect(report.origin).toBe("null");
+
+  const fwd = collected.forwarded.map((f) => f.url);
+  // Relative resolves against the iframe base to an absolute URL.
+  expect(fwd).toContain("https://node.example/v1/contract/web/KEY/page2/sub#frag");
+  expect(fwd).toContain("https://example.com/x?q=1");
+  expect(fwd).toContain("http://example.org/y");
+  // URL objects are coerced and forwarded, not dead-ended.
+  expect(fwd).toContain("https://obj.example/u");
+  expect(collected.forwarded.length).toBe(4);
+  // All forwards ask for a plain tab.
+  expect(collected.forwarded.every((f) => f.shiftKey === false)).toBe(true);
+  // The forwarded case drops the WindowProxy (returns null); none went native.
+  for (const r of report.results) expect(r.ret).toBe("null");
+  expect(report.nativeCalls.length).toBe(0);
+});
+
+test("falls back to native for non-http(s), empty, and in-place (_self) targets", async ({
+  page,
+}) => {
+  const collected = await runHarness(
+    page,
+    buildSrcdoc(BASE, [
+      { label: "about-blank", expr: "'about:blank'" },
+      { label: "empty", expr: "''" },
+      { label: "no-arg", expr: "" },
+      { label: "javascript", expr: "'javascript:alert(1)'" },
+      { label: "blob", expr: "'blob:https://x/abc'" },
+      { label: "data", expr: "'data:text/html,x'" },
+      { label: "self-target", expr: "'https://example.com/z', '_self'" },
+    ]),
+  );
+  const report = collected.report!;
+  expect(report.error).toBeUndefined();
+  // Nothing was forwarded — every case must reach the native open.
+  expect(collected.forwarded.length).toBe(0);
+  for (const r of report.results) expect(r.ret).toBe("NATIVE_SPY");
+  // _self forwards a real URL to native (in-place navigation), not the shell.
+  expect(report.nativeCalls).toContain("https://example.com/z");
+  expect(report.nativeCalls).toContain("about:blank");
+  expect(report.nativeCalls).toContain("javascript:alert(1)");
+});
+
+test("does not forward loopback targets (open_url refuses them); stays native", async ({
+  page,
+}) => {
+  const collected = await runHarness(
+    page,
+    buildSrcdoc(BASE, [
+      { label: "loopback-ip", expr: "'http://127.0.0.1:8080/x'" },
+      { label: "loopback-name", expr: "'http://localhost:8080/x'" },
+    ]),
+  );
+  const report = collected.report!;
+  expect(report.error).toBeUndefined();
+  expect(collected.forwarded.length).toBe(0);
+  expect(report.nativeCalls).toContain("http://127.0.0.1:8080/x");
+  expect(report.nativeCalls).toContain("http://localhost:8080/x");
+});
+
+test("strips the __sandbox routing param so a hash-only open serves the shell wrapper", async ({
+  page,
+}) => {
+  // A hash-only target inherits ?__sandbox=1 from the iframe base; forwarding
+  // that unchanged would open raw sandbox content top-level (no shell wrapper).
+  const collected = await runHarness(page, buildSrcdoc(BASE, [{ label: "hash-only", expr: "'#deep/link'" }]));
+  const report = collected.report!;
+  expect(report.error).toBeUndefined();
+  expect(collected.forwarded.length).toBe(1);
+  const url = collected.forwarded[0].url;
+  expect(url).not.toContain("__sandbox");
+  expect(url).toBe("https://node.example/v1/contract/web/KEY/#deep/link");
+});
+
+test("does not override window.open at top level (parent guard)", async ({ page }) => {
+  // Loaded top-level, window.parent === window, so the override must NOT engage
+  // (otherwise it would break the shell page's own window.open). Evaluate the
+  // interceptor at top level with a postMessage spy and confirm no forward.
+  await page.goto("about:blank");
+  const forwarded = await page.evaluate((src: string) => {
+    const posts: unknown[] = [];
+    (window as unknown as { postMessage: unknown }).postMessage = (m: unknown) => posts.push(m);
+    let nativeCalled = false;
+    (window as unknown as { open: unknown }).open = () => {
+      nativeCalled = true;
+      return null;
+    };
+    // Indirect eval runs the IIFE in global scope (window.parent === window).
+    (0, eval)(src);
+    (window as unknown as { open: (u: string) => unknown }).open("https://example.com/x");
+    return { posts, nativeCalled };
+  }, INTERCEPTOR);
+  expect(forwarded.nativeCalled).toBe(true);
+  expect(forwarded.posts.length).toBe(0);
+});

--- a/crates/core/tests/playwright/tests/window-open.spec.ts
+++ b/crates/core/tests/playwright/tests/window-open.spec.ts
@@ -176,6 +176,8 @@ test("falls back to native for non-http(s), empty, and in-place (_self) targets"
       { label: "blob", expr: "'blob:https://x/abc'" },
       { label: "data", expr: "'data:text/html,x'" },
       { label: "self-target", expr: "'https://example.com/z', '_self'" },
+      // Target keywords are ASCII case-insensitive: _SELF must stay native too.
+      { label: "self-upper", expr: "'https://example.com/zz', '_SELF'" },
     ]),
   );
   const report = collected.report!;
@@ -183,10 +185,32 @@ test("falls back to native for non-http(s), empty, and in-place (_self) targets"
   // Nothing was forwarded — every case must reach the native open.
   expect(collected.forwarded.length).toBe(0);
   for (const r of report.results) expect(r.ret).toBe("NATIVE_SPY");
-  // _self forwards a real URL to native (in-place navigation), not the shell.
+  // _self / _SELF forward a real URL to native (in-place navigation).
   expect(report.nativeCalls).toContain("https://example.com/z");
+  expect(report.nativeCalls).toContain("https://example.com/zz");
   expect(report.nativeCalls).toContain("about:blank");
   expect(report.nativeCalls).toContain("javascript:alert(1)");
+});
+
+test("forwards absolute external URLs without reserializing the query string", async ({
+  page,
+}) => {
+  // The __sandbox strip must NOT touch an absolute external target: reserializing
+  // its query (%20 -> +, ~ -> %7E) could invalidate signed/opaque links.
+  const signed = "https://example.com/o?X-Amz-Signature=abc&a=%2F%2f%20~";
+  const collected = await runHarness(
+    page,
+    buildSrcdoc(BASE, [{ label: "signed-external", expr: JSON.stringify(signed) }]),
+  );
+  const report = collected.report!;
+  expect(report.error).toBeUndefined();
+  expect(collected.forwarded.length).toBe(1);
+  const url = collected.forwarded[0].url;
+  // No form-encoding corruption and no dropped/added params.
+  expect(url).not.toContain("+");
+  expect(url).toContain("%20");
+  expect(url).toContain("~");
+  expect(url).toContain("X-Amz-Signature=abc");
 });
 
 test("does not forward loopback targets (open_url refuses them); stays native", async ({

--- a/crates/core/tests/playwright/tests/window-open.spec.ts
+++ b/crates/core/tests/playwright/tests/window-open.spec.ts
@@ -221,6 +221,8 @@ test("does not forward loopback targets (open_url refuses them); stays native", 
     buildSrcdoc(BASE, [
       { label: "loopback-ip", expr: "'http://127.0.0.1:8080/x'" },
       { label: "loopback-name", expr: "'http://localhost:8080/x'" },
+      // URL.hostname serializes IPv6 with brackets ([::1]); must still match.
+      { label: "loopback-ipv6", expr: "'http://[::1]:8080/x'" },
     ]),
   );
   const report = collected.report!;
@@ -228,20 +230,84 @@ test("does not forward loopback targets (open_url refuses them); stays native", 
   expect(collected.forwarded.length).toBe(0);
   expect(report.nativeCalls).toContain("http://127.0.0.1:8080/x");
   expect(report.nativeCalls).toContain("http://localhost:8080/x");
+  expect(report.nativeCalls).toContain("http://[::1]:8080/x");
 });
 
-test("strips the __sandbox routing param so a hash-only open serves the shell wrapper", async ({
+test("strips only __sandbox from a hash-only open, preserving co-inherited app params", async ({
   page,
 }) => {
-  // A hash-only target inherits ?__sandbox=1 from the iframe base; forwarding
-  // that unchanged would open raw sandbox content top-level (no shell wrapper).
-  const collected = await runHarness(page, buildSrcdoc(BASE, [{ label: "hash-only", expr: "'#deep/link'" }]));
+  // A hash-only target inherits the base query (?__sandbox=1 plus any app params
+  // like an invitation deep-link) — forwarding ?__sandbox=1 unchanged would open
+  // raw sandbox content top-level. Strip ONLY __sandbox; the co-param's bytes
+  // (%20, ~) must survive (URLSearchParams.delete would form-encode them).
+  const baseWithParam =
+    "https://node.example/v1/contract/web/KEY/?__sandbox=1&invite=a%20b~";
+  const collected = await runHarness(
+    page,
+    buildSrcdoc(baseWithParam, [{ label: "hash-only", expr: "'#deep/link'" }]),
+  );
   const report = collected.report!;
   expect(report.error).toBeUndefined();
   expect(collected.forwarded.length).toBe(1);
   const url = collected.forwarded[0].url;
   expect(url).not.toContain("__sandbox");
-  expect(url).toBe("https://node.example/v1/contract/web/KEY/#deep/link");
+  // Co-param preserved byte-for-byte (no %20 -> + or ~ -> %7E corruption).
+  expect(url).toBe(
+    "https://node.example/v1/contract/web/KEY/?invite=a%20b~#deep/link",
+  );
+});
+
+test("does not intercept in a nested descendant frame (parent !== top)", async ({
+  page,
+}) => {
+  // A contract that embeds ANOTHER served page nests the interceptor two deep:
+  // window.parent is the app frame, not the shell (window.top). Forwarding there
+  // would post to the app frame, which the shell never sees, silently losing the
+  // open. The guard must fall back to native for such descendants. The inner
+  // frame reports its window.open return value to `top`; NATIVE_SPY proves the
+  // override fell back rather than forwarding.
+  const inner = `<!doctype html><html><head><base href="${BASE}"></head><body>
+<script>
+  window.open = function (u) { window.__native = String(u); return { __spy: true }; };
+</script>
+<script>${INTERCEPTOR}</script>
+<script>
+  var r = window.open('https://example.com/x');
+  top.postMessage({ __nested__: true, ret: (r && r.__spy) ? 'NATIVE_SPY' : (r === null ? 'null' : typeof r), parentIsTop: window.parent === window.top }, '*');
+</script>
+</body></html>`;
+  // Outer app frame simply embeds the inner frame (both sandboxed). Escape the
+  // inner document's </script> tags so they don't prematurely close the outer
+  // frame's own inline <script> when this HTML is parsed.
+  const innerEmbedded = JSON.stringify(inner).replace(/<\/script>/g, "<\\/script>");
+  const outer = `<!doctype html><html><body>
+<script>
+  var b = document.createElement('iframe');
+  b.setAttribute('sandbox', 'allow-scripts allow-popups');
+  b.srcdoc = ${innerEmbedded};
+  document.body.appendChild(b);
+</script>
+</body></html>`;
+
+  await page.goto("about:blank");
+  const result = await page.evaluate(
+    (outerArg: string) =>
+      new Promise<{ ret: string; parentIsTop: boolean }>((resolve) => {
+        window.addEventListener("message", (e: MessageEvent) => {
+          const m = e.data as Record<string, unknown>;
+          if (m && m.__nested__) resolve({ ret: m.ret as string, parentIsTop: m.parentIsTop as boolean });
+        });
+        const a = document.createElement("iframe");
+        a.setAttribute("sandbox", "allow-scripts allow-popups");
+        a.srcdoc = outerArg;
+        document.body.appendChild(a);
+      }),
+    outer,
+  );
+  // In the nested frame, parent (app frame) is NOT top (this page).
+  expect(result.parentIsTop).toBe(false);
+  // So the override fell back to native rather than forwarding a lost open_url.
+  expect(result.ret).toBe("NATIVE_SPY");
 });
 
 test("does not override window.open at top level (parent guard)", async ({ page }) => {

--- a/crates/core/tests/playwright/tests/window-open.spec.ts
+++ b/crates/core/tests/playwright/tests/window-open.spec.ts
@@ -192,6 +192,44 @@ test("falls back to native for non-http(s), empty, and in-place (_self) targets"
   expect(report.nativeCalls).toContain("javascript:alert(1)");
 });
 
+test("strips __sandbox from an absolute same-origin open (window.open(location.href)), keeping subpath + params", async ({
+  page,
+}) => {
+  // window.open(location.href) is an ABSOLUTE same-origin URL that carries
+  // ?__sandbox=1; opened top-level the shell would redirect it to the shell root
+  // and drop the subpath + app params. Strip __sandbox but keep everything else.
+  const sameOriginAbs =
+    "https://node.example/v1/contract/web/KEY/sub/page?__sandbox=1&invite=a%20b~";
+  const collected = await runHarness(
+    page,
+    buildSrcdoc(BASE, [{ label: "same-origin-abs", expr: JSON.stringify(sameOriginAbs) }]),
+  );
+  const report = collected.report!;
+  expect(report.error).toBeUndefined();
+  expect(collected.forwarded.length).toBe(1);
+  const url = collected.forwarded[0].url;
+  expect(url).not.toContain("__sandbox");
+  // Subpath preserved and the co-param kept byte-for-byte (no %20 -> +).
+  expect(url).toBe(
+    "https://node.example/v1/contract/web/KEY/sub/page?invite=a%20b~",
+  );
+});
+
+test("forwards window.open(null) as the coerced relative 'null' target (native parity)", async ({
+  page,
+}) => {
+  // Native Web IDL coerces null to the string "null" (a relative URL), unlike an
+  // omitted arg (about:blank). So it must be forwarded, not sent to native.
+  const collected = await runHarness(page, buildSrcdoc(BASE, [{ label: "null-arg", expr: "null" }]));
+  const report = collected.report!;
+  expect(report.error).toBeUndefined();
+  expect(report.nativeCalls.length).toBe(0);
+  expect(collected.forwarded.length).toBe(1);
+  expect(collected.forwarded[0].url).toBe(
+    "https://node.example/v1/contract/web/KEY/null",
+  );
+});
+
 test("forwards absolute external URLs without reserializing the query string", async ({
   page,
 }) => {


### PR DESCRIPTION
## Problem

On a hosted node (try.freenet.org) the contract app runs in a **sandboxed iframe with an opaque origin** (per-contract data isolation). The per-user access key lives in `localStorage`, which an opaque-origin context can't read.

Any new tab/window spawned **from inside that iframe** inherits the sandbox — there is deliberately no `allow-popups-to-escape-sandbox` (removed for security in #1499) — so the new tab has `window.origin === "null"`, can't read the key, and **fails closed to the "Open this app in a normal tab" page**. Its address bar shows the clean URL, so the user thinks it's a fresh tab and that reloading / re-pasting should work. It doesn't: sandbox flags are sticky to that browsing context, so only a genuinely new Ctrl/Cmd+T tab escapes. This is the unresolved core of #4645; #4652 only reworded the page.

Reproduced live (Chromium + Firefox): a fresh top-level paste of the URL loads fine (`window.origin` = `https://try.freenet.org`); a popup opened from the sandboxed iframe hits the page with `window.origin === "null"` even though the address bar shows the exact clean URL.

Link clicks (left **and** middle) are already intercepted and reopened with a real origin. Two gaps remained:
1. **Native right-click → "open in new tab"** — not interceptable from JS (only the recovery page can help).
2. **Programmatic `window.open()`** from the app's own JS — bypasses the click/auxclick listeners. **This PR fixes #2.**

## Approach

The gateway already injects `navigation_interceptor.js` into the sandboxed iframe. Extend it to **override `window.open`**:

- **http(s) targets** (relative resolved to absolute against `document.baseURI`) are forwarded through the same **`open_url` shell bridge** the cross-origin anchor path already uses, so the **shell (real origin)** opens a normal, working tab.
- **Non-http(s) targets** (`about:blank`, empty, `javascript:`, `blob:`, `data:`) fall back to the native open, so unrelated behavior is unchanged.
- `open_url`'s existing scheme allow-list is the security gate for the forwarded case, exactly as for anchor clicks.
- The returned `WindowProxy` is dropped (return `null`): a popup opened from here is a *different* opaque origin the opener could never script across that boundary anyway, and `null` matches the shell's `noopener` open.

This also generalizes cleanly: a programmatic cross-origin `window.open` now behaves like an already-intercepted cross-origin link click (same CORS fix as #208/#1499), on hosted and local nodes alike.

Secondary: **clarify the recovery page** for the residual right-click case — state plainly that *this* tab is the one stuck and that reloading/retyping the URL here keeps failing; open a brand-new tab.

## Behavior change / review notes (this touches the hosted-mode sandbox surface)

- `window.open` inside a contract iframe now returns `null` for http(s) targets and opens a real-origin tab via the shell instead of a sandbox-inherited popup. An app that relied on the returned window handle (e.g. popup-postMessage flows) will get `null` — but such a popup was already a dead opaque-origin context on a hosted node, so this is not a regression there; it's an improvement (the tab now actually works). Called out for reviewers.
- No wire/protocol change. Affects only the injected iframe JS + the shell error page.

## Testing

- **New regression test** `navigation_interceptor_overrides_window_open` pins the override (forwards via `open_url`, resolves relative against `baseURI`, http(s)-only, native fallback). Updated the `fail_closed_page_gives_actionable_recovery_4645` copy assertions.
- **Behavioral verification in a real opaque-origin sandboxed iframe** (`window.origin === "null"`) via Playwright: relative + absolute http(s) forward with an absolute resolved URL and return `null`; `about:blank`/empty/`javascript:`/`blob:` fall back to native and are not forwarded. All pass.
- Full `server::path_handlers::tests` module green (84 passed).

## Deploy note

try.freenet.org is a manual from-source build on nova, so this reaches it only when that build is rebuilt (not on merge to main).

**Draft** pending full multi-model review + @sanity sign-off, since it touches the hosted sandbox surface. Residual (native right-click "open in new tab") is inherently uninterceptable from JS and is left to the (now clearer) recovery page.

Closes #4645

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)