### PR TITLE
feat: add persistent `service disable`/`enable` for the background daemon

### DIFF
--- a/crates/core/src/bin/commands/daemon_control.rs
+++ b/crates/core/src/bin/commands/daemon_control.rs
@@ -1,0 +1,116 @@
+//! Persistent enable/disable control for the background daemon.
+//!
+//! `freenet service disable` writes a marker file that `freenet network`
+//! checks at startup. While the marker is present the node refuses to run and
+//! parks itself in an inert idle state instead, so no supervisor — systemd,
+//! launchd, or the tray wrapper — can bring the node back on reboot or
+//! re-login. `freenet service enable` removes the marker.
+//!
+//! The marker lives in the *config* directory (not a runtime/tmp dir) so it
+//! survives restarts, reboots, and reinstalls of the same config — the whole
+//! point of the feature is a disable that persists "indefinitely until turned
+//! on again".
+//!
+//! This module is the single source of truth for the marker, shared by both the
+//! node startup path (`crates/core/src/bin/freenet.rs::run_network`) and the
+//! `service disable`/`enable`/`status` CLI commands
+//! (`crates/core/src/bin/commands/service.rs`). Keeping the path/predicate here
+//! (rather than duplicating the `join(...)` at each site) means the two sides
+//! can never disagree about where "disabled" is recorded.
+
+use std::path::{Path, PathBuf};
+
+/// Marker file name written under the config directory. A present file (any
+/// content) means the daemon is disabled.
+pub(crate) const DISABLED_MARKER_FILE: &str = "daemon-disabled";
+
+/// Absolute path of the daemon-disabled marker for a given config directory.
+pub(crate) fn disabled_marker_path(config_dir: &Path) -> PathBuf {
+    config_dir.join(DISABLED_MARKER_FILE)
+}
+
+/// Whether the background daemon has been disabled via `freenet service
+/// disable`. The presence of the marker file is authoritative; its contents are
+/// human-facing only.
+pub(crate) fn is_daemon_disabled(config_dir: &Path) -> bool {
+    disabled_marker_path(config_dir).exists()
+}
+
+/// Write the daemon-disabled marker. Idempotent: re-disabling an already
+/// disabled daemon simply rewrites the marker. Returns whether the daemon was
+/// *already* disabled before this call, so the CLI can tailor its message.
+pub(crate) fn write_disabled_marker(config_dir: &Path) -> std::io::Result<bool> {
+    let already = is_daemon_disabled(config_dir);
+    std::fs::create_dir_all(config_dir)?;
+    let body = "This file disables the Freenet background daemon.\n\
+                While it exists, `freenet network` refuses to start and stays idle instead,\n\
+                so no service supervisor can bring the node back across restarts or reboots.\n\
+                Delete this file, or run `freenet service enable`, to re-enable the daemon.\n";
+    std::fs::write(disabled_marker_path(config_dir), body)?;
+    Ok(already)
+}
+
+/// Remove the daemon-disabled marker. Idempotent. Returns whether a marker was
+/// actually present (i.e. the daemon *was* disabled before this call), so the
+/// CLI can distinguish "re-enabled" from "was not disabled".
+pub(crate) fn remove_disabled_marker(config_dir: &Path) -> std::io::Result<bool> {
+    match std::fs::remove_file(disabled_marker_path(config_dir)) {
+        Ok(()) => Ok(true),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(e) => Err(e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disabled_marker_roundtrip() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Use a not-yet-created nested path to prove write_disabled_marker
+        // creates the config dir on demand (mirrors a fresh install).
+        let config_dir = tmp.path().join("nested").join("freenet-config");
+
+        // Initially enabled (no marker, and the dir doesn't even exist yet).
+        assert!(!is_daemon_disabled(&config_dir));
+
+        // First disable writes the marker and reports "not already disabled".
+        let already = write_disabled_marker(&config_dir).unwrap();
+        assert!(!already, "first disable must report not-already-disabled");
+        assert!(is_daemon_disabled(&config_dir));
+        assert!(disabled_marker_path(&config_dir).exists());
+
+        // Disabling again is idempotent and reports already-disabled.
+        let already = write_disabled_marker(&config_dir).unwrap();
+        assert!(already, "second disable must report already-disabled");
+        assert!(is_daemon_disabled(&config_dir));
+
+        // Enabling removes the marker and reports it was present.
+        let was_disabled = remove_disabled_marker(&config_dir).unwrap();
+        assert!(was_disabled, "enable must report the daemon was disabled");
+        assert!(!is_daemon_disabled(&config_dir));
+
+        // Enabling again is idempotent and reports nothing was removed.
+        let was_disabled = remove_disabled_marker(&config_dir).unwrap();
+        assert!(!was_disabled, "second enable must report nothing to do");
+        assert!(!is_daemon_disabled(&config_dir));
+    }
+
+    #[test]
+    fn disabled_marker_path_is_under_config_dir() {
+        let dir = Path::new("/some/config");
+        assert_eq!(disabled_marker_path(dir), dir.join(DISABLED_MARKER_FILE));
+        assert!(disabled_marker_path(dir).starts_with(dir));
+    }
+
+    #[test]
+    fn marker_contents_are_present_but_not_load_bearing() {
+        // The predicate keys on presence, not contents: an empty marker (e.g.
+        // hand-created, or truncated) must still read as disabled.
+        let tmp = tempfile::tempdir().unwrap();
+        let config_dir = tmp.path().to_path_buf();
+        std::fs::write(disabled_marker_path(&config_dir), "").unwrap();
+        assert!(is_daemon_disabled(&config_dir));
+    }
+}

--- a/crates/core/src/bin/commands/mod.rs
+++ b/crates/core/src/bin/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod auto_update;
+pub mod daemon_control;
 pub mod report;
 pub mod rollback;
 pub mod secrets_cmd;

--- a/crates/core/src/bin/commands/service.rs
+++ b/crates/core/src/bin/commands/service.rs
@@ -26,7 +26,7 @@ mod single_instance;
 mod windows;
 pub mod wrapper;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::Subcommand;
 use freenet::config::ConfigPaths;
 use std::path::{Path, PathBuf};
@@ -91,6 +91,30 @@ pub enum ServiceCommand {
         #[arg(long)]
         system: bool,
     },
+    /// Disable the background daemon so it stays stopped across restarts.
+    ///
+    /// Writes a persistent marker in the config directory that the node checks
+    /// at startup: while it is present, `freenet network` refuses to run and
+    /// stays idle instead, so systemd, launchd, or the tray wrapper cannot
+    /// bring the node back on reboot or re-login. The still-running service is
+    /// restarted so the change takes effect immediately (the supervisor stays
+    /// alive; only the node stops doing work). Re-enable with
+    /// `freenet service enable`.
+    Disable {
+        /// Target the system-wide service instead of the user service
+        #[arg(long)]
+        system: bool,
+    },
+    /// Re-enable the background daemon previously disabled with
+    /// `freenet service disable`.
+    ///
+    /// Removes the disable marker and restarts the service so the node comes
+    /// back immediately.
+    Enable {
+        /// Target the system-wide service instead of the user service
+        #[arg(long)]
+        system: bool,
+    },
     /// Recover a wedged service install: re-template the wrapper/unit to the
     /// current binary, reap stale orphaned `freenet network` processes (PPID=1,
     /// holding the port on an old binary), and restart cleanly. Use when the
@@ -133,10 +157,12 @@ impl ServiceCommand {
                 purge,
                 keep_data,
             } => uninstall_service(*system, *purge, *keep_data),
-            ServiceCommand::Status { system } => service_status(*system),
+            ServiceCommand::Status { system } => service_status_reporting(*system, &config_dirs),
             ServiceCommand::Start { system } => start_service(*system),
             ServiceCommand::Stop { system } => stop_service(*system),
             ServiceCommand::Restart { system } => restart_service(*system),
+            ServiceCommand::Disable { system } => disable_daemon(*system, &config_dirs),
+            ServiceCommand::Enable { system } => enable_daemon(*system, &config_dirs),
             ServiceCommand::Doctor { system } => service_doctor(*system),
             ServiceCommand::Logs { err } => service_logs(*err),
             ServiceCommand::Report(cmd) => {
@@ -338,6 +364,105 @@ fn service_logs(error_only: bool) -> Result<()> {
 
 fn service_doctor(system: bool) -> Result<()> {
     purge::service_doctor(system)
+}
+
+// ── Persistent daemon enable/disable ──────────────────────────────────────────
+//
+// These are platform-independent: the disable state is a marker file in the
+// config dir (see `super::daemon_control`), honored by `freenet network` itself
+// at startup, so it works the same whether the node is supervised by systemd, a
+// launchd agent, or the tray wrapper. The `system` flag only selects which
+// service to restart so the change takes effect without waiting for a reboot.
+
+/// `freenet service disable`: write the persistent disable marker, then restart
+/// the running service so the node drops into its idle state immediately.
+fn disable_daemon(system: bool, config_dirs: &ConfigPaths) -> Result<()> {
+    let config_dir = config_dirs.config_dir();
+    let already = super::daemon_control::write_disabled_marker(&config_dir).with_context(|| {
+        format!(
+            "failed to write daemon-disabled marker in {}",
+            config_dir.display()
+        )
+    })?;
+
+    if already {
+        println!("Freenet background daemon was already disabled.");
+    } else {
+        println!(
+            "Freenet background daemon disabled. It will stay stopped across restarts and \
+             reboots until you run `freenet service enable`."
+        );
+    }
+    println!(
+        "Marker: {}",
+        super::daemon_control::disabled_marker_path(&config_dir).display()
+    );
+
+    // Best-effort: restart the (still-supervised) service so the node re-reads
+    // the marker and stops serving now instead of at the next reboot/relaunch.
+    // The supervisor stays alive; only the node child goes idle. If no service
+    // is installed/running, say so rather than failing the command — the marker
+    // is written and will take effect the next time the node starts.
+    match restart_service(system) {
+        Ok(()) => {}
+        Err(e) => {
+            println!(
+                "Note: could not restart the running service ({e}). The daemon will enter its \
+                 disabled state the next time it starts."
+            );
+        }
+    }
+    Ok(())
+}
+
+/// `freenet service enable`: remove the disable marker, then restart the service
+/// so the node comes back immediately.
+fn enable_daemon(system: bool, config_dirs: &ConfigPaths) -> Result<()> {
+    let config_dir = config_dirs.config_dir();
+    let was_disabled =
+        super::daemon_control::remove_disabled_marker(&config_dir).with_context(|| {
+            format!(
+                "failed to remove daemon-disabled marker in {}",
+                config_dir.display()
+            )
+        })?;
+
+    if !was_disabled {
+        println!("Freenet background daemon was not disabled; nothing to do.");
+        return Ok(());
+    }
+
+    println!("Freenet background daemon re-enabled.");
+    // Best-effort: restart so the node picks up the change now. If no service is
+    // installed, tell the user how to start it manually.
+    match restart_service(system) {
+        Ok(()) => {}
+        Err(e) => {
+            println!(
+                "Note: could not restart the service ({e}). Start it with \
+                 `freenet service start` (or launch `freenet network` manually)."
+            );
+        }
+    }
+    Ok(())
+}
+
+/// `freenet service status`, augmented with the persistent-disable state. When
+/// the daemon is disabled the underlying service may still report "active"
+/// (a supervised-but-idle node), so surface the disable explicitly first.
+fn service_status_reporting(system: bool, config_dirs: &ConfigPaths) -> Result<()> {
+    let config_dir = config_dirs.config_dir();
+    if super::daemon_control::is_daemon_disabled(&config_dir) {
+        println!("Freenet background daemon: DISABLED (via `freenet service disable`).");
+        println!("The node stays idle and will not join the network until you re-enable it:");
+        println!("    freenet service enable");
+        println!(
+            "Marker: {}",
+            super::daemon_control::disabled_marker_path(&config_dir).display()
+        );
+        println!();
+    }
+    service_status(system)
 }
 fn run_wrapper(version: &str) -> Result<()> {
     wrapper::run_wrapper(version)

--- a/crates/core/src/bin/freenet.rs
+++ b/crates/core/src/bin/freenet.rs
@@ -209,6 +209,16 @@ fn auto_update_is_disabled(git_dirty: &str, disable_flag: bool) -> bool {
 async fn run_network(config: Config) -> anyhow::Result<()> {
     tracing::info!("Starting freenet node in network mode");
 
+    // Honor a persistent operator disable (`freenet service disable`, #4690
+    // sibling): while the marker is present the node must not run, and must stay
+    // down across restarts/reboots. Idle instead of serving so the supervisor
+    // keeps us as a healthy (but inert) unit rather than restart-looping.
+    // `freenet service enable` removes the marker and restarts the service.
+    let config_dir = config.paths().config_dir();
+    if commands::daemon_control::is_daemon_disabled(&config_dir) {
+        return run_disabled_idle(&config_dir).await;
+    }
+
     // Check if another freenet process is already using the WS API port.
     // If so, bail out immediately instead of proceeding to bind and fail.
     // This prevents systemd restart loops when another instance is running.
@@ -237,6 +247,47 @@ async fn run_network(config: Config) -> anyhow::Result<()> {
 
     // Run node with signal handling for graceful shutdown
     run_network_node_with_signals(node, shutdown_handle, disable_auto_update).await
+}
+
+/// Park the process in an inert "disabled" state until it receives a shutdown
+/// signal. Entered when `freenet service disable` has written the daemon-
+/// disabled marker (checked in `run_network`).
+///
+/// The node deliberately does NOT bind the WS API or join the network: it stays
+/// a live-but-idle process so the service supervisor (systemd unit, launchd
+/// agent, or tray wrapper) keeps it as a healthy unit instead of restart-looping
+/// on a fast exit. It does no work until re-enabled. `freenet service enable`
+/// removes the marker and restarts the service to bring the node back.
+///
+/// Returning `Ok(())` on SIGTERM/SIGINT means a `systemctl stop` (or the wrapper
+/// killing the child) exits cleanly; with no signal the process simply parks
+/// indefinitely, which is the whole point of "disabled until turned on again".
+async fn run_disabled_idle(config_dir: &std::path::Path) -> anyhow::Result<()> {
+    use tokio::signal;
+
+    tracing::warn!(
+        marker = %commands::daemon_control::disabled_marker_path(config_dir).display(),
+        "Freenet background daemon is DISABLED (`freenet service disable`). The node will NOT \
+         start or join the network and will remain idle until you run `freenet service enable`. \
+         This persists across restarts and reboots."
+    );
+
+    #[cfg(unix)]
+    {
+        let mut sigterm = signal::unix::signal(signal::unix::SignalKind::terminate())
+            .context("failed to install SIGTERM handler")?;
+        tokio::select! {
+            _ = signal::ctrl_c() => {},
+            _ = sigterm.recv() => {},
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = signal::ctrl_c().await;
+    }
+
+    tracing::info!("Disabled daemon received shutdown signal; exiting cleanly.");
+    Ok(())
 }
 
 /// Run the network node with signal handling for graceful shutdown.


### PR DESCRIPTION
## Problem

`freenet service stop` only stops the current process. Every supervisor then brings the node back on the next reboot or re-login:

- **systemd**: `Restart=always`
- **launchd**: `RunAtLoad=true`
- **tray wrapper**: its relaunch loop

There was no supported way to say *"stay down until I turn you back on"* short of uninstalling the service or hand-editing supervisor config.

## Solution

A single persistent marker file (`daemon-disabled`) in the config directory is the source of truth, honored by the node itself — so the behavior is uniform across every supervisor with **no unit-file changes** (works on already-installed services too).

- **`commands::daemon_control`** (new module) owns the marker: path, presence predicate, write, remove. Centralizing it means the node-startup check and the CLI can never disagree about where "disabled" is recorded.
- **`freenet network` honors the marker at startup** (`run_network`). When present it enters `run_disabled_idle`: it does **not** bind the WS API or join the network, and parks until SIGTERM/SIGINT. Idling rather than exiting fast is deliberate — a fast exit would trip `Restart=always` / the wrapper relaunch loop, whereas a live-but-inert process keeps the supervisor treating the unit as *healthy* while doing no work. The on-disk marker is what makes the disable survive restarts and reboots.
- **`freenet service disable [--system]`** writes the marker, then restarts the still-supervised service so the node goes idle immediately (the supervisor stays alive; only the node stops working). **`enable`** removes the marker and restarts so the node comes back. Both are best-effort on the restart step and never hard-fail when no service is installed.
- **`freenet service status`** now surfaces a `DISABLED` banner, since the underlying unit may still report `active` for a supervised-but-idle node.

### Why a marker file (vs. `systemctl disable`)

`systemctl disable` is Linux-only and doesn't cover the launchd agent or the macOS/Windows tray wrapper, which relaunch the node from their own loops. A node-honored marker gives one consistent semantic on all three platforms without per-supervisor special-casing.

## Testing

New unit tests in `daemon_control` cover:
- enable/disable roundtrip + idempotence (double-disable reports already-disabled; double-enable reports nothing to do)
- marker path is under the config dir
- presence-not-contents semantics (an empty marker still reads as disabled)

Verified locally: `cargo build`, `cargo fmt`, `cargo clippy -- -D warnings` (clean), and the 3 new tests pass.

## Notes

- Applies to `network` mode only (the background daemon); `local` foreground/dev runs are unaffected.
- No new exit codes and no systemd/launchd unit changes — the disabled node exits `0` on signal, which existing units already treat as success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RfZxfvSP1HvG9SbmJHh4QE)_