### PR TITLE
fix(interest-sync): detect peer staleness semantically, not by summary bytes

### DIFF
--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -2202,6 +2202,51 @@ fn stale_sync_emit_budget(stale_contracts_len: usize) -> usize {
     stale_contracts_len.min(MAX_STALE_SYNCS_PER_SUMMARIES)
 }
 
+/// Per-`Summaries`-message cap on semantic-staleness probes — the WASM
+/// `get_state_delta` calls the `Summaries` handler issues to decide, for a
+/// byte-differing summary, whether a peer is genuinely stale (#4857 secondary
+/// finding). Mirrors the sibling per-message WASM-fan-out caps
+/// (`MAX_STALE_SYNCS_PER_SUMMARIES = 32` here, `MAX_DELTA_COMPUTATIONS_PER_FANOUT`
+/// in the broadcast path) and the code-style rule that per-recipient WASM work
+/// MUST be bounded: without it a peer that sends crafted/novel summary bytes for
+/// every hosted contract would force unbounded `get_state_delta` execution on
+/// the serial contract-handling loop. 32 matches the burst-control family and
+/// sits far above the handful of genuinely-diverged contracts a healthy peer
+/// reports per exchange.
+const MAX_STALENESS_PROBES_PER_SUMMARIES: usize = 32;
+
+/// What to do about one byte-differing contract when deciding staleness in the
+/// `Summaries` handler, given the cheap in-memory cache lookup and how many
+/// probes this message has already spent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StalenessProbeAction {
+    /// The shared delta cache already answered — use this verdict, no WASM,
+    /// no budget consumed. Cache hits are free, so they never count against
+    /// the probe budget (a healthy peer with a warm cache is fully evaluated).
+    UseCached(bool),
+    /// Cache miss with budget remaining — run the WASM `get_state_delta` probe
+    /// and count it against the per-message budget.
+    RunProbe,
+    /// Cache miss with the probe budget exhausted for this message — do NOT
+    /// probe; fall back to the conservative byte comparison (differing bytes =>
+    /// stale => heal, itself capped downstream by [`MAX_STALE_SYNCS_PER_SUMMARIES`]).
+    /// The contract is re-evaluated on the next heartbeat once the cache warms.
+    BudgetExhaustedFallBack,
+}
+
+/// Decide how to resolve staleness for one byte-differing contract, bounding the
+/// number of WASM probes per `Summaries` message to
+/// [`MAX_STALENESS_PROBES_PER_SUMMARIES`]. Only cache MISSES (which require WASM)
+/// consume the budget; cache hits are free and always answered. Pure so the cap
+/// is unit-testable (see `staleness_probe_cap`).
+fn plan_staleness_probe(cached: Option<bool>, probes_used: usize) -> StalenessProbeAction {
+    match cached {
+        Some(has_change) => StalenessProbeAction::UseCached(has_change),
+        None if probes_used < MAX_STALENESS_PROBES_PER_SUMMARIES => StalenessProbeAction::RunProbe,
+        None => StalenessProbeAction::BudgetExhaustedFallBack,
+    }
+}
+
 /// Maximum contract-module-cache occupancy (percent of budget) at which this
 /// node still accepts an inbound placement-migration `SubscribeHint` (#4534).
 ///
