### PR TITLE
fix: cost-aware eviction — shed zero-demand contracts dominating update-work

### DIFF
--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -2297,28 +2297,32 @@ mod state_write_attribution_pin_tests {
     }
 
     #[test]
-    fn attempt_state_update_reports_exec_cpu_micros() {
-        // Cost-aware eviction (#4861): the upsert/apply chokepoint
-        // (`attempt_state_update` in executor_impl.rs) MUST attribute the
-        // elapsed time of the blocking WASM `update_state` call to the
-        // contract on the `ExecCpuMicros` meter axis — the signal the hosting
-        // sweep's cost-pressure trigger reads. A refactor that drops the
-        // report silently re-opens the cost-blind-eviction gap (a
-        // zero-subscriber contract burning update CPU is never an eviction
+    fn executor_update_state_call_sites_report_exec_cpu_micros() {
+        // Cost-aware eviction (#4861): both executor `update_state` WASM
+        // invocations — the upsert/apply chokepoint (`attempt_state_update`)
+        // AND the sampled idempotency probe (`maybe_probe_idempotency`, which
+        // fires precisely on the storm-relevant non-idempotent class) — MUST
+        // attribute their elapsed on the `ExecCpuMicros` meter axis, the
+        // signal the hosting sweep's cost-pressure trigger reads. A refactor
+        // that drops a report silently re-opens the cost-blind-eviction gap
+        // (a zero-demand contract burning update CPU is never an eviction
         // candidate) while every behavioral test stays green — the exact
         // failure mode of the "Manually-mirrored telemetry counters" row in
-        // `.claude/rules/bug-prevention-patterns.md`.
+        // `.claude/rules/bug-prevention-patterns.md`. (The third ExecCpuMicros
+        // reporter — the per-target send-time summarize/delta — lives in
+        // broadcast_queue.rs, pinned there by
+        // `broadcast_to_single_peer_reports_send_wasm_cost_pin`.)
         //
         // Split needle so this test's own source cannot self-count.
         let needle = concat!("ResourceType::", "Exec", "CpuMicros");
         let count = count_call_sites(RUNTIME_SRC, needle);
         assert_eq!(
-            count, 1,
-            "expected exactly 1 ExecCpuMicros report site in the executor \
-             runtime sources (inside attempt_state_update); found {count}. \
-             If you added a WASM-execution chokepoint that burns \
-             attributable CPU, report it on the same axis and bump this \
-             expectation with a comment."
+            count, 2,
+            "expected exactly 2 ExecCpuMicros report sites in the executor \
+             runtime sources (attempt_state_update + the idempotency probe); \
+             found {count}. If you added a WASM-execution chokepoint that \
+             burns attributable CPU, report it on the same axis and bump \
+             this expectation with a comment."
         );
     }
 

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -2297,6 +2297,32 @@ mod state_write_attribution_pin_tests {
     }
 
     #[test]
+    fn attempt_state_update_reports_exec_cpu_micros() {
+        // Cost-aware eviction (#4861): the upsert/apply chokepoint
+        // (`attempt_state_update` in executor_impl.rs) MUST attribute the
+        // elapsed time of the blocking WASM `update_state` call to the
+        // contract on the `ExecCpuMicros` meter axis — the signal the hosting
+        // sweep's cost-pressure trigger reads. A refactor that drops the
+        // report silently re-opens the cost-blind-eviction gap (a
+        // zero-subscriber contract burning update CPU is never an eviction
+        // candidate) while every behavioral test stays green — the exact
+        // failure mode of the "Manually-mirrored telemetry counters" row in
+        // `.claude/rules/bug-prevention-patterns.md`.
+        //
+        // Split needle so this test's own source cannot self-count.
+        let needle = concat!("ResourceType::", "Exec", "CpuMicros");
+        let count = count_call_sites(RUNTIME_SRC, needle);
+        assert_eq!(
+            count, 1,
+            "expected exactly 1 ExecCpuMicros report site in the executor \
+             runtime sources (inside attempt_state_update); found {count}. \
+             If you added a WASM-execution chokepoint that burns \
+             attributable CPU, report it on the same axis and bump this \
+             expectation with a comment."
+        );
+    }
+
+    #[test]
     fn v2_delegate_callback_installers_invalidate_state_caches() {
         // V2 delegate state writes (put/update_contract_state_sync) bypass
         // `StateStore::{store,update}`, so both `state_write_callback` installers

--- a/crates/core/src/contract/executor/runtime/executor_impl.rs
+++ b/crates/core/src/contract/executor/runtime/executor_impl.rs
@@ -1463,19 +1463,48 @@ where
         key: &ContractKey,
         updates: &[UpdateData<'_>],
     ) -> Result<Either<WrappedState, Vec<RelatedContract>>, ExecutorError> {
-        let update_modification =
-            match self
-                .runtime
-                .update_state(key, parameters, current_state, updates)
-            {
-                Ok(result) => result,
-                Err(err) => {
-                    return Err(ExecutorError::execution(
-                        err,
-                        Some(InnerOpError::Upsert(*key)),
-                    ));
-                }
-            };
+        // Cost telemetry (cost-aware eviction, #4861): measure the elapsed
+        // time of the blocking WASM `update_state` call and attribute it to
+        // the contract on the `ExecCpuMicros` meter axis — INCLUDING applies
+        // whose commit is later suppressed (NoChange / byte-identical merge)
+        // and applies that ERROR (trap/timeout), since the CPU is burned
+        // regardless of whether anything commits. Feeds the hosting sweep's
+        // cost-pressure trigger so a zero-subscriber contract that dominates
+        // update CPU becomes an eviction candidate. Uses the ring's injected
+        // `TimeSource` (deterministic-sim discipline; under paused sim time
+        // the elapsed reads 0, and sim tests inject cost via
+        // `report_contract_resource_usage` directly). The report path is
+        // deadlock-safe by design (brief sync lock, no channels — see
+        // `Ring::report_contract_resource_usage`).
+        let cost_clock = self
+            .op_manager
+            .as_ref()
+            .map(|op_manager| op_manager.ring.time_source.clone());
+        let update_started = cost_clock.as_ref().map(|clock| clock.now());
+        let update_result = self
+            .runtime
+            .update_state(key, parameters, current_state, updates);
+        if let (Some(op_manager), Some(clock), Some(started)) = (
+            self.op_manager.as_ref(),
+            cost_clock.as_ref(),
+            update_started,
+        ) {
+            let elapsed = clock.now().saturating_duration_since(started);
+            op_manager.ring.report_contract_resource_usage(
+                *key.id(),
+                crate::topology::meter::ResourceType::ExecCpuMicros,
+                elapsed.as_micros() as f64,
+            );
+        }
+        let update_modification = match update_result {
+            Ok(result) => result,
+            Err(err) => {
+                return Err(ExecutorError::execution(
+                    err,
+                    Some(InnerOpError::Upsert(*key)),
+                ));
+            }
+        };
         let UpdateModification {
             new_state, related, ..
         } = update_modification;

--- a/crates/core/src/contract/executor/runtime/executor_impl.rs
+++ b/crates/core/src/contract/executor/runtime/executor_impl.rs
@@ -1604,9 +1604,31 @@ where
             return;
         }
 
+        // Cost telemetry (cost-aware eviction, #4861): the probe is a full
+        // extra WASM `update_state` invocation, and it fires precisely on the
+        // storm-relevant class (frequently-merging contracts — including
+        // non-idempotent ones). Attribute its elapsed on the same
+        // `ExecCpuMicros` axis as the main apply in `attempt_state_update`.
+        let probe_clock = self
+            .op_manager
+            .as_ref()
+            .map(|op_manager| op_manager.ring.time_source.clone());
+        let probe_started = probe_clock.as_ref().map(|clock| clock.now());
         let probe_result = self
             .runtime
             .update_state(key, parameters, post_merge_state, updates);
+        if let (Some(op_manager), Some(clock), Some(started)) = (
+            self.op_manager.as_ref(),
+            probe_clock.as_ref(),
+            probe_started,
+        ) {
+            let elapsed = clock.now().saturating_duration_since(started);
+            op_manager.ring.report_contract_resource_usage(
+                *key.id(),
+                crate::topology::meter::ResourceType::ExecCpuMicros,
+                elapsed.as_micros() as f64,
+            );
+        }
         let probe_outcome = match probe_result {
             Ok(modification) => modification,
             Err(err) => {

--- a/crates/core/src/node/network_bridge/broadcast_queue.rs
+++ b/crates/core/src/node/network_bridge/broadcast_queue.rs
@@ -747,6 +747,29 @@ pub(super) async fn broadcast_to_single_peer(
 
     let peer_key = PeerKey::from(target.pub_key().clone());
 
+    // Cost telemetry (cost-aware eviction, #4861): the per-target
+    // summarize + delta computation below is send-time WASM work burned for
+    // EVERY peer send of this contract — for a high-frequency tiny-payload
+    // storm it is a dominant, previously-unmetered CPU cost. Time it via the
+    // ring's injected TimeSource and attribute it on the `ExecCpuMicros`
+    // axis (wall elapsed of the awaited computation; may include executor
+    // queueing, which is still work this contract's send triggered).
+    // Reported at BOTH exits (the summaries-equal skip and the payload
+    // completion) so skipped sends still account for the summary work they
+    // burned.
+    let cost_clock = op_manager.ring.time_source.clone();
+    let send_wasm_started = cost_clock.now();
+    let report_send_wasm_cost = |op_manager: &Arc<OpManager>| {
+        let elapsed = cost_clock
+            .now()
+            .saturating_duration_since(send_wasm_started);
+        op_manager.ring.report_contract_resource_usage(
+            *key.id(),
+            crate::topology::meter::ResourceType::ExecCpuMicros,
+            elapsed.as_micros() as f64,
+        );
+    };
+
     // Get our summary for delta computation
     let our_summary = op_manager
         .interest_manager
@@ -784,6 +807,7 @@ pub(super) async fn broadcast_to_single_peer(
                 "Skipping broadcast - peer already has our state (byte-equal \
                  or logically converged summaries)"
             );
+            report_send_wasm_cost(op_manager);
             return;
         }
     }
@@ -850,6 +874,8 @@ pub(super) async fn broadcast_to_single_peer(
             false,
         ),
     };
+    // Attribute the summarize + delta WASM burned for this send (#4861).
+    report_send_wasm_cost(op_manager);
 
     let payload_size = payload.size();
     let update_tx = crate::message::Transaction::new::<crate::operations::update::UpdateMsg>();
@@ -1923,6 +1949,45 @@ mod tests {
             "fanout_send_needed must decide from the probe verdict via \
              summary_indicates_stale_peer (semantic policy), not inline byte \
              inequality"
+        );
+    }
+
+    /// Source-scrape pin (cost-aware eviction, #4861): the per-target
+    /// summarize + delta computation in `broadcast_to_single_peer` is
+    /// send-time WASM burned for EVERY peer send — a dominant, otherwise-
+    /// unmetered CPU cost for a high-frequency tiny-payload storm. It must be
+    /// attributed on the `ExecCpuMicros` axis at BOTH exits (the summaries-
+    /// equal skip and the payload completion). Dropping a report silently
+    /// blinds the cost-pressure eviction trigger to send-time CPU while every
+    /// behavioral test stays green.
+    #[test]
+    fn broadcast_to_single_peer_reports_send_wasm_cost_pin() {
+        let src = include_str!("broadcast_queue.rs");
+        let fn_start = src
+            .find("pub(super) async fn broadcast_to_single_peer(")
+            .expect("broadcast_to_single_peer not found");
+        let after = &src[fn_start..];
+        let fn_end = after
+            .find("\nmod tests {")
+            .or_else(|| after.find("\n#[cfg(test)]"))
+            .expect("end of broadcast_to_single_peer (start of tests module) not found");
+        let body = &after[..fn_end];
+
+        // The reporting closure must exist and be invoked at both exits.
+        let report_invocations = body.matches("report_send_wasm_cost(op_manager)").count();
+        assert_eq!(
+            report_invocations, 2,
+            "broadcast_to_single_peer must invoke report_send_wasm_cost at both \
+             exits (summaries-equal skip + payload completion) — got \
+             {report_invocations}. A dropped report blinds cost-pressure \
+             eviction (#4861) to per-send WASM cost."
+        );
+        // And the closure must report on the ExecCpuMicros axis (split needle
+        // so this test cannot self-count).
+        let axis_needle = concat!("ResourceType::", "Exec", "CpuMicros");
+        assert!(
+            body.contains(axis_needle),
+            "report_send_wasm_cost must attribute on the ExecCpuMicros axis"
         );
     }
 }

--- a/crates/core/src/node/network_bridge/broadcast_queue.rs
+++ b/crates/core/src/node/network_bridge/broadcast_queue.rs
@@ -747,27 +747,46 @@ pub(super) async fn broadcast_to_single_peer(
 
     let peer_key = PeerKey::from(target.pub_key().clone());
 
-    // Cost telemetry (cost-aware eviction, #4861): the per-target
-    // summarize + delta computation below is send-time WASM work burned for
-    // EVERY peer send of this contract — for a high-frequency tiny-payload
-    // storm it is a dominant, previously-unmetered CPU cost. Time it via the
-    // ring's injected TimeSource and attribute it on the `ExecCpuMicros`
-    // axis (wall elapsed of the awaited computation; may include executor
-    // queueing, which is still work this contract's send triggered).
-    // Reported at BOTH exits (the summaries-equal skip and the payload
-    // completion) so skipped sends still account for the summary work they
-    // burned.
+    // Cost telemetry (cost-aware eviction, #4861): attribute this per-peer
+    // send's two costs to the contract:
+    //   * `ExecCpuMicros` — the summarize + delta WASM work below, burned for
+    //     EVERY peer send (dominant, otherwise-unmetered CPU for a
+    //     high-frequency tiny-payload storm). Wall elapsed of the awaited
+    //     computation via the ring's injected TimeSource; may include executor
+    //     queueing, still work this send triggered.
+    //   * `BroadcastFanoutCost` — the ACTUAL payload bytes put on the wire,
+    //     known only HERE after delta selection (the #4903 review P1 fix: the
+    //     dispatch site can no longer charge `full-state × targets`, which
+    //     phantom-inflated a large-state contract that sends tiny deltas).
+    // Both are reported through ONE topology write lock per send
+    // (`report_contract_resource_usage_batch`, #4903 review MEDIUM) so the
+    // send CPU adds no lock traffic beyond the per-send bytes report that
+    // accurate attribution already requires. Reported at ALL exits: the two
+    // summary-skip exits report only the CPU they burned (no bytes sent — the
+    // #4903 review P2 fix adds the empty-delta exit); the send exit reports
+    // CPU + actual payload bytes.
     let cost_clock = op_manager.ring.time_source.clone();
     let send_wasm_started = cost_clock.now();
-    let report_send_wasm_cost = |op_manager: &Arc<OpManager>| {
-        let elapsed = cost_clock
+    let report_send_cost = |op_manager: &Arc<OpManager>, sent_bytes: Option<f64>| {
+        use crate::topology::meter::ResourceType;
+        let elapsed_us = cost_clock
             .now()
-            .saturating_duration_since(send_wasm_started);
-        op_manager.ring.report_contract_resource_usage(
-            *key.id(),
-            crate::topology::meter::ResourceType::ExecCpuMicros,
-            elapsed.as_micros() as f64,
-        );
+            .saturating_duration_since(send_wasm_started)
+            .as_micros() as f64;
+        match sent_bytes {
+            Some(bytes) => op_manager.ring.report_contract_resource_usage_batch(
+                *key.id(),
+                &[
+                    (ResourceType::ExecCpuMicros, elapsed_us),
+                    (ResourceType::BroadcastFanoutCost, bytes),
+                ],
+            ),
+            None => op_manager.ring.report_contract_resource_usage(
+                *key.id(),
+                ResourceType::ExecCpuMicros,
+                elapsed_us,
+            ),
+        }
     };
 
     // Get our summary for delta computation
@@ -807,7 +826,7 @@ pub(super) async fn broadcast_to_single_peer(
                 "Skipping broadcast - peer already has our state (byte-equal \
                  or logically converged summaries)"
             );
-            report_send_wasm_cost(op_manager);
+            report_send_cost(op_manager, None);
             return;
         }
     }
@@ -854,6 +873,11 @@ pub(super) async fn broadcast_to_single_peer(
                         "Skipping broadcast - contract reported empty delta \
                          (peer converged)"
                     );
+                    // #4903 review P2: the summarize + delta WASM already ran,
+                    // so account for the CPU it burned even though nothing is
+                    // sent (no bytes). Previously this exit returned without
+                    // reporting, undercounting the send-CPU axis.
+                    report_send_cost(op_manager, None);
                     return;
                 }
                 Err(err) => {
@@ -874,10 +898,13 @@ pub(super) async fn broadcast_to_single_peer(
             false,
         ),
     };
-    // Attribute the summarize + delta WASM burned for this send (#4861).
-    report_send_wasm_cost(op_manager);
-
     let payload_size = payload.size();
+    // Attribute the summarize + delta WASM (CPU) AND the actual payload bytes
+    // for this send in one batched report (#4861 / #4903 review P1 + MEDIUM):
+    // the bytes are the real delta/full-state size chosen above, not the
+    // dispatch-site `full-state × targets` over-estimate.
+    report_send_cost(op_manager, Some(payload_size as f64));
+
     let update_tx = crate::message::Transaction::new::<crate::operations::update::UpdateMsg>();
 
     // Check if we should use streaming for full state broadcasts
@@ -1952,16 +1979,17 @@ mod tests {
         );
     }
 
-    /// Source-scrape pin (cost-aware eviction, #4861): the per-target
-    /// summarize + delta computation in `broadcast_to_single_peer` is
-    /// send-time WASM burned for EVERY peer send — a dominant, otherwise-
-    /// unmetered CPU cost for a high-frequency tiny-payload storm. It must be
-    /// attributed on the `ExecCpuMicros` axis at BOTH exits (the summaries-
-    /// equal skip and the payload completion). Dropping a report silently
-    /// blinds the cost-pressure eviction trigger to send-time CPU while every
+    /// Source-scrape pin (cost-aware eviction, #4861 / #4903 review P1+P2):
+    /// `broadcast_to_single_peer` must account for its per-send cost at ALL
+    /// THREE exits — the summaries-equal skip, the empty-delta converged skip
+    /// (the review-P2 exit that previously returned without reporting), and
+    /// the payload completion. The two skip exits report only CPU (no bytes
+    /// sent); the send exit reports CPU + the ACTUAL payload bytes (review P1
+    /// — not the dispatch-site `full-state × targets` over-estimate). Dropping
+    /// a report silently blinds the cost-pressure eviction trigger while every
     /// behavioral test stays green.
     #[test]
-    fn broadcast_to_single_peer_reports_send_wasm_cost_pin() {
+    fn broadcast_to_single_peer_reports_send_cost_pin() {
         let src = include_str!("broadcast_queue.rs");
         let fn_start = src
             .find("pub(super) async fn broadcast_to_single_peer(")
@@ -1973,21 +2001,43 @@ mod tests {
             .expect("end of broadcast_to_single_peer (start of tests module) not found");
         let body = &after[..fn_end];
 
-        // The reporting closure must exist and be invoked at both exits.
-        let report_invocations = body.matches("report_send_wasm_cost(op_manager)").count();
+        // The reporting closure must be invoked at all three exits.
+        let report_invocations = body.matches("report_send_cost(op_manager").count();
         assert_eq!(
-            report_invocations, 2,
-            "broadcast_to_single_peer must invoke report_send_wasm_cost at both \
-             exits (summaries-equal skip + payload completion) — got \
-             {report_invocations}. A dropped report blinds cost-pressure \
-             eviction (#4861) to per-send WASM cost."
+            report_invocations, 3,
+            "broadcast_to_single_peer must invoke report_send_cost at all three \
+             exits (summaries-equal skip + empty-delta converged skip + payload \
+             completion) — got {report_invocations}. A dropped report blinds \
+             cost-pressure eviction (#4861) to per-send cost."
         );
-        // And the closure must report on the ExecCpuMicros axis (split needle
-        // so this test cannot self-count).
-        let axis_needle = concat!("ResourceType::", "Exec", "CpuMicros");
+        // Exactly one exit (the payload completion) sends bytes; the two skip
+        // exits report CPU only.
+        let bytes_invocations = body.matches("report_send_cost(op_manager, Some(").count();
+        assert_eq!(
+            bytes_invocations, 1,
+            "exactly the payload-completion exit reports actual bytes \
+             (Some(payload_size)); the two skip exits report CPU only (None) — \
+             got {bytes_invocations}"
+        );
+        // The closure must attribute BOTH the send-CPU and the actual fan-out
+        // bytes (split needles so this test cannot self-count).
+        let cpu_needle = concat!("ResourceType::", "Exec", "CpuMicros");
+        let bytes_needle = concat!("ResourceType::", "Broadcast", "FanoutCost");
         assert!(
-            body.contains(axis_needle),
-            "report_send_wasm_cost must attribute on the ExecCpuMicros axis"
+            body.contains(cpu_needle),
+            "report_send_cost must attribute on the ExecCpuMicros axis"
+        );
+        assert!(
+            body.contains(bytes_needle),
+            "report_send_cost must attribute the actual payload on the \
+             BroadcastFanoutCost axis (review P1 — bytes charged at the actual \
+             send, not full-state × targets at dispatch)"
+        );
+        // The actual payload size (not full state) must be what's charged.
+        assert!(
+            body.contains("report_send_cost(op_manager, Some(payload_size as f64))"),
+            "the bytes charged must be the selected payload_size (delta or full \
+             state), not the pre-delta full-state size"
         );
     }
 }

--- a/crates/core/src/node/network_bridge/broadcast_queue.rs
+++ b/crates/core/src/node/network_bridge/broadcast_queue.rs
@@ -758,35 +758,33 @@ pub(super) async fn broadcast_to_single_peer(
     //     known only HERE after delta selection (the #4903 review P1 fix: the
     //     dispatch site can no longer charge `full-state × targets`, which
     //     phantom-inflated a large-state contract that sends tiny deltas).
-    // Both are reported through ONE topology write lock per send
-    // (`report_contract_resource_usage_batch`, #4903 review MEDIUM) so the
-    // send CPU adds no lock traffic beyond the per-send bytes report that
-    // accurate attribution already requires. Reported at ALL exits: the two
-    // summary-skip exits report only the CPU they burned (no bytes sent — the
-    // #4903 review P2 fix adds the empty-delta exit); the send exit reports
-    // CPU + actual payload bytes.
+    // The CPU is reported at ALL exits (the WASM summarize+delta work is burned
+    // regardless of whether the send lands): the two summary-skip exits and the
+    // send-attempt path each report the CPU they burned. The payload BYTES are
+    // reported ONLY on a real delivery (streaming `Delivered` / inline send Ok
+    // — #4903 review round-3 Fix 4), NOT up-front: a dropped/timed-out stream or
+    // a failed enqueue put nothing on the wire, so charging its bytes inflated
+    // the contract's BroadcastFanoutCost with phantom fan-out. (This is why the
+    // send-CPU and bytes reports are no longer batched — they now happen at
+    // different points in the send lifecycle.)
     let cost_clock = op_manager.ring.time_source.clone();
     let send_wasm_started = cost_clock.now();
-    let report_send_cost = |op_manager: &Arc<OpManager>, sent_bytes: Option<f64>| {
+    // Reports ONLY the send-CPU (summarize+delta WASM), burned for every attempt
+    // regardless of whether the send lands. The fan-out payload BYTES are charged
+    // separately at the real-delivery sites below (#4903 review round-3 Fix 4),
+    // so a dropped/timed-out stream or a failed enqueue never charges phantom
+    // BroadcastFanoutCost.
+    let report_send_cpu = |op_manager: &Arc<OpManager>| {
         use crate::topology::meter::ResourceType;
         let elapsed_us = cost_clock
             .now()
             .saturating_duration_since(send_wasm_started)
             .as_micros() as f64;
-        match sent_bytes {
-            Some(bytes) => op_manager.ring.report_contract_resource_usage_batch(
-                *key.id(),
-                &[
-                    (ResourceType::ExecCpuMicros, elapsed_us),
-                    (ResourceType::BroadcastFanoutCost, bytes),
-                ],
-            ),
-            None => op_manager.ring.report_contract_resource_usage(
-                *key.id(),
-                ResourceType::ExecCpuMicros,
-                elapsed_us,
-            ),
-        }
+        op_manager.ring.report_contract_resource_usage(
+            *key.id(),
+            ResourceType::ExecCpuMicros,
+            elapsed_us,
+        );
     };
 
     // Get our summary for delta computation
@@ -826,7 +824,7 @@ pub(super) async fn broadcast_to_single_peer(
                 "Skipping broadcast - peer already has our state (byte-equal \
                  or logically converged summaries)"
             );
-            report_send_cost(op_manager, None);
+            report_send_cpu(op_manager);
             return;
         }
     }
@@ -877,7 +875,7 @@ pub(super) async fn broadcast_to_single_peer(
                     // so account for the CPU it burned even though nothing is
                     // sent (no bytes). Previously this exit returned without
                     // reporting, undercounting the send-CPU axis.
-                    report_send_cost(op_manager, None);
+                    report_send_cpu(op_manager);
                     return;
                 }
                 Err(err) => {
@@ -899,11 +897,14 @@ pub(super) async fn broadcast_to_single_peer(
         ),
     };
     let payload_size = payload.size();
-    // Attribute the summarize + delta WASM (CPU) AND the actual payload bytes
-    // for this send in one batched report (#4861 / #4903 review P1 + MEDIUM):
-    // the bytes are the real delta/full-state size chosen above, not the
-    // dispatch-site `full-state × targets` over-estimate.
-    report_send_cost(op_manager, Some(payload_size as f64));
+    // Attribute the summarize + delta WASM (CPU) burned to produce this send.
+    // Reported for EVERY attempt (the WASM work ran regardless of whether the
+    // send lands). The payload BYTES are charged separately, ONLY on a real
+    // delivery below (#4903 review round-3 Fix 4) — not here — so a dropped or
+    // failed send never charges phantom fan-out bytes. `payload_size` is the
+    // real delta/full-state size chosen above, not a `full-state × targets`
+    // over-estimate.
+    report_send_cpu(op_manager);
 
     let update_tx = crate::message::Transaction::new::<crate::operations::update::UpdateMsg>();
 
@@ -1047,6 +1048,15 @@ pub(super) async fn broadcast_to_single_peer(
                 // v0.2.73 incident.
                 BROADCAST_STREAM_METRICS.record_attempt(delivered);
                 if delivered {
+                    // #4903 review round-3 Fix 4: charge the fan-out payload
+                    // bytes ONLY on a real delivery. A dropped/timed-out stream
+                    // put no bytes on the wire; the send CPU was already charged
+                    // for the attempt above.
+                    op_manager.ring.report_contract_resource_usage(
+                        *key.id(),
+                        crate::topology::meter::ResourceType::BroadcastFanoutCost,
+                        payload_size as f64,
+                    );
                     tracing::debug!(
                         tx = %update_tx,
                         peer = %peer_addr,
@@ -1079,6 +1089,15 @@ pub(super) async fn broadcast_to_single_peer(
         // successful enqueue is the terminal state we can observe, so delivery
         // tracks the send result (unchanged pre-#4235 behavior for this path).
         if res.is_ok() {
+            // #4903 review round-3 Fix 4: charge the fan-out payload bytes on a
+            // successful send only. For the inline path a successful enqueue is
+            // the terminal delivery signal (see the branch comment above); the
+            // send CPU was already charged for the attempt.
+            op_manager.ring.report_contract_resource_usage(
+                *key.id(),
+                crate::topology::meter::ResourceType::BroadcastFanoutCost,
+                payload_size as f64,
+            );
             // Delta-incompat attribution (HQk7 resync loop): remember that we
             // just delivered a DELTA to this peer so a prompt `ResyncRequest`
             // from it can be attributed to the delta failing to apply (deltas
@@ -1979,15 +1998,17 @@ mod tests {
         );
     }
 
-    /// Source-scrape pin (cost-aware eviction, #4861 / #4903 review P1+P2):
-    /// `broadcast_to_single_peer` must account for its per-send cost at ALL
-    /// THREE exits — the summaries-equal skip, the empty-delta converged skip
-    /// (the review-P2 exit that previously returned without reporting), and
-    /// the payload completion. The two skip exits report only CPU (no bytes
-    /// sent); the send exit reports CPU + the ACTUAL payload bytes (review P1
-    /// — not the dispatch-site `full-state × targets` over-estimate). Dropping
-    /// a report silently blinds the cost-pressure eviction trigger while every
-    /// behavioral test stays green.
+    /// Source-scrape pin (cost-aware eviction, #4861 / #4903 review P1+P2 +
+    /// round-3 Fix 4): `broadcast_to_single_peer` must charge its per-send CPU
+    /// at ALL THREE exits — the summaries-equal skip, the empty-delta converged
+    /// skip (the review-P2 exit that previously returned without reporting), and
+    /// the send attempt — since the WASM summarize+delta work is burned
+    /// regardless of whether the send lands. The fan-out payload BYTES, by
+    /// contrast, are charged ONLY at the two real-delivery sites (streaming
+    /// `Delivered` + inline send Ok), NEVER up-front — a dropped/failed send put
+    /// nothing on the wire (round-3 Fix 4). Dropping a report silently blinds
+    /// the cost-pressure eviction trigger while every behavioral test stays
+    /// green.
     #[test]
     fn broadcast_to_single_peer_reports_send_cost_pin() {
         let src = include_str!("broadcast_queue.rs");
@@ -2001,43 +2022,42 @@ mod tests {
             .expect("end of broadcast_to_single_peer (start of tests module) not found");
         let body = &after[..fn_end];
 
-        // The reporting closure must be invoked at all three exits.
-        let report_invocations = body.matches("report_send_cost(op_manager").count();
+        // The CPU-only closure must be invoked at all three exits (the WASM
+        // summarize+delta work is burned regardless of whether the send lands).
+        let report_invocations = body.matches("report_send_cpu(op_manager)").count();
         assert_eq!(
             report_invocations, 3,
-            "broadcast_to_single_peer must invoke report_send_cost at all three \
-             exits (summaries-equal skip + empty-delta converged skip + payload \
-             completion) — got {report_invocations}. A dropped report blinds \
-             cost-pressure eviction (#4861) to per-send cost."
+            "broadcast_to_single_peer must invoke report_send_cpu at all three \
+             exits (summaries-equal skip + empty-delta converged skip + send \
+             attempt) — got {report_invocations}. A dropped report blinds \
+             cost-pressure eviction (#4861) to per-send CPU."
         );
-        // Exactly one exit (the payload completion) sends bytes; the two skip
-        // exits report CPU only.
-        let bytes_invocations = body.matches("report_send_cost(op_manager, Some(").count();
-        assert_eq!(
-            bytes_invocations, 1,
-            "exactly the payload-completion exit reports actual bytes \
-             (Some(payload_size)); the two skip exits report CPU only (None) — \
-             got {bytes_invocations}"
-        );
-        // The closure must attribute BOTH the send-CPU and the actual fan-out
-        // bytes (split needles so this test cannot self-count).
+        // Bytes are attributed on the BroadcastFanoutCost axis at exactly the
+        // two real-delivery sites (streaming `Delivered` + inline send Ok), and
+        // the send-CPU on the ExecCpuMicros axis (split needles so this test
+        // cannot self-count). The count of 2 (not 3) is the round-3 Fix 4 pin:
+        // the CPU closure no longer charges bytes, so a dropped/failed send
+        // charges no phantom fan-out.
         let cpu_needle = concat!("ResourceType::", "Exec", "CpuMicros");
         let bytes_needle = concat!("ResourceType::", "Broadcast", "FanoutCost");
         assert!(
             body.contains(cpu_needle),
-            "report_send_cost must attribute on the ExecCpuMicros axis"
+            "report_send_cpu must attribute on the ExecCpuMicros axis"
         );
-        assert!(
-            body.contains(bytes_needle),
-            "report_send_cost must attribute the actual payload on the \
-             BroadcastFanoutCost axis (review P1 — bytes charged at the actual \
-             send, not full-state × targets at dispatch)"
+        assert_eq!(
+            body.matches(bytes_needle).count(),
+            2,
+            "fan-out bytes must be charged on the BroadcastFanoutCost axis at \
+             exactly the two real-delivery sites (streaming Delivered + inline \
+             send Ok) — never up-front (review round-3 Fix 4)"
         );
-        // The actual payload size (not full state) must be what's charged.
-        assert!(
-            body.contains("report_send_cost(op_manager, Some(payload_size as f64))"),
-            "the bytes charged must be the selected payload_size (delta or full \
-             state), not the pre-delta full-state size"
+        // The selected payload size (delta or full state) is what's charged, at
+        // both delivery sites and nowhere else.
+        assert_eq!(
+            body.matches("payload_size as f64").count(),
+            2,
+            "each delivery-gated bytes report must charge the selected \
+             payload_size (delta or full state), not the pre-delta full-state size"
         );
     }
 }

--- a/crates/core/src/node/network_bridge/p2p_protoc/broadcast.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc/broadcast.rs
@@ -483,6 +483,21 @@ impl P2pConnManager {
             target_result.interest_resolve_failed,
         );
 
+        // Cost telemetry (cost-aware eviction, #4861): attribute the intended
+        // fan-out cost — payload bytes × target count — to the contract on the
+        // `BroadcastFanoutCost` meter axis. This is the dispatch point where
+        // the resolved target count is known, shared by the production
+        // (broadcast-queue) and simulation (inline) branches below. Feeds the
+        // hosting sweep's cost-pressure trigger so a zero-subscriber contract
+        // that dominates broadcast capacity becomes an eviction candidate.
+        // Deadlock-safe: `report_contract_resource_usage` takes a brief sync
+        // lock, no channels (see its rustdoc).
+        op_manager.ring.report_contract_resource_usage(
+            *key.id(),
+            crate::topology::meter::ResourceType::BroadcastFanoutCost,
+            new_state.size() as f64 * target_result.targets.len() as f64,
+        );
+
         // In production, enqueue each target into the broadcast queue.
         // The queue worker handles delta computation and streaming with bounded
         // concurrency (default: 2 concurrent streams) to prevent uplink saturation.
@@ -583,6 +598,18 @@ impl P2pConnManager {
             contract = %key,
             peer = %target_addr,
             "SyncStateToPeer: sending state to stale peer"
+        );
+
+        // Cost telemetry (cost-aware eviction, #4861): a targeted stale-peer
+        // heal burns the same broadcast capacity as one fan-out leg, so
+        // attribute payload × 1 to the contract on the same axis. A contract
+        // whose churning state drives constant resync heals (#4861's
+        // non-converging junk contract) accrues its real cost here even when
+        // the all-subscriber fan-out path is quiet.
+        op_manager.ring.report_contract_resource_usage(
+            *key.id(),
+            crate::topology::meter::ResourceType::BroadcastFanoutCost,
+            new_state.size() as f64,
         );
 
         #[cfg(not(feature = "simulation_tests"))]
@@ -950,5 +977,43 @@ impl P2pConnManager {
         ) {
             bridge.log_register.register_events(Either::Left(log)).await;
         }
+    }
+}
+
+#[cfg(test)]
+mod broadcast_fanout_cost_pin_tests {
+    //! Source-scrape pin for the `BroadcastFanoutCost` reporter (cost-aware
+    //! eviction, #4861). The "Manually-mirrored telemetry counters" row in
+    //! `.claude/rules/bug-prevention-patterns.md` is the precedent: a refactor
+    //! of the broadcast dispatch that drops the cost report silently blinds
+    //! the cost-pressure eviction trigger — the exact cost-blind gap this
+    //! change closes — and no behavioral test catches it because the fan-out
+    //! still works. Pin the report at the source level so the drop trips CI.
+
+    const BROADCAST_SRC: &str = include_str!("broadcast.rs");
+
+    /// Both dispatch sites — the all-subscriber fan-out
+    /// (`handle_broadcast_state_change`) and the targeted stale-peer heal
+    /// (`handle_sync_state_to_peer`) — report `BroadcastFanoutCost`. If a
+    /// site is added or removed, update this count WITH a comment explaining
+    /// where the cost of that path is now attributed.
+    #[test]
+    fn broadcast_dispatch_sites_report_fanout_cost() {
+        // Split needle so this test's own source lines never contain the
+        // contiguous token and cannot self-count.
+        let needle = concat!("ResourceType::", "Broadcast", "FanoutCost");
+        let report_sites = BROADCAST_SRC
+            .lines()
+            .filter(|line| {
+                let trimmed = line.trim_start();
+                !trimmed.starts_with("//") && trimmed.contains(needle)
+            })
+            .count();
+        assert_eq!(
+            report_sites, 2,
+            "expected exactly 2 BroadcastFanoutCost report sites in broadcast.rs \
+             (fan-out dispatch + targeted stale-peer heal); a dropped report \
+             silently blinds cost-pressure eviction (#4861)"
+        );
     }
 }

--- a/crates/core/src/node/network_bridge/p2p_protoc/broadcast.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc/broadcast.rs
@@ -483,25 +483,24 @@ impl P2pConnManager {
             target_result.interest_resolve_failed,
         );
 
-        // Cost telemetry (cost-aware eviction, #4861): attribute the intended
-        // fan-out cost to the contract at the dispatch point where the
-        // resolved target count is known, shared by the production
-        // (broadcast-queue) and simulation (inline) branches below. TWO axes:
-        // bytes (payload × targets — the uplink-volume dimension) AND message
-        // COUNT (one per target — the per-send overhead dimension). The count
-        // axis is the load-bearing storm signal: the #4861 profile (121-byte
-        // payload × ~58 targets at storm frequency) reads as a negligible
-        // byte rate while its per-message syscall/encryption/queue overhead
-        // dominates the node's real broadcast capacity. Feeds the hosting
-        // sweep's cost-pressure trigger so a zero-demand contract doing this
-        // becomes an eviction candidate. Deadlock-safe:
+        // Cost telemetry (cost-aware eviction, #4861): attribute the message
+        // COUNT — one per fan-out target — to the contract at this dispatch
+        // point, where the resolved target count is known (shared by the
+        // production broadcast-queue and simulation inline branches below).
+        // The count axis is the load-bearing storm signal: the #4861 profile
+        // (121-byte payload × ~58 targets at storm frequency) reads as a
+        // negligible byte rate while its per-message syscall/encryption/queue
+        // overhead dominates the node's real broadcast capacity. ONE report
+        // per dispatch (not per target) keeps this axis flood-free.
+        //
+        // The fan-out BYTES are NOT charged here: this pre-dispatch point
+        // predates per-peer delta selection, so charging `payload × targets`
+        // would over-attribute a large-state contract that actually sends
+        // tiny deltas (the #4903 review P1 phantom-MB/s). The actual payload
+        // bytes are charged per-send in `broadcast_to_single_peer` once the
+        // delta/full-state choice is made. Deadlock-safe:
         // `report_contract_resource_usage` takes a brief sync lock, no
         // channels (see its rustdoc).
-        op_manager.ring.report_contract_resource_usage(
-            *key.id(),
-            crate::topology::meter::ResourceType::BroadcastFanoutCost,
-            new_state.size() as f64 * target_result.targets.len() as f64,
-        );
         op_manager.ring.report_contract_resource_usage(
             *key.id(),
             crate::topology::meter::ResourceType::BroadcastMessagesSent,
@@ -612,16 +611,12 @@ impl P2pConnManager {
 
         // Cost telemetry (cost-aware eviction, #4861): a targeted stale-peer
         // heal burns the same broadcast capacity as one fan-out leg, so
-        // attribute payload × 1 (bytes) and one message (count) to the
-        // contract on the same axes. A contract whose churning state drives
-        // constant resync heals (#4861's non-converging junk contract)
-        // accrues its real cost here even when the all-subscriber fan-out
-        // path is quiet.
-        op_manager.ring.report_contract_resource_usage(
-            *key.id(),
-            crate::topology::meter::ResourceType::BroadcastFanoutCost,
-            new_state.size() as f64,
-        );
+        // attribute one message (count) to the contract. A contract whose
+        // churning state drives constant resync heals (#4861's non-converging
+        // junk contract) accrues its real cost here even when the
+        // all-subscriber fan-out path is quiet. The heal's actual payload
+        // bytes are charged per-send in `broadcast_to_single_peer` (the
+        // #4903 review P1 fix), not full-state here.
         op_manager.ring.report_contract_resource_usage(
             *key.id(),
             crate::topology::meter::ResourceType::BroadcastMessagesSent,
@@ -1010,14 +1005,18 @@ mod broadcast_fanout_cost_pin_tests {
 
     /// Both dispatch sites — the all-subscriber fan-out
     /// (`handle_broadcast_state_change`) and the targeted stale-peer heal
-    /// (`handle_sync_state_to_peer`) — report BOTH cost axes: fan-out BYTES
-    /// (payload × targets) and message COUNT (per-send overhead — the
-    /// load-bearing #4861 storm signal, since a tiny-payload storm is
-    /// invisible to the byte axis). If a site is added or removed, update
-    /// these counts WITH a comment explaining where the cost of that path is
-    /// now attributed.
+    /// (`handle_sync_state_to_peer`) — report the message COUNT (per-send
+    /// overhead — the load-bearing #4861 storm signal, since a tiny-payload
+    /// storm is invisible to the byte axis), ONE report per dispatch. They
+    /// must NOT report fan-out BYTES here: the pre-dispatch site predates
+    /// per-peer delta selection, so charging `full-state × targets` would
+    /// phantom-inflate a large-state contract that sends tiny deltas (#4903
+    /// review P1). Actual payload bytes are charged per-send in
+    /// `broadcast_queue::broadcast_to_single_peer`. If a site is added or
+    /// removed, update these counts WITH a comment explaining where the cost
+    /// of that path is now attributed.
     #[test]
-    fn broadcast_dispatch_sites_report_fanout_cost() {
+    fn broadcast_dispatch_sites_report_message_count_not_bytes() {
         // Split needles so this test's own source lines never contain the
         // contiguous tokens and cannot self-count.
         let count_sites = |needle: &str| {
@@ -1033,10 +1032,11 @@ mod broadcast_fanout_cost_pin_tests {
         let msgs_needle = concat!("ResourceType::", "Broadcast", "MessagesSent");
         assert_eq!(
             count_sites(bytes_needle),
-            2,
-            "expected exactly 2 BroadcastFanoutCost report sites in broadcast.rs \
-             (fan-out dispatch + targeted stale-peer heal); a dropped report \
-             silently blinds cost-pressure eviction (#4861)"
+            0,
+            "broadcast.rs dispatch sites must NOT charge BroadcastFanoutCost \
+             (bytes): the pre-delta-selection full-state size over-attributes \
+             a delta-sending contract (#4903 review P1). Bytes are charged \
+             per-send in broadcast_queue::broadcast_to_single_peer."
         );
         assert_eq!(
             count_sites(msgs_needle),

--- a/crates/core/src/node/network_bridge/p2p_protoc/broadcast.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc/broadcast.rs
@@ -484,18 +484,28 @@ impl P2pConnManager {
         );
 
         // Cost telemetry (cost-aware eviction, #4861): attribute the intended
-        // fan-out cost — payload bytes × target count — to the contract on the
-        // `BroadcastFanoutCost` meter axis. This is the dispatch point where
-        // the resolved target count is known, shared by the production
-        // (broadcast-queue) and simulation (inline) branches below. Feeds the
-        // hosting sweep's cost-pressure trigger so a zero-subscriber contract
-        // that dominates broadcast capacity becomes an eviction candidate.
-        // Deadlock-safe: `report_contract_resource_usage` takes a brief sync
-        // lock, no channels (see its rustdoc).
+        // fan-out cost to the contract at the dispatch point where the
+        // resolved target count is known, shared by the production
+        // (broadcast-queue) and simulation (inline) branches below. TWO axes:
+        // bytes (payload × targets — the uplink-volume dimension) AND message
+        // COUNT (one per target — the per-send overhead dimension). The count
+        // axis is the load-bearing storm signal: the #4861 profile (121-byte
+        // payload × ~58 targets at storm frequency) reads as a negligible
+        // byte rate while its per-message syscall/encryption/queue overhead
+        // dominates the node's real broadcast capacity. Feeds the hosting
+        // sweep's cost-pressure trigger so a zero-demand contract doing this
+        // becomes an eviction candidate. Deadlock-safe:
+        // `report_contract_resource_usage` takes a brief sync lock, no
+        // channels (see its rustdoc).
         op_manager.ring.report_contract_resource_usage(
             *key.id(),
             crate::topology::meter::ResourceType::BroadcastFanoutCost,
             new_state.size() as f64 * target_result.targets.len() as f64,
+        );
+        op_manager.ring.report_contract_resource_usage(
+            *key.id(),
+            crate::topology::meter::ResourceType::BroadcastMessagesSent,
+            target_result.targets.len() as f64,
         );
 
         // In production, enqueue each target into the broadcast queue.
@@ -602,14 +612,20 @@ impl P2pConnManager {
 
         // Cost telemetry (cost-aware eviction, #4861): a targeted stale-peer
         // heal burns the same broadcast capacity as one fan-out leg, so
-        // attribute payload × 1 to the contract on the same axis. A contract
-        // whose churning state drives constant resync heals (#4861's
-        // non-converging junk contract) accrues its real cost here even when
-        // the all-subscriber fan-out path is quiet.
+        // attribute payload × 1 (bytes) and one message (count) to the
+        // contract on the same axes. A contract whose churning state drives
+        // constant resync heals (#4861's non-converging junk contract)
+        // accrues its real cost here even when the all-subscriber fan-out
+        // path is quiet.
         op_manager.ring.report_contract_resource_usage(
             *key.id(),
             crate::topology::meter::ResourceType::BroadcastFanoutCost,
             new_state.size() as f64,
+        );
+        op_manager.ring.report_contract_resource_usage(
+            *key.id(),
+            crate::topology::meter::ResourceType::BroadcastMessagesSent,
+            1.0,
         );
 
         #[cfg(not(feature = "simulation_tests"))]
@@ -994,26 +1010,41 @@ mod broadcast_fanout_cost_pin_tests {
 
     /// Both dispatch sites — the all-subscriber fan-out
     /// (`handle_broadcast_state_change`) and the targeted stale-peer heal
-    /// (`handle_sync_state_to_peer`) — report `BroadcastFanoutCost`. If a
-    /// site is added or removed, update this count WITH a comment explaining
-    /// where the cost of that path is now attributed.
+    /// (`handle_sync_state_to_peer`) — report BOTH cost axes: fan-out BYTES
+    /// (payload × targets) and message COUNT (per-send overhead — the
+    /// load-bearing #4861 storm signal, since a tiny-payload storm is
+    /// invisible to the byte axis). If a site is added or removed, update
+    /// these counts WITH a comment explaining where the cost of that path is
+    /// now attributed.
     #[test]
     fn broadcast_dispatch_sites_report_fanout_cost() {
-        // Split needle so this test's own source lines never contain the
-        // contiguous token and cannot self-count.
-        let needle = concat!("ResourceType::", "Broadcast", "FanoutCost");
-        let report_sites = BROADCAST_SRC
-            .lines()
-            .filter(|line| {
-                let trimmed = line.trim_start();
-                !trimmed.starts_with("//") && trimmed.contains(needle)
-            })
-            .count();
+        // Split needles so this test's own source lines never contain the
+        // contiguous tokens and cannot self-count.
+        let count_sites = |needle: &str| {
+            BROADCAST_SRC
+                .lines()
+                .filter(|line| {
+                    let trimmed = line.trim_start();
+                    !trimmed.starts_with("//") && trimmed.contains(needle)
+                })
+                .count()
+        };
+        let bytes_needle = concat!("ResourceType::", "Broadcast", "FanoutCost");
+        let msgs_needle = concat!("ResourceType::", "Broadcast", "MessagesSent");
         assert_eq!(
-            report_sites, 2,
+            count_sites(bytes_needle),
+            2,
             "expected exactly 2 BroadcastFanoutCost report sites in broadcast.rs \
              (fan-out dispatch + targeted stale-peer heal); a dropped report \
              silently blinds cost-pressure eviction (#4861)"
+        );
+        assert_eq!(
+            count_sites(msgs_needle),
+            2,
+            "expected exactly 2 BroadcastMessagesSent report sites in broadcast.rs \
+             (fan-out dispatch + targeted stale-peer heal); dropping the message-\
+             COUNT report re-opens the exact #4861 blind spot — a tiny-payload \
+             storm that the byte axis cannot see"
         );
     }
 }

--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -2383,9 +2383,9 @@ where
 
 /// Store a relayed PUT's contract locally: `put_contract` + `host_contract`
 /// (unconditional, so EVERY genuine PUT refreshes hosting recency —
-/// invariant 3 / #4903 review Fix 1) + (if not already hosting)
-/// `announce_contract_hosted` + interest register/unregister + broadcast
-/// interest changes.
+/// invariant 3 / #4903 review Fix 1) + (on first host, gated on the atomic
+/// `host_contract` `is_new` result) `announce_contract_hosted` + interest
+/// register/unregister + broadcast interest changes.
 ///
 /// Shared between the non-streaming relay driver (`drive_relay_put`)
 /// and the streaming relay driver (`drive_relay_put_streaming`) so both
@@ -2438,7 +2438,6 @@ async fn relay_put_store_locally(
     if crate::operations::findability_probe::scatter_disabled() {
         return Ok(value);
     }
-    let was_hosting = op_manager.ring.is_hosting_contract(&key);
     let (merged_value, _state_changed) = match super::put_contract(
         op_manager,
         key,
@@ -2492,20 +2491,30 @@ async fn relay_put_store_locally(
     // EVERY genuine PUT stamps hosting recency — including a repeat PUT to a
     // contract this peer already hosts (invariant 3: "a real GET or PUT resets
     // recency", and this applies to BOTH the client-loopback and the relay-hop
-    // PUT, which share this store chokepoint). This call used to sit inside the
-    // `!was_hosting` gate below, so a write-only publisher re-PUTting an
-    // already-hosted contract was stamped once at first host and became a
+    // PUT, which share this store chokepoint). This call is unconditional so a
+    // write-only publisher re-PUTting an already-hosted contract keeps its
+    // recency fresh instead of being stamped once at first host and becoming a
     // cost-eviction candidate `COST_RATE_MIN_WINDOW` later — an evict →
-    // re-host churn loop (#4903 review Fix 1). On the already-hosted path
-    // `record_access_with_demand` only refreshes recency/size/generation
-    // (returns `is_new = false`, evicts nothing), so the first-time-hosting
-    // side effects stay gated on `!was_hosting`.
-    let access_result =
-        op_manager
-            .ring
-            .host_contract(key, value.size() as u64, crate::ring::AccessType::Put);
+    // re-host churn loop (#4903 review Fix 1). Record the POST-merge size
+    // (`merged_value`), not the pre-merge `value`, so hosting-byte accounting
+    // reflects what is actually stored (#4903 review round-3 Fix 3).
+    let access_result = op_manager.ring.host_contract(
+        key,
+        merged_value.size() as u64,
+        crate::ring::AccessType::Put,
+    );
 
-    if !was_hosting {
+    // Gate the first-time-hosting side effects on the ATOMIC `host_contract`
+    // result (`is_new`), NOT a pre-await `is_hosting_contract` snapshot
+    // (#4903 review round-3 Fix 1): a sweep can evict this contract during the
+    // `put_contract().await` above, in which case `host_contract` re-adds it
+    // (`is_new = true`) and we MUST run announce / interest-register /
+    // evicted-teardown here. A stale pre-await "was already hosting" snapshot
+    // would skip them AND drop `access_result.evicted` (leaking the contracts
+    // this re-add shed to make room). On the already-hosted refresh path
+    // `is_new` is false and `evicted` is empty (`record_access_with_demand`
+    // refreshes recency/size/generation only, evicts nothing).
+    if access_result.is_new {
         let evicted = access_result.evicted;
 
         // Sync the InterestManager for any subscribed contract the
@@ -6123,14 +6132,13 @@ mod tests {
 
     /// Pin (#4903 review Fix 1 / invariant 3): `relay_put_store_locally` MUST
     /// call `ring.host_contract(.., AccessType::Put)` UNCONDITIONALLY — i.e.
-    /// BEFORE (outside) the `if !was_hosting` first-time-hosting gate — so a
-    /// repeat PUT to an already-hosted contract refreshes hosting recency
-    /// (`recency_seq` / `last_genuine_access`). This applies to BOTH the
-    /// client-loopback and the relay-hop PUT, which share this store
-    /// chokepoint. When the stamp was gated on `!was_hosting`, a write-only
-    /// publisher re-PUTting every few seconds was stamped once at first host
-    /// and became a cost-eviction candidate `COST_RATE_MIN_WINDOW` later —
-    /// an evict → re-host churn loop.
+    /// BEFORE (outside) the first-time-hosting gate — so a repeat PUT to an
+    /// already-hosted contract refreshes hosting recency (`recency_seq` /
+    /// `last_genuine_access`). This applies to BOTH the client-loopback and the
+    /// relay-hop PUT, which share this store chokepoint. When the stamp was
+    /// gated on the first-time gate, a write-only publisher re-PUTting every few
+    /// seconds was stamped once at first host and became a cost-eviction
+    /// candidate `COST_RATE_MIN_WINDOW` later — an evict → re-host churn loop.
     #[test]
     fn relay_put_store_locally_stamps_recency_on_repeat_put() {
         let src = include_str!("op_ctx_task.rs");
@@ -6146,13 +6154,64 @@ mod tests {
             .find(".host_contract(")
             .expect("relay_put_store_locally must call ring.host_contract");
         let gate_pos = body
-            .find("if !was_hosting")
+            .find("if access_result.is_new")
             .expect("first-time-hosting gate not found");
         assert!(
             host_pos < gate_pos,
-            "host_contract MUST run before (outside) the `if !was_hosting` gate \
+            "host_contract MUST run before (outside) the first-time-hosting gate \
              so a repeat PUT refreshes hosting recency (invariant 3: a real PUT \
              resets recency; #4903 review Fix 1)"
+        );
+    }
+
+    /// Pin (#4903 review round-3 Fix 1 + Fix 3): `relay_put_store_locally` MUST
+    /// (1) gate the first-time-hosting side effects on the ATOMIC
+    ///     `access_result.is_new`, NOT a pre-await `is_hosting_contract` /
+    ///     `was_hosting` snapshot. A sweep can evict the contract during the
+    ///     `put_contract().await`; only the atomic `host_contract` result knows
+    ///     the re-add is new, so a stale pre-await snapshot would skip
+    ///     announce / interest-register and DROP `access_result.evicted`
+    ///     (leaking the contracts the re-add shed); and
+    /// (2) charge hosting bytes as the POST-merge `merged_value.size()`, not the
+    ///     pre-merge input `value.size()`.
+    #[test]
+    fn relay_put_store_locally_first_host_gate_uses_atomic_result_and_merged_size() {
+        let src = include_str!("op_ctx_task.rs");
+        let start = src
+            .find("async fn relay_put_store_locally(")
+            .expect("relay_put_store_locally not found");
+        let end = src[start..]
+            .find("\nasync fn relay_put_replicate_forward(")
+            .expect("relay_put_store_locally body end not found")
+            + start;
+        let body = &src[start..end];
+
+        // (1) The gate is the atomic result, and NO pre-await snapshot survives.
+        assert!(
+            body.contains("if access_result.is_new"),
+            "first-time-hosting side effects MUST be gated on the atomic \
+             host_contract `is_new`, not a pre-await snapshot"
+        );
+        assert!(
+            !body.contains("was_hosting"),
+            "no pre-await `was_hosting` / `is_hosting_contract` snapshot may gate \
+             the first-time-hosting side effects — a sweep can evict during \
+             put_contract().await, and a stale snapshot would skip \
+             announce/register and drop access_result.evicted (round-3 Fix 1)"
+        );
+
+        // (2) host_contract charges the POST-merge size.
+        let host_pos = body
+            .find(".host_contract(")
+            .expect("relay_put_store_locally must call ring.host_contract");
+        let rel_end = body[host_pos..]
+            .find(");")
+            .expect("host_contract call end not found");
+        let host_args = &body[host_pos..host_pos + rel_end];
+        assert!(
+            host_args.contains("merged_value.size()"),
+            "host_contract MUST charge the POST-merge merged_value.size(), not \
+             the pre-merge value.size() (round-3 Fix 3)"
         );
     }
 

--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -2381,9 +2381,11 @@ where
     }
 }
 
-/// Store a relayed PUT's contract locally: `put_contract` + (if not
-/// already hosting) `host_contract` + `announce_contract_hosted` +
-/// interest register/unregister + broadcast interest changes.
+/// Store a relayed PUT's contract locally: `put_contract` + `host_contract`
+/// (unconditional, so EVERY genuine PUT refreshes hosting recency —
+/// invariant 3 / #4903 review Fix 1) + (if not already hosting)
+/// `announce_contract_hosted` + interest register/unregister + broadcast
+/// interest changes.
 ///
 /// Shared between the non-streaming relay driver (`drive_relay_put`)
 /// and the streaming relay driver (`drive_relay_put_streaming`) so both
@@ -2487,11 +2489,23 @@ async fn relay_put_store_locally(
         }
     };
 
+    // EVERY genuine PUT stamps hosting recency — including a repeat PUT to a
+    // contract this peer already hosts (invariant 3: "a real GET or PUT resets
+    // recency", and this applies to BOTH the client-loopback and the relay-hop
+    // PUT, which share this store chokepoint). This call used to sit inside the
+    // `!was_hosting` gate below, so a write-only publisher re-PUTting an
+    // already-hosted contract was stamped once at first host and became a
+    // cost-eviction candidate `COST_RATE_MIN_WINDOW` later — an evict →
+    // re-host churn loop (#4903 review Fix 1). On the already-hosted path
+    // `record_access_with_demand` only refreshes recency/size/generation
+    // (returns `is_new = false`, evicts nothing), so the first-time-hosting
+    // side effects stay gated on `!was_hosting`.
+    let access_result =
+        op_manager
+            .ring
+            .host_contract(key, value.size() as u64, crate::ring::AccessType::Put);
+
     if !was_hosting {
-        let access_result =
-            op_manager
-                .ring
-                .host_contract(key, value.size() as u64, crate::ring::AccessType::Put);
         let evicted = access_result.evicted;
 
         // Sync the InterestManager for any subscribed contract the
@@ -6104,6 +6118,41 @@ mod tests {
             helper_src.contains("remove_evicted_in_use"),
             "helper MUST call interest_manager.remove_evicted_in_use to sync the \
              InterestManager after a subscribed eviction"
+        );
+    }
+
+    /// Pin (#4903 review Fix 1 / invariant 3): `relay_put_store_locally` MUST
+    /// call `ring.host_contract(.., AccessType::Put)` UNCONDITIONALLY — i.e.
+    /// BEFORE (outside) the `if !was_hosting` first-time-hosting gate — so a
+    /// repeat PUT to an already-hosted contract refreshes hosting recency
+    /// (`recency_seq` / `last_genuine_access`). This applies to BOTH the
+    /// client-loopback and the relay-hop PUT, which share this store
+    /// chokepoint. When the stamp was gated on `!was_hosting`, a write-only
+    /// publisher re-PUTting every few seconds was stamped once at first host
+    /// and became a cost-eviction candidate `COST_RATE_MIN_WINDOW` later —
+    /// an evict → re-host churn loop.
+    #[test]
+    fn relay_put_store_locally_stamps_recency_on_repeat_put() {
+        let src = include_str!("op_ctx_task.rs");
+        let start = src
+            .find("async fn relay_put_store_locally(")
+            .expect("relay_put_store_locally not found");
+        let end = src[start..]
+            .find("\nasync fn relay_put_replicate_forward(")
+            .expect("relay_put_store_locally body end not found")
+            + start;
+        let body = &src[start..end];
+        let host_pos = body
+            .find(".host_contract(")
+            .expect("relay_put_store_locally must call ring.host_contract");
+        let gate_pos = body
+            .find("if !was_hosting")
+            .expect("first-time-hosting gate not found");
+        assert!(
+            host_pos < gate_pos,
+            "host_contract MUST run before (outside) the `if !was_hosting` gate \
+             so a repeat PUT refreshes hosting recency (invariant 3: a real PUT \
+             resets recency; #4903 review Fix 1)"
         );
     }
 

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -4505,6 +4505,67 @@ mod tests {
         );
     }
 
+    /// Guard (#4903 review / invariant 3): the UPDATE and broadcast paths must
+    /// NEVER stamp hosting recency. "UPDATE churn never counts as genuine
+    /// access" is what keeps a zero-demand storm contract cost-evictable
+    /// (`hosting-invariants.md` invariant 3: a storm contract whose only
+    /// activity is its own UPDATE churn stays evictable) — a future refactor
+    /// that routes an UPDATE through `host_contract` / `record_get_access` /
+    /// `touch_hosting` / `mark_local_client_access` would make storms
+    /// self-protecting and silently disarm cost-pressure eviction. This pin
+    /// scans the PRODUCTION regions of the update op modules and the
+    /// broadcast queue for any recency-stamping call, with comment text
+    /// stripped so prose references stay legal.
+    #[test]
+    fn update_and_broadcast_paths_never_stamp_hosting_recency() {
+        // Strip line comments so documentation may mention the forbidden
+        // calls without tripping the pin; only real code counts.
+        fn code_only(src: &str) -> String {
+            src.lines()
+                .map(|line| line.split("//").next().unwrap_or(""))
+                .collect::<Vec<_>>()
+                .join("\n")
+        }
+
+        let sources: [(&str, &str); 3] = [
+            (
+                "operations/update/op_ctx_task.rs",
+                include_str!("op_ctx_task.rs"),
+            ),
+            ("operations/update.rs", include_str!("../update.rs")),
+            (
+                "node/network_bridge/broadcast_queue.rs",
+                include_str!("../../node/network_bridge/broadcast_queue.rs"),
+            ),
+        ];
+        // Every entry point that stamps hosting recency (`recency_seq` /
+        // `last_genuine_access`) or the local-client renewal lease
+        // (`local_client_last_access`). Matched as method calls (leading dot)
+        // so type/fn definitions elsewhere don't count.
+        let forbidden = [
+            ".host_contract(",
+            ".record_get_access(",
+            ".touch_hosting(",
+            ".touch_with_demand(",
+            ".record_contract_access(",
+            ".record_access(",
+            ".record_access_with_demand(",
+            ".mark_local_client_access(",
+        ];
+        for (name, src) in sources {
+            let prod_end = src.find("\nmod tests {").unwrap_or(src.len());
+            let prod = code_only(&src[..prod_end]);
+            for needle in forbidden {
+                assert!(
+                    !prod.contains(needle),
+                    "{name} production code must not call `{needle}` — an UPDATE/\
+                     broadcast path stamping hosting recency would let a storm \
+                     contract protect itself from cost eviction (invariant 3)"
+                );
+            }
+        }
+    }
+
     /// #4864 round-4 (item 9): a memoized payload replayed through the REAL
     /// `drive_relay_broadcast_to` by a SECOND sender is hard-skipped — the merge
     /// never reaches the executor, that sender's Invalid channel never trips (its

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -4513,9 +4513,12 @@ mod tests {
     /// that routes an UPDATE through `host_contract` / `record_get_access` /
     /// `touch_hosting` / `mark_local_client_access` would make storms
     /// self-protecting and silently disarm cost-pressure eviction. This pin
-    /// scans the PRODUCTION regions of the update op modules and the
-    /// broadcast queue for any recency-stamping call, with comment text
-    /// stripped so prose references stay legal.
+    /// scans the PRODUCTION regions of the update op modules, the broadcast
+    /// queue, AND the executor apply chokepoint (`executor_impl.rs`, #4903
+    /// review L3 — the PUT/UPDATE state-apply path, which today reports only
+    /// `ExecCpuMicros` and must never grow a recency stamp on the UPDATE side)
+    /// for any recency-stamping call, with comment text stripped so prose
+    /// references stay legal.
     #[test]
     fn update_and_broadcast_paths_never_stamp_hosting_recency() {
         // Strip line comments so documentation may mention the forbidden
@@ -4527,7 +4530,7 @@ mod tests {
                 .join("\n")
         }
 
-        let sources: [(&str, &str); 3] = [
+        let sources: [(&str, &str); 4] = [
             (
                 "operations/update/op_ctx_task.rs",
                 include_str!("op_ctx_task.rs"),
@@ -4536,6 +4539,10 @@ mod tests {
             (
                 "node/network_bridge/broadcast_queue.rs",
                 include_str!("../../node/network_bridge/broadcast_queue.rs"),
+            ),
+            (
+                "contract/executor/runtime/executor_impl.rs",
+                include_str!("../../contract/executor/runtime/executor_impl.rs"),
             ),
         ];
         // Every entry point that stamps hosting recency (`recency_seq` /

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -4372,15 +4372,20 @@ impl Ring {
         }
         // Also feed the governance manager — the meter stores rates for
         // telemetry/the dashboard's bandwidth view, while the governance
-        // manager aggregates these samples into the cost/benefit ratio that
-        // drives state. Both ingest from this one entry point so they can't
-        // diverge (governance reading from a stale meter snapshot, etc).
+        // manager aggregates cost into the cost/benefit ratio that drives its
+        // ban state. But governance ingests ONLY the axes in
+        // `governance_ingests_axis` (currently just `StateBytesWritten`) — the
+        // three #4861 cost-eviction axes are deliberately NOT fed to it (see
+        // that fn's rustdoc for the #4296 rationale). The meter above still
+        // gets EVERY axis, so cost-eviction is unaffected.
         //
         // Per-resource weight: identity (1.0) for now. Future tuning could
-        // weight CPU-µs and fanout-cost higher than state-bytes, but until we
-        // have live data to calibrate against, unit weights match what the
-        // design doc proposed as a starting point.
+        // weight axes differently, but until we have live data to calibrate
+        // against, unit weights match what the design doc proposed.
         for (resource, amount) in samples {
+            if !governance_ingests_axis(*resource) {
+                continue;
+            }
             let weight = resource_weight(*resource);
             self.governance.ingest_cost(contract_id, *amount * weight);
         }
@@ -4466,6 +4471,47 @@ fn resource_weight(resource: crate::topology::meter::ResourceType) -> f64 {
         InboundBandwidthBytes | OutboundBandwidthBytes => 1.0,
         ExecCpuMicros | ExecFuelUnits => 1.0,
         StateBytesWritten | BroadcastFanoutCost | BroadcastMessagesSent => 1.0,
+    }
+}
+
+/// Whether a cost axis feeds the GOVERNANCE cost/benefit ban decision.
+///
+/// This is deliberately an inclusion allowlist (only `StateBytesWritten`
+/// today), NOT "every axis" or "everything except X" — and it is exhaustive so
+/// a new [`ResourceType`](crate::topology::meter::ResourceType) variant must be
+/// consciously classified here.
+///
+/// WHY governance must NOT ingest the #4861 cost-eviction axes
+/// (`ExecCpuMicros`, `BroadcastFanoutCost`, `BroadcastMessagesSent`): those are
+/// per-send / per-update signals that scale with a contract's POPULARITY (a
+/// heavily-subscribed contract fans out more, so it accrues more send CPU and
+/// fan-out cost). Governance is a benefit-thresholded BAN system that — unlike
+/// the cost-eviction sweep — has NO zero-demand candidacy protection (invariant
+/// 3), so feeding it a popularity-scaled cost reproduces the #4296 "popular
+/// contract banned for being popular" false positive BY CONSTRUCTION: the
+/// contract crosses the ban threshold before its live-beneficiary count (the
+/// denominator that would spare it) can register, and a banned contract then
+/// drops inbound Subscribe, so its benefit can never catch up. The
+/// `popular_contract_with_subscribers_not_evicted` sim test is exactly this
+/// scenario. Storms are the cost-eviction sweep's job (it HAS the zero-demand
+/// protection); governance is Off in production, so excluding these axes is a
+/// pure de-risking that restores the cost basis governance was calibrated
+/// against on `main` (`StateBytesWritten`, the sole production feed via
+/// `commit_state_write`).
+///
+/// A future governance-On effort that wants to weigh CPU/fan-out MUST first add
+/// a benefit-aware normalization (e.g. cost-PER-beneficiary), NOT re-add these
+/// raw axes here — doing so silently re-opens #4296. See #4296 / #4861.
+fn governance_ingests_axis(resource: crate::topology::meter::ResourceType) -> bool {
+    use crate::topology::meter::ResourceType::*;
+    match resource {
+        // The axis governance was calibrated against on `main`.
+        StateBytesWritten => true,
+        // #4861 cost-eviction axes: popularity-scaled → meter/sweep only.
+        ExecCpuMicros | BroadcastFanoutCost | BroadcastMessagesSent => false,
+        // Peer-attributed bandwidth / fuel: never fed governance (it keys on
+        // per-contract cost), keep them out.
+        InboundBandwidthBytes | OutboundBandwidthBytes | ExecFuelUnits => false,
     }
 }
 
@@ -8563,6 +8609,71 @@ mod cost_pressure_seam_tests {
             super::hosting::COST_RATE_MIN_WINDOW,
             COST_SUSTAINED_WINDOW,
             "sustained-window mirror drifted from cache.rs COST_RATE_MIN_WINDOW",
+        );
+    }
+
+    /// Governance cost ingestion accepts ONLY `StateBytesWritten` and REJECTS
+    /// the three #4861 cost-eviction axes (and the peer/fuel axes). Pinning
+    /// this prevents silently re-feeding governance a popularity-scaled cost
+    /// axis, which reproduces the #4296 "popular contract banned for being
+    /// popular" false positive (see `governance_ingests_axis` rustdoc and the
+    /// `popular_contract_with_subscribers_not_evicted` sim test). Exhaustive so
+    /// a new ResourceType variant must be classified with the same guard.
+    #[test]
+    fn governance_ingests_only_state_bytes_written() {
+        use crate::topology::meter::ResourceType;
+        assert!(
+            super::governance_ingests_axis(ResourceType::StateBytesWritten),
+            "governance MUST ingest StateBytesWritten (its main-calibrated basis)"
+        );
+        for axis in [
+            ResourceType::ExecCpuMicros,
+            ResourceType::BroadcastFanoutCost,
+            ResourceType::BroadcastMessagesSent,
+        ] {
+            assert!(
+                !super::governance_ingests_axis(axis),
+                "governance MUST NOT ingest the #4861 cost-eviction axis {axis:?} \
+                 (popularity-scaled → resurrects #4296); it feeds the meter/sweep only"
+            );
+        }
+        for axis in [
+            ResourceType::InboundBandwidthBytes,
+            ResourceType::OutboundBandwidthBytes,
+            ResourceType::ExecFuelUnits,
+        ] {
+            assert!(
+                !super::governance_ingests_axis(axis),
+                "peer/fuel axis {axis:?} is not per-contract cost; governance must not ingest it"
+            );
+        }
+    }
+
+    /// Source-scrape pin: the governance feed in `report_contract_resource_usage_batch`
+    /// MUST stay gated by `governance_ingests_axis`, so a future edit can't drop
+    /// the gate and re-flood governance with the #4861 cost-eviction axes.
+    #[test]
+    fn governance_feed_is_gated_by_axis_allowlist() {
+        let src = include_str!("ring.rs");
+        let start = src
+            .find("fn report_contract_resource_usage_batch(")
+            .expect("report_contract_resource_usage_batch not found");
+        let body_end = src[start..]
+            .find("\n    // Note: there is intentionally no `ingest_contract_demand`")
+            .expect("end of report_contract_resource_usage_batch not found")
+            + start;
+        let body = &src[start..body_end];
+        let ingest = body
+            .find(".governance.ingest_cost(")
+            .expect("governance.ingest_cost call missing from the batch feed");
+        let gate = body
+            .find("if !governance_ingests_axis(")
+            .expect("governance feed MUST be gated by governance_ingests_axis (#4296 guard)");
+        assert!(
+            gate < ingest,
+            "the governance_ingests_axis gate MUST precede (guard) the \
+             ingest_cost call, else the #4861 axes re-flood governance and \
+             resurrect #4296"
         );
     }
 }

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -4447,7 +4447,7 @@ fn resource_weight(resource: crate::topology::meter::ResourceType) -> f64 {
     match resource {
         InboundBandwidthBytes | OutboundBandwidthBytes => 1.0,
         ExecCpuMicros | ExecFuelUnits => 1.0,
-        StateBytesWritten | BroadcastFanoutCost => 1.0,
+        StateBytesWritten | BroadcastFanoutCost | BroadcastMessagesSent => 1.0,
     }
 }
 
@@ -4648,11 +4648,16 @@ impl Ring {
 
     /// Build the per-axis attributed-cost snapshots for the hosting sweep's
     /// cost-pressure trigger (cost-aware eviction, #4861): per-contract
-    /// `ExecCpuMicros` and `BroadcastFanoutCost` rates plus their node totals,
-    /// read from the topology meter amortized over at least
-    /// [`hosting::COST_RATE_MIN_WINDOW`] (so a lone burst can't masquerade as
-    /// a sustained storm). The absolute floors and the scale-free share
-    /// threshold live beside the decision in `ring/hosting/cache.rs`.
+    /// `ExecCpuMicros`, `BroadcastFanoutCost` (bytes), and
+    /// `BroadcastMessagesSent` (per-send count — the load-bearing storm
+    /// signal) rates plus their node totals, read from the topology meter.
+    /// Sparse samples are amortized over at least
+    /// [`hosting::COST_RATE_MIN_WINDOW`] (a lone burst can't masquerade as a
+    /// sustained storm), a saturated sample buffer reads its true rate, and
+    /// candidacy is pre-filtered to sustained sources — see
+    /// `Meter::contract_cost_rates`. The floors, share threshold, and axis
+    /// assembly live beside the decision in `ring/hosting/cache.rs`
+    /// (`build_cost_axes`, shared with the storm-frequency integration test).
     ///
     /// Lock discipline: takes the topology read lock briefly and drops it
     /// before the caller takes the hosting-cache write lock — the two are
@@ -4661,31 +4666,23 @@ impl Ring {
         use crate::topology::meter::ResourceType;
         let now = self.time_source.now();
         let topo = self.connection_manager.topology_manager.read();
-        let (cpu_total, cpu_rates) = topo.contract_cost_rates(
+        let cpu = topo.contract_cost_rates(
             &ResourceType::ExecCpuMicros,
             now,
             hosting::COST_RATE_MIN_WINDOW,
         );
-        let (fanout_total, fanout_rates) = topo.contract_cost_rates(
+        let fanout_bytes = topo.contract_cost_rates(
             &ResourceType::BroadcastFanoutCost,
             now,
             hosting::COST_RATE_MIN_WINDOW,
         );
+        let messages = topo.contract_cost_rates(
+            &ResourceType::BroadcastMessagesSent,
+            now,
+            hosting::COST_RATE_MIN_WINDOW,
+        );
         drop(topo);
-        vec![
-            hosting::CostAxisPressure {
-                axis: "exec_cpu_micros_per_sec",
-                total_rate: cpu_total,
-                floor: hosting::EXEC_CPU_PRESSURE_FLOOR_MICROS_PER_SEC,
-                rates: cpu_rates,
-            },
-            hosting::CostAxisPressure {
-                axis: "broadcast_fanout_bytes_per_sec",
-                total_rate: fanout_total,
-                floor: hosting::BROADCAST_FANOUT_PRESSURE_FLOOR_BYTES_PER_SEC,
-                rates: fanout_rates,
-            },
-        ]
+        hosting::build_cost_axes(cpu, fanout_bytes, messages)
     }
 
     // ==================== Legacy GET Auto-Subscription (delegating to hosting cache) ====================

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -8371,6 +8371,135 @@ mod sleep_or_shutdown_tests {
     }
 }
 
+/// End-to-end seam test for cost-aware eviction (#4861 / #4903 review):
+/// drives the message axis through the REAL production reporter
+/// (`Ring::report_contract_resource_usage` → topology meter) and the REAL
+/// `Ring::sweep_expired_hosting()` (→ `hosting_cost_pressure_axes` →
+/// `HostingManager::sweep_expired_hosting_with_cost`) — the exact
+/// reporter → meter → axes → sweep chain the manager-level storm test
+/// (`storm_frequency_profile_crosses_cost_trigger_through_real_meter`)
+/// bypasses by assembling its axes by hand from a standalone `Meter`.
+#[cfg(test)]
+mod cost_pressure_seam_tests {
+    use std::time::Duration;
+
+    fn seam_key(seed: u8) -> freenet_stdlib::prelude::ContractKey {
+        freenet_stdlib::prelude::ContractKey::from_id_and_code(
+            freenet_stdlib::prelude::ContractInstanceId::new([seed; 32]),
+            freenet_stdlib::prelude::CodeHash::new([seed.wrapping_add(1); 32]),
+        )
+    }
+
+    /// Runs under `start_paused` so `tokio::time::Instant` — the clock behind
+    /// BOTH the Ring's production `InstantTimeSrc` (meter timestamps, sweep
+    /// reads, hosting recency) and every background interval — is virtual and
+    /// advanced deterministically with `tokio::time::advance`. The Ring's
+    /// periodic background tasks (including the 60s hosting sweep, which runs
+    /// this same seam) fire during the advances; the assertions are therefore
+    /// on the FINAL hosting state, which is identical whether a background
+    /// sweep or the explicit call below sheds the storm contract.
+    #[tokio::test(start_paused = true)]
+    async fn zero_demand_storm_is_shed_through_real_reporter_and_sweep() {
+        use crate::topology::meter::ResourceType;
+
+        // --- a real OpManager (and thus a real Ring with its production
+        // InstantTimeSrc), mirroring the fixture in node.rs
+        // (`resync_request_for_bogus_keys_does_not_consume_limiter_slots`). ---
+        let config_args = crate::config::ConfigArgs {
+            id: Some("cost-seam-4903".to_string()),
+            mode: Some(crate::contract::OperationMode::Local),
+            ..Default::default()
+        };
+        let node_config =
+            crate::node::NodeConfig::new(config_args.build().await.expect("build Config"))
+                .await
+                .expect("build NodeConfig");
+        let (_notification_rx, notification_tx) = crate::node::event_loop_notification_channel();
+        let (ops_ch_channel, _ch_channel, _wait_for_event) =
+            crate::contract::contract_handler_channel();
+        let connection_manager = crate::ring::ConnectionManager::new(&node_config);
+        let (result_router_tx, _result_router_rx) = tokio::sync::mpsc::channel(100);
+        let task_monitor = crate::node::background_task_monitor::BackgroundTaskMonitor::new();
+        let op_manager = std::sync::Arc::new(
+            crate::node::OpManager::new(
+                notification_tx,
+                ops_ch_channel,
+                &node_config,
+                crate::tracing::DynamicRegister::new(vec![]),
+                connection_manager,
+                result_router_tx,
+                &task_monitor,
+            )
+            .expect("build OpManager"),
+        );
+        op_manager.ring.attach_op_manager(&op_manager);
+        op_manager
+            .ring
+            .connection_manager
+            .set_own_addr("127.0.0.1:14100".parse().unwrap());
+        let ring = &op_manager.ring;
+
+        let junk = seam_key(1);
+        let subscribed = seam_key(2);
+        let read_hot = seam_key(3);
+
+        // Host all three through the production entry point (PUT seeds).
+        let _ = ring.host_contract(junk, 121, crate::ring::AccessType::Put);
+        let _ = ring.host_contract(subscribed, 121, crate::ring::AccessType::Put);
+        let _ = ring.host_contract(read_hot, 121, crate::ring::AccessType::Put);
+        assert!(ring.is_hosting_contract(&junk), "precondition: hosted");
+
+        // Age the PUT-seed recency stamps past the cost window, so only the
+        // demand signals added BELOW protect anything.
+        tokio::time::advance(super::hosting::COST_RATE_MIN_WINDOW + Duration::from_secs(1)).await;
+
+        // Demand: `subscribed` gains a downstream subscriber (lease outlives
+        // this test's remaining ~3 virtual minutes); `read_hot` is genuinely
+        // GET-read now (within the cost window of the final sweep).
+        assert!(ring.add_downstream_subscriber(
+            &subscribed,
+            crate::ring::interest::PeerKey(crate::transport::TransportPublicKey::from_bytes(
+                [9u8; 32]
+            )),
+        ));
+        let _ = ring.record_get_access(read_hot, 121);
+
+        // The FX2j storm profile, reported for ALL THREE contracts through
+        // the production reporter: one 58-target fan-out dispatch every 1.6s
+        // for ~3 minutes (~36 per-peer sends/s sustained). Equal rates prove
+        // protection comes from demand, not from a smaller cost share.
+        for _ in 0..110u32 {
+            for key in [&junk, &subscribed, &read_hot] {
+                ring.report_contract_resource_usage(
+                    *key.id(),
+                    ResourceType::BroadcastMessagesSent,
+                    58.0,
+                );
+            }
+            tokio::time::advance(Duration::from_millis(1600)).await;
+        }
+
+        // The REAL sweep (the same call the 60s background sweep task makes).
+        let _ = ring.sweep_expired_hosting();
+
+        assert!(
+            !ring.is_hosting_contract(&junk),
+            "the zero-demand storm contract must be shed through the real \
+             reporter → meter → hosting_cost_pressure_axes → sweep seam"
+        );
+        assert!(
+            ring.is_hosting_contract(&subscribed),
+            "a subscribed contract storming at the SAME rate must survive \
+             (candidacy, not ranking, protects it)"
+        );
+        assert!(
+            ring.is_hosting_contract(&read_hot),
+            "a recently-GET-read contract storming at the SAME rate must \
+             survive (reads are demand — invariant 3)"
+        );
+    }
+}
+
 #[derive(thiserror::Error, Debug)]
 pub(crate) enum RingError {
     #[error(transparent)]

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -4335,37 +4335,55 @@ impl Ring {
         resource: crate::topology::meter::ResourceType,
         amount: f64,
     ) {
-        // Use the injectable `TimeSource` (rather than `Instant::now()`
-        // directly) so deterministic simulation tests can drive this
-        // path. Per `.claude/rules/code-style.md` "Need current time?
-        // → USE: TimeSource trait" — the executor commit path will reach
-        // here from inside simulated nodes once the governance scoring
-        // integration tests land, and reading wall-clock there would
-        // break determinism.
-        let now = self.time_source.now();
-        let mut topo = self.connection_manager.topology_manager.write();
-        topo.report_resource_usage(
-            &crate::topology::meter::AttributionSource::Contract(contract_id),
-            resource,
-            amount,
-            now,
-        );
-        drop(topo);
-        // Also feed the governance manager — the meter stores rates
-        // for telemetry/the dashboard's bandwidth view, while the
-        // governance manager aggregates these samples into the
-        // cost/benefit ratio that drives state. Both ingest in
-        // parallel from this one entry point so there's no risk of
-        // them diverging (governance reading from a stale meter
-        // snapshot, etc).
+        self.report_contract_resource_usage_batch(contract_id, &[(resource, amount)]);
+    }
+
+    /// Report several cost axes for ONE contract under a SINGLE topology
+    /// write-lock acquisition.
+    ///
+    /// The broadcast send path (#4903 review MEDIUM) reports the send-time
+    /// WASM CPU AND the actual fan-out payload bytes for each per-peer send;
+    /// batching them into one lock (instead of two separate
+    /// `report_contract_resource_usage` calls) halves the per-send topology
+    /// write-lock traffic on a busy gateway's fan-out.
+    ///
+    /// Uses the injectable `TimeSource` (rather than `Instant::now()`
+    /// directly) so deterministic simulation tests can drive this path
+    /// (`.claude/rules/code-style.md`: "Need current time? → USE: TimeSource").
+    /// `now` is read INSIDE the write lock (#4903 review L2) so concurrent
+    /// reporters insert in lock-acquisition order and cannot trip the
+    /// `RunningAverage::insert_with_time` monotonicity `debug_assert!`.
+    pub(crate) fn report_contract_resource_usage_batch(
+        &self,
+        contract_id: freenet_stdlib::prelude::ContractInstanceId,
+        samples: &[(crate::topology::meter::ResourceType, f64)],
+    ) {
+        if samples.is_empty() {
+            return;
+        }
+        let source = crate::topology::meter::AttributionSource::Contract(contract_id);
+        {
+            let mut topo = self.connection_manager.topology_manager.write();
+            // Read `now` under the lock (see rustdoc — L2 monotonicity).
+            let now = self.time_source.now();
+            for (resource, amount) in samples {
+                topo.report_resource_usage(&source, *resource, *amount, now);
+            }
+        }
+        // Also feed the governance manager — the meter stores rates for
+        // telemetry/the dashboard's bandwidth view, while the governance
+        // manager aggregates these samples into the cost/benefit ratio that
+        // drives state. Both ingest from this one entry point so they can't
+        // diverge (governance reading from a stale meter snapshot, etc).
         //
-        // Per-resource weight: identity (1.0) for now. Future tuning
-        // could weight CPU-µs and fanout-cost higher than
-        // state-bytes, but until we have live data to calibrate
-        // against, unit weights match what the design doc proposed
-        // as a starting point.
-        let weight = resource_weight(resource);
-        self.governance.ingest_cost(contract_id, amount * weight);
+        // Per-resource weight: identity (1.0) for now. Future tuning could
+        // weight CPU-µs and fanout-cost higher than state-bytes, but until we
+        // have live data to calibrate against, unit weights match what the
+        // design doc proposed as a starting point.
+        for (resource, amount) in samples {
+            let weight = resource_weight(*resource);
+            self.governance.ingest_cost(contract_id, *amount * weight);
+        }
     }
 
     // Note: there is intentionally no `ingest_contract_demand` method
@@ -4665,23 +4683,20 @@ impl Ring {
     fn hosting_cost_pressure_axes(&self) -> Vec<hosting::CostAxisPressure> {
         use crate::topology::meter::ResourceType;
         let now = self.time_source.now();
+        // Read all three cost axes in ONE pass over the attribution meters
+        // (#4903 review perf) rather than three separate scans under the read
+        // lock. Order here must match the `build_cost_axes` argument order.
+        let axes = [
+            ResourceType::ExecCpuMicros,
+            ResourceType::BroadcastFanoutCost,
+            ResourceType::BroadcastMessagesSent,
+        ];
         let topo = self.connection_manager.topology_manager.read();
-        let cpu = topo.contract_cost_rates(
-            &ResourceType::ExecCpuMicros,
-            now,
-            hosting::COST_RATE_MIN_WINDOW,
-        );
-        let fanout_bytes = topo.contract_cost_rates(
-            &ResourceType::BroadcastFanoutCost,
-            now,
-            hosting::COST_RATE_MIN_WINDOW,
-        );
-        let messages = topo.contract_cost_rates(
-            &ResourceType::BroadcastMessagesSent,
-            now,
-            hosting::COST_RATE_MIN_WINDOW,
-        );
+        let mut rates = topo.contract_cost_rates_multi(&axes, now, hosting::COST_RATE_MIN_WINDOW);
         drop(topo);
+        let messages = rates.pop().expect("three axis results");
+        let fanout_bytes = rates.pop().expect("three axis results");
+        let cpu = rates.pop().expect("three axis results");
         hosting::build_cost_axes(cpu, fanout_bytes, messages)
     }
 

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -1739,6 +1739,11 @@ impl Ring {
             // as the rework ships (AtCapacity now sheds subscribed as a last
             // resort). Same periodic cadence.
             snapshot.hosting_subscribed_evictions_total = Some(hosting.subscribed_evictions_total);
+            // Cost-pressure eviction falsifier (cost-aware eviction, #4861):
+            // zero-demand contracts shed because their attributed update-work
+            // (CPU / broadcast fan-out) dominated the node's total. Nonzero =
+            // the trigger is firing; runaway = floors/share miscalibrated.
+            snapshot.hosting_cost_evictions_total = Some(hosting.cost_evictions_total);
             // Phantom-hosting falsifier (SUBSCRIBE-retirement step 10 §1d):
             // current count of contracts in-use via a downstream subscriber with
             // NO state on disk (contract_in_use && !contract_state_present). After
@@ -4632,7 +4637,55 @@ impl Ring {
     /// subscribers is eligible). The generation snapshot is carried through
     /// `EvictContract` so the deletion-time guard can detect a re-host race.
     pub fn sweep_expired_hosting(&self) -> crate::ring::hosting::HostingSweepResult {
-        self.hosting_manager.sweep_expired_hosting()
+        // Cost-aware eviction (#4861): feed the sweep the node's attributed
+        // update-work cost so a zero-subscriber contract dominating CPU /
+        // broadcast capacity is shed even while UNDER the byte budget (the
+        // byte-gated sweep alone never fires for a tiny-state storm contract).
+        let cost_axes = self.hosting_cost_pressure_axes();
+        self.hosting_manager
+            .sweep_expired_hosting_with_cost(&cost_axes)
+    }
+
+    /// Build the per-axis attributed-cost snapshots for the hosting sweep's
+    /// cost-pressure trigger (cost-aware eviction, #4861): per-contract
+    /// `ExecCpuMicros` and `BroadcastFanoutCost` rates plus their node totals,
+    /// read from the topology meter amortized over at least
+    /// [`hosting::COST_RATE_MIN_WINDOW`] (so a lone burst can't masquerade as
+    /// a sustained storm). The absolute floors and the scale-free share
+    /// threshold live beside the decision in `ring/hosting/cache.rs`.
+    ///
+    /// Lock discipline: takes the topology read lock briefly and drops it
+    /// before the caller takes the hosting-cache write lock — the two are
+    /// never held together.
+    fn hosting_cost_pressure_axes(&self) -> Vec<hosting::CostAxisPressure> {
+        use crate::topology::meter::ResourceType;
+        let now = self.time_source.now();
+        let topo = self.connection_manager.topology_manager.read();
+        let (cpu_total, cpu_rates) = topo.contract_cost_rates(
+            &ResourceType::ExecCpuMicros,
+            now,
+            hosting::COST_RATE_MIN_WINDOW,
+        );
+        let (fanout_total, fanout_rates) = topo.contract_cost_rates(
+            &ResourceType::BroadcastFanoutCost,
+            now,
+            hosting::COST_RATE_MIN_WINDOW,
+        );
+        drop(topo);
+        vec![
+            hosting::CostAxisPressure {
+                axis: "exec_cpu_micros_per_sec",
+                total_rate: cpu_total,
+                floor: hosting::EXEC_CPU_PRESSURE_FLOOR_MICROS_PER_SEC,
+                rates: cpu_rates,
+            },
+            hosting::CostAxisPressure {
+                axis: "broadcast_fanout_bytes_per_sec",
+                total_rate: fanout_total,
+                floor: hosting::BROADCAST_FANOUT_PRESSURE_FLOOR_BYTES_PER_SEC,
+                rates: fanout_rates,
+            },
+        ]
     }
 
     // ==================== Legacy GET Auto-Subscription (delegating to hosting cache) ====================

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -8513,6 +8513,58 @@ mod cost_pressure_seam_tests {
              survive (reads are demand — invariant 3)"
         );
     }
+
+    /// Drift guard (#4861 Codex round-3): the meter's per-axis cost floors
+    /// ([`crate::topology::meter::ResourceType::cost_pressure_floor`]) and its
+    /// sustained window ([`crate::topology::meter::COST_SUSTAINED_WINDOW`]) are
+    /// MIRRORS — the authoritative constants live in `ring::hosting::cache`,
+    /// which is not nameable from `topology::meter` (that module is private to
+    /// `hosting`, itself private to `ring`), so the meter cannot import them.
+    /// This test reads the authoritative values through the `ring`-visible
+    /// surface — `build_cost_axes` (which binds each axis to its cache.rs floor
+    /// constant) and the re-exported `COST_RATE_MIN_WINDOW` — and asserts the
+    /// meter's mirrors match, so the insert-time above-floor detection can
+    /// never key on a floor/window that differs from the eviction decision's.
+    #[test]
+    fn meter_cost_floors_mirror_cache_source_of_truth() {
+        use crate::topology::meter::{COST_SUSTAINED_WINDOW, ResourceType};
+
+        fn empty_read() -> (
+            f64,
+            std::collections::HashMap<freenet_stdlib::prelude::ContractInstanceId, f64>,
+        ) {
+            (0.0, std::collections::HashMap::new())
+        }
+
+        // build_cost_axes argument/return order: cpu, fanout_bytes, messages.
+        let axes = super::hosting::build_cost_axes(empty_read(), empty_read(), empty_read());
+        assert_eq!(
+            axes[0].floor,
+            ResourceType::ExecCpuMicros
+                .cost_pressure_floor()
+                .expect("ExecCpuMicros is a cost axis"),
+            "CPU floor mirror drifted from cache.rs source of truth",
+        );
+        assert_eq!(
+            axes[1].floor,
+            ResourceType::BroadcastFanoutCost
+                .cost_pressure_floor()
+                .expect("BroadcastFanoutCost is a cost axis"),
+            "fan-out byte floor mirror drifted from cache.rs source of truth",
+        );
+        assert_eq!(
+            axes[2].floor,
+            ResourceType::BroadcastMessagesSent
+                .cost_pressure_floor()
+                .expect("BroadcastMessagesSent is a cost axis"),
+            "message floor mirror drifted from cache.rs source of truth",
+        );
+        assert_eq!(
+            super::hosting::COST_RATE_MIN_WINDOW,
+            COST_SUSTAINED_WINDOW,
+            "sustained-window mirror drifted from cache.rs COST_RATE_MIN_WINDOW",
+        );
+    }
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/crates/core/src/ring/broken_invariants.rs
+++ b/crates/core/src/ring/broken_invariants.rs
@@ -51,9 +51,27 @@
 //!   probe's own soundness hardening (it no longer flags benign byte-flutter
 //!   — see `Executor::maybe_probe_idempotency`), false positives should be
 //!   rare *and* recoverable rather than permanent.
+//! ## Escalating TTL on re-detection (#4903 review B-tweak)
+//!
+//! A fixed TTL turns a genuinely non-idempotent contract into a limit-cycle
+//! OSCILLATOR once #4902's egress gates suppress it: the flagged node goes
+//! dark for one TTL, the flag expires, the node re-enters the still-divergent
+//! mesh, a cascade burst (sized by the drift accumulated while it was dark)
+//! re-flags it, and the cycle repeats — raising per-peer emissions well above
+//! steady participation. To damp this, the TTL ESCALATES on re-detection:
+//! first detection stays at [`BROKEN_INVARIANT_TTL`], and each re-detection
+//! within the re-flag window doubles it (capped at
+//! [`BROKEN_INVARIANT_TTL_CAP`]). A genuinely-broken contract therefore
+//! converges to mostly-dark — its re-entry duty cycle collapses geometrically,
+//! drift shrinks as fewer peers advance it, and the oscillation dies out. A
+//! contract that stops being re-detected for a full quiet window resets to
+//! baseline, and a contract flagged exactly once (the #4295 false positive)
+//! never escalates at all. See [`BrokenInvariantsTracker::record`].
+//!
 //! - **True violation:** suppressed for a TTL, then re-detected and re-flagged
-//!   (which refreshes the window, so a continuously-merging violator stays
-//!   suppressed). Re-detection is probabilistic: after expiry the probe samples
+//!   with an ESCALATED (doubled) TTL, so a continuously-oscillating violator's
+//!   dark window grows each cycle until it is effectively silent. Re-detection
+//!   is probabilistic: after expiry the probe samples
 //!   at [`crate::contract::executor`]'s `IDEMPOTENCY_PROBE_PROBABILITY` (1/32),
 //!   so the contract leaks the merges that occur between expiry and the next
 //!   sampled probe — in expectation ~32 merges, with a longer tail under a high
@@ -81,14 +99,40 @@ use tokio::time::Instant;
 use crate::contract::storages::Storage;
 use crate::util::time_source::TimeSource;
 
-/// How long a broken-invariant flag suppresses a contract before it expires
-/// and the contract is given a fresh chance (re-detected by the next sampled
-/// probe if genuinely still broken).
+/// Baseline (FIRST-detection) suppression TTL: how long a freshly-flagged
+/// contract is suppressed before its flag expires and it is given a fresh
+/// chance (re-detected by the next sampled probe if genuinely still broken).
 ///
 /// Chosen to be long enough that a genuinely non-convergent contract leaks at
 /// most ≈one merge per window (negligible amplification) yet short enough that
-/// a false positive recovers promptly rather than bricking the contract.
+/// a false positive recovers promptly rather than bricking the contract. A
+/// contract flagged exactly ONCE (the #4295 false-positive shape) is
+/// suppressed for exactly this long and then recovers — escalation (below)
+/// never touches it, so this preserves the pre-escalation false-positive
+/// conservatism unchanged.
 pub(crate) const BROKEN_INVARIANT_TTL: Duration = Duration::from_secs(300);
+
+/// Ceiling for the escalated suppression TTL (#4903 review B-tweak, stops the
+/// #4902 egress oscillation). A contract that keeps being RE-detected after
+/// each expiry doubles its TTL toward this cap; past it the TTL stops growing.
+/// Six hours: long enough that a genuinely-broken contract's re-entry
+/// oscillation collapses to a negligible duty cycle, bounded so even a
+/// (vanishingly unlikely) escalated false positive still self-heals within a
+/// working day.
+pub(crate) const BROKEN_INVARIANT_TTL_CAP: Duration = Duration::from_secs(6 * 60 * 60);
+
+/// Re-flag window multiplier (#4903 review B-tweak). Measured from the last
+/// detection, the window `[ttl, REFLAG_WINDOW_MULT × ttl)` is the "still
+/// oscillating" band: a re-detection inside it ESCALATES (doubles) the TTL,
+/// because the contract went dark for its TTL and then re-entered the mesh and
+/// was caught again. A re-detection at or beyond `REFLAG_WINDOW_MULT × ttl`
+/// means the contract stayed quiet for an escalated TTL PLUS a full window, so
+/// escalation RESETS to baseline (it is no longer oscillating — genuinely
+/// fixed, or the flag was a one-off false positive). This multiplier is also
+/// the age at which [`BrokenInvariantsTracker::cleanup`] reclaims an idle
+/// entry, so the escalation memory outlives the suppression window (allowing a
+/// prompt re-detection to escalate rather than restart) but stays bounded.
+const REFLAG_WINDOW_MULT: u32 = 2;
 
 /// Per-contract cooldown for the deterministic identical-input idempotency
 /// probe (`Executor::probe_identical_input_idempotency`). The #4151
@@ -126,12 +170,20 @@ impl BrokenInvariant {
     }
 }
 
-/// An in-memory flag together with the instant it was (re-)recorded, so the
-/// flag can expire after [`BROKEN_INVARIANT_TTL`].
+/// An in-memory flag together with the instant it was (re-)recorded and the
+/// CURRENT (possibly escalated) suppression TTL for this detection, so the
+/// flag can expire after its own `ttl` and the escalation policy can grow that
+/// TTL on repeated re-detection (#4903 review B-tweak).
 #[derive(Debug, Clone, Copy)]
 struct FlagEntry {
     kind: BrokenInvariant,
     recorded_at: Instant,
+    /// Suppression TTL for THIS detection cycle. Starts at
+    /// [`BROKEN_INVARIANT_TTL`] on first detection and doubles (capped at
+    /// [`BROKEN_INVARIANT_TTL_CAP`]) on each re-detection within the re-flag
+    /// window; resets to baseline after a full quiet window. In-memory only —
+    /// a restart re-hydrates flags at the baseline TTL.
+    ttl: Duration,
 }
 
 /// Tracks per-contract broken-invariant flags with optional persistent backing.
@@ -199,7 +251,7 @@ impl BrokenInvariantsTracker {
     pub fn is_broken(&self, id: &ContractInstanceId) -> bool {
         let now = self.time_source.now();
         match self.flags.get(id) {
-            Some(entry) => now.saturating_duration_since(entry.recorded_at) < BROKEN_INVARIANT_TTL,
+            Some(entry) => now.saturating_duration_since(entry.recorded_at) < entry.ttl,
             None => false,
         }
     }
@@ -211,7 +263,7 @@ impl BrokenInvariantsTracker {
     pub fn get(&self, id: &ContractInstanceId) -> Option<BrokenInvariant> {
         let now = self.time_source.now();
         self.flags.get(id).and_then(|entry| {
-            if now.saturating_duration_since(entry.recorded_at) < BROKEN_INVARIANT_TTL {
+            if now.saturating_duration_since(entry.recorded_at) < entry.ttl {
                 Some(entry.kind)
             } else {
                 None
@@ -219,40 +271,115 @@ impl BrokenInvariantsTracker {
         })
     }
 
-    /// Mark `id` as broken with `kind`, stamping the current time. Re-recording
-    /// an already-flagged contract refreshes its expiry (so a contract the
-    /// probe keeps re-detecting stays suppressed). Persists best-effort to
-    /// storage if wired; persistence errors are logged but never block the
-    /// in-memory flag from taking effect (we'd rather suppress the storm than
-    /// crash on a database hiccup).
+    /// The current (possibly escalated) suppression TTL for `id`, if flagged.
+    /// Test-only accessor for the escalation-policy tests.
+    #[cfg(test)]
+    pub fn current_ttl(&self, id: &ContractInstanceId) -> Option<Duration> {
+        self.flags.get(id).map(|entry| entry.ttl)
+    }
+
+    /// Mark `id` as broken with `kind`, stamping the current time and applying
+    /// the escalating-TTL policy (#4903 review B-tweak).
+    ///
+    /// - **First detection** (no live entry): baseline [`BROKEN_INVARIANT_TTL`].
+    /// - **Re-detection within the re-flag window** (`[ttl, REFLAG_WINDOW_MULT ×
+    ///   ttl)` since the last detection): ESCALATE — double the TTL, capped at
+    ///   [`BROKEN_INVARIANT_TTL_CAP`]. This is a contract that went dark for its
+    ///   TTL, re-entered the mesh, and was caught again — the #4902 oscillator.
+    ///   Escalating collapses its re-entry duty cycle geometrically.
+    /// - **Re-detection while still suppressed** (`< ttl`): refresh the stamp
+    ///   at the SAME TTL (same detection cycle; not a new oscillation).
+    /// - **Re-detection after a full quiet window** (`≥ REFLAG_WINDOW_MULT ×
+    ///   ttl`): RESET to baseline — no longer oscillating.
+    ///
+    /// A contract flagged exactly ONCE (the #4295 false-positive shape) never
+    /// re-detects, so it never escalates: its behavior is identical to the
+    /// pre-escalation baseline.
+    ///
+    /// Persists best-effort to storage on first detection if wired; persistence
+    /// errors are logged but never block the in-memory flag (we'd rather
+    /// suppress the storm than crash on a database hiccup). The escalation level
+    /// is in-memory only — the persisted row records just the flag kind, so a
+    /// restart re-hydrates at the baseline TTL.
     pub fn record(&self, id: ContractInstanceId, kind: BrokenInvariant) {
-        let recorded_at = self.time_source.now();
-        let was_new = self
-            .flags
-            .insert(id, FlagEntry { kind, recorded_at })
-            .is_none();
-        if was_new {
-            tracing::warn!(
-                contract = %id,
-                invariant = ?kind,
-                event = "broken_invariant_detected",
-                "Marking contract as broken — gating outbound broadcast and merge propagation"
-            );
-            // Persistence is currently only wired for the redb backend;
-            // sqlite-only builds keep the in-memory flag but skip the
-            // on-disk hydration. This is the same trade-off
-            // `HostingManager` makes — see #4279 deferred follow-up to
-            // add sqlite parity.
-            #[cfg(feature = "redb")]
-            if let Some(storage) = self.storage.read().as_ref() {
-                if let Err(e) = storage.store_broken_invariant(&id, kind.to_byte()) {
-                    tracing::warn!(
-                        contract = %id,
-                        error = %e,
-                        "Failed to persist broken-invariant flag (in-memory flag still active)"
-                    );
+        use dashmap::mapref::entry::Entry;
+        let now = self.time_source.now();
+
+        // Decide the new TTL under the shard guard, then release it before any
+        // logging / persistence (never hold a DashMap guard across the storage
+        // lock).
+        enum Outcome {
+            New,
+            Escalated(Duration),
+            Refreshed,
+        }
+        let outcome = match self.flags.entry(id) {
+            Entry::Occupied(mut o) => {
+                let elapsed = now.saturating_duration_since(o.get().recorded_at);
+                let ttl = o.get().ttl;
+                let reflag_window = ttl * REFLAG_WINDOW_MULT;
+                let (new_ttl, outcome) = if elapsed >= reflag_window {
+                    // Quiet for an escalated TTL plus a full window → reset.
+                    (BROKEN_INVARIANT_TTL, Outcome::Refreshed)
+                } else if elapsed >= ttl {
+                    // Re-detected after expiry, within the re-flag window →
+                    // escalate (double, capped).
+                    let escalated = (ttl * 2).min(BROKEN_INVARIANT_TTL_CAP);
+                    (escalated, Outcome::Escalated(escalated))
+                } else {
+                    // Still within the active suppression window → same cycle.
+                    (ttl, Outcome::Refreshed)
+                };
+                *o.get_mut() = FlagEntry {
+                    kind,
+                    recorded_at: now,
+                    ttl: new_ttl,
+                };
+                outcome
+            }
+            Entry::Vacant(v) => {
+                v.insert(FlagEntry {
+                    kind,
+                    recorded_at: now,
+                    ttl: BROKEN_INVARIANT_TTL,
+                });
+                Outcome::New
+            }
+        };
+
+        match outcome {
+            Outcome::New => {
+                tracing::warn!(
+                    contract = %id,
+                    invariant = ?kind,
+                    event = "broken_invariant_detected",
+                    "Marking contract as broken — gating outbound broadcast and merge propagation"
+                );
+                // Persistence is currently only wired for the redb backend;
+                // sqlite-only builds keep the in-memory flag but skip the
+                // on-disk hydration. This is the same trade-off
+                // `HostingManager` makes — see #4279 deferred follow-up to
+                // add sqlite parity.
+                #[cfg(feature = "redb")]
+                if let Some(storage) = self.storage.read().as_ref() {
+                    if let Err(e) = storage.store_broken_invariant(&id, kind.to_byte()) {
+                        tracing::warn!(
+                            contract = %id,
+                            error = %e,
+                            "Failed to persist broken-invariant flag (in-memory flag still active)"
+                        );
+                    }
                 }
             }
+            Outcome::Escalated(new_ttl) => {
+                tracing::debug!(
+                    contract = %id,
+                    escalated_ttl_secs = new_ttl.as_secs(),
+                    event = "broken_invariant_ttl_escalated",
+                    "Re-detected broken contract — escalating suppression TTL (#4902 egress oscillation)"
+                );
+            }
+            Outcome::Refreshed => {}
         }
     }
 
@@ -286,27 +413,32 @@ impl BrokenInvariantsTracker {
     /// for contracts that are no longer being read on the hot path.
     pub fn cleanup(&self) {
         let now = self.time_source.now();
-        // Snapshot the currently-expired ids (read-only).
+        // Reclaim an entry only once it is past its RESET boundary
+        // (`REFLAG_WINDOW_MULT × ttl` since the last detection), not merely
+        // past its suppression TTL: between `ttl` and `REFLAG_WINDOW_MULT ×
+        // ttl` the flag no longer suppresses (`is_broken` is false) but the
+        // entry is retained as escalation memory, so a prompt re-detection can
+        // ESCALATE rather than restart at baseline (#4903 review B-tweak).
+        // Snapshot the reclaimable ids (read-only).
+        let reclaimable = |entry: &FlagEntry| {
+            now.saturating_duration_since(entry.recorded_at) >= entry.ttl * REFLAG_WINDOW_MULT
+        };
         let candidates: Vec<ContractInstanceId> = self
             .flags
             .iter()
-            .filter(|e| {
-                now.saturating_duration_since(e.value().recorded_at) >= BROKEN_INVARIANT_TTL
-            })
+            .filter(|e| reclaimable(e.value()))
             .map(|e| *e.key())
             .collect();
         for id in candidates {
-            // Atomically re-check expiry under the shard guard and remove only
-            // if STILL expired. This closes a TOCTOU race: a concurrent
+            // Atomically re-check under the shard guard and remove only if
+            // STILL reclaimable. This closes a TOCTOU race: a concurrent
             // `record()` (e.g. a probe re-detecting the same contract) may have
-            // refreshed `recorded_at` between the snapshot above and here — in
-            // which case `remove_if` keeps the fresh entry, and we must NOT
-            // purge its persisted row (a restart needs it to re-hydrate the
-            // active suppression). We only touch storage when we actually
-            // removed an expired entry.
-            let removed = self.flags.remove_if(&id, |_, entry| {
-                now.saturating_duration_since(entry.recorded_at) >= BROKEN_INVARIANT_TTL
-            });
+            // refreshed `recorded_at`/escalated `ttl` between the snapshot above
+            // and here — in which case `remove_if` keeps the fresh entry, and we
+            // must NOT purge its persisted row (a restart needs it to re-hydrate
+            // the active suppression). We only touch storage when we actually
+            // removed a reclaimable entry.
+            let removed = self.flags.remove_if(&id, |_, entry| reclaimable(entry));
             if removed.is_some() {
                 self.remove_from_storage(&id);
             }
@@ -359,7 +491,19 @@ impl BrokenInvariantsTracker {
                 let recorded_at = self.time_source.now();
                 for (id, byte) in entries {
                     if let Some(kind) = BrokenInvariant::from_byte(byte) {
-                        self.flags.insert(id, FlagEntry { kind, recorded_at });
+                        // Escalation state is in-memory only, so a reload starts
+                        // each flag at the baseline TTL (#4903 review B-tweak):
+                        // a restart resets any prior escalation, and the
+                        // contract re-escalates from scratch if it keeps
+                        // oscillating.
+                        self.flags.insert(
+                            id,
+                            FlagEntry {
+                                kind,
+                                recorded_at,
+                                ttl: BROKEN_INVARIANT_TTL,
+                            },
+                        );
                     } else {
                         tracing::warn!(
                             contract = %id,
@@ -485,23 +629,40 @@ mod tests {
         assert_eq!(t.get(&id), None, "expired flag reports no kind");
     }
 
-    /// `cleanup` physically reclaims expired entries from the in-memory map.
+    /// `cleanup` physically reclaims an entry only once it is past its RESET
+    /// boundary (`REFLAG_WINDOW_MULT × ttl`), not merely past its suppression
+    /// TTL: between the two it is retained as escalation memory so a prompt
+    /// re-detection can escalate rather than restart at baseline.
     #[test]
-    fn cleanup_reclaims_expired_entries() {
+    fn cleanup_reclaims_entries_past_reset_boundary() {
         let (t, ts) = mk_tracker();
         let id = fake_id(7);
         t.record(id, BrokenInvariant::NonIdempotent);
         assert_eq!(t.flags.len(), 1);
 
-        // Before expiry, cleanup keeps it.
-        ts.advance_time(BROKEN_INVARIANT_TTL / 2);
+        // Suppression has expired (past ttl) but we are still inside the
+        // reset boundary (< 2 × ttl): the entry is retained as escalation
+        // memory even though it no longer suppresses.
+        ts.advance_time(BROKEN_INVARIANT_TTL + Duration::from_secs(1));
+        assert!(
+            !t.is_broken(&id),
+            "past its ttl the flag no longer suppresses"
+        );
         t.cleanup();
-        assert_eq!(t.flags.len(), 1, "non-expired entry retained by cleanup");
+        assert_eq!(
+            t.flags.len(),
+            1,
+            "entry retained as escalation memory until the reset boundary"
+        );
 
-        // After expiry, cleanup removes it.
+        // Past the reset boundary (2 × ttl), cleanup reclaims it.
         ts.advance_time(BROKEN_INVARIANT_TTL);
         t.cleanup();
-        assert_eq!(t.flags.len(), 0, "expired entry reclaimed by cleanup");
+        assert_eq!(
+            t.flags.len(),
+            0,
+            "entry past the reset boundary reclaimed by cleanup"
+        );
     }
 
     /// Re-recording refreshes the expiry window so a contract the probe keeps
@@ -566,5 +727,187 @@ mod tests {
         }
         // Unknown bytes are rejected (forward-compat: skip rather than panic).
         assert_eq!(BrokenInvariant::from_byte(255), None);
+    }
+
+    // ===== Escalating-TTL policy (#4903 review B-tweak, #4902 oscillation) =====
+
+    /// (i) The FIRST detection uses exactly the baseline TTL and suppresses for
+    /// exactly that long — unchanged from the pre-escalation behavior, so the
+    /// #4295 false-positive conservatism is preserved.
+    #[test]
+    fn first_flag_uses_baseline_ttl() {
+        let (t, ts) = mk_tracker();
+        let id = fake_id(20);
+        t.record(id, BrokenInvariant::NonIdempotent);
+        assert_eq!(
+            t.current_ttl(&id),
+            Some(BROKEN_INVARIANT_TTL),
+            "first flag = baseline TTL"
+        );
+        ts.advance_time(BROKEN_INVARIANT_TTL - Duration::from_secs(1));
+        assert!(t.is_broken(&id), "suppressed right up to the baseline TTL");
+        ts.advance_time(Duration::from_secs(2));
+        assert!(
+            !t.is_broken(&id),
+            "first flag expires after exactly the baseline TTL"
+        );
+    }
+
+    /// (ii) Each re-detection within the re-flag window doubles the TTL,
+    /// geometrically, up to the cap — then stays pinned at the cap.
+    #[test]
+    fn re_detection_escalates_ttl_geometrically_to_cap() {
+        let (t, ts) = mk_tracker();
+        let id = fake_id(21);
+        t.record(id, BrokenInvariant::NonIdempotent);
+
+        let mut expected = BROKEN_INVARIANT_TTL;
+        assert_eq!(t.current_ttl(&id), Some(expected));
+        for cycle in 0..12 {
+            let ttl = t.current_ttl(&id).unwrap();
+            // Go dark for the whole TTL, then re-detect 1s into the re-flag
+            // window (a fresh oscillation cycle).
+            ts.advance_time(ttl + Duration::from_secs(1));
+            assert!(!t.is_broken(&id), "flag expired before re-detection");
+            t.record(id, BrokenInvariant::NonIdempotent);
+            expected = (expected * 2).min(BROKEN_INVARIANT_TTL_CAP);
+            assert_eq!(
+                t.current_ttl(&id),
+                Some(expected),
+                "re-detection at cycle {cycle} must double the TTL (capped)"
+            );
+        }
+        // The early doublings are exactly 300 → 600 → 1200 → 2400 …
+        // and the sequence converged to the cap.
+        assert_eq!(t.current_ttl(&id), Some(BROKEN_INVARIANT_TTL_CAP));
+    }
+
+    /// (iii) A re-detection AFTER a full quiet window (≥ 2× the current TTL
+    /// with no re-detection) resets escalation to baseline — the contract is
+    /// no longer oscillating.
+    #[test]
+    fn quiet_window_resets_escalation_to_baseline() {
+        let (t, ts) = mk_tracker();
+        let id = fake_id(22);
+        t.record(id, BrokenInvariant::NonIdempotent);
+        // Escalate once: 300 → 600.
+        ts.advance_time(BROKEN_INVARIANT_TTL + Duration::from_secs(1));
+        t.record(id, BrokenInvariant::NonIdempotent);
+        assert_eq!(t.current_ttl(&id), Some(BROKEN_INVARIANT_TTL * 2));
+
+        // Now go quiet for a full reset window (≥ 2× the current TTL) with no
+        // re-detection, then re-detect: escalation resets to baseline.
+        let ttl = t.current_ttl(&id).unwrap();
+        ts.advance_time(ttl * 2 + Duration::from_secs(1));
+        t.record(id, BrokenInvariant::NonIdempotent);
+        assert_eq!(
+            t.current_ttl(&id),
+            Some(BROKEN_INVARIANT_TTL),
+            "a re-detection after a full quiet window resets to baseline"
+        );
+    }
+
+    /// (v) A contract flagged exactly ONCE (the #4295 false-positive shape) is
+    /// never re-detected, so it never escalates: it self-heals after one
+    /// baseline TTL and is reclaimed at the reset boundary.
+    #[test]
+    fn single_false_positive_never_escalates() {
+        let (t, ts) = mk_tracker();
+        let id = fake_id(23);
+        t.record(id, BrokenInvariant::NonIdempotent);
+        assert_eq!(t.current_ttl(&id), Some(BROKEN_INVARIANT_TTL));
+
+        // Self-heals after one baseline TTL; the entry is retained (as
+        // escalation memory) but the TTL is still baseline — no escalation.
+        ts.advance_time(BROKEN_INVARIANT_TTL + Duration::from_secs(1));
+        assert!(!t.is_broken(&id), "false positive self-heals after one TTL");
+        assert_eq!(
+            t.current_ttl(&id),
+            Some(BROKEN_INVARIANT_TTL),
+            "no re-detection means no escalation"
+        );
+
+        // Past the reset boundary, cleanup reclaims it entirely.
+        ts.advance_time(BROKEN_INVARIANT_TTL);
+        t.cleanup();
+        assert!(
+            t.current_ttl(&id).is_none(),
+            "reclaimed after the reset boundary"
+        );
+    }
+
+    /// (iv) A simulated oscillator (dark / re-enter / re-flag cycles) whose
+    /// TTL escalates converges to a vanishing emission duty cycle. The model:
+    /// each cycle the host is dark for its (escalating) TTL, then re-enters the
+    /// mesh for a CONSTANT re-detection delay (bounded by the 1/32 probe
+    /// cadence, independent of the dark-window length) before being re-flagged.
+    /// The re-entry cascade's size is proportional to the drift accumulated
+    /// during the dark window WHILE OTHER hosts are active — and in a fleet
+    /// escalating in lockstep the active-other fraction is itself the shrinking
+    /// duty cycle, so per-cycle emission ≈ dark_window × duty_cycle, which is
+    /// bounded (≈ the constant re-detection delay). We assert the dark fraction
+    /// → ~1, the TTL reaches the cap, and cumulative emission is far below the
+    /// fixed-TTL baseline over the same horizon.
+    #[test]
+    fn oscillator_escalation_collapses_duty_cycle() {
+        let (t, ts) = mk_tracker();
+        let id = fake_id(24);
+        let redetect_delay = Duration::from_secs(10);
+
+        t.record(id, BrokenInvariant::NonIdempotent);
+
+        let mut total_dark = Duration::ZERO;
+        let mut total_active = Duration::ZERO;
+        let mut total_emission = 0.0_f64;
+
+        for _ in 0..20 {
+            let ttl = t.current_ttl(&id).unwrap();
+            // Dark for the whole TTL (suppressed).
+            assert!(
+                t.is_broken(&id),
+                "suppressed at the start of the dark window"
+            );
+            total_dark += ttl;
+            ts.advance_time(ttl);
+            assert!(
+                !t.is_broken(&id),
+                "flag expired at the end of the dark window"
+            );
+
+            // Re-entry: active for the constant re-detection delay, accruing a
+            // cascade ∝ dark_window × (fleet active fraction ≈ this cycle's
+            // duty cycle).
+            let cycle_len = ttl + redetect_delay;
+            let active_fraction = redetect_delay.as_secs_f64() / cycle_len.as_secs_f64();
+            total_emission += ttl.as_secs_f64() * active_fraction;
+            total_active += redetect_delay;
+            ts.advance_time(redetect_delay);
+            t.record(id, BrokenInvariant::NonIdempotent);
+        }
+
+        // Dark fraction → ~1 (duty cycle → ~0).
+        let dark_fraction =
+            total_dark.as_secs_f64() / (total_dark.as_secs_f64() + total_active.as_secs_f64());
+        assert!(
+            dark_fraction > 0.98,
+            "dark fraction must converge toward 1 (duty cycle collapses), got {dark_fraction}"
+        );
+
+        // Escalation is monotonic to the ceiling.
+        assert_eq!(t.current_ttl(&id), Some(BROKEN_INVARIANT_TTL_CAP));
+
+        // Cumulative re-entry emission is bounded: far below the fixed-TTL
+        // baseline (which re-cascades every baseline TTL) over the SAME horizon.
+        let horizon = total_dark + total_active;
+        let baseline_cycle = BROKEN_INVARIANT_TTL + redetect_delay;
+        let baseline_cycles = horizon.as_secs_f64() / baseline_cycle.as_secs_f64();
+        let baseline_active_fraction = redetect_delay.as_secs_f64() / baseline_cycle.as_secs_f64();
+        let baseline_emission =
+            baseline_cycles * BROKEN_INVARIANT_TTL.as_secs_f64() * baseline_active_fraction;
+        assert!(
+            total_emission < baseline_emission / 5.0,
+            "escalation must slash cumulative re-entry cascade emission vs the \
+             fixed-TTL baseline (escalated {total_emission:.1}, baseline {baseline_emission:.1})"
+        );
     }
 }

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -3299,7 +3299,12 @@ mod tests {
     ///    (recency-aware candidacy);
     /// 5. a single large-state fan-out burst (5 MB × 30 targets, first report
     ///    seconds before the sweep) is NOT shed (sustained-pressure gate), so
-    ///    one burst can never mass-evict a large-state contract.
+    ///    one burst can never mass-evict a large-state contract;
+    /// 6. an OLD-first-sample contract whose only recent activity is a
+    ///    ~60-second flurry is NOT shed (#4903 review Fix 2: the sustained
+    ///    gate keys on the span of the recent samples, not the lifetime
+    ///    first-sample age — which is set once, never reset, and would
+    ///    otherwise admit any later burst on a long-known contract).
     #[tokio::test]
     async fn storm_frequency_profile_crosses_cost_trigger_through_real_meter() {
         use crate::topology::meter::{AttributionSource, Meter, ResourceType};
@@ -3310,6 +3315,7 @@ mod tests {
         let junk = make_contract_key(1);
         let read_hot = make_contract_key(2);
         let burst = make_contract_key(3);
+        let old_then_burst = make_contract_key(4);
 
         // 10 minutes of storm: one fan-out dispatch every 1.6s to 58 targets
         // of a 121-byte payload (the FX2j profile), for junk AND read_hot
@@ -3346,6 +3352,24 @@ mod tests {
             burst_bytes,
             now - Duration::from_secs(1),
         );
+        // OLD-first-sample contract (#4903 review Fix 2): one sample 10
+        // minutes before the sweep, then a ~60s buffer-saturating flurry just
+        // before it (120 samples at 0.5s cadence — the retained 100 span
+        // ~50s, far under the min_window/2 sustained bar).
+        meter.report(
+            &AttributionSource::Contract(*old_then_burst.id()),
+            ResourceType::BroadcastMessagesSent,
+            58.0,
+            t0,
+        );
+        for i in 0..120u64 {
+            meter.report(
+                &AttributionSource::Contract(*old_then_burst.id()),
+                ResourceType::BroadcastMessagesSent,
+                5.0,
+                t0 + Duration::from_secs(540) + Duration::from_millis(500 * i),
+            );
+        }
 
         // --- the real reads + the shared axis assembly. ---
         let cpu = meter.contract_cost_rates(
@@ -3386,9 +3410,18 @@ mod tests {
              under-read is back"
         );
         // The burst contract is in the TOTAL but excluded from candidacy
-        // (sustained gate: first report is 1s old).
+        // (sustained gate: its recent samples span ~0s).
         assert!(!msgs.1.contains_key(burst.id()));
         assert!(!fanout.1.contains_key(burst.id()));
+        // (6) The old-first-sample flurry is ALSO excluded from candidacy:
+        // its within-window samples span only ~50s. Under the pre-fix
+        // lifetime-first-sample-age gate (first report 10 min old — trivially
+        // "sustained") it would be a candidate here and this assertion fails.
+        assert!(
+            !msgs.1.contains_key(old_then_burst.id()),
+            "an old-first-sample contract's short flurry must not be a candidate \
+             (#4903 review Fix 2)"
+        );
 
         let axes = cache::build_cost_axes(cpu, fanout, msgs);
 
@@ -3401,6 +3434,7 @@ mod tests {
         manager.record_contract_access(junk, 121, AccessType::Put);
         manager.record_contract_access(read_hot, 121, AccessType::Put);
         manager.record_contract_access(burst, 5 * 1024 * 1024, AccessType::Put);
+        manager.record_contract_access(old_then_burst, 121, AccessType::Put);
         // The storm has run long past the cost window with no genuine access…
         clock.advance_time(cache::COST_RATE_MIN_WINDOW + Duration::from_secs(1));
         // …but read_hot was genuinely GET-read just now.
@@ -3424,6 +3458,12 @@ mod tests {
         assert!(
             manager.is_hosting_contract(&burst),
             "a single large fan-out burst must not mass-evict (sustained gate)"
+        );
+        assert!(
+            manager.is_hosting_contract(&old_then_burst),
+            "an old-first-sample contract's ~60s flurry must not evict it \
+             (#4903 review Fix 2: sustained = recent-sample SPAN, not lifetime \
+             first-sample age)"
         );
     }
 

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -58,6 +58,14 @@ pub(crate) use cache::MIN_DEFAULT_HOSTING_BUDGET_BYTES;
 /// default is RAM-scaled (capability-relative, A2) rather than a flat constant.
 pub(crate) use cache::default_hosting_budget_bytes;
 pub use cache::{AccessType, EvictedInUseTeardown, RecordAccessResult};
+/// Cost-pressure eviction inputs + day-one calibration constants (cost-aware
+/// eviction, #4861). Re-exported so `Ring` (which reads the topology meter)
+/// can build the per-axis snapshots the sweep consumes; the policy constants
+/// live beside the decision in `cache.rs`.
+pub(crate) use cache::{
+    BROADCAST_FANOUT_PRESSURE_FLOOR_BYTES_PER_SEC, COST_RATE_MIN_WINDOW, CostAxisPressure,
+    EXEC_CPU_PRESSURE_FLOOR_MICROS_PER_SEC,
+};
 /// Aggregate disk-budget sizing defaults + pure clamp math (#4683). Re-exported
 /// so `config` can resolve the persisted `hosting-disk-pct` / `max-hosting-disk`
 /// defaults and `ring`/`HostingManager` can size the eviction floor.
@@ -2460,14 +2468,51 @@ impl HostingManager {
     /// guard can detect a re-host race — plus, for any still-in-use victim shed
     /// as a last resort, the subscription state torn down so the caller can sync
     /// the `InterestManager` (PR #4734 Fix 1).
+    // No-axes convenience wrapper (the pure byte sweep). Production always
+    // goes through `Ring::sweep_expired_hosting`, which supplies the cost
+    // axes to `sweep_expired_hosting_with_cost`; this wrapper is retained for
+    // tests exercising the no-cost degradation path.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn sweep_expired_hosting(&self) -> HostingSweepResult {
+        self.sweep_expired_hosting_with_cost(&[])
+    }
+
+    /// [`Self::sweep_expired_hosting`] plus the cost-pressure decision
+    /// (cost-aware eviction, #4861): after the byte-budget sweep, shed
+    /// zero-demand contracts whose attributed update-work cost dominates the
+    /// node's total on a cost axis — even while UNDER the byte budget. The
+    /// caller (`Ring::sweep_expired_hosting`) builds `cost_axes` from the
+    /// topology meter; an empty slice degrades to the pure byte sweep. Both
+    /// phases run under ONE hosting-cache write guard so the combined
+    /// decision is atomic against concurrent accesses; cost victims flow
+    /// through the same teardown / metadata-cleanup / reclaim funnel as byte
+    /// victims (their `was_in_use` is `false` by construction, so the in-use
+    /// teardown is a no-op for them).
+    pub fn sweep_expired_hosting_with_cost(
+        &self,
+        cost_axes: &[cache::CostAxisPressure],
+    ) -> HostingSweepResult {
         // AtCapacity: the Overflow op-backstop-pierce trigger is intentionally
         // unwired in production (see cache::MemoryPressure). AtCapacity itself
         // CAN now shed a subscribed contract as a last resort — see below.
-        let evicted = self.hosting_cache.write().sweep_expired(
-            |key| self.local_and_downstream_counts(key),
-            cache::MemoryPressure::AtCapacity,
-        );
+        //
+        // `local_and_downstream_counts` reads only the subscription DashMaps —
+        // never `hosting_cache` — so calling it from inside the write guard
+        // does not re-enter the lock (same pattern as `record_contract_access`).
+        let evicted = {
+            let mut cache_guard = self.hosting_cache.write();
+            let mut evicted = cache_guard.sweep_expired(
+                |key| self.local_and_downstream_counts(key),
+                cache::MemoryPressure::AtCapacity,
+            );
+            if !cost_axes.is_empty() {
+                evicted.extend(cache_guard.evict_cost_pressure(
+                    &|key: &ContractKey| self.local_and_downstream_counts(key),
+                    cost_axes,
+                ));
+            }
+            evicted
+        };
 
         // Tear down subscription state for any still-in-use victim BEFORE the
         // caller reclaims it, so `contract_in_use` is false when the reclaim gate
@@ -3161,6 +3206,82 @@ mod tests {
 
         assert!(result.is_new);
         assert!(manager.is_subscribed(&contract));
+    }
+
+    /// THE cost-aware-eviction discriminator (#4861), at the manager level:
+    /// under cost pressure — with the byte budget nowhere near exceeded (the
+    /// exact shape of the production storm: a 121-byte zero-subscriber
+    /// contract holding ~58% of the gateway's broadcast capacity, never
+    /// evicted because the sweep was byte-gated) — the sweep sheds the
+    /// zero-subscriber cost offender, while a SUBSCRIBED contract holding an
+    /// equally dominant cost share is untouched. The victim flows through the
+    /// standard [`HostingSweepResult::expired`] funnel (the same list the
+    /// ring maintenance task feeds to `unregister_local_hosting` →
+    /// advertisement retraction and `reclaim_evicted_contract` → disk
+    /// reclamation), with no in-use teardown (cost victims are zero-demand by
+    /// construction). Removing the subscriber then flips the protection: the
+    /// same contract becomes evictable on the next cost sweep — proving the
+    /// gate is the subscriber, not the key.
+    #[tokio::test]
+    async fn cost_pressure_sweep_evicts_zero_subscriber_offender_not_subscribed() {
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
+        let junk = make_contract_key(1);
+        let hot_subscribed = make_contract_key(2);
+        manager.record_contract_access(junk, 121, AccessType::Put);
+        manager.record_contract_access(hot_subscribed, 121, AccessType::Put);
+        manager.add_downstream_subscriber(&hot_subscribed, make_peer_key(10));
+
+        let axes = vec![CostAxisPressure {
+            axis: "exec_cpu_micros_per_sec",
+            total_rate: 100_000.0,
+            floor: EXEC_CPU_PRESSURE_FLOOR_MICROS_PER_SEC,
+            rates: [(*junk.id(), 58_000.0), (*hot_subscribed.id(), 41_000.0)]
+                .into_iter()
+                .collect(),
+        }];
+
+        let result = manager.sweep_expired_hosting_with_cost(&axes);
+        let expired_keys: Vec<ContractKey> = result.expired.iter().map(|(k, _)| *k).collect();
+        assert_eq!(
+            expired_keys,
+            vec![junk],
+            "the zero-subscriber cost offender is shed; the subscribed \
+             contract is protected by candidacy, not ranking"
+        );
+        assert!(
+            result.evicted_in_use_teardown.is_empty(),
+            "cost victims are zero-demand — nothing to tear down"
+        );
+        assert!(!manager.is_hosting_contract(&junk));
+        assert!(manager.is_hosting_contract(&hot_subscribed));
+
+        // Idempotent under unchanged pressure: the offender is gone, the
+        // subscribed contract stays protected.
+        let again = manager.sweep_expired_hosting_with_cost(&axes);
+        assert!(again.expired.is_empty());
+        assert!(manager.is_hosting_contract(&hot_subscribed));
+
+        // Protection follows the SUBSCRIBER: once the downstream subscriber
+        // leaves, the same high-cost contract becomes a candidate.
+        manager.remove_downstream_subscriber(&hot_subscribed, &make_peer_key(10));
+        let after_unsub = manager.sweep_expired_hosting_with_cost(&axes);
+        let after_keys: Vec<ContractKey> = after_unsub.expired.iter().map(|(k, _)| *k).collect();
+        assert_eq!(after_keys, vec![hot_subscribed]);
+        assert!(!manager.is_hosting_contract(&hot_subscribed));
+    }
+
+    /// The no-cost degradation path: `sweep_expired_hosting()` (no axes) is
+    /// the pure byte sweep and never cost-evicts, so every pre-existing
+    /// caller is behaviorally unchanged.
+    #[tokio::test]
+    async fn sweep_without_cost_axes_never_cost_evicts() {
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
+        let junk = make_contract_key(1);
+        manager.record_contract_access(junk, 121, AccessType::Put);
+        let result = manager.sweep_expired_hosting();
+        assert!(result.expired.is_empty());
+        assert!(manager.is_hosting_contract(&junk));
+        assert_eq!(manager.hosting_cache_stats().cost_evictions_total, 0);
     }
 
     /// `subscribed_keys_in` (the bounded connection-drop-shadow lookup, #4642)

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -3301,10 +3301,10 @@ mod tests {
     ///    seconds before the sweep) is NOT shed (sustained-pressure gate), so
     ///    one burst can never mass-evict a large-state contract;
     /// 6. an OLD-first-sample contract whose only recent activity is a
-    ///    ~60-second flurry is NOT shed (#4903 review Fix 2: the sustained
-    ///    gate keys on the span of the recent samples, not the lifetime
-    ///    first-sample age — which is set once, never reset, and would
-    ///    otherwise admit any later burst on a long-known contract).
+    ///    ~60-second flurry is NOT shed (#4903 review Fix 2 / BLOCKER: the
+    ///    continuity gap-reset restarts the activity run at the flurry, so its
+    ///    `activity_span` is only ~60s — a long-known contract's later burst
+    ///    can never masquerade as sustained).
     #[tokio::test]
     async fn storm_frequency_profile_crosses_cost_trigger_through_real_meter() {
         use crate::topology::meter::{AttributionSource, Meter, ResourceType};
@@ -3352,10 +3352,11 @@ mod tests {
             burst_bytes,
             now - Duration::from_secs(1),
         );
-        // OLD-first-sample contract (#4903 review Fix 2): one sample 10
-        // minutes before the sweep, then a ~60s buffer-saturating flurry just
-        // before it (120 samples at 0.5s cadence — the retained 100 span
-        // ~50s, far under the min_window/2 sustained bar).
+        // OLD-first-sample contract (#4903 review Fix 2 / BLOCKER): one sample
+        // 10 minutes before the sweep, then a ~60s flurry just before it (120
+        // samples at 0.5s cadence). The >max-gap silence between them restarts
+        // the activity run at the flurry, so its activity_span is ~60s — under
+        // the sustained bar.
         meter.report(
             &AttributionSource::Contract(*old_then_burst.id()),
             ResourceType::BroadcastMessagesSent,
@@ -3413,14 +3414,15 @@ mod tests {
         // (sustained gate: its recent samples span ~0s).
         assert!(!msgs.1.contains_key(burst.id()));
         assert!(!fanout.1.contains_key(burst.id()));
-        // (6) The old-first-sample flurry is ALSO excluded from candidacy:
-        // its within-window samples span only ~50s. Under the pre-fix
-        // lifetime-first-sample-age gate (first report 10 min old — trivially
-        // "sustained") it would be a candidate here and this assertion fails.
+        // (6) The old-first-sample flurry is ALSO excluded from candidacy: the
+        // gap-reset restarts its activity run at the flurry, so activity_span
+        // is ~60s. Under the pre-fix lifetime-first-sample-age gate (first
+        // report 10 min old — trivially "sustained") it would be a candidate
+        // here and this assertion fails.
         assert!(
             !msgs.1.contains_key(old_then_burst.id()),
             "an old-first-sample contract's short flurry must not be a candidate \
-             (#4903 review Fix 2)"
+             (#4903 review Fix 2 / BLOCKER)"
         );
 
         let axes = cache::build_cost_axes(cpu, fanout, msgs);
@@ -3465,6 +3467,74 @@ mod tests {
              (#4903 review Fix 2: sustained = recent-sample SPAN, not lifetime \
              first-sample age)"
         );
+    }
+
+    /// #4903 review BLOCKER, end-to-end: a FAST-cadence (0.5s) zero-demand
+    /// storm — whose count-bounded sample buffer spans only ~50s, far under the
+    /// 150s sustained bar — is shed by the real sweep. Under the old
+    /// buffer-span sustained gate this exact storm (the fastest, worst profile)
+    /// was PERMANENTLY exempt from candidacy while still inflating the share
+    /// denominator; the continuity-tracked `activity_span` makes it a
+    /// candidate, so the sweep sheds it.
+    #[tokio::test]
+    async fn fast_cadence_storm_is_shed_through_real_sweep() {
+        use crate::topology::meter::{AttributionSource, Meter, ResourceType};
+
+        let meter = Meter::new_with_window_size(100);
+        let t0 = Instant::now();
+        let fast_junk = make_contract_key(1);
+
+        // 400s of storm at 0.5s cadence (800 dispatches): the 100-sample buffer
+        // retains only the last ~50s of it — the old gate's fatal blind spot.
+        for i in 0..800u64 {
+            meter.report(
+                &AttributionSource::Contract(*fast_junk.id()),
+                ResourceType::BroadcastMessagesSent,
+                58.0,
+                t0 + Duration::from_millis(500 * i),
+            );
+        }
+        let now = t0 + Duration::from_millis(500 * 799) + Duration::from_secs(1);
+
+        let msgs = meter.contract_cost_rates(
+            &ResourceType::BroadcastMessagesSent,
+            now,
+            cache::COST_RATE_MIN_WINDOW,
+        );
+        assert!(
+            msgs.1.contains_key(fast_junk.id()),
+            "the 0.5s-cadence storm must be a candidate (activity_span, not the \
+             ~50s buffer span, decides sustained-ness)"
+        );
+        let cpu = meter.contract_cost_rates(
+            &ResourceType::ExecCpuMicros,
+            now,
+            cache::COST_RATE_MIN_WINDOW,
+        );
+        let fanout = meter.contract_cost_rates(
+            &ResourceType::BroadcastFanoutCost,
+            now,
+            cache::COST_RATE_MIN_WINDOW,
+        );
+        let axes = cache::build_cost_axes(cpu, fanout, msgs);
+
+        let clock = crate::util::time_source::SharedMockTimeSource::new();
+        let manager = HostingManager::with_time_source(
+            DEFAULT_HOSTING_BUDGET_BYTES,
+            std::sync::Arc::new(clock.clone()),
+        );
+        manager.record_contract_access(fast_junk, 121, AccessType::Put);
+        // Long past the cost window with no genuine access.
+        clock.advance_time(cache::COST_RATE_MIN_WINDOW + Duration::from_secs(1));
+
+        let result = manager.sweep_expired_hosting_with_cost(&axes);
+        let expired_keys: Vec<ContractKey> = result.expired.iter().map(|(k, _)| *k).collect();
+        assert_eq!(
+            expired_keys,
+            vec![fast_junk],
+            "the fast-cadence zero-demand storm must be shed end-to-end"
+        );
+        assert!(!manager.is_hosting_contract(&fast_junk));
     }
 
     /// The no-cost degradation path: `sweep_expired_hosting()` (no axes) is

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -61,11 +61,8 @@ pub use cache::{AccessType, EvictedInUseTeardown, RecordAccessResult};
 /// Cost-pressure eviction inputs + day-one calibration constants (cost-aware
 /// eviction, #4861). Re-exported so `Ring` (which reads the topology meter)
 /// can build the per-axis snapshots the sweep consumes; the policy constants
-/// live beside the decision in `cache.rs`.
-pub(crate) use cache::{
-    BROADCAST_FANOUT_PRESSURE_FLOOR_BYTES_PER_SEC, COST_RATE_MIN_WINDOW, CostAxisPressure,
-    EXEC_CPU_PRESSURE_FLOOR_MICROS_PER_SEC,
-};
+/// and the shared axis assembly live beside the decision in `cache.rs`.
+pub(crate) use cache::{COST_RATE_MIN_WINDOW, CostAxisPressure, build_cost_axes};
 /// Aggregate disk-budget sizing defaults + pure clamp math (#4683). Re-exported
 /// so `config` can resolve the persisted `hosting-disk-pct` / `max-hosting-disk`
 /// defaults and `ring`/`HostingManager` can size the eviction floor.
@@ -3224,17 +3221,24 @@ mod tests {
     /// gate is the subscriber, not the key.
     #[tokio::test]
     async fn cost_pressure_sweep_evicts_zero_subscriber_offender_not_subscribed() {
-        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
+        let clock = crate::util::time_source::SharedMockTimeSource::new();
+        let manager = HostingManager::with_time_source(
+            DEFAULT_HOSTING_BUDGET_BYTES,
+            std::sync::Arc::new(clock.clone()),
+        );
         let junk = make_contract_key(1);
         let hot_subscribed = make_contract_key(2);
         manager.record_contract_access(junk, 121, AccessType::Put);
         manager.record_contract_access(hot_subscribed, 121, AccessType::Put);
         manager.add_downstream_subscriber(&hot_subscribed, make_peer_key(10));
+        // Age the PUT-seed genuine-access stamps past the cost window: the
+        // storm has been running long past it with no genuine GET/PUT.
+        clock.advance_time(cache::COST_RATE_MIN_WINDOW + Duration::from_secs(1));
 
         let axes = vec![CostAxisPressure {
             axis: "exec_cpu_micros_per_sec",
             total_rate: 100_000.0,
-            floor: EXEC_CPU_PRESSURE_FLOOR_MICROS_PER_SEC,
+            floor: cache::EXEC_CPU_PRESSURE_FLOOR_MICROS_PER_SEC,
             rates: [(*junk.id(), 58_000.0), (*hot_subscribed.id(), 41_000.0)]
                 .into_iter()
                 .collect(),
@@ -3262,12 +3266,165 @@ mod tests {
         assert!(manager.is_hosting_contract(&hot_subscribed));
 
         // Protection follows the SUBSCRIBER: once the downstream subscriber
-        // leaves, the same high-cost contract becomes a candidate.
+        // leaves — and the termination grace window (the recency reset at
+        // subscription termination, invariant 3) has elapsed — the same
+        // high-cost contract becomes a candidate.
         manager.remove_downstream_subscriber(&hot_subscribed, &make_peer_key(10));
+        clock.advance_time(cache::COST_RATE_MIN_WINDOW + Duration::from_secs(1));
         let after_unsub = manager.sweep_expired_hosting_with_cost(&axes);
         let after_keys: Vec<ContractKey> = after_unsub.expired.iter().map(|(k, _)| *k).collect();
         assert_eq!(after_keys, vec![hot_subscribed]);
         assert!(!manager.is_hosting_contract(&hot_subscribed));
+    }
+
+    /// STORM-FREQUENCY integration test (#4861): drive the REAL production
+    /// storm profile — 121-byte payload, ~58 co-host targets, sustained
+    /// ~0.62 dispatches/s (~36 per-peer sends/s) for 10 minutes — through the
+    /// ACTUAL `Meter` (production 100-sample window, real count-truncation),
+    /// the real `contract_cost_rates` read, the shared `build_cost_axes`
+    /// assembly, and the real sweep. This is the test the synthetic-axes
+    /// tests above cannot substitute for: it proves the metering itself
+    /// registers the storm (the reviewers' finding was that byte-denominated
+    /// fanout reads ~4 KB/s vs a 131 KB/s floor — 30x under — and the
+    /// 100-sample window truncated the rate further, so the trigger would
+    /// NEVER fire for the real profile).
+    ///
+    /// Asserts, in order:
+    /// 1. the byte axis alone indeed CANNOT see the storm (the bug);
+    /// 2. the message-count axis reads the storm's TRUE ~36/s despite the
+    ///    saturated 100-sample buffer (the window fix — the old
+    ///    min-window-clamped math reads ~19/s and this assertion fails);
+    /// 3. the storm contract IS shed through the real sweep;
+    /// 4. an equally-storming but recently-GET-read contract is NOT shed
+    ///    (recency-aware candidacy);
+    /// 5. a single large-state fan-out burst (5 MB × 30 targets, first report
+    ///    seconds before the sweep) is NOT shed (sustained-pressure gate), so
+    ///    one burst can never mass-evict a large-state contract.
+    #[tokio::test]
+    async fn storm_frequency_profile_crosses_cost_trigger_through_real_meter() {
+        use crate::topology::meter::{AttributionSource, Meter, ResourceType};
+
+        // --- the real meter, production window size (TopologyManager::new). ---
+        let meter = Meter::new_with_window_size(100);
+        let t0 = Instant::now();
+        let junk = make_contract_key(1);
+        let read_hot = make_contract_key(2);
+        let burst = make_contract_key(3);
+
+        // 10 minutes of storm: one fan-out dispatch every 1.6s to 58 targets
+        // of a 121-byte payload (the FX2j profile), for junk AND read_hot
+        // (read_hot proves protection comes from recency, not a smaller cost).
+        for i in 0..375u64 {
+            let at = t0 + Duration::from_millis(1600 * i);
+            for id in [junk.id(), read_hot.id()] {
+                meter.report(
+                    &AttributionSource::Contract(*id),
+                    ResourceType::BroadcastMessagesSent,
+                    58.0,
+                    at,
+                );
+                meter.report(
+                    &AttributionSource::Contract(*id),
+                    ResourceType::BroadcastFanoutCost,
+                    121.0 * 58.0,
+                    at,
+                );
+            }
+        }
+        let now = t0 + Duration::from_secs(600);
+        // ONE large-state fan-out burst just before the sweep: 5 MB × 30.
+        let burst_bytes = 5.0 * 1024.0 * 1024.0 * 30.0;
+        meter.report(
+            &AttributionSource::Contract(*burst.id()),
+            ResourceType::BroadcastMessagesSent,
+            30.0,
+            now - Duration::from_secs(1),
+        );
+        meter.report(
+            &AttributionSource::Contract(*burst.id()),
+            ResourceType::BroadcastFanoutCost,
+            burst_bytes,
+            now - Duration::from_secs(1),
+        );
+
+        // --- the real reads + the shared axis assembly. ---
+        let cpu = meter.contract_cost_rates(
+            &ResourceType::ExecCpuMicros,
+            now,
+            cache::COST_RATE_MIN_WINDOW,
+        );
+        let fanout = meter.contract_cost_rates(
+            &ResourceType::BroadcastFanoutCost,
+            now,
+            cache::COST_RATE_MIN_WINDOW,
+        );
+        let msgs = meter.contract_cost_rates(
+            &ResourceType::BroadcastMessagesSent,
+            now,
+            cache::COST_RATE_MIN_WINDOW,
+        );
+
+        // (1) The byte axis alone cannot see the storm: the junk contract's
+        // byte rate is far below the byte floor (this is the production bug —
+        // ~4 KB/s vs 131 KB/s).
+        let junk_byte_rate = fanout.1.get(junk.id()).copied().unwrap_or(0.0);
+        assert!(
+            junk_byte_rate < cache::BROADCAST_FANOUT_PRESSURE_FLOOR_BYTES_PER_SEC / 20.0,
+            "precondition: the tiny-payload storm must be invisible to the \
+             byte axis (got {junk_byte_rate} B/s) — otherwise this test no \
+             longer reproduces the #4861 blind spot"
+        );
+        // (2) The message-count axis reads the TRUE sustained rate despite
+        // count-truncation: ~36/s. Under the pre-fix min-window-clamped math
+        // the saturated 100-sample buffer reads 100×58/300s ≈ 19/s and this
+        // fails.
+        let junk_msg_rate = msgs.1.get(junk.id()).copied().unwrap_or(0.0);
+        assert!(
+            junk_msg_rate > 30.0,
+            "saturated-buffer rate must reflect the true storm frequency \
+             (~36 msgs/s), got {junk_msg_rate}/s — the count-truncation \
+             under-read is back"
+        );
+        // The burst contract is in the TOTAL but excluded from candidacy
+        // (sustained gate: first report is 1s old).
+        assert!(!msgs.1.contains_key(burst.id()));
+        assert!(!fanout.1.contains_key(burst.id()));
+
+        let axes = cache::build_cost_axes(cpu, fanout, msgs);
+
+        // --- the real sweep over real hosted entries. ---
+        let clock = crate::util::time_source::SharedMockTimeSource::new();
+        let manager = HostingManager::with_time_source(
+            DEFAULT_HOSTING_BUDGET_BYTES,
+            std::sync::Arc::new(clock.clone()),
+        );
+        manager.record_contract_access(junk, 121, AccessType::Put);
+        manager.record_contract_access(read_hot, 121, AccessType::Put);
+        manager.record_contract_access(burst, 5 * 1024 * 1024, AccessType::Put);
+        // The storm has run long past the cost window with no genuine access…
+        clock.advance_time(cache::COST_RATE_MIN_WINDOW + Duration::from_secs(1));
+        // …but read_hot was genuinely GET-read just now.
+        manager.record_contract_access(read_hot, 121, AccessType::Get);
+
+        let result = manager.sweep_expired_hosting_with_cost(&axes);
+        let expired_keys: Vec<ContractKey> = result.expired.iter().map(|(k, _)| *k).collect();
+        // (3) the storm contract is shed; (4) the recently-read one is not;
+        // (5) the single-burst large-state contract is not.
+        assert_eq!(
+            expired_keys,
+            vec![junk],
+            "the sustained zero-demand storm contract must be the ONLY victim"
+        );
+        assert!(result.evicted_in_use_teardown.is_empty());
+        assert!(!manager.is_hosting_contract(&junk));
+        assert!(
+            manager.is_hosting_contract(&read_hot),
+            "an equally-storming but recently-read contract must survive"
+        );
+        assert!(
+            manager.is_hosting_contract(&burst),
+            "a single large fan-out burst must not mass-evict (sustained gate)"
+        );
     }
 
     /// The no-cost degradation path: `sweep_expired_hosting()` (no axes) is

--- a/crates/core/src/ring/hosting/cache.rs
+++ b/crates/core/src/ring/hosting/cache.rs
@@ -840,7 +840,10 @@ pub(crate) fn victim_order(
 //
 // Candidacy is restricted to ZERO-DEMAND contracts in invariant 3's full
 // sense: `local_subs == 0 && downstream_subs == 0` AND no genuine GET/PUT
-// within the cost window AND `attributed_cost > 0`. A SUBSCRIBED contract is
+// within the cost window AND no local-client access within the reconciliation
+// renewal lease (`SUBSCRIPTION_LEASE_DURATION` — so the cost sweep never sheds
+// a contract the renewal loop still leases, including for one lease window
+// after a restart) AND `attributed_cost > 0`. A SUBSCRIBED contract is
 // NEVER a cost-eviction candidate, and neither is an actively-read one (the
 // never-subscribed-but-read River UI-container class) — the subscriber-
 // primary tiers of [`victim_order`] are not reordered by cost (cost breaks
@@ -952,9 +955,12 @@ pub(crate) fn build_cost_axes(
 
 /// The cost-eviction candidacy predicate: only a contract with ZERO demand
 /// may be shed by cost pressure, where zero demand means no local client
-/// subscriptions AND no downstream subscribers AND no genuine GET/PUT access
-/// within the cost window (`recently_accessed == false`) — matching invariant
-/// 3's demand definition, which includes reads. A subscribed contract is
+/// subscriptions AND no downstream subscribers AND no recent demand
+/// (`recently_accessed == false` — the caller passes true for a genuine
+/// GET/PUT within the cost window OR a local-client access within the
+/// reconciliation renewal lease; see [`HostingCache::evict_cost_pressure`]) —
+/// matching invariant 3's demand definition, which includes reads. A
+/// subscribed contract is
 /// NEVER a candidate, and neither is an actively-read/written one (the
 /// never-subscribed-but-read River UI-container class invariant 3 protects) —
 /// by construction, not by ranking — so cost pressure cannot reorder the
@@ -1838,7 +1844,9 @@ impl<T: TimeSource> HostingCache<T> {
     ///
     /// Per axis, when `total_rate > floor`, the candidates are the hosted
     /// contracts satisfying [`cost_eviction_candidate`] (zero local
-    /// subscriptions AND zero downstream subscribers AND strictly positive
+    /// subscriptions AND zero downstream subscribers AND no recent demand —
+    /// neither a genuine GET/PUT within the cost window nor a local-client
+    /// access within the reconciliation renewal lease — AND strictly positive
     /// attributed rate) whose rate exceeds [`COST_SHARE_THRESHOLD`] ×
     /// `total_rate`.
     /// Candidates are shed in DESCENDING attributed-rate order (contract-key
@@ -1852,12 +1860,13 @@ impl<T: TimeSource> HostingCache<T> {
     /// The subscriber-primary tiers are untouched by construction: a contract
     /// with ANY subscriber fails candidacy outright, so `was_in_use` is
     /// `false` for every returned victim and the caller's in-use teardown is
-    /// a no-op. Recency is neither read nor refreshed here (an UPDATE-storm
-    /// contract deliberately accrues no recency — cache.rs recency semantics
-    /// unchanged); the in-flight-op races this opens are the same ones the
-    /// periodic byte sweep already has, closed downstream by the
-    /// `write_generation` re-host guard and the `contract_in_use` re-check in
-    /// `RuntimePool::remove_contract`.
+    /// a no-op. Recency is READ here (the `last_genuine_access` /
+    /// `local_client_last_access` candidacy guards) but never REFRESHED (an
+    /// UPDATE-storm contract deliberately accrues no recency — cache.rs
+    /// recency-stamping semantics unchanged); the in-flight-op races this
+    /// opens are the same ones the periodic byte sweep already has, closed
+    /// downstream by the `write_generation` re-host guard and the
+    /// `contract_in_use` re-check in `RuntimePool::remove_contract`.
     ///
     /// `subscriber_counts(key)` is the caller's genuine-demand split, read
     /// once per candidate and captured atomically with the decision (same
@@ -1884,13 +1893,33 @@ impl<T: TimeSource> HostingCache<T> {
                 .filter_map(|(key, entry)| {
                     let rate = axis.rates.get(key.id()).copied().unwrap_or(0.0);
                     let (local, downstream) = subscriber_counts(key);
-                    // Genuine GET/PUT within the cost window = read-demand,
-                    // which invariant 3 counts as demand: not a candidate.
-                    // UPDATE churn never stamps `last_genuine_access`, so a
-                    // storm contract cannot protect itself.
+                    // Recent demand by the SAME definition the rest of the
+                    // system honors (review Fix 1 / invariant 3), so cost
+                    // eviction can never shed a contract reconciliation
+                    // still leases (an evict → re-lease churn loop):
+                    //
+                    // 1. A genuine GET/PUT within the cost window
+                    //    (`last_genuine_access`) — read/write demand.
+                    //    UPDATE churn never stamps it, so a storm contract
+                    //    cannot protect itself.
+                    // 2. A LOCAL-CLIENT access within the renewal lease
+                    //    (`local_client_last_access` <
+                    //    `SUBSCRIPTION_LEASE_DURATION`) — the exact signal
+                    //    `contracts_needing_renewal` branch 3 renews on.
+                    //    This covers both the 5–8-minute tail after a local
+                    //    access (the lease outlives the cost window) and the
+                    //    restart window: a reload stamps
+                    //    `local_client_last_access = now` for locally-
+                    //    accessed contracts while `last_genuine_access`
+                    //    restarts at `None`, so without this clause the cost
+                    //    sweep could evict a contract the reconcile loop was
+                    //    still renewing.
                     let recently_accessed = entry
                         .last_genuine_access
-                        .is_some_and(|at| now.saturating_duration_since(at) < COST_RATE_MIN_WINDOW);
+                        .is_some_and(|at| now.saturating_duration_since(at) < COST_RATE_MIN_WINDOW)
+                        || entry.local_client_last_access.is_some_and(|at| {
+                            now.saturating_duration_since(at) < super::SUBSCRIPTION_LEASE_DURATION
+                        });
                     (cost_eviction_candidate(local, downstream, rate, recently_accessed)
                         && rate > share_cutoff)
                         .then_some((*key, rate))
@@ -2301,6 +2330,154 @@ mod tests {
         let evicted = cache.evict_cost_pressure(&|_: &ContractKey| (0, 0), &axes);
         assert_eq!(evicted.len(), 1);
         assert_eq!(evicted[0].key, read_hot);
+    }
+
+    /// #4903 review Fix 1 (repeat-PUT facet), cache level: a repeat PUT to an
+    /// ALREADY-hosted contract refreshes `last_genuine_access`, so a
+    /// write-only publisher PUTting continuously is never a cost-eviction
+    /// candidate — and the protection still expires once the PUTs stop.
+    /// (The production wiring — `relay_put_store_locally` calling
+    /// `host_contract` outside its `!was_hosting` gate — is pinned by
+    /// `relay_put_store_locally_stamps_recency_on_repeat_put` in
+    /// `operations/put/op_ctx_task.rs`.)
+    #[test]
+    fn evict_cost_pressure_repeat_put_refreshes_protection() {
+        let (mut cache, clock) = make_cache(1024 * 1024);
+        let publisher = make_key(1);
+        cache.record_access(publisher, 121, AccessType::Put, 1, |_| (0, 0));
+        // Long past the cost window since first host…
+        clock.advance_time(COST_RATE_MIN_WINDOW + Duration::from_secs(1));
+        // …but the publisher keeps PUTting (the refresh path: the entry is
+        // already hosted, so this is `record_access` on an existing entry).
+        cache.record_access(publisher, 121, AccessType::Put, 2, |_| (0, 0));
+
+        let axes = [cost_axis(100_000.0, 50_000.0, &[(&publisher, 90_000.0)])];
+        let evicted = cache.evict_cost_pressure(&|_: &ContractKey| (0, 0), &axes);
+        assert!(
+            evicted.is_empty(),
+            "a repeat PUT is genuine client access (invariant 3) — the \
+             write-only publisher must not be cost-evicted into a churn loop"
+        );
+        assert!(cache.get(&publisher).is_some());
+
+        // Once the PUTs stop for a full cost window the protection lapses.
+        clock.advance_time(COST_RATE_MIN_WINDOW + Duration::from_secs(1));
+        let evicted = cache.evict_cost_pressure(&|_: &ContractKey| (0, 0), &axes);
+        assert_eq!(evicted.len(), 1);
+        assert_eq!(evicted[0].key, publisher);
+    }
+
+    /// #4903 review Fix 1 (local-lease facet): a local-client access within
+    /// the reconciliation renewal lease (`SUBSCRIPTION_LEASE_DURATION`, 8 min
+    /// — LONGER than the 5-min cost window) protects from cost eviction, so
+    /// the sweep can never shed a contract `contracts_needing_renewal` is
+    /// still renewing (the minutes-5-to-8 churn window).
+    #[test]
+    fn evict_cost_pressure_local_client_lease_protects() {
+        use crate::ring::hosting::SUBSCRIPTION_LEASE_DURATION;
+        let (mut cache, clock) = make_cache(1024 * 1024);
+        let local = make_key(1);
+        cache.record_access(local, 121, AccessType::Put, 1, |_| (0, 0));
+        clock.advance_time(COST_RATE_MIN_WINDOW + Duration::from_secs(1));
+        // Local client touches it now (GET via the HTTP/WS gateway path).
+        cache.mark_local_client_access(&local);
+        // Advance PAST the cost window but WITHIN the renewal lease: the
+        // genuine-access stamp is stale, the local lease is not.
+        clock.advance_time(COST_RATE_MIN_WINDOW + Duration::from_secs(1));
+        assert!(cache.has_recent_local_client_access(&local, SUBSCRIPTION_LEASE_DURATION));
+
+        let axes = [cost_axis(100_000.0, 50_000.0, &[(&local, 90_000.0)])];
+        let evicted = cache.evict_cost_pressure(&|_: &ContractKey| (0, 0), &axes);
+        assert!(
+            evicted.is_empty(),
+            "a contract inside the local-client renewal lease must not be a \
+             cost victim (reconciliation still leases it — invariant 3)"
+        );
+
+        // Once the lease lapses too, the contract is shed.
+        clock.advance_time(SUBSCRIPTION_LEASE_DURATION);
+        let evicted = cache.evict_cost_pressure(&|_: &ContractKey| (0, 0), &axes);
+        assert_eq!(evicted.len(), 1);
+        assert_eq!(evicted[0].key, local);
+    }
+
+    /// #4903 review Fix 1 (restart facet): a restart reload leaves
+    /// `last_genuine_access = None` but seeds `local_client_last_access = now`
+    /// for locally-accessed contracts (one renewal window to re-establish
+    /// subscriptions). Cost candidacy must honor that lease — without it the
+    /// sweep evicts a just-reloaded contract reconciliation is about to renew
+    /// (~2.5 min churn after every restart). A reloaded contract with NO
+    /// pre-restart local access gets no such grace.
+    #[test]
+    fn evict_cost_pressure_restart_local_lease_protects() {
+        use crate::ring::hosting::SUBSCRIPTION_LEASE_DURATION;
+        let (mut cache, clock) = make_cache(1024 * 1024);
+        let local = make_key(1);
+        let unloved = make_key(2);
+        cache.load_persisted_entry(
+            local,
+            121,
+            AccessType::Get,
+            Duration::from_secs(3600),
+            true, // locally accessed pre-restart → lease seeded at load
+        );
+        cache.load_persisted_entry(
+            unloved,
+            121,
+            AccessType::Put,
+            Duration::from_secs(3600),
+            false,
+        );
+        cache.finalize_loading();
+
+        let axes = [cost_axis(
+            100_000.0,
+            50_000.0,
+            &[(&local, 40_000.0), (&unloved, 40_000.0)],
+        )];
+        let evicted = cache.evict_cost_pressure(&|_: &ContractKey| (0, 0), &axes);
+        let keys: Vec<ContractKey> = evicted.iter().map(|e| e.key).collect();
+        assert_eq!(
+            keys,
+            vec![unloved],
+            "post-restart: the locally-leased reload survives, the never-\
+             locally-accessed one is shed"
+        );
+        assert!(cache.get(&local).is_some());
+
+        // The restart grace is time-bounded: one renewal lease, then the
+        // reloaded contract competes like anything else.
+        clock.advance_time(SUBSCRIPTION_LEASE_DURATION + Duration::from_secs(1));
+        let evicted = cache.evict_cost_pressure(&|_: &ContractKey| (0, 0), &axes);
+        assert_eq!(evicted.len(), 1);
+        assert_eq!(evicted[0].key, local);
+    }
+
+    /// Exact-25%-share boundary: a contract holding EXACTLY the threshold
+    /// share of the axis total is NOT shed (the share test is strict `>`);
+    /// epsilon above it IS.
+    #[test]
+    fn evict_cost_pressure_exact_share_boundary_not_shed() {
+        let (mut cache, clock) = make_cache(1024 * 1024);
+        let boundary = make_key(1);
+        cache.record_access(boundary, 121, AccessType::Put, 1, |_| (0, 0));
+        clock.advance_time(COST_RATE_MIN_WINDOW + Duration::from_secs(1));
+
+        // rate == 0.25 × total exactly: NOT an offender.
+        let at_threshold = [cost_axis(100_000.0, 50_000.0, &[(&boundary, 25_000.0)])];
+        assert!(
+            cache
+                .evict_cost_pressure(&|_: &ContractKey| (0, 0), &at_threshold)
+                .is_empty(),
+            "exactly the 25% share must NOT trigger (strict >)"
+        );
+        assert!(cache.get(&boundary).is_some());
+
+        // Strictly above the threshold: shed.
+        let above = [cost_axis(100_000.0, 50_000.0, &[(&boundary, 25_000.1)])];
+        let evicted = cache.evict_cost_pressure(&|_: &ContractKey| (0, 0), &above);
+        assert_eq!(evicted.len(), 1);
+        assert_eq!(evicted[0].key, boundary);
     }
 
     /// A LOCAL client subscription protects exactly like a downstream one.

--- a/crates/core/src/ring/hosting/cache.rs
+++ b/crates/core/src/ring/hosting/cache.rs
@@ -1892,6 +1892,21 @@ impl<T: TimeSource> HostingCache<T> {
                 .iter()
                 .filter_map(|(key, entry)| {
                     let rate = axis.rates.get(key.id()).copied().unwrap_or(0.0);
+                    // Cheap, highly-selective gate FIRST (#4903 review perf):
+                    // only a contract whose attributed rate exceeds the share
+                    // cutoff can ever be a victim, so short-circuit BEFORE the
+                    // two DashMap `subscriber_counts` gets and the recency
+                    // check. This filter runs under the hosting write lock on
+                    // every sweep where any axis is over its floor (a busy
+                    // gateway: always), across every hosted contract, so paying
+                    // the subscriber lookup only for the handful over the cutoff
+                    // matters. `rate <= cutoff` rejects rate == 0 and negatives;
+                    // a NaN rate (defensive: meter math) is not <= cutoff so it
+                    // falls through here, but `cost_eviction_candidate` then
+                    // rejects it (its `attributed_rate > 0.0` is false for NaN).
+                    if rate <= share_cutoff {
+                        return None;
+                    }
                     let (local, downstream) = subscriber_counts(key);
                     // Recent demand by the SAME definition the rest of the
                     // system honors (review Fix 1 / invariant 3), so cost
@@ -1920,8 +1935,7 @@ impl<T: TimeSource> HostingCache<T> {
                         || entry.local_client_last_access.is_some_and(|at| {
                             now.saturating_duration_since(at) < super::SUBSCRIPTION_LEASE_DURATION
                         });
-                    (cost_eviction_candidate(local, downstream, rate, recently_accessed)
-                        && rate > share_cutoff)
+                    cost_eviction_candidate(local, downstream, rate, recently_accessed)
                         .then_some((*key, rate))
                 })
                 .collect();

--- a/crates/core/src/ring/hosting/cache.rs
+++ b/crates/core/src/ring/hosting/cache.rs
@@ -2049,20 +2049,34 @@ impl<T: TimeSource> HostingCache<T> {
             // `finalize_loading`.
             recency_seq: 0,
             // Restore the genuine-access recency across restart for the
-            // cost-eviction guard (#4903 review round-3 Fix 5). Unlike
-            // `recency_seq` (an unrestorable sequence number), `last_genuine_access`
-            // is a TIMESTAMP and the persisted row records the last ACCESS TYPE,
-            // so we CAN tell whether the last pre-restart access was a genuine
-            // GET/PUT and, if so, seed it from the persisted age — a contract
-            // GET-read or PUT within `COST_RATE_MIN_WINDOW` before restart then
-            // keeps its cost-eviction protection (invariant 3: "a real GET or PUT
-            // resets recency") instead of being immediately cost-evictable. A
-            // SUBSCRIBE is NOT genuine access, so it stays unprotected (None) —
-            // matching the live `resets_recency` rule in
-            // `record_access_with_demand`.
+            // cost-eviction guard (#4903 review round-3 Fix 5, narrowed by the
+            // round-3-final review). `last_genuine_access` is a TIMESTAMP and the
+            // persisted row records the last ACCESS TYPE, so a contract GET-read
+            // within `COST_RATE_MIN_WINDOW` before restart keeps its
+            // cost-eviction protection (invariant 3: a real GET resets recency)
+            // instead of being immediately cost-evictable.
+            //
+            // ONLY `AccessType::Get` is restored — NOT `Put`. The persisted
+            // `access_type` is NOT a reliable "last genuine access" signal for
+            // Put: `StateStorage::store` (redb + sqlite) unconditionally stamps
+            // `access_type = Put` on EVERY state write, and `StateStore::update`
+            // (the UPDATE merge path) goes through `store`, so ordinary UPDATE
+            // churn persists `Put`. Restoring `Put` would therefore treat a
+            // zero-demand UPDATE-storm contract as genuine-accessed after every
+            // restart, shielding it from cost eviction for a full cost window
+            // each time (indefinitely under crash/restart cycles) — reintroducing
+            // the exact invariant-3 violation "a contract's own UPDATE churn
+            // never counts as genuine access" through the persistence layer.
+            // `Get` (0) can only be written by the hosting-manager access record
+            // for a genuine read (no state-write path ever writes 0), so it is
+            // safe. Cost: a write-only publisher loses cost protection across a
+            // restart until its next live PUT re-stamps `last_genuine_access`
+            // (via `record_access_with_demand`) — acceptable, since publishers
+            // re-PUT periodically and the alternative shields storms. SUBSCRIBE
+            // is not genuine access either → None.
             last_genuine_access: match access_type {
-                AccessType::Get | AccessType::Put => Some(last_accessed),
-                AccessType::Subscribe => None,
+                AccessType::Get => Some(last_accessed),
+                AccessType::Put | AccessType::Subscribe => None,
             },
             // Loaded entries start at the caller-supplied cold demand (the
             // distance prior when this peer's location is known at load, else
@@ -2492,13 +2506,15 @@ mod tests {
     }
 
     /// #4903 review round-3 Fix 5: a restart reload RESTORES
-    /// `last_genuine_access` from the persisted last-access age for GET/PUT
-    /// access types, so a contract genuinely read or written within the cost
-    /// window before restart keeps its cost-eviction protection across the
-    /// restart (invariant 3), even with NO local-client access. A SUBSCRIBE
-    /// reload is not genuine access and gets no such protection. Before Fix 5
-    /// the loader hard-coded `last_genuine_access = None`, so a
-    /// network-accessed (non-local) contract was immediately cost-evictable
+    /// `last_genuine_access` from the persisted last-access age for a GET
+    /// access type, so a contract genuinely READ within the cost window before
+    /// restart keeps its cost-eviction protection across the restart
+    /// (invariant 3), even with NO local-client access. A SUBSCRIBE reload is
+    /// not genuine access and gets no such protection. (PUT reloads are also NOT
+    /// restored — see `evict_cost_pressure_restart_does_not_restore_put_reload`
+    /// for why, since the persistence layer stamps Put on every UPDATE write.)
+    /// Before Fix 5 the loader hard-coded `last_genuine_access = None`, so a
+    /// network-GET-read (non-local) contract was immediately cost-evictable
     /// after every restart.
     #[test]
     fn evict_cost_pressure_restart_restores_recent_genuine_access() {
@@ -2546,6 +2562,61 @@ mod tests {
         let evicted = cache.evict_cost_pressure(&|_: &ContractKey| (0, 0), &axes);
         assert_eq!(evicted.len(), 1);
         assert_eq!(evicted[0].key, recent_get);
+    }
+
+    /// #4903 review round-3-final: a reload whose persisted `access_type` is PUT
+    /// must NOT restore `last_genuine_access`, so a zero-demand UPDATE-storm
+    /// contract stays a cost-eviction candidate after restart. This is the
+    /// storm-relevant guard: `StateStorage::store` (redb + sqlite) stamps
+    /// `access_type = Put` on EVERY state write, and `StateStore::update` (the
+    /// UPDATE merge path) goes through `store`, so ordinary UPDATE churn persists
+    /// `Put`. If the loader restored `Put`, a pure-UPDATE storm contract would be
+    /// shielded from cost eviction for a full cost window after every restart
+    /// (indefinitely under crash/restart cycles) — reintroducing the invariant-3
+    /// violation "a contract's own UPDATE churn never counts as genuine access"
+    /// through persistence. A recent GET reload right beside it is still
+    /// protected (the narrowing keeps genuine reads safe).
+    #[test]
+    fn evict_cost_pressure_restart_does_not_restore_put_reload() {
+        let (mut cache, _clock) = make_cache(1024 * 1024);
+        let update_storm = make_key(1); // last persisted access_type = Put
+        let genuine_get = make_key(2); // last persisted access_type = Get
+        // Both last written/read 1s before restart — as recent as possible, so
+        // if a stale `Put` were restored it WOULD be protected. Neither is
+        // locally accessed. The storm contract's `Put` comes from UPDATE churn
+        // via `store`, not a genuine PUT — indistinguishable in the persisted
+        // metadata, which is exactly why `Put` is not restored.
+        cache.load_persisted_entry(
+            update_storm,
+            121,
+            AccessType::Put,
+            Duration::from_secs(1),
+            false,
+        );
+        cache.load_persisted_entry(
+            genuine_get,
+            121,
+            AccessType::Get,
+            Duration::from_secs(1),
+            false,
+        );
+        cache.finalize_loading();
+
+        let axes = [cost_axis(
+            100_000.0,
+            50_000.0,
+            &[(&update_storm, 40_000.0), (&genuine_get, 40_000.0)],
+        )];
+        let evicted = cache.evict_cost_pressure(&|_: &ContractKey| (0, 0), &axes);
+        let keys: Vec<ContractKey> = evicted.iter().map(|e| e.key).collect();
+        assert_eq!(
+            keys,
+            vec![update_storm],
+            "post-restart: a PUT reload (indistinguishable from UPDATE-storm \
+             churn in the persisted metadata) is NOT protected and stays a cost \
+             candidate; a genuine GET reload beside it IS protected"
+        );
+        assert!(cache.get(&genuine_get).is_some());
     }
 
     /// Exact-25%-share boundary: a contract holding EXACTLY the threshold

--- a/crates/core/src/ring/hosting/cache.rs
+++ b/crates/core/src/ring/hosting/cache.rs
@@ -564,6 +564,21 @@ pub struct HostedContract {
     /// protected by being the most-recently-accessed without any `min_ttl` floor
     /// (dropped 2026-07-08).
     pub recency_seq: u64,
+    /// Wall-clock instant of this entry's most recent **genuine GET/PUT
+    /// access** — the same events that stamp [`Self::recency_seq`], recorded
+    /// as a TIME so the cost-pressure eviction candidacy (cost-aware
+    /// eviction, #4861) can ask "was this contract genuinely read or written
+    /// within the cost window?" (`recency_seq` is an ordering, not a clock,
+    /// so it cannot answer that). Stamped by GET/PUT in `record_access*`, by
+    /// `touch_with_demand` (local-serve GET), and at subscription TERMINATION
+    /// (`record_abandonment` — the recency clock starts there, invariant 3),
+    /// mirroring `recency_seq` exactly. NOT stamped by SUBSCRIBE, renewal, or
+    /// UPDATE traffic — a storm contract whose only activity is its own
+    /// update churn stays cost-evictable, while a genuinely-read zero-
+    /// subscriber contract (the River UI-container class invariant 3
+    /// protects) is not a cost candidate. `None` = never genuinely accessed
+    /// this run (SUBSCRIBE-only seeds, restart reloads).
+    pub last_genuine_access: Option<Instant>,
     /// Demand-ordered (Greedy-Dual) priority: `eviction_floor + predicted_demand` captured at the
     /// last read-demand refresh (or at insert). The over-budget walk evicts the
     /// entry with the lowest `keep_score` (ties broken by `last_accessed`). A
@@ -796,27 +811,44 @@ pub(crate) fn victim_order(
 // =============================================================================
 //
 // The byte budget above measures on-disk STATE bytes only, so a tiny contract
-// that burns the node's update-work capacity (WASM CPU on every apply,
-// broadcast fan-out on every commit) never creates eviction pressure: the
-// #4861 storm contract was 121 bytes of state holding ~58% of a gateway's
-// broadcast capacity with ZERO subscribers, and the byte-gated sweep never
-// ran. Cost pressure closes that gap: the periodic sweep additionally reads
-// the per-contract attributed cost rates from the topology meter
-// (`ExecCpuMicros`, `BroadcastFanoutCost`) and — when the node's total
-// update-work on an axis is above a modest absolute floor AND some
-// zero-demand contract holds more than [`COST_SHARE_THRESHOLD`] of it —
-// sheds that contract, even while comfortably under the byte budget.
+// that burns the node's update-work capacity (WASM CPU on every apply and
+// every per-target send, per-message overhead on every broadcast) never
+// creates eviction pressure: the #4861 storm contract was 121 bytes of state
+// holding ~58% of a gateway's broadcast capacity with ZERO subscribers, and
+// the byte-gated sweep never ran. Cost pressure closes that gap: the periodic
+// sweep additionally reads the per-contract attributed cost rates from the
+// topology meter — `ExecCpuMicros` (apply + probe + per-target
+// summarize/delta WASM), `BroadcastFanoutCost` (payload × targets, the
+// uplink-volume dimension), and `BroadcastMessagesSent` (per-peer send COUNT,
+// the per-send-overhead dimension and the load-bearing storm signal: a
+// tiny-payload high-frequency storm is invisible in bytes but reads its true
+// message rate here) — and, when the node's total update-work on an axis is
+// above a modest absolute floor AND some zero-demand contract holds more than
+// [`COST_SHARE_THRESHOLD`] of it, sheds that contract, even while comfortably
+// under the byte budget.
 //
 // The trigger is deliberately SCALE-FREE (a share of the node's own observed
 // work, not an absolute capacity number) so day one needs no per-hardware
 // calibration; the absolute floors only keep an idle node from evicting the
-// one contract that does any work at all. Candidacy is restricted to
-// `local_subs == 0 && downstream_subs == 0 && attributed_cost > 0`, so a
-// SUBSCRIBED contract is NEVER a cost-eviction candidate — the subscriber-
+// one contract that does any work at all. Two guards keep it honest:
+// SUSTAINED pressure (the meter read admits a contract into candidacy only
+// once its reporting is at least half the cost window old, so a single large
+// fan-out burst can never mass-evict — see `Meter::contract_cost_rates`) and
+// the saturated-buffer true-rate fix (a full sample ring divides by its
+// actual span, so a sustained high-frequency storm's real rate is
+// representable instead of being count-truncated below the floor).
+//
+// Candidacy is restricted to ZERO-DEMAND contracts in invariant 3's full
+// sense: `local_subs == 0 && downstream_subs == 0` AND no genuine GET/PUT
+// within the cost window AND `attributed_cost > 0`. A SUBSCRIBED contract is
+// NEVER a cost-eviction candidate, and neither is an actively-read one (the
+// never-subscribed-but-read River UI-container class) — the subscriber-
 // primary tiers of [`victim_order`] are not reordered by cost (cost breaks
 // ties only WITHIN the zero-demand tier), and the #4296 "River room evicted
 // for being popular" false positive is unreachable by construction, not
-// merely unlikely. See `.claude/rules/hosting-invariants.md` invariant 3.
+// merely unlikely. A storm contract stays evictable because its only
+// activity is its own UPDATE churn, which never counts as genuine access.
+// See `.claude/rules/hosting-invariants.md` invariant 3.
 
 /// Share of the node's total attributed update-work on one cost axis above
 /// which a single zero-demand contract is considered a cost offender. The
@@ -838,11 +870,27 @@ pub(crate) const EXEC_CPU_PRESSURE_FLOOR_MICROS_PER_SEC: f64 = 50_000.0;
 /// the scale-free share above is the primary signal.
 pub(crate) const BROADCAST_FANOUT_PRESSURE_FLOOR_BYTES_PER_SEC: f64 = 128.0 * 1024.0;
 
+/// Absolute floor for the node-total `BroadcastMessagesSent` rate (per-peer
+/// broadcast messages per second) below which the message-COUNT axis never
+/// triggers cost pressure.
+///
+/// This axis is the load-bearing storm signal (#4861): the observed
+/// production profile — a 121-byte contract fanning to ~58 co-hosts at
+/// ~36 per-peer sends/s, sustained — reads as only ~4 KB/s on the byte axis
+/// (~30x under its floor) while dominating the gateway's real broadcast
+/// capacity through per-send overhead (syscall/encryption/queue work +
+/// per-target summarize WASM). Counted as MESSAGES it reads as its true
+/// ~36/s, comfortably over this floor. Calibration: 10 msgs/s sustained
+/// across the 5-min window = 3000 sends of overhead — real load on any
+/// hardware — while a lightly-used legitimate contract (a chat room fanning
+/// a few updates a minute to a handful of peers) stays well under 1/s.
+pub(crate) const BROADCAST_MESSAGES_PRESSURE_FLOOR_PER_SEC: f64 = 10.0;
+
 /// Minimum averaging window for the cost-rate reads feeding the trigger.
 /// A lone burst (one big fan-out reported moments before the sweep) is
 /// amortized over at least this window instead of the meter's 1-second
 /// clamp, so only load SUSTAINED across the window registers as pressure.
-/// See `RunningAverage::get_rate_with_min_window`.
+/// See `RunningAverage::windowed_rate`.
 pub(crate) const COST_RATE_MIN_WINDOW: Duration = Duration::from_secs(300);
 
 /// Node-level attributed-cost snapshot for ONE cost axis, handed to the
@@ -858,22 +906,70 @@ pub(crate) struct CostAxisPressure {
     /// Absolute floor: at or below this total the axis never triggers.
     pub floor: f64,
     /// Per-contract attributed rates (axis units per second). Contracts
-    /// absent from the map have zero attributed cost.
+    /// absent from the map have zero attributed cost. Pre-filtered by the
+    /// meter read to SUSTAINED sources only (first sample at least half the
+    /// cost window old), so a single large burst is never a candidate; every
+    /// positive-rate contract still counts in [`Self::total_rate`].
     pub rates: std::collections::HashMap<freenet_stdlib::prelude::ContractInstanceId, f64>,
 }
 
+/// Assemble the three cost-pressure axes from `(total_rate, per_contract)`
+/// meter reads, binding each to its floor constant. Shared by
+/// `Ring::hosting_cost_pressure_axes` (production) and the storm-frequency
+/// integration test, so the test exercises the same axis assembly the sweep
+/// uses.
+pub(crate) type ContractCostRead = (
+    f64,
+    std::collections::HashMap<freenet_stdlib::prelude::ContractInstanceId, f64>,
+);
+
+pub(crate) fn build_cost_axes(
+    exec_cpu: ContractCostRead,
+    fanout_bytes: ContractCostRead,
+    messages: ContractCostRead,
+) -> Vec<CostAxisPressure> {
+    vec![
+        CostAxisPressure {
+            axis: "exec_cpu_micros_per_sec",
+            total_rate: exec_cpu.0,
+            floor: EXEC_CPU_PRESSURE_FLOOR_MICROS_PER_SEC,
+            rates: exec_cpu.1,
+        },
+        CostAxisPressure {
+            axis: "broadcast_fanout_bytes_per_sec",
+            total_rate: fanout_bytes.0,
+            floor: BROADCAST_FANOUT_PRESSURE_FLOOR_BYTES_PER_SEC,
+            rates: fanout_bytes.1,
+        },
+        CostAxisPressure {
+            axis: "broadcast_messages_per_sec",
+            total_rate: messages.0,
+            floor: BROADCAST_MESSAGES_PRESSURE_FLOOR_PER_SEC,
+            rates: messages.1,
+        },
+    ]
+}
+
 /// The cost-eviction candidacy predicate: only a contract with ZERO demand
-/// (no local client subscriptions AND no downstream subscribers) and strictly
-/// positive attributed cost may be shed by cost pressure. A subscribed
-/// contract is NEVER a candidate — by construction, not by ranking — so cost
-/// pressure cannot reorder the subscriber-primary tiers of [`victim_order`].
-/// NaN-safe: a NaN rate fails the `> 0.0` comparison and is not a candidate.
+/// may be shed by cost pressure, where zero demand means no local client
+/// subscriptions AND no downstream subscribers AND no genuine GET/PUT access
+/// within the cost window (`recently_accessed == false`) — matching invariant
+/// 3's demand definition, which includes reads. A subscribed contract is
+/// NEVER a candidate, and neither is an actively-read/written one (the
+/// never-subscribed-but-read River UI-container class invariant 3 protects) —
+/// by construction, not by ranking — so cost pressure cannot reorder the
+/// subscriber-primary tiers of [`victim_order`] and cannot touch read-hot
+/// contracts. A storm contract stays evictable because its only activity is
+/// its own UPDATE churn, which deliberately never counts as genuine access.
+/// The rate must also be strictly positive (cost pressure is not a generic
+/// zero-subscriber purge). NaN-safe: a NaN rate fails `> 0.0`.
 pub(crate) fn cost_eviction_candidate(
     local_subs: usize,
     downstream_subs: usize,
     attributed_rate: f64,
+    recently_accessed: bool,
 ) -> bool {
-    local_subs == 0 && downstream_subs == 0 && attributed_rate > 0.0
+    local_subs == 0 && downstream_subs == 0 && !recently_accessed && attributed_rate > 0.0
 }
 
 impl<T: TimeSource> HostingCache<T> {
@@ -1253,9 +1349,12 @@ impl<T: TimeSource> HostingCache<T> {
             existing.predicted_demand = predicted_demand;
 
             // A real GET or PUT refreshes the eviction recency key (a PUT is
-            // genuine client access; SUBSCRIBE/renewal does not).
+            // genuine client access; SUBSCRIBE/renewal does not). The
+            // wall-clock twin (`last_genuine_access`) feeds the cost-eviction
+            // recency guard (#4861).
             if resets_recency {
                 existing.recency_seq = seq;
+                existing.last_genuine_access = Some(now);
             }
 
             let observed_read_rate = if is_read {
@@ -1296,6 +1395,7 @@ impl<T: TimeSource> HostingCache<T> {
                 // at 0 (never client-accessed), so it sorts to evict first among
                 // zero-subscriber entries.
                 recency_seq: if resets_recency { seq } else { 0 },
+                last_genuine_access: resets_recency.then_some(now),
                 keep_score: self.eviction_floor + predicted_demand,
                 predicted_demand,
                 read_count: if is_read { 1 } else { 0 },
@@ -1436,8 +1536,10 @@ impl<T: TimeSource> HostingCache<T> {
             existing.last_accessed = now;
             existing.last_access_seq = seq;
             // A touch is a local-cache GET serve — a real GET read, so it
-            // refreshes the eviction recency key (unlike SUBSCRIBE/PUT/renewal).
+            // refreshes the eviction recency key (unlike SUBSCRIBE/renewal)
+            // and the wall-clock cost-eviction recency guard (#4861).
             existing.recency_seq = seq;
+            existing.last_genuine_access = Some(now);
             existing.read_count = existing.read_count.saturating_add(1);
             // A fresh touch is evidence of demand — clear any abandoned marker,
             // refresh the stored demand estimate to the caller's freshly-derived
@@ -1516,8 +1618,12 @@ impl<T: TimeSource> HostingCache<T> {
             existing.abandoned_at = Some(now);
             // Reset the recency clock at termination (see the doc above) so the
             // formerly-subscribed contract is not instantly evicted for an old
-            // last-read accrued while it sat in the subscription tier.
+            // last-read accrued while it sat in the subscription tier. The
+            // wall-clock twin gives the same grace against COST eviction
+            // (#4861): a just-unsubscribed contract gets one cost window
+            // before its update-work cost can make it a candidate.
             existing.recency_seq = seq;
+            existing.last_genuine_access = Some(now);
             // Strip demand credit (demoted telemetry only): drop keep_score to
             // the frontier.
             existing.keep_score = floor;
@@ -1764,6 +1870,7 @@ impl<T: TimeSource> HostingCache<T> {
     where
         G: Fn(&ContractKey) -> (usize, usize),
     {
+        let now = self.time_source.now();
         let mut evicted = Vec::new();
         for axis in axes {
             // NaN-safe: a NaN/zero/sub-floor total never triggers the axis.
@@ -1773,11 +1880,19 @@ impl<T: TimeSource> HostingCache<T> {
             let share_cutoff = COST_SHARE_THRESHOLD * axis.total_rate;
             let mut offenders: Vec<(ContractKey, f64)> = self
                 .contracts
-                .keys()
-                .filter_map(|key| {
+                .iter()
+                .filter_map(|(key, entry)| {
                     let rate = axis.rates.get(key.id()).copied().unwrap_or(0.0);
                     let (local, downstream) = subscriber_counts(key);
-                    (cost_eviction_candidate(local, downstream, rate) && rate > share_cutoff)
+                    // Genuine GET/PUT within the cost window = read-demand,
+                    // which invariant 3 counts as demand: not a candidate.
+                    // UPDATE churn never stamps `last_genuine_access`, so a
+                    // storm contract cannot protect itself.
+                    let recently_accessed = entry
+                        .last_genuine_access
+                        .is_some_and(|at| now.saturating_duration_since(at) < COST_RATE_MIN_WINDOW);
+                    (cost_eviction_candidate(local, downstream, rate, recently_accessed)
+                        && rate > share_cutoff)
                         .then_some((*key, rate))
                 })
                 .collect();
@@ -1881,6 +1996,10 @@ impl<T: TimeSource> HostingCache<T> {
             // entry). A live GET after restart re-stamps it to a true value. See
             // `finalize_loading`.
             recency_seq: 0,
+            // Same reasoning as `recency_seq`: persistence can't distinguish a
+            // genuine GET/PUT from a SUBSCRIBE, so a reload starts with no
+            // genuine-access claim; a live GET/PUT re-stamps it (#4861).
+            last_genuine_access: None,
             // Loaded entries start at the caller-supplied cold demand (the
             // distance prior when this peer's location is known at load, else
             // neutral). The first live read re-scores against the current prior.
@@ -2058,25 +2177,32 @@ mod tests {
     // Cost-pressure eviction (cost-aware eviction, #4861)
     // =========================================================================
 
-    /// The candidacy predicate: ONLY zero-demand (no local subscriptions, no
-    /// downstream subscribers) contracts with strictly positive attributed
-    /// cost are cost-eviction candidates. Any subscriber — local or
-    /// downstream — makes a contract non-candidate by construction.
+    /// The candidacy predicate: ONLY zero-demand contracts — no local
+    /// subscriptions, no downstream subscribers, AND no genuine GET/PUT
+    /// within the cost window (invariant 3 counts reads as demand) — with
+    /// strictly positive attributed cost are cost-eviction candidates. Any
+    /// subscriber OR recent genuine access makes a contract non-candidate by
+    /// construction.
     #[test]
     fn cost_eviction_candidate_requires_zero_demand_and_nonzero_cost() {
         // The one shape that qualifies.
-        assert!(cost_eviction_candidate(0, 0, 1.0));
+        assert!(cost_eviction_candidate(0, 0, 1.0, false));
         // A local client subscription protects, regardless of cost.
-        assert!(!cost_eviction_candidate(1, 0, f64::MAX));
+        assert!(!cost_eviction_candidate(1, 0, f64::MAX, false));
         // A downstream subscriber protects, regardless of cost.
-        assert!(!cost_eviction_candidate(0, 1, f64::MAX));
-        assert!(!cost_eviction_candidate(2, 3, 100.0));
+        assert!(!cost_eviction_candidate(0, 1, f64::MAX, false));
+        assert!(!cost_eviction_candidate(2, 3, 100.0, false));
+        // A genuine GET/PUT within the cost window protects, regardless of
+        // cost — the read-but-never-subscribed class (River UI container)
+        // invariant 3 says must be retained.
+        assert!(!cost_eviction_candidate(0, 0, f64::MAX, true));
+        assert!(!cost_eviction_candidate(1, 1, f64::MAX, true));
         // Zero-demand but no attributed cost: not a candidate (nothing to
         // shed — cost pressure must never become a generic zero-sub purge).
-        assert!(!cost_eviction_candidate(0, 0, 0.0));
+        assert!(!cost_eviction_candidate(0, 0, 0.0, false));
         // Negative / NaN rates (defensive: meter math) are not cost.
-        assert!(!cost_eviction_candidate(0, 0, -1.0));
-        assert!(!cost_eviction_candidate(0, 0, f64::NAN));
+        assert!(!cost_eviction_candidate(0, 0, -1.0, false));
+        assert!(!cost_eviction_candidate(0, 0, f64::NAN, false));
     }
 
     /// Helper: one cost axis with the given total/floor and per-contract
@@ -2097,7 +2223,7 @@ mod tests {
     /// it).
     #[test]
     fn evict_cost_pressure_sheds_zero_demand_offender_never_subscribed() {
-        let (mut cache, _ts) = make_cache(1024 * 1024);
+        let (mut cache, clock) = make_cache(1024 * 1024);
         let junk = make_key(1);
         let subscribed = make_key(2);
         let quiet = make_key(3);
@@ -2106,6 +2232,9 @@ mod tests {
         cache.record_access(subscribed, 121, AccessType::Put, 3, |_| (0, 0));
         cache.record_access(quiet, 121, AccessType::Put, 1, |_| (0, 0));
         assert!(cache.stats().current_bytes < cache.stats().budget_bytes);
+        // Age the PUT-seed genuine-access stamps past the cost window: the
+        // storm has run for a long time with no further genuine GET/PUT.
+        clock.advance_time(COST_RATE_MIN_WINDOW + Duration::from_secs(1));
 
         // junk holds 58% of the axis total with zero subscribers; the
         // subscribed contract holds 40% with a downstream subscriber; quiet
@@ -2144,12 +2273,43 @@ mod tests {
         );
     }
 
+    /// A genuine GET/PUT within the cost window protects a ZERO-subscriber
+    /// contract from cost eviction (invariant 3: reads are demand — the
+    /// never-subscribed-but-read River UI-container class), and the
+    /// protection expires once the access ages past the window. UPDATE churn
+    /// gets no such protection: it never stamps `last_genuine_access`.
+    #[test]
+    fn evict_cost_pressure_recent_genuine_access_protects() {
+        let (mut cache, clock) = make_cache(1024 * 1024);
+        let read_hot = make_key(1);
+        cache.record_access(read_hot, 121, AccessType::Put, 1, |_| (0, 0));
+        clock.advance_time(COST_RATE_MIN_WINDOW + Duration::from_secs(1));
+        // A genuine GET just now (the local-serve `touch` path — a real read).
+        cache.touch(&read_hot);
+
+        let axes = [cost_axis(100_000.0, 50_000.0, &[(&read_hot, 90_000.0)])];
+        let evicted = cache.evict_cost_pressure(&|_: &ContractKey| (0, 0), &axes);
+        assert!(
+            evicted.is_empty(),
+            "a genuinely-read zero-subscriber contract must not be a cost victim"
+        );
+        assert!(cache.get(&read_hot).is_some());
+
+        // The same contract with the same cost IS shed once the read ages
+        // past the cost window — proving the gate is the recent access.
+        clock.advance_time(COST_RATE_MIN_WINDOW + Duration::from_secs(1));
+        let evicted = cache.evict_cost_pressure(&|_: &ContractKey| (0, 0), &axes);
+        assert_eq!(evicted.len(), 1);
+        assert_eq!(evicted[0].key, read_hot);
+    }
+
     /// A LOCAL client subscription protects exactly like a downstream one.
     #[test]
     fn evict_cost_pressure_local_subscription_protects() {
-        let (mut cache, _ts) = make_cache(1024 * 1024);
+        let (mut cache, clock) = make_cache(1024 * 1024);
         let hot = make_key(1);
         cache.record_access(hot, 121, AccessType::Put, 1, |_| (0, 0));
+        clock.advance_time(COST_RATE_MIN_WINDOW + Duration::from_secs(1));
         let axes = [cost_axis(100_000.0, 50_000.0, &[(&hot, 90_000.0)])];
         let evicted = cache.evict_cost_pressure(&|_: &ContractKey| (1, 0), &axes);
         assert!(
@@ -2163,9 +2323,10 @@ mod tests {
     /// work never cost-evicts, even at a 100% share.
     #[test]
     fn evict_cost_pressure_respects_absolute_floor() {
-        let (mut cache, _ts) = make_cache(1024 * 1024);
+        let (mut cache, clock) = make_cache(1024 * 1024);
         let only = make_key(1);
         cache.record_access(only, 121, AccessType::Put, 1, |_| (0, 0));
+        clock.advance_time(COST_RATE_MIN_WINDOW + Duration::from_secs(1));
         // Total below the floor: the lone contract holds 100% of not-much.
         let axes = [cost_axis(10_000.0, 50_000.0, &[(&only, 10_000.0)])];
         let evicted = cache.evict_cost_pressure(&|_: &ContractKey| (0, 0), &axes);
@@ -2187,11 +2348,12 @@ mod tests {
     /// none of which dominates are all retained.
     #[test]
     fn evict_cost_pressure_respects_share_threshold() {
-        let (mut cache, _ts) = make_cache(1024 * 1024);
+        let (mut cache, clock) = make_cache(1024 * 1024);
         let a = make_key(1);
         let b = make_key(2);
         cache.record_access(a, 121, AccessType::Put, 1, |_| (0, 0));
         cache.record_access(b, 121, AccessType::Put, 1, |_| (0, 0));
+        clock.advance_time(COST_RATE_MIN_WINDOW + Duration::from_secs(1));
         // Each holds 20% — above the floor in total, but no single offender
         // exceeds the 25% share.
         let axes = [cost_axis(
@@ -2211,13 +2373,14 @@ mod tests {
     /// and a second axis naturally skips contracts already shed by the first.
     #[test]
     fn evict_cost_pressure_sheds_all_super_threshold_offenders_descending() {
-        let (mut cache, _ts) = make_cache(1024 * 1024);
+        let (mut cache, clock) = make_cache(1024 * 1024);
         let big = make_key(1);
         let bigger = make_key(2);
         let small = make_key(3);
         cache.record_access(big, 121, AccessType::Put, 1, |_| (0, 0));
         cache.record_access(bigger, 121, AccessType::Put, 2, |_| (0, 0));
         cache.record_access(small, 121, AccessType::Put, 3, |_| (0, 0));
+        clock.advance_time(COST_RATE_MIN_WINDOW + Duration::from_secs(1));
         let axes = [
             cost_axis(
                 100_000.0,

--- a/crates/core/src/ring/hosting/cache.rs
+++ b/crates/core/src/ring/hosting/cache.rs
@@ -316,6 +316,16 @@ pub(crate) struct HostingCacheStats {
     /// ships, so a rising differenced rate here is the signal to check whether
     /// budgets are too tight / demand is churning subscribed contracts.
     pub subscribed_evictions_total: u64,
+    /// Monotonic count of COST-PRESSURE evictions (cost-aware eviction,
+    /// #4861): zero-demand contracts shed because their attributed update-work
+    /// cost (WASM CPU / broadcast fan-out) dominated the node's total on a
+    /// cost axis, independently of the byte budget. Disjoint from
+    /// [`Self::budget_evictions_total`] (byte-budget-triggered evictions
+    /// only). The field falsifier for the cost trigger: a nonzero differenced
+    /// rate means the node is actively shedding cost offenders; a runaway rate
+    /// means the floors / share threshold are miscalibrated and churning cheap
+    /// contracts.
+    pub cost_evictions_total: u64,
 }
 
 /// Per-contract Greedy-Dual priority row for the local-peer dashboard.
@@ -732,6 +742,10 @@ pub struct HostingCache<T: TimeSource> {
     /// last-resort shed AND the Overflow valve). See
     /// [`HostingCacheStats::subscribed_evictions_total`].
     subscribed_evictions_total: u64,
+    /// Monotonic count of cost-pressure evictions (cost-aware eviction,
+    /// #4861). Only [`Self::evict_cost_pressure`] increments it. See
+    /// [`HostingCacheStats::cost_evictions_total`].
+    cost_evictions_total: u64,
     /// Time source for testability
     time_source: T,
 }
@@ -777,6 +791,91 @@ pub(crate) fn victim_order(
         .then_with(|| a_key.as_bytes().cmp(b_key.as_bytes()))
 }
 
+// =============================================================================
+// Cost-pressure eviction (cost-aware eviction, #4861)
+// =============================================================================
+//
+// The byte budget above measures on-disk STATE bytes only, so a tiny contract
+// that burns the node's update-work capacity (WASM CPU on every apply,
+// broadcast fan-out on every commit) never creates eviction pressure: the
+// #4861 storm contract was 121 bytes of state holding ~58% of a gateway's
+// broadcast capacity with ZERO subscribers, and the byte-gated sweep never
+// ran. Cost pressure closes that gap: the periodic sweep additionally reads
+// the per-contract attributed cost rates from the topology meter
+// (`ExecCpuMicros`, `BroadcastFanoutCost`) and — when the node's total
+// update-work on an axis is above a modest absolute floor AND some
+// zero-demand contract holds more than [`COST_SHARE_THRESHOLD`] of it —
+// sheds that contract, even while comfortably under the byte budget.
+//
+// The trigger is deliberately SCALE-FREE (a share of the node's own observed
+// work, not an absolute capacity number) so day one needs no per-hardware
+// calibration; the absolute floors only keep an idle node from evicting the
+// one contract that does any work at all. Candidacy is restricted to
+// `local_subs == 0 && downstream_subs == 0 && attributed_cost > 0`, so a
+// SUBSCRIBED contract is NEVER a cost-eviction candidate — the subscriber-
+// primary tiers of [`victim_order`] are not reordered by cost (cost breaks
+// ties only WITHIN the zero-demand tier), and the #4296 "River room evicted
+// for being popular" false positive is unreachable by construction, not
+// merely unlikely. See `.claude/rules/hosting-invariants.md` invariant 3.
+
+/// Share of the node's total attributed update-work on one cost axis above
+/// which a single zero-demand contract is considered a cost offender. The
+/// scale-free half of the cost-pressure trigger.
+pub(crate) const COST_SHARE_THRESHOLD: f64 = 0.25;
+
+/// Absolute floor for the node-total `ExecCpuMicros` rate (µs of WASM
+/// `update_state` execution per second) below which the CPU axis never
+/// triggers cost pressure. 50_000 µs/s = 5% of one core spent applying
+/// contract updates, sustained across the meter window — a node doing less
+/// update work than that is not under CPU pressure regardless of shares.
+/// Day-one calibration; the scale-free share above is the primary signal.
+pub(crate) const EXEC_CPU_PRESSURE_FLOOR_MICROS_PER_SEC: f64 = 50_000.0;
+
+/// Absolute floor for the node-total `BroadcastFanoutCost` rate (payload
+/// bytes × target count per second) below which the fan-out axis never
+/// triggers cost pressure. 128 KiB/s of intended fan-out egress (~1 Mbit/s)
+/// is a modest but real share of a small peer's uplink. Day-one calibration;
+/// the scale-free share above is the primary signal.
+pub(crate) const BROADCAST_FANOUT_PRESSURE_FLOOR_BYTES_PER_SEC: f64 = 128.0 * 1024.0;
+
+/// Minimum averaging window for the cost-rate reads feeding the trigger.
+/// A lone burst (one big fan-out reported moments before the sweep) is
+/// amortized over at least this window instead of the meter's 1-second
+/// clamp, so only load SUSTAINED across the window registers as pressure.
+/// See `RunningAverage::get_rate_with_min_window`.
+pub(crate) const COST_RATE_MIN_WINDOW: Duration = Duration::from_secs(300);
+
+/// Node-level attributed-cost snapshot for ONE cost axis, handed to the
+/// sweep by the caller (`Ring` reads the topology meter — see
+/// `Ring::hosting_cost_pressure_axes`; this module never touches the meter).
+#[derive(Debug, Clone)]
+pub(crate) struct CostAxisPressure {
+    /// Axis name for logs/telemetry (e.g. `"exec_cpu_micros_per_sec"`).
+    pub axis: &'static str,
+    /// Node-total attributed rate across ALL contracts (axis units per
+    /// second), the denominator of the share test.
+    pub total_rate: f64,
+    /// Absolute floor: at or below this total the axis never triggers.
+    pub floor: f64,
+    /// Per-contract attributed rates (axis units per second). Contracts
+    /// absent from the map have zero attributed cost.
+    pub rates: std::collections::HashMap<freenet_stdlib::prelude::ContractInstanceId, f64>,
+}
+
+/// The cost-eviction candidacy predicate: only a contract with ZERO demand
+/// (no local client subscriptions AND no downstream subscribers) and strictly
+/// positive attributed cost may be shed by cost pressure. A subscribed
+/// contract is NEVER a candidate — by construction, not by ranking — so cost
+/// pressure cannot reorder the subscriber-primary tiers of [`victim_order`].
+/// NaN-safe: a NaN rate fails the `> 0.0` comparison and is not a candidate.
+pub(crate) fn cost_eviction_candidate(
+    local_subs: usize,
+    downstream_subs: usize,
+    attributed_rate: f64,
+) -> bool {
+    local_subs == 0 && downstream_subs == 0 && attributed_rate > 0.0
+}
+
 impl<T: TimeSource> HostingCache<T> {
     /// Create a new hosting cache with the given byte budget.
     pub fn new(budget_bytes: u64, time_source: T) -> Self {
@@ -792,6 +891,7 @@ impl<T: TimeSource> HostingCache<T> {
             evicted_unread_age_secs_sum: 0,
             oom_valve_evictions_total: 0,
             subscribed_evictions_total: 0,
+            cost_evictions_total: 0,
             time_source,
         }
     }
@@ -1514,6 +1614,7 @@ impl<T: TimeSource> HostingCache<T> {
             contract_count: self.contracts.len() as u64,
             budget_evictions_total: self.budget_evictions_total,
             subscribed_evictions_total: self.subscribed_evictions_total,
+            cost_evictions_total: self.cost_evictions_total,
             evictions_of_recently_read_total: self.evictions_of_recently_read_total,
             evicted_unread_total: self.evicted_unread_total,
             evicted_unread_age_secs_sum: self.evicted_unread_age_secs_sum,
@@ -1621,6 +1722,101 @@ impl<T: TimeSource> HostingCache<T> {
         // subscriber-primary (fewest local, then fewest downstream, then
         // least-recent real GET/PUT). No `protected` key on the periodic sweep.
         self.evict_over_budget(&subscriber_counts, pressure, None)
+    }
+
+    /// Cost-pressure eviction (cost-aware eviction, #4861): shed zero-demand
+    /// contracts whose attributed update-work cost dominates the node's total
+    /// on a cost axis — even while UNDER the byte budget (this is what forces
+    /// the sweep to act when byte pressure never materializes; see the module
+    /// section "Cost-pressure eviction").
+    ///
+    /// Per axis, when `total_rate > floor`, the candidates are the hosted
+    /// contracts satisfying [`cost_eviction_candidate`] (zero local
+    /// subscriptions AND zero downstream subscribers AND attributed rate
+    /// > 0) whose rate exceeds [`COST_SHARE_THRESHOLD`] × `total_rate`.
+    /// Candidates are shed in DESCENDING attributed-rate order (contract-key
+    /// bytes as a deterministic tiebreak); the deficit is covered exactly when
+    /// no remaining zero-demand contract holds more than the threshold share
+    /// of the axis total, i.e. every super-threshold offender is shed. Shares
+    /// are computed against the PRE-eviction total, so the decision is a
+    /// single deterministic pass, not a feedback loop. A contract shed by an
+    /// earlier axis is naturally absent from later axes' candidate sets.
+    ///
+    /// The subscriber-primary tiers are untouched by construction: a contract
+    /// with ANY subscriber fails candidacy outright, so `was_in_use` is
+    /// `false` for every returned victim and the caller's in-use teardown is
+    /// a no-op. Recency is neither read nor refreshed here (an UPDATE-storm
+    /// contract deliberately accrues no recency — cache.rs recency semantics
+    /// unchanged); the in-flight-op races this opens are the same ones the
+    /// periodic byte sweep already has, closed downstream by the
+    /// `write_generation` re-host guard and the `contract_in_use` re-check in
+    /// `RuntimePool::remove_contract`.
+    ///
+    /// `subscriber_counts(key)` is the caller's genuine-demand split, read
+    /// once per candidate and captured atomically with the decision (same
+    /// discipline as [`Self::evict_over_budget`]).
+    pub fn evict_cost_pressure<G>(
+        &mut self,
+        subscriber_counts: &G,
+        axes: &[CostAxisPressure],
+    ) -> Vec<EvictedContract>
+    where
+        G: Fn(&ContractKey) -> (usize, usize),
+    {
+        let mut evicted = Vec::new();
+        for axis in axes {
+            // NaN-safe: a NaN/zero/sub-floor total never triggers the axis.
+            if axis.total_rate.is_nan() || axis.total_rate <= axis.floor {
+                continue;
+            }
+            let share_cutoff = COST_SHARE_THRESHOLD * axis.total_rate;
+            let mut offenders: Vec<(ContractKey, f64)> = self
+                .contracts
+                .keys()
+                .filter_map(|key| {
+                    let rate = axis.rates.get(key.id()).copied().unwrap_or(0.0);
+                    let (local, downstream) = subscriber_counts(key);
+                    (cost_eviction_candidate(local, downstream, rate) && rate > share_cutoff)
+                        .then_some((*key, rate))
+                })
+                .collect();
+            // Descending by attributed rate; key bytes break exact-rate ties
+            // deterministically.
+            offenders.sort_by(|a, b| {
+                b.1.partial_cmp(&a.1)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+                    .then_with(|| a.0.as_bytes().cmp(b.0.as_bytes()))
+            });
+            for (key, rate) in offenders {
+                if let Some(entry) = self.contracts.remove(&key) {
+                    self.current_bytes = self.current_bytes.saturating_sub(entry.size_bytes);
+                    self.cost_evictions_total = self.cost_evictions_total.saturating_add(1);
+                    // Operator-facing: this is the storm diagnosis surfacing in
+                    // the field. read_count is logged (not gated on) so the
+                    // field can tell whether cost eviction is hitting contracts
+                    // with genuine read demand.
+                    tracing::warn!(
+                        contract = %key,
+                        axis = axis.axis,
+                        attributed_rate = rate,
+                        node_total_rate = axis.total_rate,
+                        share = rate / axis.total_rate,
+                        read_count = entry.read_count,
+                        state_bytes = entry.size_bytes,
+                        "cost-pressure eviction: shedding zero-subscriber contract \
+                         dominating this node's attributed update-work (#4861)"
+                    );
+                    evicted.push(EvictedContract {
+                        key,
+                        write_generation: entry.write_generation,
+                        // Candidacy requires (local, downstream) == (0, 0) at
+                        // decision time, so the victim was NOT in use.
+                        was_in_use: false,
+                    });
+                }
+            }
+        }
+        evicted
     }
 
     /// Load a contract entry from persisted data during startup, using an
@@ -1855,6 +2051,193 @@ mod tests {
             victim_order((1, 1, 1, &k1), (1, 1, 1, &k1)),
             Ordering::Equal
         );
+    }
+
+    // =========================================================================
+    // Cost-pressure eviction (cost-aware eviction, #4861)
+    // =========================================================================
+
+    /// The candidacy predicate: ONLY zero-demand (no local subscriptions, no
+    /// downstream subscribers) contracts with strictly positive attributed
+    /// cost are cost-eviction candidates. Any subscriber — local or
+    /// downstream — makes a contract non-candidate by construction.
+    #[test]
+    fn cost_eviction_candidate_requires_zero_demand_and_nonzero_cost() {
+        // The one shape that qualifies.
+        assert!(cost_eviction_candidate(0, 0, 1.0));
+        // A local client subscription protects, regardless of cost.
+        assert!(!cost_eviction_candidate(1, 0, f64::MAX));
+        // A downstream subscriber protects, regardless of cost.
+        assert!(!cost_eviction_candidate(0, 1, f64::MAX));
+        assert!(!cost_eviction_candidate(2, 3, 100.0));
+        // Zero-demand but no attributed cost: not a candidate (nothing to
+        // shed — cost pressure must never become a generic zero-sub purge).
+        assert!(!cost_eviction_candidate(0, 0, 0.0));
+        // Negative / NaN rates (defensive: meter math) are not cost.
+        assert!(!cost_eviction_candidate(0, 0, -1.0));
+        assert!(!cost_eviction_candidate(0, 0, f64::NAN));
+    }
+
+    /// Helper: one cost axis with the given total/floor and per-contract
+    /// rates.
+    fn cost_axis(total_rate: f64, floor: f64, rates: &[(&ContractKey, f64)]) -> CostAxisPressure {
+        CostAxisPressure {
+            axis: "test_axis",
+            total_rate,
+            floor,
+            rates: rates.iter().map(|(k, r)| (*k.id(), *r)).collect(),
+        }
+    }
+
+    /// The discriminator at the cache level: under cost pressure — while
+    /// comfortably UNDER the byte budget — the zero-subscriber contract
+    /// dominating the axis is shed, while a SUBSCRIBED contract holding an
+    /// equally dominant share is untouched (candidacy, not ranking, protects
+    /// it).
+    #[test]
+    fn evict_cost_pressure_sheds_zero_demand_offender_never_subscribed() {
+        let (mut cache, _ts) = make_cache(1024 * 1024);
+        let junk = make_key(1);
+        let subscribed = make_key(2);
+        let quiet = make_key(3);
+        // Tiny states: byte budget is nowhere near exceeded (the #4861 shape).
+        cache.record_access(junk, 121, AccessType::Put, 7, |_| (0, 0));
+        cache.record_access(subscribed, 121, AccessType::Put, 3, |_| (0, 0));
+        cache.record_access(quiet, 121, AccessType::Put, 1, |_| (0, 0));
+        assert!(cache.stats().current_bytes < cache.stats().budget_bytes);
+
+        // junk holds 58% of the axis total with zero subscribers; the
+        // subscribed contract holds 40% with a downstream subscriber; quiet
+        // does no attributable work.
+        let axes = [cost_axis(
+            100_000.0,
+            50_000.0,
+            &[(&junk, 58_000.0), (&subscribed, 40_000.0)],
+        )];
+        let counts = |key: &ContractKey| if *key == subscribed { (0, 1) } else { (0, 0) };
+        let evicted = cache.evict_cost_pressure(&counts, &axes);
+
+        assert_eq!(evicted.len(), 1, "exactly the dominant zero-sub offender");
+        assert_eq!(evicted[0].key, junk);
+        assert_eq!(
+            evicted[0].write_generation, 7,
+            "generation snapshot travels with the eviction for the re-host guard"
+        );
+        assert!(
+            !evicted[0].was_in_use,
+            "cost victims are zero-demand by construction"
+        );
+        assert!(cache.get(&subscribed).is_some(), "subscribed survives");
+        assert!(cache.get(&quiet).is_some(), "no-cost contract survives");
+        assert!(cache.get(&junk).is_none());
+        let stats = cache.stats();
+        assert_eq!(stats.cost_evictions_total, 1);
+        assert_eq!(
+            stats.budget_evictions_total, 0,
+            "cost evictions must not masquerade as byte-budget evictions"
+        );
+        assert_eq!(
+            stats.current_bytes,
+            2 * 121,
+            "byte accounting reflects the shed entry"
+        );
+    }
+
+    /// A LOCAL client subscription protects exactly like a downstream one.
+    #[test]
+    fn evict_cost_pressure_local_subscription_protects() {
+        let (mut cache, _ts) = make_cache(1024 * 1024);
+        let hot = make_key(1);
+        cache.record_access(hot, 121, AccessType::Put, 1, |_| (0, 0));
+        let axes = [cost_axis(100_000.0, 50_000.0, &[(&hot, 90_000.0)])];
+        let evicted = cache.evict_cost_pressure(&|_: &ContractKey| (1, 0), &axes);
+        assert!(
+            evicted.is_empty(),
+            "a locally-subscribed contract is never a cost victim"
+        );
+        assert!(cache.get(&hot).is_some());
+    }
+
+    /// The absolute floor gates the axis: a node doing little total update
+    /// work never cost-evicts, even at a 100% share.
+    #[test]
+    fn evict_cost_pressure_respects_absolute_floor() {
+        let (mut cache, _ts) = make_cache(1024 * 1024);
+        let only = make_key(1);
+        cache.record_access(only, 121, AccessType::Put, 1, |_| (0, 0));
+        // Total below the floor: the lone contract holds 100% of not-much.
+        let axes = [cost_axis(10_000.0, 50_000.0, &[(&only, 10_000.0)])];
+        let evicted = cache.evict_cost_pressure(&|_: &ContractKey| (0, 0), &axes);
+        assert!(
+            evicted.is_empty(),
+            "sub-floor totals never trigger cost pressure"
+        );
+        // Exactly AT the floor also does not trigger (strict >).
+        let axes = [cost_axis(50_000.0, 50_000.0, &[(&only, 50_000.0)])];
+        assert!(
+            cache
+                .evict_cost_pressure(&|_: &ContractKey| (0, 0), &axes)
+                .is_empty()
+        );
+        assert_eq!(cache.stats().cost_evictions_total, 0);
+    }
+
+    /// The share threshold gates candidacy: many small zero-sub contracts
+    /// none of which dominates are all retained.
+    #[test]
+    fn evict_cost_pressure_respects_share_threshold() {
+        let (mut cache, _ts) = make_cache(1024 * 1024);
+        let a = make_key(1);
+        let b = make_key(2);
+        cache.record_access(a, 121, AccessType::Put, 1, |_| (0, 0));
+        cache.record_access(b, 121, AccessType::Put, 1, |_| (0, 0));
+        // Each holds 20% — above the floor in total, but no single offender
+        // exceeds the 25% share.
+        let axes = [cost_axis(
+            100_000.0,
+            50_000.0,
+            &[(&a, 20_000.0), (&b, 20_000.0)],
+        )];
+        let evicted = cache.evict_cost_pressure(&|_: &ContractKey| (0, 0), &axes);
+        assert!(
+            evicted.is_empty(),
+            "no single contract dominates → no eviction"
+        );
+    }
+
+    /// Multiple super-threshold offenders are shed in descending-rate order
+    /// (the deficit is covered when every super-threshold offender is gone),
+    /// and a second axis naturally skips contracts already shed by the first.
+    #[test]
+    fn evict_cost_pressure_sheds_all_super_threshold_offenders_descending() {
+        let (mut cache, _ts) = make_cache(1024 * 1024);
+        let big = make_key(1);
+        let bigger = make_key(2);
+        let small = make_key(3);
+        cache.record_access(big, 121, AccessType::Put, 1, |_| (0, 0));
+        cache.record_access(bigger, 121, AccessType::Put, 2, |_| (0, 0));
+        cache.record_access(small, 121, AccessType::Put, 3, |_| (0, 0));
+        let axes = [
+            cost_axis(
+                100_000.0,
+                50_000.0,
+                &[(&big, 30_000.0), (&bigger, 45_000.0), (&small, 10_000.0)],
+            ),
+            // Second axis where an already-shed contract also dominates: it
+            // is gone from the hosted set, so only itself would qualify and
+            // nothing double-evicts.
+            cost_axis(2_000_000.0, 131_072.0, &[(&bigger, 1_900_000.0)]),
+        ];
+        let evicted = cache.evict_cost_pressure(&|_: &ContractKey| (0, 0), &axes);
+        let keys: Vec<ContractKey> = evicted.iter().map(|e| e.key).collect();
+        assert_eq!(
+            keys,
+            vec![bigger, big],
+            "descending attributed-rate order; sub-threshold contract retained; \
+             no double-eviction across axes"
+        );
+        assert!(cache.get(&small).is_some());
+        assert_eq!(cache.stats().cost_evictions_total, 2);
     }
 
     #[test]

--- a/crates/core/src/ring/hosting/cache.rs
+++ b/crates/core/src/ring/hosting/cache.rs
@@ -818,8 +818,9 @@ pub(crate) fn victim_order(
 // the byte-gated sweep never ran. Cost pressure closes that gap: the periodic
 // sweep additionally reads the per-contract attributed cost rates from the
 // topology meter — `ExecCpuMicros` (apply + probe + per-target
-// summarize/delta WASM), `BroadcastFanoutCost` (payload × targets, the
-// uplink-volume dimension), and `BroadcastMessagesSent` (per-peer send COUNT,
+// summarize/delta WASM), `BroadcastFanoutCost` (the actual per-send payload
+// bytes put on the wire, charged on real delivery only — the uplink-volume
+// dimension), and `BroadcastMessagesSent` (per-peer send COUNT,
 // the per-send-overhead dimension and the load-bearing storm signal: a
 // tiny-payload high-frequency storm is invisible in bytes but reads its true
 // message rate here) — and, when the node's total update-work on an axis is
@@ -832,8 +833,10 @@ pub(crate) fn victim_order(
 // calibration; the absolute floors only keep an idle node from evicting the
 // one contract that does any work at all. Two guards keep it honest:
 // SUSTAINED pressure (the meter read admits a contract into candidacy only
-// once its reporting is at least half the cost window old, so a single large
-// fan-out burst can never mass-evict — see `Meter::contract_cost_rates`) and
+// once its true windowed rate has stayed at or above the axis floor
+// continuously for at least half the cost window, so neither a below-floor
+// keep-alive trickle nor a single large fan-out burst can mass-evict — see
+// `Meter::contract_cost_rates`) and
 // the saturated-buffer true-rate fix (a full sample ring divides by its
 // actual span, so a sustained high-frequency storm's real rate is
 // representable instead of being count-truncated below the floor).
@@ -910,9 +913,15 @@ pub(crate) struct CostAxisPressure {
     pub floor: f64,
     /// Per-contract attributed rates (axis units per second). Contracts
     /// absent from the map have zero attributed cost. Pre-filtered by the
-    /// meter read to SUSTAINED sources only (first sample at least half the
-    /// cost window old), so a single large burst is never a candidate; every
-    /// positive-rate contract still counts in [`Self::total_rate`].
+    /// meter read to SUSTAINED sources only: a contract appears here only once
+    /// its true windowed rate has stayed at or above the axis floor
+    /// continuously for at least half the cost window (a >60s report-silence
+    /// gap-resets the run), so neither a below-floor keep-alive trickle nor a
+    /// single large burst is ever a candidate. A deliberate metering limit: a
+    /// source reporting fewer than one sample per 60s on an axis never counts
+    /// as sustained on it (a real storm's cadence is far denser, and the byte
+    /// budget backstops slow-large profiles). Every positive-rate contract
+    /// still counts in [`Self::total_rate`].
     pub rates: std::collections::HashMap<freenet_stdlib::prelude::ContractInstanceId, f64>,
 }
 
@@ -2031,18 +2040,30 @@ impl<T: TimeSource> HostingCache<T> {
             // Assigned a proper order by `finalize_loading` once all entries are
             // loaded (sorted by persisted recency). Temporary 0 until then.
             last_access_seq: 0,
-            // Reloaded entries stay at 0 ("never GET-read since restart") and are
-            // NOT re-stamped by `finalize_loading`: persistence records only a
-            // generic last-ACCESS time that can't distinguish a real GET from a
-            // PUT/SUBSCRIBE, so stamping real-GET recency from it would fabricate
-            // demand (a never-read PUT seed out-surviving a genuinely GET-read
-            // entry). A live GET after restart re-stamps it to a true value. See
+            // `recency_seq` is a per-run monotonic SEQUENCE number, not a
+            // timestamp, so there is no meaningful pre-restart value to restore:
+            // reloaded entries stay at 0 ("never GET-read since restart") and are
+            // NOT re-stamped by `finalize_loading`. `last_accessed` (from the
+            // persisted age) carries the recency ordering instead; a live GET
+            // after restart re-stamps `recency_seq` to a true value. See
             // `finalize_loading`.
             recency_seq: 0,
-            // Same reasoning as `recency_seq`: persistence can't distinguish a
-            // genuine GET/PUT from a SUBSCRIBE, so a reload starts with no
-            // genuine-access claim; a live GET/PUT re-stamps it (#4861).
-            last_genuine_access: None,
+            // Restore the genuine-access recency across restart for the
+            // cost-eviction guard (#4903 review round-3 Fix 5). Unlike
+            // `recency_seq` (an unrestorable sequence number), `last_genuine_access`
+            // is a TIMESTAMP and the persisted row records the last ACCESS TYPE,
+            // so we CAN tell whether the last pre-restart access was a genuine
+            // GET/PUT and, if so, seed it from the persisted age — a contract
+            // GET-read or PUT within `COST_RATE_MIN_WINDOW` before restart then
+            // keeps its cost-eviction protection (invariant 3: "a real GET or PUT
+            // resets recency") instead of being immediately cost-evictable. A
+            // SUBSCRIBE is NOT genuine access, so it stays unprotected (None) —
+            // matching the live `resets_recency` rule in
+            // `record_access_with_demand`.
+            last_genuine_access: match access_type {
+                AccessType::Get | AccessType::Put => Some(last_accessed),
+                AccessType::Subscribe => None,
+            },
             // Loaded entries start at the caller-supplied cold demand (the
             // distance prior when this peer's location is known at load, else
             // neutral). The first live read re-scores against the current prior.
@@ -2415,13 +2436,16 @@ mod tests {
         assert_eq!(evicted[0].key, local);
     }
 
-    /// #4903 review Fix 1 (restart facet): a restart reload leaves
-    /// `last_genuine_access = None` but seeds `local_client_last_access = now`
-    /// for locally-accessed contracts (one renewal window to re-establish
-    /// subscriptions). Cost candidacy must honor that lease — without it the
-    /// sweep evicts a just-reloaded contract reconciliation is about to renew
-    /// (~2.5 min churn after every restart). A reloaded contract with NO
-    /// pre-restart local access gets no such grace.
+    /// #4903 review Fix 1 (restart facet): a restart reload seeds
+    /// `local_client_last_access = now` for locally-accessed contracts (one
+    /// renewal window to re-establish subscriptions). Cost candidacy must honor
+    /// that lease — without it the sweep evicts a just-reloaded contract
+    /// reconciliation is about to renew (~2.5 min churn after every restart). A
+    /// reloaded contract with NO pre-restart local access gets no such grace.
+    /// Here the pre-restart access is 1h old (stale past the cost window), so
+    /// the round-3 Fix-5 genuine-access restore does not protect either entry —
+    /// only the local-client lease does. (The recent-access facet of Fix 5 is
+    /// covered by `evict_cost_pressure_restart_restores_recent_genuine_access`.)
     #[test]
     fn evict_cost_pressure_restart_local_lease_protects() {
         use crate::ring::hosting::SUBSCRIPTION_LEASE_DURATION;
@@ -2465,6 +2489,63 @@ mod tests {
         let evicted = cache.evict_cost_pressure(&|_: &ContractKey| (0, 0), &axes);
         assert_eq!(evicted.len(), 1);
         assert_eq!(evicted[0].key, local);
+    }
+
+    /// #4903 review round-3 Fix 5: a restart reload RESTORES
+    /// `last_genuine_access` from the persisted last-access age for GET/PUT
+    /// access types, so a contract genuinely read or written within the cost
+    /// window before restart keeps its cost-eviction protection across the
+    /// restart (invariant 3), even with NO local-client access. A SUBSCRIBE
+    /// reload is not genuine access and gets no such protection. Before Fix 5
+    /// the loader hard-coded `last_genuine_access = None`, so a
+    /// network-accessed (non-local) contract was immediately cost-evictable
+    /// after every restart.
+    #[test]
+    fn evict_cost_pressure_restart_restores_recent_genuine_access() {
+        let (mut cache, clock) = make_cache(1024 * 1024);
+        let recent_get = make_key(1);
+        let recent_sub = make_key(2);
+        // Both last accessed 60s before restart (well within the 300s cost
+        // window); NEITHER locally accessed, so only the genuine-access restore
+        // can protect them.
+        cache.load_persisted_entry(
+            recent_get,
+            121,
+            AccessType::Get,
+            Duration::from_secs(60),
+            false,
+        );
+        cache.load_persisted_entry(
+            recent_sub,
+            121,
+            AccessType::Subscribe,
+            Duration::from_secs(60),
+            false,
+        );
+        cache.finalize_loading();
+
+        let axes = [cost_axis(
+            100_000.0,
+            50_000.0,
+            &[(&recent_get, 40_000.0), (&recent_sub, 40_000.0)],
+        )];
+        let evicted = cache.evict_cost_pressure(&|_: &ContractKey| (0, 0), &axes);
+        let keys: Vec<ContractKey> = evicted.iter().map(|e| e.key).collect();
+        assert_eq!(
+            keys,
+            vec![recent_sub],
+            "post-restart: a recently GET-read contract keeps its restored \
+             genuine-access cost protection; a SUBSCRIBE reload (not genuine \
+             access) does not"
+        );
+        assert!(cache.get(&recent_get).is_some());
+
+        // The restored protection is time-bounded: once the pre-restart access
+        // ages past the cost window, the GET reload competes like anything else.
+        clock.advance_time(COST_RATE_MIN_WINDOW);
+        let evicted = cache.evict_cost_pressure(&|_: &ContractKey| (0, 0), &axes);
+        assert_eq!(evicted.len(), 1);
+        assert_eq!(evicted[0].key, recent_get);
     }
 
     /// Exact-25%-share boundary: a contract holding EXACTLY the threshold

--- a/crates/core/src/ring/hosting/cache.rs
+++ b/crates/core/src/ring/hosting/cache.rs
@@ -1732,8 +1732,9 @@ impl<T: TimeSource> HostingCache<T> {
     ///
     /// Per axis, when `total_rate > floor`, the candidates are the hosted
     /// contracts satisfying [`cost_eviction_candidate`] (zero local
-    /// subscriptions AND zero downstream subscribers AND attributed rate
-    /// > 0) whose rate exceeds [`COST_SHARE_THRESHOLD`] × `total_rate`.
+    /// subscriptions AND zero downstream subscribers AND strictly positive
+    /// attributed rate) whose rate exceeds [`COST_SHARE_THRESHOLD`] ×
+    /// `total_rate`.
     /// Candidates are shed in DESCENDING attributed-rate order (contract-key
     /// bytes as a deterministic tiebreak); the deficit is covered exactly when
     /// no remaining zero-demand contract holds more than the threshold share

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -265,6 +265,16 @@ pub(crate) struct RouterSnapshotInfo {
     /// Populated by `Ring` on the snapshot cadence. `None` until the ring is
     /// built. Per-node aggregate scalar.
     pub hosting_subscribed_evictions_total: Option<u64>,
+    /// Cost-pressure eviction falsifier (cost-aware eviction, #4861): monotonic
+    /// count of zero-demand contracts shed because their attributed update-work
+    /// cost (WASM CPU / broadcast fan-out) dominated the node's total on a cost
+    /// axis, independently of the byte budget. Disjoint from
+    /// `hosting_budget_evictions_total` (byte-budget-triggered only). A nonzero
+    /// differenced rate means the cost trigger is firing; a runaway rate means
+    /// the floors / share threshold are miscalibrated and churning cheap
+    /// contracts. Populated by `Ring` on the snapshot cadence. `None` until the
+    /// ring is built. Per-node aggregate scalar.
+    pub hosting_cost_evictions_total: Option<u64>,
     /// Phantom-hosting falsifier (SUBSCRIBE-retirement step 10 §1d): the count of
     /// contracts registered as in-use via a downstream subscriber whose state is
     /// NOT present on disk (`contract_in_use && !contract_state_present`). After
@@ -1344,6 +1354,7 @@ impl Router {
             hosting_disk_total_bytes: None,
             hosting_oom_valve_evictions_total: None,
             hosting_subscribed_evictions_total: None,
+            hosting_cost_evictions_total: None,
             phantom_in_use_contracts: None,
             // Terminal advertisement-consult counters (piece C, #4646),
             // populated by Ring from the network_status singleton on the

--- a/crates/core/src/topology.rs
+++ b/crates/core/src/topology.rs
@@ -3045,7 +3045,8 @@ impl Limits {
             ResourceType::ExecCpuMicros
             | ResourceType::ExecFuelUnits
             | ResourceType::StateBytesWritten
-            | ResourceType::BroadcastFanoutCost => {
+            | ResourceType::BroadcastFanoutCost
+            | ResourceType::BroadcastMessagesSent => {
                 unreachable!(
                     "Limits::get called for non-bandwidth resource {:?} — \
                      these are tracked but not bandwidth-rate-limited",

--- a/crates/core/src/topology.rs
+++ b/crates/core/src/topology.rs
@@ -431,12 +431,11 @@ impl TopologyManager {
         self.meter.attributed_usage_rate(source, resource_type, now)
     }
 
-    /// Per-contract attributed cost rates + their sum for one cost axis,
-    /// amortized over at least `min_window`. Read by the hosting sweep's
-    /// cost-pressure trigger (cost-aware eviction, #4861); see
-    /// [`Meter::contract_cost_rates`].
-    /// Read several cost axes in one pass over the meter (the hosting sweep
-    /// reads all three per tick — #4903 review perf). Delegates to
+    /// Per-contract attributed cost rates + their sum for SEVERAL cost axes,
+    /// read in one pass over the meter (the hosting sweep reads all three per
+    /// tick — #4903 review perf), each amortized over at least `min_window`.
+    /// Read by the hosting sweep's cost-pressure trigger (cost-aware eviction,
+    /// #4861). Delegates to
     /// [`crate::topology::meter::Meter::contract_cost_rates_multi`].
     pub(crate) fn contract_cost_rates_multi(
         &self,

--- a/crates/core/src/topology.rs
+++ b/crates/core/src/topology.rs
@@ -431,6 +431,22 @@ impl TopologyManager {
         self.meter.attributed_usage_rate(source, resource_type, now)
     }
 
+    /// Per-contract attributed cost rates + their sum for one cost axis,
+    /// amortized over at least `min_window`. Read by the hosting sweep's
+    /// cost-pressure trigger (cost-aware eviction, #4861); see
+    /// [`Meter::contract_cost_rates`].
+    pub(crate) fn contract_cost_rates(
+        &self,
+        resource: &ResourceType,
+        now: Instant,
+        min_window: std::time::Duration,
+    ) -> (
+        f64,
+        std::collections::HashMap<freenet_stdlib::prelude::ContractInstanceId, f64>,
+    ) {
+        self.meter.contract_cost_rates(resource, now, min_window)
+    }
+
     /// Determine whether to add or remove connections based on current connection
     /// count and resource usage.
     ///

--- a/crates/core/src/topology.rs
+++ b/crates/core/src/topology.rs
@@ -435,16 +435,20 @@ impl TopologyManager {
     /// amortized over at least `min_window`. Read by the hosting sweep's
     /// cost-pressure trigger (cost-aware eviction, #4861); see
     /// [`Meter::contract_cost_rates`].
-    pub(crate) fn contract_cost_rates(
+    /// Read several cost axes in one pass over the meter (the hosting sweep
+    /// reads all three per tick — #4903 review perf). Delegates to
+    /// [`crate::topology::meter::Meter::contract_cost_rates_multi`].
+    pub(crate) fn contract_cost_rates_multi(
         &self,
-        resource: &ResourceType,
+        resources: &[ResourceType],
         now: Instant,
         min_window: std::time::Duration,
-    ) -> (
+    ) -> Vec<(
         f64,
         std::collections::HashMap<freenet_stdlib::prelude::ContractInstanceId, f64>,
-    ) {
-        self.meter.contract_cost_rates(resource, now, min_window)
+    )> {
+        self.meter
+            .contract_cost_rates_multi(resources, now, min_window)
     }
 
     /// Determine whether to add or remove connections based on current connection

--- a/crates/core/src/topology/meter.rs
+++ b/crates/core/src/topology/meter.rs
@@ -161,27 +161,34 @@ impl Meter {
     /// Iterates the attribution meters, keeping only
     /// [`AttributionSource::Contract`] entries (peer/delegate bandwidth sources
     /// never participate in contract cost eviction), and reads each contract's
-    /// rate via [`RunningAverage::windowed_rate`]: sparse samples are diluted
-    /// over at least `min_window` (a lone burst cannot masquerade as a
-    /// sustained storm), while a saturated sample buffer divides by its actual
-    /// span so a sustained high-frequency storm's TRUE rate is representable
-    /// (the count-truncation under-read that hid the #4861 profile).
+    /// rate via [`RunningAverage::windowed_rate`]: only samples within the
+    /// last `min_window` participate (a source that stops reporting decays to
+    /// nothing instead of holding a stale rate — review Fix 3), sparse
+    /// samples are diluted over at least `min_window` (a lone burst cannot
+    /// masquerade as a sustained storm), while a fully-recent saturated
+    /// sample buffer divides by its actual span so a sustained high-frequency
+    /// storm's TRUE rate is representable (the count-truncation under-read
+    /// that hid the #4861 profile).
     ///
     /// Returns `(total_rate, per_contract_rate)` in axis units per second.
     /// EVERY positive-rate contract counts toward `total_rate` (the share
     /// denominator), but the per-contract map — the eviction CANDIDACY input —
-    /// contains only contracts whose reporting is SUSTAINED (first sample at
-    /// least `min_window / 2` old). A contract absent from the map has zero
-    /// attributed cost for candidacy purposes, so a single large fan-out
-    /// burst (first report moments ago) can never make its contract a cost
-    /// victim, no matter how big the burst.
+    /// contains only contracts whose reporting is SUSTAINED: the within-window
+    /// samples must SPAN at least `min_window / 2`
+    /// ([`crate::topology::running_average::WindowedRate::retained_span`]).
+    /// A contract absent from the map has zero attributed cost for candidacy
+    /// purposes, so a short burst — even a buffer-saturating one, and even on
+    /// a source whose FIRST-EVER sample is arbitrarily old (the lifetime
+    /// first-sample age was the review-Fix-2 hole: set once and never reset)
+    /// — can never make its contract a cost victim, no matter how big the
+    /// burst.
     pub(crate) fn contract_cost_rates(
         &self,
         resource: &ResourceType,
         at_time: Instant,
         min_window: Duration,
     ) -> (f64, std::collections::HashMap<ContractInstanceId, f64>) {
-        let sustained_min_age = min_window / 2;
+        let sustained_min_span = min_window / 2;
         let mut per_contract = std::collections::HashMap::new();
         let mut total = 0.0_f64;
         for entry in self.attribution_meters.iter() {
@@ -197,7 +204,7 @@ impl Meter {
             let per_second = windowed.rate.per_second();
             if per_second > 0.0 {
                 total += per_second;
-                if windowed.first_sample_age >= sustained_min_age {
+                if windowed.retained_span >= sustained_min_span {
                     per_contract.insert(*id, per_second);
                 }
             }
@@ -702,14 +709,16 @@ mod tests {
     }
 
     /// `contract_cost_rates` (cost-aware eviction, #4861) aggregates ONLY
-    /// Contract-attributed sources; sparse samples are amortized over the
-    /// minimum window (a lone burst cannot masquerade as a sustained storm);
-    /// a SATURATED sample buffer reads its true rate over its actual span
-    /// (the count-truncation fix — without it a sustained high-frequency
-    /// storm's rate is capped at samples×value/window and can hide under the
-    /// floor); and the per-contract candidacy map admits only SUSTAINED
-    /// sources (first sample at least half the window old) while every
-    /// positive rate still counts toward the total.
+    /// Contract-attributed sources; samples older than the minimum window are
+    /// ignored (a quiet source decays — review Fix 3); sparse samples are
+    /// amortized over the minimum window (a lone burst cannot masquerade as a
+    /// sustained storm); a fully-recent SATURATED sample buffer reads its
+    /// true rate over its actual span (the count-truncation fix — without it
+    /// a sustained high-frequency storm's rate is capped at
+    /// samples×value/window and can hide under the floor); and the
+    /// per-contract candidacy map admits only SUSTAINED sources (within-
+    /// window samples spanning at least half the window) while every positive
+    /// rate still counts toward the total.
     #[test]
     fn contract_cost_rates_aggregates_contract_sources_with_min_window() {
         let meter = Meter::new_with_window_size(100);
@@ -717,7 +726,8 @@ mod tests {
         let min_window = Duration::from_secs(300);
         let now = t0 + Duration::from_secs(600);
 
-        // Sustained sparse source: two 30_000µs samples over 10 minutes.
+        // Sparse source: two 30_000µs samples over 10 minutes. Only the
+        // second falls within the last `min_window` of the read.
         meter.report(
             &contract_source(1),
             ResourceType::ExecCpuMicros,
@@ -761,16 +771,22 @@ mod tests {
             meter.contract_cost_rates(&ResourceType::ExecCpuMicros, now, min_window);
         let id1 = ContractInstanceId::new([1u8; 32]);
         let id2 = ContractInstanceId::new([2u8; 32]);
-        // Sustained sparse source: 60_000µs over its 600s retained span.
-        assert!((cpu_rates[&id1] - 60_000.0 / 600.0).abs() < 1e-6);
+        // Sparse source: the t0 sample is older than the window and ignored
+        // (review Fix 3), leaving one within-window sample — diluted over the
+        // window (30_000/300s = 100/s) and NOT sustained (span 0), so it
+        // counts toward the total but is no candidacy entry.
+        assert!(
+            !cpu_rates.contains_key(&id1),
+            "a lone within-window sample must not be a candidate"
+        );
         // Burst source: counted in the TOTAL (diluted over min_window: 30M/300s
-        // = 100_000/s) but EXCLUDED from the candidacy map (first sample 1s
-        // old — not sustained), so one burst can never nominate a victim.
+        // = 100_000/s) but EXCLUDED from the candidacy map (recent samples
+        // span ~0s — not sustained), so one burst can never nominate a victim.
         assert!(
             !cpu_rates.contains_key(&id2),
             "burst must not be a candidate"
         );
-        let expected_total = 60_000.0 / 600.0 + 30_000_000.0 / 300.0;
+        let expected_total = 30_000.0 / 300.0 + 30_000_000.0 / 300.0;
         assert!((cpu_total - expected_total).abs() < 1e-6);
 
         // Saturated storm source: true rate over the RETAINED span (~158.4s),
@@ -784,6 +800,114 @@ mod tests {
             "saturated buffer must read the true storm rate (~36.6/s), got {rate3}/s"
         );
         assert!((msgs_total - rate3).abs() < 1e-9);
+    }
+
+    /// Review Fix 2 regression: an OLD first-ever sample must not admit a
+    /// later short burst into candidacy. Before the fix the sustained gate
+    /// keyed on the lifetime `first_sample_time` (set once, never reset), so
+    /// a contract that reported once long ago passed the gate forever and a
+    /// buffer-saturating 60-second flurry then read a high instantaneous
+    /// rate and became a cost-eviction candidate — "a single burst can never
+    /// make its contract a victim" was false for old-first-sample sources.
+    #[test]
+    fn contract_cost_rates_old_first_sample_then_burst_is_not_a_candidate() {
+        let meter = Meter::new_with_window_size(100);
+        let t0 = Instant::now();
+        let min_window = Duration::from_secs(300);
+
+        // First-ever sample, 10 minutes before the read.
+        meter.report(
+            &contract_source(1),
+            ResourceType::BroadcastMessagesSent,
+            58.0,
+            t0,
+        );
+        // A 60-second buffer-saturating flurry just before the read: 120
+        // samples at 0.5s cadence (the buffer keeps the last 100, spanning
+        // ~49.5s — all recent, so the rate reads high).
+        let burst_start = t0 + Duration::from_secs(540);
+        for i in 0..120u64 {
+            meter.report(
+                &contract_source(1),
+                ResourceType::BroadcastMessagesSent,
+                58.0,
+                burst_start + Duration::from_millis(500 * i),
+            );
+        }
+        let now = t0 + Duration::from_secs(601);
+
+        let (total, rates) =
+            meter.contract_cost_rates(&ResourceType::BroadcastMessagesSent, now, min_window);
+        let id1 = ContractInstanceId::new([1u8; 32]);
+        assert!(
+            !rates.contains_key(&id1),
+            "an old-first-sample source's short burst must NOT be a candidate \
+             (the recent samples span only ~50s, not min_window/2)"
+        );
+        assert!(
+            total > 0.0,
+            "the burst still counts toward the node total (share denominator)"
+        );
+    }
+
+    /// Review Fix 3 regression: a contract that stops reporting decays out of
+    /// the cost read within a bounded time (one `min_window` of silence) —
+    /// it leaves the candidacy map first (its recent samples no longer span
+    /// half the window) and then stops inflating the node total entirely,
+    /// instead of holding its stale storm rate for as long as the
+    /// count-bounded buffer retains old samples.
+    #[test]
+    fn contract_cost_rates_quiet_contract_decays_out_within_min_window() {
+        let meter = Meter::new_with_window_size(100);
+        let t0 = Instant::now();
+        let min_window = Duration::from_secs(300);
+        let id1 = ContractInstanceId::new([1u8; 32]);
+
+        // The FX2j storm profile: 150 samples of 58 msgs at 1.6s cadence.
+        for i in 0..150u64 {
+            meter.report(
+                &contract_source(1),
+                ResourceType::BroadcastMessagesSent,
+                58.0,
+                t0 + Duration::from_millis(1600 * i),
+            );
+        }
+        let storm_end = t0 + Duration::from_millis(1600 * 149);
+
+        // Live: a sustained candidate at its true rate.
+        let (live_total, live_rates) = meter.contract_cost_rates(
+            &ResourceType::BroadcastMessagesSent,
+            storm_end + Duration::from_secs(1),
+            min_window,
+        );
+        assert!(live_rates[&id1] > 30.0);
+        assert!(live_total > 30.0);
+
+        // After 180s of silence the within-window samples span under half
+        // the window: no longer a CANDIDATE (even though some rate remains
+        // in the total while recent samples linger).
+        let (_, stale_rates) = meter.contract_cost_rates(
+            &ResourceType::BroadcastMessagesSent,
+            storm_end + Duration::from_secs(180),
+            min_window,
+        );
+        assert!(
+            !stale_rates.contains_key(&id1),
+            "a quiet contract must drop out of candidacy as its recent span shrinks"
+        );
+
+        // After a full min_window of silence every sample is stale: the
+        // contract contributes NOTHING (no total inflation, no candidacy).
+        let (gone_total, gone_rates) = meter.contract_cost_rates(
+            &ResourceType::BroadcastMessagesSent,
+            storm_end + min_window + Duration::from_secs(1),
+            min_window,
+        );
+        assert!(gone_rates.is_empty());
+        assert_eq!(
+            gone_total, 0.0,
+            "a source quiet for min_window must stop inflating total_rate"
+        );
     }
 
     #[test]

--- a/crates/core/src/topology/meter.rs
+++ b/crates/core/src/topology/meter.rs
@@ -56,6 +56,50 @@ pub(crate) const MAX_ATTRIBUTION_SOURCES: usize = 4096;
 /// the same schedule.
 pub(crate) const ATTRIBUTION_SOURCE_TTL: Duration = Duration::from_secs(15 * 60);
 
+// ---------------------------------------------------------------------------
+// Cost-pressure per-axis floors + sustained window (#4861 Codex round-3).
+//
+// These MIRROR the authoritative constants in `ring/hosting/cache.rs`
+// (`EXEC_CPU_PRESSURE_FLOOR_MICROS_PER_SEC`, `BROADCAST_FANOUT_PRESSURE_FLOOR_
+// BYTES_PER_SEC`, `BROADCAST_MESSAGES_PRESSURE_FLOOR_PER_SEC`,
+// `COST_RATE_MIN_WINDOW`). They cannot be imported: the `cache` module is
+// private to `hosting`, which is itself private to `ring`, so the constants
+// are not nameable from `topology::meter`. The insert-time above-floor
+// sustained-run detection (`RunningAverage::new_cost_sustained`) needs the
+// floor + window at sample time, on this side of that privacy boundary.
+//
+// The drift risk is closed by the guard test
+// `ring::cost_pressure_seam_tests::meter_cost_floors_mirror_cache_source_of_truth`,
+// which reads the authoritative cache.rs values (through `build_cost_axes`
+// and the re-exported `COST_RATE_MIN_WINDOW`, both reachable from `ring`) and
+// asserts they equal these mirrors — so CI fails if the two ever diverge.
+// ---------------------------------------------------------------------------
+
+/// Mirror of `cache::EXEC_CPU_PRESSURE_FLOOR_MICROS_PER_SEC`.
+const EXEC_CPU_COST_FLOOR_MICROS_PER_SEC: f64 = 50_000.0;
+/// Mirror of `cache::BROADCAST_FANOUT_PRESSURE_FLOOR_BYTES_PER_SEC`.
+const BROADCAST_FANOUT_COST_FLOOR_BYTES_PER_SEC: f64 = 128.0 * 1024.0;
+/// Mirror of `cache::BROADCAST_MESSAGES_PRESSURE_FLOOR_PER_SEC`.
+const BROADCAST_MESSAGES_COST_FLOOR_PER_SEC: f64 = 10.0;
+/// Mirror of `cache::COST_RATE_MIN_WINDOW`. `pub(crate)` so the `ring` guard
+/// test can assert it equals the authoritative value.
+pub(crate) const COST_SUSTAINED_WINDOW: Duration = Duration::from_secs(300);
+
+/// Construct the [`RunningAverage`] for one `(source, resource)` cell.
+/// Contract cost axes ([`ResourceType::cost_pressure_floor`] is `Some`) get
+/// insert-time ABOVE-FLOOR sustained-run tracking (#4861 Codex round-3) so
+/// their eviction-candidacy gate keys on sustained above-FLOOR cost rather
+/// than mere sample continuity; every other axis keeps the plain running
+/// average, behaviorally unchanged.
+fn new_running_average(window_size: usize, resource: ResourceType) -> RunningAverage {
+    match resource.cost_pressure_floor() {
+        Some(floor) => {
+            RunningAverage::new_cost_sustained(window_size, floor, COST_SUSTAINED_WINDOW)
+        }
+        None => RunningAverage::new(window_size),
+    }
+}
+
 /// A structure that keeps track of the usage of dynamic resources which are consumed over time.
 /// It provides methods to report and query resource usage, both total and attributed to specific
 /// sources.
@@ -358,6 +402,7 @@ impl Meter {
         // must be size-bounded at insertion). Reporting against an existing
         // source never grows the map, so the scan is skipped on the hot path.
         use dashmap::mapref::entry::Entry;
+        let window_size = self.running_average_window_size;
         match self.attribution_meters.entry(attribution.clone()) {
             Entry::Occupied(mut occupied) => {
                 let totals = occupied.get_mut();
@@ -365,7 +410,7 @@ impl Meter {
                 totals
                     .map
                     .entry(resource)
-                    .or_insert_with(|| RunningAverage::new(self.running_average_window_size))
+                    .or_insert_with(|| new_running_average(window_size, resource))
                     .insert_with_time(at_time, value);
                 return;
             }
@@ -384,7 +429,7 @@ impl Meter {
         totals
             .map
             .entry(resource)
-            .or_insert_with(|| RunningAverage::new(self.running_average_window_size))
+            .or_insert_with(|| new_running_average(window_size, resource))
             .insert_with_time(at_time, value);
     }
 
@@ -574,6 +619,32 @@ impl ResourceType {
             ResourceType::InboundBandwidthBytes,
             ResourceType::OutboundBandwidthBytes,
         ]
+    }
+
+    /// The cost-pressure floor (axis units per second) for the three contract
+    /// COST axes, or `None` for every other resource. A cost axis's
+    /// [`RunningAverage`] uses this floor to track a sustained ABOVE-FLOOR run
+    /// at insert time (#4861 Codex round-3): its eviction-candidacy sustained
+    /// signal counts only while the contract's true windowed rate stays at or
+    /// above this floor, so a below-floor keep-alive trickle plus one dense
+    /// burst never registers as sustained cost.
+    ///
+    /// Values MIRROR the authoritative `ring/hosting/cache.rs` floor constants
+    /// (not importable across the private `hosting`/`cache` module boundary);
+    /// the `ring` guard test `meter_cost_floors_mirror_cache_source_of_truth`
+    /// fails CI if they drift. Enumerated exhaustively (no `_` arm) so a new
+    /// `ResourceType` must consciously declare its floor, matching the
+    /// [`AttributionSource::contributes_to`] discipline.
+    pub(crate) fn cost_pressure_floor(&self) -> Option<f64> {
+        match self {
+            ResourceType::ExecCpuMicros => Some(EXEC_CPU_COST_FLOOR_MICROS_PER_SEC),
+            ResourceType::BroadcastFanoutCost => Some(BROADCAST_FANOUT_COST_FLOOR_BYTES_PER_SEC),
+            ResourceType::BroadcastMessagesSent => Some(BROADCAST_MESSAGES_COST_FLOOR_PER_SEC),
+            ResourceType::InboundBandwidthBytes
+            | ResourceType::OutboundBandwidthBytes
+            | ResourceType::ExecFuelUnits
+            | ResourceType::StateBytesWritten => None,
+        }
     }
 
     /// Every resource type the meter understands, including non-bandwidth
@@ -1058,6 +1129,13 @@ mod tests {
     /// the old buffer-span gate that flood spanned only a couple of dispatches
     /// (< min_window/2) and could NEVER nominate. With `activity_span` the
     /// continuous run is what matters, so the CPU axis nominates.
+    ///
+    /// Per-sample CPU is 2000µs so the storm's true rate — 58 × 2000 / 1.6s ≈
+    /// 72_500µs/s — clears the 50_000µs/s CPU floor: under the ABOVE-FLOOR
+    /// sustained gate (#4861 Codex round-3) a candidate must sustain a rate at
+    /// or above the axis floor, so the flood modeled here has to be a genuine
+    /// above-floor storm, not a trickle of tiny samples that would (correctly)
+    /// no longer qualify.
     #[test]
     fn contract_cost_rates_multi_target_cpu_flood_nominates() {
         let meter = Meter::new_with_window_size(100);
@@ -1072,7 +1150,7 @@ mod tests {
                 meter.report(
                     &contract_source(1),
                     ResourceType::ExecCpuMicros,
-                    200.0,
+                    2000.0,
                     t0 + dispatch + Duration::from_millis(15 * target),
                 );
             }
@@ -1084,8 +1162,8 @@ mod tests {
             meter.contract_cost_rates(&ResourceType::ExecCpuMicros, now, min_window);
         assert!(
             rates.contains_key(&ContractInstanceId::new([1u8; 32])),
-            "a multi-target (58/dispatch) CPU flood must nominate on the \
-             ExecCpuMicros axis"
+            "a multi-target (58/dispatch) above-floor CPU flood must nominate \
+             on the ExecCpuMicros axis"
         );
         assert!(total > 0.0);
     }
@@ -1120,25 +1198,29 @@ mod tests {
 
     /// Boundary (#4903 review round-2 requirement): the 60s gap-reset must have
     /// generous headroom above ANY cadence that exceeds a floor, so a genuine
-    /// sustained storm never spuriously resets its run. The slowest
-    /// floor-exceeding message cadence (58 msgs per dispatch, 10 msgs/s floor)
-    /// is a dispatch every ~5.8s — far under 60s. A contract reporting even
-    /// more slowly than that (every 30s) is still ONE continuous run and stays
-    /// sustained: no spurious gap-reset.
+    /// sustained storm never spuriously resets its run. A contract reporting
+    /// every 30s (well under the 60s gap threshold) is ONE continuous run and
+    /// stays sustained: no spurious gap-reset.
+    ///
+    /// The 400-msgs-per-report value keeps the storm's true rate — 400 / 30s ≈
+    /// 13/s — above the 10 msgs/s floor, as the ABOVE-FLOOR sustained gate
+    /// (#4861 Codex round-3) requires: sustainedness is a sustained above-FLOOR
+    /// run, so the reporter modeled here has to clear the floor at its 30s
+    /// cadence for the "no spurious 30s gap-reset" property to be observable.
     #[test]
     fn contract_cost_rates_slow_cadence_does_not_gap_reset() {
         let meter = Meter::new_with_window_size(100);
         let t0 = Instant::now();
         let min_window = Duration::from_secs(300);
 
-        // Report every 30s (well under the 60s gap threshold but far slower
-        // than any real storm) for 240s continuous.
+        // Report every 30s (well under the 60s gap threshold) for 240s
+        // continuous, at a per-report volume that clears the message floor.
         let mut t = Duration::ZERO;
         while t <= Duration::from_secs(240) {
             meter.report(
                 &contract_source(1),
                 ResourceType::BroadcastMessagesSent,
-                58.0,
+                400.0,
                 t0 + t,
             );
             t += Duration::from_secs(30);
@@ -1189,6 +1271,98 @@ mod tests {
         assert!(
             total > 0.0,
             "the recent burst still counts toward the total"
+        );
+    }
+
+    /// #4861 Codex round-3 (THE finding): a contract that emits trivial
+    /// below-floor keep-alive samples CONTINUOUSLY (every 30s, under the 60s
+    /// gap — so sample continuity is never broken) for longer than
+    /// `min_window / 2`, then a SINGLE dense burst, must NOT be a candidate.
+    /// The old sustained gate keyed on `activity_start` (sample continuity),
+    /// which the no-gap trickle held alive for 180s+, so the lone burst's high
+    /// saturated-buffer rate would nominate the contract on ONE burst —
+    /// violating invariant 3's "a single burst never triggers". The above-floor
+    /// gate tracks how long the TRUE rate has stayed at or above the axis
+    /// floor, which the trickle never does, so the run only opens mid-burst and
+    /// spans a few seconds (< min_window/2). Before the fix this assertion
+    /// FAILS (the contract IS a candidate); after it passes.
+    #[test]
+    fn contract_cost_rates_trickle_then_single_burst_is_not_a_candidate() {
+        let meter = Meter::new_with_window_size(100);
+        let t0 = Instant::now();
+        let min_window = Duration::from_secs(300);
+        let id1 = ContractInstanceId::new([1u8; 32]);
+
+        // Trickle: 0.1 msgs every 30s (< 60s gap, so sampling stays continuous;
+        // 0.1/30s ≈ 0.003/s — far below the 10 msgs/s floor) for 180s.
+        let mut t = Duration::ZERO;
+        while t <= Duration::from_secs(180) {
+            meter.report(
+                &contract_source(1),
+                ResourceType::BroadcastMessagesSent,
+                0.1,
+                t0 + t,
+            );
+            t += Duration::from_secs(30);
+        }
+        // Then ONE dense burst (120 samples over ~3s — saturates the buffer and
+        // reads a high true rate).
+        let burst_start = t0 + Duration::from_secs(181);
+        for i in 0..120u64 {
+            meter.report(
+                &contract_source(1),
+                ResourceType::BroadcastMessagesSent,
+                58.0,
+                burst_start + Duration::from_millis(25 * i),
+            );
+        }
+        let now = burst_start + Duration::from_secs(4);
+
+        let (total, rates) =
+            meter.contract_cost_rates(&ResourceType::BroadcastMessagesSent, now, min_window);
+        assert!(
+            !rates.contains_key(&id1),
+            "a continuous below-floor trickle then a SINGLE dense burst must \
+             NOT be a candidate: sample continuity is sustained but above-FLOOR \
+             cost is not (Codex round-3)"
+        );
+        assert!(
+            total > 0.0,
+            "the burst still counts toward the node total (share denominator)"
+        );
+    }
+
+    /// The counterpart to the trickle-then-burst boundary: the SAME dense burst
+    /// shape, but REPEATED continuously (above the floor throughout) for longer
+    /// than `min_window / 2`, IS a candidate — this is genuine sustained
+    /// above-floor cost, not a lone burst.
+    #[test]
+    fn contract_cost_rates_repeated_dense_bursts_above_floor_is_a_candidate() {
+        let meter = Meter::new_with_window_size(100);
+        let t0 = Instant::now();
+        let min_window = Duration::from_secs(300);
+        let id1 = ContractInstanceId::new([1u8; 32]);
+
+        // The 25ms-cadence dense burst of the test above, sustained for 200s:
+        // ~2320 msgs/s (buffer-saturating), continuously above the 10/s floor.
+        let mut i = 0u64;
+        while Duration::from_millis(25 * i) <= Duration::from_secs(200) {
+            meter.report(
+                &contract_source(1),
+                ResourceType::BroadcastMessagesSent,
+                58.0,
+                t0 + Duration::from_millis(25 * i),
+            );
+            i += 1;
+        }
+        let now = t0 + Duration::from_millis(25 * (i - 1)) + Duration::from_secs(1);
+
+        let (_total, rates) =
+            meter.contract_cost_rates(&ResourceType::BroadcastMessagesSent, now, min_window);
+        assert!(
+            rates.contains_key(&id1),
+            "a dense burst sustained ABOVE the floor for > min_window/2 IS a \
+             candidate (sustained above-floor cost)"
         );
     }
 

--- a/crates/core/src/topology/meter.rs
+++ b/crates/core/src/topology/meter.rs
@@ -173,43 +173,83 @@ impl Meter {
     /// Returns `(total_rate, per_contract_rate)` in axis units per second.
     /// EVERY positive-rate contract counts toward `total_rate` (the share
     /// denominator), but the per-contract map — the eviction CANDIDACY input —
-    /// contains only contracts whose reporting is SUSTAINED: the within-window
-    /// samples must SPAN at least `min_window / 2`
-    /// ([`crate::topology::running_average::WindowedRate::retained_span`]).
-    /// A contract absent from the map has zero attributed cost for candidacy
-    /// purposes, so a short burst — even a buffer-saturating one, and even on
-    /// a source whose FIRST-EVER sample is arbitrarily old (the lifetime
-    /// first-sample age was the review-Fix-2 hole: set once and never reset)
+    /// contains only contracts whose reporting is SUSTAINED: the source's
+    /// current CONTINUOUS activity run must be at least `min_window / 2` long
+    /// ([`crate::topology::running_average::WindowedRate::activity_span`]).
+    /// That run length is buffer-CAPACITY-independent (tracked at insert time
+    /// via `activity_start`), so it works at ANY report cadence above the
+    /// floor — the fix for the review BLOCKER, where the old span-of-the-
+    /// count-bounded-buffer signal INVERTED against high-frequency storms
+    /// (fast cadence ⇒ short buffer span ⇒ never "sustained" ⇒ the worst
+    /// storms were permanently exempted). A contract absent from the map has
+    /// zero attributed cost for candidacy purposes, so a short burst — even a
+    /// buffer-saturating one, and even on a source whose first-ever sample is
+    /// arbitrarily old (a >`SUSTAINED_ACTIVITY_MAX_GAP` gap restarts the run)
     /// — can never make its contract a cost victim, no matter how big the
     /// burst.
+    ///
+    /// Single-axis convenience wrapper over [`Self::contract_cost_rates_multi`]
+    /// for the unit tests; production reads all three cost axes in one pass via
+    /// the multi form (#4903 review perf).
+    #[cfg(test)]
     pub(crate) fn contract_cost_rates(
         &self,
         resource: &ResourceType,
         at_time: Instant,
         min_window: Duration,
     ) -> (f64, std::collections::HashMap<ContractInstanceId, f64>) {
+        let mut out =
+            self.contract_cost_rates_multi(std::slice::from_ref(resource), at_time, min_window);
+        out.pop()
+            .expect("exactly one result for one requested axis")
+    }
+
+    /// Multi-axis form of [`Self::contract_cost_rates`]: read SEVERAL cost
+    /// axes in a SINGLE pass over the attribution meters, returning one
+    /// `(total_rate, per_contract_rate)` per requested axis in the same order.
+    ///
+    /// The hosting sweep needs all three cost axes (CPU, fan-out bytes,
+    /// broadcast messages) every tick; reading them with three separate
+    /// [`Self::contract_cost_rates`] calls scanned the (potentially large)
+    /// attribution-meter map three times under the topology read lock (#4903
+    /// review perf). One pass amortizes the scan; the per-source windowing and
+    /// the SUSTAINED continuous-run gate are identical to the single-axis form.
+    pub(crate) fn contract_cost_rates_multi(
+        &self,
+        resources: &[ResourceType],
+        at_time: Instant,
+        min_window: Duration,
+    ) -> Vec<(f64, std::collections::HashMap<ContractInstanceId, f64>)> {
         let sustained_min_span = min_window / 2;
-        let mut per_contract = std::collections::HashMap::new();
-        let mut total = 0.0_f64;
+        let mut results: Vec<(f64, std::collections::HashMap<ContractInstanceId, f64>)> = resources
+            .iter()
+            .map(|_| (0.0_f64, std::collections::HashMap::new()))
+            .collect();
+        if resources.is_empty() {
+            return results;
+        }
         for entry in self.attribution_meters.iter() {
             let AttributionSource::Contract(id) = entry.key() else {
                 continue;
             };
-            let Some(avg) = entry.value().map.get(resource) else {
-                continue;
-            };
-            let Some(windowed) = avg.windowed_rate(at_time, min_window) else {
-                continue;
-            };
-            let per_second = windowed.rate.per_second();
-            if per_second > 0.0 {
-                total += per_second;
-                if windowed.retained_span >= sustained_min_span {
-                    per_contract.insert(*id, per_second);
+            let source_map = &entry.value().map;
+            for (i, resource) in resources.iter().enumerate() {
+                let Some(avg) = source_map.get(resource) else {
+                    continue;
+                };
+                let Some(windowed) = avg.windowed_rate(at_time, min_window) else {
+                    continue;
+                };
+                let per_second = windowed.rate.per_second();
+                if per_second > 0.0 {
+                    results[i].0 += per_second;
+                    if windowed.activity_span >= sustained_min_span {
+                        results[i].1.insert(*id, per_second);
+                    }
                 }
             }
         }
-        (total, per_contract)
+        results
     }
 
     /// Estimates the usage rate for a given resource type based on existing data.
@@ -716,8 +756,9 @@ mod tests {
     /// true rate over its actual span (the count-truncation fix — without it
     /// a sustained high-frequency storm's rate is capped at
     /// samples×value/window and can hide under the floor); and the
-    /// per-contract candidacy map admits only SUSTAINED sources (within-
-    /// window samples spanning at least half the window) while every positive
+    /// per-contract candidacy map admits only SUSTAINED sources (a continuous
+    /// activity run of at least half the window — the buffer-capacity-
+    /// independent `activity_span`, #4903 review BLOCKER) while every positive
     /// rate still counts toward the total.
     #[test]
     fn contract_cost_rates_aggregates_contract_sources_with_min_window() {
@@ -773,15 +814,16 @@ mod tests {
         let id2 = ContractInstanceId::new([2u8; 32]);
         // Sparse source: the t0 sample is older than the window and ignored
         // (review Fix 3), leaving one within-window sample — diluted over the
-        // window (30_000/300s = 100/s) and NOT sustained (span 0), so it
-        // counts toward the total but is no candidacy entry.
+        // window (30_000/300s = 100/s) and NOT sustained (the >max-gap silence
+        // between the two samples restarts the run, so activity_span is 0), so
+        // it counts toward the total but is no candidacy entry.
         assert!(
             !cpu_rates.contains_key(&id1),
             "a lone within-window sample must not be a candidate"
         );
         // Burst source: counted in the TOTAL (diluted over min_window: 30M/300s
-        // = 100_000/s) but EXCLUDED from the candidacy map (recent samples
-        // span ~0s — not sustained), so one burst can never nominate a victim.
+        // = 100_000/s) but EXCLUDED from the candidacy map (activity run ~0s —
+        // not sustained), so one burst can never nominate a victim.
         assert!(
             !cpu_rates.contains_key(&id2),
             "burst must not be a candidate"
@@ -802,13 +844,13 @@ mod tests {
         assert!((msgs_total - rate3).abs() < 1e-9);
     }
 
-    /// Review Fix 2 regression: an OLD first-ever sample must not admit a
-    /// later short burst into candidacy. Before the fix the sustained gate
-    /// keyed on the lifetime `first_sample_time` (set once, never reset), so
-    /// a contract that reported once long ago passed the gate forever and a
-    /// buffer-saturating 60-second flurry then read a high instantaneous
-    /// rate and became a cost-eviction candidate — "a single burst can never
-    /// make its contract a victim" was false for old-first-sample sources.
+    /// Review Fix 2 / BLOCKER regression: an OLD first-ever sample must not
+    /// admit a later short burst into candidacy. The continuity gap-reset
+    /// (a >`SUSTAINED_ACTIVITY_MAX_GAP` silence restarts the activity run)
+    /// makes the burst's `activity_span` measure only the burst, so a
+    /// buffer-saturating 60-second flurry after a long silence is not
+    /// sustained — "a single burst can never make its contract a victim"
+    /// holds for old-first-sample sources too.
     #[test]
     fn contract_cost_rates_old_first_sample_then_burst_is_not_a_candidate() {
         let meter = Meter::new_with_window_size(100);
@@ -842,7 +884,8 @@ mod tests {
         assert!(
             !rates.contains_key(&id1),
             "an old-first-sample source's short burst must NOT be a candidate \
-             (the recent samples span only ~50s, not min_window/2)"
+             (the gap-reset restarts the run at the burst, activity_span ~50s \
+             < min_window/2)"
         );
         assert!(
             total > 0.0,
@@ -850,12 +893,13 @@ mod tests {
         );
     }
 
-    /// Review Fix 3 regression: a contract that stops reporting decays out of
-    /// the cost read within a bounded time (one `min_window` of silence) —
-    /// it leaves the candidacy map first (its recent samples no longer span
-    /// half the window) and then stops inflating the node total entirely,
-    /// instead of holding its stale storm rate for as long as the
-    /// count-bounded buffer retains old samples.
+    /// Review Fix 3 / BLOCKER regression: a contract that stops reporting
+    /// decays out of the cost read within a bounded time — it leaves the
+    /// candidacy map first (after one `SUSTAINED_ACTIVITY_MAX_GAP` of silence
+    /// its activity run is no longer current, `activity_span` → 0) and then
+    /// stops inflating the node total entirely (once every sample ages past
+    /// `min_window`), instead of holding its stale storm rate for as long as
+    /// the count-bounded buffer retains old samples.
     #[test]
     fn contract_cost_rates_quiet_contract_decays_out_within_min_window() {
         let meter = Meter::new_with_window_size(100);
@@ -883,9 +927,9 @@ mod tests {
         assert!(live_rates[&id1] > 30.0);
         assert!(live_total > 30.0);
 
-        // After 180s of silence the within-window samples span under half
-        // the window: no longer a CANDIDATE (even though some rate remains
-        // in the total while recent samples linger).
+        // After 180s of silence (longer than SUSTAINED_ACTIVITY_MAX_GAP) the
+        // activity run is no longer current: no longer a CANDIDATE (even
+        // though some rate remains in the total while recent samples linger).
         let (_, stale_rates) = meter.contract_cost_rates(
             &ResourceType::BroadcastMessagesSent,
             storm_end + Duration::from_secs(180),
@@ -893,7 +937,8 @@ mod tests {
         );
         assert!(
             !stale_rates.contains_key(&id1),
-            "a quiet contract must drop out of candidacy as its recent span shrinks"
+            "a quiet contract must drop out of candidacy once its activity run \
+             goes stale"
         );
 
         // After a full min_window of silence every sample is stale: the
@@ -907,6 +952,243 @@ mod tests {
         assert_eq!(
             gone_total, 0.0,
             "a source quiet for min_window must stop inflating total_rate"
+        );
+    }
+
+    /// #4903 review BLOCKER regression: storms at ANY report cadence above the
+    /// floor must nominate. The old sustained gate keyed on the span of the
+    /// count-bounded sample buffer, which shrinks with cadence — a fast storm's
+    /// 100-sample buffer spans only a few tens of seconds, far under
+    /// `min_window / 2`, so the FASTEST (worst) storms were PERMANENTLY exempt.
+    /// The continuity-tracked `activity_span` is buffer-capacity-independent,
+    /// so a 1.4s-cadence storm AND a 0.5s-cadence storm (buffer span ~50s) both
+    /// nominate.
+    #[test]
+    fn contract_cost_rates_fast_storm_cadences_nominate() {
+        let meter = Meter::new_with_window_size(100);
+        let t0 = Instant::now();
+        let min_window = Duration::from_secs(300);
+        let run = Duration::from_secs(220); // > min_window/2, continuous
+
+        // id1: 1.4s cadence (just under the old [1.52s, 3.03s] catchable band).
+        let mut t = Duration::ZERO;
+        while t <= run {
+            meter.report(
+                &contract_source(1),
+                ResourceType::BroadcastMessagesSent,
+                58.0,
+                t0 + t,
+            );
+            t += Duration::from_millis(1400);
+        }
+        // id2: 0.5s cadence — the 100-sample buffer spans only ~50s, deep
+        // inside the old inversion (never "sustained" under the buffer-span
+        // gate), yet the run is 220s.
+        let mut t = Duration::ZERO;
+        while t <= run {
+            meter.report(
+                &contract_source(2),
+                ResourceType::BroadcastMessagesSent,
+                58.0,
+                t0 + t,
+            );
+            t += Duration::from_millis(500);
+        }
+
+        let now = t0 + run + Duration::from_secs(1);
+        let (_total, rates) =
+            meter.contract_cost_rates(&ResourceType::BroadcastMessagesSent, now, min_window);
+        let id1 = ContractInstanceId::new([1u8; 32]);
+        let id2 = ContractInstanceId::new([2u8; 32]);
+        assert!(
+            rates.contains_key(&id1),
+            "a 1.4s-cadence storm must be a candidate"
+        );
+        assert!(
+            rates.contains_key(&id2),
+            "a 0.5s-cadence storm (buffer span ~50s ≪ min_window/2) must STILL \
+             be a candidate — the BLOCKER inversion is fixed"
+        );
+    }
+
+    /// A storm whose cadence is IRREGULAR — a 1.6s fan-out interleaved with
+    /// sporadic targeted stale-peer heal samples — is still one continuous run
+    /// (every gap stays under `SUSTAINED_ACTIVITY_MAX_GAP`), so it nominates.
+    #[test]
+    fn contract_cost_rates_heal_interleaved_storm_nominates() {
+        let meter = Meter::new_with_window_size(100);
+        let t0 = Instant::now();
+        let min_window = Duration::from_secs(300);
+
+        // 220s of fan-out at 1.6s, plus an extra heal sample at a jittered
+        // offset every ~5th dispatch — irregular but never a >max-gap silence.
+        let mut t = Duration::ZERO;
+        let mut n = 0u64;
+        while t <= Duration::from_secs(220) {
+            meter.report(
+                &contract_source(1),
+                ResourceType::BroadcastMessagesSent,
+                58.0,
+                t0 + t,
+            );
+            if n % 5 == 0 {
+                meter.report(
+                    &contract_source(1),
+                    ResourceType::BroadcastMessagesSent,
+                    1.0,
+                    t0 + t + Duration::from_millis(700),
+                );
+            }
+            n += 1;
+            t += Duration::from_millis(1600);
+        }
+
+        let now = t0 + Duration::from_secs(221);
+        let (_total, rates) =
+            meter.contract_cost_rates(&ResourceType::BroadcastMessagesSent, now, min_window);
+        assert!(
+            rates.contains_key(&ContractInstanceId::new([1u8; 32])),
+            "a heal-interleaved (irregular-cadence) storm must be a candidate"
+        );
+    }
+
+    /// The `ExecCpuMicros` axis must be able to nominate a multi-target CPU
+    /// storm. The send-time summarize/delta CPU is reported per PEER send, so a
+    /// 58-target fan-out floods the axis with 58 samples per dispatch — under
+    /// the old buffer-span gate that flood spanned only a couple of dispatches
+    /// (< min_window/2) and could NEVER nominate. With `activity_span` the
+    /// continuous run is what matters, so the CPU axis nominates.
+    #[test]
+    fn contract_cost_rates_multi_target_cpu_flood_nominates() {
+        let meter = Meter::new_with_window_size(100);
+        let t0 = Instant::now();
+        let min_window = Duration::from_secs(300);
+
+        // 120 dispatches at 1.6s (192s continuous); each dispatch reports 58
+        // per-target CPU samples spread across the ~1s send window.
+        let mut dispatch = Duration::ZERO;
+        for _ in 0..120u64 {
+            for target in 0..58u64 {
+                meter.report(
+                    &contract_source(1),
+                    ResourceType::ExecCpuMicros,
+                    200.0,
+                    t0 + dispatch + Duration::from_millis(15 * target),
+                );
+            }
+            dispatch += Duration::from_millis(1600);
+        }
+
+        let now = t0 + dispatch + Duration::from_secs(1);
+        let (total, rates) =
+            meter.contract_cost_rates(&ResourceType::ExecCpuMicros, now, min_window);
+        assert!(
+            rates.contains_key(&ContractInstanceId::new([1u8; 32])),
+            "a multi-target (58/dispatch) CPU flood must nominate on the \
+             ExecCpuMicros axis"
+        );
+        assert!(total > 0.0);
+    }
+
+    /// Boundary: a single dense burst — even one that saturates the sample
+    /// buffer — is NOT a candidate (its continuous run is short), though it
+    /// still counts toward the total (share denominator).
+    #[test]
+    fn contract_cost_rates_single_dense_burst_never_nominates() {
+        let meter = Meter::new_with_window_size(100);
+        let t0 = Instant::now();
+        let min_window = Duration::from_secs(300);
+
+        // 200 samples over 30s (saturates the 100-sample buffer), then read.
+        for i in 0..200u64 {
+            meter.report(
+                &contract_source(1),
+                ResourceType::BroadcastMessagesSent,
+                58.0,
+                t0 + Duration::from_millis(150 * i),
+            );
+        }
+        let now = t0 + Duration::from_secs(31);
+        let (total, rates) =
+            meter.contract_cost_rates(&ResourceType::BroadcastMessagesSent, now, min_window);
+        assert!(
+            !rates.contains_key(&ContractInstanceId::new([1u8; 32])),
+            "a 30s dense burst must not be sustained (run < min_window/2)"
+        );
+        assert!(total > 0.0, "the burst still counts toward the total");
+    }
+
+    /// Boundary (#4903 review round-2 requirement): the 60s gap-reset must have
+    /// generous headroom above ANY cadence that exceeds a floor, so a genuine
+    /// sustained storm never spuriously resets its run. The slowest
+    /// floor-exceeding message cadence (58 msgs per dispatch, 10 msgs/s floor)
+    /// is a dispatch every ~5.8s — far under 60s. A contract reporting even
+    /// more slowly than that (every 30s) is still ONE continuous run and stays
+    /// sustained: no spurious gap-reset.
+    #[test]
+    fn contract_cost_rates_slow_cadence_does_not_gap_reset() {
+        let meter = Meter::new_with_window_size(100);
+        let t0 = Instant::now();
+        let min_window = Duration::from_secs(300);
+
+        // Report every 30s (well under the 60s gap threshold but far slower
+        // than any real storm) for 240s continuous.
+        let mut t = Duration::ZERO;
+        while t <= Duration::from_secs(240) {
+            meter.report(
+                &contract_source(1),
+                ResourceType::BroadcastMessagesSent,
+                58.0,
+                t0 + t,
+            );
+            t += Duration::from_secs(30);
+        }
+        let now = t0 + Duration::from_secs(241);
+        let (_total, rates) =
+            meter.contract_cost_rates(&ResourceType::BroadcastMessagesSent, now, min_window);
+        assert!(
+            rates.contains_key(&ContractInstanceId::new([1u8; 32])),
+            "a continuous 30s-cadence reporter must stay one sustained run — the \
+             60s gap threshold must not spuriously reset a sub-60s cadence"
+        );
+    }
+
+    /// Boundary (#4903 review round-2 requirement): an INTERMITTENT burst
+    /// pattern — a 3s storm, then 90s of silence, repeated — must NOT
+    /// accumulate span across the silences. Each >60s gap restarts the run, so
+    /// every burst's `activity_span` is only ~3s and the contract is NEVER
+    /// sustained, no matter how many cycles run.
+    #[test]
+    fn contract_cost_rates_intermittent_bursts_do_not_accumulate_span() {
+        let meter = Meter::new_with_window_size(100);
+        let t0 = Instant::now();
+        let min_window = Duration::from_secs(300);
+
+        // Three cycles of {3s burst (7 samples @ 0.5s), 90s silence}.
+        let cycle = Duration::from_secs(93);
+        for c in 0..3u64 {
+            let start = cycle * c as u32;
+            for i in 0..7u64 {
+                meter.report(
+                    &contract_source(1),
+                    ResourceType::BroadcastMessagesSent,
+                    58.0,
+                    t0 + start + Duration::from_millis(500 * i),
+                );
+            }
+        }
+        // Read right after the third burst (t0 + 186 + 3).
+        let now = t0 + cycle * 2 + Duration::from_secs(4);
+        let (total, rates) =
+            meter.contract_cost_rates(&ResourceType::BroadcastMessagesSent, now, min_window);
+        assert!(
+            !rates.contains_key(&ContractInstanceId::new([1u8; 32])),
+            "intermittent bursts separated by >60s silences must never become \
+             sustained — span must not accumulate across the gaps"
+        );
+        assert!(
+            total > 0.0,
+            "the recent burst still counts toward the total"
         );
     }
 

--- a/crates/core/src/topology/meter.rs
+++ b/crates/core/src/topology/meter.rs
@@ -155,6 +155,47 @@ impl Meter {
         rates
     }
 
+    /// Per-CONTRACT attributed usage rates for one cost axis, plus their sum,
+    /// for the cost-pressure eviction trigger (cost-aware eviction, #4861).
+    ///
+    /// Iterates the attribution meters, keeping only
+    /// [`AttributionSource::Contract`] entries (peer/delegate bandwidth sources
+    /// never participate in contract cost eviction), and reads each contract's
+    /// rate amortized over at least `min_window` (see
+    /// [`RunningAverage::get_rate_with_min_window`]) so a one-off burst
+    /// reported moments before the read cannot masquerade as a sustained
+    /// storm. Zero-rate entries are omitted, so an entry in the returned map
+    /// means "this contract did attributable work in the retained sample
+    /// window".
+    ///
+    /// Returns `(total_rate, per_contract_rate)` in axis units per second.
+    pub(crate) fn contract_cost_rates(
+        &self,
+        resource: &ResourceType,
+        at_time: Instant,
+        min_window: Duration,
+    ) -> (f64, std::collections::HashMap<ContractInstanceId, f64>) {
+        let mut per_contract = std::collections::HashMap::new();
+        let mut total = 0.0_f64;
+        for entry in self.attribution_meters.iter() {
+            let AttributionSource::Contract(id) = entry.key() else {
+                continue;
+            };
+            let Some(avg) = entry.value().map.get(resource) else {
+                continue;
+            };
+            let Some(rate) = avg.get_rate_with_min_window(at_time, min_window) else {
+                continue;
+            };
+            let per_second = rate.per_second();
+            if per_second > 0.0 {
+                total += per_second;
+                per_contract.insert(*id, per_second);
+            }
+        }
+        (total, per_contract)
+    }
+
     /// Estimates the usage rate for a given resource type based on existing data.
     ///
     /// This function calculates the estimated usage rate by taking the 50th percentile value (or another
@@ -635,6 +676,82 @@ mod tests {
             150.0
         );
         Ok(())
+    }
+
+    /// `contract_cost_rates` (cost-aware eviction, #4861) aggregates ONLY
+    /// Contract-attributed sources, amortizes over the caller's minimum
+    /// window (so a lone burst cannot masquerade as a sustained storm), and
+    /// returns a total consistent with the per-contract map.
+    #[test]
+    fn contract_cost_rates_aggregates_contract_sources_with_min_window() {
+        let meter = Meter::new_with_window_size(100);
+        let t0 = Instant::now();
+        let min_window = Duration::from_secs(300);
+
+        // Two contract sources doing sustained CPU work, one peer source
+        // (bandwidth) that must be excluded, and one contract source with
+        // work on a DIFFERENT axis only.
+        meter.report(
+            &contract_source(1),
+            ResourceType::ExecCpuMicros,
+            30_000.0,
+            t0,
+        );
+        meter.report(
+            &contract_source(1),
+            ResourceType::ExecCpuMicros,
+            30_000.0,
+            t0 + Duration::from_secs(10),
+        );
+        meter.report(
+            &contract_source(2),
+            ResourceType::ExecCpuMicros,
+            15_000.0,
+            t0 + Duration::from_secs(5),
+        );
+        meter.report(
+            &AttributionSource::Peer(PeerKeyLocation::random()),
+            ResourceType::InboundBandwidthBytes,
+            999_999.0,
+            t0,
+        );
+        meter.report(
+            &contract_source(3),
+            ResourceType::BroadcastFanoutCost,
+            1_000_000.0,
+            t0,
+        );
+
+        let (total, rates) = meter.contract_cost_rates(
+            &ResourceType::ExecCpuMicros,
+            t0 + Duration::from_secs(20),
+            min_window,
+        );
+
+        // Rates are amortized over the 300s minimum window, NOT the ~20s of
+        // real sample span (and never the 1s clamp): 60_000µs / 300s = 200/s.
+        let id1 = ContractInstanceId::new([1u8; 32]);
+        let id2 = ContractInstanceId::new([2u8; 32]);
+        assert_eq!(rates.len(), 2, "peer + other-axis sources are excluded");
+        assert!((rates[&id1] - 200.0).abs() < 1e-9);
+        assert!((rates[&id2] - 50.0).abs() < 1e-9);
+        assert!(
+            (total - 250.0).abs() < 1e-9,
+            "total = sum of per-contract rates"
+        );
+
+        // The other axis sees only its own source.
+        let (fan_total, fan_rates) = meter.contract_cost_rates(
+            &ResourceType::BroadcastFanoutCost,
+            t0 + Duration::from_secs(20),
+            min_window,
+        );
+        let id3 = ContractInstanceId::new([3u8; 32]);
+        assert_eq!(fan_rates.len(), 1);
+        // Burst dilution: a single 1MB fan-out reads as 1MB/300s ≈ 3.4KB/s,
+        // not the 1MB/s the 1-second clamp would report.
+        assert!((fan_rates[&id3] - 1_000_000.0 / 300.0).abs() < 1e-6);
+        assert!((fan_total - fan_rates[&id3]).abs() < 1e-9);
     }
 
     #[test]

--- a/crates/core/src/topology/meter.rs
+++ b/crates/core/src/topology/meter.rs
@@ -161,20 +161,27 @@ impl Meter {
     /// Iterates the attribution meters, keeping only
     /// [`AttributionSource::Contract`] entries (peer/delegate bandwidth sources
     /// never participate in contract cost eviction), and reads each contract's
-    /// rate amortized over at least `min_window` (see
-    /// [`RunningAverage::get_rate_with_min_window`]) so a one-off burst
-    /// reported moments before the read cannot masquerade as a sustained
-    /// storm. Zero-rate entries are omitted, so an entry in the returned map
-    /// means "this contract did attributable work in the retained sample
-    /// window".
+    /// rate via [`RunningAverage::windowed_rate`]: sparse samples are diluted
+    /// over at least `min_window` (a lone burst cannot masquerade as a
+    /// sustained storm), while a saturated sample buffer divides by its actual
+    /// span so a sustained high-frequency storm's TRUE rate is representable
+    /// (the count-truncation under-read that hid the #4861 profile).
     ///
     /// Returns `(total_rate, per_contract_rate)` in axis units per second.
+    /// EVERY positive-rate contract counts toward `total_rate` (the share
+    /// denominator), but the per-contract map — the eviction CANDIDACY input —
+    /// contains only contracts whose reporting is SUSTAINED (first sample at
+    /// least `min_window / 2` old). A contract absent from the map has zero
+    /// attributed cost for candidacy purposes, so a single large fan-out
+    /// burst (first report moments ago) can never make its contract a cost
+    /// victim, no matter how big the burst.
     pub(crate) fn contract_cost_rates(
         &self,
         resource: &ResourceType,
         at_time: Instant,
         min_window: Duration,
     ) -> (f64, std::collections::HashMap<ContractInstanceId, f64>) {
+        let sustained_min_age = min_window / 2;
         let mut per_contract = std::collections::HashMap::new();
         let mut total = 0.0_f64;
         for entry in self.attribution_meters.iter() {
@@ -184,13 +191,15 @@ impl Meter {
             let Some(avg) = entry.value().map.get(resource) else {
                 continue;
             };
-            let Some(rate) = avg.get_rate_with_min_window(at_time, min_window) else {
+            let Some(windowed) = avg.windowed_rate(at_time, min_window) else {
                 continue;
             };
-            let per_second = rate.per_second();
+            let per_second = windowed.rate.per_second();
             if per_second > 0.0 {
                 total += per_second;
-                per_contract.insert(*id, per_second);
+                if windowed.first_sample_age >= sustained_min_age {
+                    per_contract.insert(*id, per_second);
+                }
             }
         }
         (total, per_contract)
@@ -425,6 +434,7 @@ impl AttributionSource {
             (Peer(_), ExecFuelUnits) => false,
             (Peer(_), StateBytesWritten) => false,
             (Peer(_), BroadcastFanoutCost) => false,
+            (Peer(_), BroadcastMessagesSent) => false,
             // Delegate sources predate this PR; their existing usage
             // pattern is bandwidth-relevant for accounting purposes.
             (Delegate(_), InboundBandwidthBytes) => true,
@@ -433,6 +443,7 @@ impl AttributionSource {
             (Delegate(_), ExecFuelUnits) => false,
             (Delegate(_), StateBytesWritten) => false,
             (Delegate(_), BroadcastFanoutCost) => false,
+            (Delegate(_), BroadcastMessagesSent) => false,
             // Contract sources contribute the four contract-governance
             // resource types (CPU, fuel, state-bytes, fan-out cost) and
             // NEVER bandwidth — those are peer-attributed even when the
@@ -443,6 +454,7 @@ impl AttributionSource {
             (Contract(_), ExecFuelUnits) => true,
             (Contract(_), StateBytesWritten) => true,
             (Contract(_), BroadcastFanoutCost) => true,
+            (Contract(_), BroadcastMessagesSent) => true,
         }
     }
 }
@@ -491,6 +503,16 @@ pub(crate) enum ResourceType {
     ExecFuelUnits,
     StateBytesWritten,
     BroadcastFanoutCost,
+    /// Per-peer broadcast MESSAGES dispatched for a contract (count units,
+    /// one per target per fan-out, one per targeted stale-peer heal). Added
+    /// for cost-aware eviction (#4861): a tiny-payload contract fanning to
+    /// many co-hosts at a high message RATE burns per-send overhead
+    /// (syscall / encryption / queue work) that byte-denominated
+    /// [`Self::BroadcastFanoutCost`] cannot see — 121-byte messages at storm
+    /// frequency read as a negligible byte rate while dominating the node's
+    /// real broadcast capacity. This axis counts sends, so N tiny sends
+    /// register as N.
+    BroadcastMessagesSent,
 }
 
 impl ResourceType {
@@ -510,7 +532,7 @@ impl ResourceType {
     /// Every resource type the meter understands, including non-bandwidth
     /// resources added for contract governance.
     #[allow(dead_code)] // wired up incrementally by per-resource-type reporters
-    pub(crate) fn all_tracked() -> [ResourceType; 6] {
+    pub(crate) fn all_tracked() -> [ResourceType; 7] {
         [
             ResourceType::InboundBandwidthBytes,
             ResourceType::OutboundBandwidthBytes,
@@ -518,6 +540,7 @@ impl ResourceType {
             ResourceType::ExecFuelUnits,
             ResourceType::StateBytesWritten,
             ResourceType::BroadcastFanoutCost,
+            ResourceType::BroadcastMessagesSent,
         ]
     }
 }
@@ -679,18 +702,22 @@ mod tests {
     }
 
     /// `contract_cost_rates` (cost-aware eviction, #4861) aggregates ONLY
-    /// Contract-attributed sources, amortizes over the caller's minimum
-    /// window (so a lone burst cannot masquerade as a sustained storm), and
-    /// returns a total consistent with the per-contract map.
+    /// Contract-attributed sources; sparse samples are amortized over the
+    /// minimum window (a lone burst cannot masquerade as a sustained storm);
+    /// a SATURATED sample buffer reads its true rate over its actual span
+    /// (the count-truncation fix — without it a sustained high-frequency
+    /// storm's rate is capped at samples×value/window and can hide under the
+    /// floor); and the per-contract candidacy map admits only SUSTAINED
+    /// sources (first sample at least half the window old) while every
+    /// positive rate still counts toward the total.
     #[test]
     fn contract_cost_rates_aggregates_contract_sources_with_min_window() {
         let meter = Meter::new_with_window_size(100);
         let t0 = Instant::now();
         let min_window = Duration::from_secs(300);
+        let now = t0 + Duration::from_secs(600);
 
-        // Two contract sources doing sustained CPU work, one peer source
-        // (bandwidth) that must be excluded, and one contract source with
-        // work on a DIFFERENT axis only.
+        // Sustained sparse source: two 30_000µs samples over 10 minutes.
         meter.report(
             &contract_source(1),
             ResourceType::ExecCpuMicros,
@@ -701,57 +728,62 @@ mod tests {
             &contract_source(1),
             ResourceType::ExecCpuMicros,
             30_000.0,
-            t0 + Duration::from_secs(10),
+            t0 + Duration::from_secs(590),
         );
+        // Burst source: one huge sample 1s before the read.
         meter.report(
             &contract_source(2),
             ResourceType::ExecCpuMicros,
-            15_000.0,
-            t0 + Duration::from_secs(5),
+            30_000_000.0,
+            now - Duration::from_secs(1),
         );
+        // Peer (bandwidth) source: must be excluded entirely.
         meter.report(
             &AttributionSource::Peer(PeerKeyLocation::random()),
             ResourceType::InboundBandwidthBytes,
             999_999.0,
             t0,
         );
-        meter.report(
-            &contract_source(3),
-            ResourceType::BroadcastFanoutCost,
-            1_000_000.0,
-            t0,
-        );
+        // Saturated high-frequency source on a different axis: 150 samples of
+        // 58 messages at 1.6s cadence (storm profile). The ring keeps the last
+        // 100, spanning ~158.4s.
+        for i in 0..150u64 {
+            meter.report(
+                &contract_source(3),
+                ResourceType::BroadcastMessagesSent,
+                58.0,
+                t0 + Duration::from_millis(1600 * i),
+            );
+        }
+        let msgs_now = t0 + Duration::from_millis(1600 * 149) + Duration::from_secs(1);
 
-        let (total, rates) = meter.contract_cost_rates(
-            &ResourceType::ExecCpuMicros,
-            t0 + Duration::from_secs(20),
-            min_window,
-        );
-
-        // Rates are amortized over the 300s minimum window, NOT the ~20s of
-        // real sample span (and never the 1s clamp): 60_000µs / 300s = 200/s.
+        let (cpu_total, cpu_rates) =
+            meter.contract_cost_rates(&ResourceType::ExecCpuMicros, now, min_window);
         let id1 = ContractInstanceId::new([1u8; 32]);
         let id2 = ContractInstanceId::new([2u8; 32]);
-        assert_eq!(rates.len(), 2, "peer + other-axis sources are excluded");
-        assert!((rates[&id1] - 200.0).abs() < 1e-9);
-        assert!((rates[&id2] - 50.0).abs() < 1e-9);
+        // Sustained sparse source: 60_000µs over its 600s retained span.
+        assert!((cpu_rates[&id1] - 60_000.0 / 600.0).abs() < 1e-6);
+        // Burst source: counted in the TOTAL (diluted over min_window: 30M/300s
+        // = 100_000/s) but EXCLUDED from the candidacy map (first sample 1s
+        // old — not sustained), so one burst can never nominate a victim.
         assert!(
-            (total - 250.0).abs() < 1e-9,
-            "total = sum of per-contract rates"
+            !cpu_rates.contains_key(&id2),
+            "burst must not be a candidate"
         );
+        let expected_total = 60_000.0 / 600.0 + 30_000_000.0 / 300.0;
+        assert!((cpu_total - expected_total).abs() < 1e-6);
 
-        // The other axis sees only its own source.
-        let (fan_total, fan_rates) = meter.contract_cost_rates(
-            &ResourceType::BroadcastFanoutCost,
-            t0 + Duration::from_secs(20),
-            min_window,
-        );
+        // Saturated storm source: true rate over the RETAINED span (~158.4s),
+        // NOT diluted to 100×58/300s ≈ 19.3/s. 100×58/158.4 ≈ 36.6/s.
+        let (msgs_total, msgs_rates) =
+            meter.contract_cost_rates(&ResourceType::BroadcastMessagesSent, msgs_now, min_window);
         let id3 = ContractInstanceId::new([3u8; 32]);
-        assert_eq!(fan_rates.len(), 1);
-        // Burst dilution: a single 1MB fan-out reads as 1MB/300s ≈ 3.4KB/s,
-        // not the 1MB/s the 1-second clamp would report.
-        assert!((fan_rates[&id3] - 1_000_000.0 / 300.0).abs() < 1e-6);
-        assert!((fan_total - fan_rates[&id3]).abs() < 1e-9);
+        let rate3 = msgs_rates[&id3];
+        assert!(
+            rate3 > 30.0,
+            "saturated buffer must read the true storm rate (~36.6/s), got {rate3}/s"
+        );
+        assert!((msgs_total - rate3).abs() < 1e-9);
     }
 
     #[test]

--- a/crates/core/src/topology/running_average.rs
+++ b/crates/core/src/topology/running_average.rs
@@ -9,6 +9,13 @@ pub(crate) struct RunningAverage {
     samples: VecDeque<(Instant, f64)>,
     sum_samples: f64,
     total_sample_count: usize,
+    /// Time of the FIRST sample ever recorded on this average (not merely the
+    /// oldest retained sample, which count-truncation keeps young for
+    /// high-frequency sources). Read by [`Self::windowed_rate`] so the
+    /// cost-pressure trigger (cost-aware eviction, #4861) can require
+    /// SUSTAINED reporting before an axis may act — a single large burst has
+    /// a first-sample age of ~0 and is excluded.
+    first_sample_time: Option<Instant>,
 }
 
 impl RunningAverage {
@@ -18,6 +25,7 @@ impl RunningAverage {
             samples: VecDeque::with_capacity(max_samples),
             sum_samples: 0.0,
             total_sample_count: 0,
+            first_sample_time: None,
         }
     }
 
@@ -25,6 +33,9 @@ impl RunningAverage {
         // Require that now is after the last sample time
         if let Some((last_sample_time, _)) = self.samples.back() {
             debug_assert!(now >= *last_sample_time);
+        }
+        if self.first_sample_time.is_none() {
+            self.first_sample_time = Some(now);
         }
         self.total_sample_count += 1;
         if self.samples.len() < self.max_samples {
@@ -47,31 +58,59 @@ impl RunningAverage {
         Some(Rate::new(self.sum_samples, divisor))
     }
 
-    /// Like [`Self::get_rate_at_time`] but with a caller-supplied minimum
-    /// averaging window instead of the 1-second clamp.
+    /// Cost-axis rate read for the cost-pressure eviction trigger
+    /// (cost-aware eviction, #4861). Differs from [`Self::get_rate_at_time`]
+    /// in two load-bearing ways:
     ///
-    /// Used by the cost-pressure eviction trigger (cost-aware eviction,
-    /// #4861): `get_rate_at_time`'s 1-second minimum window means a single
-    /// large sample reported moments before a read produces an enormous
-    /// instantaneous rate (`value / 1s`). For an EVICTION decision that spike
-    /// would make a lone broadcast look like a sustained storm. Amortizing the
-    /// sample sum over at least `min_window` means only load actually
-    /// SUSTAINED across the window registers as a high rate; a one-off burst
-    /// is diluted by the window and decays as `now` advances past the oldest
-    /// retained sample.
-    pub(crate) fn get_rate_with_min_window(
-        &self,
-        now: Instant,
-        min_window: Duration,
-    ) -> Option<Rate> {
+    /// 1. **Sparse samples are diluted by `min_window`** instead of the
+    ///    1-second clamp: a single large sample reported moments before the
+    ///    read would otherwise produce an enormous instantaneous rate
+    ///    (`value / 1s`), making a lone broadcast look like a sustained
+    ///    storm to an EVICTION decision.
+    /// 2. **A saturated buffer divides by its ACTUAL span**, not the minimum
+    ///    window: the ring buffer keeps at most `max_samples` samples, so a
+    ///    sustained high-frequency storm's retained samples may span only a
+    ///    few tens of seconds — dividing that sum by `min_window` would cap
+    ///    the representable rate at `max_samples × avg_value / min_window`,
+    ///    silently under-reading the exact storm profile the trigger exists
+    ///    to catch (a full buffer PROVES the activity filled the whole
+    ///    retained span, so its sum/span is the true rate — no dilution
+    ///    needed). Burst protection for the saturated case comes from
+    ///    [`WindowedRate::first_sample_age`]: the caller requires sustained
+    ///    reporting before acting.
+    pub(crate) fn windowed_rate(&self, now: Instant, min_window: Duration) -> Option<WindowedRate> {
         if self.samples.is_empty() {
             return None;
         }
         let oldest_sample_time = self.samples.front().unwrap().0;
-        let sample_duration = now.saturating_duration_since(oldest_sample_time);
-        let divisor = sample_duration.max(min_window).max(Duration::from_secs(1));
-        Some(Rate::new(self.sum_samples, divisor))
+        let retained_span = now.saturating_duration_since(oldest_sample_time);
+        let saturated = self.samples.len() >= self.max_samples;
+        let divisor = if saturated {
+            retained_span.max(Duration::from_secs(1))
+        } else {
+            retained_span.max(min_window).max(Duration::from_secs(1))
+        };
+        let first_sample_age = self
+            .first_sample_time
+            .map(|t| now.saturating_duration_since(t))
+            .unwrap_or_default();
+        Some(WindowedRate {
+            rate: Rate::new(self.sum_samples, divisor),
+            first_sample_age,
+        })
     }
+}
+
+/// Result of [`RunningAverage::windowed_rate`]: the min-window-aware rate
+/// plus how long this average has been receiving samples (the sustained-
+/// pressure input for the cost-eviction trigger, #4861).
+pub(crate) struct WindowedRate {
+    pub rate: Rate,
+    /// `now − first_sample_time`: how long ago this source FIRST reported.
+    /// NOT the oldest retained sample's age — count-truncation keeps that
+    /// young for high-frequency sources, which is exactly when the sustained
+    /// signal matters.
+    pub first_sample_age: Duration,
 }
 
 #[cfg(test)]

--- a/crates/core/src/topology/running_average.rs
+++ b/crates/core/src/topology/running_average.rs
@@ -9,13 +9,6 @@ pub(crate) struct RunningAverage {
     samples: VecDeque<(Instant, f64)>,
     sum_samples: f64,
     total_sample_count: usize,
-    /// Time of the FIRST sample ever recorded on this average (not merely the
-    /// oldest retained sample, which count-truncation keeps young for
-    /// high-frequency sources). Read by [`Self::windowed_rate`] so the
-    /// cost-pressure trigger (cost-aware eviction, #4861) can require
-    /// SUSTAINED reporting before an axis may act — a single large burst has
-    /// a first-sample age of ~0 and is excluded.
-    first_sample_time: Option<Instant>,
 }
 
 impl RunningAverage {
@@ -25,7 +18,6 @@ impl RunningAverage {
             samples: VecDeque::with_capacity(max_samples),
             sum_samples: 0.0,
             total_sample_count: 0,
-            first_sample_time: None,
         }
     }
 
@@ -33,9 +25,6 @@ impl RunningAverage {
         // Require that now is after the last sample time
         if let Some((last_sample_time, _)) = self.samples.back() {
             debug_assert!(now >= *last_sample_time);
-        }
-        if self.first_sample_time.is_none() {
-            self.first_sample_time = Some(now);
         }
         self.total_sample_count += 1;
         if self.samples.len() < self.max_samples {
@@ -60,57 +49,97 @@ impl RunningAverage {
 
     /// Cost-axis rate read for the cost-pressure eviction trigger
     /// (cost-aware eviction, #4861). Differs from [`Self::get_rate_at_time`]
-    /// in two load-bearing ways:
+    /// in three load-bearing ways:
     ///
-    /// 1. **Sparse samples are diluted by `min_window`** instead of the
+    /// 1. **Only samples within the last `min_window` participate** (the
+    ///    time-bound, review Fix 3). The sample buffer is COUNT-bounded, so
+    ///    without this a source that stormed and then went quiet would keep
+    ///    reading its stale high rate for as long as the buffer happened to
+    ///    retain the old samples — feeding both the eviction candidacy and
+    ///    the node-total denominator minutes after the activity stopped. The
+    ///    cost rate is defined as "attributed work within the last
+    ///    `min_window`", so a quiet source decays: partially at first (stale
+    ///    samples drop out of the sum), and to `None` once every retained
+    ///    sample is older than `min_window`.
+    /// 2. **Sparse samples are diluted by `min_window`** instead of the
     ///    1-second clamp: a single large sample reported moments before the
     ///    read would otherwise produce an enormous instantaneous rate
     ///    (`value / 1s`), making a lone broadcast look like a sustained
     ///    storm to an EVICTION decision.
-    /// 2. **A saturated buffer divides by its ACTUAL span**, not the minimum
-    ///    window: the ring buffer keeps at most `max_samples` samples, so a
-    ///    sustained high-frequency storm's retained samples may span only a
-    ///    few tens of seconds — dividing that sum by `min_window` would cap
-    ///    the representable rate at `max_samples × avg_value / min_window`,
-    ///    silently under-reading the exact storm profile the trigger exists
-    ///    to catch (a full buffer PROVES the activity filled the whole
+    /// 3. **A fully-recent saturated buffer divides by its ACTUAL span**,
+    ///    not the minimum window: the ring buffer keeps at most
+    ///    `max_samples` samples, so a sustained high-frequency storm's
+    ///    retained samples may span only a few tens of seconds — dividing
+    ///    that sum by `min_window` would cap the representable rate at
+    ///    `max_samples × avg_value / min_window`, silently under-reading the
+    ///    exact storm profile the trigger exists to catch (a full buffer
+    ///    whose EVERY sample is recent proves the activity filled the whole
     ///    retained span, so its sum/span is the true rate — no dilution
-    ///    needed). Burst protection for the saturated case comes from
-    ///    [`WindowedRate::first_sample_age`]: the caller requires sustained
-    ///    reporting before acting.
+    ///    needed). If any retained sample was excluded by the time-bound,
+    ///    the remaining recent subset no longer proves saturation density
+    ///    and the diluted (`min_window`) divisor applies. Burst protection
+    ///    for the saturated case comes from [`WindowedRate::retained_span`]:
+    ///    the caller requires the recent samples to SPAN a sustained period
+    ///    before acting.
     pub(crate) fn windowed_rate(&self, now: Instant, min_window: Duration) -> Option<WindowedRate> {
-        if self.samples.is_empty() {
-            return None;
+        // Time-bound (review Fix 3): only samples no older than `min_window`
+        // count. Samples are appended in time order, so scanning the whole
+        // (small, count-bounded) buffer is cheap and needs no index math.
+        let mut recent_sum = 0.0_f64;
+        let mut oldest_recent: Option<Instant> = None;
+        let mut newest_recent: Option<Instant> = None;
+        let mut excluded_any = false;
+        for (at, value) in &self.samples {
+            if now.saturating_duration_since(*at) > min_window {
+                excluded_any = true;
+                continue;
+            }
+            if oldest_recent.is_none() {
+                oldest_recent = Some(*at);
+            }
+            newest_recent = Some(*at);
+            recent_sum += value;
         }
-        let oldest_sample_time = self.samples.front().unwrap().0;
-        let retained_span = now.saturating_duration_since(oldest_sample_time);
-        let saturated = self.samples.len() >= self.max_samples;
+        // Every retained sample is stale (or the buffer is empty): the
+        // source has done no attributable work within the window.
+        let oldest = oldest_recent?;
+        let newest = newest_recent.expect("newest set whenever oldest is");
+        // The span the recent samples actually cover (newest − oldest): the
+        // sustained-activity signal (review Fix 2). Deliberately NOT the
+        // lifetime first-sample age — that is set once and never reset, so a
+        // source whose first-ever sample was old would pass a "sustained"
+        // gate forever and a later short burst could nominate it.
+        let retained_span = newest.saturating_duration_since(oldest);
+        let since_oldest = now.saturating_duration_since(oldest);
+        // "Saturated" (true-rate) reading requires the full buffer AND no
+        // time-excluded sample: only then does the buffer prove continuous
+        // activity across its span. See rustdoc point 3.
+        let saturated = self.samples.len() >= self.max_samples && !excluded_any;
         let divisor = if saturated {
-            retained_span.max(Duration::from_secs(1))
+            since_oldest.max(Duration::from_secs(1))
         } else {
-            retained_span.max(min_window).max(Duration::from_secs(1))
+            since_oldest.max(min_window).max(Duration::from_secs(1))
         };
-        let first_sample_age = self
-            .first_sample_time
-            .map(|t| now.saturating_duration_since(t))
-            .unwrap_or_default();
         Some(WindowedRate {
-            rate: Rate::new(self.sum_samples, divisor),
-            first_sample_age,
+            rate: Rate::new(recent_sum, divisor),
+            retained_span,
         })
     }
 }
 
 /// Result of [`RunningAverage::windowed_rate`]: the min-window-aware rate
-/// plus how long this average has been receiving samples (the sustained-
-/// pressure input for the cost-eviction trigger, #4861).
+/// plus how long the RECENT (within-window) samples actually span (the
+/// sustained-pressure input for the cost-eviction trigger, #4861).
 pub(crate) struct WindowedRate {
     pub rate: Rate,
-    /// `now − first_sample_time`: how long ago this source FIRST reported.
-    /// NOT the oldest retained sample's age — count-truncation keeps that
-    /// young for high-frequency sources, which is exactly when the sustained
-    /// signal matters.
-    pub first_sample_age: Duration,
+    /// `newest_recent_sample − oldest_recent_sample`: the period the
+    /// currently-held, within-window samples actually cover. A genuine
+    /// sustained storm's recent samples span a large fraction of the window;
+    /// a short burst's span only a few tens of seconds — no matter how old
+    /// the source's FIRST-EVER sample is (the lifetime first-sample age was
+    /// the review-Fix-2 hole: set once, never reset, so an old-first-sample
+    /// source passed the sustained gate forever).
+    pub retained_span: Duration,
 }
 
 #[cfg(test)]
@@ -139,6 +168,160 @@ mod tests {
         running_avg.insert_with_time(now + Duration::from_secs(3), 8.0);
         assert_eq!(running_avg.samples.len(), 3);
         assert_eq!(running_avg.sum_samples, 18.0);
+    }
+
+    /// Direct coverage for the cost-axis read (`windowed_rate`, #4861):
+    /// empty buffer, single-sample dilution, saturated true-rate,
+    /// unsaturated dilution, the retained-span sustained signal, and the
+    /// review-Fix-3 time-bound.
+    mod windowed_rate {
+        use super::*;
+
+        const MIN_WINDOW: Duration = Duration::from_secs(300);
+
+        #[test]
+        fn empty_buffer_returns_none() {
+            let avg = RunningAverage::new(3);
+            assert!(avg.windowed_rate(Instant::now(), MIN_WINDOW).is_none());
+        }
+
+        /// A lone sample moments before the read is diluted over the whole
+        /// `min_window` (never `value / ~1s`), and its retained span is zero
+        /// — a burst can neither read high nor look sustained.
+        #[test]
+        fn single_sample_is_diluted_by_min_window() {
+            let mut avg = RunningAverage::new(100);
+            let now = Instant::now();
+            avg.insert_with_time(now - Duration::from_secs(1), 3_000.0);
+            let windowed = avg.windowed_rate(now, MIN_WINDOW).unwrap();
+            assert!((windowed.rate.per_second() - 3_000.0 / 300.0).abs() < 1e-9);
+            assert_eq!(windowed.retained_span, Duration::ZERO);
+        }
+
+        /// A saturated buffer whose every sample is recent reads its TRUE
+        /// rate over `now − oldest_retained` — the count-truncation fix that
+        /// makes the #4861 storm profile representable.
+        #[test]
+        fn saturated_recent_buffer_divides_by_actual_span() {
+            let mut avg = RunningAverage::new(3);
+            let t0 = Instant::now();
+            for i in 0..5u64 {
+                avg.insert_with_time(t0 + Duration::from_secs(10 * i), 100.0);
+            }
+            // Retained: samples at t0+20/+30/+40; read 10s after the last.
+            let now = t0 + Duration::from_secs(50);
+            let windowed = avg.windowed_rate(now, MIN_WINDOW).unwrap();
+            assert!((windowed.rate.per_second() - 300.0 / 30.0).abs() < 1e-9);
+            assert_eq!(windowed.retained_span, Duration::from_secs(20));
+        }
+
+        /// An unsaturated buffer is diluted by `min_window` even when its
+        /// samples span less: sparse reporting cannot read a high rate.
+        #[test]
+        fn unsaturated_buffer_is_diluted_by_min_window() {
+            let mut avg = RunningAverage::new(100);
+            let t0 = Instant::now();
+            avg.insert_with_time(t0, 600.0);
+            avg.insert_with_time(t0 + Duration::from_secs(60), 600.0);
+            let now = t0 + Duration::from_secs(70);
+            let windowed = avg.windowed_rate(now, MIN_WINDOW).unwrap();
+            assert!((windowed.rate.per_second() - 1_200.0 / 300.0).abs() < 1e-9);
+            assert_eq!(windowed.retained_span, Duration::from_secs(60));
+        }
+
+        /// The sustained signal is the span of the RECENT samples, not the
+        /// lifetime first-sample age (review Fix 2): an old first-ever
+        /// sample followed by a fresh saturating burst yields a SMALL
+        /// retained span, because the old sample is either count-evicted or
+        /// time-excluded.
+        #[test]
+        fn old_first_sample_then_burst_has_small_retained_span() {
+            let mut avg = RunningAverage::new(100);
+            let t0 = Instant::now();
+            // First-ever sample, 10 minutes before the read.
+            avg.insert_with_time(t0, 1.0);
+            // A 60-second buffer-saturating flurry just before the read
+            // (120 samples: the old sample is pushed out of the buffer).
+            let burst_start = t0 + Duration::from_secs(540);
+            for i in 0..120u64 {
+                avg.insert_with_time(burst_start + Duration::from_millis(500 * i), 58.0);
+            }
+            let now = t0 + Duration::from_secs(601);
+            let windowed = avg.windowed_rate(now, MIN_WINDOW).unwrap();
+            assert!(
+                windowed.retained_span < Duration::from_secs(60),
+                "a 60s flurry must not look sustained: span {:?}",
+                windowed.retained_span
+            );
+        }
+
+        /// Same shape but the burst does NOT saturate the buffer, so the old
+        /// sample is still RETAINED — the time-bound (review Fix 3) must
+        /// exclude it, keeping the retained span small.
+        #[test]
+        fn old_retained_sample_is_time_excluded_from_span() {
+            let mut avg = RunningAverage::new(100);
+            let t0 = Instant::now();
+            avg.insert_with_time(t0, 1.0);
+            let burst_start = t0 + Duration::from_secs(560);
+            for i in 0..40u64 {
+                avg.insert_with_time(burst_start + Duration::from_secs(i), 58.0);
+            }
+            let now = t0 + Duration::from_secs(601);
+            let windowed = avg.windowed_rate(now, MIN_WINDOW).unwrap();
+            assert!(
+                windowed.retained_span < Duration::from_secs(60),
+                "the stale first sample must not stretch the span: {:?}",
+                windowed.retained_span
+            );
+            // The stale sample is also excluded from the SUM.
+            assert!((windowed.rate.per_second() - (40.0 * 58.0) / 300.0).abs() < 1e-9);
+        }
+
+        /// The time-bound (review Fix 3): a source that stops reporting
+        /// decays — stale samples drop out of the sum, and once EVERY
+        /// retained sample is older than `min_window` the read is `None` —
+        /// instead of holding its stale storm rate for as long as the
+        /// count-bounded buffer retains the samples.
+        #[test]
+        fn quiet_source_decays_to_none_within_min_window() {
+            let mut avg = RunningAverage::new(100);
+            let t0 = Instant::now();
+            // A saturating storm: 150 samples at 1.6s cadence (~158s span).
+            for i in 0..150u64 {
+                avg.insert_with_time(t0 + Duration::from_millis(1600 * i), 58.0);
+            }
+            let storm_end = t0 + Duration::from_millis(1600 * 149);
+
+            // Read DURING the storm: the true rate (all samples recent).
+            let live = avg
+                .windowed_rate(storm_end + Duration::from_secs(1), MIN_WINDOW)
+                .unwrap();
+            assert!(
+                live.rate.per_second() > 30.0,
+                "an active storm must read its true rate, got {}",
+                live.rate.per_second()
+            );
+
+            // 180s of silence: the oldest samples have aged past the
+            // window, so the sum shrinks AND the diluted divisor applies —
+            // the rate must have decayed well below the live reading.
+            let partly_stale = avg
+                .windowed_rate(storm_end + Duration::from_secs(180), MIN_WINDOW)
+                .unwrap();
+            assert!(
+                partly_stale.rate.per_second() < live.rate.per_second() / 2.0,
+                "a quiet source must decay, got {}",
+                partly_stale.rate.per_second()
+            );
+
+            // Once every sample is stale, the source reads None.
+            assert!(
+                avg.windowed_rate(storm_end + MIN_WINDOW + Duration::from_secs(1), MIN_WINDOW)
+                    .is_none(),
+                "a source quiet for a full min_window must read None"
+            );
+        }
     }
 
     #[test]

--- a/crates/core/src/topology/running_average.rs
+++ b/crates/core/src/topology/running_average.rs
@@ -46,6 +46,32 @@ impl RunningAverage {
         let divisor = sample_duration.max(MINIMUM_TIME_WINDOW);
         Some(Rate::new(self.sum_samples, divisor))
     }
+
+    /// Like [`Self::get_rate_at_time`] but with a caller-supplied minimum
+    /// averaging window instead of the 1-second clamp.
+    ///
+    /// Used by the cost-pressure eviction trigger (cost-aware eviction,
+    /// #4861): `get_rate_at_time`'s 1-second minimum window means a single
+    /// large sample reported moments before a read produces an enormous
+    /// instantaneous rate (`value / 1s`). For an EVICTION decision that spike
+    /// would make a lone broadcast look like a sustained storm. Amortizing the
+    /// sample sum over at least `min_window` means only load actually
+    /// SUSTAINED across the window registers as a high rate; a one-off burst
+    /// is diluted by the window and decays as `now` advances past the oldest
+    /// retained sample.
+    pub(crate) fn get_rate_with_min_window(
+        &self,
+        now: Instant,
+        min_window: Duration,
+    ) -> Option<Rate> {
+        if self.samples.is_empty() {
+            return None;
+        }
+        let oldest_sample_time = self.samples.front().unwrap().0;
+        let sample_duration = now.saturating_duration_since(oldest_sample_time);
+        let divisor = sample_duration.max(min_window).max(Duration::from_secs(1));
+        Some(Rate::new(self.sum_samples, divisor))
+    }
 }
 
 #[cfg(test)]

--- a/crates/core/src/topology/running_average.rs
+++ b/crates/core/src/topology/running_average.rs
@@ -19,19 +19,48 @@ use tokio::time::Instant;
 /// minute, so 60 s of cost-stream silence means the storm has paused.
 pub(crate) const SUSTAINED_ACTIVITY_MAX_GAP: Duration = Duration::from_secs(60);
 
+/// Above-floor sustained-run configuration for a contract COST axis (#4861
+/// Codex round-3). Present only on the three cost-pressure axes; every other
+/// [`RunningAverage`] leaves it absent and keeps the sample-continuity
+/// (`activity_start`) sustained signal untouched.
+#[derive(Clone, Copy, Debug)]
+struct CostSustainedConfig {
+    /// Axis floor (units/sec). A run counts as "above floor" for as long as
+    /// the true windowed rate stays at or above this.
+    floor: f64,
+    /// Window the above-floor rate is measured over at insert time. MUST be
+    /// the same window the reader passes to [`RunningAverage::windowed_rate`]
+    /// (`COST_RATE_MIN_WINDOW`) so the insert-time detection and the read-time
+    /// rate agree on which samples are in scope.
+    window: Duration,
+}
+
 #[derive(Clone, Debug)]
 pub(crate) struct RunningAverage {
     max_samples: usize,
     samples: VecDeque<(Instant, f64)>,
     sum_samples: f64,
     total_sample_count: usize,
-    /// Start of the current continuous run of activity (gap-reset on a silence
-    /// longer than [`SUSTAINED_ACTIVITY_MAX_GAP`]). Tracked at INSERT time so
-    /// it survives count-bounding — a high-frequency source drops old samples
-    /// but its activity start is remembered here. Read by
-    /// [`Self::windowed_rate`] as the buffer-capacity-independent
-    /// sustained-activity signal for the cost-eviction trigger (#4861).
+    /// Start of the current continuous run of SAMPLING activity (gap-reset on
+    /// a silence longer than [`SUSTAINED_ACTIVITY_MAX_GAP`]). Tracked at INSERT
+    /// time so it survives count-bounding — a high-frequency source drops old
+    /// samples but its activity start is remembered here. For a NON-cost
+    /// average this is the sustained signal read by [`Self::windowed_rate`];
+    /// for a cost average the above-floor run (`above_floor_start`) is read
+    /// instead, but this field is still maintained cheaply and unchanged.
     activity_start: Option<Instant>,
+    /// Above-floor sustained-run config for the contract cost axes (#4861
+    /// Codex round-3). `None` for every other average.
+    cost_sustained: Option<CostSustainedConfig>,
+    /// Start of the current continuous ABOVE-FLOOR run: the instant the true
+    /// windowed rate first reached the axis floor and has stayed there since.
+    /// Gap-reset on a >[`SUSTAINED_ACTIVITY_MAX_GAP`] silence and cleared the
+    /// moment the rate drops below the floor. Maintained only when
+    /// `cost_sustained` is set; read by [`Self::windowed_rate`] as the cost
+    /// axes' sustained signal so a below-floor keep-alive trickle that merely
+    /// keeps SAMPLING continuous can never look sustained (the round-3 fix:
+    /// `activity_span` proved sustained SAMPLING, not sustained COST).
+    above_floor_start: Option<Instant>,
 }
 
 impl RunningAverage {
@@ -42,6 +71,25 @@ impl RunningAverage {
             sum_samples: 0.0,
             total_sample_count: 0,
             activity_start: None,
+            cost_sustained: None,
+            above_floor_start: None,
+        }
+    }
+
+    /// Like [`Self::new`] but tracks a sustained ABOVE-FLOOR run for a contract
+    /// cost axis: [`WindowedRate::activity_span`] then measures how long the
+    /// true windowed rate has continuously stayed at or above `floor`
+    /// (units/sec, measured over `window`), instead of how long the source has
+    /// merely been SAMPLING. This is the cost-eviction candidacy gate's
+    /// sustained input (#4861 Codex round-3): a source emitting trivial
+    /// below-floor keep-alive samples plus one dense burst keeps sample
+    /// continuity alive but never sustains above-floor cost, so it must not be
+    /// a candidate. `window` must equal the window the reader passes to
+    /// [`Self::windowed_rate`] (`COST_RATE_MIN_WINDOW`).
+    pub(crate) fn new_cost_sustained(max_samples: usize, floor: f64, window: Duration) -> Self {
+        RunningAverage {
+            cost_sustained: Some(CostSustainedConfig { floor, window }),
+            ..Self::new(max_samples)
         }
     }
 
@@ -70,6 +118,50 @@ impl RunningAverage {
         } else if let Some((_, old_value)) = self.samples.pop_front() {
             self.samples.push_back((now, value));
             self.sum_samples += value - old_value;
+        }
+
+        // Cost-axis ABOVE-FLOOR sustained-run tracking (#4861 Codex round-3).
+        // Runs only for cost-configured averages, AFTER the push (so `now` is
+        // in the buffer), and captures the run at INSERT time because the read
+        // sees only the final count-bounded buffer — the early trickle samples
+        // are gone by read time, so the above-floor history must be recorded
+        // as samples arrive.
+        if let Some(cfg) = self.cost_sustained {
+            // Same gap-reset as `activity_start`: a >SUSTAINED_ACTIVITY_MAX_GAP
+            // silence breaks the run, so a dense burst after a long quiet
+            // cannot inherit an earlier above-floor run. (`gap_restart` was
+            // computed from the last sample time BEFORE the push above.)
+            if gap_restart {
+                self.above_floor_start = None;
+            }
+            // True (undiluted) windowed rate at `now`: the in-window sum over
+            // its ACTUAL span. Deliberately NOT diluted by `window` the way
+            // `windowed_rate`'s MAGNITUDE reading is: that dilution exists to
+            // stop a lone burst from reading a huge instantaneous rate, but the
+            // boolean above-floor RUN already rejects lone bursts by run LENGTH
+            // (a single dense burst's run is only its own few seconds). Diluting
+            // here would instead impose a spurious warm-up — a genuine fast
+            // storm reads below floor until ~half the buffer fills — that
+            // shortens its sustained run below the bar and stops it nominating
+            // (regressing the fast-storm guarantee). The true delivery rate is
+            // the correct "is this source above the floor" signal; the run
+            // length is the correct "is it sustained" signal.
+            let above_floor = self
+                .windowed_scan(now, cfg.window)
+                .map(|scan| {
+                    let span = now
+                        .saturating_duration_since(scan.oldest)
+                        .max(Duration::from_secs(1));
+                    Rate::new(scan.recent_sum, span).per_second() >= cfg.floor
+                })
+                .unwrap_or(false);
+            if above_floor {
+                // Open the run at the first above-floor sample; keep the
+                // earlier start once the run is already open.
+                self.above_floor_start.get_or_insert(now);
+            } else {
+                self.above_floor_start = None;
+            }
         }
     }
 
@@ -118,15 +210,70 @@ impl RunningAverage {
     ///    for the saturated case comes from [`WindowedRate::activity_span`]:
     ///    the caller requires a sustained continuous run before acting.
     pub(crate) fn windowed_rate(&self, now: Instant, min_window: Duration) -> Option<WindowedRate> {
-        // Time-bound (review Fix 3): only samples no older than `min_window`
-        // count. Samples are appended in time order, so scanning the whole
-        // (small, count-bounded) buffer is cheap and needs no index math.
+        let scan = self.windowed_scan(now, min_window)?;
+        let since_oldest = now.saturating_duration_since(scan.oldest);
+        // "Saturated" (true-rate) reading requires the full buffer AND no
+        // time-excluded sample: only then does the buffer prove continuous
+        // activity across its span (see [`WindowScan`] and rustdoc point 3).
+        let divisor = if scan.saturated {
+            since_oldest.max(Duration::from_secs(1))
+        } else {
+            since_oldest.max(min_window).max(Duration::from_secs(1))
+        };
+        // Sustained-activity signal. For a COST-configured average this is the
+        // ABOVE-FLOOR run (`above_floor_start`, tracked at insert time): the
+        // run counts only while the true windowed rate stays >= the axis
+        // floor, so a below-floor keep-alive trickle that merely keeps SAMPLING
+        // continuous is NOT sustained (#4861 Codex round-3). For every other
+        // average it is the sample-continuity run (`activity_start`, #4903
+        // review BLOCKER), unchanged: the length of the current continuous
+        // run, buffer-CAPACITY-independent so a fast storm whose count-bounded
+        // buffer spans only tens of seconds is still recognized as sustained.
+        // A single burst (short run) can't reach the caller's `min_window / 2`
+        // bar, and a >SUSTAINED_ACTIVITY_MAX_GAP silence restarts the run.
+        //
+        // A run only counts as CURRENT if the newest sample is itself recent
+        // (within SUSTAINED_ACTIVITY_MAX_GAP of `now`): a source that stormed
+        // and then fell silent is no longer sustained, so it drops out of
+        // candidacy after one gap of silence (well before its samples fully
+        // age out of `min_window` and its rate decays to zero), rather than
+        // lingering as a candidate on the strength of a run that has ended.
+        let run_start = if self.cost_sustained.is_some() {
+            self.above_floor_start
+        } else {
+            self.activity_start
+        };
+        let currently_active =
+            now.saturating_duration_since(scan.newest) <= SUSTAINED_ACTIVITY_MAX_GAP;
+        let activity_span = match run_start {
+            Some(start) if currently_active => scan.newest.saturating_duration_since(start),
+            _ => Duration::ZERO,
+        };
+        Some(WindowedRate {
+            rate: Rate::new(scan.recent_sum, divisor),
+            activity_span,
+        })
+    }
+
+    /// Shared count-and-time-bounded scan behind BOTH the read-time
+    /// [`Self::windowed_rate`] and the insert-time above-floor check. Sums the
+    /// samples within `window` of `now`, reporting the recent span endpoints
+    /// and whether the retained buffer is SATURATED (full AND no sample was
+    /// excluded by the time-bound — only then does it prove continuous activity
+    /// across its span; see `windowed_rate` rustdoc point 3). Returns `None`
+    /// when no sample lies within the window. Extracted so the two callers
+    /// cannot diverge on the time-bound / saturation determination — the
+    /// divisor POLICY differs by purpose (see the insert-time comment) but the
+    /// scan is identical (#4861 Codex round-3).
+    fn windowed_scan(&self, now: Instant, window: Duration) -> Option<WindowScan> {
+        // Samples are appended in time order, so scanning the whole (small,
+        // count-bounded) buffer is cheap and needs no index math.
         let mut recent_sum = 0.0_f64;
         let mut oldest_recent: Option<Instant> = None;
         let mut newest_recent: Option<Instant> = None;
         let mut excluded_any = false;
         for (at, value) in &self.samples {
-            if now.saturating_duration_since(*at) > min_window {
+            if now.saturating_duration_since(*at) > window {
                 excluded_any = true;
                 continue;
             }
@@ -136,48 +283,31 @@ impl RunningAverage {
             newest_recent = Some(*at);
             recent_sum += value;
         }
-        // Every retained sample is stale (or the buffer is empty): the
-        // source has done no attributable work within the window.
+        // Every retained sample is stale (or the buffer is empty): the source
+        // has done no attributable work within the window.
         let oldest = oldest_recent?;
         let newest = newest_recent.expect("newest set whenever oldest is");
-        let since_oldest = now.saturating_duration_since(oldest);
-        // "Saturated" (true-rate) reading requires the full buffer AND no
-        // time-excluded sample: only then does the buffer prove continuous
-        // activity across its span. See rustdoc point 3.
-        let saturated = self.samples.len() >= self.max_samples && !excluded_any;
-        let divisor = if saturated {
-            since_oldest.max(Duration::from_secs(1))
-        } else {
-            since_oldest.max(min_window).max(Duration::from_secs(1))
-        };
-        // Sustained-activity signal (#4903 review BLOCKER): the length of the
-        // current continuous run, measured from `activity_start` (set/reset at
-        // insert time, see SUSTAINED_ACTIVITY_MAX_GAP) to the newest sample.
-        // Deliberately NOT the span of the count-bounded sample buffer — that
-        // span shrinks with cadence, so a fast storm's buffer spans only a few
-        // tens of seconds and could never reach the caller's `min_window / 2`
-        // bar (the inversion this replaces). `activity_start` survives
-        // count-bounding, so the run length is representable at any rate. A
-        // single burst (short run) still can't reach the bar, and a gap longer
-        // than SUSTAINED_ACTIVITY_MAX_GAP restarts the run, so an old-first-
-        // sample source followed by a fresh burst is not sustained either.
-        //
-        // A run only counts as CURRENT if the newest sample is itself recent
-        // (within SUSTAINED_ACTIVITY_MAX_GAP of `now`): a source that stormed
-        // and then fell silent is no longer sustained, so it drops out of
-        // candidacy after one gap of silence (well before its samples fully
-        // age out of `min_window` and its rate decays to zero), rather than
-        // lingering as a candidate on the strength of a run that has ended.
-        let currently_active = now.saturating_duration_since(newest) <= SUSTAINED_ACTIVITY_MAX_GAP;
-        let activity_span = match self.activity_start {
-            Some(start) if currently_active => newest.saturating_duration_since(start),
-            _ => Duration::ZERO,
-        };
-        Some(WindowedRate {
-            rate: Rate::new(recent_sum, divisor),
-            activity_span,
+        Some(WindowScan {
+            recent_sum,
+            oldest,
+            newest,
+            saturated: self.samples.len() >= self.max_samples && !excluded_any,
         })
     }
+}
+
+/// In-window scan ingredients shared by [`RunningAverage::windowed_rate`] and
+/// the insert-time above-floor check (#4861 Codex round-3).
+struct WindowScan {
+    /// Sum of the sample values within the window.
+    recent_sum: f64,
+    /// Oldest in-window sample time.
+    oldest: Instant,
+    /// Newest in-window sample time.
+    newest: Instant,
+    /// The buffer is full AND no retained sample was excluded by the
+    /// time-bound (so its `sum / span` is the true rate).
+    saturated: bool,
 }
 
 /// Result of [`RunningAverage::windowed_rate`]: the min-window-aware rate
@@ -185,16 +315,23 @@ impl RunningAverage {
 /// sustained-pressure input for the cost-eviction trigger, #4861).
 pub(crate) struct WindowedRate {
     pub rate: Rate,
-    /// `newest_recent_sample − activity_start`: how long the source has been
+    /// `newest_recent_sample − run_start`: how long the current run has been
     /// CONTINUOUSLY active (gap-reset on a silence longer than
-    /// [`SUSTAINED_ACTIVITY_MAX_GAP`]). A genuine sustained storm's run grows
-    /// past `min_window / 2` at ANY report cadence above the floor; a short
-    /// burst's run stays small no matter how dense; an old-first-sample source
-    /// followed by a fresh burst has its run restart at the burst. This is
-    /// buffer-CAPACITY-independent — the fix for the review BLOCKER, where the
-    /// count-bounded buffer's span inverted against high-frequency storms
-    /// (fast cadence ⇒ short buffer span ⇒ never "sustained" ⇒ the worst
-    /// storms were permanently exempted from candidacy).
+    /// [`SUSTAINED_ACTIVITY_MAX_GAP`]). For a cost-configured average the run
+    /// is the ABOVE-FLOOR run (`above_floor_start`): it grows only while the
+    /// true windowed rate stays at or above the axis floor, so a below-floor
+    /// keep-alive trickle that keeps SAMPLING continuous does not count and a
+    /// single dense burst — even one preceded by a long below-floor trickle —
+    /// stays short (#4861 Codex round-3). For every other average it is the
+    /// sample-continuity run (`activity_start`). Either way a genuine sustained
+    /// storm's run grows past `min_window / 2` at ANY report cadence above the
+    /// floor; a short burst's run stays small no matter how dense; an
+    /// old-first-sample source followed by a fresh burst has its run restart at
+    /// the burst. Buffer-CAPACITY-independent — the fix for the earlier review
+    /// BLOCKER, where the count-bounded buffer's span inverted against
+    /// high-frequency storms (fast cadence ⇒ short buffer span ⇒ never
+    /// "sustained" ⇒ the worst storms were permanently exempted from
+    /// candidacy).
     pub activity_span: Duration,
 }
 
@@ -444,6 +581,122 @@ mod tests {
                 avg.windowed_rate(storm_end + MIN_WINDOW + Duration::from_secs(1), MIN_WINDOW)
                     .is_none(),
                 "a source quiet for a full min_window must read None"
+            );
+        }
+
+        // --- above-floor sustained-run tracking (#4861 Codex round-3) ---
+        // These use the cost-configured constructor; the tests above use the
+        // plain `new` (non-cost) path, which keeps the `activity_start`
+        // sample-continuity signal unchanged.
+
+        const FLOOR: f64 = 10.0;
+
+        /// A below-floor keep-alive trickle (0.1/sample every 30s — under the
+        /// 60s gap so SAMPLING stays continuous) followed by ONE dense burst is
+        /// NOT sustained above-floor: the above-floor run opens only mid-burst
+        /// and spans a few seconds, far under `min_window / 2`. This is the
+        /// Codex round-3 scenario: `activity_start` alone (sampling continuity)
+        /// would report ~180s here.
+        #[test]
+        fn cost_trickle_then_single_burst_run_is_short() {
+            let mut avg = RunningAverage::new_cost_sustained(100, FLOOR, MIN_WINDOW);
+            let t0 = Instant::now();
+            let mut t = Duration::ZERO;
+            while t <= Duration::from_secs(180) {
+                avg.insert_with_time(t0 + t, 0.1);
+                t += Duration::from_secs(30);
+            }
+            let burst_start = t0 + Duration::from_secs(181);
+            for i in 0..120u64 {
+                avg.insert_with_time(burst_start + Duration::from_millis(25 * i), 58.0);
+            }
+            let now = burst_start + Duration::from_secs(4);
+            let windowed = avg.windowed_rate(now, MIN_WINDOW).unwrap();
+            assert!(
+                windowed.activity_span < MIN_WINDOW / 2,
+                "a below-floor trickle then one burst is not sustained \
+                 above-floor: span {:?}",
+                windowed.activity_span
+            );
+        }
+
+        /// The counterpart: the SAME dense cadence sustained ABOVE the floor for
+        /// longer than `min_window / 2` IS sustained. At 1.4s cadence (58/sample
+        /// ≈ 41/s, above the floor) the run reaches the bar over its FULL length
+        /// — the above-floor detection uses the true delivery rate, so there is
+        /// no diluted warm-up (the naive "reuse windowed_rate's diluted divisor"
+        /// approach reads below floor for ~71s and would push this 200s run's
+        /// sustained span below the 150s bar).
+        #[test]
+        fn cost_sustained_above_floor_reaches_bar_without_warmup_penalty() {
+            let mut avg = RunningAverage::new_cost_sustained(100, FLOOR, MIN_WINDOW);
+            let t0 = Instant::now();
+            // i in 0..143 at 1.4s cadence → last sample at 142 × 1.4 = 198.8s.
+            let n = 143u64;
+            for i in 0..n {
+                avg.insert_with_time(t0 + Duration::from_millis(1400 * i), 58.0);
+            }
+            let last = t0 + Duration::from_millis(1400 * (n - 1));
+            let windowed = avg
+                .windowed_rate(last + Duration::from_secs(1), MIN_WINDOW)
+                .unwrap();
+            assert!(
+                windowed.activity_span >= MIN_WINDOW / 2,
+                "a 1.4s-cadence above-floor storm must be sustained over its \
+                 full run (no warm-up penalty): span {:?}",
+                windowed.activity_span
+            );
+        }
+
+        /// A source SAMPLING continuously (every 5s, never a gap) but whose true
+        /// rate stays below the floor (1.0 per 5s = 0.2/s ≪ 10/s) never opens
+        /// the above-floor run, so it is never sustained no matter how long it
+        /// runs — cost-sustainedness is above-FLOOR cost, not mere sampling.
+        #[test]
+        fn cost_continuous_below_floor_source_never_sustained() {
+            let mut avg = RunningAverage::new_cost_sustained(100, FLOOR, MIN_WINDOW);
+            let t0 = Instant::now();
+            let mut t = Duration::ZERO;
+            while t <= Duration::from_secs(400) {
+                avg.insert_with_time(t0 + t, 1.0);
+                t += Duration::from_secs(5);
+            }
+            let now = t0 + Duration::from_secs(401);
+            let windowed = avg.windowed_rate(now, MIN_WINDOW).unwrap();
+            assert_eq!(
+                windowed.activity_span,
+                Duration::ZERO,
+                "a continuously-sampling but below-floor source is never \
+                 sustained above-floor"
+            );
+        }
+
+        /// The gap-reset applies to the above-floor run too: a sustained
+        /// above-floor storm, then a >`SUSTAINED_ACTIVITY_MAX_GAP` silence, then
+        /// a short fresh storm — the run restarts at the second storm, so its
+        /// span is only its own length (preserving the round-2 gap-reset).
+        #[test]
+        fn cost_gap_reset_restarts_above_floor_run() {
+            let mut avg = RunningAverage::new_cost_sustained(100, FLOOR, MIN_WINDOW);
+            let t0 = Instant::now();
+            let mut t = Duration::ZERO;
+            while t <= Duration::from_secs(200) {
+                avg.insert_with_time(t0 + t, 58.0);
+                t += Duration::from_millis(1600);
+            }
+            let resume = t0 + Duration::from_secs(200) + Duration::from_secs(90);
+            let mut t2 = Duration::ZERO;
+            while t2 <= Duration::from_secs(30) {
+                avg.insert_with_time(resume + t2, 58.0);
+                t2 += Duration::from_millis(1600);
+            }
+            let now = resume + Duration::from_secs(31);
+            let windowed = avg.windowed_rate(now, MIN_WINDOW).unwrap();
+            assert!(
+                windowed.activity_span < MIN_WINDOW / 2,
+                "the >max-gap silence restarts the above-floor run at the second \
+                 storm: span {:?}",
+                windowed.activity_span
             );
         }
     }

--- a/crates/core/src/topology/running_average.rs
+++ b/crates/core/src/topology/running_average.rs
@@ -3,12 +3,35 @@ use std::collections::VecDeque;
 use std::time::Duration;
 use tokio::time::Instant;
 
+/// Maximum silence between two samples that still counts as ONE continuous
+/// run of activity for the cost-eviction sustained gate (#4861 / #4903 review
+/// BLOCKER). A source reporting at least this often is treated as
+/// continuously active, so [`RunningAverage::windowed_rate`]'s `activity_span`
+/// keeps growing; a gap longer than this restarts the run (so two separated
+/// bursts never sum into a false "sustained", and an old-first-sample source
+/// followed by a fresh burst is not sustained). It is deliberately
+/// buffer-CAPACITY-independent: the previous sustained signal (span of the
+/// count-bounded sample buffer) INVERTED against high-frequency storms — a
+/// buffer of `max_samples` at a fast cadence spans only a few tens of seconds
+/// and could never reach `min_window / 2`, so the fastest (worst) storms were
+/// permanently exempted from candidacy. ~min_window/5 for the 300 s cost
+/// window; a genuinely-storming contract fans out far more often than once a
+/// minute, so 60 s of cost-stream silence means the storm has paused.
+pub(crate) const SUSTAINED_ACTIVITY_MAX_GAP: Duration = Duration::from_secs(60);
+
 #[derive(Clone, Debug)]
 pub(crate) struct RunningAverage {
     max_samples: usize,
     samples: VecDeque<(Instant, f64)>,
     sum_samples: f64,
     total_sample_count: usize,
+    /// Start of the current continuous run of activity (gap-reset on a silence
+    /// longer than [`SUSTAINED_ACTIVITY_MAX_GAP`]). Tracked at INSERT time so
+    /// it survives count-bounding — a high-frequency source drops old samples
+    /// but its activity start is remembered here. Read by
+    /// [`Self::windowed_rate`] as the buffer-capacity-independent
+    /// sustained-activity signal for the cost-eviction trigger (#4861).
+    activity_start: Option<Instant>,
 }
 
 impl RunningAverage {
@@ -18,14 +41,28 @@ impl RunningAverage {
             samples: VecDeque::with_capacity(max_samples),
             sum_samples: 0.0,
             total_sample_count: 0,
+            activity_start: None,
         }
     }
 
     pub(crate) fn insert_with_time(&mut self, now: Instant, value: f64) {
-        // Require that now is after the last sample time
-        if let Some((last_sample_time, _)) = self.samples.back() {
-            debug_assert!(now >= *last_sample_time);
+        // Continuous-activity tracking for the cost-eviction sustained gate
+        // (#4861): a gap longer than SUSTAINED_ACTIVITY_MAX_GAP since the last
+        // sample (or the very first sample) starts a fresh run. This is
+        // computed from the last sample time BEFORE the push below, and is
+        // independent of the count-bounded buffer, so a fast storm whose old
+        // samples are evicted still remembers when its run began.
+        let gap_restart = match self.samples.back() {
+            Some((last_sample_time, _)) => {
+                debug_assert!(now >= *last_sample_time);
+                now.saturating_duration_since(*last_sample_time) > SUSTAINED_ACTIVITY_MAX_GAP
+            }
+            None => true,
+        };
+        if gap_restart || self.activity_start.is_none() {
+            self.activity_start = Some(now);
         }
+
         self.total_sample_count += 1;
         if self.samples.len() < self.max_samples {
             self.samples.push_back((now, value));
@@ -78,9 +115,8 @@ impl RunningAverage {
     ///    needed). If any retained sample was excluded by the time-bound,
     ///    the remaining recent subset no longer proves saturation density
     ///    and the diluted (`min_window`) divisor applies. Burst protection
-    ///    for the saturated case comes from [`WindowedRate::retained_span`]:
-    ///    the caller requires the recent samples to SPAN a sustained period
-    ///    before acting.
+    ///    for the saturated case comes from [`WindowedRate::activity_span`]:
+    ///    the caller requires a sustained continuous run before acting.
     pub(crate) fn windowed_rate(&self, now: Instant, min_window: Duration) -> Option<WindowedRate> {
         // Time-bound (review Fix 3): only samples no older than `min_window`
         // count. Samples are appended in time order, so scanning the whole
@@ -104,12 +140,6 @@ impl RunningAverage {
         // source has done no attributable work within the window.
         let oldest = oldest_recent?;
         let newest = newest_recent.expect("newest set whenever oldest is");
-        // The span the recent samples actually cover (newest − oldest): the
-        // sustained-activity signal (review Fix 2). Deliberately NOT the
-        // lifetime first-sample age — that is set once and never reset, so a
-        // source whose first-ever sample was old would pass a "sustained"
-        // gate forever and a later short burst could nominate it.
-        let retained_span = newest.saturating_duration_since(oldest);
         let since_oldest = now.saturating_duration_since(oldest);
         // "Saturated" (true-rate) reading requires the full buffer AND no
         // time-excluded sample: only then does the buffer prove continuous
@@ -120,26 +150,52 @@ impl RunningAverage {
         } else {
             since_oldest.max(min_window).max(Duration::from_secs(1))
         };
+        // Sustained-activity signal (#4903 review BLOCKER): the length of the
+        // current continuous run, measured from `activity_start` (set/reset at
+        // insert time, see SUSTAINED_ACTIVITY_MAX_GAP) to the newest sample.
+        // Deliberately NOT the span of the count-bounded sample buffer — that
+        // span shrinks with cadence, so a fast storm's buffer spans only a few
+        // tens of seconds and could never reach the caller's `min_window / 2`
+        // bar (the inversion this replaces). `activity_start` survives
+        // count-bounding, so the run length is representable at any rate. A
+        // single burst (short run) still can't reach the bar, and a gap longer
+        // than SUSTAINED_ACTIVITY_MAX_GAP restarts the run, so an old-first-
+        // sample source followed by a fresh burst is not sustained either.
+        //
+        // A run only counts as CURRENT if the newest sample is itself recent
+        // (within SUSTAINED_ACTIVITY_MAX_GAP of `now`): a source that stormed
+        // and then fell silent is no longer sustained, so it drops out of
+        // candidacy after one gap of silence (well before its samples fully
+        // age out of `min_window` and its rate decays to zero), rather than
+        // lingering as a candidate on the strength of a run that has ended.
+        let currently_active = now.saturating_duration_since(newest) <= SUSTAINED_ACTIVITY_MAX_GAP;
+        let activity_span = match self.activity_start {
+            Some(start) if currently_active => newest.saturating_duration_since(start),
+            _ => Duration::ZERO,
+        };
         Some(WindowedRate {
             rate: Rate::new(recent_sum, divisor),
-            retained_span,
+            activity_span,
         })
     }
 }
 
 /// Result of [`RunningAverage::windowed_rate`]: the min-window-aware rate
-/// plus how long the RECENT (within-window) samples actually span (the
+/// plus the length of the current continuous activity run (the
 /// sustained-pressure input for the cost-eviction trigger, #4861).
 pub(crate) struct WindowedRate {
     pub rate: Rate,
-    /// `newest_recent_sample − oldest_recent_sample`: the period the
-    /// currently-held, within-window samples actually cover. A genuine
-    /// sustained storm's recent samples span a large fraction of the window;
-    /// a short burst's span only a few tens of seconds — no matter how old
-    /// the source's FIRST-EVER sample is (the lifetime first-sample age was
-    /// the review-Fix-2 hole: set once, never reset, so an old-first-sample
-    /// source passed the sustained gate forever).
-    pub retained_span: Duration,
+    /// `newest_recent_sample − activity_start`: how long the source has been
+    /// CONTINUOUSLY active (gap-reset on a silence longer than
+    /// [`SUSTAINED_ACTIVITY_MAX_GAP`]). A genuine sustained storm's run grows
+    /// past `min_window / 2` at ANY report cadence above the floor; a short
+    /// burst's run stays small no matter how dense; an old-first-sample source
+    /// followed by a fresh burst has its run restart at the burst. This is
+    /// buffer-CAPACITY-independent — the fix for the review BLOCKER, where the
+    /// count-bounded buffer's span inverted against high-frequency storms
+    /// (fast cadence ⇒ short buffer span ⇒ never "sustained" ⇒ the worst
+    /// storms were permanently exempted from candidacy).
+    pub activity_span: Duration,
 }
 
 #[cfg(test)]
@@ -172,8 +228,8 @@ mod tests {
 
     /// Direct coverage for the cost-axis read (`windowed_rate`, #4861):
     /// empty buffer, single-sample dilution, saturated true-rate,
-    /// unsaturated dilution, the retained-span sustained signal, and the
-    /// review-Fix-3 time-bound.
+    /// unsaturated dilution, the continuity-tracked `activity_span` sustained
+    /// signal (#4903 review BLOCKER), and the review-Fix-3 time-bound.
     mod windowed_rate {
         use super::*;
 
@@ -186,7 +242,7 @@ mod tests {
         }
 
         /// A lone sample moments before the read is diluted over the whole
-        /// `min_window` (never `value / ~1s`), and its retained span is zero
+        /// `min_window` (never `value / ~1s`), and its activity span is zero
         /// — a burst can neither read high nor look sustained.
         #[test]
         fn single_sample_is_diluted_by_min_window() {
@@ -195,12 +251,15 @@ mod tests {
             avg.insert_with_time(now - Duration::from_secs(1), 3_000.0);
             let windowed = avg.windowed_rate(now, MIN_WINDOW).unwrap();
             assert!((windowed.rate.per_second() - 3_000.0 / 300.0).abs() < 1e-9);
-            assert_eq!(windowed.retained_span, Duration::ZERO);
+            assert_eq!(windowed.activity_span, Duration::ZERO);
         }
 
         /// A saturated buffer whose every sample is recent reads its TRUE
         /// rate over `now − oldest_retained` — the count-truncation fix that
-        /// makes the #4861 storm profile representable.
+        /// makes the #4861 storm profile representable. The `activity_span`
+        /// spans the whole continuous run (from the FIRST sample, which the
+        /// count-bounded buffer has since evicted), not just the retained
+        /// samples — the BLOCKER fix.
         #[test]
         fn saturated_recent_buffer_divides_by_actual_span() {
             let mut avg = RunningAverage::new(3);
@@ -208,15 +267,19 @@ mod tests {
             for i in 0..5u64 {
                 avg.insert_with_time(t0 + Duration::from_secs(10 * i), 100.0);
             }
-            // Retained: samples at t0+20/+30/+40; read 10s after the last.
+            // Retained samples: t0+20/+30/+40; read 10s after the last. Rate
+            // divides by the retained span (30s); activity_span covers the
+            // whole run from t0 (the evicted first sample) to the newest (40s).
             let now = t0 + Duration::from_secs(50);
             let windowed = avg.windowed_rate(now, MIN_WINDOW).unwrap();
             assert!((windowed.rate.per_second() - 300.0 / 30.0).abs() < 1e-9);
-            assert_eq!(windowed.retained_span, Duration::from_secs(20));
+            assert_eq!(windowed.activity_span, Duration::from_secs(40));
         }
 
         /// An unsaturated buffer is diluted by `min_window` even when its
-        /// samples span less: sparse reporting cannot read a high rate.
+        /// samples span less: sparse reporting cannot read a high rate. Two
+        /// samples 60s apart are one continuous run (gap ≤ the max gap), so
+        /// the activity span is the full 60s.
         #[test]
         fn unsaturated_buffer_is_diluted_by_min_window() {
             let mut avg = RunningAverage::new(100);
@@ -226,16 +289,16 @@ mod tests {
             let now = t0 + Duration::from_secs(70);
             let windowed = avg.windowed_rate(now, MIN_WINDOW).unwrap();
             assert!((windowed.rate.per_second() - 1_200.0 / 300.0).abs() < 1e-9);
-            assert_eq!(windowed.retained_span, Duration::from_secs(60));
+            assert_eq!(windowed.activity_span, Duration::from_secs(60));
         }
 
-        /// The sustained signal is the span of the RECENT samples, not the
-        /// lifetime first-sample age (review Fix 2): an old first-ever
-        /// sample followed by a fresh saturating burst yields a SMALL
-        /// retained span, because the old sample is either count-evicted or
-        /// time-excluded.
+        /// The sustained signal is the length of the CURRENT continuous run,
+        /// not the lifetime span (#4903 review BLOCKER + Fix 2): an old
+        /// first-ever sample followed by a fresh burst yields a SMALL activity
+        /// span, because the >`SUSTAINED_ACTIVITY_MAX_GAP` silence restarts
+        /// the run at the burst.
         #[test]
-        fn old_first_sample_then_burst_has_small_retained_span() {
+        fn old_first_sample_then_burst_has_small_activity_span() {
             let mut avg = RunningAverage::new(100);
             let t0 = Instant::now();
             // First-ever sample, 10 minutes before the read.
@@ -249,17 +312,18 @@ mod tests {
             let now = t0 + Duration::from_secs(601);
             let windowed = avg.windowed_rate(now, MIN_WINDOW).unwrap();
             assert!(
-                windowed.retained_span < Duration::from_secs(60),
-                "a 60s flurry must not look sustained: span {:?}",
-                windowed.retained_span
+                windowed.activity_span < Duration::from_secs(60),
+                "a 60s flurry after a long silence must not look sustained: span {:?}",
+                windowed.activity_span
             );
         }
 
         /// Same shape but the burst does NOT saturate the buffer, so the old
-        /// sample is still RETAINED — the time-bound (review Fix 3) must
-        /// exclude it, keeping the retained span small.
+        /// sample is still RETAINED — the continuity gap-reset must still
+        /// restart the run at the burst (activity span small), and the
+        /// time-bound (review Fix 3) excludes the stale sample from the SUM.
         #[test]
-        fn old_retained_sample_is_time_excluded_from_span() {
+        fn old_retained_sample_does_not_stretch_activity_span() {
             let mut avg = RunningAverage::new(100);
             let t0 = Instant::now();
             avg.insert_with_time(t0, 1.0);
@@ -270,12 +334,72 @@ mod tests {
             let now = t0 + Duration::from_secs(601);
             let windowed = avg.windowed_rate(now, MIN_WINDOW).unwrap();
             assert!(
-                windowed.retained_span < Duration::from_secs(60),
-                "the stale first sample must not stretch the span: {:?}",
-                windowed.retained_span
+                windowed.activity_span < Duration::from_secs(60),
+                "the stale first sample must not stretch the run: {:?}",
+                windowed.activity_span
             );
             // The stale sample is also excluded from the SUM.
             assert!((windowed.rate.per_second() - (40.0 * 58.0) / 300.0).abs() < 1e-9);
+        }
+
+        /// The BLOCKER regression: a high-frequency storm — whose
+        /// count-bounded buffer spans only a few tens of seconds, far under
+        /// `min_window / 2` — is nonetheless SUSTAINED, because `activity_span`
+        /// tracks the continuous run (from `activity_start`), not the buffer
+        /// span. Before the fix this storm read a tiny "retained span" and was
+        /// permanently exempt from candidacy.
+        #[test]
+        fn fast_storm_activity_span_reaches_sustained_bar() {
+            let mut avg = RunningAverage::new(100);
+            let t0 = Instant::now();
+            // 0.5s cadence for 200s continuous: the 100-sample buffer spans
+            // only ~50s (< min_window/2 = 150s), but the run is 200s.
+            for i in 0..400u64 {
+                avg.insert_with_time(t0 + Duration::from_millis(500 * i), 58.0);
+            }
+            let last = t0 + Duration::from_millis(500 * 399);
+            let windowed = avg
+                .windowed_rate(last + Duration::from_secs(1), MIN_WINDOW)
+                .unwrap();
+            assert!(
+                windowed.activity_span >= MIN_WINDOW / 2,
+                "a continuous fast storm must be sustained regardless of buffer \
+                 span: activity_span {:?}",
+                windowed.activity_span
+            );
+        }
+
+        /// A source that stormed and then fell silent drops out of the
+        /// sustained signal after one `SUSTAINED_ACTIVITY_MAX_GAP` of silence
+        /// (activity_span → 0), well before its samples age out — so it stops
+        /// being a candidate promptly even while its rate is still decaying.
+        #[test]
+        fn silent_source_activity_span_collapses_after_gap() {
+            let mut avg = RunningAverage::new(100);
+            let t0 = Instant::now();
+            for i in 0..150u64 {
+                avg.insert_with_time(t0 + Duration::from_millis(1600 * i), 58.0);
+            }
+            let storm_end = t0 + Duration::from_millis(1600 * 149);
+            // Live: sustained.
+            let live = avg
+                .windowed_rate(storm_end + Duration::from_secs(1), MIN_WINDOW)
+                .unwrap();
+            assert!(live.activity_span >= MIN_WINDOW / 2);
+            // After a gap longer than the max gap but within min_window: the
+            // rate is still positive but the run is no longer current.
+            let stale = avg
+                .windowed_rate(
+                    storm_end + SUSTAINED_ACTIVITY_MAX_GAP + Duration::from_secs(1),
+                    MIN_WINDOW,
+                )
+                .unwrap();
+            assert!(stale.rate.per_second() > 0.0);
+            assert_eq!(
+                stale.activity_span,
+                Duration::ZERO,
+                "a source silent longer than the max gap is not currently sustained"
+            );
         }
 
         /// The time-bound (review Fix 3): a source that stops reporting

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -2344,6 +2344,15 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                     "hosting_subscribed_evictions_total".to_string(),
                     serde_json::json!(snapshot.hosting_subscribed_evictions_total),
                 );
+                // Cost-pressure eviction falsifier (cost-aware eviction,
+                // #4861): zero-demand contracts shed for dominating the
+                // node's attributed update-work. Same hand-mirrored footgun —
+                // invisible to the collector unless added here. Pinned by
+                // `router_snapshot_json_includes_cost_evictions_gauge`.
+                obj.insert(
+                    "hosting_cost_evictions_total".to_string(),
+                    serde_json::json!(snapshot.hosting_cost_evictions_total),
+                );
                 // Phantom-hosting falsifier (SUBSCRIBE-retirement step 10 §1d):
                 // current count of contracts in-use via a downstream subscriber
                 // with NO state on disk. Should read 0 after register-after-state.
@@ -2870,6 +2879,26 @@ mod tests {
         assert_eq!(
             json["hosting_subscribed_evictions_total"], 287,
             "hosting_subscribed_evictions_total must reach the OTLP body"
+        );
+    }
+
+    /// Pin: the cost-pressure eviction falsifier gauge (cost-aware eviction,
+    /// #4861) must reach the hand-mirrored OTLP body. It counts zero-demand
+    /// contracts shed for dominating the node's attributed update-work (CPU /
+    /// broadcast fan-out); a silent drop would blind central telemetry to
+    /// whether the cost trigger fires in the field — the validation signal the
+    /// whole cost-aware-eviction change rests on.
+    #[test]
+    fn router_snapshot_json_includes_cost_evictions_gauge() {
+        use arbitrary::{Arbitrary, Unstructured};
+        let mut u = Unstructured::new(&[0u8; 4096]);
+        let mut info = crate::router::RouterSnapshotInfo::arbitrary(&mut u)
+            .expect("construct RouterSnapshotInfo for test");
+        info.hosting_cost_evictions_total = Some(58);
+        let json = event_kind_to_json(&EventKind::RouterSnapshot(Box::new(info)));
+        assert_eq!(
+            json["hosting_cost_evictions_total"], 58,
+            "hosting_cost_evictions_total must reach the OTLP body"
         );
     }
 

--- a/crates/core/src/transport.rs
+++ b/crates/core/src/transport.rs
@@ -761,11 +761,18 @@ mod tests {
 #[cfg(test)]
 mod version_discovery_tests {
     use super::*;
+    use serial_test::serial;
 
-    // These tests mutate global statics and must run sequentially.
-    // Use `cargo test -- --test-threads=1 version_discovery` if running standalone.
+    // These tests mutate the process-global version-discovery statics
+    // (`HIGHEST_SEEN_VERSION` et al.), so they MUST NOT run concurrently with
+    // each other — an interleaved `report_peer_version` from a sibling test
+    // corrupts another's `get_highest_seen_version` read. `#[serial(...)]`
+    // enforces that (the module comment previously only *asked* for
+    // `--test-threads=1`, which the default multi-threaded runner ignores,
+    // making these tests flaky in the full suite).
 
     #[test]
+    #[serial(version_discovery)]
     fn single_reporter_not_trusted() {
         reset_version_discovery();
         report_peer_version((0, 1, 153));
@@ -774,6 +781,7 @@ mod version_discovery_tests {
     }
 
     #[test]
+    #[serial(version_discovery)]
     fn two_reporters_trusted() {
         reset_version_discovery();
         report_peer_version((0, 1, 153));
@@ -782,6 +790,7 @@ mod version_discovery_tests {
     }
 
     #[test]
+    #[serial(version_discovery)]
     fn higher_version_resets_count() {
         reset_version_discovery();
         report_peer_version((0, 1, 153));
@@ -798,6 +807,7 @@ mod version_discovery_tests {
     }
 
     #[test]
+    #[serial(version_discovery)]
     fn major_minor_bumps_accepted() {
         reset_version_discovery();
         report_peer_version((1, 0, 0));


### PR DESCRIPTION
## Problem

Production update-broadcast storm (#4861): three broken contracts (FX2j…, 82ZZ… — non-idempotent counter test contracts — and HQk7…) drive the large majority of network update traffic. They survive because eviction was byte-only: a 121-byte contract emitting tens of messages/second is invisible to a byte meter. After 0.2.104 the storm *intensified* (~6x pre-release baseline, stable plateau): #4902's new egress suppression combined with its fixed 300s flag TTL turns a genuinely non-idempotent contract into a limit-cycle oscillator (flagged node goes fully dark → flag expires → stale re-entry into the drifted mesh → divergence cascade larger than the steady participation it replaced → re-flag). Minute-resolution logs on a mid-degree peer show ~10 burst/flag/dark cycles per hour and a ~6x per-peer emission increase across its own upgrade; a within-peer paired telemetry comparison over 237 upgraders confirms ~4.3x.

## Approach

Two complementary fixes:

1. **Cost-aware eviction** (`topology/meter.rs`, `topology/running_average.rs`, `ring/hosting/cache.rs`, `ring/hosting.rs`, put/update `op_ctx_task.rs`, `broadcast_queue.rs`, `broadcast.rs`): a peer's attributed update-work cost — per-contract WASM CPU µs/s (apply + probe + per-send summarize/delta), broadcast fan-out bytes/s (actual delivered payload only), and per-peer broadcast messages/s (the load-bearing storm axis) — creates eviction pressure. When an axis exceeds an absolute floor AND a zero-demand contract holds >25% of it sustained (its windowed rate continuously above the floor for ≥ half the 5-minute cost window; a single burst never qualifies), the sweep sheds that contract, highest attributed cost first. "Zero-demand" honors invariant 3's full demand definition: no local subscription, no downstream subscriber, no genuine GET/PUT in-window (a contract's own UPDATE churn never counts; the genuinely-read never-subscribed class is protected, including across restarts via persisted access-type restore). Spec: `.claude/rules/hosting-invariants.md` invariant 3, "Cost pressure triggers the same decision (2026-07-21, #4861)".

2. **Escalating broken-invariant suppression TTL** (`ring/broken_invariants.rs`): first detection keeps today's 300s TTL (preserving #4295 false-positive conservatism — a single false flag never escalates); re-detection within [ttl, 2·ttl) doubles the TTL, capped at 6h; a quiet period ≥ 2·ttl resets to baseline. A genuinely broken contract converges to mostly-dark instead of oscillating: as hosts escalate, mesh drift shrinks and re-entry cascades vanish. This closes the oscillator for the whole non-idempotent class, including future junk contracts mild enough to stay under the cost-eviction thresholds.

Eviction removes today's storm contracts everywhere the auto-updating fleet runs; the TTL escalation removes the amplification dynamic that 0.2.104 introduced.

## Testing

- Full lib suite green: 4254 passed / 0 failed (features `trace,websocket,redb,wasmtime-backend,testing`); clippy (CI-exact, `-D warnings`) and fmt clean.
- Storm-profile tests through the real reporter→meter→sweep path: fast cadences (1.4s, 0.5s, ~36 samples/s), heal-interleaved sampling, multi-target CPU floods — all nominate; single bursts, trickle-then-burst, intermittent burst/silence patterns — never nominate. Exact-25%-share boundary pinned.
- Churn regressions pinned: repeat-PUT refreshes recency (write-only publisher never churns), reconciliation lease honored by candidacy, restart restores persisted GET/PUT recency, UPDATE/broadcast paths can never stamp recency (source-scrape pin incl. `executor_impl.rs`).
- TTL escalation: baseline-unchanged first flag, geometric escalation to cap, quiet-reset, single-false-positive-never-escalates, and an oscillator simulation asserting duty-cycle collapse (dark fraction > 0.98, cumulative re-entry emission < 1/5 of fixed-TTL baseline).

## Review record

This PR was NO-GO'd four times and re-worked to a clean gate each time; every round ran an external (Codex) pass plus independent adversarial Claude passes:

- R1 (pre-rework): 2 P1 churn bugs (Codex + adversarial) → rework.
- R2: 3 findings + 5-test gap list (3 reviewers, unanimous) → rework commit `fb78e776`.
- R3 (on `6a2a8713`): unanimous NO-GO — count-bounded sustained gate inverted against high-frequency storms (would have been a no-op against the live storm) + byte over-attribution + CPU-report gaps → fix commit `ca9efb7f`/`fca80c77`.
- R4 (on `ca9efb7f`): adversarial pass GO; Codex found 5 further findings (evict-during-await race, trickle-then-burst gate bypass, merged-size accounting, phantom bytes on failed sends, restart recency loss) → fix commit `6059e974`, each finding verified-then-fixed with regression pins.
- R5 (final, on `215d2bb1` + `6059e974`): adversarial pass GO on both (TTL window arithmetic, false-positive safety, invariant-1 compliance; all five R4 fixes verified genuinely fixed, test edits confirmed as corrections). Codex found 1 further finding: the restart-recency restore was poisoned at the persistence layer (both storage backends stamp `access_type=Put` on every state write, so UPDATE churn persists as Put and would be restored as genuine access after restart, shielding the storm under crash/restart cycles). Fixed in `4c89256f` (restore Get-only; red-then-green regression test), with a focused re-verification pass on that delta before merge.

- R6 (CI Simulation catch): the full Simulation suite (first non-draft run) surfaced a pre-existing in-branch regression — the #4861 cost feeds also flowed into `GovernanceManager::ingest_cost`, whose benefit-thresholded ban lacks invariant-3's zero-demand protections, resurrecting the #4296 popular-contract false positive in the governance sim (bisect: green on origin/main, red before AND after the rework rounds with identical costs — the rework changed governance cost by zero). Fixed in `eb8cf53a`: governance ingestion decoupled to its main-calibrated StateBytesWritten basis via an exhaustive per-axis allowlist (all axes still feed the cost-eviction meter/sweep); pinned by an allowlist unit test and a source-scrape gate pin; `popular_contract_with_subscribers_not_evicted` 3/3 green and `governance_ban_chain_end_to_end` still bans genuine abusers. Focused re-verification on the delta before merge.

Closes #4861.

[AI-assisted - Claude]
