### PR TITLE
fix(broadcast): skip converged peers semantically in the live fan-out (finishes #4894)

### DIFF
--- a/crates/core/src/node/network_bridge/broadcast_queue.rs
+++ b/crates/core/src/node/network_bridge/broadcast_queue.rs
@@ -153,6 +153,147 @@ pub(super) fn should_broadcast_contract(op_manager: &Arc<OpManager>, key: &Contr
     op_manager.ring.should_summarize_or_broadcast(key)
 }
 
+/// Decision for one (contract, peer) fan-out send, derived WITHOUT any WASM
+/// call — a byte comparison plus the shared in-memory delta cache. See
+/// [`plan_fanout_send`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum FanoutSendPlan {
+    /// The peer already has our state: byte-identical summaries, or a cached
+    /// EMPTY delta proving logical convergence despite differing summary
+    /// bytes. Nothing to send.
+    Skip,
+    /// The peer needs our state: a cached NON-EMPTY delta (genuine
+    /// divergence), or byte-differing summaries with no semantic verdict
+    /// available and no probe budget left (the conservative pre-#4894
+    /// fallback — never silently skip a possible real divergence).
+    Send,
+    /// Byte-differing summaries, no cached verdict, probe budget remaining:
+    /// the caller should run the bounded WASM `get_state_delta` probe
+    /// ([`InterestManager::peer_summary_has_pending_state`]) and decide from
+    /// its verdict. Callers without an async context must treat this as
+    /// `Send` (conservative).
+    ///
+    /// [`InterestManager::peer_summary_has_pending_state`]:
+    /// crate::ring::interest::InterestManager::peer_summary_has_pending_state
+    Probe,
+}
+
+/// Cache-only layer of the fan-out's semantic staleness decision (#4894's
+/// fan-out counterpart).
+///
+/// The live broadcast fan-out used to skip a peer only when its cached summary
+/// was BYTE-identical to ours. That is wrong for the same reason the
+/// InterestSync `Summaries` byte-compare was wrong (#4894 / #4857 secondary
+/// finding): a contract whose `summarize_state` serializes
+/// non-deterministically (HashMap/HashSet iteration order, per-process
+/// `RandomState`) yields different summary bytes for the SAME logical state on
+/// different peers. The byte compare then never skips, `compute_delta` either
+/// returns an empty delta (which the pre-fix arm "fell back" from by sending
+/// FULL STATE) or is refused outright by the `is_delta_efficient` gate on
+/// big-summary contracts — so a fully-converged pair re-flooded full state on
+/// every heartbeat-driven sync and every fan-out (the nondeterministic-summary
+/// heal storm; e.g. the `Eumk9HNQ` contract that "healed" hard while its state
+/// never changed).
+///
+/// This helper reuses the #4894 machinery: byte-equal summaries short-circuit
+/// to [`FanoutSendPlan::Skip`]; byte-differing summaries consult the shared
+/// delta cache ([`InterestManager::cached_staleness_verdict`]) under the same
+/// probe rationing (`plan_staleness_probe`, budget mirroring
+/// `MAX_STALENESS_PROBES_PER_SUMMARIES`). Pure/sync so it is unit-testable
+/// with a bare [`InterestManager`]; the async probe half lives in
+/// [`fanout_send_needed`].
+///
+/// Convergence safety: identical to #4894 — the skip set is a strict SUBSET of
+/// the pre-fix byte-compare skip set plus exactly those pairs whose
+/// contract-computed delta is EMPTY (copies that already hold our state, for
+/// which the removed send would have transferred nothing). A genuinely
+/// diverged pair yields a non-empty delta and still sends; an unavailable
+/// verdict falls back to the conservative byte-differ ⇒ send behavior.
+///
+/// [`InterestManager`]: crate::ring::interest::InterestManager
+/// [`InterestManager::cached_staleness_verdict`]:
+/// crate::ring::interest::InterestManager::cached_staleness_verdict
+pub(super) fn plan_fanout_send<T: crate::util::time_source::TimeSource + Sync>(
+    interest_manager: &crate::ring::interest::InterestManager<T>,
+    key: &ContractKey,
+    our_summary: &freenet_stdlib::prelude::StateSummary<'static>,
+    their_summary: &freenet_stdlib::prelude::StateSummary<'static>,
+    probes_used: usize,
+) -> FanoutSendPlan {
+    use crate::node::{StalenessProbeAction, plan_staleness_probe};
+
+    // Byte-identical summaries are trivially converged (the pre-existing skip).
+    if our_summary.as_ref() == their_summary.as_ref() {
+        return FanoutSendPlan::Skip;
+    }
+    // Bytes differ: ask the shared delta cache before trusting the bytes.
+    // Cache key order matches `compute_delta` / the Summaries arm:
+    // (contract, THEIR summary, OUR summary).
+    let cached = interest_manager.cached_staleness_verdict(
+        key,
+        their_summary.as_ref(),
+        our_summary.as_ref(),
+    );
+    match plan_staleness_probe(cached, probes_used) {
+        StalenessProbeAction::UseCached(true) => FanoutSendPlan::Send,
+        StalenessProbeAction::UseCached(false) => FanoutSendPlan::Skip,
+        StalenessProbeAction::RunProbe => FanoutSendPlan::Probe,
+        // Budget spent: conservative pre-fix behavior (differing bytes ⇒
+        // send). Re-evaluated on the next fan-out once the cache warms.
+        StalenessProbeAction::BudgetExhaustedFallBack => FanoutSendPlan::Send,
+    }
+}
+
+/// Full semantic staleness decision for one (contract, peer) fan-out send:
+/// [`plan_fanout_send`] plus the bounded WASM `get_state_delta` probe on a
+/// cache miss. Returns `true` when the peer needs our state (send), `false`
+/// when it is converged (skip).
+///
+/// `probes_used` is the per-fan-out-invocation probe budget counter (mirrors
+/// the `Summaries` handler's per-message `MAX_STALENESS_PROBES_PER_SUMMARIES`
+/// budget in node.rs): only cache MISSES that reach the WASM probe consume it.
+/// The production per-peer queue task calls this once per (contract, peer)
+/// entry — at most ONE probe per invocation, trivially within budget, and
+/// bounded overall by the same queue/semaphore caps that already bound
+/// `compute_delta` WASM work per entry. The sim-inline fan-out shares one
+/// counter across all targets of a fan-out, capping the WASM probes a single
+/// fan-out pass can issue. Probe results land in the shared delta cache, so
+/// repeated fan-outs for an unchanged pair cost no further WASM.
+///
+/// Note the probe deliberately bypasses the [`is_delta_efficient`] wire gate
+/// (see `peer_summary_has_pending_state`): staleness detection wants the
+/// semantic answer even for big-summary contracts, because the alternative it
+/// replaces is a spurious FULL-STATE send on every fan-out — strictly more
+/// expensive than one delta computation.
+///
+/// [`is_delta_efficient`]: crate::ring::interest::is_delta_efficient
+pub(super) async fn fanout_send_needed(
+    op_manager: &OpManager,
+    key: &ContractKey,
+    our_summary: &freenet_stdlib::prelude::StateSummary<'static>,
+    their_summary: &freenet_stdlib::prelude::StateSummary<'static>,
+    probes_used: &mut usize,
+) -> bool {
+    match plan_fanout_send(
+        &op_manager.interest_manager,
+        key,
+        our_summary,
+        their_summary,
+        *probes_used,
+    ) {
+        FanoutSendPlan::Send => true,
+        FanoutSendPlan::Skip => false,
+        FanoutSendPlan::Probe => {
+            *probes_used += 1;
+            let verdict = op_manager
+                .interest_manager
+                .peer_summary_has_pending_state(op_manager, key, their_summary, our_summary)
+                .await;
+            crate::ring::interest::summary_indicates_stale_peer(our_summary, their_summary, verdict)
+        }
+    }
+}
+
 // The `BroadcastQueue` struct (constants, types, impl) is only used in the
 // production `p2p_protoc` path. Under `simulation_tests` the code routes
 // through `broadcast_to_single_peer` directly (see p2p_protoc.rs), so the
