### PR TITLE
fix: resync on dropped broadcast delta to prevent permanent divergence (#4857)

### DIFF
--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -1235,13 +1235,61 @@ async fn drive_relay_broadcast_to(
                     AutoFetchReason::InboundRelay,
                 );
             } else if queue_full {
-                tracing::debug!(
-                    tx = %incoming_tx,
-                    contract = %key,
-                    sender = %sender_addr,
-                    event = "queue_full_amplification_suppressed",
-                    "UPDATE relay: per-contract queue saturated, suppressed ResyncRequest/auto-fetch to avoid amplification"
-                );
+                // Issue #4857: a queue-full drop is SILENT. The receiver never
+                // applied the delta, but the SENDER cached its summary as ours
+                // on send-Ok (broadcast_queue.rs::record_delivery_to_interest),
+                // so it believes we are current and will never re-send the
+                // dropped change. Left unhealed, a rarely-changing field
+                // (member_info, a ban, a config) diverges permanently until the
+                // ~5-min InterestSync heartbeat happens to correct it.
+                //
+                // Emit a ResyncRequest so the sender CLEARS its cached summary
+                // of us (node.rs ResyncRequest handler) and re-sends full state.
+                // Issue #4251 suppressed this ENTIRELY because one request per
+                // dropped delta amplifies into a full-state storm onto the same
+                // saturated queue (~40 ResyncRequests/sec on a hot contract).
+                // The rate limit bounds that to at most one request per
+                // (contract, sender) per RESYNC_REQUEST_MIN_INTERVAL, which
+                // heals the divergence without re-opening the storm. The auto-
+                // fetch branch stays suppressed on queue-full (we already hold
+                // the contract; a GET onto the same saturated queue is pure
+                // amplification with no healing value).
+                //
+                // do NOT re-add an unthrottled emission here — see #4251/#4857.
+                if op_manager
+                    .interest_manager
+                    .should_send_resync_request(&key, sender_addr)
+                {
+                    tracing::info!(
+                        tx = %incoming_tx,
+                        contract = %key,
+                        target = %sender_addr,
+                        event = "resync_request_sent",
+                        reason = "queue_full",
+                        "UPDATE relay: sending rate-limited ResyncRequest after queue-full drop (#4857)"
+                    );
+                    if let Err(e) = op_manager
+                        .notify_node_event(NodeEvent::SendInterestMessage {
+                            target: sender_addr,
+                            message: InterestMessage::ResyncRequest { key },
+                        })
+                        .await
+                    {
+                        tracing::warn!(
+                            tx = %incoming_tx,
+                            error = %e,
+                            "UPDATE relay: failed to send queue-full ResyncRequest"
+                        );
+                    }
+                } else {
+                    tracing::debug!(
+                        tx = %incoming_tx,
+                        contract = %key,
+                        sender = %sender_addr,
+                        event = "queue_full_resync_throttled",
+                        "UPDATE relay: queue-full ResyncRequest throttled (rate limit) to avoid amplification"
+                    );
+                }
             }
             return Err(err);
         }
@@ -2583,15 +2631,16 @@ mod tests {
         );
     }
 
-    /// Issue #4251 regression pin: `drive_relay_broadcast_to` MUST
-    /// gate ResyncRequest emission AND `try_auto_fetch_contract` on
-    /// `!err.is_contract_queue_full()`. The two amplification branches
-    /// are what turn a single saturated contract into a network-wide
-    /// storm — ResyncRequest asks the sender for full state (bigger
-    /// payload onto the same full queue), and auto-fetch enqueues a
-    /// GET right back onto the saturated handler.
+    /// Issue #4857 / #4251 reconciliation pin: on a queue-full broadcast
+    /// drop, `drive_relay_broadcast_to` must emit a RATE-LIMITED
+    /// `ResyncRequest` — neither suppress it (which left rarely-changing
+    /// fields permanently diverged, #4857) nor emit it unthrottled (which
+    /// amplified into a full-state storm, #4251). The queue-full arm MUST
+    /// therefore BOTH gate on `should_send_resync_request` (the rate limit)
+    /// AND emit `InterestMessage::ResyncRequest` (the heal). Auto-fetch stays
+    /// suppressed on queue-full (a GET onto the saturated queue heals nothing).
     #[test]
