### PR TITLE
fix(update): stop resending doomed deltas to delta-incapable contracts (HQk7 resync loop)

### DIFF
--- a/crates/core/src/contract/executor/runtime/executor_impl.rs
+++ b/crates/core/src/contract/executor/runtime/executor_impl.rs
@@ -2621,3 +2621,105 @@ where
         Ok(())
     }
 }
+
+/// Source-scrape pins for the full-state version-gate invariant
+/// (HQk7 fork investigation).
+///
+/// Production observed a fork-oscillation storm where a contract's stored
+/// state flip-flopped between two divergent full states (2180 ↔ 1952 bytes)
+/// on every resync apply. The investigation verified that the CORE side is
+/// correct: every full-state install over EXISTING state routes through the
+/// contract's own `update_state` (via `attempt_state_update`), so a contract
+/// WITH a version gate keeps its higher-version state — the observed flips
+/// were the contract itself accepting both forks (its `update_state` predates
+/// the version gate). These pins keep that invariant true: a future refactor
+/// must not add a blind `state_store` write for the resync/upsert path that
+/// would bypass a well-behaved contract's version acceptance.
+#[cfg(test)]
+mod full_state_version_gate_pins {
+    /// Slice `bridged_upsert_contract_state_inner`'s body (its signature to
+    /// the next method's signature).
+    fn upsert_body() -> &'static str {
+        let src = include_str!("executor_impl.rs");
+        let start = src
+            .find("pub(in crate::contract::executor) async fn bridged_upsert_contract_state_inner(")
+            .expect("bridged_upsert_contract_state_inner not found");
+        let after = &src[start..];
+        let end = after
+            .find("pub(in crate::contract::executor) async fn bridged_summarize_contract_state(")
+            .expect("next method after bridged_upsert_contract_state_inner not found");
+        &after[..end]
+    }
+
+    /// A full state over EXISTING state must reach the contract's
+    /// `update_state` (the contract's version acceptance is the ONLY version
+    /// oracle core has), and the only WASM-merge bypass writing an initial
+    /// state must be gated on the contract being NEW.
+    #[test]
+    fn full_state_over_existing_state_runs_contract_update_state() {
+        let body = upsert_body();
+
+        // The incoming full state becomes an UpdateData::State merge input…
+        let updates_pos = body
+            .find("vec![UpdateData::State(incoming_state.clone().into())]")
+            .expect("full state must be wrapped as UpdateData::State for the WASM merge");
+        // …consumed by attempt_state_update (which invokes update_state).
+        let merge_pos = body
+            .find(".attempt_state_update(&params, &current_state, &key, &updates)")
+            .expect("bridged upsert must merge via attempt_state_update");
+        assert!(
+            updates_pos < merge_pos,
+            "the full-state update input must feed attempt_state_update \
+             (updates {updates_pos} < merge {merge_pos})"
+        );
+
+        // The direct initial-state store must be inside the is_new_contract
+        // branch: the gate check must precede the single `.store(` call.
+        let is_new_pos = body
+            .find("if is_new_contract {")
+            .expect("is_new_contract gate not found");
+        let store_pos = body
+            .find(".store(key, state_to_store, params.clone())")
+            .expect("initial-state store call not found");
+        assert!(
+            is_new_pos < store_pos,
+            "the direct state_store write must be gated on is_new_contract \
+             (gate {is_new_pos} < store {store_pos}) — a blind store for an \
+             existing contract would bypass the contract's version gate \
+             (the HQk7 fork-oscillation failure class)"
+        );
+        assert_eq!(
+            body.matches(".store(key,").count(),
+            1,
+            "exactly one direct state_store.store call is allowed in the \
+             upsert path (the is_new_contract initial install)"
+        );
+    }
+
+    /// The corrupted-state recovery path (the ONE branch that replaces
+    /// existing state without a successful WASM merge) must stay gated on the
+    /// LOCAL state failing `validate_state` (#3109). Without that gate, a
+    /// merge rejection of a stale incoming full state would "recover" by
+    /// installing it — exactly the lower-version-overwrites-higher bypass
+    /// this module pins against.
+    #[test]
+    fn corrupted_state_recovery_requires_invalid_local_state() {
+        let body = upsert_body();
+
+        let local_valid_pos = body
+            .find("let local_valid = self")
+            .expect("recovery path must validate the LOCAL state (#3109)");
+        let keep_local_pos = body
+            .find("if local_valid {")
+            .expect("recovery must return the merge error when local state is valid");
+        let recovery_pos = body
+            .find("recovery_performed = true;")
+            .expect("corrupted-state recovery marker not found");
+        assert!(
+            local_valid_pos < keep_local_pos && keep_local_pos < recovery_pos,
+            "recovery ordering must be: validate local ({local_valid_pos}) < \
+             keep-local-when-valid ({keep_local_pos}) < recovery ({recovery_pos}) — \
+             recovery may only replace state the contract itself calls invalid"
+        );
+    }
+}

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -4089,6 +4089,53 @@ mod tests {
         );
     }
 
+    /// Source-scrape pin (HQk7 fork investigation): the `ResyncResponse` arm
+    /// must apply the received full state through the contract handler's
+    /// `UpdateQuery` merge path — i.e. through the contract's own
+    /// `validate_state`/`update_state` — and never via a direct store. The
+    /// executor-side pins (`full_state_version_gate_pins` in
+    /// `executor_impl.rs`) guard the upsert body; this pin guards the
+    /// likelier regression site, the resync arm itself, where a future
+    /// "optimization" could bypass the merge with a blind state write and
+    /// silently disable a well-behaved contract's version gate (the
+    /// lower-version-overwrites-higher failure class).
+    #[test]
+    fn resync_response_arm_applies_via_update_query_not_blind_store() {
+        let src = include_str!("node.rs");
+
+        let handler_start = src
+            .find("async fn handle_interest_sync_message(")
+            .expect("handle_interest_sync_message not found");
+        // Scope to the apply segment of the ResyncResponse arm: from the
+        // received-log marker (unique to the arm) to the applied-log marker.
+        // The correlation gate, UpdateData construction, and contract-handler
+        // dispatch all live between the two.
+        let recv_off = src[handler_start..]
+            .find("event = \"resync_response_received\"")
+            .expect("resync_response_received marker not found");
+        let applied_off = src[handler_start..]
+            .find("event = \"resync_applied\"")
+            .expect("resync_applied marker not found");
+        let apply_segment = &src[handler_start + recv_off..handler_start + applied_off];
+
+        assert!(
+            apply_segment.contains("UpdateData::State("),
+            "the resync full state must be wrapped as UpdateData::State"
+        );
+        assert!(
+            apply_segment.contains("ContractHandlerEvent::UpdateQuery"),
+            "the resync apply must route through notify_contract_handler \
+             (ContractHandlerEvent::UpdateQuery) so the contract's own \
+             validate_state/update_state judge the incoming state"
+        );
+        assert!(
+            !apply_segment.contains("PutQuery") && !apply_segment.contains(".store("),
+            "the resync arm must NOT install state via PutQuery or a direct \
+             store — that would bypass the contract's version acceptance for \
+             already-held contracts"
+        );
+    }
+
     /// Regression pin for the D2 `is_upstream` clobber in the `ChangeInterests`
     /// interest-sync arm.
     ///

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -3059,6 +3059,22 @@ async fn handle_interest_sync_message(
             op_manager.interest_manager.record_resync_request_received();
             crate::config::GlobalTestMetrics::record_resync_request();
 
+            // Delta-incompatibility signal (HQk7 resync loop): a ResyncRequest
+            // arriving shortly after WE delivered a delta to this peer for
+            // this contract means our delta failed to apply there. Count it
+            // toward the sender-side "this contract can't take deltas" memo so
+            // the broadcast path falls back to full-state sends instead of
+            // recomputing doomed deltas. Runs BEFORE the rate limiters AND
+            // before the broken-contract egress gate below — the signal is
+            // valid even when the full-state response is suppressed (a broken
+            // contract that also can't take deltas still wants full-state
+            // fallback recorded for the peers we DO serve). See
+            // `crate::ring::delta_incompat`.
+            op_manager
+                .ring
+                .delta_incompat
+                .note_resync_request(*key.id(), source);
+
             // Egress gate (broken invariants): a contract flagged as
             // violating CRDT idempotency must not have its full state
             // served to peers. The executor already suppresses commit +
@@ -4030,6 +4046,46 @@ mod tests {
             "the Summaries arm must ration WASM probes through \
              plan_staleness_probe (MAX_STALENESS_PROBES_PER_SUMMARIES cap) — \
              an uncapped probe per contract is a DoS amplification surface"
+        );
+    }
+
+    /// Source-scrape pin (HQk7 resync loop): the `ResyncRequest` arm must feed
+    /// the sender-side delta-incompatibility memo (`note_resync_request`)
+    /// BEFORE the response rate limiters run. A ResyncRequest arriving shortly
+    /// after we delivered a delta to that peer is the wire-visible form of the
+    /// peer's `delta_apply_failed`; it is a valid incompatibility signal even
+    /// when the full-state response itself is suppressed by the #4861
+    /// limiters, so gating it behind them would starve the memo exactly during
+    /// the storm it exists to stop. See `crate::ring::delta_incompat`.
+    #[test]
+    fn resync_request_arm_feeds_delta_incompat_memo_before_limiters() {
+        let src = include_str!("node.rs");
+
+        let handler_start = src
+            .find("async fn handle_interest_sync_message(")
+            .expect("handle_interest_sync_message not found");
+        // Scope to the `ResyncRequest` arm = its match start .. the
+        // `ResyncResponse` arm, so the assertions can't false-pass on
+        // unrelated code elsewhere in the handler.
+        let req_off = src[handler_start..]
+            .find("InterestMessage::ResyncRequest { key }")
+            .expect("ResyncRequest arm not found");
+        let resp_off = src[handler_start..]
+            .find("InterestMessage::ResyncResponse {")
+            .expect("ResyncResponse arm not found");
+        let req_arm = &src[handler_start + req_off..handler_start + resp_off];
+
+        let memo_pos = req_arm
+            .find(".note_resync_request(")
+            .expect("the ResyncRequest arm must feed the delta-incompat memo");
+        let limiter_pos = req_arm
+            .find("resync_response_limiter")
+            .expect("per-(peer, contract) response limiter not found in ResyncRequest arm");
+        assert!(
+            memo_pos < limiter_pos,
+            "note_resync_request must run BEFORE the response rate limiters \
+             (memo {memo_pos} < limiter {limiter_pos}) — a suppressed response \
+             is still a valid delta-incompatibility signal"
         );
     }
 

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -4087,6 +4087,22 @@ mod tests {
              (memo {memo_pos} < limiter {limiter_pos}) — a suppressed response \
              is still a valid delta-incompatibility signal"
         );