@@ -596,13 +737,24 @@ pub(super) async fn broadcast_to_single_peer(
         .interest_manager
         .get_peer_summary(&key, &peer_key);
 
-    // Skip if summaries are equal (no change to send)
+    // Semantic skip (#4894's fan-out counterpart). Byte-identical summaries
+    // skip as before; byte-DIFFERING summaries are no longer trusted as proof
+    // of divergence — a contract whose summary serializes
+    // non-deterministically yields different bytes for the SAME logical
+    // state, and re-sending full state for such a converged pair on every
+    // fan-out is the nondeterministic-summary heal storm. `fanout_send_needed`
+    // asks the shared delta cache / the contract itself (bounded probe)
+    // whether the peer actually lacks state we hold.
     if let (Some(ours), Some(theirs)) = (&our_summary, &their_summary) {
-        if ours.as_ref() == theirs.as_ref() {
+        // Per-invocation probe budget: one (contract, peer) pair per call, so
+        // at most one WASM probe per queue entry (see `fanout_send_needed`).
+        let mut staleness_probes_used = 0usize;
+        if !fanout_send_needed(op_manager, &key, ours, theirs, &mut staleness_probes_used).await {
             tracing::trace!(
                 contract = %key,
                 peer = %peer_addr,
-                "Skipping broadcast - peer already has our state"
+                "Skipping broadcast - peer already has our state (byte-equal \
+                 or logically converged summaries)"
             );
             return;
         }
@@ -618,14 +770,19 @@ pub(super) async fn broadcast_to_single_peer(
             {
                 Ok(Some(delta)) => (DeltaOrFullState::Delta(delta.as_ref().to_vec()), true),
                 Ok(None) => {
-                    tracing::debug!(
+                    // The contract computed an EMPTY delta against the peer's
+                    // summary: the peer is logically converged despite the
+                    // byte-differing summaries. The pre-fix arm "fell back" to
+                    // sending FULL STATE here, which is what re-flooded a
+                    // converged-but-nondeterministic-summary contract on every
+                    // fan-out (the heal storm). Nothing to send — skip.
+                    tracing::trace!(
                         contract = %key,
-                        "Delta computation returned no change, sending full state"
+                        peer = %peer_addr,
+                        "Skipping broadcast - contract reported empty delta \
+                         (peer converged)"
                     );
-                    (
-                        DeltaOrFullState::FullState(new_state.as_ref().to_vec()),
-                        false,
-                    )
+                    return;
                 }
                 Err(err) => {
                     tracing::debug!(
@@ -860,7 +1017,9 @@ pub(super) async fn broadcast_to_single_peer(
 mod tests {
     use std::time::Duration;
 
-    use freenet_stdlib::prelude::{CodeHash, ContractInstanceId, ContractKey, StateSummary};
+    use freenet_stdlib::prelude::{
+        CodeHash, ContractInstanceId, ContractKey, StateDelta, StateSummary,
+    };
 
     use crate::ring::PeerKey;
     use crate::ring::interest::InterestManager;
@@ -868,7 +1027,8 @@ mod tests {
     use crate::util::time_source::SharedMockTimeSource;
 
     use super::{
-        BroadcastStreamMetrics, record_streaming_delivery, streaming_completion_delivered,
+        BroadcastStreamMetrics, FanoutSendPlan, plan_fanout_send, record_streaming_delivery,
+        streaming_completion_delivered,
     };
 
     /// `BroadcastStreamMetrics` counts every attempt and, separately, only the
@@ -1318,6 +1478,274 @@ mod tests {
             failure_calls, 2,
             "exactly the two early-failure exits must record record_attempt(false) \
              (got {failure_calls}); the third exit records record_attempt(delivered)"
+        );
+    }
+
+    // ---- Semantic fan-out skip (#4894's fan-out counterpart / the ----------
+    // ---- nondeterministic-summary heal storm) ------------------------------
+    //
+    // The live broadcast fan-out used to skip a peer only on BYTE-identical
+    // summaries. A contract whose summary serializes non-deterministically
+    // (HashMap/HashSet order) yields different bytes for the SAME logical
+    // state across peers, so the byte compare never skipped; the delta path
+    // then either returned an empty delta (which the pre-fix arm answered by
+    // sending FULL STATE) or was refused by the `is_delta_efficient` gate on
+    // big-summary contracts — so a fully-converged pair re-flooded full state
+    // on every fan-out (contracts like `Eumk9HNQ` healing hard while their
+    // state never changed). These tests exercise the cache-only decision core
+    // `plan_fanout_send`; the wiring is pinned by
+    // `fanout_path_uses_semantic_delta_skip_pin`.
+
+    fn make_manager() -> InterestManager<SharedMockTimeSource> {
+        InterestManager::new(SharedMockTimeSource::new())
+    }
+
+    /// Reproducing test (mirrors #4894's
+    /// `nondeterministic_summary_does_not_flag_converged_peer_stale`): two
+    /// peers with the SAME logical state but byte-differing summaries must NOT
+    /// be re-sent full state by the fan-out once the contract has said the
+    /// pair is converged (empty delta).
+    #[test]
+    fn nondeterministic_converged_summaries_skip_fanout_resend() {
+        let manager = make_manager();
+        let contract = make_contract_key(50);
+
+        // Two summaries of the SAME logical state that serialize to DIFFERENT
+        // bytes (models cross-peer HashMap/HashSet iteration-order divergence).
+        let ours = StateSummary::from(vec![1u8, 2, 3]);
+        let theirs = StateSummary::from(vec![3u8, 2, 1]);
+        assert_ne!(
+            ours.as_ref(),
+            theirs.as_ref(),
+            "precondition: summaries differ byte-wise (the pre-fix byte-compare \
+             would NOT skip, and the delta path fell back to full state)"
+        );
+
+        // The contract, asked for the delta of our state against their
+        // summary, returned EMPTY: logically converged. Model it exactly as
+        // production does — via the shared delta cache.
+        manager.cache_delta(
+            &contract,
+            theirs.as_ref(),
+            ours.as_ref(),
+            StateDelta::from(Vec::<u8>::new()),
+        );
+
+        // FIX: the fan-out must SKIP this peer — no full-state re-flood.
+        assert_eq!(
+            plan_fanout_send(&manager, &contract, &ours, &theirs, 0),
+            FanoutSendPlan::Skip,
+            "a converged-but-byte-differing pair must be skipped by the fan-out \
+             (pre-fix: full state was re-sent on every fan-out — the heal storm)"
+        );
+    }
+
+    /// Convergence safety: a genuinely diverged pair (non-empty delta) must
+    /// STILL be sent/healed — the fix only removes spurious re-sends.
+    #[test]
+    fn genuinely_diverged_summaries_still_send() {
+        let manager = make_manager();
+        let contract = make_contract_key(51);
+
+        let ours = StateSummary::from(vec![9u8, 9, 9]);
+        let theirs = StateSummary::from(vec![1u8]);
+
+        manager.cache_delta(
+            &contract,
+            theirs.as_ref(),
+            ours.as_ref(),
+            StateDelta::from(vec![42u8]),
+        );
+
+        assert_eq!(
+            plan_fanout_send(&manager, &contract, &ours, &theirs, 0),
+            FanoutSendPlan::Send,
+            "a genuine divergence (non-empty delta) must still be sent"
+        );
+    }
+
+    /// Byte-identical summaries skip WITHOUT consulting the cache or spending
+    /// probe budget — even a (stale, cross-contract-polluted) cached non-empty
+    /// delta for the same byte pair must not force a send.
+    #[test]
+    fn byte_equal_summaries_skip_before_cache_lookup() {
+        let manager = make_manager();
+        let contract = make_contract_key(52);
+
+        let ours = StateSummary::from(vec![7u8, 7, 7]);
+        let theirs = StateSummary::from(vec![7u8, 7, 7]);
+
+        // Poison the cache for this (equal-bytes) pair: the byte-equal
+        // short-circuit must win regardless.
+        manager.cache_delta(
+            &contract,
+            theirs.as_ref(),
+            ours.as_ref(),
+            StateDelta::from(vec![1u8]),
+        );
+
+        assert_eq!(
+            plan_fanout_send(&manager, &contract, &ours, &theirs, 0),
+            FanoutSendPlan::Skip,
+            "byte-identical summaries are trivially converged; the byte-equal \
+             short-circuit must precede any delta-cache verdict"
+        );
+    }
+
+    /// Per-invocation probe cap (mirrors the `Summaries` handler's
+    /// `MAX_STALENESS_PROBES_PER_SUMMARIES` budget): a cache MISS probes only
+    /// while budget remains; once exhausted the plan falls back to the
+    /// conservative byte-differ ⇒ send behavior instead of probing — never to
+    /// a silent skip.
+    #[test]
+    fn probe_budget_gates_wasm_probe_and_falls_back_to_send() {
+        use crate::node::MAX_STALENESS_PROBES_PER_SUMMARIES;
+
+        let manager = make_manager();
+        let contract = make_contract_key(53);
+
+        let ours = StateSummary::from(vec![1u8, 2, 3]);
+        let theirs = StateSummary::from(vec![3u8, 2, 1]);
+
+        // No cached verdict, budget available → probe the contract.
+        assert_eq!(
+            plan_fanout_send(&manager, &contract, &ours, &theirs, 0),
+            FanoutSendPlan::Probe,
+            "a cache miss within budget must run the bounded WASM probe"
+        );
+        assert_eq!(
+            plan_fanout_send(
+                &manager,
+                &contract,
+                &ours,
+                &theirs,
+                MAX_STALENESS_PROBES_PER_SUMMARIES - 1
+            ),
+            FanoutSendPlan::Probe,
+            "the last budget slot is still spendable"
+        );
+
+        // Budget exhausted → conservative SEND (byte-differ fallback), no probe.
+        assert_eq!(
+            plan_fanout_send(
+                &manager,
+                &contract,
+                &ours,
+                &theirs,
+                MAX_STALENESS_PROBES_PER_SUMMARIES
+            ),
+            FanoutSendPlan::Send,
+            "an exhausted probe budget must fall back to the conservative \
+             byte-differ ⇒ send behavior, never a silent skip"
+        );
+
+        // A cache HIT is free: it answers even with the budget exhausted.
+        manager.cache_delta(
+            &contract,
+            theirs.as_ref(),
+            ours.as_ref(),
+            StateDelta::from(Vec::<u8>::new()),
+        );
+        assert_eq!(
+            plan_fanout_send(
+                &manager,
+                &contract,
+                &ours,
+                &theirs,
+                MAX_STALENESS_PROBES_PER_SUMMARIES * 10
+            ),
+            FanoutSendPlan::Skip,
+            "cache hits never consume budget and still answer (converged ⇒ skip)"
+        );
+    }
+
+    /// Source-scrape pin: the fan-out path must decide the per-peer send
+    /// SEMANTICALLY — routing through `fanout_send_needed` (the
+    /// `plan_fanout_send` cache layer + the bounded
+    /// `peer_summary_has_pending_state` contract probe +
+    /// `summary_indicates_stale_peer` policy) — and the `compute_delta`
+    /// `Ok(None)` (empty delta = converged) arm must SKIP, not fall back to
+    /// full state. Mirrors node.rs's
+    /// `summaries_arm_uses_semantic_staleness_probe_pin`: the data-layer unit
+    /// tests above stay green even if `broadcast_to_single_peer` is reverted
+    /// to a bare byte compare + full-state fallback (re-opening the
+    /// nondeterministic-summary heal storm), so this pins the WIRING.
+    #[test]
+    fn fanout_path_uses_semantic_delta_skip_pin() {
+        let src = include_str!("broadcast_queue.rs");
+
+        // --- broadcast_to_single_peer wiring ---
+        let fn_start = src
+            .find("pub(super) async fn broadcast_to_single_peer(")
+            .expect("broadcast_to_single_peer not found");
+        let after = &src[fn_start..];
+        let fn_end = after
+            .find("\nmod tests {")
+            .or_else(|| after.find("\n#[cfg(test)]"))
+            .expect("end of broadcast_to_single_peer (start of tests module) not found");
+        let body = &after[..fn_end];
+
+        assert!(
+            body.contains("fanout_send_needed("),
+            "broadcast_to_single_peer must route the per-peer skip decision \
+             through fanout_send_needed — a bare summary byte comparison \
+             re-opens the nondeterministic-summary heal storm"
+        );
+
+        // The Ok(None) arm (contract returned empty delta = converged) must
+        // SKIP (return), never construct a FullState payload.
+        let ok_none_off = body
+            .find("Ok(None) =>")
+            .expect("compute_delta Ok(None) arm not found in broadcast_to_single_peer");
+        let err_off = body[ok_none_off..]
+            .find("Err(err) =>")
+            .expect("compute_delta Err arm not found after Ok(None) arm");
+        let ok_none_arm = &body[ok_none_off..ok_none_off + err_off];
+        assert!(
+            !ok_none_arm.contains("FullState"),
+            "the Ok(None) (empty delta = converged) arm must NOT fall back to \
+             sending full state — that re-flood on every fan-out IS the heal \
+             storm. Arm body:\n{ok_none_arm}"
+        );
+        assert!(
+            ok_none_arm.contains("return;"),
+            "the Ok(None) (empty delta = converged) arm must skip the send \
+             entirely (return). Arm body:\n{ok_none_arm}"
+        );
+
+        // --- helper internals: the semantic machinery is actually consulted ---
+        let helpers_start = src
+            .find("pub(super) fn plan_fanout_send")
+            .expect("plan_fanout_send not found");
+        let helpers_end = src
+            .find("// The `BroadcastQueue` struct (constants, types, impl)")
+            .expect("queue module comment anchor not found");
+        assert!(
+            helpers_start < helpers_end,
+            "plan_fanout_send / fanout_send_needed must be defined before the \
+             queue module"
+        );
+        let helpers = &src[helpers_start..helpers_end];
+        assert!(
+            helpers.contains("plan_staleness_probe"),
+            "plan_fanout_send must ration WASM probes through \
+             plan_staleness_probe (the MAX_STALENESS_PROBES_PER_SUMMARIES cap)"
+        );
+        assert!(
+            helpers.contains("cached_staleness_verdict"),
+            "plan_fanout_send must consult the shared delta cache \
+             (cached_staleness_verdict) before trusting summary bytes"
+        );
+        assert!(
+            helpers.contains("peer_summary_has_pending_state"),
+            "fanout_send_needed must resolve cache misses via the bounded \
+             contract delta probe (peer_summary_has_pending_state)"
+        );
+        assert!(
+            helpers.contains("summary_indicates_stale_peer"),
+            "fanout_send_needed must decide from the probe verdict via \
+             summary_indicates_stale_peer (semantic policy), not inline byte \
+             inequality"
         );
     }
 }

--- a/crates/core/src/node/network_bridge/broadcast_queue.rs
+++ b/crates/core/src/node/network_bridge/broadcast_queue.rs
@@ -178,6 +178,31 @@ pub(super) enum FanoutSendPlan {
     Probe,
 }
 
+/// The two summaries a fan-out send decision compares, bundled with NAMED
+/// fields so call sites cannot positionally transpose them.
+///
+/// The underlying probe API takes the pair POSITIONALLY in the OPPOSITE order
+/// to how the fan-out naturally reads
+/// (`peer_summary_has_pending_state(.., their_summary, our_summary)`,
+/// interest.rs), and so does the delta cache
+/// (`cached_staleness_verdict(key, theirs, ours)`). A transposed positional
+/// call site would compile, pass every unit test and source-scrape pin, and
+/// compute `delta(our_state vs our OWN summary)` — always empty — wrongly
+/// skipping nearly every broadcast (a network-wide update blackout). Bundling
+/// the pair is the `.claude/rules/bug-prevention-patterns.md` "paired fields
+/// that must co-occur — bundle in a sub-struct" fix shape: the only
+/// positional-order decisions left live INSIDE [`plan_fanout_send`] /
+/// [`fanout_send_needed`], directly next to the APIs they map onto, and every
+/// call site names the fields (`SummaryPair { ours, theirs }`), so a swap
+/// requires explicitly writing `ours: theirs, theirs: ours`.
+#[derive(Clone, Copy)]
+pub(super) struct SummaryPair<'a> {
+    /// OUR current summary for the contract (the sender's local state).
+    pub ours: &'a freenet_stdlib::prelude::StateSummary<'static>,
+    /// The PEER's cached summary (what we believe the receiver holds).
+    pub theirs: &'a freenet_stdlib::prelude::StateSummary<'static>,
+}
+
 /// Cache-only layer of the fan-out's semantic staleness decision (#4894's
 /// fan-out counterpart).
 ///
@@ -216,24 +241,22 @@ pub(super) enum FanoutSendPlan {
 pub(super) fn plan_fanout_send<T: crate::util::time_source::TimeSource + Sync>(
     interest_manager: &crate::ring::interest::InterestManager<T>,
     key: &ContractKey,
-    our_summary: &freenet_stdlib::prelude::StateSummary<'static>,
-    their_summary: &freenet_stdlib::prelude::StateSummary<'static>,
+    summaries: SummaryPair<'_>,
     probes_used: usize,
 ) -> FanoutSendPlan {
     use crate::node::{StalenessProbeAction, plan_staleness_probe};
 
+    let SummaryPair { ours, theirs } = summaries;
+
     // Byte-identical summaries are trivially converged (the pre-existing skip).
-    if our_summary.as_ref() == their_summary.as_ref() {
+    if ours.as_ref() == theirs.as_ref() {
         return FanoutSendPlan::Skip;
     }
     // Bytes differ: ask the shared delta cache before trusting the bytes.
     // Cache key order matches `compute_delta` / the Summaries arm:
-    // (contract, THEIR summary, OUR summary).
-    let cached = interest_manager.cached_staleness_verdict(
-        key,
-        their_summary.as_ref(),
-        our_summary.as_ref(),
-    );
+    // (contract, THEIR summary, OUR summary). This is one of the two
+    // positional mappings `SummaryPair` exists to confine here.
+    let cached = interest_manager.cached_staleness_verdict(key, theirs.as_ref(), ours.as_ref());
     match plan_staleness_probe(cached, probes_used) {
         StalenessProbeAction::UseCached(true) => FanoutSendPlan::Send,
         StalenessProbeAction::UseCached(false) => FanoutSendPlan::Skip,
@@ -270,26 +293,24 @@ pub(super) fn plan_fanout_send<T: crate::util::time_source::TimeSource + Sync>(
 pub(super) async fn fanout_send_needed(
     op_manager: &OpManager,
     key: &ContractKey,
-    our_summary: &freenet_stdlib::prelude::StateSummary<'static>,
-    their_summary: &freenet_stdlib::prelude::StateSummary<'static>,
+    summaries: SummaryPair<'_>,
     probes_used: &mut usize,
 ) -> bool {
-    match plan_fanout_send(
-        &op_manager.interest_manager,
-        key,
-        our_summary,
-        their_summary,
-        *probes_used,
-    ) {
+    match plan_fanout_send(&op_manager.interest_manager, key, summaries, *probes_used) {
         FanoutSendPlan::Send => true,
         FanoutSendPlan::Skip => false,
         FanoutSendPlan::Probe => {
             *probes_used += 1;
+            let SummaryPair { ours, theirs } = summaries;
+            // The probe API takes the pair positionally as (their, our) — the
+            // other mapping `SummaryPair` exists to confine here. Transposing
+            // these would compute delta(our state vs our OWN summary) =
+            // always empty = wrongful skip of every broadcast.
             let verdict = op_manager
                 .interest_manager
-                .peer_summary_has_pending_state(op_manager, key, their_summary, our_summary)
+                .peer_summary_has_pending_state(op_manager, key, theirs, ours)
                 .await;
-            crate::ring::interest::summary_indicates_stale_peer(our_summary, their_summary, verdict)
+            crate::ring::interest::summary_indicates_stale_peer(ours, theirs, verdict)
         }
     }
 }
@@ -749,7 +770,14 @@ pub(super) async fn broadcast_to_single_peer(
         // Per-invocation probe budget: one (contract, peer) pair per call, so
         // at most one WASM probe per queue entry (see `fanout_send_needed`).
         let mut staleness_probes_used = 0usize;
-        if !fanout_send_needed(op_manager, &key, ours, theirs, &mut staleness_probes_used).await {
+        if !fanout_send_needed(
+            op_manager,
+            &key,
+            SummaryPair { ours, theirs },
+            &mut staleness_probes_used,
+        )
+        .await
+        {
             tracing::trace!(
                 contract = %key,
                 peer = %peer_addr,
@@ -1027,8 +1055,8 @@ mod tests {
     use crate::util::time_source::SharedMockTimeSource;
 
     use super::{
-        BroadcastStreamMetrics, FanoutSendPlan, plan_fanout_send, record_streaming_delivery,
-        streaming_completion_delivered,
+        BroadcastStreamMetrics, FanoutSendPlan, SummaryPair, plan_fanout_send,
+        record_streaming_delivery, streaming_completion_delivered,
     };
 
     /// `BroadcastStreamMetrics` counts every attempt and, separately, only the
@@ -1533,7 +1561,15 @@ mod tests {
 
         // FIX: the fan-out must SKIP this peer — no full-state re-flood.
         assert_eq!(
-            plan_fanout_send(&manager, &contract, &ours, &theirs, 0),
+            plan_fanout_send(
+                &manager,
+                &contract,
+                SummaryPair {
+                    ours: &ours,
+                    theirs: &theirs
+                },
+                0
+            ),
             FanoutSendPlan::Skip,
             "a converged-but-byte-differing pair must be skipped by the fan-out \
              (pre-fix: full state was re-sent on every fan-out — the heal storm)"
@@ -1558,7 +1594,15 @@ mod tests {
         );
 
         assert_eq!(
-            plan_fanout_send(&manager, &contract, &ours, &theirs, 0),
+            plan_fanout_send(
+                &manager,
+                &contract,
+                SummaryPair {
+                    ours: &ours,
+                    theirs: &theirs
+                },
+                0
+            ),
             FanoutSendPlan::Send,
             "a genuine divergence (non-empty delta) must still be sent"
         );
@@ -1585,7 +1629,15 @@ mod tests {
         );
 
         assert_eq!(
-            plan_fanout_send(&manager, &contract, &ours, &theirs, 0),
+            plan_fanout_send(
+                &manager,
+                &contract,
+                SummaryPair {
+                    ours: &ours,
+                    theirs: &theirs
+                },
+                0
+            ),
             FanoutSendPlan::Skip,
             "byte-identical summaries are trivially converged; the byte-equal \
              short-circuit must precede any delta-cache verdict"
@@ -1609,7 +1661,15 @@ mod tests {
 
         // No cached verdict, budget available → probe the contract.
         assert_eq!(
-            plan_fanout_send(&manager, &contract, &ours, &theirs, 0),
+            plan_fanout_send(
+                &manager,
+                &contract,
+                SummaryPair {
+                    ours: &ours,
+                    theirs: &theirs
+                },
+                0
+            ),
             FanoutSendPlan::Probe,
             "a cache miss within budget must run the bounded WASM probe"
         );
@@ -1617,8 +1677,10 @@ mod tests {
             plan_fanout_send(
                 &manager,
                 &contract,
-                &ours,
-                &theirs,
+                SummaryPair {
+                    ours: &ours,
+                    theirs: &theirs
+                },
                 MAX_STALENESS_PROBES_PER_SUMMARIES - 1
             ),
             FanoutSendPlan::Probe,
@@ -1630,8 +1692,10 @@ mod tests {
             plan_fanout_send(
                 &manager,
                 &contract,
-                &ours,
-                &theirs,
+                SummaryPair {
+                    ours: &ours,
+                    theirs: &theirs
+                },
                 MAX_STALENESS_PROBES_PER_SUMMARIES
             ),
             FanoutSendPlan::Send,
@@ -1650,8 +1714,10 @@ mod tests {
             plan_fanout_send(
                 &manager,
                 &contract,
-                &ours,
-                &theirs,
+                SummaryPair {
+                    ours: &ours,
+                    theirs: &theirs
+                },
                 MAX_STALENESS_PROBES_PER_SUMMARIES * 10
             ),
             FanoutSendPlan::Skip,

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -4708,6 +4708,67 @@ mod tests {
         );
     }
 
+    /// Semantic fan-out skip pin — sim-inline counterpart of
+    /// `broadcast_queue::fanout_path_uses_semantic_delta_skip_pin` (#4894's
+    /// fan-out counterpart / the nondeterministic-summary heal storm).
+    ///
+    /// The sim-only `broadcast_state_to_peers` duplicates the production
+    /// per-peer send body, so it must mirror BOTH halves of the fix: the
+    /// per-peer skip decision routes through
+    /// `broadcast_queue::fanout_send_needed` (semantic staleness, not a bare
+    /// summary byte compare), and the `compute_delta` `Ok(None)` (empty delta
+    /// = converged) arm SKIPS instead of falling back to full state. Without
+    /// this pin the behavioral broadcast simulation tests would diverge from
+    /// production and silently regress the storm.
+    #[test]
+    fn broadcast_state_to_peers_uses_semantic_delta_skip() {
+        // Lives in the `broadcast` submodule after the p2p_protoc.rs split.
+        const SOURCE: &str = include_str!("p2p_protoc/broadcast.rs");
+
+        let fn_anchor = "async fn broadcast_state_to_peers(";
+        let fn_start = SOURCE
+            .find(fn_anchor)
+            .expect("broadcast_state_to_peers renamed or removed");
+        let after_header = &SOURCE[fn_start + fn_anchor.len()..];
+        let body_end = [
+            after_header.find("\n    async fn "),
+            after_header.find("\n    pub(super) async fn "),
+        ]
+        .into_iter()
+        .flatten()
+        .min()
+        .map(|p| fn_start + fn_anchor.len() + p)
+        .unwrap_or(SOURCE.len());
+        let body = &SOURCE[fn_start..body_end];
+
+        assert!(
+            body.contains("fanout_send_needed("),
+            "broadcast_state_to_peers must route the per-peer skip decision \
+             through broadcast_queue::fanout_send_needed — a bare summary byte \
+             comparison re-opens the nondeterministic-summary heal storm on \
+             the sim-inline fan-out path"
+        );
+
+        let ok_none_off = body
+            .find("Ok(None) =>")
+            .expect("compute_delta Ok(None) arm not found in broadcast_state_to_peers");
+        let err_off = body[ok_none_off..]
+            .find("Err(err) =>")
+            .expect("compute_delta Err arm not found after Ok(None) arm");
+        let ok_none_arm = &body[ok_none_off..ok_none_off + err_off];
+        assert!(
+            !ok_none_arm.contains("FullState"),
+            "the sim fan-out's Ok(None) (empty delta = converged) arm must NOT \
+             fall back to sending full state — mirror the production skip. Arm \
+             body:\n{ok_none_arm}"
+        );
+        assert!(
+            ok_none_arm.contains("continue;"),
+            "the sim fan-out's Ok(None) (empty delta = converged) arm must skip \
+             this peer (continue). Arm body:\n{ok_none_arm}"
+        );
+    }
+
     /// Phase 7 egress self-block pin (#4300). `handle_broadcast_state_change`
     /// MUST skip the fan-out for a banned contract — the egress
     /// `contract_ban_list.is_banned(key.id())` check must appear BEFORE

--- a/crates/core/src/node/network_bridge/p2p_protoc/broadcast.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc/broadcast.rs
@@ -606,6 +606,12 @@ impl P2pConnManager {
         let mut send_success: usize = 0;
         let mut send_failed: usize = 0;
 
+        // Per-fan-out probe budget shared across all targets, mirroring the
+        // production `broadcast_to_single_peer` semantic skip and the
+        // `Summaries` handler's per-message MAX_STALENESS_PROBES_PER_SUMMARIES
+        // cap (see `broadcast_queue::fanout_send_needed`).
+        let mut staleness_probes_used = 0usize;
+
         for target in &target_result.targets {
             let Some(peer_addr) = target.socket_addr() else {
                 continue;
@@ -618,13 +624,26 @@ impl P2pConnManager {
                 .interest_manager
                 .get_peer_summary(&key, &peer_key);
 
-            // Skip if summaries are equal (no change to send)
+            // Semantic skip (#4894's fan-out counterpart): byte-equal
+            // summaries skip as before; byte-differing summaries consult the
+            // shared delta cache / a bounded contract probe so a
+            // converged-but-nondeterministic-summary pair does not re-flood
+            // full state. Mirrors production `broadcast_to_single_peer`.
             if let (Some(ours), Some(theirs)) = (&our_summary, &their_summary) {
-                if ours.as_ref() == theirs.as_ref() {
+                if !super::super::broadcast_queue::fanout_send_needed(
+                    op_manager,
+                    &key,
+                    ours,
+                    theirs,
+                    &mut staleness_probes_used,
+                )
+                .await
+                {
                     tracing::trace!(
                         contract = %key,
                         peer = %peer_addr,
-                        "Skipping broadcast - peer already has our state"
+                        "Skipping broadcast - peer already has our state \
+                         (byte-equal or logically converged summaries)"
                     );
                     skipped_summary_match += 1;
                     continue;
@@ -645,16 +664,19 @@ impl P2pConnManager {
                             true,
                         ),
                         Ok(None) => {
-                            tracing::debug!(
+                            // Empty delta = the peer is logically converged
+                            // despite byte-differing summaries. The pre-fix
+                            // arm sent FULL STATE here (the
+                            // nondeterministic-summary heal storm). Mirrors
+                            // production `broadcast_to_single_peer`: skip.
+                            tracing::trace!(
                                 contract = %key,
-                                "Delta computation returned no change, sending full state"
+                                peer = %peer_addr,
+                                "Skipping broadcast - contract reported empty \
+                                 delta (peer converged)"
                             );
-                            (
-                                crate::message::DeltaOrFullState::FullState(
-                                    new_state.as_ref().to_vec(),
-                                ),
-                                false,
-                            )
+                            skipped_summary_match += 1;
+                            continue;
                         }
                         Err(err) => {
                             tracing::debug!(

--- a/crates/core/src/node/network_bridge/p2p_protoc/broadcast.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc/broadcast.rs
@@ -633,8 +633,7 @@ impl P2pConnManager {
                 if !super::super::broadcast_queue::fanout_send_needed(
                     op_manager,
                     &key,
-                    ours,
-                    theirs,
+                    super::super::broadcast_queue::SummaryPair { ours, theirs },
                     &mut staleness_probes_used,
                 )
                 .await


### PR DESCRIPTION
## Problem

#4894 fixed the InterestSync `Summaries` heal arm: it replaced the raw summary byte-compare with a semantic staleness probe (`peer_summary_has_pending_state` / `summary_indicates_stale_peer` under the `plan_staleness_probe` budget), because a contract whose summary serializes non-deterministically (HashMap/HashSet iteration order) yields different summary bytes for the SAME logical state on different peers.

But the same raw byte-compare survived untouched in the live broadcast fan-out (`broadcast_to_single_peer`, `broadcast_queue.rs`), with two compounding problems:

1. **The skip check was byte-only.** A converged-but-byte-differing pair never skipped, so every fan-out (heartbeat-driven `SyncStateToPeer` heals and real `BroadcastStateChange` updates alike) proceeded to the delta path.
2. **The `compute_delta` → `Ok(None)` arm sent FULL STATE.** When the contract itself reported an *empty delta* ("this peer already has everything I have"), the arm fell back to sending full state instead of skipping. And on big-summary contracts, `compute_delta`'s `is_delta_efficient` gate refused to even ask the contract, going straight to full state.

Net effect: a contract with a non-deterministic summary re-floods full state to converged peers on every heartbeat — the spurious-heal storm (contracts like `Eumk9HNQ` that "heal" hard while their state never changes), even after #4894 quieted the `Summaries` arm itself.

(This does NOT address the non-idempotent junk-contract storm — those contracts genuinely diverge on every apply, so an empty-delta skip can't help them; that is handled separately via eviction/quarantine.)

## Approach

Finish #4894 at the fan-out's single egress chokepoint, in two layers:

- **`Ok(None)` arm skips.** The contract computed an empty delta = the peer is logically converged = nothing to send. Return without sending (production) / `continue` (sim twin). This is the minimal core of the fix.
- **Semantic skip decision.** Replace the byte-equality skip with the #4894 machinery, shared by both twins via two new helpers in `broadcast_queue.rs`:
  - `plan_fanout_send` (sync, cache-only, unit-testable): byte-equal → skip; byte-differ → consult the shared delta cache (`cached_staleness_verdict`) under the same probe rationing (`plan_staleness_probe`, budget mirroring `MAX_STALENESS_PROBES_PER_SUMMARIES`).
  - `fanout_send_needed` (async): on a cache miss within budget, run the bounded WASM probe (`peer_summary_has_pending_state`) and decide via `summary_indicates_stale_peer`. The probe deliberately bypasses the `is_delta_efficient` wire gate — the alternative it replaces is a spurious FULL-STATE send, strictly more expensive than one delta computation.
- **Sim twin mirrored** (`p2p_protoc/broadcast.rs::broadcast_state_to_peers`) so simulation matches production, with one probe budget shared across the fan-out's targets.
- **`SummaryPair` argument bundle** (review hardening): the helper family reads `(ours, theirs)` while the underlying APIs take the pair positionally as `(their, our)` (`peer_summary_has_pending_state`, `cached_staleness_verdict`). A transposed positional call site would compile, pass every test and pin, and compute `delta(our_state vs our OWN summary)` = always empty → near-universal wrongful skip (an update blackout). Per the bug-prevention "paired fields that must co-occur — bundle in a sub-struct" pattern, both helpers now take a `SummaryPair { ours, theirs }` with named fields; the only positional-order mappings left live inside the helpers, directly next to the APIs they map onto, and both call sites construct the pair by field name.

**Probe budget:** the production per-(contract, peer) queue task can spend at most ONE probe per invocation (fresh counter per call), bounded overall by the same queue/semaphore caps that already bound `compute_delta` WASM work; the sim-inline loop shares one counter across all targets of a fan-out. Probe results land in the shared delta cache, so repeated fan-outs for an unchanged pair cost no further WASM.

**Convergence safety** (identical argument to #4894): the new skip set is a strict subset of the old byte-compare skip set plus exactly those pairs whose contract-computed delta is EMPTY — copies that already hold our state, for which the removed send would have transferred nothing. A genuinely diverged pair yields a non-empty delta and still sends (as a delta, with the existing delta-apply-failure → `ResyncRequest` → full-state resend backstop); an unavailable probe verdict falls back to the conservative byte-differ ⇒ send behavior, so a real divergence is never silently skipped.

**Residual risk — wrong cached peer summary.** The delta (and the `Ok(None)` verdict) is computed against OUR cache of the peer's summary, which can be wrong: `Delivered` is sender-side completion, so a streaming send with a lost tail caches a summary the peer never actually reached. Pre-fix, the `Ok(None)`→full-state fallback acted as an accidental belt-and-suspenders resend for that case; with the skip, such a peer waits for recovery instead. This is bounded and recoverable by the two existing backstops: the peer's delta-apply failure (or its own detection of divergence) triggers a `ResyncRequest` that clears the sender's cached summary → next send is full state; and the ~5-min InterestSync exchange has the peer report its REAL summary, which byte-differs from our state, misses the delta cache, probes, and heals. It is also the exact trust already shipped and field-validated in #4894 for the heartbeat heal arm — the fan-out only raises the frequency at which the same cached-summary assumption is exercised.

## Testing

New unit tests in `node::network_bridge::broadcast_queue::tests` (mirroring #4894's `ring::interest::tests`):

- `nondeterministic_converged_summaries_skip_fanout_resend` — reproducing test: same logical state, byte-differing summaries, contract says empty delta → the fan-out skips (pre-fix: full state re-sent on every fan-out).
- `genuinely_diverged_summaries_still_send` — non-empty delta → still sent/healed.
- `byte_equal_summaries_skip_before_cache_lookup` — the byte-equal short-circuit precedes any cache verdict.
- `probe_budget_gates_wasm_probe_and_falls_back_to_send` — the per-invocation probe cap: probes only while budget remains, conservative SEND (never a silent skip) once exhausted, cache hits free.

(All exercise the helpers through the `SummaryPair` named-field bundle, matching the production call shape.)

Source-scrape wiring pins (mirroring #4894's `summaries_arm_uses_semantic_staleness_probe_pin`, so a revert to a bare byte-compare or a full-state `Ok(None)` fallback fails CI):

- `fanout_path_uses_semantic_delta_skip_pin` (broadcast_queue.rs) — `broadcast_to_single_peer` routes through `fanout_send_needed`; the `Ok(None)` arm contains no `FullState` and returns; the helpers actually consult `plan_staleness_probe` / `cached_staleness_verdict` / `peer_summary_has_pending_state` / `summary_indicates_stale_peer`.
- `broadcast_state_to_peers_uses_semantic_delta_skip` (p2p_protoc.rs) — the sim twin mirrors both halves.

`cargo fmt`, `cargo clippy -- -D warnings` (default and `simulation_tests` features), and the full `-p freenet` lib test suite run clean locally.

Refs #4894.

[AI-assisted - Claude]