-    fn broadcast_to_suppresses_amplification_on_queue_full() {
+    fn broadcast_to_sends_throttled_resync_on_queue_full() {
         let src = include_str!("op_ctx_task.rs");
         let start = src
             .find("async fn drive_relay_broadcast_to(")
@@ -2603,26 +2652,194 @@ mod tests {
             .unwrap_or(after.len());
         let driver_src = &src[start..start + 1 + end];
 
-        // Gate must be present; both amplification call sites must still
-        // exist (suppressed on queue-full, not deleted). Runtime gating
-        // behavior is covered by the update.rs tests; this is a structural
-        // pin so a refactor that drops the check fails CI.
+        // The queue-full classification must still exist (it drives the arm).
         assert!(
-            driver_src.contains("is_contract_queue_full()"),
-            "drive_relay_broadcast_to must call is_contract_queue_full() \
-             to gate the ResyncRequest / auto-fetch amplification — see \
-             issue #4251"
+            driver_src.contains("let queue_full = err.is_contract_queue_full();"),
+            "drive_relay_broadcast_to must still classify queue-full via \
+             is_contract_queue_full() — see issue #4251"
+        );
+
+        // Scope the heal assertions to the `else if queue_full { ... }` arm so
+        // the delta-apply arm's ResyncRequest cannot satisfy this pin.
+        let arm_start = driver_src
+            .find("} else if queue_full {")
+            .expect("queue-full arm missing in drive_relay_broadcast_to");
+        let queue_full_arm = &driver_src[arm_start..];
+
+        assert!(
+            queue_full_arm.contains("should_send_resync_request"),
+            "the queue-full arm MUST gate its ResyncRequest on \
+             should_send_resync_request — the rate limit that bounds the #4251 \
+             amplification. Dropping the throttle re-opens the ResyncRequest storm."
         );
         assert!(
-            driver_src.contains("InterestMessage::ResyncRequest"),
-            "drive_relay_broadcast_to should still contain the ResyncRequest \
-             branch (gated on !queue_full)"
+            queue_full_arm.contains("InterestMessage::ResyncRequest"),
+            "the queue-full arm MUST emit InterestMessage::ResyncRequest so the \
+             sender clears its poisoned summary cache and re-sends full state — \
+             without it a silently-dropped delta diverges permanently (#4857)."
         );
         assert!(
-            driver_src.contains("try_auto_fetch_contract"),
-            "drive_relay_broadcast_to should still contain the auto-fetch \
-             branch (gated on !queue_full)"
+            !queue_full_arm.contains("try_auto_fetch_contract"),
+            "the queue-full arm must NOT auto-fetch — a GET onto the same \
+             saturated queue is pure amplification with no healing value (#4251)."
         );
+    }
+
+    /// Drain the event-loop notification channel (non-blocking) and return the
+    /// targets of every `ResyncRequest(key)` emitted since the last drain.
+    fn drain_resync_targets(
+        rx: &mut crate::node::EventLoopNotificationsReceiver,
+        key: ContractKey,
+    ) -> Vec<SocketAddr> {
+        let mut targets = Vec::new();
+        while let Ok(ev) = rx.notifications_receiver.try_recv() {
+            if let Either::Right(NodeEvent::SendInterestMessage {
+                target,
+                message: InterestMessage::ResyncRequest { key: k },
+            }) = ev
+            {
+                if k == key {
+                    targets.push(target);
+                }
+            }
+        }
+        targets
+    }
+
+    /// Issue #4857 behavioral reproduction: when an inbound broadcast delta is
+    /// dropped with `ContractQueueFull`, `drive_relay_broadcast_to` MUST emit a
+    /// `ResyncRequest` back to the sender so the sender clears its poisoned
+    /// summary cache and re-sends the dropped change — and that emission MUST be
+    /// rate-limited so a burst of drops does not re-open the #4251 storm.
+    ///
+    /// On `origin/main` this test FAILS: the queue-full arm suppresses the
+    /// ResyncRequest entirely, so `first` is empty (the divergence is silent and
+    /// permanent). With the fix, the first drop emits exactly one ResyncRequest
+    /// and the immediate second drop is throttled.
+    ///
+    /// The drop is injected at the contract-handler seam (a stand-in handler
+    /// answers every `UpdateQuery` with `ContractQueueFull`) rather than by
+    /// saturating the real 100-slot fair queue, which is non-deterministic.
+    #[tokio::test]
+    async fn queue_full_broadcast_emits_throttled_resync_request() {
+        // ── Build a minimal real OpManager (mirrors op_state_manager.rs
+        //    build_reroot_test_op_manager). ────────────────────────────────
+        let config_args = crate::config::ConfigArgs {
+            id: Some("queue-full-resync-4857".to_string()),
+            mode: Some(crate::contract::OperationMode::Local),
+            ..Default::default()
+        };
+        let node_config =
+            crate::node::NodeConfig::new(config_args.build().await.expect("build Config"))
+                .await
+                .expect("build NodeConfig");
+        let (mut notification_rx, notification_tx) = crate::node::event_loop_notification_channel();
+        let (ops_ch_channel, mut ch_channel, _wait_for_event) =
+            crate::contract::contract_handler_channel();
+        let connection_manager = crate::ring::ConnectionManager::new(&node_config);
+        let (result_router_tx, _result_router_rx) = tokio::sync::mpsc::channel(100);
+        let task_monitor = crate::node::background_task_monitor::BackgroundTaskMonitor::new();
+        let op_manager = Arc::new(
+            OpManager::new(
+                notification_tx,
+                ops_ch_channel,
+                &node_config,
+                crate::tracing::DynamicRegister::new(vec![]),
+                connection_manager,
+                result_router_tx,
+                &task_monitor,
+            )
+            .expect("build OpManager"),
+        );
+        op_manager.ring.attach_op_manager(&op_manager);
+        let self_addr: SocketAddr = "127.0.0.1:12000".parse().unwrap();
+        op_manager.ring.connection_manager.set_own_addr(self_addr);
+
+        // ── Contract-handler stand-in: answer GetQuery with "no state" and
+        //    every UpdateQuery with ContractQueueFull (the silent drop a
+        //    saturated receiver hits under load). ──────────────────────────
+        let handler = tokio::spawn(async move {
+            while let Ok((id, ev, _priority)) = ch_channel.recv_from_sender().await {
+                let response = match ev {
+                    ContractHandlerEvent::GetQuery { .. } => ContractHandlerEvent::GetResponse {
+                        key: None,
+                        response: Ok(StoreResponse {
+                            state: None,
+                            contract: None,
+                        }),
+                    },
+                    ContractHandlerEvent::UpdateQuery { .. } => {
+                        ContractHandlerEvent::UpdateResponse {
+                            new_value: Err(crate::contract::ExecutorError::other(
+                                crate::contract::ContractQueueFull,
+                            )),
+                            state_changed: false,
+                        }
+                    }
+                    other => panic!("unexpected handler event in stand-in: {other:?}"),
+                };
+                if ch_channel.send_to_sender(id, response).await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        let key = ContractKey::from_id_and_code(
+            ContractInstanceId::new([7u8; 32]),
+            CodeHash::new([8u8; 32]),
+        );
+        let sender_addr: SocketAddr = "127.0.0.1:12100".parse().unwrap();
+
+        // First broadcast delta → dropped queue-full → MUST emit a ResyncRequest.
+        let r1 = drive_relay_broadcast_to(
+            &op_manager,
+            Transaction::new::<UpdateMsg>(),
+            key,
+            DeltaOrFullState::Delta(vec![1, 2, 3]),
+            Vec::new(),
+            sender_addr,
+        )
+        .await;
+        assert!(
+            r1.as_ref()
+                .err()
+                .is_some_and(|e| e.is_contract_queue_full()),
+            "expected a queue-full error from the stand-in handler, got {r1:?}"
+        );
+        let first = drain_resync_targets(&mut notification_rx, key);
+        assert_eq!(
+            first,
+            vec![sender_addr],
+            "a queue-full drop MUST emit exactly one ResyncRequest to the sender \
+             so it clears its poisoned summary and re-sends (heals #4857)"
+        );
+
+        // Second broadcast with DIFFERENT delta bytes (so it is not a dedup hit)
+        // within the throttle window → still queue-full, but ResyncRequest is
+        // throttled (bounds the #4251 amplification).
+        let r2 = drive_relay_broadcast_to(
+            &op_manager,
+            Transaction::new::<UpdateMsg>(),
+            key,
+            DeltaOrFullState::Delta(vec![4, 5, 6]),
+            Vec::new(),
+            sender_addr,
+        )
+        .await;
+        assert!(
+            r2.as_ref()
+                .err()
+                .is_some_and(|e| e.is_contract_queue_full()),
+            "second broadcast should still hit queue-full, got {r2:?}"
+        );
+        let second = drain_resync_targets(&mut notification_rx, key);
+        assert!(
+            second.is_empty(),
+            "a second queue-full drop within the throttle window MUST NOT emit \
+             another ResyncRequest (bounds #4251 amplification), got {second:?}"
+        );
+
+        handler.abort();
     }
 
     /// Issue #4251 follow-up: the four `run_relay_*` driver wrappers each

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -1045,6 +1045,73 @@ async fn drive_relay_request_update(
     Ok(())
 }
 
+/// On a queue-full broadcast drop, emit a RATE-LIMITED `ResyncRequest` to the
+/// sender so it clears its poisoned summary cache of us and re-sends the change
+/// it believes we already have (#4857).
+///
+/// A `ContractQueueFull` drop is SILENT: the receiver never applied the delta /
+/// full state, but the SENDER cached its own summary as ours on send-Ok
+/// (`broadcast_queue.rs::record_delivery_to_interest`), so it believes we are
+/// current and will never re-send the dropped change. Left unhealed, a
+/// rarely-changing field (member_info, a ban, a config) diverges permanently
+/// until the ~5-min InterestSync heartbeat happens to correct it. An inbound
+/// `ResyncRequest` makes the sender clear that cached summary (node.rs handler)
+/// and re-send full state.
+///
+/// Issue #4251 suppressed this entirely because one request per dropped delta
+/// amplifies into a full-state storm onto the same saturated queue (~40
+/// ResyncRequests/sec on a hot contract). The rate limit
+/// (`InterestManager::should_send_resync_request`) bounds that to at most one
+/// request per (contract, sender) per `RESYNC_REQUEST_MIN_INTERVAL`.
+///
+/// Shared by both broadcast drivers (`drive_relay_broadcast_to` and
+/// `drive_relay_broadcast_to_streaming`) so the two queue-full paths cannot
+/// drift. The caller keeps auto-fetch suppressed on queue-full (we already hold
+/// the contract; a GET onto the same saturated queue is pure amplification).
+///
+/// do NOT re-add an unthrottled emission — see #4251/#4857.
+async fn send_queue_full_resync_request(
+    op_manager: &OpManager,
+    key: ContractKey,
+    sender_addr: SocketAddr,
+    incoming_tx: Transaction,
+) {
+    if op_manager
+        .interest_manager
+        .should_send_resync_request(&key, sender_addr)
+    {
+        tracing::info!(
+            tx = %incoming_tx,
+            contract = %key,
+            target = %sender_addr,
+            event = "resync_request_sent",
+            reason = "queue_full",
+            "UPDATE relay: sending rate-limited ResyncRequest after queue-full drop (#4857)"
+        );
+        if let Err(e) = op_manager
+            .notify_node_event(NodeEvent::SendInterestMessage {
+                target: sender_addr,
+                message: InterestMessage::ResyncRequest { key },
+            })
+            .await
+        {
+            tracing::warn!(
+                tx = %incoming_tx,
+                error = %e,
+                "UPDATE relay: failed to send queue-full ResyncRequest"
+            );
+        }
+    } else {
+        tracing::debug!(
+            tx = %incoming_tx,
+            contract = %key,
+            sender = %sender_addr,
+            event = "queue_full_resync_throttled",
+            "UPDATE relay: queue-full ResyncRequest throttled (rate limit) to avoid amplification"
+        );
+    }
+}
+
 /// Inner driver for `BroadcastTo`. Mirrors `update.rs:595-825`.
 ///
 /// 1. Update sender's cached summary in `interest_manager`.
@@ -1235,61 +1302,12 @@ async fn drive_relay_broadcast_to(
                     AutoFetchReason::InboundRelay,
                 );
             } else if queue_full {
-                // Issue #4857: a queue-full drop is SILENT. The receiver never
-                // applied the delta, but the SENDER cached its summary as ours
-                // on send-Ok (broadcast_queue.rs::record_delivery_to_interest),
-                // so it believes we are current and will never re-send the
-                // dropped change. Left unhealed, a rarely-changing field
-                // (member_info, a ban, a config) diverges permanently until the
-                // ~5-min InterestSync heartbeat happens to correct it.
-                //
-                // Emit a ResyncRequest so the sender CLEARS its cached summary
-                // of us (node.rs ResyncRequest handler) and re-sends full state.
-                // Issue #4251 suppressed this ENTIRELY because one request per
-                // dropped delta amplifies into a full-state storm onto the same
-                // saturated queue (~40 ResyncRequests/sec on a hot contract).
-                // The rate limit bounds that to at most one request per
-                // (contract, sender) per RESYNC_REQUEST_MIN_INTERVAL, which
-                // heals the divergence without re-opening the storm. The auto-
-                // fetch branch stays suppressed on queue-full (we already hold
-                // the contract; a GET onto the same saturated queue is pure
-                // amplification with no healing value).
-                //
-                // do NOT re-add an unthrottled emission here — see #4251/#4857.
-                if op_manager
-                    .interest_manager
-                    .should_send_resync_request(&key, sender_addr)
-                {
-                    tracing::info!(
-                        tx = %incoming_tx,
-                        contract = %key,
-                        target = %sender_addr,
-                        event = "resync_request_sent",
-                        reason = "queue_full",
-                        "UPDATE relay: sending rate-limited ResyncRequest after queue-full drop (#4857)"
-                    );
-                    if let Err(e) = op_manager
-                        .notify_node_event(NodeEvent::SendInterestMessage {
-                            target: sender_addr,
-                            message: InterestMessage::ResyncRequest { key },
-                        })
-                        .await
-                    {
-                        tracing::warn!(
-                            tx = %incoming_tx,
-                            error = %e,
-                            "UPDATE relay: failed to send queue-full ResyncRequest"
-                        );
-                    }
-                } else {
-                    tracing::debug!(
-                        tx = %incoming_tx,
-                        contract = %key,
-                        sender = %sender_addr,
-                        event = "queue_full_resync_throttled",
-                        "UPDATE relay: queue-full ResyncRequest throttled (rate limit) to avoid amplification"
-                    );
-                }
+                // Issue #4857: a queue-full drop is SILENT — the sender cached
+                // our summary on send-Ok and will never re-send the dropped
+                // change. Emit a rate-limited ResyncRequest so it re-syncs. The
+                // auto-fetch branch stays suppressed on queue-full (we already
+                // hold the contract). Shared with the streaming driver.
+                send_queue_full_resync_request(op_manager, key, sender_addr, incoming_tx).await;
             }
             return Err(err);
         }
@@ -1863,6 +1881,31 @@ async fn drive_relay_broadcast_to_streaming(
         sender_summary_bytes,
     } = payload;
 
+    apply_streaming_broadcast(
+        op_manager,
+        incoming_tx,
+        key,
+        state_bytes,
+        sender_summary_bytes,
+        sender_addr,
+    )
+    .await
+}
+
+/// Apply an assembled streaming full-state broadcast (steps 4-9 of
+/// `drive_relay_broadcast_to_streaming`): update the sender's cached summary,
+/// dedup, WASM-merge the full state, classify failures, and fan out the
+/// proactive summary. Extracted from the driver so the #4857 queue-full heal on
+/// the streaming path is unit-testable without the transport stream plumbing
+/// (steps 1-3: claim + assemble + deserialize).
+async fn apply_streaming_broadcast(
+    op_manager: &OpManager,
+    incoming_tx: Transaction,
+    key: ContractKey,
+    state_bytes: Vec<u8>,
+    sender_summary_bytes: Vec<u8>,
+    sender_addr: SocketAddr,
+) -> Result<(), OpError> {
     // Step 4: update sender's cached summary.
     let sender_summary = StateSummary::from(sender_summary_bytes.clone());
     if let Some(sender_pkl) = op_manager
@@ -1957,6 +2000,17 @@ async fn drive_relay_broadcast_to_streaming(
                     )
                     .await;
                 });
+            } else if err.is_contract_queue_full() {
+                // Issue #4857 on the STREAMING full-state path: identical
+                // poisoning to the non-streaming driver. A delivered streaming
+                // full-state broadcast caches the peer summary
+                // (broadcast_queue.rs → record_streaming_delivery →
+                // record_delivery_to_interest), so a queue-full drop here leaves
+                // the sender believing we are current while our subsequent CRDT
+                // deltas merge onto a diverged base WITHOUT error — the
+                // delta-apply-failure heal never fires. Emit the same
+                // rate-limited ResyncRequest as the non-streaming path.
+                send_queue_full_resync_request(op_manager, key, sender_addr, incoming_tx).await;
             }
             return Err(err);
         }
