### PR TITLE
fix(update): contain poison-contract CPU churn — enforced WASM preemption, merge-failure backoff, resync rate limits (#4861)

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -177,7 +177,7 @@ pub struct ConfigArgs {
     /// until it fits. Bounding by bytes (not entry count) stops a node hosting
     /// many contracts from thrashing the cache and recompiling on every access
     /// (issue #4441). When unset, the default scales with system RAM
-    /// (`clamp(total_ram / 8, 64 MiB, 1.5 GiB)`); set this to override.
+    /// (`clamp(total_ram / 8, 64 MiB, 4 GiB)`); set this to override.
     #[arg(long, env = "FREENET_MODULE_CACHE_BUDGET_BYTES")]
     pub module_cache_budget_bytes: Option<usize>,
 

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -3421,6 +3421,9 @@ std::thread_local! {
     // `StateDelta` ships via `ProbeReconcile`).
     static GLOBAL_PUT_PROBE_EXISTING_MESH_DELTA_COUNT: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
     static GLOBAL_PUT_PROBE_EXISTING_MESH_DELTA_BYTES: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+    // UPDATE broadcast merges skipped by the per-contract merge-failure backoff
+    // (poison-contract quarantine, #4861).
+    static GLOBAL_MERGES_SUPPRESSED_BY_BACKOFF: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
 }
 
 /// Global test metrics for tracking events across the simulation network.
@@ -3464,6 +3467,7 @@ impl GlobalTestMetrics {
         GLOBAL_PUT_PROBE_NEW_CONTRACT_BYTES.with(|c| c.set(0));
         GLOBAL_PUT_PROBE_EXISTING_MESH_DELTA_COUNT.with(|c| c.set(0));
         GLOBAL_PUT_PROBE_EXISTING_MESH_DELTA_BYTES.with(|c| c.set(0));
+        GLOBAL_MERGES_SUPPRESSED_BY_BACKOFF.with(|c| c.set(0));
     }
 
     /// Records that a ResyncRequest was received.
@@ -3475,6 +3479,18 @@ impl GlobalTestMetrics {
     /// Returns the total number of ResyncRequests received since last reset.
     pub fn resync_requests() -> u64 {
         GLOBAL_RESYNC_REQUESTS.with(|c| c.get())
+    }
+
+    /// Records that an UPDATE broadcast merge was skipped by the per-contract
+    /// merge-failure backoff (poison-contract quarantine, #4861).
+    pub fn record_merge_suppressed_by_backoff() {
+        GLOBAL_MERGES_SUPPRESSED_BY_BACKOFF.with(|c| c.set(c.get() + 1));
+    }
+
+    /// Returns the number of merges skipped by the merge-failure backoff since
+    /// last reset.
+    pub fn merges_suppressed_by_backoff() -> u64 {
+        GLOBAL_MERGES_SUPPRESSED_BY_BACKOFF.with(|c| c.get())
     }
 
     /// Records that a delta was sent in a state change broadcast.

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -3424,6 +3424,10 @@ std::thread_local! {
     // UPDATE broadcast merges skipped by the per-contract merge-failure backoff
     // (poison-contract quarantine, #4861).
     static GLOBAL_MERGES_SUPPRESSED_BY_BACKOFF: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+    // ResyncRequest emissions / ResyncResponse sends suppressed by the resync
+    // rate limiters (#4861).
+    static GLOBAL_RESYNC_REQUESTS_SUPPRESSED: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+    static GLOBAL_RESYNC_RESPONSES_SUPPRESSED: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
 }
 
 /// Global test metrics for tracking events across the simulation network.
@@ -3468,6 +3472,8 @@ impl GlobalTestMetrics {
         GLOBAL_PUT_PROBE_EXISTING_MESH_DELTA_COUNT.with(|c| c.set(0));
         GLOBAL_PUT_PROBE_EXISTING_MESH_DELTA_BYTES.with(|c| c.set(0));
         GLOBAL_MERGES_SUPPRESSED_BY_BACKOFF.with(|c| c.set(0));
+        GLOBAL_RESYNC_REQUESTS_SUPPRESSED.with(|c| c.set(0));
+        GLOBAL_RESYNC_RESPONSES_SUPPRESSED.with(|c| c.set(0));
     }
 
     /// Records that a ResyncRequest was received.
@@ -3491,6 +3497,28 @@ impl GlobalTestMetrics {
     /// last reset.
     pub fn merges_suppressed_by_backoff() -> u64 {
         GLOBAL_MERGES_SUPPRESSED_BY_BACKOFF.with(|c| c.get())
+    }
+
+    /// Records that a `ResyncRequest` emission was suppressed by the per-contract
+    /// resync emit rate limiter (#4861).
+    pub fn record_resync_request_suppressed() {
+        GLOBAL_RESYNC_REQUESTS_SUPPRESSED.with(|c| c.set(c.get() + 1));
+    }
+
+    /// Returns the number of ResyncRequest emissions suppressed since last reset.
+    pub fn resync_requests_suppressed() -> u64 {
+        GLOBAL_RESYNC_REQUESTS_SUPPRESSED.with(|c| c.get())
+    }
+
+    /// Records that a `ResyncResponse` send was suppressed by the
+    /// per-(peer, contract) responder rate limiter (#4861).
+    pub fn record_resync_response_suppressed() {
+        GLOBAL_RESYNC_RESPONSES_SUPPRESSED.with(|c| c.set(c.get() + 1));
+    }
+
+    /// Returns the number of ResyncResponse sends suppressed since last reset.
+    pub fn resync_responses_suppressed() -> u64 {
+        GLOBAL_RESYNC_RESPONSES_SUPPRESSED.with(|c| c.get())
     }
 
     /// Records that a delta was sent in a state change broadcast.

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -543,8 +543,28 @@ impl ConfigArgs {
                 .get_or_insert(cfg.per_user_inactive_ttl_secs);
             self.inactive_user_sweep_interval_secs
                 .get_or_insert(cfg.inactive_user_sweep_interval_secs);
-            self.module_cache_budget_bytes
-                .get_or_insert(cfg.module_cache_budget_bytes);
+            // #4864 upgrade migration: an existing node whose config.toml was
+            // auto-written on a >12 GiB box carries the OLD auto-derived clamp
+            // `module-cache-budget-bytes = 1610612736` (1.5 GiB, the previous
+            // MAX_DEFAULT_MODULE_CACHE_BUDGET_BYTES, which only ever appeared as
+            // an auto-derived value on boxes with >12 GiB RAM). A plain
+            // get_or_insert would merge that stale 1.5 GiB back and pin the node
+            // to it forever, so the exact large gateways this change targets
+            // would NEVER see the new 4 GiB default. That exact value is the only
+            // distinguishable "this was auto-derived, not operator-chosen" signal
+            // we have, so treat it as auto: skip the merge, leave self None, and
+            // let build() RE-DERIVE it via default_module_cache_budget_bytes()
+            // below (yielding 4 GiB on a large box). CLI/env explicit values are
+            // parsed into `self` BEFORE this file merge, so they still win. Any
+            // OTHER persisted value is an explicit operator choice and is
+            // preserved unchanged. Accepted, release-notes-worthy edge: an
+            // operator who EXPLICITLY set exactly 1.5 GiB is indistinguishable
+            // from the old auto-default and will be re-derived.
+            const OLD_AUTO_MODULE_CACHE_BUDGET_SENTINEL: usize = 1_610_612_736;
+            if cfg.module_cache_budget_bytes != OLD_AUTO_MODULE_CACHE_BUDGET_SENTINEL {
+                self.module_cache_budget_bytes
+                    .get_or_insert(cfg.module_cache_budget_bytes);
+            }
             self.shutdown_drain_secs
                 .get_or_insert(cfg.shutdown_drain_secs);
             self.max_blocking_threads
@@ -4916,6 +4936,81 @@ mod tests {
         assert_eq!(
             iface_tx_enabled, seed.telemetry.iface_tx_enabled,
             "iface_tx_enabled"
+        );
+    }
+
+    #[tokio::test]
+    async fn module_cache_budget_old_auto_sentinel_re_derives_but_explicit_values_persist() {
+        // #4864: an existing node whose config.toml was auto-written on a >12 GiB
+        // box carries the OLD auto-derived 1.5 GiB clamp
+        // (module-cache-budget-bytes = 1_610_612_736, the previous
+        // MAX_DEFAULT_MODULE_CACHE_BUDGET_BYTES). build()'s merge must treat that
+        // exact sentinel as "auto" and RE-DERIVE the current default (so large
+        // gateways pick up the new 4 GiB clamp instead of staying pinned to
+        // 1.5 GiB forever), while PRESERVING any other persisted value (a genuine
+        // operator choice) and DERIVING when the field is absent.
+
+        // Resolve the freshly-derived default the SAME way the production default
+        // fn does, so the assertions are host-independent (no hard-coded number).
+        // On a box where the derived default happens to equal the sentinel (exactly
+        // 12 GiB RAM) case 1 still holds: re-derivation is a no-op there.
+        let derived_default = crate::wasm_runtime::default_module_cache_budget_bytes();
+
+        // Seed config.toml with `module-cache-budget-bytes = seed` (or omit the key
+        // when `seed` is None), rebuild from clap-bare args, and return the resolved
+        // value. Mirrors all_persisted_config_fields_round_trip_through_build: a base
+        // build creates the on-disk secret files + a valid full Config to serialize.
+        async fn rebuilt_budget(seed: Option<usize>) -> usize {
+            let temp_dir = tempfile::tempdir().unwrap();
+            let mut base = clap_bare_args(temp_dir.path()).build().await.unwrap();
+            let toml_str = match seed {
+                Some(v) => {
+                    base.module_cache_budget_bytes = v;
+                    toml::to_string(&base).unwrap()
+                }
+                None => {
+                    // Drop the field so build() sees it as absent and the serde
+                    // default fills it — exercises the "absent -> derive" path.
+                    // The key is a top-level scalar, so removing its single line
+                    // keeps the TOML valid.
+                    toml::to_string(&base)
+                        .unwrap()
+                        .lines()
+                        .filter(|l| !l.trim_start().starts_with("module-cache-budget-bytes"))
+                        .collect::<Vec<_>>()
+                        .join("\n")
+                }
+            };
+            std::fs::write(temp_dir.path().join("config.toml"), toml_str).unwrap();
+            clap_bare_args(temp_dir.path())
+                .build()
+                .await
+                .unwrap()
+                .module_cache_budget_bytes
+        }
+
+        // 1. Exact old-auto sentinel -> RE-DERIVED to the fresh default (NOT the
+        //    stale 1.5 GiB value).
+        let from_sentinel = rebuilt_budget(Some(1_610_612_736)).await;
+        assert_eq!(
+            from_sentinel, derived_default,
+            "the old auto-derived 1.5 GiB sentinel must re-derive to the fresh \
+             default, not stay pinned at 1_610_612_736"
+        );
+
+        // 2. Some other explicit persisted value -> preserved exactly.
+        let explicit = 777_000_000usize;
+        let from_explicit = rebuilt_budget(Some(explicit)).await;
+        assert_eq!(
+            from_explicit, explicit,
+            "an explicit non-sentinel operator value must round-trip unchanged"
+        );
+
+        // 3. Field absent from config.toml -> resolves to the derived default.
+        let from_absent = rebuilt_budget(None).await;
+        assert_eq!(
+            from_absent, derived_default,
+            "an absent field must resolve to the derived default"
         );
     }
 

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -1234,7 +1234,7 @@ pub struct Config {
     /// ~1.25× this value. Bounds the cache by total compiled bytes rather than
     /// entry count, so a node hosting many contracts doesn't thrash (issue
     /// #4441). When unset, the default scales with system RAM
-    /// (`clamp(total_ram / 8, 64 MiB, 1.5 GiB)`) so a small VPS doesn't OOM and
+    /// (`clamp(total_ram / 8, 64 MiB, 4 GiB)`) so a small VPS doesn't OOM and
     /// a big gateway still caches a large working set.
     #[serde(
         default = "default_module_cache_budget_bytes",
@@ -1354,7 +1354,7 @@ const fn default_inactive_user_sweep_interval_secs() -> u64 {
 }
 
 /// Default contract-module cache byte budget, scaled to system RAM
-/// (`clamp(total_ram / 8, 64 MiB, 1.5 GiB)`).
+/// (`clamp(total_ram / 8, 64 MiB, 4 GiB)`).
 ///
 /// Resolves to [`crate::wasm_runtime::default_module_cache_budget_bytes`], the
 /// single source of truth, so the operator-facing default and the in-code

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -3425,9 +3425,12 @@ std::thread_local! {
     // (poison-contract quarantine, #4861).
     static GLOBAL_MERGES_SUPPRESSED_BY_BACKOFF: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
     // ResyncRequest emissions / ResyncResponse sends suppressed by the resync
-    // rate limiters (#4861).
+    // rate limiters (#4861). Response suppression is split by which limiter
+    // fired: the per-(peer, contract) limit vs the global per-contract cap
+    // (#4864 review — indistinguishable in telemetry when shared).
     static GLOBAL_RESYNC_REQUESTS_SUPPRESSED: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
-    static GLOBAL_RESYNC_RESPONSES_SUPPRESSED: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+    static GLOBAL_RESYNC_RESPONSES_SUPPRESSED_PER_PEER: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+    static GLOBAL_RESYNC_RESPONSES_SUPPRESSED_GLOBAL: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
 }
 
 /// Global test metrics for tracking events across the simulation network.
@@ -3473,7 +3476,8 @@ impl GlobalTestMetrics {
         GLOBAL_PUT_PROBE_EXISTING_MESH_DELTA_BYTES.with(|c| c.set(0));
         GLOBAL_MERGES_SUPPRESSED_BY_BACKOFF.with(|c| c.set(0));
         GLOBAL_RESYNC_REQUESTS_SUPPRESSED.with(|c| c.set(0));
-        GLOBAL_RESYNC_RESPONSES_SUPPRESSED.with(|c| c.set(0));
+        GLOBAL_RESYNC_RESPONSES_SUPPRESSED_PER_PEER.with(|c| c.set(0));
+        GLOBAL_RESYNC_RESPONSES_SUPPRESSED_GLOBAL.with(|c| c.set(0));
     }
 
     /// Records that a ResyncRequest was received.
@@ -3510,15 +3514,35 @@ impl GlobalTestMetrics {
         GLOBAL_RESYNC_REQUESTS_SUPPRESSED.with(|c| c.get())
     }
 
-    /// Records that a `ResyncResponse` send was suppressed by the
-    /// per-(peer, contract) responder rate limiter (#4861).
-    pub fn record_resync_response_suppressed() {
-        GLOBAL_RESYNC_RESPONSES_SUPPRESSED.with(|c| c.set(c.get() + 1));
+    /// Records a `ResyncResponse` send suppressed by the per-(peer, contract)
+    /// responder rate limiter (#4861).
+    pub fn record_resync_response_suppressed_per_peer() {
+        GLOBAL_RESYNC_RESPONSES_SUPPRESSED_PER_PEER.with(|c| c.set(c.get() + 1));
     }
 
-    /// Returns the number of ResyncResponse sends suppressed since last reset.
+    /// Records a `ResyncResponse` send suppressed by the GLOBAL per-contract
+    /// responder cap (#4861 / #4864 review — separate counter so the two
+    /// limiters are distinguishable in telemetry).
+    pub fn record_resync_response_suppressed_global() {
+        GLOBAL_RESYNC_RESPONSES_SUPPRESSED_GLOBAL.with(|c| c.set(c.get() + 1));
+    }
+
+    /// Returns ResyncResponse sends suppressed by the per-(peer, contract)
+    /// limiter since last reset.
+    pub fn resync_responses_suppressed_per_peer() -> u64 {
+        GLOBAL_RESYNC_RESPONSES_SUPPRESSED_PER_PEER.with(|c| c.get())
+    }
+
+    /// Returns ResyncResponse sends suppressed by the global per-contract cap
+    /// since last reset.
+    pub fn resync_responses_suppressed_global() -> u64 {
+        GLOBAL_RESYNC_RESPONSES_SUPPRESSED_GLOBAL.with(|c| c.get())
+    }
+
+    /// Returns total ResyncResponse sends suppressed (per-peer + global) since
+    /// last reset.
     pub fn resync_responses_suppressed() -> u64 {
-        GLOBAL_RESYNC_RESPONSES_SUPPRESSED.with(|c| c.get())
+        Self::resync_responses_suppressed_per_peer() + Self::resync_responses_suppressed_global()
     }
 
     /// Records that a delta was sent in a state change broadcast.

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -3451,6 +3451,7 @@ std::thread_local! {
     static GLOBAL_RESYNC_REQUESTS_SUPPRESSED: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
     static GLOBAL_RESYNC_RESPONSES_SUPPRESSED_PER_PEER: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
     static GLOBAL_RESYNC_RESPONSES_SUPPRESSED_GLOBAL: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+    static GLOBAL_RESYNC_RESPONSES_UNSOLICITED: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
 }
 
 /// Global test metrics for tracking events across the simulation network.
@@ -3498,6 +3499,7 @@ impl GlobalTestMetrics {
         GLOBAL_RESYNC_REQUESTS_SUPPRESSED.with(|c| c.set(0));
         GLOBAL_RESYNC_RESPONSES_SUPPRESSED_PER_PEER.with(|c| c.set(0));
         GLOBAL_RESYNC_RESPONSES_SUPPRESSED_GLOBAL.with(|c| c.set(0));
+        GLOBAL_RESYNC_RESPONSES_UNSOLICITED.with(|c| c.set(0));
     }
 
     /// Records that a ResyncRequest was received.
@@ -3557,6 +3559,19 @@ impl GlobalTestMetrics {
     /// since last reset.
     pub fn resync_responses_suppressed_global() -> u64 {
         GLOBAL_RESYNC_RESPONSES_SUPPRESSED_GLOBAL.with(|c| c.get())
+    }
+
+    /// Records a received `ResyncResponse` DROPPED because it had no matching
+    /// outstanding `ResyncRequest` — unsolicited or replayed, or TTL-expired
+    /// (#4864 round-8, Codex P1). The apply is refused before any WASM runs.
+    pub fn record_resync_response_unsolicited() {
+        GLOBAL_RESYNC_RESPONSES_UNSOLICITED.with(|c| c.set(c.get() + 1));
+    }
+
+    /// Returns the number of unsolicited/replayed ResyncResponses dropped since
+    /// last reset.
+    pub fn resync_responses_unsolicited() -> u64 {
+        GLOBAL_RESYNC_RESPONSES_UNSOLICITED.with(|c| c.get())
     }
 
     /// Returns total ResyncResponse sends suppressed (per-peer + global) since

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -2054,8 +2054,10 @@ mod tests {
                     .into();
             // The UPDATE merge path constructs the ExecutorError with
             // op = Some(Upsert(key)), routing through update_exec_error.
-            let err =
-                ExecutorError::execution(contract_err, Some(super::super::InnerOpError::Upsert(key)));
+            let err = ExecutorError::execution(
+                contract_err,
+                Some(super::super::InnerOpError::Upsert(key)),
+            );
             assert!(
                 err.is_wasm_timeout(),
                 "MaxComputeTimeExceeded on the Upsert path MUST classify as a wasm timeout"

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -277,8 +277,34 @@ enum HostTimeoutClass {
 }
 
 enum InnerOpError {
+    /// UPDATE / re-PUT merge: a contract-exec failure surfaces as
+    /// `StdContractError::Update{cause}` (so `is_contract_exec_rejection` matches
+    /// and the client sees an UpdateResponse-shaped error).
     Upsert(ContractKey),
+    /// Fresh PUT (#4864 round-9 item 4): a contract-exec failure surfaces as
+    /// `StdContractError::Put{cause}` so a fresh PUT's validation error keeps
+    /// PutResponse semantics instead of masquerading as an UPDATE error.
+    Put(ContractKey),
     Delegate(DelegateKey),
+}
+
+/// Which op a shared validation helper is running for (#4864 round-9 item 4), so
+/// it can classify a `validate_state` exec failure as the RIGHT client error:
+/// `Update` for the UPDATE / re-PUT callers (keeps the merge-backoff
+/// classification), `Put` for the fresh-PUT `verify_and_store_contract` path.
+#[derive(Clone, Copy)]
+pub(crate) enum ValidationOpKind {
+    Update,
+    Put,
+}
+
+impl ValidationOpKind {
+    fn op_for(self, key: ContractKey) -> InnerOpError {
+        match self {
+            ValidationOpKind::Update => InnerOpError::Upsert(key),
+            ValidationOpKind::Put => InnerOpError::Put(key),
+        }
+    }
 }
 
 impl std::error::Error for ExecutorError {}
@@ -352,8 +378,23 @@ impl ExecutorError {
         let error = outer_error.deref();
 
         if let RuntimeInnerError::ContractExecError(e) = error {
-            if let Some(InnerOpError::Upsert(key)) = &op {
-                return ExecutorError::request(StdContractError::update_exec_error(*key, e));
+            match &op {
+                Some(InnerOpError::Upsert(key)) => {
+                    return ExecutorError::request(StdContractError::update_exec_error(*key, e));
+                }
+                // #4864 round-9 item 4: fresh PUT → Put{cause}, same
+                // "execution error:" prefix as update_exec_error so log-severity /
+                // is_wasm_timeout provenance behave identically, but a Put variant
+                // for PutResponse semantics (is_contract_exec_rejection matches only
+                // Update, so a fresh-PUT exec failure correctly does NOT look like
+                // an UPDATE-side auto-fetchable rejection).
+                Some(InnerOpError::Put(key)) => {
+                    return ExecutorError::request(StdContractError::Put {
+                        key: *key,
+                        cause: format!("execution error: {e}").into(),
+                    });
+                }
+                _ => {}
             }
         }
 
@@ -382,6 +423,14 @@ impl ExecutorError {
             match op {
                 Some(InnerOpError::Upsert(key)) => {
                     return ExecutorError::request(StdContractError::update_exec_error(key, e));
+                }
+                // #4864 round-9 item 4: fresh PUT → Put{cause} (see the
+                // ContractExecError branch above for rationale).
+                Some(InnerOpError::Put(key)) => {
+                    return ExecutorError::request(StdContractError::Put {
+                        key,
+                        cause: format!("execution error: {e}").into(),
+                    });
                 }
                 _ => return ExecutorError::other(anyhow::anyhow!("execution error: {e}")),
             }
@@ -2384,26 +2433,73 @@ mod tests {
             );
         }
 
-        /// Source-scrape pin (#4864 round-7 Codex P1): the UPDATE-path validation
-        /// helpers must classify `validate_state` failures with
-        /// `Some(InnerOpError::Upsert(*key))`, never `op = None`. A regression to
-        /// `None` would silently make the driver record nothing for a contract
-        /// whose runaway half is `validate_state`. Paired with the behavioral test
-        /// above, which pins that the Upsert form actually classifies.
+        /// #4864 round-9 item 4: a shared validation helper serves both UPDATE and
+        /// fresh-PUT callers. A fresh PUT's validate_state exec failure must surface
+        /// as a `Put` variant (PutResponse semantics), NOT an `Update` — while an
+        /// UPDATE's stays `Update` and keeps its is_wasm_timeout classification. The
+        /// host-timeout provenance is set for BOTH (op-independent, round-9 item 1).
         #[test]
-        fn update_path_validation_sites_pass_upsert_op_not_none() {
-            // (source, fn-signature-needle) for each validation helper.
-            let cases: [(&str, &str); 2] = [
+        fn put_op_validation_error_is_put_variant_update_op_is_update() {
+            use crate::wasm_runtime::{ContractError, ContractExecError, RuntimeInnerError};
+            let key = test_fixtures::make_contract_key();
+            let mk = || -> ContractError {
+                RuntimeInnerError::ContractExecError(ContractExecError::MaxComputeTimeExceeded)
+                    .into()
+            };
+
+            // Fresh PUT op → Put variant. NOT a contract-exec rejection (which matches
+            // only Update), so a fresh PUT does not look like an UPDATE-side
+            // auto-fetchable rejection. Host-timeout provenance still classifies.
+            let put_err =
+                ExecutorError::execution(mk(), Some(super::super::InnerOpError::Put(key)));
+            assert!(
+                put_err.is_wasm_timeout(),
+                "host-timeout provenance classifies even on the Put op"
+            );
+            assert!(
+                !put_err.is_contract_exec_rejection(),
+                "a Put variant is NOT an UPDATE-side exec rejection"
+            );
+            match put_err.unwrap_request() {
+                RequestError::ContractError(StdContractError::Put { .. }) => {}
+                other => panic!("fresh-PUT validation error must be a Put variant, got {other:?}"),
+            }
+
+            // UPDATE op → Update variant, is_contract_exec_rejection true, timeout true.
+            let upd_err =
+                ExecutorError::execution(mk(), Some(super::super::InnerOpError::Upsert(key)));
+            assert!(upd_err.is_wasm_timeout());
+            assert!(upd_err.is_contract_exec_rejection());
+            match upd_err.unwrap_request() {
+                RequestError::ContractError(StdContractError::Update { .. }) => {}
+                other => panic!("UPDATE validation error must be an Update variant, got {other:?}"),
+            }
+        }
+
+        /// Source-scrape pin (#4864 round-7 Codex P1, updated round-9 item 4): the
+        /// UPDATE-path validation helpers must CLASSIFY `validate_state` failures
+        /// (never `op = None`, which would make the driver record nothing for a
+        /// contract whose runaway half is `validate_state`). The base
+        /// `fetch_related_for_validation` still hardcodes the Upsert op; the shared
+        /// `fetch_related_for_validation_network` now classifies via the
+        /// caller-supplied op kind (`validation_op.op_for`) so a fresh PUT gets a
+        /// `Put` variant — but STILL never `op = None`.
+        #[test]
+        fn update_path_validation_sites_classify_never_op_none() {
+            // (source, fn-signature-needle, expected-classification-needle).
+            let cases: [(&str, &str, &str); 2] = [
                 (
                     include_str!("executor/runtime/executor_impl.rs"),
                     "async fn fetch_related_for_validation(",
+                    "Some(InnerOpError::Upsert(*key))",
                 ),
                 (
                     include_str!("executor/runtime/contract_ops.rs"),
                     "async fn fetch_related_for_validation_network(",
+                    "Some(validation_op.op_for(*key))",
                 ),
             ];
-            for (src, sig) in cases {
+            for (src, sig, expected) in cases {
                 let start = src
                     .find(sig)
                     .unwrap_or_else(|| panic!("validation helper `{sig}` not found"));
@@ -2432,10 +2528,10 @@ mod tests {
                     "`{sig}` must call validate_state (scrape anchor)"
                 );
                 assert!(
-                    body.contains("Some(InnerOpError::Upsert(*key))"),
-                    "`{sig}` must classify validate_state failures with \
-                     Some(InnerOpError::Upsert(*key)) (#4864 round-7), so a \
-                     validation-phase timeout reaches the merge-failure backoff"
+                    body.contains(expected),
+                    "`{sig}` must classify validate_state failures via `{expected}` \
+                     so a validation-phase timeout reaches the merge-failure backoff \
+                     (#4864 round-7/9)"
                 );
                 assert!(
                     !body.contains("execution(e, None)"),
@@ -2444,6 +2540,32 @@ mod tests {
                      nothing (#4864 round-7)"
                 );
             }
+        }
+
+        /// #4864 round-9 item 4 pin: the fresh-PUT path
+        /// (`verify_and_store_contract`) must validate with `ValidationOpKind::Put`
+        /// so its validation error keeps PutResponse semantics (a Put variant), not
+        /// Update. A regression to Update would mislabel a fresh PUT's validation
+        /// failure as an UPDATE error.
+        #[test]
+        fn fresh_put_validation_uses_put_op_kind() {
+            let src = include_str!("executor/runtime/contract_ops.rs");
+            let start = src
+                .find("async fn verify_and_store_contract(")
+                .expect("verify_and_store_contract not found");
+            let rest = &src[start + 1..];
+            let end = rest
+                .find("\n    async fn ")
+                .or_else(|| rest.find("\n    fn "))
+                .map(|i| i + 1)
+                .unwrap_or(rest.len());
+            let body = &src[start..start + 1 + end];
+            assert!(
+                body.contains("ValidationOpKind::Put"),
+                "verify_and_store_contract (fresh PUT) must validate with \
+                 ValidationOpKind::Put — a fresh PUT's validation error must be a Put \
+                 variant, not Update (#4864 round-9 item 4)"
+            );
         }
 
         /// Pin (#4861 review): the DESERIALIZATION-poison class — a contract's

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -426,6 +426,42 @@ impl ExecutorError {
         }
     }
 
+    /// Returns true ONLY when the contract's WASM merge/validate exceeded the
+    /// execution time limit — the #4861 poison-contract case where every apply
+    /// runs past `max_execution_seconds`. Both the wall-clock timeout and the
+    /// epoch-deadline interrupt (#4861) converge on `WasmError::Timeout` →
+    /// `ContractExecError::MaxComputeTimeExceeded` → `update_exec_error`, whose
+    /// cause is "execution error: The operation exceeded the maximum allowed
+    /// compute time".
+    ///
+    /// Used by the per-contract merge-failure backoff (#4861) to select the
+    /// longer *Timeout*-class cooldown: a runaway merge is far more expensive to
+    /// re-attempt than a cheap `InvalidUpdate` rejection, so a contract that
+    /// times out should be quarantined harder than one that merely rejects a
+    /// stale delta. Narrow by design — matched on the same stable
+    /// "execution error:" prefix as `is_invalid_update_rejection`, so out-of-gas,
+    /// traps, and other exec errors return false and keep the base
+    /// (Invalid-class) cooldown.
+    ///
+    /// String-matched (not a typed downcast like `is_contract_queue_full`)
+    /// deliberately: the timeout must KEEP its `Update{cause}` representation so
+    /// `is_contract_exec_rejection` still returns true for it (a timeout means
+    /// the contract IS present locally, so no auto-fetch), and so a client-local
+    /// UPDATE timeout still surfaces a typed `ContractError::Update` to the
+    /// client. The compute-time message is defined in this crate
+    /// (`ContractExecError::MaxComputeTimeExceeded`), so the string is stable.
+    pub fn is_wasm_timeout(&self) -> bool {
+        match &self.inner {
+            Either::Left(req_err) => matches!(
+                req_err.as_ref(),
+                RequestError::ContractError(StdContractError::Update { cause, .. })
+                    if cause.starts_with("execution error:")
+                        && cause.contains("maximum allowed compute time")
+            ),
+            Either::Right(_) => false,
+        }
+    }
+
     /// Returns true if this error is the typed `ContractQueueFull` marker.
     ///
     /// Produced by:
@@ -1977,6 +2013,87 @@ mod tests {
             assert!(
                 !err.is_fatal(),
                 "MaxComputeTimeExceeded must not be fatal - it would kill the entire contract handler"
+            );
+        }
+
+        // ── is_wasm_timeout predicate (#4861) ─────────────────────────────
+        //
+        // Selects the longer Timeout-class merge-failure backoff. Must match
+        // ONLY the compute-time-exceeded case, distinct from OOG / invalid
+        // update / queue-full, all of which flow through similar wrappers.
+
+        #[test]
+        fn test_wasm_timeout_true_for_max_compute_time_update_error() {
+            let key = test_fixtures::make_contract_key();
+            // Exact representation the UPDATE merge path produces on a timeout
+            // (both wall-clock and epoch-deadline converge here).
+            let err = ExecutorError::request(StdContractError::update_exec_error(
+                key,
+                "The operation exceeded the maximum allowed compute time",
+            ));
+            assert!(
+                err.is_wasm_timeout(),
+                "max-compute-time update error MUST be recognized as a wasm timeout"
+            );
+            // A timeout keeps its exec-rejection classification (contract IS
+            // present ⇒ auto-fetch must stay suppressed) ...
+            assert!(
+                err.is_contract_exec_rejection(),
+                "a timeout is a contract-exec rejection (auto-fetch stays gated)"
+            );
+            // ... and is NOT a benign invalid-update rejection.
+            assert!(!err.is_invalid_update_rejection());
+        }
+
+        #[test]
+        fn test_wasm_timeout_via_execution_conversion_on_upsert() {
+            use crate::wasm_runtime::{ContractError, ContractExecError, RuntimeInnerError};
+            let key = test_fixtures::make_contract_key();
+            let contract_err: ContractError =
+                RuntimeInnerError::ContractExecError(ContractExecError::MaxComputeTimeExceeded)
+                    .into();
+            // The UPDATE merge path constructs the ExecutorError with
+            // op = Some(Upsert(key)), routing through update_exec_error.
+            let err =
+                ExecutorError::execution(contract_err, Some(super::super::InnerOpError::Upsert(key)));
+            assert!(
+                err.is_wasm_timeout(),
+                "MaxComputeTimeExceeded on the Upsert path MUST classify as a wasm timeout"
+            );
+        }
+
+        #[test]
+        fn test_wasm_timeout_false_for_out_of_gas() {
+            let key = test_fixtures::make_contract_key();
+            let err = ExecutorError::request(StdContractError::update_exec_error(
+                key,
+                "The operation ran out of gas. This might be caused by an infinite loop or an inefficient computation.",
+            ));
+            assert!(
+                !err.is_wasm_timeout(),
+                "out-of-gas MUST NOT be classified as a wasm timeout"
+            );
+        }
+
+        #[test]
+        fn test_wasm_timeout_false_for_invalid_update() {
+            let key = test_fixtures::make_contract_key();
+            let err = ExecutorError::request(StdContractError::update_exec_error(
+                key,
+                "invalid contract update, reason: stale",
+            ));
+            assert!(
+                !err.is_wasm_timeout(),
+                "benign invalid-update rejection MUST NOT be a wasm timeout"
+            );
+        }
+
+        #[test]
+        fn test_wasm_timeout_false_for_queue_full() {
+            let err = ExecutorError::other(ContractQueueFull);
+            assert!(
+                !err.is_wasm_timeout(),
+                "queue-full backpressure MUST NOT be a wasm timeout"
             );
         }
 

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -2071,6 +2071,39 @@ mod tests {
             );
         }
 
+        /// Pin (#4861 review): the DESERIALIZATION-poison class — a contract's
+        /// `update_state` returning `ContractError::Deser` for a malformed
+        /// circulating delta (the `FBFRDjxV…` production case) — MUST reach the
+        /// merge-failure backoff. It routes `ContractExecError::ContractError`
+        /// through `update_exec_error`, so the cause carries the
+        /// "execution error:" prefix and `is_contract_exec_rejection` (the
+        /// backoff recording gate) matches; it is neither a timeout nor an
+        /// invalid-update rejection.
+        #[test]
+        fn test_deser_poison_classifies_as_exec_rejection_for_backoff() {
+            use crate::wasm_runtime::{ContractError, ContractExecError, RuntimeInnerError};
+            let key = test_fixtures::make_contract_key();
+            let deser = freenet_stdlib::prelude::ContractError::Deser(
+                "Semantic(None, \"invalid type: null, expected map\")".to_string(),
+            );
+            let contract_err: ContractError =
+                RuntimeInnerError::ContractExecError(ContractExecError::from(deser)).into();
+            let err = ExecutorError::execution(
+                contract_err,
+                Some(super::super::InnerOpError::Upsert(key)),
+            );
+            assert!(
+                err.is_contract_exec_rejection(),
+                "a contract-returned Deser error on the Upsert path must satisfy \
+                 the backoff recording gate"
+            );
+            assert!(!err.is_wasm_timeout(), "deser poison is not a timeout");
+            assert!(
+                !err.is_invalid_update_rejection(),
+                "deser poison is not the benign invalid-update rejection"
+            );
+        }
+
         #[test]
         fn test_wasm_timeout_false_for_out_of_gas() {
             let key = test_fixtures::make_contract_key();

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -1731,12 +1731,19 @@ mod tests {
         const MAX_POOL_SIZE: usize = 16;
         let summary_aggregate = MAX_POOL_SIZE * SUMMARY_CACHE_MAX_BYTES; // <= 512 MiB
         let delta_aggregate = MAX_POOL_SIZE * DELTA_CACHE_MAX_BYTES; // <= 1 GiB
-        // Shared module cache ceiling (single, not per-worker).
-        let module_ceiling = crate::wasm_runtime::MAX_DEFAULT_MODULE_CACHE_BUDGET_BYTES; // 1.5 GiB
-        let total = summary_aggregate + delta_aggregate + module_ceiling;
-        // Keep total cache commitment under half the gateway limit (7600 MiB, i.e.
-        // ~7.42 GiB / ~7.97 GB; 7_600 * 1024 * 1024 is 7600 MiB, not 7.6 GiB).
+        // Reference gateway RAM (7600 MiB ≈ 7.42 GiB; 7_600 * 1024 * 1024 is
+        // 7600 MiB, not 7.6 GiB).
         let gateway_limit: usize = 7_600 * 1024 * 1024;
+        // Shared module cache ceiling (single, not per-worker), sized to the RAM
+        // this gateway actually has — NOT the absolute MAX clamp. The 4 GiB MAX
+        // only binds on hosts with >32 GiB RAM; on a 7.6 GiB gateway the
+        // `total_ram / 8` divisor binds at ~950 MiB, so using the MAX here would
+        // model an impossible 4 GiB module cache on a 7.6 GiB box. (MAX-clamp
+        // aggregate safety on a >32 GiB host is guarded separately by
+        // `module_cache::tests::max_clamp_combined_ceiling_is_safe_at_binding_host`.)
+        let module_ceiling = crate::wasm_runtime::budget_for_ram(gateway_limit);
+        let total = summary_aggregate + delta_aggregate + module_ceiling;
+        // Keep total cache commitment under half the gateway RAM.
         assert!(
             total <= gateway_limit / 2,
             "worst-case cache aggregate {total} (summary {summary_aggregate} + delta \

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -2071,6 +2071,64 @@ mod tests {
             );
         }
 
+        /// #4864 round-5 (Codex P1): a GUEST-ENTRY epoch interrupt (a runaway
+        /// module start function in `create_instance`, or the allocator in
+        /// `initiate_buffer`) surfaces as `WasmError::Timeout` at the engine layer
+        /// (the engine test `epoch_interrupt_during_instantiation_classifies_as_timeout`
+        /// asserts that). The runtime routes it through `classify_result`, which
+        /// normalizes it to the SAME `MaxComputeTimeExceeded` the blocking merge
+        /// path produces — so the resulting `ExecutorError::is_wasm_timeout()` is
+        /// true and the merge-failure backoff picks the contract-wide Timeout
+        /// class, not per-sender Invalid. Before the fix the guest-entry
+        /// `WasmError::Timeout` went through the generic conversion ("execution
+        /// timeout"), which `is_wasm_timeout` does NOT match.
+        #[test]
+        fn guest_entry_timeout_classifies_as_wasm_timeout() {
+            let key = test_fixtures::make_contract_key();
+            // The runtime's classify_result normalizes a guest-entry Timeout.
+            let contract_err = crate::wasm_runtime::classify_result::<i64>(Err(
+                crate::wasm_runtime::engine::WasmError::Timeout,
+            ))
+            .expect_err("a WasmError::Timeout must classify as an error");
+            let err = ExecutorError::execution(
+                contract_err,
+                Some(super::super::InnerOpError::Upsert(key)),
+            );
+            assert!(
+                err.is_wasm_timeout(),
+                "a guest-entry epoch-interrupt timeout, normalized by classify_result, \
+                 MUST classify as a wasm timeout (contract-wide Timeout backoff, not Invalid)"
+            );
+        }
+
+        /// Source-scrape pin (#4864 round-5): EVERY guest-entry engine call in the
+        /// runtime (`create_instance`, `initiate_buffer`) must be wrapped by
+        /// `classify_result`, so an epoch-interrupt Timeout normalizes to the
+        /// Timeout class. A future refactor that adds an unwrapped guest-entry
+        /// call would silently reintroduce the misclassification.
+        #[test]
+        fn guest_entry_calls_route_through_classify_result() {
+            let src = include_str!("../wasm_runtime/runtime.rs");
+            let create_calls = src.matches("engine.create_instance(").count();
+            let create_wrapped = src
+                .matches("classify_result(engine.create_instance(")
+                .count();
+            assert!(
+                create_calls > 0 && create_calls == create_wrapped,
+                "every engine.create_instance call in runtime.rs must be wrapped in \
+                 classify_result ({create_wrapped}/{create_calls} wrapped)"
+            );
+            let buffer_calls = src.matches("engine.initiate_buffer(").count();
+            let buffer_wrapped = src
+                .matches("classify_result(self.engine.initiate_buffer(")
+                .count();
+            assert!(
+                buffer_calls > 0 && buffer_calls == buffer_wrapped,
+                "every initiate_buffer call in runtime.rs must be wrapped in \
+                 classify_result ({buffer_wrapped}/{buffer_calls} wrapped)"
+            );
+        }
+
         /// Pin (#4861 review): the DESERIALIZATION-poison class — a contract's
         /// `update_state` returning `ContractError::Deser` for a malformed
         /// circulating delta (the `FBFRDjxV…` production case) — MUST reach the

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -2220,6 +2220,124 @@ mod tests {
             );
         }
 
+        /// #4864 round-7 (Codex P1): a validation-phase WASM error (a runaway
+        /// `validate_state` that blows the deadline, or a queue-saturation
+        /// scheduler timeout) MUST classify exactly like a merge-phase error. The
+        /// UPDATE-path validation helpers previously wrapped these with `op = None`,
+        /// which routes a `WasmError`/`ContractExecError` to `ExecutorError::other`
+        /// (`Either::Right`) — so `is_contract_exec_rejection`, `is_wasm_timeout`,
+        /// and `is_scheduler_timeout` all returned false and the UPDATE driver
+        /// recorded NOTHING, letting a contract whose runaway half is
+        /// `validate_state` burn the full budget per broadcast without ever backing
+        /// off. With `op = Some(Upsert(key))` (the fix) the SAME error routes
+        /// through `update_exec_error` and classifies.
+        #[test]
+        fn validation_phase_exec_errors_with_upsert_op_classify() {
+            use crate::wasm_runtime::{ContractError, ContractExecError, RuntimeInnerError};
+            let key = test_fixtures::make_contract_key();
+            let mk = |exec: ContractExecError| -> ContractError {
+                RuntimeInnerError::ContractExecError(exec).into()
+            };
+
+            // FIXED wrapper (op = Some(Upsert(key))): a runaway validate_state that
+            // blew the deadline classifies as a real wasm timeout, and stays a
+            // contract-exec rejection (contract present ⇒ no auto-fetch).
+            let timeout_fixed = ExecutorError::execution(
+                mk(ContractExecError::MaxComputeTimeExceeded),
+                Some(super::super::InnerOpError::Upsert(key)),
+            );
+            assert!(
+                timeout_fixed.is_wasm_timeout(),
+                "validation-phase MaxComputeTimeExceeded on the Upsert path MUST be a wasm timeout"
+            );
+            assert!(timeout_fixed.is_contract_exec_rejection());
+
+            // A queue-saturation scheduler timeout during validation classifies as
+            // the transient scheduler class (excluded from the backoff), NOT a real
+            // timeout — same as the merge-phase scheduler timeout.
+            let sched_fixed = ExecutorError::execution(
+                mk(ContractExecError::SchedulerOverloaded),
+                Some(super::super::InnerOpError::Upsert(key)),
+            );
+            assert!(
+                sched_fixed.is_scheduler_timeout(),
+                "validation-phase SchedulerOverloaded on the Upsert path MUST be a scheduler timeout"
+            );
+            assert!(!sched_fixed.is_wasm_timeout());
+            assert!(sched_fixed.is_contract_exec_rejection());
+
+            // The bug the fix closes: with op = None the SAME error escapes every
+            // classification predicate, so the driver records nothing.
+            let timeout_bug =
+                ExecutorError::execution(mk(ContractExecError::MaxComputeTimeExceeded), None);
+            assert!(
+                !timeout_bug.is_wasm_timeout() && !timeout_bug.is_contract_exec_rejection(),
+                "op = None escapes classification — the pre-fix behavior this closes"
+            );
+        }
+
+        /// Source-scrape pin (#4864 round-7 Codex P1): the UPDATE-path validation
+        /// helpers must classify `validate_state` failures with
+        /// `Some(InnerOpError::Upsert(*key))`, never `op = None`. A regression to
+        /// `None` would silently make the driver record nothing for a contract
+        /// whose runaway half is `validate_state`. Paired with the behavioral test
+        /// above, which pins that the Upsert form actually classifies.
+        #[test]
+        fn update_path_validation_sites_pass_upsert_op_not_none() {
+            // (source, fn-signature-needle) for each validation helper.
+            let cases: [(&str, &str); 2] = [
+                (
+                    include_str!("executor/runtime/executor_impl.rs"),
+                    "async fn fetch_related_for_validation(",
+                ),
+                (
+                    include_str!("executor/runtime/contract_ops.rs"),
+                    "async fn fetch_related_for_validation_network(",
+                ),
+            ];
+            for (src, sig) in cases {
+                let start = src
+                    .find(sig)
+                    .unwrap_or_else(|| panic!("validation helper `{sig}` not found"));
+                // Bound the body at the NEXT method in the impl block (any
+                // visibility), so the negative assertion below can't overrun into a
+                // different function that legitimately uses `execution(e, None)`.
+                let rest = &src[start + sig.len()..];
+                let end = [
+                    "\n    fn ",
+                    "\n    async fn ",
+                    "\n    pub(super) fn ",
+                    "\n    pub(super) async fn ",
+                    "\n    pub(crate) fn ",
+                    "\n    pub(crate) async fn ",
+                    "\n    pub(in crate::contract::executor) async fn ",
+                ]
+                .iter()
+                .filter_map(|needle| rest.find(needle))
+                .min()
+                .map(|i| start + sig.len() + i)
+                .unwrap_or(src.len());
+                let body = &src[start..end];
+
+                assert!(
+                    body.contains("validate_state"),
+                    "`{sig}` must call validate_state (scrape anchor)"
+                );
+                assert!(
+                    body.contains("Some(InnerOpError::Upsert(*key))"),
+                    "`{sig}` must classify validate_state failures with \
+                     Some(InnerOpError::Upsert(*key)) (#4864 round-7), so a \
+                     validation-phase timeout reaches the merge-failure backoff"
+                );
+                assert!(
+                    !body.contains("execution(e, None)"),
+                    "`{sig}` must NOT wrap a validate_state failure with op = None — \
+                     that escapes classification and the UPDATE driver records \
+                     nothing (#4864 round-7)"
+                );
+            }
+        }
+
         /// Pin (#4861 review): the DESERIALIZATION-poison class — a contract's
         /// `update_state` returning `ContractError::Deser` for a malformed
         /// circulating delta (the `FBFRDjxV…` production case) — MUST reach the

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -1103,9 +1103,11 @@ const DELTA_CACHE_MIN_BYTES: usize = 8 * 1024 * 1024;
 /// Upper clamp for the delta-cache byte budget (64 MiB). Matches PR #4794's
 /// ceiling. Per-executor × up to 16 pool workers → ≤ 1 GiB aggregate delta-cache
 /// RAM. Combined with the summary cache (≤ 512 MiB aggregate) and the shared
-/// module cache (≤ 1.5 GiB) the total cache commitment stays a safe fraction of a
-/// production gateway's memory (≈ 3 GiB worst case, well under the 7600 MiB (= 7.42 GiB)
-/// gateway limit). NOTE: this budget is PER-EXECUTOR; aggregate RAM is
+/// module cache (RAM/8, absolute max 4 GiB — but the divisor binds well below
+/// that on typical gateways: ~950 MiB on a 7.6 GiB box) the total cache
+/// commitment stays a safe fraction of a production gateway's memory (see
+/// `cache_byte_budgets_are_aggregate_safe`, which models the RAM-scaled budget
+/// rather than the absolute max). NOTE: this budget is PER-EXECUTOR; aggregate RAM is
 /// `pool_size × (summary_budget + delta_budget)`, not a single node-wide figure.
 /// `pool_size` tracks CPU count (core count), so a RAM-scaled per-executor budget
 /// is multiplied by cores: on an exotic high-core/low-RAM box the aggregate is a

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -243,6 +243,37 @@ impl std::error::Error for DeferRelatedFetch {}
 pub struct ExecutorError {
     inner: Either<Box<RequestError>, anyhow::Error>,
     fatal: bool,
+    /// Typed provenance for a HOST-originated execution timeout (#4864 round-9).
+    /// Set ONLY by [`ExecutorError::execution`] when it sees a
+    /// `ContractExecError::{MaxComputeTimeExceeded, SchedulerOverloaded}` — the
+    /// two variants the host's `classify_result` (wasm_runtime/contract.rs) alone
+    /// constructs from a `WasmError`, NEVER a contract via its own return text.
+    ///
+    /// This is the security-critical fix: `is_wasm_timeout` / `is_scheduler_timeout`
+    /// gate on THIS field, not on the `Update{cause}` substring. `update_exec_error`
+    /// flattens the typed variant into a cause string ("… maximum allowed compute
+    /// time …"), and a malicious `update_state`/`validate_state` can RETURN a
+    /// rejection whose text contains that same phrase — which would otherwise be
+    /// misclassified as a real host timeout and earn the contract-wide, trip-at-one
+    /// Timeout quarantine, suppressing honest peers for up to 2h. The typed field
+    /// is unforgeable through contract return text.
+    host_timeout: Option<HostTimeoutClass>,
+}
+
+/// Provenance class for a host-originated execution timeout (#4864 round-9). See
+/// [`ExecutorError::host_timeout`]. Constructed only on the `classify_result` →
+/// `ContractExecError` → `ExecutorError::execution` path, so a contract cannot
+/// forge either class by returning text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HostTimeoutClass {
+    /// The guest RAN and exceeded its compute deadline (`WasmError::Timeout` →
+    /// `ContractExecError::MaxComputeTimeExceeded`). A real, contract-intrinsic
+    /// timeout — earns the Timeout-class merge-failure backoff.
+    ComputeExceeded,
+    /// The guest NEVER ran — it sat queued on a saturated blocking pool past the
+    /// deadline (`WasmError::SchedulerOverloaded`). Transient load, not a contract
+    /// fault — EXCLUDED from the backoff.
+    SchedulerOverloaded,
 }
 
 enum InnerOpError {
@@ -257,6 +288,7 @@ impl ExecutorError {
         Self {
             inner: Either::Right(error.into()),
             fatal: false,
+            host_timeout: None,
         }
     }
 
@@ -265,6 +297,7 @@ impl ExecutorError {
         Self {
             inner: Either::Right(anyhow::anyhow!("internal error")),
             fatal: false,
+            host_timeout: None,
         }
     }
 
@@ -272,10 +305,46 @@ impl ExecutorError {
         Self {
             inner: Either::Left(Box::new(error.into())),
             fatal: false,
+            host_timeout: None,
         }
     }
 
     fn execution(
+        outer_error: crate::wasm_runtime::ContractError,
+        op: Option<InnerOpError>,
+    ) -> Self {
+        use crate::wasm_runtime::{ContractExecError, RuntimeInnerError};
+        // TYPED PROVENANCE (#4864 round-9): capture the host timeout class from
+        // the TYPED `ContractExecError` variant BEFORE `update_exec_error` flattens
+        // it into a contract-forgeable string cause. These two variants originate
+        // ONLY from the host `classify_result` (wasm_runtime/contract.rs), so a
+        // contract cannot set this field by returning text. Op-INDEPENDENT: a
+        // timeout is a host timeout whether or not the op maps it to `Update`.
+        // `matches!` (not a wildcard `match`) so a new ContractExecError variant
+        // stays a compile-clean "not a host timeout" without a catch-all arm.
+        let host_timeout = if matches!(
+            outer_error.deref(),
+            RuntimeInnerError::ContractExecError(ContractExecError::MaxComputeTimeExceeded)
+        ) {
+            Some(HostTimeoutClass::ComputeExceeded)
+        } else if matches!(
+            outer_error.deref(),
+            RuntimeInnerError::ContractExecError(ContractExecError::SchedulerOverloaded)
+        ) {
+            Some(HostTimeoutClass::SchedulerOverloaded)
+        } else {
+            None
+        };
+        let mut err = Self::execution_classified(outer_error, op);
+        err.host_timeout = host_timeout;
+        err
+    }
+
+    /// The op-based routing half of [`ExecutorError::execution`] (produces the
+    /// `Update{cause}` request error / delegate error / `other`). The typed
+    /// `host_timeout` provenance is stamped by the `execution` wrapper above; keep
+    /// them separate so the string cause never becomes the timeout signal.
+    fn execution_classified(
         outer_error: crate::wasm_runtime::ContractError,
         op: Option<InnerOpError>,
     ) -> Self {
@@ -426,77 +495,53 @@ impl ExecutorError {
         }
     }
 
-    /// Returns true ONLY when the contract's WASM merge/validate exceeded the
-    /// execution time limit — the #4861 poison-contract case where every apply
+    /// Returns true ONLY when the contract's WASM merge/validate ran and exceeded
+    /// the execution time limit — the #4861 poison-contract case where every apply
     /// runs past `max_execution_seconds`. Both the wall-clock timeout and the
     /// epoch-deadline interrupt (#4861) converge on `WasmError::Timeout` →
-    /// `ContractExecError::MaxComputeTimeExceeded` → `update_exec_error`, whose
-    /// cause is "execution error: The operation exceeded the maximum allowed
-    /// compute time".
+    /// `ContractExecError::MaxComputeTimeExceeded` in the host `classify_result`.
     ///
     /// Used by the per-contract merge-failure backoff (#4861) to select the
     /// longer *Timeout*-class cooldown: a runaway merge is far more expensive to
     /// re-attempt than a cheap `InvalidUpdate` rejection, so a contract that
-    /// times out should be quarantined harder than one that merely rejects a
-    /// stale delta. Narrow by design — matched on the same stable
-    /// "execution error:" prefix as `is_invalid_update_rejection`, so out-of-gas,
-    /// traps, and other exec errors return false and keep the base
-    /// (Invalid-class) cooldown.
+    /// times out is quarantined harder (contract-wide, trip-at-ONE) than one that
+    /// merely rejects a stale delta.
     ///
-    /// String-matched (not a typed downcast like `is_contract_queue_full`)
-    /// deliberately: the timeout must KEEP its `Update{cause}` representation so
-    /// `is_contract_exec_rejection` still returns true for it (a timeout means
-    /// the contract IS present locally, so no auto-fetch), and so a client-local
-    /// UPDATE timeout still surfaces a typed `ContractError::Update` to the
-    /// client. The compute-time message is defined in this crate
-    /// (`ContractExecError::MaxComputeTimeExceeded`), so the string is stable.
+    /// TYPED PROVENANCE (#4864 round-9): gated on the unforgeable
+    /// [`ExecutorError::host_timeout`] field, NOT on the `Update{cause}` substring.
+    /// The earlier substring form (`cause.contains("maximum allowed compute time")`)
+    /// was contract-controllable: a malicious `update_state`/`validate_state` can
+    /// RETURN a rejection whose text contains that phrase, and `update_exec_error`
+    /// embeds it into the same cause — so the substring form would have let a
+    /// contract forge the harsh Timeout-class quarantine and suppress honest peers
+    /// for up to 2h. The typed field is set only by the host classification path.
+    /// Op-independent (a timeout is a host timeout even when the op leaves it on
+    /// the `other`/`Either::Right` path); `is_contract_exec_rejection` still keys
+    /// off the `Update{cause}` string for the (harmless-if-forged) auto-fetch gate.
     pub fn is_wasm_timeout(&self) -> bool {
-        match &self.inner {
-            Either::Left(req_err) => matches!(
-                req_err.as_ref(),
-                RequestError::ContractError(StdContractError::Update { cause, .. })
-                    if cause.starts_with("execution error:")
-                        && cause.contains("maximum allowed compute time")
-            ),
-            Either::Right(_) => false,
-        }
+        self.host_timeout == Some(HostTimeoutClass::ComputeExceeded)
     }
 
     /// Returns true ONLY when the contract's WASM merge/validate call never ran
     /// because it sat QUEUED on a saturated blocking pool past the wall-clock
     /// deadline — the #4864 round-6 scheduler-overload case, where the guest
     /// never entered execution (distinct from a runaway guest that DID run and
-    /// blew the deadline, which stays a real `is_wasm_timeout`). The engine
-    /// classifies it as `WasmError::SchedulerOverloaded` →
-    /// `ContractExecError::SchedulerOverloaded` → `update_exec_error`, whose
-    /// cause is "execution error: The operation was queued too long on a
-    /// saturated execution pool and never ran".
+    /// blew the deadline, which is `is_wasm_timeout`). The engine classifies it as
+    /// `WasmError::SchedulerOverloaded` → `ContractExecError::SchedulerOverloaded`
+    /// in the host `classify_result`.
     ///
     /// Used by the per-contract merge-failure backoff record site to EXCLUDE a
-    /// scheduler timeout (exactly like `is_contract_queue_full`): the guest
-    /// never executed, so the failure is transient load, not a contract fault,
-    /// and quarantining the contract for a delta it never applied would be
-    /// wrong. Because the guest never ran, this is deliberately DISJOINT from
-    /// `is_wasm_timeout` — a scheduler timeout must NOT pick the Timeout-class
-    /// quarantine that a genuine runaway merge earns.
+    /// scheduler timeout (exactly like `is_contract_queue_full`): the guest never
+    /// executed, so the failure is transient load, not a contract fault, and
+    /// quarantining the contract for a delta it never applied would be wrong.
+    /// Deliberately DISJOINT from `is_wasm_timeout`.
     ///
-    /// String-matched (not a typed downcast) for the same reason as
-    /// `is_wasm_timeout`: the error must KEEP its `Update{cause}`
-    /// representation so `is_contract_exec_rejection` still returns true (the
-    /// contract IS present locally ⇒ no auto-fetch), and a client-local UPDATE
-    /// still surfaces a typed `ContractError::Update`. The message is defined
-    /// in this crate (`ContractExecError::SchedulerOverloaded`), so the string
-    /// is stable.
+    /// TYPED PROVENANCE (#4864 round-9): like `is_wasm_timeout`, gated on the
+    /// unforgeable [`ExecutorError::host_timeout`] field rather than the
+    /// contract-controllable cause substring, so a contract cannot forge the
+    /// scheduler class either.
     pub fn is_scheduler_timeout(&self) -> bool {
-        match &self.inner {
-            Either::Left(req_err) => matches!(
-                req_err.as_ref(),
-                RequestError::ContractError(StdContractError::Update { cause, .. })
-                    if cause.starts_with("execution error:")
-                        && cause.contains("queued too long on a saturated execution pool")
-            ),
-            Either::Right(_) => false,
-        }
+        self.host_timeout == Some(HostTimeoutClass::SchedulerOverloaded)
     }
 
     /// Returns true if this error is the typed `ContractQueueFull` marker.
@@ -569,6 +614,7 @@ impl ExecutorError {
         Self {
             inner: Either::Right(anyhow::Error::new(DeferRelatedFetch { missing })),
             fatal: false,
+            host_timeout: None,
         }
     }
 
@@ -582,11 +628,13 @@ impl ExecutorError {
                 Err(err) => Err(Self {
                     inner: Either::Right(err),
                     fatal: self.fatal,
+                    host_timeout: self.host_timeout,
                 }),
             },
             inner @ Either::Left(_) => Err(Self {
                 inner,
                 fatal: self.fatal,
+                host_timeout: self.host_timeout,
             }),
         }
     }
@@ -614,6 +662,31 @@ impl ExecutorError {
             Either::Right(_) => unreachable!("called unwrap_request on a non-request error"),
         }
     }
+
+    /// Test-only faithful constructor for a HOST compute-time timeout (#4864
+    /// round-9): mirrors the production path
+    /// (`classify_result` → `ContractExecError::MaxComputeTimeExceeded` →
+    /// `execution`), so the typed `host_timeout` provenance is set exactly as in
+    /// production. Lets tests in OTHER modules build a real timeout that
+    /// `is_wasm_timeout()` recognizes — a plain `update_exec_error(..)` string
+    /// does NOT (that is precisely the contract-forge case the typing rejects).
+    #[cfg(test)]
+    pub(crate) fn test_host_compute_timeout(key: ContractKey) -> Self {
+        use crate::wasm_runtime::{ContractError, ContractExecError, RuntimeInnerError};
+        let ce: ContractError =
+            RuntimeInnerError::ContractExecError(ContractExecError::MaxComputeTimeExceeded).into();
+        Self::execution(ce, Some(InnerOpError::Upsert(key)))
+    }
+
+    /// Test-only faithful constructor for a HOST scheduler-overload timeout
+    /// (#4864 round-9). See [`ExecutorError::test_host_compute_timeout`].
+    #[cfg(test)]
+    pub(crate) fn test_host_scheduler_timeout(key: ContractKey) -> Self {
+        use crate::wasm_runtime::{ContractError, ContractExecError, RuntimeInnerError};
+        let ce: ContractError =
+            RuntimeInnerError::ContractExecError(ContractExecError::SchedulerOverloaded).into();
+        Self::execution(ce, Some(InnerOpError::Upsert(key)))
+    }
 }
 
 impl From<RequestError> for ExecutorError {
@@ -621,6 +694,7 @@ impl From<RequestError> for ExecutorError {
         Self {
             inner: Either::Left(Box::new(value)),
             fatal: false,
+            host_timeout: None,
         }
     }
 }
@@ -639,6 +713,7 @@ impl From<Box<RequestError>> for ExecutorError {
         Self {
             inner: Either::Left(value),
             fatal: false,
+            host_timeout: None,
         }
     }
 }
@@ -2054,7 +2129,6 @@ mod tests {
             let contract_err: ContractError =
                 RuntimeInnerError::ContractExecError(ContractExecError::MaxComputeTimeExceeded)
                     .into();
-            // op: None simulates validate_state() path where the bug manifested
             let err = ExecutorError::execution(contract_err, None);
             assert!(
                 !err.is_fatal(),
@@ -2068,27 +2142,50 @@ mod tests {
         // ONLY the compute-time-exceeded case, distinct from OOG / invalid
         // update / queue-full, all of which flow through similar wrappers.
 
+        /// #4864 round-9 (Codex P1, the load-bearing fix): a contract CANNOT forge
+        /// the Timeout classification by RETURNING a rejection whose cause text
+        /// contains "maximum allowed compute time". `is_wasm_timeout` now gates on
+        /// the unforgeable host-provenance marker, not the `Update{cause}` string.
+        /// Only a HOST-originated timeout (classify_result → MaxComputeTimeExceeded
+        /// → execution) is a wasm timeout; a contract-supplied string that happens
+        /// to contain the phrase is NOT (else it could earn the contract-wide,
+        /// trip-at-one, up-to-2h Timeout quarantine and suppress honest peers).
         #[test]
-        fn test_wasm_timeout_true_for_max_compute_time_update_error() {
+        fn contract_cannot_forge_wasm_timeout_via_cause_string() {
             let key = test_fixtures::make_contract_key();
-            // Exact representation the UPDATE merge path produces on a timeout
-            // (both wall-clock and epoch-deadline converge here).
-            let err = ExecutorError::request(StdContractError::update_exec_error(
+
+            // FORGED: a contract-returned rejection whose text contains the
+            // compute-time phrase (this is exactly what a malicious update_state
+            // could produce through update_exec_error). MUST NOT be a wasm timeout.
+            let forged = ExecutorError::request(StdContractError::update_exec_error(
                 key,
-                "The operation exceeded the maximum allowed compute time",
+                "rejected: your update mentioned the maximum allowed compute time, nice try",
             ));
             assert!(
-                err.is_wasm_timeout(),
-                "max-compute-time update error MUST be recognized as a wasm timeout"
+                !forged.is_wasm_timeout(),
+                "a contract-forged cause string MUST NOT classify as a host wasm timeout \
+                 (#4864 round-9) — otherwise a contract could self-inflict the harsh \
+                 Timeout-class quarantine on honest peers"
             );
-            // A timeout keeps its exec-rejection classification (contract IS
-            // present ⇒ auto-fetch must stay suppressed) ...
             assert!(
-                err.is_contract_exec_rejection(),
-                "a timeout is a contract-exec rejection (auto-fetch stays gated)"
+                !forged.is_scheduler_timeout(),
+                "nor forge the scheduler-timeout class"
             );
-            // ... and is NOT a benign invalid-update rejection.
-            assert!(!err.is_invalid_update_rejection());
+            // It is still a contract-exec rejection (the string gate is harmless —
+            // it only suppresses auto-fetch, correct for a contract that IS present)
+            // and not a benign invalid-update rejection.
+            assert!(forged.is_contract_exec_rejection());
+            assert!(!forged.is_invalid_update_rejection());
+
+            // HOST-originated: the real timeout the merge path produces. This IS a
+            // wasm timeout, and keeps its exec-rejection classification.
+            let real = ExecutorError::test_host_compute_timeout(key);
+            assert!(
+                real.is_wasm_timeout(),
+                "a host-originated MaxComputeTimeExceeded MUST classify as a wasm timeout"
+            );
+            assert!(real.is_contract_exec_rejection());
+            assert!(!real.is_invalid_update_rejection());
         }
 
         #[test]
@@ -2147,11 +2244,10 @@ mod tests {
 
             // The two are disjoint from the OTHER side too: a genuine
             // MaxComputeTimeExceeded (guest ran and blew the deadline) is a real
-            // wasm timeout and is NOT a scheduler timeout.
-            let real_timeout = ExecutorError::request(StdContractError::update_exec_error(
-                key,
-                "The operation exceeded the maximum allowed compute time",
-            ));
+            // wasm timeout and is NOT a scheduler timeout. Built via the HOST path
+            // (#4864 round-9) — a plain update_exec_error string would no longer
+            // classify, by design.
+            let real_timeout = ExecutorError::test_host_compute_timeout(key);
             assert!(
                 real_timeout.is_wasm_timeout(),
                 "a real compute-time timeout stays a wasm timeout"
@@ -2266,13 +2362,25 @@ mod tests {
             assert!(!sched_fixed.is_wasm_timeout());
             assert!(sched_fixed.is_contract_exec_rejection());
 
-            // The bug the fix closes: with op = None the SAME error escapes every
-            // classification predicate, so the driver records nothing.
+            // The bug the round-7 fix closes: with op = None the error stays on the
+            // `other`/Either::Right path, so it is NOT a contract-exec rejection →
+            // the backoff RECORD gate (is_contract_exec_rejection && !is_scheduler_
+            // timeout) skips it. THAT is why the validation sites must pass Upsert.
             let timeout_bug =
                 ExecutorError::execution(mk(ContractExecError::MaxComputeTimeExceeded), None);
             assert!(
-                !timeout_bug.is_wasm_timeout() && !timeout_bug.is_contract_exec_rejection(),
-                "op = None escapes classification — the pre-fix behavior this closes"
+                !timeout_bug.is_contract_exec_rejection(),
+                "op = None leaves the error off the Update path, so the backoff record \
+                 gate (is_contract_exec_rejection) skips it — the reason validation \
+                 must pass Upsert"
+            );
+            // Post-#4864-round-9, is_wasm_timeout is HOST-provenance and
+            // op-INDEPENDENT, so the typed timeout class is set even for op=None.
+            // (That alone does not make the driver record — the exec-rejection gate
+            // does, and it needs the Upsert path above.)
+            assert!(
+                timeout_bug.is_wasm_timeout(),
+                "is_wasm_timeout is host-provenance (op-independent) post round-9"
             );
         }
 

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -462,6 +462,43 @@ impl ExecutorError {
         }
     }
 
+    /// Returns true ONLY when the contract's WASM merge/validate call never ran
+    /// because it sat QUEUED on a saturated blocking pool past the wall-clock
+    /// deadline — the #4864 round-6 scheduler-overload case, where the guest
+    /// never entered execution (distinct from a runaway guest that DID run and
+    /// blew the deadline, which stays a real `is_wasm_timeout`). The engine
+    /// classifies it as `WasmError::SchedulerOverloaded` →
+    /// `ContractExecError::SchedulerOverloaded` → `update_exec_error`, whose
+    /// cause is "execution error: The operation was queued too long on a
+    /// saturated execution pool and never ran".
+    ///
+    /// Used by the per-contract merge-failure backoff record site to EXCLUDE a
+    /// scheduler timeout (exactly like `is_contract_queue_full`): the guest
+    /// never executed, so the failure is transient load, not a contract fault,
+    /// and quarantining the contract for a delta it never applied would be
+    /// wrong. Because the guest never ran, this is deliberately DISJOINT from
+    /// `is_wasm_timeout` — a scheduler timeout must NOT pick the Timeout-class
+    /// quarantine that a genuine runaway merge earns.
+    ///
+    /// String-matched (not a typed downcast) for the same reason as
+    /// `is_wasm_timeout`: the error must KEEP its `Update{cause}`
+    /// representation so `is_contract_exec_rejection` still returns true (the
+    /// contract IS present locally ⇒ no auto-fetch), and a client-local UPDATE
+    /// still surfaces a typed `ContractError::Update`. The message is defined
+    /// in this crate (`ContractExecError::SchedulerOverloaded`), so the string
+    /// is stable.
+    pub fn is_scheduler_timeout(&self) -> bool {
+        match &self.inner {
+            Either::Left(req_err) => matches!(
+                req_err.as_ref(),
+                RequestError::ContractError(StdContractError::Update { cause, .. })
+                    if cause.starts_with("execution error:")
+                        && cause.contains("queued too long on a saturated execution pool")
+            ),
+            Either::Right(_) => false,
+        }
+    }
+
     /// Returns true if this error is the typed `ContractQueueFull` marker.
     ///
     /// Produced by:
@@ -2068,6 +2105,58 @@ mod tests {
             assert!(
                 err.is_wasm_timeout(),
                 "MaxComputeTimeExceeded on the Upsert path MUST classify as a wasm timeout"
+            );
+        }
+
+        /// #4864 round-6: a SCHEDULER timeout (the merge closure sat queued on a
+        /// saturated blocking pool past the deadline and the guest NEVER ran)
+        /// must be a distinct classification from a real compute-time timeout.
+        /// It flows `ContractExecError::SchedulerOverloaded` → `update_exec_error`
+        /// (op = Some(Upsert(key))), so it carries the "execution error:" prefix
+        /// and stays a contract-exec rejection (contract IS present ⇒ no
+        /// auto-fetch), yet the op_ctx_task record site excludes it from the
+        /// merge-failure backoff via `!err.is_scheduler_timeout()`. Crucially it
+        /// is DISJOINT from `is_wasm_timeout`: the guest never executed, so it
+        /// must NOT earn the Timeout-class quarantine a runaway merge does.
+        #[test]
+        fn test_scheduler_timeout_is_distinct_transient_classification() {
+            use crate::wasm_runtime::{ContractError, ContractExecError, RuntimeInnerError};
+            let key = test_fixtures::make_contract_key();
+            let contract_err: ContractError =
+                RuntimeInnerError::ContractExecError(ContractExecError::SchedulerOverloaded).into();
+            let err = ExecutorError::execution(
+                contract_err,
+                Some(super::super::InnerOpError::Upsert(key)),
+            );
+            assert!(
+                err.is_scheduler_timeout(),
+                "SchedulerOverloaded on the Upsert path MUST classify as a scheduler timeout"
+            );
+            assert!(
+                !err.is_wasm_timeout(),
+                "a scheduler timeout MUST be disjoint from a real wasm timeout — the \
+                 guest never ran, so it must not pick the Timeout-class quarantine"
+            );
+            assert!(
+                err.is_contract_exec_rejection(),
+                "a scheduler timeout IS an exec rejection (contract present ⇒ no auto-fetch); \
+                 the backoff record site excludes it via the && !is_scheduler_timeout() gate"
+            );
+
+            // The two are disjoint from the OTHER side too: a genuine
+            // MaxComputeTimeExceeded (guest ran and blew the deadline) is a real
+            // wasm timeout and is NOT a scheduler timeout.
+            let real_timeout = ExecutorError::request(StdContractError::update_exec_error(
+                key,
+                "The operation exceeded the maximum allowed compute time",
+            ));
+            assert!(
+                real_timeout.is_wasm_timeout(),
+                "a real compute-time timeout stays a wasm timeout"
+            );
+            assert!(
+                !real_timeout.is_scheduler_timeout(),
+                "a real compute-time timeout MUST NOT be misclassified as a scheduler timeout"
             );
         }
 

--- a/crates/core/src/contract/executor/runtime/contract_ops.rs
+++ b/crates/core/src/contract/executor/runtime/contract_ops.rs
@@ -72,6 +72,9 @@ impl Executor<Runtime> {
                     &new_state,
                     &related_contracts,
                     None,
+                    // Re-PUT into an existing contract returns an UpdateResponse
+                    // (this branch), so classify a validation failure as Update.
+                    ValidationOpKind::Update,
                 )
                 .await?;
             if validate_result != ValidateResult::Valid {
@@ -297,6 +300,9 @@ impl Executor<Runtime> {
                 &new_state,
                 &RelatedContracts::default(),
                 None,
+                // Local UPDATE path — classify a validation failure as Update
+                // (keeps the merge-failure backoff classification).
+                ValidationOpKind::Update,
             )
             .await?;
 
@@ -437,6 +443,10 @@ impl Executor<Runtime> {
                 &state,
                 &related_contracts,
                 Some(&contract_for_validation),
+                // Fresh PUT (verify_and_store_contract) returns a PutResponse, so a
+                // validation failure must surface as a Put variant, not Update
+                // (#4864 round-9 item 4).
+                ValidationOpKind::Put,
             )
             .await
             .inspect_err(|_| {
@@ -644,26 +654,27 @@ impl Executor<Runtime> {
         state: &WrappedState,
         initial_related: &RelatedContracts<'_>,
         already_fetched_contract: Option<&ContractContainer>,
+        // #4864 round-9 item 4: which op this validation is running for, so a
+        // validate_state exec failure classifies as the RIGHT client error —
+        // `Update` for the UPDATE / re-PUT callers, `Put` for the fresh-PUT
+        // `verify_and_store_contract` path (PutResponse semantics).
+        validation_op: ValidationOpKind,
     ) -> Result<ValidateResult, ExecutorError> {
-        // #4864 round-7 (Codex P1): classify validation-phase WASM errors with
-        // `op = Some(Upsert(*key))` so a runaway/timed-out `validate_state` on the
-        // UPDATE path (this helper serves `get_updated_state`) routes through
-        // `update_exec_error` and reaches the merge-failure backoff, exactly like
-        // a merge-phase error. `op = None` escaped classification entirely. `key`
-        // is in scope; the fix is trivially correct. This helper is also used by
-        // the local re-PUT merge in `perform_contract_put`, where the same change
-        // is strictly more accurate (a validation exec error means the contract IS
-        // present, so `is_contract_exec_rejection` should be true and no auto-fetch
-        // should fire).
+        // #4864 round-7 (Codex P1): classify validation-phase WASM errors (route
+        // through execution so a runaway/timed-out `validate_state` reaches the
+        // merge-failure backoff and carries the typed timeout provenance).
+        // Round-9 item 4: the op KIND is now caller-supplied (Update vs Put) rather
+        // than hardcoded Upsert, so a fresh PUT's validation error surfaces as a
+        // Put variant instead of masquerading as an UPDATE error.
         let result = match already_fetched_contract {
             Some(contract) => self
                 .runtime
                 .validate_state_with_contract(key, params, state, initial_related, contract)
-                .map_err(|e| ExecutorError::execution(e, Some(InnerOpError::Upsert(*key))))?,
+                .map_err(|e| ExecutorError::execution(e, Some(validation_op.op_for(*key))))?,
             None => self
                 .runtime
                 .validate_state(key, params, state, initial_related)
-                .map_err(|e| ExecutorError::execution(e, Some(InnerOpError::Upsert(*key))))?,
+                .map_err(|e| ExecutorError::execution(e, Some(validation_op.op_for(*key))))?,
         };
 
         let requested_ids = match result {
@@ -764,17 +775,17 @@ impl Executor<Runtime> {
         }
 
         let populated_related = RelatedContracts::from(related_map);
-        // #4864 round-7: classify the second-round validation error too (see the
-        // first `validate_state` match above for the rationale).
+        // #4864 round-7/9: classify the second-round validation error too, with the
+        // caller-supplied op kind (see the first `validate_state` match above).
         let retry_result = match already_fetched_contract {
             Some(contract) => self
                 .runtime
                 .validate_state_with_contract(key, params, state, &populated_related, contract)
-                .map_err(|e| ExecutorError::execution(e, Some(InnerOpError::Upsert(*key))))?,
+                .map_err(|e| ExecutorError::execution(e, Some(validation_op.op_for(*key))))?,
             None => self
                 .runtime
                 .validate_state(key, params, state, &populated_related)
-                .map_err(|e| ExecutorError::execution(e, Some(InnerOpError::Upsert(*key))))?,
+                .map_err(|e| ExecutorError::execution(e, Some(validation_op.op_for(*key))))?,
         };
 
         if let ValidateResult::RequestRelated(_) = &retry_result {

--- a/crates/core/src/contract/executor/runtime/contract_ops.rs
+++ b/crates/core/src/contract/executor/runtime/contract_ops.rs
@@ -645,15 +645,25 @@ impl Executor<Runtime> {
         initial_related: &RelatedContracts<'_>,
         already_fetched_contract: Option<&ContractContainer>,
     ) -> Result<ValidateResult, ExecutorError> {
+        // #4864 round-7 (Codex P1): classify validation-phase WASM errors with
+        // `op = Some(Upsert(*key))` so a runaway/timed-out `validate_state` on the
+        // UPDATE path (this helper serves `get_updated_state`) routes through
+        // `update_exec_error` and reaches the merge-failure backoff, exactly like
+        // a merge-phase error. `op = None` escaped classification entirely. `key`
+        // is in scope; the fix is trivially correct. This helper is also used by
+        // the local re-PUT merge in `perform_contract_put`, where the same change
+        // is strictly more accurate (a validation exec error means the contract IS
+        // present, so `is_contract_exec_rejection` should be true and no auto-fetch
+        // should fire).
         let result = match already_fetched_contract {
             Some(contract) => self
                 .runtime
                 .validate_state_with_contract(key, params, state, initial_related, contract)
-                .map_err(|e| ExecutorError::execution(e, None))?,
+                .map_err(|e| ExecutorError::execution(e, Some(InnerOpError::Upsert(*key))))?,
             None => self
                 .runtime
                 .validate_state(key, params, state, initial_related)
-                .map_err(|e| ExecutorError::execution(e, None))?,
+                .map_err(|e| ExecutorError::execution(e, Some(InnerOpError::Upsert(*key))))?,
         };
 
         let requested_ids = match result {
@@ -754,15 +764,17 @@ impl Executor<Runtime> {
         }
 
         let populated_related = RelatedContracts::from(related_map);
+        // #4864 round-7: classify the second-round validation error too (see the
+        // first `validate_state` match above for the rationale).
         let retry_result = match already_fetched_contract {
             Some(contract) => self
                 .runtime
                 .validate_state_with_contract(key, params, state, &populated_related, contract)
-                .map_err(|e| ExecutorError::execution(e, None))?,
+                .map_err(|e| ExecutorError::execution(e, Some(InnerOpError::Upsert(*key))))?,
             None => self
                 .runtime
                 .validate_state(key, params, state, &populated_related)
-                .map_err(|e| ExecutorError::execution(e, None))?,
+                .map_err(|e| ExecutorError::execution(e, Some(InnerOpError::Upsert(*key))))?,
         };
 
         if let ValidateResult::RequestRelated(_) = &retry_result {

--- a/crates/core/src/contract/executor/runtime/executor_impl.rs
+++ b/crates/core/src/contract/executor/runtime/executor_impl.rs
@@ -1908,7 +1908,18 @@ where
         let result = self
             .runtime
             .validate_state(key, params, state, initial_related)
-            .map_err(|e| ExecutorError::execution(e, None))?;
+            // #4864 round-7 (Codex P1): a validation-phase WASM error (a runaway
+            // `validate_state` that blows the deadline, or a queue-saturation
+            // scheduler timeout) must classify exactly like a merge-phase error.
+            // With `op = Some(Upsert(*key))` it routes through `update_exec_error`
+            // → `Update{cause: "execution error: ..."}`, so `is_wasm_timeout` /
+            // `is_scheduler_timeout` / `is_contract_exec_rejection` all match and
+            // the UPDATE driver records the backoff. `op = None` would route it to
+            // `ExecutorError::other` and the driver would record NOTHING, letting a
+            // contract whose runaway half is `validate_state` burn the full budget
+            // per broadcast without ever backing off. `key` is in scope here, so
+            // the fix is trivially correct.
+            .map_err(|e| ExecutorError::execution(e, Some(InnerOpError::Upsert(*key))))?;
 
         let requested_ids = match result {
             ValidateResult::Valid | ValidateResult::Invalid => return Ok(result),
@@ -2096,7 +2107,9 @@ where
         let retry_result = self
             .runtime
             .validate_state(key, params, state, &populated_related)
-            .map_err(|e| ExecutorError::execution(e, None))?;
+            // #4864 round-7: classify the second-round validation error too (see
+            // the first `validate_state` call above for the rationale).
+            .map_err(|e| ExecutorError::execution(e, Some(InnerOpError::Upsert(*key))))?;
 
         // If the contract requests more related contracts, that's depth>1 — reject
         if let ValidateResult::RequestRelated(_) = &retry_result {

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -3125,6 +3125,21 @@ async fn handle_interest_sync_message(
                     // reset, since they carry the same fork-flip ambiguity. See
                     // the source-scrape pin
                     // `resync_apply_does_not_reset_merge_backoff`.
+                    //
+                    // BUT this CHANGED apply advances the state, which
+                    // invalidates the failed-payload MEMO's premise (a delta that
+                    // failed against the old state may be valid against the new
+                    // one) — clear ONLY the memo (#4864 round-4 P2). This is NOT a
+                    // backoff reset: no cooldown channel is touched, so the
+                    // strictly-delta-only no-reset doctrine and the
+                    // `resync_apply_does_not_reset_merge_backoff` pin (which
+                    // forbids a backoff reset from any node.rs site) both still
+                    // hold — `invalidate_payload_memo` is a distinct method that
+                    // clears only the memo, never a cooldown.
+                    op_manager
+                        .ring
+                        .merge_backoff
+                        .invalidate_payload_memo(key.id());
                     tracing::info!(
                         from = %source,
                         contract = %key,

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -3112,9 +3112,10 @@ async fn handle_interest_sync_message(
                     // flips the node to the other fork (~1 cycle/min forever); if
                     // that reset the backoff, the backoff would never trip and the
                     // storm would continue. The backoff is reset ONLY by a
-                    // genuine successful merge in the broadcast drivers (a delta
-                    // apply / streaming full-state broadcast), which is real
-                    // convergence progress. See the source-scrape pin
+                    // genuine successful DELTA merge in the broadcast driver —
+                    // full-state merges (streaming broadcast included) never
+                    // reset, since they carry the same fork-flip ambiguity. See
+                    // the source-scrape pin
                     // `resync_apply_does_not_reset_merge_backoff`.
                     tracing::info!(
                         from = %source,
@@ -5650,9 +5651,10 @@ mod tests {
         /// the semantic fork-oscillation poison class (it just flips the node to
         /// the other fork), so resetting here would make the backoff never trip
         /// and let the ~1-cycle/min storm continue. The backoff is reset ONLY by
-        /// a genuine successful DELTA / streaming-broadcast merge in the UPDATE
-        /// broadcast drivers (`operations/update/op_ctx_task.rs`), which is real
-        /// convergence progress.
+        /// a genuine successful DELTA merge in the UPDATE broadcast driver
+        /// (`operations/update/op_ctx_task.rs`) — full-state merges, streaming
+        /// broadcast included, never reset because they carry the same
+        /// fork-flip ambiguity as a resync apply.
         #[test]
         fn resync_apply_does_not_reset_merge_backoff() {
             // Assemble the needle from parts so the contiguous call string never

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -2954,12 +2954,15 @@ async fn handle_interest_sync_message(
             // existence check, so a peer spraying bogus contract keys could
             // exhaust the strictly-capped limiter maps and then DENY new legit
             // (peer, contract) keys (fail-closed → no response). A cheap
-            // synchronous redb point-lookup for state presence — the same probe
-            // the interest-sync gates use — rejects unknown contracts before they
-            // can touch a limiter slot. (A known contract whose state we can no
-            // longer fetch a moment later still bails at get_contract_state below,
-            // but only after passing this gate plus the rate limits.)
-            if !op_manager.ring.contract_state_present(&key) {
+            // state-presence probe rejects unknown contracts before they can touch
+            // a limiter slot. The ASYNC variant (#4864 round-5) keeps the redb
+            // synchronous point-lookup fast-path AND adds a real SQLite EXISTS
+            // probe, so the gate is backend-agnostic (the sync probe was a no-op
+            // on sqlite builds, reopening the hole there). (A known contract whose
+            // state we can no longer fetch a moment later still bails at
+            // get_contract_state below, but only after passing this gate plus the
+            // rate limits.)
+            if !op_manager.ring.contract_state_present_async(&key).await {
                 tracing::debug!(
                     from = %source,
                     contract = %key,
@@ -4057,6 +4060,22 @@ mod tests {
         let result = NodeConfig::parse_socket_addr(&addr).await;
         assert!(result.is_err());
     }
+
+    // TODO(#4864 round-5): sqlite bogus-key flood test — blocked by the crate
+    // having NO compilable SQLite-only feature combination. The round-5 fix
+    // added an async SQLite EXISTS probe (`contract_state_present_async` →
+    // `get_state_size`) so bogus ResyncRequests are rejected before consuming a
+    // limiter slot on a SQLite build too, but that path cannot be exercised in a
+    // test: `cargo build/test -p freenet --no-default-features --features
+    // sqlite,...` fails to compile (~52 lib errors / ~99 lib-test errors). The
+    // SQLite `Pool` backend (crates/core/src/contract/storages/sqlite.rs) has
+    // drifted behind `ReDb` and is missing ~15 methods the rest of the crate
+    // calls (get_state_sync / store_state_sync / update_state_sync,
+    // contract_blob_lock, {load_all,store,remove}_{contract,delegate,secrets,
+    // user_secrets}_index). A SQLite mirror of the redb test below can only be
+    // added once the SQLite backend is repaired (out of scope here: this change
+    // was restricted to node.rs and may not touch sqlite.rs). The redb test
+    // below covers the redb backend's synchronous fast-path.
 
     /// #4864 round-4 P1: a peer spraying `ResyncRequest`s for contracts we do
     /// NOT hold must not be able to exhaust the strictly-capped resync-response
@@ -5763,10 +5782,12 @@ mod tests {
         #[test]
         fn resync_request_handler_rate_limits_response() {
             let arm = resync_request_arm();
-            // (1) cheap existence check BEFORE either limiter.
-            let exists_pos = arm.find("contract_state_present(&key)").expect(
+            // (1) cheap existence check BEFORE either limiter (async so the probe
+            // is backend-agnostic: redb sync fast-path + real SQLite EXISTS,
+            // #4864 round-5).
+            let exists_pos = arm.find("contract_state_present_async(&key)").expect(
                 "ResyncRequest handler must do a cheap state-presence check BEFORE \
-                 the rate limiters (#4864 round-4)",
+                 the rate limiters (#4864 round-4/round-5)",
             );
             let gate_pos = arm.find("resync_response_limiter").expect(
                 "ResyncRequest handler must rate-limit the response via \

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -2949,6 +2949,26 @@ async fn handle_interest_sync_message(
             op_manager.interest_manager.record_resync_request_received();
             crate::config::GlobalTestMetrics::record_resync_request();
 
+            // CHEAP existence check BEFORE the rate limiters (#4864 round-4 P1).
+            // Both limiter buckets allocate a slot (vacant-at-capacity) BEFORE any
+            // existence check, so a peer spraying bogus contract keys could
+            // exhaust the strictly-capped limiter maps and then DENY new legit
+            // (peer, contract) keys (fail-closed → no response). A cheap
+            // synchronous redb point-lookup for state presence — the same probe
+            // the interest-sync gates use — rejects unknown contracts before they
+            // can touch a limiter slot. (A known contract whose state we can no
+            // longer fetch a moment later still bails at get_contract_state below,
+            // but only after passing this gate plus the rate limits.)
+            if !op_manager.ring.contract_state_present(&key) {
+                tracing::debug!(
+                    from = %source,
+                    contract = %key,
+                    event = "resync_response_no_state",
+                    "ResyncRequest for a contract we have no state for — not responding (pre-limiter existence check)"
+                );
+                return None;
+            }
+
             // Rate-limit the full-state response per (peer, contract) (#4861).
             // This is the mixed-version-rollout guard: a not-yet-upgraded peer
             // that still emits unlimited ResyncRequests must not be able to make
@@ -4036,6 +4056,109 @@ mod tests {
         let addr = Address::Hostname("localhost:not_a_port".to_string());
         let result = NodeConfig::parse_socket_addr(&addr).await;
         assert!(result.is_err());
+    }
+
+    /// #4864 round-4 P1: a peer spraying `ResyncRequest`s for contracts we do
+    /// NOT hold must not be able to exhaust the strictly-capped resync-response
+    /// limiter maps. Both limiters allocate a bucket slot (vacant-at-capacity)
+    /// the moment `check_and_record` runs, so if the existence check did not
+    /// precede them, N distinct bogus keys would occupy N slots and then start
+    /// DENYING new legit `(peer, contract)` keys (fail-closed → no response for
+    /// contracts we actually host).
+    ///
+    /// The `ResyncRequest` arm now does a cheap synchronous redb state-presence
+    /// point lookup BEFORE either limiter and bails on absence, so bogus keys
+    /// never touch a limiter slot. This test fires 50 distinct bogus keys and
+    /// asserts (a) every response is `None`, and (b) both limiter maps stay
+    /// EMPTY — proving the pre-limiter existence gate holds.
+    ///
+    /// Requires a real (empty) redb hosting store: with NO storage handle,
+    /// `contract_state_present` conservatively returns `true` for every key
+    /// (see `hosting.rs::contract_state_present`), which would let the requests
+    /// through and populate the limiters, making the test vacuous. Gated on the
+    /// `redb` feature (a default feature; runs under `--features testing`) for
+    /// the same reason the #4612 store test is: only the redb backend has the
+    /// cheap synchronous existence check.
+    #[cfg(feature = "redb")]
+    #[tokio::test]
+    async fn resync_request_for_bogus_keys_does_not_consume_limiter_slots() {
+        // Build a real OpManager (mirrors `build_broadcast_test_node` in
+        // operations/update/op_ctx_task.rs; no contract-handler spawn needed
+        // because the existence check returns before any handler interaction).
+        let config_args = crate::config::ConfigArgs {
+            id: Some("resync-bogus-4864".to_string()),
+            mode: Some(crate::contract::OperationMode::Local),
+            ..Default::default()
+        };
+        let node_config = NodeConfig::new(config_args.build().await.expect("build Config"))
+            .await
+            .expect("build NodeConfig");
+        let (_notification_rx, notification_tx) = crate::node::event_loop_notification_channel();
+        let (ops_ch_channel, _ch_channel, _wait_for_event) =
+            crate::contract::contract_handler_channel();
+        let connection_manager = crate::ring::ConnectionManager::new(&node_config);
+        let (result_router_tx, _result_router_rx) = tokio::sync::mpsc::channel(100);
+        let task_monitor = crate::node::background_task_monitor::BackgroundTaskMonitor::new();
+        let op_manager = std::sync::Arc::new(
+            crate::node::OpManager::new(
+                notification_tx,
+                ops_ch_channel,
+                &node_config,
+                crate::tracing::DynamicRegister::new(vec![]),
+                connection_manager,
+                result_router_tx,
+                &task_monitor,
+            )
+            .expect("build OpManager"),
+        );
+        op_manager.ring.attach_op_manager(&op_manager);
+        op_manager
+            .ring
+            .connection_manager
+            .set_own_addr("127.0.0.1:14000".parse().unwrap());
+
+        // Attach an EMPTY redb hosting store so `contract_state_present`
+        // returns false for unknown keys (a fresh store creates the STATE
+        // table but holds no state). Keep `dir` alive for the whole test so
+        // the temp directory is not removed while the store is open.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let storage = crate::contract::storages::Storage::new(dir.path())
+            .await
+            .expect("storage");
+        op_manager.ring.set_hosting_storage(storage);
+
+        let source: SocketAddr = "127.0.0.1:15000".parse().unwrap();
+        for i in 0u8..50 {
+            // Distinct bogus key per iteration; none of these are stored.
+            let key = freenet_stdlib::prelude::ContractKey::from_id_and_code(
+                freenet_stdlib::prelude::ContractInstanceId::new([i; 32]),
+                freenet_stdlib::prelude::CodeHash::new([i; 32]),
+            );
+            let response = handle_interest_sync_message(
+                &op_manager,
+                source,
+                crate::message::InterestMessage::ResyncRequest { key },
+            )
+            .await;
+            assert!(
+                response.is_none(),
+                "ResyncRequest for a contract with no stored state (bogus key {i}) \
+                 must produce no response"
+            );
+        }
+
+        assert_eq!(
+            op_manager.ring.resync_response_limiter.len(),
+            0,
+            "#4864: bogus keys must NOT occupy per-(peer, contract) limiter slots \
+             (the pre-limiter existence check must reject them first)"
+        );
+        assert_eq!(
+            op_manager.ring.resync_response_global_limiter.len(),
+            0,
+            "#4864: bogus keys must NOT occupy global per-contract limiter slots \
+             (the pre-limiter existence check must reject them first)"
+        );
     }
 
     // Superseded: Old addr-only equality (same_addr_different_keys → equal) was replaced
@@ -5631,13 +5754,20 @@ mod tests {
             );
         }
 
-        /// Pin (#4861): the responder MUST rate-limit the full-state
-        /// `ResyncResponse` per (peer, contract), gating BEFORE the expensive
-        /// state/summary fetch, so a not-yet-upgraded peer flooding
-        /// `ResyncRequest`s can't make this node full-state-reply in a loop.
+        /// Pin (#4861 + #4864 round-4): the responder MUST, in order, (1) do a
+        /// cheap state-presence check, (2) rate-limit per (peer, contract), (3)
+        /// apply the global per-contract cap, and only then (4) do the expensive
+        /// state/summary fetch. The existence check gating FIRST is the #4864
+        /// round-4 fix — otherwise a peer spraying bogus keys exhausts the capped
+        /// limiter maps and denies legit (peer, contract) keys.
         #[test]
         fn resync_request_handler_rate_limits_response() {
             let arm = resync_request_arm();
+            // (1) cheap existence check BEFORE either limiter.
+            let exists_pos = arm.find("contract_state_present(&key)").expect(
+                "ResyncRequest handler must do a cheap state-presence check BEFORE \
+                 the rate limiters (#4864 round-4)",
+            );
             let gate_pos = arm.find("resync_response_limiter").expect(
                 "ResyncRequest handler must rate-limit the response via \
                  resync_response_limiter (#4861)",
@@ -5656,6 +5786,12 @@ mod tests {
             let global_pos = arm.find("resync_response_global_limiter").expect(
                 "ResyncRequest handler must also apply the GLOBAL per-contract \
                  response cap (#4861)",
+            );
+            assert!(
+                exists_pos < gate_pos,
+                "the cheap existence check ({exists_pos}) must run BEFORE the \
+                 per-peer limiter ({gate_pos}) so a bogus contract never consumes \
+                 a limiter slot (#4864 round-4)"
             );
             assert!(
                 gate_pos < global_pos && global_pos < state_fetch_pos,

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -5670,7 +5670,7 @@ mod tests {
             // Assemble the needle from parts so the contiguous call string never
             // appears verbatim in this file — otherwise `.contains(<literal>)`
             // would match its OWN argument via `include_str!` (self-reference).
-            let needle = concat!("merge_backoff", ".record_success(");
+            let needle = concat!("merge_backoff", ".record_success");
             assert!(
                 !SOURCE.contains(needle),
                 "node.rs must NOT reset the merge backoff anywhere — a \

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -4080,7 +4080,7 @@ mod tests {
         assert!(result.is_err());
     }
 
-    // TODO(#4864 round-5): sqlite bogus-key flood test — blocked by the crate
+    // TODO(#4869): sqlite bogus-key flood test — blocked by the crate
     // having NO compilable SQLite-only feature combination. The round-5 fix
     // added an async SQLite EXISTS probe (`contract_state_present_async` →
     // `get_state_size`) so bogus ResyncRequests are rejected before consuming a

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -3109,6 +3109,34 @@ async fn handle_interest_sync_message(
                 "Received ResyncResponse with full state"
             );
 
+            // #4864 round-8 (Codex P1): CORRELATE with an outstanding ResyncRequest
+            // WE sent to this peer for this contract, BEFORE touching the contract
+            // handler. The apply below runs a full-state WASM merge that is
+            // deliberately NOT backoff-gated, so an unsolicited or replayed
+            // ResyncResponse would burn up to a full WASM budget per message,
+            // bypassing every emitter-side gate (those only bound OUR requests).
+            // `consume` require-and-consumes a matching (contract, source) entry;
+            // consume-on-first-match makes replay dead, and a stale (TTL-expired)
+            // or absent entry drops the response without running WASM. Mixed-version
+            // safe: an old peer only ever answers OUR request, so a legit response
+            // always has an entry unless it raced the 60s TTL (anti-entropy heals
+            // that corner).
+            if !op_manager
+                .ring
+                .outstanding_resync_requests
+                .consume(*key.id(), source)
+            {
+                crate::config::GlobalTestMetrics::record_resync_response_unsolicited();
+                tracing::debug!(
+                    from = %source,
+                    contract = %key,
+                    event = "resync_response_unsolicited",
+                    "ResyncResponse with no matching outstanding request — dropping \
+                     without applying (unsolicited, replayed, or TTL-expired)"
+                );
+                return None;
+            }
+
             // Apply the full state using an update.
             //
             // This full-state WASM merge is deliberately NOT gated by the
@@ -4347,6 +4375,333 @@ mod tests {
             }
             other => panic!("expected Some(ResyncResponse) for a held contract, got {other:?}"),
         }
+    }
+
+    /// #4864 round-8 (Codex P1): an UNSOLICITED `ResyncResponse` — one with NO
+    /// matching outstanding `ResyncRequest` we recorded for that
+    /// `(contract, source)` — MUST be dropped by the correlation gate BEFORE any
+    /// state is applied. This is the SECURITY property: the resync apply runs a
+    /// full-state WASM merge that is deliberately NOT backoff-gated, so without
+    /// the gate a peer could spray unsolicited full-state responses and burn a
+    /// full WASM merge budget per message, bypassing every emitter-side rate
+    /// limit (those only bound OUR requests). The gate
+    /// (`outstanding_resync_requests.consume(..)`) runs before
+    /// `notify_contract_handler(ContractHandlerEvent::UpdateQuery { .. })`, so an
+    /// unsolicited response never reaches the contract handler at all.
+    ///
+    /// Asserts: (a) the handler returns `None`; (b) NO `UpdateQuery` ever reached
+    /// the (stand-in) contract handler — the WASM-apply path was never entered;
+    /// (c) the unsolicited-drop metric incremented exactly once.
+    #[tokio::test]
+    async fn resync_response_unsolicited_is_dropped_without_applying() {
+        use crate::contract::ContractHandlerEvent;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        // Build a real OpManager (same harness as
+        // resync_request_for_held_contract_passes_gate_and_responds).
+        let config_args = crate::config::ConfigArgs {
+            id: Some("resync-resp-unsolicited-4864".to_string()),
+            mode: Some(crate::contract::OperationMode::Local),
+            ..Default::default()
+        };
+        let node_config = NodeConfig::new(config_args.build().await.expect("build Config"))
+            .await
+            .expect("build NodeConfig");
+        let (_notification_rx, notification_tx) = crate::node::event_loop_notification_channel();
+        let (ops_ch_channel, mut ch_channel, _wait_for_event) =
+            crate::contract::contract_handler_channel();
+        let connection_manager = crate::ring::ConnectionManager::new(&node_config);
+        let (result_router_tx, _result_router_rx) = tokio::sync::mpsc::channel(100);
+        let task_monitor = crate::node::background_task_monitor::BackgroundTaskMonitor::new();
+        let op_manager = std::sync::Arc::new(
+            crate::node::OpManager::new(
+                notification_tx,
+                ops_ch_channel,
+                &node_config,
+                crate::tracing::DynamicRegister::new(vec![]),
+                connection_manager,
+                result_router_tx,
+                &task_monitor,
+            )
+            .expect("build OpManager"),
+        );
+        op_manager.ring.attach_op_manager(&op_manager);
+        op_manager
+            .ring
+            .connection_manager
+            .set_own_addr("127.0.0.1:14200".parse().unwrap());
+
+        // Stand-in contract handler: flips `update_query_seen` to true if it EVER
+        // receives an UpdateQuery (proof the WASM-apply path was entered),
+        // answering it so nothing hangs. For this test it must NEVER fire — any
+        // event reaching the handler is the regression this guards against.
+        let update_query_seen = std::sync::Arc::new(AtomicBool::new(false));
+        let handler_flag = update_query_seen.clone();
+        let _handler = tokio::spawn(async move {
+            while let Ok((id, ev, _priority)) = ch_channel.recv_from_sender().await {
+                let response = match ev {
+                    ContractHandlerEvent::UpdateQuery { .. } => {
+                        handler_flag.store(true, Ordering::SeqCst);
+                        ContractHandlerEvent::UpdateResponse {
+                            new_value: Ok(freenet_stdlib::prelude::WrappedState::new(vec![
+                                1u8, 2, 3,
+                            ])),
+                            state_changed: true,
+                        }
+                    }
+                    other => panic!(
+                        "an unsolicited ResyncResponse must not reach the contract \
+                         handler, got: {other:?}"
+                    ),
+                };
+                if ch_channel.send_to_sender(id, response).await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        let key = freenet_stdlib::prelude::ContractKey::from_id_and_code(
+            freenet_stdlib::prelude::ContractInstanceId::new([202u8; 32]),
+            freenet_stdlib::prelude::CodeHash::new([203u8; 32]),
+        );
+        let source: SocketAddr = "127.0.0.1:15200".parse().unwrap();
+
+        // NO outstanding entry seeded → the response is unsolicited.
+        assert_eq!(
+            op_manager.ring.outstanding_resync_requests.len(),
+            0,
+            "precondition: no outstanding ResyncRequest recorded for this (contract, source)"
+        );
+
+        crate::config::GlobalTestMetrics::reset();
+
+        let response = handle_interest_sync_message(
+            &op_manager,
+            source,
+            crate::message::InterestMessage::ResyncResponse {
+                key,
+                state_bytes: vec![1u8, 2, 3],
+                summary_bytes: vec![4u8, 5, 6],
+            },
+        )
+        .await;
+
+        // Give the (should-be-idle) handler task a scheduling window: if the gate
+        // had wrongly forwarded an UpdateQuery, it would surface now. (The arm
+        // AWAITS the handler round-trip, so a leak would already have set the flag
+        // before the call above returned; this is belt-and-suspenders.)
+        tokio::task::yield_now().await;
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+        assert!(
+            response.is_none(),
+            "an unsolicited ResyncResponse must produce no reply"
+        );
+        assert!(
+            !update_query_seen.load(Ordering::SeqCst),
+            "SECURITY (#4864 round-8): the correlation gate must drop the unsolicited \
+             ResyncResponse BEFORE any UpdateQuery / WASM apply — the contract handler \
+             must never see it"
+        );
+        assert_eq!(
+            crate::config::GlobalTestMetrics::resync_responses_unsolicited(),
+            1,
+            "the unsolicited-drop must be counted exactly once (#4864 round-8)"
+        );
+    }
+
+    /// #4864 round-8 (Codex P1): a SOLICITED `ResyncResponse` — one that matches
+    /// an outstanding `ResyncRequest` we recorded — passes the correlation gate
+    /// and IS applied (reaches the contract handler's `UpdateQuery`). Crucially
+    /// the gate `consume`s the entry on first match, so an identical REPLAY of the
+    /// same response finds nothing and is dropped WITHOUT a second apply — replay
+    /// is dead.
+    ///
+    /// Asserts (first call): the `UpdateQuery` reached the handler (applied), and
+    /// the outstanding entry was consumed (`len() == 0`), and the unsolicited-drop
+    /// metric stayed 0. (Replay call): returns `None`, NO second `UpdateQuery`, and
+    /// the unsolicited-drop metric incremented to 1.
+    #[tokio::test]
+    async fn resync_response_solicited_applies_then_replay_is_suppressed() {
+        use crate::contract::ContractHandlerEvent;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        // Build a real OpManager (same harness as
+        // resync_request_for_held_contract_passes_gate_and_responds).
+        let config_args = crate::config::ConfigArgs {
+            id: Some("resync-resp-solicited-4864".to_string()),
+            mode: Some(crate::contract::OperationMode::Local),
+            ..Default::default()
+        };
+        let node_config = NodeConfig::new(config_args.build().await.expect("build Config"))
+            .await
+            .expect("build NodeConfig");
+        let (_notification_rx, notification_tx) = crate::node::event_loop_notification_channel();
+        let (ops_ch_channel, mut ch_channel, _wait_for_event) =
+            crate::contract::contract_handler_channel();
+        let connection_manager = crate::ring::ConnectionManager::new(&node_config);
+        let (result_router_tx, _result_router_rx) = tokio::sync::mpsc::channel(100);
+        let task_monitor = crate::node::background_task_monitor::BackgroundTaskMonitor::new();
+        let op_manager = std::sync::Arc::new(
+            crate::node::OpManager::new(
+                notification_tx,
+                ops_ch_channel,
+                &node_config,
+                crate::tracing::DynamicRegister::new(vec![]),
+                connection_manager,
+                result_router_tx,
+                &task_monitor,
+            )
+            .expect("build OpManager"),
+        );
+        op_manager.ring.attach_op_manager(&op_manager);
+        op_manager
+            .ring
+            .connection_manager
+            .set_own_addr("127.0.0.1:14300".parse().unwrap());
+
+        // Stand-in contract handler: answers UpdateQuery with a SUCCESSFUL,
+        // state-changed merge (mirrors the ResyncResponse arm's
+        // `UpdateResponse { new_value: Ok(_), state_changed: true, .. }` match)
+        // and records that the apply was reached.
+        let update_query_seen = std::sync::Arc::new(AtomicBool::new(false));
+        let handler_flag = update_query_seen.clone();
+        let _handler = tokio::spawn(async move {
+            while let Ok((id, ev, _priority)) = ch_channel.recv_from_sender().await {
+                let response = match ev {
+                    ContractHandlerEvent::UpdateQuery { .. } => {
+                        handler_flag.store(true, Ordering::SeqCst);
+                        ContractHandlerEvent::UpdateResponse {
+                            new_value: Ok(freenet_stdlib::prelude::WrappedState::new(vec![
+                                9u8, 8, 7,
+                            ])),
+                            state_changed: true,
+                        }
+                    }
+                    other => {
+                        panic!("unexpected handler event in solicited-resync stand-in: {other:?}")
+                    }
+                };
+                if ch_channel.send_to_sender(id, response).await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        let key = freenet_stdlib::prelude::ContractKey::from_id_and_code(
+            freenet_stdlib::prelude::ContractInstanceId::new([204u8; 32]),
+            freenet_stdlib::prelude::CodeHash::new([205u8; 32]),
+        );
+        let source: SocketAddr = "127.0.0.1:15300".parse().unwrap();
+
+        // Seed the outstanding entry: WE sent a ResyncRequest to `source` for
+        // `key`, so the incoming response is solicited.
+        op_manager
+            .ring
+            .outstanding_resync_requests
+            .record(*key.id(), source);
+        assert_eq!(
+            op_manager.ring.outstanding_resync_requests.len(),
+            1,
+            "precondition: exactly one outstanding ResyncRequest recorded"
+        );
+
+        crate::config::GlobalTestMetrics::reset();
+
+        // FIRST delivery: solicited → passes the gate → applied.
+        let resp1 = handle_interest_sync_message(
+            &op_manager,
+            source,
+            crate::message::InterestMessage::ResyncResponse {
+                key,
+                state_bytes: vec![1u8, 2, 3],
+                summary_bytes: vec![4u8, 5, 6],
+            },
+        )
+        .await;
+        assert!(
+            resp1.is_none(),
+            "a ResyncResponse never produces a reply (it applies locally)"
+        );
+        assert!(
+            update_query_seen.load(Ordering::SeqCst),
+            "a solicited ResyncResponse must be applied (reach the UpdateQuery apply)"
+        );
+        assert_eq!(
+            op_manager.ring.outstanding_resync_requests.len(),
+            0,
+            "the correlation gate must CONSUME the outstanding entry on apply (#4864 round-8)"
+        );
+        assert_eq!(
+            crate::config::GlobalTestMetrics::resync_responses_unsolicited(),
+            0,
+            "a solicited response must NOT be counted as unsolicited"
+        );
+
+        // REPLAY: byte-identical response. The entry was already consumed, so the
+        // gate finds nothing and drops it — no second apply.
+        update_query_seen.store(false, Ordering::SeqCst);
+        let resp2 = handle_interest_sync_message(
+            &op_manager,
+            source,
+            crate::message::InterestMessage::ResyncResponse {
+                key,
+                state_bytes: vec![1u8, 2, 3],
+                summary_bytes: vec![4u8, 5, 6],
+            },
+        )
+        .await;
+
+        // Window for a wrongly-forwarded UpdateQuery to surface (belt-and-suspenders;
+        // a real leak would have set the flag before the awaited call returned).
+        tokio::task::yield_now().await;
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+        assert!(
+            resp2.is_none(),
+            "a replayed ResyncResponse must produce no reply"
+        );
+        assert!(
+            !update_query_seen.load(Ordering::SeqCst),
+            "SECURITY (#4864 round-8): a replayed ResyncResponse must NOT reach a second \
+             UpdateQuery apply — consume-on-first-match makes replay dead"
+        );
+        assert_eq!(
+            crate::config::GlobalTestMetrics::resync_responses_unsolicited(),
+            1,
+            "the replayed response must be counted as an unsolicited drop (#4864 round-8)"
+        );
+    }
+
+    /// #4864 round-8 (Codex P1) source-scrape pin: the `ResyncResponse` receive
+    /// arm MUST require-and-consume an outstanding `ResyncRequest`
+    /// (`outstanding_resync_requests.consume(..)`) BEFORE it applies the state via
+    /// `ContractHandlerEvent::UpdateQuery`. If the consume ever moves after (or is
+    /// downgraded to a non-consuming peek), an unsolicited or replayed
+    /// ResyncResponse would reach the un-backoff-gated full-state WASM merge —
+    /// exactly the DoS surface the behavioral tests above guard against.
+    #[test]
+    fn resync_response_arm_consumes_outstanding_before_apply() {
+        let src = include_str!("node.rs");
+        let arm = src
+            .find(r#"event = "resync_response_received""#)
+            .expect("ResyncResponse receive anchor not found");
+        let region = &src[arm..];
+        let consume = region.find("outstanding_resync_requests").expect(
+            "ResyncResponse arm must correlate via outstanding_resync_requests (#4864 round-8)",
+        );
+        let apply = region
+            .find("ContractHandlerEvent::UpdateQuery")
+            .expect("ResyncResponse arm must apply via UpdateQuery");
+        assert!(
+            consume < apply,
+            "outstanding_resync_requests.consume MUST run BEFORE the UpdateQuery apply so an \
+             unsolicited/replayed ResyncResponse never reaches WASM (#4864 round-8)"
+        );
+        assert!(
+            region[consume..(consume + 120).min(region.len())].contains(".consume("),
+            "the correlation must be a require-and-consume (.consume), not a peek"
+        );
     }
 
     // Superseded: Old addr-only equality (same_addr_different_keys → equal) was replaced
@@ -6029,11 +6384,17 @@ mod tests {
         /// 10-min TTL.
         #[test]
         fn resync_changed_apply_invalidates_payload_memo() {
-            // Window-bound to the ResyncResponse apply arm so the far-away test
-            // literals below cannot satisfy the needles (self-reference guard).
+            // Window-bound to the ResyncResponse RECEIVE-and-apply arm so the
+            // far-away test literals below cannot satisfy the needles
+            // (self-reference guard). Anchored on the receive-log event (assembled
+            // via concat so this literal isn't self-matched) rather than the first
+            // `InterestMessage::ResyncResponse {` — that matched the SEND-side
+            // construction in the ResyncRequest arm, and the #4864 round-8 consume
+            // gate inserted between the receive log and the apply pushed the
+            // sub-arm markers past the old fixed window.
             let start = SOURCE
-                .find(concat!("InterestMessage::Resync", "Response {"))
-                .expect("ResyncResponse arm not found");
+                .find(concat!("event = \"resync_response_", "received\""))
+                .expect("ResyncResponse receive arm not found");
             let arm = &SOURCE[start..(start + 6000).min(SOURCE.len())];
             let invalidate = concat!("invalidate_", "payload_memo(");
             // Match the PATTERN form (trailing comma) so a prose mention of

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -3132,7 +3132,9 @@ async fn handle_interest_sync_message(
                 .await
             {
                 Ok(ContractHandlerEvent::UpdateResponse {
-                    new_value: Ok(_), ..
+                    new_value: Ok(_),
+                    state_changed: true,
+                    ..
                 }) => {
                     // NOTE (#4861): deliberately do NOT reset the merge-failure
                     // backoff here. A full-state resync apply "succeeds" (even
@@ -3152,8 +3154,13 @@ async fn handle_interest_sync_message(
                     // BUT this CHANGED apply advances the state, which
                     // invalidates the failed-payload MEMO's premise (a delta that
                     // failed against the old state may be valid against the new
-                    // one) — clear ONLY the memo (#4864 round-4 P2). This is NOT a
-                    // backoff reset: no cooldown channel is touched, so the
+                    // one) — clear ONLY the memo (#4864 round-4 P2). Gated on
+                    // `state_changed: true` (#4864 round-5 item 8): the executor
+                    // returns `UpdateResponse { state_changed: false }` for a
+                    // redundant no-op apply (CurrentWon / NoChange-with-fetch),
+                    // and invalidating on THOSE would needlessly re-admit
+                    // known-bad payloads without a real state advance. This is NOT
+                    // a backoff reset: no cooldown channel is touched, so the
                     // strictly-delta-only no-reset doctrine and the
                     // `resync_apply_does_not_reset_merge_backoff` pin (which
                     // forbids a backoff reset from any node.rs site) both still
@@ -3171,9 +3178,21 @@ async fn handle_interest_sync_message(
                         "ResyncResponse state applied successfully"
                     );
                 }
-                Ok(ContractHandlerEvent::UpdateNoChange { .. }) => {
-                    // As above (#4861): a no-change resync apply is not a
-                    // convergence signal, so it must not reset the backoff.
+                Ok(ContractHandlerEvent::UpdateResponse {
+                    new_value: Ok(_),
+                    state_changed: false,
+                    ..
+                })
+                | Ok(ContractHandlerEvent::UpdateNoChange { .. }) => {
+                    // A no-op resync apply (CurrentWon / NoChange — the executor
+                    // returns either `UpdateResponse { state_changed: false }` or
+                    // `UpdateNoChange`) did NOT advance the state. As above
+                    // (#4861) it is not a convergence signal, so it must not reset
+                    // the backoff — AND it is not a memo-invalidation either
+                    // (#4864 round-5 item 8): the failed-payload memo's premise
+                    // still holds when the state did not change, so
+                    // `invalidate_payload_memo` is deliberately NOT called here,
+                    // and the log field is honestly `changed = false`.
                     tracing::info!(
                         from = %source,
                         contract = %key,
@@ -4178,6 +4197,156 @@ mod tests {
             "#4864: bogus keys must NOT occupy global per-contract limiter slots \
              (the pre-limiter existence check must reject them first)"
         );
+    }
+
+    /// #4864 round-5 item 5 — POSITIVE CONTROL twin of
+    /// `resync_request_for_bogus_keys_does_not_consume_limiter_slots`.
+    ///
+    /// The bogus-keys test proves the existence gate REJECTS absent contracts
+    /// (both limiter maps stay EMPTY). On its own that stays green even if
+    /// `contract_state_present_async` regressed to ALWAYS-false — a gate that
+    /// rejects *everything* would also leave the maps empty. This twin removes
+    /// that blind spot: a `ResyncRequest` for a contract we DO hold must PASS
+    /// the gate, so a limiter slot IS consumed (`len() >= 1`), and — because
+    /// the stand-in handler answers the post-gate state/summary fetches — a
+    /// full `ResyncResponse` comes back.
+    ///
+    /// Together the pair proves the gate DISCRIMINATES (bogus → `len() == 0`,
+    /// held → `len() >= 1`), not merely that it always-rejects or always-accepts.
+    ///
+    /// redb-gated for the same reason as the twin: only the redb backend has
+    /// the cheap synchronous existence check, and an empty/unset store would
+    /// make the precondition unrepresentable.
+    #[cfg(feature = "redb")]
+    #[tokio::test]
+    async fn resync_request_for_held_contract_passes_gate_and_responds() {
+        use crate::contract::{ContractHandlerEvent, StoreResponse};
+        use freenet_stdlib::prelude::{StateSummary, WrappedState};
+
+        // Build a real OpManager (identical harness to the bogus-keys twin),
+        // but this time WITH a stand-in contract handler: the held path reaches
+        // `get_contract_state` / `get_contract_summary` after the gate, which
+        // round-trip through the contract-handling channel, so an unanswered
+        // channel would hang the test.
+        let config_args = crate::config::ConfigArgs {
+            id: Some("resync-held-4864".to_string()),
+            mode: Some(crate::contract::OperationMode::Local),
+            ..Default::default()
+        };
+        let node_config = NodeConfig::new(config_args.build().await.expect("build Config"))
+            .await
+            .expect("build NodeConfig");
+        let (_notification_rx, notification_tx) = crate::node::event_loop_notification_channel();
+        let (ops_ch_channel, mut ch_channel, _wait_for_event) =
+            crate::contract::contract_handler_channel();
+        let connection_manager = crate::ring::ConnectionManager::new(&node_config);
+        let (result_router_tx, _result_router_rx) = tokio::sync::mpsc::channel(100);
+        let task_monitor = crate::node::background_task_monitor::BackgroundTaskMonitor::new();
+        let op_manager = std::sync::Arc::new(
+            crate::node::OpManager::new(
+                notification_tx,
+                ops_ch_channel,
+                &node_config,
+                crate::tracing::DynamicRegister::new(vec![]),
+                connection_manager,
+                result_router_tx,
+                &task_monitor,
+            )
+            .expect("build OpManager"),
+        );
+        op_manager.ring.attach_op_manager(&op_manager);
+        op_manager
+            .ring
+            .connection_manager
+            .set_own_addr("127.0.0.1:14100".parse().unwrap());
+
+        // The one contract we DO hold.
+        let key = freenet_stdlib::prelude::ContractKey::from_id_and_code(
+            freenet_stdlib::prelude::ContractInstanceId::new([200u8; 32]),
+            freenet_stdlib::prelude::CodeHash::new([201u8; 32]),
+        );
+
+        // Store its state into the hosting store BEFORE handing the store to
+        // the ring, so `contract_state_present_async(&key)` (the redb sync
+        // point lookup on the STATE table — the same table `store_state_sync`
+        // writes and `get_state_size` reads) returns true.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let storage = crate::contract::storages::Storage::new(dir.path())
+            .await
+            .expect("storage");
+        storage
+            .store_state_sync(&key, WrappedState::new(vec![9u8, 9, 9]))
+            .expect("store held state");
+        op_manager.ring.set_hosting_storage(storage);
+
+        // Precondition: the sync redb probe (what the async gate delegates to
+        // under redb) sees the state we just stored.
+        assert!(
+            op_manager.ring.contract_state_present(&key),
+            "precondition: the held contract's state must be present in the store"
+        );
+
+        // Stand-in contract handler: answers the post-gate GET (full state) and
+        // GET-summary so the responder can build a ResyncResponse. Owns the
+        // receiver for the whole test.
+        let handler_key = key;
+        let _handler = tokio::spawn(async move {
+            while let Ok((id, ev, _priority)) = ch_channel.recv_from_sender().await {
+                let response = match ev {
+                    ContractHandlerEvent::GetQuery { .. } => ContractHandlerEvent::GetResponse {
+                        key: Some(handler_key),
+                        response: Ok(StoreResponse {
+                            state: Some(WrappedState::new(vec![9u8, 9, 9])),
+                            contract: None,
+                        }),
+                    },
+                    ContractHandlerEvent::GetSummaryQuery { key } => {
+                        ContractHandlerEvent::GetSummaryResponse {
+                            key,
+                            summary: Ok(StateSummary::from(vec![7u8, 7, 7])),
+                        }
+                    }
+                    other => {
+                        panic!("unexpected handler event in held-contract stand-in: {other:?}")
+                    }
+                };
+                if ch_channel.send_to_sender(id, response).await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        let source: SocketAddr = "127.0.0.1:15100".parse().unwrap();
+        let response = handle_interest_sync_message(
+            &op_manager,
+            source,
+            crate::message::InterestMessage::ResyncRequest { key },
+        )
+        .await;
+
+        // PRIMARY assertion (the exact regression this guards): the gate PASSED,
+        // so a limiter slot WAS consumed — impossible if the existence check had
+        // regressed to always-reject.
+        assert!(
+            op_manager.ring.resync_response_limiter.len() >= 1,
+            "#4864: a ResyncRequest for a HELD contract must PASS the existence \
+             gate and consume a per-(peer, contract) limiter slot (contrast the \
+             bogus-keys twin, which asserts len() == 0)"
+        );
+        assert!(
+            op_manager.ring.resync_response_global_limiter.len() >= 1,
+            "#4864: a ResyncRequest for a HELD contract must PASS the existence \
+             gate and consume a global per-contract limiter slot"
+        );
+
+        // Stronger check: with the state + summary answered, a full ResyncResponse
+        // for the held key is produced (the whole happy path, not just the gate).
+        match response {
+            Some(crate::message::InterestMessage::ResyncResponse { key: got, .. }) => {
+                assert_eq!(got, key, "ResyncResponse must be for the held contract");
+            }
+            other => panic!("expected Some(ResyncResponse) for a held contract, got {other:?}"),
+        }
     }
 
     // Superseded: Old addr-only equality (same_addr_different_keys → equal) was replaced
@@ -5849,6 +6018,41 @@ mod tests {
                  resync-apply (or any node.rs) reset would defeat the #4861 \
                  fork-oscillation containment. Reset belongs only in the broadcast \
                  drivers on a genuine merge success."
+            );
+        }
+
+        /// Pin (#4864 round-5 item 6): the CHANGED ResyncResponse apply arm MUST
+        /// call `invalidate_payload_memo` (presence — the no-reset pin above only
+        /// asserts ABSENCE of a reset), and it must live in the `state_changed:
+        /// true` sub-arm so a no-op apply does NOT invalidate the memo (item 8).
+        /// Dropping the call silently widens the memo staleness corner to the full
+        /// 10-min TTL.
+        #[test]
+        fn resync_changed_apply_invalidates_payload_memo() {
+            // Window-bound to the ResyncResponse apply arm so the far-away test
+            // literals below cannot satisfy the needles (self-reference guard).
+            let start = SOURCE
+                .find(concat!("InterestMessage::Resync", "Response {"))
+                .expect("ResyncResponse arm not found");
+            let arm = &SOURCE[start..(start + 6000).min(SOURCE.len())];
+            let invalidate = concat!("invalidate_", "payload_memo(");
+            // Match the PATTERN form (trailing comma) so a prose mention of
+            // `state_changed: false` in the changed:true arm's comment is not
+            // mistaken for the false sub-arm (self-reference guard).
+            let changed_true = arm
+                .find("state_changed: true,")
+                .expect("state_changed:true sub-arm not found");
+            let invalidate_pos = arm.find(invalidate).expect(
+                "the CHANGED ResyncResponse apply arm must call invalidate_payload_memo \
+                 (#4864 round-5 item 6)",
+            );
+            let changed_false = arm
+                .find("state_changed: false,")
+                .expect("state_changed:false sub-arm not found");
+            assert!(
+                changed_true < invalidate_pos && invalidate_pos < changed_false,
+                "invalidate_payload_memo must live in the state_changed:true sub-arm \
+                 so a no-op apply (state_changed:false) does NOT invalidate the memo"
             );
         }
     }

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -3063,6 +3063,10 @@ async fn handle_interest_sync_message(
                 Ok(ContractHandlerEvent::UpdateResponse {
                     new_value: Ok(_), ..
                 }) => {
+                    // A resync full-state apply that merged cleanly means the
+                    // contract's merge works for this state — clear any
+                    // merge-failure backoff so normal broadcasts resume (#4861).
+                    op_manager.ring.merge_backoff.record_success(key.id());
                     tracing::info!(
                         from = %source,
                         contract = %key,
@@ -3072,6 +3076,9 @@ async fn handle_interest_sync_message(
                     );
                 }
                 Ok(ContractHandlerEvent::UpdateNoChange { .. }) => {
+                    // Merge ran and produced no change (state already current);
+                    // still a successful merge, so clear the backoff (#4861).
+                    op_manager.ring.merge_backoff.record_success(key.id());
                     tracing::info!(
                         from = %source,
                         contract = %key,

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -2949,6 +2949,26 @@ async fn handle_interest_sync_message(
             op_manager.interest_manager.record_resync_request_received();
             crate::config::GlobalTestMetrics::record_resync_request();
 
+            // Rate-limit the full-state response per (peer, contract) (#4861).
+            // This is the mixed-version-rollout guard: a not-yet-upgraded peer
+            // that still emits unlimited ResyncRequests must not be able to make
+            // this (upgraded) node full-state-reply in a loop. When suppressed,
+            // simply don't respond — the requester will retry later.
+            if !op_manager
+                .ring
+                .resync_response_limiter
+                .check_and_record((source, *key.id()))
+            {
+                crate::config::GlobalTestMetrics::record_resync_response_suppressed();
+                tracing::debug!(
+                    from = %source,
+                    contract = %key,
+                    event = "resync_response_suppressed",
+                    "ResyncResponse suppressed by per-(peer, contract) rate limit"
+                );
+                return None;
+            }
+
             // Clear cached summary for this peer
             let peer_key = get_peer_key_from_addr(op_manager, source);
             if let Some(ref pk) = peer_key {
@@ -5556,6 +5576,32 @@ mod tests {
                 "ResyncRequest handler must clear the cached summary with \
                  `update_peer_summary(&key, pk, None)` (the `None` clears it). \
                  Caching a summary here instead would defeat the #4145 backstop."
+            );
+        }
+
+        /// Pin (#4861): the responder MUST rate-limit the full-state
+        /// `ResyncResponse` per (peer, contract), gating BEFORE the expensive
+        /// state/summary fetch, so a not-yet-upgraded peer flooding
+        /// `ResyncRequest`s can't make this node full-state-reply in a loop.
+        #[test]
+        fn resync_request_handler_rate_limits_response() {
+            let arm = resync_request_arm();
+            let gate_pos = arm.find("resync_response_limiter").expect(
+                "ResyncRequest handler must rate-limit the response via \
+                 resync_response_limiter (#4861)",
+            );
+            let state_fetch_pos = arm
+                .find("get_contract_state(op_manager, &key)")
+                .expect("state fetch not found in ResyncRequest arm");
+            assert!(
+                gate_pos < state_fetch_pos,
+                "the responder rate-limit gate ({gate_pos}) must run BEFORE the \
+                 state fetch ({state_fetch_pos}) so a suppressed request pays no \
+                 fetch/summary cost"
+            );
+            assert!(
+                arm.contains("record_resync_response_suppressed()"),
+                "the suppressed branch must record the resync-response-suppressed metric"
             );
         }
     }

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -2969,6 +2969,26 @@ async fn handle_interest_sync_message(
                 return None;
             }
 
+            // GLOBAL per-contract cap, checked AFTER the per-peer limit (#4861).
+            // Per-(peer, contract) alone is insufficient: production saw ~45
+            // distinct requester IPs drive ~9,733 full-state responses/day for
+            // one forked contract. This bounds a single contract's total
+            // resync-response cost (~12/min) regardless of requester count.
+            if !op_manager
+                .ring
+                .resync_response_global_limiter
+                .check_and_record(*key.id())
+            {
+                crate::config::GlobalTestMetrics::record_resync_response_suppressed();
+                tracing::debug!(
+                    from = %source,
+                    contract = %key,
+                    event = "resync_response_suppressed_global",
+                    "ResyncResponse suppressed by global per-contract rate limit"
+                );
+                return None;
+            }
+
             // Clear cached summary for this peer
             let peer_key = get_peer_key_from_addr(op_manager, source);
             if let Some(ref pk) = peer_key {
@@ -3083,10 +3103,19 @@ async fn handle_interest_sync_message(
                 Ok(ContractHandlerEvent::UpdateResponse {
                     new_value: Ok(_), ..
                 }) => {
-                    // A resync full-state apply that merged cleanly means the
-                    // contract's merge works for this state — clear any
-                    // merge-failure backoff so normal broadcasts resume (#4861).
-                    op_manager.ring.merge_backoff.record_success(key.id());
+                    // NOTE (#4861): deliberately do NOT reset the merge-failure
+                    // backoff here. A full-state resync apply "succeeds" (even
+                    // with changed=true) merely by REPLACING the local state — it
+                    // proves nothing about convergence. In the observed semantic
+                    // fork-oscillation poison class, two stable divergent states
+                    // reject each other's deltas and every resync apply just
+                    // flips the node to the other fork (~1 cycle/min forever); if
+                    // that reset the backoff, the backoff would never trip and the
+                    // storm would continue. The backoff is reset ONLY by a
+                    // genuine successful merge in the broadcast drivers (a delta
+                    // apply / streaming full-state broadcast), which is real
+                    // convergence progress. See the source-scrape pin
+                    // `resync_apply_does_not_reset_merge_backoff`.
                     tracing::info!(
                         from = %source,
                         contract = %key,
@@ -3096,9 +3125,8 @@ async fn handle_interest_sync_message(
                     );
                 }
                 Ok(ContractHandlerEvent::UpdateNoChange { .. }) => {
-                    // Merge ran and produced no change (state already current);
-                    // still a successful merge, so clear the backoff (#4861).
-                    op_manager.ring.merge_backoff.record_success(key.id());
+                    // As above (#4861): a no-change resync apply is not a
+                    // convergence signal, so it must not reset the backoff.
                     tracing::info!(
                         from = %source,
                         contract = %key,
@@ -5599,9 +5627,44 @@ mod tests {
                  state fetch ({state_fetch_pos}) so a suppressed request pays no \
                  fetch/summary cost"
             );
+            // The GLOBAL per-contract cap must also gate, after the per-peer
+            // limit and before the state fetch (#4861).
+            let global_pos = arm.find("resync_response_global_limiter").expect(
+                "ResyncRequest handler must also apply the GLOBAL per-contract \
+                 response cap (#4861)",
+            );
+            assert!(
+                gate_pos < global_pos && global_pos < state_fetch_pos,
+                "global cap ({global_pos}) must be checked after the per-peer \
+                 limit ({gate_pos}) and before the state fetch ({state_fetch_pos})"
+            );
             assert!(
                 arm.contains("record_resync_response_suppressed()"),
                 "the suppressed branch must record the resync-response-suppressed metric"
+            );
+        }
+
+        /// Pin (#4861): NO code path in node.rs may reset the merge-failure
+        /// backoff. In particular the ResyncResponse APPLY arm must not — a
+        /// full-state resync apply "succeeds" by replacing local state even in
+        /// the semantic fork-oscillation poison class (it just flips the node to
+        /// the other fork), so resetting here would make the backoff never trip
+        /// and let the ~1-cycle/min storm continue. The backoff is reset ONLY by
+        /// a genuine successful DELTA / streaming-broadcast merge in the UPDATE
+        /// broadcast drivers (`operations/update/op_ctx_task.rs`), which is real
+        /// convergence progress.
+        #[test]
+        fn resync_apply_does_not_reset_merge_backoff() {
+            // Assemble the needle from parts so the contiguous call string never
+            // appears verbatim in this file — otherwise `.contains(<literal>)`
+            // would match its OWN argument via `include_str!` (self-reference).
+            let needle = concat!("merge_backoff", ".record_success(");
+            assert!(
+                !SOURCE.contains(needle),
+                "node.rs must NOT reset the merge backoff anywhere — a \
+                 resync-apply (or any node.rs) reset would defeat the #4861 \
+                 fork-oscillation containment. Reset belongs only in the broadcast \
+                 drivers on a genuine merge success."
             );
         }
     }

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -2959,7 +2959,7 @@ async fn handle_interest_sync_message(
                 .resync_response_limiter
                 .check_and_record((source, *key.id()))
             {
-                crate::config::GlobalTestMetrics::record_resync_response_suppressed();
+                crate::config::GlobalTestMetrics::record_resync_response_suppressed_per_peer();
                 tracing::debug!(
                     from = %source,
                     contract = %key,
@@ -2979,7 +2979,7 @@ async fn handle_interest_sync_message(
                 .resync_response_global_limiter
                 .check_and_record(*key.id())
             {
-                crate::config::GlobalTestMetrics::record_resync_response_suppressed();
+                crate::config::GlobalTestMetrics::record_resync_response_suppressed_global();
                 tracing::debug!(
                     from = %source,
                     contract = %key,
@@ -3086,7 +3086,15 @@ async fn handle_interest_sync_message(
                 "Received ResyncResponse with full state"
             );
 
-            // Apply the full state using an update
+            // Apply the full state using an update.
+            //
+            // This full-state WASM merge is deliberately NOT gated by the
+            // merge-failure backoff (#4861): unlike the broadcast drivers, the
+            // resync path is already double-bounded — the emitter-side per- and
+            // per-(peer,contract) + global rate limits throttle how often
+            // ResyncRequests (and thus these responses) are produced at all, and
+            // epoch preemption caps the cost of each individual merge. Gating it
+            // here would also risk suppressing a genuine heal.
             let state = freenet_stdlib::prelude::State::from(state_bytes.clone());
             let update_data = freenet_stdlib::prelude::UpdateData::State(state);
 
@@ -5640,8 +5648,10 @@ mod tests {
                  limit ({gate_pos}) and before the state fetch ({state_fetch_pos})"
             );
             assert!(
-                arm.contains("record_resync_response_suppressed()"),
-                "the suppressed branch must record the resync-response-suppressed metric"
+                arm.contains("record_resync_response_suppressed_per_peer()")
+                    && arm.contains("record_resync_response_suppressed_global()"),
+                "each suppressed branch must record its own (per-peer vs global) \
+                 resync-response-suppressed metric (#4864 review)"
             );
         }
 

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -6395,7 +6395,11 @@ mod tests {
             let start = SOURCE
                 .find(concat!("event = \"resync_response_", "received\""))
                 .expect("ResyncResponse receive arm not found");
-            let arm = &SOURCE[start..(start + 6000).min(SOURCE.len())];
+            // Window widened to 8000 (#4864 round-9 addendum): after the round-8
+            // consume gate the margin to `state_changed: false,` was only ~125
+            // bytes, so the next addition to the arm would push it past the bound
+            // and fail with a misleading "sub-arm not found".
+            let arm = &SOURCE[start..(start + 8000).min(SOURCE.len())];
             let invalidate = concat!("invalidate_", "payload_memo(");
             // Match the PATTERN form (trailing comma) so a prose mention of
             // `state_changed: false` in the changed:true arm's comment is not

--- a/crates/core/src/operations.rs
+++ b/crates/core/src/operations.rs
@@ -192,6 +192,16 @@ impl OpError {
     pub fn is_wasm_timeout(&self) -> bool {
         matches!(self, Self::ExecutorError(e) if e.is_wasm_timeout())
     }
+
+    /// Returns true ONLY when the contract's WASM merge/validate never ran
+    /// because it sat queued on a saturated blocking pool past the deadline
+    /// (#4864 round-6). The broadcast drivers' record sites EXCLUDE it from the
+    /// merge-failure backoff (like queue-full) and route it through the
+    /// transient resync heal, since the guest never applied the delta. Disjoint
+    /// from `is_wasm_timeout`. See `ExecutorError::is_scheduler_timeout`.
+    pub fn is_scheduler_timeout(&self) -> bool {
+        matches!(self, Self::ExecutorError(e) if e.is_scheduler_timeout())
+    }
 }
 
 impl<T> From<SendError<T>> for OpError {

--- a/crates/core/src/operations.rs
+++ b/crates/core/src/operations.rs
@@ -184,6 +184,14 @@ impl OpError {
     pub fn is_contract_queue_full(&self) -> bool {
         matches!(self, Self::ExecutorError(e) if e.is_contract_queue_full())
     }
+
+    /// Returns true ONLY when the contract's WASM merge/validate hit the
+    /// execution time limit (#4861). Used by the per-contract merge-failure
+    /// backoff to select the longer Timeout-class cooldown. See
+    /// `ExecutorError::is_wasm_timeout`.
+    pub fn is_wasm_timeout(&self) -> bool {
+        matches!(self, Self::ExecutorError(e) if e.is_wasm_timeout())
+    }
 }
 
 impl<T> From<SendError<T>> for OpError {

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -1221,18 +1221,13 @@ mod tests {
         }
 
         fn scheduler_timeout_failure() -> ExecutorError {
-            // Mirrors the production cause: ContractExecError::SchedulerOverloaded
-            // via update_exec_error → "execution error: The operation was queued
-            // too long on a saturated execution pool and never ran". The guest
-            // never ran, so this is transient load, not a contract fault, yet it
-            // KEEPS the "execution error:" prefix (contract present ⇒ no
-            // auto-fetch). Matches is_scheduler_timeout.
-            let req: RequestError = StdContractError::update_exec_error(
-                make_contract_key(1),
-                "The operation was queued too long on a saturated execution pool and never ran",
-            )
-            .into();
-            req.into()
+            // Build via the HOST path (#4864 round-9): a real scheduler-overload
+            // timeout carries the unforgeable typed provenance
+            // (classify_result → ContractExecError::SchedulerOverloaded → execution),
+            // which is what is_scheduler_timeout now keys on. A plain
+            // update_exec_error string would NOT classify — that is exactly the
+            // contract-forge case the typing rejects.
+            ExecutorError::test_host_scheduler_timeout(make_contract_key(1))
         }
 
         #[test]

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -525,6 +525,23 @@ pub(crate) fn log_broadcast_to_streaming_failure(
             event = "queue_full",
             "BroadcastToStreaming update skipped: per-contract queue saturated"
         );
+    } else if err.is_scheduler_timeout() {
+        // #4864 round-7: the merge closure sat queued on a saturated execution
+        // pool past the deadline and the guest NEVER ran. The contract IS present
+        // (so no auto-fetch — the return value below already gates on
+        // is_contract_exec_rejection, which is true for a scheduler timeout), and
+        // this fires under exactly the load it represents. DEBUG, not WARN,
+        // mirroring the #4251 queue-full treatment: a WARN here would be loud
+        // precisely when the node is most overloaded, and it would be factually
+        // wrong to blame the contract ("not ready locally") for a pool-saturation
+        // event.
+        tracing::debug!(
+            tx = %tx,
+            %key,
+            error = %err,
+            event = "scheduler_overloaded",
+            "BroadcastToStreaming update skipped: execution pool saturated, guest never ran (transient)"
+        );
     } else {
         tracing::warn!(
             tx = %tx,
@@ -1203,6 +1220,21 @@ mod tests {
             ExecutorError::other(crate::contract::ContractQueueFull)
         }
 
+        fn scheduler_timeout_failure() -> ExecutorError {
+            // Mirrors the production cause: ContractExecError::SchedulerOverloaded
+            // via update_exec_error → "execution error: The operation was queued
+            // too long on a saturated execution pool and never ran". The guest
+            // never ran, so this is transient load, not a contract fault, yet it
+            // KEEPS the "execution error:" prefix (contract present ⇒ no
+            // auto-fetch). Matches is_scheduler_timeout.
+            let req: RequestError = StdContractError::update_exec_error(
+                make_contract_key(1),
+                "The operation was queued too long on a saturated execution pool and never ran",
+            )
+            .into();
+            req.into()
+        }
+
         #[test]
         fn update_contract_failure_logs_info_for_invalid_update_rejection() {
             let logger = TestLogger::new().capture_logs().with_level("info").init();
@@ -1402,6 +1434,54 @@ mod tests {
                 "the misleading 'contract not ready locally' message must not appear \
                  for queue-full — the contract IS present, the queue is just busy, \
                  got: {:?}",
+                logger.logs()
+            );
+        }
+
+        /// #4864 round-7: a SCHEDULER timeout (the merge closure sat queued on a
+        /// saturated execution pool and the guest never ran) must log at DEBUG,
+        /// NOT WARN — like queue-full (#4251), a WARN here would be loud precisely
+        /// under the overload it represents — and must NOT blame the contract with
+        /// the "contract not ready locally" message (the contract IS present).
+        /// Auto-fetch is skipped (contract present ⇒ is_contract_exec_rejection).
+        #[test]
+        fn broadcast_to_streaming_failure_skips_auto_fetch_and_uses_debug_for_scheduler_timeout() {
+            let logger = TestLogger::new().capture_logs().with_level("debug").init();
+            let tx = Transaction::new::<UpdateMsg>();
+            let err: OpError = scheduler_timeout_failure().into();
+            // Precondition: the fixture really is classified as a scheduler timeout.
+            assert!(
+                err.is_scheduler_timeout(),
+                "fixture must classify as a scheduler timeout"
+            );
+
+            let needs_auto_fetch =
+                log_broadcast_to_streaming_failure(&tx, &make_contract_key(1), &err);
+
+            assert!(
+                !needs_auto_fetch,
+                "scheduler timeout MUST NOT trigger self-heal auto-fetch — the contract \
+                 IS present, the pool was just saturated; enqueuing a GET onto the \
+                 saturated handler is the amplification we avoid"
+            );
+            assert!(
+                logger.contains("scheduler_overloaded"),
+                "scheduler timeout must emit event=scheduler_overloaded, got: {:?}",
+                logger.logs()
+            );
+            assert!(
+                !logger.logs().iter().any(|l| l.contains("WARN")),
+                "scheduler timeout must NOT log at WARN — it fires under exactly the \
+                 saturation it represents, got: {:?}",
+                logger.logs()
+            );
+            assert!(
+                !logger
+                    .logs()
+                    .iter()
+                    .any(|l| l.contains("contract not ready locally")),
+                "the misleading 'contract not ready locally' message must not appear \
+                 for a scheduler timeout — the contract IS present, got: {:?}",
                 logger.logs()
             );
         }

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -1296,45 +1296,61 @@ async fn drive_relay_broadcast_to(
 
             if is_delta && !queue_full {
                 // Delta application failed → send ResyncRequest. Mirrors
-                // update.rs:710-758.
-                tracing::warn!(
-                    tx = %incoming_tx,
-                    contract = %key,
-                    sender = %sender_addr,
-                    error = %err,
-                    event = "delta_apply_failed",
-                    "UPDATE relay: delta apply failed, sending ResyncRequest"
-                );
-
-                if let Some(sender_pkl) = op_manager
-                    .ring
-                    .connection_manager
-                    .get_peer_by_addr(sender_addr)
-                {
-                    let sender_key = crate::ring::PeerKey::from(sender_pkl.pub_key().clone());
-                    op_manager
-                        .interest_manager
-                        .update_peer_summary(&key, &sender_key, None);
-                }
-
-                tracing::info!(
-                    tx = %incoming_tx,
-                    contract = %key,
-                    target = %sender_addr,
-                    event = "resync_request_sent",
-                    "UPDATE relay: sending ResyncRequest after delta failure"
-                );
-                if let Err(e) = op_manager
-                    .notify_node_event(NodeEvent::SendInterestMessage {
-                        target: sender_addr,
-                        message: InterestMessage::ResyncRequest { key },
-                    })
-                    .await
-                {
+                // update.rs:710-758. Rate-limited per-contract (#4861): a poison
+                // contract that fails deltas from many senders must not drive a
+                // full-state resync storm. When the emit is suppressed, skip the
+                // sender summary-clear too — it is part of the resync handshake,
+                // so clearing it without emitting would just force the sender to
+                // full-state us on the next interest cycle.
+                if op_manager.ring.resync_emit_limiter.check_and_record(*key.id()) {
                     tracing::warn!(
                         tx = %incoming_tx,
-                        error = %e,
-                        "UPDATE relay: failed to send ResyncRequest"
+                        contract = %key,
+                        sender = %sender_addr,
+                        error = %err,
+                        event = "delta_apply_failed",
+                        "UPDATE relay: delta apply failed, sending ResyncRequest"
+                    );
+
+                    if let Some(sender_pkl) = op_manager
+                        .ring
+                        .connection_manager
+                        .get_peer_by_addr(sender_addr)
+                    {
+                        let sender_key = crate::ring::PeerKey::from(sender_pkl.pub_key().clone());
+                        op_manager
+                            .interest_manager
+                            .update_peer_summary(&key, &sender_key, None);
+                    }
+
+                    tracing::info!(
+                        tx = %incoming_tx,
+                        contract = %key,
+                        target = %sender_addr,
+                        event = "resync_request_sent",
+                        "UPDATE relay: sending ResyncRequest after delta failure"
+                    );
+                    if let Err(e) = op_manager
+                        .notify_node_event(NodeEvent::SendInterestMessage {
+                            target: sender_addr,
+                            message: InterestMessage::ResyncRequest { key },
+                        })
+                        .await
+                    {
+                        tracing::warn!(
+                            tx = %incoming_tx,
+                            error = %e,
+                            "UPDATE relay: failed to send ResyncRequest"
+                        );
+                    }
+                } else {
+                    crate::config::GlobalTestMetrics::record_resync_request_suppressed();
+                    tracing::debug!(
+                        tx = %incoming_tx,
+                        contract = %key,
+                        target = %sender_addr,
+                        event = "resync_request_suppressed",
+                        "UPDATE relay: ResyncRequest suppressed by per-contract rate limit"
                     );
                 }
             } else if !is_delta && !err.is_contract_exec_rejection() && !queue_full {
@@ -2590,6 +2606,33 @@ mod tests {
             driver_src.contains("is_wasm_timeout()"),
             "the failure class must distinguish a WASM timeout (longer cooldown) \
              via is_wasm_timeout()"
+        );
+    }
+
+    /// Pin (#4861): the `ResyncRequest` emission on delta-apply failure MUST be
+    /// gated by the per-contract emit rate limiter, and the sender summary-clear
+    /// MUST live inside that gate (it is part of the resync handshake — clearing
+    /// it without emitting would force the sender to full-state us next cycle).
+    #[test]
+    fn broadcast_to_resync_emit_is_rate_limited() {
+        let driver_src = broadcast_to_driver_src();
+        let gate_pos = driver_src
+            .find("resync_emit_limiter.check_and_record(")
+            .expect("ResyncRequest emit must be gated by resync_emit_limiter");
+        let summary_clear_pos = driver_src
+            .find("update_peer_summary(&key, &sender_key, None)")
+            .expect("sender summary-clear missing");
+        let resync_pos = driver_src
+            .find("InterestMessage::ResyncRequest")
+            .expect("ResyncRequest emission missing");
+        assert!(
+            gate_pos < summary_clear_pos && summary_clear_pos < resync_pos,
+            "emit rate-limit gate ({gate_pos}) must wrap BOTH the summary-clear \
+             ({summary_clear_pos}) and the ResyncRequest emission ({resync_pos})"
+        );
+        assert!(
+            driver_src.contains("record_resync_request_suppressed()"),
+            "the suppressed branch must record the resync-request-suppressed metric"
         );
     }
 

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -300,7 +300,7 @@ async fn drive_client_update(
                     // merge works now — clear any merge-failure backoff so inbound
                     // broadcasts resume (#4864 review P2, delta-only).
                     if is_delta_update {
-                        op_manager.ring.merge_backoff.record_success(key.id());
+                        op_manager.ring.merge_backoff.record_success_local(key.id());
                     }
                     execution
                 }
@@ -395,7 +395,7 @@ async fn drive_client_update(
                     // Successful client-local DELTA merge on the remote-target
                     // path clears the backoff too (#4864 review P2, delta-only).
                     if is_delta_update {
-                        op_manager.ring.merge_backoff.record_success(key.id());
+                        op_manager.ring.merge_backoff.record_success_local(key.id());
                     }
                     execution
                 }
@@ -1244,7 +1244,11 @@ async fn drive_relay_broadcast_to(
     // verbatim by `record_failure` in the error arm, so lazy computation would
     // only duplicate the work on the failure path.
     let payload_hash = crate::ring::merge_backoff::merge_payload_hash(is_delta, &payload_bytes);
-    match op_manager.ring.merge_backoff.check(key.id(), payload_hash) {
+    match op_manager
+        .ring
+        .merge_backoff
+        .check(key.id(), sender_addr, payload_hash)
+    {
         crate::ring::merge_backoff::MergeDecision::Allow => {}
         decision @ (crate::ring::merge_backoff::MergeDecision::InBackoff
         | crate::ring::merge_backoff::MergeDecision::KnownFailedPayload) => {
@@ -1286,7 +1290,10 @@ async fn drive_relay_broadcast_to(
             // do NOT reset here; the resync-apply path in node.rs does not reset
             // either (see the note there).
             if is_delta {
-                op_manager.ring.merge_backoff.record_success(key.id());
+                op_manager
+                    .ring
+                    .merge_backoff
+                    .record_success_from_sender(key.id(), sender_addr);
             }
             result
         }
@@ -1303,10 +1310,12 @@ async fn drive_relay_broadcast_to(
                 } else {
                     crate::ring::merge_backoff::MergeFailureClass::Invalid
                 };
-                op_manager
-                    .ring
-                    .merge_backoff
-                    .record_failure(key.id(), class, payload_hash);
+                op_manager.ring.merge_backoff.record_failure(
+                    key.id(),
+                    sender_addr,
+                    class,
+                    payload_hash,
+                );
             }
 
             // On benign stale-version rejection (not OOG/traps/validation
@@ -2053,7 +2062,7 @@ async fn apply_streaming_broadcast(
     match op_manager
         .ring
         .merge_backoff
-        .check(key.id(), stream_payload_hash)
+        .check(key.id(), sender_addr, stream_payload_hash)
     {
         crate::ring::merge_backoff::MergeDecision::Allow => {}
         decision @ (crate::ring::merge_backoff::MergeDecision::InBackoff
@@ -2127,10 +2136,12 @@ async fn apply_streaming_broadcast(
                 } else {
                     crate::ring::merge_backoff::MergeFailureClass::Invalid
                 };
-                op_manager
-                    .ring
-                    .merge_backoff
-                    .record_failure(key.id(), class, stream_payload_hash);
+                op_manager.ring.merge_backoff.record_failure(
+                    key.id(),
+                    sender_addr,
+                    class,
+                    stream_payload_hash,
+                );
             }
 
             // Classify failure: real failure → self-heal via
@@ -2624,7 +2635,7 @@ mod tests {
             .find("broadcast_dedup_cache.check_and_insert")
             .expect("dedup check missing");
         let backoff_pos = driver_src
-            .find("merge_backoff.check(")
+            .find(".check(key.id(), sender_addr, payload_hash)")
             .expect("merge_backoff.check gate missing in BroadcastTo driver");
         let merge_pos = driver_src
             .find("super::update_contract(")
@@ -2648,7 +2659,7 @@ mod tests {
     fn broadcast_to_backoff_records_success_and_gated_failure() {
         let driver_src = broadcast_to_driver_src();
         let success_pos = driver_src
-            .find("merge_backoff.record_success(")
+            .find(".record_success_from_sender(")
             .expect("drive_relay_broadcast_to must clear the backoff on a successful merge");
         // The reset must be gated on is_delta (delta-only convergence signal).
         let is_delta_gate_pos = driver_src
@@ -2656,8 +2667,8 @@ mod tests {
             .expect("backoff reset must be gated on `if is_delta` (#4861)");
         assert!(
             is_delta_gate_pos < success_pos,
-            "merge_backoff.record_success MUST be inside an `if is_delta` gate so \
-             a full-state apply does not reset the backoff (#4861 fork oscillation)"
+            "merge_backoff.record_success_from_sender MUST be inside an `if is_delta` \
+             gate so a full-state apply does not reset the backoff (#4861 fork oscillation)"
         );
         let record_pos = driver_src
             .find(".record_failure(")
@@ -2731,7 +2742,7 @@ mod tests {
         // rustfmt breaks across lines here (the longer `stream_payload_hash`
         // pushes the chain over the chain-width limit).
         let backoff_pos = driver_src
-            .find(".check(key.id(), stream_payload_hash)")
+            .find(".check(key.id(), sender_addr, stream_payload_hash)")
             .expect("streaming merge path missing merge_backoff.check gate");
         let merge_pos = driver_src
             .find("super::update_contract(")
@@ -2744,7 +2755,9 @@ mod tests {
         // a full-state merge is the same fork-flippable operation as a resync
         // apply, so the streaming path must NOT reset the backoff. (Assemble
         // the needle so this literal is not a self-referential match.)
-        let record_success = concat!("record_", "success(");
+        // Match any `record_success*` variant (record_success_from_sender /
+        // record_success_local) — the streaming full-state path must call none.
+        let record_success = concat!("record_", "success");
         assert!(
             !driver_src.contains(record_success),
             "streaming path must NOT reset the backoff — a full-state merge is \
@@ -2773,10 +2786,11 @@ mod tests {
             .or_else(|| after.find("\n#[cfg(test)]"))
             .unwrap_or(after.len());
         let body = &src[start..start + 1 + end];
-        let success = concat!("merge_backoff.record_", "success(");
+        let success = concat!(".record_", "success_local(");
         assert!(
             body.contains(success),
-            "drive_client_update must reset the backoff on a successful merge (#4864 P2)"
+            "drive_client_update must reset the backoff on a successful merge via \
+             record_success_local (contract-wide only, not per-sender) (#4864 P2)"
         );
         assert!(
             body.contains("is_delta_update"),
@@ -3385,15 +3399,34 @@ mod tests {
         )
     }
 
-    /// Like [`build_queue_full_test_node`], but the stand-in handler FAILS every
-    /// delta `UpdateQuery` with a generic contract-exec rejection (recorded by
-    /// the backoff) and SUCCEEDS every full-state `UpdateQuery`, while counting
-    /// the `UpdateQuery` events that reach it. `GetSummaryQuery` (from the
+    /// A `ContractQueueFull` executor error (transient backpressure). Satisfies
+    /// `is_contract_queue_full()` but NOT `is_contract_exec_rejection()`, so the
+    /// backoff recording gate MUST skip it (queue-full is load, not poison).
+    fn queue_full_err() -> crate::contract::ExecutorError {
+        crate::contract::ExecutorError::other(crate::contract::ContractQueueFull)
+    }
+
+    /// What the exec-reject stand-in handler returns for a DELTA `UpdateQuery`.
+    #[derive(Clone, Copy)]
+    enum DeltaOutcome {
+        /// Fail with a contract-exec rejection (recorded by the backoff).
+        ExecReject,
+        /// Fail with `ContractQueueFull` (NOT recorded — transient load).
+        QueueFull,
+        /// Succeed (state changed) — used to exercise a clean DELTA merge.
+        Success,
+    }
+
+    /// Build a node whose stand-in contract handler resolves every DELTA
+    /// `UpdateQuery` per `delta_outcome` (fail-exec-reject / fail-queue-full /
+    /// succeed) and SUCCEEDS every full-state `UpdateQuery`, while counting the
+    /// `UpdateQuery` events that reach it. `GetSummaryQuery` (from the
     /// post-success proactive-summary spawn) is answered benignly. The counter
-    /// lets a test assert the backoff PREVENTS executor invocation (#4864 review
-    /// testing H1).
-    async fn build_exec_reject_test_node(
+    /// lets a test assert whether the backoff PREVENTS executor invocation
+    /// (#4864 review testing H1 / P1).
+    async fn build_broadcast_test_node(
         id: &str,
+        delta_outcome: DeltaOutcome,
     ) -> (
         Arc<OpManager>,
         crate::node::EventLoopNotificationsReceiver,
@@ -3457,9 +3490,19 @@ mod tests {
                             UpdateData::Delta(_) | UpdateData::RelatedDelta { .. }
                         );
                         if is_delta {
-                            ContractHandlerEvent::UpdateResponse {
-                                new_value: Err(exec_reject_err(key)),
-                                state_changed: false,
+                            match delta_outcome {
+                                DeltaOutcome::ExecReject => ContractHandlerEvent::UpdateResponse {
+                                    new_value: Err(exec_reject_err(key)),
+                                    state_changed: false,
+                                },
+                                DeltaOutcome::QueueFull => ContractHandlerEvent::UpdateResponse {
+                                    new_value: Err(queue_full_err()),
+                                    state_changed: false,
+                                },
+                                DeltaOutcome::Success => ContractHandlerEvent::UpdateResponse {
+                                    new_value: Ok(WrappedState::from(vec![1u8, 2, 3])),
+                                    state_changed: true,
+                                },
                             }
                         } else {
                             ContractHandlerEvent::UpdateResponse {
@@ -3481,6 +3524,19 @@ mod tests {
         let guard: Box<dyn std::any::Any> =
             Box::new((handler, result_router_rx, task_monitor, wait_for_event));
         (op_manager, notification_rx, update_query_count, guard)
+    }
+
+    /// Convenience wrapper: a node whose stand-in handler fails every delta with
+    /// a contract-exec rejection (the common case for the backoff-gate tests).
+    async fn build_exec_reject_test_node(
+        id: &str,
+    ) -> (
+        Arc<OpManager>,
+        crate::node::EventLoopNotificationsReceiver,
+        std::sync::Arc<std::sync::atomic::AtomicUsize>,
+        Box<dyn std::any::Any>,
+    ) {
+        build_broadcast_test_node(id, DeltaOutcome::ExecReject).await
     }
 
     /// #4864 review (testing H1): the load-bearing #4861 behavior — the backoff
@@ -3628,6 +3684,215 @@ mod tests {
             queries_after_trip,
             "the backoff tripped across the full-state success (no reset) — the \
              following delta merge is skipped"
+        );
+    }
+
+    /// #4864 review P1 (the adversarial regression, driven through the REAL
+    /// driver): one sender tripping its Invalid channel must NOT suppress a
+    /// DIFFERENT sender's delta — the second sender's merge still reaches the
+    /// executor. A contract-wide gate would blackout the healthy sender here,
+    /// which is the peer-triggerable-blackout this per-sender rework prevents.
+    #[tokio::test]
+    async fn backoff_gate_is_scoped_per_sender_in_driver() {
+        use std::sync::atomic::Ordering;
+        crate::config::GlobalTestMetrics::reset();
+        let (op_manager, mut notification_rx, update_queries, _guard) =
+            build_exec_reject_test_node("backoff-per-sender-4864").await;
+        let key = ContractKey::from_id_and_code(
+            ContractInstanceId::new([41u8; 32]),
+            CodeHash::new([42u8; 32]),
+        );
+        let sender_a: SocketAddr = "127.0.0.1:12400".parse().unwrap();
+        let sender_b: SocketAddr = "127.0.0.1:12500".parse().unwrap();
+
+        // Sender A trips its own Invalid channel (3 consecutive delta failures).
+        for bytes in [vec![1u8], vec![2u8], vec![3u8]] {
+            let _ = drive_relay_broadcast_to(
+                &op_manager,
+                Transaction::new::<UpdateMsg>(),
+                key,
+                DeltaOrFullState::Delta(bytes),
+                Vec::new(),
+                sender_a,
+            )
+            .await;
+            let _ = drain_resync_targets(&mut notification_rx, key);
+        }
+        assert_eq!(
+            update_queries.load(Ordering::Relaxed),
+            3,
+            "A's 3 failing merges reached the executor"
+        );
+
+        // A's next delta is now suppressed (A's channel tripped).
+        let ra = drive_relay_broadcast_to(
+            &op_manager,
+            Transaction::new::<UpdateMsg>(),
+            key,
+            DeltaOrFullState::Delta(vec![4u8]),
+            Vec::new(),
+            sender_a,
+        )
+        .await;
+        assert!(ra.is_ok(), "A's suppressed broadcast completes Ok");
+        assert_eq!(
+            update_queries.load(Ordering::Relaxed),
+            3,
+            "A's suppressed delta MUST NOT reach the executor"
+        );
+
+        // Sender B's delta (distinct payload) STILL reaches the executor — the
+        // contract stays live for healthy senders despite A's backoff. It fails
+        // via the stand-in, so B's channel starts counting, but the merge RAN.
+        let rb = drive_relay_broadcast_to(
+            &op_manager,
+            Transaction::new::<UpdateMsg>(),
+            key,
+            DeltaOrFullState::Delta(vec![5u8]),
+            Vec::new(),
+            sender_b,
+        )
+        .await;
+        let _ = drain_resync_targets(&mut notification_rx, key);
+        assert!(
+            rb.is_err(),
+            "B's delta reaches the merge (fails via stand-in)"
+        );
+        assert_eq!(
+            update_queries.load(Ordering::Relaxed),
+            4,
+            "B's delta MUST reach the executor despite A's per-sender backoff"
+        );
+    }
+
+    /// #4864 review item 7(b): `ContractQueueFull` is transient backpressure, not
+    /// poison — the driver's `is_contract_exec_rejection()` gate must NOT record
+    /// it, so no amount of consecutive queue-full failures trips the backoff.
+    /// Every delta keeps reaching the executor (no suppression).
+    #[tokio::test]
+    async fn queue_full_failures_do_not_trip_backoff() {
+        use std::sync::atomic::Ordering;
+        crate::config::GlobalTestMetrics::reset();
+        let (op_manager, mut notification_rx, update_queries, _guard) =
+            build_broadcast_test_node("backoff-queuefull-4864", DeltaOutcome::QueueFull).await;
+        let key = ContractKey::from_id_and_code(
+            ContractInstanceId::new([51u8; 32]),
+            CodeHash::new([52u8; 32]),
+        );
+        let sender: SocketAddr = "127.0.0.1:12600".parse().unwrap();
+
+        // Five consecutive queue-full delta failures (well past the N=3 Invalid
+        // trip threshold). None may be recorded to the backoff.
+        for bytes in [vec![1u8], vec![2u8], vec![3u8], vec![4u8], vec![5u8]] {
+            let _ = drive_relay_broadcast_to(
+                &op_manager,
+                Transaction::new::<UpdateMsg>(),
+                key,
+                DeltaOrFullState::Delta(bytes),
+                Vec::new(),
+                sender,
+            )
+            .await;
+            let _ = drain_resync_targets(&mut notification_rx, key);
+        }
+        assert_eq!(
+            update_queries.load(Ordering::Relaxed),
+            5,
+            "every queue-full delta must still reach the executor — queue-full \
+             must NOT trip the backoff (it is transient load, not poison)"
+        );
+        assert_eq!(
+            crate::config::GlobalTestMetrics::merges_suppressed_by_backoff(),
+            0,
+            "no merge may be suppressed — queue-full never records a backoff entry"
+        );
+        assert_eq!(
+            op_manager.ring.merge_backoff.contracts_in_backoff(),
+            0,
+            "no contract may be in backoff after only queue-full failures"
+        );
+    }
+
+    /// #4864 review item 6: a successful client-local DELTA driven through the
+    /// REAL `drive_client_update` clears the CONTRACT-WIDE side (Timeout + memo)
+    /// via `record_success_local`, but must NOT clear a remote sender's Invalid
+    /// channel (a local success says nothing about that sender's fork).
+    #[tokio::test]
+    async fn client_local_delta_success_clears_contract_side_not_other_senders() {
+        let (op_manager, _notification_rx, _update_queries, _guard) =
+            build_broadcast_test_node("backoff-client-local-4864", DeltaOutcome::Success).await;
+        let key = ContractKey::from_id_and_code(
+            ContractInstanceId::new([61u8; 32]),
+            CodeHash::new([62u8; 32]),
+        );
+        // Make the local node host the contract so drive_client_update's
+        // target=None path applies the update locally instead of erroring.
+        op_manager
+            .ring
+            .host_contract(key, 100, crate::ring::AccessType::Put);
+
+        let remote_sender: SocketAddr = "127.0.0.1:12700".parse().unwrap();
+        let probe_sender: SocketAddr = "127.0.0.1:12800".parse().unwrap();
+
+        // Seed a contract-wide Timeout (trips at 1) and a remote sender's tripped
+        // Invalid channel (3 consecutive).
+        op_manager.ring.merge_backoff.record_failure(
+            key.id(),
+            remote_sender,
+            crate::ring::merge_backoff::MergeFailureClass::Timeout,
+            0x01,
+        );
+        for h in [0x11u64, 0x12, 0x13] {
+            op_manager.ring.merge_backoff.record_failure(
+                key.id(),
+                remote_sender,
+                crate::ring::merge_backoff::MergeFailureClass::Invalid,
+                h,
+            );
+        }
+        // Precondition: the contract-wide Timeout suppresses a fresh probe sender.
+        assert_eq!(
+            op_manager
+                .ring
+                .merge_backoff
+                .check(key.id(), probe_sender, 0x99),
+            crate::ring::merge_backoff::MergeDecision::InBackoff,
+            "seeded contract-wide Timeout should suppress before the client success"
+        );
+
+        // Drive a successful client-local DELTA through the real driver.
+        let outcome = drive_client_update(
+            &op_manager,
+            Transaction::new::<UpdateMsg>(),
+            key,
+            UpdateData::Delta(StateDelta::from(vec![7u8, 7, 7])),
+            RelatedContracts::default(),
+        )
+        .await;
+        assert!(
+            outcome.is_ok(),
+            "client-local delta merge should succeed via the stand-in: {outcome:?}"
+        );
+
+        // Contract-wide side (Timeout + memo) is cleared: the probe sender, which
+        // has no Invalid channel of its own, is now Allowed.
+        assert_eq!(
+            op_manager
+                .ring
+                .merge_backoff
+                .check(key.id(), probe_sender, 0x99),
+            crate::ring::merge_backoff::MergeDecision::Allow,
+            "record_success_local must clear the contract-wide Timeout + memo"
+        );
+        // But the remote sender's Invalid channel is UNTOUCHED — still suppressed.
+        assert_eq!(
+            op_manager
+                .ring
+                .merge_backoff
+                .check(key.id(), remote_sender, 0x99),
+            crate::ring::merge_backoff::MergeDecision::InBackoff,
+            "a local client's success must NOT clear a remote sender's Invalid \
+             channel (it says nothing about that sender's fork)"
         );
     }
 

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -2073,7 +2073,16 @@ async fn apply_streaming_broadcast(
         ..
     } = match update_result {
         Ok(exec) => {
-            op_manager.ring.merge_backoff.record_success(key.id());
+            // Strictly delta-only reset (#4861): a streaming full-state broadcast
+            // merge is mechanically the SAME operation as a ResyncResponse apply
+            // (a WASM merge of an incoming FULL STATE), so the fork-oscillation
+            // trap applies identically — a large forked contract would oscillate
+            // via streaming full states and reset its own backoff on every flip,
+            // so the backoff would never trip. Only a clean DELTA apply proves the
+            // receiver shared the sender's base (genuine convergence). Streaming
+            // is always full state, so it NEVER resets the backoff here; a
+            // recovered contract's entry simply ages out via the reaper if
+            // failures stop.
             exec
         }
         Err(err) => {
@@ -2667,15 +2676,18 @@ mod tests {
         );
     }
 
-    /// Pin (#4861): the streaming full-state driver must carry the same
+    /// Pin (#4861): the streaming full-state merge path must carry the same
     /// backoff gate + record wiring (a poison contract must be quarantined on
-    /// the streaming path too).
+    /// the streaming path too). The streaming merge logic lives in
+    /// `apply_streaming_broadcast` (steps 4-9), which
+    /// `drive_relay_broadcast_to_streaming` delegates to after assembling the
+    /// stream — scrape that function, not the thin transport wrapper.
     #[test]
     fn broadcast_to_streaming_has_backoff_wiring() {
         let src = include_str!("op_ctx_task.rs");
         let start = src
-            .find("async fn drive_relay_broadcast_to_streaming(")
-            .expect("streaming driver not found");
+            .find("async fn apply_streaming_broadcast(")
+            .expect("apply_streaming_broadcast (streaming merge path) not found");
         let after = &src[start + 1..];
         let end = after
             .find("\nasync fn ")
@@ -2688,22 +2700,28 @@ mod tests {
         // pushes the chain over the chain-width limit).
         let backoff_pos = driver_src
             .find(".check(key.id(), stream_payload_hash)")
-            .expect("streaming driver missing merge_backoff.check gate");
+            .expect("streaming merge path missing merge_backoff.check gate");
         let merge_pos = driver_src
             .find("super::update_contract(")
-            .expect("streaming driver missing update_contract");
+            .expect("streaming merge path missing update_contract");
         assert!(
             backoff_pos < merge_pos,
-            "streaming driver's merge_backoff.check MUST run before update_contract"
+            "streaming merge_backoff.check MUST run before update_contract"
         );
+        // Strictly delta-only reset (#4861): streaming is always full state, and
+        // a full-state merge is the same fork-flippable operation as a resync
+        // apply, so the streaming path must NOT reset the backoff. (Assemble
+        // the needle so this literal is not a self-referential match.)
+        let record_success = concat!("record_", "success(");
         assert!(
-            driver_src.contains("merge_backoff.record_success("),
-            "streaming driver must clear the backoff on a successful merge"
+            !driver_src.contains(record_success),
+            "streaming path must NOT reset the backoff — a full-state merge is \
+             not convergence evidence (only a clean DELTA apply is). See #4861."
         );
         assert!(
             driver_src.contains(".record_failure(")
                 && driver_src.contains("is_contract_exec_rejection()"),
-            "streaming driver must record gated failures like the non-streaming driver"
+            "streaming path must record gated failures like the non-streaming driver"
         );
     }
 

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -300,7 +300,13 @@ async fn drive_client_update(
                     // merge works now — clear any merge-failure backoff so inbound
                     // broadcasts resume (#4864 review P2, delta-only).
                     if is_delta_update {
-                        op_manager.ring.merge_backoff.record_success_local(key.id());
+                        // Contract-wide clear only when the state advanced
+                        // (execution.changed) — a no-op client delta must not
+                        // wipe a live Timeout quarantine (#4864 round-4).
+                        op_manager
+                            .ring
+                            .merge_backoff
+                            .record_success_local(key.id(), execution.changed);
                     }
                     execution
                 }
@@ -395,7 +401,13 @@ async fn drive_client_update(
                     // Successful client-local DELTA merge on the remote-target
                     // path clears the backoff too (#4864 review P2, delta-only).
                     if is_delta_update {
-                        op_manager.ring.merge_backoff.record_success_local(key.id());
+                        // Contract-wide clear only when the state advanced
+                        // (execution.changed) — a no-op client delta must not
+                        // wipe a live Timeout quarantine (#4864 round-4).
+                        op_manager
+                            .ring
+                            .merge_backoff
+                            .record_success_local(key.id(), execution.changed);
                     }
                     execution
                 }
@@ -1290,10 +1302,15 @@ async fn drive_relay_broadcast_to(
             // do NOT reset here; the resync-apply path in node.rs does not reset
             // either (see the note there).
             if is_delta {
-                op_manager
-                    .ring
-                    .merge_backoff
-                    .record_success_from_sender(key.id(), sender_addr);
+                // Per-sender Invalid channel clears unconditionally on a clean
+                // delta apply (channel-trust); the contract-wide Timeout + memo
+                // clear only when the state ADVANCED (result.changed) — a no-op
+                // delta must not wipe a live Timeout quarantine (#4864 round-4).
+                op_manager.ring.merge_backoff.record_success_from_sender(
+                    key.id(),
+                    sender_addr,
+                    result.changed,
+                );
             }
             result
         }
@@ -2124,6 +2141,19 @@ async fn apply_streaming_broadcast(
             // is always full state, so it NEVER resets the backoff here; a
             // recovered contract's entry simply ages out via the reaper if
             // failures stop.
+            //
+            // BUT a state-advancing full-state apply (exec.changed) invalidates
+            // the failed-payload MEMO's premise: a delta that failed against the
+            // OLD state may be valid against the new one (#4864 round-4 P2). This
+            // clears ONLY the memo — NOT any cooldown channel — so it is NOT a
+            // backoff reset (the delta-only no-reset doctrine stands; the
+            // streaming pin still forbids resetting the backoff here).
+            if exec.changed {
+                op_manager
+                    .ring
+                    .merge_backoff
+                    .invalidate_payload_memo(key.id());
+            }
             exec
         }
         Err(err) => {

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -307,6 +307,16 @@ async fn drive_client_update(
                             .ring
                             .merge_backoff
                             .record_success_local(key.id(), execution.changed);
+                    } else if execution.changed {
+                        // #4864 round-9 item 3: a CHANGED client FULL-STATE apply
+                        // advances the state, invalidating the failed-payload MEMO's
+                        // premise — clear ONLY the memo (mirrors the relay + streaming
+                        // + resync paths). NOT a backoff reset (fork-flip no-reset
+                        // doctrine holds); gated on execution.changed.
+                        op_manager
+                            .ring
+                            .merge_backoff
+                            .invalidate_payload_memo(key.id());
                     }
                     execution
                 }
@@ -408,6 +418,15 @@ async fn drive_client_update(
                             .ring
                             .merge_backoff
                             .record_success_local(key.id(), execution.changed);
+                    } else if execution.changed {
+                        // #4864 round-9 item 3: a CHANGED client FULL-STATE apply on
+                        // the remote-target path invalidates the failed-payload MEMO
+                        // premise — clear ONLY the memo (mirrors the other paths).
+                        // NOT a backoff reset; gated on execution.changed.
+                        op_manager
+                            .ring
+                            .merge_backoff
+                            .invalidate_payload_memo(key.id());
                     }
                     execution
                 }
@@ -1357,6 +1376,23 @@ async fn drive_relay_broadcast_to(
                     sender_addr,
                     result.changed,
                 );
+            } else if result.changed {
+                // #4864 round-9 item 3: a CHANGED FULL-STATE broadcast apply
+                // advances the state, which invalidates the failed-payload MEMO's
+                // premise (a delta that failed against the OLD state may be valid
+                // against the NEW one). Mirror the streaming Ok arm and the
+                // resync-apply path in node.rs: clear ONLY the memo. This is NOT a
+                // backoff reset — no cooldown channel is touched — so the fork-flip
+                // no-reset doctrine still holds (a full-state merge carries the same
+                // fork ambiguity). Gated on result.changed so a no-op full-state
+                // apply does not needlessly re-admit known-bad payloads. Without
+                // this, a payload that failed against old state stayed
+                // KnownFailedPayload for up to FAILED_PAYLOAD_TTL (10min) after the
+                // full state advanced it — the non-streaming relay's omission.
+                op_manager
+                    .ring
+                    .merge_backoff
+                    .invalidate_payload_memo(key.id());
             }
             result
         }
@@ -4525,6 +4561,64 @@ mod tests {
              {{ .. }}` block ({open_brace}..{close_brace}) so a no-op streaming apply \
              does not invalidate the memo"
         );
+    }
+
+    /// #4864 round-9 item 3: the NON-streaming CHANGED full-state success arms
+    /// (relay `drive_relay_broadcast_to` + client `drive_client_update`) MUST also
+    /// invalidate the failed-payload memo (memo only, NO backoff reset), so a
+    /// payload that failed against old state doesn't stay KnownFailedPayload for up
+    /// to FAILED_PAYLOAD_TTL after a full state advances it — the omission the
+    /// streaming and resync-apply paths did NOT have. Mirror of
+    /// `streaming_changed_apply_invalidates_payload_memo` for the other two drivers.
+    #[test]
+    fn nonstreaming_changed_fullstate_success_invalidates_payload_memo() {
+        let src = include_str!("op_ctx_task.rs");
+        let invalidate = concat!("invalidate_", "payload_memo(");
+        for (fn_needle, changed_expr) in [
+            (
+                "async fn drive_relay_broadcast_to(",
+                "else if result.changed",
+            ),
+            ("async fn drive_client_update(", "else if execution.changed"),
+        ] {
+            let body = extract_fn_body(src, fn_needle);
+            let gate = body.find(changed_expr).unwrap_or_else(|| {
+                panic!(
+                    "`{fn_needle}` must have an `{changed_expr}` full-state success arm \
+                     (#4864 round-9 item 3)"
+                )
+            });
+            // Brace-match the else-if block; the memo invalidation must be INSIDE it
+            // (so a NO-op full-state apply does not invalidate the memo).
+            let open_brace = gate
+                + body[gate..]
+                    .find('{')
+                    .expect("else-if block must have a body");
+            let mut depth = 0usize;
+            let mut close = None;
+            for (i, ch) in body[open_brace..].char_indices() {
+                match ch {
+                    '{' => depth += 1,
+                    '}' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            close = Some(open_brace + i);
+                            break;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            let close = close.expect("else-if block must be balanced");
+            let inv = body
+                .find(invalidate)
+                .unwrap_or_else(|| panic!("`{fn_needle}` must call invalidate_payload_memo"));
+            assert!(
+                open_brace < inv && inv < close,
+                "`{fn_needle}`: invalidate_payload_memo must be INSIDE the \
+                 `{changed_expr}` full-state block (memo-only, gated on changed)"
+            );
+        }
     }
 
     /// Issue #4251 follow-up: the four `run_relay_*` driver wrappers each

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -1244,9 +1244,18 @@ async fn drive_relay_broadcast_to(
         ..
     } = match update_result {
         Ok(result) => {
-            // Merge succeeded → the contract's state advanced, so any prior
-            // merge-failure backoff for it is stale. Clear it (#4861).
-            op_manager.ring.merge_backoff.record_success(key.id());
+            // Reset the merge-failure backoff ONLY on a successful DELTA merge
+            // (#4861): a delta that applies cleanly proves the incoming change
+            // was compatible with local state — genuine convergence. A
+            // successful FULL-STATE apply just replaces state and "succeeds"
+            // regardless of which fork it carries, so it proves nothing about
+            // convergence (the semantic fork-oscillation poison class flips
+            // forks on every full-state apply). Full-state broadcasts therefore
+            // do NOT reset here; the resync-apply path in node.rs does not reset
+            // either (see the note there).
+            if is_delta {
+                op_manager.ring.merge_backoff.record_success(key.id());
+            }
             result
         }
         Err(err) => {
@@ -2587,17 +2596,27 @@ mod tests {
         );
     }
 
-    /// Pin (#4861): a successful merge MUST clear the backoff (state advanced),
-    /// and a failure MUST be recorded — but ONLY for genuine contract-exec
-    /// rejections. Gating `record_failure` on `is_contract_exec_rejection()`
-    /// excludes queue-full (transient load) and missing-contract failures
-    /// (healed by auto-fetch); backing either off would block recovery.
+    /// Pin (#4861): the backoff reset MUST be gated on `is_delta` (only a
+    /// successful DELTA merge resets — a full-state apply proves nothing about
+    /// convergence, see the fork-oscillation note), and a failure MUST be
+    /// recorded — but ONLY for genuine contract-exec rejections. Gating
+    /// `record_failure` on `is_contract_exec_rejection()` excludes queue-full
+    /// (transient load) and missing-contract failures (healed by auto-fetch);
+    /// backing either off would block recovery.
     #[test]
     fn broadcast_to_backoff_records_success_and_gated_failure() {
         let driver_src = broadcast_to_driver_src();
+        let success_pos = driver_src
+            .find("merge_backoff.record_success(")
+            .expect("drive_relay_broadcast_to must clear the backoff on a successful merge");
+        // The reset must be gated on is_delta (delta-only convergence signal).
+        let is_delta_gate_pos = driver_src
+            .find("if is_delta {")
+            .expect("backoff reset must be gated on `if is_delta` (#4861)");
         assert!(
-            driver_src.contains("merge_backoff.record_success("),
-            "drive_relay_broadcast_to must clear the backoff on a successful merge"
+            is_delta_gate_pos < success_pos,
+            "merge_backoff.record_success MUST be inside an `if is_delta` gate so \
+             a full-state apply does not reset the backoff (#4861 fork oscillation)"
         );
         let record_pos = driver_src
             .find(".record_failure(")

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -1114,38 +1114,62 @@ async fn send_queue_full_resync_request(
     sender_addr: SocketAddr,
     incoming_tx: Transaction,
 ) {
-    if op_manager
+    if !op_manager
         .interest_manager
         .should_send_resync_request(&key, sender_addr)
     {
-        tracing::info!(
-            tx = %incoming_tx,
-            contract = %key,
-            target = %sender_addr,
-            event = "resync_request_sent",
-            reason = "queue_full",
-            "UPDATE relay: sending rate-limited ResyncRequest after queue-full drop (#4857)"
-        );
-        if let Err(e) = op_manager
-            .notify_node_event(NodeEvent::SendInterestMessage {
-                target: sender_addr,
-                message: InterestMessage::ResyncRequest { key },
-            })
-            .await
-        {
-            tracing::warn!(
-                tx = %incoming_tx,
-                error = %e,
-                "UPDATE relay: failed to send queue-full ResyncRequest"
-            );
-        }
-    } else {
+        // Per-(contract, sender)/30s throttle (existing #4857 bound).
         tracing::debug!(
             tx = %incoming_tx,
             contract = %key,
             sender = %sender_addr,
             event = "queue_full_resync_throttled",
             "UPDATE relay: queue-full ResyncRequest throttled (rate limit) to avoid amplification"
+        );
+        return;
+    }
+
+    // ALSO subject to the GLOBAL per-contract emit cap (#4864 round-4 P1): the
+    // #4857 queue-full heal path previously bypassed it, so a saturated contract
+    // with many senders still emitted per-(contract, sender)/30s. Routing it
+    // through resync_emit_limiter bounds the contract's TOTAL queue-full resync
+    // emission the same way the delta-failure path is (node.rs mirrors this with
+    // record_resync_request_suppressed on global-cap suppression).
+    if !op_manager
+        .ring
+        .resync_emit_limiter
+        .check_and_record(*key.id())
+    {
+        crate::config::GlobalTestMetrics::record_resync_request_suppressed();
+        tracing::debug!(
+            tx = %incoming_tx,
+            contract = %key,
+            sender = %sender_addr,
+            event = "queue_full_resync_suppressed_global",
+            "UPDATE relay: queue-full ResyncRequest suppressed by global per-contract cap"
+        );
+        return;
+    }
+
+    tracing::info!(
+        tx = %incoming_tx,
+        contract = %key,
+        target = %sender_addr,
+        event = "resync_request_sent",
+        reason = "queue_full",
+        "UPDATE relay: sending rate-limited ResyncRequest after queue-full drop (#4857)"
+    );
+    if let Err(e) = op_manager
+        .notify_node_event(NodeEvent::SendInterestMessage {
+            target: sender_addr,
+            message: InterestMessage::ResyncRequest { key },
+        })
+        .await
+    {
+        tracing::warn!(
+            tx = %incoming_tx,
+            error = %e,
+            "UPDATE relay: failed to send queue-full ResyncRequest"
         );
     }
 }
@@ -3073,13 +3097,15 @@ mod tests {
         );
     }
 
-    /// Issue #4857 / #4251 reconciliation pin. On a queue-full broadcast drop,
-    /// BOTH broadcast drivers must emit a RATE-LIMITED `ResyncRequest` — neither
-    /// suppress it (permanent divergence, #4857) nor emit it unthrottled
-    /// (full-state storm, #4251). Both route through the shared
-    /// `send_queue_full_resync_request` helper, which nests the
-    /// `InterestMessage::ResyncRequest` emit INSIDE the `should_send_resync_request`
-    /// rate-limit gate. Auto-fetch stays suppressed on each driver's queue-full arm.
+    /// Issue #4857 / #4251 reconciliation pin (+ #4864 round-4). On a queue-full
+    /// broadcast drop, BOTH broadcast drivers must emit a RATE-LIMITED
+    /// `ResyncRequest` — neither suppress it (permanent divergence, #4857) nor
+    /// emit it unthrottled (full-state storm, #4251). Both route through the
+    /// shared `send_queue_full_resync_request` helper, which gates the
+    /// `InterestMessage::ResyncRequest` emit behind BOTH the per-(contract, sender)
+    /// `should_send_resync_request` throttle AND the global per-contract
+    /// `resync_emit_limiter` cap (each a `!gate { return; }` guard before the
+    /// emit). Auto-fetch stays suppressed on each driver's queue-full arm.
     #[test]
     fn broadcast_to_sends_throttled_resync_on_queue_full() {
         let src = include_str!("op_ctx_task.rs");
@@ -3149,25 +3175,26 @@ mod tests {
             "streaming queue-full arm must NOT auto-fetch (#4251)"
         );
 
-        // The shared helper nests the emit INSIDE the throttle gate: the
-        // `should_send_resync_request` check comes BEFORE the emit, which comes
-        // BEFORE the throttled `else` branch. An emit outside the gate would
-        // re-open the #4251 storm.
+        // The shared helper gates the single emit behind BOTH the per-(contract,
+        // sender) throttle AND the global per-contract emit cap (#4251/#4857 +
+        // #4864 round-4). Each is a `!gate { return; }` guard that precedes the
+        // emit, so an unthrottled emission cannot re-open the #4251 storm.
         let helper = fn_body("async fn send_queue_full_resync_request(");
-        let gate = helper
+        let per_sender = helper
             .find(".should_send_resync_request(")
             .expect("helper must gate on should_send_resync_request (rate limit, #4251)");
+        let global_cap = helper.find("resync_emit_limiter").expect(
+            "helper must ALSO gate on the global per-contract emit cap \
+             (resync_emit_limiter, #4864 round-4)",
+        );
         let emit = helper
             .find("InterestMessage::ResyncRequest")
             .expect("helper must emit InterestMessage::ResyncRequest (heal, #4857)");
-        let gate_else = helper
-            .find("} else {")
-            .expect("helper must have a throttled `else` branch");
         assert!(
-            gate < emit && emit < gate_else,
-            "the ResyncRequest emit MUST be nested INSIDE the \
-             `if should_send_resync_request {{ .. }}` gate (before the throttled \
-             `else`), so an unthrottled emission cannot re-open the #4251 storm"
+            per_sender < emit && global_cap < emit,
+            "the ResyncRequest emit ({emit}) MUST come AFTER both the per-sender \
+             throttle ({per_sender}) and the global emit cap ({global_cap}), so an \
+             unthrottled emission cannot re-open the #4251 storm"
         );
     }
 
@@ -3840,6 +3867,75 @@ mod tests {
             op_manager.ring.merge_backoff.contracts_in_backoff(),
             0,
             "no contract may be in backoff after only queue-full failures"
+        );
+    }
+
+    /// #4864 round-4 P1 (item 3): the #4857 queue-full resync heal must be bound
+    /// by the GLOBAL per-contract emit cap. A flood of DISTINCT senders (each
+    /// passing its own per-(contract, sender) throttle) sending queue-full deltas
+    /// for ONE contract must emit at most `EMIT_BURST` ResyncRequests total — not
+    /// one per sender. Without the global cap this would be one per sender.
+    #[tokio::test]
+    async fn queue_full_resync_flood_is_bounded_by_global_emit_cap() {
+        crate::config::GlobalTestMetrics::reset();
+        let (op_manager, mut notification_rx, _update_queries, _guard) =
+            build_broadcast_test_node("queuefull-emit-cap-4864", DeltaOutcome::QueueFull).await;
+        let key = ContractKey::from_id_and_code(
+            ContractInstanceId::new([71u8; 32]),
+            CodeHash::new([72u8; 32]),
+        );
+        // Six DISTINCT senders (each clears its own per-sender throttle) each send
+        // a distinct-payload queue-full delta for the SAME contract.
+        let sender_count = 6u16;
+        for i in 0..sender_count {
+            let sender: SocketAddr = format!("127.0.0.1:{}", 13000 + i).parse().unwrap();
+            let _ = drive_relay_broadcast_to(
+                &op_manager,
+                Transaction::new::<UpdateMsg>(),
+                key,
+                DeltaOrFullState::Delta(vec![i as u8]),
+                Vec::new(),
+                sender,
+            )
+            .await;
+        }
+        // The global per-contract emit cap (EMIT_BURST = 2) bounds total emissions
+        // regardless of sender count — NOT one per sender.
+        let emissions = drain_resync_targets(&mut notification_rx, key);
+        let burst = crate::ring::resync_rate_limit::EMIT_BURST as usize;
+        assert_eq!(
+            emissions.len(),
+            burst,
+            "queue-full resync emissions ({}) must be bounded by the global \
+             per-contract cap (EMIT_BURST = {}), not one per sender ({sender_count})",
+            emissions.len(),
+            burst
+        );
+    }
+
+    /// Pin (#4864 round-4 item 3): the queue-full resync heal helper must route
+    /// through BOTH the per-(contract, sender) throttle AND the global
+    /// per-contract emit cap — the latter was the #4857 bypass.
+    #[test]
+    fn queue_full_resync_helper_goes_through_global_emit_cap() {
+        let src = include_str!("op_ctx_task.rs");
+        let start = src
+            .find("async fn send_queue_full_resync_request(")
+            .expect("send_queue_full_resync_request not found");
+        let after = &src[start + 1..];
+        let end = after
+            .find("\nasync fn ")
+            .or_else(|| after.find("\n#[cfg(test)]"))
+            .unwrap_or(after.len());
+        let body = &src[start..start + 1 + end];
+        assert!(
+            body.contains("resync_emit_limiter"),
+            "the queue-full resync helper must route through the GLOBAL \
+             per-contract emit cap (resync_emit_limiter) (#4864 round-4)"
+        );
+        assert!(
+            body.contains("should_send_resync_request"),
+            "and keep the per-(contract, sender) throttle"
         );
     }
 

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -1302,7 +1302,11 @@ async fn drive_relay_broadcast_to(
                 // sender summary-clear too — it is part of the resync handshake,
                 // so clearing it without emitting would just force the sender to
                 // full-state us on the next interest cycle.
-                if op_manager.ring.resync_emit_limiter.check_and_record(*key.id()) {
+                if op_manager
+                    .ring
+                    .resync_emit_limiter
+                    .check_and_record(*key.id())
+                {
                     tracing::warn!(
                         tx = %incoming_tx,
                         contract = %key,
@@ -2004,7 +2008,11 @@ async fn apply_streaming_broadcast(
     // always full state (`is_delta = false`) and never emit a ResyncRequest, so
     // only the merge-skip applies. Cleared the instant a merge succeeds (below).
     let stream_payload_hash = crate::ring::merge_backoff::merge_payload_hash(false, &state_bytes);
-    match op_manager.ring.merge_backoff.check(key.id(), stream_payload_hash) {
+    match op_manager
+        .ring
+        .merge_backoff
+        .check(key.id(), stream_payload_hash)
+    {
         crate::ring::merge_backoff::MergeDecision::Allow => {}
         decision => {
             crate::config::GlobalTestMetrics::record_merge_suppressed_by_backoff();
@@ -2616,8 +2624,10 @@ mod tests {
     #[test]
     fn broadcast_to_resync_emit_is_rate_limited() {
         let driver_src = broadcast_to_driver_src();
+        // Match the field name (fmt-stable) rather than the full method call,
+        // which rustfmt may break across lines.
         let gate_pos = driver_src
-            .find("resync_emit_limiter.check_and_record(")
+            .find("resync_emit_limiter")
             .expect("ResyncRequest emit must be gated by resync_emit_limiter");
         let summary_clear_pos = driver_src
             .find("update_peer_summary(&key, &sender_key, None)")
@@ -2652,8 +2662,11 @@ mod tests {
             .unwrap_or(after.len());
         let driver_src = &src[start..start + 1 + end];
 
+        // Match the args (fmt-stable) rather than `merge_backoff.check(`, which
+        // rustfmt breaks across lines here (the longer `stream_payload_hash`
+        // pushes the chain over the chain-width limit).
         let backoff_pos = driver_src
-            .find("merge_backoff.check(")
+            .find(".check(key.id(), stream_payload_hash)")
             .expect("streaming driver missing merge_backoff.check gate");
         let merge_pos = driver_src
             .find("super::update_contract(")
@@ -2667,7 +2680,8 @@ mod tests {
             "streaming driver must clear the backoff on a successful merge"
         );
         assert!(
-            driver_src.contains(".record_failure(") && driver_src.contains("is_contract_exec_rejection()"),
+            driver_src.contains(".record_failure(")
+                && driver_src.contains("is_contract_exec_rejection()"),
             "streaming driver must record gated failures like the non-streaming driver"
         );
     }

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -3939,6 +3939,95 @@ mod tests {
         );
     }
 
+    /// #4864 round-4 (item 9): a memoized payload replayed through the REAL
+    /// `drive_relay_broadcast_to` by a SECOND sender is hard-skipped — the merge
+    /// never reaches the executor, that sender's Invalid channel never trips (its
+    /// OWN novel delta still merges), and no ResyncRequest is emitted. Seed the
+    /// memo directly with THREE DISTINCT payloads (so each replay is a genuine
+    /// memo hit rather than a `BroadcastDedupCache` hit — the dedup cache is
+    /// content-addressed too, so an identical replay would be swallowed by dedup
+    /// before reaching the backoff gate).
+    #[tokio::test]
+    async fn memoized_payload_replay_from_second_sender_is_hard_skipped() {
+        use std::sync::atomic::Ordering;
+        crate::config::GlobalTestMetrics::reset();
+        let (op_manager, mut notification_rx, update_queries, _guard) =
+            build_exec_reject_test_node("memo-replay-4864").await;
+        let key = ContractKey::from_id_and_code(
+            ContractInstanceId::new([83u8; 32]),
+            CodeHash::new([84u8; 32]),
+        );
+        let sender_a: SocketAddr = "127.0.0.1:13300".parse().unwrap();
+        let sender_b: SocketAddr = "127.0.0.1:13400".parse().unwrap();
+
+        // Seed the contract-wide memo with three distinct poison delta payloads
+        // (as if sender A had already failed them). record_failure memoizes each.
+        let poisons = [vec![91u8], vec![92u8], vec![93u8]];
+        for p in &poisons {
+            let h = crate::ring::merge_backoff::merge_payload_hash(true, p);
+            op_manager.ring.merge_backoff.record_failure(
+                key.id(),
+                sender_a,
+                crate::ring::merge_backoff::MergeFailureClass::Invalid,
+                h,
+            );
+        }
+
+        // Sender B replays each memoized payload: each is a hard memo skip.
+        for p in &poisons {
+            let r = drive_relay_broadcast_to(
+                &op_manager,
+                Transaction::new::<UpdateMsg>(),
+                key,
+                DeltaOrFullState::Delta(p.clone()),
+                Vec::new(),
+                sender_b,
+            )
+            .await;
+            assert!(
+                r.is_ok(),
+                "a memoized-payload skip completes Ok (like a dedup skip)"
+            );
+        }
+        assert_eq!(
+            update_queries.load(Ordering::Relaxed),
+            0,
+            "B's replays of memoized payloads MUST NOT reach the executor"
+        );
+        assert_eq!(
+            crate::config::GlobalTestMetrics::merges_suppressed_by_backoff(),
+            poisons.len() as u64,
+            "each replay must be a memo skip (bumps merges_suppressed_by_backoff), \
+             not a dedup skip"
+        );
+        assert!(
+            drain_resync_targets(&mut notification_rx, key).is_empty(),
+            "a memo skip must NOT emit a ResyncRequest"
+        );
+
+        // B's channel never tripped — its OWN novel delta still reaches the merge.
+        let novel = drive_relay_broadcast_to(
+            &op_manager,
+            Transaction::new::<UpdateMsg>(),
+            key,
+            DeltaOrFullState::Delta(vec![94u8]),
+            Vec::new(),
+            sender_b,
+        )
+        .await;
+        let _ = drain_resync_targets(&mut notification_rx, key);
+        assert!(
+            novel.is_err(),
+            "B's novel delta reaches the merge (fails via stand-in)"
+        );
+        assert_eq!(
+            update_queries.load(Ordering::Relaxed),
+            1,
+            "B's novel delta MUST reach the executor — the memo skips never advanced \
+             B's channel"
+        );
+    }
+
     /// #4864 review item 6: a successful client-local DELTA driven through the
     /// REAL `drive_client_update` clears the CONTRACT-WIDE side (Timeout + memo)
     /// via `record_success_local`, but must NOT clear a remote sender's Invalid

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -1114,9 +1114,15 @@ async fn send_queue_full_resync_request(
     sender_addr: SocketAddr,
     incoming_tx: Transaction,
 ) {
+    // PEEK the per-(contract, sender)/30s throttle WITHOUT recording (#4864
+    // round-5 item 9). This heal is double-gated (this per-sender throttle AND the
+    // global emit cap below); recording the window here and then being suppressed
+    // by the global cap would burn the 30s window with no emit, blocking this
+    // (contract, sender) from retrying for up to 30s after the global cap's tokens
+    // refill. The window is recorded ONLY when the emit actually happens (below).
     if !op_manager
         .interest_manager
-        .should_send_resync_request(&key, sender_addr)
+        .peek_should_send_resync_request(&key, sender_addr)
     {
         // Per-(contract, sender)/30s throttle (existing #4857 bound).
         tracing::debug!(
@@ -1133,8 +1139,11 @@ async fn send_queue_full_resync_request(
     // #4857 queue-full heal path previously bypassed it, so a saturated contract
     // with many senders still emitted per-(contract, sender)/30s. Routing it
     // through resync_emit_limiter bounds the contract's TOTAL queue-full resync
-    // emission the same way the delta-failure path is (node.rs mirrors this with
-    // record_resync_request_suppressed on global-cap suppression).
+    // emission. (This is NOT a mirror of the delta-failure path — that path is
+    // global-cap-only, with no per-sender throttle. The global suppression records
+    // the same `record_resync_request_suppressed` metric node.rs does.) On
+    // suppression, the per-sender window is NOT recorded (see the peek above), so
+    // the sender retries as soon as global tokens refill.
     if !op_manager
         .ring
         .resync_emit_limiter
@@ -1151,6 +1160,10 @@ async fn send_queue_full_resync_request(
         return;
     }
 
+    // Both gates passed → NOW record the per-sender throttle window and emit.
+    op_manager
+        .interest_manager
+        .record_resync_request_sent(&key, sender_addr);
     tracing::info!(
         tx = %incoming_tx,
         contract = %key,
@@ -3178,11 +3191,14 @@ mod tests {
         // The shared helper gates the single emit behind BOTH the per-(contract,
         // sender) throttle AND the global per-contract emit cap (#4251/#4857 +
         // #4864 round-4). Each is a `!gate { return; }` guard that precedes the
-        // emit, so an unthrottled emission cannot re-open the #4251 storm.
+        // emit, so an unthrottled emission cannot re-open the #4251 storm. The
+        // per-sender throttle is PEEKED (not recorded) until the emit, and its
+        // window is recorded ONLY at the emit (#4864 round-5 item 9), so a
+        // global-cap suppression does not burn the window.
         let helper = fn_body("async fn send_queue_full_resync_request(");
-        let per_sender = helper
-            .find(".should_send_resync_request(")
-            .expect("helper must gate on should_send_resync_request (rate limit, #4251)");
+        let per_sender = helper.find(".peek_should_send_resync_request(").expect(
+            "helper must PEEK the per-sender throttle without recording (#4864 round-5 item 9)",
+        );
         let global_cap = helper.find("resync_emit_limiter").expect(
             "helper must ALSO gate on the global per-contract emit cap \
              (resync_emit_limiter, #4864 round-4)",
@@ -3190,11 +3206,20 @@ mod tests {
         let emit = helper
             .find("InterestMessage::ResyncRequest")
             .expect("helper must emit InterestMessage::ResyncRequest (heal, #4857)");
+        let record = helper.find(".record_resync_request_sent(").expect(
+            "helper must record the per-sender throttle window (only on emit, #4864 round-5)",
+        );
         assert!(
             per_sender < emit && global_cap < emit,
             "the ResyncRequest emit ({emit}) MUST come AFTER both the per-sender \
-             throttle ({per_sender}) and the global emit cap ({global_cap}), so an \
-             unthrottled emission cannot re-open the #4251 storm"
+             throttle peek ({per_sender}) and the global emit cap ({global_cap}), so \
+             an unthrottled emission cannot re-open the #4251 storm"
+        );
+        assert!(
+            global_cap < record && record < emit,
+            "the per-sender window record ({record}) MUST come AFTER the global cap \
+             ({global_cap}) and before/at the emit ({emit}) — recording earlier \
+             would burn the 30s window on a global-cap suppression (#4864 round-5 item 9)"
         );
     }
 
@@ -3470,8 +3495,13 @@ mod tests {
         ExecReject,
         /// Fail with `ContractQueueFull` (NOT recorded — transient load).
         QueueFull,
-        /// Succeed (state changed) — used to exercise a clean DELTA merge.
+        /// Succeed with `state_changed: true` — a clean DELTA merge that advanced
+        /// state.
         Success,
+        /// Succeed with `state_changed: false` — a NO-OP delta merge (e.g. an
+        /// idempotent re-apply). The state did NOT advance, so the contract-side
+        /// backoff clear must NOT fire (#4864 round-5 item 4).
+        SuccessNoChange,
     }
 
     /// Build a node whose stand-in contract handler resolves every DELTA
@@ -3560,6 +3590,12 @@ mod tests {
                                     new_value: Ok(WrappedState::from(vec![1u8, 2, 3])),
                                     state_changed: true,
                                 },
+                                DeltaOutcome::SuccessNoChange => {
+                                    ContractHandlerEvent::UpdateResponse {
+                                        new_value: Ok(WrappedState::from(vec![1u8, 2, 3])),
+                                        state_changed: false,
+                                    }
+                                }
                             }
                         } else {
                             ContractHandlerEvent::UpdateResponse {
@@ -4192,6 +4228,148 @@ mod tests {
                 .check(key.id(), remote_sender, 0x99),
             crate::ring::merge_backoff::MergeDecision::InBackoff,
             "a client FULL-STATE success must NOT clear a remote sender's Invalid channel"
+        );
+    }
+
+    /// #4864 round-5 item 4: a successful client-local DELTA that did NOT advance
+    /// state (`state_changed == false`, e.g. an idempotent re-apply) driven
+    /// through the REAL `drive_client_update` must NOT clear the contract-side
+    /// backoff — `record_success_local` is gated `changed`, so a no-op success is
+    /// not a state-generation signal. This closes the round-4 no-op-wipe bug end
+    /// to end (previously not drivable: no harness variant returned Ok with
+    /// `state_changed: false`).
+    #[tokio::test]
+    async fn client_local_no_op_delta_success_does_not_clear_contract_side() {
+        let (op_manager, _notification_rx, _update_queries, _guard) = build_broadcast_test_node(
+            "backoff-client-nochange-4864",
+            DeltaOutcome::SuccessNoChange,
+        )
+        .await;
+        let key = ContractKey::from_id_and_code(
+            ContractInstanceId::new([65u8; 32]),
+            CodeHash::new([66u8; 32]),
+        );
+        op_manager
+            .ring
+            .host_contract(key, 100, crate::ring::AccessType::Put);
+
+        let remote_sender: SocketAddr = "127.0.0.1:15300".parse().unwrap();
+        let probe_sender: SocketAddr = "127.0.0.1:15400".parse().unwrap();
+
+        // Seed a contract-wide Timeout + a remote sender's tripped Invalid channel.
+        op_manager.ring.merge_backoff.record_failure(
+            key.id(),
+            remote_sender,
+            crate::ring::merge_backoff::MergeFailureClass::Timeout,
+            0x01,
+        );
+        for h in [0x11u64, 0x12, 0x13] {
+            op_manager.ring.merge_backoff.record_failure(
+                key.id(),
+                remote_sender,
+                crate::ring::merge_backoff::MergeFailureClass::Invalid,
+                h,
+            );
+        }
+        assert_eq!(
+            op_manager
+                .ring
+                .merge_backoff
+                .check(key.id(), probe_sender, 0x99),
+            crate::ring::merge_backoff::MergeDecision::InBackoff,
+            "seeded contract-wide Timeout should suppress before the client update"
+        );
+
+        // Drive a client-local DELTA (is_delta_update == true) that SUCCEEDS with
+        // state_changed == false via the stand-in.
+        let outcome = drive_client_update(
+            &op_manager,
+            Transaction::new::<UpdateMsg>(),
+            key,
+            UpdateData::Delta(StateDelta::from(vec![7u8, 7, 7])),
+            RelatedContracts::default(),
+        )
+        .await;
+        assert!(
+            outcome.is_ok(),
+            "no-op client-local delta should succeed via the stand-in: {outcome:?}"
+        );
+
+        // The contract-side backoff is NOT cleared (the state did not advance): the
+        // probe is still suppressed by the contract-wide Timeout.
+        assert_eq!(
+            op_manager
+                .ring
+                .merge_backoff
+                .check(key.id(), probe_sender, 0x99),
+            crate::ring::merge_backoff::MergeDecision::InBackoff,
+            "a no-op (changed=false) client delta success must NOT clear the \
+             contract-wide Timeout (record_success_local is gated on changed)"
+        );
+        // ... and the remote sender's Invalid channel is likewise untouched.
+        assert_eq!(
+            op_manager
+                .ring
+                .merge_backoff
+                .check(key.id(), remote_sender, 0x99),
+            crate::ring::merge_backoff::MergeDecision::InBackoff,
+            "a no-op client delta success must NOT clear a remote sender's Invalid channel"
+        );
+    }
+
+    /// Pin (#4864 round-5 item 4): the three success call sites must pass the REAL
+    /// `changed` field, not a literal `true` — a literal would re-introduce the
+    /// round-4 no-op-wipe bug (wiping the contract-side Timeout/memo on every
+    /// no-op merge) while passing every other test.
+    #[test]
+    fn success_sites_pass_real_changed_flag_not_a_literal() {
+        let src = include_str!("op_ctx_task.rs");
+        // Both drive_client_update success arms pass execution.changed.
+        let client = extract_fn_body(src, "async fn drive_client_update(");
+        let client_calls = client
+            .matches("record_success_local(key.id(), execution.changed)")
+            .count();
+        assert!(
+            client_calls >= 2,
+            "both drive_client_update success arms must pass the REAL \
+             execution.changed to record_success_local (found {client_calls}, \
+             expected >= 2) — not a literal `true` (#4864 round-5 item 4)"
+        );
+        assert!(
+            !client.contains("record_success_local(key.id(), true)"),
+            "drive_client_update must NOT hardcode `true` for the changed flag"
+        );
+        // The relay broadcast success arm passes result.changed.
+        let relay = broadcast_to_driver_src();
+        assert!(
+            relay.contains("result.changed"),
+            "drive_relay_broadcast_to must pass the REAL result.changed to \
+             record_success_from_sender, not a literal `true` (#4864 round-5 item 4)"
+        );
+    }
+
+    /// Pin (#4864 round-5 item 6): the CHANGED streaming full-state apply arm MUST
+    /// call `invalidate_payload_memo` inside the `if exec.changed` gate — same
+    /// reason as the node.rs resync-apply site: a state-advancing full-state apply
+    /// invalidates the memo's premise. Dropping it silently widens the staleness
+    /// corner to the full 10-min TTL. (The streaming path still must NOT reset the
+    /// backoff — covered by `broadcast_to_streaming_has_backoff_wiring`.)
+    #[test]
+    fn streaming_changed_apply_invalidates_payload_memo() {
+        let src = include_str!("op_ctx_task.rs");
+        let st = extract_fn_body(src, "async fn apply_streaming_broadcast(");
+        let changed_gate = st
+            .find("if exec.changed")
+            .expect("streaming Ok arm must gate on `if exec.changed`");
+        let invalidate = concat!("invalidate_", "payload_memo(");
+        let inv_pos = st.find(invalidate).expect(
+            "the CHANGED streaming full-state apply must call invalidate_payload_memo \
+             (#4864 round-5 item 6)",
+        );
+        assert!(
+            changed_gate < inv_pos,
+            "invalidate_payload_memo must be inside the `if exec.changed` gate so a \
+             no-op streaming apply does not invalidate the memo"
         );
     }
 

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -1174,6 +1174,13 @@ async fn send_queue_full_resync_request(
         reason = "queue_full",
         "UPDATE relay: sending rate-limited ResyncRequest after queue-full drop (#4857)"
     );
+    // #4864 round-8: record the outstanding request so the matching ResyncResponse
+    // from this peer is authorized ONCE at the receive arm; an unsolicited or
+    // replayed response finds no entry and is dropped without running WASM.
+    op_manager
+        .ring
+        .outstanding_resync_requests
+        .record(*key.id(), sender_addr);
     if let Err(e) = op_manager
         .notify_node_event(NodeEvent::SendInterestMessage {
             target: sender_addr,
@@ -1452,6 +1459,14 @@ async fn drive_relay_broadcast_to(
                         event = "resync_request_sent",
                         "UPDATE relay: sending ResyncRequest after delta failure"
                     );
+                    // #4864 round-8: record the outstanding request so only the
+                    // matching ResyncResponse from this peer is authorized (once)
+                    // at the receive arm; unsolicited/replayed responses are
+                    // dropped without running WASM.
+                    op_manager
+                        .ring
+                        .outstanding_resync_requests
+                        .record(*key.id(), sender_addr);
                     if let Err(e) = op_manager
                         .notify_node_event(NodeEvent::SendInterestMessage {
                             target: sender_addr,
@@ -4044,6 +4059,44 @@ mod tests {
         assert!(
             body.contains("begin_resync_request"),
             "and keep the per-(contract, sender) throttle"
+        );
+    }
+
+    /// #4864 round-8 pin (Codex P1): every PRODUCTION `ResyncRequest` emission
+    /// MUST be preceded by an `outstanding_resync_requests.record(...)` so the
+    /// receive arm can correlate (and consume) the matching `ResyncResponse`. A
+    /// future emit site that forgets to record would make its legitimate response
+    /// look unsolicited (a silent heal regression) — and the record is the whole
+    /// basis of the receive-side DoS gate, so it must never drift from the emit.
+    #[test]
+    fn every_production_resync_request_emit_records_outstanding() {
+        let src = include_str!("op_ctx_task.rs");
+        // Bound to PRODUCTION code (before the test module) so the mock emit in
+        // the harness below is not counted.
+        let prod_end = src.find("\nmod tests {").unwrap_or(src.len());
+        let prod = &src[..prod_end];
+
+        let mut emits = 0usize;
+        let mut cursor = 0usize;
+        while let Some(rel) = prod[cursor..].find("message: InterestMessage::ResyncRequest") {
+            let pos = cursor + rel;
+            emits += 1;
+            // Look back a bounded window for the record call that authorizes the
+            // ResyncResponse this emit will provoke (fmt-robust: match the field
+            // identifier, which survives line-wrapping of the method chain).
+            let window_start = pos.saturating_sub(600);
+            assert!(
+                prod[window_start..pos].contains("outstanding_resync_requests"),
+                "a production ResyncRequest emit at byte {pos} is NOT preceded by an \
+                 outstanding_resync_requests.record(...) within 600 bytes — the \
+                 receive arm would drop its response as unsolicited (#4864 round-8)"
+            );
+            cursor = pos + 1;
+        }
+        assert!(
+            emits >= 2,
+            "expected at least the queue-full-helper and delta-failure ResyncRequest \
+             emit sites in production ({emits} found) — has the emit path moved?"
         );
     }
 

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -1214,7 +1214,8 @@ async fn drive_relay_broadcast_to(
     let payload_hash = crate::ring::merge_backoff::merge_payload_hash(is_delta, &payload_bytes);
     match op_manager.ring.merge_backoff.check(key.id(), payload_hash) {
         crate::ring::merge_backoff::MergeDecision::Allow => {}
-        decision => {
+        decision @ (crate::ring::merge_backoff::MergeDecision::InBackoff
+        | crate::ring::merge_backoff::MergeDecision::KnownFailedPayload) => {
             crate::config::GlobalTestMetrics::record_merge_suppressed_by_backoff();
             tracing::debug!(
                 tx = %incoming_tx,
@@ -2014,7 +2015,8 @@ async fn apply_streaming_broadcast(
         .check(key.id(), stream_payload_hash)
     {
         crate::ring::merge_backoff::MergeDecision::Allow => {}
-        decision => {
+        decision @ (crate::ring::merge_backoff::MergeDecision::InBackoff
+        | crate::ring::merge_backoff::MergeDecision::KnownFailedPayload) => {
             crate::config::GlobalTestMetrics::record_merge_suppressed_by_backoff();
             tracing::debug!(
                 tx = %incoming_tx,

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -1204,6 +1204,28 @@ async fn drive_relay_broadcast_to(
         return Ok(());
     }
 
+    // ── Step 3b: merge-failure backoff gate (#4861) ───────────────────────
+    //
+    // Quarantine "poison" contracts whose merges reliably fail/time out. While a
+    // contract is in cooldown (or this exact payload is known-failed) skip the
+    // WASM merge entirely and — critically — do NOT emit the ResyncRequest
+    // amplification or clear the sender's cached summary. Complete exactly like
+    // the dedup-skip path above. Cleared the instant a merge succeeds (below).
+    let payload_hash = crate::ring::merge_backoff::merge_payload_hash(is_delta, &payload_bytes);
+    match op_manager.ring.merge_backoff.check(key.id(), payload_hash) {
+        crate::ring::merge_backoff::MergeDecision::Allow => {}
+        decision => {
+            crate::config::GlobalTestMetrics::record_merge_suppressed_by_backoff();
+            tracing::debug!(
+                tx = %incoming_tx,
+                %key,
+                ?decision,
+                "UPDATE relay: BroadcastTo merge skipped — contract in merge-failure backoff"
+            );
+            return Ok(());
+        }
+    }
+
     // ── Step 4: apply broadcast via WASM merge ────────────────────────────
     let update_result = super::update_contract(
         op_manager,
@@ -1220,8 +1242,31 @@ async fn drive_relay_broadcast_to(
         changed,
         ..
     } = match update_result {
-        Ok(result) => result,
+        Ok(result) => {
+            // Merge succeeded → the contract's state advanced, so any prior
+            // merge-failure backoff for it is stale. Clear it (#4861).
+            op_manager.ring.merge_backoff.record_success(key.id());
+            result
+        }
         Err(err) => {
+            // Record the merge failure for the per-contract backoff (#4861),
+            // but ONLY for genuine contract-exec failures (the merge ran and the
+            // contract rejected it or it timed out). `is_contract_exec_rejection`
+            // excludes queue-full (transient load) and missing-contract failures
+            // (healed by the auto-fetch below) — backing either off would be
+            // wrong. A timeout gets the longer Timeout-class cooldown.
+            if err.is_contract_exec_rejection() {
+                let class = if err.is_wasm_timeout() {
+                    crate::ring::merge_backoff::MergeFailureClass::Timeout
+                } else {
+                    crate::ring::merge_backoff::MergeFailureClass::Invalid
+                };
+                op_manager
+                    .ring
+                    .merge_backoff
+                    .record_failure(key.id(), class, payload_hash);
+            }
+
             // On benign stale-version rejection (not OOG/traps/validation
             // failures — see `is_invalid_update_rejection`), nudge the sender's
             // peer-summary cache of us toward Some(our_summary). Helper gates
@@ -1939,6 +1984,24 @@ async fn apply_streaming_broadcast(
         return Ok(());
     }
 
+    // Step 5b: merge-failure backoff gate (#4861). Streaming broadcasts are
+    // always full state (`is_delta = false`) and never emit a ResyncRequest, so
+    // only the merge-skip applies. Cleared the instant a merge succeeds (below).
+    let stream_payload_hash = crate::ring::merge_backoff::merge_payload_hash(false, &state_bytes);
+    match op_manager.ring.merge_backoff.check(key.id(), stream_payload_hash) {
+        crate::ring::merge_backoff::MergeDecision::Allow => {}
+        decision => {
+            crate::config::GlobalTestMetrics::record_merge_suppressed_by_backoff();
+            tracing::debug!(
+                tx = %incoming_tx,
+                %key,
+                ?decision,
+                "UPDATE relay (driver streaming): merge skipped — contract in merge-failure backoff"
+            );
+            return Ok(());
+        }
+    }
+
     let state_for_telemetry = WrappedState::from(state_bytes.clone());
 
     // Step 6: telemetry — broadcast received.
@@ -1974,8 +2037,26 @@ async fn apply_streaming_broadcast(
         changed,
         ..
     } = match update_result {
-        Ok(exec) => exec,
+        Ok(exec) => {
+            op_manager.ring.merge_backoff.record_success(key.id());
+            exec
+        }
         Err(err) => {
+            // Record poison-contract merge failures for the backoff (#4861),
+            // same classification as the non-streaming driver: only genuine
+            // contract-exec rejections, timeout → longer cooldown.
+            if err.is_contract_exec_rejection() {
+                let class = if err.is_wasm_timeout() {
+                    crate::ring::merge_backoff::MergeFailureClass::Timeout
+                } else {
+                    crate::ring::merge_backoff::MergeFailureClass::Invalid
+                };
+                op_manager
+                    .ring
+                    .merge_backoff
+                    .record_failure(key.id(), class, stream_payload_hash);
+            }
+
             // Classify failure: real failure → self-heal via
             // try_auto_fetch_contract; benign stale-version rejection →
             // send_summary_back_on_rejection. Mirrors legacy at
@@ -2437,6 +2518,114 @@ mod tests {
              when the WASM merge rejects — otherwise the sender's cached view \
              of us stays wrong and it keeps full-state-broadcasting identical \
              content"
+        );
+    }
+
+    /// Helper: return the source of `drive_relay_broadcast_to`'s body,
+    /// bounded to the next top-level `async fn` / test module.
+    #[cfg(test)]
+    fn broadcast_to_driver_src() -> &'static str {
+        let src = include_str!("op_ctx_task.rs");
+        let start = src
+            .find("async fn drive_relay_broadcast_to(")
+            .expect("drive_relay_broadcast_to not found");
+        let after = &src[start + 1..];
+        let end = after
+            .find("\nasync fn ")
+            .or_else(|| after.find("\n#[cfg(test)]"))
+            .unwrap_or(after.len());
+        &src[start..start + 1 + end]
+    }
+
+    /// Pin (#4861): the merge-failure backoff gate MUST run AFTER the dedup
+    /// check and BEFORE `update_contract`. If it ran after the merge, a poison
+    /// contract would still re-run the (failing, expensive) WASM merge on every
+    /// inbound broadcast — the exact CPU churn the backoff exists to stop.
+    #[test]
+    fn broadcast_to_backoff_gate_runs_before_merge() {
+        let driver_src = broadcast_to_driver_src();
+        let dedup_pos = driver_src
+            .find("broadcast_dedup_cache.check_and_insert")
+            .expect("dedup check missing");
+        let backoff_pos = driver_src
+            .find("merge_backoff.check(")
+            .expect("merge_backoff.check gate missing in BroadcastTo driver");
+        let merge_pos = driver_src
+            .find("super::update_contract(")
+            .expect("update_contract call missing");
+        assert!(
+            dedup_pos < backoff_pos && backoff_pos < merge_pos,
+            "merge_backoff.check MUST appear after the dedup check and before \
+             update_contract() (order: dedup {dedup_pos} < backoff {backoff_pos} \
+             < merge {merge_pos})"
+        );
+    }
+
+    /// Pin (#4861): a successful merge MUST clear the backoff (state advanced),
+    /// and a failure MUST be recorded — but ONLY for genuine contract-exec
+    /// rejections. Gating `record_failure` on `is_contract_exec_rejection()`
+    /// excludes queue-full (transient load) and missing-contract failures
+    /// (healed by auto-fetch); backing either off would block recovery.
+    #[test]
+    fn broadcast_to_backoff_records_success_and_gated_failure() {
+        let driver_src = broadcast_to_driver_src();
+        assert!(
+            driver_src.contains("merge_backoff.record_success("),
+            "drive_relay_broadcast_to must clear the backoff on a successful merge"
+        );
+        let record_pos = driver_src
+            .find(".record_failure(")
+            .expect("merge_backoff.record_failure missing in BroadcastTo driver");
+        // The record_failure must be inside an is_contract_exec_rejection guard.
+        let guard_pos = driver_src
+            .find("if err.is_contract_exec_rejection() {")
+            .expect("record_failure must be gated on is_contract_exec_rejection");
+        assert!(
+            guard_pos < record_pos,
+            "merge_backoff.record_failure MUST be gated on \
+             is_contract_exec_rejection() so queue-full and missing-contract \
+             failures do NOT create a backoff entry (#4861)"
+        );
+        assert!(
+            driver_src.contains("is_wasm_timeout()"),
+            "the failure class must distinguish a WASM timeout (longer cooldown) \
+             via is_wasm_timeout()"
+        );
+    }
+
+    /// Pin (#4861): the streaming full-state driver must carry the same
+    /// backoff gate + record wiring (a poison contract must be quarantined on
+    /// the streaming path too).
+    #[test]
+    fn broadcast_to_streaming_has_backoff_wiring() {
+        let src = include_str!("op_ctx_task.rs");
+        let start = src
+            .find("async fn drive_relay_broadcast_to_streaming(")
+            .expect("streaming driver not found");
+        let after = &src[start + 1..];
+        let end = after
+            .find("\nasync fn ")
+            .or_else(|| after.find("\n#[cfg(test)]"))
+            .unwrap_or(after.len());
+        let driver_src = &src[start..start + 1 + end];
+
+        let backoff_pos = driver_src
+            .find("merge_backoff.check(")
+            .expect("streaming driver missing merge_backoff.check gate");
+        let merge_pos = driver_src
+            .find("super::update_contract(")
+            .expect("streaming driver missing update_contract");
+        assert!(
+            backoff_pos < merge_pos,
+            "streaming driver's merge_backoff.check MUST run before update_contract"
+        );
+        assert!(
+            driver_src.contains("merge_backoff.record_success("),
+            "streaming driver must clear the backoff on a successful merge"
+        );
+        assert!(
+            driver_src.contains(".record_failure(") && driver_src.contains("is_contract_exec_rejection()"),
+            "streaming driver must record gated failures like the non-streaming driver"
         );
     }
 

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -2873,6 +2873,19 @@ mod tests {
                 && driver_src.contains("is_contract_exec_rejection()"),
             "streaming path must record gated failures like the non-streaming driver"
         );
+        // #4864 round-7: the streaming record gate MUST also exclude scheduler
+        // timeouts (the guest-never-ran, queued-on-a-saturated-pool case), exactly
+        // like the relay driver (pinned in
+        // broadcast_to_backoff_records_success_and_gated_failure). Without this
+        // needle a refactor dropping the exclusion from the streaming driver would
+        // silently re-quarantine a healthy contract on transient scheduler
+        // overload — the round-6/7 regression this exclusion exists to prevent.
+        assert!(
+            driver_src.contains("!err.is_scheduler_timeout()"),
+            "streaming record gate MUST exclude scheduler timeouts \
+             (!err.is_scheduler_timeout(), #4864 round-6/7): a queued-never-ran \
+             failure is transient load, not a contract fault — mirror of the relay pin"
+        );
     }
 
     /// Pin (#4864 review P2): a successful client-local DELTA merge in

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -3254,9 +3254,12 @@ mod tests {
             "helper must RESERVE the per-sender throttle atomically via \
              begin_resync_request (#4864 round-6 item 2)",
         );
-        let global_cap = helper.find("resync_emit_limiter").expect(
+        // Anchor on the CALL, not the bare identifier — a comment earlier in the
+        // helper mentions `resync_emit_limiter` before the real gate (#4864 round-6
+        // item 6c).
+        let global_cap = helper.find(".check_and_record(*key.id())").expect(
             "helper must ALSO gate on the global per-contract emit cap \
-             (resync_emit_limiter, #4864 round-4)",
+             (resync_emit_limiter.check_and_record, #4864 round-4)",
         );
         let emit = helper
             .find("InterestMessage::ResyncRequest")
@@ -4395,12 +4398,18 @@ mod tests {
             !client.contains("record_success_local(key.id(), true)"),
             "drive_client_update must NOT hardcode `true` for the changed flag"
         );
-        // The relay broadcast success arm passes result.changed.
+        // The relay broadcast success arm passes result.changed AS THE ARGUMENT of
+        // record_success_from_sender (anchored to the call, not a loose match on
+        // the whole body — #4864 round-6 item 6a).
         let relay = broadcast_to_driver_src();
+        let call = relay.find(".record_success_from_sender(").expect(
+            "drive_relay_broadcast_to must clear the backoff via record_success_from_sender",
+        );
+        let call_args = &relay[call..(call + 160).min(relay.len())];
         assert!(
-            relay.contains("result.changed"),
-            "drive_relay_broadcast_to must pass the REAL result.changed to \
-             record_success_from_sender, not a literal `true` (#4864 round-5 item 4)"
+            call_args.contains("result.changed"),
+            "record_success_from_sender must be passed the REAL result.changed \
+             (found in its arg list), not a literal `true` (#4864 round-5 item 4)"
         );
     }
 
@@ -4417,15 +4426,38 @@ mod tests {
         let changed_gate = st
             .find("if exec.changed")
             .expect("streaming Ok arm must gate on `if exec.changed`");
+        // Brace-match the `if exec.changed { ... }` block so we assert containment,
+        // not just relative order (#4864 round-6 item 6b).
+        let open_brace = changed_gate
+            + st[changed_gate..]
+                .find('{')
+                .expect("if exec.changed block must have a body");
+        let mut depth = 0usize;
+        let mut close_brace = None;
+        for (i, ch) in st[open_brace..].char_indices() {
+            match ch {
+                '{' => depth += 1,
+                '}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        close_brace = Some(open_brace + i);
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        let close_brace = close_brace.expect("if exec.changed block must be balanced");
         let invalidate = concat!("invalidate_", "payload_memo(");
         let inv_pos = st.find(invalidate).expect(
             "the CHANGED streaming full-state apply must call invalidate_payload_memo \
              (#4864 round-5 item 6)",
         );
         assert!(
-            changed_gate < inv_pos,
-            "invalidate_payload_memo must be inside the `if exec.changed` gate so a \
-             no-op streaming apply does not invalidate the memo"
+            open_brace < inv_pos && inv_pos < close_brace,
+            "invalidate_payload_memo ({inv_pos}) must be INSIDE the `if exec.changed \
+             {{ .. }}` block ({open_brace}..{close_brace}) so a no-op streaming apply \
+             does not invalidate the memo"
         );
     }
 

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -174,6 +174,17 @@ async fn drive_client_update(
 ) -> Result<DriverOutcome, OpError> {
     let sender_addr = op_manager.ring.connection_manager.peer_addr()?;
 
+    // Whether this client update is a pure DELTA — the only convergence-proving
+    // merge, per the strictly-delta-only backoff-reset rule (#4861). Captured
+    // before `update_data` is moved into `update_contract` below; used to clear
+    // the merge-failure backoff when a local client's delta recovers a contract
+    // (#4864 review P2). A client full-state (State) update just replaces state
+    // and proves nothing, so it does NOT reset.
+    let is_delta_update = matches!(
+        &update_data,
+        UpdateData::Delta(_) | UpdateData::RelatedDelta { .. }
+    );
+
     // --- Find target peer (proximity cache → ring routing) ---
     // Mirrors request_update's target selection at update.rs:1871-1995.
 
@@ -284,7 +295,15 @@ async fn drive_client_update(
             )
             .await
             {
-                Ok(execution) => execution,
+                Ok(execution) => {
+                    // A successful client-local DELTA merge proves the contract's
+                    // merge works now — clear any merge-failure backoff so inbound
+                    // broadcasts resume (#4864 review P2, delta-only).
+                    if is_delta_update {
+                        op_manager.ring.merge_backoff.record_success(key.id());
+                    }
+                    execution
+                }
                 Err(err) if err.is_missing_contract_parameters() => {
                     tracing::error!(
                         tx = %client_tx,
@@ -372,7 +391,14 @@ async fn drive_client_update(
                 changed: _,
                 ..
             } = match local_apply {
-                Ok(execution) => execution,
+                Ok(execution) => {
+                    // Successful client-local DELTA merge on the remote-target
+                    // path clears the backoff too (#4864 review P2, delta-only).
+                    if is_delta_update {
+                        op_manager.ring.merge_backoff.record_success(key.id());
+                    }
+                    execution
+                }
                 Err(err) => {
                     // The wire format `UpdateMsg::RequestUpdate.value:
                     // WrappedState` carries a post-merge full state, so this
@@ -1211,6 +1237,12 @@ async fn drive_relay_broadcast_to(
     // WASM merge entirely and — critically — do NOT emit the ResyncRequest
     // amplification or clear the sender's cached summary. Complete exactly like
     // the dedup-skip path above. Cleared the instant a merge succeeds (below).
+    //
+    // The payload hash is computed EAGERLY even on the common Allow path (#4864
+    // review declined lazy-hash suggestion): a single ahash of the payload bytes
+    // is negligible next to the WASM merge it gates, and the hash is reused
+    // verbatim by `record_failure` in the error arm, so lazy computation would
+    // only duplicate the work on the failure path.
     let payload_hash = crate::ring::merge_backoff::merge_payload_hash(is_delta, &payload_bytes);
     match op_manager.ring.merge_backoff.check(key.id(), payload_hash) {
         crate::ring::merge_backoff::MergeDecision::Allow => {}
@@ -2725,6 +2757,33 @@ mod tests {
         );
     }
 
+    /// Pin (#4864 review P2): a successful client-local DELTA merge in
+    /// `drive_client_update` MUST reset the merge-failure backoff (so a contract
+    /// a local client recovers stops suppressing inbound broadcasts), gated
+    /// delta-only (a client full-state update proves nothing).
+    #[test]
+    fn client_local_delta_success_resets_backoff() {
+        let src = include_str!("op_ctx_task.rs");
+        let start = src
+            .find("async fn drive_client_update(")
+            .expect("drive_client_update not found");
+        let after = &src[start + 1..];
+        let end = after
+            .find("\nasync fn ")
+            .or_else(|| after.find("\n#[cfg(test)]"))
+            .unwrap_or(after.len());
+        let body = &src[start..start + 1 + end];
+        let success = concat!("merge_backoff.record_", "success(");
+        assert!(
+            body.contains(success),
+            "drive_client_update must reset the backoff on a successful merge (#4864 P2)"
+        );
+        assert!(
+            body.contains("is_delta_update"),
+            "the client-local backoff reset must be gated delta-only (is_delta_update)"
+        );
+    }
+
     /// Pin: both relay drivers MUST gate on
     /// `active_relay_update_txs` to reject duplicate inbound
     /// messages for an in-flight tx (amplification guard).
@@ -3307,6 +3366,268 @@ mod tests {
             drain_resync_targets(&mut notification_rx, key).is_empty(),
             "a second streaming queue-full drop within the throttle window MUST \
              NOT emit another ResyncRequest (bounds #4251 amplification)"
+        );
+    }
+
+    /// A generic contract-exec rejection: `is_contract_exec_rejection() == true`
+    /// (recorded by the merge backoff as the Invalid class) but NOT
+    /// `is_invalid_update_rejection` (so the driver does not spawn summary-back)
+    /// and NOT a wasm timeout. Used by the behavioral backoff-gate tests.
+    #[cfg(test)]
+    fn exec_reject_err(key: ContractKey) -> crate::contract::ExecutorError {
+        crate::contract::ExecutorError::from(
+            freenet_stdlib::client_api::RequestError::ContractError(
+                freenet_stdlib::client_api::ContractError::update_exec_error(
+                    key,
+                    "contract merge failed (test poison)",
+                ),
+            ),
+        )
+    }
+
+    /// Like [`build_queue_full_test_node`], but the stand-in handler FAILS every
+    /// delta `UpdateQuery` with a generic contract-exec rejection (recorded by
+    /// the backoff) and SUCCEEDS every full-state `UpdateQuery`, while counting
+    /// the `UpdateQuery` events that reach it. `GetSummaryQuery` (from the
+    /// post-success proactive-summary spawn) is answered benignly. The counter
+    /// lets a test assert the backoff PREVENTS executor invocation (#4864 review
+    /// testing H1).
+    async fn build_exec_reject_test_node(
+        id: &str,
+    ) -> (
+        Arc<OpManager>,
+        crate::node::EventLoopNotificationsReceiver,
+        std::sync::Arc<std::sync::atomic::AtomicUsize>,
+        Box<dyn std::any::Any>,
+    ) {
+        use std::sync::atomic::Ordering;
+        let config_args = crate::config::ConfigArgs {
+            id: Some(id.to_string()),
+            mode: Some(crate::contract::OperationMode::Local),
+            ..Default::default()
+        };
+        let node_config =
+            crate::node::NodeConfig::new(config_args.build().await.expect("build Config"))
+                .await
+                .expect("build NodeConfig");
+        let (notification_rx, notification_tx) = crate::node::event_loop_notification_channel();
+        let (ops_ch_channel, mut ch_channel, wait_for_event) =
+            crate::contract::contract_handler_channel();
+        let connection_manager = crate::ring::ConnectionManager::new(&node_config);
+        let (result_router_tx, result_router_rx) = tokio::sync::mpsc::channel(100);
+        let task_monitor = crate::node::background_task_monitor::BackgroundTaskMonitor::new();
+        let op_manager = Arc::new(
+            OpManager::new(
+                notification_tx,
+                ops_ch_channel,
+                &node_config,
+                crate::tracing::DynamicRegister::new(vec![]),
+                connection_manager,
+                result_router_tx,
+                &task_monitor,
+            )
+            .expect("build OpManager"),
+        );
+        op_manager.ring.attach_op_manager(&op_manager);
+        let self_addr: SocketAddr = "127.0.0.1:12000".parse().unwrap();
+        op_manager.ring.connection_manager.set_own_addr(self_addr);
+
+        let update_query_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let counter = update_query_count.clone();
+        let handler = tokio::spawn(async move {
+            while let Ok((id, ev, _priority)) = ch_channel.recv_from_sender().await {
+                let response = match ev {
+                    ContractHandlerEvent::GetQuery { .. } => ContractHandlerEvent::GetResponse {
+                        key: None,
+                        response: Ok(StoreResponse {
+                            state: None,
+                            contract: None,
+                        }),
+                    },
+                    ContractHandlerEvent::GetSummaryQuery { key } => {
+                        ContractHandlerEvent::GetSummaryResponse {
+                            key,
+                            summary: Ok(StateSummary::from(Vec::new())),
+                        }
+                    }
+                    ContractHandlerEvent::UpdateQuery { key, data, .. } => {
+                        counter.fetch_add(1, Ordering::Relaxed);
+                        let is_delta = matches!(
+                            &data,
+                            UpdateData::Delta(_) | UpdateData::RelatedDelta { .. }
+                        );
+                        if is_delta {
+                            ContractHandlerEvent::UpdateResponse {
+                                new_value: Err(exec_reject_err(key)),
+                                state_changed: false,
+                            }
+                        } else {
+                            ContractHandlerEvent::UpdateResponse {
+                                new_value: Ok(WrappedState::from(vec![1u8, 2, 3])),
+                                state_changed: true,
+                            }
+                        }
+                    }
+                    other => {
+                        panic!("unexpected handler event in exec-reject stand-in: {other:?}")
+                    }
+                };
+                if ch_channel.send_to_sender(id, response).await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        let guard: Box<dyn std::any::Any> =
+            Box::new((handler, result_router_rx, task_monitor, wait_for_event));
+        (op_manager, notification_rx, update_query_count, guard)
+    }
+
+    /// #4864 review (testing H1): the load-bearing #4861 behavior — the backoff
+    /// PREVENTS executor invocation in the REAL driver. After the (N=3) Invalid
+    /// threshold trips, the next broadcast's merge is SKIPPED: no additional
+    /// `UpdateQuery` reaches the handler, the suppression metric is bumped, and
+    /// no `ResyncRequest` is emitted while suppressed.
+    #[tokio::test]
+    async fn backoff_gate_skips_merge_after_invalid_threshold_trips() {
+        use std::sync::atomic::Ordering;
+        crate::config::GlobalTestMetrics::reset();
+        let (op_manager, mut notification_rx, update_queries, _guard) =
+            build_exec_reject_test_node("backoff-gate-4864").await;
+        let key = ContractKey::from_id_and_code(
+            ContractInstanceId::new([21u8; 32]),
+            CodeHash::new([22u8; 32]),
+        );
+        let sender: SocketAddr = "127.0.0.1:12200".parse().unwrap();
+
+        // Three consecutive delta failures (distinct bytes so none is a dedup
+        // hit) trip the Invalid threshold; each runs the merge → 1 UpdateQuery.
+        for bytes in [vec![1u8], vec![2u8], vec![3u8]] {
+            let r = drive_relay_broadcast_to(
+                &op_manager,
+                Transaction::new::<UpdateMsg>(),
+                key,
+                DeltaOrFullState::Delta(bytes),
+                Vec::new(),
+                sender,
+            )
+            .await;
+            assert!(r.is_err(), "each poison delta must fail the merge");
+            let _ = drain_resync_targets(&mut notification_rx, key); // failure path may emit
+        }
+        assert_eq!(
+            update_queries.load(Ordering::Relaxed),
+            3,
+            "3 failing merges reached the executor"
+        );
+        let suppressed_before = crate::config::GlobalTestMetrics::merges_suppressed_by_backoff();
+
+        // The 4th broadcast: the backoff has tripped → the merge is SKIPPED.
+        let r4 = drive_relay_broadcast_to(
+            &op_manager,
+            Transaction::new::<UpdateMsg>(),
+            key,
+            DeltaOrFullState::Delta(vec![4u8]),
+            Vec::new(),
+            sender,
+        )
+        .await;
+        assert!(
+            r4.is_ok(),
+            "a suppressed broadcast completes Ok (like a dedup skip)"
+        );
+        assert_eq!(
+            update_queries.load(Ordering::Relaxed),
+            3,
+            "the suppressed merge MUST NOT reach the executor (no 4th UpdateQuery)"
+        );
+        assert!(
+            crate::config::GlobalTestMetrics::merges_suppressed_by_backoff() > suppressed_before,
+            "the suppressed merge MUST bump merges_suppressed_by_backoff"
+        );
+        assert!(
+            drain_resync_targets(&mut notification_rx, key).is_empty(),
+            "no ResyncRequest may be emitted while the merge is suppressed"
+        );
+    }
+
+    /// #4864 review (testing #2): a full-state success does NOT reset the backoff
+    /// (strictly delta-only). Two delta failures + a full-state success leave the
+    /// consecutive count intact, so a 3rd delta failure still trips (proving no
+    /// reset) and the following delta is suppressed.
+    #[tokio::test]
+    async fn full_state_success_does_not_reset_backoff() {
+        use std::sync::atomic::Ordering;
+        crate::config::GlobalTestMetrics::reset();
+        let (op_manager, mut notification_rx, update_queries, _guard) =
+            build_exec_reject_test_node("backoff-fullstate-noreset-4864").await;
+        let key = ContractKey::from_id_and_code(
+            ContractInstanceId::new([31u8; 32]),
+            CodeHash::new([32u8; 32]),
+        );
+        let sender: SocketAddr = "127.0.0.1:12300".parse().unwrap();
+
+        // Two delta failures (count = 2, below the trip threshold).
+        for bytes in [vec![1u8], vec![2u8]] {
+            let _ = drive_relay_broadcast_to(
+                &op_manager,
+                Transaction::new::<UpdateMsg>(),
+                key,
+                DeltaOrFullState::Delta(bytes),
+                Vec::new(),
+                sender,
+            )
+            .await;
+            let _ = drain_resync_targets(&mut notification_rx, key);
+        }
+        // A full-state broadcast SUCCEEDS via the stand-in — but must NOT reset
+        // the consecutive count (strictly delta-only reset).
+        let ok = drive_relay_broadcast_to(
+            &op_manager,
+            Transaction::new::<UpdateMsg>(),
+            key,
+            DeltaOrFullState::FullState(vec![9, 9, 9]),
+            Vec::new(),
+            sender,
+        )
+        .await;
+        assert!(
+            ok.is_ok(),
+            "full-state merge should succeed via the stand-in"
+        );
+        let _ = drain_resync_targets(&mut notification_rx, key);
+
+        // A 3rd delta failure now trips (count 2 → 3), proving the success did
+        // NOT reset it to 0 (else the count would only reach 1 here).
+        let _ = drive_relay_broadcast_to(
+            &op_manager,
+            Transaction::new::<UpdateMsg>(),
+            key,
+            DeltaOrFullState::Delta(vec![3u8]),
+            Vec::new(),
+            sender,
+        )
+        .await;
+        let _ = drain_resync_targets(&mut notification_rx, key);
+        let queries_after_trip = update_queries.load(Ordering::Relaxed);
+
+        // The following delta is SUPPRESSED (merge skipped) — the backoff tripped
+        // across the full-state success, so the count was never reset.
+        let r = drive_relay_broadcast_to(
+            &op_manager,
+            Transaction::new::<UpdateMsg>(),
+            key,
+            DeltaOrFullState::Delta(vec![4u8]),
+            Vec::new(),
+            sender,
+        )
+        .await;
+        assert!(r.is_ok());
+        assert_eq!(
+            update_queries.load(Ordering::Relaxed),
+            queries_after_trip,
+            "the backoff tripped across the full-state success (no reset) — the \
+             following delta merge is skipped"
         );
     }
 

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -4111,6 +4111,90 @@ mod tests {
         );
     }
 
+    /// #4864 round-4 addendum (CI rule-review): the client-path mirror of
+    /// `full_state_success_does_not_reset_backoff`. A successful client-local
+    /// FULL-STATE update (`is_delta_update == false`) driven through the REAL
+    /// `drive_client_update` must NOT reset the backoff — `record_success_local`
+    /// is gated `is_delta_update`, and a full-state apply is fork-flippable so it
+    /// proves nothing about convergence. Closes the bot warning that the
+    /// delta-only gating was source-scrape-only. (With round-4 item 1 the
+    /// contract-side clear also needs `changed`, but the `is_delta` gate fires
+    /// first, so this holds regardless of `changed`.)
+    #[tokio::test]
+    async fn client_local_full_state_success_does_not_reset_backoff() {
+        let (op_manager, _notification_rx, _update_queries, _guard) =
+            build_broadcast_test_node("backoff-client-fullstate-4864", DeltaOutcome::Success).await;
+        let key = ContractKey::from_id_and_code(
+            ContractInstanceId::new([63u8; 32]),
+            CodeHash::new([64u8; 32]),
+        );
+        op_manager
+            .ring
+            .host_contract(key, 100, crate::ring::AccessType::Put);
+
+        let remote_sender: SocketAddr = "127.0.0.1:15100".parse().unwrap();
+        let probe_sender: SocketAddr = "127.0.0.1:15200".parse().unwrap();
+
+        // Seed a contract-wide Timeout + a remote sender's tripped Invalid channel.
+        op_manager.ring.merge_backoff.record_failure(
+            key.id(),
+            remote_sender,
+            crate::ring::merge_backoff::MergeFailureClass::Timeout,
+            0x01,
+        );
+        for h in [0x11u64, 0x12, 0x13] {
+            op_manager.ring.merge_backoff.record_failure(
+                key.id(),
+                remote_sender,
+                crate::ring::merge_backoff::MergeFailureClass::Invalid,
+                h,
+            );
+        }
+        assert_eq!(
+            op_manager
+                .ring
+                .merge_backoff
+                .check(key.id(), probe_sender, 0x99),
+            crate::ring::merge_backoff::MergeDecision::InBackoff,
+            "seeded contract-wide Timeout should suppress before the client update"
+        );
+
+        // Drive a successful client-local FULL-STATE update (is_delta_update=false).
+        let outcome = drive_client_update(
+            &op_manager,
+            Transaction::new::<UpdateMsg>(),
+            key,
+            UpdateData::State(State::from(vec![9u8, 9, 9])),
+            RelatedContracts::default(),
+        )
+        .await;
+        assert!(
+            outcome.is_ok(),
+            "client-local full-state update should succeed via the stand-in: {outcome:?}"
+        );
+
+        // The backoff is NOT reset: the contract-wide Timeout still suppresses the
+        // probe (a full-state apply is not convergence evidence, delta-only reset).
+        assert_eq!(
+            op_manager
+                .ring
+                .merge_backoff
+                .check(key.id(), probe_sender, 0x99),
+            crate::ring::merge_backoff::MergeDecision::InBackoff,
+            "a client FULL-STATE success must NOT clear the contract-wide Timeout \
+             (record_success_local is gated is_delta_update)"
+        );
+        // ... and the remote sender's Invalid channel is likewise untouched.
+        assert_eq!(
+            op_manager
+                .ring
+                .merge_backoff
+                .check(key.id(), remote_sender, 0x99),
+            crate::ring::merge_backoff::MergeDecision::InBackoff,
+            "a client FULL-STATE success must NOT clear a remote sender's Invalid channel"
+        );
+    }
+
     /// Issue #4251 follow-up: the four `run_relay_*` driver wrappers each
     /// log at WARN when the inner driver returns an error. PR #4253 gated
     /// the amplification side effects (auto-fetch, ResyncRequest) on

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -1099,7 +1099,7 @@ async fn drive_relay_request_update(
 /// Issue #4251 suppressed this entirely because one request per dropped delta
 /// amplifies into a full-state storm onto the same saturated queue (~40
 /// ResyncRequests/sec on a hot contract). The rate limit
-/// (`InterestManager::should_send_resync_request`) bounds that to at most one
+/// (`InterestManager::begin_resync_request`) bounds that to at most one
 /// request per (contract, sender) per `RESYNC_REQUEST_MIN_INTERVAL`.
 ///
 /// Shared by both broadcast drivers (`drive_relay_broadcast_to` and
@@ -1114,15 +1114,17 @@ async fn send_queue_full_resync_request(
     sender_addr: SocketAddr,
     incoming_tx: Transaction,
 ) {
-    // PEEK the per-(contract, sender)/30s throttle WITHOUT recording (#4864
-    // round-5 item 9). This heal is double-gated (this per-sender throttle AND the
-    // global emit cap below); recording the window here and then being suppressed
-    // by the global cap would burn the 30s window with no emit, blocking this
-    // (contract, sender) from retrying for up to 30s after the global cap's tokens
-    // refill. The window is recorded ONLY when the emit actually happens (below).
+    // RESERVE the per-(contract, sender)/30s throttle window atomically (#4864
+    // round-6 item 2). `begin` checks AND records under the throttle's own lock,
+    // so two concurrent queue-full callbacks for the same (contract, sender)
+    // cannot both pass this gate and go on to both consume the global burst +
+    // emit duplicates inside the window. If the global cap then rejects, we
+    // `cancel` the reservation below (releasing the window) — preserving the
+    // round-5 improvement that a globally-suppressed emit does not burn the 30s
+    // window.
     if !op_manager
         .interest_manager
-        .peek_should_send_resync_request(&key, sender_addr)
+        .begin_resync_request(&key, sender_addr)
     {
         // Per-(contract, sender)/30s throttle (existing #4857 bound).
         tracing::debug!(
@@ -1142,13 +1144,16 @@ async fn send_queue_full_resync_request(
     // emission. (This is NOT a mirror of the delta-failure path — that path is
     // global-cap-only, with no per-sender throttle. The global suppression records
     // the same `record_resync_request_suppressed` metric node.rs does.) On
-    // suppression, the per-sender window is NOT recorded (see the peek above), so
+    // suppression, CANCEL the reservation so the per-sender window is released and
     // the sender retries as soon as global tokens refill.
     if !op_manager
         .ring
         .resync_emit_limiter
         .check_and_record(*key.id())
     {
+        op_manager
+            .interest_manager
+            .cancel_resync_request(&key, sender_addr);
         crate::config::GlobalTestMetrics::record_resync_request_suppressed();
         tracing::debug!(
             tx = %incoming_tx,
@@ -1160,10 +1165,7 @@ async fn send_queue_full_resync_request(
         return;
     }
 
-    // Both gates passed → NOW record the per-sender throttle window and emit.
-    op_manager
-        .interest_manager
-        .record_resync_request_sent(&key, sender_addr);
+    // Both gates passed → the reservation stands (already recorded by `begin`).
     tracing::info!(
         tx = %incoming_tx,
         contract = %key,
@@ -3116,7 +3118,7 @@ mod tests {
     /// emit it unthrottled (full-state storm, #4251). Both route through the
     /// shared `send_queue_full_resync_request` helper, which gates the
     /// `InterestMessage::ResyncRequest` emit behind BOTH the per-(contract, sender)
-    /// `should_send_resync_request` throttle AND the global per-contract
+    /// `begin_resync_request` throttle AND the global per-contract
     /// `resync_emit_limiter` cap (each a `!gate { return; }` guard before the
     /// emit). Auto-fetch stays suppressed on each driver's queue-full arm.
     #[test]
@@ -3192,12 +3194,14 @@ mod tests {
         // sender) throttle AND the global per-contract emit cap (#4251/#4857 +
         // #4864 round-4). Each is a `!gate { return; }` guard that precedes the
         // emit, so an unthrottled emission cannot re-open the #4251 storm. The
-        // per-sender throttle is PEEKED (not recorded) until the emit, and its
-        // window is recorded ONLY at the emit (#4864 round-5 item 9), so a
-        // global-cap suppression does not burn the window.
+        // per-sender throttle is RESERVED atomically (`begin`, records under the
+        // lock) then RELEASED (`cancel`) if the global cap rejects (#4864 round-6
+        // item 2), so concurrent callbacks can't both pass and a globally
+        // suppressed emit does not burn the window.
         let helper = fn_body("async fn send_queue_full_resync_request(");
-        let per_sender = helper.find(".peek_should_send_resync_request(").expect(
-            "helper must PEEK the per-sender throttle without recording (#4864 round-5 item 9)",
+        let per_sender = helper.find(".begin_resync_request(").expect(
+            "helper must RESERVE the per-sender throttle atomically via \
+             begin_resync_request (#4864 round-6 item 2)",
         );
         let global_cap = helper.find("resync_emit_limiter").expect(
             "helper must ALSO gate on the global per-contract emit cap \
@@ -3206,20 +3210,21 @@ mod tests {
         let emit = helper
             .find("InterestMessage::ResyncRequest")
             .expect("helper must emit InterestMessage::ResyncRequest (heal, #4857)");
-        let record = helper.find(".record_resync_request_sent(").expect(
-            "helper must record the per-sender throttle window (only on emit, #4864 round-5)",
+        let cancel = helper.find(".cancel_resync_request(").expect(
+            "helper must CANCEL the reservation when the global cap rejects, so the \
+             window is released (#4864 round-6 item 2)",
         );
         assert!(
             per_sender < emit && global_cap < emit,
             "the ResyncRequest emit ({emit}) MUST come AFTER both the per-sender \
-             throttle peek ({per_sender}) and the global emit cap ({global_cap}), so \
-             an unthrottled emission cannot re-open the #4251 storm"
+             throttle reservation ({per_sender}) and the global emit cap ({global_cap}), \
+             so an unthrottled emission cannot re-open the #4251 storm"
         );
         assert!(
-            global_cap < record && record < emit,
-            "the per-sender window record ({record}) MUST come AFTER the global cap \
-             ({global_cap}) and before/at the emit ({emit}) — recording earlier \
-             would burn the 30s window on a global-cap suppression (#4864 round-5 item 9)"
+            per_sender < global_cap && global_cap < cancel && cancel < emit,
+            "the cancel ({cancel}) MUST be in the global-cap reject branch — after the \
+             reservation ({per_sender}) and the global cap ({global_cap}), before the \
+             emit ({emit}) — so a global-cap suppression releases the window (#4864 round-6)"
         );
     }
 
@@ -3970,7 +3975,7 @@ mod tests {
              per-contract emit cap (resync_emit_limiter) (#4864 round-4)"
         );
         assert!(
-            body.contains("should_send_resync_request"),
+            body.contains("begin_resync_request"),
             "and keep the per-(contract, sender) throttle"
         );
     }

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -1360,7 +1360,12 @@ async fn drive_relay_broadcast_to(
             // excludes queue-full (transient load) and missing-contract failures
             // (healed by the auto-fetch below) — backing either off would be
             // wrong. A timeout gets the longer Timeout-class cooldown.
-            if err.is_contract_exec_rejection() {
+            //
+            // #4864 round-6: a SCHEDULER timeout (guest never ran, blocking-pool
+            // saturation) IS an exec rejection by cause-prefix, but the guest
+            // never executed the delta, so it must NOT be quarantined — exclude
+            // it here exactly like queue-full.
+            if err.is_contract_exec_rejection() && !err.is_scheduler_timeout() {
                 let class = if err.is_wasm_timeout() {
                     crate::ring::merge_backoff::MergeFailureClass::Timeout
                 } else {
@@ -1399,7 +1404,13 @@ async fn drive_relay_broadcast_to(
             // sender to resend full state onto the same saturated queue, and
             // auto-fetch enqueues a GET right back onto it. Skip both; still
             // surface the error to the caller for telemetry.
-            let queue_full = err.is_contract_queue_full();
+            //
+            // #4864 round-6: a scheduler timeout (guest never ran, blocking-pool
+            // saturation) is the SAME transient/load class — the delta was never
+            // applied and we still hold the contract — so it takes the identical
+            // heal path (resync, no auto-fetch). Keep the name `queue_full` so
+            // the downstream branch logic is untouched.
+            let queue_full = err.is_contract_queue_full() || err.is_scheduler_timeout();
 
             if is_delta && !queue_full {
                 // Delta application failed → send ResyncRequest. Mirrors
@@ -2198,8 +2209,10 @@ async fn apply_streaming_broadcast(
         Err(err) => {
             // Record poison-contract merge failures for the backoff (#4861),
             // same classification as the non-streaming driver: only genuine
-            // contract-exec rejections, timeout → longer cooldown.
-            if err.is_contract_exec_rejection() {
+            // contract-exec rejections, timeout → longer cooldown. #4864 round-6:
+            // exclude a scheduler timeout (guest never ran) just like the
+            // non-streaming driver — it must not quarantine the contract.
+            if err.is_contract_exec_rejection() && !err.is_scheduler_timeout() {
                 let class = if err.is_wasm_timeout() {
                     crate::ring::merge_backoff::MergeFailureClass::Timeout
                 } else {
@@ -2212,6 +2225,14 @@ async fn apply_streaming_broadcast(
                     stream_payload_hash,
                 );
             }
+
+            // #4864 round-6: a scheduler timeout (guest never ran, blocking-pool
+            // saturation) is the SAME transient/load class as queue-full — heal
+            // via ResyncRequest, no auto-fetch (we still hold the contract).
+            // `log_broadcast_to_streaming_failure` already returns false for it
+            // (it is an exec rejection), so the auto-fetch branch stays
+            // suppressed; keep the name `queue_full` so the heal arm is untouched.
+            let queue_full = err.is_contract_queue_full() || err.is_scheduler_timeout();
 
             // Classify failure: real failure → self-heal via
             // try_auto_fetch_contract; benign stale-version rejection →
@@ -2237,7 +2258,7 @@ async fn apply_streaming_broadcast(
                     )
                     .await;
                 });
-            } else if err.is_contract_queue_full() {
+            } else if queue_full {
                 // Issue #4857 on the STREAMING full-state path: identical
                 // poisoning to the non-streaming driver. A delivered streaming
                 // full-state broadcast caches the peer summary
@@ -2742,15 +2763,30 @@ mod tests {
         let record_pos = driver_src
             .find(".record_failure(")
             .expect("merge_backoff.record_failure missing in BroadcastTo driver");
-        // The record_failure must be inside an is_contract_exec_rejection guard.
+        // The record_failure must be inside an is_contract_exec_rejection guard
+        // that ALSO excludes scheduler timeouts (#4864 round-6): a scheduler
+        // timeout is an exec rejection by cause-prefix but the guest never ran,
+        // so it must not create a backoff entry.
         let guard_pos = driver_src
-            .find("if err.is_contract_exec_rejection() {")
-            .expect("record_failure must be gated on is_contract_exec_rejection");
+            .find("if err.is_contract_exec_rejection() && !err.is_scheduler_timeout() {")
+            .expect(
+                "record_failure must be gated on \
+                 is_contract_exec_rejection() && !err.is_scheduler_timeout()",
+            );
         assert!(
             guard_pos < record_pos,
             "merge_backoff.record_failure MUST be gated on \
              is_contract_exec_rejection() so queue-full and missing-contract \
              failures do NOT create a backoff entry (#4861)"
+        );
+        // #4864 round-6: the same guard must exclude a scheduler timeout via
+        // !err.is_scheduler_timeout() — the guest-never-ran case takes the
+        // transient (queue-full-style) path, never the contract quarantine.
+        assert!(
+            driver_src.contains("!err.is_scheduler_timeout()"),
+            "the record gate MUST exclude scheduler timeouts via \
+             !err.is_scheduler_timeout() (#4864 round-6): a queued-never-ran \
+             merge must not quarantine the contract"
         );
         assert!(
             driver_src.contains("is_wasm_timeout()"),
@@ -3149,10 +3185,16 @@ mod tests {
         };
 
         // Non-streaming driver delegates to the helper and does NOT auto-fetch.
+        // #4864 round-6: the `queue_full` local now also folds in a scheduler
+        // timeout (transient load, same heal path), so the classification is
+        // `is_contract_queue_full() || is_scheduler_timeout()`.
         let ns = fn_body("async fn drive_relay_broadcast_to(");
         assert!(
-            ns.contains("let queue_full = err.is_contract_queue_full();"),
-            "drive_relay_broadcast_to must still classify queue-full (#4251)"
+            ns.contains(
+                "let queue_full = err.is_contract_queue_full() || err.is_scheduler_timeout();"
+            ),
+            "drive_relay_broadcast_to must still classify queue-full and fold in \
+             scheduler timeouts (#4251, #4864 round-6)"
         );
         let ns_arm = queue_full_arm(ns, "} else if queue_full {");
         assert!(
@@ -3177,8 +3219,17 @@ mod tests {
              apply_streaming_broadcast — otherwise the streaming apply/heal logic \
              is unreachable"
         );
+        // #4864 round-6: the streaming heal arm is now gated on the same
+        // `queue_full` local (queue-full OR scheduler timeout).
         let st = fn_body("async fn apply_streaming_broadcast(");
-        let st_arm = queue_full_arm(st, "} else if err.is_contract_queue_full() {");
+        assert!(
+            st.contains(
+                "let queue_full = err.is_contract_queue_full() || err.is_scheduler_timeout();"
+            ),
+            "apply_streaming_broadcast must classify queue-full and fold in \
+             scheduler timeouts (#4251, #4864 round-6)"
+        );
+        let st_arm = queue_full_arm(st, "} else if queue_full {");
         assert!(
             st_arm.contains("send_queue_full_resync_request("),
             "apply_streaming_broadcast queue-full arm MUST delegate to \

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -237,6 +237,14 @@ pub(crate) struct Ring {
     /// full-state responses/day for one forked contract. Checked AFTER the
     /// per-peer limit. See `crate::ring::resync_rate_limit`.
     pub(crate) resync_response_global_limiter: Arc<resync_rate_limit::ResyncResponseGlobalLimiter>,
+    /// Correlation map for outstanding `ResyncRequest`s WE emitted (#4864
+    /// round-8, Codex P1). The `ResyncResponse` apply path runs a full-state WASM
+    /// merge that is deliberately NOT backoff-gated, so without correlation it is
+    /// an unmetered DoS surface — a peer could stream/replay unsolicited responses
+    /// bypassing every emitter-side gate. The receive arm require-and-consumes a
+    /// matching `(contract, source)` entry BEFORE applying; consume-on-first-match
+    /// kills replay. See `crate::ring::resync_rate_limit::OutstandingResyncRequests`.
+    pub(crate) outstanding_resync_requests: Arc<resync_rate_limit::OutstandingResyncRequests>,
     /// Per-contract ban list. Populated by the governance reaper on
     /// `BanTriggered` / `BanLifted` transitions; consulted at the
     /// inbound dispatch site to drop wire requests for banned
@@ -633,6 +641,9 @@ impl Ring {
             )),
             resync_response_global_limiter: Arc::new(
                 resync_rate_limit::new_response_global_limiter(time_source.clone()),
+            ),
+            outstanding_resync_requests: Arc::new(
+                resync_rate_limit::new_outstanding_resync_requests(time_source.clone()),
             ),
             contract_ban_list: Arc::new(contract_ban_list::ContractBanList::new(
                 time_source.clone(),
@@ -1315,6 +1326,11 @@ impl Ring {
             ring.resync_emit_limiter.cleanup();
             ring.resync_response_limiter.cleanup();
             ring.resync_response_global_limiter.cleanup();
+
+            // Reap outstanding-ResyncRequest correlation entries past their TTL
+            // (#4864 round-8) so a burst of requests whose responses never arrive
+            // cannot pin the map past OUTSTANDING_RESYNC_TTL.
+            ring.outstanding_resync_requests.cleanup();
 
             // Phase 7 ban-list maintenance. Defense-in-depth — the
             // BanLifted decisions below explicitly unban, but if any

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -231,6 +231,12 @@ pub(crate) struct Ring {
     /// unlimited `ResyncRequest`s cannot make an upgraded peer full-state-reply
     /// in a loop. See `crate::ring::resync_rate_limit`.
     pub(crate) resync_response_limiter: Arc<resync_rate_limit::ResyncResponseLimiter>,
+    /// GLOBAL per-contract cap on `ResyncResponse` emission, aggregated across
+    /// ALL requesters (#4861). Per-(peer, contract) limiting alone is
+    /// insufficient — production saw ~45 distinct requester IPs drive ~9,733
+    /// full-state responses/day for one forked contract. Checked AFTER the
+    /// per-peer limit. See `crate::ring::resync_rate_limit`.
+    pub(crate) resync_response_global_limiter: Arc<resync_rate_limit::ResyncResponseGlobalLimiter>,
     /// Per-contract ban list. Populated by the governance reaper on
     /// `BanTriggered` / `BanLifted` transitions; consulted at the
     /// inbound dispatch site to drop wire requests for banned
@@ -625,6 +631,9 @@ impl Ring {
             resync_response_limiter: Arc::new(resync_rate_limit::new_response_limiter(
                 time_source.clone(),
             )),
+            resync_response_global_limiter: Arc::new(
+                resync_rate_limit::new_response_global_limiter(time_source.clone()),
+            ),
             contract_ban_list: Arc::new(contract_ban_list::ContractBanList::new(
                 time_source.clone(),
             )),
@@ -1305,6 +1314,7 @@ impl Ring {
             // bounded.
             ring.resync_emit_limiter.cleanup();
             ring.resync_response_limiter.cleanup();
+            ring.resync_response_global_limiter.cleanup();
 
             // Phase 7 ban-list maintenance. Defense-in-depth — the
             // BanLifted decisions below explicitly unban, but if any

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -127,13 +127,13 @@ pub(crate) use hosting::{MAX_DEFAULT_HOSTING_BUDGET_BYTES, MIN_DEFAULT_HOSTING_B
 pub mod interest;
 mod live_tx;
 mod location;
+pub(crate) mod merge_backoff;
 pub(crate) mod peer_cache;
 mod peer_connection_backoff;
 mod peer_key_location;
 mod placement_migration_metrics;
-pub mod topology_registry;
-pub(crate) mod merge_backoff;
 pub(crate) mod resync_rate_limit;
+pub mod topology_registry;
 pub(crate) mod update_rate_limit;
 
 // GET auto-subscribe (`AUTO_SUBSCRIBE_ON_GET`) was REMOVED in piece E of the

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -133,6 +133,7 @@ mod peer_key_location;
 mod placement_migration_metrics;
 pub mod topology_registry;
 pub(crate) mod merge_backoff;
+pub(crate) mod resync_rate_limit;
 pub(crate) mod update_rate_limit;
 
 // GET auto-subscribe (`AUTO_SUBSCRIBE_ON_GET`) was REMOVED in piece E of the
@@ -220,6 +221,16 @@ pub(crate) struct Ring {
     /// inbound broadcast instead of O(WASM merge). Cleared the instant a merge
     /// succeeds. See `crate::ring::merge_backoff`.
     pub(crate) merge_backoff: Arc<merge_backoff::MergeBackoff>,
+    /// Per-contract cap on how often THIS node emits a `ResyncRequest` (#4861).
+    /// Bounds the full-state resync amplification independently of the merge
+    /// outcome. See `crate::ring::resync_rate_limit`.
+    pub(crate) resync_emit_limiter: Arc<resync_rate_limit::ResyncEmitLimiter>,
+    /// Per-`(peer, contract)` cap on how often this node answers a given peer's
+    /// `ResyncRequest` with a full-state `ResyncResponse` (#4861). The
+    /// mixed-version-rollout guard: a not-yet-upgraded peer that still emits
+    /// unlimited `ResyncRequest`s cannot make an upgraded peer full-state-reply
+    /// in a loop. See `crate::ring::resync_rate_limit`.
+    pub(crate) resync_response_limiter: Arc<resync_rate_limit::ResyncResponseLimiter>,
     /// Per-contract ban list. Populated by the governance reaper on
     /// `BanTriggered` / `BanLifted` transitions; consulted at the
     /// inbound dispatch site to drop wire requests for banned
@@ -610,6 +621,10 @@ impl Ring {
                 time_source.clone(),
             )),
             merge_backoff: Arc::new(merge_backoff::MergeBackoff::new(time_source.clone())),
+            resync_emit_limiter: Arc::new(resync_rate_limit::new_emit_limiter(time_source.clone())),
+            resync_response_limiter: Arc::new(resync_rate_limit::new_response_limiter(
+                time_source.clone(),
+            )),
             contract_ban_list: Arc::new(contract_ban_list::ContractBanList::new(
                 time_source.clone(),
             )),
@@ -1284,6 +1299,12 @@ impl Ring {
             // haven't failed a merge recently; a poison contract still in
             // cooldown is preserved.
             ring.merge_backoff.cleanup_expired();
+
+            // Sweep recovered/idle resync rate-limiter buckets (#4861) so the
+            // per-contract emit and per-(peer, contract) responder maps stay
+            // bounded.
+            ring.resync_emit_limiter.cleanup();
+            ring.resync_response_limiter.cleanup();
 
             // Phase 7 ban-list maintenance. Defense-in-depth — the
             // BanLifted decisions below explicitly unban, but if any

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -132,6 +132,7 @@ mod peer_connection_backoff;
 mod peer_key_location;
 mod placement_migration_metrics;
 pub mod topology_registry;
+pub(crate) mod merge_backoff;
 pub(crate) mod update_rate_limit;
 
 // GET auto-subscribe (`AUTO_SUBSCRIBE_ON_GET`) was REMOVED in piece E of the
@@ -212,6 +213,13 @@ pub(crate) struct Ring {
     /// `crate::ring::update_rate_limit` and `docs/design/contract-hardening.md`
     /// Phase 2.
     pub(crate) update_rate_limiter: Arc<update_rate_limit::UpdateRateLimiter>,
+    /// Per-contract merge-failure backoff (#4861). Quarantines "poison"
+    /// contracts whose WASM merges reliably fail/time out: while a contract is
+    /// in its exponential cooldown the UPDATE broadcast drivers skip the merge
+    /// (and its `ResyncRequest` amplification) entirely, so it costs O(1) per
+    /// inbound broadcast instead of O(WASM merge). Cleared the instant a merge
+    /// succeeds. See `crate::ring::merge_backoff`.
+    pub(crate) merge_backoff: Arc<merge_backoff::MergeBackoff>,
     /// Per-contract ban list. Populated by the governance reaper on
     /// `BanTriggered` / `BanLifted` transitions; consulted at the
     /// inbound dispatch site to drop wire requests for banned
@@ -601,6 +609,7 @@ impl Ring {
             update_rate_limiter: Arc::new(update_rate_limit::UpdateRateLimiter::new(
                 time_source.clone(),
             )),
+            merge_backoff: Arc::new(merge_backoff::MergeBackoff::new(time_source.clone())),
             contract_ban_list: Arc::new(contract_ban_list::ContractBanList::new(
                 time_source.clone(),
             )),
@@ -1269,6 +1278,12 @@ impl Ring {
             // bounded; CLEANUP_AGE is 5 minutes so this drops entries
             // for pairs that haven't tried an UPDATE since then.
             ring.update_rate_limiter.cleanup();
+
+            // Sweep idle merge-failure backoff entries (#4861) on the same
+            // cadence. Drops entries for contracts past their cooldown that
+            // haven't failed a merge recently; a poison contract still in
+            // cooldown is preserved.
+            ring.merge_backoff.cleanup_expired();
 
             // Phase 7 ban-list maintenance. Defense-in-depth — the
             // BanLifted decisions below explicitly unban, but if any

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -3530,6 +3530,16 @@ impl Ring {
         self.hosting_manager.contract_state_present(contract)
     }
 
+    /// Async existence probe (redb sync fast-path + real SQLite EXISTS probe) —
+    /// see [`hosting::HostingManager::contract_state_present_async`]. Used by the
+    /// ResyncResponse responder so the pre-limiter existence gate is backend-
+    /// agnostic (#4864 round-5 P1).
+    pub(crate) async fn contract_state_present_async(&self, contract: &ContractKey) -> bool {
+        self.hosting_manager
+            .contract_state_present_async(contract)
+            .await
+    }
+
     /// Whether at least one LOCAL WebSocket client is currently subscribed to
     /// `contract` (real local demand, distinct from downstream peer
     /// subscribers). Used by the reconcile input-builder (keystone step-2,

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -2178,6 +2178,49 @@ impl HostingManager {
         true
     }
 
+    /// Async existence probe for the ResyncResponse responder (#4864 round-5 P1).
+    /// The sync [`Self::contract_state_present`] only has a redb fast-path, so on
+    /// a SQLite build (`--no-default-features --features sqlite`) it returns
+    /// `true` for every key — reopening the responder limiter-map key-flood hole
+    /// there. This async variant keeps the redb SYNC fast-path (a cheap point
+    /// lookup, no `.await`) and adds a REAL SQLite existence probe via the async
+    /// `get_state_size` (`SELECT LENGTH(state) … WHERE contract = ?`), so a bogus
+    /// key is rejected before it can consume a limiter slot on EITHER backend.
+    /// Conservative on error / no-storage: returns `true` (assume present) so a
+    /// genuinely-hosted contract is never wrongly refused a resync response.
+    pub(crate) async fn contract_state_present_async(&self, key: &ContractKey) -> bool {
+        #[cfg(feature = "redb")]
+        {
+            // redb: the synchronous point lookup is already cheap — no await.
+            self.contract_state_present(key)
+        }
+        #[cfg(all(feature = "sqlite", not(feature = "redb")))]
+        {
+            // Clone the pool handle out of the (sync parking_lot) guard so the
+            // `.await` below never holds a lock across an await point.
+            let storage = self.storage.read().as_ref().cloned();
+            match storage {
+                Some(storage) => match storage.get_state_size(key).await {
+                    Ok(size) => size.is_some(),
+                    Err(e) => {
+                        tracing::debug!(
+                            contract = %key,
+                            error = %e,
+                            "sqlite state-presence check failed; assuming present"
+                        );
+                        true
+                    }
+                },
+                None => true,
+            }
+        }
+        #[cfg(not(any(feature = "redb", feature = "sqlite")))]
+        {
+            let _ = key;
+            true
+        }
+    }
+
     /// The composed #4610 gate: summarize / broadcast a contract's state ONLY
     /// when we host or actively serve it AND we actually hold its state:
     /// `(is_hosting_contract || contract_in_use) && contract_state_present`.

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -620,6 +620,43 @@ impl<T: TimeSource + Sync> InterestManager<T> {
         true
     }
 
+    /// PEEK the per-(contract, target) resync-request throttle WITHOUT recording a
+    /// send: returns true when a send would be ALLOWED (the
+    /// [`RESYNC_REQUEST_MIN_INTERVAL`] window has elapsed, or none was ever sent).
+    ///
+    /// Pair with [`Self::record_resync_request_sent`], which starts the window
+    /// ONLY once the send actually happens (#4864 round-5 item 9). The queue-full
+    /// heal is double-gated (this per-sender throttle AND the global per-contract
+    /// emit cap); the combined check-AND-record `should_send_resync_request` would
+    /// burn the 30s window for a send the global cap then suppressed, blocking
+    /// this (contract, target) from retrying for up to 30s after the global cap's
+    /// tokens refill.
+    pub fn peek_should_send_resync_request(
+        &self,
+        contract: &ContractKey,
+        target: SocketAddr,
+    ) -> bool {
+        let now = self.time_source.now();
+        let key = (*contract, target);
+        let mut throttle = self.resync_request_throttle.lock();
+        // `get` bumps LRU recency but records no send timestamp.
+        match throttle.get(&key) {
+            Some(&last) => now.duration_since(last) >= RESYNC_REQUEST_MIN_INTERVAL,
+            None => true,
+        }
+    }
+
+    /// Record that a resync request was actually SENT for (contract, target),
+    /// starting a fresh [`RESYNC_REQUEST_MIN_INTERVAL`] throttle window. Call only
+    /// AFTER the send passes every gate and is emitted (#4864 round-5 item 9); see
+    /// [`Self::peek_should_send_resync_request`].
+    pub fn record_resync_request_sent(&self, contract: &ContractKey, target: SocketAddr) {
+        let now = self.time_source.now();
+        self.resync_request_throttle
+            .lock()
+            .put((*contract, target), now);
+    }
+
     /// Remove all interests for a peer (called on peer disconnect).
     ///
     /// Uses the reverse index for O(1) lookup instead of O(contracts) scan.

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -348,7 +348,7 @@ pub struct InterestManager<T: TimeSource> {
 
     /// Rate-limit gate for queue-full `ResyncRequest`s, keyed by
     /// (contract, target peer address). Bounded LRU so remote peers cannot grow
-    /// it without bound. See [`InterestManager::should_send_resync_request`] and
+    /// it without bound. See [`InterestManager::begin_resync_request`] and
     /// issue #4857.
     resync_request_throttle: Mutex<LruCache<(ContractKey, SocketAddr), Instant>>,
 }
@@ -595,19 +595,29 @@ impl<T: TimeSource + Sync> InterestManager<T> {
         }
     }
 
-    /// Rate-limit gate for queue-full `ResyncRequest`s to `target` for
-    /// `contract`. Returns `true` (and records the send) when at least
-    /// [`RESYNC_REQUEST_MIN_INTERVAL`] has elapsed since the last such request
-    /// for this (contract, target) pair, or when none was ever sent.
+    /// RESERVE the per-(contract, target) queue-full `ResyncRequest` throttle
+    /// window: atomically checks AND records the send under the throttle's own
+    /// lock, returning `true` when at least [`RESYNC_REQUEST_MIN_INTERVAL`] has
+    /// elapsed since the last such request (or none was ever sent), `false`
+    /// otherwise.
     ///
-    /// Issue #4857: a `ContractQueueFull` broadcast drop is silent — the
-    /// receiver never applied the delta, but the SENDER cached its own summary
-    /// as ours on send-Ok, so it believes we are current and will never re-send
-    /// the dropped change. A `ResyncRequest` makes the sender clear that cached
-    /// summary and re-send full state. Issue #4251 suppressed the request
-    /// entirely because one-per-dropped-delta amplifies into a full-state storm;
-    /// this gate keeps the healing signal but bounds it to one per window.
-    pub fn should_send_resync_request(&self, contract: &ContractKey, target: SocketAddr) -> bool {
+    /// The `begin`/[`Self::cancel_resync_request`] reservation-commit pair
+    /// restores atomicity under the double-gate (#4864 round-6 item 2): recording
+    /// under the lock means two concurrent queue-full callbacks for the same
+    /// (contract, target) cannot both pass, so they cannot both consume the global
+    /// burst and emit duplicates inside the window. If a later gate (the global
+    /// per-contract emit cap) then rejects, the caller `cancel`s the reservation
+    /// so the window is released — preserving the round-5 improvement that a
+    /// globally-suppressed emit does not burn the 30s window.
+    ///
+    /// Issue #4857: a `ContractQueueFull` broadcast drop is silent — the receiver
+    /// never applied the delta, but the SENDER cached its own summary as ours on
+    /// send-Ok, so it believes we are current and will never re-send the dropped
+    /// change. A `ResyncRequest` makes the sender clear that cached summary and
+    /// re-send full state. Issue #4251 suppressed the request entirely because
+    /// one-per-dropped-delta amplifies into a full-state storm; this gate keeps
+    /// the healing signal but bounds it to one per window.
+    pub fn begin_resync_request(&self, contract: &ContractKey, target: SocketAddr) -> bool {
         let now = self.time_source.now();
         let key = (*contract, target);
         let mut throttle = self.resync_request_throttle.lock();
@@ -620,41 +630,16 @@ impl<T: TimeSource + Sync> InterestManager<T> {
         true
     }
 
-    /// PEEK the per-(contract, target) resync-request throttle WITHOUT recording a
-    /// send: returns true when a send would be ALLOWED (the
-    /// [`RESYNC_REQUEST_MIN_INTERVAL`] window has elapsed, or none was ever sent).
-    ///
-    /// Pair with [`Self::record_resync_request_sent`], which starts the window
-    /// ONLY once the send actually happens (#4864 round-5 item 9). The queue-full
-    /// heal is double-gated (this per-sender throttle AND the global per-contract
-    /// emit cap); the combined check-AND-record `should_send_resync_request` would
-    /// burn the 30s window for a send the global cap then suppressed, blocking
-    /// this (contract, target) from retrying for up to 30s after the global cap's
-    /// tokens refill.
-    pub fn peek_should_send_resync_request(
-        &self,
-        contract: &ContractKey,
-        target: SocketAddr,
-    ) -> bool {
-        let now = self.time_source.now();
-        let key = (*contract, target);
-        let mut throttle = self.resync_request_throttle.lock();
-        // `get` bumps LRU recency but records no send timestamp.
-        match throttle.get(&key) {
-            Some(&last) => now.duration_since(last) >= RESYNC_REQUEST_MIN_INTERVAL,
-            None => true,
-        }
-    }
-
-    /// Record that a resync request was actually SENT for (contract, target),
-    /// starting a fresh [`RESYNC_REQUEST_MIN_INTERVAL`] throttle window. Call only
-    /// AFTER the send passes every gate and is emitted (#4864 round-5 item 9); see
-    /// [`Self::peek_should_send_resync_request`].
-    pub fn record_resync_request_sent(&self, contract: &ContractKey, target: SocketAddr) {
-        let now = self.time_source.now();
+    /// Cancel a reservation made by [`Self::begin_resync_request`]: removes the
+    /// just-recorded throttle window for (contract, target) so the sender can
+    /// retry as soon as the OTHER gate (the global emit cap) refills, rather than
+    /// waiting out the full [`RESYNC_REQUEST_MIN_INTERVAL`] (#4864 round-6 item 2).
+    /// Call only after a `begin` that returned `true` whose send was then rejected
+    /// downstream.
+    pub fn cancel_resync_request(&self, contract: &ContractKey, target: SocketAddr) {
         self.resync_request_throttle
             .lock()
-            .put((*contract, target), now);
+            .pop(&(*contract, target));
     }
 
     /// Remove all interests for a peer (called on peer disconnect).
@@ -1663,52 +1648,90 @@ mod tests {
         assert_eq!(retrieved.unwrap().as_ref(), summary.as_ref());
     }
 
-    /// Issue #4857: `should_send_resync_request` must emit at most one
+    /// Issue #4857: `begin_resync_request` must emit at most one
     /// `ResyncRequest` per (contract, peer) per `RESYNC_REQUEST_MIN_INTERVAL`.
     /// The first drop heals immediately; a burst of further drops within the
     /// window is throttled (bounding the #4251 amplification); after the window
     /// elapses a fresh request is allowed again.
     #[test]
-    fn should_send_resync_request_rate_limits_per_contract_peer() {
+    fn begin_resync_request_rate_limits_per_contract_peer() {
         let (manager, time) = make_manager();
         let contract = make_contract_key(1);
         let addr: SocketAddr = "127.0.0.1:5001".parse().unwrap();
 
         // First drop for this (contract, peer) → allowed (immediate heal).
         assert!(
-            manager.should_send_resync_request(&contract, addr),
+            manager.begin_resync_request(&contract, addr),
             "first ResyncRequest for a fresh (contract, peer) must be allowed"
         );
         // Immediate repeat within the window → throttled.
         assert!(
-            !manager.should_send_resync_request(&contract, addr),
+            !manager.begin_resync_request(&contract, addr),
             "a second ResyncRequest within RESYNC_REQUEST_MIN_INTERVAL must be throttled"
         );
 
         // A DIFFERENT peer for the same contract is an independent bucket.
         let other_addr: SocketAddr = "127.0.0.1:5002".parse().unwrap();
         assert!(
-            manager.should_send_resync_request(&contract, other_addr),
+            manager.begin_resync_request(&contract, other_addr),
             "a distinct peer must not share the first peer's throttle bucket"
         );
         // A DIFFERENT contract for the same peer is also independent.
         let other_contract = make_contract_key(2);
         assert!(
-            manager.should_send_resync_request(&other_contract, addr),
+            manager.begin_resync_request(&other_contract, addr),
             "a distinct contract must not share the first contract's throttle bucket"
         );
 
         // Just before the interval elapses → still throttled.
         time.advance_time(RESYNC_REQUEST_MIN_INTERVAL - Duration::from_millis(1));
         assert!(
-            !manager.should_send_resync_request(&contract, addr),
+            !manager.begin_resync_request(&contract, addr),
             "ResyncRequest must stay throttled until the full interval elapses"
         );
         // After the interval elapses → allowed again.
         time.advance_time(Duration::from_millis(2));
         assert!(
-            manager.should_send_resync_request(&contract, addr),
+            manager.begin_resync_request(&contract, addr),
             "ResyncRequest must be allowed again once RESYNC_REQUEST_MIN_INTERVAL has elapsed"
+        );
+    }
+
+    /// #4864 round-6 item 2: the begin/cancel reservation-commit semantics.
+    /// `begin` reserves the window (records under the lock); `cancel` releases it
+    /// (so a downstream rejection does not burn the 30s window); `begin` without a
+    /// `cancel` holds the window (a second immediate begin is rejected).
+    #[test]
+    fn begin_cancel_resync_request_reservation_semantics() {
+        let (manager, time) = make_manager();
+        let contract = make_contract_key(1);
+        let addr: SocketAddr = "127.0.0.1:5003".parse().unwrap();
+
+        // begin reserves; cancel releases → a subsequent begin succeeds immediately
+        // (the window was NOT burned).
+        assert!(
+            manager.begin_resync_request(&contract, addr),
+            "first begin reserves"
+        );
+        manager.cancel_resync_request(&contract, addr);
+        assert!(
+            manager.begin_resync_request(&contract, addr),
+            "begin after cancel must succeed — cancel releases the reserved window"
+        );
+
+        // This last begin was NOT cancelled → the window is held: an immediate
+        // second begin is rejected (the reservation stands, as after a real emit).
+        assert!(
+            !manager.begin_resync_request(&contract, addr),
+            "a begin without a matching cancel must hold the 30s window (second begin rejected)"
+        );
+
+        // cancel is idempotent-safe on an absent bucket (no panic) and, once the
+        // interval elapses, begin is allowed again.
+        time.advance_time(RESYNC_REQUEST_MIN_INTERVAL);
+        assert!(
+            manager.begin_resync_request(&contract, addr),
+            "begin allowed once RESYNC_REQUEST_MIN_INTERVAL elapses"
         );
     }
 

--- a/crates/core/src/ring/merge_backoff.rs
+++ b/crates/core/src/ring/merge_backoff.rs
@@ -192,12 +192,18 @@ const MAX_FAILED_PAYLOADS_PER_CONTRACT: usize = 32;
 /// Hard cap on tracked keys per map. At ~200 bytes/entry, 16 384 ≈ 3 MB. Bounds
 /// the worst case where an attacker chooses fresh contract ids or sender ports.
 pub(crate) const MAX_TRACKED_CONTRACTS: usize = 16_384;
-/// Idle-entry cleanup grace period. An entry past its cooldown is retained until
-/// it has been idle (no new failure) this long, preserving the failure counter
-/// across consecutive failure→cooldown→retry cycles. Aligned with the longest
-/// cooldown ([`TIMEOUT_CAP`]) so a contract still in a long cooldown is never
-/// dropped early.
-const CLEANUP_AGE: Duration = TIMEOUT_CAP;
+/// Idle-entry cleanup grace for the per-sender `Invalid` map (#4864 round-4 M3).
+/// An entry past its cooldown is retained until idle (no new failure) this long,
+/// preserving the failure counter across a failure→cooldown→retry cycle. Scaled
+/// to the longest Invalid cooldown ([`INVALID_CAP`], 30 min) rather than the
+/// contract-map's 2h grace — that shrinks the port-flood fill-persistence window
+/// ~4x (a peer churning fresh source ports can occupy an `Invalid` slot for at
+/// most this long past its last failure) while still spanning any Invalid cooldown.
+const INVALID_CLEANUP_AGE: Duration = INVALID_CAP;
+/// Idle-entry cleanup grace for the contract-wide map. Aligned with the longest
+/// cooldown ([`TIMEOUT_CAP`], 2h) so a contract still in a long Timeout cooldown
+/// is never dropped early.
+const CONTRACT_CLEANUP_AGE: Duration = TIMEOUT_CAP;
 
 /// Compute the memoization/dedup hash for a broadcast payload. Mirrors
 /// [`crate::operations::update::BroadcastDedupCache`]: includes the `is_delta`
@@ -331,8 +337,8 @@ impl Cooldown {
         now >= self.next_allowed
     }
 
-    fn idle(&self, now: Instant) -> bool {
-        now.saturating_duration_since(self.last_failure) > CLEANUP_AGE
+    fn idle(&self, now: Instant, grace: Duration) -> bool {
+        now.saturating_duration_since(self.last_failure) > grace
     }
 }
 
@@ -417,14 +423,15 @@ impl MergeBackoff {
     /// Decide whether a merge for `contract` presented by `sender` with the given
     /// payload should run.
     ///
-    /// Suppression kicks in ONLY once the relevant channel has failed at least
-    /// `class.trip_threshold()` times consecutively without an intervening
-    /// success (#4864 review M1): the presenting sender's `Invalid` channel, or
-    /// the contract's `Timeout` channel. `KnownFailedPayload` (contract-wide,
-    /// content-addressed) takes precedence over `InBackoff`, but only once the
-    /// contract is quarantined for this sender (sender Invalid tripped OR
-    /// contract Timeout tripped) so a benign first reject is never suppressed.
-    /// Bumps `suppressed_total` on any non-`Allow` outcome.
+    /// Cooldown suppression (`InBackoff`) kicks in ONLY once the relevant channel
+    /// has failed at least `class.trip_threshold()` times consecutively without
+    /// an intervening success (#4864 review M1): the presenting sender's
+    /// `Invalid` channel, or the contract's `Timeout` channel. `KnownFailedPayload`
+    /// (contract-wide, content-addressed) is a HARD skip with NO trip gate — an
+    /// exact payload that already failed is skipped for ANY sender the instant it
+    /// is memoized (execution is deterministic, so the same bytes fail
+    /// identically for everyone), and it takes precedence over `InBackoff`. Bumps
+    /// `suppressed_total` on any non-`Allow` outcome.
     ///
     /// Reads the two maps sequentially and never holds both shard guards at once
     /// (no cross-map lock order); the tiny TOCTOU window against a concurrent
@@ -621,14 +628,16 @@ impl MergeBackoff {
     }
 
     /// Drop entries whose cooldown has elapsed AND that have been idle longer
-    /// than [`CLEANUP_AGE`]; prune per-entry expired payload memos. Call from the
-    /// Ring reaper. Bounds memory as idle contracts/senders roll off.
+    /// than the per-map grace ([`INVALID_CLEANUP_AGE`] for the Invalid map,
+    /// [`CONTRACT_CLEANUP_AGE`] for the contract map); prune per-entry expired
+    /// payload memos. Call from the Ring reaper. Bounds memory as idle
+    /// contracts/senders roll off.
     pub fn cleanup_expired(&self) {
         let now = self.time_source.now();
 
         let mut removed_invalid = 0usize;
         self.invalid_by_sender.retain(|_, cd| {
-            if cd.past_cooldown(now) && cd.idle(now) {
+            if cd.past_cooldown(now) && cd.idle(now, INVALID_CLEANUP_AGE) {
                 removed_invalid += 1;
                 return false;
             }
@@ -643,7 +652,7 @@ impl MergeBackoff {
         self.contract.retain(|_, cs| {
             cs.prune_payloads(now);
             let past_cooldown = cs.timeout.past_cooldown(now);
-            let idle = now.saturating_duration_since(cs.last_touch) > CLEANUP_AGE;
+            let idle = now.saturating_duration_since(cs.last_touch) > CONTRACT_CLEANUP_AGE;
             if past_cooldown && cs.failed_payloads.is_empty() && idle {
                 removed_contract += 1;
                 return false;
@@ -1153,25 +1162,39 @@ mod tests {
         );
     }
 
+    /// #4864 round-4 M3: the per-sender `Invalid` map uses a SHORTER idle grace
+    /// ([`INVALID_CLEANUP_AGE`], 30 min) than the contract map
+    /// ([`CONTRACT_CLEANUP_AGE`], 2 h), so a port-flood's `Invalid` slots roll off
+    /// ~4x sooner while the contract-wide entry keeps its longer grace.
     #[test]
-    fn cleanup_removes_idle_expired_entries() {
+    fn cleanup_uses_per_class_idle_grace() {
         let (b, ts) = mk();
         let c = mk_contract(1);
         let s = mk_addr(10);
         b.record_failure(&c, s, MergeFailureClass::Invalid, 1);
         assert_eq!(b.invalid_len(), 1);
         assert_eq!(b.contract_len(), 1);
-        ts.advance_time(CLEANUP_AGE + Duration::from_secs(1));
+        // Past the SHORTER Invalid grace: the per-sender channel is swept, but the
+        // contract entry (longer grace) is retained.
+        ts.advance_time(INVALID_CLEANUP_AGE + Duration::from_secs(1));
         b.cleanup_expired();
         assert_eq!(
             b.invalid_len(),
             0,
-            "idle expired sender channel must be swept"
+            "idle Invalid channel must be swept after INVALID_CLEANUP_AGE"
         );
         assert_eq!(
             b.contract_len(),
+            1,
+            "contract entry keeps the longer CONTRACT_CLEANUP_AGE grace"
+        );
+        // Past the contract grace too: the contract entry is swept.
+        ts.advance_time(CONTRACT_CLEANUP_AGE);
+        b.cleanup_expired();
+        assert_eq!(
+            b.contract_len(),
             0,
-            "idle expired contract entry must be swept"
+            "idle contract entry must be swept after CONTRACT_CLEANUP_AGE"
         );
         assert_eq!(b.invalid_size.load(Ordering::Relaxed), 0);
         assert_eq!(b.contract_size.load(Ordering::Relaxed), 0);

--- a/crates/core/src/ring/merge_backoff.rs
+++ b/crates/core/src/ring/merge_backoff.rs
@@ -1,4 +1,4 @@
-//! Per-contract merge-failure backoff — the load-bearing #4861 storm fix.
+//! Merge-failure backoff — the load-bearing #4861 storm fix.
 //!
 //! ## What this does
 //!
@@ -8,7 +8,9 @@
 //! contract-layer bug; core's job is only to BOUND the cost):
 //!
 //! - **Compute poison** — every merge exceeds the execution budget (a runaway
-//!   `update_state`). The [`MergeFailureClass::Timeout`] class targets this.
+//!   `update_state`). The [`MergeFailureClass::Timeout`] class targets this. A
+//!   5s CPU burn is contract-intrinsic (whoever sent it, the node cannot afford
+//!   probes), so Timeout suppression is **contract-wide**.
 //! - **Semantic fork oscillation** — two stable divergent states, each side's
 //!   deltas rejected by the other; every resync full-state apply just flips the
 //!   node to the other fork forever (~1 cycle/min). Contained here because the
@@ -23,22 +25,63 @@
 //! full-state `ResyncRequest`, which pulled a fresh full state that failed
 //! again — a self-sustaining storm across many senders.
 //!
-//! This tracks, per [`ContractInstanceId`], a cooldown that grows exponentially
-//! with consecutive merge failures. While a contract is in cooldown the driver
-//! skips the WASM merge entirely (and skips the `ResyncRequest` amplification),
-//! so a poison contract costs O(1) per inbound broadcast instead of O(WASM
-//! merge). A successful merge clears the entry immediately.
+//! ## Suppression scope: per-sender Invalid, contract-wide Timeout
 //!
-//! Two independent skip signals, both cleared by a successful merge:
+//! [`MergeFailureClass::Invalid`] failures are tracked and suppressed
+//! **per-`(ContractInstanceId, sender)`**. [`MergeFailureClass::Timeout`]
+//! failures and the failed-payload memo are **contract-wide**. This split is a
+//! deliberate anti-abuse boundary (#4864 review P1):
 //!
-//! - **Cooldown** ([`MergeDecision::InBackoff`]): time-based, skips *all* merges
-//!   for the contract until `next_allowed`. Escalates per failure.
+//! - **Single-attacker blackout is impossible.** A contract-wide Invalid gate
+//!   keyed only on the contract id would let ONE connected peer send 3 distinct
+//!   invalid deltas (spaced past the [`UpdateRateLimiter`]) and put a *healthy*
+//!   contract into a contract-wide cooldown; during that cooldown every honest
+//!   peer's valid delta is dropped unexecuted, so the success that would clear
+//!   the entry can never land (self-sustaining blackout, re-poisoned each
+//!   expiry toward the 30-min cap). Per-sender Invalid scoping means a bad
+//!   sender only ever suppresses ITS OWN deltas; other peers merge normally and
+//!   keep the contract live.
+//! - **Fork storms stay contained per-channel.** The 45 diverged senders of the
+//!   production fork each trip their own `(contract, sender)` channel (~3
+//!   executions, then cooldown) while healthy senders flow — matching the
+//!   observed evidence better than a single contract-wide gate.
+//! - **Compute poison stays contract-wide.** A Timeout is a full ~5s CPU burn
+//!   regardless of who sent it; the node cannot afford to keep probing it per
+//!   sender, and an attacker who can make a healthy contract burn 5s per delta
+//!   is exactly what a contract-wide quarantine must stop.
+//!
+//! The sender key is its `SocketAddr` (ip+port). Per the ring rules a raw
+//! `SocketAddr` is normally a poor peer identifier because NAT'd peers can share
+//! an IP — but ip+**port** distinguishes distinct NAT'd connections, the driver
+//! has the addr in hand (no `PeerKeyLocation` lookup), and the entry is
+//! ephemeral (TTL-swept, capped), so this matches the [`UpdateRateLimiter`]
+//! precedent rather than warranting a heavier identity. The trade-off: a peer
+//! that reconnects on a fresh port starts a fresh Invalid channel (a bounded
+//! re-probe, not a correctness issue).
+//!
+//! ## The two suppression signals
+//!
+//! Both are cleared by a successful DELTA merge:
+//!
+//! - **Cooldown** ([`MergeDecision::InBackoff`]): time-based. The per-sender
+//!   Invalid channel skips only that sender's deltas; the contract-wide Timeout
+//!   channel skips all merges for the contract. Escalates per failure.
 //! - **Known-failed-payload memoization** ([`MergeDecision::KnownFailedPayload`]):
 //!   a specific `(is_delta, bytes)` payload that already failed cannot change
 //!   outcome until the contract's state changes, so it is skipped even after the
-//!   cooldown elapses (bounded by [`FAILED_PAYLOAD_TTL`]). Any successful merge
-//!   (a state-generation bump) drops the whole entry, re-admitting every
-//!   payload.
+//!   cooldown elapses (bounded by [`FAILED_PAYLOAD_TTL`]). The memo is
+//!   **contract-wide and content-addressed**, and the skip is a HARD one: an
+//!   identical bad payload replayed via ANY sender is skipped the instant it is
+//!   memoized — no trip gate. Contract execution is deterministic, so the exact
+//!   bad bytes fail identically for every sender; re-running is pure waste, and
+//!   trip-gating would hand each fresh sender in the fork storm 3 free
+//!   executions of a known-bad payload. The skip can never block a legitimate
+//!   delta (new content = different bytes = memo miss), and it is ZERO-COST:
+//!   the driver returns without running the merge, so the presenting sender's
+//!   channel is NOT advanced and no `ResyncRequest` is emitted (the benign
+//!   stale-reject penalises a channel only when the merge actually RUNS and
+//!   fails). Any successful merge (a state-generation bump) drops the memo,
+//!   re-admitting every payload.
 //!
 //! ## Failure classes
 //!
@@ -47,7 +90,11 @@
 //! [`MergeFailureClass::Invalid`] (a cheap contract-side rejection or other exec
 //! error): a runaway merge that pins the single contract-handling thread is far
 //! more expensive to re-attempt than a merge that returns a rejection quickly.
-//! A timeout escalates the entry's class to `Timeout` and never downgrades.
+//! The two classes are tracked in SEPARATE channels (per-sender Invalid vs
+//! contract-wide Timeout), so there is no in-entry class escalation and hence no
+//! escalation-inflation to correct: a contract's first Timeout cooldown is
+//! always [`TIMEOUT_BASE`] no matter how many Invalid failures preceded it (the
+//! #4864 review O1 concern is structurally avoided by the split).
 //!
 //! ## Trip threshold (why a single Invalid failure does not suppress)
 //!
@@ -60,21 +107,22 @@
 //! - A benign stale-version `InvalidUpdate` reject (#3914) is cheap and normal —
 //!   a busy contract hits it on every re-broadcast the 60s dedup missed, always
 //!   interleaved with the successful newer-version merges. Tripping at 1 would
-//!   blackout the contract for 30s, during which NO merge runs so no success can
-//!   land to clear it (success starvation) — escalating a healthy contract.
-//!   Requiring 3 *consecutive* failures means a benign reject (which a success
-//!   always interrupts) never trips.
-//! - A poison / fork contract fails consecutively with zero clean deltas, so it
-//!   reaches 3 and trips (the fork storm at ~2 failures/min trips in ~90s).
+//!   blackout that sender's channel for 30s. Requiring 3 *consecutive* failures
+//!   (per sender) means a benign reject (which a success always interrupts)
+//!   never trips.
+//! - A poison / fork sender fails consecutively with zero clean deltas, so its
+//!   channel reaches 3 and trips (the fork storm at ~2 failures/min trips in
+//!   ~90s).
 //! - A `Timeout` is a full ~5s CPU burn every time; one is enough, so it trips
 //!   at 1.
 //!
 //! ## Bounded growth
 //!
-//! Modeled on [`crate::ring::update_rate_limit::UpdateRateLimiter`]: a
-//! [`DashMap`] with a strict [`AtomicUsize`] size cap ([`MAX_TRACKED_CONTRACTS`])
-//! so an attacker churning fresh contract ids cannot grow the map, plus a
-//! periodic TTL sweep ([`Self::cleanup_expired`]) hooked into the Ring reaper.
+//! Modeled on [`crate::ring::update_rate_limit::UpdateRateLimiter`]: each
+//! [`DashMap`] (per-sender Invalid, contract-wide Timeout+memo) has a strict
+//! [`AtomicUsize`] size cap ([`MAX_TRACKED_CONTRACTS`]) so an attacker churning
+//! fresh contract ids (or `(contract, sender)` pairs) cannot grow the maps, plus
+//! a periodic TTL sweep ([`Self::cleanup_expired`]) hooked into the Ring reaper.
 //! Per-contract failed-payload history is a bounded [`VecDeque`]
 //! ([`MAX_FAILED_PAYLOADS_PER_CONTRACT`]).
 //!
@@ -86,9 +134,13 @@
 //!   missing-contract failures (those are healed by auto-fetch, not by backing
 //!   off) — the caller only records `is_contract_exec_rejection` failures.
 //! - Not applied to client-local UPDATEs: a local client always gets a direct
-//!   merge + error.
+//!   merge + error. (A successful client-local DELTA does clear the
+//!   contract-wide Timeout + memo via [`Self::record_success_local`], but leaves
+//!   per-sender Invalid channels intact — a local success says nothing about any
+//!   specific remote sender's fork.)
 
 use std::collections::VecDeque;
+use std::net::SocketAddr;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::time::Duration;
@@ -112,15 +164,13 @@ const TIMEOUT_BASE: Duration = Duration::from_secs(120);
 const TIMEOUT_CAP: Duration = Duration::from_secs(2 * 60 * 60);
 
 /// Consecutive `Invalid`-class failures (with NO intervening success) required
-/// before the FIRST cooldown suppresses merges (#4864 review M1). Trip-at-1
-/// would blackout a healthy busy contract on a single benign stale-version
-/// `InvalidUpdate` reject (#3914: production hits these on every re-broadcast
-/// missed by the 60s dedup): during the 30s blackout no merge runs, so no
-/// success can land to clear the entry (success starvation), risking escalation
-/// of a non-poison contract. A benign reject interleaves with successes, so it
-/// never reaches 3 consecutive; a genuine poison/fork contract fails
-/// consecutively and trips. The fork storm (~2 failures/min, zero clean deltas)
-/// still trips within ~90s.
+/// before the FIRST cooldown suppresses merges for a given `(contract, sender)`
+/// (#4864 review M1). Trip-at-1 would blackout a sender's channel on a single
+/// benign stale-version `InvalidUpdate` reject (#3914: production hits these on
+/// every re-broadcast missed by the 60s dedup). A benign reject interleaves with
+/// successes, so it never reaches 3 consecutive; a genuine poison/fork sender
+/// fails consecutively and trips. The fork storm (~2 failures/min, zero clean
+/// deltas) still trips within ~90s.
 const INVALID_TRIP_THRESHOLD: u32 = 3;
 /// Consecutive `Timeout`-class failures required before suppression. One is
 /// enough: every timeout is a full ~5s CPU burn on the single contract thread,
@@ -132,8 +182,8 @@ const FAILED_PAYLOAD_TTL: Duration = Duration::from_secs(10 * 60);
 /// Max remembered failed-payload hashes per contract. Bounds per-entry memory
 /// and caps the memoization at the most-recent distinct failing payloads.
 const MAX_FAILED_PAYLOADS_PER_CONTRACT: usize = 32;
-/// Hard cap on tracked contracts. At ~200 bytes/entry, 16 384 ≈ 3 MB. Bounds the
-/// worst case where an attacker chooses fresh contract ids.
+/// Hard cap on tracked keys per map. At ~200 bytes/entry, 16 384 ≈ 3 MB. Bounds
+/// the worst case where an attacker chooses fresh contract ids or sender ports.
 pub(crate) const MAX_TRACKED_CONTRACTS: usize = 16_384;
 /// Idle-entry cleanup grace period. An entry past its cooldown is retained until
 /// it has been idle (no new failure) this long, preserving the failure counter
@@ -154,13 +204,33 @@ pub(crate) fn merge_payload_hash(is_delta: bool, payload_bytes: &[u8]) -> u64 {
     hasher.finish()
 }
 
-/// Failure class deciding the cooldown parameters.
+/// `base * 2^(failures - trip_threshold)`, capped, with ±20% jitter (seeded
+/// `GlobalRng`, so reproducible under simulation). The exponent is measured from
+/// the TRIP point, so the FIRST suppressing cooldown (at
+/// `failures == trip_threshold`) is the base, then escalates (#4864 review M1).
+/// `saturating_sub` floors the pre-trip failures at the base too — those
+/// cooldowns are never consulted (see [`MergeBackoff::check`]).
+fn cooldown_for(class: MergeFailureClass, consecutive_failures: u32) -> Duration {
+    let base = class.base();
+    let cap = class.cap();
+    let exponent = consecutive_failures
+        .saturating_sub(class.trip_threshold())
+        .min(20);
+    let raw = base.saturating_mul(1u32 << exponent.min(30));
+    let capped = raw.min(cap);
+    let jitter: f64 = GlobalRng::random_range(0.8_f64..=1.2_f64);
+    capped.mul_f64(jitter)
+}
+
+/// Failure class deciding the cooldown parameters (and the suppression scope:
+/// `Invalid` is per-sender, `Timeout` is contract-wide).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum MergeFailureClass {
     /// Cheap contract-side rejection (`InvalidUpdate`) or any other non-timeout
-    /// execution error (trap, OOG, deser). Base [`INVALID_BASE`].
+    /// execution error (trap, OOG, deser). Base [`INVALID_BASE`]. Per-sender.
     Invalid,
     /// The WASM merge exceeded the execution time limit. Base [`TIMEOUT_BASE`].
+    /// Contract-wide.
     Timeout,
 }
 
@@ -176,15 +246,6 @@ impl MergeFailureClass {
         match self {
             MergeFailureClass::Invalid => INVALID_CAP,
             MergeFailureClass::Timeout => TIMEOUT_CAP,
-        }
-    }
-
-    /// `Timeout` outranks `Invalid`: a timeout escalates an entry and never
-    /// downgrades.
-    fn rank(self) -> u8 {
-        match self {
-            MergeFailureClass::Invalid => 0,
-            MergeFailureClass::Timeout => 1,
         }
     }
 
@@ -204,8 +265,8 @@ impl MergeFailureClass {
 pub(crate) enum MergeDecision {
     /// Not in backoff and payload not known-failed — run the merge.
     Allow,
-    /// The contract is in a cooldown window — skip the merge (and any
-    /// amplification, e.g. `ResyncRequest`).
+    /// The sender's Invalid channel or the contract's Timeout is in a cooldown
+    /// window — skip the merge (and any amplification, e.g. `ResyncRequest`).
     InBackoff,
     /// This exact payload already failed and no successful merge has cleared the
     /// entry since — skip; the outcome cannot change until the state changes.
@@ -220,16 +281,73 @@ impl MergeDecision {
     }
 }
 
-struct Entry {
+/// One exponential cooldown channel. Used per-`(contract, sender)` for the
+/// `Invalid` class and once per contract (inside [`ContractState`]) for the
+/// `Timeout` class. The class is fixed by WHERE the channel lives, so it is not
+/// stored here. `consecutive_failures == 0` is the inert "no failure recorded"
+/// state (never suppresses, since `0 < trip_threshold`).
+struct Cooldown {
     consecutive_failures: u32,
-    class: MergeFailureClass,
     next_allowed: Instant,
     last_failure: Instant,
-    /// `(payload_hash, recorded_at)`, newest at back. Bounded + TTL-pruned.
-    failed_payloads: VecDeque<(u64, Instant)>,
 }
 
-impl Entry {
+impl Cooldown {
+    fn inert(now: Instant) -> Self {
+        Self {
+            consecutive_failures: 0,
+            next_allowed: now,
+            last_failure: now,
+        }
+    }
+
+    /// Record one failure of `class`, escalating the cooldown.
+    fn record(&mut self, class: MergeFailureClass, now: Instant) {
+        self.consecutive_failures = self.consecutive_failures.saturating_add(1);
+        self.last_failure = now;
+        self.next_allowed = now + cooldown_for(class, self.consecutive_failures);
+    }
+
+    /// Has this channel reached its class trip threshold (poison, regardless of
+    /// whether the current cooldown window is still open)? Gates the memo.
+    fn tripped(&self, class: MergeFailureClass) -> bool {
+        self.consecutive_failures >= class.trip_threshold()
+    }
+
+    /// Is this channel actively suppressing right now (tripped AND still inside
+    /// the cooldown window)?
+    fn suppressing(&self, class: MergeFailureClass, now: Instant) -> bool {
+        self.tripped(class) && now < self.next_allowed
+    }
+
+    fn past_cooldown(&self, now: Instant) -> bool {
+        now >= self.next_allowed
+    }
+
+    fn idle(&self, now: Instant) -> bool {
+        now.saturating_duration_since(self.last_failure) > CLEANUP_AGE
+    }
+}
+
+/// Contract-wide state: the `Timeout`-class cooldown plus the content-addressed
+/// failed-payload memo (both apply to ALL senders).
+struct ContractState {
+    timeout: Cooldown,
+    /// `(payload_hash, recorded_at)`, newest at back. Bounded + TTL-pruned.
+    failed_payloads: VecDeque<(u64, Instant)>,
+    /// Last time any failure touched this entry (drives the idle sweep).
+    last_touch: Instant,
+}
+
+impl ContractState {
+    fn new(now: Instant) -> Self {
+        Self {
+            timeout: Cooldown::inert(now),
+            failed_payloads: VecDeque::new(),
+            last_touch: now,
+        }
+    }
+
     /// Drop failed-payload records older than [`FAILED_PAYLOAD_TTL`].
     fn prune_payloads(&mut self, now: Instant) {
         while let Some((_, at)) = self.failed_payloads.front() {
@@ -240,16 +358,32 @@ impl Entry {
             }
         }
     }
+
+    /// Memoize a failing payload (dedup + bounded + TTL-pruned).
+    fn memoize(&mut self, payload_hash: u64, now: Instant) {
+        self.prune_payloads(now);
+        if self.failed_payloads.iter().any(|(h, _)| *h == payload_hash) {
+            return;
+        }
+        if self.failed_payloads.len() >= MAX_FAILED_PAYLOADS_PER_CONTRACT {
+            self.failed_payloads.pop_front();
+        }
+        self.failed_payloads.push_back((payload_hash, now));
+    }
 }
 
-/// Per-contract merge-failure backoff tracker. All state lives in one
-/// [`DashMap`]; concurrency + bounding mirror
-/// [`crate::ring::update_rate_limit::UpdateRateLimiter`].
+/// Merge-failure backoff tracker. Two [`DashMap`]s: a per-`(contract, sender)`
+/// `Invalid`-class map and a per-contract `Timeout`+memo map. Concurrency +
+/// bounding mirror [`crate::ring::update_rate_limit::UpdateRateLimiter`].
 pub(crate) struct MergeBackoff {
-    entries: DashMap<ContractInstanceId, Entry>,
-    /// Authoritative size counter for the strict cap (see `UpdateRateLimiter`
-    /// for why `len()` can't be used under a shard guard).
-    size: AtomicUsize,
+    /// Per-`(contract, sender)` `Invalid`-class cooldown.
+    invalid_by_sender: DashMap<(ContractInstanceId, SocketAddr), Cooldown>,
+    /// Authoritative size counter for the invalid map's strict cap.
+    invalid_size: AtomicUsize,
+    /// Per-contract `Timeout`-class cooldown + contract-wide failed-payload memo.
+    contract: DashMap<ContractInstanceId, ContractState>,
+    /// Authoritative size counter for the contract map's strict cap.
+    contract_size: AtomicUsize,
     max_tracked: usize,
     time_source: Arc<dyn TimeSource + Send + Sync>,
     /// Total merges skipped (cooldown + known-payload) since creation.
@@ -263,165 +397,218 @@ impl MergeBackoff {
 
     pub fn with_max(time_source: Arc<dyn TimeSource + Send + Sync>, max_tracked: usize) -> Self {
         Self {
-            entries: DashMap::new(),
-            size: AtomicUsize::new(0),
+            invalid_by_sender: DashMap::new(),
+            invalid_size: AtomicUsize::new(0),
+            contract: DashMap::new(),
+            contract_size: AtomicUsize::new(0),
             max_tracked,
             time_source,
             suppressed_total: AtomicU64::new(0),
         }
     }
 
-    /// Decide whether a merge for `contract` with the given payload should run.
+    /// Decide whether a merge for `contract` presented by `sender` with the given
+    /// payload should run.
     ///
-    /// Suppression (both `InBackoff` and `KnownFailedPayload`) kicks in ONLY once
-    /// the contract has failed at least `class.trip_threshold()` times
-    /// consecutively without an intervening success (#4864 review M1): a healthy
-    /// busy contract that gets one benign stale-version `InvalidUpdate` reject
-    /// must not be blacked out (the blackout would starve the success that clears
-    /// it). `KnownFailedPayload` takes precedence over `InBackoff` (a specific
-    /// failed payload is skipped even once the cooldown elapses). Bumps
-    /// `suppressed_total` on any non-`Allow` outcome. Does NOT create an entry
-    /// for an untracked contract (the common Allow path is a single shard read).
-    pub fn check(&self, contract: &ContractInstanceId, payload_hash: u64) -> MergeDecision {
+    /// Suppression kicks in ONLY once the relevant channel has failed at least
+    /// `class.trip_threshold()` times consecutively without an intervening
+    /// success (#4864 review M1): the presenting sender's `Invalid` channel, or
+    /// the contract's `Timeout` channel. `KnownFailedPayload` (contract-wide,
+    /// content-addressed) takes precedence over `InBackoff`, but only once the
+    /// contract is quarantined for this sender (sender Invalid tripped OR
+    /// contract Timeout tripped) so a benign first reject is never suppressed.
+    /// Bumps `suppressed_total` on any non-`Allow` outcome.
+    ///
+    /// Reads the two maps sequentially and never holds both shard guards at once
+    /// (no cross-map lock order); the tiny TOCTOU window against a concurrent
+    /// record is benign for a backoff heuristic.
+    pub fn check(
+        &self,
+        contract: &ContractInstanceId,
+        sender: SocketAddr,
+        payload_hash: u64,
+    ) -> MergeDecision {
         let now = self.time_source.now();
-        let Some(mut entry) = self.entries.get_mut(contract) else {
-            return MergeDecision::Allow;
-        };
-        entry.prune_payloads(now);
-        // Below the class's trip threshold, always run the merge — the entry is
-        // still counting failures but not yet "poison". A success (record_success)
-        // clears it before it ever trips, which is exactly the benign case.
-        if entry.consecutive_failures < entry.class.trip_threshold() {
-            return MergeDecision::Allow;
+
+        // Per-sender Invalid channel — read the suppress flag, then release the
+        // shard guard before touching the contract map.
+        let sender_suppressing = self
+            .invalid_by_sender
+            .get(&(*contract, sender))
+            .map(|cd| cd.suppressing(MergeFailureClass::Invalid, now))
+            .unwrap_or(false);
+
+        if let Some(mut cs) = self.contract.get_mut(contract) {
+            cs.prune_payloads(now);
+            // Content-addressed memo is a HARD skip for ANY sender the instant a
+            // payload is memoized — no trip gate. Contract execution is
+            // deterministic, so an exact payload that already failed against the
+            // current state fails identically for every sender; re-running it is
+            // pure waste (the production fork storm replays identical deltas via
+            // ~45 senders — trip-gating the memo would hand each fresh sender 3
+            // free executions of a known-bad payload). Skipping it can never
+            // block a legitimate delta: new content = different bytes = memo
+            // miss. The skip is ZERO-COST for the sender's channel: the driver
+            // returns without running the merge, so `record_failure` is never
+            // called (no failure-count increment) and no ResyncRequest is
+            // emitted. Cleared when a success advances the state.
+            if cs.failed_payloads.iter().any(|(h, _)| *h == payload_hash) {
+                self.suppressed_total.fetch_add(1, Ordering::Relaxed);
+                return MergeDecision::KnownFailedPayload;
+            }
+            if cs.timeout.suppressing(MergeFailureClass::Timeout, now) {
+                self.suppressed_total.fetch_add(1, Ordering::Relaxed);
+                return MergeDecision::InBackoff;
+            }
         }
-        if entry
-            .failed_payloads
-            .iter()
-            .any(|(h, _)| *h == payload_hash)
-        {
-            self.suppressed_total.fetch_add(1, Ordering::Relaxed);
-            return MergeDecision::KnownFailedPayload;
-        }
-        if now < entry.next_allowed {
+
+        if sender_suppressing {
             self.suppressed_total.fetch_add(1, Ordering::Relaxed);
             return MergeDecision::InBackoff;
         }
         MergeDecision::Allow
     }
 
-    /// Record a failed merge, escalating the contract's cooldown and memoizing
-    /// the payload. A `Timeout` failure escalates the entry's class (and never
-    /// downgrades). At the tracked-contracts cap, a failure for a *new* contract
-    /// is dropped (graceful degradation — bounded memory under id churn).
+    /// Record a failed merge. An `Invalid` failure escalates the presenting
+    /// sender's per-`(contract, sender)` cooldown; a `Timeout` failure escalates
+    /// the contract-wide `Timeout` cooldown. Either way the payload is memoized
+    /// contract-wide. At a map's tracked cap, a failure for a *new* key is
+    /// dropped (graceful degradation — bounded memory under id/port churn).
     pub fn record_failure(
         &self,
         contract: &ContractInstanceId,
+        sender: SocketAddr,
         class: MergeFailureClass,
         payload_hash: u64,
     ) {
         let now = self.time_source.now();
-        use dashmap::mapref::entry::Entry as DEntry;
-        match self.entries.entry(*contract) {
-            DEntry::Occupied(mut occ) => {
-                let entry = occ.get_mut();
-                Self::apply_failure(entry, class, payload_hash, now);
+        if class == MergeFailureClass::Invalid {
+            self.record_invalid_sender(*contract, sender, now);
+        }
+        // Contract-wide side: memoize the payload always; escalate the Timeout
+        // cooldown when this is a Timeout failure.
+        self.with_contract_entry(*contract, now, |cs| {
+            if class == MergeFailureClass::Timeout {
+                cs.timeout.record(MergeFailureClass::Timeout, now);
             }
+            cs.last_touch = now;
+            cs.memoize(payload_hash, now);
+        });
+    }
+
+    fn record_invalid_sender(
+        &self,
+        contract: ContractInstanceId,
+        sender: SocketAddr,
+        now: Instant,
+    ) {
+        use dashmap::mapref::entry::Entry as DEntry;
+        match self.invalid_by_sender.entry((contract, sender)) {
+            DEntry::Occupied(mut occ) => occ.get_mut().record(MergeFailureClass::Invalid, now),
             DEntry::Vacant(vac) => {
                 // Reserve a slot before inserting (strict cap, see UpdateRateLimiter).
-                let prev = self.size.fetch_add(1, Ordering::Relaxed);
+                let prev = self.invalid_size.fetch_add(1, Ordering::Relaxed);
                 if prev >= self.max_tracked {
-                    self.size.fetch_sub(1, Ordering::Relaxed);
+                    self.invalid_size.fetch_sub(1, Ordering::Relaxed);
                     return;
                 }
-                let mut entry = Entry {
-                    consecutive_failures: 0,
-                    class,
-                    next_allowed: now,
-                    last_failure: now,
-                    failed_payloads: VecDeque::new(),
-                };
-                Self::apply_failure(&mut entry, class, payload_hash, now);
-                vac.insert(entry);
+                let mut cd = Cooldown::inert(now);
+                cd.record(MergeFailureClass::Invalid, now);
+                vac.insert(cd);
             }
         }
     }
 
-    fn apply_failure(entry: &mut Entry, class: MergeFailureClass, payload_hash: u64, now: Instant) {
-        // Escalate class upward only (Timeout dominates Invalid). On escalation,
-        // restart the consecutive count at the NEW class's pre-trip point so the
-        // first cooldown after escalating is that class's BASE, not base shifted
-        // by the pre-escalation failures (review O1: Invalid,Invalid,Timeout must
-        // yield TIMEOUT_BASE=120s, not 480s — the old class's history says
-        // nothing about how far the new class has escalated).
-        if class.rank() > entry.class.rank() {
-            entry.class = class;
-            entry.consecutive_failures = class.trip_threshold().saturating_sub(1);
+    /// Get-or-create the contract-wide entry (respecting the strict cap) and run
+    /// `f` on it. At the cap, a *new* contract's failure is dropped and `f` is
+    /// not run.
+    fn with_contract_entry(
+        &self,
+        contract: ContractInstanceId,
+        now: Instant,
+        f: impl FnOnce(&mut ContractState),
+    ) {
+        use dashmap::mapref::entry::Entry as DEntry;
+        match self.contract.entry(contract) {
+            DEntry::Occupied(mut occ) => f(occ.get_mut()),
+            DEntry::Vacant(vac) => {
+                let prev = self.contract_size.fetch_add(1, Ordering::Relaxed);
+                if prev >= self.max_tracked {
+                    self.contract_size.fetch_sub(1, Ordering::Relaxed);
+                    return;
+                }
+                let mut cs = ContractState::new(now);
+                f(&mut cs);
+                vac.insert(cs);
+            }
         }
-        entry.consecutive_failures = entry.consecutive_failures.saturating_add(1);
-        entry.last_failure = now;
+    }
 
-        let cooldown = Self::cooldown_for(entry.class, entry.consecutive_failures);
-        entry.next_allowed = now + cooldown;
-
-        // Memoize the failing payload (dedup + bounded + TTL-pruned).
-        entry.prune_payloads(now);
-        if !entry
-            .failed_payloads
-            .iter()
-            .any(|(h, _)| *h == payload_hash)
+    /// A successful DELTA merge from `sender`: clears THIS sender's `Invalid`
+    /// channel, plus the contract-wide `Timeout` cooldown and the failed-payload
+    /// memo (the state advanced, so every remembered failure is stale). Other
+    /// senders' `Invalid` channels are left intact — they may genuinely sit on
+    /// the other fork.
+    pub fn record_success_from_sender(&self, contract: &ContractInstanceId, sender: SocketAddr) {
+        if self
+            .invalid_by_sender
+            .remove(&(*contract, sender))
+            .is_some()
         {
-            if entry.failed_payloads.len() >= MAX_FAILED_PAYLOADS_PER_CONTRACT {
-                entry.failed_payloads.pop_front();
-            }
-            entry.failed_payloads.push_back((payload_hash, now));
+            self.invalid_size.fetch_sub(1, Ordering::Relaxed);
         }
+        self.clear_contract_side(contract);
     }
 
-    /// `base * 2^(failures - trip_threshold)`, capped, with ±20% jitter (seeded
-    /// `GlobalRng`, so reproducible under simulation). The exponent is measured
-    /// from the TRIP point, so the FIRST suppressing cooldown (at
-    /// `failures == trip_threshold`) is the base, then escalates as before
-    /// (#4864 review M1). `saturating_sub` floors the pre-trip failures at the
-    /// base too — those cooldowns are never consulted (see `check`).
-    fn cooldown_for(class: MergeFailureClass, consecutive_failures: u32) -> Duration {
-        let base = class.base();
-        let cap = class.cap();
-        let exponent = consecutive_failures
-            .saturating_sub(class.trip_threshold())
-            .min(20);
-        let raw = base.saturating_mul(1u32 << exponent.min(30));
-        let capped = raw.min(cap);
-        let jitter: f64 = GlobalRng::random_range(0.8_f64..=1.2_f64);
-        capped.mul_f64(jitter)
+    /// A successful client-local DELTA merge: clears the contract-wide `Timeout`
+    /// cooldown and the failed-payload memo ONLY. Per-sender `Invalid` channels
+    /// are untouched — a local client's success proves the contract merges but
+    /// says nothing about any specific remote sender's fork.
+    pub fn record_success_local(&self, contract: &ContractInstanceId) {
+        self.clear_contract_side(contract);
     }
 
-    /// Record a successful merge: the contract's state advanced, so every
-    /// remembered failure is stale. Drops the entry entirely (clears both the
-    /// cooldown and the payload memoization).
-    pub fn record_success(&self, contract: &ContractInstanceId) {
-        if self.entries.remove(contract).is_some() {
-            self.size.fetch_sub(1, Ordering::Relaxed);
+    /// Drop the contract-wide entry (clears both the `Timeout` cooldown and the
+    /// payload memo). Does not touch any per-sender `Invalid` channel.
+    fn clear_contract_side(&self, contract: &ContractInstanceId) {
+        if self.contract.remove(contract).is_some() {
+            self.contract_size.fetch_sub(1, Ordering::Relaxed);
         }
     }
 
     /// Drop entries whose cooldown has elapsed AND that have been idle longer
     /// than [`CLEANUP_AGE`]; prune per-entry expired payload memos. Call from the
-    /// Ring reaper. Bounds memory as idle contracts roll off.
+    /// Ring reaper. Bounds memory as idle contracts/senders roll off.
     pub fn cleanup_expired(&self) {
         let now = self.time_source.now();
-        let mut removed = 0usize;
-        self.entries.retain(|_, entry| {
-            let past_cooldown = now >= entry.next_allowed;
-            let idle = now.saturating_duration_since(entry.last_failure) > CLEANUP_AGE;
-            if past_cooldown && idle {
-                removed += 1;
+
+        let mut removed_invalid = 0usize;
+        self.invalid_by_sender.retain(|_, cd| {
+            if cd.past_cooldown(now) && cd.idle(now) {
+                removed_invalid += 1;
                 return false;
             }
-            entry.prune_payloads(now);
             true
         });
-        if removed > 0 {
-            self.size.fetch_sub(removed, Ordering::Relaxed);
+        if removed_invalid > 0 {
+            self.invalid_size
+                .fetch_sub(removed_invalid, Ordering::Relaxed);
+        }
+
+        let mut removed_contract = 0usize;
+        self.contract.retain(|_, cs| {
+            cs.prune_payloads(now);
+            let past_cooldown = cs.timeout.past_cooldown(now);
+            let idle = now.saturating_duration_since(cs.last_touch) > CLEANUP_AGE;
+            if past_cooldown && cs.failed_payloads.is_empty() && idle {
+                removed_contract += 1;
+                return false;
+            }
+            true
+        });
+        if removed_contract > 0 {
+            self.contract_size
+                .fetch_sub(removed_contract, Ordering::Relaxed);
         }
     }
 
@@ -434,28 +621,40 @@ impl MergeBackoff {
         self.suppressed_total.load(Ordering::Relaxed)
     }
 
-    /// Number of contracts currently SUPPRESSING merges (gauge). Counts only
-    /// entries that `check` would actually suppress: past the class trip
-    /// threshold AND inside the cooldown window (an entry still accumulating its
-    /// first `trip_threshold - 1` failures is not yet quarantined). Scans the map
-    /// (bounded by [`MAX_TRACKED_CONTRACTS`]).
+    /// Number of distinct contracts currently SUPPRESSING at least one merge
+    /// path (gauge): a contract counts if its `Timeout` channel is suppressing OR
+    /// any of its per-sender `Invalid` channels is. Scans both maps (bounded by
+    /// [`MAX_TRACKED_CONTRACTS`]).
     #[cfg_attr(not(test), allow(dead_code))]
     pub fn contracts_in_backoff(&self) -> usize {
         let now = self.time_source.now();
-        self.entries
-            .iter()
-            .filter(|e| {
-                let entry = e.value();
-                entry.consecutive_failures >= entry.class.trip_threshold()
-                    && now < entry.next_allowed
-            })
-            .count()
+        let mut suppressing = std::collections::HashSet::new();
+        for e in self.contract.iter() {
+            if e.value()
+                .timeout
+                .suppressing(MergeFailureClass::Timeout, now)
+            {
+                suppressing.insert(*e.key());
+            }
+        }
+        for e in self.invalid_by_sender.iter() {
+            if e.value().suppressing(MergeFailureClass::Invalid, now) {
+                suppressing.insert(e.key().0);
+            }
+        }
+        suppressing.len()
     }
 
-    /// Number of tracked contracts (tests / dashboard).
-    #[cfg_attr(not(test), allow(dead_code))]
-    pub fn len(&self) -> usize {
-        self.entries.len()
+    /// Number of tracked per-sender `Invalid` channels (tests).
+    #[cfg(test)]
+    fn invalid_len(&self) -> usize {
+        self.invalid_by_sender.len()
+    }
+
+    /// Number of tracked contract-wide entries (tests).
+    #[cfg(test)]
+    fn contract_len(&self) -> usize {
+        self.contract.len()
     }
 }
 
@@ -468,6 +667,10 @@ mod tests {
         ContractInstanceId::new([byte; 32])
     }
 
+    fn mk_addr(port: u16) -> SocketAddr {
+        SocketAddr::from(([127, 0, 0, 1], port))
+    }
+
     fn mk() -> (MergeBackoff, SharedMockTimeSource) {
         let ts = SharedMockTimeSource::new();
         (MergeBackoff::new(Arc::new(ts.clone())), ts)
@@ -476,146 +679,190 @@ mod tests {
     #[test]
     fn untracked_contract_is_allowed() {
         let (b, _ts) = mk();
-        assert_eq!(b.check(&mk_contract(1), 42), MergeDecision::Allow);
-        assert_eq!(b.len(), 0, "check must not create an entry");
+        assert_eq!(
+            b.check(&mk_contract(1), mk_addr(1), 42),
+            MergeDecision::Allow
+        );
+        assert_eq!(b.invalid_len(), 0, "check must not create an entry");
+        assert_eq!(b.contract_len(), 0, "check must not create an entry");
     }
 
     /// #4864 review M1 test (b): sustained consecutive Invalid failures (no
-    /// successes) do NOT suppress on failures 1-2, then trip at the 3rd.
+    /// successes) from ONE sender do NOT suppress on failures 1-2, then trip at
+    /// the 3rd.
     #[test]
     fn invalid_trips_only_after_three_consecutive_failures() {
         let (b, _ts) = mk();
         let c = mk_contract(1);
-        // Failures 1 and 2 are counted but do NOT suppress.
-        b.record_failure(&c, MergeFailureClass::Invalid, 1);
+        let s = mk_addr(10);
+        b.record_failure(&c, s, MergeFailureClass::Invalid, 1);
+        assert_eq!(b.check(&c, s, 2), MergeDecision::Allow, "failure 1");
+        b.record_failure(&c, s, MergeFailureClass::Invalid, 3);
+        assert_eq!(b.check(&c, s, 4), MergeDecision::Allow, "failure 2");
+        b.record_failure(&c, s, MergeFailureClass::Invalid, 5);
         assert_eq!(
-            b.check(&c, 2),
-            MergeDecision::Allow,
-            "failure 1 must not suppress"
+            b.check(&c, s, 6),
+            MergeDecision::InBackoff,
+            "failure 3 trips"
         );
-        b.record_failure(&c, MergeFailureClass::Invalid, 3);
-        assert_eq!(
-            b.check(&c, 4),
-            MergeDecision::Allow,
-            "failure 2 must not suppress"
-        );
-        // The 3rd consecutive failure trips the Invalid threshold.
-        b.record_failure(&c, MergeFailureClass::Invalid, 5);
-        assert_eq!(b.check(&c, 6), MergeDecision::InBackoff, "failure 3 trips");
         assert_eq!(b.suppressed_total(), 1);
     }
 
-    /// #4864 review M1 test (a): two Invalid failures followed by a success are
-    /// never suppressed, and the entry (and its consecutive counter) is cleared.
+    /// #4864 review P1 (the point of the per-sender rework): one sender tripping
+    /// its Invalid channel must NOT suppress a DIFFERENT sender's delta — the
+    /// second sender's merge still runs. A contract-wide gate would blackout the
+    /// healthy sender here.
+    #[test]
+    fn invalid_backoff_is_scoped_per_sender() {
+        let (b, _ts) = mk();
+        let c = mk_contract(1);
+        let poison = mk_addr(10);
+        let healthy = mk_addr(20);
+        // Poison sender trips its own channel (3 consecutive failures).
+        for h in [1u64, 2, 3] {
+            b.record_failure(&c, poison, MergeFailureClass::Invalid, h);
+        }
+        assert_eq!(
+            b.check(&c, poison, 99),
+            MergeDecision::InBackoff,
+            "the poison sender is suppressed on its own channel"
+        );
+        // A different sender's delta is NOT suppressed — the contract stays live.
+        assert_eq!(
+            b.check(&c, healthy, 99),
+            MergeDecision::Allow,
+            "a healthy sender must still reach the merge (per-sender scoping)"
+        );
+    }
+
+    /// #4864 review M1 test (a): two Invalid failures followed by a success from
+    /// the same sender are never suppressed, and that sender's channel is cleared.
     #[test]
     fn invalid_two_failures_then_success_never_suppressed() {
         let (b, _ts) = mk();
         let c = mk_contract(1);
-        b.record_failure(&c, MergeFailureClass::Invalid, 1);
-        assert!(b.check(&c, 2).is_allowed());
-        b.record_failure(&c, MergeFailureClass::Invalid, 3);
-        assert!(b.check(&c, 4).is_allowed());
-        // A success interrupts the run — the benign-reject case.
-        b.record_success(&c);
-        assert_eq!(b.len(), 0, "success clears the entry (counter reset)");
+        let s = mk_addr(10);
+        b.record_failure(&c, s, MergeFailureClass::Invalid, 1);
+        assert!(b.check(&c, s, 2).is_allowed());
+        b.record_failure(&c, s, MergeFailureClass::Invalid, 3);
+        assert!(b.check(&c, s, 4).is_allowed());
+        b.record_success_from_sender(&c, s);
+        assert_eq!(b.invalid_len(), 0, "success clears the sender's channel");
         assert_eq!(b.suppressed_total(), 0, "nothing was ever suppressed");
-        // A fresh failure now starts the count from 1 (no lingering escalation).
-        b.record_failure(&c, MergeFailureClass::Invalid, 5);
+        b.record_failure(&c, s, MergeFailureClass::Invalid, 5);
         assert_eq!(
-            b.check(&c, 6),
+            b.check(&c, s, 6),
             MergeDecision::Allow,
             "post-success failure 1 must not suppress"
         );
     }
 
     #[test]
-    fn success_clears_backoff() {
+    fn success_from_sender_clears_that_sender_and_contract_side() {
         let (b, _ts) = mk();
         let c = mk_contract(1);
-        // Trip the Invalid threshold (3 consecutive).
+        let s = mk_addr(10);
         for h in [1u64, 3, 5] {
-            b.record_failure(&c, MergeFailureClass::Invalid, h);
+            b.record_failure(&c, s, MergeFailureClass::Invalid, h);
         }
-        assert!(!b.check(&c, 2).is_allowed());
-        b.record_success(&c);
-        assert_eq!(b.check(&c, 2), MergeDecision::Allow);
+        assert!(!b.check(&c, s, 2).is_allowed());
+        b.record_success_from_sender(&c, s);
+        assert_eq!(b.check(&c, s, 2), MergeDecision::Allow);
         assert_eq!(
-            b.check(&c, 1),
+            b.check(&c, s, 1),
             MergeDecision::Allow,
             "memoized payload cleared too"
         );
-        assert_eq!(b.len(), 0);
+        assert_eq!(b.invalid_len(), 0);
+        assert_eq!(b.contract_len(), 0);
+    }
+
+    /// A success from sender S must NOT clear a DIFFERENT sender's Invalid
+    /// channel (that sender may sit on the other fork). The contract-wide side
+    /// (Timeout + memo) IS cleared.
+    #[test]
+    fn success_from_sender_leaves_other_senders_intact() {
+        let (b, _ts) = mk();
+        let c = mk_contract(1);
+        let s1 = mk_addr(10);
+        let s2 = mk_addr(20);
+        for h in [1u64, 2, 3] {
+            b.record_failure(&c, s1, MergeFailureClass::Invalid, h);
+        }
+        for h in [4u64, 5, 6] {
+            b.record_failure(&c, s2, MergeFailureClass::Invalid, h);
+        }
+        // A success from s1 clears s1 but not s2.
+        b.record_success_from_sender(&c, s1);
+        assert_eq!(b.check(&c, s1, 100), MergeDecision::Allow, "s1 cleared");
+        assert_eq!(
+            b.check(&c, s2, 101),
+            MergeDecision::InBackoff,
+            "s2's independent channel is untouched"
+        );
+    }
+
+    /// `record_success_local` (client-local success) clears the contract-wide
+    /// Timeout + memo but leaves EVERY per-sender Invalid channel intact — a
+    /// local client's success says nothing about any remote sender's fork.
+    #[test]
+    fn record_success_local_clears_contract_side_leaves_sender_channels() {
+        let (b, _ts) = mk();
+        let c = mk_contract(1);
+        let s = mk_addr(10);
+        b.record_failure(&c, s, MergeFailureClass::Timeout, 1);
+        for h in [2u64, 3, 4] {
+            b.record_failure(&c, s, MergeFailureClass::Invalid, h);
+        }
+        b.record_success_local(&c);
+        // Contract-wide Timeout gone: a fresh sender with no channel is Allowed.
+        assert_eq!(b.check(&c, mk_addr(99), 100), MergeDecision::Allow);
+        // The sender's own Invalid channel is untouched — still suppressing.
+        assert_eq!(b.check(&c, s, 100), MergeDecision::InBackoff);
     }
 
     #[test]
     fn known_failed_payload_skipped_even_after_cooldown() {
         let (b, ts) = mk();
         let c = mk_contract(1);
-        // Trip the threshold with the SAME payload three times (consecutive).
+        let s = mk_addr(10);
         for _ in 0..3 {
-            b.record_failure(&c, MergeFailureClass::Invalid, 99);
+            b.record_failure(&c, s, MergeFailureClass::Invalid, 99);
         }
-        // Advance well past the Invalid first cooldown (base 30s + jitter) so the
-        // time-based InBackoff no longer applies.
         ts.advance_time(Duration::from_secs(60));
-        // The specific failed payload is still skipped (memoization) ...
-        assert_eq!(b.check(&c, 99), MergeDecision::KnownFailedPayload);
-        // ... but a fresh payload is now allowed (cooldown elapsed).
-        assert_eq!(b.check(&c, 7), MergeDecision::Allow);
+        assert_eq!(b.check(&c, s, 99), MergeDecision::KnownFailedPayload);
+        assert_eq!(b.check(&c, s, 7), MergeDecision::Allow);
     }
 
     #[test]
     fn known_failed_payload_expires_after_ttl() {
         let (b, ts) = mk();
         let c = mk_contract(1);
+        let s = mk_addr(10);
         for _ in 0..3 {
-            b.record_failure(&c, MergeFailureClass::Invalid, 99);
+            b.record_failure(&c, s, MergeFailureClass::Invalid, 99);
         }
         ts.advance_time(FAILED_PAYLOAD_TTL + Duration::from_secs(1));
-        // Past the memo TTL the payload is no longer KnownFailedPayload; the
-        // cooldown is also long past, so it's Allow.
-        assert_eq!(b.check(&c, 99), MergeDecision::Allow);
+        assert_eq!(b.check(&c, s, 99), MergeDecision::Allow);
     }
 
-    /// #4864 review M1 test (c): a Timeout trips at the FIRST failure.
+    /// #4864 review M1 test (c): a Timeout trips at the FIRST failure and is
+    /// contract-wide (suppresses regardless of which sender presents next).
     #[test]
-    fn timeout_still_trips_at_first_failure() {
+    fn timeout_trips_at_first_failure_and_is_contract_wide() {
         let (b, _ts) = mk();
         let c = mk_contract(1);
-        b.record_failure(&c, MergeFailureClass::Timeout, 1);
+        b.record_failure(&c, mk_addr(10), MergeFailureClass::Timeout, 1);
         assert_eq!(
-            b.check(&c, 2),
+            b.check(&c, mk_addr(10), 2),
             MergeDecision::InBackoff,
             "a single timeout (full ~5s CPU burn) must trip immediately"
         );
-    }
-
-    /// Review O1 (#4864): escalating Invalid→Timeout must restart the cooldown
-    /// exponent at the NEW class's base. Two pre-escalation Invalid failures
-    /// followed by a Timeout must yield the first Timeout cooldown at
-    /// TIMEOUT_BASE (120s, jitter window [96s, 144s]) — NOT
-    /// `TIMEOUT_BASE * 2^2 = 480s` from counting the Invalid history.
-    #[test]
-    fn class_escalation_restarts_cooldown_at_new_class_base() {
-        let (b, ts) = mk();
-        let c = mk_contract(1);
-        b.record_failure(&c, MergeFailureClass::Invalid, 1);
-        b.record_failure(&c, MergeFailureClass::Invalid, 2);
-        b.record_failure(&c, MergeFailureClass::Timeout, 3);
+        // Contract-wide: a DIFFERENT sender is also suppressed.
         assert_eq!(
-            b.check(&c, 4),
+            b.check(&c, mk_addr(20), 3),
             MergeDecision::InBackoff,
-            "timeout trips immediately even mid-Invalid-sequence"
-        );
-        // 145s > TIMEOUT_BASE(120s) * 1.2 max jitter: a base-cooldown entry has
-        // elapsed. If the exponent had counted the two Invalid failures
-        // (480s * [0.8, 1.2] = [384s, 576s]) this would still be InBackoff.
-        ts.advance_time(Duration::from_secs(145));
-        assert_eq!(
-            b.check(&c, 5),
-            MergeDecision::Allow,
-            "first post-escalation cooldown must be the Timeout BASE, not \
-             base << pre-escalation failures"
+            "Timeout suppression is contract-wide, not per-sender"
         );
     }
 
@@ -624,63 +871,78 @@ mod tests {
         let (b, ts) = mk();
         let invalid = mk_contract(1);
         let timeout = mk_contract(2);
-        // Trip invalid with 3 consecutive failures → first cooldown = base 30s.
+        let s = mk_addr(10);
         for h in [1u64, 2, 3] {
-            b.record_failure(&invalid, MergeFailureClass::Invalid, h);
+            b.record_failure(&invalid, s, MergeFailureClass::Invalid, h);
         }
-        // Trip timeout with 1 failure → cooldown = base 120s.
-        b.record_failure(&timeout, MergeFailureClass::Timeout, 1);
-
-        // After 60s (> Invalid base 30s+jitter, < Timeout base 120s), the
-        // Invalid contract's cooldown has elapsed but the Timeout's has not.
+        b.record_failure(&timeout, s, MergeFailureClass::Timeout, 1);
         ts.advance_time(Duration::from_secs(60));
         assert_eq!(
-            b.check(&invalid, 555),
+            b.check(&invalid, s, 555),
             MergeDecision::Allow,
             "invalid-class cooldown (30s) should have elapsed by 60s"
         );
         assert_eq!(
-            b.check(&timeout, 555),
+            b.check(&timeout, s, 555),
             MergeDecision::InBackoff,
             "timeout-class cooldown (120s) should still be active at 60s"
         );
     }
 
+    /// The Invalid (per-sender) and Timeout (contract-wide) channels are tracked
+    /// independently: a Timeout persists and keeps suppressing even as later
+    /// Invalid failures arrive, and its FIRST cooldown is TIMEOUT_BASE regardless
+    /// of preceding Invalid failures (#4864 review O1 is structurally avoided —
+    /// no shared counter to inflate).
     #[test]
-    fn timeout_escalates_class_and_never_downgrades() {
+    fn timeout_and_invalid_tracked_independently() {
         let (b, ts) = mk();
         let c = mk_contract(1);
-        // First an Invalid failure, then a Timeout: the entry escalates to
-        // Timeout params and stays there even if a later Invalid arrives.
-        b.record_failure(&c, MergeFailureClass::Invalid, 1);
-        b.record_failure(&c, MergeFailureClass::Timeout, 2);
-        b.record_failure(&c, MergeFailureClass::Invalid, 3);
-        // 60s < Timeout base — still in backoff, proving it kept Timeout params.
+        let s = mk_addr(10);
+        // Two Invalid failures then a Timeout — the Timeout's first cooldown must
+        // be ~120s (its base), not base shifted by the Invalid history.
+        b.record_failure(&c, s, MergeFailureClass::Invalid, 1);
+        b.record_failure(&c, s, MergeFailureClass::Invalid, 2);
+        b.record_failure(&c, s, MergeFailureClass::Timeout, 3);
+        let cs = b.contract.get(&c).unwrap();
+        let cooldown = cs
+            .timeout
+            .next_allowed
+            .saturating_duration_since(cs.timeout.last_failure);
+        drop(cs);
+        assert!(
+            cooldown >= TIMEOUT_BASE.mul_f64(0.8) && cooldown <= TIMEOUT_BASE.mul_f64(1.2),
+            "first Timeout cooldown {cooldown:?} must be TIMEOUT_BASE ±20%, not \
+             inflated by the two preceding Invalid failures"
+        );
+        // A later Invalid does not downgrade / clear the still-active Timeout.
         ts.advance_time(Duration::from_secs(60));
-        assert_eq!(b.check(&c, 999), MergeDecision::InBackoff);
+        b.record_failure(&c, s, MergeFailureClass::Invalid, 4);
+        assert_eq!(
+            b.check(&c, mk_addr(99), 999),
+            MergeDecision::InBackoff,
+            "the contract-wide Timeout keeps suppressing (never downgrades)"
+        );
     }
 
     #[test]
     fn cooldown_escalates_after_trip() {
         let (b, ts) = mk();
         let c = mk_contract(1);
-        // Trip the Invalid threshold (3 consecutive) → FIRST cooldown = base ~30s.
+        let s = mk_addr(10);
         for h in [1u64, 2, 3] {
-            b.record_failure(&c, MergeFailureClass::Invalid, h);
+            b.record_failure(&c, s, MergeFailureClass::Invalid, h);
         }
-        // Let the ~30s first cooldown elapse.
         ts.advance_time(Duration::from_secs(40));
         assert_eq!(
-            b.check(&c, 10),
+            b.check(&c, s, 10),
             MergeDecision::Allow,
             "first (base) cooldown should have elapsed by 40s"
         );
-        // A 4th consecutive failure escalates to ~60s (base * 2). 40s is NOT
-        // enough now — escalation continues past the trip, as before.
-        b.record_failure(&c, MergeFailureClass::Invalid, 4);
+        b.record_failure(&c, s, MergeFailureClass::Invalid, 4);
         ts.advance_time(Duration::from_secs(40));
         assert_eq!(
-            b.check(&c, 11),
+            b.check(&c, s, 11),
             MergeDecision::InBackoff,
             "post-trip failure must escalate the cooldown past 40s"
         );
@@ -688,15 +950,13 @@ mod tests {
 
     #[test]
     fn cooldown_jitter_stays_within_bounds() {
-        // ±20% jitter: a first Invalid failure must land in [24s, 36s].
         for seed_byte in 0..32u8 {
             let (b, _ts) = mk();
             let c = mk_contract(seed_byte);
-            b.record_failure(&c, MergeFailureClass::Invalid, 1);
-            let entry = b.entries.get(&c).unwrap();
-            let cooldown = entry
-                .next_allowed
-                .saturating_duration_since(entry.last_failure);
+            let s = mk_addr(10);
+            b.record_failure(&c, s, MergeFailureClass::Invalid, 1);
+            let cd = b.invalid_by_sender.get(&(c, s)).unwrap();
+            let cooldown = cd.next_allowed.saturating_duration_since(cd.last_failure);
             assert!(
                 cooldown >= Duration::from_secs(24) && cooldown <= Duration::from_secs(36),
                 "first-failure cooldown {cooldown:?} must be 30s ±20%"
@@ -708,16 +968,12 @@ mod tests {
     fn cooldown_capped_at_class_max() {
         let (b, _ts) = mk();
         let c = mk_contract(1);
-        // Many consecutive failures must saturate at INVALID_CAP (+jitter),
-        // never overflow.
+        let s = mk_addr(10);
         for i in 0..40u64 {
-            b.record_failure(&c, MergeFailureClass::Invalid, i);
+            b.record_failure(&c, s, MergeFailureClass::Invalid, i);
         }
-        let entry = b.entries.get(&c).unwrap();
-        let cooldown = entry
-            .next_allowed
-            .saturating_duration_since(entry.last_failure);
-        // Capped at 30 min, +20% jitter ceiling = 36 min.
+        let cd = b.invalid_by_sender.get(&(c, s)).unwrap();
+        let cooldown = cd.next_allowed.saturating_duration_since(cd.last_failure);
         assert!(
             cooldown <= INVALID_CAP.mul_f64(1.2),
             "escalating cooldown {cooldown:?} must stay capped near INVALID_CAP"
@@ -726,31 +982,46 @@ mod tests {
     }
 
     #[test]
+    fn tracked_senders_are_capped() {
+        let ts = SharedMockTimeSource::new();
+        let b = MergeBackoff::with_max(Arc::new(ts.clone()), 4);
+        let c = mk_contract(1);
+        for port in 0..4u16 {
+            b.record_failure(&c, mk_addr(port), MergeFailureClass::Invalid, 1);
+        }
+        assert_eq!(b.invalid_len(), 4);
+        // 5th distinct sender is dropped (not tracked) — bounded memory.
+        b.record_failure(&c, mk_addr(99), MergeFailureClass::Invalid, 1);
+        assert_eq!(b.invalid_len(), 4, "cap must bound the per-sender channels");
+        // But an already-tracked sender keeps escalating.
+        b.record_failure(&c, mk_addr(0), MergeFailureClass::Invalid, 2);
+        assert_eq!(b.invalid_len(), 4);
+    }
+
+    #[test]
     fn tracked_contracts_are_capped() {
         let ts = SharedMockTimeSource::new();
         let b = MergeBackoff::with_max(Arc::new(ts.clone()), 4);
+        let s = mk_addr(10);
         for i in 0..4u8 {
-            b.record_failure(&mk_contract(i), MergeFailureClass::Invalid, 1);
+            b.record_failure(&mk_contract(i), s, MergeFailureClass::Timeout, 1);
         }
-        assert_eq!(b.len(), 4);
-        // 5th distinct contract is dropped (not tracked) — bounded memory.
-        b.record_failure(&mk_contract(99), MergeFailureClass::Invalid, 1);
-        assert_eq!(b.len(), 4, "cap must bound the tracked-contract count");
-        // But an already-tracked contract keeps escalating.
-        b.record_failure(&mk_contract(0), MergeFailureClass::Invalid, 2);
-        assert_eq!(b.len(), 4);
+        assert_eq!(b.contract_len(), 4);
+        b.record_failure(&mk_contract(99), s, MergeFailureClass::Timeout, 1);
+        assert_eq!(b.contract_len(), 4, "cap must bound the contract entries");
     }
 
     #[test]
     fn failed_payloads_are_bounded_per_contract() {
         let (b, _ts) = mk();
         let c = mk_contract(1);
+        let s = mk_addr(10);
         for i in 0..(MAX_FAILED_PAYLOADS_PER_CONTRACT as u64 + 10) {
-            b.record_failure(&c, MergeFailureClass::Invalid, i);
+            b.record_failure(&c, s, MergeFailureClass::Invalid, i);
         }
-        let entry = b.entries.get(&c).unwrap();
+        let cs = b.contract.get(&c).unwrap();
         assert!(
-            entry.failed_payloads.len() <= MAX_FAILED_PAYLOADS_PER_CONTRACT,
+            cs.failed_payloads.len() <= MAX_FAILED_PAYLOADS_PER_CONTRACT,
             "per-contract failed-payload history must stay bounded"
         );
     }
@@ -759,56 +1030,58 @@ mod tests {
     fn cleanup_removes_idle_expired_entries() {
         let (b, ts) = mk();
         let c = mk_contract(1);
-        b.record_failure(&c, MergeFailureClass::Invalid, 1);
-        assert_eq!(b.len(), 1);
-        // Past cooldown AND past CLEANUP_AGE → removed.
+        let s = mk_addr(10);
+        b.record_failure(&c, s, MergeFailureClass::Invalid, 1);
+        assert_eq!(b.invalid_len(), 1);
+        assert_eq!(b.contract_len(), 1);
         ts.advance_time(CLEANUP_AGE + Duration::from_secs(1));
         b.cleanup_expired();
-        assert_eq!(b.len(), 0, "idle expired entry must be swept");
-        assert_eq!(b.size.load(Ordering::Relaxed), 0);
+        assert_eq!(
+            b.invalid_len(),
+            0,
+            "idle expired sender channel must be swept"
+        );
+        assert_eq!(
+            b.contract_len(),
+            0,
+            "idle expired contract entry must be swept"
+        );
+        assert_eq!(b.invalid_size.load(Ordering::Relaxed), 0);
+        assert_eq!(b.contract_size.load(Ordering::Relaxed), 0);
     }
 
     #[test]
     fn cleanup_preserves_active_cooldown() {
         let (b, ts) = mk();
         let c = mk_contract(1);
-        b.record_failure(&c, MergeFailureClass::Timeout, 1);
-        // Well within the 2h Timeout cooldown.
+        b.record_failure(&c, mk_addr(10), MergeFailureClass::Timeout, 1);
         ts.advance_time(Duration::from_secs(60));
         b.cleanup_expired();
-        assert_eq!(b.len(), 1, "an entry still in cooldown must not be swept");
+        assert_eq!(
+            b.contract_len(),
+            1,
+            "an entry still in cooldown must not be swept"
+        );
     }
 
     #[test]
     fn fork_oscillation_escalates_into_backoff_without_reset() {
-        // Regression for the #4861 semantic fork-oscillation poison class: two
-        // divergent forks each reject the other's delta, and every ResyncResponse
-        // full-state apply flips the node to the other fork — a "success" that
-        // proves nothing about convergence. Because a resync apply does NOT reset
-        // the backoff (node.rs) and a full-state apply doesn't reset it either
-        // (only a successful DELTA merge does), the alternating delta failures
-        // accumulate and the contract enters backoff, suppressing further merges
-        // (and thus the ResyncRequest amplification). If a resync/full-state
-        // apply reset the entry, the count would return to 1 every cycle and the
-        // loop would never be contained.
+        // Regression for the #4861 semantic fork-oscillation poison class: a
+        // single fork sender's alternating deltas each fail, and every
+        // ResyncResponse full-state apply flips the node to the other fork — a
+        // "success" that proves nothing about convergence and does NOT reset the
+        // backoff (node.rs). The per-sender failures accumulate and the sender's
+        // channel enters backoff.
         let (b, ts) = mk();
         let c = mk_contract(1);
-        // Three alternating fork deltas (distinct payloads), 40s apart, each
-        // failing against the current fork, with a resync flip between them that
-        // does NOT reset the backoff. Advance BETWEEN failures only — not after
-        // the 3rd — so the check lands inside the first (~30s) cooldown.
-        b.record_failure(&c, MergeFailureClass::Invalid, 0xAAAA);
+        let s = mk_addr(10);
+        b.record_failure(&c, s, MergeFailureClass::Invalid, 0xAAAA);
         ts.advance_time(Duration::from_secs(40));
-        // ... resync flips to the other fork (NO record_success — the fix).
-        b.record_failure(&c, MergeFailureClass::Invalid, 0xBBBB);
+        b.record_failure(&c, s, MergeFailureClass::Invalid, 0xBBBB);
         ts.advance_time(Duration::from_secs(40));
-        b.record_failure(&c, MergeFailureClass::Invalid, 0xCCCC);
-
-        // Three consecutive failures without a reset trip the Invalid threshold;
-        // a fresh (non-memoized) delta is now suppressed — proving the count
-        // accumulated across cycles rather than resetting on each resync/flip.
+        b.record_failure(&c, s, MergeFailureClass::Invalid, 0xCCCC);
         assert_eq!(
-            b.check(&c, 0xDDDD),
+            b.check(&c, s, 0xDDDD),
             MergeDecision::InBackoff,
             "alternating fork deltas must trip the backoff (no resync reset)"
         );
@@ -817,13 +1090,14 @@ mod tests {
     #[test]
     fn contracts_in_backoff_gauge() {
         let (b, ts) = mk();
-        // Trip the Invalid contract (3 consecutive) and the Timeout contract (1).
+        let s = mk_addr(10);
+        // Trip the Invalid contract (3 consecutive from one sender) and the
+        // Timeout contract (1).
         for h in [1u64, 2, 3] {
-            b.record_failure(&mk_contract(1), MergeFailureClass::Invalid, h);
+            b.record_failure(&mk_contract(1), s, MergeFailureClass::Invalid, h);
         }
-        b.record_failure(&mk_contract(2), MergeFailureClass::Timeout, 1);
+        b.record_failure(&mk_contract(2), s, MergeFailureClass::Timeout, 1);
         assert_eq!(b.contracts_in_backoff(), 2);
-        // Advance past the Invalid first cooldown (~30s) only.
         ts.advance_time(Duration::from_secs(60));
         assert_eq!(
             b.contracts_in_backoff(),
@@ -832,19 +1106,52 @@ mod tests {
         );
     }
 
-    /// The gauge must NOT count a contract still below its trip threshold (a
-    /// pre-trip entry has a `next_allowed` set but `check` would still Allow).
+    /// The gauge must NOT count a contract still below its trip threshold.
     #[test]
     fn contracts_in_backoff_gauge_excludes_pre_trip_entries() {
         let (b, _ts) = mk();
         let c = mk_contract(1);
-        b.record_failure(&c, MergeFailureClass::Invalid, 1);
-        b.record_failure(&c, MergeFailureClass::Invalid, 2);
-        // 2 < 3: not yet suppressing, so the gauge must not count it.
+        let s = mk_addr(10);
+        b.record_failure(&c, s, MergeFailureClass::Invalid, 1);
+        b.record_failure(&c, s, MergeFailureClass::Invalid, 2);
         assert_eq!(b.contracts_in_backoff(), 0);
-        assert!(b.check(&c, 3).is_allowed());
-        // The 3rd failure trips it.
-        b.record_failure(&c, MergeFailureClass::Invalid, 3);
+        assert!(b.check(&c, s, 3).is_allowed());
+        b.record_failure(&c, s, MergeFailureClass::Invalid, 3);
         assert_eq!(b.contracts_in_backoff(), 1);
+    }
+
+    /// #4864 review item 7(a) (memo is a HARD content-addressed skip): a payload
+    /// that failed is `KnownFailedPayload` IMMEDIATELY — even pre-trip, and even
+    /// presented by a DIFFERENT sender (deterministic execution: the same bad
+    /// bytes fail for everyone). But a sender's NOVEL payloads still run: the
+    /// memo hard-skip never blocks a legitimate delta.
+    #[test]
+    fn memoized_payload_is_hard_skipped_for_any_sender_pre_trip() {
+        let (b, _ts) = mk();
+        let c = mk_contract(1);
+        let s1 = mk_addr(10);
+        let s2 = mk_addr(20);
+        // s1 fails two DISTINCT payloads — its channel is at 2, still PRE-trip.
+        b.record_failure(&c, s1, MergeFailureClass::Invalid, 0x11);
+        b.record_failure(&c, s1, MergeFailureClass::Invalid, 0x22);
+        // Both exact payloads are KnownFailedPayload immediately — pre-trip, and
+        // even for s1 itself (no trip gate).
+        assert_eq!(
+            b.check(&c, s1, 0x11),
+            MergeDecision::KnownFailedPayload,
+            "a memoized payload is hard-skipped immediately, even pre-trip"
+        );
+        // ... and for a DIFFERENT sender that never saw it.
+        assert_eq!(
+            b.check(&c, s2, 0x22),
+            MergeDecision::KnownFailedPayload,
+            "the memo is content-addressed: any sender replaying it is hard-skipped"
+        );
+        // But s2's OWN novel payload still runs (memo miss, empty channel).
+        assert_eq!(
+            b.check(&c, s2, 0x33),
+            MergeDecision::Allow,
+            "a novel payload must still run — the memo never blocks new content"
+        );
     }
 }

--- a/crates/core/src/ring/merge_backoff.rs
+++ b/crates/core/src/ring/merge_backoff.rs
@@ -1,0 +1,596 @@
+//! Per-contract merge-failure backoff — the load-bearing #4861 storm fix.
+//!
+//! ## What this does
+//!
+//! A "poison" contract is one whose delta/state merges reliably fail: either
+//! the contract's `update_state` rejects every apply ("Invalid update"), or —
+//! worse — every apply exceeds the execution budget (a runaway merge). In the
+//! #4861 incident a handful of such contracts drove network-wide CPU churn:
+//! every re-broadcast that slipped past the 60s [`BroadcastDedupCache`] re-ran
+//! the (failing, expensive) WASM merge, and every delta failure emitted a
+//! full-state `ResyncRequest`, which pulled a fresh full state that failed
+//! again — a self-sustaining storm across many senders.
+//!
+//! This tracks, per [`ContractInstanceId`], a cooldown that grows exponentially
+//! with consecutive merge failures. While a contract is in cooldown the driver
+//! skips the WASM merge entirely (and skips the `ResyncRequest` amplification),
+//! so a poison contract costs O(1) per inbound broadcast instead of O(WASM
+//! merge). A successful merge clears the entry immediately.
+//!
+//! Two independent skip signals, both cleared by a successful merge:
+//!
+//! - **Cooldown** ([`MergeDecision::InBackoff`]): time-based, skips *all* merges
+//!   for the contract until `next_allowed`. Escalates per failure.
+//! - **Known-failed-payload memoization** ([`MergeDecision::KnownFailedPayload`]):
+//!   a specific `(is_delta, bytes)` payload that already failed cannot change
+//!   outcome until the contract's state changes, so it is skipped even after the
+//!   cooldown elapses (bounded by [`FAILED_PAYLOAD_TTL`]). Any successful merge
+//!   (a state-generation bump) drops the whole entry, re-admitting every
+//!   payload.
+//!
+//! ## Failure classes
+//!
+//! [`MergeFailureClass::Timeout`] (a WASM execution timeout — see
+//! `ExecutorError::is_wasm_timeout`) gets a much longer base/cap than
+//! [`MergeFailureClass::Invalid`] (a cheap contract-side rejection or other exec
+//! error): a runaway merge that pins the single contract-handling thread is far
+//! more expensive to re-attempt than a merge that returns a rejection quickly.
+//! A timeout escalates the entry's class to `Timeout` and never downgrades.
+//!
+//! ## Bounded growth
+//!
+//! Modeled on [`crate::ring::update_rate_limit::UpdateRateLimiter`]: a
+//! [`DashMap`] with a strict [`AtomicUsize`] size cap ([`MAX_TRACKED_CONTRACTS`])
+//! so an attacker churning fresh contract ids cannot grow the map, plus a
+//! periodic TTL sweep ([`Self::cleanup_expired`]) hooked into the Ring reaper.
+//! Per-contract failed-payload history is a bounded [`VecDeque`]
+//! ([`MAX_FAILED_PAYLOADS_PER_CONTRACT`]).
+//!
+//! ## What this is NOT
+//!
+//! - Not a ban. A poison contract self-heals the instant a merge succeeds
+//!   (its state changed) or after the cooldown/TTL elapses.
+//! - Not applied to queue-full backpressure (transient load, not poison) or to
+//!   missing-contract failures (those are healed by auto-fetch, not by backing
+//!   off) — the caller only records `is_contract_exec_rejection` failures.
+//! - Not applied to client-local UPDATEs: a local client always gets a direct
+//!   merge + error.
+
+use std::collections::VecDeque;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::time::Duration;
+
+use dashmap::DashMap;
+use freenet_stdlib::prelude::ContractInstanceId;
+use tokio::time::Instant;
+
+use crate::config::GlobalRng;
+use crate::util::time_source::TimeSource;
+
+/// Base cooldown for an `Invalid`-class failure (cheap contract rejection).
+const INVALID_BASE: Duration = Duration::from_secs(30);
+/// Cap for `Invalid`-class cooldown (30 min).
+const INVALID_CAP: Duration = Duration::from_secs(30 * 60);
+/// Base cooldown for a `Timeout`-class failure (runaway merge). Longer than
+/// `Invalid` because re-attempting a merge that pins the contract thread for the
+/// whole execution budget is far more costly than one that rejects quickly.
+const TIMEOUT_BASE: Duration = Duration::from_secs(120);
+/// Cap for `Timeout`-class cooldown (2h).
+const TIMEOUT_CAP: Duration = Duration::from_secs(2 * 60 * 60);
+
+/// How long a failed `(is_delta, bytes)` payload hash is remembered (10 min).
+const FAILED_PAYLOAD_TTL: Duration = Duration::from_secs(10 * 60);
+/// Max remembered failed-payload hashes per contract. Bounds per-entry memory
+/// and caps the memoization at the most-recent distinct failing payloads.
+const MAX_FAILED_PAYLOADS_PER_CONTRACT: usize = 32;
+/// Hard cap on tracked contracts. At ~200 bytes/entry, 16 384 ≈ 3 MB. Bounds the
+/// worst case where an attacker chooses fresh contract ids.
+pub(crate) const MAX_TRACKED_CONTRACTS: usize = 16_384;
+/// Idle-entry cleanup grace period. An entry past its cooldown is retained until
+/// it has been idle (no new failure) this long, preserving the failure counter
+/// across consecutive failure→cooldown→retry cycles. Aligned with the longest
+/// cooldown ([`TIMEOUT_CAP`]) so a contract still in a long cooldown is never
+/// dropped early.
+const CLEANUP_AGE: Duration = TIMEOUT_CAP;
+
+/// Compute the memoization/dedup hash for a broadcast payload. Mirrors
+/// [`crate::operations::update::BroadcastDedupCache`]: includes the `is_delta`
+/// discriminant so a delta and a full state with identical bytes do not collide.
+pub(crate) fn merge_payload_hash(is_delta: bool, payload_bytes: &[u8]) -> u64 {
+    use ahash::AHasher;
+    use std::hash::Hasher;
+    let mut hasher = AHasher::default();
+    hasher.write_u8(u8::from(is_delta));
+    hasher.write(payload_bytes);
+    hasher.finish()
+}
+
+/// Failure class deciding the cooldown parameters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MergeFailureClass {
+    /// Cheap contract-side rejection (`InvalidUpdate`) or any other non-timeout
+    /// execution error (trap, OOG, deser). Base [`INVALID_BASE`].
+    Invalid,
+    /// The WASM merge exceeded the execution time limit. Base [`TIMEOUT_BASE`].
+    Timeout,
+}
+
+impl MergeFailureClass {
+    fn base(self) -> Duration {
+        match self {
+            MergeFailureClass::Invalid => INVALID_BASE,
+            MergeFailureClass::Timeout => TIMEOUT_BASE,
+        }
+    }
+
+    fn cap(self) -> Duration {
+        match self {
+            MergeFailureClass::Invalid => INVALID_CAP,
+            MergeFailureClass::Timeout => TIMEOUT_CAP,
+        }
+    }
+
+    /// `Timeout` outranks `Invalid`: a timeout escalates an entry and never
+    /// downgrades.
+    fn rank(self) -> u8 {
+        match self {
+            MergeFailureClass::Invalid => 0,
+            MergeFailureClass::Timeout => 1,
+        }
+    }
+}
+
+/// Outcome of a pre-merge backoff check.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MergeDecision {
+    /// Not in backoff and payload not known-failed — run the merge.
+    Allow,
+    /// The contract is in a cooldown window — skip the merge (and any
+    /// amplification, e.g. `ResyncRequest`).
+    InBackoff,
+    /// This exact payload already failed and no successful merge has cleared the
+    /// entry since — skip; the outcome cannot change until the state changes.
+    KnownFailedPayload,
+}
+
+impl MergeDecision {
+    /// True when the merge should proceed.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn is_allowed(self) -> bool {
+        matches!(self, MergeDecision::Allow)
+    }
+}
+
+struct Entry {
+    consecutive_failures: u32,
+    class: MergeFailureClass,
+    next_allowed: Instant,
+    last_failure: Instant,
+    /// `(payload_hash, recorded_at)`, newest at back. Bounded + TTL-pruned.
+    failed_payloads: VecDeque<(u64, Instant)>,
+}
+
+impl Entry {
+    /// Drop failed-payload records older than [`FAILED_PAYLOAD_TTL`].
+    fn prune_payloads(&mut self, now: Instant) {
+        while let Some((_, at)) = self.failed_payloads.front() {
+            if now.saturating_duration_since(*at) > FAILED_PAYLOAD_TTL {
+                self.failed_payloads.pop_front();
+            } else {
+                break;
+            }
+        }
+    }
+}
+
+/// Per-contract merge-failure backoff tracker. All state lives in one
+/// [`DashMap`]; concurrency + bounding mirror
+/// [`crate::ring::update_rate_limit::UpdateRateLimiter`].
+pub(crate) struct MergeBackoff {
+    entries: DashMap<ContractInstanceId, Entry>,
+    /// Authoritative size counter for the strict cap (see `UpdateRateLimiter`
+    /// for why `len()` can't be used under a shard guard).
+    size: AtomicUsize,
+    max_tracked: usize,
+    time_source: Arc<dyn TimeSource + Send + Sync>,
+    /// Total merges skipped (cooldown + known-payload) since creation.
+    suppressed_total: AtomicU64,
+}
+
+impl MergeBackoff {
+    pub fn new(time_source: Arc<dyn TimeSource + Send + Sync>) -> Self {
+        Self::with_max(time_source, MAX_TRACKED_CONTRACTS)
+    }
+
+    pub fn with_max(
+        time_source: Arc<dyn TimeSource + Send + Sync>,
+        max_tracked: usize,
+    ) -> Self {
+        Self {
+            entries: DashMap::new(),
+            size: AtomicUsize::new(0),
+            max_tracked,
+            time_source,
+            suppressed_total: AtomicU64::new(0),
+        }
+    }
+
+    /// Decide whether a merge for `contract` with the given payload should run.
+    ///
+    /// `KnownFailedPayload` takes precedence over `InBackoff` (a specific failed
+    /// payload is skipped even once the cooldown elapses). Bumps
+    /// `suppressed_total` on any non-`Allow` outcome. Does NOT create an entry
+    /// for an untracked contract (the common Allow path is a single shard read).
+    pub fn check(&self, contract: &ContractInstanceId, payload_hash: u64) -> MergeDecision {
+        let now = self.time_source.now();
+        let Some(mut entry) = self.entries.get_mut(contract) else {
+            return MergeDecision::Allow;
+        };
+        entry.prune_payloads(now);
+        if entry.failed_payloads.iter().any(|(h, _)| *h == payload_hash) {
+            self.suppressed_total.fetch_add(1, Ordering::Relaxed);
+            return MergeDecision::KnownFailedPayload;
+        }
+        if now < entry.next_allowed {
+            self.suppressed_total.fetch_add(1, Ordering::Relaxed);
+            return MergeDecision::InBackoff;
+        }
+        MergeDecision::Allow
+    }
+
+    /// Record a failed merge, escalating the contract's cooldown and memoizing
+    /// the payload. A `Timeout` failure escalates the entry's class (and never
+    /// downgrades). At the tracked-contracts cap, a failure for a *new* contract
+    /// is dropped (graceful degradation — bounded memory under id churn).
+    pub fn record_failure(
+        &self,
+        contract: &ContractInstanceId,
+        class: MergeFailureClass,
+        payload_hash: u64,
+    ) {
+        let now = self.time_source.now();
+        use dashmap::mapref::entry::Entry as DEntry;
+        match self.entries.entry(*contract) {
+            DEntry::Occupied(mut occ) => {
+                let entry = occ.get_mut();
+                Self::apply_failure(entry, class, payload_hash, now);
+            }
+            DEntry::Vacant(vac) => {
+                // Reserve a slot before inserting (strict cap, see UpdateRateLimiter).
+                let prev = self.size.fetch_add(1, Ordering::Relaxed);
+                if prev >= self.max_tracked {
+                    self.size.fetch_sub(1, Ordering::Relaxed);
+                    return;
+                }
+                let mut entry = Entry {
+                    consecutive_failures: 0,
+                    class,
+                    next_allowed: now,
+                    last_failure: now,
+                    failed_payloads: VecDeque::new(),
+                };
+                Self::apply_failure(&mut entry, class, payload_hash, now);
+                vac.insert(entry);
+            }
+        }
+    }
+
+    fn apply_failure(entry: &mut Entry, class: MergeFailureClass, payload_hash: u64, now: Instant) {
+        // Escalate class upward only (Timeout dominates Invalid).
+        if class.rank() > entry.class.rank() {
+            entry.class = class;
+        }
+        entry.consecutive_failures = entry.consecutive_failures.saturating_add(1);
+        entry.last_failure = now;
+
+        let cooldown = Self::cooldown_for(entry.class, entry.consecutive_failures);
+        entry.next_allowed = now + cooldown;
+
+        // Memoize the failing payload (dedup + bounded + TTL-pruned).
+        entry.prune_payloads(now);
+        if !entry.failed_payloads.iter().any(|(h, _)| *h == payload_hash) {
+            if entry.failed_payloads.len() >= MAX_FAILED_PAYLOADS_PER_CONTRACT {
+                entry.failed_payloads.pop_front();
+            }
+            entry.failed_payloads.push_back((payload_hash, now));
+        }
+    }
+
+    /// `base * 2^(failures-1)`, capped, with ±20% jitter (seeded `GlobalRng`, so
+    /// reproducible under simulation). Mirrors `ExponentialBackoff` + the
+    /// code-style jitter rule.
+    fn cooldown_for(class: MergeFailureClass, consecutive_failures: u32) -> Duration {
+        let base = class.base();
+        let cap = class.cap();
+        let exponent = consecutive_failures.saturating_sub(1).min(20);
+        let raw = base.saturating_mul(1u32 << exponent.min(30));
+        let capped = raw.min(cap);
+        let jitter: f64 = GlobalRng::random_range(0.8_f64..=1.2_f64);
+        capped.mul_f64(jitter)
+    }
+
+    /// Record a successful merge: the contract's state advanced, so every
+    /// remembered failure is stale. Drops the entry entirely (clears both the
+    /// cooldown and the payload memoization).
+    pub fn record_success(&self, contract: &ContractInstanceId) {
+        if self.entries.remove(contract).is_some() {
+            self.size.fetch_sub(1, Ordering::Relaxed);
+        }
+    }
+
+    /// Drop entries whose cooldown has elapsed AND that have been idle longer
+    /// than [`CLEANUP_AGE`]; prune per-entry expired payload memos. Call from the
+    /// Ring reaper. Bounds memory as idle contracts roll off.
+    pub fn cleanup_expired(&self) {
+        let now = self.time_source.now();
+        let mut removed = 0usize;
+        self.entries.retain(|_, entry| {
+            let past_cooldown = now >= entry.next_allowed;
+            let idle = now.saturating_duration_since(entry.last_failure) > CLEANUP_AGE;
+            if past_cooldown && idle {
+                removed += 1;
+                return false;
+            }
+            entry.prune_payloads(now);
+            true
+        });
+        if removed > 0 {
+            self.size.fetch_sub(removed, Ordering::Relaxed);
+        }
+    }
+
+    /// Total merges skipped by this backoff since creation (dashboard / tests).
+    /// Not yet surfaced on the live dashboard (a `RingStatsSnapshot` wire field
+    /// is a clean follow-up); the sim-test signal is
+    /// `GlobalTestMetrics::merges_suppressed_by_backoff`.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn suppressed_total(&self) -> u64 {
+        self.suppressed_total.load(Ordering::Relaxed)
+    }
+
+    /// Number of contracts currently in an active cooldown window (gauge).
+    /// Scans the map (bounded by [`MAX_TRACKED_CONTRACTS`]).
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn contracts_in_backoff(&self) -> usize {
+        let now = self.time_source.now();
+        self.entries
+            .iter()
+            .filter(|e| now < e.value().next_allowed)
+            .count()
+    }
+
+    /// Number of tracked contracts (tests / dashboard).
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::util::time_source::SharedMockTimeSource;
+
+    fn mk_contract(byte: u8) -> ContractInstanceId {
+        ContractInstanceId::new([byte; 32])
+    }
+
+    fn mk() -> (MergeBackoff, SharedMockTimeSource) {
+        let ts = SharedMockTimeSource::new();
+        (MergeBackoff::new(Arc::new(ts.clone())), ts)
+    }
+
+    #[test]
+    fn untracked_contract_is_allowed() {
+        let (b, _ts) = mk();
+        assert_eq!(b.check(&mk_contract(1), 42), MergeDecision::Allow);
+        assert_eq!(b.len(), 0, "check must not create an entry");
+    }
+
+    #[test]
+    fn failure_puts_contract_in_backoff() {
+        let (b, _ts) = mk();
+        let c = mk_contract(1);
+        b.record_failure(&c, MergeFailureClass::Invalid, 1);
+        // A DIFFERENT payload during cooldown is InBackoff (time-based skip).
+        assert_eq!(b.check(&c, 2), MergeDecision::InBackoff);
+        assert_eq!(b.suppressed_total(), 1);
+    }
+
+    #[test]
+    fn success_clears_backoff() {
+        let (b, _ts) = mk();
+        let c = mk_contract(1);
+        b.record_failure(&c, MergeFailureClass::Invalid, 1);
+        assert!(!b.check(&c, 2).is_allowed());
+        b.record_success(&c);
+        assert_eq!(b.check(&c, 2), MergeDecision::Allow);
+        assert_eq!(b.check(&c, 1), MergeDecision::Allow, "memoized payload cleared too");
+        assert_eq!(b.len(), 0);
+    }
+
+    #[test]
+    fn known_failed_payload_skipped_even_after_cooldown() {
+        let (b, ts) = mk();
+        let c = mk_contract(1);
+        b.record_failure(&c, MergeFailureClass::Invalid, 99);
+        // Advance well past the Invalid cooldown (base 30s + jitter) so the
+        // time-based InBackoff no longer applies.
+        ts.advance_time(Duration::from_secs(60));
+        // The specific failed payload is still skipped (memoization) ...
+        assert_eq!(b.check(&c, 99), MergeDecision::KnownFailedPayload);
+        // ... but a fresh payload is now allowed (cooldown elapsed).
+        assert_eq!(b.check(&c, 7), MergeDecision::Allow);
+    }
+
+    #[test]
+    fn known_failed_payload_expires_after_ttl() {
+        let (b, ts) = mk();
+        let c = mk_contract(1);
+        b.record_failure(&c, MergeFailureClass::Invalid, 99);
+        ts.advance_time(FAILED_PAYLOAD_TTL + Duration::from_secs(1));
+        // Past the memo TTL the payload is no longer KnownFailedPayload; the
+        // cooldown is also long past, so it's Allow.
+        assert_eq!(b.check(&c, 99), MergeDecision::Allow);
+    }
+
+    #[test]
+    fn timeout_class_gets_longer_cooldown_than_invalid() {
+        let (b, ts) = mk();
+        let invalid = mk_contract(1);
+        let timeout = mk_contract(2);
+        b.record_failure(&invalid, MergeFailureClass::Invalid, 1);
+        b.record_failure(&timeout, MergeFailureClass::Timeout, 1);
+
+        // After 60s (> Invalid base 30s+jitter, < Timeout base 120s), the
+        // Invalid contract's cooldown has elapsed but the Timeout's has not.
+        ts.advance_time(Duration::from_secs(60));
+        assert_eq!(
+            b.check(&invalid, 555),
+            MergeDecision::Allow,
+            "invalid-class cooldown (30s) should have elapsed by 60s"
+        );
+        assert_eq!(
+            b.check(&timeout, 555),
+            MergeDecision::InBackoff,
+            "timeout-class cooldown (120s) should still be active at 60s"
+        );
+    }
+
+    #[test]
+    fn timeout_escalates_class_and_never_downgrades() {
+        let (b, ts) = mk();
+        let c = mk_contract(1);
+        // First an Invalid failure, then a Timeout: the entry escalates to
+        // Timeout params and stays there even if a later Invalid arrives.
+        b.record_failure(&c, MergeFailureClass::Invalid, 1);
+        b.record_failure(&c, MergeFailureClass::Timeout, 2);
+        b.record_failure(&c, MergeFailureClass::Invalid, 3);
+        // 60s < Timeout base — still in backoff, proving it kept Timeout params.
+        ts.advance_time(Duration::from_secs(60));
+        assert_eq!(b.check(&c, 999), MergeDecision::InBackoff);
+    }
+
+    #[test]
+    fn cooldown_escalates_with_consecutive_failures() {
+        let (b, ts) = mk();
+        let c = mk_contract(1);
+        // First failure: ~30s cooldown. Let it elapse.
+        b.record_failure(&c, MergeFailureClass::Invalid, 1);
+        ts.advance_time(Duration::from_secs(40));
+        assert_eq!(b.check(&c, 2), MergeDecision::Allow);
+        // Second failure: ~60s cooldown (base * 2). 40s is NOT enough now.
+        b.record_failure(&c, MergeFailureClass::Invalid, 3);
+        ts.advance_time(Duration::from_secs(40));
+        assert_eq!(
+            b.check(&c, 4),
+            MergeDecision::InBackoff,
+            "second consecutive failure must escalate the cooldown past 40s"
+        );
+    }
+
+    #[test]
+    fn cooldown_jitter_stays_within_bounds() {
+        // ±20% jitter: a first Invalid failure must land in [24s, 36s].
+        for seed_byte in 0..32u8 {
+            let (b, _ts) = mk();
+            let c = mk_contract(seed_byte);
+            b.record_failure(&c, MergeFailureClass::Invalid, 1);
+            let entry = b.entries.get(&c).unwrap();
+            let cooldown = entry.next_allowed.saturating_duration_since(entry.last_failure);
+            assert!(
+                cooldown >= Duration::from_secs(24) && cooldown <= Duration::from_secs(36),
+                "first-failure cooldown {cooldown:?} must be 30s ±20%"
+            );
+        }
+    }
+
+    #[test]
+    fn cooldown_capped_at_class_max() {
+        let (b, _ts) = mk();
+        let c = mk_contract(1);
+        // Many consecutive failures must saturate at INVALID_CAP (+jitter),
+        // never overflow.
+        for i in 0..40u64 {
+            b.record_failure(&c, MergeFailureClass::Invalid, i);
+        }
+        let entry = b.entries.get(&c).unwrap();
+        let cooldown = entry.next_allowed.saturating_duration_since(entry.last_failure);
+        // Capped at 30 min, +20% jitter ceiling = 36 min.
+        assert!(
+            cooldown <= INVALID_CAP.mul_f64(1.2),
+            "escalating cooldown {cooldown:?} must stay capped near INVALID_CAP"
+        );
+        assert!(cooldown >= INVALID_CAP.mul_f64(0.8));
+    }
+
+    #[test]
+    fn tracked_contracts_are_capped() {
+        let ts = SharedMockTimeSource::new();
+        let b = MergeBackoff::with_max(Arc::new(ts.clone()), 4);
+        for i in 0..4u8 {
+            b.record_failure(&mk_contract(i), MergeFailureClass::Invalid, 1);
+        }
+        assert_eq!(b.len(), 4);
+        // 5th distinct contract is dropped (not tracked) — bounded memory.
+        b.record_failure(&mk_contract(99), MergeFailureClass::Invalid, 1);
+        assert_eq!(b.len(), 4, "cap must bound the tracked-contract count");
+        // But an already-tracked contract keeps escalating.
+        b.record_failure(&mk_contract(0), MergeFailureClass::Invalid, 2);
+        assert_eq!(b.len(), 4);
+    }
+
+    #[test]
+    fn failed_payloads_are_bounded_per_contract() {
+        let (b, _ts) = mk();
+        let c = mk_contract(1);
+        for i in 0..(MAX_FAILED_PAYLOADS_PER_CONTRACT as u64 + 10) {
+            b.record_failure(&c, MergeFailureClass::Invalid, i);
+        }
+        let entry = b.entries.get(&c).unwrap();
+        assert!(
+            entry.failed_payloads.len() <= MAX_FAILED_PAYLOADS_PER_CONTRACT,
+            "per-contract failed-payload history must stay bounded"
+        );
+    }
+
+    #[test]
+    fn cleanup_removes_idle_expired_entries() {
+        let (b, ts) = mk();
+        let c = mk_contract(1);
+        b.record_failure(&c, MergeFailureClass::Invalid, 1);
+        assert_eq!(b.len(), 1);
+        // Past cooldown AND past CLEANUP_AGE → removed.
+        ts.advance_time(CLEANUP_AGE + Duration::from_secs(1));
+        b.cleanup_expired();
+        assert_eq!(b.len(), 0, "idle expired entry must be swept");
+        assert_eq!(b.size.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn cleanup_preserves_active_cooldown() {
+        let (b, ts) = mk();
+        let c = mk_contract(1);
+        b.record_failure(&c, MergeFailureClass::Timeout, 1);
+        // Well within the 2h Timeout cooldown.
+        ts.advance_time(Duration::from_secs(60));
+        b.cleanup_expired();
+        assert_eq!(b.len(), 1, "an entry still in cooldown must not be swept");
+    }
+
+    #[test]
+    fn contracts_in_backoff_gauge() {
+        let (b, ts) = mk();
+        b.record_failure(&mk_contract(1), MergeFailureClass::Invalid, 1);
+        b.record_failure(&mk_contract(2), MergeFailureClass::Timeout, 1);
+        assert_eq!(b.contracts_in_backoff(), 2);
+        // Advance past the Invalid cooldown only.
+        ts.advance_time(Duration::from_secs(60));
+        assert_eq!(
+            b.contracts_in_backoff(),
+            1,
+            "only the still-cooling Timeout contract should count"
+        );
+    }
+}

--- a/crates/core/src/ring/merge_backoff.rs
+++ b/crates/core/src/ring/merge_backoff.rs
@@ -2,10 +2,22 @@
 //!
 //! ## What this does
 //!
-//! A "poison" contract is one whose delta/state merges reliably fail: either
-//! the contract's `update_state` rejects every apply ("Invalid update"), or —
-//! worse — every apply exceeds the execution budget (a runaway merge). In the
-//! #4861 incident a handful of such contracts drove network-wide CPU churn:
+//! A "poison" contract is one whose delta/state merges reliably fail. The #4861
+//! incident surfaced three distinct poison classes, all of which this backoff
+//! must contain WITHOUT assuming the divergence ever heals (the fault is a
+//! contract-layer bug; core's job is only to BOUND the cost):
+//!
+//! - **Compute poison** — every merge exceeds the execution budget (a runaway
+//!   `update_state`). The [`MergeFailureClass::Timeout`] class targets this.
+//! - **Semantic fork oscillation** — two stable divergent states, each side's
+//!   deltas rejected by the other; every resync full-state apply just flips the
+//!   node to the other fork forever (~1 cycle/min). Contained here because the
+//!   backoff is reset ONLY by a genuine successful DELTA merge, never by a
+//!   fork-flipping full-state/resync apply (see the note in `node.rs`).
+//! - **Deserialization poison** — a malformed delta circulating that no holder
+//!   can apply. Presents as [`MergeFailureClass::Invalid`].
+//!
+//! In all three, a handful of such contracts drove network-wide CPU churn:
 //! every re-broadcast that slipped past the 60s [`BroadcastDedupCache`] re-ran
 //! the (failing, expensive) WASM merge, and every delta failure emitted a
 //! full-state `ResyncRequest`, which pulled a fresh full state that failed
@@ -590,6 +602,43 @@ mod tests {
         ts.advance_time(Duration::from_secs(60));
         b.cleanup_expired();
         assert_eq!(b.len(), 1, "an entry still in cooldown must not be swept");
+    }
+
+    #[test]
+    fn fork_oscillation_escalates_into_backoff_without_reset() {
+        // Regression for the #4861 semantic fork-oscillation poison class: two
+        // divergent forks each reject the other's delta, and every ResyncResponse
+        // full-state apply flips the node to the other fork — a "success" that
+        // proves nothing about convergence. Because a resync apply does NOT reset
+        // the backoff (node.rs) and a full-state apply doesn't reset it either
+        // (only a successful DELTA merge does), the alternating delta failures
+        // accumulate and the contract enters backoff, suppressing further merges
+        // (and thus the ResyncRequest amplification). If a resync/full-state
+        // apply reset the entry, the count would return to 1 every cycle and the
+        // loop would never be contained.
+        let (b, ts) = mk();
+        let c = mk_contract(1);
+        let fork_a_delta = 0xAAAA;
+        let fork_b_delta = 0xBBBB;
+
+        // Cycle 1: a fork-B delta fails to apply against fork-A state.
+        b.record_failure(&c, MergeFailureClass::Invalid, fork_b_delta);
+        // ... a resync flips us to fork B (NO record_success — that's the fix).
+        // Cycle 2: a fork-A delta now fails against fork-B state. Let the first
+        // (~30s) cooldown lapse so this models a genuine later re-attempt.
+        ts.advance_time(Duration::from_secs(40));
+        b.record_failure(&c, MergeFailureClass::Invalid, fork_a_delta);
+
+        // Two consecutive failures without a reset ⇒ escalated (~60s) cooldown.
+        // 40s later a fresh (non-memoized) delta is still suppressed, proving the
+        // count escalated past a single-failure 30s cooldown rather than resetting
+        // each cycle.
+        ts.advance_time(Duration::from_secs(40));
+        assert_eq!(
+            b.check(&c, 0xCCCC),
+            MergeDecision::InBackoff,
+            "alternating fork deltas must escalate the backoff (no resync reset)"
+        );
     }
 
     #[test]

--- a/crates/core/src/ring/merge_backoff.rs
+++ b/crates/core/src/ring/merge_backoff.rs
@@ -49,6 +49,26 @@
 //! more expensive to re-attempt than a merge that returns a rejection quickly.
 //! A timeout escalates the entry's class to `Timeout` and never downgrades.
 //!
+//! ## Trip threshold (why a single Invalid failure does not suppress)
+//!
+//! The two classes also differ in HOW MANY consecutive failures (with no
+//! intervening success) must accrue before the FIRST cooldown suppresses:
+//! `Invalid` requires [`INVALID_TRIP_THRESHOLD`] (3), `Timeout` requires
+//! [`TIMEOUT_TRIP_THRESHOLD`] (1). The discriminator is whether the failure is
+//! *cheap and interleaves with successes* or *consecutive-without-success*:
+//!
+//! - A benign stale-version `InvalidUpdate` reject (#3914) is cheap and normal —
+//!   a busy contract hits it on every re-broadcast the 60s dedup missed, always
+//!   interleaved with the successful newer-version merges. Tripping at 1 would
+//!   blackout the contract for 30s, during which NO merge runs so no success can
+//!   land to clear it (success starvation) — escalating a healthy contract.
+//!   Requiring 3 *consecutive* failures means a benign reject (which a success
+//!   always interrupts) never trips.
+//! - A poison / fork contract fails consecutively with zero clean deltas, so it
+//!   reaches 3 and trips (the fork storm at ~2 failures/min trips in ~90s).
+//! - A `Timeout` is a full ~5s CPU burn every time; one is enough, so it trips
+//!   at 1.
+//!
 //! ## Bounded growth
 //!
 //! Modeled on [`crate::ring::update_rate_limit::UpdateRateLimiter`]: a
@@ -90,6 +110,22 @@ const INVALID_CAP: Duration = Duration::from_secs(30 * 60);
 const TIMEOUT_BASE: Duration = Duration::from_secs(120);
 /// Cap for `Timeout`-class cooldown (2h).
 const TIMEOUT_CAP: Duration = Duration::from_secs(2 * 60 * 60);
+
+/// Consecutive `Invalid`-class failures (with NO intervening success) required
+/// before the FIRST cooldown suppresses merges (#4864 review M1). Trip-at-1
+/// would blackout a healthy busy contract on a single benign stale-version
+/// `InvalidUpdate` reject (#3914: production hits these on every re-broadcast
+/// missed by the 60s dedup): during the 30s blackout no merge runs, so no
+/// success can land to clear the entry (success starvation), risking escalation
+/// of a non-poison contract. A benign reject interleaves with successes, so it
+/// never reaches 3 consecutive; a genuine poison/fork contract fails
+/// consecutively and trips. The fork storm (~2 failures/min, zero clean deltas)
+/// still trips within ~90s.
+const INVALID_TRIP_THRESHOLD: u32 = 3;
+/// Consecutive `Timeout`-class failures required before suppression. One is
+/// enough: every timeout is a full ~5s CPU burn on the single contract thread,
+/// so there is no cheap-interleaved-with-success case to tolerate.
+const TIMEOUT_TRIP_THRESHOLD: u32 = 1;
 
 /// How long a failed `(is_delta, bytes)` payload hash is remembered (10 min).
 const FAILED_PAYLOAD_TTL: Duration = Duration::from_secs(10 * 60);
@@ -149,6 +185,16 @@ impl MergeFailureClass {
         match self {
             MergeFailureClass::Invalid => 0,
             MergeFailureClass::Timeout => 1,
+        }
+    }
+
+    /// Consecutive-failures-without-success required before this class starts
+    /// suppressing merges. See [`INVALID_TRIP_THRESHOLD`] /
+    /// [`TIMEOUT_TRIP_THRESHOLD`].
+    fn trip_threshold(self) -> u32 {
+        match self {
+            MergeFailureClass::Invalid => INVALID_TRIP_THRESHOLD,
+            MergeFailureClass::Timeout => TIMEOUT_TRIP_THRESHOLD,
         }
     }
 }
@@ -227,8 +273,13 @@ impl MergeBackoff {
 
     /// Decide whether a merge for `contract` with the given payload should run.
     ///
-    /// `KnownFailedPayload` takes precedence over `InBackoff` (a specific failed
-    /// payload is skipped even once the cooldown elapses). Bumps
+    /// Suppression (both `InBackoff` and `KnownFailedPayload`) kicks in ONLY once
+    /// the contract has failed at least `class.trip_threshold()` times
+    /// consecutively without an intervening success (#4864 review M1): a healthy
+    /// busy contract that gets one benign stale-version `InvalidUpdate` reject
+    /// must not be blacked out (the blackout would starve the success that clears
+    /// it). `KnownFailedPayload` takes precedence over `InBackoff` (a specific
+    /// failed payload is skipped even once the cooldown elapses). Bumps
     /// `suppressed_total` on any non-`Allow` outcome. Does NOT create an entry
     /// for an untracked contract (the common Allow path is a single shard read).
     pub fn check(&self, contract: &ContractInstanceId, payload_hash: u64) -> MergeDecision {
@@ -237,6 +288,12 @@ impl MergeBackoff {
             return MergeDecision::Allow;
         };
         entry.prune_payloads(now);
+        // Below the class's trip threshold, always run the merge — the entry is
+        // still counting failures but not yet "poison". A success (record_success)
+        // clears it before it ever trips, which is exactly the benign case.
+        if entry.consecutive_failures < entry.class.trip_threshold() {
+            return MergeDecision::Allow;
+        }
         if entry
             .failed_payloads
             .iter()
@@ -314,13 +371,18 @@ impl MergeBackoff {
         }
     }
 
-    /// `base * 2^(failures-1)`, capped, with ±20% jitter (seeded `GlobalRng`, so
-    /// reproducible under simulation). Mirrors `ExponentialBackoff` + the
-    /// code-style jitter rule.
+    /// `base * 2^(failures - trip_threshold)`, capped, with ±20% jitter (seeded
+    /// `GlobalRng`, so reproducible under simulation). The exponent is measured
+    /// from the TRIP point, so the FIRST suppressing cooldown (at
+    /// `failures == trip_threshold`) is the base, then escalates as before
+    /// (#4864 review M1). `saturating_sub` floors the pre-trip failures at the
+    /// base too — those cooldowns are never consulted (see `check`).
     fn cooldown_for(class: MergeFailureClass, consecutive_failures: u32) -> Duration {
         let base = class.base();
         let cap = class.cap();
-        let exponent = consecutive_failures.saturating_sub(1).min(20);
+        let exponent = consecutive_failures
+            .saturating_sub(class.trip_threshold())
+            .min(20);
         let raw = base.saturating_mul(1u32 << exponent.min(30));
         let capped = raw.min(cap);
         let jitter: f64 = GlobalRng::random_range(0.8_f64..=1.2_f64);
@@ -366,14 +428,21 @@ impl MergeBackoff {
         self.suppressed_total.load(Ordering::Relaxed)
     }
 
-    /// Number of contracts currently in an active cooldown window (gauge).
-    /// Scans the map (bounded by [`MAX_TRACKED_CONTRACTS`]).
+    /// Number of contracts currently SUPPRESSING merges (gauge). Counts only
+    /// entries that `check` would actually suppress: past the class trip
+    /// threshold AND inside the cooldown window (an entry still accumulating its
+    /// first `trip_threshold - 1` failures is not yet quarantined). Scans the map
+    /// (bounded by [`MAX_TRACKED_CONTRACTS`]).
     #[cfg_attr(not(test), allow(dead_code))]
     pub fn contracts_in_backoff(&self) -> usize {
         let now = self.time_source.now();
         self.entries
             .iter()
-            .filter(|e| now < e.value().next_allowed)
+            .filter(|e| {
+                let entry = e.value();
+                entry.consecutive_failures >= entry.class.trip_threshold()
+                    && now < entry.next_allowed
+            })
             .count()
     }
 
@@ -405,21 +474,62 @@ mod tests {
         assert_eq!(b.len(), 0, "check must not create an entry");
     }
 
+    /// #4864 review M1 test (b): sustained consecutive Invalid failures (no
+    /// successes) do NOT suppress on failures 1-2, then trip at the 3rd.
     #[test]
-    fn failure_puts_contract_in_backoff() {
+    fn invalid_trips_only_after_three_consecutive_failures() {
+        let (b, _ts) = mk();
+        let c = mk_contract(1);
+        // Failures 1 and 2 are counted but do NOT suppress.
+        b.record_failure(&c, MergeFailureClass::Invalid, 1);
+        assert_eq!(
+            b.check(&c, 2),
+            MergeDecision::Allow,
+            "failure 1 must not suppress"
+        );
+        b.record_failure(&c, MergeFailureClass::Invalid, 3);
+        assert_eq!(
+            b.check(&c, 4),
+            MergeDecision::Allow,
+            "failure 2 must not suppress"
+        );
+        // The 3rd consecutive failure trips the Invalid threshold.
+        b.record_failure(&c, MergeFailureClass::Invalid, 5);
+        assert_eq!(b.check(&c, 6), MergeDecision::InBackoff, "failure 3 trips");
+        assert_eq!(b.suppressed_total(), 1);
+    }
+
+    /// #4864 review M1 test (a): two Invalid failures followed by a success are
+    /// never suppressed, and the entry (and its consecutive counter) is cleared.
+    #[test]
+    fn invalid_two_failures_then_success_never_suppressed() {
         let (b, _ts) = mk();
         let c = mk_contract(1);
         b.record_failure(&c, MergeFailureClass::Invalid, 1);
-        // A DIFFERENT payload during cooldown is InBackoff (time-based skip).
-        assert_eq!(b.check(&c, 2), MergeDecision::InBackoff);
-        assert_eq!(b.suppressed_total(), 1);
+        assert!(b.check(&c, 2).is_allowed());
+        b.record_failure(&c, MergeFailureClass::Invalid, 3);
+        assert!(b.check(&c, 4).is_allowed());
+        // A success interrupts the run — the benign-reject case.
+        b.record_success(&c);
+        assert_eq!(b.len(), 0, "success clears the entry (counter reset)");
+        assert_eq!(b.suppressed_total(), 0, "nothing was ever suppressed");
+        // A fresh failure now starts the count from 1 (no lingering escalation).
+        b.record_failure(&c, MergeFailureClass::Invalid, 5);
+        assert_eq!(
+            b.check(&c, 6),
+            MergeDecision::Allow,
+            "post-success failure 1 must not suppress"
+        );
     }
 
     #[test]
     fn success_clears_backoff() {
         let (b, _ts) = mk();
         let c = mk_contract(1);
-        b.record_failure(&c, MergeFailureClass::Invalid, 1);
+        // Trip the Invalid threshold (3 consecutive).
+        for h in [1u64, 3, 5] {
+            b.record_failure(&c, MergeFailureClass::Invalid, h);
+        }
         assert!(!b.check(&c, 2).is_allowed());
         b.record_success(&c);
         assert_eq!(b.check(&c, 2), MergeDecision::Allow);
@@ -435,8 +545,11 @@ mod tests {
     fn known_failed_payload_skipped_even_after_cooldown() {
         let (b, ts) = mk();
         let c = mk_contract(1);
-        b.record_failure(&c, MergeFailureClass::Invalid, 99);
-        // Advance well past the Invalid cooldown (base 30s + jitter) so the
+        // Trip the threshold with the SAME payload three times (consecutive).
+        for _ in 0..3 {
+            b.record_failure(&c, MergeFailureClass::Invalid, 99);
+        }
+        // Advance well past the Invalid first cooldown (base 30s + jitter) so the
         // time-based InBackoff no longer applies.
         ts.advance_time(Duration::from_secs(60));
         // The specific failed payload is still skipped (memoization) ...
@@ -449,11 +562,26 @@ mod tests {
     fn known_failed_payload_expires_after_ttl() {
         let (b, ts) = mk();
         let c = mk_contract(1);
-        b.record_failure(&c, MergeFailureClass::Invalid, 99);
+        for _ in 0..3 {
+            b.record_failure(&c, MergeFailureClass::Invalid, 99);
+        }
         ts.advance_time(FAILED_PAYLOAD_TTL + Duration::from_secs(1));
         // Past the memo TTL the payload is no longer KnownFailedPayload; the
         // cooldown is also long past, so it's Allow.
         assert_eq!(b.check(&c, 99), MergeDecision::Allow);
+    }
+
+    /// #4864 review M1 test (c): a Timeout trips at the FIRST failure.
+    #[test]
+    fn timeout_still_trips_at_first_failure() {
+        let (b, _ts) = mk();
+        let c = mk_contract(1);
+        b.record_failure(&c, MergeFailureClass::Timeout, 1);
+        assert_eq!(
+            b.check(&c, 2),
+            MergeDecision::InBackoff,
+            "a single timeout (full ~5s CPU burn) must trip immediately"
+        );
     }
 
     #[test]
@@ -461,7 +589,11 @@ mod tests {
         let (b, ts) = mk();
         let invalid = mk_contract(1);
         let timeout = mk_contract(2);
-        b.record_failure(&invalid, MergeFailureClass::Invalid, 1);
+        // Trip invalid with 3 consecutive failures → first cooldown = base 30s.
+        for h in [1u64, 2, 3] {
+            b.record_failure(&invalid, MergeFailureClass::Invalid, h);
+        }
+        // Trip timeout with 1 failure → cooldown = base 120s.
         b.record_failure(&timeout, MergeFailureClass::Timeout, 1);
 
         // After 60s (> Invalid base 30s+jitter, < Timeout base 120s), the
@@ -494,20 +626,28 @@ mod tests {
     }
 
     #[test]
-    fn cooldown_escalates_with_consecutive_failures() {
+    fn cooldown_escalates_after_trip() {
         let (b, ts) = mk();
         let c = mk_contract(1);
-        // First failure: ~30s cooldown. Let it elapse.
-        b.record_failure(&c, MergeFailureClass::Invalid, 1);
-        ts.advance_time(Duration::from_secs(40));
-        assert_eq!(b.check(&c, 2), MergeDecision::Allow);
-        // Second failure: ~60s cooldown (base * 2). 40s is NOT enough now.
-        b.record_failure(&c, MergeFailureClass::Invalid, 3);
+        // Trip the Invalid threshold (3 consecutive) → FIRST cooldown = base ~30s.
+        for h in [1u64, 2, 3] {
+            b.record_failure(&c, MergeFailureClass::Invalid, h);
+        }
+        // Let the ~30s first cooldown elapse.
         ts.advance_time(Duration::from_secs(40));
         assert_eq!(
-            b.check(&c, 4),
+            b.check(&c, 10),
+            MergeDecision::Allow,
+            "first (base) cooldown should have elapsed by 40s"
+        );
+        // A 4th consecutive failure escalates to ~60s (base * 2). 40s is NOT
+        // enough now — escalation continues past the trip, as before.
+        b.record_failure(&c, MergeFailureClass::Invalid, 4);
+        ts.advance_time(Duration::from_secs(40));
+        assert_eq!(
+            b.check(&c, 11),
             MergeDecision::InBackoff,
-            "second consecutive failure must escalate the cooldown past 40s"
+            "post-trip failure must escalate the cooldown past 40s"
         );
     }
 
@@ -618,41 +758,58 @@ mod tests {
         // loop would never be contained.
         let (b, ts) = mk();
         let c = mk_contract(1);
-        let fork_a_delta = 0xAAAA;
-        let fork_b_delta = 0xBBBB;
-
-        // Cycle 1: a fork-B delta fails to apply against fork-A state.
-        b.record_failure(&c, MergeFailureClass::Invalid, fork_b_delta);
-        // ... a resync flips us to fork B (NO record_success — that's the fix).
-        // Cycle 2: a fork-A delta now fails against fork-B state. Let the first
-        // (~30s) cooldown lapse so this models a genuine later re-attempt.
+        // Three alternating fork deltas (distinct payloads), 40s apart, each
+        // failing against the current fork, with a resync flip between them that
+        // does NOT reset the backoff. Advance BETWEEN failures only — not after
+        // the 3rd — so the check lands inside the first (~30s) cooldown.
+        b.record_failure(&c, MergeFailureClass::Invalid, 0xAAAA);
         ts.advance_time(Duration::from_secs(40));
-        b.record_failure(&c, MergeFailureClass::Invalid, fork_a_delta);
-
-        // Two consecutive failures without a reset ⇒ escalated (~60s) cooldown.
-        // 40s later a fresh (non-memoized) delta is still suppressed, proving the
-        // count escalated past a single-failure 30s cooldown rather than resetting
-        // each cycle.
+        // ... resync flips to the other fork (NO record_success — the fix).
+        b.record_failure(&c, MergeFailureClass::Invalid, 0xBBBB);
         ts.advance_time(Duration::from_secs(40));
+        b.record_failure(&c, MergeFailureClass::Invalid, 0xCCCC);
+
+        // Three consecutive failures without a reset trip the Invalid threshold;
+        // a fresh (non-memoized) delta is now suppressed — proving the count
+        // accumulated across cycles rather than resetting on each resync/flip.
         assert_eq!(
-            b.check(&c, 0xCCCC),
+            b.check(&c, 0xDDDD),
             MergeDecision::InBackoff,
-            "alternating fork deltas must escalate the backoff (no resync reset)"
+            "alternating fork deltas must trip the backoff (no resync reset)"
         );
     }
 
     #[test]
     fn contracts_in_backoff_gauge() {
         let (b, ts) = mk();
-        b.record_failure(&mk_contract(1), MergeFailureClass::Invalid, 1);
+        // Trip the Invalid contract (3 consecutive) and the Timeout contract (1).
+        for h in [1u64, 2, 3] {
+            b.record_failure(&mk_contract(1), MergeFailureClass::Invalid, h);
+        }
         b.record_failure(&mk_contract(2), MergeFailureClass::Timeout, 1);
         assert_eq!(b.contracts_in_backoff(), 2);
-        // Advance past the Invalid cooldown only.
+        // Advance past the Invalid first cooldown (~30s) only.
         ts.advance_time(Duration::from_secs(60));
         assert_eq!(
             b.contracts_in_backoff(),
             1,
             "only the still-cooling Timeout contract should count"
         );
+    }
+
+    /// The gauge must NOT count a contract still below its trip threshold (a
+    /// pre-trip entry has a `next_allowed` set but `check` would still Allow).
+    #[test]
+    fn contracts_in_backoff_gauge_excludes_pre_trip_entries() {
+        let (b, _ts) = mk();
+        let c = mk_contract(1);
+        b.record_failure(&c, MergeFailureClass::Invalid, 1);
+        b.record_failure(&c, MergeFailureClass::Invalid, 2);
+        // 2 < 3: not yet suppressing, so the gauge must not count it.
+        assert_eq!(b.contracts_in_backoff(), 0);
+        assert!(b.check(&c, 3).is_allowed());
+        // The 3rd failure trips it.
+        b.record_failure(&c, MergeFailureClass::Invalid, 3);
+        assert_eq!(b.contracts_in_backoff(), 1);
     }
 }

--- a/crates/core/src/ring/merge_backoff.rs
+++ b/crates/core/src/ring/merge_backoff.rs
@@ -203,10 +203,7 @@ impl MergeBackoff {
         Self::with_max(time_source, MAX_TRACKED_CONTRACTS)
     }
 
-    pub fn with_max(
-        time_source: Arc<dyn TimeSource + Send + Sync>,
-        max_tracked: usize,
-    ) -> Self {
+    pub fn with_max(time_source: Arc<dyn TimeSource + Send + Sync>, max_tracked: usize) -> Self {
         Self {
             entries: DashMap::new(),
             size: AtomicUsize::new(0),
@@ -228,7 +225,11 @@ impl MergeBackoff {
             return MergeDecision::Allow;
         };
         entry.prune_payloads(now);
-        if entry.failed_payloads.iter().any(|(h, _)| *h == payload_hash) {
+        if entry
+            .failed_payloads
+            .iter()
+            .any(|(h, _)| *h == payload_hash)
+        {
             self.suppressed_total.fetch_add(1, Ordering::Relaxed);
             return MergeDecision::KnownFailedPayload;
         }
@@ -289,7 +290,11 @@ impl MergeBackoff {
 
         // Memoize the failing payload (dedup + bounded + TTL-pruned).
         entry.prune_payloads(now);
-        if !entry.failed_payloads.iter().any(|(h, _)| *h == payload_hash) {
+        if !entry
+            .failed_payloads
+            .iter()
+            .any(|(h, _)| *h == payload_hash)
+        {
             if entry.failed_payloads.len() >= MAX_FAILED_PAYLOADS_PER_CONTRACT {
                 entry.failed_payloads.pop_front();
             }
@@ -406,7 +411,11 @@ mod tests {
         assert!(!b.check(&c, 2).is_allowed());
         b.record_success(&c);
         assert_eq!(b.check(&c, 2), MergeDecision::Allow);
-        assert_eq!(b.check(&c, 1), MergeDecision::Allow, "memoized payload cleared too");
+        assert_eq!(
+            b.check(&c, 1),
+            MergeDecision::Allow,
+            "memoized payload cleared too"
+        );
         assert_eq!(b.len(), 0);
     }
 
@@ -498,7 +507,9 @@ mod tests {
             let c = mk_contract(seed_byte);
             b.record_failure(&c, MergeFailureClass::Invalid, 1);
             let entry = b.entries.get(&c).unwrap();
-            let cooldown = entry.next_allowed.saturating_duration_since(entry.last_failure);
+            let cooldown = entry
+                .next_allowed
+                .saturating_duration_since(entry.last_failure);
             assert!(
                 cooldown >= Duration::from_secs(24) && cooldown <= Duration::from_secs(36),
                 "first-failure cooldown {cooldown:?} must be 30s ±20%"
@@ -516,7 +527,9 @@ mod tests {
             b.record_failure(&c, MergeFailureClass::Invalid, i);
         }
         let entry = b.entries.get(&c).unwrap();
-        let cooldown = entry.next_allowed.saturating_duration_since(entry.last_failure);
+        let cooldown = entry
+            .next_allowed
+            .saturating_duration_since(entry.last_failure);
         // Capped at 30 min, +20% jitter ceiling = 36 min.
         assert!(
             cooldown <= INVALID_CAP.mul_f64(1.2),

--- a/crates/core/src/ring/merge_backoff.rs
+++ b/crates/core/src/ring/merge_backoff.rs
@@ -75,13 +75,20 @@
 //!   memoized — no trip gate. Contract execution is deterministic, so the exact
 //!   bad bytes fail identically for every sender; re-running is pure waste, and
 //!   trip-gating would hand each fresh sender in the fork storm 3 free
-//!   executions of a known-bad payload. The skip can never block a legitimate
-//!   delta (new content = different bytes = memo miss), and it is ZERO-COST:
-//!   the driver returns without running the merge, so the presenting sender's
-//!   channel is NOT advanced and no `ResyncRequest` is emitted (the benign
-//!   stale-reject penalises a channel only when the merge actually RUNS and
-//!   fails). Any successful merge (a state-generation bump) drops the memo,
-//!   re-admitting every payload.
+//!   executions of a known-bad payload. A payload with NEW content is a memo
+//!   miss (different bytes) and always runs; the skip is ZERO-COST — the driver
+//!   returns without running the merge, so the presenting sender's channel is
+//!   NOT advanced and no `ResyncRequest` is emitted (the benign stale-reject
+//!   penalises a channel only when the merge actually RUNS and fails). The one
+//!   bounded staleness window: a delta that failed against state A can become
+//!   valid against state B, but the EXACT same bytes stay memoized until the
+//!   state advances. That window is bounded three ways — any `changed` DELTA
+//!   success drops the whole memo; a state-advancing FULL-STATE apply
+//!   ([`Self::invalidate_payload_memo`], called on a changed streaming/resync
+//!   apply) drops the memo without touching cooldowns; and the ~5-min InterestSync
+//!   anti-entropy plus the [`FAILED_PAYLOAD_TTL`] (10 min) heal it otherwise. A
+//!   PUT-path state advance that does NOT route through those sites leaves the
+//!   memo stale for at most the TTL — an accepted, TTL-bounded corner.
 //!
 //! ## Failure classes
 //!
@@ -544,12 +551,28 @@ impl MergeBackoff {
         }
     }
 
-    /// A successful DELTA merge from `sender`: clears THIS sender's `Invalid`
-    /// channel, plus the contract-wide `Timeout` cooldown and the failed-payload
-    /// memo (the state advanced, so every remembered failure is stale). Other
-    /// senders' `Invalid` channels are left intact — they may genuinely sit on
-    /// the other fork.
-    pub fn record_success_from_sender(&self, contract: &ContractInstanceId, sender: SocketAddr) {
+    /// A successful DELTA merge from `sender`.
+    ///
+    /// The per-sender `Invalid` channel clear is UNCONDITIONAL on a clean delta
+    /// apply (even a no-op `changed == false`): the delta was accepted by the
+    /// contract, which is a channel-TRUST signal for that sender regardless of
+    /// whether it advanced state.
+    ///
+    /// The contract-wide clear (`Timeout` cooldown + failed-payload memo) is
+    /// gated on `changed == true` (#4864 round-4 P1): those signals record that
+    /// the STATE was poison, so they are stale only once the state actually
+    /// ADVANCES. A no-op success (`UpdateNoChange`) means the state did NOT
+    /// advance — the memoized failures and the Timeout quarantine are still
+    /// valid, and clearing them on routine no-op deltas would let a busy
+    /// contract wipe a live 120s→2h Timeout quarantine on every unrelated delta
+    /// (leaving only the 60s dedup floor). Other senders' `Invalid` channels are
+    /// always left intact — they may genuinely sit on the other fork.
+    pub fn record_success_from_sender(
+        &self,
+        contract: &ContractInstanceId,
+        sender: SocketAddr,
+        changed: bool,
+    ) {
         if self
             .invalid_by_sender
             .remove(&(*contract, sender))
@@ -557,15 +580,36 @@ impl MergeBackoff {
         {
             self.invalid_size.fetch_sub(1, Ordering::Relaxed);
         }
-        self.clear_contract_side(contract);
+        if changed {
+            self.clear_contract_side(contract);
+        }
     }
 
     /// A successful client-local DELTA merge: clears the contract-wide `Timeout`
-    /// cooldown and the failed-payload memo ONLY. Per-sender `Invalid` channels
-    /// are untouched — a local client's success proves the contract merges but
-    /// says nothing about any specific remote sender's fork.
-    pub fn record_success_local(&self, contract: &ContractInstanceId) {
-        self.clear_contract_side(contract);
+    /// cooldown and the failed-payload memo — but ONLY when `changed == true`
+    /// (the state actually advanced; see [`Self::record_success_from_sender`] for
+    /// why a no-op success must not clear). Per-sender `Invalid` channels are
+    /// untouched — a local client's success proves the contract merges but says
+    /// nothing about any specific remote sender's fork.
+    pub fn record_success_local(&self, contract: &ContractInstanceId, changed: bool) {
+        if changed {
+            self.clear_contract_side(contract);
+        }
+    }
+
+    /// A state-advancing FULL-STATE apply (streaming full-state broadcast with
+    /// `changed == true`, or a changed `ResyncResponse` apply) invalidates the
+    /// failed-payload memo's premise: a delta that failed against the OLD state
+    /// may be valid against the new one. Clears ONLY the failed-payload memo —
+    /// NOT any cooldown channel. This is NOT a backoff reset: the strictly
+    /// delta-only no-reset doctrine stands (a full-state apply is fork-flippable
+    /// and never proves convergence, so the `Timeout`/`Invalid` cooldowns
+    /// persist). It only re-admits payloads whose known-bad verdict no longer
+    /// holds after the state generation changed.
+    pub fn invalidate_payload_memo(&self, contract: &ContractInstanceId) {
+        if let Some(mut cs) = self.contract.get_mut(contract) {
+            cs.failed_payloads.clear();
+        }
     }
 
     /// Drop the contract-wide entry (clears both the `Timeout` cooldown and the
@@ -746,7 +790,7 @@ mod tests {
         assert!(b.check(&c, s, 2).is_allowed());
         b.record_failure(&c, s, MergeFailureClass::Invalid, 3);
         assert!(b.check(&c, s, 4).is_allowed());
-        b.record_success_from_sender(&c, s);
+        b.record_success_from_sender(&c, s, true);
         assert_eq!(b.invalid_len(), 0, "success clears the sender's channel");
         assert_eq!(b.suppressed_total(), 0, "nothing was ever suppressed");
         b.record_failure(&c, s, MergeFailureClass::Invalid, 5);
@@ -766,7 +810,7 @@ mod tests {
             b.record_failure(&c, s, MergeFailureClass::Invalid, h);
         }
         assert!(!b.check(&c, s, 2).is_allowed());
-        b.record_success_from_sender(&c, s);
+        b.record_success_from_sender(&c, s, true);
         assert_eq!(b.check(&c, s, 2), MergeDecision::Allow);
         assert_eq!(
             b.check(&c, s, 1),
@@ -793,7 +837,7 @@ mod tests {
             b.record_failure(&c, s2, MergeFailureClass::Invalid, h);
         }
         // A success from s1 clears s1 but not s2.
-        b.record_success_from_sender(&c, s1);
+        b.record_success_from_sender(&c, s1, true);
         assert_eq!(b.check(&c, s1, 100), MergeDecision::Allow, "s1 cleared");
         assert_eq!(
             b.check(&c, s2, 101),
@@ -814,11 +858,94 @@ mod tests {
         for h in [2u64, 3, 4] {
             b.record_failure(&c, s, MergeFailureClass::Invalid, h);
         }
-        b.record_success_local(&c);
+        b.record_success_local(&c, true);
         // Contract-wide Timeout gone: a fresh sender with no channel is Allowed.
         assert_eq!(b.check(&c, mk_addr(99), 100), MergeDecision::Allow);
         // The sender's own Invalid channel is untouched — still suppressing.
         assert_eq!(b.check(&c, s, 100), MergeDecision::InBackoff);
+    }
+
+    /// #4864 round-4 P1: the contract-side clear (Timeout + memo) requires
+    /// `changed == true`. A no-op success (changed=false) must leave the memo AND
+    /// the Timeout cooldown intact — the state did not advance, so the recorded
+    /// poison is still valid. `changed == true` clears both.
+    #[test]
+    fn contract_side_clear_requires_changed_true() {
+        let (b, _ts) = mk();
+        let c = mk_contract(1);
+        let s = mk_addr(10);
+        // Contract-wide Timeout (trips at 1) + a memoized poison payload 0xBAD.
+        b.record_failure(&c, s, MergeFailureClass::Timeout, 0xBAD);
+        // A no-op delta success (changed=false) must NOT clear the contract side.
+        b.record_success_from_sender(&c, s, false);
+        assert_eq!(
+            b.check(&c, mk_addr(99), 0xBAD),
+            MergeDecision::KnownFailedPayload,
+            "memo must survive a no-change success (state did not advance)"
+        );
+        assert_eq!(
+            b.check(&c, mk_addr(99), 0x11),
+            MergeDecision::InBackoff,
+            "Timeout cooldown must survive a no-change success"
+        );
+        // A changed=true success clears the contract side.
+        b.record_success_from_sender(&c, s, true);
+        assert_eq!(
+            b.check(&c, mk_addr(99), 0xBAD),
+            MergeDecision::Allow,
+            "memo cleared on a state-advancing success"
+        );
+        assert_eq!(b.check(&c, mk_addr(99), 0x11), MergeDecision::Allow);
+    }
+
+    /// #4864 round-4 P1: the per-sender Invalid channel clear is UNCONDITIONAL on
+    /// a clean delta apply — even a no-op (changed=false) apply clears it (the
+    /// delta was accepted → channel-trust signal for that sender).
+    #[test]
+    fn sender_invalid_channel_clears_on_clean_delta_regardless_of_changed() {
+        let (b, _ts) = mk();
+        let c = mk_contract(1);
+        let s = mk_addr(10);
+        for h in [1u64, 2, 3] {
+            b.record_failure(&c, s, MergeFailureClass::Invalid, h);
+        }
+        assert_eq!(b.invalid_len(), 1);
+        b.record_success_from_sender(&c, s, false);
+        assert_eq!(
+            b.invalid_len(),
+            0,
+            "the sender's Invalid channel clears even on a no-change apply"
+        );
+    }
+
+    /// #4864 round-4 P2: `invalidate_payload_memo` (called on a state-advancing
+    /// full-state apply) re-admits memoized payloads but leaves cooldown channels
+    /// intact — it is a memo invalidation, NOT a backoff reset.
+    #[test]
+    fn invalidate_payload_memo_readmits_payload_but_keeps_cooldown_channel() {
+        let (b, ts) = mk();
+        let c = mk_contract(1);
+        let s = mk_addr(10);
+        // Trip s's Invalid channel with payload 0xBAD, then advance past the ~30s
+        // cooldown but within the 10-min memo TTL.
+        for _ in 0..3 {
+            b.record_failure(&c, s, MergeFailureClass::Invalid, 0xBAD);
+        }
+        ts.advance_time(Duration::from_secs(60));
+        assert_eq!(b.check(&c, s, 0xBAD), MergeDecision::KnownFailedPayload);
+        assert_eq!(b.check(&c, s, 0x11), MergeDecision::Allow);
+        // A state-advancing full-state apply invalidates the memo's premise.
+        b.invalidate_payload_memo(&c);
+        assert_eq!(
+            b.check(&c, s, 0xBAD),
+            MergeDecision::Allow,
+            "memo cleared → the payload is re-admitted after the state advanced"
+        );
+        assert_eq!(
+            b.invalid_len(),
+            1,
+            "the cooldown channel is NOT cleared by memo invalidation"
+        );
     }
 
     #[test]

--- a/crates/core/src/ring/merge_backoff.rs
+++ b/crates/core/src/ring/merge_backoff.rs
@@ -347,9 +347,15 @@ impl MergeBackoff {
     }
 
     fn apply_failure(entry: &mut Entry, class: MergeFailureClass, payload_hash: u64, now: Instant) {
-        // Escalate class upward only (Timeout dominates Invalid).
+        // Escalate class upward only (Timeout dominates Invalid). On escalation,
+        // restart the consecutive count at the NEW class's pre-trip point so the
+        // first cooldown after escalating is that class's BASE, not base shifted
+        // by the pre-escalation failures (review O1: Invalid,Invalid,Timeout must
+        // yield TIMEOUT_BASE=120s, not 480s — the old class's history says
+        // nothing about how far the new class has escalated).
         if class.rank() > entry.class.rank() {
             entry.class = class;
+            entry.consecutive_failures = class.trip_threshold().saturating_sub(1);
         }
         entry.consecutive_failures = entry.consecutive_failures.saturating_add(1);
         entry.last_failure = now;
@@ -581,6 +587,35 @@ mod tests {
             b.check(&c, 2),
             MergeDecision::InBackoff,
             "a single timeout (full ~5s CPU burn) must trip immediately"
+        );
+    }
+
+    /// Review O1 (#4864): escalating Invalid→Timeout must restart the cooldown
+    /// exponent at the NEW class's base. Two pre-escalation Invalid failures
+    /// followed by a Timeout must yield the first Timeout cooldown at
+    /// TIMEOUT_BASE (120s, jitter window [96s, 144s]) — NOT
+    /// `TIMEOUT_BASE * 2^2 = 480s` from counting the Invalid history.
+    #[test]
+    fn class_escalation_restarts_cooldown_at_new_class_base() {
+        let (b, ts) = mk();
+        let c = mk_contract(1);
+        b.record_failure(&c, MergeFailureClass::Invalid, 1);
+        b.record_failure(&c, MergeFailureClass::Invalid, 2);
+        b.record_failure(&c, MergeFailureClass::Timeout, 3);
+        assert_eq!(
+            b.check(&c, 4),
+            MergeDecision::InBackoff,
+            "timeout trips immediately even mid-Invalid-sequence"
+        );
+        // 145s > TIMEOUT_BASE(120s) * 1.2 max jitter: a base-cooldown entry has
+        // elapsed. If the exponent had counted the two Invalid failures
+        // (480s * [0.8, 1.2] = [384s, 576s]) this would still be InBackoff.
+        ts.advance_time(Duration::from_secs(145));
+        assert_eq!(
+            b.check(&c, 5),
+            MergeDecision::Allow,
+            "first post-escalation cooldown must be the Timeout BASE, not \
+             base << pre-escalation failures"
         );
     }
 

--- a/crates/core/src/ring/merge_backoff.rs
+++ b/crates/core/src/ring/merge_backoff.rs
@@ -61,7 +61,9 @@
 //!
 //! ## The two suppression signals
 //!
-//! Both are cleared by a successful DELTA merge:
+//! Both are cleared by a successful DELTA merge (the contract-wide Timeout + memo
+//! only when the state advanced, `changed == true`; the per-sender Invalid channel
+//! unconditionally — see [`Self::record_success_from_sender`]):
 //!
 //! - **Cooldown** ([`MergeDecision::InBackoff`]): time-based. The per-sender
 //!   Invalid channel skips only that sender's deltas; the contract-wide Timeout

--- a/crates/core/src/ring/resync_rate_limit.rs
+++ b/crates/core/src/ring/resync_rate_limit.rs
@@ -57,6 +57,16 @@ pub(crate) const RESPOND_REFILL_INTERVAL: Duration = Duration::from_secs(30);
 /// Burst of full-state responses to a single peer for a contract.
 pub(crate) const RESPOND_BURST: f64 = 1.0;
 
+/// GLOBAL per-contract minimum interval between sent `ResyncResponse`s,
+/// aggregated across ALL requesters (#4861). Per-`(peer, contract)` limiting
+/// alone is insufficient: production saw ~45 distinct requester IPs for one
+/// forked contract driving ~9,733 full-state responses in a day. This caps a
+/// single contract's total resync-response cost at ≈12/min regardless of how
+/// many distinct peers ask.
+pub(crate) const RESPOND_GLOBAL_REFILL_INTERVAL: Duration = Duration::from_secs(5);
+/// Burst of full-state responses for a contract across all requesters.
+pub(crate) const RESPOND_GLOBAL_BURST: f64 = 2.0;
+
 /// Hard cap on tracked keys (per limiter). At ~64 bytes/entry, 16 384 ≈ 1 MB.
 pub(crate) const MAX_TRACKED_KEYS: usize = 16_384;
 
@@ -201,6 +211,8 @@ impl<K: Eq + Hash + Clone> TokenBucketLimiter<K> {
 pub(crate) type ResyncEmitLimiter = TokenBucketLimiter<ContractInstanceId>;
 /// A per-`(peer, contract)` `ResyncResponse` responder limiter.
 pub(crate) type ResyncResponseLimiter = TokenBucketLimiter<(SocketAddr, ContractInstanceId)>;
+/// A GLOBAL per-contract `ResyncResponse` limiter (aggregated over all peers).
+pub(crate) type ResyncResponseGlobalLimiter = TokenBucketLimiter<ContractInstanceId>;
 
 /// Build the emit-side limiter with the tuned defaults.
 pub(crate) fn new_emit_limiter(
@@ -214,7 +226,7 @@ pub(crate) fn new_emit_limiter(
     )
 }
 
-/// Build the responder-side limiter with the tuned defaults.
+/// Build the per-`(peer, contract)` responder-side limiter with tuned defaults.
 pub(crate) fn new_response_limiter(
     time_source: Arc<dyn TimeSource + Send + Sync>,
 ) -> ResyncResponseLimiter {
@@ -222,6 +234,18 @@ pub(crate) fn new_response_limiter(
         time_source,
         RESPOND_BURST,
         RESPOND_REFILL_INTERVAL,
+        MAX_TRACKED_KEYS,
+    )
+}
+
+/// Build the GLOBAL per-contract responder-side limiter with tuned defaults.
+pub(crate) fn new_response_global_limiter(
+    time_source: Arc<dyn TimeSource + Send + Sync>,
+) -> ResyncResponseGlobalLimiter {
+    TokenBucketLimiter::new(
+        time_source,
+        RESPOND_GLOBAL_BURST,
+        RESPOND_GLOBAL_REFILL_INTERVAL,
         MAX_TRACKED_KEYS,
     )
 }
@@ -331,6 +355,40 @@ mod tests {
         assert!(
             (10..=12).contains(&allowed),
             "responder flood over 5 min must send ~11 responses, got {allowed}"
+        );
+    }
+
+    #[test]
+    fn global_responder_cap_bounds_across_many_distinct_peers() {
+        // #4861: per-(peer, contract) limiting is insufficient — production saw
+        // ~45 distinct requester IPs for one forked contract. The GLOBAL
+        // per-contract limiter caps total responses regardless of requester
+        // count. Simulate 45 distinct peers each requesting the SAME contract
+        // once per second for 5 minutes; the global limiter (keyed by contract
+        // only) admits at most burst + window/interval.
+        let ts = SharedMockTimeSource::new();
+        let l = new_response_global_limiter(Arc::new(ts.clone()));
+        let contract = mk_contract(1);
+        for _ in 0..300 {
+            // 45 distinct peers hammer within the same second — all hit the one
+            // per-contract bucket, so only the first with a token gets through.
+            for p in 0..45u8 {
+                let _ = p; // peer identity is irrelevant to the GLOBAL limiter
+                l.check_and_record(contract);
+            }
+            ts.advance_time(Duration::from_secs(1));
+        }
+        // burst(2) + 300s / 5s = 2 + 60 = 62 admits, out of 300*45 = 13500 asks.
+        let allowed = l.allowed_total();
+        assert!(
+            (60..=64).contains(&allowed),
+            "global cap must bound one contract to ~62 responses over 5 min \
+             regardless of requester count, got {allowed}"
+        );
+        assert!(
+            allowed < 100,
+            "global cap keeps a single forked contract well under the ~9,733/day \
+             production storm, got {allowed} in 5 min"
         );
     }
 

--- a/crates/core/src/ring/resync_rate_limit.rs
+++ b/crates/core/src/ring/resync_rate_limit.rs
@@ -1,0 +1,382 @@
+//! Rate limiting for the ResyncRequest/ResyncResponse full-state protocol
+//! (#4861).
+//!
+//! ## Why
+//!
+//! When a delta broadcast fails to apply, the UPDATE relay emits a
+//! `ResyncRequest`, and the receiver replies with a full-state `ResyncResponse`
+//! that is re-merged. For a "poison" contract whose deltas fail from many
+//! senders this becomes a self-sustaining full-state storm (~16 resyncs/min per
+//! contract in the incident): each failure pulls a fresh full state that fails
+//! again. The per-contract merge backoff (`crate::ring::merge_backoff`) stops
+//! re-running the merge, but two amplification edges remain and this module
+//! caps both:
+//!
+//! - **Emit side** (per-contract): a hard ceiling on how often *this* node emits
+//!   a `ResyncRequest` for a given contract, independent of the merge outcome.
+//! - **Responder side** (per `(peer, contract)`): a hard ceiling on how often
+//!   this node answers a *given peer's* `ResyncRequest` for a contract. This is
+//!   the mixed-version-rollout guard: a not-yet-upgraded peer that still emits
+//!   unlimited `ResyncRequest`s cannot make an upgraded peer full-state-reply in
+//!   a loop.
+//!
+//! ## Mechanism: token bucket
+//!
+//! Each key owns a token bucket with capacity `burst` refilling one token per
+//! `refill_interval`. A check consumes one token if available (allow) or is
+//! denied. This gives a small burst for a genuinely-diverged contract to resync
+//! promptly, then a flat steady-state ceiling of `1 / refill_interval`.
+//!
+//! ## Bounded growth
+//!
+//! Same discipline as [`crate::ring::update_rate_limit::UpdateRateLimiter`]: a
+//! [`DashMap`] with a strict [`AtomicUsize`] size cap so an attacker churning
+//! keys cannot grow the map, plus a periodic TTL sweep hooked into the Ring
+//! reaper.
+
+use std::hash::Hash;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::time::Duration;
+
+use dashmap::DashMap;
+use freenet_stdlib::prelude::ContractInstanceId;
+use tokio::time::Instant;
+
+use crate::util::time_source::TimeSource;
+
+/// Per-contract minimum interval between emitted `ResyncRequest`s. A diverged
+/// contract only needs an occasional full-state pull; a storm hits this ceiling.
+pub(crate) const EMIT_REFILL_INTERVAL: Duration = Duration::from_secs(60);
+/// Burst of emitted `ResyncRequest`s allowed before the steady-state ceiling.
+pub(crate) const EMIT_BURST: f64 = 2.0;
+
+/// Per-`(peer, contract)` minimum interval between sent `ResyncResponse`s.
+pub(crate) const RESPOND_REFILL_INTERVAL: Duration = Duration::from_secs(30);
+/// Burst of full-state responses to a single peer for a contract.
+pub(crate) const RESPOND_BURST: f64 = 1.0;
+
+/// Hard cap on tracked keys (per limiter). At ~64 bytes/entry, 16 384 ≈ 1 MB.
+pub(crate) const MAX_TRACKED_KEYS: usize = 16_384;
+
+/// Idle-key cleanup age. A fully-refilled key idle this long is dropped (a fresh
+/// key gets a full bucket, so dropping a recovered one loses nothing).
+const CLEANUP_AGE: Duration = Duration::from_secs(5 * 60);
+
+struct Bucket {
+    tokens: f64,
+    last_refill: Instant,
+}
+
+impl Bucket {
+    /// Refill by elapsed-time / interval, capped at `capacity`.
+    fn refill(&mut self, now: Instant, capacity: f64, interval: Duration) {
+        let elapsed = now.saturating_duration_since(self.last_refill);
+        let gained = elapsed.as_secs_f64() / interval.as_secs_f64();
+        self.tokens = (self.tokens + gained).min(capacity);
+        self.last_refill = now;
+    }
+}
+
+/// A token-bucket rate limiter keyed by `K`. One token per key is consumed per
+/// allowed event; the bucket holds up to `capacity` and refills one token per
+/// `refill_interval`.
+pub(crate) struct TokenBucketLimiter<K: Eq + Hash + Clone> {
+    buckets: DashMap<K, Bucket>,
+    size: AtomicUsize,
+    max_tracked: usize,
+    capacity: f64,
+    refill_interval: Duration,
+    time_source: Arc<dyn TimeSource + Send + Sync>,
+    allowed_total: AtomicU64,
+    suppressed_total: AtomicU64,
+}
+
+impl<K: Eq + Hash + Clone> TokenBucketLimiter<K> {
+    pub fn new(
+        time_source: Arc<dyn TimeSource + Send + Sync>,
+        capacity: f64,
+        refill_interval: Duration,
+        max_tracked: usize,
+    ) -> Self {
+        Self {
+            buckets: DashMap::new(),
+            size: AtomicUsize::new(0),
+            max_tracked,
+            capacity,
+            refill_interval,
+            time_source,
+            allowed_total: AtomicU64::new(0),
+            suppressed_total: AtomicU64::new(0),
+        }
+    }
+
+    /// Check-and-consume one token for `key`. Returns `true` when the event is
+    /// allowed (a token was consumed), `false` when rate-limited or the tracking
+    /// map is at capacity for a new key.
+    pub fn check_and_record(&self, key: K) -> bool {
+        let now = self.time_source.now();
+        use dashmap::mapref::entry::Entry;
+        match self.buckets.entry(key) {
+            Entry::Occupied(mut occ) => {
+                let bucket = occ.get_mut();
+                bucket.refill(now, self.capacity, self.refill_interval);
+                if bucket.tokens >= 1.0 {
+                    bucket.tokens -= 1.0;
+                    self.allowed_total.fetch_add(1, Ordering::Relaxed);
+                    true
+                } else {
+                    self.suppressed_total.fetch_add(1, Ordering::Relaxed);
+                    false
+                }
+            }
+            Entry::Vacant(vac) => {
+                // Reserve a slot before inserting (strict cap, see UpdateRateLimiter).
+                let prev = self.size.fetch_add(1, Ordering::Relaxed);
+                if prev >= self.max_tracked {
+                    self.size.fetch_sub(1, Ordering::Relaxed);
+                    self.suppressed_total.fetch_add(1, Ordering::Relaxed);
+                    return false;
+                }
+                // A brand-new key starts with a full bucket and spends one token.
+                vac.insert(Bucket {
+                    tokens: self.capacity - 1.0,
+                    last_refill: now,
+                });
+                self.allowed_total.fetch_add(1, Ordering::Relaxed);
+                true
+            }
+        }
+    }
+
+    /// Drop fully-refilled keys idle longer than [`CLEANUP_AGE`]. Call from the
+    /// Ring reaper. A dropped key is indistinguishable from a fresh one (both get
+    /// a full bucket), so this never changes behavior — only bounds memory.
+    /// Retained entries are left unmutated (their `last_refill` stays the real
+    /// last-use time, so the next check refills correctly).
+    pub fn cleanup(&self) {
+        let now = self.time_source.now();
+        let capacity = self.capacity;
+        let interval = self.refill_interval;
+        let mut removed = 0usize;
+        self.buckets.retain(|_, bucket| {
+            let elapsed = now.saturating_duration_since(bucket.last_refill);
+            let gained = elapsed.as_secs_f64() / interval.as_secs_f64();
+            let tokens_now = (bucket.tokens + gained).min(capacity);
+            let recovered = tokens_now >= capacity;
+            let idle = elapsed > CLEANUP_AGE;
+            if recovered && idle {
+                removed += 1;
+                false
+            } else {
+                true
+            }
+        });
+        if removed > 0 {
+            self.size.fetch_sub(removed, Ordering::Relaxed);
+        }
+    }
+
+    /// Total events allowed since creation (dashboard / tests).
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn allowed_total(&self) -> u64 {
+        self.allowed_total.load(Ordering::Relaxed)
+    }
+
+    /// Total events suppressed (rate-limited or capacity) since creation.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn suppressed_total(&self) -> u64 {
+        self.suppressed_total.load(Ordering::Relaxed)
+    }
+
+    /// Number of tracked keys (tests / dashboard).
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn len(&self) -> usize {
+        self.buckets.len()
+    }
+}
+
+/// A per-contract `ResyncRequest` emit limiter.
+pub(crate) type ResyncEmitLimiter = TokenBucketLimiter<ContractInstanceId>;
+/// A per-`(peer, contract)` `ResyncResponse` responder limiter.
+pub(crate) type ResyncResponseLimiter = TokenBucketLimiter<(SocketAddr, ContractInstanceId)>;
+
+/// Build the emit-side limiter with the tuned defaults.
+pub(crate) fn new_emit_limiter(
+    time_source: Arc<dyn TimeSource + Send + Sync>,
+) -> ResyncEmitLimiter {
+    TokenBucketLimiter::new(time_source, EMIT_BURST, EMIT_REFILL_INTERVAL, MAX_TRACKED_KEYS)
+}
+
+/// Build the responder-side limiter with the tuned defaults.
+pub(crate) fn new_response_limiter(
+    time_source: Arc<dyn TimeSource + Send + Sync>,
+) -> ResyncResponseLimiter {
+    TokenBucketLimiter::new(
+        time_source,
+        RESPOND_BURST,
+        RESPOND_REFILL_INTERVAL,
+        MAX_TRACKED_KEYS,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::util::time_source::SharedMockTimeSource;
+
+    fn mk_contract(byte: u8) -> ContractInstanceId {
+        ContractInstanceId::new([byte; 32])
+    }
+
+    fn mk_peer(byte: u8) -> SocketAddr {
+        SocketAddr::from(([10, 0, 0, byte], 30000 + byte as u16))
+    }
+
+    #[test]
+    fn emit_allows_burst_then_throttles() {
+        let ts = SharedMockTimeSource::new();
+        let l = new_emit_limiter(Arc::new(ts.clone()));
+        let c = mk_contract(1);
+        // Burst of 2 allowed immediately.
+        assert!(l.check_and_record(c));
+        assert!(l.check_and_record(c));
+        // Third within the window is throttled.
+        assert!(!l.check_and_record(c));
+        assert_eq!(l.allowed_total(), 2);
+        assert_eq!(l.suppressed_total(), 1);
+    }
+
+    #[test]
+    fn emit_refills_one_per_interval() {
+        let ts = SharedMockTimeSource::new();
+        let l = new_emit_limiter(Arc::new(ts.clone()));
+        let c = mk_contract(1);
+        // Drain the burst.
+        assert!(l.check_and_record(c));
+        assert!(l.check_and_record(c));
+        assert!(!l.check_and_record(c));
+        // After one refill interval, exactly one more is allowed.
+        ts.advance_time(EMIT_REFILL_INTERVAL + Duration::from_secs(1));
+        assert!(l.check_and_record(c));
+        assert!(!l.check_and_record(c), "only one token refilled");
+    }
+
+    #[test]
+    fn emit_flood_is_bounded_to_ceil_window_over_interval() {
+        // Model of `may21_flood_pattern_is_throttled`: a flood of delta
+        // failures over a 5-minute window admits at most burst + window/interval
+        // ResyncRequests.
+        let ts = SharedMockTimeSource::new();
+        let l = new_emit_limiter(Arc::new(ts.clone()));
+        let c = mk_contract(1);
+        // 300 attempts, one per second (5 minutes).
+        for _ in 0..300 {
+            l.check_and_record(c);
+            ts.advance_time(Duration::from_secs(1));
+        }
+        // Expected admits ≈ burst(2) + 300s/60s = 2 + 5 = 7. Allow a small band.
+        let allowed = l.allowed_total();
+        assert!(
+            (6..=8).contains(&allowed),
+            "flood over 5 min must admit ~7 ResyncRequests, got {allowed}"
+        );
+        assert_eq!(allowed + l.suppressed_total(), 300);
+    }
+
+    #[test]
+    fn emit_different_contracts_independent() {
+        let ts = SharedMockTimeSource::new();
+        let l = new_emit_limiter(Arc::new(ts.clone()));
+        // Each contract gets its own bucket.
+        assert!(l.check_and_record(mk_contract(1)));
+        assert!(l.check_and_record(mk_contract(2)));
+        assert!(l.check_and_record(mk_contract(1)));
+        assert!(l.check_and_record(mk_contract(2)));
+        // Now both are drained.
+        assert!(!l.check_and_record(mk_contract(1)));
+        assert!(!l.check_and_record(mk_contract(2)));
+    }
+
+    #[test]
+    fn responder_burst_one_then_throttles() {
+        let ts = SharedMockTimeSource::new();
+        let l = new_response_limiter(Arc::new(ts.clone()));
+        let key = (mk_peer(1), mk_contract(1));
+        assert!(l.check_and_record(key));
+        assert!(!l.check_and_record(key), "responder burst is 1");
+        ts.advance_time(RESPOND_REFILL_INTERVAL + Duration::from_secs(1));
+        assert!(l.check_and_record(key));
+    }
+
+    #[test]
+    fn responder_flood_from_one_peer_is_bounded() {
+        // A not-yet-upgraded peer floods ResyncRequests for one contract; the
+        // upgraded responder answers at most ~window/interval times.
+        let ts = SharedMockTimeSource::new();
+        let l = new_response_limiter(Arc::new(ts.clone()));
+        let key = (mk_peer(1), mk_contract(1));
+        for _ in 0..300 {
+            l.check_and_record(key);
+            ts.advance_time(Duration::from_secs(1));
+        }
+        // burst(1) + 300s/30s = 1 + 10 = 11.
+        let allowed = l.allowed_total();
+        assert!(
+            (10..=12).contains(&allowed),
+            "responder flood over 5 min must send ~11 responses, got {allowed}"
+        );
+    }
+
+    #[test]
+    fn responder_different_peers_independent() {
+        let ts = SharedMockTimeSource::new();
+        let l = new_response_limiter(Arc::new(ts.clone()));
+        let c = mk_contract(1);
+        // Two peers requesting the same contract are independent.
+        assert!(l.check_and_record((mk_peer(1), c)));
+        assert!(l.check_and_record((mk_peer(2), c)));
+        // Each is now throttled for its own pair.
+        assert!(!l.check_and_record((mk_peer(1), c)));
+        assert!(!l.check_and_record((mk_peer(2), c)));
+    }
+
+    #[test]
+    fn tracked_keys_capped() {
+        let ts = SharedMockTimeSource::new();
+        let l = TokenBucketLimiter::new(Arc::new(ts.clone()), 1.0, RESPOND_REFILL_INTERVAL, 4);
+        for i in 0..4u8 {
+            assert!(l.check_and_record((mk_peer(i), mk_contract(i))));
+        }
+        assert_eq!(l.len(), 4);
+        // 5th distinct key is dropped (capacity), suppressed.
+        assert!(!l.check_and_record((mk_peer(99), mk_contract(99))));
+        assert_eq!(l.len(), 4);
+    }
+
+    #[test]
+    fn cleanup_removes_recovered_idle_keys() {
+        let ts = SharedMockTimeSource::new();
+        let l = new_emit_limiter(Arc::new(ts.clone()));
+        l.check_and_record(mk_contract(1));
+        l.check_and_record(mk_contract(2));
+        assert_eq!(l.len(), 2);
+        // Fully recover + idle past CLEANUP_AGE.
+        ts.advance_time(CLEANUP_AGE + EMIT_REFILL_INTERVAL * 3);
+        l.cleanup();
+        assert_eq!(l.len(), 0, "recovered idle keys must be swept");
+        assert_eq!(l.size.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn cleanup_preserves_recently_used_keys() {
+        let ts = SharedMockTimeSource::new();
+        let l = new_emit_limiter(Arc::new(ts.clone()));
+        l.check_and_record(mk_contract(1));
+        // Only a short time passes — not idle enough to sweep.
+        ts.advance_time(Duration::from_secs(10));
+        l.cleanup();
+        assert_eq!(l.len(), 1, "recently-used key must be preserved");
+    }
+}

--- a/crates/core/src/ring/resync_rate_limit.rs
+++ b/crates/core/src/ring/resync_rate_limit.rs
@@ -206,7 +206,12 @@ pub(crate) type ResyncResponseLimiter = TokenBucketLimiter<(SocketAddr, Contract
 pub(crate) fn new_emit_limiter(
     time_source: Arc<dyn TimeSource + Send + Sync>,
 ) -> ResyncEmitLimiter {
-    TokenBucketLimiter::new(time_source, EMIT_BURST, EMIT_REFILL_INTERVAL, MAX_TRACKED_KEYS)
+    TokenBucketLimiter::new(
+        time_source,
+        EMIT_BURST,
+        EMIT_REFILL_INTERVAL,
+        MAX_TRACKED_KEYS,
+    )
 }
 
 /// Build the responder-side limiter with the tuned defaults.

--- a/crates/core/src/ring/resync_rate_limit.rs
+++ b/crates/core/src/ring/resync_rate_limit.rs
@@ -33,6 +33,16 @@
 //! [`DashMap`] with a strict [`AtomicUsize`] size cap so an attacker churning
 //! keys cannot grow the map, plus a periodic TTL sweep hooked into the Ring
 //! reaper.
+//!
+//! There is deliberately NO per-connection cleanup on peer disconnect for the
+//! per-`(peer, contract)` responder map (#4864 review — declined): a
+//! disconnected peer's entries simply age out via the [`CLEANUP_AGE`] TTL sweep,
+//! and the total is bounded by the strict [`MAX_TRACKED_KEYS`] cap plus the
+//! global per-contract cap. Under extreme `(peer, contract)` churn a NEW key at
+//! capacity is denied (`check_and_record` returns `false`), which for the
+//! responder means "don't send this response" — a safe, conservative outcome,
+//! not a correctness bug. This matches the `UpdateRateLimiter` precedent, which
+//! also relies on the TTL sweep rather than disconnect hooks.
 
 use std::hash::Hash;
 use std::net::SocketAddr;

--- a/crates/core/src/ring/resync_rate_limit.rs
+++ b/crates/core/src/ring/resync_rate_limit.rs
@@ -260,6 +260,127 @@ pub(crate) fn new_response_global_limiter(
     )
 }
 
+/// TTL for an outstanding `ResyncRequest` correlation entry (#4864 round-8). One
+/// [`EMIT_REFILL_INTERVAL`] (60s): a legitimate `ResyncResponse` arrives well
+/// within this, so a later one is treated as unsolicited and healed by the ~5-min
+/// anti-entropy heartbeat instead of executing a full-state WASM merge.
+pub(crate) const OUTSTANDING_RESYNC_TTL: Duration = Duration::from_secs(60);
+
+/// Correlation map for outstanding `ResyncRequest`s (#4864 round-8, Codex P1).
+///
+/// A received `ResyncResponse` triggers a full-state WASM merge on the resync
+/// apply path that is deliberately NOT gated by the merge-failure backoff (a
+/// full-state apply is fork-flippable, so gating it there could suppress a
+/// genuine heal). Without correlation, that makes the apply path an unmetered
+/// DoS surface: a peer can stream or replay unsolicited `ResyncResponse`s, each
+/// burning up to a full WASM budget, bypassing every emitter-side gate (the emit
+/// limiter only bounds OUR requests).
+///
+/// This records `(contract, target_addr)` when WE emit a `ResyncRequest`; the
+/// receive arm require-and-consumes a matching `(contract, source_addr)` entry
+/// BEFORE the apply, dropping the response (no WASM) on no match.
+/// Consume-on-first-match makes replay dead — a second copy of a solicited
+/// response finds no entry.
+///
+/// Mixed-version safe: an old peer only ever sends a `ResyncResponse` in reply to
+/// OUR `ResyncRequest`, so a legitimate response always has a matching entry
+/// unless it raced the [`OUTSTANDING_RESYNC_TTL`] — that corner heals via
+/// anti-entropy. Bounded exactly like the limiters (strict [`MAX_TRACKED_KEYS`]
+/// cap + reaper TTL sweep) so a request storm can't grow the map without bound.
+pub(crate) struct OutstandingResyncRequests {
+    /// `(contract, peer)` → the time we emitted the request.
+    entries: DashMap<(ContractInstanceId, SocketAddr), Instant>,
+    size: AtomicUsize,
+    max_tracked: usize,
+    ttl: Duration,
+    time_source: Arc<dyn TimeSource + Send + Sync>,
+}
+
+impl OutstandingResyncRequests {
+    pub fn new(time_source: Arc<dyn TimeSource + Send + Sync>) -> Self {
+        Self {
+            entries: DashMap::new(),
+            size: AtomicUsize::new(0),
+            max_tracked: MAX_TRACKED_KEYS,
+            ttl: OUTSTANDING_RESYNC_TTL,
+            time_source,
+        }
+    }
+
+    /// Record that we emitted a `ResyncRequest` for `contract` to `target`.
+    ///
+    /// Re-emitting to the same `(contract, target)` refreshes the timestamp. A
+    /// brand-new key at the strict cap is DROPPED (fail-closed): the eventual
+    /// response is then treated as unsolicited, so we forgo one heal that
+    /// anti-entropy recovers — never a correctness loss, and the cap keeps an
+    /// attacker from growing the map by inducing our emissions.
+    pub fn record(&self, contract: ContractInstanceId, target: SocketAddr) {
+        let now = self.time_source.now();
+        use dashmap::mapref::entry::Entry;
+        match self.entries.entry((contract, target)) {
+            Entry::Occupied(mut occ) => {
+                *occ.get_mut() = now;
+            }
+            Entry::Vacant(vac) => {
+                let prev = self.size.fetch_add(1, Ordering::Relaxed);
+                if prev >= self.max_tracked {
+                    self.size.fetch_sub(1, Ordering::Relaxed);
+                    return;
+                }
+                vac.insert(now);
+            }
+        }
+    }
+
+    /// Require-and-consume a matching outstanding entry for a received
+    /// `ResyncResponse` from `source`. Returns `true` iff a NON-EXPIRED matching
+    /// entry existed — the caller may then apply the state. The entry is REMOVED
+    /// on any match (expired or not), so a replay/duplicate of the same response
+    /// finds nothing and is rejected.
+    pub fn consume(&self, contract: ContractInstanceId, source: SocketAddr) -> bool {
+        let now = self.time_source.now();
+        match self.entries.remove(&(contract, source)) {
+            Some((_, emitted)) => {
+                self.size.fetch_sub(1, Ordering::Relaxed);
+                now.saturating_duration_since(emitted) <= self.ttl
+            }
+            None => false,
+        }
+    }
+
+    /// Drop entries older than the TTL. Call from the Ring reaper so a burst of
+    /// requests whose responses never arrive cannot pin memory past the TTL.
+    pub fn cleanup(&self) {
+        let now = self.time_source.now();
+        let ttl = self.ttl;
+        let mut removed = 0usize;
+        self.entries.retain(|_, emitted| {
+            if now.saturating_duration_since(*emitted) > ttl {
+                removed += 1;
+                false
+            } else {
+                true
+            }
+        });
+        if removed > 0 {
+            self.size.fetch_sub(removed, Ordering::Relaxed);
+        }
+    }
+
+    /// Number of tracked outstanding requests (tests / dashboard).
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+/// Build the outstanding-request correlation map.
+pub(crate) fn new_outstanding_resync_requests(
+    time_source: Arc<dyn TimeSource + Send + Sync>,
+) -> OutstandingResyncRequests {
+    OutstandingResyncRequests::new(time_source)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -271,6 +392,101 @@ mod tests {
 
     fn mk_peer(byte: u8) -> SocketAddr {
         SocketAddr::from(([10, 0, 0, byte], 30000 + byte as u16))
+    }
+
+    #[test]
+    fn outstanding_resync_solicited_response_consumes_and_replay_is_rejected() {
+        let ts = SharedMockTimeSource::new();
+        let m = new_outstanding_resync_requests(Arc::new(ts.clone()));
+        let c = mk_contract(1);
+        let peer = mk_peer(1);
+
+        // No entry → an unsolicited response is rejected and applies nothing.
+        assert!(
+            !m.consume(c, peer),
+            "a response with no outstanding request must be rejected"
+        );
+
+        // We emit a request → the response from that peer is authorized ONCE.
+        m.record(c, peer);
+        assert_eq!(m.len(), 1);
+        assert!(
+            m.consume(c, peer),
+            "the solicited response must be accepted"
+        );
+        assert_eq!(m.len(), 0, "consume must remove the entry");
+
+        // Replay of the same response finds no entry → rejected (replay is dead).
+        assert!(
+            !m.consume(c, peer),
+            "a replayed/duplicate response must be rejected after the first consume"
+        );
+    }
+
+    #[test]
+    fn outstanding_resync_is_scoped_per_contract_and_peer() {
+        let ts = SharedMockTimeSource::new();
+        let m = new_outstanding_resync_requests(Arc::new(ts.clone()));
+        let c = mk_contract(1);
+        m.record(c, mk_peer(1));
+        // A response for the SAME contract from a DIFFERENT peer is unsolicited.
+        assert!(!m.consume(c, mk_peer(2)));
+        // A response for a DIFFERENT contract from the recorded peer is unsolicited.
+        assert!(!m.consume(mk_contract(2), mk_peer(1)));
+        // The real match still stands and consumes.
+        assert!(m.consume(c, mk_peer(1)));
+    }
+
+    #[test]
+    fn outstanding_resync_ttl_expiry_rejects_and_cleanup_reaps() {
+        let ts = SharedMockTimeSource::new();
+        let m = new_outstanding_resync_requests(Arc::new(ts.clone()));
+        let c = mk_contract(1);
+        let peer = mk_peer(1);
+
+        // Just UNDER the TTL → still accepted.
+        m.record(c, peer);
+        ts.advance_time(OUTSTANDING_RESYNC_TTL - Duration::from_millis(1));
+        assert!(
+            m.consume(c, peer),
+            "a response within the TTL must be accepted"
+        );
+
+        // Past the TTL → the stale entry is consumed-and-REJECTED.
+        m.record(c, peer);
+        ts.advance_time(OUTSTANDING_RESYNC_TTL + Duration::from_millis(1));
+        assert!(
+            !m.consume(c, peer),
+            "a response arriving past the TTL must be rejected as unsolicited"
+        );
+        assert_eq!(m.len(), 0, "a consumed (even if stale) entry is removed");
+
+        // cleanup() reaps expired entries whose response never arrived.
+        m.record(mk_contract(9), mk_peer(9));
+        assert_eq!(m.len(), 1);
+        ts.advance_time(OUTSTANDING_RESYNC_TTL + Duration::from_secs(1));
+        m.cleanup();
+        assert_eq!(m.len(), 0, "cleanup must reap entries older than the TTL");
+    }
+
+    #[test]
+    fn outstanding_resync_is_strictly_capped() {
+        let ts = SharedMockTimeSource::new();
+        let m = new_outstanding_resync_requests(Arc::new(ts.clone()));
+        // Fill to the cap with distinct (contract, peer) keys.
+        for i in 0..MAX_TRACKED_KEYS {
+            let c = ContractInstanceId::new([(i % 256) as u8; 32]);
+            let peer = SocketAddr::from(([10, (i >> 16) as u8, (i >> 8) as u8, i as u8], 40000));
+            m.record(c, peer);
+        }
+        assert_eq!(m.len(), MAX_TRACKED_KEYS, "map fills to exactly the cap");
+        // One more distinct key is dropped (fail-closed), not admitted.
+        let overflow_c = ContractInstanceId::new([0xAB; 32]);
+        let overflow_peer = SocketAddr::from(([172, 16, 0, 1], 41000));
+        m.record(overflow_c, overflow_peer);
+        assert_eq!(m.len(), MAX_TRACKED_KEYS, "over-cap insert is dropped");
+        // Its response is therefore treated as unsolicited.
+        assert!(!m.consume(overflow_c, overflow_peer));
     }
 
     #[test]

--- a/crates/core/src/wasm_runtime.rs
+++ b/crates/core/src/wasm_runtime.rs
@@ -17,7 +17,9 @@ mod state_store;
 #[cfg(all(test, feature = "wasmtime-backend"))]
 mod tests;
 
-pub(crate) use contract::{ContractRuntimeBridge, ContractRuntimeInterface, ContractStoreBridge};
+pub(crate) use contract::{
+    ContractRuntimeBridge, ContractRuntimeInterface, ContractStoreBridge, classify_result,
+};
 pub use contract_store::{ContractStore, SharedContractIndex};
 pub(crate) use delegate::DelegateRuntimeInterface;
 pub use delegate_store::DelegateStore;

--- a/crates/core/src/wasm_runtime.rs
+++ b/crates/core/src/wasm_runtime.rs
@@ -36,7 +36,7 @@ pub(crate) use module_cache::{
 // the re-export isn't an unused import under `-D warnings` in release.
 #[cfg(test)]
 pub(crate) use module_cache::{
-    MAX_DEFAULT_MODULE_CACHE_BUDGET_BYTES, MIN_DEFAULT_MODULE_CACHE_BUDGET_BYTES,
+    MAX_DEFAULT_MODULE_CACHE_BUDGET_BYTES, MIN_DEFAULT_MODULE_CACHE_BUDGET_BYTES, budget_for_ram,
 };
 pub(crate) use native_api::{
     DELEGATE_SUBSCRIPTIONS, DelegateContextCache, SharedDelegateCounter, SharedInheritedOrigins,

--- a/crates/core/src/wasm_runtime/contract.rs
+++ b/crates/core/src/wasm_runtime/contract.rs
@@ -324,8 +324,23 @@ impl ContractRuntimeInterface for super::Runtime {
     }
 }
 
-/// Convert a WasmError from the engine into the appropriate RuntimeResult error.
-fn classify_result(result: Result<i64, WasmError>) -> RuntimeResult<i64> {
+/// Convert a `WasmError` from the engine into the canonical [`RuntimeResult`]
+/// error. Timeout and out-of-gas get their dedicated [`ContractExecError`]
+/// representations; everything else keeps the generic conversion.
+///
+/// Generic over the success type so it can normalize BOTH the merge/validate
+/// `i64` returns AND the guest-entry setup calls (`create_instance` →
+/// `InstanceHandle`, `initiate_buffer` → `i64`). Routing the guest-entry calls
+/// through here is load-bearing (#4864 round-5): an epoch interrupt during a
+/// runaway module start function / allocator surfaces as [`WasmError::Timeout`],
+/// and MUST normalize to [`ContractExecError::MaxComputeTimeExceeded`] — the same
+/// canonical representation the blocking merge path produces — so
+/// `ExecutorError::is_wasm_timeout` recognizes it and the merge-failure backoff
+/// picks the contract-wide Timeout class. The generic `WasmError` → `ContractError`
+/// conversion instead formats Timeout as "execution timeout", which
+/// `is_wasm_timeout` does NOT match, so the timeout would wrongly get the
+/// per-sender Invalid class.
+pub(crate) fn classify_result<T>(result: Result<T, WasmError>) -> RuntimeResult<T> {
     match result {
         Ok(value) => Ok(value),
         Err(WasmError::OutOfGas) => Err(ContractExecError::OutOfGas.into()),

--- a/crates/core/src/wasm_runtime/contract.rs
+++ b/crates/core/src/wasm_runtime/contract.rs
@@ -345,6 +345,11 @@ pub(crate) fn classify_result<T>(result: Result<T, WasmError>) -> RuntimeResult<
         Ok(value) => Ok(value),
         Err(WasmError::OutOfGas) => Err(ContractExecError::OutOfGas.into()),
         Err(WasmError::Timeout) => Err(ContractExecError::MaxComputeTimeExceeded.into()),
+        // #4864 round-6: a scheduler-overload timeout (guest never ran, blocking-
+        // pool saturation) maps to its own transient variant. The op_ctx_task
+        // record site excludes it from the merge-failure backoff, so it is NOT
+        // quarantined contract-wide the way a real Timeout is.
+        Err(WasmError::SchedulerOverloaded) => Err(ContractExecError::SchedulerOverloaded.into()),
         Err(e) => Err(e.into()),
     }
 }

--- a/crates/core/src/wasm_runtime/engine.rs
+++ b/crates/core/src/wasm_runtime/engine.rs
@@ -84,6 +84,14 @@ pub(crate) enum WasmError {
     #[error("execution timeout")]
     Timeout,
 
+    /// The execution never ran because it sat queued on a saturated blocking
+    /// pool past the wall-clock deadline (#4864 round-6). Distinct from
+    /// [`WasmError::Timeout`]: the guest never started, so this is a transient
+    /// load condition, NOT a contract-intrinsic timeout, and callers treat it
+    /// like queue-full backpressure (no per-contract quarantine).
+    #[error("scheduler overloaded")]
+    SchedulerOverloaded,
+
     /// Catch-all for backend-specific errors.
     #[error(transparent)]
     Other(anyhow::Error),

--- a/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
+++ b/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
@@ -955,13 +955,21 @@ impl WasmEngine for WasmtimeEngine {
             }
         };
 
-        // Arm the epoch deadline before the guest runs on the blocking thread
-        // (#4861). The wall-clock poll below is a backstop; the epoch trap is
-        // what actually stops a runaway synchronous guest.
-        arm_epoch_deadline(&mut store, self.epoch_deadline_ticks);
+        // #4864 round-7: arm the epoch deadline INSIDE the blocking closure, as
+        // the guest's first act — NOT here, before the closure is enqueued.
+        // Arming before enqueue let the queue wait on a saturated blocking pool
+        // consume the epoch budget, so a queued job would insta-trap on start and
+        // a HEALTHY contract would be quarantined (contract-wide Timeout). Arming
+        // at guest-start makes the epoch budget (and the wall-clock backstop in
+        // execute_wasm_blocking) measure from when the guest actually runs. The
+        // wall-clock poll is a backstop; the epoch trap is what actually stops a
+        // runaway synchronous guest. Capture the tick budget by value since the
+        // closure can't borrow `self`.
+        let epoch_ticks = self.epoch_deadline_ticks;
 
         let result = execute_wasm_blocking(
             move || {
+                arm_epoch_deadline(&mut store, epoch_ticks);
                 // Use call_async because async_support(true) is enabled in the engine Config
                 let r = block_on_async(func.call_async(&mut store, (a, b)));
                 (r, store)
@@ -1027,14 +1035,18 @@ impl WasmEngine for WasmtimeEngine {
             }
         };
 
-        // Arm the epoch deadline before the guest runs on the blocking thread
-        // (#4861). This is the primary contract merge/validate path — the wall-
-        // clock poll below only aborts the tokio task, so the epoch trap is what
-        // actually stops a runaway synchronous guest that ignores the timeout.
-        arm_epoch_deadline(&mut store, self.epoch_deadline_ticks);
+        // #4864 round-7: arm the epoch deadline INSIDE the blocking closure, as
+        // the guest's first act — NOT here, before the closure is enqueued (see
+        // call_2i64_blocking for the full rationale). This is the primary contract
+        // merge/validate path, so a pre-enqueue arm consumed by queue wait would
+        // quarantine a healthy contract under blocking-pool saturation. The wall-
+        // clock poll only aborts the tokio task; the epoch trap is what actually
+        // stops a runaway synchronous guest that ignores the timeout.
+        let epoch_ticks = self.epoch_deadline_ticks;
 
         let result = execute_wasm_blocking(
             move || {
+                arm_epoch_deadline(&mut store, epoch_ticks);
                 // Use call_async because async_support(true) is enabled in the engine Config
                 let r = block_on_async(func.call_async(&mut store, (a, b, c)));
                 (r, store)
@@ -1842,24 +1854,108 @@ enum BlockingResult {
     Panic(anyhow::Error),
 }
 
+/// Verdict from the wall-clock backstop poll in [`execute_wasm_blocking`].
+#[derive(Debug, PartialEq, Eq)]
+enum WallVerdict {
+    /// Neither bound exceeded yet — keep polling.
+    KeepWaiting,
+    /// The guest RAN and consumed its full budget (measured from guest-start,
+    /// not from enqueue) — a real, contract-intrinsic timeout backing up the
+    /// epoch trap. Quarantine-worthy.
+    GuestOverran,
+    /// The closure never got off the blocking-pool queue within the queue bound
+    /// — transient scheduler overload the guest never entered. NOT a contract
+    /// fault; must not be charged to the contract.
+    QueuedTooLong,
+}
+
+/// #4864 round-7: classify the wall-clock backstop, bounding queue wait and the
+/// per-guest compute budget SEPARATELY.
+///
+/// The epoch deadline is now armed INSIDE the blocking closure (at guest-start,
+/// see `call_2i64_blocking` / `call_3i64_blocking`), so the wall-clock loop
+/// measures the guest's budget from `started_at`, not from enqueue. That closes
+/// two failure modes under blocking-pool saturation:
+///
+/// - (a) A job that sat queued past `budget` and then ran would, if the budget
+///   were measured from enqueue (and the epoch armed pre-enqueue), insta-trip on
+///   start and be quarantined as a real timeout even though it is HEALTHY. Now a
+///   not-yet-started job that hits the queue bound is [`WallVerdict::QueuedTooLong`]
+///   (transient), and a job that starts gets its FULL budget from its own start.
+/// - (b) A job that started just before an enqueue-relative deadline would be
+///   classified as a real timeout after mere milliseconds of guest time. Now the
+///   guest must actually consume `budget` of run time to earn `GuestOverran`.
+///
+/// The total wall bound is `queue_wait + budget`, each individually `<= budget`.
+///
+/// - `started_at`: `Some(elapsed-at-guest-start)` once the guest began running,
+///   `None` while still queued.
+/// - `elapsed`: time since enqueue.
+/// - `budget`: both the per-guest compute budget AND the queue bound.
+fn classify_wall_timeout(
+    started_at: Option<Duration>,
+    elapsed: Duration,
+    budget: Duration,
+) -> WallVerdict {
+    match started_at {
+        // Guest is running: a real timeout only once it has consumed its full
+        // budget measured from its OWN start, not from enqueue.
+        Some(started_at) => {
+            if elapsed.saturating_sub(started_at) >= budget {
+                WallVerdict::GuestOverran
+            } else {
+                WallVerdict::KeepWaiting
+            }
+        }
+        // Never started: transient scheduler overload once queued past the bound.
+        None => {
+            if elapsed >= budget {
+                WallVerdict::QueuedTooLong
+            } else {
+                WallVerdict::KeepWaiting
+            }
+        }
+    }
+}
+
 fn execute_wasm_blocking<F>(f: F, max_execution_seconds: f64) -> BlockingResult
 where
     F: FnOnce() -> WasmResult + Send + 'static,
 {
-    let timeout = Duration::from_secs_f64(max_execution_seconds);
+    // `budget` bounds BOTH the queue wait (before the guest starts) and the
+    // guest's own compute time (after it starts), SEPARATELY — see
+    // `classify_wall_timeout`.
+    let budget = Duration::from_secs_f64(max_execution_seconds);
     let start = std::time::Instant::now();
 
-    // #4864 round-6: distinguish a guest that RAN and blew the wall-clock
-    // deadline (a real, contract-intrinsic timeout — the epoch backstop) from a
-    // closure that never got off the blocking-pool queue (a transient scheduler
-    // overload the guest never entered). The wrapped closure's FIRST act flips
-    // `started`, so a wall-clock fire with `started == false` means the guest
-    // never ran and the failure must NOT be charged to the contract.
+    // #4864 round-6/7: distinguish a guest that RAN and blew its budget (a real,
+    // contract-intrinsic timeout — the epoch backstop) from a closure that never
+    // got off the blocking-pool queue (a transient scheduler overload the guest
+    // never entered). The wrapper records `started_at` (ms since enqueue) then
+    // flips `started` as the closure's first acts; the CALLER's closure then arms
+    // the epoch deadline as ITS first act, so the guest's budget starts at
+    // guest-start, not at enqueue. A wall-clock fire with `started == false` means
+    // the guest never ran and the failure must NOT be charged to the contract.
     let started = Arc::new(AtomicBool::new(false));
+    let started_at_ms = Arc::new(AtomicU64::new(0));
     let started_for_guest = Arc::clone(&started);
+    let started_at_for_guest = Arc::clone(&started_at_ms);
     let f = move || {
+        // Record started_at BEFORE flipping `started`, so the poll loop that
+        // observes started==true (SeqCst) is guaranteed to read a valid
+        // started_at.
+        started_at_for_guest.store(start.elapsed().as_millis() as u64, Ordering::SeqCst);
         started_for_guest.store(true, Ordering::SeqCst);
         f()
+    };
+
+    // Read the guest-start clock as `Some` only once the guest has actually
+    // started, so a stale started_at of 0 is never mistaken for a guest that
+    // began at t=0 while it is in fact still queued.
+    let read_started_at = || -> Option<Duration> {
+        started
+            .load(Ordering::SeqCst)
+            .then(|| Duration::from_millis(started_at_ms.load(Ordering::SeqCst)))
     };
 
     // `block_in_place` (in the multi-thread arm below) is only legal on a
@@ -1894,28 +1990,27 @@ where
                     };
                 }
 
-                if start.elapsed() >= timeout {
-                    task_handle.abort();
-                    // #4864 round-6: only a guest that actually STARTED is a real
-                    // (contract-intrinsic) timeout. A closure still queued on a
-                    // saturated blocking pool never ran, so classify it as a
-                    // transient scheduler overload instead of quarantining the
-                    // contract.
-                    if started.load(Ordering::SeqCst) {
+                match classify_wall_timeout(read_started_at(), start.elapsed(), budget) {
+                    WallVerdict::KeepWaiting => {}
+                    WallVerdict::GuestOverran => {
+                        task_handle.abort();
                         tracing::warn!(
                             timeout_secs = max_execution_seconds,
                             elapsed_ms = start.elapsed().as_millis(),
-                            "WASM execution timed out (guest running; epoch backstop)"
+                            "WASM execution timed out (guest running past its budget; epoch backstop)"
                         );
                         return BlockingResult::Timeout;
                     }
-                    tracing::warn!(
-                        timeout_secs = max_execution_seconds,
-                        elapsed_ms = start.elapsed().as_millis(),
-                        "WASM execution timed out while QUEUED (guest never started; \
-                         blocking-pool saturation) — treated as transient, contract not quarantined"
-                    );
-                    return BlockingResult::QueuedTimeout;
+                    WallVerdict::QueuedTooLong => {
+                        task_handle.abort();
+                        tracing::warn!(
+                            timeout_secs = max_execution_seconds,
+                            elapsed_ms = start.elapsed().as_millis(),
+                            "WASM execution timed out while QUEUED (guest never started; \
+                             blocking-pool saturation) — treated as transient, contract not quarantined"
+                        );
+                        return BlockingResult::QueuedTimeout;
+                    }
                 }
 
                 std::thread::sleep(Duration::from_millis(10));
@@ -1956,27 +2051,30 @@ where
                     }
                 }
 
-                if start.elapsed() >= timeout {
-                    // #4864 round-6: same started-flag classification as the
-                    // multi-thread arm. The detached thread is left to finish
-                    // and drop the store on its own (as before); only the
-                    // RESULT classification differs by whether the guest ran.
-                    if started.load(Ordering::SeqCst) {
+                // Same started-flag classification as the multi-thread arm. The
+                // detached thread is left to finish and drop the store on its own
+                // (as before); only the RESULT classification differs by whether
+                // the guest ran.
+                match classify_wall_timeout(read_started_at(), start.elapsed(), budget) {
+                    WallVerdict::KeepWaiting => {}
+                    WallVerdict::GuestOverran => {
                         tracing::warn!(
                             timeout_secs = max_execution_seconds,
                             elapsed_ms = start.elapsed().as_millis(),
-                            "WASM execution timed out (guest running; epoch backstop, no tokio runtime)"
+                            "WASM execution timed out (guest running past its budget; epoch backstop, no tokio runtime)"
                         );
                         return BlockingResult::Timeout;
                     }
-                    tracing::warn!(
-                        timeout_secs = max_execution_seconds,
-                        elapsed_ms = start.elapsed().as_millis(),
-                        "WASM execution timed out while QUEUED (guest never started; \
-                         blocking-pool saturation, no tokio runtime) — treated as transient, \
-                         contract not quarantined"
-                    );
-                    return BlockingResult::QueuedTimeout;
+                    WallVerdict::QueuedTooLong => {
+                        tracing::warn!(
+                            timeout_secs = max_execution_seconds,
+                            elapsed_ms = start.elapsed().as_millis(),
+                            "WASM execution timed out while QUEUED (guest never started; \
+                             blocking-pool saturation, no tokio runtime) — treated as transient, \
+                             contract not quarantined"
+                        );
+                        return BlockingResult::QueuedTimeout;
+                    }
                 }
 
                 std::thread::sleep(Duration::from_millis(10));
@@ -2273,6 +2371,105 @@ mod tests {
                 );
                 prev = entry_pos;
             }
+        }
+    }
+
+    /// #4864 round-7 (Codex P1): the wall-clock backstop must bound queue wait and
+    /// per-guest compute budget SEPARATELY, measured from `started_at` (guest
+    /// start) rather than from enqueue. Encodes both failure modes the fix closes.
+    #[test]
+    fn classify_wall_timeout_bounds_queue_and_budget_separately() {
+        use super::{WallVerdict, classify_wall_timeout};
+        let budget = Duration::from_millis(100);
+
+        // Not started, under the queue bound → keep waiting.
+        assert_eq!(
+            classify_wall_timeout(None, Duration::from_millis(50), budget),
+            WallVerdict::KeepWaiting
+        );
+        // Not started, past the queue bound → transient (never charged to the
+        // contract). This is fix (a): a job that never got off the queue is not a
+        // contract fault.
+        assert_eq!(
+            classify_wall_timeout(None, Duration::from_millis(100), budget),
+            WallVerdict::QueuedTooLong
+        );
+        assert_eq!(
+            classify_wall_timeout(None, Duration::from_millis(250), budget),
+            WallVerdict::QueuedTooLong
+        );
+
+        // Started at t=0, guest under budget → keep waiting.
+        assert_eq!(
+            classify_wall_timeout(Some(Duration::ZERO), Duration::from_millis(50), budget),
+            WallVerdict::KeepWaiting
+        );
+        // Started at t=0, guest consumed its full budget → real timeout.
+        assert_eq!(
+            classify_wall_timeout(Some(Duration::ZERO), Duration::from_millis(100), budget),
+            WallVerdict::GuestOverran
+        );
+
+        // Fix (b): started LATE (queued 90ms) — total elapsed 150ms exceeds
+        // `budget`, but the guest has only run 60ms (< budget), so it is NOT a real
+        // timeout. Pre-fix (enqueue-relative) this would have fired GuestOverran
+        // after only 10ms of guest time, quarantining a healthy contract.
+        assert_eq!(
+            classify_wall_timeout(
+                Some(Duration::from_millis(90)),
+                Duration::from_millis(150),
+                budget
+            ),
+            WallVerdict::KeepWaiting
+        );
+        // Same late start, once the guest has run its full budget (90 + 100 = 190).
+        assert_eq!(
+            classify_wall_timeout(
+                Some(Duration::from_millis(90)),
+                Duration::from_millis(190),
+                budget
+            ),
+            WallVerdict::GuestOverran
+        );
+    }
+
+    /// #4864 round-7 pin: the blocking guest-entry paths MUST arm the epoch
+    /// deadline INSIDE the closure passed to `execute_wasm_blocking` (so the
+    /// budget starts at guest-start), not before it (which would let queue wait on
+    /// a saturated pool consume the budget and quarantine a healthy contract).
+    /// Asserts the `arm_epoch_deadline(` call in each fn sits AFTER the
+    /// `execute_wasm_blocking(` call. Complements
+    /// `every_guest_entry_is_preceded_by_arm_epoch_deadline`, which only checks the
+    /// arm precedes the guest entry textually (true both before and after the fix).
+    #[test]
+    fn blocking_paths_arm_epoch_inside_the_closure() {
+        let src = include_str!("wasmtime_engine.rs");
+        for fn_name in ["fn call_2i64_blocking(", "fn call_3i64_blocking("] {
+            let start = src
+                .find(fn_name)
+                .unwrap_or_else(|| panic!("`{fn_name}` not found"));
+            let rest = &src[start + fn_name.len()..];
+            // Bound the body at the next method or the impl close.
+            let end = ["\n    fn ", "\n}"]
+                .iter()
+                .filter_map(|needle| rest.find(needle))
+                .min()
+                .map(|i| start + fn_name.len() + i)
+                .unwrap_or(src.len());
+            let body = &src[start..end];
+
+            let ewb = body
+                .find("execute_wasm_blocking(")
+                .unwrap_or_else(|| panic!("`{fn_name}` must call execute_wasm_blocking"));
+            let arm = body
+                .find("arm_epoch_deadline(")
+                .unwrap_or_else(|| panic!("`{fn_name}` must arm the epoch deadline"));
+            assert!(
+                arm > ewb,
+                "`{fn_name}`: arm_epoch_deadline must be INSIDE the execute_wasm_blocking \
+                 closure (after the call), not before it — else queue wait consumes the \
+                 epoch budget and a healthy contract is quarantined (#4864 round-7)"
+            );
         }
     }
 

--- a/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
+++ b/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
@@ -354,6 +354,17 @@ static EPOCH_TICKER_HEARTBEAT_MS: AtomicU64 = AtomicU64::new(0);
 static EPOCH_TICKS_TOTAL: AtomicU64 = AtomicU64::new(0);
 /// Millis-since-base of the last emitted "ticker stale" ERROR (rate-limit).
 static EPOCH_TICKER_STALE_WARNED_MS: AtomicU64 = AtomicU64::new(0);
+/// Whether the process-wide epoch ticker thread has SUCCESSFULLY started
+/// (#4864 round-8). Set true only on a successful spawn; a failed spawn resets
+/// it so the NEXT `register_engine_for_epoch` retries. A `OnceLock` latched
+/// "started" even when the spawn FAILED, permanently disabling preemption after
+/// a single transient thread-exhaustion failure.
+static EPOCH_TICKER_STARTED: AtomicBool = AtomicBool::new(false);
+/// Millis-since-[`epoch_ticker_base`] of the FIRST time any store armed a
+/// deadline (#4864 round-8). `0` = no arm yet. Lets the liveness check flag a
+/// ticker that NEVER started (heartbeat stuck at 0) once we've been arming for
+/// well past the startup window, instead of staying silent forever.
+static EPOCH_FIRST_ARM_MS: AtomicU64 = AtomicU64::new(0);
 
 /// Registry of live engines the epoch ticker drives.
 ///
@@ -378,10 +389,35 @@ fn register_engine_for_epoch(engine: &Engine) {
     start_epoch_ticker();
 }
 
-/// Lazily start the single process-wide epoch ticker thread.
+/// Claim the exclusive right to attempt the epoch-ticker spawn (#4864 round-8).
+/// Returns `true` for exactly the ONE caller that flips the flag false→true;
+/// every other caller (already started, or another thread mid-attempt) gets
+/// `false`. Factored out (pure over the injected flag) so the retry state machine
+/// is unit-testable without spawning a thread.
+fn epoch_ticker_try_claim(started: &AtomicBool) -> bool {
+    if started.load(Ordering::Acquire) {
+        return false;
+    }
+    started
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_ok()
+}
+
+/// Release a claim after the spawn FAILED (#4864 round-8), so the next
+/// `register_engine_for_epoch` retries. Without this, a transient thread-spawn
+/// failure would latch "started" and permanently disable epoch preemption.
+fn epoch_ticker_reset_after_failed_spawn(started: &AtomicBool) {
+    started.store(false, Ordering::Release);
+}
+
+/// Lazily start the single process-wide epoch ticker thread, RETRYING on a
+/// failed spawn (#4864 round-8): a `OnceLock` latched even a failed spawn,
+/// permanently disabling preemption after one transient thread-exhaustion.
 fn start_epoch_ticker() {
-    static STARTED: OnceLock<()> = OnceLock::new();
-    STARTED.get_or_init(|| {
+    if !epoch_ticker_try_claim(&EPOCH_TICKER_STARTED) {
+        return;
+    }
+    {
         // Pin the heartbeat origin before the thread starts.
         let _ = epoch_ticker_base();
         let spawn = std::thread::Builder::new()
@@ -422,13 +458,20 @@ fn start_epoch_ticker() {
                 }
             });
         if let Err(e) = spawn {
-            // Extremely unlikely (thread-spawn failure). Without the ticker the
-            // epoch deadline never advances, so timeouts fall back to the
-            // wall-clock poll in `execute_wasm_blocking` (the pre-#4861
-            // behavior) — degraded, not broken.
-            tracing::error!("failed to spawn wasm-epoch-ticker thread: {e}");
+            // Thread-spawn failure (e.g. transient thread exhaustion). RESET the
+            // started flag so the next engine registration retries (#4864
+            // round-8) — a latched failure would permanently disable preemption.
+            // Meanwhile timeouts fall back to the wall-clock poll in
+            // `execute_wasm_blocking` (the pre-#4861 behavior) — degraded, not
+            // broken. The never-started liveness check in
+            // `detect_stale_epoch_ticker` makes a persistent failure loud.
+            epoch_ticker_reset_after_failed_spawn(&EPOCH_TICKER_STARTED);
+            tracing::error!(
+                "failed to spawn wasm-epoch-ticker thread: {e}; will retry on next \
+                 engine registration"
+            );
         }
-    });
+    }
 }
 
 /// Cheap per-arm liveness check for the epoch ticker (#4864 review). If the
@@ -437,17 +480,53 @@ fn start_epoch_ticker() {
 /// rate-limited ERROR so the degradation is loudly visible. (Execution still
 /// falls back to the wall-clock poll in `execute_wasm_blocking`, so this is
 /// degraded, not broken.)
+/// Pure liveness decision for the epoch ticker (#4864 review + round-8), factored
+/// out so it is unit-testable without the global ticker statics. Reports the
+/// ticker DEAD when EITHER:
+/// - it ticked before but its heartbeat is now older than `stale_after_ms`
+///   (went-silent — the thread died); OR
+/// - it has NEVER ticked (`heartbeat_ms == 0`) AND we have been arming deadlines
+///   for longer than `stale_after_ms` since the first arm (never-started — e.g. a
+///   spawn failure the retry never got to re-attempt). `first_arm_ms == 0` (no
+///   arm yet) is never "dead": there is nothing to preempt.
+fn epoch_ticker_is_dead(
+    heartbeat_ms: u64,
+    first_arm_ms: u64,
+    now_ms: u64,
+    stale_after_ms: u64,
+) -> bool {
+    if heartbeat_ms == 0 {
+        first_arm_ms != 0 && now_ms.saturating_sub(first_arm_ms) > stale_after_ms
+    } else {
+        now_ms.saturating_sub(heartbeat_ms) > stale_after_ms
+    }
+}
+
 fn detect_stale_epoch_ticker() {
-    let heartbeat = EPOCH_TICKER_HEARTBEAT_MS.load(Ordering::Relaxed);
-    if heartbeat == 0 {
-        return; // ticker has not completed a first iteration yet — not "stale"
-    }
     let now_ms = epoch_ticker_base().elapsed().as_millis() as u64;
+    // Record the FIRST-EVER arm time (never the 0 sentinel) so the never-started
+    // branch of `epoch_ticker_is_dead` can measure how long we've been arming
+    // without a single tick (#4864 round-8). Ignore the result: either this call
+    // set it, or a concurrent arm already did — both are correct.
+    let _prev =
+        EPOCH_FIRST_ARM_MS.compare_exchange(0, now_ms.max(1), Ordering::Relaxed, Ordering::Relaxed);
+
+    let heartbeat = EPOCH_TICKER_HEARTBEAT_MS.load(Ordering::Relaxed);
+    let first_arm = EPOCH_FIRST_ARM_MS.load(Ordering::Relaxed);
     let stale_after_ms = 10 * EPOCH_TICK_PERIOD.as_millis() as u64;
-    if now_ms.saturating_sub(heartbeat) <= stale_after_ms {
-        return; // healthy
+    if !epoch_ticker_is_dead(heartbeat, first_arm, now_ms, stale_after_ms) {
+        return; // healthy, or still inside the startup grace window
     }
-    // Stale: emit at most ~once/60s (compare-and-swap so exactly one thread wins).
+
+    // The age we report: silence since the last tick, or (never-started) time
+    // since the first arm.
+    let heartbeat_age_ms = if heartbeat == 0 {
+        now_ms.saturating_sub(first_arm)
+    } else {
+        now_ms.saturating_sub(heartbeat)
+    };
+
+    // Emit at most ~once/60s (compare-and-swap so exactly one thread wins).
     let last_warn = EPOCH_TICKER_STALE_WARNED_MS.load(Ordering::Relaxed);
     // `last_warn == 0` is the zero-init sentinel ("never warned"), NOT a real
     // warning at base-epoch 0: allow the FIRST warn unconditionally, else an
@@ -459,8 +538,9 @@ fn detect_stale_epoch_ticker() {
             .is_ok()
     {
         tracing::error!(
-            heartbeat_age_ms = now_ms.saturating_sub(heartbeat),
+            heartbeat_age_ms,
             ticks_total = EPOCH_TICKS_TOTAL.load(Ordering::Relaxed),
+            never_started = heartbeat == 0,
             "wasm-epoch-ticker appears DEAD — epoch preemption disabled; runaway \
              guest timeouts now fall back to the wall-clock poll only"
         );
@@ -2259,6 +2339,94 @@ mod tests {
         // The margin is exactly one tick above the naive ceil for a whole-second
         // budget (the case the review flagged for [4.9s, 5.0s] finishers).
         assert_eq!(epoch_deadline_ticks(5.0) - 1, 50);
+    }
+
+    /// #4864 round-8: the epoch-ticker start is RETRYABLE — a claim whose spawn
+    /// succeeds latches "started"; a claim whose spawn FAILS is reset so a later
+    /// registration retries. Tests the pure state machine over a LOCAL flag (a
+    /// real thread-spawn failure is not forceable in a unit test).
+    #[test]
+    fn epoch_ticker_claim_retries_after_failed_spawn() {
+        use super::{epoch_ticker_reset_after_failed_spawn, epoch_ticker_try_claim};
+        let started = AtomicBool::new(false);
+
+        // The first caller claims the spawn; a concurrent/later caller does not.
+        assert!(
+            epoch_ticker_try_claim(&started),
+            "the first caller claims the spawn"
+        );
+        assert!(
+            !epoch_ticker_try_claim(&started),
+            "a second caller must NOT double-spawn while a claim stands"
+        );
+
+        // Simulate a FAILED spawn → reset → the next caller retries.
+        epoch_ticker_reset_after_failed_spawn(&started);
+        assert!(
+            epoch_ticker_try_claim(&started),
+            "after a failed spawn resets the flag, the next caller retries (not latched)"
+        );
+
+        // Simulate a SUCCESSFUL spawn → no reset → subsequent callers never re-spawn.
+        assert!(
+            !epoch_ticker_try_claim(&started),
+            "after a successful claim (no reset), the ticker is never re-spawned"
+        );
+    }
+
+    /// #4864 review + round-8: the epoch-ticker liveness decision, over injected
+    /// inputs (no global statics). Covers the went-silent case (ticked, then the
+    /// heartbeat aged out) AND the never-started case (heartbeat stuck at 0 while
+    /// we've been arming deadlines past the startup window — e.g. a spawn failure
+    /// the retry never re-attempted).
+    #[test]
+    fn epoch_ticker_is_dead_covers_silent_and_never_started() {
+        use super::epoch_ticker_is_dead;
+        let stale = 1000u64;
+
+        // No arm yet → nothing to preempt → never "dead".
+        assert!(!epoch_ticker_is_dead(0, 0, 5000, stale));
+
+        // Never ticked, but arming only just began (within the window) → alive.
+        assert!(!epoch_ticker_is_dead(0, 100, 100 + stale, stale));
+        // Never ticked, arming longer than the window → DEAD (never started).
+        assert!(epoch_ticker_is_dead(0, 100, 100 + stale + 1, stale));
+
+        // Ticked recently → alive.
+        assert!(!epoch_ticker_is_dead(5000, 100, 5000 + stale, stale));
+        // Ticked, then went silent past the window → DEAD.
+        assert!(epoch_ticker_is_dead(5000, 100, 5000 + stale + 1, stale));
+    }
+
+    /// #4864 round-8 pin: `start_epoch_ticker` must use the RETRYABLE claim/reset
+    /// form (compare_exchange on `EPOCH_TICKER_STARTED` + reset on spawn failure),
+    /// NOT a `OnceLock` that latches a failed spawn forever.
+    #[test]
+    fn start_epoch_ticker_uses_retryable_claim_not_oncelock() {
+        let src = include_str!("wasmtime_engine.rs");
+        let start = src
+            .find("fn start_epoch_ticker(")
+            .expect("start_epoch_ticker not found");
+        let after = &src[start..];
+        let end = after[1..]
+            .find("\nfn ")
+            .map(|i| i + 1)
+            .unwrap_or(after.len());
+        let body = &after[..end];
+        assert!(
+            body.contains("epoch_ticker_try_claim(&EPOCH_TICKER_STARTED)"),
+            "start_epoch_ticker must claim the spawn via epoch_ticker_try_claim (#4864 round-8)"
+        );
+        assert!(
+            body.contains("epoch_ticker_reset_after_failed_spawn(&EPOCH_TICKER_STARTED)"),
+            "start_epoch_ticker must RESET the flag on spawn failure so a later \
+             registration retries (#4864 round-8)"
+        );
+        assert!(
+            !body.contains("OnceLock"),
+            "start_epoch_ticker must NOT gate on a OnceLock — that latches a failed \
+             spawn forever and permanently disables epoch preemption"
+        );
     }
 
     /// WAT whose module START function loops forever — exercises an epoch

--- a/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
+++ b/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
@@ -752,6 +752,13 @@ impl WasmEngine for WasmtimeEngine {
             // ran near the budget would leave set_id ~zero ticks and trap it
             // spuriously. Every guest entry must be immediately preceded by its
             // own arm (pinned by `every_guest_entry_is_preceded_by_arm_epoch_deadline`).
+            //
+            // Adversarial ceiling (#4864 round-5 item 10): giving set_id a FRESH
+            // budget is correct per-call, but it means create_instance's worst-case
+            // GUEST CPU is ~2x max_execution_seconds (a start function running just
+            // under budget, then set_id running a fresh full budget). That is
+            // bounded at EXACTLY 2 guest entries — the pin above enumerates every
+            // guest entry in this method, so the factor cannot silently grow.
             arm_epoch_deadline(store, self.epoch_deadline_ticks);
             block_on_async(typed_func.call_async(&mut *store, id)).map_err(|e| {
                 classify_guest_entry_error(e, |e| WasmError::Runtime(e.to_string()))

--- a/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
+++ b/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
@@ -141,6 +141,7 @@
 //! We wrap with `block_on_async()` to maintain a synchronous interface for callers.
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
@@ -335,6 +336,25 @@ const STORE_MAX_AGE: Duration = Duration::from_secs(4 * 3600);
 /// `max_execution_seconds` (+ up to one tick of slack) rather than unbounded.
 const EPOCH_TICK_PERIOD: Duration = Duration::from_millis(100);
 
+/// Process-start reference instant for the epoch-ticker heartbeat (#4864). Real
+/// wall clock on purpose: this measures a real background thread's liveness, not
+/// simulation time (consistent with the rest of this file's `Instant` usage).
+fn epoch_ticker_base() -> Instant {
+    static BASE: OnceLock<Instant> = OnceLock::new();
+    *BASE.get_or_init(Instant::now)
+}
+
+/// Milliseconds-since-[`epoch_ticker_base`] of the ticker's most recent loop
+/// iteration. `0` = the ticker has not completed an iteration yet.
+/// [`arm_epoch_deadline`] reads this to detect a DEAD ticker (#4864 review): if
+/// the ticker thread ever stops, epoch preemption is silently disabled, so a
+/// stale heartbeat must be loudly visible.
+static EPOCH_TICKER_HEARTBEAT_MS: AtomicU64 = AtomicU64::new(0);
+/// Total epoch-ticker iterations performed (observability metric).
+static EPOCH_TICKS_TOTAL: AtomicU64 = AtomicU64::new(0);
+/// Millis-since-base of the last emitted "ticker stale" ERROR (rate-limit).
+static EPOCH_TICKER_STALE_WARNED_MS: AtomicU64 = AtomicU64::new(0);
+
 /// Registry of live engines the epoch ticker drives.
 ///
 /// Holds `EngineWeak` (not `Engine`) so a dropped engine is reclaimed: the
@@ -362,22 +382,43 @@ fn register_engine_for_epoch(engine: &Engine) {
 fn start_epoch_ticker() {
     static STARTED: OnceLock<()> = OnceLock::new();
     STARTED.get_or_init(|| {
+        // Pin the heartbeat origin before the thread starts.
+        let _ = epoch_ticker_base();
         let spawn = std::thread::Builder::new()
             .name("wasm-epoch-ticker".to_string())
             .spawn(|| {
                 loop {
                     std::thread::sleep(EPOCH_TICK_PERIOD);
-                    let mut reg = epoch_engine_registry()
-                        .lock()
-                        .unwrap_or_else(|p| p.into_inner());
-                    // Increment every live engine's epoch; drop dead weak refs.
-                    reg.retain(|weak| match weak.upgrade() {
-                        Some(engine) => {
-                            engine.increment_epoch();
-                            true
-                        }
-                        None => false,
-                    });
+                    // Catch a transient panic in ONE iteration (#4864 review): a
+                    // panic escaping this loop would kill the thread and silently
+                    // disable epoch preemption for the whole process lifetime.
+                    // Log and keep ticking instead.
+                    let ticked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        let mut reg = epoch_engine_registry()
+                            .lock()
+                            .unwrap_or_else(|p| p.into_inner());
+                        // Increment every live engine's epoch; drop dead weak refs.
+                        reg.retain(|weak| match weak.upgrade() {
+                            Some(engine) => {
+                                engine.increment_epoch();
+                                true
+                            }
+                            None => false,
+                        });
+                    }));
+                    if ticked.is_err() {
+                        tracing::error!(
+                            "wasm-epoch-ticker iteration panicked; continuing (this \
+                             tick's epoch increments were skipped)"
+                        );
+                    }
+                    // Heartbeat + metric: the loop is alive (even a panicked
+                    // iteration means the thread survived catch_unwind).
+                    EPOCH_TICKS_TOTAL.fetch_add(1, Ordering::Relaxed);
+                    EPOCH_TICKER_HEARTBEAT_MS.store(
+                        epoch_ticker_base().elapsed().as_millis() as u64,
+                        Ordering::Relaxed,
+                    );
                 }
             });
         if let Err(e) = spawn {
@@ -390,14 +431,55 @@ fn start_epoch_ticker() {
     });
 }
 
+/// Cheap per-arm liveness check for the epoch ticker (#4864 review). If the
+/// ticker has ticked before but its heartbeat is now far older than the tick
+/// period, the thread is dead and epoch preemption is silently disabled — emit a
+/// rate-limited ERROR so the degradation is loudly visible. (Execution still
+/// falls back to the wall-clock poll in `execute_wasm_blocking`, so this is
+/// degraded, not broken.)
+fn detect_stale_epoch_ticker() {
+    let heartbeat = EPOCH_TICKER_HEARTBEAT_MS.load(Ordering::Relaxed);
+    if heartbeat == 0 {
+        return; // ticker has not completed a first iteration yet — not "stale"
+    }
+    let now_ms = epoch_ticker_base().elapsed().as_millis() as u64;
+    let stale_after_ms = 10 * EPOCH_TICK_PERIOD.as_millis() as u64;
+    if now_ms.saturating_sub(heartbeat) <= stale_after_ms {
+        return; // healthy
+    }
+    // Stale: emit at most ~once/60s (compare-and-swap so exactly one thread wins).
+    let last_warn = EPOCH_TICKER_STALE_WARNED_MS.load(Ordering::Relaxed);
+    if now_ms.saturating_sub(last_warn) >= 60_000
+        && EPOCH_TICKER_STALE_WARNED_MS
+            .compare_exchange(last_warn, now_ms, Ordering::Relaxed, Ordering::Relaxed)
+            .is_ok()
+    {
+        tracing::error!(
+            heartbeat_age_ms = now_ms.saturating_sub(heartbeat),
+            ticks_total = EPOCH_TICKS_TOTAL.load(Ordering::Relaxed),
+            "wasm-epoch-ticker appears DEAD — epoch preemption disabled; runaway \
+             guest timeouts now fall back to the wall-clock poll only"
+        );
+    }
+}
+
 /// Number of epoch ticks that make up one execution deadline: the store traps
 /// after this many [`Engine::increment_epoch`] calls (~`EPOCH_TICK_PERIOD`
-/// each). `ceil(max_execution_seconds / tick)`, floored at 1 so a tiny
-/// configured timeout still gets at least one tick before tripping.
+/// each). `ceil(max_execution_seconds / tick) + 1`, floored at 1 tick before the
+/// margin so a tiny configured timeout still gets at least one tick.
+///
+/// The `+ 1` is a phase-safety margin (#4864 review): the global ticker runs
+/// free and is NOT synchronized with arming, so the first increment after a
+/// deadline is armed can land anywhere in `[0, EPOCH_TICK_PERIOD)`. Without the
+/// margin a `ceil`-computed N-tick deadline could trap up to one whole tick
+/// EARLY (≈4.9s for a 5.0s budget), nondeterministically killing a guest that
+/// legitimately finishes in `[T - tick, T]`. The margin shifts the enforced
+/// window from `[T - tick, T]` to `[T, T + tick]` — never early, at most one
+/// tick (~100 ms) late.
 fn epoch_deadline_ticks(max_execution_seconds: f64) -> u64 {
     let tick_secs = EPOCH_TICK_PERIOD.as_secs_f64();
     let ticks = (max_execution_seconds / tick_secs).ceil();
-    (ticks as u64).max(1)
+    (ticks as u64).max(1) + 1
 }
 
 /// Arm `store`'s epoch deadline for ONE guest execution.
@@ -417,6 +499,8 @@ fn epoch_deadline_ticks(max_execution_seconds: f64) -> u64 {
 fn arm_epoch_deadline(store: &mut Store<HostState>, ticks: u64) {
     store.set_epoch_deadline(ticks);
     store.epoch_deadline_trap();
+    // Piggyback a cheap dead-ticker health check on this already-per-call site.
+    detect_stale_epoch_ticker();
 }
 
 /// Wasmtime 27.x backend implementation.
@@ -644,8 +728,12 @@ impl WasmEngine for WasmtimeEngine {
 
         // Instantiate the module using the pre-configured linker
         // CRITICAL: Must use instantiate_async() because async_support(true) is enabled
-        let instance = block_on_async(self.linker.instantiate_async(&mut *store, module))
-            .map_err(|e| WasmError::Instantiation(e.to_string()))?;
+        // An epoch interrupt here (a runaway module start function) is classified
+        // as a timeout, not Instantiation (#4864 review); other errors keep it.
+        let instance =
+            block_on_async(self.linker.instantiate_async(&mut *store, module)).map_err(|e| {
+                classify_guest_entry_error(e, |e| WasmError::Instantiation(e.to_string()))
+            })?;
 
         // Call __frnt_set_id to set the instance ID (used for MEM_ADDR lookup)
         // CRITICAL: Must use call_async() because async_support(true) is enabled
@@ -653,8 +741,9 @@ impl WasmEngine for WasmtimeEngine {
             let typed_func = set_id_func
                 .typed::<i64, ()>(&*store)
                 .map_err(|e| WasmError::Export(e.to_string()))?;
-            block_on_async(typed_func.call_async(&mut *store, id))
-                .map_err(|e| WasmError::Runtime(e.to_string()))?;
+            block_on_async(typed_func.call_async(&mut *store, id)).map_err(|e| {
+                classify_guest_entry_error(e, |e| WasmError::Runtime(e.to_string()))
+            })?;
         }
 
         // Note: MEM_ADDR insertion is handled by RunningInstance::new in runtime.rs
@@ -728,8 +817,10 @@ impl WasmEngine for WasmtimeEngine {
             .map_err(|e| WasmError::Export(e.to_string()))?;
         arm_epoch_deadline(store, self.epoch_deadline_ticks);
         // CRITICAL: Must use call_async() because async_support(true) is enabled
+        // An epoch interrupt here (a runaway allocator) is classified as a
+        // timeout, not a generic Runtime error (#4864 review).
         block_on_async(func.call_async(&mut *store, size))
-            .map_err(|e| WasmError::Runtime(e.to_string()))
+            .map_err(|e| classify_guest_entry_error(e, |e| WasmError::Runtime(e.to_string())))
     }
 
     fn call_void(&mut self, handle: &InstanceHandle, name: &str) -> Result<(), WasmError> {
@@ -1644,24 +1735,49 @@ fn block_on_async<F: std::future::Future>(future: F) -> F::Output {
     }
 }
 
+/// True if `error` carries wasmtime's epoch-deadline interrupt trap
+/// (`Trap::Interrupt`) — our execution-timeout mechanism firing (#4861): the
+/// guest ran past its armed deadline and wasmtime interrupted it at an epoch
+/// check.
+fn is_epoch_interrupt(error: &WasmtimeError) -> bool {
+    error
+        .downcast_ref::<wasmtime::Trap>()
+        .is_some_and(|t| matches!(t, wasmtime::Trap::Interrupt))
+}
+
+/// Map an error from a GUEST-ENTRY call — instantiation (module start
+/// function), `__frnt_set_id`, or `__frnt__initiate_buffer` — to a
+/// [`WasmError`], routing an epoch-deadline interrupt to [`WasmError::Timeout`]
+/// (#4864 review). Without this, a runaway guest during the init/allocator phase
+/// would surface as `Instantiation`/`Runtime` — neither `is_wasm_timeout` (wrong
+/// merge-backoff cooldown class) nor even `is_contract_exec_rejection` (not
+/// recorded at all). Non-interrupt errors keep their original category via
+/// `otherwise`, preserving the existing error text.
+fn classify_guest_entry_error(
+    error: WasmtimeError,
+    otherwise: impl FnOnce(WasmtimeError) -> WasmError,
+) -> WasmError {
+    if is_epoch_interrupt(&error) {
+        tracing::warn!("WASM execution timed out (epoch deadline exceeded during guest entry)");
+        return WasmError::Timeout;
+    }
+    otherwise(error)
+}
+
 /// Classify a wasmtime Error, checking fuel status.
 fn classify_runtime_error(
     enabled_metering: bool,
     store: &mut Store<HostState>,
     error: WasmtimeError,
 ) -> WasmError {
-    // An epoch-deadline trap (`Trap::Interrupt`) is our execution-timeout
-    // mechanism firing (#4861): the guest ran past the armed deadline and
-    // wasmtime interrupted it at an epoch check. Classify it as a timeout (not a
-    // generic runtime error) so it flows to `ContractExecError::
-    // MaxComputeTimeExceeded` exactly like the wall-clock `BlockingResult::
-    // Timeout` path, keeping the "timed out" classification consistent. Checked
-    // first because it is a timeout regardless of whether metering is on.
-    if let Some(trap) = error.downcast_ref::<wasmtime::Trap>() {
-        if matches!(trap, wasmtime::Trap::Interrupt) {
-            tracing::warn!("WASM execution timed out (epoch deadline exceeded)");
-            return WasmError::Timeout;
-        }
+    // An epoch-deadline interrupt is our execution timeout (#4861). Classify it
+    // as a timeout (not a generic runtime error) so it flows to
+    // `ContractExecError::MaxComputeTimeExceeded` exactly like the wall-clock
+    // `BlockingResult::Timeout` path. Checked first because it is a timeout
+    // regardless of whether metering is on.
+    if is_epoch_interrupt(&error) {
+        tracing::warn!("WASM execution timed out (epoch deadline exceeded)");
+        return WasmError::Timeout;
     }
     if enabled_metering {
         // Check if we ran out of fuel
@@ -1945,6 +2061,128 @@ mod tests {
             ),
             "epoch-deadline trap must classify as WasmError::Timeout"
         );
+    }
+
+    /// #4864 review (fix 3): `epoch_deadline_ticks` = `ceil(secs / 100ms) + 1`,
+    /// the `+ 1` a phase-safety margin so a free-running ticker never traps a
+    /// guest EARLY. Boundary cases.
+    #[test]
+    fn epoch_deadline_ticks_has_phase_margin() {
+        // EPOCH_TICK_PERIOD is 100ms.
+        assert_eq!(epoch_deadline_ticks(5.0), 51, "5.0s → ceil(50)+1");
+        assert_eq!(epoch_deadline_ticks(0.05), 2, "0.05s → ceil(0.5)=1, +1");
+        assert_eq!(
+            epoch_deadline_ticks(0.1),
+            2,
+            "0.1s → ceil(1)=1, +1 (exact multiple)"
+        );
+        assert_eq!(epoch_deadline_ticks(0.0), 2, "degenerate 0 → floor 1, +1");
+        assert_eq!(epoch_deadline_ticks(1.0), 11, "1.0s → ceil(10)+1");
+        // A larger budget never gets fewer ticks.
+        assert!(epoch_deadline_ticks(10.0) > epoch_deadline_ticks(5.0));
+        // The margin is exactly one tick above the naive ceil for a whole-second
+        // budget (the case the review flagged for [4.9s, 5.0s] finishers).
+        assert_eq!(epoch_deadline_ticks(5.0) - 1, 50);
+    }
+
+    /// WAT whose module START function loops forever — exercises an epoch
+    /// interrupt during the INSTANTIATION guest-entry phase.
+    const START_LOOP_WAT: &str = r#"
+        (module
+          (func $spin (loop (br 0)))
+          (start $spin))
+    "#;
+
+    /// REGRESSION (#4864 review, fix 4): an epoch interrupt during a guest-entry
+    /// phase — here a runaway module START function during `instantiate_async` —
+    /// must classify as `WasmError::Timeout`, NOT `Instantiation`. Otherwise the
+    /// merge backoff records the wrong cooldown class (or nothing at all).
+    #[test]
+    fn epoch_interrupt_during_instantiation_classifies_as_timeout() {
+        // Short budget so the test is fast: ceil(0.2/0.1)+1 = 3 ticks (~300ms).
+        let config = RuntimeConfig {
+            max_execution_seconds: 0.2,
+            enable_metering: false,
+            ..RuntimeConfig::default()
+        };
+        let mut engine = WasmtimeEngine::new(&config, false).expect("engine creation");
+        let module = engine
+            .compile(START_LOOP_WAT.as_bytes())
+            .expect("compile start-loop module");
+
+        let start = std::time::Instant::now();
+        // create_instance runs the start function via instantiate_async; the
+        // global epoch ticker preempts it once the armed 3-tick deadline elapses.
+        let result = engine.create_instance(&module, 1, 0);
+        let elapsed = start.elapsed();
+
+        // `InstanceHandle` is not Debug, so match rather than `{result:?}`.
+        match &result {
+            Err(WasmError::Timeout) => {}
+            Err(other) => panic!(
+                "runaway module start function must classify as WasmError::Timeout, got {other:?}"
+            ),
+            Ok(_) => {
+                panic!("runaway module start function must time out, but instantiation succeeded")
+            }
+        }
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "instantiation-phase preemption should be prompt; took {elapsed:?}"
+        );
+    }
+
+    /// Source-scrape pin (#4864 review, fix 8): every guest-entry call site
+    /// (`instantiate_async` / `call_async`) MUST be preceded by an
+    /// `arm_epoch_deadline` in the same function, so a future refactor cannot
+    /// silently re-open the unbounded-runaway-guest hole by adding a guest-entry
+    /// path without arming the epoch deadline.
+    #[test]
+    fn every_guest_entry_is_preceded_by_arm_epoch_deadline() {
+        let src = include_str!("wasmtime_engine.rs");
+        // The engine methods that run guest code (exclude test bodies + the
+        // helper defs). Each must contain `arm_epoch_deadline` before its first
+        // guest-entry `block_on_async(...call_async/instantiate_async)`.
+        for fn_name in [
+            "fn create_instance(",
+            "fn initiate_buffer(",
+            "fn call_void(",
+            "fn call_3i64(",
+            "fn call_3i64_async_imports(",
+            "fn call_2i64_blocking(",
+            "fn call_3i64_blocking(",
+        ] {
+            let start = src
+                .find(fn_name)
+                .unwrap_or_else(|| panic!("guest-entry method `{fn_name}` not found"));
+            let after = &src[start..];
+            let end = after
+                .find("\n    fn ")
+                .or_else(|| after.find("\n    pub(crate) fn "))
+                .unwrap_or(after.len());
+            let body = &after[..end];
+            let arm_pos = body.find("arm_epoch_deadline").unwrap_or_else(|| {
+                panic!("`{fn_name}` runs guest code but never calls arm_epoch_deadline (#4864)")
+            });
+            // The guest-entry call in these methods is a block_on_async of a
+            // `.call_async(` / `.instantiate_async(`. Match the method-call
+            // syntax (leading dot + open paren) so a prose mention of
+            // "call_async" in a doc comment is not treated as the entry site.
+            // Take the EARLIEST of the two so arm must precede whichever guest
+            // entry comes first in the body.
+            let entry_pos = [body.find(".call_async("), body.find(".instantiate_async(")]
+                .into_iter()
+                .flatten()
+                .min();
+            if let Some(entry_pos) = entry_pos {
+                assert!(
+                    arm_pos < entry_pos,
+                    "`{fn_name}`: arm_epoch_deadline ({arm_pos}) must precede the \
+                     guest-entry call ({entry_pos}) — else the guest runs with a \
+                     stale/unset deadline"
+                );
+            }
+        }
     }
 
     /// REGRESSION (issue #4441 fix-up): with `offload_compilation = true` on a

--- a/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
+++ b/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
@@ -146,8 +146,8 @@ use std::time::{Duration, Instant};
 
 use dashmap::DashMap;
 use wasmtime::{
-    Cache, CacheConfig, Caller, Config, Engine, Error as WasmtimeError, Instance, Linker, Module,
-    OptLevel, ResourceLimiter, Store,
+    Cache, CacheConfig, Caller, Config, Engine, EngineWeak, Error as WasmtimeError, Instance,
+    Linker, Module, OptLevel, ResourceLimiter, Store,
 };
 
 use super::{InstanceHandle, WasmEngine, WasmError};
@@ -316,6 +316,109 @@ const STORE_REFRESH_THRESHOLD: u64 = 500;
 /// should never fire under normal operation.
 const STORE_MAX_AGE: Duration = Duration::from_secs(4 * 3600);
 
+/// Period between global epoch increments (#4861).
+///
+/// Wasmtime's wall-clock timeout (`execute_wasm_blocking`) can only `abort()`
+/// the *tokio task* wrapping a contract call; it cannot stop synchronous WASM
+/// already running on the blocking thread, so a runaway guest (an infinite
+/// loop, a pathological merge) keeps burning a whole thread arbitrarily long
+/// after "WASM execution timed out". With `enable_metering = false` (the
+/// production default) there is no fuel to run out either. Epoch interruption
+/// is the mechanism that actually preempts the guest: wasmtime inserts an epoch
+/// check at every loop backedge and function entry, so once the engine's epoch
+/// passes a store's armed deadline the guest traps at the next check.
+///
+/// A single background thread increments the epoch of every live engine every
+/// `EPOCH_TICK_PERIOD`. Combined with a per-execution deadline of
+/// `ceil(max_execution_seconds / EPOCH_TICK_PERIOD)` ticks (see
+/// [`epoch_deadline_ticks`]) this bounds a runaway guest to roughly
+/// `max_execution_seconds` (+ up to one tick of slack) rather than unbounded.
+const EPOCH_TICK_PERIOD: Duration = Duration::from_millis(100);
+
+/// Registry of live engines the epoch ticker drives.
+///
+/// Holds `EngineWeak` (not `Engine`) so a dropped engine is reclaimed: the
+/// ticker prunes any weak ref that no longer upgrades on its next pass, and the
+/// registry never keeps an otherwise-dead engine alive.
+fn epoch_engine_registry() -> &'static Mutex<Vec<EngineWeak>> {
+    static REG: OnceLock<Mutex<Vec<EngineWeak>>> = OnceLock::new();
+    REG.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+/// Register `engine` with the global epoch ticker, starting the ticker thread
+/// on first use. Called once per freshly-created backend engine (in
+/// [`WasmtimeEngine::create_engine`]); clones sharing the same backend
+/// (`new_with_shared_backend`) share the one registered weak ref, since
+/// `increment_epoch` on a shared `Engine` covers all its stores.
+fn register_engine_for_epoch(engine: &Engine) {
+    epoch_engine_registry()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .push(engine.weak());
+    start_epoch_ticker();
+}
+
+/// Lazily start the single process-wide epoch ticker thread.
+fn start_epoch_ticker() {
+    static STARTED: OnceLock<()> = OnceLock::new();
+    STARTED.get_or_init(|| {
+        let spawn = std::thread::Builder::new()
+            .name("wasm-epoch-ticker".to_string())
+            .spawn(|| {
+                loop {
+                    std::thread::sleep(EPOCH_TICK_PERIOD);
+                    let mut reg = epoch_engine_registry()
+                        .lock()
+                        .unwrap_or_else(|p| p.into_inner());
+                    // Increment every live engine's epoch; drop dead weak refs.
+                    reg.retain(|weak| match weak.upgrade() {
+                        Some(engine) => {
+                            engine.increment_epoch();
+                            true
+                        }
+                        None => false,
+                    });
+                }
+            });
+        if let Err(e) = spawn {
+            // Extremely unlikely (thread-spawn failure). Without the ticker the
+            // epoch deadline never advances, so timeouts fall back to the
+            // wall-clock poll in `execute_wasm_blocking` (the pre-#4861
+            // behavior) — degraded, not broken.
+            tracing::error!("failed to spawn wasm-epoch-ticker thread: {e}");
+        }
+    });
+}
+
+/// Number of epoch ticks that make up one execution deadline: the store traps
+/// after this many [`Engine::increment_epoch`] calls (~`EPOCH_TICK_PERIOD`
+/// each). `ceil(max_execution_seconds / tick)`, floored at 1 so a tiny
+/// configured timeout still gets at least one tick before tripping.
+fn epoch_deadline_ticks(max_execution_seconds: f64) -> u64 {
+    let tick_secs = EPOCH_TICK_PERIOD.as_secs_f64();
+    let ticks = (max_execution_seconds / tick_secs).ceil();
+    (ticks as u64).max(1)
+}
+
+/// Arm `store`'s epoch deadline for ONE guest execution.
+///
+/// Must be called before every call that runs guest (wasm) code. With epoch
+/// interruption enabled a store traps the instant the current engine epoch has
+/// reached its deadline, and the deadline is relative to the epoch at arm time —
+/// so an un-re-armed store inherits a stale (already-elapsed) deadline and the
+/// guest traps immediately. `epoch_deadline_trap()` selects trap-on-deadline
+/// (NOT `epoch_deadline_async_yield_and_update`): a runaway guest is killed, not
+/// paused-and-resumed.
+///
+/// Only GUEST code is interrupted — wasmtime's epoch checks live at wasm loop
+/// backedges and function entries. A blocking HOST-function call in progress is
+/// never cut off mid-flight; the trap can only fire once control returns to
+/// guest code. So a slow host call completes normally.
+fn arm_epoch_deadline(store: &mut Store<HostState>, ticks: u64) {
+    store.set_epoch_deadline(ticks);
+    store.epoch_deadline_trap();
+}
+
 /// Wasmtime 27.x backend implementation.
 pub(crate) struct WasmtimeEngine {
     /// The wasmtime Engine (shared, Arc-wrapped internally).
@@ -334,6 +437,12 @@ pub(crate) struct WasmtimeEngine {
     enabled_metering: bool,
     /// Max fuel for each execution (computed from max_execution_seconds).
     max_fuel: u64,
+    /// Epoch-deadline ticks armed before each guest execution (#4861). Computed
+    /// once from `max_execution_seconds` (see [`epoch_deadline_ticks`]); the
+    /// store traps after this many global epoch increments if the guest hasn't
+    /// returned. This is the real preemption backstop behind the wall-clock
+    /// timeout — see [`EPOCH_TICK_PERIOD`].
+    epoch_deadline_ticks: u64,
     /// Instances created in the current Store; reset on `replace_store`.
     /// See [`STORE_REFRESH_THRESHOLD`].
     lifetime_instances: u64,
@@ -424,11 +533,15 @@ impl WasmEngine for WasmtimeEngine {
         Self::register_host_functions(&mut linker)?;
 
         // Create the store with HostState
+        let epoch_deadline_ticks = epoch_deadline_ticks(config.max_execution_seconds);
         let mut store = Store::new(&engine, HostState::new(DEFAULT_MAX_MEMORY_PAGES));
         store.limiter(|state| state); // Enable ResourceLimiter
         if enabled_metering {
             store.set_fuel(max_fuel).map_err(|e| anyhow::anyhow!(e))?;
         }
+        // Arm the initial deadline + select trap behavior; every guest call
+        // re-arms it (see `arm_epoch_deadline`).
+        arm_epoch_deadline(&mut store, epoch_deadline_ticks);
 
         // Host memory sharing is not yet implemented in the wasmtime backend.
         // Fail explicitly rather than silently degrading.
@@ -448,6 +561,7 @@ impl WasmEngine for WasmtimeEngine {
             max_execution_seconds: config.max_execution_seconds,
             enabled_metering,
             max_fuel,
+            epoch_deadline_ticks,
             lifetime_instances: 0,
             store_created_at: Instant::now(),
             offload_compilation: config.offload_compilation,
@@ -522,6 +636,11 @@ impl WasmEngine for WasmtimeEngine {
                 .set_fuel(self.max_fuel)
                 .map_err(|e| WasmError::Other(anyhow::anyhow!(e)))?;
         }
+
+        // Arm the epoch deadline before instantiation runs any guest start
+        // function (#4861); the store is reused across calls so a stale deadline
+        // would otherwise trap here.
+        arm_epoch_deadline(store, self.epoch_deadline_ticks);
 
         // Instantiate the module using the pre-configured linker
         // CRITICAL: Must use instantiate_async() because async_support(true) is enabled
@@ -607,6 +726,7 @@ impl WasmEngine for WasmtimeEngine {
         let func = instance
             .get_typed_func::<u32, i64>(&mut *store, "__frnt__initiate_buffer")
             .map_err(|e| WasmError::Export(e.to_string()))?;
+        arm_epoch_deadline(store, self.epoch_deadline_ticks);
         // CRITICAL: Must use call_async() because async_support(true) is enabled
         block_on_async(func.call_async(&mut *store, size))
             .map_err(|e| WasmError::Runtime(e.to_string()))
@@ -614,6 +734,7 @@ impl WasmEngine for WasmtimeEngine {
 
     fn call_void(&mut self, handle: &InstanceHandle, name: &str) -> Result<(), WasmError> {
         let enabled_metering = self.enabled_metering;
+        let epoch_ticks = self.epoch_deadline_ticks;
         let store = self
             .store
             .as_mut()
@@ -625,6 +746,7 @@ impl WasmEngine for WasmtimeEngine {
         let func = instance
             .get_typed_func::<(), ()>(&mut *store, name)
             .map_err(|e| WasmError::Export(e.to_string()))?;
+        arm_epoch_deadline(store, epoch_ticks);
         // Use call_async because async_support(true) is enabled in the engine Config
         block_on_async(func.call_async(&mut *store, ()))
             .map_err(|e| classify_runtime_error(enabled_metering, store, e))
@@ -639,6 +761,7 @@ impl WasmEngine for WasmtimeEngine {
         c: i64,
     ) -> Result<i64, WasmError> {
         let enabled_metering = self.enabled_metering;
+        let epoch_ticks = self.epoch_deadline_ticks;
         let store = self
             .store
             .as_mut()
@@ -650,6 +773,7 @@ impl WasmEngine for WasmtimeEngine {
         let func = instance
             .get_typed_func::<(i64, i64, i64), i64>(&mut *store, name)
             .map_err(|e| WasmError::Export(e.to_string()))?;
+        arm_epoch_deadline(store, epoch_ticks);
         // Use call_async because async_support(true) is enabled in the engine Config
         block_on_async(func.call_async(&mut *store, (a, b, c)))
             .map_err(|e| classify_runtime_error(enabled_metering, store, e))
@@ -683,6 +807,7 @@ impl WasmEngine for WasmtimeEngine {
             .get_typed_func::<(i64, i64, i64), i64>(&mut *store, name)
             .map_err(|e| WasmError::Export(e.to_string()))?;
 
+        arm_epoch_deadline(store, self.epoch_deadline_ticks);
         // Call the async-aware function using block_on_async
         let result = block_on_async(func.call_async(&mut *store, (a, b, c)));
         result.map_err(|e| classify_runtime_error(self.enabled_metering, store, e))
@@ -719,6 +844,11 @@ impl WasmEngine for WasmtimeEngine {
                 return Err(WasmError::Export(e.to_string()));
             }
         };
+
+        // Arm the epoch deadline before the guest runs on the blocking thread
+        // (#4861). The wall-clock poll below is a backstop; the epoch trap is
+        // what actually stops a runaway synchronous guest.
+        arm_epoch_deadline(&mut store, self.epoch_deadline_ticks);
 
         let result = execute_wasm_blocking(
             move || {
@@ -782,6 +912,12 @@ impl WasmEngine for WasmtimeEngine {
                 return Err(WasmError::Export(e.to_string()));
             }
         };
+
+        // Arm the epoch deadline before the guest runs on the blocking thread
+        // (#4861). This is the primary contract merge/validate path — the wall-
+        // clock poll below only aborts the tokio task, so the epoch trap is what
+        // actually stops a runaway synchronous guest that ignores the timeout.
+        arm_epoch_deadline(&mut store, self.epoch_deadline_ticks);
 
         let result = execute_wasm_blocking(
             move || {
@@ -899,11 +1035,13 @@ impl WasmtimeEngine {
         let mut linker = Linker::new(&backend);
         Self::register_host_functions(&mut linker)?;
 
+        let epoch_deadline_ticks = epoch_deadline_ticks(config.max_execution_seconds);
         let mut store = Store::new(&backend, HostState::new(DEFAULT_MAX_MEMORY_PAGES));
         store.limiter(|state| state);
         if enabled_metering {
             store.set_fuel(max_fuel).map_err(|e| anyhow::anyhow!(e))?;
         }
+        arm_epoch_deadline(&mut store, epoch_deadline_ticks);
 
         if host_mem {
             return Err(anyhow::anyhow!(
@@ -922,6 +1060,7 @@ impl WasmtimeEngine {
             max_execution_seconds: config.max_execution_seconds,
             enabled_metering,
             max_fuel,
+            epoch_deadline_ticks,
             lifetime_instances: 0,
             store_created_at: Instant::now(),
             offload_compilation: config.offload_compilation,
@@ -936,6 +1075,16 @@ impl WasmtimeEngine {
         if config.enable_metering {
             wasmtime_config.consume_fuel(true);
         }
+
+        // Enable epoch-based interruption unconditionally (#4861). This is the
+        // only mechanism that actually preempts a synchronous runaway guest: the
+        // wall-clock timeout can only abort the wrapping tokio task, and metering
+        // (fuel) is off by default. Each store arms a per-execution deadline (see
+        // `arm_epoch_deadline`) and a background thread advances the epoch (see
+        // `register_engine_for_epoch` below / `EPOCH_TICK_PERIOD`). Note: this is
+        // part of the engine's compile-cache key, so enabling it recompiles
+        // cached modules once on upgrade.
+        wasmtime_config.epoch_interruption(true);
 
         // Set memory limits via config
         // async_stack_size must exceed max_wasm_stack
@@ -1056,6 +1205,11 @@ impl WasmtimeEngine {
         let engine =
             Engine::new(&wasmtime_config).map_err(|e| WasmError::Other(anyhow::anyhow!(e)))?;
 
+        // Drive this engine's epoch from the global ticker so armed store
+        // deadlines actually elapse (#4861). Registered once per fresh backend
+        // engine; `new_with_shared_backend` reuses the already-registered one.
+        register_engine_for_epoch(&engine);
+
         Ok((engine, max_fuel, config.enable_metering))
     }
 
@@ -1086,6 +1240,10 @@ impl WasmtimeEngine {
                 tracing::error!("Failed to set fuel on replacement store: {e}");
             }
         }
+        // Re-arm the epoch deadline on the fresh store; every guest call re-arms
+        // again, but arming here keeps the invariant "a live store always has a
+        // future deadline" (an un-armed epoch store traps immediately).
+        arm_epoch_deadline(&mut store, self.epoch_deadline_ticks);
         self.instances.clear();
         self.store = Some(store);
         self.lifetime_instances = 0;
@@ -1492,6 +1650,19 @@ fn classify_runtime_error(
     store: &mut Store<HostState>,
     error: WasmtimeError,
 ) -> WasmError {
+    // An epoch-deadline trap (`Trap::Interrupt`) is our execution-timeout
+    // mechanism firing (#4861): the guest ran past the armed deadline and
+    // wasmtime interrupted it at an epoch check. Classify it as a timeout (not a
+    // generic runtime error) so it flows to `ContractExecError::
+    // MaxComputeTimeExceeded` exactly like the wall-clock `BlockingResult::
+    // Timeout` path, keeping the "timed out" classification consistent. Checked
+    // first because it is a timeout regardless of whether metering is on.
+    if let Some(trap) = error.downcast_ref::<wasmtime::Trap>() {
+        if matches!(trap, wasmtime::Trap::Interrupt) {
+            tracing::warn!("WASM execution timed out (epoch deadline exceeded)");
+            return WasmError::Timeout;
+        }
+    }
     if enabled_metering {
         // Check if we ran out of fuel
         if let Ok(remaining) = store.get_fuel() {
@@ -1700,6 +1871,77 @@ mod tests {
         let handle = engine.create_instance(&module, 0, 1024).unwrap();
         engine.drop_instance(&handle);
         assert!(engine.module_compiled_size(&module) > 0);
+    }
+
+    /// WAT for a contract-shaped export that never returns — an infinite loop.
+    /// Signature `(i64,i64,i64)->i64` matches `call_3i64_blocking`'s typed call;
+    /// `unreachable` after the loop satisfies the result type regardless of the
+    /// loop's reachability analysis.
+    const INFINITE_LOOP_WAT: &str = r#"
+        (module
+          (func (export "spin") (param i64 i64 i64) (result i64)
+            (loop $l (br $l))
+            unreachable))
+    "#;
+
+    /// REGRESSION (#4861): epoch-based preemption must actually STOP a runaway
+    /// (infinite-loop) guest.
+    ///
+    /// With metering off (the production default) there is no fuel to exhaust,
+    /// and the wall-clock "timeout" in `execute_wasm_blocking` only aborts the
+    /// *tokio task* wrapping the call — the synchronous guest keeps burning its
+    /// blocking thread forever. Epoch interruption is the only thing that
+    /// preempts it. This test runs the infinite loop with **no wall-clock
+    /// wrapper at all**, so the ONLY thing that can make the call return is the
+    /// global epoch ticker tripping the store's armed deadline. If preemption
+    /// regresses, the call never returns and the test hangs (harness timeout =
+    /// failure).
+    #[test]
+    fn epoch_preemption_stops_infinite_loop() {
+        // create_backend_engine enables epoch_interruption AND registers the
+        // engine with the global epoch ticker (100ms period). Metering off.
+        let config = RuntimeConfig {
+            enable_metering: false,
+            ..RuntimeConfig::default()
+        };
+        let engine = WasmtimeEngine::create_backend_engine(&config).unwrap();
+        let module = Module::new(&engine, INFINITE_LOOP_WAT.as_bytes())
+            .expect("infinite-loop WAT must compile");
+
+        let mut store = Store::new(&engine, HostState::new(DEFAULT_MAX_MEMORY_PAGES));
+        store.limiter(|s| s);
+        // Short deadline (2 ticks ≈ 200ms) so the test is fast; trap-on-deadline.
+        arm_epoch_deadline(&mut store, 2);
+
+        let instance = block_on_async(Linker::new(&engine).instantiate_async(&mut store, &module))
+            .expect("instantiation must succeed");
+        let func = instance
+            .get_typed_func::<(i64, i64, i64), i64>(&mut store, "spin")
+            .expect("spin export must exist");
+
+        let start = std::time::Instant::now();
+        let result = block_on_async(func.call_async(&mut store, (0, 0, 0)));
+        let elapsed = start.elapsed();
+
+        let err = result
+            .expect_err("infinite loop must be preempted by the epoch deadline, not run forever");
+        // Bounded return proves the guest was actually stopped (generous 5s
+        // ceiling = ~200ms deadline + ticker phase + CI slack).
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "epoch preemption took too long ({elapsed:?}) — guest was not stopped promptly"
+        );
+        // The trap must be the epoch interrupt, and classify as a timeout so it
+        // flows to ContractExecError::MaxComputeTimeExceeded.
+        assert!(
+            err.downcast_ref::<wasmtime::Trap>()
+                .is_some_and(|t| matches!(t, wasmtime::Trap::Interrupt)),
+            "preemption must surface as a Trap::Interrupt, got: {err:?}"
+        );
+        assert!(
+            matches!(classify_runtime_error(false, &mut store, err), WasmError::Timeout),
+            "epoch-deadline trap must classify as WasmError::Timeout"
+        );
     }
 
     /// REGRESSION (issue #4441 fix-up): with `offload_compilation = true` on a

--- a/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
+++ b/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
@@ -745,6 +745,14 @@ impl WasmEngine for WasmtimeEngine {
             let typed_func = set_id_func
                 .typed::<i64, ()>(&*store)
                 .map_err(|e| WasmError::Export(e.to_string()))?;
+            // Re-arm the epoch deadline before this SECOND guest call (#4864
+            // round-4 P2). The store is reused across calls, so without re-arming
+            // __frnt_set_id would inherit whatever ticks REMAIN from the
+            // instantiation deadline armed above — a module whose start function
+            // ran near the budget would leave set_id ~zero ticks and trap it
+            // spuriously. Every guest entry must be immediately preceded by its
+            // own arm (pinned by `every_guest_entry_is_preceded_by_arm_epoch_deadline`).
+            arm_epoch_deadline(store, self.epoch_deadline_ticks);
             block_on_async(typed_func.call_async(&mut *store, id)).map_err(|e| {
                 classify_guest_entry_error(e, |e| WasmError::Runtime(e.to_string()))
             })?;
@@ -2136,17 +2144,16 @@ mod tests {
         );
     }
 
-    /// Source-scrape pin (#4864 review, fix 8): every guest-entry call site
-    /// (`instantiate_async` / `call_async`) MUST be preceded by an
-    /// `arm_epoch_deadline` in the same function, so a future refactor cannot
-    /// silently re-open the unbounded-runaway-guest hole by adding a guest-entry
-    /// path without arming the epoch deadline.
+    /// Source-scrape pin (#4864 review, fix 8 + round-4 P2): EVERY guest-entry
+    /// call site (`instantiate_async` / `call_async`) — not just the first — MUST
+    /// be preceded by an `arm_epoch_deadline(` since the previous guest entry in
+    /// the same function. The store is reused across calls, so a SECOND guest
+    /// call that is not re-armed inherits the first call's remaining epoch budget
+    /// (the `__frnt_set_id` case). This also future-proofs against a refactor
+    /// adding a guest-entry path without arming the deadline.
     #[test]
     fn every_guest_entry_is_preceded_by_arm_epoch_deadline() {
         let src = include_str!("wasmtime_engine.rs");
-        // The engine methods that run guest code (exclude test bodies + the
-        // helper defs). Each must contain `arm_epoch_deadline` before its first
-        // guest-entry `block_on_async(...call_async/instantiate_async)`.
         for fn_name in [
             "fn create_instance(",
             "fn initiate_buffer(",
@@ -2165,26 +2172,40 @@ mod tests {
                 .or_else(|| after.find("\n    pub(crate) fn "))
                 .unwrap_or(after.len());
             let body = &after[..end];
-            let arm_pos = body.find("arm_epoch_deadline").unwrap_or_else(|| {
-                panic!("`{fn_name}` runs guest code but never calls arm_epoch_deadline (#4864)")
-            });
-            // The guest-entry call in these methods is a block_on_async of a
-            // `.call_async(` / `.instantiate_async(`. Match the method-call
-            // syntax (leading dot + open paren) so a prose mention of
-            // "call_async" in a doc comment is not treated as the entry site.
-            // Take the EARLIEST of the two so arm must precede whichever guest
-            // entry comes first in the body.
-            let entry_pos = [body.find(".call_async("), body.find(".instantiate_async(")]
-                .into_iter()
-                .flatten()
-                .min();
-            if let Some(entry_pos) = entry_pos {
+
+            // Every guest-entry occurrence (both call kinds), sorted. Match the
+            // method-call syntax (leading dot + open paren) so a prose mention of
+            // "call_async" in a doc comment is not treated as an entry.
+            let mut entries: Vec<usize> = body
+                .match_indices(".call_async(")
+                .chain(body.match_indices(".instantiate_async("))
+                .map(|(i, _)| i)
+                .collect();
+            entries.sort_unstable();
+            if entries.is_empty() {
+                continue;
+            }
+            // Real arm CALLS only (`arm_epoch_deadline(`), not prose/identifier
+            // mentions like this pin's own name.
+            let arms: Vec<usize> = body
+                .match_indices("arm_epoch_deadline(")
+                .map(|(i, _)| i)
+                .collect();
+            assert!(
+                !arms.is_empty(),
+                "`{fn_name}` runs guest code but never calls arm_epoch_deadline (#4864)"
+            );
+            // Each guest entry must have an arm SINCE the previous entry (before
+            // the first entry, `prev == 0`).
+            let mut prev = 0usize;
+            for entry_pos in entries {
                 assert!(
-                    arm_pos < entry_pos,
-                    "`{fn_name}`: arm_epoch_deadline ({arm_pos}) must precede the \
-                     guest-entry call ({entry_pos}) — else the guest runs with a \
-                     stale/unset deadline"
+                    arms.iter().any(|&a| a > prev && a < entry_pos),
+                    "`{fn_name}`: guest entry at {entry_pos} has no arm_epoch_deadline \
+                     since the previous guest entry ({prev}) — a store reused across \
+                     calls must be re-armed before EACH guest call (#4864 round-4)"
                 );
+                prev = entry_pos;
             }
         }
     }

--- a/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
+++ b/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
@@ -793,63 +793,55 @@ impl WasmEngine for WasmtimeEngine {
         id: i64,
         req_bytes: usize,
     ) -> Result<InstanceHandle, WasmError> {
+        {
+            let store = self
+                .store
+                .as_mut()
+                .ok_or_else(|| WasmError::Other(anyhow::anyhow!("engine store not available")))?;
+
+            // Reset fuel if metering is enabled. (Pre-guest-entry; no arena
+            // residue if this fails, so no recovery needed on this early return.)
+            if self.enabled_metering {
+                store
+                    .set_fuel(self.max_fuel)
+                    .map_err(|e| WasmError::Other(anyhow::anyhow!(e)))?;
+            }
+        }
+
+        // The guest-entry half (instantiate + __frnt_set_id + ensure_memory) is
+        // factored out so we can RECOVER THE STORE on ANY guest-entry
+        // timeout/error before returning (#4864 round-9 item 2). Previously an
+        // epoch interrupt during __frnt_set_id returned via `?` AFTER the module
+        // was instantiated but BEFORE `instances.insert` / `lifetime_instances += 1`,
+        // so the store-refresh accounting never counted it: wasmtime's Store arena
+        // retained the dropped instance's allocation, and repeated init timeouts
+        // across fresh contract ids accumulated untracked arena memory that never
+        // triggered a count-based refresh.
+        let epoch_ticks = self.epoch_deadline_ticks;
         let store = self
             .store
             .as_mut()
             .ok_or_else(|| WasmError::Other(anyhow::anyhow!("engine store not available")))?;
-
-        // Reset fuel if metering is enabled
-        if self.enabled_metering {
-            store
-                .set_fuel(self.max_fuel)
-                .map_err(|e| WasmError::Other(anyhow::anyhow!(e)))?;
-        }
-
-        // Arm the epoch deadline before instantiation runs any guest start
-        // function (#4861); the store is reused across calls so a stale deadline
-        // would otherwise trap here.
-        arm_epoch_deadline(store, self.epoch_deadline_ticks);
-
-        // Instantiate the module using the pre-configured linker
-        // CRITICAL: Must use instantiate_async() because async_support(true) is enabled
-        // An epoch interrupt here (a runaway module start function) is classified
-        // as a timeout, not Instantiation (#4864 review); other errors keep it.
-        let instance =
-            block_on_async(self.linker.instantiate_async(&mut *store, module)).map_err(|e| {
-                classify_guest_entry_error(e, |e| WasmError::Instantiation(e.to_string()))
-            })?;
-
-        // Call __frnt_set_id to set the instance ID (used for MEM_ADDR lookup)
-        // CRITICAL: Must use call_async() because async_support(true) is enabled
-        if let Some(set_id_func) = instance.get_func(&mut *store, "__frnt_set_id") {
-            let typed_func = set_id_func
-                .typed::<i64, ()>(&*store)
-                .map_err(|e| WasmError::Export(e.to_string()))?;
-            // Re-arm the epoch deadline before this SECOND guest call (#4864
-            // round-4 P2). The store is reused across calls, so without re-arming
-            // __frnt_set_id would inherit whatever ticks REMAIN from the
-            // instantiation deadline armed above — a module whose start function
-            // ran near the budget would leave set_id ~zero ticks and trap it
-            // spuriously. Every guest entry must be immediately preceded by its
-            // own arm (pinned by `every_guest_entry_is_preceded_by_arm_epoch_deadline`).
-            //
-            // Adversarial ceiling (#4864 round-5 item 10): giving set_id a FRESH
-            // budget is correct per-call, but it means create_instance's worst-case
-            // GUEST CPU is ~2x max_execution_seconds (a start function running just
-            // under budget, then set_id running a fresh full budget). That is
-            // bounded at EXACTLY 2 guest entries — the pin above enumerates every
-            // guest entry in this method, so the factor cannot silently grow.
-            arm_epoch_deadline(store, self.epoch_deadline_ticks);
-            block_on_async(typed_func.call_async(&mut *store, id)).map_err(|e| {
-                classify_guest_entry_error(e, |e| WasmError::Runtime(e.to_string()))
-            })?;
-        }
+        let instance = match Self::instantiate_and_init(
+            store,
+            &self.linker,
+            module,
+            id,
+            req_bytes,
+            epoch_ticks,
+        ) {
+            Ok(instance) => instance,
+            Err(e) => {
+                // The `store` borrow above ends with `match`, so recover_store
+                // (which reborrows &mut self) is free to replace the store and
+                // drop the failed instance's arena residue.
+                self.recover_store();
+                return Err(e);
+            }
+        };
 
         // Note: MEM_ADDR insertion is handled by RunningInstance::new in runtime.rs
         // which has the correct contract key. Do NOT insert here with a default key.
-
-        // Ensure sufficient memory for the request
-        Self::ensure_memory(store, &instance, req_bytes)?;
 
         self.instances.insert(id, instance);
         self.lifetime_instances += 1;
@@ -1421,6 +1413,66 @@ impl WasmtimeEngine {
         register_engine_for_epoch(&engine);
 
         Ok((engine, max_fuel, config.enable_metering))
+    }
+
+    /// Instantiate `module`, run its `__frnt_set_id`, and ensure request memory —
+    /// the guest-entry half of [`create_instance`], factored out so the caller can
+    /// RECOVER THE STORE on any guest-entry timeout/error before returning (#4864
+    /// round-9 item 2). Every guest entry here is immediately preceded by its own
+    /// `arm_epoch_deadline` (pinned by
+    /// `every_guest_entry_is_preceded_by_arm_epoch_deadline`, which now scrapes
+    /// this method).
+    fn instantiate_and_init(
+        store: &mut Store<HostState>,
+        linker: &Linker<HostState>,
+        module: &Module,
+        id: i64,
+        req_bytes: usize,
+        epoch_deadline_ticks: u64,
+    ) -> Result<Instance, WasmError> {
+        // Arm the epoch deadline before instantiation runs any guest start
+        // function (#4861); the store is reused across calls so a stale deadline
+        // would otherwise trap here.
+        arm_epoch_deadline(store, epoch_deadline_ticks);
+
+        // Instantiate the module using the pre-configured linker.
+        // CRITICAL: Must use instantiate_async() because async_support(true) is enabled.
+        // An epoch interrupt here (a runaway module start function) is classified
+        // as a timeout, not Instantiation (#4864 review); other errors keep it.
+        let instance =
+            block_on_async(linker.instantiate_async(&mut *store, module)).map_err(|e| {
+                classify_guest_entry_error(e, |e| WasmError::Instantiation(e.to_string()))
+            })?;
+
+        // Call __frnt_set_id to set the instance ID (used for MEM_ADDR lookup).
+        // CRITICAL: Must use call_async() because async_support(true) is enabled.
+        if let Some(set_id_func) = instance.get_func(&mut *store, "__frnt_set_id") {
+            let typed_func = set_id_func
+                .typed::<i64, ()>(&*store)
+                .map_err(|e| WasmError::Export(e.to_string()))?;
+            // Re-arm the epoch deadline before this SECOND guest call (#4864
+            // round-4 P2). The store is reused across calls, so without re-arming
+            // __frnt_set_id would inherit whatever ticks REMAIN from the
+            // instantiation deadline armed above — a module whose start function
+            // ran near the budget would leave set_id ~zero ticks and trap it
+            // spuriously.
+            //
+            // Adversarial ceiling (#4864 round-5 item 10): giving set_id a FRESH
+            // budget is correct per-call, but it means create_instance's worst-case
+            // GUEST CPU is ~2x max_execution_seconds (a start function running just
+            // under budget, then set_id running a fresh full budget). That is
+            // bounded at EXACTLY 2 guest entries — the pin enumerates every guest
+            // entry here, so the factor cannot silently grow.
+            arm_epoch_deadline(store, epoch_deadline_ticks);
+            block_on_async(typed_func.call_async(&mut *store, id)).map_err(|e| {
+                classify_guest_entry_error(e, |e| WasmError::Runtime(e.to_string()))
+            })?;
+        }
+
+        // Ensure sufficient memory for the request.
+        Self::ensure_memory(store, &instance, req_bytes)?;
+
+        Ok(instance)
     }
 
     /// Recover the engine after a timeout or panic that consumed the store.
@@ -2487,7 +2539,10 @@ mod tests {
     fn every_guest_entry_is_preceded_by_arm_epoch_deadline() {
         let src = include_str!("wasmtime_engine.rs");
         for fn_name in [
-            "fn create_instance(",
+            // #4864 round-9 item 2: create_instance's guest entries moved into
+            // instantiate_and_init so the store can be recovered on a guest-entry
+            // timeout; scrape the new home of those entries.
+            "fn instantiate_and_init(",
             "fn initiate_buffer(",
             "fn call_void(",
             "fn call_3i64(",
@@ -2540,6 +2595,42 @@ mod tests {
                 prev = entry_pos;
             }
         }
+    }
+
+    /// #4864 round-9 item 2 pin: `create_instance` MUST recover the store on a
+    /// guest-entry (instantiate / `__frnt_set_id`) failure. Without it, a timeout
+    /// that returns before `instances.insert` / `lifetime_instances += 1` leaves
+    /// the failed instance's allocation in the wasmtime Store arena uncounted, so
+    /// repeated init timeouts across fresh contract ids accumulate untracked arena
+    /// memory that never triggers a count-based refresh.
+    #[test]
+    fn create_instance_recovers_store_on_guest_entry_failure() {
+        let src = include_str!("wasmtime_engine.rs");
+        let start = src
+            .find("fn create_instance(")
+            .expect("create_instance not found");
+        let after = &src[start..];
+        let end = after[1..]
+            .find("\n    fn ")
+            .map(|i| i + 1)
+            .unwrap_or(after.len());
+        let body = &after[..end];
+
+        let call = body
+            .find("Self::instantiate_and_init(")
+            .expect("create_instance must delegate guest entry to instantiate_and_init");
+        let recover = body.find("self.recover_store();").expect(
+            "create_instance must recover the store on a guest-entry failure \
+             (#4864 round-9 item 2)",
+        );
+        assert!(
+            call < recover,
+            "recover_store must be in the instantiate_and_init error path (after the call)"
+        );
+        assert!(
+            body[recover..(recover + 120).min(body.len())].contains("return Err(e)"),
+            "the recovery arm must still return the guest-entry error (not swallow it)"
+        );
     }
 
     /// #4864 round-7 (Codex P1): the wall-clock backstop must bound queue wait and

--- a/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
+++ b/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
@@ -449,7 +449,11 @@ fn detect_stale_epoch_ticker() {
     }
     // Stale: emit at most ~once/60s (compare-and-swap so exactly one thread wins).
     let last_warn = EPOCH_TICKER_STALE_WARNED_MS.load(Ordering::Relaxed);
-    if now_ms.saturating_sub(last_warn) >= 60_000
+    // `last_warn == 0` is the zero-init sentinel ("never warned"), NOT a real
+    // warning at base-epoch 0: allow the FIRST warn unconditionally, else an
+    // early ticker death is silently suppressed until now_ms reaches 60_000.
+    let should_warn = last_warn == 0 || now_ms.saturating_sub(last_warn) >= 60_000;
+    if should_warn
         && EPOCH_TICKER_STALE_WARNED_MS
             .compare_exchange(last_warn, now_ms, Ordering::Relaxed, Ordering::Relaxed)
             .is_ok()

--- a/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
+++ b/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
@@ -141,7 +141,7 @@
 //! We wrap with `block_on_async()` to maintain a synchronous interface for callers.
 
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
@@ -983,6 +983,10 @@ impl WasmEngine for WasmtimeEngine {
                 self.recover_store();
                 Err(WasmError::Timeout)
             }
+            BlockingResult::QueuedTimeout => {
+                self.recover_store();
+                Err(WasmError::SchedulerOverloaded)
+            }
             BlockingResult::Panic(err) => {
                 self.recover_store();
                 Err(WasmError::Other(err))
@@ -1051,6 +1055,10 @@ impl WasmEngine for WasmtimeEngine {
             BlockingResult::Timeout => {
                 self.recover_store();
                 Err(WasmError::Timeout)
+            }
+            BlockingResult::QueuedTimeout => {
+                self.recover_store();
+                Err(WasmError::SchedulerOverloaded)
             }
             BlockingResult::Panic(err) => {
                 self.recover_store();
@@ -1820,7 +1828,17 @@ type WasmResult = (Result<i64, WasmtimeError>, Store<HostState>);
 enum BlockingResult {
     Ok(i64, Store<HostState>),
     WasmError(WasmtimeError, Store<HostState>),
+    /// Wall-clock deadline fired while the guest was RUNNING (`started == true`)
+    /// — a real, contract-intrinsic timeout backing up the epoch trap. The
+    /// store is unrecoverable (the aborted task/thread still owns it), so the
+    /// caller recovers a fresh store like the other timeout arms.
     Timeout,
+    /// Wall-clock deadline fired while the closure was still QUEUED on a
+    /// saturated blocking pool (`started == false`) — the guest never ran
+    /// (#4864 round-6). Transient load, NOT a contract fault; the caller maps
+    /// it to [`WasmError::SchedulerOverloaded`] and recovers the store as with
+    /// `Timeout`.
+    QueuedTimeout,
     Panic(anyhow::Error),
 }
 
@@ -1830,6 +1848,19 @@ where
 {
     let timeout = Duration::from_secs_f64(max_execution_seconds);
     let start = std::time::Instant::now();
+
+    // #4864 round-6: distinguish a guest that RAN and blew the wall-clock
+    // deadline (a real, contract-intrinsic timeout — the epoch backstop) from a
+    // closure that never got off the blocking-pool queue (a transient scheduler
+    // overload the guest never entered). The wrapped closure's FIRST act flips
+    // `started`, so a wall-clock fire with `started == false` means the guest
+    // never ran and the failure must NOT be charged to the contract.
+    let started = Arc::new(AtomicBool::new(false));
+    let started_for_guest = Arc::clone(&started);
+    let f = move || {
+        started_for_guest.store(true, Ordering::SeqCst);
+        f()
+    };
 
     // `block_in_place` (in the multi-thread arm below) is only legal on a
     // multi-threaded runtime; it PANICS on a current_thread runtime. Route a
@@ -1864,13 +1895,27 @@ where
                 }
 
                 if start.elapsed() >= timeout {
+                    task_handle.abort();
+                    // #4864 round-6: only a guest that actually STARTED is a real
+                    // (contract-intrinsic) timeout. A closure still queued on a
+                    // saturated blocking pool never ran, so classify it as a
+                    // transient scheduler overload instead of quarantining the
+                    // contract.
+                    if started.load(Ordering::SeqCst) {
+                        tracing::warn!(
+                            timeout_secs = max_execution_seconds,
+                            elapsed_ms = start.elapsed().as_millis(),
+                            "WASM execution timed out (guest running; epoch backstop)"
+                        );
+                        return BlockingResult::Timeout;
+                    }
                     tracing::warn!(
                         timeout_secs = max_execution_seconds,
                         elapsed_ms = start.elapsed().as_millis(),
-                        "WASM execution timed out"
+                        "WASM execution timed out while QUEUED (guest never started; \
+                         blocking-pool saturation) — treated as transient, contract not quarantined"
                     );
-                    task_handle.abort();
-                    return BlockingResult::Timeout;
+                    return BlockingResult::QueuedTimeout;
                 }
 
                 std::thread::sleep(Duration::from_millis(10));
@@ -1912,12 +1957,26 @@ where
                 }
 
                 if start.elapsed() >= timeout {
+                    // #4864 round-6: same started-flag classification as the
+                    // multi-thread arm. The detached thread is left to finish
+                    // and drop the store on its own (as before); only the
+                    // RESULT classification differs by whether the guest ran.
+                    if started.load(Ordering::SeqCst) {
+                        tracing::warn!(
+                            timeout_secs = max_execution_seconds,
+                            elapsed_ms = start.elapsed().as_millis(),
+                            "WASM execution timed out (guest running; epoch backstop, no tokio runtime)"
+                        );
+                        return BlockingResult::Timeout;
+                    }
                     tracing::warn!(
                         timeout_secs = max_execution_seconds,
                         elapsed_ms = start.elapsed().as_millis(),
-                        "WASM execution timed out (no tokio runtime)"
+                        "WASM execution timed out while QUEUED (guest never started; \
+                         blocking-pool saturation, no tokio runtime) — treated as transient, \
+                         contract not quarantined"
                     );
-                    return BlockingResult::Timeout;
+                    return BlockingResult::QueuedTimeout;
                 }
 
                 std::thread::sleep(Duration::from_millis(10));

--- a/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
+++ b/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
@@ -1939,7 +1939,10 @@ mod tests {
             "preemption must surface as a Trap::Interrupt, got: {err:?}"
         );
         assert!(
-            matches!(classify_runtime_error(false, &mut store, err), WasmError::Timeout),
+            matches!(
+                classify_runtime_error(false, &mut store, err),
+                WasmError::Timeout
+            ),
             "epoch-deadline trap must classify as WasmError::Timeout"
         );
     }

--- a/crates/core/src/wasm_runtime/module_cache.rs
+++ b/crates/core/src/wasm_runtime/module_cache.rs
@@ -1097,38 +1097,37 @@ pub(crate) fn migration_admission_recovered_now(
 /// contracts. Below this the cache would thrash on a normal node.
 pub const MIN_DEFAULT_MODULE_CACHE_BUDGET_BYTES: usize = 64 * 1024 * 1024;
 
-/// Upper clamp for the default contract-module cache budget (1.5 GiB).
+/// Upper clamp for the default contract-module cache budget (4 GiB).
 ///
 /// Two competing pressures set this ceiling:
 ///
 /// - **Too low → large gateways thrash.** A production gateway hosts hundreds
-///   of contracts and, post-#4404 placement migration, also carries a sizeable
-///   *interest* set on contracts it doesn't hold (the #4441 incident saw ~85
-///   such phantom-interest contracts on technic). At the measured ~1.5 MiB per
-///   compiled module, the previous 384 MiB ceiling held only ~256 modules — so
-///   the cache permanently evicts-and-recompiles a working set it can't fit,
-///   pinning the single-threaded contract loop. nova (125 GiB RAM) is the
-///   canonical case: `total_ram / 8` is ~15 GiB, so the *only* thing capping
-///   its default cache was this clamp, and 384 MiB was well below its working
-///   set. 1.5 GiB holds ~1000 modules at the measured size — comfortably above
-///   a healthy gateway's hot set — and matches the ceiling of the RAM-scaled
-///   hosted-*state* budget (`ring::MAX_DEFAULT_HOSTING_BUDGET_BYTES`, 1 GiB):
-///   a node allowed ~1 GiB of contract state should be able to cache the
-///   corresponding compiled code.
-/// - **Too high → wasted memory on huge hosts.** Past ~1000 resident modules
-///   the working-set benefit flattens while absolute memory cost keeps rising.
-///   Without a ceiling, `total_ram / 8` would default a 125 GiB box to a
-///   ~15 GiB compiled-module cache it can't benefit from. The clamp keeps the
-///   default a bounded, defensible commitment.
+///   to thousands of contracts and, post-#4404 placement migration, also
+///   carries a sizeable *interest* set on contracts it doesn't hold (the #4441
+///   incident saw ~85 such phantom-interest contracts on technic). At the
+///   measured ~1.5 MiB per compiled module, the previous 384 MiB ceiling held
+///   only ~256 modules and 1.5 GiB (#4481) held ~1000 — but a busy production
+///   gateway can carry far more: a ~2652-contract gateway needs ~4 GiB and
+///   thrashed at the 1.5 GiB ceiling (~7 evict-and-recompiles/min), each
+///   recompile pinning the single-threaded contract loop (#4861). nova
+///   (125 GiB RAM) is the canonical case: `total_ram / 8` is ~15 GiB, so the
+///   *only* thing capping its default cache is this clamp. 4 GiB holds ~2650
+///   modules at the measured size — enough for the busy-gateway working set
+///   observed in #4861 — and stays a small fraction of such a gateway's RAM.
+/// - **Too high → wasted memory on huge hosts.** Past the resident working set
+///   the benefit flattens while absolute memory cost keeps rising. Without a
+///   ceiling, `total_ram / 8` would default a 125 GiB box to a ~15 GiB
+///   compiled-module cache it can't benefit from. The clamp keeps the default a
+///   bounded, defensible commitment.
 ///
 /// This clamp only binds on hosts with more than
-/// `MAX * DEFAULT_MODULE_CACHE_RAM_DIVISOR` (= 12 GiB) of RAM; below that the
+/// `MAX * DEFAULT_MODULE_CACHE_RAM_DIVISOR` (= 32 GiB) of RAM; below that the
 /// `total_ram / 8` divisor binds first, so raising this ceiling does **not**
 /// change the default on small/medium hosts (see
 /// `default_module_cache_budget_bytes`). Operators who truly need more raise it
 /// explicitly via the config override below (the explicit override is
 /// unclamped).
-pub const MAX_DEFAULT_MODULE_CACHE_BUDGET_BYTES: usize = 1536 * 1024 * 1024;
+pub const MAX_DEFAULT_MODULE_CACHE_BUDGET_BYTES: usize = 4096 * 1024 * 1024;
 
 /// Fraction of total system RAM used to size the default contract cache budget.
 ///
@@ -1166,15 +1165,15 @@ const FALLBACK_TOTAL_RAM_BYTES: usize = 1024 * 1024 * 1024;
 ///
 /// Returns `clamp(total_ram / DEFAULT_MODULE_CACHE_RAM_DIVISOR,
 /// MIN_DEFAULT_MODULE_CACHE_BUDGET_BYTES, MAX_DEFAULT_MODULE_CACHE_BUDGET_BYTES)`
-/// (currently `clamp(total_ram / 8, 64 MiB, 1.5 GiB)`). The same fix for issue
+/// (currently `clamp(total_ram / 8, 64 MiB, 4 GiB)`). The same fix for issue
 /// #4441 (a node hosting >1024 contracts thrashed/OOM'd the old count cap) must
 /// not itself OOM a small box: the `total_ram / 8` divisor — not the absolute
 /// MAX clamp — is the small-box protection, and giving the delegate cache only a
 /// fraction (`DELEGATE_MODULE_CACHE_BUDGET_DIVISOR`) keeps the COMBINED default
-/// ceiling safe on small hosts. The MAX clamp only binds on large hosts (>12 GiB
+/// ceiling safe on small hosts. The MAX clamp only binds on large hosts (>32 GiB
 /// RAM); it exists to stop the divisor from handing a huge box a cache far
 /// larger than any useful working set, not to protect small boxes. See
-/// `MAX_DEFAULT_MODULE_CACHE_BUDGET_BYTES` for why 1.5 GiB.
+/// `MAX_DEFAULT_MODULE_CACHE_BUDGET_BYTES` for why 4 GiB.
 ///
 /// The explicit `--module-cache-budget-bytes` flag /
 /// `FREENET_MODULE_CACHE_BUDGET_BYTES` env / `module-cache-budget-bytes` config
@@ -1204,8 +1203,8 @@ fn budget_for_ram(total_ram: usize) -> usize {
 ///
 /// This is the **minimum** of the host's physical RAM and any cgroup memory
 /// limit applied to the process. Using the cgroup limit matters because raising
-/// the cache clamp to 1.5 GiB would otherwise let a node inside a small
-/// container (say a 2 GiB limit on a 128 GiB host) default to a ~1.5 GiB cache
+/// the cache clamp to 4 GiB would otherwise let a node inside a small
+/// container (say a 2 GiB limit on a 128 GiB host) default to a multi-GiB cache
 /// sized from the *host* total and OOM the container. Taking the min means a
 /// constrained container gets a budget scaled to its real limit, while a host
 /// systemd service (the production gateways) sees no cgroup limit and uses
@@ -1612,9 +1611,10 @@ mod tests {
     /// sizes where the divisor (not the MAX clamp) binds.
     #[test]
     fn combined_default_ceiling_is_safe_on_small_box() {
-        // RAM sizes from a tiny 512 MiB VPS up to 12 GiB — the largest host at
-        // which the divisor still binds below the MAX clamp.
-        for total_ram_gib_eighths in 1..=96u64 {
+        // RAM sizes from a tiny 512 MiB VPS up to 32 GiB — the largest host at
+        // which the divisor still binds below the MAX clamp (MAX × divisor =
+        // 4 GiB × 8 = 32 GiB).
+        for total_ram_gib_eighths in 1..=256u64 {
             // step in 1/8-GiB increments so we cover sub-GiB hosts too.
             let total_ram = (total_ram_gib_eighths as usize) * (128 * 1024 * 1024);
             let contract = budget_for_ram(total_ram);
@@ -1702,11 +1702,11 @@ mod tests {
     /// its working set (hundreds of hosted contracts plus the post-#4404
     /// phantom-interest set) fits without permanent evict-and-recompile thrash.
     ///
-    /// At `total_ram / 8`, any host with >12 GiB RAM lands on the MAX clamp, so
+    /// At `total_ram / 8`, any host with >32 GiB RAM lands on the MAX clamp, so
     /// the budget equals the MAX. This test pins that the MAX is high enough to
-    /// hold a realistic gateway working set (~1000 modules at the measured
-    /// ~1.5 MiB) and is strictly larger than the pre-fix 384 MiB that caused the
-    /// thrash.
+    /// hold a realistic busy-gateway working set (~2650 modules at the measured
+    /// ~1.5 MiB, per the #4861 2652-contract gateway) and is strictly larger
+    /// than the pre-fix 384 MiB that caused the thrash.
     #[test]
     fn large_gateway_default_exceeds_old_clamp() {
         const OLD_MAX: usize = 384 * 1024 * 1024;
@@ -1726,9 +1726,10 @@ mod tests {
         );
         let modules_held = budget / MEASURED_MODULE_SIZE;
         assert!(
-            modules_held >= 900,
-            "the default ceiling must hold a realistic gateway working set \
-             (~1000 modules at ~1.5 MiB each); holds {modules_held}"
+            modules_held >= 2000,
+            "the default ceiling must hold a realistic busy-gateway working set \
+             (~2650 modules at ~1.5 MiB each, per the #4861 2652-contract \
+             gateway); holds {modules_held}"
         );
     }
 
@@ -1970,11 +1971,11 @@ mod tests {
         assert_eq!(occupancy_pct(1_500, 1_000), Some(150));
     }
 
-    /// A fully-occupied 1.5 GiB budget must not overflow `total * 100`.
+    /// A fully-occupied max-budget cache must not overflow `total * 100`.
     #[test]
     fn occupancy_pct_handles_gib_scale_without_overflow() {
-        // `1.5 GiB * 100` is ~1.6e11, well within u64; assert no overflow panic.
-        let budget = 1_536u64 * 1024 * 1024;
+        // `4 GiB * 100` is ~4.3e11, well within u64; assert no overflow panic.
+        let budget = 4_096u64 * 1024 * 1024;
         assert_eq!(occupancy_pct(budget, budget), Some(100));
         // Cleanly-divisible large budget to assert the 90% boundary exactly
         // (avoids integer-truncation noise from a non-divisible GiB budget).

--- a/crates/core/src/wasm_runtime/module_cache.rs
+++ b/crates/core/src/wasm_runtime/module_cache.rs
@@ -1192,7 +1192,13 @@ pub fn default_module_cache_budget_bytes() -> usize {
 /// small-box / large-box boundary behavior is unit-testable without depending on
 /// the test host's real RAM. Returns the contract-cache byte budget for a host
 /// with `total_ram` bytes of physical RAM.
-fn budget_for_ram(total_ram: usize) -> usize {
+///
+/// `pub(crate)` so callers reasoning about aggregate cache commitment on a
+/// *specific* host size (e.g. `executor::tests::cache_byte_budgets_are_aggregate_safe`)
+/// can ask for the module budget that host actually gets — the RAM-scaled
+/// divisor value, NOT the absolute [`MAX_DEFAULT_MODULE_CACHE_BUDGET_BYTES`]
+/// clamp (which only binds on hosts with >32 GiB RAM).
+pub(crate) fn budget_for_ram(total_ram: usize) -> usize {
     (total_ram / DEFAULT_MODULE_CACHE_RAM_DIVISOR).clamp(
         MIN_DEFAULT_MODULE_CACHE_BUDGET_BYTES,
         MAX_DEFAULT_MODULE_CACHE_BUDGET_BYTES,

--- a/crates/core/src/wasm_runtime/runtime.rs
+++ b/crates/core/src/wasm_runtime/runtime.rs
@@ -153,6 +153,16 @@ pub enum ContractExecError {
 
     #[error("The operation exceeded the maximum allowed compute time")]
     MaxComputeTimeExceeded,
+
+    /// The operation never ran: it sat queued on a saturated execution pool
+    /// past the wall-clock deadline and the guest never started (#4864
+    /// round-6). Distinct from [`ContractExecError::MaxComputeTimeExceeded`]
+    /// (a guest that DID run and blew the deadline). The message string is
+    /// load-bearing — `ExecutorError::is_scheduler_timeout` matches on the
+    /// "queued too long on a saturated execution pool" phrase after it flows
+    /// through `update_exec_error`.
+    #[error("The operation was queued too long on a saturated execution pool and never ran")]
+    SchedulerOverloaded,
 }
 
 pub struct RuntimeConfig {

--- a/crates/core/src/wasm_runtime/runtime.rs
+++ b/crates/core/src/wasm_runtime/runtime.rs
@@ -157,10 +157,18 @@ pub enum ContractExecError {
     /// The operation never ran: it sat queued on a saturated execution pool
     /// past the wall-clock deadline and the guest never started (#4864
     /// round-6). Distinct from [`ContractExecError::MaxComputeTimeExceeded`]
-    /// (a guest that DID run and blew the deadline). The message string is
-    /// load-bearing — `ExecutorError::is_scheduler_timeout` matches on the
-    /// "queued too long on a saturated execution pool" phrase after it flows
-    /// through `update_exec_error`.
+    /// (a guest that DID run and blew the deadline).
+    ///
+    /// Classification is by TYPED PROVENANCE, NOT this string (#4864 round-9):
+    /// `ExecutorError::is_scheduler_timeout` reads the `host_timeout` field that
+    /// `ExecutorError::execution` sets ONLY when it sees this typed variant — which
+    /// the host `classify_result` alone constructs. The message string is NOT the
+    /// classification gate; it only supplies the cause text for the "execution
+    /// error:" prefix and logging. Do NOT delete the `host_timeout` field and fall
+    /// back to matching this phrase: a contract can RETURN a rejection whose text
+    /// contains it, which would reintroduce the exact forge vector round-9 closed
+    /// (a contract self-inflicting the scheduler/timeout quarantine class on honest
+    /// peers). See `ExecutorError::host_timeout` in `contract/executor.rs`.
     #[error("The operation was queued too long on a saturated execution pool and never ran")]
     SchedulerOverloaded,
 }

--- a/crates/core/src/wasm_runtime/runtime.rs
+++ b/crates/core/src/wasm_runtime/runtime.rs
@@ -66,7 +66,11 @@ impl RunningInstance {
         req_bytes: usize,
     ) -> RuntimeResult<Self> {
         let id = INSTANCE_ID.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-        let handle = engine.create_instance(module, id, req_bytes)?;
+        // Route the guest-entry call through classify_result so an epoch interrupt
+        // during a runaway module start function normalizes to
+        // MaxComputeTimeExceeded (Timeout class), not the generic "execution
+        // timeout" that is_wasm_timeout misses (#4864 round-5).
+        let handle = super::classify_result(engine.create_instance(module, id, req_bytes))?;
 
         // Record memory address and size for host function pointer arithmetic
         let (ptr, size) = engine.memory_info(&handle)?;
@@ -534,7 +538,9 @@ impl Runtime {
         T: AsRef<[u8]>,
     {
         let data = data.as_ref();
-        let builder_ptr = self.engine.initiate_buffer(handle, data.len() as u32)?;
+        // classify_result: a guest-entry epoch interrupt → Timeout class (#4864 round-5).
+        let builder_ptr =
+            super::classify_result(self.engine.initiate_buffer(handle, data.len() as u32))?;
         let linear_mem = self.linear_mem(handle)?;
         // SAFETY: `builder_ptr` is returned by the WASM allocator and points to a valid
         // `BufferBuilder` within the instance's linear memory described by `linear_mem`.
@@ -551,7 +557,9 @@ impl Runtime {
         handle: &InstanceHandle,
         capacity: usize,
     ) -> RuntimeResult<BufferMut<'_>> {
-        let builder_ptr = self.engine.initiate_buffer(handle, capacity as u32)?;
+        // classify_result: a guest-entry epoch interrupt → Timeout class (#4864 round-5).
+        let builder_ptr =
+            super::classify_result(self.engine.initiate_buffer(handle, capacity as u32))?;
         let linear_mem = self.linear_mem(handle)?;
         // SAFETY: `builder_ptr` is returned by the WASM allocator and points to a valid
         // `BufferBuilder` within the instance's linear memory described by `linear_mem`.


### PR DESCRIPTION
## Problem

Production peers burn CPU indefinitely on "poison" contracts — the cause of the user-reported periodic 100% CPU on small VMs (#4861). Forensics on the nova gateway identified three poison classes running at full rate for 36h+:

1. **Compute poison**: a contract whose every merge exceeds the 5s execution budget (100-210 timeouts/hr, ≈14-29% of a core, continuously, on every host).
2. **Semantic fork oscillation**: two stable divergent states rejecting each other's deltas; every full-state resync "succeeds" but merely flips the node to the other fork (~1 cycle/min, 45 distinct senders, 9,733 ResyncResponses sent for one contract in a day).
3. **Deserialization poison**: a malformed delta circulating forever.

Core amplified all three: any delta-apply failure emitted a ResyncRequest with no failure counter, no backoff, no rate limit, and no give-up — and the ResyncResponse full-state apply re-ran WASM. Worse, with `enable_metering` off (the default), the 5s "timeout" only abandoned the result: `abort()` cannot stop synchronous WASM, so the guest kept burning its blocking thread arbitrarily long, and a hostile infinite-loop contract would burn a thread permanently.

## Solution

Five mechanisms, all behavioral — **zero wire-format changes**:

1. **Epoch-based preemption** (`wasmtime_engine.rs`): `epoch_interruption(true)` + a global 100ms ticker + per-call `set_epoch_deadline` with trap-on-deadline. The execution budget is now actually enforced — a runaway guest traps within one tick of the deadline instead of running forever. `Trap::Interrupt` is classified as the execution-timeout error. Regression test runs an infinite-loop WAT with no wall-clock wrapper. Note: `epoch_interruption` is part of wasmtime's compile-cache key, so every cached WASM module recompiles once on the first load after upgrade (a one-time cost).
2. **Typed timeout classification** (`contract/executor.rs`): `is_wasm_timeout()` so drivers can distinguish compute poison from semantic rejection.
3. **Per-contract merge-failure backoff** (`ring/merge_backoff.rs`): consecutive failures put a contract into exponential cooldown (Invalid: trips only after 3 consecutive failures with no intervening success, then 30s→30min; Timeout: trips at the first failure, 120s→2h; ±20% jitter — one benign stale-version reject must never blackout a healthy contract, while each timeout is a full 5s CPU burn), during which deltas are dropped *before* WASM executes and no ResyncRequest is sent. Includes a 10-min failed-payload memo (a failed (state, delta) pair cannot change outcome until the state changes). **Reset is strictly delta-only**: only a clean delta apply proves the receiver shared the sender's base. Full-state merges — streaming broadcast and resync apply alike — never reset, because in the fork-oscillation class they "succeed" by flipping forks (source-scrape pins enforce this). **Suppression scope (round-3 review, anti-blackout):** Invalid-class failures are tracked per-(contract, sender), so one bad peer only suppresses its own deltas and cannot blackout a healthy contract for every honest peer; Timeout-class failures stay contract-wide (a ~5s CPU burn is contract-intrinsic). The failed-payload memo is contract-wide, content-addressed, and a hard skip for any sender (deterministic execution means the same bad bytes fail identically for everyone; the skip is zero-cost — it advances no sender channel and emits no ResyncRequest). A remote delta success clears that sender's Invalid channel plus the contract-wide Timeout and memo; a client-local delta success clears only the contract-wide Timeout and memo, leaving remote senders' Invalid channels intact. **State-advance gating (round-4):** the per-sender Invalid channel clears on any clean delta apply (channel-trust), but the contract-wide Timeout + memo clear only when the merge advanced state (`changed == true`) — a no-op (UpdateNoChange) delta must not wipe a live Timeout quarantine, else a busy contract carrying a co-circulating timeout payload clears the 120s→2h quarantine on every routine delta. A state-advancing full-state apply (streaming/resync, changed) invalidates only the failed-payload memo (`invalidate_payload_memo`), never a cooldown, so the strictly-delta-only no-reset doctrine still holds.
4. **Resync rate limiting** (`ring/resync_rate_limit.rs`): emitter-side per-contract token bucket (burst 2/60s); responder-side per-(peer,contract) bucket (mixed-version guard against un-upgraded storming peers) plus a **global per-contract cap** (~12/min) — production showed 45 requester IPs, so per-peer limiting alone is insufficient. **Responder existence-gate (round-4, made backend-agnostic in round-5):** a cheap state-presence probe (`contract_state_present_async` — a synchronous redb point-lookup fast-path, or a real SQLite `EXISTS` query) runs before both limiter buckets, making the order exists → per-peer → global → state fetch, so a peer spraying bogus keys can never exhaust the strictly-capped limiter maps (which would fail-close legitimate contracts). The old sync-only probe was a no-op on SQLite builds; the async variant closes that gap on both backends (the SQLite branch is correct-but-dormant until the SQLite backend compiles again — #4869). The #4857 queue-full resync heal now also routes through the global per-contract emit cap (previously only per-(contract, sender) throttled), so a saturated contract with many senders emits at most the burst allowance total, not one per sender. Flood test: 45 peers × 5min → ~62 responses vs ~9,733/day today.
5. **Module-cache budget clamp raise** (1.5→4 GiB max; RAM/8 base unchanged, small boxes unaffected): the 2,652-contract gateway thrashes the 1.5 GiB cap at ~7 recompiles/min. **Upgrade migration:** an existing >12 GiB node whose config.toml carries the old auto-derived `module-cache-budget-bytes = 1610612736` (1.5 GiB) is re-derived to the new default instead of staying pinned to the stale value; CLI/env and any other persisted value are preserved. Accepted edge (release-notes): an operator who explicitly set exactly 1.5 GiB is indistinguishable from the old auto-default and will also be re-derived.

Containment philosophy: core bounds the cost of a broken/hostile contract; it never assumes the contract-layer bug heals. The InterestSync anti-entropy heartbeat remains the recovery path once a contract exits cooldown.

Hosting-invariants note: touches the UPDATE path only. Invariant 1 (served copies fresh): a contract in backoff has already lost convergence (every merge fails); the bounded stale window during cooldown falls under the invariant's permitted transients, and anti-entropy remains the healer. No placement/eviction/subscription semantics changed.

## Testing

- Infinite-loop WAT preemption regression test (no wall-clock wrapper — only the epoch trap can return it).
- Fork-oscillation regression: alternating delta-fail/resync-apply must still escalate into backoff (this exact pattern defeated a naive reset-on-success design).
- Flood tests for all three limiters (modeled on the May-21 UpdateRateLimiter flood test).
- Source-scrape pins: reset gated on `is_delta`; streaming path never resets; node.rs never resets; responder gates ordered exists → per-peer → global → state fetch (a 50-bogus-key flood consumes no limiter slot); queue-full resync heal bounded by the global per-contract emit cap; epoch deadline re-armed before every guest entry.
- MergeBackoff unit suite: per-sender/contract-wide channels, cooldown escalation, jitter bounds, memo TTL, cap, cleanup; DST-compliant (TimeSource + GlobalRng throughout).
- `cargo fmt` / CI-exact `clippy -D warnings` clean; targeted `nextest` 194/194 + doc-fix pins.

Root-cause forensics + measurements: #4861 (issue + comment).

Follow-ups (deliberately out of scope): SQLite state-store backend repair (#4869); per-contract CPU duty-cycle budget (the hard adversarial guarantee, PR 2); contract-layer fixes for the specific poison contracts (River room merge cost, fork reconciliation); dashboard wiring for the new suppression counters.

Part of #4861

[AI-assisted - Claude]




