### PR TITLE
ci: raise nightly job timeout so the 500-node step is not silently cancelled

### DIFF
--- a/.github/workflows/simulation-nightly.yml
+++ b/.github/workflows/simulation-nightly.yml
@@ -31,7 +31,18 @@ jobs:
   large-scale-simulation:
     name: Large Scale Simulation
     runs-on: ubicloud-standard-16
-    timeout-minutes: 150
+    # This job runs the nextest suite (~109 min) then the 500-node step
+    # (≤60 min, its own cap below) sequentially, plus ~4 min build/setup.
+    # 150 became too tight once the nextest suite grew (~77→~109 min over
+    # mid-2026): the job hit 150 min mid-way through the 500-node step and
+    # CANCELLED it. A cancelled job is not a `failure`, so the alert jobs
+    # (which gate on `result == 'failure'`) never fired — the 500-node
+    # reliability gate was silently skipped for weeks. 195 fits both steps
+    # with ~20 min headroom. If the nextest suite keeps growing, prefer
+    # splitting the 500-node step into its own parallel job (with its own
+    # timeout wired into the notify jobs' `needs`/`if`) over raising this
+    # further.
+    timeout-minutes: 195
 
     env:
       RUST_LOG: info,turmoil=warn
@@ -108,9 +119,11 @@ jobs:
             --no-capture \
             --profile nightly
 
-      # Large scale test (500 nodes) - uses direct runner (no turmoil overhead)
-      # With simulation-mode timer optimizations (~5x fewer timer firings),
-      # completes in ~4 min locally for 10000 events.
+      # Large scale test (500 nodes) - uses direct runner (no turmoil overhead).
+      # Takes ~33-46 min on the CI runner (the "~4 min locally" figure this
+      # comment used to cite was badly stale). The 60-min step cap below is the
+      # binding limit on this step; if it trips, the sim genuinely slowed —
+      # investigate rather than reflexively bumping the cap.
       - name: Large scale test (500 nodes)
         timeout-minutes: 60
         env:


### PR DESCRIPTION
## Problem

The `large-scale-simulation` nightly job runs the nextest suite (**~109 min**) then the 500-node `fdev` reliability gate (**~33–46 min**) sequentially under a single `timeout-minutes: 150`. As the nextest suite grew (~77→~109 min over mid-2026), the job began hitting 150 min part-way through the 500-node step and **cancelling** it.

A cancelled job is not a `failure`, and both notify jobs gate on `needs.large-scale-simulation.result == 'failure'` — so **the alert never fired**: the 500-node reliability gate (`--min-success-rate 1.0`, which panics below 100%) has been silently skipped for weeks. Last clean 500-node completion was **2026-06-25 (PASSED)**; every "failure" since has been its own 60-min *step* cap, never the assertion.

Timing evidence (`actions/runs/<id>/jobs`):
| Run | nextest | 500-node | job outcome |
|-----|---------|----------|-------------|
| 29516974600 (07-16) | 109 min ✅ | 38 min then **cancelled** | job hit 150 min → cancelled (silent) |
| 28146766646 (06-25) | 81 min | 33 min ✅ | success (fit under 150 when nextest was shorter) |

## Approach

Raise the job `timeout-minutes` **150 → 195**. nextest (~109) + 500-node (≤60 step cap) + build/setup (~4) ≈ 173 min, so 195 fits both with ~20 min headroom while still bounding a genuine hang.

**Chosen over splitting the 500-node into its own parallel job:** nextest timing is stable at ~109 min (not variable — a 16-min "cancel" I saw was a `cancel-in-progress` supersede, not a timeout), so a raise reliably fits, and it avoids rewiring the alert `needs`/`if` — a mistake there would recreate the very silent-failure hole this fixes. If the nextest suite keeps growing, the split becomes the right follow-up (noted in the workflow comment). The ~30-min nextest growth is itself worth a look as a possible test slowdown — flagged separately, not in scope here.

The 500-node step keeps its own 60-min cap as the binding limit on that step (a trip there is a real "sim slowed" signal). Also corrected the badly-stale "~4 min locally" comment.

## Testing

CI-config change. Verified by triggering the nightly on this branch (uses this ref's 195-min timeout) and confirming the 500-node step now **runs to completion and passes at 100% success** — i.e. the raise unmasks a healthy gate, not a hidden regression. (Merge gated on that run being green.)

[AI-assisted - Claude]
