### PR TITLE
fix(server): persist notification flood-cap across page reloads (#4849)

### DIFF
--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -2683,16 +2683,31 @@ mod tests {
             html.contains("function setText(el, text)"),
             "setText helper (textContent-only) missing"
         );
-        // innerHTML must not appear anywhere in the overlay code path. The
-        // boundary marker below was previously `setInterval(checkPermissions`
-        // but that polling loop is gone; we now bound the slice at the
-        // EventSource-fallback `setInterval(reconcileFromPending`.
-        let overlay_start = html.find("__freenet_perm_overlay").unwrap();
+        // Bound the overlay code path by the explicit `perm-overlay-flow`
+        // markers in shell_bridge.js, NOT a code anchor. The previous bound
+        // (`setInterval(reconcileFromPending` / `EventSource`) stopped SHORT of
+        // the SSE `prompt_added`/`prompt_removed` handlers, which ARE part of
+        // the prompt-render flow #3836 protects — so a browser Notification
+        // reintroduced into an SSE handler would have slipped past this guard.
+        // The markers bracket the whole overlay + SSE region so the asserts
+        // below scan all of it (#4849 F2).
+        let overlay_start = html
+            .find("perm-overlay-flow:BEGIN")
+            .expect("perm-overlay-flow:BEGIN marker must bracket the overlay flow");
         let overlay_end = html[overlay_start..]
-            .find("setInterval(reconcileFromPending")
-            .or_else(|| html[overlay_start..].find("EventSource"))
-            .expect("overlay slice must end at the SSE setup or fallback poll");
+            .find("perm-overlay-flow:END")
+            .expect("perm-overlay-flow:END marker must bracket the overlay flow");
         let overlay_slice = &html[overlay_start..overlay_start + overlay_end];
+        // The negative asserts below are only meaningful if the slice actually
+        // CONTAINS the SSE prompt-render surface. Pin that the marker-bounded
+        // region includes the `prompt_added`/`prompt_removed` handlers, so a
+        // refactor that moves them past `perm-overlay-flow:END` (shrinking the
+        // slice) fails HERE rather than silently making the negative asserts
+        // pass vacuously — the exact regression F2 exists to prevent (#4849).
+        assert!(
+            overlay_slice.contains("'prompt_added'") && overlay_slice.contains("'prompt_removed'"),
+            "overlay guard slice must cover the SSE prompt handlers (#4849 F2)"
+        );
         assert!(
             !overlay_slice.contains("innerHTML"),
             "overlay code path must not use innerHTML (XSS surface)"
@@ -3376,6 +3391,52 @@ mod tests {
         assert!(
             SHELL_BRIDGE_JS.contains("Notification.requestPermission(done)"),
             "permission prompt must be requested from the shell affordance click"
+        );
+    }
+
+    /// Regression for #4849: the notification-proxy flood-cap (the rolling
+    /// global window in `makeNotifyRateLimiter`) must be PERSISTED per-contract
+    /// so a full page reload can't reset it. Without this, a consented contract
+    /// could fire the whole budget, force a reload (a same-contract v1<->v2
+    /// `navigate`, which the shell reloads as cross-contract), and start over
+    /// with an empty limiter. The behavioral proof is in
+    /// shell_bridge_notifications.test.mjs (the reload rehydration case); this
+    /// pins the WIRING at the source level so a refactor can't silently drop
+    /// the persistence and re-open the reload-reset hole.
+    #[test]
+    fn bridge_js_notification_flood_cap_persisted_across_reload() {
+        // The limiter is constructed WITH the persistence store, not the old
+        // no-arg makeNotifyRateLimiter().
+        assert!(
+            SHELL_BRIDGE_JS.contains("makeNotifyRateLimiter(makeNotifyRateStore())"),
+            "rate limiter must be constructed with the persistence store (#4849)"
+        );
+        // The store is keyed off the version-less contract consent key (so the
+        // window survives a v1<->v2 reload) with a `:rate` suffix, and is backed
+        // by sessionStorage (per-tab, same-origin, reload-surviving).
+        assert!(
+            SHELL_BRIDGE_JS.contains("ckey + ':rate'"),
+            "rate window must use a contract-scoped storage key (#4849)"
+        );
+        assert!(
+            SHELL_BRIDGE_JS.contains("sessionStorage.getItem(storeKey)")
+                && SHELL_BRIDGE_JS.contains("sessionStorage.setItem(storeKey"),
+            "rate window must be persisted in sessionStorage (#4849)"
+        );
+        // The factory actually rehydrates from and saves to the injected store.
+        assert!(
+            SHELL_BRIDGE_JS.contains("store.load()")
+                && SHELL_BRIDGE_JS.contains("store.save(recent)"),
+            "limiter must rehydrate from and persist to the injected store (#4849)"
+        );
+        // The bfcache reset variant is closed by a `pageshow`-persisted resync
+        // (the IIFE does not re-run on back-forward-cache restore, so the
+        // in-memory window would otherwise stay stale). Pin the wiring so a
+        // refactor can't silently drop it.
+        assert!(
+            SHELL_BRIDGE_JS.contains("pageshow")
+                && SHELL_BRIDGE_JS.contains("notifyLimiter.resync()"),
+            "flood-cap window must be resynced from the store on bfcache restore (#4849)"
         );
     }
 

--- a/crates/core/src/server/path_handlers/assets/shell_bridge.js
+++ b/crates/core/src/server/path_handlers/assets/shell_bridge.js
@@ -13,8 +13,18 @@ function freenetBridge(authToken, userToken, hostedMode) {
   var inMemoryConsent = Object.create(null);
   // Per-tag + global rate limiter for the notification proxy (see the
   // marker-bracketed `makeNotifyRateLimiter` factory below, unit-tested in
-  // shell_bridge_notifications.test.mjs).
-  var notifyLimiter = makeNotifyRateLimiter();
+  // shell_bridge_notifications.test.mjs). Its rolling global window is
+  // persisted per-contract via makeNotifyRateStore so a full page reload can't
+  // reset the flood cap (#4849).
+  var notifyLimiter = makeNotifyRateLimiter(makeNotifyRateStore());
+  // bfcache restore does NOT re-run this IIFE, so a page restored from the
+  // back-forward cache keeps its stale in-memory flood-cap window. Resync it
+  // from the store on a persisted `pageshow` so a Back-restored contract page
+  // can't reset the cap (#4849). The shell's open WebSocket + EventSource
+  // usually make it bfcache-ineligible, but this doesn't rely on that.
+  window.addEventListener('pageshow', function (e) {
+    if (e && e.persisted) notifyLimiter.resync();
+  });
 
   // FAIL CLOSED whenever a HOSTED browser has no usable per-user token (#4381).
   //
@@ -301,6 +311,58 @@ function freenetBridge(authToken, userToken, hostedMode) {
     } catch (e) {}
   }
 
+  // Contract-scoped persistence for the notification rate limiter's rolling
+  // global window, so a full page reload can't reset the flood cap (#4849): a
+  // consented contract could otherwise fire the whole GLOBAL_MAX budget, force
+  // a reload (e.g. a same-contract v1<->v2 `navigate`, which the shell treats
+  // as cross-contract and reloads the top document), and start over with an
+  // empty limiter. Keyed by the SAME version-less contract key as consent
+  // (`freenet_notify:<key>`), so the window survives that v1<->v2 reload while
+  // staying isolated per contract. sessionStorage is the right store: per-tab
+  // (each tab is its own notification surface), same-origin so it persists
+  // across the shell's in-place navigate, and auto-cleared when the tab closes.
+  // Returns null when there's no contract key — the limiter then runs in-memory
+  // only, which is harmless because without a contract key there is no consent
+  // and so no notification ever fires.
+  // notify-rate-store:BEGIN — the sessionStorage adapter for the flood-cap
+  // window. Extracted verbatim between these markers by
+  // shell_bridge_notifications.test.mjs (with stubbed `sessionStorage` /
+  // `contractConsentKey`) so its load/save behavior — the Array.isArray guard,
+  // JSON round-trip, non-finite + future-timestamp filtering, and fail-safe
+  // try/catch — is actually exercised, not just source-grepped.
+  function makeNotifyRateStore() {
+    var ckey = contractConsentKey();
+    if (!ckey) return null;
+    var storeKey = ckey + ':rate';
+    return {
+      load: function () {
+        try {
+          var raw = sessionStorage.getItem(storeKey);
+          if (!raw) return null;
+          var arr = JSON.parse(raw);
+          if (!Array.isArray(arr)) return null;
+          // Drop non-finite entries, and any timestamp in the FUTURE relative
+          // to now: a backward wall-clock correction between loads would
+          // otherwise leave future-dated entries that the 60s window filter
+          // keeps (its `now - t` goes negative), locking out notifications
+          // until the clock catches up. Clamping here bounds that to 60s (#4849).
+          var nowMs = Date.now();
+          return arr.filter(function (t) {
+            return typeof t === 'number' && isFinite(t) && t <= nowMs;
+          });
+        } catch (e) {
+          return null;
+        }
+      },
+      save: function (recent) {
+        try {
+          sessionStorage.setItem(storeKey, JSON.stringify(recent));
+        } catch (e) {}
+      },
+    };
+  }
+  // notify-rate-store:END
+
   // A per-tag throttle (so distinct rooms aren't dropped) plus a rolling global
   // cap (so a consented contract can't flood with unique tags), with a bounded
   // per-tag map so a distinct-tag flood can't grow memory unbounded. `ok(tag,
@@ -311,13 +373,24 @@ function freenetBridge(authToken, userToken, hostedMode) {
   // markers and unit-tested by
   // crates/core/src/server/shell_bridge_notifications.test.mjs. Keep it pure
   // (no reference to anything outside this function) so the extraction works.
-  function makeNotifyRateLimiter() {
+  function makeNotifyRateLimiter(store) {
     var TAG_MIN_MS = 3000; // same-tag throttle window
     var GLOBAL_MAX = 20; // max notifications per rolling window
     var GLOBAL_WINDOW_MS = 60000;
     var MAP_CAP = 128; // bound the per-tag map; evict down to MAP_CAP/2
     var tagTimes = Object.create(null);
+    // The rolling global window of accepted-notification timestamps. Optionally
+    // rehydrated from an injected `store` so a full page RELOAD can't reset the
+    // flood cap (#4849). `store` is an optional {load, save} adapter, kept OUT
+    // of this factory so the factory stays pure (references only its params and
+    // locals) and the Node unit test can extract it verbatim between the
+    // markers and drive it — or inject an in-memory store. Any stale entries in
+    // a rehydrated window are dropped by the window filter on the first `ok`.
     var recent = [];
+    if (store && typeof store.load === 'function') {
+      var loaded = store.load();
+      if (loaded && loaded.length) recent = loaded;
+    }
     return {
       ok: function (tag, now) {
         var last = tagTimes[tag];
@@ -328,6 +401,10 @@ function freenetBridge(authToken, userToken, hostedMode) {
         if (recent.length >= GLOBAL_MAX) return false;
         tagTimes[tag] = now;
         recent.push(now);
+        // Persist the window so a reload rehydrates it (see #4849). Saved only
+        // on the accept path: a stale (unfiltered) persisted window is dropped
+        // by the filter above on the next load, so this is always conservative.
+        if (store && typeof store.save === 'function') store.save(recent);
         var keys = Object.keys(tagTimes);
         if (keys.length > MAP_CAP) {
           keys.sort(function (a, b) {
@@ -338,6 +415,24 @@ function freenetBridge(authToken, userToken, hostedMode) {
           }
         }
         return true;
+      },
+      // Re-read the persisted window into `recent`. Used on bfcache restore: a
+      // back-forward-cache page keeps its stale in-memory window and never
+      // re-runs the constructor, so a Back-restored older contract page could
+      // otherwise reset the flood cap (#4849). Conservative — replaces only
+      // when the store has a non-empty window, so a transient empty/error load
+      // never resets an in-memory window.
+      resync: function () {
+        if (store && typeof store.load === 'function') {
+          var loaded = store.load();
+          if (loaded && loaded.length) recent = loaded;
+        }
+      },
+      // Current size of the per-tag map, so the unit test can assert the
+      // MAP_CAP eviction actually bounds it (removing the eviction block would
+      // let this grow past MAP_CAP and fail the test). Not used in production.
+      tagCount: function () {
+        return Object.keys(tagTimes).length;
       },
     };
   }
@@ -1043,6 +1138,16 @@ function freenetBridge(authToken, userToken, hostedMode) {
   // that caused the originating tab to silently miss prompts whenever it
   // wasn't foregrounded; SSE eliminates both the polling-floor latency and
   // the visibility race.
+  // perm-overlay-flow:BEGIN — the delegate permission-prompt overlay and its
+  // Server-Sent-Events stream. #3836 requires that NOTHING in this whole region
+  // constructs a browser Notification: delegate permission prompts must render
+  // as in-page overlay cards, never as OS notifications a user can miss or
+  // dismiss. The Rust guard `shell_page_permission_overlay_present_and_safe`
+  // scans this marker-bounded region (NOT a code anchor), so the SSE
+  // `prompt_added`/`prompt_removed` handlers below — part of the prompt-render
+  // flow — are INSIDE the guarded region (#4849 F2). The legitimate
+  // message-notification code (showAppNotification) sits far above BEGIN, so it
+  // is outside this region and unaffected.
   var overlayRoot = null;
   var overlayCards = {}; // nonce -> card element
   var OVERLAY_CSS =
@@ -1468,4 +1573,5 @@ function freenetBridge(authToken, userToken, hostedMode) {
     // legacy 3-second poll so users on those clients still see prompts.
     startFallbackPoll();
   }
+  // perm-overlay-flow:END
 }

--- a/crates/core/src/server/shell_bridge_notifications.test.mjs
+++ b/crates/core/src/server/shell_bridge_notifications.test.mjs
@@ -46,6 +46,60 @@ const makeNotifyRateLimiter = new Function(
   `${fnSource}\nreturn makeNotifyRateLimiter;`,
 )();
 
+// --- Extract the sessionStorage adapter verbatim too --------------------
+// `makeNotifyRateStore` is real production code (the Array.isArray guard, JSON
+// round-trip, non-finite + future-timestamp filtering, fail-safe try/catch)
+// that the injected in-memory store in case 6 never exercises. Extract it
+// between its markers and drive it with stubbed `sessionStorage` /
+// `contractConsentKey` so that behavior is actually tested.
+const SBEGIN = 'notify-rate-store:BEGIN';
+const SEND = 'notify-rate-store:END';
+const sb = src.indexOf(SBEGIN);
+const se = src.indexOf(SEND);
+if (sb < 0 || se < 0 || se < sb) {
+  console.error(
+    `FAIL: could not find ${SBEGIN}/${SEND} markers in ${assetPath}. The ` +
+      'sessionStorage adapter must stay bracketed so this test can drive it.',
+  );
+  process.exit(1);
+}
+const storeRegion = src.slice(sb, se);
+const storeFnStart = storeRegion.indexOf('function makeNotifyRateStore(');
+if (storeFnStart < 0) {
+  console.error('FAIL: no `function makeNotifyRateStore(` between the store markers.');
+  process.exit(1);
+}
+const storeFnSource = storeRegion.slice(storeFnStart);
+// Build the adapter with controllable stubs. `back` is the raw sessionStorage
+// backing map; `ctrl.throwing` simulates private-mode / quota throws; `path`
+// drives contractConsentKey's key derivation (a non-contract path => null key).
+function makeStoreHarness(path) {
+  const back = {};
+  const ctrl = { throwing: false };
+  const sessionStorage = {
+    getItem(k) {
+      if (ctrl.throwing) throw new Error('boom');
+      return k in back ? back[k] : null;
+    },
+    setItem(k, v) {
+      if (ctrl.throwing) throw new Error('quota');
+      back[k] = String(v);
+    },
+  };
+  const contractConsentKey = () => {
+    const m = String(path).match(/\/v[12]\/contract\/web\/([^/?#]+)/);
+    return m ? 'freenet_notify:' + m[1] : null;
+  };
+  const makeNotifyRateStore = new Function(
+    'sessionStorage',
+    'contractConsentKey',
+    `${storeFnSource}\nreturn makeNotifyRateStore;`,
+  )(sessionStorage, contractConsentKey);
+  const store = makeNotifyRateStore();
+  const ckey = contractConsentKey();
+  return { store, back, ctrl, key: ckey ? ckey + ':rate' : null };
+}
+
 let failures = 0;
 function check(name, cond) {
   if (cond) {
@@ -90,9 +144,13 @@ function check(name, cond) {
   check('window expiry frees capacity at t=60000', rl.ok('new', 60000) === true);
 }
 
-// 5. Bounded per-tag map: a flood of >128 distinct tags must not throw and the
-//    limiter must keep working (eviction path). Space calls >60s apart so
-//    neither the per-tag nor the global-window gate blocks them.
+// 5. Bounded per-tag map: a flood of >128 distinct tags must not throw, the
+//    limiter must keep working, AND the per-tag map must stay bounded by the
+//    MAP_CAP eviction. Space calls >60s apart so neither the per-tag throttle
+//    nor the global-window gate blocks them. The tagCount assertion is what
+//    actually exercises eviction: with only the "no throw" check, deleting the
+//    MAP_CAP eviction block entirely would keep this test green (#4849 F3) —
+//    an unbounded map is a memory leak the old test couldn't see.
 {
   const rl = makeNotifyRateLimiter();
   let allOk = true;
@@ -100,6 +158,135 @@ function check(name, cond) {
     if (rl.ok('flood' + i, i * 61000) !== true) allOk = false;
   }
   check('300 spaced distinct tags all pass (eviction bounded, no throw)', allOk);
+  check('per-tag map stays bounded by MAP_CAP after the flood', rl.tagCount() <= 128);
+}
+
+// 6. Reload persistence (#4849): the rolling global window is rehydrated from
+//    an injected store, so a full page RELOAD can't reset the flood cap. A
+//    consented contract that fires the cap, then forces a reload, must NOT get
+//    a fresh budget. The storeless control proves the persistence is what
+//    closes the hole.
+{
+  let saved = null;
+  const store = {
+    load: () => (saved === null ? null : saved.slice()),
+    save: (recent) => {
+      saved = recent.slice();
+    },
+  };
+  // First "page load": fill the rolling window to the global cap.
+  const before = makeNotifyRateLimiter(store);
+  let filled = 0;
+  for (let i = 0; i < 20; i++) if (before.ok('t' + i, 1000 + i)) filled++;
+  check('cap fills on first load', filled === 20);
+  check('window persisted to store', Array.isArray(saved) && saved.length === 20);
+  // Simulate the reload: a NEW limiter rehydrates from the same store. The next
+  // notification (still inside the 60s window) must be blocked — no reset.
+  const afterReload = makeNotifyRateLimiter(store);
+  check(
+    'rehydrated limiter still at cap after reload (flood-cap not reset)',
+    afterReload.ok('post-reload', 1500) === false,
+  );
+  // Control: a storeless limiter DOES reset on reload — exactly the #4849 hole
+  // the persisted store closes.
+  const noStore = makeNotifyRateLimiter();
+  check(
+    'storeless limiter resets on reload (control — the bug the store fixes)',
+    noStore.ok('post-reload', 1500) === true,
+  );
+  // A FULL-cap window rehydrated from BEFORE the 60s window must FREE capacity,
+  // not stay stuck at cap: the stale entries age out on the first `ok` past the
+  // window. Uses a full GLOBAL_MAX (20) window so the check is NON-VACUOUS —
+  // with fewer than the cap, `ok` would return true even if the window filter
+  // were broken. (A "trust the stored count" shortcut would wrongly suppress
+  // all notifications across a >60s reload until tab close.)
+  const staleStore = {
+    load: () => Array.from({ length: 20 }, (_, i) => i),
+    save: () => {},
+  };
+  const afterStale = makeNotifyRateLimiter(staleStore);
+  check(
+    'rehydrated full stale (>60s old) window frees capacity',
+    afterStale.ok('fresh', 70000) === true,
+  );
+}
+
+// 8. bfcache resync (#4849): resync() re-reads the persisted window so a
+//    back-forward-cache-restored page — whose in-memory window is frozen and
+//    whose IIFE never re-ran — adopts the authoritative store window instead of
+//    firing on its stale in-memory one. Conservative: it must NEVER wipe the
+//    in-memory window on an empty/missing store load.
+{
+  let stored = [];
+  // save is a no-op here; the test drives `stored` directly to simulate another
+  // same-contract page updating the shared store while this page is frozen.
+  const store = { load: () => stored.slice(), save: () => {} };
+  const restored = makeNotifyRateLimiter(store); // store empty at construct -> recent = []
+  // Another page fills the store to cap while this one is frozen in bfcache.
+  stored = Array.from({ length: 20 }, (_, i) => 1000 + i);
+  restored.resync();
+  check(
+    'resync adopts the persisted window on bfcache restore',
+    restored.ok('a', 1500) === false,
+  );
+  // Conservative guard: an empty store load must NOT wipe the adopted window
+  // (else a bfcache restore against a cleared store would reset the cap — the
+  // exact bug). This is the load-bearing `if (loaded && loaded.length)` branch.
+  stored = [];
+  restored.resync();
+  check(
+    'resync does not wipe the window on an empty store load',
+    restored.ok('b', 1600) === false,
+  );
+}
+
+// 7. The real sessionStorage adapter (makeNotifyRateStore) — behavioral. The
+//    fail-safe guards here are production code the injected in-memory store in
+//    case 6 never touches; the Array.isArray guard is the sharpest (without it
+//    a non-array stored value flows into `recent` and `recent.filter(...)`
+//    throws in `ok()`, breaking ALL notifications for the contract).
+{
+  const h = makeStoreHarness('/v2/contract/web/KEY/');
+  // Round-trip: save then load returns the finite numbers.
+  h.store.save([100, 200, 300]);
+  const rt = h.store.load();
+  check(
+    'adapter round-trips a valid window',
+    Array.isArray(rt) && rt.length === 3 && rt[0] === 100 && rt[2] === 300,
+  );
+  // Non-array stored value -> null (the sharp Array.isArray guard).
+  h.back[h.key] = JSON.stringify('not-an-array');
+  check('adapter returns null for a non-array stored value', h.store.load() === null);
+  // Corrupt JSON -> null (fail safe).
+  h.back[h.key] = '{not valid json';
+  check('adapter returns null for corrupt JSON', h.store.load() === null);
+  // Non-number / non-finite entries filtered out.
+  h.back[h.key] = JSON.stringify([1, 'x', null, Infinity, 2]);
+  const filtered = h.store.load();
+  check(
+    'adapter filters non-finite / non-number entries',
+    Array.isArray(filtered) && filtered.length === 2 && filtered[0] === 1 && filtered[1] === 2,
+  );
+  // Future-dated timestamps (backward clock correction) clamped out.
+  h.back[h.key] = JSON.stringify([1000, Date.now() + 10 * 60 * 1000]);
+  const clamped = h.store.load();
+  check(
+    'adapter drops future-dated timestamps (clock rollback)',
+    Array.isArray(clamped) && clamped.length === 1 && clamped[0] === 1000,
+  );
+  // Storage throwing (private mode / quota): load -> null, save -> no throw.
+  h.ctrl.throwing = true;
+  let saveThrew = false;
+  try {
+    h.store.save([1]);
+  } catch (e) {
+    saveThrew = true;
+  }
+  check('adapter save swallows storage errors', saveThrew === false);
+  check('adapter load returns null when storage throws', h.store.load() === null);
+  // No contract key -> null store (limiter runs in-memory, no persistence).
+  const none = makeStoreHarness('/some/other/path');
+  check('makeNotifyRateStore returns null when there is no contract key', none.store === null);
 }
 
 if (failures > 0) {


### PR DESCRIPTION
## Problem

The notification-proxy flood-cap (20 notifications / 60s, in `shell_bridge.js`'s `makeNotifyRateLimiter`) lives in a per-document `var`, so a **full page reload resets it**. A contract the user has *already consented to* can fire its 20 notifications, then `postMessage` a same-contract v1↔v2 `navigate` — which the shell treats as cross-contract and reloads the top document — to get a fresh, empty limiter, and repeat for an unbounded flood budget. Surfaced as **F1** in the #4801 multi-model re-review (external Codex pass, ~P2). It's bounded and visible (only an already-consented app; each cycle is a visible tab reload) and breaks no security boundary, so it was consciously accepted at #4801's merge and deferred to this issue.

This PR also closes the two P3 hardening items from the same review:
- **F2** — the #3836 permission-overlay guard (`shell_page_permission_overlay_present_and_safe`) scanned a slice that ended *before* the SSE `prompt_added`/`prompt_removed` handlers, which are part of the prompt-render flow #3836 protects — so a browser `Notification` reintroduced into an SSE handler would have slipped past the guard.
- **F3** — the bounded-map eviction unit test spaced its calls so the 60s global window emptied every call; deleting the `MAP_CAP` eviction block entirely would have kept it green — it never actually exercised eviction.

## Approach

**F1 — persist the rolling window (contract-scoped, reload-surviving).** `makeNotifyRateLimiter` now takes an optional injected `{load, save}` store: it rehydrates the rolling global window on construction and persists it after each accepted notification. A new `makeNotifyRateStore()` backs it with `sessionStorage`, keyed by the **same version-less contract key as consent** (`freenet_notify:<key>:rate`) — so the window survives the exact v1↔v2 reload the exploit relies on, while staying isolated per contract. `sessionStorage` is the right store: per-tab, same-origin (persists across the shell's in-place navigate), and auto-cleared on tab close. The store is deliberately kept **outside** the factory so the factory stays pure and the Node unit test can still extract it verbatim between its markers; passing no store preserves the prior in-memory behavior. Stale entries in a rehydrated window are dropped by the existing 60s filter on the first `ok`, so the cap correctly frees up after 60s across reloads (no over-blocking).

**F2 — bracket the whole overlay+SSE region with explicit markers.** New `perm-overlay-flow:BEGIN/END` markers bound the region; the Rust guard now scans between them instead of stopping at a code anchor, so the SSE handlers are inside the guarded region. (The legitimate message-notification code sits above `BEGIN`, so it stays outside the region — the #3836 asserts don't false-positive on it.)

**F3 — assert boundedness.** The limiter exposes a `tagCount()` accessor (unused in production) so the eviction test asserts the per-tag map stays ≤ `MAP_CAP` after a 300-tag flood; removing the eviction block now fails the test.

## Testing

- `shell_bridge_notifications.test.mjs` (Node, run by the `lint-assets` CI job), **25 checks**: case 6 fills the cap, simulates a reload via a fresh limiter rehydrating from the same store, and asserts the next notification is still blocked (a storeless control proves the persistence is the closer); a >60s-stale rehydration frees capacity; case 5 asserts `tagCount() <= MAP_CAP`; **case 7 drives the real `makeNotifyRateStore` adapter** (marker-extracted with a stubbed `sessionStorage`) through its guards — non-array / corrupt-JSON → null, non-finite + future-timestamp filtering, storage-throw fail-safe, no-contract-key → null.
- Rust: a new `bridge_js_notification_flood_cap_persisted_across_reload` pins the F1 wiring (store construction, contract-scoped `:rate` key, sessionStorage get/set, load/save); `shell_page_permission_overlay_present_and_safe` (F2) now also asserts the SSE `prompt_added`/`prompt_removed` handlers are *inside* the marker-bounded slice, so the guard can't shrink to a vacuous pass.

## Review hardening (from this PR's multi-model review)

- **bfcache resync:** a `pageshow` handler resyncs the persisted window on back-forward-cache restore (the constructor doesn't re-run), closing a reload-shaped reset the persistence otherwise wouldn't cover — without relying on the shell being bfcache-ineligible.
- **Backward-clock clamp:** `load` drops future-dated timestamps, so a backward wall-clock correction can't leave the cap stuck (bounded to 60s; fails safe either way).
- **F2 self-validating:** positive `prompt_added`/`prompt_removed`-in-slice asserts, so a refactor moving the SSE handlers past `perm-overlay-flow:END` fails loudly instead of silently un-covering them.
- **Adapter behavioral coverage:** `makeNotifyRateStore` is now marker-extracted and behaviorally tested (was source-grep-only).

Closes #4849

[AI-assisted - Claude]