+        // Also lock memo-before-broken-gate: B's `is_contract_broken → return
+        // None` egress gate sits between the memo and the limiters, and the
+        // arming's own comment requires it run "before the broken-contract
+        // egress gate". Without this assertion a future edit could move the
+        // arming after the gate (silently dropping the signal for broken
+        // contracts) and still pass the memo-before-limiter check above.
+        let broken_pos = req_arm
+            .find("is_contract_broken")
+            .expect("the ResyncRequest arm must gate on the broken-contract egress check (B)");
+        assert!(
+            memo_pos < broken_pos,
+            "note_resync_request must run BEFORE the broken-contract egress gate \
+             (memo {memo_pos} < broken {broken_pos}) — the delta-incompatibility \
+             signal is valid even when the full-state response is suppressed for a \
+             broken contract"
+        );
     }
 
     /// Source-scrape pin (HQk7 fork investigation): the `ResyncResponse` arm

--- a/crates/core/src/node/network_bridge/broadcast_queue.rs
+++ b/crates/core/src/node/network_bridge/broadcast_queue.rs
@@ -788,8 +788,28 @@ pub(super) async fn broadcast_to_single_peer(
         }
     }
 
+    // Sender-side delta-incompatibility memo (the HQk7 resync loop): a
+    // contract that repeatedly rejects deltas (its `update_state` only
+    // accepts full states) turns every delta send into
+    // delta → "Invalid update" → ResyncRequest → full-state resync → repeat.
+    // While the memo is armed, skip the delta computation entirely and send
+    // full state directly. See `crate::ring::delta_incompat`.
+    let deltas_suppressed = op_manager.ring.delta_incompat.suppress_deltas(key.id());
+    if deltas_suppressed {
+        tracing::debug!(
+            contract = %key,
+            peer = %peer_addr,
+            event = "delta_suppressed_incompat",
+            "Contract is in delta-incompat backoff — sending full state instead of a delta"
+        );
+    }
+
     // Compute delta if we have their summary
     let (payload, sent_delta) = match (&our_summary, &their_summary) {
+        _ if deltas_suppressed => (
+            DeltaOrFullState::FullState(new_state.as_ref().to_vec()),
+            false,
+        ),
         (Some(ours), Some(theirs)) => {
             match op_manager
                 .interest_manager
@@ -1006,6 +1026,17 @@ pub(super) async fn broadcast_to_single_peer(
         // successful enqueue is the terminal state we can observe, so delivery
         // tracks the send result (unchanged pre-#4235 behavior for this path).
         if res.is_ok() {
+            // Delta-incompat attribution (HQk7 resync loop): remember that we
+            // just delivered a DELTA to this peer so a prompt `ResyncRequest`
+            // from it can be attributed to the delta failing to apply (deltas
+            // only ever take this inline path — streaming is full-state-only).
+            // See `crate::ring::delta_incompat`.
+            if sent_delta {
+                op_manager
+                    .ring
+                    .delta_incompat
+                    .record_delta_sent(*key.id(), peer_addr);
+            }
             // Record telemetry, refresh peer interest, and cache the peer
             // summary — see `record_delivery_to_interest`. The streaming branch
             // applies the same gate via `record_streaming_delivery` (#4235);
@@ -1455,6 +1486,65 @@ mod tests {
             "broadcast_to_single_peer must gate on should_broadcast_contract BEFORE \
              calling get_contract_summary (#4473) — otherwise the summarize storm \
              fires for every phantom contract before the gate can skip it"
+        );
+    }
+
+    /// Source-scrape pin (HQk7 resync loop): `broadcast_to_single_peer` must
+    /// consult the sender-side delta-incompatibility memo BEFORE computing a
+    /// delta, and must record every delivered delta send for ResyncRequest
+    /// attribution. If the gate is dropped (or moved after `compute_delta`),
+    /// a delta-incapable contract goes back to
+    /// delta → "Invalid update" → ResyncRequest → full-state resync → repeat
+    /// (3,102 delta_apply_failed events for one contract in a 2h production
+    /// window); if the attribution recording is dropped, the memo's
+    /// sender-side arm signal (`note_resync_request`) can never fire.
+    /// See `crate::ring::delta_incompat`.
+    #[test]
+    fn broadcast_to_single_peer_gates_deltas_on_incompat_memo() {
+        let src = include_str!("broadcast_queue.rs");
+        let fn_start = src
+            .find("pub(super) async fn broadcast_to_single_peer(")
+            .expect("broadcast_to_single_peer not found");
+        let after = &src[fn_start..];
+        let fn_end = after
+            .find("\nmod tests {")
+            .or_else(|| after.find("\n#[cfg(test)]"))
+            .expect("end of broadcast_to_single_peer not found");
+        let body = &after[..fn_end];
+
+        // 1. The memo gate must run BEFORE the delta computation and map
+        //    suppression to a full-state payload.
+        let gate_pos = body
+            .find(".suppress_deltas(")
+            .expect("broadcast_to_single_peer must consult the delta-incompat memo");
+        let delta_pos = body
+            .find(".compute_delta(")
+            .expect("compute_delta call not found");
+        assert!(
+            gate_pos < delta_pos,
+            "the delta-incompat gate must be consulted BEFORE compute_delta \
+             (gate {gate_pos} < compute_delta {delta_pos}) — otherwise the \
+             doomed delta is still computed and sent"
+        );
+        assert!(
+            body.contains("_ if deltas_suppressed => ("),
+            "suppression must short-circuit the payload match to FullState"
+        );
+
+        // 2. Delivered delta sends must be recorded for ResyncRequest
+        //    attribution, gated on sent_delta (full-state sends must NOT
+        //    create attributions — a resync after a full-state send says
+        //    nothing about delta compatibility).
+        let record_pos = body
+            .find(".record_delta_sent(")
+            .expect("broadcast_to_single_peer must record delivered delta sends");
+        let sent_delta_gate = body
+            .find("if sent_delta {")
+            .expect("record_delta_sent must be gated on sent_delta");
+        assert!(
+            sent_delta_gate < record_pos,
+            "record_delta_sent must sit inside the `if sent_delta` gate \
+             (gate {sent_delta_gate} < record {record_pos})"
         );
     }
 

--- a/crates/core/src/node/network_bridge/broadcast_queue.rs
+++ b/crates/core/src/node/network_bridge/broadcast_queue.rs
@@ -1530,6 +1530,27 @@ mod tests {
             body.contains("_ if deltas_suppressed => ("),
             "suppression must short-circuit the payload match to FullState"
         );
+        // The guard arm must be FIRST in the payload match: Rust evaluates
+        // arms in order, so `_ if deltas_suppressed` has to precede the
+        // `(Some(ours), Some(theirs))` compute_delta arm — otherwise a
+        // suppressed contract with both summaries present would compute and
+        // send the doomed delta (or, post-#4901, hit the Ok(None) converged
+        // skip) instead of forcing full state. The `.suppress_deltas(` call
+        // above precedes the match regardless, so only this arm-ordering
+        // assertion catches a reordering regression.
+        let guard_arm = body
+            .find("_ if deltas_suppressed => (")
+            .expect("guard arm not found");
+        let compute_arm = body
+            .find("(Some(ours), Some(theirs)) => {")
+            .expect("compute_delta arm `(Some(ours), Some(theirs))` not found");
+        assert!(
+            guard_arm < compute_arm,
+            "the `_ if deltas_suppressed` guard arm must come BEFORE the \
+             `(Some(ours), Some(theirs))` compute_delta arm (guard {guard_arm} \
+             < compute {compute_arm}) — a suppressed delta-incapable contract \
+             must never reach compute_delta"
+        );
 
         // 2. Delivered delta sends must be recorded for ResyncRequest
         //    attribution, gated on sent_delta (full-state sends must NOT

--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -805,6 +805,23 @@ async fn try_summary_first_put(
         }
     }
 
+    // Delta-incompat gate (HQk7 resync loop): if the contract is armed as
+    // delta-incapable, the ProbeReconcile delta below is doomed at the
+    // holder ("Invalid update"). Fall through to the full-state driver
+    // instead — the same recovery the delta-computation-failure arm uses.
+    // See `crate::ring::delta_incompat`.
+    if op_manager.ring.delta_incompat.suppress_deltas(key.id()) {
+        tracing::debug!(
+            tx = %client_tx,
+            contract = %key,
+            event = "delta_suppressed_incompat",
+            phase = "summary_first_delta_suppressed",
+            "PUT summary-first: contract is in delta-incompat backoff; \
+             falling through to full-state driver"
+        );
+        return SummaryFirstOutcome::FallThrough;
+    }
+
     let our_state_size = merged_value.size();
     let delta = match op_manager
         .interest_manager
@@ -4265,6 +4282,41 @@ mod tests {
 
     fn dummy_key() -> ContractKey {
         ContractKey::from_id_and_code(ContractInstanceId::new([1u8; 32]), CodeHash::new([2u8; 32]))
+    }
+
+    /// Source-scrape pin (HQk7 resync loop): the summary-first PUT path must
+    /// consult the delta-incompat memo BEFORE computing the ProbeReconcile
+    /// delta and fall through to the full-state driver for an armed
+    /// contract. Without the gate this path keeps sending doomed deltas to a
+    /// delta-incapable holder (bounded per-PUT, no loop — but every one is a
+    /// wasted WASM delta computation plus a guaranteed "Invalid update" at
+    /// the holder). See `crate::ring::delta_incompat`.
+    #[test]
+    fn summary_first_put_gates_delta_on_incompat_memo() {
+        let src = include_str!("op_ctx_task.rs");
+        let fn_start = src
+            .find("async fn try_summary_first_put(")
+            .expect("try_summary_first_put not found");
+        let after = &src[fn_start..];
+        let fn_end = after.find("\nasync fn ").unwrap_or(after.len());
+        let body = &after[..fn_end];
+
+        let gate_pos = body
+            .find(".suppress_deltas(")
+            .expect("try_summary_first_put must consult the delta-incompat memo");
+        let delta_pos = body
+            .find(".compute_delta(")
+            .expect("ProbeReconcile compute_delta call not found");
+        assert!(
+            gate_pos < delta_pos,
+            "the delta-incompat gate must run BEFORE compute_delta \
+             (gate {gate_pos} < compute_delta {delta_pos})"
+        );
+        let fallthrough = &body[gate_pos..delta_pos];
+        assert!(
+            fallthrough.contains("SummaryFirstOutcome::FallThrough"),
+            "an armed contract must fall through to the full-state driver"
+        );
     }
 
     fn dummy_tx() -> Transaction {

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -1613,6 +1613,16 @@ async fn drive_relay_broadcast_to(
                     sender_addr,
                     result.changed,
                 );
+                // Delta-incompat memo self-heal (HQk7 resync loop): a delta
+                // that applied cleanly proves the contract takes deltas, so
+                // drop the memo and its failure counter. Deliberately NOT
+                // gated on `result.changed` — a no-op delta apply still ran
+                // the contract's delta path successfully, which is the exact
+                // property the memo tracks. See `crate::ring::delta_incompat`.
+                op_manager
+                    .ring
+                    .delta_incompat
+                    .record_delta_success(key.id());
             } else if result.changed {
                 // #4864 round-9 item 3: a CHANGED FULL-STATE broadcast apply
                 // advances the state, which invalidates the failed-payload MEMO's
@@ -1657,6 +1667,20 @@ async fn drive_relay_broadcast_to(
                     class,
                     payload_hash,
                 );
+                // Delta-incompatibility signal (HQk7 resync loop): an
+                // `Invalid`-class DELTA rejection is the receiver-side form of
+                // "this contract can't take deltas". We fan the same contract
+                // out to our own downstreams, so count it toward the
+                // sender-side memo that switches our broadcasts to full state.
+                // Timeout-class failures are load, not incompatibility — and
+                // full-state merges say nothing about deltas — so both are
+                // excluded. See `crate::ring::delta_incompat`.
+                if is_delta && class == crate::ring::merge_backoff::MergeFailureClass::Invalid {
+                    op_manager
+                        .ring
+                        .delta_incompat
+                        .note_delta_apply_failed(*key.id());
+                }
             }
 
             // On benign stale-version rejection (not OOG/traps/validation
@@ -2996,6 +3020,50 @@ mod tests {
              when the WASM merge rejects — otherwise the sender's cached view \
              of us stays wrong and it keeps full-state-broadcasting identical \
              content"
+        );
+    }
+
+    /// Pin (HQk7 resync loop): the BroadcastTo driver must feed the
+    /// delta-incompatibility memo on BOTH edges — arm it on an
+    /// `Invalid`-class DELTA rejection (receiver-side signal that the
+    /// contract can't take deltas) and clear it on a successful delta apply
+    /// (self-heal). If either call is dropped, the sender-side full-state
+    /// fallback in `broadcast_to_single_peer` either never arms (the doomed
+    /// delta → ResyncRequest → full-state loop resumes) or never heals (a
+    /// recovered contract is stuck on full-state sends until TTL expiry).
+    /// See `crate::ring::delta_incompat`.
+    #[test]
+    fn broadcast_to_feeds_delta_incompat_memo() {
+        let driver_src = broadcast_to_driver_src();
+
+        // Arm: inside the exec-rejection failure classification, gated on
+        // is_delta AND the Invalid class (Timeout is load, not
+        // incompatibility; full-state merges say nothing about deltas).
+        let arm_pos = driver_src
+            .find(".note_delta_apply_failed(")
+            .expect("drive_relay_broadcast_to must arm the delta-incompat memo on delta failure");
+        assert!(
+            driver_src.contains(
+                "if is_delta && class == crate::ring::merge_backoff::MergeFailureClass::Invalid"
+            ),
+            "the delta-incompat arm must be gated on is_delta AND the Invalid \
+             failure class — arming on Timeout (load) or full-state failures \
+             would flip healthy contracts to full-state fan-out"
+        );
+
+        // Clear: inside the `if is_delta` success arm, next to the backoff
+        // reset (the same delta-only convergence signal).
+        let clear_pos = driver_src
+            .find(".record_delta_success(")
+            .expect("drive_relay_broadcast_to must clear the delta-incompat memo on delta success");
+        let is_delta_gate_pos = driver_src
+            .find("if is_delta {")
+            .expect("is_delta success gate not found");
+        assert!(
+            is_delta_gate_pos < clear_pos && clear_pos < arm_pos,
+            "record_delta_success must sit inside the `if is_delta` success arm \
+             (delta-only signal), before the failure classification \
+             (order: is_delta gate {is_delta_gate_pos} < clear {clear_pos} < arm {arm_pos})"
         );
     }
 

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -84,6 +84,7 @@ mod broken_invariants;
 mod connection_backoff;
 mod connection_manager;
 pub(crate) mod contract_ban_list;
+pub(crate) mod delta_incompat;
 pub(crate) use connection_manager::ConnectionManager;
 // Nearest-neighbor ring lattice (successor+predecessor base edges).
 // `nn_lattice_active_for` is the full activation gate — the flag AND the
@@ -221,6 +222,12 @@ pub(crate) struct Ring {
     /// inbound broadcast instead of O(WASM merge). Cleared the instant a merge
     /// succeeds. See `crate::ring::merge_backoff`.
     pub(crate) merge_backoff: Arc<merge_backoff::MergeBackoff>,
+    /// SENDER-side memo of contracts whose deltas are known-doomed (the HQk7
+    /// resync loop). Armed by repeated resync-after-our-delta signals or local
+    /// `Invalid`-class delta-apply failures; while armed, the broadcast path
+    /// skips delta computation and sends full state. TTL-bounded, LRU-capped,
+    /// cleared by a successful delta apply. See `crate::ring::delta_incompat`.
+    pub(crate) delta_incompat: Arc<delta_incompat::DeltaIncompat>,
     /// Per-contract cap on how often THIS node emits a `ResyncRequest` (#4861).
     /// Bounds the full-state resync amplification independently of the merge
     /// outcome. See `crate::ring::resync_rate_limit`.
@@ -635,6 +642,7 @@ impl Ring {
                 time_source.clone(),
             )),
             merge_backoff: Arc::new(merge_backoff::MergeBackoff::new(time_source.clone())),
+            delta_incompat: Arc::new(delta_incompat::DeltaIncompat::new(time_source.clone())),
             resync_emit_limiter: Arc::new(resync_rate_limit::new_emit_limiter(time_source.clone())),
             resync_response_limiter: Arc::new(resync_rate_limit::new_response_limiter(
                 time_source.clone(),
@@ -1319,6 +1327,11 @@ impl Ring {
             // haven't failed a merge recently; a poison contract still in
             // cooldown is preserved.
             ring.merge_backoff.cleanup_expired();
+
+            // Sweep stale delta-send attributions and idle unarmed entries in
+            // the delta-incompatibility memo (HQk7 resync loop); an armed
+            // (unexpired) memo is preserved.
+            ring.delta_incompat.cleanup();
 
             // Sweep recovered/idle resync rate-limiter buckets (#4861) so the
             // per-contract emit and per-(peer, contract) responder maps stay

--- a/crates/core/src/ring/delta_incompat.rs
+++ b/crates/core/src/ring/delta_incompat.rs
@@ -30,22 +30,35 @@
 //!
 //! ## Mechanism
 //!
-//! Two signals arm the memo, both counted per contract:
+//! Two signals strike against a contract:
 //!
 //! 1. **Resync-after-our-delta** (sender-side observation): a `ResyncRequest`
 //!    arrives from a peer we sent a delta to for that contract within the
 //!    attribution window ([`DELTA_ATTRIBUTION_WINDOW`]). A receiver that
 //!    fails a delta apply immediately ResyncRequests the delta's sender
 //!    (`operations/update/op_ctx_task.rs`), so this is the wire-visible form
-//!    of the receiver's `delta_apply_failed`.
+//!    of the receiver's `delta_apply_failed`. The wire signal is AMBIGUOUS,
+//!    however: a receiver also ResyncRequests after a queue-full drop
+//!    (#4857) or a Timeout-class WASM failure — pure LOAD, indistinguishable
+//!    at the sender. Resync strikes therefore only count toward arming once
+//!    they have come from **at least two DISTINCT peer addresses**: two
+//!    independent receivers bouncing our deltas is strong evidence the
+//!    CONTRACT rejects deltas, while any number of resyncs from a single
+//!    peer says only that that one peer is overloaded (or malicious — this
+//!    also closes the single-peer false-arm vector, since attribution is
+//!    per-`(contract, peer)` and one address can never arm alone).
 //! 2. **Local delta-apply failure** (receiver-side observation): our own WASM
 //!    apply of a received delta failed with an `Invalid`-class contract
 //!    rejection. We fan the same contract out to *our* downstreams, so what
-//!    we just learned applies to our own delta sends too.
+//!    we just learned applies to our own delta sends too. This is genuine
+//!    per-node evidence (the contract itself rejected the delta on OUR
+//!    executor), so it counts contract-wide with no corroboration
+//!    requirement.
 //!
-//! [`INCOMPAT_TRIP_THRESHOLD`] consecutive failure signals (with no
-//! intervening successful delta apply) arm the memo for
-//! [`DELTA_INCOMPAT_TTL`]. Trip-at-1 would flip a healthy contract to
+//! The memo arms for [`DELTA_INCOMPAT_TTL`] when the EFFECTIVE strike count
+//! — local strikes plus (resync strikes if corroborated by ≥2 distinct
+//! peers, else 0) — reaches [`INCOMPAT_TRIP_THRESHOLD`], with no intervening
+//! successful delta apply. Trip-at-1 would flip a healthy contract to
 //! full-state fan-out on a single benign stale-version rejection (the same
 //! rationale as `merge_backoff::INVALID_TRIP_THRESHOLD`); a delta-incapable
 //! contract fails every delta from every peer, so it trips within one or two
@@ -97,8 +110,12 @@ pub(crate) const DELTA_INCOMPAT_TTL: Duration = Duration::from_secs(10 * 60);
 /// plus queueing; 60s matches `resync_rate_limit::OUTSTANDING_RESYNC_TTL`.
 pub(crate) const DELTA_ATTRIBUTION_WINDOW: Duration = Duration::from_secs(60);
 
-/// Consecutive failure signals (no intervening successful delta apply)
-/// required to arm the memo. See module docs for the trip-at-1 rationale.
+/// EFFECTIVE strikes (no intervening successful delta apply) required to arm
+/// the memo: local strikes plus resync strikes, the latter counting only once
+/// corroborated by ≥2 distinct peers (see module docs). The strike that
+/// brings the effective count to this value arms — the check runs uniformly
+/// on every strike (including the very first), so a value of 1 means
+/// trip-at-1, not trip-at-2.
 pub(crate) const INCOMPAT_TRIP_THRESHOLD: u32 = 3;
 
 /// Hard cap on tracked contracts. At ~64 bytes/entry ≈ 0.5 MB worst case.
@@ -112,13 +129,51 @@ pub(crate) const MAX_TRACKED_DELTA_SENDS: usize = 16_384;
 const CONTRACT_CLEANUP_AGE: Duration = Duration::from_secs(20 * 60);
 
 struct ContractEntry {
-    /// Consecutive failure signals since the last successful delta apply.
-    consecutive_failures: u32,
+    /// Strikes from OUR OWN failed delta applies (`Invalid`-class contract
+    /// rejections) since the last successful delta apply. Genuine per-node
+    /// evidence: counts contract-wide with no corroboration requirement.
+    local_strikes: u32,
+    /// Strikes from attributed `ResyncRequest`s since the last successful
+    /// delta apply. Wire-ambiguous evidence (also fires on receiver
+    /// queue-full/timeout, i.e. pure load): only counts toward arming once
+    /// `multi_peer_resync` is set.
+    resync_strikes: u32,
+    /// The first peer address that contributed a resync strike; used to
+    /// detect the second DISTINCT address.
+    first_resync_peer: Option<SocketAddr>,
+    /// Set once resync strikes have come from ≥2 distinct peer addresses —
+    /// the corroboration that upgrades them from "one peer is overloaded or
+    /// lying" to "the contract rejects deltas".
+    multi_peer_resync: bool,
     /// While `Some(t)` with `t > now`, deltas for this contract are
     /// suppressed in favor of full state.
     armed_until: Option<Instant>,
     /// Last failure signal, for idle cleanup.
     last_event: Instant,
+}
+
+impl ContractEntry {
+    fn new(now: Instant) -> Self {
+        Self {
+            local_strikes: 0,
+            resync_strikes: 0,
+            first_resync_peer: None,
+            multi_peer_resync: false,
+            armed_until: None,
+            last_event: now,
+        }
+    }
+
+    /// Strikes that count toward arming: local strikes always; resync
+    /// strikes only once corroborated by ≥2 distinct peers.
+    fn effective_strikes(&self) -> u32 {
+        let resync = if self.multi_peer_resync {
+            self.resync_strikes
+        } else {
+            0
+        };
+        self.local_strikes.saturating_add(resync)
+    }
 }
 
 /// Sender-side "this contract can't take deltas" memo. See module docs.
@@ -187,43 +242,63 @@ impl DeltaIncompat {
             // Stale attribution — not evidence about the delta we sent.
             return false;
         }
-        self.note_failure(contract, now);
+        self.note_failure(contract, now, Some(peer));
         true
     }
 
     /// Our own WASM apply of a RECEIVED delta for `contract` failed with an
     /// `Invalid`-class contract rejection (the receiver-side form of the same
-    /// signal; see module docs).
+    /// signal; see module docs). Counts contract-wide — genuine per-node
+    /// evidence, no distinct-peer corroboration required.
     pub fn note_delta_apply_failed(&self, contract: ContractInstanceId) {
         let now = self.time_source.now();
-        self.note_failure(contract, now);
+        self.note_failure(contract, now, None);
     }
 
-    fn note_failure(&self, contract: ContractInstanceId, now: Instant) {
+    /// Apply one strike. `resync_peer` is `Some` for the wire-ambiguous
+    /// resync-after-delta signal (counted only once ≥2 distinct peers have
+    /// contributed; see module docs) and `None` for a local delta-apply
+    /// failure (always counted). The arm check runs uniformly on every
+    /// strike — including the one that creates the entry — so the threshold
+    /// constant means exactly "arm at N effective strikes".
+    fn note_failure(
+        &self,
+        contract: ContractInstanceId,
+        now: Instant,
+        resync_peer: Option<SocketAddr>,
+    ) {
         let mut armed = false;
-        match self.contracts.entry(contract) {
-            dashmap::mapref::entry::Entry::Occupied(mut e) => {
-                let entry = e.get_mut();
-                entry.consecutive_failures = entry.consecutive_failures.saturating_add(1);
-                entry.last_event = now;
-                if entry.consecutive_failures >= INCOMPAT_TRIP_THRESHOLD {
-                    let was_armed = matches!(entry.armed_until, Some(until) if until > now);
-                    entry.armed_until = Some(now + DELTA_INCOMPAT_TTL);
-                    armed = !was_armed;
+        {
+            let mut entry = match self.contracts.entry(contract) {
+                dashmap::mapref::entry::Entry::Occupied(e) => e.into_ref(),
+                dashmap::mapref::entry::Entry::Vacant(e) => {
+                    // Strict cap: at capacity, skip (no suppression for the
+                    // new contract, but no unbounded growth either).
+                    if self.contracts_size.load(Ordering::Relaxed) >= MAX_TRACKED_CONTRACTS {
+                        return;
+                    }
+                    self.contracts_size.fetch_add(1, Ordering::Relaxed);
+                    e.insert(ContractEntry::new(now))
+                }
+            };
+            match resync_peer {
+                Some(peer) => {
+                    entry.resync_strikes = entry.resync_strikes.saturating_add(1);
+                    match entry.first_resync_peer {
+                        None => entry.first_resync_peer = Some(peer),
+                        Some(first) if first != peer => entry.multi_peer_resync = true,
+                        Some(_) => {}
+                    }
+                }
+                None => {
+                    entry.local_strikes = entry.local_strikes.saturating_add(1);
                 }
             }
-            dashmap::mapref::entry::Entry::Vacant(e) => {
-                // Strict cap: at capacity, skip (no suppression for the new
-                // contract, but no unbounded growth either).
-                if self.contracts_size.load(Ordering::Relaxed) >= MAX_TRACKED_CONTRACTS {
-                    return;
-                }
-                e.insert(ContractEntry {
-                    consecutive_failures: 1,
-                    armed_until: None,
-                    last_event: now,
-                });
-                self.contracts_size.fetch_add(1, Ordering::Relaxed);
+            entry.last_event = now;
+            if entry.effective_strikes() >= INCOMPAT_TRIP_THRESHOLD {
+                let was_armed = matches!(entry.armed_until, Some(until) if until > now);
+                entry.armed_until = Some(now + DELTA_INCOMPAT_TTL);
+                armed = !was_armed;
             }
         }
         if armed {
@@ -321,8 +396,9 @@ mod tests {
         (ts, memo)
     }
 
-    /// The core Bug-2 repro: repeated resync-after-delta signals arm the
-    /// memo, after which delta sends are suppressed (full-state fallback).
+    /// The core Bug-2 repro: repeated resync-after-delta signals from
+    /// DISTINCT peers arm the memo, after which delta sends are suppressed
+    /// (full-state fallback).
     #[test]
     fn resync_after_delta_arms_after_threshold() {
         let (_ts, memo) = setup();
@@ -340,8 +416,45 @@ mod tests {
         }
         assert!(
             memo.suppress_deltas(&c),
-            "after {INCOMPAT_TRIP_THRESHOLD} attributed resyncs the sender must \
-             fall back to full-state sends"
+            "after {INCOMPAT_TRIP_THRESHOLD} attributed resyncs from distinct \
+             peers the sender must fall back to full-state sends"
+        );
+        assert_eq!(memo.armed_total(), 1);
+    }
+
+    /// Single-peer resync strikes must NEVER arm — the wire ResyncRequest is
+    /// ambiguous (queue-full drops and Timeout-class WASM failures fire it
+    /// too, i.e. pure load), so one overloaded or malicious peer bouncing
+    /// our deltas is not evidence about the CONTRACT. A second DISTINCT peer
+    /// corroborating is, and arms.
+    #[test]
+    fn single_peer_resyncs_do_not_arm_but_two_distinct_peers_do() {
+        let (_ts, memo) = setup();
+        let c = contract(11);
+        let lone = peer(4300);
+        // Far past the threshold, all from ONE peer: never arms.
+        for i in 0..(INCOMPAT_TRIP_THRESHOLD * 3) {
+            memo.record_delta_sent(c, lone);
+            assert!(
+                memo.note_resync_request(c, lone),
+                "attributed resync must still be consumed/counted (i={i})"
+            );
+            assert!(
+                !memo.suppress_deltas(&c),
+                "resync strikes from a single peer must NOT arm (i={i}) — \
+                 one peer bouncing deltas is load/malice, not contract evidence"
+            );
+        }
+        assert_eq!(memo.armed_total(), 0);
+
+        // One strike from a second DISTINCT peer corroborates: the whole
+        // resync strike count now applies and the memo arms.
+        let second = peer(4301);
+        memo.record_delta_sent(c, second);
+        assert!(memo.note_resync_request(c, second));
+        assert!(
+            memo.suppress_deltas(&c),
+            "a second distinct peer must corroborate the resync strikes and arm"
         );
         assert_eq!(memo.armed_total(), 1);
     }

--- a/crates/core/src/ring/delta_incompat.rs
+++ b/crates/core/src/ring/delta_incompat.rs
@@ -1,0 +1,496 @@
+//! Sender-side memo of contracts whose deltas are known-doomed.
+//!
+//! ## Why
+//!
+//! Some deployed contracts cannot apply *any* delta: their `update_state`
+//! accepts only `UpdateData::State` and rejects `UpdateData::Delta` outright
+//! with `InvalidUpdate`. The canonical case is the HQk7 web-container (built
+//! against freenet-stdlib 0.1.35): every delta the summary-diff fan-out sends
+//! it is rejected, so each broadcast produces
+//!
+//! ```text
+//! delta send → "Invalid update" → delta_apply_failed → ResyncRequest →
+//! full-state ResyncResponse → (state changes) → next delta send → …
+//! ```
+//!
+//! a self-sustaining resync loop (3,102 `delta_apply_failed` events for one
+//! contract in a 2h production window). The existing defenses don't break the
+//! cycle:
+//!
+//! - [`crate::ring::merge_backoff`] is RECEIVER-side: it stops the receiver
+//!   re-running doomed merges, but the sender keeps computing and sending
+//!   fresh doomed deltas.
+//! - The merge backoff's failed-payload memo can't help either, because every
+//!   state change produces fresh delta bytes — the memo never matches.
+//! - The resync rate limiters bound the full-state amplification, not the
+//!   doomed delta sends that trigger it.
+//!
+//! What is missing is a SENDER-side memo: "this contract can't take deltas —
+//! send full state directly." That is this module.
+//!
+//! ## Mechanism
+//!
+//! Two signals arm the memo, both counted per contract:
+//!
+//! 1. **Resync-after-our-delta** (sender-side observation): a `ResyncRequest`
+//!    arrives from a peer we sent a delta to for that contract within the
+//!    attribution window ([`DELTA_ATTRIBUTION_WINDOW`]). A receiver that
+//!    fails a delta apply immediately ResyncRequests the delta's sender
+//!    (`operations/update/op_ctx_task.rs`), so this is the wire-visible form
+//!    of the receiver's `delta_apply_failed`.
+//! 2. **Local delta-apply failure** (receiver-side observation): our own WASM
+//!    apply of a received delta failed with an `Invalid`-class contract
+//!    rejection. We fan the same contract out to *our* downstreams, so what
+//!    we just learned applies to our own delta sends too.
+//!
+//! [`INCOMPAT_TRIP_THRESHOLD`] consecutive failure signals (with no
+//! intervening successful delta apply) arm the memo for
+//! [`DELTA_INCOMPAT_TTL`]. Trip-at-1 would flip a healthy contract to
+//! full-state fan-out on a single benign stale-version rejection (the same
+//! rationale as `merge_backoff::INVALID_TRIP_THRESHOLD`); a delta-incapable
+//! contract fails every delta from every peer, so it trips within one or two
+//! broadcast rounds anyway.
+//!
+//! While armed, [`DeltaIncompat::suppress_deltas`] tells the broadcast path
+//! (`broadcast_queue::broadcast_to_single_peer`) to skip delta computation
+//! and send full state directly.
+//!
+//! ## Self-healing
+//!
+//! - A successful delta apply for the contract clears the memo AND the
+//!   failure counter ([`DeltaIncompat::record_delta_success`]) — proof the
+//!   contract does take deltas.
+//! - Otherwise the memo expires after [`DELTA_INCOMPAT_TTL`]; the next delta
+//!   either works (memo stays clear) or re-arms it.
+//!
+//! ## Bounded growth
+//!
+//! Same discipline as the sibling ring maps ([`crate::ring::merge_backoff`],
+//! [`crate::ring::resync_rate_limit`]): strict size caps enforced at insert
+//! (vacant-at-capacity is skipped — an attacker churning contract ids or
+//! source ports cannot grow the maps; the failure mode is "no suppression /
+//! no attribution", never unbounded memory), plus a periodic TTL sweep hooked
+//! into the Ring reaper.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::time::Duration;
+
+use dashmap::DashMap;
+use freenet_stdlib::prelude::ContractInstanceId;
+use tokio::time::Instant;
+
+use crate::util::time_source::TimeSource;
+
+/// How long a contract stays in full-state-only mode once the memo arms.
+///
+/// Long enough to kill the resync loop's steady state (~1 cycle/min per peer
+/// in the HQk7 incident); short enough that a spuriously-armed healthy
+/// contract pays at most 10 min of full-state fan-out before deltas are
+/// retried. Matches `merge_backoff::FAILED_PAYLOAD_TTL`.
+pub(crate) const DELTA_INCOMPAT_TTL: Duration = Duration::from_secs(10 * 60);
+
+/// How long after sending a delta an incoming `ResyncRequest` from that peer
+/// is attributed to the delta failing to apply. Receivers ResyncRequest the
+/// sender immediately on a failed delta apply, so the true gap is round-trip
+/// plus queueing; 60s matches `resync_rate_limit::OUTSTANDING_RESYNC_TTL`.
+pub(crate) const DELTA_ATTRIBUTION_WINDOW: Duration = Duration::from_secs(60);
+
+/// Consecutive failure signals (no intervening successful delta apply)
+/// required to arm the memo. See module docs for the trip-at-1 rationale.
+pub(crate) const INCOMPAT_TRIP_THRESHOLD: u32 = 3;
+
+/// Hard cap on tracked contracts. At ~64 bytes/entry ≈ 0.5 MB worst case.
+pub(crate) const MAX_TRACKED_CONTRACTS: usize = 8_192;
+
+/// Hard cap on tracked `(contract, peer)` delta-send attributions.
+pub(crate) const MAX_TRACKED_DELTA_SENDS: usize = 16_384;
+
+/// Idle contract entries (no failure signal this long, memo expired) are
+/// swept. Spans the TTL so an armed entry is never dropped early.
+const CONTRACT_CLEANUP_AGE: Duration = Duration::from_secs(20 * 60);
+
+struct ContractEntry {
+    /// Consecutive failure signals since the last successful delta apply.
+    consecutive_failures: u32,
+    /// While `Some(t)` with `t > now`, deltas for this contract are
+    /// suppressed in favor of full state.
+    armed_until: Option<Instant>,
+    /// Last failure signal, for idle cleanup.
+    last_event: Instant,
+}
+
+/// Sender-side "this contract can't take deltas" memo. See module docs.
+pub(crate) struct DeltaIncompat {
+    contracts: DashMap<ContractInstanceId, ContractEntry>,
+    contracts_size: AtomicUsize,
+    /// `(contract, peer) -> when we last delivered a delta to that peer`,
+    /// consulted (and consumed) when the peer ResyncRequests the contract.
+    recent_delta_sends: DashMap<(ContractInstanceId, SocketAddr), Instant>,
+    sends_size: AtomicUsize,
+    time_source: Arc<dyn TimeSource + Send + Sync>,
+    /// Total times the memo armed (telemetry/testing).
+    armed_total: AtomicU64,
+    /// Total delta sends suppressed in favor of full state (telemetry/testing).
+    suppressed_total: AtomicU64,
+}
+
+impl DeltaIncompat {
+    pub fn new(time_source: Arc<dyn TimeSource + Send + Sync>) -> Self {
+        Self {
+            contracts: DashMap::new(),
+            contracts_size: AtomicUsize::new(0),
+            recent_delta_sends: DashMap::new(),
+            sends_size: AtomicUsize::new(0),
+            time_source,
+            armed_total: AtomicU64::new(0),
+            suppressed_total: AtomicU64::new(0),
+        }
+    }
+
+    /// Record that we delivered a DELTA broadcast for `contract` to `peer`.
+    ///
+    /// Called from the broadcast send path on a delivered delta so a
+    /// subsequent `ResyncRequest` from that peer can be attributed to the
+    /// delta failing to apply.
+    pub fn record_delta_sent(&self, contract: ContractInstanceId, peer: SocketAddr) {
+        let now = self.time_source.now();
+        match self.recent_delta_sends.entry((contract, peer)) {
+            dashmap::mapref::entry::Entry::Occupied(mut e) => {
+                *e.get_mut() = now;
+            }
+            dashmap::mapref::entry::Entry::Vacant(e) => {
+                // Strict cap: at capacity, skip. Failure mode is a missed
+                // attribution (no arming from this peer), never map growth.
+                if self.sends_size.load(Ordering::Relaxed) >= MAX_TRACKED_DELTA_SENDS {
+                    return;
+                }
+                e.insert(now);
+                self.sends_size.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
+
+    /// A `ResyncRequest` for `contract` arrived from `peer`. If we delivered
+    /// a delta to that peer within [`DELTA_ATTRIBUTION_WINDOW`], count it as
+    /// a delta-incompatibility failure signal (consuming the attribution so a
+    /// replayed/duplicate request cannot double-count). Returns `true` if the
+    /// signal was counted.
+    pub fn note_resync_request(&self, contract: ContractInstanceId, peer: SocketAddr) -> bool {
+        let now = self.time_source.now();
+        let Some((_, sent_at)) = self.recent_delta_sends.remove(&(contract, peer)) else {
+            return false;
+        };
+        self.sends_size.fetch_sub(1, Ordering::Relaxed);
+        if now.saturating_duration_since(sent_at) > DELTA_ATTRIBUTION_WINDOW {
+            // Stale attribution — not evidence about the delta we sent.
+            return false;
+        }
+        self.note_failure(contract, now);
+        true
+    }
+
+    /// Our own WASM apply of a RECEIVED delta for `contract` failed with an
+    /// `Invalid`-class contract rejection (the receiver-side form of the same
+    /// signal; see module docs).
+    pub fn note_delta_apply_failed(&self, contract: ContractInstanceId) {
+        let now = self.time_source.now();
+        self.note_failure(contract, now);
+    }
+
+    fn note_failure(&self, contract: ContractInstanceId, now: Instant) {
+        let mut armed = false;
+        match self.contracts.entry(contract) {
+            dashmap::mapref::entry::Entry::Occupied(mut e) => {
+                let entry = e.get_mut();
+                entry.consecutive_failures = entry.consecutive_failures.saturating_add(1);
+                entry.last_event = now;
+                if entry.consecutive_failures >= INCOMPAT_TRIP_THRESHOLD {
+                    let was_armed = matches!(entry.armed_until, Some(until) if until > now);
+                    entry.armed_until = Some(now + DELTA_INCOMPAT_TTL);
+                    armed = !was_armed;
+                }
+            }
+            dashmap::mapref::entry::Entry::Vacant(e) => {
+                // Strict cap: at capacity, skip (no suppression for the new
+                // contract, but no unbounded growth either).
+                if self.contracts_size.load(Ordering::Relaxed) >= MAX_TRACKED_CONTRACTS {
+                    return;
+                }
+                e.insert(ContractEntry {
+                    consecutive_failures: 1,
+                    armed_until: None,
+                    last_event: now,
+                });
+                self.contracts_size.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+        if armed {
+            self.armed_total.fetch_add(1, Ordering::Relaxed);
+            tracing::info!(
+                contract = %contract,
+                ttl_secs = DELTA_INCOMPAT_TTL.as_secs(),
+                event = "delta_incompat_armed",
+                "Contract repeatedly rejects deltas — sending full state instead for the TTL"
+            );
+        }
+    }
+
+    /// Should the broadcast path skip delta computation and send full state
+    /// for `contract`? `true` while the memo is armed and unexpired.
+    pub fn suppress_deltas(&self, contract: &ContractInstanceId) -> bool {
+        let now = self.time_source.now();
+        let suppressed = self
+            .contracts
+            .get(contract)
+            .is_some_and(|e| matches!(e.armed_until, Some(until) if until > now));
+        if suppressed {
+            self.suppressed_total.fetch_add(1, Ordering::Relaxed);
+        }
+        suppressed
+    }
+
+    /// A delta for `contract` applied cleanly — the contract demonstrably
+    /// takes deltas, so drop the memo and the failure counter.
+    pub fn record_delta_success(&self, contract: &ContractInstanceId) {
+        if self.contracts.remove(contract).is_some() {
+            self.contracts_size.fetch_sub(1, Ordering::Relaxed);
+        }
+    }
+
+    /// Periodic sweep (Ring reaper): drop stale delta-send attributions and
+    /// idle, unarmed contract entries.
+    pub fn cleanup(&self) {
+        let now = self.time_source.now();
+        let mut removed_sends = 0usize;
+        self.recent_delta_sends.retain(|_, sent_at| {
+            let keep = now.saturating_duration_since(*sent_at) <= DELTA_ATTRIBUTION_WINDOW;
+            if !keep {
+                removed_sends += 1;
+            }
+            keep
+        });
+        if removed_sends > 0 {
+            self.sends_size.fetch_sub(removed_sends, Ordering::Relaxed);
+        }
+        let mut removed_contracts = 0usize;
+        self.contracts.retain(|_, e| {
+            let armed = matches!(e.armed_until, Some(until) if until > now);
+            let keep = armed || now.saturating_duration_since(e.last_event) <= CONTRACT_CLEANUP_AGE;
+            if !keep {
+                removed_contracts += 1;
+            }
+            keep
+        });
+        if removed_contracts > 0 {
+            self.contracts_size
+                .fetch_sub(removed_contracts, Ordering::Relaxed);
+        }
+    }
+
+    /// Total times the memo armed (telemetry/testing).
+    #[allow(dead_code)]
+    pub fn armed_total(&self) -> u64 {
+        self.armed_total.load(Ordering::Relaxed)
+    }
+
+    /// Total delta sends suppressed (telemetry/testing).
+    #[allow(dead_code)]
+    pub fn suppressed_total(&self) -> u64 {
+        self.suppressed_total.load(Ordering::Relaxed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::util::time_source::SharedMockTimeSource;
+
+    fn contract(byte: u8) -> ContractInstanceId {
+        ContractInstanceId::new([byte; 32])
+    }
+
+    fn peer(port: u16) -> SocketAddr {
+        format!("127.0.0.1:{port}").parse().unwrap()
+    }
+
+    fn setup() -> (SharedMockTimeSource, DeltaIncompat) {
+        let ts = SharedMockTimeSource::new();
+        let memo = DeltaIncompat::new(Arc::new(ts.clone()));
+        (ts, memo)
+    }
+
+    /// The core Bug-2 repro: repeated resync-after-delta signals arm the
+    /// memo, after which delta sends are suppressed (full-state fallback).
+    #[test]
+    fn resync_after_delta_arms_after_threshold() {
+        let (_ts, memo) = setup();
+        let c = contract(1);
+        for i in 0..INCOMPAT_TRIP_THRESHOLD {
+            assert!(
+                !memo.suppress_deltas(&c),
+                "must not suppress before the threshold trips (i={i})"
+            );
+            memo.record_delta_sent(c, peer(4000 + i as u16));
+            assert!(
+                memo.note_resync_request(c, peer(4000 + i as u16)),
+                "attributed resync must count as a failure signal"
+            );
+        }
+        assert!(
+            memo.suppress_deltas(&c),
+            "after {INCOMPAT_TRIP_THRESHOLD} attributed resyncs the sender must \
+             fall back to full-state sends"
+        );
+        assert_eq!(memo.armed_total(), 1);
+    }
+
+    /// A ResyncRequest with no recent delta send to that peer is NOT evidence
+    /// of delta incompatibility (resyncs also fire for staleness heals).
+    #[test]
+    fn unattributed_resync_does_not_count() {
+        let (_ts, memo) = setup();
+        let c = contract(2);
+        for _ in 0..10 {
+            assert!(!memo.note_resync_request(c, peer(4100)));
+        }
+        assert!(!memo.suppress_deltas(&c));
+        assert_eq!(memo.armed_total(), 0);
+    }
+
+    /// Attribution expires after the window: a late ResyncRequest (e.g. a
+    /// periodic staleness heal long after our delta) does not count.
+    #[test]
+    fn stale_attribution_does_not_count() {
+        let (ts, memo) = setup();
+        let c = contract(3);
+        memo.record_delta_sent(c, peer(4200));
+        ts.advance_time(DELTA_ATTRIBUTION_WINDOW + Duration::from_secs(1));
+        assert!(!memo.note_resync_request(c, peer(4200)));
+        assert!(!memo.suppress_deltas(&c));
+    }
+
+    /// Receiver-side arm: local delta-apply failures count toward the same
+    /// threshold.
+    #[test]
+    fn local_delta_apply_failures_arm() {
+        let (_ts, memo) = setup();
+        let c = contract(4);
+        for _ in 0..INCOMPAT_TRIP_THRESHOLD {
+            assert!(!memo.suppress_deltas(&c));
+            memo.note_delta_apply_failed(c);
+        }
+        assert!(memo.suppress_deltas(&c));
+    }
+
+    /// Self-healing #1: a successful delta apply clears both the memo and the
+    /// failure counter — the next failure starts the count from scratch.
+    #[test]
+    fn delta_success_clears_memo_and_counter() {
+        let (_ts, memo) = setup();
+        let c = contract(5);
+        for _ in 0..INCOMPAT_TRIP_THRESHOLD {
+            memo.note_delta_apply_failed(c);
+        }
+        assert!(memo.suppress_deltas(&c));
+
+        memo.record_delta_success(&c);
+        assert!(
+            !memo.suppress_deltas(&c),
+            "a successful delta apply must clear the memo"
+        );
+
+        // Counter reset too: threshold-1 further failures must not re-arm.
+        for _ in 0..(INCOMPAT_TRIP_THRESHOLD - 1) {
+            memo.note_delta_apply_failed(c);
+        }
+        assert!(
+            !memo.suppress_deltas(&c),
+            "the failure counter must restart from zero after a success"
+        );
+    }
+
+    /// Self-healing #2: the memo expires after the TTL so deltas are retried.
+    #[test]
+    fn memo_expires_after_ttl() {
+        let (ts, memo) = setup();
+        let c = contract(6);
+        for _ in 0..INCOMPAT_TRIP_THRESHOLD {
+            memo.note_delta_apply_failed(c);
+        }
+        assert!(memo.suppress_deltas(&c));
+        ts.advance_time(DELTA_INCOMPAT_TTL + Duration::from_secs(1));
+        assert!(
+            !memo.suppress_deltas(&c),
+            "the memo must expire after DELTA_INCOMPAT_TTL"
+        );
+    }
+
+    /// A re-failure after expiry re-arms immediately (the counter is already
+    /// past the threshold — the contract is still broken).
+    #[test]
+    fn refailure_after_expiry_rearms() {
+        let (ts, memo) = setup();
+        let c = contract(7);
+        for _ in 0..INCOMPAT_TRIP_THRESHOLD {
+            memo.note_delta_apply_failed(c);
+        }
+        ts.advance_time(DELTA_INCOMPAT_TTL + Duration::from_secs(1));
+        assert!(!memo.suppress_deltas(&c));
+        memo.note_delta_apply_failed(c);
+        assert!(
+            memo.suppress_deltas(&c),
+            "a failure after expiry must re-arm without re-counting from zero"
+        );
+        assert_eq!(memo.armed_total(), 2);
+    }
+
+    /// Strict size caps: neither map grows past its ceiling under key churn.
+    #[test]
+    fn maps_are_capacity_capped() {
+        let (_ts, memo) = setup();
+        for i in 0..(MAX_TRACKED_DELTA_SENDS + 100) {
+            let mut id = [0u8; 32];
+            id[..8].copy_from_slice(&(i as u64).to_be_bytes());
+            memo.record_delta_sent(ContractInstanceId::new(id), peer(5000));
+        }
+        assert!(memo.recent_delta_sends.len() <= MAX_TRACKED_DELTA_SENDS);
+
+        for i in 0..(MAX_TRACKED_CONTRACTS + 100) {
+            let mut id = [0u8; 32];
+            id[..8].copy_from_slice(&(i as u64).to_be_bytes());
+            memo.note_delta_apply_failed(ContractInstanceId::new(id));
+        }
+        assert!(memo.contracts.len() <= MAX_TRACKED_CONTRACTS);
+    }
+
+    /// Cleanup sweeps stale attributions and idle unarmed entries but never
+    /// an armed one.
+    #[test]
+    fn cleanup_sweeps_stale_but_keeps_armed() {
+        let (ts, memo) = setup();
+        let armed = contract(8);
+        for _ in 0..INCOMPAT_TRIP_THRESHOLD {
+            memo.note_delta_apply_failed(armed);
+        }
+        let idle = contract(9);
+        memo.note_delta_apply_failed(idle);
+        memo.record_delta_sent(contract(10), peer(6000));
+
+        ts.advance_time(DELTA_ATTRIBUTION_WINDOW + Duration::from_secs(1));
+        memo.cleanup();
+        assert!(
+            memo.recent_delta_sends.is_empty(),
+            "stale delta-send attributions must be swept"
+        );
+        assert!(memo.suppress_deltas(&armed), "armed entry must survive");
+
+        ts.advance_time(CONTRACT_CLEANUP_AGE);
+        memo.cleanup();
+        assert!(
+            !memo.contracts.contains_key(&idle),
+            "idle unarmed entry must be swept"
+        );
+    }
+}


### PR DESCRIPTION
## Problem

The production storm around contract `HQk7zGRQagL9AVUMM39C3W3nRVv81xk9BCAeY9MikirK` (an early stdlib-0.1.35 web-container) exposed a sender-side gap in the resync machinery.

HQk7's `update_state` accepts only `UpdateData::State` and rejects every delta with `"Invalid update"`. On 0.2.103 the summary-diff fan-out keeps computing deltas for it, so every broadcast becomes a self-sustaining loop:

```
delta send → "Invalid update" → delta_apply_failed → ResyncRequest →
full-state ResyncResponse → state changes → next delta → repeat
```

Measured: 3,102 `delta_apply_failed` events for this one contract in a 2h window; on the nova gateway alone, 59 `delta_apply_failed`/hr and 311 `resync_request_received`/hr for HQk7. The existing defenses cannot break the cycle:

- `ring/merge_backoff.rs` is RECEIVER-side — the sender keeps computing fresh doomed deltas.
- The #4861 failed-payload memo never matches — every state change produces fresh delta bytes.
- The resync rate limiters bound the full-state amplification, not the doomed delta sends that trigger it.

## Approach

A sender-side, TTL-bounded **delta-incompatibility memo** (`crates/core/src/ring/delta_incompat.rs`), analogous in discipline to `merge_backoff` / `resync_rate_limit`:

- **Arm signals** (counted per contract, `INCOMPAT_TRIP_THRESHOLD = 3` consecutive, mirroring `merge_backoff::INVALID_TRIP_THRESHOLD`'s rationale so one benign stale rejection can't flip a healthy contract):
  1. a `ResyncRequest` arriving within `DELTA_ATTRIBUTION_WINDOW` (60s) of a delta we delivered to that peer (the wire-visible form of the peer's `delta_apply_failed`) — armed in the `ResyncRequest` arm in `node.rs`, BEFORE the rate limiters so a suppressed response still counts;
  2. our own `Invalid`-class DELTA apply failure in the BroadcastTo driver (we fan the same contract to our own downstreams).
- **Effect**: `broadcast_to_single_peer` consults the memo before `compute_delta` and sends FULL STATE directly while armed.
- **Self-healing**: a successful delta apply clears the memo + counter; otherwise it expires after `DELTA_INCOMPAT_TTL` (10 min).
- **Bounded**: strict size caps at insert (8,192 contracts / 16,384 attributions; vacant-at-capacity skipped so churned keys cannot grow the maps) + Ring-reaper sweep.

### The suspected version-gate bypass (investigated, no core fix needed)

The same storm showed HQk7's stored state flip-flopping `2180 ↔ 1952` bytes (fork oscillation), suspected to be a resync/upsert path installing full state WITHOUT re-running the contract's version gate. Investigation outcome — **there is no core-side bypass**:

- Gateway logs show the flips happen inside `upsert_contract_state_deferrable` with `changed=true` and ZERO `corrupted_state_recovery` / `initial_state_installed` events — i.e. the apply went through `attempt_state_update` → the contract's own `update_state`, exactly like a normal update.
- Extracted the actual production WASM + params + state from the gateway store (probe reconstructs the exact key `HQk7zGRQ…`, proving identity) and ran it in the real runtime: its `update_state` ACCEPTS any full state over any current state (v1-over-v2, v2-over-v2, v3-over-v2 all accepted; deltas rejected with `"Invalid update"`). This build simply predates the `version <= current` gate the later web-container has — the flip-flop is the contract accepting both forks, which core cannot second-guess (the contract's `update_state` IS the only version oracle).
- The only two paths that install full state without a WASM merge are the fresh-install branch (gated on `is_new_contract`) and the #3109 corrupted-state recovery (gated on the LOCAL state failing `validate_state`, one-shot guard). Both gates are now pinned by source-scrape tests (`full_state_version_gate_pins` in `executor_impl.rs`) so a future refactor cannot add a blind `state_store` write for the resync path.

Residual (out of scope here, flagging for design discussion): with deltas suppressed, full-state sends to a gate-less contract still "succeed" on both forks, so fork oscillation can continue at the (much lower) full-state broadcast cadence without the resync round-trips. Damping that class for merge-ACCEPTING contracts (merge_backoff only trips on failing merges) is a separate design question.

## Testing

- `ring::delta_incompat::tests` (9 behavioral tests, mock time source): arm-after-threshold via attributed resyncs, unattributed/stale resyncs don't count, receiver-side arm, clear-on-success (memo AND counter), TTL expiry, immediate re-arm after expiry, strict capacity caps, reaper sweep keeps armed entries.
- Source-scrape pins (house style): `broadcast_to_single_peer_gates_deltas_on_incompat_memo` (gate before `compute_delta`, suppression → FullState, attribution gated on `sent_delta`), `resync_request_arm_feeds_delta_incompat_memo_before_limiters` (node.rs), `broadcast_to_feeds_delta_incompat_memo` (driver arms on `is_delta && Invalid` only, clears inside the `if is_delta` success arm), `full_state_version_gate_pins::*` (executor_impl.rs).
- Full `cargo test -p freenet --lib`: 4153 passed / 0 failed. `cargo fmt --check` clean; `cargo clippy -p freenet --lib` clean (the 11 `--tests` errors are pre-existing on the 0.2.103 baseline, count unchanged).

[AI-assisted - Claude]