@@ -2609,8 +2663,8 @@ mod tests {
     fn broadcast_to_streaming_dedup_runs_before_merge() {
         let src = include_str!("op_ctx_task.rs");
         let start = src
-            .find("async fn drive_relay_broadcast_to_streaming(")
-            .expect("drive_relay_broadcast_to_streaming not found");
+            .find("async fn apply_streaming_broadcast(")
+            .expect("apply_streaming_broadcast not found");
         let after = &src[start + 1..];
         let end = after
             .find("\nasync fn ")
@@ -2627,61 +2681,105 @@ mod tests {
         assert!(
             dedup_pos < merge_pos,
             "broadcast_dedup_cache.check_and_insert MUST appear before \
-             update_contract() in drive_relay_broadcast_to_streaming"
+             update_contract() in apply_streaming_broadcast"
         );
     }
 
-    /// Issue #4857 / #4251 reconciliation pin: on a queue-full broadcast
-    /// drop, `drive_relay_broadcast_to` must emit a RATE-LIMITED
-    /// `ResyncRequest` — neither suppress it (which left rarely-changing
-    /// fields permanently diverged, #4857) nor emit it unthrottled (which
-    /// amplified into a full-state storm, #4251). The queue-full arm MUST
-    /// therefore BOTH gate on `should_send_resync_request` (the rate limit)
-    /// AND emit `InterestMessage::ResyncRequest` (the heal). Auto-fetch stays
-    /// suppressed on queue-full (a GET onto the saturated queue heals nothing).
+    /// Issue #4857 / #4251 reconciliation pin. On a queue-full broadcast drop,
+    /// BOTH broadcast drivers must emit a RATE-LIMITED `ResyncRequest` — neither
+    /// suppress it (permanent divergence, #4857) nor emit it unthrottled
+    /// (full-state storm, #4251). Both route through the shared
+    /// `send_queue_full_resync_request` helper, which nests the
+    /// `InterestMessage::ResyncRequest` emit INSIDE the `should_send_resync_request`
+    /// rate-limit gate. Auto-fetch stays suppressed on each driver's queue-full arm.
     #[test]
     fn broadcast_to_sends_throttled_resync_on_queue_full() {
         let src = include_str!("op_ctx_task.rs");
-        let start = src
-            .find("async fn drive_relay_broadcast_to(")
-            .expect("drive_relay_broadcast_to not found");
-        let after = &src[start + 1..];
-        let end = after
-            .find("\nasync fn ")
-            .or_else(|| after.find("\n#[cfg(test)]"))
-            .unwrap_or(after.len());
-        let driver_src = &src[start..start + 1 + end];
 
-        // The queue-full classification must still exist (it drives the arm).
+        // Slice a top-level `async fn NAME(` body out of the source (up to the
+        // next top-level `async fn` or the test module).
+        let fn_body = |name: &str| -> &str {
+            let start = src.find(name).unwrap_or_else(|| panic!("{name} not found"));
+            let after = &src[start + 1..];
+            let end = after
+                .find("\nasync fn ")
+                .or_else(|| after.find("\n#[cfg(test)]"))
+                .unwrap_or(after.len());
+            &src[start..start + 1 + end]
+        };
+        // Slice the queue-full match arm (from `marker` up to its closing
+        // `return Err(err);`) out of a driver body.
+        let queue_full_arm = |body: &'static str, marker: &str| -> &'static str {
+            let arm_start = body
+                .find(marker)
+                .unwrap_or_else(|| panic!("queue-full arm `{marker}` missing"));
+            let arm_end = body[arm_start..]
+                .find("return Err(err);")
+                .expect("return after queue-full arm missing");
+            &body[arm_start..arm_start + arm_end]
+        };
+
+        // Non-streaming driver delegates to the helper and does NOT auto-fetch.
+        let ns = fn_body("async fn drive_relay_broadcast_to(");
         assert!(
-            driver_src.contains("let queue_full = err.is_contract_queue_full();"),
-            "drive_relay_broadcast_to must still classify queue-full via \
-             is_contract_queue_full() — see issue #4251"
+            ns.contains("let queue_full = err.is_contract_queue_full();"),
+            "drive_relay_broadcast_to must still classify queue-full (#4251)"
+        );
+        let ns_arm = queue_full_arm(ns, "} else if queue_full {");
+        assert!(
+            ns_arm.contains("send_queue_full_resync_request("),
+            "drive_relay_broadcast_to queue-full arm MUST delegate to \
+             send_queue_full_resync_request (heals #4857)"
+        );
+        assert!(
+            !ns_arm.contains("try_auto_fetch_contract"),
+            "drive_relay_broadcast_to queue-full arm must NOT auto-fetch (#4251)"
         );
 
-        // Scope the heal assertions to the `else if queue_full { ... }` arm so
-        // the delta-apply arm's ResyncRequest cannot satisfy this pin.
-        let arm_start = driver_src
-            .find("} else if queue_full {")
-            .expect("queue-full arm missing in drive_relay_broadcast_to");
-        let queue_full_arm = &driver_src[arm_start..];
+        // Streaming path: the queue-full arm lives in `apply_streaming_broadcast`
+        // (steps 4-9, extracted from the driver for testability). It delegates to
+        // the SAME helper and does NOT auto-fetch (auto-fetch lives in the
+        // separate log_broadcast_to_streaming_failure branch). Missing arm ⇒
+        // #4857 open on the streaming full-state path.
+        assert!(
+            fn_body("async fn drive_relay_broadcast_to_streaming(")
+                .contains("apply_streaming_broadcast("),
+            "drive_relay_broadcast_to_streaming must delegate to \
+             apply_streaming_broadcast — otherwise the streaming apply/heal logic \
+             is unreachable"
+        );
+        let st = fn_body("async fn apply_streaming_broadcast(");
+        let st_arm = queue_full_arm(st, "} else if err.is_contract_queue_full() {");
+        assert!(
+            st_arm.contains("send_queue_full_resync_request("),
+            "apply_streaming_broadcast queue-full arm MUST delegate to \
+             send_queue_full_resync_request — otherwise #4857 stays OPEN on the \
+             streaming full-state path"
+        );
+        assert!(
+            !st_arm.contains("try_auto_fetch_contract"),
+            "streaming queue-full arm must NOT auto-fetch (#4251)"
+        );
 
+        // The shared helper nests the emit INSIDE the throttle gate: the
+        // `should_send_resync_request` check comes BEFORE the emit, which comes
+        // BEFORE the throttled `else` branch. An emit outside the gate would
+        // re-open the #4251 storm.
+        let helper = fn_body("async fn send_queue_full_resync_request(");
+        let gate = helper
+            .find(".should_send_resync_request(")
+            .expect("helper must gate on should_send_resync_request (rate limit, #4251)");
+        let emit = helper
+            .find("InterestMessage::ResyncRequest")
+            .expect("helper must emit InterestMessage::ResyncRequest (heal, #4857)");
+        let gate_else = helper
+            .find("} else {")
+            .expect("helper must have a throttled `else` branch");
         assert!(
-            queue_full_arm.contains("should_send_resync_request"),
-            "the queue-full arm MUST gate its ResyncRequest on \
-             should_send_resync_request — the rate limit that bounds the #4251 \
-             amplification. Dropping the throttle re-opens the ResyncRequest storm."
-        );
-        assert!(
-            queue_full_arm.contains("InterestMessage::ResyncRequest"),
-            "the queue-full arm MUST emit InterestMessage::ResyncRequest so the \
-             sender clears its poisoned summary cache and re-sends full state — \
-             without it a silently-dropped delta diverges permanently (#4857)."
-        );
-        assert!(
-            !queue_full_arm.contains("try_auto_fetch_contract"),
-            "the queue-full arm must NOT auto-fetch — a GET onto the same \
-             saturated queue is pure amplification with no healing value (#4251)."
+            gate < emit && emit < gate_else,
+            "the ResyncRequest emit MUST be nested INSIDE the \
+             `if should_send_resync_request {{ .. }}` gate (before the throttled \
+             `else`), so an unthrottled emission cannot re-open the #4251 storm"
         );
     }
 
@@ -2706,26 +2804,26 @@ mod tests {
         targets
     }
 
-    /// Issue #4857 behavioral reproduction: when an inbound broadcast delta is
-    /// dropped with `ContractQueueFull`, `drive_relay_broadcast_to` MUST emit a
-    /// `ResyncRequest` back to the sender so the sender clears its poisoned
-    /// summary cache and re-sends the dropped change — and that emission MUST be
-    /// rate-limited so a burst of drops does not re-open the #4251 storm.
-    ///
-    /// On `origin/main` this test FAILS: the queue-full arm suppresses the
-    /// ResyncRequest entirely, so `first` is empty (the divergence is silent and
-    /// permanent). With the fix, the first drop emits exactly one ResyncRequest
-    /// and the immediate second drop is throttled.
-    ///
-    /// The drop is injected at the contract-handler seam (a stand-in handler
-    /// answers every `UpdateQuery` with `ContractQueueFull`) rather than by
-    /// saturating the real 100-slot fair queue, which is non-deterministic.
-    #[tokio::test]
-    async fn queue_full_broadcast_emits_throttled_resync_request() {
-        // ── Build a minimal real OpManager (mirrors op_state_manager.rs
-        //    build_reroot_test_op_manager). ────────────────────────────────
+    /// Build a minimal real OpManager wired to a contract-handler stand-in that
+    /// answers every `UpdateQuery` with `ContractQueueFull` (the silent drop a
+    /// saturated receiver hits under load) and every `GetQuery` with "no state".
+    /// Returns the op_manager, the event-loop notification receiver (to observe
+    /// emitted `ResyncRequest`s), and a keep-alive guard holding the handler task
+    /// plus the channel halves that must outlive the op_manager. Mirrors
+    /// `op_state_manager.rs::build_reroot_test_op_manager`; shared by the #4857
+    /// queue-full behavioral tests for the non-streaming and streaming paths.
+    async fn build_queue_full_test_node(
+        id: &str,
+    ) -> (
+        Arc<OpManager>,
+        crate::node::EventLoopNotificationsReceiver,
+        Box<dyn std::any::Any>,
+    ) {
+        // Distinct `id` per caller: `ConfigArgs::build` derives a Local-mode data
+        // directory from it, so two concurrently-running tests sharing an id race
+        // on that directory (flaky "No such file or directory").
         let config_args = crate::config::ConfigArgs {
-            id: Some("queue-full-resync-4857".to_string()),
+            id: Some(id.to_string()),
             mode: Some(crate::contract::OperationMode::Local),
             ..Default::default()
         };
@@ -2733,11 +2831,11 @@ mod tests {
             crate::node::NodeConfig::new(config_args.build().await.expect("build Config"))
                 .await
                 .expect("build NodeConfig");
-        let (mut notification_rx, notification_tx) = crate::node::event_loop_notification_channel();
-        let (ops_ch_channel, mut ch_channel, _wait_for_event) =
+        let (notification_rx, notification_tx) = crate::node::event_loop_notification_channel();
+        let (ops_ch_channel, mut ch_channel, wait_for_event) =
             crate::contract::contract_handler_channel();
         let connection_manager = crate::ring::ConnectionManager::new(&node_config);
-        let (result_router_tx, _result_router_rx) = tokio::sync::mpsc::channel(100);
+        let (result_router_tx, result_router_rx) = tokio::sync::mpsc::channel(100);
         let task_monitor = crate::node::background_task_monitor::BackgroundTaskMonitor::new();
         let op_manager = Arc::new(
             OpManager::new(
@@ -2755,9 +2853,6 @@ mod tests {
         let self_addr: SocketAddr = "127.0.0.1:12000".parse().unwrap();
         op_manager.ring.connection_manager.set_own_addr(self_addr);
 
-        // ── Contract-handler stand-in: answer GetQuery with "no state" and
-        //    every UpdateQuery with ContractQueueFull (the silent drop a
-        //    saturated receiver hits under load). ──────────────────────────
         let handler = tokio::spawn(async move {
             while let Ok((id, ev, _priority)) = ch_channel.recv_from_sender().await {
                 let response = match ev {
@@ -2784,6 +2879,30 @@ mod tests {
             }
         });
 
+        let guard: Box<dyn std::any::Any> =
+            Box::new((handler, result_router_rx, task_monitor, wait_for_event));
+        (op_manager, notification_rx, guard)
+    }
+
+    /// Issue #4857 behavioral reproduction (non-streaming delta path): when an
+    /// inbound broadcast delta is dropped with `ContractQueueFull`,
+    /// `drive_relay_broadcast_to` MUST emit a `ResyncRequest` back to the sender
+    /// so it clears its poisoned summary cache and re-sends the dropped change —
+    /// and that emission MUST be rate-limited so a burst of drops does not
+    /// re-open the #4251 storm.
+    ///
+    /// On `origin/main` this test FAILS: the queue-full arm suppresses the
+    /// ResyncRequest entirely, so `first` is empty (the divergence is silent and
+    /// permanent). With the fix, the first drop emits exactly one ResyncRequest
+    /// and the immediate second drop is throttled.
+    ///
+    /// The drop is injected at the contract-handler seam (a stand-in handler
+    /// answers every `UpdateQuery` with `ContractQueueFull`) rather than by
+    /// saturating the real 100-slot fair queue, which is non-deterministic.
+    #[tokio::test]
+    async fn queue_full_broadcast_emits_throttled_resync_request() {
+        let (op_manager, mut notification_rx, _guard) =
+            build_queue_full_test_node("queue-full-resync-4857-delta").await;
         let key = ContractKey::from_id_and_code(
             ContractInstanceId::new([7u8; 32]),
             CodeHash::new([8u8; 32]),
@@ -2806,9 +2925,8 @@ mod tests {
                 .is_some_and(|e| e.is_contract_queue_full()),
             "expected a queue-full error from the stand-in handler, got {r1:?}"
         );
-        let first = drain_resync_targets(&mut notification_rx, key);
         assert_eq!(
-            first,
+            drain_resync_targets(&mut notification_rx, key),
             vec![sender_addr],
             "a queue-full drop MUST emit exactly one ResyncRequest to the sender \
              so it clears its poisoned summary and re-sends (heals #4857)"
@@ -2832,14 +2950,79 @@ mod tests {
                 .is_some_and(|e| e.is_contract_queue_full()),
             "second broadcast should still hit queue-full, got {r2:?}"
         );
-        let second = drain_resync_targets(&mut notification_rx, key);
         assert!(
-            second.is_empty(),
+            drain_resync_targets(&mut notification_rx, key).is_empty(),
             "a second queue-full drop within the throttle window MUST NOT emit \
-             another ResyncRequest (bounds #4251 amplification), got {second:?}"
+             another ResyncRequest (bounds #4251 amplification)"
+        );
+    }
+
+    /// Issue #4857 behavioral reproduction (STREAMING full-state path): the
+    /// large-room case the round-2 review flagged. A delivered streaming
+    /// full-state broadcast caches the peer summary, so a `ContractQueueFull`
+    /// drop here poisons the sender identically to the delta path — and the
+    /// streaming Err arm previously had NO resync branch. `apply_streaming_broadcast`
+    /// (steps 4-9 of `drive_relay_broadcast_to_streaming`) MUST now emit the same
+    /// throttled `ResyncRequest`.
+    ///
+    /// On `origin/main` (and on the round-1 fix, which only patched the
+    /// non-streaming driver) this FAILS: `first` is empty. With the round-2 fix
+    /// the first drop emits one ResyncRequest and the second is throttled.
+    #[tokio::test]
+    async fn queue_full_streaming_broadcast_emits_throttled_resync_request() {
+        let (op_manager, mut notification_rx, _guard) =
+            build_queue_full_test_node("queue-full-resync-4857-streaming").await;
+        let key = ContractKey::from_id_and_code(
+            ContractInstanceId::new([9u8; 32]),
+            CodeHash::new([10u8; 32]),
+        );
+        let sender_addr: SocketAddr = "127.0.0.1:12200".parse().unwrap();
+
+        // First streaming full-state → dropped queue-full → MUST emit a ResyncRequest.
+        let r1 = apply_streaming_broadcast(
+            &op_manager,
+            Transaction::new::<UpdateMsg>(),
+            key,
+            vec![1, 2, 3],
+            Vec::new(),
+            sender_addr,
+        )
+        .await;
+        assert!(
+            r1.as_ref()
+                .err()
+                .is_some_and(|e| e.is_contract_queue_full()),
+            "expected a queue-full error from the stand-in handler, got {r1:?}"
+        );
+        assert_eq!(
+            drain_resync_targets(&mut notification_rx, key),
+            vec![sender_addr],
+            "a queue-full streaming full-state drop MUST emit exactly one \
+             ResyncRequest (heals #4857 on the streaming path)"
         );
 
-        handler.abort();
+        // Second streaming full-state with DIFFERENT bytes (not a dedup hit)
+        // within the throttle window → still queue-full, ResyncRequest throttled.
+        let r2 = apply_streaming_broadcast(
+            &op_manager,
+            Transaction::new::<UpdateMsg>(),
+            key,
+            vec![4, 5, 6],
+            Vec::new(),
+            sender_addr,
+        )
+        .await;
+        assert!(
+            r2.as_ref()
+                .err()
+                .is_some_and(|e| e.is_contract_queue_full()),
+            "second streaming broadcast should still hit queue-full, got {r2:?}"
+        );
+        assert!(
+            drain_resync_targets(&mut notification_rx, key).is_empty(),
+            "a second streaming queue-full drop within the throttle window MUST \
+             NOT emit another ResyncRequest (bounds #4251 amplification)"
+        );
     }
 
     /// Issue #4251 follow-up: the four `run_relay_*` driver wrappers each
@@ -2898,8 +3081,8 @@ mod tests {
     fn broadcast_to_streaming_classifies_failures() {
         let src = include_str!("op_ctx_task.rs");
         let start = src
-            .find("async fn drive_relay_broadcast_to_streaming(")
-            .expect("drive_relay_broadcast_to_streaming not found");
+            .find("async fn apply_streaming_broadcast(")
+            .expect("apply_streaming_broadcast not found");
         let after = &src[start + 1..];
         let end = after
             .find("\nasync fn ")
@@ -2909,17 +3092,17 @@ mod tests {
 
         assert!(
             driver_src.contains("log_broadcast_to_streaming_failure"),
-            "drive_relay_broadcast_to_streaming must call \
+            "apply_streaming_broadcast must call \
              log_broadcast_to_streaming_failure for failure classification"
         );
         assert!(
             driver_src.contains("try_auto_fetch_contract"),
-            "drive_relay_broadcast_to_streaming must call try_auto_fetch_contract \
+            "apply_streaming_broadcast must call try_auto_fetch_contract \
              on real (non-benign) failures for self-heal"
         );
         assert!(
             driver_src.contains("send_summary_back_on_rejection"),
-            "drive_relay_broadcast_to_streaming must spawn \
+            "apply_streaming_broadcast must spawn \
              send_summary_back_on_rejection on is_invalid_update_rejection"
         );
     }
@@ -2931,8 +3114,8 @@ mod tests {
     fn broadcast_to_streaming_spawns_proactive_summary() {
         let src = include_str!("op_ctx_task.rs");
         let start = src
-            .find("async fn drive_relay_broadcast_to_streaming(")
-            .expect("drive_relay_broadcast_to_streaming not found");
+            .find("async fn apply_streaming_broadcast(")
+            .expect("apply_streaming_broadcast not found");
         let after = &src[start + 1..];
         let end = after
             .find("\nasync fn ")
@@ -2941,7 +3124,7 @@ mod tests {
         let driver_src = &src[start..start + 1 + end];
         assert!(
             driver_src.contains("send_proactive_summary_notification"),
-            "drive_relay_broadcast_to_streaming must spawn \
+            "apply_streaming_broadcast must spawn \
              send_proactive_summary_notification on successful state change"
         );
     }
@@ -2981,7 +3164,7 @@ mod tests {
         assert!(
             src.contains("pub(crate) fn log_broadcast_to_streaming_failure("),
             "log_broadcast_to_streaming_failure must remain pub(crate) — \
-             reused by drive_relay_broadcast_to_streaming"
+             reused by apply_streaming_broadcast"
         );
     }
 

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -46,6 +46,7 @@ use freenet_stdlib::prelude::{ContractKey, StateDelta, StateSummary};
 use lru::LruCache;
 use parking_lot::Mutex;
 use std::collections::{HashMap, HashSet};
+use std::net::SocketAddr;
 use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
@@ -85,6 +86,30 @@ use crate::config::GlobalRng;
 
 /// Maximum number of entries in the delta memoization cache.
 const DELTA_CACHE_SIZE: usize = 1024;
+
+/// Minimum interval between queue-full `ResyncRequest`s to the same peer for
+/// the same contract (issue #4857).
+///
+/// A `ContractQueueFull` broadcast drop is silent: the receiver never applied
+/// the delta, but the SENDER cached its own summary as ours on send-Ok
+/// (`broadcast_queue.rs::record_delivery_to_interest`), so it believes we are
+/// current and will never re-send the dropped change. Left unhealed, a
+/// rarely-changing field diverges permanently until the ~5-min InterestSync
+/// heartbeat happens to correct it. Emitting a `ResyncRequest` makes the sender
+/// clear its cached summary of us and re-send full state — but issue #4251
+/// showed that one request per dropped delta amplifies into a full-state storm
+/// onto the same saturated queue. This interval bounds that amplification to at
+/// most one request per (contract, peer) window while still healing far faster
+/// than the heartbeat backstop.
+const RESYNC_REQUEST_MIN_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Bound on the number of (contract, peer) entries in the queue-full
+/// `ResyncRequest` throttle. The key is influenced by remote peers (any peer
+/// can broadcast any contract to us), so it MUST be bounded — see the
+/// per-key-collection rule in `.claude/rules/code-style.md`. LRU eviction fails
+/// open: forgetting an entry merely permits one extra healing `ResyncRequest`,
+/// which is safe.
+const RESYNC_THROTTLE_CACHE_SIZE: usize = 4096;
 
 /// Timeout for contract handler queries in the broadcast path (summary and
 /// delta computation). Much shorter than the default 300s to prevent spawned
@@ -320,6 +345,12 @@ pub struct InterestManager<T: TimeSource> {
     /// the removal after the deadline passes. If the peer reconnects before the
     /// deadline, the entry is removed from this map and interests are preserved.
     pending_removals: DashMap<PeerKey, Instant>,
+
+    /// Rate-limit gate for queue-full `ResyncRequest`s, keyed by
+    /// (contract, target peer address). Bounded LRU so remote peers cannot grow
+    /// it without bound. See [`InterestManager::should_send_resync_request`] and
+    /// issue #4857.
+    resync_request_throttle: Mutex<LruCache<(ContractKey, SocketAddr), Instant>>,
 }
 
 impl<T: TimeSource + Sync> InterestManager<T> {
@@ -340,6 +371,10 @@ impl<T: TimeSource + Sync> InterestManager<T> {
             resync_requests_received: AtomicU64::new(0),
             summary_notify_timestamps: DashMap::new(),
             pending_removals: DashMap::new(),
+            resync_request_throttle: Mutex::new(LruCache::new(
+                NonZeroUsize::new(RESYNC_THROTTLE_CACHE_SIZE)
+                    .expect("RESYNC_THROTTLE_CACHE_SIZE must be > 0"),
+            )),
         }
     }
 
@@ -558,6 +593,31 @@ impl<T: TimeSource + Sync> InterestManager<T> {
         } else {
             false
         }
+    }
+
+    /// Rate-limit gate for queue-full `ResyncRequest`s to `target` for
+    /// `contract`. Returns `true` (and records the send) when at least
+    /// [`RESYNC_REQUEST_MIN_INTERVAL`] has elapsed since the last such request
+    /// for this (contract, target) pair, or when none was ever sent.
+    ///
+    /// Issue #4857: a `ContractQueueFull` broadcast drop is silent — the
+    /// receiver never applied the delta, but the SENDER cached its own summary
+    /// as ours on send-Ok, so it believes we are current and will never re-send
+    /// the dropped change. A `ResyncRequest` makes the sender clear that cached
+    /// summary and re-send full state. Issue #4251 suppressed the request
+    /// entirely because one-per-dropped-delta amplifies into a full-state storm;
+    /// this gate keeps the healing signal but bounds it to one per window.
+    pub fn should_send_resync_request(&self, contract: &ContractKey, target: SocketAddr) -> bool {
+        let now = self.time_source.now();
+        let key = (*contract, target);
+        let mut throttle = self.resync_request_throttle.lock();
+        if let Some(&last) = throttle.get(&key) {
+            if now.duration_since(last) < RESYNC_REQUEST_MIN_INTERVAL {
+                return false;
+            }
+        }
+        throttle.put(key, now);
+        true
     }
 
     /// Remove all interests for a peer (called on peer disconnect).
@@ -1564,6 +1624,55 @@ mod tests {
         let retrieved = manager.get_peer_summary(&contract, &peer);
         assert!(retrieved.is_some());
         assert_eq!(retrieved.unwrap().as_ref(), summary.as_ref());
+    }
+
+    /// Issue #4857: `should_send_resync_request` must emit at most one
+    /// `ResyncRequest` per (contract, peer) per `RESYNC_REQUEST_MIN_INTERVAL`.
+    /// The first drop heals immediately; a burst of further drops within the
+    /// window is throttled (bounding the #4251 amplification); after the window
+    /// elapses a fresh request is allowed again.
+    #[test]
+    fn should_send_resync_request_rate_limits_per_contract_peer() {
+        let (manager, time) = make_manager();
+        let contract = make_contract_key(1);
+        let addr: SocketAddr = "127.0.0.1:5001".parse().unwrap();
+
+        // First drop for this (contract, peer) → allowed (immediate heal).
+        assert!(
+            manager.should_send_resync_request(&contract, addr),
+            "first ResyncRequest for a fresh (contract, peer) must be allowed"
+        );
+        // Immediate repeat within the window → throttled.
+        assert!(
+            !manager.should_send_resync_request(&contract, addr),
+            "a second ResyncRequest within RESYNC_REQUEST_MIN_INTERVAL must be throttled"
+        );
+
+        // A DIFFERENT peer for the same contract is an independent bucket.
+        let other_addr: SocketAddr = "127.0.0.1:5002".parse().unwrap();
+        assert!(
+            manager.should_send_resync_request(&contract, other_addr),
+            "a distinct peer must not share the first peer's throttle bucket"
+        );
+        // A DIFFERENT contract for the same peer is also independent.
+        let other_contract = make_contract_key(2);
+        assert!(
+            manager.should_send_resync_request(&other_contract, addr),
+            "a distinct contract must not share the first contract's throttle bucket"
+        );
+
+        // Just before the interval elapses → still throttled.
+        time.advance_time(RESYNC_REQUEST_MIN_INTERVAL - Duration::from_millis(1));
+        assert!(
+            !manager.should_send_resync_request(&contract, addr),
+            "ResyncRequest must stay throttled until the full interval elapses"
+        );
+        // After the interval elapses → allowed again.
+        time.advance_time(Duration::from_millis(2));
+        assert!(
+            manager.should_send_resync_request(&contract, addr),
+            "ResyncRequest must be allowed again once RESYNC_REQUEST_MIN_INTERVAL has elapsed"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

State updates can be **permanently lost for rarely-changing contract fields** (member_info, a ban, a config value). When a receiver drops a broadcast with `ContractQueueFull`, the drop is **silent**: the SENDER already cached its own summary as the neighbor's on send-Ok (`broadcast_queue.rs::record_delivery_to_interest`, and the streaming sibling `record_streaming_delivery`), so it believes the neighbor is current and never re-sends the missed change. Every later broadcast is `diff(current, poisoned_summary)` = only newer changes, so the dropped field never reappears. Only the ~5-min InterestSync heartbeat can correct it (imperfectly — the heal rides the same poisonable path). New messages self-mask the bug because each re-ships the latest `recent_messages` window.

The tension this PR resolves: the queue-full arm **suppressed** the healing `ResyncRequest` entirely. Issue **#4251** (PR #4253) added that suppression because an *unbounded* ResyncRequest per dropped delta amplified into a full-state storm onto the same saturated queue (~40 ResyncRequests/sec on a hot contract). So emit → storm (#4251); suppress → diverge (#4857).

Both broadcast paths are affected: the non-streaming `drive_relay_broadcast_to` (delta) **and** the streaming full-state `drive_relay_broadcast_to_streaming` (reachable for large River rooms streaming >64KB full-state to a summary-less/just-cleared subscriber).

## Solution

Emit a **rate-limited** `ResyncRequest` on the queue-full drop instead of suppressing it, on **both** paths via one shared `send_queue_full_resync_request` helper. An inbound ResyncRequest makes the sender **clear** its cached summary of us (node.rs handler) and re-send full state.

- `InterestManager::should_send_resync_request(contract, target)` — bounded-LRU per-`(contract, peer)` throttle (fail-open on eviction; LRU because the key is influenced by remote peers, so it must be bounded per `.claude/rules/code-style.md`). Interval `RESYNC_REQUEST_MIN_INTERVAL = 30s`, chosen as ~10x under the 5-min heartbeat backstop while keeping River's ~80-target fan-out below the #4251 storm.
- Streaming steps 4-9 extracted into `apply_streaming_broadcast` so the streaming heal is unit-testable without the transport stream-assembly plumbing.
- Auto-fetch stays suppressed on queue-full (a GET onto the same saturated queue is pure amplification with no healing value).

**Why (a) not (b):** the issue proposed either (a) a receiver-side rate-limited NACK or (b) stop caching the neighbor summary on sender-side send-Ok. (b) standalone would re-introduce the **#4442** full-state broadcast storm — caching on delivered-send is exactly what lets a new subscriber's next broadcast collapse to a small delta. (a) is the minimal, safe fix.

### Honest bounds (the #4251↔#4857 tension is MANAGED, not eliminated)

The throttle is per-`(contract, receiver)`, so aggregate resync load scales **O(N)** with receiver count, and each `ResyncResponse` is **full state** (larger than the dropped delta). For River's ~80-target fan-out this is ~2-3 ResyncRequests/sec (~15x under the 40/sec that triggered #4251), but the bound is not universal. Under **sustained** saturation the heal round-trips the same full queue and defers until it drains, so "heals faster than the heartbeat" holds for the common **transient** case and after saturation clears — not during sustained overload. The durable half of the heal (the sender clearing its poisoned summary) is a small control-plane InterestMessage that does **not** ride the saturated contract queue, so it lands even while the queue is full; the full-state resend is what defers. Net: bounded amplification + faster common-case heal, with the heartbeat as the ultimate backstop.

## Testing

- **`queue_full_broadcast_emits_throttled_resync_request`** (behavioral, delta path) and **`queue_full_streaming_broadcast_emits_throttled_resync_request`** (behavioral, streaming path): each stands up a real `OpManager` with a contract-handler stand-in that replies `ContractQueueFull`, drives the real driver logic, and asserts **one** ResyncRequest on the first drop and **none** on the throttled second. Both verified to **FAIL** without their respective fix (`left: []`, no ResyncRequest) and pass with it.
- **`should_send_resync_request_rate_limits_per_contract_peer`** (unit): first allowed, immediate repeat throttled, distinct `(contract, peer)` buckets independent, re-allowed after the interval.
- **`broadcast_to_sends_throttled_resync_on_queue_full`** (tightened structural pin): BOTH drivers' queue-full arms delegate to the shared helper; the helper nests the `InterestMessage::ResyncRequest` emit INSIDE the `should_send_resync_request` gate (emit position between gate and the throttled `else`); neither arm auto-fetches. Verified it FAILS when the streaming arm is removed.

**Heal-loop coverage** is piecewise (a true end-to-end multi-node heal needs the sim harness with coarse fault injection): emit → existing behavioral tests above; ResyncRequest → sender clears its cached summary → existing `resync_request_handler_clears_cached_peer_summary`; cleared summary (None) → next broadcast sends full state → existing `broadcast_queue` summary-caching tests.

Regression check: update module (70), interest (40), broadcast_queue (8), node resync (1) all green; `cargo fmt` + `cargo clippy --lib -D warnings` clean.

## Scope / follow-ups

Fixes the **primary** divergence only. The two secondary findings in #4857 are left as follow-ups:
1. `is_stale` byte-compares nondeterministic (ciborium HashMap) summary bytes, so the equal-summary skip rarely fires and heartbeat heals fire spuriously.
2. Over-disk-budget peers silently reject growth-only updates (a second permanent-divergence shape).

Closes #4857

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B49wBfvR8EjpfYTw5muNV9

[AI-assisted - Claude]