@@ -2674,6 +2719,12 @@ async fn handle_interest_sync_message(
                 Vec::new();
 
             if let Some(pk) = peer_key {
+                // Per-message budget for semantic-staleness WASM probes
+                // (`get_state_delta`), spent across ALL entries/contracts in
+                // this Summaries message. Bounds the DoS surface of a peer
+                // sending novel summary bytes for every hosted contract. See
+                // `MAX_STALENESS_PROBES_PER_SUMMARIES` / `plan_staleness_probe`.
+                let mut staleness_probes_used = 0usize;
                 for entry in entries {
                     for contract in op_manager.interest_manager.lookup_by_hash(entry.hash) {
                         if !op_manager.interest_manager.has_local_interest(&contract) {
@@ -2713,12 +2764,40 @@ async fn handle_interest_sync_message(
                                     // Byte-identical => converged; skip the probe.
                                     None
                                 } else {
-                                    op_manager
-                                        .interest_manager
-                                        .peer_summary_has_pending_state(
-                                            op_manager, &contract, theirs, ours,
-                                        )
-                                        .await
+                                    // Cheap in-memory cache lookup first (no WASM,
+                                    // no budget). Only a genuine cache MISS needs a
+                                    // WASM `get_state_delta`, so only misses are
+                                    // rationed by the per-message probe budget.
+                                    let cached =
+                                        op_manager.interest_manager.cached_staleness_verdict(
+                                            &contract,
+                                            theirs.as_ref(),
+                                            ours.as_ref(),
+                                        );
+                                    match plan_staleness_probe(cached, staleness_probes_used) {
+                                        StalenessProbeAction::UseCached(has_change) => {
+                                            Some(has_change)
+                                        }
+                                        StalenessProbeAction::RunProbe => {
+                                            staleness_probes_used += 1;
+                                            op_manager
+                                                .interest_manager
+                                                .peer_summary_has_pending_state(
+                                                    op_manager, &contract, theirs, ours,
+                                                )
+                                                .await
+                                        }
+                                        StalenessProbeAction::BudgetExhaustedFallBack => {
+                                            // Budget spent for this message: fall
+                                            // back to the conservative byte-compare
+                                            // (differing bytes => stale => heal,
+                                            // capped by MAX_STALE_SYNCS_PER_SUMMARIES).
+                                            // Re-evaluated next heartbeat once the
+                                            // cache warms. `None` => byte-compare in
+                                            // `summary_indicates_stale_peer`.
+                                            None
+                                        }
+                                    }
                                 };
                                 crate::ring::interest::summary_indicates_stale_peer(
                                     ours,
@@ -3880,6 +3959,57 @@ mod tests {
             gated_calls >= 3,
             "expected the 3 periodic interest-sync arms to call \
              summary_if_hosted_or_in_use, found {gated_calls}"
+        );
+    }
+
+    /// Pin: the `Summaries` interest-sync arm must decide staleness
+    /// SEMANTICALLY — routing through `peer_summary_has_pending_state` (the
+    /// contract `get_state_delta` probe) and `summary_indicates_stale_peer`
+    /// (the decision policy), under the per-message probe cap via
+    /// `plan_staleness_probe` — NOT a bare summary byte comparison (#4857
+    /// secondary finding / the summarize storm).
+    ///
+    /// The data-layer unit tests in `ring/interest.rs` exercise those helpers
+    /// directly, so they stay green even if this handler hunk is reverted to a
+    /// bare `ours != theirs` byte compare (re-opening the storm). This
+    /// source-scrape is the only guard on the handler WIRING — mirrors the
+    /// sibling `interest_sync_periodic_arms_summarize_only_hosted_or_in_use_pin`
+    /// and the #3791 targeted-heal source-scrape pins.
+    #[test]
+    fn summaries_arm_uses_semantic_staleness_probe_pin() {
+        let src = include_str!("node.rs");
+
+        let handler_start = src
+            .find("async fn handle_interest_sync_message(")
+            .expect("handle_interest_sync_message not found");
+        // Scope to the `Summaries` arm = its match start .. the next arm
+        // (`ChangeInterests`), so the assertions can't false-pass on unrelated
+        // code elsewhere in the handler.
+        let summaries_off = src[handler_start..]
+            .find("InterestMessage::Summaries { entries }")
+            .expect("Summaries arm not found");
+        let change_off = src[handler_start..]
+            .find("InterestMessage::ChangeInterests")
+            .expect("ChangeInterests arm not found");
+        let summaries_arm = &src[handler_start + summaries_off..handler_start + change_off];
+
+        assert!(
+            summaries_arm.contains("peer_summary_has_pending_state"),
+            "the Summaries arm must consult the contract delta probe \
+             (peer_summary_has_pending_state) to decide staleness — a bare \
+             summary byte comparison re-opens the #4857 summarize storm"
+        );
+        assert!(
+            summaries_arm.contains("summary_indicates_stale_peer"),
+            "the Summaries arm must decide staleness via \
+             summary_indicates_stale_peer (semantic policy), not inline byte \
+             inequality"
+        );
+        assert!(
+            summaries_arm.contains("plan_staleness_probe"),
+            "the Summaries arm must ration WASM probes through \
+             plan_staleness_probe (MAX_STALENESS_PROBES_PER_SUMMARIES cap) — \
+             an uncapped probe per contract is a DoS amplification surface"
         );
     }
 
@@ -6860,6 +6990,89 @@ mod tests {
                 "stale-sync rotation offset is no longer drawn from GlobalRng — \
                  a fixed/non-random rotation does not avoid starvation and \
                  breaks simulation determinism"
+            );
+        }
+    }
+
+    // ───────────────────────────────────────────────────────────
+    // Per-message cap on semantic-staleness WASM probes
+    // (`MAX_STALENESS_PROBES_PER_SUMMARIES`). A peer sending crafted/novel
+    // summary bytes for every hosted contract must not force unbounded
+    // `get_state_delta` execution on the serial contract loop (#4857
+    // secondary-finding DoS hardening). Cache hits are free and never
+    // consume the budget; only cache MISSES (which need WASM) are rationed,
+    // and the overflow falls back to the conservative byte comparison.
+    // ───────────────────────────────────────────────────────────
+    mod staleness_probe_cap {
+        use super::super::{
+            MAX_STALENESS_PROBES_PER_SUMMARIES, StalenessProbeAction, plan_staleness_probe,
+        };
+
+        #[test]
+        fn cache_hit_bypasses_budget() {
+            // A cache hit does no WASM, so it is answered even far past the cap.
+            assert_eq!(
+                plan_staleness_probe(Some(true), 0),
+                StalenessProbeAction::UseCached(true)
+            );
+            assert_eq!(
+                plan_staleness_probe(Some(false), MAX_STALENESS_PROBES_PER_SUMMARIES * 10),
+                StalenessProbeAction::UseCached(false)
+            );
+        }
+
+        #[test]
+        fn cache_miss_probes_until_budget_then_falls_back() {
+            // Under budget: run the WASM probe.
+            assert_eq!(
+                plan_staleness_probe(None, 0),
+                StalenessProbeAction::RunProbe
+            );
+            assert_eq!(
+                plan_staleness_probe(None, MAX_STALENESS_PROBES_PER_SUMMARIES - 1),
+                StalenessProbeAction::RunProbe
+            );
+            // At/over budget: stop probing, fall back to the byte comparison.
+            assert_eq!(
+                plan_staleness_probe(None, MAX_STALENESS_PROBES_PER_SUMMARIES),
+                StalenessProbeAction::BudgetExhaustedFallBack
+            );
+            assert_eq!(
+                plan_staleness_probe(None, MAX_STALENESS_PROBES_PER_SUMMARIES + 5),
+                StalenessProbeAction::BudgetExhaustedFallBack
+            );
+        }
+
+        /// Simulates the handler loop's counter over a run of byte-differing
+        /// cache-MISS contracts (the DoS shape: novel bytes for every contract)
+        /// and asserts WASM probes are hard-capped while the overflow falls back
+        /// to the conservative byte compare.
+        #[test]
+        fn probe_budget_caps_wasm_probes_per_message() {
+            let total_contracts = MAX_STALENESS_PROBES_PER_SUMMARIES * 3; // 96 > cap
+            let mut probes_used = 0usize;
+            let mut probed = 0usize;
+            let mut fell_back = 0usize;
+            for _ in 0..total_contracts {
+                match plan_staleness_probe(None, probes_used) {
+                    StalenessProbeAction::RunProbe => {
+                        probes_used += 1;
+                        probed += 1;
+                    }
+                    StalenessProbeAction::BudgetExhaustedFallBack => fell_back += 1,
+                    StalenessProbeAction::UseCached(_) => {
+                        unreachable!("every contract is a cache miss in this scenario")
+                    }
+                }
+            }
+            assert_eq!(
+                probed, MAX_STALENESS_PROBES_PER_SUMMARIES,
+                "WASM probes must be hard-capped at the per-message budget"
+            );
+            assert_eq!(
+                fell_back,
+                total_contracts - MAX_STALENESS_PROBES_PER_SUMMARIES,
+                "every over-budget contract must fall back to byte-compare"
             );
         }
     }

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -2695,10 +2695,41 @@ async fn handle_interest_sync_message(
                             }
                         }
 
-                        let is_stale = our_summary
-                            .as_ref()
-                            .zip(their_summary.as_ref())
-                            .is_some_and(|(ours, theirs)| ours.as_ref() != theirs.as_ref());
+                        // Semantic staleness (#4857 secondary finding / the
+                        // 2.56M `summarize_contract_state` storm). A raw byte
+                        // comparison of summaries is WRONG: a contract whose
+                        // summary serializes non-deterministically (HashMap /
+                        // HashSet order) yields different summary bytes for the
+                        // SAME logical state across peers, so a byte compare
+                        // flags a converged peer stale and fires a full-state
+                        // heal every heartbeat. Only pay the (bounded, cached)
+                        // contract delta probe when the summaries actually
+                        // differ byte-wise; ask the contract itself whether we
+                        // hold state the peer lacks. See
+                        // `summary_indicates_stale_peer`.
+                        let is_stale = match (our_summary.as_ref(), their_summary.as_ref()) {
+                            (Some(ours), Some(theirs)) => {
+                                let delta_verdict = if ours.as_ref() == theirs.as_ref() {
+                                    // Byte-identical => converged; skip the probe.
+                                    None
+                                } else {
+                                    op_manager
+                                        .interest_manager
+                                        .peer_summary_has_pending_state(
+                                            op_manager, &contract, theirs, ours,
+                                        )
+                                        .await
+                                };
+                                crate::ring::interest::summary_indicates_stale_peer(
+                                    ours,
+                                    theirs,
+                                    delta_verdict,
+                                )
+                            }
+                            // One side has no summary => no basis to heal
+                            // (unchanged from the prior `.zip()` semantics).
+                            _ => false,
+                        };
 
                         op_manager.interest_manager.update_peer_summary(
                             &contract,

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -86,6 +86,14 @@ use crate::config::GlobalExecutor;
 use crate::config::GlobalRng;
 
 /// Maximum number of entries in the delta memoization cache.
+///
+// TODO(fast-follow): size this by hosted×neighbors rather than a flat 1024, so
+// the interest-heartbeat staleness probes (`peer_summary_has_pending_state`)
+// and broadcast deltas keep their working set cached across cycles on
+// large-hosted-set peers. Deferred: the per-message probe budget
+// (`MAX_STALENESS_PROBES_PER_SUMMARIES`) already bounds the cold-cache
+// worst-case load, and summaries are memoized outside WASM so byte keys stay
+// stable while state is unchanged.
 const DELTA_CACHE_SIZE: usize = 1024;
 
 /// Minimum interval between queue-full `ResyncRequest`s to the same peer for
@@ -1520,11 +1528,30 @@ impl<T: TimeSource + Sync> InterestManager<T> {
     /// detection wants the semantic answer even for contracts where a delta
     /// would be larger than full state, because the alternative it replaces is a
     /// spurious FULL-STATE heal on every heartbeat — strictly more expensive
-    /// than one delta computation. The result rides the SAME delta cache as
-    /// `compute_delta` (keyed by contract + both summary hashes, invalidated
-    /// whenever our state changes because that changes `our_summary`), so a
-    /// converged pair costs one contract round-trip and is then served from
-    /// cache — no per-heartbeat re-summarize storm.
+    /// than one delta computation.
+    ///
+    /// Steady-state cost: the result rides the SAME delta cache as
+    /// `compute_delta` (keyed by contract + both summary hashes). Note that
+    /// outer cache is BYTE-keyed, so under non-deterministic summary
+    /// serialization it *can* miss even for an unchanged pair. The real reason
+    /// the per-heartbeat load stays flat is upstream of this cache: (a) contract
+    /// summaries are memoized OUTSIDE the WASM boundary keyed on a
+    /// state-change-detector hash (`bridged_summarize_contract_state`), so a
+    /// peer's `our_summary`/`their_summary` bytes are STABLE while state is
+    /// unchanged — which keeps this cache's byte key stable across heartbeats —
+    /// and (b) the executor-level delta cache is keyed on `state_hash`
+    /// (`bridged_get_contract_state_delta`), so even a byte-key miss here elides
+    /// the WASM call when the state has not changed. The per-message probe
+    /// budget (`MAX_STALENESS_PROBES_PER_SUMMARIES`) bounds the residual
+    /// cold-cache worst case. Net: a converged pair costs at most one WASM
+    /// `get_state_delta` per state change, not one per heartbeat.
+    ///
+    /// Convergence caveat: the `Some(false)` "converged" verdict is only as
+    /// correct as the contract's `get_state_delta` being a correct semilattice
+    /// diff (empty delta iff our state adds nothing over their summary). A
+    /// contract with a buggy diff could under-report divergence here exactly as
+    /// it already would on the broadcast delta-optimization path; this reuses
+    /// that same, pre-existing trust assumption rather than adding a new one.
     pub async fn peer_summary_has_pending_state(
         &self,
         op_manager: &crate::node::OpManager,
@@ -1545,6 +1572,17 @@ impl<T: TimeSource + Sync> InterestManager<T> {
         // Slow path: ask the contract for the delta of our state against their
         // summary. `GetDeltaQuery` is the same event `compute_delta` uses, and
         // we cache the result under the same key so both paths share it.
+        //
+        // Priority: this runs at the DEFAULT (NetworkRelay) priority that
+        // `notify_contract_handler_with_timeout` uses — deliberately NOT
+        // `Priority::Background`. A Background probe would be SHED first under
+        // contract-handler saturation, returning `None` → the caller falls back
+        // to the byte-compare, which flags the (converged-but-byte-differing)
+        // peer stale and fires a FULL-STATE heal — re-enabling the very storm
+        // this probe suppresses, exactly when the node is most loaded. The probe
+        // is strictly cheaper than the heal it prevents, so it must run even
+        // under load; the per-message `MAX_STALENESS_PROBES_PER_SUMMARIES` cap
+        // (not de-prioritization) is what bounds its cost.
         match op_manager
             .notify_contract_handler_with_timeout(
                 ContractHandlerEvent::GetDeltaQuery {

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -314,6 +314,54 @@ pub fn is_delta_efficient(summary_size: usize, state_size: usize) -> bool {
     summary_size * 2 < state_size
 }
 
+/// Decide whether a peer that reported `their_summary` is stale relative to our
+/// `our_summary` — i.e. whether the InterestSync heartbeat should heal it with
+/// our state.
+///
+/// A raw byte comparison of the two summaries is WRONG on its own: a contract
+/// whose `summarize_state` serializes a `HashMap`/`HashSet` (non-deterministic
+/// iteration order, per-process `RandomState`) produces DIFFERENT summary bytes
+/// for the SAME logical state on different peers. Byte-inequality then flags a
+/// fully-converged peer stale and fires a full-state heal on every ~5-min
+/// heartbeat — the 2.56M rate-limited `summarize_contract_state` storm observed
+/// on the 0.2.102 gateway (freenet/freenet-core#4857 secondary finding). The
+/// core cannot canonicalize the opaque summary bytes itself (it does not know
+/// the contract's encoding), so it delegates the judgement to the contract via
+/// its own `get_state_delta` — surfaced here as `delta_indicates_change`:
+///
+/// - `Some(true)`: our state holds data the peer's summary lacks (a non-empty
+///   delta), so the peer is genuinely stale — heal it.
+/// - `Some(false)`: the contract's delta is empty, so the peer is logically
+///   converged despite differing summary bytes — NOT stale.
+/// - `None`: no semantic verdict is available (the delta probe was unavailable
+///   or timed out), so fall back to the raw byte comparison, i.e. the
+///   conservative pre-fix behaviour, so a genuine divergence is never skipped.
+///
+/// Convergence safety: the returned "stale" set is a strict subset of the
+/// pre-fix byte-compare set. The only peers this newly treats as NOT stale are
+/// those whose summary bytes differ yet whose contract-computed delta is empty —
+/// exactly the copies that already hold our state, for which the removed heal
+/// would have transferred nothing. Any real divergence still yields a non-empty
+/// delta (`Some(true)`) and heals, on this and every subsequent heartbeat.
+pub(crate) fn summary_indicates_stale_peer(
+    our_summary: &StateSummary<'static>,
+    their_summary: &StateSummary<'static>,
+    delta_indicates_change: Option<bool>,
+) -> bool {
+    // Byte-identical summaries are trivially converged. Equal bytes were never
+    // stale under the pre-fix logic either, so short-circuit before consulting
+    // any (potentially contract-buggy) delta verdict: identical bytes must
+    // never heal.
+    if our_summary.as_ref() == their_summary.as_ref() {
+        return false;
+    }
+    // Bytes differ. Trust the contract's semantic verdict when present (robust
+    // to non-deterministic summary serialization); otherwise preserve the
+    // conservative pre-fix behaviour (differing bytes => stale) so a real
+    // divergence is never silently missed.
+    delta_indicates_change.unwrap_or(true)
+}
+
 /// Manages interest tracking and delta computation for all contracts.
 ///
 /// This is the central data structure for the delta-based synchronization system.
@@ -1433,6 +1481,109 @@ impl<T: TimeSource + Sync> InterestManager<T> {
             }
             Ok(other) => Err(format!("Unexpected response to GetDeltaQuery: {:?}", other)),
             Err(e) => Err(format!("Error computing delta: {}", e)),
+        }
+    }
+
+    /// In-memory-only staleness verdict derived from the shared delta cache.
+    ///
+    /// Returns `Some(true)` if a cached delta for the `(their_summary,
+    /// our_summary)` pair is non-empty (the peer is missing state we hold),
+    /// `Some(false)` if it is empty (logically converged despite differing
+    /// summary bytes), or `None` if no delta is cached (the caller must fall
+    /// back to a contract round-trip via [`peer_summary_has_pending_state`]).
+    ///
+    /// This touches only the in-process LRU cache — never the contract handler
+    /// loop — so it is safe to call on the hot heartbeat path.
+    pub fn cached_staleness_verdict(
+        &self,
+        key: &ContractKey,
+        their_summary: &[u8],
+        our_summary: &[u8],
+    ) -> Option<bool> {
+        self.get_cached_delta(key, their_summary, our_summary)
+            .map(|delta| !delta.as_ref().is_empty())
+    }
+
+    /// Ask the contract whether our state holds anything the peer's summary
+    /// lacks — the semantic form of "is this peer stale?" used by the
+    /// InterestSync heartbeat in place of a raw summary byte comparison.
+    ///
+    /// Returns `Some(true)` when the contract's `get_state_delta` yields a
+    /// non-empty delta (genuine divergence), `Some(false)` when it is empty
+    /// (converged despite differing summary bytes — the non-deterministic
+    /// serialization case that drove the #4857 summarize storm), or `None`
+    /// when the delta could not be computed (caller falls back to the byte
+    /// comparison via [`summary_indicates_stale_peer`]).
+    ///
+    /// Unlike [`compute_delta`](Self::compute_delta) this deliberately does NOT
+    /// apply the wire-efficiency gate ([`is_delta_efficient`]): staleness
+    /// detection wants the semantic answer even for contracts where a delta
+    /// would be larger than full state, because the alternative it replaces is a
+    /// spurious FULL-STATE heal on every heartbeat — strictly more expensive
+    /// than one delta computation. The result rides the SAME delta cache as
+    /// `compute_delta` (keyed by contract + both summary hashes, invalidated
+    /// whenever our state changes because that changes `our_summary`), so a
+    /// converged pair costs one contract round-trip and is then served from
+    /// cache — no per-heartbeat re-summarize storm.
+    pub async fn peer_summary_has_pending_state(
+        &self,
+        op_manager: &crate::node::OpManager,
+        key: &ContractKey,
+        their_summary: &StateSummary<'static>,
+        our_summary: &StateSummary<'static>,
+    ) -> Option<bool> {
+        use crate::contract::ContractHandlerEvent;
+
+        let their_bytes = their_summary.as_ref();
+        let our_bytes = our_summary.as_ref();
+
+        // Fast path: shared in-memory delta cache, no contract round-trip.
+        if let Some(verdict) = self.cached_staleness_verdict(key, their_bytes, our_bytes) {
+            return Some(verdict);
+        }
+
+        // Slow path: ask the contract for the delta of our state against their
+        // summary. `GetDeltaQuery` is the same event `compute_delta` uses, and
+        // we cache the result under the same key so both paths share it.
+        match op_manager
+            .notify_contract_handler_with_timeout(
+                ContractHandlerEvent::GetDeltaQuery {
+                    key: *key,
+                    their_summary: their_summary.clone(),
+                },
+                BROADCAST_CH_TIMEOUT,
+            )
+            .await
+        {
+            Ok(ContractHandlerEvent::GetDeltaResponse { delta: Ok(d), .. }) => {
+                let has_change = !d.as_ref().is_empty();
+                self.cache_delta(key, their_bytes, our_bytes, d);
+                Some(has_change)
+            }
+            Ok(ContractHandlerEvent::GetDeltaResponse { delta: Err(e), .. }) => {
+                tracing::debug!(
+                    contract = %key,
+                    error = %e,
+                    "Staleness delta probe failed — falling back to summary byte comparison"
+                );
+                None
+            }
+            Ok(other) => {
+                tracing::warn!(
+                    contract = %key,
+                    response = ?other,
+                    "Unexpected response to GetDeltaQuery (staleness probe)"
+                );
+                None
+            }
+            Err(e) => {
+                tracing::debug!(
+                    contract = %key,
+                    error = %e,
+                    "Error computing staleness delta probe — falling back to byte comparison"
+                );
+                None
+            }
         }
     }
 
@@ -3425,6 +3576,159 @@ mod tests {
              rounds: {:?}",
             ghosts.len(),
             &ghosts[..ghosts.len().min(10)]
+        );
+    }
+
+    // ---- Semantic staleness (#4857 secondary finding / summarize storm) ----
+    //
+    // The InterestSync heartbeat used to decide "is this peer stale?" with a
+    // raw byte comparison of `summarize_state` output. A contract whose summary
+    // serializes non-deterministically (HashMap/HashSet iteration order,
+    // per-process RandomState) produces DIFFERENT summary bytes for the SAME
+    // logical state across peers, so the byte compare flagged a fully-converged
+    // peer stale and fired a full-state heal every heartbeat — the 2.56M
+    // rate-limited `summarize_contract_state` storm observed on the 0.2.102
+    // gateway. The fix asks the CONTRACT (via its own `get_state_delta`,
+    // surfaced here through the shared delta cache / `cached_staleness_verdict`)
+    // whether we actually hold state the peer lacks.
+
+    #[test]
+    fn nondeterministic_summary_does_not_flag_converged_peer_stale() {
+        let (manager, _time) = make_manager();
+        let contract = make_contract_key(1);
+
+        // Two summaries of the SAME logical state that serialize to DIFFERENT
+        // bytes (models cross-peer HashMap/HashSet iteration-order divergence).
+        let ours = StateSummary::from(vec![1u8, 2, 3]);
+        let theirs = StateSummary::from(vec![3u8, 2, 1]);
+
+        // Precondition / reproduction: the pre-fix logic was exactly
+        // `is_stale = our_bytes != their_bytes`, which flags this converged
+        // peer stale and triggers the spurious heal.
+        assert_ne!(
+            ours.as_ref(),
+            theirs.as_ref(),
+            "precondition: summaries differ byte-wise (the false-stale trigger)"
+        );
+        assert!(
+            summary_indicates_stale_peer(&ours, &theirs, None),
+            "pre-fix byte comparison (no contract verdict) flags the converged \
+             peer stale — this is the storm we are reproducing"
+        );
+
+        // The contract, asked for the delta of our state against their summary,
+        // returns an EMPTY delta: logically converged despite differing bytes.
+        // Model it exactly as production does — via the shared delta cache the
+        // staleness oracle consults.
+        manager.cache_delta(
+            &contract,
+            theirs.as_ref(),
+            ours.as_ref(),
+            StateDelta::from(Vec::<u8>::new()),
+        );
+        let verdict = manager.cached_staleness_verdict(&contract, theirs.as_ref(), ours.as_ref());
+        assert_eq!(
+            verdict,
+            Some(false),
+            "an empty cached delta means the contract sees the peer as converged"
+        );
+
+        // FIX: byte-differing summaries + empty delta => NOT stale => no heal.
+        assert!(
+            !summary_indicates_stale_peer(&ours, &theirs, verdict),
+            "empty delta must suppress the spurious heal (fixes the storm)"
+        );
+    }
+
+    #[test]
+    fn genuinely_diverged_peer_is_still_flagged_stale() {
+        let (manager, _time) = make_manager();
+        let contract = make_contract_key(2);
+
+        let ours = StateSummary::from(vec![9u8, 9, 9]);
+        let theirs = StateSummary::from(vec![1u8]);
+
+        // Contract returns a NON-EMPTY delta: our state holds data theirs lacks.
+        manager.cache_delta(
+            &contract,
+            theirs.as_ref(),
+            ours.as_ref(),
+            StateDelta::from(vec![42u8]),
+        );
+        let verdict = manager.cached_staleness_verdict(&contract, theirs.as_ref(), ours.as_ref());
+        assert_eq!(
+            verdict,
+            Some(true),
+            "a non-empty delta is a real divergence"
+        );
+
+        // A genuine divergence must STILL heal — the fix only removes spurious
+        // heals, never a real one.
+        assert!(
+            summary_indicates_stale_peer(&ours, &theirs, verdict),
+            "genuine divergence must still be flagged stale and heal"
+        );
+    }
+
+    #[test]
+    fn identical_summaries_are_never_stale_without_probing() {
+        let ours = StateSummary::from(vec![7u8, 7, 7]);
+        let theirs = StateSummary::from(vec![7u8, 7, 7]);
+
+        // Byte-identical summaries are trivially converged; the decision is
+        // `false` regardless of (indeed, without needing) any delta verdict.
+        assert!(!summary_indicates_stale_peer(&ours, &theirs, None));
+        assert!(!summary_indicates_stale_peer(&ours, &theirs, Some(true)));
+    }
+
+    #[test]
+    fn missing_delta_verdict_falls_back_to_byte_comparison() {
+        let ours = StateSummary::from(vec![1u8, 2, 3]);
+        let theirs_differ = StateSummary::from(vec![3u8, 2, 1]);
+        let theirs_same = StateSummary::from(vec![1u8, 2, 3]);
+
+        // When no semantic verdict is available (probe failed/timed out), we
+        // preserve the conservative pre-fix behaviour: bytes differ => stale,
+        // bytes equal => not stale. This guarantees we never SILENTLY skip a
+        // real heal just because the delta probe was unavailable.
+        assert!(summary_indicates_stale_peer(&ours, &theirs_differ, None));
+        assert!(!summary_indicates_stale_peer(&ours, &theirs_same, None));
+    }
+
+    #[test]
+    fn cached_staleness_verdict_reports_absence_and_emptiness() {
+        let (manager, _time) = make_manager();
+        let contract = make_contract_key(3);
+        let ours = StateSummary::from(vec![5u8]);
+        let theirs = StateSummary::from(vec![6u8]);
+
+        // Not cached yet => no verdict (caller falls back to a contract probe).
+        assert_eq!(
+            manager.cached_staleness_verdict(&contract, theirs.as_ref(), ours.as_ref()),
+            None
+        );
+
+        // Empty delta => converged; non-empty => diverged.
+        manager.cache_delta(
+            &contract,
+            theirs.as_ref(),
+            ours.as_ref(),
+            StateDelta::from(Vec::<u8>::new()),
+        );
+        assert_eq!(
+            manager.cached_staleness_verdict(&contract, theirs.as_ref(), ours.as_ref()),
+            Some(false)
+        );
+
+        manager.cache_delta(
+            &contract,
+            theirs.as_ref(),
+            ours.as_ref(),
+            StateDelta::from(vec![1u8]),
+        );
+        assert_eq!(
+            manager.cached_staleness_verdict(&contract, theirs.as_ref(), ours.as_ref()),
+            Some(true)
         );
     }
 }


### PR DESCRIPTION
## Problem

The InterestSync anti-entropy heartbeat decides "is this peer stale?" with a **raw byte comparison of `summarize_state` output** (`crates/core/src/node.rs`, the `Summaries` handler in `handle_interest_sync_message`):

```rust
let is_stale = our_summary.as_ref().zip(their_summary.as_ref())
    .is_some_and(|(ours, theirs)| ours.as_ref() != theirs.as_ref());
```

A contract whose `Summary` serializes **non-deterministically** — `HashMap`/`HashSet` iteration order, per-process `RandomState`, etc. — produces **different summary bytes for the *same* logical state** on different peers. Byte-inequality then flags a fully-converged peer stale and fires a targeted full-state heal (`SyncStateToPeer`) on **every** ~5-min heartbeat, for **every** such contract.

On the current production gateway (0.2.102) this manifested as a `summarize_contract_state` **storm**: ~2.56M rate-limited `summarize_contract_state` calls, plus 131K dropped `peer_connection` and 32K dropped `process_network_message` events — enough to stall PUT propagation (publishes time out) and degrade all routed operations.

This is the **secondary finding** on #4857 (the primary — silent `ContractQueueFull` drop + sender-side summary poisoning — was fixed in #4858/#4862). River's #416 made *new* room-contract summaries deterministic (`BTreeMap`/`BTreeSet`), but old-generation rooms and any other non-deterministic-summary contract keep the storm alive, so the fix must be **core-side**.

## Approach

The core **cannot** canonicalize the opaque summary bytes itself — summaries are contract-defined bytes and the core does not know the encoding. So instead of comparing bytes, when the two summaries differ byte-wise we ask the **contract itself**, via its own `get_state_delta`, whether our state holds anything the peer's summary lacks:

- **empty delta** → the peer is logically converged despite differing summary bytes → **not stale**, no spurious heal.
- **non-empty delta** → a genuine divergence → **stale**, heal as before.

This reuses the exact semantic the **broadcast fan-out already relies on** (`InterestManager::compute_delta` returns `Ok(None)` on an empty delta, already documented as "logically equivalent despite differing summary bytes ... non-deterministic serialization order"). It rides the **same delta cache** (`InterestManager` in-memory LRU keyed by contract + both summary hashes, backed by the executor's state-hash/summary-hash cache), so a converged pair costs **one** contract round-trip and is then served from cache — no per-heartbeat re-summarize storm. The byte-equal fast path skips the probe entirely.

New code (all in `crates/core/src/ring/interest.rs`), wired in at the one `is_stale` site in `node.rs`:

- `summary_indicates_stale_peer(our, their, delta_verdict)` — pure decision policy.
- `cached_staleness_verdict(...)` — in-memory-only verdict from the shared delta cache (no contract loop touch).
- `peer_summary_has_pending_state(...)` — async oracle: cache first, else one `GetDeltaQuery`, caches the result.

### Why convergence cannot break

The new "stale" set is a **strict subset** of the pre-fix byte-compare set:

- The **only** peers newly treated as *not* stale are those whose summary bytes differ yet whose contract-computed delta is **empty** — copies that already hold our state, for which the removed heal would have transferred nothing.
- Any **real** divergence still yields a non-empty delta → `is_stale = true` → heal, on this heartbeat and **every subsequent one** (a still-stale peer keeps the same summary, so it re-heals until it applies our state — the retry semantics are unchanged).
- **Byte-identical** summaries short-circuit to *not stale* (unchanged behaviour, and now robust even against a buggy delta verdict).
- If the delta probe is **unavailable** (error/timeout), we **fall back to the pre-fix byte comparison** (`None => bytes differ ⇒ stale`), so a genuine divergence is never silently skipped.
- Direction is correct: `get_state_delta(our_state, their_summary)` = "what we have that they lack", which is exactly the condition under which *we* should heal *them*. If instead *they* are ahead, our delta is empty (we don't heal them) and *their* side detects *us* stale and heals — the existing both-sides/merge-wins design (see the handler comment) is preserved.

This preserves hosting-invariant 1 (a served copy is fresh; anti-entropy heals on genuine mismatch): the heal trigger moves from *byte* mismatch to *semantic* mismatch, healing exactly when there is genuinely something to send.

## Testing

Reproducing unit tests in `ring::interest::tests`:

- `nondeterministic_summary_does_not_flag_converged_peer_stale` — two summaries of the **same** logical state with **different** bytes are flagged stale under the pre-fix byte comparison (reproduces the storm trigger) but **NOT** stale once the contract's empty delta is consulted (the fix).
- `genuinely_diverged_peer_is_still_flagged_stale` — a non-empty delta is still flagged stale and heals.
- `identical_summaries_are_never_stale_without_probing`, `missing_delta_verdict_falls_back_to_byte_comparison`, `cached_staleness_verdict_reports_absence_and_emptiness` — boundary/fallback coverage.

`cargo test -p freenet --lib ring::interest::tests` → 46 passed. `cargo clippy -p freenet --lib -- -D warnings` clean. `cargo fmt` applied.

## Notes for review

This is a Full-tier change (propagation/consensus-adjacent). Draft for multi-model + Fable review and a smoke test before release. Two points worth a hard look: (1) the added `GetDeltaQuery` round-trips on the heartbeat — argued bounded because the delta cache is shared with the broadcast path and invalidated only on state change; (2) the trust placed in `get_state_delta` emptiness, which is the same trust the broadcast delta-optimization path already places.

Refs #4857 (secondary finding). Related: #2044 (UPDATE state-change detection uses fragile byte equality — same class, different site).

## Review findings addressed (round 1)

All 4 reviewers said GO on the core mechanism (summaries memoized outside WASM → cache keys heartbeat-stable → heal amplifier severed; convergence-safe strict subset; concurrency-safe). One HIGH + 3 cheap high-value fixes were landed in this PR (commit `79681eda`):

1. **(HIGH) Per-message probe budget — closed a new DoS amplification surface.** The Summaries handler issues a WASM `get_state_delta` probe per byte-differing contract; uncapped, a peer sending crafted/novel summary bytes for every hosted contract could force unbounded WASM on the serial contract loop. Added `MAX_STALENESS_PROBES_PER_SUMMARIES = 32` (mirrors the sibling `MAX_STALE_SYNCS_PER_SUMMARIES` heal cap and `MAX_DELTA_COMPUTATIONS_PER_FANOUT`, and the code-style rule that per-recipient WASM MUST be bounded). Only cache **misses** (which need WASM) consume the budget — cache hits are free and always answered, so a healthy warm-cache peer is fully evaluated; a mass-cold-cache burst is capped and the overflow falls back to the conservative byte-compare (differing bytes ⇒ stale ⇒ heal, itself capped by the heal cap), re-evaluated next heartbeat. Pure `plan_staleness_probe` → unit-tested (`staleness_probe_cap` mod, 3 tests incl. the cap-and-fallback accounting).
2. **Source-scrape pin (`summaries_arm_uses_semantic_staleness_probe_pin`).** The data-layer unit tests stay green if the handler hunk is reverted to a bare byte compare; the pin asserts the Summaries arm routes through `peer_summary_has_pending_state`, `summary_indicates_stale_peer`, and `plan_staleness_probe` (mirrors the sibling interest-sync / #3791 targeted-heal source-scrape pins).
3. **Priority comment.** Documented that the probe deliberately runs at DEFAULT (NetworkRelay), **not** Background: a Background probe would be shed under handler saturation → `None` → byte-compare **heal** → the storm re-enabled exactly when the node is most loaded. The per-message cap (not de-prioritization) is what bounds cost.
4. **Doc softening.** `peer_summary_has_pending_state` rustdoc no longer implies the byte-keyed outer delta cache alone prevents re-summarize; the real steady-state mitigation is summaries memoized outside WASM (stable bytes while state unchanged) + the executor-level `state_hash`-keyed delta cache. Also notes the `Some(false)` verdict trusts the contract's `get_state_delta` being a correct semilattice diff (the same trust the broadcast delta path already makes).

## Deferred fast-follows (out of scope for this PR)

To be filed as separate issues by the coordinator; the per-message probe cap already bounds worst-case load so none blocks this PR:

- Size `DELTA_CACHE_SIZE` by hosted×neighbors instead of a flat 1024 (a `// TODO(fast-follow)` marks the site).
- Cancel timed-out probe work in the contract handler.
- Broadcast-path "delta larger than full state" bandwidth nit.

[AI-assisted - Claude]
