### PR TITLE
feat(delegates): node-side one-shot secret copy-forward on registration with predecessors (#4117)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2161,6 +2161,8 @@ dependencies = [
 [[package]]
 name = "freenet-macros"
 version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26e5c6bee9ffa0e2683bc8b41a7bd9f1e57e7fd49ac4f6ae433e5a82e9006df"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2268,6 +2270,8 @@ dependencies = [
 [[package]]
 name = "freenet-stdlib"
 version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffa7063130085b2319850c4407b6ae76de7b5a38cdd12e36a4684ff562cd1ceb"
 dependencies = [
  "arbitrary",
  "bincode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -160,7 +160,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1590,7 +1590,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1800,7 +1800,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1866,7 +1866,7 @@ dependencies = [
  "ed25519-dalek",
  "either",
  "freenet",
- "freenet-stdlib 0.8.3",
+ "freenet-stdlib 0.8.4",
  "futures 0.3.32",
  "glob",
  "hex",
@@ -2061,7 +2061,7 @@ dependencies = [
  "flatbuffers 25.12.19",
  "flate2",
  "freenet-macros 0.1.0",
- "freenet-stdlib 0.8.3",
+ "freenet-stdlib 0.8.4",
  "freenet-test-network",
  "futures 0.3.32",
  "headers",
@@ -2161,8 +2161,6 @@ dependencies = [
 [[package]]
 name = "freenet-macros"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26e5c6bee9ffa0e2683bc8b41a7bd9f1e57e7fd49ac4f6ae433e5a82e9006df"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2179,7 +2177,7 @@ dependencies = [
  "clap",
  "freenet",
  "freenet-ping-types",
- "freenet-stdlib 0.8.3",
+ "freenet-stdlib 0.8.4",
  "freenet-test-network",
  "futures 0.3.32",
  "rand 0.9.4",
@@ -2199,7 +2197,7 @@ name = "freenet-ping-contract"
 version = "0.1.11"
 dependencies = [
  "freenet-ping-types",
- "freenet-stdlib 0.8.3",
+ "freenet-stdlib 0.8.4",
  "serde_json",
 ]
 
@@ -2209,7 +2207,7 @@ version = "0.1.11"
 dependencies = [
  "chrono",
  "clap",
- "freenet-stdlib 0.8.3",
+ "freenet-stdlib 0.8.4",
  "humantime",
  "humantime-serde",
  "serde",
@@ -2269,9 +2267,7 @@ dependencies = [
 
 [[package]]
 name = "freenet-stdlib"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ce69f7b87ca5fedb784da0194e26a3315bc23b11e346f7a8413c48abdcac73f"
+version = "0.8.4"
 dependencies = [
  "arbitrary",
  "bincode",
@@ -2333,7 +2329,7 @@ dependencies = [
  "byteorder",
  "ciborium",
  "ed25519-dalek",
- "freenet-stdlib 0.8.3",
+ "freenet-stdlib 0.8.4",
  "rand 0.9.4",
  "serde",
 ]
@@ -3503,7 +3499,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4065,7 +4061,7 @@ dependencies = [
  "once_cell",
  "png",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4197,7 +4193,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5761,7 +5757,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6265,7 +6261,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6667,7 +6663,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6704,7 +6700,7 @@ dependencies = [
 name = "test-contract-integration"
 version = "0.1.11"
 dependencies = [
- "freenet-stdlib 0.8.3",
+ "freenet-stdlib 0.8.4",
  "serde",
  "serde_json",
 ]
@@ -6714,14 +6710,14 @@ name = "test-contract-mock-aligned"
 version = "0.1.0"
 dependencies = [
  "blake3",
- "freenet-stdlib 0.8.3",
+ "freenet-stdlib 0.8.4",
 ]
 
 [[package]]
 name = "test-contract-update-nochange"
 version = "0.1.0"
 dependencies = [
- "freenet-stdlib 0.8.3",
+ "freenet-stdlib 0.8.4",
  "serde",
  "serde_json",
 ]
@@ -7420,7 +7416,7 @@ dependencies = [
  "once_cell",
  "png",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8310,7 +8306,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8736,7 +8732,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,13 +152,8 @@ muda = "0.19"
 zip = { version = "8", default-features = false, features = ["deflate", "time"] }
 
 # Freenet
-# TODO(#4117): bump target is 0.8.4, which adds
-# `DelegateRequest::RegisterDelegateWithPredecessors` (stdlib PR #86). Until
-# 0.8.4 is published to crates.io, the `[patch.crates-io]` block at the bottom
-# of this file redirects to the local stdlib worktree. Before this PR leaves
-# draft / goes to review, DELETE that patch block (the version line below is
-# already the published target). See the stdlib-first release policy in
-# .claude/rules/git-workflow.md.
+# 0.8.4 adds `DelegateRequest::RegisterDelegateWithPredecessors` (stdlib PR #86),
+# consumed by the #4117 delegate secret copy-forward.
 freenet-stdlib = "0.8.4"
 
 # Crypto (secrets-at-rest KEK + DEK derivation, see crates/core/src/config/kek.rs).
@@ -200,14 +195,3 @@ opt-level = 3
 # lto = true
 # codegen-units = 1
 # panic = "abort"
-
-# TEMPORARY (#4117) — DELETE BEFORE REVIEW/MERGE.
-# Redirects freenet-stdlib to the local worktree carrying
-# `DelegateRequest::RegisterDelegateWithPredecessors` until stdlib 0.8.4 is
-# published to crates.io (stdlib PR #86, branch feat/register-delegate-with-predecessors).
-# The version line above (`freenet-stdlib = "0.8.4"`) is already the published
-# target, so the flip-to-published step is simply removing this block. Per
-# .claude/rules/git-workflow.md this MUST NOT reach review — CI cannot resolve a
-# path dep on a fresh checkout.
-[patch.crates-io]
-freenet-stdlib = { path = "/home/ian/code/freenet/freenet-stdlib-reg-predecessors/rust" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,14 @@ muda = "0.19"
 zip = { version = "8", default-features = false, features = ["deflate", "time"] }
 
 # Freenet
-freenet-stdlib = "0.8.2"
+# TODO(#4117): bump target is 0.8.4, which adds
+# `DelegateRequest::RegisterDelegateWithPredecessors` (stdlib PR #86). Until
+# 0.8.4 is published to crates.io, the `[patch.crates-io]` block at the bottom
+# of this file redirects to the local stdlib worktree. Before this PR leaves
+# draft / goes to review, DELETE that patch block (the version line below is
+# already the published target). See the stdlib-first release policy in
+# .claude/rules/git-workflow.md.
+freenet-stdlib = "0.8.4"
 
 # Crypto (secrets-at-rest KEK + DEK derivation, see crates/core/src/config/kek.rs).
 # `sha2` is already declared above (workspace-wide); only `hkdf` and `keyring`
@@ -193,3 +200,14 @@ opt-level = 3
 # lto = true
 # codegen-units = 1
 # panic = "abort"
+
+# TEMPORARY (#4117) — DELETE BEFORE REVIEW/MERGE.
+# Redirects freenet-stdlib to the local worktree carrying
+# `DelegateRequest::RegisterDelegateWithPredecessors` until stdlib 0.8.4 is
+# published to crates.io (stdlib PR #86, branch feat/register-delegate-with-predecessors).
+# The version line above (`freenet-stdlib = "0.8.4"`) is already the published
+# target, so the flip-to-published step is simply removing this block. Per
+# .claude/rules/git-workflow.md this MUST NOT reach review — CI cannot resolve a
+# path dep on a fresh checkout.
+[patch.crates-io]
+freenet-stdlib = { path = "/home/ian/code/freenet/freenet-stdlib-reg-predecessors/rust" }

--- a/apps/freenet-ping/app/tests/run_delegate_secret_copy_forward_e2e.rs
+++ b/apps/freenet-ping/app/tests/run_delegate_secret_copy_forward_e2e.rs
@@ -100,24 +100,39 @@ async fn delegate_app_msg(
     }
 }
 
-/// E2E test for the delegate secret copy-forward feature (#4117).
+/// E2E test for the delegate secret copy-forward feature's H1 same-origin gate
+/// (#4117), exercised end-to-end over token-less raw WebSocket connections.
 ///
 /// A delegate's on-disk key is BLAKE3(code_hash || params), so any WASM
 /// rebuild (or, as here, a param change simulating one) mints a new key and
 /// a new, empty secret namespace. `DelegateRequest::RegisterDelegateWithPredecessors`
 /// carries Local-scope secrets forward from a list of predecessor keys into
-/// the newly-registered successor's namespace so `get_secret` still resolves
-/// under the new key.
+/// the newly-registered successor's namespace so `get_secret` can resolve
+/// under the new key — but ONLY when the registering request's web-app origin
+/// equals the predecessor's FIRST-registration origin (the H1 same-origin
+/// gate; see `SecretsStore::migrate_secrets`). A raw WS connection like the
+/// one this test harness opens carries no web-app origin attestation, so both
+/// registrations below run with `origin_contract = None`; `None` is NEVER
+/// privileged by the gate (not even against a predecessor with no recorded
+/// origin), so the copy-forward is REFUSED.
 ///
 /// This test registers a "predecessor" delegate (test-delegate-2), stores a
 /// Local-scope secret in it via `set_secret` (exercised through the
 /// `StoreSecret` app message), then registers a "successor" delegate — same
 /// WASM, different params, so a DIFFERENT `DelegateKey` — via
-/// `RegisterDelegateWithPredecessors` naming the predecessor. It asserts the
-/// successor can read the migrated secret under the SAME `SecretsId`, and
-/// that the predecessor's own copy is untouched (no-delete invariant).
+/// `RegisterDelegateWithPredecessors` naming the predecessor. It asserts that
+/// registration itself still succeeds (the gate never fails registration,
+/// only the copy), that the successor genuinely has NO migrated secret (the
+/// refusal took effect), and that the predecessor's own copy is untouched
+/// (no-delete invariant, independent of the gate outcome). The
+/// successful-copy path — where the registering origin matches the
+/// predecessor's recorded origin — is covered end-to-end by the store-level
+/// `migrate_secrets` tests and the handler-level
+/// `register_delegate_with_predecessors_copies_secrets_forward` test in
+/// `crates/core/src`, both of which can inject an origin directly; this raw-WS
+/// harness has no way to attach a web-app origin to a connection.
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-async fn test_delegate_secret_copy_forward_e2e() -> anyhow::Result<()> {
+async fn test_delegate_secret_copy_forward_e2e_refuses_token_less_origin() -> anyhow::Result<()> {
     // Same WASM, different params => different DelegateKeys
     // (DelegateKey = BLAKE3(code_hash || params)), simulating a WASM rebuild
     // that mints a new successor key while keeping the same delegate logic.
@@ -273,9 +288,14 @@ async fn test_delegate_secret_copy_forward_e2e() -> anyhow::Result<()> {
             }
         }
 
-        // Step 5: The successor must resolve the SAME SecretsId — the
-        // predecessor's secret was copied forward into the successor's
-        // namespace, re-encrypted under the successor's Local DEK.
+        // Step 5: The successor must NOT resolve the migrated SecretsId. Both
+        // registrations above ran over a token-less connection
+        // (`origin_contract = None`), and the H1 same-origin gate never
+        // privileges `None` — so `migrate_secrets` refused the copy
+        // (`origin_refused`, and `no_provenance` too since this predecessor was
+        // never given a recorded origin). Registration itself still succeeded
+        // (Step 4), demonstrating the gate never fails registration, only the
+        // copy.
         match delegate_app_msg(
             &mut client,
             &succ_key,
@@ -284,16 +304,18 @@ async fn test_delegate_secret_copy_forward_e2e() -> anyhow::Result<()> {
         )
         .await?
         {
-            OutboundAppMessage::SecretResult(Some(value)) => {
-                assert_eq!(
-                    value, SECRET_VALUE,
-                    "successor must read the migrated secret carried forward from the predecessor"
-                );
-                tracing::info!("Successor read the migrated secret — copy-forward verified!");
-            }
             OutboundAppMessage::SecretResult(None) => {
+                tracing::info!(
+                    "Successor correctly has NO migrated secret — the H1 same-origin gate \
+                     refused the token-less (None-origin) copy-forward, as expected"
+                );
+            }
+            OutboundAppMessage::SecretResult(Some(value)) => {
                 return Err(anyhow!(
-                    "successor has no secret under the migrated SecretsId — copy-forward did not run"
+                    "successor unexpectedly read a migrated secret ({} bytes) via a \
+                     token-less registration — the H1 same-origin gate should have refused \
+                     this copy (None is never privileged)",
+                    value.len()
                 ));
             }
             other => return Err(anyhow!("Expected SecretResult, got: {other:?}")),
@@ -324,7 +346,10 @@ async fn test_delegate_secret_copy_forward_e2e() -> anyhow::Result<()> {
             }
         }
 
-        tracing::info!("Delegate secret copy-forward E2E checks passed!");
+        tracing::info!(
+            "Delegate secret copy-forward E2E checks passed: token-less registration \
+             succeeded, and the H1 same-origin gate correctly refused the copy!"
+        );
         Ok::<_, anyhow::Error>(())
     });
 

--- a/apps/freenet-ping/app/tests/run_delegate_secret_copy_forward_e2e.rs
+++ b/apps/freenet-ping/app/tests/run_delegate_secret_copy_forward_e2e.rs
@@ -1,0 +1,342 @@
+mod common;
+
+use std::{net::TcpListener, time::Duration};
+
+use anyhow::anyhow;
+use freenet::server::serve_client_api;
+use freenet_stdlib::{
+    client_api::{ClientRequest, DelegateRequest, HostResponse},
+    prelude::*,
+};
+use futures::FutureExt;
+use rand::SeedableRng;
+use serde::{Deserialize, Serialize};
+use tokio::select;
+
+use common::{
+    TEST_DELEGATE_CIPHER, TEST_DELEGATE_NONCE, allocate_test_node_block,
+    base_node_test_config_with_rng, connect_ws_with_retry, test_ip_for_node, test_node_config,
+};
+
+/// Message types matching `test-delegate-2`'s `InboundAppMessage`
+/// (tests/test-delegate-2/src/lib.rs). Variant ORDER must match the compiled
+/// delegate's enum exactly, since bincode discriminants are index-based —
+/// mirrors the same mirror-enum pattern used by
+/// crates/core/tests/hosted_mode_migrate.rs. Only `StoreSecret` and
+/// `GetNonExistentSecret` are exercised by this test; the rest are kept to
+/// preserve variant ordering.
+#[allow(dead_code)]
+#[derive(Debug, Serialize, Deserialize)]
+enum InboundAppMessage {
+    CreateInboxRequest,
+    PleaseSignMessage(Vec<u8>),
+    WriteContext(Vec<u8>),
+    ReadContext,
+    ClearContext,
+    IncrementCounter,
+    HasSecret(Vec<u8>),
+    GetNonExistentSecret(Vec<u8>),
+    StoreSecret { key: Vec<u8>, value: Vec<u8> },
+    RemoveSecret(Vec<u8>),
+    WriteLargeContext(usize),
+    StoreLargeSecret { key: Vec<u8>, size: usize },
+}
+
+/// Message types matching `test-delegate-2`'s `OutboundAppMessage`.
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+enum OutboundAppMessage {
+    CreateInboxResponse(Vec<u8>),
+    MessageSigned(Vec<u8>),
+    ContextData(Vec<u8>),
+    CounterValue(u32),
+    SecretExists(bool),
+    SecretResult(Option<Vec<u8>>),
+    ContextWritten,
+    ContextCleared,
+    SecretStored,
+    SecretRemoved,
+    LargeContextWritten(usize),
+    LargeSecretStored(usize),
+    SecretStoreFailed,
+}
+
+/// Sends `msg` as an `ApplicationMessages` request to `key`/`params` and
+/// decodes the single `OutboundAppMessage` reply.
+async fn delegate_app_msg(
+    client: &mut freenet_stdlib::client_api::WebApi,
+    key: &DelegateKey,
+    params: &Parameters<'static>,
+    msg: &InboundAppMessage,
+) -> anyhow::Result<OutboundAppMessage> {
+    let payload = bincode::serialize(msg)?;
+    let app_msg = ApplicationMessage::new(payload);
+
+    client
+        .send(ClientRequest::DelegateOp(
+            DelegateRequest::ApplicationMessages {
+                key: key.clone(),
+                params: params.clone(),
+                inbound: vec![InboundDelegateMsg::ApplicationMessage(app_msg)],
+            },
+        ))
+        .await?;
+
+    let resp = tokio::time::timeout(Duration::from_secs(30), client.recv()).await??;
+    match resp {
+        HostResponse::DelegateResponse { values, .. } => {
+            let app_msg = values
+                .iter()
+                .find_map(|m| match m {
+                    OutboundDelegateMsg::ApplicationMessage(msg) => Some(msg),
+                    _ => None,
+                })
+                .ok_or_else(|| anyhow!("expected an ApplicationMessage in the response"))?;
+            Ok(bincode::deserialize::<OutboundAppMessage>(
+                &app_msg.payload,
+            )?)
+        }
+        other => Err(anyhow!("expected DelegateResponse, got: {other:?}")),
+    }
+}
+
+/// E2E test for the delegate secret copy-forward feature (#4117).
+///
+/// A delegate's on-disk key is BLAKE3(code_hash || params), so any WASM
+/// rebuild (or, as here, a param change simulating one) mints a new key and
+/// a new, empty secret namespace. `DelegateRequest::RegisterDelegateWithPredecessors`
+/// carries Local-scope secrets forward from a list of predecessor keys into
+/// the newly-registered successor's namespace so `get_secret` still resolves
+/// under the new key.
+///
+/// This test registers a "predecessor" delegate (test-delegate-2), stores a
+/// Local-scope secret in it via `set_secret` (exercised through the
+/// `StoreSecret` app message), then registers a "successor" delegate — same
+/// WASM, different params, so a DIFFERENT `DelegateKey` — via
+/// `RegisterDelegateWithPredecessors` naming the predecessor. It asserts the
+/// successor can read the migrated secret under the SAME `SecretsId`, and
+/// that the predecessor's own copy is untouched (no-delete invariant).
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn test_delegate_secret_copy_forward_e2e() -> anyhow::Result<()> {
+    // Same WASM, different params => different DelegateKeys
+    // (DelegateKey = BLAKE3(code_hash || params)), simulating a WASM rebuild
+    // that mints a new successor key while keeping the same delegate logic.
+    let pred_params = Parameters::from(vec![1u8]);
+    let pred_delegate = freenet::test_utils::load_delegate("test-delegate-2", pred_params.clone())?;
+    let pred_key = pred_delegate.key().clone();
+
+    let succ_params = Parameters::from(vec![2u8]);
+    let succ_delegate = freenet::test_utils::load_delegate("test-delegate-2", succ_params.clone())?;
+    let succ_key = succ_delegate.key().clone();
+
+    assert_ne!(
+        pred_key, succ_key,
+        "predecessor and successor must have different DelegateKeys"
+    );
+
+    const SECRET_KEY: &[u8] = b"delegate-secret-copy-forward-e2e";
+    const SECRET_VALUE: &[u8] = b"secret-value-carried-across-rebuild";
+
+    // Allocate unique IP for this test's gateway
+    let base_node_idx = allocate_test_node_block(1);
+    let gw_ip = test_ip_for_node(base_node_idx);
+
+    // Reserve ports
+    let network_socket_gw = TcpListener::bind(std::net::SocketAddr::new(gw_ip.into(), 0))?;
+    let ws_api_port_socket_gw = TcpListener::bind(std::net::SocketAddr::new(gw_ip.into(), 0))?;
+
+    let test_seed = *b"secret_copy_forward_e2e_testseed";
+    let mut test_rng = rand::rngs::StdRng::from_seed(test_seed);
+
+    let (config_gw, _preset_cfg_gw) = base_node_test_config_with_rng(
+        true,
+        vec![],
+        Some(network_socket_gw.local_addr()?.port()),
+        ws_api_port_socket_gw.local_addr()?.port(),
+        "gw_delegate_secret_copy_forward",
+        None,
+        None,
+        Some(gw_ip),
+        &mut test_rng,
+    )
+    .await?;
+    let ws_api_port_gw = config_gw.ws_api.ws_api_port.unwrap();
+
+    std::mem::drop(network_socket_gw);
+    std::mem::drop(ws_api_port_socket_gw);
+
+    let gateway_node = async {
+        let config = config_gw.build().await?;
+        let node = test_node_config(config.clone())
+            .await?
+            .build(serve_client_api(config.ws_api).await?)
+            .await?;
+        node.run().await
+    }
+    .boxed_local();
+
+    let test = tokio::time::timeout(Duration::from_secs(120), async {
+        let uri_gw =
+            format!("ws://{gw_ip}:{ws_api_port_gw}/v1/contract/command?encodingProtocol=native");
+        let mut client = connect_ws_with_retry(&uri_gw, "Gateway", 60).await?;
+
+        // Step 1: Register the predecessor delegate.
+        client
+            .send(ClientRequest::DelegateOp(
+                DelegateRequest::RegisterDelegate {
+                    delegate: pred_delegate.clone(),
+                    cipher: TEST_DELEGATE_CIPHER,
+                    nonce: TEST_DELEGATE_NONCE,
+                },
+            ))
+            .await?;
+        let resp = tokio::time::timeout(Duration::from_secs(30), client.recv()).await??;
+        match resp {
+            HostResponse::DelegateResponse { key, .. } => {
+                assert_eq!(
+                    key, pred_key,
+                    "Key mismatch registering predecessor delegate"
+                );
+                tracing::info!("Registered predecessor delegate: {key}");
+            }
+            other => {
+                return Err(anyhow!(
+                    "Expected DelegateResponse for predecessor registration, got: {other:?}"
+                ));
+            }
+        }
+
+        // Step 2: Store a Local-scope secret in the predecessor (no user
+        // token on this connection, so `set_secret` lands in `SecretScope::Local`
+        // — the only scope the node-side copy-forward can re-encrypt, since
+        // its DEK is derivable at rest from the delegate key + node KEK).
+        match delegate_app_msg(
+            &mut client,
+            &pred_key,
+            &pred_params,
+            &InboundAppMessage::StoreSecret {
+                key: SECRET_KEY.to_vec(),
+                value: SECRET_VALUE.to_vec(),
+            },
+        )
+        .await?
+        {
+            OutboundAppMessage::SecretStored => {
+                tracing::info!("Predecessor stored the Local-scope secret");
+            }
+            other => return Err(anyhow!("Expected SecretStored, got: {other:?}")),
+        }
+
+        // Step 3: Read the secret back from the predecessor to confirm it's
+        // actually stored before we exercise the migration.
+        match delegate_app_msg(
+            &mut client,
+            &pred_key,
+            &pred_params,
+            &InboundAppMessage::GetNonExistentSecret(SECRET_KEY.to_vec()),
+        )
+        .await?
+        {
+            OutboundAppMessage::SecretResult(Some(value)) => {
+                assert_eq!(
+                    value, SECRET_VALUE,
+                    "predecessor secret must read back as stored"
+                );
+                tracing::info!("Predecessor secret verified before migration");
+            }
+            other => return Err(anyhow!("Expected SecretResult(Some(..)), got: {other:?}")),
+        }
+
+        // Step 4: Register the successor delegate (different DelegateKey),
+        // naming the predecessor so the node runs the one-shot secret
+        // copy-forward as part of registration.
+        client
+            .send(ClientRequest::DelegateOp(
+                DelegateRequest::RegisterDelegateWithPredecessors {
+                    delegate: succ_delegate.clone(),
+                    cipher: TEST_DELEGATE_CIPHER,
+                    nonce: TEST_DELEGATE_NONCE,
+                    predecessors: vec![pred_key.clone()],
+                },
+            ))
+            .await?;
+        let resp = tokio::time::timeout(Duration::from_secs(30), client.recv()).await??;
+        match resp {
+            HostResponse::DelegateResponse { key, .. } => {
+                assert_eq!(key, succ_key, "Key mismatch registering successor delegate");
+                tracing::info!("Registered successor delegate with predecessors: {key}");
+            }
+            other => {
+                return Err(anyhow!(
+                    "Expected DelegateResponse for successor registration, got: {other:?}"
+                ));
+            }
+        }
+
+        // Step 5: The successor must resolve the SAME SecretsId — the
+        // predecessor's secret was copied forward into the successor's
+        // namespace, re-encrypted under the successor's Local DEK.
+        match delegate_app_msg(
+            &mut client,
+            &succ_key,
+            &succ_params,
+            &InboundAppMessage::GetNonExistentSecret(SECRET_KEY.to_vec()),
+        )
+        .await?
+        {
+            OutboundAppMessage::SecretResult(Some(value)) => {
+                assert_eq!(
+                    value, SECRET_VALUE,
+                    "successor must read the migrated secret carried forward from the predecessor"
+                );
+                tracing::info!("Successor read the migrated secret — copy-forward verified!");
+            }
+            OutboundAppMessage::SecretResult(None) => {
+                return Err(anyhow!(
+                    "successor has no secret under the migrated SecretsId — copy-forward did not run"
+                ));
+            }
+            other => return Err(anyhow!("Expected SecretResult, got: {other:?}")),
+        }
+
+        // Step 6: No-delete invariant — the predecessor's own copy must still
+        // be readable; copy-forward only ever reads the predecessor, never
+        // mutates or deletes it.
+        match delegate_app_msg(
+            &mut client,
+            &pred_key,
+            &pred_params,
+            &InboundAppMessage::GetNonExistentSecret(SECRET_KEY.to_vec()),
+        )
+        .await?
+        {
+            OutboundAppMessage::SecretResult(Some(value)) => {
+                assert_eq!(
+                    value, SECRET_VALUE,
+                    "predecessor secret must remain intact after copy-forward (no-delete invariant)"
+                );
+                tracing::info!("Predecessor secret confirmed intact after copy-forward");
+            }
+            other => {
+                return Err(anyhow!(
+                    "Expected predecessor SecretResult(Some(..)) to remain after copy-forward, got: {other:?}"
+                ));
+            }
+        }
+
+        tracing::info!("Delegate secret copy-forward E2E checks passed!");
+        Ok::<_, anyhow::Error>(())
+    });
+
+    select! {
+        gw = gateway_node => {
+            let Err(gw) = gw;
+            anyhow::bail!("Gateway node failed: {}", gw);
+        }
+        r = test => {
+            r??;
+        }
+    }
+
+    Ok(())
+}

--- a/crates/core/src/client_events.rs
+++ b/crates/core/src/client_events.rs
@@ -1535,14 +1535,24 @@ async fn process_open_request(
                     freenet_stdlib::client_api::DelegateRequest::UnregisterDelegate(key) => {
                         crate::contract::delegate_app_registry::remove_delegate(key);
                     }
-                    // RegisterDelegate installs a delegate binary (admin op), not
-                    // an app conversation, so it registers no routing path. The
-                    // wildcard also absorbs future `#[non_exhaustive]` variants;
-                    // it exists ONLY to satisfy non_exhaustive (see
-                    // git-workflow.md) — new app-facing variants must be handled
-                    // explicitly above, not swept here.
+                    // RegisterDelegate and RegisterDelegateWithPredecessors both
+                    // INSTALL a delegate binary (admin ops), not an app
+                    // conversation, so neither registers a routing path — the
+                    // path is established by an ApplicationMessages request that
+                    // carries a notification channel (above), never by
+                    // registration. RegisterDelegateWithPredecessors additionally
+                    // triggers the node-side secret copy-forward (#4117), which
+                    // is likewise not an app-routing event. Both are listed
+                    // EXPLICITLY (not swept) per this match's contract that
+                    // app-facing variants must be handled above the wildcard; the
+                    // wildcard remains ONLY to satisfy `#[non_exhaustive]` for
+                    // genuinely future variants (see git-workflow.md).
                     #[allow(clippy::wildcard_enum_match_arm)]
-                    freenet_stdlib::client_api::DelegateRequest::RegisterDelegate { .. } | _ => {}
+                    freenet_stdlib::client_api::DelegateRequest::RegisterDelegate { .. }
+                    | freenet_stdlib::client_api::DelegateRequest::RegisterDelegateWithPredecessors {
+                        ..
+                    }
+                    | _ => {}
                 }
 
                 // Derive a short discriminant tag for the INFO logs, but only when INFO is

--- a/crates/core/src/client_events.rs
+++ b/crates/core/src/client_events.rs
@@ -1594,6 +1594,9 @@ async fn process_open_request(
                         freenet_stdlib::client_api::DelegateRequest::RegisterDelegate {
                             ..
                         } => "RegisterDelegate".to_string(),
+                        freenet_stdlib::client_api::DelegateRequest::RegisterDelegateWithPredecessors {
+                            ..
+                        } => "RegisterDelegateWithPredecessors".to_string(),
                         freenet_stdlib::client_api::DelegateRequest::UnregisterDelegate(_) => {
                             "UnregisterDelegate".to_string()
                         }

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -520,12 +520,18 @@ where
     CH: ContractHandler + Send + 'static,
     P: UserInputPrompter,
 {
-    // Extract initial params from the request (only ApplicationMessages has params we need)
+    // Extract initial params from the request (only ApplicationMessages has params we need).
+    // The registration variants (including RegisterDelegateWithPredecessors,
+    // #4117) carry no params relevant here — registration's empty response exits
+    // the loop before params are read — but the new variant is listed EXPLICITLY
+    // for local consistency with this match's style; the wildcard remains only to
+    // satisfy `#[non_exhaustive]`.
     let initial_params = match &initial_req {
         DelegateRequest::ApplicationMessages { params, .. } => params.clone(),
-        DelegateRequest::RegisterDelegate { .. } | DelegateRequest::UnregisterDelegate(_) | _ => {
-            Parameters::from(Vec::new())
-        }
+        DelegateRequest::RegisterDelegate { .. }
+        | DelegateRequest::RegisterDelegateWithPredecessors { .. }
+        | DelegateRequest::UnregisterDelegate(_)
+        | _ => Parameters::from(Vec::new()),
     };
 
     let mut current_req = initial_req;

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -1897,6 +1897,69 @@ mod remove_contract_tests {
             !reg_path(&succ_raw).exists(),
             "a rejected raw-oversize request must register NOTHING"
         );
+
+        // (4) EXACTLY 64 UNIQUE predecessors (the at-cap boundary) → ACCEPTED.
+        let succ_at_cap = Delegate::from((&vec![0u8].into(), &vec![0xD4u8].into()));
+        let at_cap: Vec<_> = (0u8..64).map(make_pred).collect(); // 64 distinct
+        assert_eq!(at_cap.len(), MAX_MIGRATION_PREDECESSORS);
+        let req_at_cap = DelegateRequest::RegisterDelegateWithPredecessors {
+            delegate: DelegateContainer::Wasm(DelegateWasmAPIVersion::V1(succ_at_cap.clone())),
+            cipher: [7u8; 32],
+            nonce: [9u8; 24],
+            predecessors: at_cap,
+        };
+        executor
+            .delegate_request(req_at_cap, None, None, None)
+            .expect("an exactly-at-cap UNIQUE count (64) must be accepted");
+        assert!(
+            reg_path(&succ_at_cap).exists(),
+            "the at-cap boundary (64 unique) must register the successor"
+        );
+
+        // (5) EMPTY predecessor list → ACCEPTED, behaving like a plain
+        //     RegisterDelegate (successor registered, nothing to copy). Pins the
+        //     intended zero-predecessor semantics (the code does NOT reject empty).
+        let succ_empty = Delegate::from((&vec![0u8].into(), &vec![0xE5u8].into()));
+        let req_empty = DelegateRequest::RegisterDelegateWithPredecessors {
+            delegate: DelegateContainer::Wasm(DelegateWasmAPIVersion::V1(succ_empty.clone())),
+            cipher: [7u8; 32],
+            nonce: [9u8; 24],
+            predecessors: Vec::new(),
+        };
+        executor
+            .delegate_request(req_empty, None, None, None)
+            .expect("an empty predecessor list must be accepted (plain-register equivalent)");
+        assert!(
+            reg_path(&succ_empty).exists(),
+            "an empty-predecessor request must register the successor"
+        );
+
+        // (6) A raw list at EXACTLY the sanity bound (1024) with a within-cap
+        //     UNIQUE count (64) → ACCEPTED (the raw-bound boundary: only > the
+        //     bound is rejected).
+        let succ_raw_boundary = Delegate::from((&vec![0u8].into(), &vec![0xF6u8].into()));
+        let mut raw_at_bound: Vec<_> = Vec::new();
+        for _ in 0..(MAX_MIGRATION_PREDECESSORS_RAW / MAX_MIGRATION_PREDECESSORS) {
+            for i in 0..MAX_MIGRATION_PREDECESSORS as u8 {
+                raw_at_bound.push(make_pred(i));
+            }
+        } // 16 * 64 = 1024 raw, 64 unique
+        assert_eq!(raw_at_bound.len(), MAX_MIGRATION_PREDECESSORS_RAW);
+        let req_raw_boundary = DelegateRequest::RegisterDelegateWithPredecessors {
+            delegate: DelegateContainer::Wasm(DelegateWasmAPIVersion::V1(
+                succ_raw_boundary.clone(),
+            )),
+            cipher: [7u8; 32],
+            nonce: [9u8; 24],
+            predecessors: raw_at_bound,
+        };
+        executor
+            .delegate_request(req_raw_boundary, None, None, None)
+            .expect("a raw list at exactly the sanity bound (unique within cap) must be accepted");
+        assert!(
+            reg_path(&succ_raw_boundary).exists(),
+            "the raw-bound boundary (raw == 1024, 64 unique) must register the successor"
+        );
     }
 
     /// Core regression test: storing a contract makes its state retrievable

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -1551,7 +1551,9 @@ mod remove_contract_tests {
         // Record the predecessor's FIRST-registration origin (H1 same-origin
         // gate): the migrating registration below must present this SAME origin
         // for the copy to be allowed.
-        secrets_store.record_delegate_registration_origin(pred.key(), Some(ORIGIN));
+        secrets_store
+            .record_delegate_registration_origin(pred.key(), Some(ORIGIN))
+            .unwrap();
 
         let successor_secret_path = secrets_dir
             .join(succ.key().encode())
@@ -1615,6 +1617,187 @@ mod remove_contract_tests {
         assert!(
             !successor_secret_path.exists(),
             "one-shot marker must prevent resurrection on re-registration"
+        );
+    }
+
+    /// Handler-level (#4117 H1, persistence-succeeds-before-usable): if the
+    /// first-writer origin record cannot be DURABLY persisted, the WHOLE
+    /// registration is aborted — for BOTH the plain `RegisterDelegate` and the
+    /// `RegisterDelegateWithPredecessors` variants. The delegate is NOT
+    /// registered (no `.reg` file) and no predecessor secret is copied, so a
+    /// registered-but-recordless delegate (a claimable first-writer slot an
+    /// attacker could later name as its own) can never exist. Once the disk
+    /// recovers, the app's retry registers, records, and copies normally. Uses
+    /// the fault-injecting redb backend to fail the origin-record write on demand.
+    #[cfg(feature = "redb")]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn register_aborts_when_origin_record_fails_then_recovers() {
+        use crate::contract::storages::redb::{FailingBackend, open_redb_with_backend};
+        use crate::wasm_runtime::SecretScope;
+        use freenet_stdlib::client_api::DelegateRequest;
+        use freenet_stdlib::prelude::{
+            ContractInstanceId, Delegate, DelegateContainer, DelegateWasmAPIVersion, SecretsId,
+        };
+        use zeroize::Zeroizing;
+
+        const ORIGIN: [u8; 32] = [0x11u8; 32];
+
+        let temp_dir = crate::util::tests::get_temp_dir();
+        let delegate_dir = temp_dir.path().join("delegate");
+        let secrets_dir = temp_dir.path().join("secrets");
+
+        // A secrets-store DB whose backend I/O can be flipped to fail on demand.
+        let backend = FailingBackend::new();
+        let db = open_redb_with_backend(backend.clone());
+
+        let contract_store =
+            ContractStore::new(temp_dir.path().join("contracts"), 10_000, db.clone())
+                .expect("create contract store");
+        let delegate_store = DelegateStore::new(delegate_dir.clone(), 10_000, db.clone())
+            .expect("create delegate store");
+        let mut secrets_store =
+            SecretsStore::new(secrets_dir.clone(), Default::default(), db.clone())
+                .expect("create secrets store");
+
+        let pred = Delegate::from((&vec![0u8].into(), &vec![1u8].into()));
+        let succ = Delegate::from((&vec![0u8].into(), &vec![2u8].into()));
+
+        // Seed a predecessor Local secret + its first-registration origin WHILE the
+        // backend is healthy (both must exist for the copy to be allowed later).
+        let secret_id = SecretsId::new(b"room:alice".to_vec());
+        secrets_store
+            .store_secret(
+                pred.key(),
+                &secret_id,
+                SecretScope::Local,
+                Zeroizing::new(b"profile".to_vec()),
+            )
+            .expect("seed predecessor secret");
+        secrets_store
+            .record_delegate_registration_origin(pred.key(), Some(ORIGIN))
+            .expect("record predecessor origin");
+
+        let state_store = StateStore::new(db.clone(), 10_000_000).expect("create state store");
+        let runtime = Runtime::build(contract_store, delegate_store, secrets_store, false)
+            .expect("build runtime");
+        let mut executor = Executor::new(
+            state_store,
+            || Ok(()),
+            crate::contract::executor::OperationMode::Local,
+            runtime,
+            None,
+        )
+        .await
+        .expect("create executor");
+
+        let origin_contract = ContractInstanceId::new(ORIGIN);
+        let succ_reg_path = delegate_dir.join(succ.key().encode()).with_extension("reg");
+        let succ_secret_path = secrets_dir
+            .join(succ.key().encode())
+            .join(secret_id.encode());
+        let pred_secret_path = secrets_dir
+            .join(pred.key().encode())
+            .join(secret_id.encode());
+
+        // ---- The disk now fails: the successor's origin-record write cannot persist.
+        backend.start_failing();
+
+        // (a) RegisterDelegateWithPredecessors MUST abort: no register, no copy.
+        let req = DelegateRequest::RegisterDelegateWithPredecessors {
+            delegate: DelegateContainer::Wasm(DelegateWasmAPIVersion::V1(succ.clone())),
+            cipher: [7u8; 32],
+            nonce: [9u8; 24],
+            predecessors: vec![pred.key().clone()],
+        };
+        assert!(
+            executor
+                .delegate_request(req, Some(&origin_contract), None, None)
+                .is_err(),
+            "registration must FAIL when the first-writer origin record cannot persist"
+        );
+        assert!(
+            !succ_reg_path.exists(),
+            "an aborted registration must register NOTHING (no .reg file on disk)"
+        );
+        assert!(
+            !succ_secret_path.exists(),
+            "an aborted registration must copy NOTHING"
+        );
+
+        // (b) Plain RegisterDelegate MUST abort under the SAME failure (both variants).
+        let plain = Delegate::from((&vec![0u8].into(), &vec![3u8].into()));
+        let plain_reg_path = delegate_dir
+            .join(plain.key().encode())
+            .with_extension("reg");
+        let req_plain = DelegateRequest::RegisterDelegate {
+            delegate: DelegateContainer::Wasm(DelegateWasmAPIVersion::V1(plain.clone())),
+            cipher: [7u8; 32],
+            nonce: [9u8; 24],
+        };
+        assert!(
+            executor
+                .delegate_request(req_plain, Some(&origin_contract), None, None)
+                .is_err(),
+            "plain RegisterDelegate must ALSO fail when the origin record cannot persist"
+        );
+        assert!(
+            !plain_reg_path.exists(),
+            "an aborted RegisterDelegate must register NOTHING"
+        );
+
+        // The predecessor's own secret is untouched throughout.
+        assert!(
+            pred_secret_path.exists(),
+            "the predecessor's own secret must survive the failed migrating registrations"
+        );
+
+        // ---- Recovery: the disk heals (a fresh handle over a healthy backend);
+        // the app retries and the registration now completes end-to-end.
+        drop(executor); // release the poisoned db handle
+        let db2 = open_redb_with_backend(FailingBackend::new()); // healthy
+        let contract_store2 =
+            ContractStore::new(temp_dir.path().join("contracts"), 10_000, db2.clone())
+                .expect("create contract store 2");
+        let delegate_store2 = DelegateStore::new(delegate_dir.clone(), 10_000, db2.clone())
+            .expect("create delegate store 2");
+        let secrets_store2 =
+            SecretsStore::new(secrets_dir.clone(), Default::default(), db2.clone())
+                .expect("create secrets store 2");
+        // The origin table lived in the failed DB; on a real node it persists
+        // across the restart, but here the fresh handle starts empty, so
+        // re-establish the predecessor's origin as the app's retry would.
+        secrets_store2
+            .record_delegate_registration_origin(pred.key(), Some(ORIGIN))
+            .expect("re-record predecessor origin after recovery");
+        let state_store2 = StateStore::new(db2, 10_000_000).expect("create state store 2");
+        let runtime2 = Runtime::build(contract_store2, delegate_store2, secrets_store2, false)
+            .expect("build runtime 2");
+        let mut executor2 = Executor::new(
+            state_store2,
+            || Ok(()),
+            crate::contract::executor::OperationMode::Local,
+            runtime2,
+            None,
+        )
+        .await
+        .expect("create executor 2");
+
+        let req2 = DelegateRequest::RegisterDelegateWithPredecessors {
+            delegate: DelegateContainer::Wasm(DelegateWasmAPIVersion::V1(succ.clone())),
+            cipher: [7u8; 32],
+            nonce: [9u8; 24],
+            predecessors: vec![pred.key().clone()],
+        };
+        executor2
+            .delegate_request(req2, Some(&origin_contract), None, None)
+            .expect("retry after recovery must succeed");
+        assert!(
+            succ_reg_path.exists(),
+            "after recovery the successor IS registered (.reg present)"
+        );
+        assert!(
+            succ_secret_path.exists(),
+            "after recovery the predecessor secret IS copied forward"
         );
     }
 

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -1502,14 +1502,22 @@ mod remove_contract_tests {
     /// on disk (the successor's secret file materializes), so no successor
     /// secret-store handle is needed. Also asserts the one-shot marker prevents
     /// resurrection when the delegate re-registers after the user deletes a copy.
+    ///
+    /// Exercises the H1 same-origin gate (#4117): the predecessor's
+    /// FIRST-registration origin is recorded as `Some(ORIGIN)` before the
+    /// migrating registration, and the registration itself supplies
+    /// `origin_contract = Some(&contract_instance_id)` whose bytes equal
+    /// `ORIGIN` — otherwise the copy would be refused as `no_provenance`.
     #[tokio::test(flavor = "multi_thread")]
     async fn register_delegate_with_predecessors_copies_secrets_forward() {
         use crate::wasm_runtime::SecretScope;
         use freenet_stdlib::client_api::{DelegateRequest, HostResponse};
         use freenet_stdlib::prelude::{
-            Delegate, DelegateContainer, DelegateWasmAPIVersion, SecretsId,
+            ContractInstanceId, Delegate, DelegateContainer, DelegateWasmAPIVersion, SecretsId,
         };
         use zeroize::Zeroizing;
+
+        const ORIGIN: [u8; 32] = [0x11u8; 32];
 
         let temp_dir = crate::util::tests::get_temp_dir();
         let db = Storage::new(temp_dir.path()).await.expect("create db");
@@ -1540,6 +1548,11 @@ mod remove_contract_tests {
             )
             .expect("seed predecessor secret");
 
+        // Record the predecessor's FIRST-registration origin (H1 same-origin
+        // gate): the migrating registration below must present this SAME origin
+        // for the copy to be allowed.
+        secrets_store.record_delegate_registration_origin(pred.key(), Some(ORIGIN));
+
         let successor_secret_path = secrets_dir
             .join(succ.key().encode())
             .join(secret_id.encode());
@@ -1561,6 +1574,8 @@ mod remove_contract_tests {
         .await
         .expect("create executor");
 
+        let origin_contract = ContractInstanceId::new(ORIGIN);
+
         let req = DelegateRequest::RegisterDelegateWithPredecessors {
             delegate: DelegateContainer::Wasm(DelegateWasmAPIVersion::V1(succ.clone())),
             cipher: [7u8; 32],
@@ -1568,7 +1583,7 @@ mod remove_contract_tests {
             predecessors: vec![pred.key().clone()],
         };
         let resp = executor
-            .delegate_request(req, None, None, None)
+            .delegate_request(req, Some(&origin_contract), None, None)
             .expect("register-with-predecessors must succeed");
         match resp {
             HostResponse::DelegateResponse { key, .. } => {
@@ -1584,7 +1599,9 @@ mod remove_contract_tests {
         );
 
         // One-shot / anti-resurrection at the handler level: delete the copy and
-        // re-register — the marker must make the re-run a no-op.
+        // re-register — the marker must make the re-run a no-op (the marker gate
+        // short-circuits before the origin gate, so the same origin is supplied
+        // here purely for realism, not because it's load-bearing for this part).
         std::fs::remove_file(&successor_secret_path).expect("remove copied secret");
         let req2 = DelegateRequest::RegisterDelegateWithPredecessors {
             delegate: DelegateContainer::Wasm(DelegateWasmAPIVersion::V1(succ.clone())),
@@ -1593,7 +1610,7 @@ mod remove_contract_tests {
             predecessors: vec![pred.key().clone()],
         };
         executor
-            .delegate_request(req2, None, None, None)
+            .delegate_request(req2, Some(&origin_contract), None, None)
             .expect("re-registration must succeed");
         assert!(
             !successor_secret_path.exists(),

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -1495,6 +1495,112 @@ mod remove_contract_tests {
             .with_extension("wasm")
     }
 
+    /// Handler-level (#4117): a `RegisterDelegateWithPredecessors` request
+    /// registers the successor AND copies a predecessor's Local secret into the
+    /// successor's namespace end-to-end — the request→register→migrate→disk
+    /// wiring that the store-level `migrate_secrets` tests do not cover. Verified
+    /// on disk (the successor's secret file materializes), so no successor
+    /// secret-store handle is needed. Also asserts the one-shot marker prevents
+    /// resurrection when the delegate re-registers after the user deletes a copy.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn register_delegate_with_predecessors_copies_secrets_forward() {
+        use crate::wasm_runtime::SecretScope;
+        use freenet_stdlib::client_api::{DelegateRequest, HostResponse};
+        use freenet_stdlib::prelude::{
+            Delegate, DelegateContainer, DelegateWasmAPIVersion, SecretsId,
+        };
+        use zeroize::Zeroizing;
+
+        let temp_dir = crate::util::tests::get_temp_dir();
+        let db = Storage::new(temp_dir.path()).await.expect("create db");
+        let contract_store =
+            ContractStore::new(temp_dir.path().join("contracts"), 10_000, db.clone())
+                .expect("create contract store");
+        let delegate_store =
+            DelegateStore::new(temp_dir.path().join("delegate"), 10_000, db.clone())
+                .expect("create delegate store");
+        let secrets_dir = temp_dir.path().join("secrets");
+        let mut secrets_store =
+            SecretsStore::new(secrets_dir.clone(), Default::default(), db.clone())
+                .expect("create secrets store");
+
+        // Same params, different code == an ABI bump that mints a new key.
+        let pred = Delegate::from((&vec![0u8].into(), &vec![1u8].into()));
+        let succ = Delegate::from((&vec![0u8].into(), &vec![2u8].into()));
+
+        // Seed a predecessor Local secret under its DERIVED DEK (the at-rest
+        // path) BEFORE moving the secrets store into the runtime.
+        let secret_id = SecretsId::new(b"room:alice".to_vec());
+        secrets_store
+            .store_secret(
+                pred.key(),
+                &secret_id,
+                SecretScope::Local,
+                Zeroizing::new(b"profile".to_vec()),
+            )
+            .expect("seed predecessor secret");
+
+        let successor_secret_path = secrets_dir
+            .join(succ.key().encode())
+            .join(secret_id.encode());
+        assert!(
+            !successor_secret_path.exists(),
+            "successor secret must not exist before migration"
+        );
+
+        let state_store = StateStore::new(db, 10_000_000).expect("create state store");
+        let runtime = Runtime::build(contract_store, delegate_store, secrets_store, false)
+            .expect("build runtime");
+        let mut executor = Executor::new(
+            state_store,
+            || Ok(()),
+            crate::contract::executor::OperationMode::Local,
+            runtime,
+            None,
+        )
+        .await
+        .expect("create executor");
+
+        let req = DelegateRequest::RegisterDelegateWithPredecessors {
+            delegate: DelegateContainer::Wasm(DelegateWasmAPIVersion::V1(succ.clone())),
+            cipher: [7u8; 32],
+            nonce: [9u8; 24],
+            predecessors: vec![pred.key().clone()],
+        };
+        let resp = executor
+            .delegate_request(req, None, None, None)
+            .expect("register-with-predecessors must succeed");
+        match resp {
+            HostResponse::DelegateResponse { key, .. } => {
+                assert_eq!(&key, succ.key(), "response carries the successor key");
+            }
+            other => panic!("expected DelegateResponse, got {other:?}"),
+        }
+
+        // The predecessor's Local secret was copied into the successor namespace.
+        assert!(
+            successor_secret_path.exists(),
+            "successor secret file must exist after copy-forward"
+        );
+
+        // One-shot / anti-resurrection at the handler level: delete the copy and
+        // re-register — the marker must make the re-run a no-op.
+        std::fs::remove_file(&successor_secret_path).expect("remove copied secret");
+        let req2 = DelegateRequest::RegisterDelegateWithPredecessors {
+            delegate: DelegateContainer::Wasm(DelegateWasmAPIVersion::V1(succ.clone())),
+            cipher: [7u8; 32],
+            nonce: [9u8; 24],
+            predecessors: vec![pred.key().clone()],
+        };
+        executor
+            .delegate_request(req2, None, None, None)
+            .expect("re-registration must succeed");
+        assert!(
+            !successor_secret_path.exists(),
+            "one-shot marker must prevent resurrection on re-registration"
+        );
+    }
+
     /// Core regression test: storing a contract makes its state retrievable
     /// and its `.wasm` blob present on disk; `remove_contract` reclaims both.
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -1801,6 +1801,104 @@ mod remove_contract_tests {
         );
     }
 
+    /// #4117 P2b/M1: the predecessor-list bound is TWO-tiered and enforced
+    /// through the real `Executor::delegate_request` path (not just the pure
+    /// dedupe fn). The cap is on the UNIQUE count, matching the docstrings:
+    ///   - 65 DISTINCT predecessors (> the deduped cap of 64) → request REJECTED,
+    ///     nothing registered (silent truncation would strand older generations);
+    ///   - a duplicate-heavy list whose UNIQUE count is within the cap → ACCEPTED
+    ///     (duplicates dropped, not counted);
+    ///   - a raw list past the DoS sanity bound → REJECTED up front regardless of
+    ///     unique count.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn register_with_predecessors_cap_is_on_unique_count_end_to_end() {
+        use super::delegates::{MAX_MIGRATION_PREDECESSORS, MAX_MIGRATION_PREDECESSORS_RAW};
+        use freenet_stdlib::client_api::DelegateRequest;
+        use freenet_stdlib::prelude::{Delegate, DelegateContainer, DelegateWasmAPIVersion};
+
+        let (mut executor, _contracts_dir, temp_dir) = build_disk_executor("pred-cap").await;
+        let delegate_dir = temp_dir.path().join("delegate");
+
+        let make_pred = |i: u8| {
+            Delegate::from((&vec![i].into(), &vec![0u8].into()))
+                .key()
+                .clone()
+        };
+        let reg_path =
+            |succ: &Delegate| delegate_dir.join(succ.key().encode()).with_extension("reg");
+
+        // (1) 65 UNIQUE predecessors > the deduped cap of 64 → REJECTED.
+        let succ_over = Delegate::from((&vec![0u8].into(), &vec![0xA1u8].into()));
+        let over: Vec<_> = (0u8..=64).map(make_pred).collect(); // 65 distinct
+        assert_eq!(over.len(), MAX_MIGRATION_PREDECESSORS + 1);
+        let req_over = DelegateRequest::RegisterDelegateWithPredecessors {
+            delegate: DelegateContainer::Wasm(DelegateWasmAPIVersion::V1(succ_over.clone())),
+            cipher: [7u8; 32],
+            nonce: [9u8; 24],
+            predecessors: over,
+        };
+        assert!(
+            executor
+                .delegate_request(req_over, None, None, None)
+                .is_err(),
+            "an over-cap UNIQUE predecessor list must be rejected"
+        );
+        assert!(
+            !reg_path(&succ_over).exists(),
+            "a rejected over-cap request must register NOTHING"
+        );
+
+        // (2) A duplicate-heavy list whose UNIQUE count (3) is within the cap →
+        //     ACCEPTED (duplicates dropped, not counted).
+        let succ_ok = Delegate::from((&vec![0u8].into(), &vec![0xB2u8].into()));
+        let mut dupes: Vec<_> = Vec::new();
+        for _ in 0..40 {
+            dupes.push(make_pred(1));
+            dupes.push(make_pred(2));
+            dupes.push(make_pred(3));
+        } // 120 raw, 3 unique
+        assert!(
+            dupes.len() > MAX_MIGRATION_PREDECESSORS
+                && dupes.len() <= MAX_MIGRATION_PREDECESSORS_RAW,
+            "the duplicate-heavy list must exceed the deduped cap in RAW length \
+             yet stay under the raw sanity bound, to isolate the dedupe semantics"
+        );
+        let req_ok = DelegateRequest::RegisterDelegateWithPredecessors {
+            delegate: DelegateContainer::Wasm(DelegateWasmAPIVersion::V1(succ_ok.clone())),
+            cipher: [7u8; 32],
+            nonce: [9u8; 24],
+            predecessors: dupes,
+        };
+        executor
+            .delegate_request(req_ok, None, None, None)
+            .expect("a duplicate-heavy but under-cap-UNIQUE list must be accepted");
+        assert!(
+            reg_path(&succ_ok).exists(),
+            "an accepted request must register the successor"
+        );
+
+        // (3) A raw list past the DoS sanity bound → REJECTED up front regardless
+        //     of unique count (all identical here: unique = 1, raw > the bound).
+        let succ_raw = Delegate::from((&vec![0u8].into(), &vec![0xC3u8].into()));
+        let raw_huge = vec![make_pred(7); MAX_MIGRATION_PREDECESSORS_RAW + 1];
+        let req_raw = DelegateRequest::RegisterDelegateWithPredecessors {
+            delegate: DelegateContainer::Wasm(DelegateWasmAPIVersion::V1(succ_raw.clone())),
+            cipher: [7u8; 32],
+            nonce: [9u8; 24],
+            predecessors: raw_huge,
+        };
+        assert!(
+            executor
+                .delegate_request(req_raw, None, None, None)
+                .is_err(),
+            "a raw list past the DoS sanity bound must be rejected even when unique count is small"
+        );
+        assert!(
+            !reg_path(&succ_raw).exists(),
+            "a rejected raw-oversize request must register NOTHING"
+        );
+    }
+
     /// Core regression test: storing a contract makes its state retrievable
     /// and its `.wasm` blob present on disk; `remove_contract` reclaims both.
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/core/src/contract/executor/runtime/delegates.rs
+++ b/crates/core/src/contract/executor/runtime/delegates.rs
@@ -7,6 +7,45 @@
 
 use super::*;
 
+/// Upper bound on the number of predecessor delegate keys a single
+/// `RegisterDelegateWithPredecessors` request may drive copy-forward for
+/// (#4117 P2/M1). The predecessor list is client-controlled, and each
+/// predecessor drives synchronous marker/index/redb writes on the contract
+/// loop, so an unbounded (or duplicate-padded) list is a disk-growth / loop-
+/// stall amplification vector. 64 matches the delegate-lineage / probe-hop
+/// bound used by the app-side migration driver (`DEFAULT_MAX_PROBE_HOPS`): a
+/// realistic delegate never accumulates anywhere near 64 retired generations.
+/// Over the cap the list is deduped-then-truncated with a warning;
+/// registration itself still succeeds.
+const MAX_MIGRATION_PREDECESSORS: usize = 64;
+
+/// Dedupe (preserving newest-first order) then cap a client-supplied predecessor
+/// list at `cap` (#4117 P2/M1). Returns the bounded list and whether it was
+/// truncated (either dropped duplicates OR hit the cap), so the caller can warn.
+/// Extracted as a free function so the amplification bound is unit-testable
+/// without standing up an executor.
+fn dedupe_and_cap_predecessors(
+    predecessors: Vec<DelegateKey>,
+    cap: usize,
+) -> (Vec<DelegateKey>, bool) {
+    let requested = predecessors.len();
+    let mut seen = std::collections::HashSet::new();
+    let mut bounded: Vec<DelegateKey> = Vec::with_capacity(requested.min(cap));
+    let mut capped = false;
+    for p in predecessors {
+        if !seen.insert(p.clone()) {
+            continue; // duplicate — pure waste
+        }
+        if bounded.len() >= cap {
+            capped = true;
+            break;
+        }
+        bounded.push(p);
+    }
+    let truncated = capped || bounded.len() != requested;
+    (bounded, truncated)
+}
+
 impl Executor<Runtime> {
     /// Export this hosted user's per-user delegate secrets into an encrypted
     /// bundle, sealed under the user's `token` (hosted-mode export, P3-live of
@@ -128,7 +167,18 @@ impl Executor<Runtime> {
                 .push(*contract);
         }
         match self.runtime.register_delegate(delegate, cipher, nonce) {
-            Ok(_) => Ok(key),
+            Ok(_) => {
+                // Durably record the registration origin for the H1 same-origin
+                // copy-forward gate (#4117): a future migration naming this
+                // delegate as a predecessor copies its Local secrets only to a
+                // successor registered from the SAME web-app origin (or the
+                // Admin/None class for a loopback/CLI registration).
+                let origin_bytes: Option<[u8; 32]> =
+                    origin_contract.and_then(|c| c.as_bytes().try_into().ok());
+                self.runtime
+                    .record_delegate_registration_origin(&key, origin_bytes);
+                Ok(key)
+            }
             Err(err) => {
                 tracing::warn!(
                     delegate_key = %key,
@@ -204,21 +254,35 @@ impl Executor<Runtime> {
                     origin_contract,
                 ) {
                     Ok(key) => {
+                        // Bound + dedupe the client-controlled predecessor list
+                        // (#4117 P2/M1): each predecessor drives synchronous
+                        // marker/index/redb writes on the contract loop, so an
+                        // unbounded or duplicate-padded list is an amplification
+                        // vector. See `dedupe_and_cap_predecessors`.
+                        let requested = predecessors.len();
+                        let (bounded, truncated) =
+                            dedupe_and_cap_predecessors(predecessors, MAX_MIGRATION_PREDECESSORS);
+                        if truncated {
+                            tracing::warn!(
+                                delegate_key = %key,
+                                requested,
+                                cap = MAX_MIGRATION_PREDECESSORS,
+                                "delegate secret copy-forward: predecessor list over cap; deduped + truncated (registration still succeeds)"
+                            );
+                        }
                         // Record the originating web-app contract (when present)
-                        // verbatim in the migration marker as a consent-primary-v1
-                        // AUDIT FACT. `ContractInstanceId::as_bytes` is the 32-byte
-                        // id; `try_into` never fails but is used to stay panic-free.
+                        // verbatim in the migration marker as an AUDIT FACT.
+                        // `ContractInstanceId::as_bytes` is the 32-byte id;
+                        // `try_into` never fails but is used to stay panic-free.
                         let origin_bytes: Option<[u8; 32]> =
                             origin_contract.and_then(|c| c.as_bytes().try_into().ok());
-                        let report = self.runtime.migrate_delegate_secrets(
-                            &predecessors,
-                            &key,
-                            origin_bytes,
-                        );
+                        let report =
+                            self.runtime
+                                .migrate_delegate_secrets(&bounded, &key, origin_bytes);
                         if report.total_errors() > 0 {
                             tracing::warn!(
                                 delegate_key = %key,
-                                predecessors = predecessors.len(),
+                                predecessors = bounded.len(),
                                 copied = report.total_copied(),
                                 skipped_existing = report.total_skipped_existing(),
                                 user_scope_skipped = report.total_user_scope_skipped(),
@@ -229,7 +293,7 @@ impl Executor<Runtime> {
                         } else {
                             tracing::info!(
                                 delegate_key = %key,
-                                predecessors = predecessors.len(),
+                                predecessors = bounded.len(),
                                 copied = report.total_copied(),
                                 skipped_existing = report.total_skipped_existing(),
                                 user_scope_skipped = report.total_user_scope_skipped(),
@@ -388,6 +452,33 @@ mod resolve_message_origin_tests {
     /// and both are gone. See #4813.
     fn origins() -> crate::wasm_runtime::SharedInheritedOrigins {
         crate::wasm_runtime::new_inherited_origins()
+    }
+
+    /// #4117 P2/M1: the predecessor list is deduped (preserving newest-first
+    /// order) then capped, and the truncation flag is set for either a dropped
+    /// duplicate or a hit cap. Bounds the client-driven copy-forward work.
+    #[test]
+    fn dedupe_and_cap_predecessors_bounds_the_list() {
+        // Unique, under cap → unchanged, not truncated.
+        let keys: Vec<DelegateKey> = (0u8..5).map(dkey).collect();
+        let (bounded, truncated) = dedupe_and_cap_predecessors(keys.clone(), 64);
+        assert_eq!(bounded, keys);
+        assert!(!truncated);
+
+        // Duplicates are dropped (first occurrence wins, order preserved) and
+        // flagged as truncated.
+        let dupes = vec![dkey(1), dkey(2), dkey(1), dkey(3), dkey(2)];
+        let (bounded, truncated) = dedupe_and_cap_predecessors(dupes, 64);
+        assert_eq!(bounded, vec![dkey(1), dkey(2), dkey(3)]);
+        assert!(truncated, "dropping a duplicate flags truncation");
+
+        // Over the cap → truncated to the cap, keeping the first (newest) `cap`.
+        let many: Vec<DelegateKey> = (0u8..200).map(dkey).collect();
+        let (bounded, truncated) = dedupe_and_cap_predecessors(many, 64);
+        assert_eq!(bounded.len(), 64);
+        assert_eq!(bounded[0], dkey(0));
+        assert_eq!(bounded[63], dkey(63));
+        assert!(truncated);
     }
 
     /// Caller delegate identity wins over a concurrently-supplied WebApp

--- a/crates/core/src/contract/executor/runtime/delegates.rs
+++ b/crates/core/src/contract/executor/runtime/delegates.rs
@@ -151,20 +151,34 @@ impl Executor<Runtime> {
 
         // RECORD BEFORE REGISTER (#4117 P1, H1 first-writer gate). The immutable
         // first-writer origin record is written (insert-if-absent) BEFORE the
-        // delegate is registered. If we registered first and the record write
-        // then failed (or crashed between), the delegate would be usable but
-        // RECORDLESS, and the next — possibly attacker — registration would claim
-        // the empty first-writer slot (stealing the victim's provenance).
-        // Recording first makes a crash between the two harmless (a record for an
-        // unregistered delegate gates nothing, and the same app's retry
-        // re-registers under its already-recorded origin). A record-write failure
-        // is surfaced (logged inside record_delegate_registration_origin) and
-        // leaves copy-forward fail-closed (no record ⇒ NoProvenance); the next
-        // registration retries the insert-if-absent.
+        // delegate is registered, and a record-write failure ABORTS THE WHOLE
+        // REGISTRATION (persistence-succeeds-before-usable). If we registered
+        // first, or proceeded despite a failed record, the delegate would be
+        // usable but RECORDLESS — an empty first-writer slot the next, possibly
+        // attacker, registration could claim (stealing the victim's provenance
+        // and then migrating its accumulated secrets). Registration already
+        // depends on delegate-store disk health, so a failing origin-record DB is
+        // a visibly sick node and the app simply retries; a usable-but-unowned
+        // delegate is the one unacceptable state. Recording first also makes a
+        // crash BETWEEN record and register harmless (a record for an
+        // unregistered delegate gates nothing, and the app's retry re-registers
+        // under its already-recorded origin — Ok(false), still success).
         let origin_bytes: Option<[u8; 32]> =
             origin_contract.and_then(|c| c.as_bytes().try_into().ok());
-        self.runtime
-            .record_delegate_registration_origin(&key, origin_bytes);
+        if let Err(err) = self
+            .runtime
+            .record_delegate_registration_origin(&key, origin_bytes)
+        {
+            tracing::warn!(
+                delegate_key = %key,
+                error = %err,
+                phase = "record_origin_failed",
+                "aborting delegate registration: could not durably record the first-registration origin (persistence-succeeds-before-usable)"
+            );
+            return Err(ExecutorError::other(anyhow::anyhow!(
+                "delegate registration aborted: could not durably record first-registration origin (H1 gate): {err}"
+            )));
+        }
 
         let arr = (&cipher).into();
         let cipher = XChaCha20Poly1305::new(arr);

--- a/crates/core/src/contract/executor/runtime/delegates.rs
+++ b/crates/core/src/contract/executor/runtime/delegates.rs
@@ -19,31 +19,22 @@ use super::*;
 /// registration itself still succeeds.
 const MAX_MIGRATION_PREDECESSORS: usize = 64;
 
-/// Dedupe (preserving newest-first order) then cap a client-supplied predecessor
-/// list at `cap` (#4117 P2/M1). Returns the bounded list and whether it was
-/// truncated (either dropped duplicates OR hit the cap), so the caller can warn.
-/// Extracted as a free function so the amplification bound is unit-testable
-/// without standing up an executor.
-fn dedupe_and_cap_predecessors(
-    predecessors: Vec<DelegateKey>,
-    cap: usize,
-) -> (Vec<DelegateKey>, bool) {
-    let requested = predecessors.len();
+/// Dedupe a client-supplied predecessor list, preserving newest-first order
+/// (#4117 P2/M1). A duplicate is pure waste (the migration is idempotent per
+/// pair), so it is dropped SILENTLY. The cap is enforced by the CALLER on the
+/// deduped length: over the cap, the whole request is REJECTED before
+/// registration (never silently truncated, which would strand older
+/// generations — the client is expected to split its request). Extracted as a
+/// free function so the dedupe is unit-testable without standing up an executor.
+fn dedupe_predecessors(predecessors: Vec<DelegateKey>) -> Vec<DelegateKey> {
     let mut seen = std::collections::HashSet::new();
-    let mut bounded: Vec<DelegateKey> = Vec::with_capacity(requested.min(cap));
-    let mut capped = false;
+    let mut out: Vec<DelegateKey> = Vec::with_capacity(predecessors.len());
     for p in predecessors {
-        if !seen.insert(p.clone()) {
-            continue; // duplicate — pure waste
+        if seen.insert(p.clone()) {
+            out.push(p);
         }
-        if bounded.len() >= cap {
-            capped = true;
-            break;
-        }
-        bounded.push(p);
     }
-    let truncated = capped || bounded.len() != requested;
-    (bounded, truncated)
+    out
 }
 
 impl Executor<Runtime> {
@@ -240,12 +231,35 @@ impl Executor<Runtime> {
                 nonce,
                 predecessors,
             } => {
+                // Bound the client-controlled predecessor list BEFORE registering
+                // (#4117 P2b/M1). Dedupe silently (a repeat is pure waste — the
+                // migration is idempotent per pair), then REJECT the whole request
+                // if the deduped list still exceeds the cap: each predecessor
+                // drives synchronous marker/index/redb writes on the contract
+                // loop, so an unbounded list is an amplification vector, and
+                // silently truncating would strand older generations. The client
+                // splits an over-cap request.
+                let deduped = dedupe_predecessors(predecessors);
+                if deduped.len() > MAX_MIGRATION_PREDECESSORS {
+                    let key = delegate.key().clone();
+                    tracing::warn!(
+                        delegate_key = %key,
+                        predecessors = deduped.len(),
+                        cap = MAX_MIGRATION_PREDECESSORS,
+                        "RegisterDelegateWithPredecessors rejected: too many predecessors (split the request)"
+                    );
+                    return Err(ExecutorError::other(anyhow::anyhow!(
+                        "RegisterDelegateWithPredecessors: {} predecessors exceeds the cap of {}",
+                        deduped.len(),
+                        MAX_MIGRATION_PREDECESSORS
+                    )));
+                }
+
                 // Register exactly as `RegisterDelegate` does, THEN run the
-                // one-shot, Local-scope copy-forward of the predecessors' secrets
-                // (#4117). The copy is best-effort and never fails registration:
-                // an absent/partly-unreadable predecessor is recorded in the
+                // one-shot, Local-scope copy-forward of the predecessors' secrets.
+                // The copy is best-effort and never fails registration: a
+                // refused/absent/partly-unreadable predecessor is recorded in the
                 // report and logged, but the successor still registers. See
-                // `Runtime::migrate_delegate_secrets` /
                 // `SecretsStore::migrate_secrets` for the full contract.
                 match self.register_delegate_and_record_origin(
                     delegate,
@@ -254,35 +268,18 @@ impl Executor<Runtime> {
                     origin_contract,
                 ) {
                     Ok(key) => {
-                        // Bound + dedupe the client-controlled predecessor list
-                        // (#4117 P2/M1): each predecessor drives synchronous
-                        // marker/index/redb writes on the contract loop, so an
-                        // unbounded or duplicate-padded list is an amplification
-                        // vector. See `dedupe_and_cap_predecessors`.
-                        let requested = predecessors.len();
-                        let (bounded, truncated) =
-                            dedupe_and_cap_predecessors(predecessors, MAX_MIGRATION_PREDECESSORS);
-                        if truncated {
-                            tracing::warn!(
-                                delegate_key = %key,
-                                requested,
-                                cap = MAX_MIGRATION_PREDECESSORS,
-                                "delegate secret copy-forward: predecessor list over cap; deduped + truncated (registration still succeeds)"
-                            );
-                        }
-                        // Record the originating web-app contract (when present)
-                        // verbatim in the migration marker as an AUDIT FACT.
+                        // Record the originating web-app contract (when present).
                         // `ContractInstanceId::as_bytes` is the 32-byte id;
                         // `try_into` never fails but is used to stay panic-free.
                         let origin_bytes: Option<[u8; 32]> =
                             origin_contract.and_then(|c| c.as_bytes().try_into().ok());
                         let report =
                             self.runtime
-                                .migrate_delegate_secrets(&bounded, &key, origin_bytes);
+                                .migrate_delegate_secrets(&deduped, &key, origin_bytes);
                         if report.total_errors() > 0 {
                             tracing::warn!(
                                 delegate_key = %key,
-                                predecessors = bounded.len(),
+                                predecessors = deduped.len(),
                                 copied = report.total_copied(),
                                 skipped_existing = report.total_skipped_existing(),
                                 user_scope_skipped = report.total_user_scope_skipped(),
@@ -293,7 +290,7 @@ impl Executor<Runtime> {
                         } else {
                             tracing::info!(
                                 delegate_key = %key,
-                                predecessors = bounded.len(),
+                                predecessors = deduped.len(),
                                 copied = report.total_copied(),
                                 skipped_existing = report.total_skipped_existing(),
                                 user_scope_skipped = report.total_user_scope_skipped(),
@@ -454,31 +451,25 @@ mod resolve_message_origin_tests {
         crate::wasm_runtime::new_inherited_origins()
     }
 
-    /// #4117 P2/M1: the predecessor list is deduped (preserving newest-first
-    /// order) then capped, and the truncation flag is set for either a dropped
-    /// duplicate or a hit cap. Bounds the client-driven copy-forward work.
+    /// #4117 P2/M1: the predecessor list is deduped silently, preserving
+    /// newest-first order (first occurrence wins). The cap itself is enforced in
+    /// the handler on the deduped length (over-cap → the whole request is
+    /// rejected, never silently truncated).
     #[test]
-    fn dedupe_and_cap_predecessors_bounds_the_list() {
-        // Unique, under cap → unchanged, not truncated.
+    fn dedupe_predecessors_preserves_order_and_drops_duplicates() {
+        // Unique → unchanged, order preserved.
         let keys: Vec<DelegateKey> = (0u8..5).map(dkey).collect();
-        let (bounded, truncated) = dedupe_and_cap_predecessors(keys.clone(), 64);
-        assert_eq!(bounded, keys);
-        assert!(!truncated);
+        assert_eq!(dedupe_predecessors(keys.clone()), keys);
 
-        // Duplicates are dropped (first occurrence wins, order preserved) and
-        // flagged as truncated.
+        // Duplicates dropped, first occurrence wins, order preserved.
         let dupes = vec![dkey(1), dkey(2), dkey(1), dkey(3), dkey(2)];
-        let (bounded, truncated) = dedupe_and_cap_predecessors(dupes, 64);
-        assert_eq!(bounded, vec![dkey(1), dkey(2), dkey(3)]);
-        assert!(truncated, "dropping a duplicate flags truncation");
+        assert_eq!(dedupe_predecessors(dupes), vec![dkey(1), dkey(2), dkey(3)]);
 
-        // Over the cap → truncated to the cap, keeping the first (newest) `cap`.
+        // Dedupe does not itself cap: a large unique list passes through (the
+        // handler rejects it against MAX_MIGRATION_PREDECESSORS).
         let many: Vec<DelegateKey> = (0u8..200).map(dkey).collect();
-        let (bounded, truncated) = dedupe_and_cap_predecessors(many, 64);
-        assert_eq!(bounded.len(), 64);
-        assert_eq!(bounded[0], dkey(0));
-        assert_eq!(bounded[63], dkey(63));
-        assert!(truncated);
+        assert_eq!(dedupe_predecessors(many).len(), 200);
+        assert!(200 > MAX_MIGRATION_PREDECESSORS);
     }
 
     /// Caller delegate identity wins over a concurrently-supplied WebApp

--- a/crates/core/src/contract/executor/runtime/delegates.rs
+++ b/crates/core/src/contract/executor/runtime/delegates.rs
@@ -148,6 +148,24 @@ impl Executor<Runtime> {
     ) -> Result<DelegateKey, ExecutorError> {
         use chacha20poly1305::{KeyInit, XChaCha20Poly1305};
         let key = delegate.key().clone();
+
+        // RECORD BEFORE REGISTER (#4117 P1, H1 first-writer gate). The immutable
+        // first-writer origin record is written (insert-if-absent) BEFORE the
+        // delegate is registered. If we registered first and the record write
+        // then failed (or crashed between), the delegate would be usable but
+        // RECORDLESS, and the next — possibly attacker — registration would claim
+        // the empty first-writer slot (stealing the victim's provenance).
+        // Recording first makes a crash between the two harmless (a record for an
+        // unregistered delegate gates nothing, and the same app's retry
+        // re-registers under its already-recorded origin). A record-write failure
+        // is surfaced (logged inside record_delegate_registration_origin) and
+        // leaves copy-forward fail-closed (no record ⇒ NoProvenance); the next
+        // registration retries the insert-if-absent.
+        let origin_bytes: Option<[u8; 32]> =
+            origin_contract.and_then(|c| c.as_bytes().try_into().ok());
+        self.runtime
+            .record_delegate_registration_origin(&key, origin_bytes);
+
         let arr = (&cipher).into();
         let cipher = XChaCha20Poly1305::new(arr);
         let nonce = nonce.into();
@@ -158,18 +176,7 @@ impl Executor<Runtime> {
                 .push(*contract);
         }
         match self.runtime.register_delegate(delegate, cipher, nonce) {
-            Ok(_) => {
-                // Durably record the registration origin for the H1 same-origin
-                // copy-forward gate (#4117): a future migration naming this
-                // delegate as a predecessor copies its Local secrets only to a
-                // successor registered from the SAME web-app origin (or the
-                // Admin/None class for a loopback/CLI registration).
-                let origin_bytes: Option<[u8; 32]> =
-                    origin_contract.and_then(|c| c.as_bytes().try_into().ok());
-                self.runtime
-                    .record_delegate_registration_origin(&key, origin_bytes);
-                Ok(key)
-            }
+            Ok(_) => Ok(key),
             Err(err) => {
                 tracing::warn!(
                     delegate_key = %key,
@@ -232,28 +239,30 @@ impl Executor<Runtime> {
                 predecessors,
             } => {
                 // Bound the client-controlled predecessor list BEFORE registering
-                // (#4117 P2b/M1). Dedupe silently (a repeat is pure waste — the
-                // migration is idempotent per pair), then REJECT the whole request
-                // if the deduped list still exceeds the cap: each predecessor
-                // drives synchronous marker/index/redb writes on the contract
-                // loop, so an unbounded list is an amplification vector, and
-                // silently truncating would strand older generations. The client
-                // splits an over-cap request.
-                let deduped = dedupe_predecessors(predecessors);
-                if deduped.len() > MAX_MIGRATION_PREDECESSORS {
+                // (#4117 P2b/M1). CHEAP EARLY LENGTH CHECK FIRST — reject an
+                // over-length request before ANY per-element work (dedupe / HashSet
+                // inserts), so a giant list can't burn the contract loop just to be
+                // rejected. Each predecessor drives synchronous marker/index/redb
+                // writes, so an unbounded list is an amplification vector, and
+                // silently truncating would strand older generations; the client
+                // splits an over-cap request (and should send no duplicates). Then
+                // dedupe silently (a repeat is pure waste — migration is idempotent
+                // per pair) the now-bounded list.
+                if predecessors.len() > MAX_MIGRATION_PREDECESSORS {
                     let key = delegate.key().clone();
                     tracing::warn!(
                         delegate_key = %key,
-                        predecessors = deduped.len(),
+                        predecessors = predecessors.len(),
                         cap = MAX_MIGRATION_PREDECESSORS,
                         "RegisterDelegateWithPredecessors rejected: too many predecessors (split the request)"
                     );
                     return Err(ExecutorError::other(anyhow::anyhow!(
                         "RegisterDelegateWithPredecessors: {} predecessors exceeds the cap of {}",
-                        deduped.len(),
+                        predecessors.len(),
                         MAX_MIGRATION_PREDECESSORS
                     )));
                 }
+                let deduped = dedupe_predecessors(predecessors);
 
                 // Register exactly as `RegisterDelegate` does, THEN run the
                 // one-shot, Local-scope copy-forward of the predecessors' secrets.

--- a/crates/core/src/contract/executor/runtime/delegates.rs
+++ b/crates/core/src/contract/executor/runtime/delegates.rs
@@ -7,7 +7,7 @@
 
 use super::*;
 
-/// Upper bound on the number of predecessor delegate keys a single
+/// Upper bound on the number of UNIQUE predecessor delegate keys a single
 /// `RegisterDelegateWithPredecessors` request may drive copy-forward for
 /// (#4117 P2/M1). The predecessor list is client-controlled, and each
 /// predecessor drives synchronous marker/index/redb writes on the contract
@@ -15,9 +15,24 @@ use super::*;
 /// stall amplification vector. 64 matches the delegate-lineage / probe-hop
 /// bound used by the app-side migration driver (`DEFAULT_MAX_PROBE_HOPS`): a
 /// realistic delegate never accumulates anywhere near 64 retired generations.
-/// Over the cap the list is deduped-then-truncated with a warning;
-/// registration itself still succeeds.
-const MAX_MIGRATION_PREDECESSORS: usize = 64;
+/// This is the DEDUPED cap, enforced on the UNIQUE count: a request whose
+/// unique predecessor count exceeds it is REJECTED whole (never silently
+/// truncated, which would strand older generations — the client splits its
+/// request). Duplicates are dropped first and never count against it, so a
+/// duplicate-heavy but genuinely-small list is accepted. A separate, much
+/// larger raw-length sanity bound ([`MAX_MIGRATION_PREDECESSORS_RAW`]) rejects a
+/// giant list up front so the dedupe work itself stays bounded.
+pub(super) const MAX_MIGRATION_PREDECESSORS: usize = 64;
+
+/// Pre-dedupe SANITY bound on the RAW predecessor-list length: 16× the deduped
+/// cap [`MAX_MIGRATION_PREDECESSORS`]. This is pure DoS protection — it caps the
+/// dedupe / `HashSet`-insert work for a giant list BEFORE any per-element
+/// processing — NOT the semantic limit. No legitimate client comes anywhere
+/// near it: a realistic delegate has a handful of retired generations, and even
+/// a duplicate-heavy legitimate list stays far under 1024. The semantic limit
+/// is the deduped cap above; a list whose UNIQUE count is within the cap is
+/// accepted even when the raw list carried duplicates.
+pub(super) const MAX_MIGRATION_PREDECESSORS_RAW: usize = MAX_MIGRATION_PREDECESSORS * 16;
 
 /// Dedupe a client-supplied predecessor list, preserving newest-first order
 /// (#4117 P2/M1). A duplicate is pure waste (the migration is idempotent per
@@ -253,30 +268,50 @@ impl Executor<Runtime> {
                 predecessors,
             } => {
                 // Bound the client-controlled predecessor list BEFORE registering
-                // (#4117 P2b/M1). CHEAP EARLY LENGTH CHECK FIRST — reject an
-                // over-length request before ANY per-element work (dedupe / HashSet
-                // inserts), so a giant list can't burn the contract loop just to be
-                // rejected. Each predecessor drives synchronous marker/index/redb
-                // writes, so an unbounded list is an amplification vector, and
-                // silently truncating would strand older generations; the client
-                // splits an over-cap request (and should send no duplicates). Then
-                // dedupe silently (a repeat is pure waste — migration is idempotent
-                // per pair) the now-bounded list.
-                if predecessors.len() > MAX_MIGRATION_PREDECESSORS {
+                // (#4117 P2b/M1) with TWO tiers, so the DoS bound and the
+                // documented DEDUPED semantics both hold:
+                //   (a) a cheap pre-dedupe SANITY check on the RAW length rejects
+                //       a giant list up front, keeping the dedupe / HashSet work
+                //       itself bounded (a giant list can't burn the contract
+                //       loop just to be rejected);
+                //   (b) dedupe silently (a repeat is pure waste — migration is
+                //       idempotent per pair);
+                //   (c) enforce the real cap on the UNIQUE count, matching every
+                //       docstring and test. A duplicate-heavy but genuinely-small
+                //       list is ACCEPTED; an over-cap UNIQUE list is REJECTED
+                //       whole (silent truncation would strand older generations —
+                //       the client splits its request).
+                // Each predecessor drives synchronous marker/index/redb writes,
+                // so an unbounded list is a disk-growth / loop-stall vector.
+                if predecessors.len() > MAX_MIGRATION_PREDECESSORS_RAW {
                     let key = delegate.key().clone();
                     tracing::warn!(
                         delegate_key = %key,
                         predecessors = predecessors.len(),
-                        cap = MAX_MIGRATION_PREDECESSORS,
-                        "RegisterDelegateWithPredecessors rejected: too many predecessors (split the request)"
+                        raw_cap = MAX_MIGRATION_PREDECESSORS_RAW,
+                        "RegisterDelegateWithPredecessors rejected: raw predecessor list too large (DoS sanity bound)"
                     );
                     return Err(ExecutorError::other(anyhow::anyhow!(
-                        "RegisterDelegateWithPredecessors: {} predecessors exceeds the cap of {}",
+                        "RegisterDelegateWithPredecessors: raw predecessor list of {} exceeds the sanity bound of {}",
                         predecessors.len(),
-                        MAX_MIGRATION_PREDECESSORS
+                        MAX_MIGRATION_PREDECESSORS_RAW
                     )));
                 }
                 let deduped = dedupe_predecessors(predecessors);
+                if deduped.len() > MAX_MIGRATION_PREDECESSORS {
+                    let key = delegate.key().clone();
+                    tracing::warn!(
+                        delegate_key = %key,
+                        unique_predecessors = deduped.len(),
+                        cap = MAX_MIGRATION_PREDECESSORS,
+                        "RegisterDelegateWithPredecessors rejected: too many UNIQUE predecessors (split the request)"
+                    );
+                    return Err(ExecutorError::other(anyhow::anyhow!(
+                        "RegisterDelegateWithPredecessors: {} unique predecessors exceeds the cap of {}",
+                        deduped.len(),
+                        MAX_MIGRATION_PREDECESSORS
+                    )));
+                }
 
                 // Register exactly as `RegisterDelegate` does, THEN run the
                 // one-shot, Local-scope copy-forward of the predecessors' secrets.

--- a/crates/core/src/contract/executor/runtime/delegates.rs
+++ b/crates/core/src/contract/executor/runtime/delegates.rs
@@ -103,6 +103,44 @@ impl Executor<Runtime> {
             })
     }
 
+    /// Register a delegate and record its WebApp origin, shared by the
+    /// `RegisterDelegate` and `RegisterDelegateWithPredecessors` request arms so
+    /// the two cannot drift. Installs the client-supplied cipher/nonce, records
+    /// `origin_contract` as this delegate's attestation, and registers the WASM
+    /// module. Returns the delegate key on success, or a mapped
+    /// [`ExecutorError`] (already carrying `RegisterError(key)`) on failure.
+    fn register_delegate_and_record_origin(
+        &mut self,
+        delegate: DelegateContainer,
+        cipher: [u8; 32],
+        nonce: [u8; 24],
+        origin_contract: Option<&ContractInstanceId>,
+    ) -> Result<DelegateKey, ExecutorError> {
+        use chacha20poly1305::{KeyInit, XChaCha20Poly1305};
+        let key = delegate.key().clone();
+        let arr = (&cipher).into();
+        let cipher = XChaCha20Poly1305::new(arr);
+        let nonce = nonce.into();
+        if let Some(contract) = origin_contract {
+            self.delegate_origin_ids
+                .entry(key.clone())
+                .or_default()
+                .push(*contract);
+        }
+        match self.runtime.register_delegate(delegate, cipher, nonce) {
+            Ok(_) => Ok(key),
+            Err(err) => {
+                tracing::warn!(
+                    delegate_key = %key,
+                    error = %err,
+                    phase = "register_failed",
+                    "Failed to register delegate"
+                );
+                Err(ExecutorError::other(StdDelegateError::RegisterError(key)))
+            }
+        }
+    }
+
     pub fn delegate_request(
         &mut self,
         req: DelegateRequest<'_>,
@@ -134,32 +172,77 @@ impl Executor<Runtime> {
                 delegate,
                 cipher,
                 nonce,
+            } => match self.register_delegate_and_record_origin(
+                delegate,
+                cipher,
+                nonce,
+                origin_contract,
+            ) {
+                Ok(key) => Ok(DelegateResponse {
+                    key,
+                    values: Vec::new(),
+                }),
+                Err(err) => Err(err),
+            },
+            DelegateRequest::RegisterDelegateWithPredecessors {
+                delegate,
+                cipher,
+                nonce,
+                predecessors,
             } => {
-                use chacha20poly1305::{KeyInit, XChaCha20Poly1305};
-                let key = delegate.key().clone();
-                let arr = (&cipher).into();
-                let cipher = XChaCha20Poly1305::new(arr);
-                let nonce = nonce.into();
-                if let Some(contract) = origin_contract {
-                    self.delegate_origin_ids
-                        .entry(key.clone())
-                        .or_default()
-                        .push(*contract);
-                }
-                match self.runtime.register_delegate(delegate, cipher, nonce) {
-                    Ok(_) => Ok(DelegateResponse {
-                        key,
-                        values: Vec::new(),
-                    }),
-                    Err(err) => {
-                        tracing::warn!(
-                            delegate_key = %key,
-                            error = %err,
-                            phase = "register_failed",
-                            "Failed to register delegate"
+                // Register exactly as `RegisterDelegate` does, THEN run the
+                // one-shot, Local-scope copy-forward of the predecessors' secrets
+                // (#4117). The copy is best-effort and never fails registration:
+                // an absent/partly-unreadable predecessor is recorded in the
+                // report and logged, but the successor still registers. See
+                // `Runtime::migrate_delegate_secrets` /
+                // `SecretsStore::migrate_secrets` for the full contract.
+                match self.register_delegate_and_record_origin(
+                    delegate,
+                    cipher,
+                    nonce,
+                    origin_contract,
+                ) {
+                    Ok(key) => {
+                        // Record the originating web-app contract (when present)
+                        // verbatim in the migration marker as a consent-primary-v1
+                        // AUDIT FACT. `ContractInstanceId::as_bytes` is the 32-byte
+                        // id; `try_into` never fails but is used to stay panic-free.
+                        let origin_bytes: Option<[u8; 32]> =
+                            origin_contract.and_then(|c| c.as_bytes().try_into().ok());
+                        let report = self.runtime.migrate_delegate_secrets(
+                            &predecessors,
+                            &key,
+                            origin_bytes,
                         );
-                        Err(ExecutorError::other(StdDelegateError::RegisterError(key)))
+                        if report.total_errors() > 0 {
+                            tracing::warn!(
+                                delegate_key = %key,
+                                predecessors = predecessors.len(),
+                                copied = report.total_copied(),
+                                skipped_existing = report.total_skipped_existing(),
+                                user_scope_skipped = report.total_user_scope_skipped(),
+                                errors = report.total_errors(),
+                                phase = "secret_copy_forward",
+                                "delegate secret copy-forward completed with errors"
+                            );
+                        } else {
+                            tracing::info!(
+                                delegate_key = %key,
+                                predecessors = predecessors.len(),
+                                copied = report.total_copied(),
+                                skipped_existing = report.total_skipped_existing(),
+                                user_scope_skipped = report.total_user_scope_skipped(),
+                                phase = "secret_copy_forward",
+                                "delegate secret copy-forward completed"
+                            );
+                        }
+                        Ok(DelegateResponse {
+                            key,
+                            values: Vec::new(),
+                        })
                     }
+                    Err(err) => Err(err),
                 }
             }
             DelegateRequest::UnregisterDelegate(key) => {

--- a/crates/core/src/contract/storages/redb.rs
+++ b/crates/core/src/contract/storages/redb.rs
@@ -1219,6 +1219,10 @@ impl ReDb {
     /// Persist the copy-forward marker for `(predecessor, successor)`. The
     /// `value` is the opaque, versioned audit blob built by the secrets store.
     /// Idempotent: re-writing the same pair overwrites in place.
+    ///
+    /// # Errors
+    /// Returns `Err` if the underlying redb write transaction, table open, or
+    /// commit fails (e.g. a backend I/O error).
     pub fn store_migration_marker(
         &self,
         predecessor: &DelegateKey,
@@ -1237,6 +1241,10 @@ impl ReDb {
     /// Fetch the copy-forward marker for `(predecessor, successor)`, or `None`
     /// if this pair has never been migrated. The returned bytes are the opaque
     /// audit blob the secrets store wrote; only the store interprets them.
+    ///
+    /// # Errors
+    /// Returns `Err` if the underlying redb read transaction, table open, or
+    /// lookup fails (e.g. a backend I/O error).
     pub fn get_migration_marker(
         &self,
         predecessor: &DelegateKey,
@@ -1283,6 +1291,11 @@ impl ReDb {
     ///
     /// Value encoding (unchanged): `[has_admin_none: 1][origin: 32 if Some]` — a
     /// first-Some writer stores `[0][C]`, a first-None writer stores `[1]`.
+    ///
+    /// # Errors
+    /// Returns `Err` if the underlying redb write transaction, table open,
+    /// lookup, or commit fails (e.g. a backend I/O error). The caller MUST fail
+    /// the registration on `Err` (persistence-succeeds-before-usable).
     pub fn record_delegate_origin_first_writer(
         &self,
         delegate: &DelegateKey,
@@ -1315,6 +1328,11 @@ impl ReDb {
     /// origins)`, or `None` if the delegate has never been registered on this
     /// node (the NoProvenance case — copy-forward refuses). With first-writer
     /// -wins, `origins` holds at most one entry.
+    ///
+    /// # Errors
+    /// Returns `Err` if the underlying redb read transaction, table open, or
+    /// lookup fails (e.g. a backend I/O error). Copy-forward treats an `Err`
+    /// here as fail-closed (refuse the copy).
     #[allow(clippy::type_complexity)]
     pub fn get_delegate_origins(
         &self,
@@ -1370,6 +1388,10 @@ impl ReDb {
     /// hash `hash`, as an individually-keyed row (#4117 P2a — no read-modify
     /// -write amplification). Idempotent; bounded at
     /// [`Self::MAX_RESERVED_MARKER_HASHES_PER_DELEGATE`] per delegate.
+    ///
+    /// # Errors
+    /// Returns `Err` if the underlying redb write transaction, table open, range
+    /// count, or commit fails (e.g. a backend I/O error).
     pub fn add_reserved_marker_hash(
         &self,
         delegate: &DelegateKey,
@@ -1413,6 +1435,11 @@ impl ReDb {
     /// this to EXCLUDE markers from copy-forward, so a read failure MUST NOT be
     /// silently treated as "no markers" (that would let a marker chain-copy as
     /// user data): the caller fails closed on `Err`.
+    ///
+    /// # Errors
+    /// Returns `Err` if the underlying redb read transaction, table open, or
+    /// range scan fails (e.g. a backend I/O error). Callers MUST fail closed on
+    /// `Err` rather than treating it as "no markers".
     pub fn get_reserved_marker_hashes(
         &self,
         delegate: &DelegateKey,

--- a/crates/core/src/contract/storages/redb.rs
+++ b/crates/core/src/contract/storages/redb.rs
@@ -1338,8 +1338,11 @@ impl ReDb {
         let rest = &bytes[1..];
         let mut origins = Vec::with_capacity(rest.len() / 32);
         for chunk in rest.chunks_exact(32) {
-            let arr: [u8; 32] = chunk.try_into().unwrap();
-            origins.push(arr);
+            // `chunks_exact(32)` yields exactly-32 slices, but decode fallibly
+            // (no production `.unwrap()`): a wrong-length chunk is skipped.
+            if let Ok(arr) = <[u8; 32]>::try_from(chunk) {
+                origins.push(arr);
+            }
         }
         (has_admin_none, origins)
     }
@@ -1421,9 +1424,13 @@ impl ReDb {
             for entry in tbl.range(lo.as_slice()..=hi.as_slice())? {
                 let (k, _v) = entry?;
                 let key_bytes = k.value();
-                if key_bytes.len() == 96 {
-                    let hash: [u8; 32] = key_bytes[64..].try_into().unwrap();
-                    out.push(hash);
+                // Rows are always 96 bytes (delegate64||hash), but decode
+                // fallibly (no production `.unwrap()`): a malformed row is
+                // skipped rather than panicking the read.
+                if let Some(suffix) = key_bytes.get(64..) {
+                    if let Ok(hash) = <[u8; 32]>::try_from(suffix) {
+                        out.push(hash);
+                    }
                 }
             }
             Ok(out)

--- a/crates/core/src/contract/storages/redb.rs
+++ b/crates/core/src/contract/storages/redb.rs
@@ -1907,6 +1907,77 @@ mod tests {
         DelegateKey::new([key_seed; 32], CodeHash::from(&[code_seed; 32]))
     }
 
+    /// #4117 H1: the delegate-origin record is FIRST-WRITER-WINS — the first
+    /// write wins and returns `true`, a later write is a no-op returning `false`,
+    /// and the read observes the ORIGINAL (a racing loser sees the winner's
+    /// record). A `None` first-writer records the Admin/None class.
+    #[tokio::test]
+    async fn delegate_origin_first_writer_wins() {
+        let temp_dir = TempDir::new().unwrap();
+        let db = ReDb::new(temp_dir.path()).await.unwrap();
+        let d = fake_delegate_key(0x33, 0x44);
+        assert!(db.get_delegate_origins(&d).unwrap().is_none());
+
+        let a = [0xA1u8; 32];
+        assert!(db.record_delegate_origin_first_writer(&d, Some(a)).unwrap());
+        // A later, different origin is a no-op (loser).
+        let b = [0xB2u8; 32];
+        assert!(!db.record_delegate_origin_first_writer(&d, Some(b)).unwrap());
+        let (has_none, origins) = db.get_delegate_origins(&d).unwrap().unwrap();
+        assert!(!has_none);
+        assert_eq!(origins, vec![a], "the read observes only the first origin");
+
+        // A None first-writer records the Admin/None class (never privileged).
+        let d2 = fake_delegate_key(0x55, 0x66);
+        assert!(db.record_delegate_origin_first_writer(&d2, None).unwrap());
+        assert!(
+            !db.record_delegate_origin_first_writer(&d2, Some(a))
+                .unwrap()
+        );
+        let (has_none2, origins2) = db.get_delegate_origins(&d2).unwrap().unwrap();
+        assert!(has_none2);
+        assert!(origins2.is_empty());
+    }
+
+    /// #4117 P2a: the reserved-marker-hash table is individually keyed,
+    /// idempotent, per-delegate isolated, and per-delegate CAPPED.
+    #[tokio::test]
+    async fn reserved_marker_hashes_capped_and_isolated() {
+        let temp_dir = TempDir::new().unwrap();
+        let db = ReDb::new(temp_dir.path()).await.unwrap();
+        let d = fake_delegate_key(0x77, 0x88);
+        let other = fake_delegate_key(0x99, 0xAA);
+
+        let h1 = [1u8; 32];
+        let h2 = [2u8; 32];
+        db.add_reserved_marker_hash(&d, &h1).unwrap();
+        db.add_reserved_marker_hash(&d, &h1).unwrap(); // idempotent
+        db.add_reserved_marker_hash(&d, &h2).unwrap();
+        db.add_reserved_marker_hash(&other, &[9u8; 32]).unwrap();
+
+        let mut got = db.get_reserved_marker_hashes(&d).unwrap();
+        got.sort();
+        assert_eq!(got, vec![h1, h2]);
+        assert_eq!(
+            db.get_reserved_marker_hashes(&other).unwrap(),
+            vec![[9u8; 32]],
+            "reserved hashes are per-delegate isolated"
+        );
+
+        // Cap: adding well past the per-delegate cap never exceeds it.
+        let cap = ReDb::MAX_RESERVED_MARKER_HASHES_PER_DELEGATE;
+        for i in 0..(cap as u32 + 10) {
+            let mut h = [0u8; 32];
+            h[..4].copy_from_slice(&i.to_le_bytes());
+            db.add_reserved_marker_hash(&d, &h).unwrap();
+        }
+        assert_eq!(
+            db.get_reserved_marker_hashes(&d).unwrap().len(),
+            cap,
+            "per-delegate reserved-hash count is bounded at the cap"
+        );
+    }
+
     /// Full store → get → remove → load round trip for the per-user secrets
     /// index, exercising `store_user_secrets_index`, `get_user_secrets_index`,
     /// `remove_user_secrets_index` (otherwise uncalled in non-test builds),

--- a/crates/core/src/contract/storages/redb.rs
+++ b/crates/core/src/contract/storages/redb.rs
@@ -77,6 +77,40 @@ pub(crate) const USER_SECRETS_INDEX_TABLE: TableDefinition<&[u8], &[u8]> =
 pub(crate) const MIGRATION_MARKER_TABLE: TableDefinition<&[u8], &[u8]> =
     TableDefinition::new("delegate_secret_migration_marker");
 
+/// Durable record of the web-app contract origins under which each delegate has
+/// been registered (#4117 H1 same-origin gate). Written on EVERY successful
+/// delegate registration (both `RegisterDelegate` and
+/// `RegisterDelegateWithPredecessors`). Copy-forward consults it: a predecessor's
+/// Local secrets are copied into a successor ONLY when the registering request's
+/// origin is among the predecessor's recorded origins (or both are the Admin/None
+/// class), so a malicious web-app cannot register a delegate that names an
+/// unrelated victim delegate as a predecessor to exfiltrate its secrets
+/// (predecessor keys are public-derivable). See `SecretsStore::delegate_origins`.
+///
+/// Key: DelegateKey (64 bytes)
+/// Value: `[has_admin_none: 1][N × ContractInstanceId(32)]` — `has_admin_none`
+///        records that the delegate was at least once registered with no contract
+///        origin (loopback / CLI / admin).
+pub(crate) const DELEGATE_ORIGINS_TABLE: TableDefinition<&[u8], &[u8]> =
+    TableDefinition::new("delegate_registration_origins");
+
+/// Durable, UNCAPPED set of the secret hashes each delegate holds in the reserved
+/// `\0freenet-migrate/` coordination namespace (#4117 finding 4a). Recorded at
+/// `store_secret` time whenever a Local secret's raw key is under that namespace
+/// (covers both this node's `pred-done:` markers and the app-side `pred-wip:`
+/// markers, since both are written via the registering `set_secret`/`store_secret`
+/// path). Copy-forward excludes these hashes from BOTH the value copy and the
+/// enumeration copy. It exists because the advisory `.keys` enumeration registry
+/// is CAPPED (`MAX_REGISTERED_KEYS_PER_SCOPE`) and may be unreadable — at/above
+/// the cap or with a missing registry, a marker's raw key would be invisible to a
+/// registry-based check and could chain-copy as user data, poisoning `had_data`
+/// and falsely gating a later migration. This table is registry-independent.
+///
+/// Key: DelegateKey (64 bytes)
+/// Value: concatenated 32-byte secret hashes (N × 32 bytes)
+pub(crate) const RESERVED_MARKER_HASHES_TABLE: TableDefinition<&[u8], &[u8]> =
+    TableDefinition::new("delegate_reserved_marker_hashes");
+
 /// Metadata about a hosted contract, persisted to survive restarts.
 #[derive(Debug, Clone, Copy)]
 pub struct HostingMetadata {
@@ -481,6 +515,28 @@ impl ReDb {
                     table = "MIGRATION_MARKER_TABLE",
                     phase = "table_init_failed",
                     "Failed to open MIGRATION_MARKER_TABLE"
+                );
+                e
+            })?;
+
+            // Delegate registration origins (#4117 H1) + reserved-marker hashes
+            // (#4117 4a). Both created on first open of upgraded databases too.
+            txn.open_table(DELEGATE_ORIGINS_TABLE).map_err(|e| {
+                tracing::error!(
+                    error = %e,
+                    table = "DELEGATE_ORIGINS_TABLE",
+                    phase = "table_init_failed",
+                    "Failed to open DELEGATE_ORIGINS_TABLE"
+                );
+                e
+            })?;
+
+            txn.open_table(RESERVED_MARKER_HASHES_TABLE).map_err(|e| {
+                tracing::error!(
+                    error = %e,
+                    table = "RESERVED_MARKER_HASHES_TABLE",
+                    phase = "table_init_failed",
+                    "Failed to open RESERVED_MARKER_HASHES_TABLE"
                 );
                 e
             })?;
@@ -1188,6 +1244,140 @@ impl ReDb {
             match tbl.get(key_bytes.as_slice())? {
                 Some(v) => Ok(Some(v.value().to_vec())),
                 None => Ok(None),
+            }
+        })
+    }
+
+    // ========== Delegate registration origins (#4117 H1) ==========
+
+    /// 64-byte delegate key `DelegateKey.key(32) || code_hash(32)` — the same
+    /// encoding the secrets-index tables use.
+    ///
+    /// NOTE (#4117 L3): this redb row key includes the `code_hash`, whereas the
+    /// copy-forward's on-disk namespace and the migration gate are keyed on the
+    /// 32-byte delegate KEY only (`DelegateKey::encode()`). This is harmless:
+    /// `key = BLAKE3(code_hash || params)`, so key and code_hash move together —
+    /// two `DelegateKey`s that share a key but differ in code_hash cannot occur
+    /// for a real delegate. The wider row key just matches the sibling
+    /// secrets-index tables' convention.
+    fn delegate_key64(delegate: &DelegateKey) -> [u8; 64] {
+        let mut b = [0u8; 64];
+        b[..32].copy_from_slice(delegate.as_ref());
+        b[32..].copy_from_slice(delegate.code_hash().as_ref());
+        b
+    }
+
+    /// Record a web-app contract origin for `delegate` (idempotent). `origin =
+    /// None` records the Admin/None class (loopback / CLI registration). Grows
+    /// the row's origin set; a repeated origin is a no-op.
+    pub fn record_delegate_origin(
+        &self,
+        delegate: &DelegateKey,
+        origin: Option<[u8; 32]>,
+    ) -> Result<(), redb::Error> {
+        let key = Self::delegate_key64(delegate);
+        let txn = self.begin_write()?;
+        {
+            let mut tbl = txn.open_table(DELEGATE_ORIGINS_TABLE)?;
+            let (mut has_admin_none, mut origins) = match tbl.get(key.as_slice())? {
+                Some(v) => Self::decode_origins(v.value()),
+                None => (false, Vec::new()),
+            };
+            match origin {
+                None => has_admin_none = true,
+                Some(o) => {
+                    if !origins.iter().any(|e| e == &o) {
+                        origins.push(o);
+                    }
+                }
+            }
+            let mut value = Vec::with_capacity(1 + origins.len() * 32);
+            value.push(u8::from(has_admin_none));
+            for o in &origins {
+                value.extend_from_slice(o);
+            }
+            tbl.insert(key.as_slice(), value.as_slice())?;
+        }
+        Self::commit_guarded(txn)
+    }
+
+    /// Fetch `delegate`'s recorded origins as `(has_admin_none, origins)`, or
+    /// `None` if the delegate has never been registered on this node (the
+    /// grandfather case for copy-forward).
+    #[allow(clippy::type_complexity)]
+    pub fn get_delegate_origins(
+        &self,
+        delegate: &DelegateKey,
+    ) -> Result<Option<(bool, Vec<[u8; 32]>)>, redb::Error> {
+        let key = Self::delegate_key64(delegate);
+        self.read_guarded(|txn| {
+            let tbl = txn.open_table(DELEGATE_ORIGINS_TABLE)?;
+            match tbl.get(key.as_slice())? {
+                Some(v) => Ok(Some(Self::decode_origins(v.value()))),
+                None => Ok(None),
+            }
+        })
+    }
+
+    fn decode_origins(bytes: &[u8]) -> (bool, Vec<[u8; 32]>) {
+        if bytes.is_empty() {
+            return (false, Vec::new());
+        }
+        let has_admin_none = bytes[0] != 0;
+        let rest = &bytes[1..];
+        let mut origins = Vec::with_capacity(rest.len() / 32);
+        for chunk in rest.chunks_exact(32) {
+            let arr: [u8; 32] = chunk.try_into().unwrap();
+            origins.push(arr);
+        }
+        (has_admin_none, origins)
+    }
+
+    // ========== Reserved-marker hashes (#4117 finding 4a) ==========
+
+    /// Record that `delegate` holds a reserved-namespace coordination secret
+    /// with hash `hash` (idempotent). Uncapped and registry-independent.
+    pub fn add_reserved_marker_hash(
+        &self,
+        delegate: &DelegateKey,
+        hash: &[u8; 32],
+    ) -> Result<(), redb::Error> {
+        let key = Self::delegate_key64(delegate);
+        let txn = self.begin_write()?;
+        {
+            let mut tbl = txn.open_table(RESERVED_MARKER_HASHES_TABLE)?;
+            let mut hashes: Vec<u8> = match tbl.get(key.as_slice())? {
+                Some(v) => v.value().to_vec(),
+                None => Vec::new(),
+            };
+            // Idempotent: skip if already present.
+            if !hashes.chunks_exact(32).any(|c| c == hash.as_slice()) {
+                hashes.extend_from_slice(hash);
+                tbl.insert(key.as_slice(), hashes.as_slice())?;
+            }
+        }
+        Self::commit_guarded(txn)
+    }
+
+    /// All reserved-namespace secret hashes recorded for `delegate`.
+    pub fn get_reserved_marker_hashes(
+        &self,
+        delegate: &DelegateKey,
+    ) -> Result<Vec<[u8; 32]>, redb::Error> {
+        let key = Self::delegate_key64(delegate);
+        self.read_guarded(|txn| {
+            let tbl = txn.open_table(RESERVED_MARKER_HASHES_TABLE)?;
+            match tbl.get(key.as_slice())? {
+                Some(v) => {
+                    let bytes = v.value();
+                    let mut out = Vec::with_capacity(bytes.len() / 32);
+                    for chunk in bytes.chunks_exact(32) {
+                        let arr: [u8; 32] = chunk.try_into().unwrap();
+                        out.push(arr);
+                    }
+                    Ok(out)
+                }
+                None => Ok(Vec::new()),
             }
         })
     }

--- a/crates/core/src/contract/storages/redb.rs
+++ b/crates/core/src/contract/storages/redb.rs
@@ -60,6 +60,23 @@ pub(crate) const SECRETS_INDEX_TABLE: TableDefinition<&[u8], &[u8]> =
 pub(crate) const USER_SECRETS_INDEX_TABLE: TableDefinition<&[u8], &[u8]> =
     TableDefinition::new("user_secrets_index");
 
+/// One-shot idempotence / anti-resurrection marker for delegate secret
+/// copy-forward (`SecretsStore::migrate_secrets`, #4117). One row per
+/// `(predecessor, successor)` delegate pair. Presence alone gates the copy:
+/// once a `(predecessor, successor)` migration has run, it is NEVER re-run, so
+/// a secret the user deleted from the successor after migration cannot be
+/// resurrected by a later re-registration. The row value is a small AUDIT FACT
+/// (schema version, the originating contract when known, and the copied/skipped
+/// counts) — see `SecretsStore::migrate_secrets`. Created on first open of
+/// upgraded databases too (redb materializes a missing table inside the same
+/// write txn that opens it), so a pre-#4117 database gains an empty table
+/// without disturbing any existing table.
+///
+/// Key: predecessor DelegateKey (64 bytes) || successor DelegateKey (64 bytes) = 128 bytes
+/// Value: versioned marker blob (see `migration_marker` codec in the secrets store)
+pub(crate) const MIGRATION_MARKER_TABLE: TableDefinition<&[u8], &[u8]> =
+    TableDefinition::new("delegate_secret_migration_marker");
+
 /// Metadata about a hosted contract, persisted to survive restarts.
 #[derive(Debug, Clone, Copy)]
 pub struct HostingMetadata {
@@ -450,6 +467,20 @@ impl ReDb {
                     table = "BROKEN_INVARIANTS_TABLE",
                     phase = "table_init_failed",
                     "Failed to open BROKEN_INVARIANTS_TABLE"
+                );
+                e
+            })?;
+
+            // Delegate secret copy-forward marker (#4117). Created on first open
+            // of upgraded databases too (same missing-table-in-write-txn
+            // materialization as the tables above), so a pre-#4117 database
+            // gains an empty table without disturbing any existing one.
+            txn.open_table(MIGRATION_MARKER_TABLE).map_err(|e| {
+                tracing::error!(
+                    error = %e,
+                    table = "MIGRATION_MARKER_TABLE",
+                    phase = "table_init_failed",
+                    "Failed to open MIGRATION_MARKER_TABLE"
                 );
                 e
             })?;
@@ -1105,6 +1136,59 @@ impl ReDb {
                 result.push(((delegate_key, user_id_bytes), secret_keys));
             }
             Ok(result)
+        })
+    }
+
+    // ============ Delegate Secret Copy-Forward Marker (#4117) ============
+    // One-shot idempotence / anti-resurrection marker keyed on the
+    // `(predecessor, successor)` delegate pair. See `MIGRATION_MARKER_TABLE`
+    // and `SecretsStore::migrate_secrets`.
+
+    /// Build the 128-byte composite key `predecessor(64) || successor(64)`,
+    /// where each 64-byte half is `DelegateKey.key(32) || code_hash(32)` — the
+    /// same DelegateKey encoding the secrets-index tables use.
+    fn migration_marker_key(predecessor: &DelegateKey, successor: &DelegateKey) -> [u8; 128] {
+        let mut key_bytes = [0u8; 128];
+        key_bytes[..32].copy_from_slice(predecessor.as_ref());
+        key_bytes[32..64].copy_from_slice(predecessor.code_hash().as_ref());
+        key_bytes[64..96].copy_from_slice(successor.as_ref());
+        key_bytes[96..].copy_from_slice(successor.code_hash().as_ref());
+        key_bytes
+    }
+
+    /// Persist the copy-forward marker for `(predecessor, successor)`. The
+    /// `value` is the opaque, versioned audit blob built by the secrets store.
+    /// Idempotent: re-writing the same pair overwrites in place.
+    pub fn store_migration_marker(
+        &self,
+        predecessor: &DelegateKey,
+        successor: &DelegateKey,
+        value: &[u8],
+    ) -> Result<(), redb::Error> {
+        let key_bytes = Self::migration_marker_key(predecessor, successor);
+        let txn = self.begin_write()?;
+        {
+            let mut tbl = txn.open_table(MIGRATION_MARKER_TABLE)?;
+            tbl.insert(key_bytes.as_slice(), value)?;
+        }
+        Self::commit_guarded(txn)
+    }
+
+    /// Fetch the copy-forward marker for `(predecessor, successor)`, or `None`
+    /// if this pair has never been migrated. The returned bytes are the opaque
+    /// audit blob the secrets store wrote; only the store interprets them.
+    pub fn get_migration_marker(
+        &self,
+        predecessor: &DelegateKey,
+        successor: &DelegateKey,
+    ) -> Result<Option<Vec<u8>>, redb::Error> {
+        let key_bytes = Self::migration_marker_key(predecessor, successor);
+        self.read_guarded(|txn| {
+            let tbl = txn.open_table(MIGRATION_MARKER_TABLE)?;
+            match tbl.get(key_bytes.as_slice())? {
+                Some(v) => Ok(Some(v.value().to_vec())),
+                None => Ok(None),
+            }
         })
     }
 

--- a/crates/core/src/contract/storages/redb.rs
+++ b/crates/core/src/contract/storages/redb.rs
@@ -105,9 +105,13 @@ pub(crate) const DELEGATE_ORIGINS_TABLE: TableDefinition<&[u8], &[u8]> =
 /// the cap or with a missing registry, a marker's raw key would be invisible to a
 /// registry-based check and could chain-copy as user data, poisoning `had_data`
 /// and falsely gating a later migration. This table is registry-independent.
+/// INDIVIDUALLY KEYED (#4117 P2a): one row per `(delegate, hash)`, so recording a
+/// marker is a single insert, never a read-modify-write of a growing blob (an
+/// amplification vector). Per-delegate rows are bounded
+/// (`MAX_RESERVED_MARKER_HASHES_PER_DELEGATE`) and read via a prefix range scan.
 ///
-/// Key: DelegateKey (64 bytes)
-/// Value: concatenated 32-byte secret hashes (N × 32 bytes)
+/// Key: DelegateKey (64 bytes) || secret hash (32 bytes) = 96 bytes
+/// Value: single presence byte
 pub(crate) const RESERVED_MARKER_HASHES_TABLE: TableDefinition<&[u8], &[u8]> =
     TableDefinition::new("delegate_reserved_marker_hashes");
 
@@ -1267,43 +1271,50 @@ impl ReDb {
         b
     }
 
-    /// Record a web-app contract origin for `delegate` (idempotent). `origin =
-    /// None` records the Admin/None class (loopback / CLI registration). Grows
-    /// the row's origin set; a repeated origin is a no-op.
-    pub fn record_delegate_origin(
+    /// Record the origin under which `delegate` was FIRST registered —
+    /// FIRST-WRITER-WINS and IMMUTABLE (#4117 H1). The record is written only if
+    /// none exists; a later registration NEVER modifies it. This is the whole
+    /// security property: an attacker who re-registers a victim's
+    /// (public-derivable) WASM later cannot add itself to the origin set, so it
+    /// can never satisfy the copy-forward same-origin gate for that delegate.
+    /// `origin = None` records the Admin/None class (a token-less / loopback
+    /// registration), which the gate treats as NEVER privileged. Returns whether
+    /// a NEW record was written (`false` if one already existed).
+    ///
+    /// Value encoding (unchanged): `[has_admin_none: 1][origin: 32 if Some]` — a
+    /// first-Some writer stores `[0][C]`, a first-None writer stores `[1]`.
+    pub fn record_delegate_origin_first_writer(
         &self,
         delegate: &DelegateKey,
         origin: Option<[u8; 32]>,
-    ) -> Result<(), redb::Error> {
+    ) -> Result<bool, redb::Error> {
         let key = Self::delegate_key64(delegate);
         let txn = self.begin_write()?;
-        {
+        let wrote = {
             let mut tbl = txn.open_table(DELEGATE_ORIGINS_TABLE)?;
-            let (mut has_admin_none, mut origins) = match tbl.get(key.as_slice())? {
-                Some(v) => Self::decode_origins(v.value()),
-                None => (false, Vec::new()),
-            };
-            match origin {
-                None => has_admin_none = true,
-                Some(o) => {
-                    if !origins.iter().any(|e| e == &o) {
-                        origins.push(o);
+            if tbl.get(key.as_slice())?.is_some() {
+                false
+            } else {
+                let mut value = Vec::with_capacity(1 + 32);
+                match origin {
+                    None => value.push(1u8), // Admin/None class, no Some origin
+                    Some(o) => {
+                        value.push(0u8);
+                        value.extend_from_slice(&o);
                     }
                 }
+                tbl.insert(key.as_slice(), value.as_slice())?;
+                true
             }
-            let mut value = Vec::with_capacity(1 + origins.len() * 32);
-            value.push(u8::from(has_admin_none));
-            for o in &origins {
-                value.extend_from_slice(o);
-            }
-            tbl.insert(key.as_slice(), value.as_slice())?;
-        }
-        Self::commit_guarded(txn)
+        };
+        Self::commit_guarded(txn)?;
+        Ok(wrote)
     }
 
-    /// Fetch `delegate`'s recorded origins as `(has_admin_none, origins)`, or
-    /// `None` if the delegate has never been registered on this node (the
-    /// grandfather case for copy-forward).
+    /// Fetch `delegate`'s FIRST-registration origin as `(has_admin_none,
+    /// origins)`, or `None` if the delegate has never been registered on this
+    /// node (the NoProvenance case — copy-forward refuses). With first-writer
+    /// -wins, `origins` holds at most one entry.
     #[allow(clippy::type_complexity)]
     pub fn get_delegate_origins(
         &self,
@@ -1333,52 +1344,89 @@ impl ReDb {
         (has_admin_none, origins)
     }
 
-    // ========== Reserved-marker hashes (#4117 finding 4a) ==========
+    // ========== Reserved-marker hashes (#4117 finding 4a / P2a) ==========
 
-    /// Record that `delegate` holds a reserved-namespace coordination secret
-    /// with hash `hash` (idempotent). Uncapped and registry-independent.
+    /// Per-delegate cap on recorded reserved-marker hashes. Bounds the table
+    /// against a delegate that somehow accretes many reserved entries; a real
+    /// delegate's reserved set is at most its predecessor count (itself capped at
+    /// registration). Over the cap, further entries are not recorded (the
+    /// below-cap `.keys` union still covers a freshly-written marker).
+    pub(crate) const MAX_RESERVED_MARKER_HASHES_PER_DELEGATE: usize = 256;
+
+    /// 96-byte row key `delegate_key64(64) || hash(32)` for the individually
+    /// -keyed reserved-marker table (no read-modify-write of a growing blob —
+    /// #4117 P2a).
+    fn reserved_marker_row_key(delegate: &DelegateKey, hash: &[u8; 32]) -> [u8; 96] {
+        let mut k = [0u8; 96];
+        k[..64].copy_from_slice(&Self::delegate_key64(delegate));
+        k[64..].copy_from_slice(hash);
+        k
+    }
+
+    /// Record that `delegate` holds a reserved-namespace coordination secret with
+    /// hash `hash`, as an individually-keyed row (#4117 P2a — no read-modify
+    /// -write amplification). Idempotent; bounded at
+    /// [`Self::MAX_RESERVED_MARKER_HASHES_PER_DELEGATE`] per delegate.
     pub fn add_reserved_marker_hash(
         &self,
         delegate: &DelegateKey,
         hash: &[u8; 32],
     ) -> Result<(), redb::Error> {
-        let key = Self::delegate_key64(delegate);
+        let row_key = Self::reserved_marker_row_key(delegate, hash);
+        let (lo, hi) = Self::reserved_marker_range(delegate);
         let txn = self.begin_write()?;
         {
             let mut tbl = txn.open_table(RESERVED_MARKER_HASHES_TABLE)?;
-            let mut hashes: Vec<u8> = match tbl.get(key.as_slice())? {
-                Some(v) => v.value().to_vec(),
-                None => Vec::new(),
-            };
-            // Idempotent: skip if already present.
-            if !hashes.chunks_exact(32).any(|c| c == hash.as_slice()) {
-                hashes.extend_from_slice(hash);
-                tbl.insert(key.as_slice(), hashes.as_slice())?;
+            // Idempotent + capped. Counting the existing rows is bounded by the
+            // cap; a present row means we're done.
+            if tbl.get(row_key.as_slice())?.is_none() {
+                let count = tbl.range(lo.as_slice()..=hi.as_slice())?.count();
+                if count < Self::MAX_RESERVED_MARKER_HASHES_PER_DELEGATE {
+                    tbl.insert(row_key.as_slice(), [1u8].as_slice())?;
+                } else {
+                    tracing::warn!(
+                        delegate = %delegate.encode(),
+                        cap = Self::MAX_RESERVED_MARKER_HASHES_PER_DELEGATE,
+                        "reserved-marker hash set at cap; not recording (below-cap .keys union still covers fresh markers)"
+                    );
+                }
             }
         }
         Self::commit_guarded(txn)
     }
 
-    /// All reserved-namespace secret hashes recorded for `delegate`.
+    /// Inclusive `[lo, hi]` 96-byte range bounds covering every reserved-marker
+    /// row for `delegate` (its 64-byte prefix followed by all-zero .. all-ones
+    /// hash).
+    fn reserved_marker_range(delegate: &DelegateKey) -> ([u8; 96], [u8; 96]) {
+        let mut lo = [0u8; 96];
+        lo[..64].copy_from_slice(&Self::delegate_key64(delegate));
+        let mut hi = [0xffu8; 96];
+        hi[..64].copy_from_slice(&Self::delegate_key64(delegate));
+        (lo, hi)
+    }
+
+    /// All reserved-namespace secret hashes recorded for `delegate`. Callers use
+    /// this to EXCLUDE markers from copy-forward, so a read failure MUST NOT be
+    /// silently treated as "no markers" (that would let a marker chain-copy as
+    /// user data): the caller fails closed on `Err`.
     pub fn get_reserved_marker_hashes(
         &self,
         delegate: &DelegateKey,
     ) -> Result<Vec<[u8; 32]>, redb::Error> {
-        let key = Self::delegate_key64(delegate);
+        let (lo, hi) = Self::reserved_marker_range(delegate);
         self.read_guarded(|txn| {
             let tbl = txn.open_table(RESERVED_MARKER_HASHES_TABLE)?;
-            match tbl.get(key.as_slice())? {
-                Some(v) => {
-                    let bytes = v.value();
-                    let mut out = Vec::with_capacity(bytes.len() / 32);
-                    for chunk in bytes.chunks_exact(32) {
-                        let arr: [u8; 32] = chunk.try_into().unwrap();
-                        out.push(arr);
-                    }
-                    Ok(out)
+            let mut out = Vec::new();
+            for entry in tbl.range(lo.as_slice()..=hi.as_slice())? {
+                let (k, _v) = entry?;
+                let key_bytes = k.value();
+                if key_bytes.len() == 96 {
+                    let hash: [u8; 32] = key_bytes[64..].try_into().unwrap();
+                    out.push(hash);
                 }
-                None => Ok(Vec::new()),
             }
+            Ok(out)
         })
     }
 

--- a/crates/core/src/contract/storages/redb.rs
+++ b/crates/core/src/contract/storages/redb.rs
@@ -1605,6 +1605,13 @@ impl StateStorage for ReDb {
     }
 }
 
+// Test-only fault-injection helpers, re-exported so sibling modules' tests
+// (e.g. the secrets-store origin-record failure path, #4117) can build a
+// `ReDb` whose backend I/O can be flipped to fail on demand. Defined inside
+// `mod tests` below; surfaced at module level here for cross-module test use.
+#[cfg(test)]
+pub(crate) use tests::{FailingBackend, open_redb_with_backend};
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1939,6 +1946,35 @@ mod tests {
         assert!(origins2.is_empty());
     }
 
+    /// #4117 H1 (persistence-succeeds-before-usable): a durable-write failure in
+    /// `record_delegate_origin_first_writer` SURFACES as `Err` — it is never
+    /// swallowed into a silent `Ok`. This is the storage-layer foundation of the
+    /// rule that a failed origin record must ABORT the whole registration (a
+    /// registered-but-recordless delegate has a claimable first-writer slot).
+    /// Uses the fault-injecting backend to produce a REAL redb I/O failure.
+    #[test]
+    fn record_delegate_origin_first_writer_surfaces_backend_failure() {
+        let backend = FailingBackend::new();
+        let db = open_redb_with_backend(backend.clone());
+        let d = fake_delegate_key(0x12, 0x34);
+
+        // Healthy: the first write succeeds and is observable.
+        assert!(
+            db.record_delegate_origin_first_writer(&d, Some([0x11u8; 32]))
+                .unwrap(),
+            "healthy first write must succeed and return `true`"
+        );
+
+        // Disk fails: a subsequent origin write MUST return Err, never a silent Ok.
+        backend.start_failing();
+        let d2 = fake_delegate_key(0x56, 0x78);
+        assert!(
+            db.record_delegate_origin_first_writer(&d2, Some([0x22u8; 32]))
+                .is_err(),
+            "a durable-write failure must surface as Err, never a silent Ok"
+        );
+    }
+
     /// #4117 P2a: the reserved-marker-hash table is individually keyed,
     /// idempotent, per-delegate isolated, and per-delegate CAPPED.
     #[tokio::test]
@@ -2107,13 +2143,13 @@ mod tests {
     /// `StorageError::PreviousIo`) so the poison-detection and recovery path can be
     /// exercised without relying on the error message string.
     #[derive(Debug, Clone)]
-    struct FailingBackend {
+    pub(crate) struct FailingBackend {
         inner: Arc<redb::backends::InMemoryBackend>,
         fail: Arc<std::sync::atomic::AtomicBool>,
     }
 
     impl FailingBackend {
-        fn new() -> Self {
+        pub(crate) fn new() -> Self {
             Self {
                 inner: Arc::new(redb::backends::InMemoryBackend::new()),
                 fail: Arc::new(std::sync::atomic::AtomicBool::new(false)),
@@ -2121,7 +2157,7 @@ mod tests {
         }
 
         /// Make every subsequent I/O call fail, simulating a disk EIO / csum failure.
-        fn start_failing(&self) {
+        pub(crate) fn start_failing(&self) {
             self.fail.store(true, std::sync::atomic::Ordering::SeqCst);
         }
 
@@ -2160,7 +2196,7 @@ mod tests {
     }
 
     /// Open a fully-initialised [`ReDb`] over an arbitrary backend (test-only).
-    fn open_redb_with_backend<B: redb::StorageBackend>(backend: B) -> ReDb {
+    pub(crate) fn open_redb_with_backend<B: redb::StorageBackend>(backend: B) -> ReDb {
         let db = Database::builder()
             .create_with_backend(backend)
             .expect("create_with_backend");

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -3706,6 +3706,9 @@ pub async fn run_local_node(
                 // if the token expired between WebSocket connect and this request)
                 let op_name = match op {
                     DelegateRequest::RegisterDelegate { .. } => "RegisterDelegate",
+                    DelegateRequest::RegisterDelegateWithPredecessors { .. } => {
+                        "RegisterDelegateWithPredecessors"
+                    }
                     DelegateRequest::ApplicationMessages { .. } => "ApplicationMessages",
                     DelegateRequest::UnregisterDelegate(_) => "UnregisterDelegate",
                     _ => "Unknown",

--- a/crates/core/src/wasm_runtime.rs
+++ b/crates/core/src/wasm_runtime.rs
@@ -54,8 +54,8 @@ pub use runtime::{ContractExecError, Runtime};
 pub(crate) use runtime::{RuntimeConfig, SharedModuleCache};
 pub use secrets_store::{
     DEFAULT_LAST_SEEN_DEBOUNCE_SECS, DEFAULT_PER_USER_INACTIVE_TTL_SECS,
-    DEFAULT_PER_USER_SECRET_QUOTA_BYTES, ExportSecretEntry, SecretScope, SecretStoreError,
-    SecretsStore, UserId, UserSecretContext, should_spawn_inactive_user_sweep,
+    DEFAULT_PER_USER_SECRET_QUOTA_BYTES, ExportSecretEntry, MigrationReport, SecretScope,
+    SecretStoreError, SecretsStore, UserId, UserSecretContext, should_spawn_inactive_user_sweep,
     spawn_inactive_user_sweep, stamp_user_last_seen, wall_clock_unix_secs,
 };
 // NOTE: InMemoryContractStore and SimulationStores are available but currently unused

--- a/crates/core/src/wasm_runtime/runtime.rs
+++ b/crates/core/src/wasm_runtime/runtime.rs
@@ -467,15 +467,19 @@ impl Runtime {
 
     /// Durably record the web-app origin under which `delegate` was registered,
     /// for the H1 same-origin copy-forward gate (#4117). Called on every
-    /// successful registration. Another route to the `pub(super) secret_store`
-    /// from the executor module tree, like `migrate_delegate_secrets`.
+    /// registration, BEFORE it is registered. Another route to the
+    /// `pub(super) secret_store` from the executor module tree, like
+    /// `migrate_delegate_secrets`.
+    ///
+    /// Propagates the store's error: a persistence failure MUST fail the whole
+    /// registration (see `SecretsStore::record_delegate_registration_origin`).
     pub(crate) fn record_delegate_registration_origin(
         &self,
         delegate: &DelegateKey,
         origin: Option<[u8; 32]>,
-    ) {
+    ) -> Result<(), super::SecretStoreError> {
         self.secret_store
-            .record_delegate_registration_origin(delegate, origin);
+            .record_delegate_registration_origin(delegate, origin)
     }
 
     pub fn build_with_config(

--- a/crates/core/src/wasm_runtime/runtime.rs
+++ b/crates/core/src/wasm_runtime/runtime.rs
@@ -439,6 +439,32 @@ impl Runtime {
         )
     }
 
+    /// One-shot, idempotent, Local-scope copy-forward of delegate secrets from
+    /// `predecessors` into `successor` (#4117), the node-side primitive behind
+    /// `DelegateRequest::RegisterDelegateWithPredecessors`. Another route to the
+    /// `pub(super) secret_store` for a write from outside the `wasm_runtime`
+    /// module (the executor lives in a different module tree and wraps secret
+    /// access in `Runtime` methods, exactly as `register_delegate` /
+    /// `import_secret_bundle` do).
+    ///
+    /// Never returns an error: every failure is recorded in the returned
+    /// [`super::MigrationReport`] and logged, so a registration is never blocked
+    /// by a predecessor's data being absent or partly unreadable. See
+    /// [`SecretsStore::migrate_secrets`] for the full contract (Local-only DEK
+    /// carve-out, no-delete invariant, one-shot / anti-resurrection marker).
+    ///
+    /// Runs ON the contract loop (serialized with delegate `store_secret`),
+    /// mirroring the on-loop write discipline of `import_secret_bundle`.
+    pub(crate) fn migrate_delegate_secrets(
+        &mut self,
+        predecessors: &[DelegateKey],
+        successor: &DelegateKey,
+        origin_contract: Option<[u8; 32]>,
+    ) -> super::MigrationReport {
+        self.secret_store
+            .migrate_secrets(predecessors, successor, origin_contract)
+    }
+
     pub fn build_with_config(
         contract_store: ContractStore,
         delegate_store: DelegateStore,

--- a/crates/core/src/wasm_runtime/runtime.rs
+++ b/crates/core/src/wasm_runtime/runtime.rs
@@ -465,6 +465,19 @@ impl Runtime {
             .migrate_secrets(predecessors, successor, origin_contract)
     }
 
+    /// Durably record the web-app origin under which `delegate` was registered,
+    /// for the H1 same-origin copy-forward gate (#4117). Called on every
+    /// successful registration. Another route to the `pub(super) secret_store`
+    /// from the executor module tree, like `migrate_delegate_secrets`.
+    pub(crate) fn record_delegate_registration_origin(
+        &self,
+        delegate: &DelegateKey,
+        origin: Option<[u8; 32]>,
+    ) {
+        self.secret_store
+            .record_delegate_registration_origin(delegate, origin);
+    }
+
     pub fn build_with_config(
         contract_store: ContractStore,
         delegate_store: DelegateStore,

--- a/crates/core/src/wasm_runtime/secrets_store.rs
+++ b/crates/core/src/wasm_runtime/secrets_store.rs
@@ -52,7 +52,9 @@ pub use sweep::{
     spawn_inactive_user_sweep, stamp_user_last_seen, wall_clock_unix_secs,
 };
 
-pub use store::{ExportScopeError, ExportSecretEntry, SecretStoreError, SecretsStore};
+pub use store::{
+    ExportScopeError, ExportSecretEntry, MigrationReport, SecretStoreError, SecretsStore,
+};
 
 // ── pub(super) re-exports ─────────────────────────────────────────────────────
 // `secret_snapshots` and other wasm_runtime siblings import these.

--- a/crates/core/src/wasm_runtime/secrets_store/store.rs
+++ b/crates/core/src/wasm_runtime/secrets_store/store.rs
@@ -2449,11 +2449,11 @@ impl SecretsStore {
             //    copied OR already there) to drive the enumeration-registry copy.
             let mut copy_error = false;
             let mut present_hashes: HashSet<SecretKey> = HashSet::new();
-            // Coordination-marker secrets (the reserved `freenet-migrate`
+            // Coordination-marker secrets (the whole reserved `\0freenet-migrate/`
             // namespace) are NEVER copied forward — they are per-generation
             // metadata, not user data, and chain-copying them would accrete stale
-            // markers under later successors.
-            let marker_hashes = self.predecessor_marker_hashes(predecessor);
+            // markers under later successors and diverge from the app-side path.
+            let marker_hashes = self.predecessor_reserved_marker_hashes(predecessor);
             for hash in &hashes {
                 if marker_hashes.contains(hash) {
                     continue;
@@ -2689,20 +2689,20 @@ impl SecretsStore {
         Ok(count)
     }
 
-    /// Hashes of the predecessor's Local secrets that are freenet-migrate
-    /// coordination markers (raw key under [`MIGRATE_MARKER_KEY_PREFIX`]), so the
-    /// copy-forward walk can SKIP them. Markers are per-generation coordination
-    /// metadata written under a successor, NOT user secrets, and must not
-    /// chain-copy into a further successor (the reserved namespace is excluded
-    /// from copy). Best-effort: an unreadable registry yields an empty set
+    /// Hashes of the predecessor's Local secrets that live in the reserved
+    /// freenet-migrate coordination namespace ([`MIGRATE_RESERVED_NAMESPACE_PREFIX`]
+    /// — both this node's `pred-done:` markers AND the app-side `pred-wip:`
+    /// markers), so the copy-forward walk can SKIP them. They are per-generation
+    /// coordination metadata, NOT user secrets, and must not chain-copy into a
+    /// further successor. Best-effort: an unreadable registry yields an empty set
     /// (markers then fall through as ordinary secrets — the degraded case), never
     /// an error. Relies on markers being written via `store_secret` (which
     /// registers the raw key), so their raw key is recoverable here.
-    fn predecessor_marker_hashes(&self, predecessor: &DelegateKey) -> HashSet<SecretKey> {
+    fn predecessor_reserved_marker_hashes(&self, predecessor: &DelegateKey) -> HashSet<SecretKey> {
         let mut out = HashSet::new();
         if let Ok(keys) = self.read_key_registry(predecessor, &SecretScope::Local) {
             for raw in keys {
-                if raw.starts_with(MIGRATE_MARKER_KEY_PREFIX) {
+                if raw.starts_with(MIGRATE_RESERVED_NAMESPACE_PREFIX) {
                     out.insert(*SecretsId::new(raw).hash());
                 }
             }
@@ -2752,7 +2752,7 @@ impl SecretsStore {
                 break;
             }
             // Never enumerate the reserved coordination-marker namespace.
-            if raw.starts_with(MIGRATE_MARKER_KEY_PREFIX) {
+            if raw.starts_with(MIGRATE_RESERVED_NAMESPACE_PREFIX) {
                 continue;
             }
             // Only register a key whose value is actually present under the
@@ -2792,6 +2792,18 @@ impl SecretsStore {
 /// the whole `\0freenet-migrate/` namespace out of `list_secret_keys`/exports,
 /// and the copy-forward walk skips it so it is never enumerated forward.
 const MIGRATE_MARKER_KEY_PREFIX: &[u8] = b"\0freenet-migrate/v1/pred-done:";
+
+/// Reserved-namespace prefix covering ALL freenet-migrate coordination keys —
+/// the `pred-done:` completion markers this node writes AND the `pred-wip:`
+/// two-phase intent markers the app-side `freenet-migrate` path writes (which
+/// the node never writes). Copy-forward EXCLUDES this whole namespace from both
+/// the value copy and the enumeration copy, so a chained migration never sweeps
+/// a coordination marker onward. This is load-bearing for cross-transport
+/// consistency: the app-side import structurally skips every `\0freenet-migrate/`
+/// key, so the node must too, or a node-migrated successor would carry markers an
+/// app-migrated one never would and the two would diverge on a later chained
+/// migration. `MIGRATE_MARKER_KEY_PREFIX` is a subset of this namespace.
+const MIGRATE_RESERVED_NAMESPACE_PREFIX: &[u8] = b"\0freenet-migrate/";
 
 /// Build the `SecretsId` of the "predecessor migrated" marker recorded under the
 /// SUCCESSOR delegate: [`MIGRATE_MARKER_KEY_PREFIX`] followed by the
@@ -9017,6 +9029,75 @@ mod test {
         Ok(())
     }
 
+    /// The WHOLE reserved `\0freenet-migrate/` namespace is excluded from
+    /// copy-forward, not just `pred-done:` — including the app-side `pred-wip:`
+    /// intent markers the node never writes but may find on a predecessor an
+    /// app-side migration touched. Excluding the whole namespace keeps the node
+    /// and app transports' marker sets byte-identical.
+    #[tokio::test]
+    async fn migrate_excludes_whole_reserved_namespace() -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let secrets_dir = temp_dir.path().join("s");
+        std::fs::create_dir_all(&secrets_dir)?;
+        let db = create_test_db(temp_dir.path()).await;
+        let mut store = SecretsStore::new(secrets_dir, Default::default(), db)?;
+
+        let pred = Delegate::from((&vec![0].into(), &vec![1].into()));
+        let succ = Delegate::from((&vec![0].into(), &vec![2].into()));
+
+        // A real user secret plus an app-written WIP intent marker under the
+        // predecessor (the node never writes WIP, but an app-side migration may).
+        let real = SecretsId::new(b"room:real".to_vec());
+        let wip_raw = {
+            let mut k = b"\0freenet-migrate/v1/pred-wip:".to_vec();
+            k.extend_from_slice(&[0xAB; 32]);
+            k
+        };
+        let wip = SecretsId::new(wip_raw.clone());
+        store.store_secret(
+            pred.key(),
+            &real,
+            SecretScope::Local,
+            Zeroizing::new(b"v".to_vec()),
+        )?;
+        store.store_secret(
+            pred.key(),
+            &wip,
+            SecretScope::Local,
+            Zeroizing::new(b"1".to_vec()),
+        )?;
+
+        let report = store.migrate_secrets(std::slice::from_ref(pred.key()), succ.key(), None);
+        // Only the real secret copies; the reserved-namespace key does not.
+        assert_eq!(report.total_copied(), 1, "only the real secret copies");
+        assert!(
+            store
+                .get_secret(succ.key(), &real, SecretScope::Local)
+                .is_ok(),
+            "the real secret migrates"
+        );
+        assert!(
+            store
+                .get_secret(succ.key(), &wip, SecretScope::Local)
+                .is_err(),
+            "the reserved-namespace WIP key must NOT copy forward"
+        );
+        // The WIP key is not enumerable under the successor. (The successor DOES
+        // carry its own `pred-done:` marker for `pred` — expected bookkeeping —
+        // so we assert the WIP key specifically is absent, not that the namespace
+        // is empty.)
+        let reserved = store.list_secret_keys(
+            succ.key(),
+            SecretScope::Local,
+            MIGRATE_RESERVED_NAMESPACE_PREFIX,
+        );
+        assert!(
+            !reserved.contains(&wip_raw),
+            "the WIP key must not be enumerable under the successor"
+        );
+        Ok(())
+    }
+
     /// Byte-exact pin of the crate-format marker key + value, MIRRORING the
     /// public `freenet-migrate` contract. A drift here (or in the crate) breaks
     /// the shared marker and is caught by CI on whichever side changed.
@@ -9026,6 +9107,10 @@ mod test {
             MIGRATE_MARKER_KEY_PREFIX,
             b"\0freenet-migrate/v1/pred-done:"
         );
+        // The whole reserved namespace is excluded from copy-forward (covers the
+        // app-side `pred-wip:` markers too); `pred-done:` lives under it.
+        assert_eq!(MIGRATE_RESERVED_NAMESPACE_PREFIX, b"\0freenet-migrate/");
+        assert!(MIGRATE_MARKER_KEY_PREFIX.starts_with(MIGRATE_RESERVED_NAMESPACE_PREFIX));
 
         let pred = DelegateKey::new([7u8; 32], CodeHash::from(&[9u8; 32]));
         let sid = pred_done_marker_secret_id(&pred);

--- a/crates/core/src/wasm_runtime/secrets_store/store.rs
+++ b/crates/core/src/wasm_runtime/secrets_store/store.rs
@@ -2259,6 +2259,467 @@ impl SecretsStore {
         self.add_to_index(delegate, &scope, *secret_hash)?;
         Ok(true)
     }
+
+    /// One-shot, idempotent, **Local-scope-only** copy-forward of delegate
+    /// secrets from one or more `predecessors` to a `successor` delegate key
+    /// (#4117).
+    ///
+    /// A delegate's on-disk key is `BLAKE3(code_hash || params)`, so ANY change
+    /// to the delegate's compiled WASM mints a new key, a new secrets namespace,
+    /// and an "empty new install" for every existing user. This copies each
+    /// predecessor's secret VALUES forward into the successor's namespace,
+    /// re-encrypting them from the predecessor's Local DEK to the successor's,
+    /// so a delegate rebuild no longer wipes user state.
+    ///
+    /// **Local scope only, by construction.** The Local DEK is
+    /// `HKDF(salt = delegate_key, ikm = node_KEK)`, both available at rest, so
+    /// the node can decrypt a predecessor's Local secret and re-encrypt it for
+    /// the successor without any client input. The per-user (hosted) DEK is
+    /// `HKDF(salt = delegate_key, ikm = client_dek_secret)`, and `dek_secret`
+    /// is supplied per request and is NOT available at rest — so User-scope
+    /// secrets simply cannot be re-encrypted here. They are never touched; the
+    /// count of User-scope blobs a predecessor holds is recorded in the report
+    /// (`user_scope_skipped`) as observability for that carve-out.
+    ///
+    /// **No-delete invariant.** Predecessor data is only ever read, never
+    /// deleted or mutated. `overwrite = false` on the successor side means an
+    /// existing successor value (one it wrote itself, or one an earlier
+    /// predecessor already supplied) is preserved — first writer wins.
+    ///
+    /// **One-shot / anti-resurrection.** Each `(predecessor, successor)` pair is
+    /// gated by a persistent marker (redb `MIGRATION_MARKER_TABLE`). The marker
+    /// — NOT deletion — is what prevents resurrection: once a pair has migrated,
+    /// it never migrates again, so a secret the user DELETES from the successor
+    /// after migration cannot reappear when the delegate re-registers (which
+    /// apps do routinely, e.g. on every startup). The marker is written even
+    /// after partial per-secret errors, precisely so a retry cannot reopen that
+    /// window; per-secret read/import failures indicate genuine on-disk
+    /// corruption (the node wrote every blob it reads) that a retry would not
+    /// fix, and are logged loudly instead.
+    ///
+    /// **Never fails registration.** All errors (an absent predecessor, an
+    /// unreadable blob, even a failed marker write) are recorded in the returned
+    /// [`MigrationReport`] and logged; this function returns a report, never an
+    /// `Err`, so the caller registers the successor regardless. An unknown /
+    /// absent predecessor is a clean no-op.
+    ///
+    /// `origin_contract` is the 32-byte id of the web-app contract that drove
+    /// the registration, when known. It is recorded verbatim in the marker as a
+    /// consent-primary-v1 AUDIT FACT (the client gates on user consent; the node
+    /// records the origin). Durable origin-binding authorization is a filed
+    /// follow-up, not enforced here.
+    ///
+    /// Runs synchronously on the caller (the contract loop, via the
+    /// `RegisterDelegateWithPredecessors` handler), mirroring the on-loop write
+    /// discipline of `store_secret` / the live bundle import. The work is bounded
+    /// by the predecessors' own on-disk secret count.
+    pub fn migrate_secrets(
+        &mut self,
+        predecessors: &[DelegateKey],
+        successor: &DelegateKey,
+        origin_contract: Option<[u8; 32]>,
+    ) -> MigrationReport {
+        let mut report = MigrationReport {
+            successor: successor.clone(),
+            per_predecessor: Vec::with_capacity(predecessors.len()),
+        };
+
+        for predecessor in predecessors {
+            let mut pm = PredecessorMigration::new(predecessor.clone());
+
+            // A delegate that lists itself (or a repeated predecessor) as its
+            // own predecessor has nothing to copy: source and destination share
+            // the same on-disk namespace and DEK. Skip without writing a marker
+            // — there is nothing to gate. `encode()` is key-only, so this also
+            // collapses two DelegateKeys that differ only in `code_hash`.
+            if predecessor.encode() == successor.encode() {
+                report.per_predecessor.push(pm);
+                continue;
+            }
+
+            // 1. One-shot marker gate. Presence means this exact
+            //    (predecessor, successor) copy already ran; never re-run it.
+            //    Fail CLOSED on a read anomaly: treat it as "already migrated"
+            //    so a corrupt/unreadable marker can never reopen the
+            //    resurrection window by re-copying a user-deleted secret.
+            match self.db.get_migration_marker(predecessor, successor) {
+                Ok(Some(bytes)) => {
+                    // Surface the prior migration's recorded audit fact so a
+                    // repeated registration (apps re-register on every start) is
+                    // observable rather than a silent no-op.
+                    if let Some(prior) = MigrationMarker::decode(&bytes) {
+                        tracing::debug!(
+                            predecessor = %predecessor.encode(),
+                            successor = %successor.encode(),
+                            prior_copied = prior.copied,
+                            prior_skipped_existing = prior.skipped_existing,
+                            prior_user_scope_skipped = prior.user_scope_skipped,
+                            prior_errors = prior.error_count,
+                            "delegate secret copy-forward: already migrated; skipping"
+                        );
+                    }
+                    pm.already_migrated = true;
+                    report.per_predecessor.push(pm);
+                    continue;
+                }
+                Ok(None) => {}
+                Err(e) => {
+                    tracing::error!(
+                        predecessor = %predecessor.encode(),
+                        successor = %successor.encode(),
+                        error = %e,
+                        "delegate secret copy-forward: marker read failed; skipping copy (fail-closed)"
+                    );
+                    pm.already_migrated = true;
+                    pm.errors.push(format!("marker read failed: {e}"));
+                    report.per_predecessor.push(pm);
+                    continue;
+                }
+            }
+
+            // 2. Enumerate the predecessor's Local-scope secrets from disk. An
+            //    absent predecessor directory yields nothing (clean no-op for an
+            //    unknown predecessor, which still records the marker below); any
+            //    other read error means we could not even list the predecessor,
+            //    so nothing is copied and NO marker is written (step 5) — a later
+            //    re-registration then retries a genuinely transient I/O failure.
+            let mut hashes: Vec<SecretKey> = Vec::new();
+            let enumeration_ok =
+                match self.walk_predecessor_local_secrets(predecessor, |h| hashes.push(h)) {
+                    Ok(()) => true,
+                    Err(e) => {
+                        tracing::warn!(
+                            predecessor = %predecessor.encode(),
+                            error = %e,
+                            "delegate secret copy-forward: failed to enumerate predecessor secrets"
+                        );
+                        pm.errors
+                            .push(format!("enumerate predecessor secrets failed: {e}"));
+                        false
+                    }
+                };
+
+            // 3. Read each secret under the predecessor's Local DEK, re-encrypt
+            //    under the successor's Local DEK (overwrite = false → first
+            //    writer wins). A per-secret failure is recorded, never fatal.
+            for hash in &hashes {
+                let encoded = bs58::encode(hash)
+                    .with_alphabet(bs58::Alphabet::BITCOIN)
+                    .into_string();
+                match self.read_secret_by_hash(predecessor, hash, &SecretScope::Local) {
+                    Ok(plaintext) => {
+                        match self.import_secret_by_hash(
+                            successor,
+                            hash,
+                            SecretScope::Local,
+                            plaintext,
+                            false,
+                        ) {
+                            Ok(true) => pm.copied += 1,
+                            Ok(false) => pm.skipped_existing += 1,
+                            Err(e) => {
+                                tracing::warn!(
+                                    predecessor = %predecessor.encode(),
+                                    successor = %successor.encode(),
+                                    secret = %encoded,
+                                    error = %e,
+                                    "delegate secret copy-forward: import failed"
+                                );
+                                pm.errors.push(format!("import {encoded} failed: {e}"));
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            predecessor = %predecessor.encode(),
+                            secret = %encoded,
+                            error = %e,
+                            "delegate secret copy-forward: read failed"
+                        );
+                        pm.errors.push(format!("read {encoded} failed: {e}"));
+                    }
+                }
+            }
+
+            // 4. Record (never migrate) any User/hosted-scope secrets the
+            //    predecessor holds — the per-user DEK is not derivable at rest.
+            match self.count_predecessor_user_scope_secrets(predecessor) {
+                Ok(n) => pm.user_scope_skipped = n,
+                Err(e) => pm
+                    .errors
+                    .push(format!("user-scope secret count failed: {e}")),
+            }
+
+            // 5. Write the one-shot marker (audit fact), UNLESS enumeration
+            //    failed (step 2) — a failed enumeration copied nothing, so there
+            //    is no resurrection risk to gate and skipping the marker lets a
+            //    later re-registration retry a transient I/O failure. Once
+            //    enumeration succeeded the marker IS written even with per-secret
+            //    errors: those indicate on-disk corruption a retry would not fix,
+            //    and some secrets may have copied, which a retry could resurrect
+            //    after a user deletion. A marker WRITE failure leaves idempotence
+            //    non-durable — logged and recorded, but still non-fatal.
+            if enumeration_ok {
+                let value = encode_migration_marker(
+                    origin_contract,
+                    pm.copied,
+                    pm.skipped_existing,
+                    pm.user_scope_skipped,
+                    pm.errors.len(),
+                );
+                if let Err(e) = self
+                    .db
+                    .store_migration_marker(predecessor, successor, &value)
+                {
+                    tracing::error!(
+                        predecessor = %predecessor.encode(),
+                        successor = %successor.encode(),
+                        error = %e,
+                        "delegate secret copy-forward: failed to persist marker; idempotence not durable"
+                    );
+                    pm.errors.push(format!("marker write failed: {e}"));
+                }
+            }
+
+            report.per_predecessor.push(pm);
+        }
+
+        report
+    }
+
+    /// Enumerate the Local-scope secret hashes `predecessor` holds on disk: the
+    /// regular files directly under `base_path/<predecessor.encode()>` whose
+    /// name bs58-decodes to a 32-byte hash. The predecessor-scoped analogue of
+    /// the inner loop of [`Self::walk_scope_secrets_on_disk`] — it descends only
+    /// the one delegate's directory instead of every delegate under `base_path`.
+    ///
+    /// A missing predecessor directory is the expected "this node never held
+    /// that old delegate's secrets" case and yields no entries; any other read
+    /// error is unexpected and fails loud so the caller can record it.
+    fn walk_predecessor_local_secrets(
+        &self,
+        predecessor: &DelegateKey,
+        mut visit: impl FnMut(SecretKey),
+    ) -> Result<(), SecretStoreError> {
+        let scope_path = self.base_path.join(predecessor.encode());
+        let files = match fs::read_dir(&scope_path) {
+            Ok(rd) => rd,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(e) => return Err(SecretStoreError::IO(e)),
+        };
+        for file_entry in files {
+            let file_entry = file_entry.map_err(SecretStoreError::IO)?;
+            let name = file_entry.file_name();
+            let Some(name) = name.to_str() else { continue };
+            // Skip the enumeration registry, snapshot dir, tmp files, and the
+            // `users/` subtree (a dir whose name never bs58-decodes to 32 bytes
+            // anyway). Same filter as `walk_scope_secrets_on_disk`.
+            if name == KEY_REGISTRY_FILE || name == SNAPSHOTS_DIR || name.ends_with(".tmp") {
+                continue;
+            }
+            let Some(secret_hash) = decode_bs58_32(name) else {
+                continue;
+            };
+            match file_entry.file_type() {
+                Ok(ft) if ft.is_file() => {}
+                _ => continue,
+            }
+            visit(secret_hash);
+        }
+        Ok(())
+    }
+
+    /// Count the User/hosted-scope secret blobs `predecessor` holds on disk
+    /// (under `base_path/<predecessor.encode()>/users/<user_id>/`). Copy-forward
+    /// never migrates these (the per-user DEK is not derivable at rest); this
+    /// count is recorded purely as observability for that carve-out. A missing
+    /// `users/` subtree (the common single-user case) yields 0.
+    fn count_predecessor_user_scope_secrets(
+        &self,
+        predecessor: &DelegateKey,
+    ) -> Result<usize, SecretStoreError> {
+        let users_dir = self.base_path.join(predecessor.encode()).join("users");
+        let user_dirs = match fs::read_dir(&users_dir) {
+            Ok(rd) => rd,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+            Err(e) => return Err(SecretStoreError::IO(e)),
+        };
+        let mut count = 0usize;
+        for user_entry in user_dirs {
+            let user_entry = user_entry.map_err(SecretStoreError::IO)?;
+            let user_path = user_entry.path();
+            if !user_path.is_dir() {
+                continue;
+            }
+            let files = match fs::read_dir(&user_path) {
+                Ok(rd) => rd,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(e) => return Err(SecretStoreError::IO(e)),
+            };
+            for file_entry in files {
+                let file_entry = file_entry.map_err(SecretStoreError::IO)?;
+                let name = file_entry.file_name();
+                let Some(name) = name.to_str() else { continue };
+                if name == KEY_REGISTRY_FILE || name == SNAPSHOTS_DIR || name.ends_with(".tmp") {
+                    continue;
+                }
+                if decode_bs58_32(name).is_none() {
+                    continue;
+                }
+                if matches!(file_entry.file_type(), Ok(ft) if ft.is_file()) {
+                    count += 1;
+                }
+            }
+        }
+        Ok(count)
+    }
+}
+
+/// On-disk schema version for the copy-forward marker blob (the redb
+/// `MIGRATION_MARKER_TABLE` value). Bump only on a layout change; the decoder
+/// tolerates trailing bytes, so a newer writer may append fields without
+/// breaking an older reader.
+const MIGRATION_MARKER_VERSION: u8 = 1;
+
+/// Serialize a copy-forward marker value. Fixed 50-byte v1 layout:
+/// `[version:1][has_origin:1][origin:32][copied:u32][skipped:u32][user_skipped:u32][errors:u32]`
+/// (all `u32` little-endian). See [`MigrationMarker`] for the decoder.
+fn encode_migration_marker(
+    origin_contract: Option<[u8; 32]>,
+    copied: usize,
+    skipped_existing: usize,
+    user_scope_skipped: usize,
+    error_count: usize,
+) -> Vec<u8> {
+    let mut v = Vec::with_capacity(50);
+    v.push(MIGRATION_MARKER_VERSION);
+    v.push(u8::from(origin_contract.is_some()));
+    v.extend_from_slice(&origin_contract.unwrap_or([0u8; 32]));
+    // Counts are bounded by a delegate's on-disk secret count; u32 is ample and
+    // saturating-casts a pathological overflow rather than wrapping.
+    v.extend_from_slice(&(copied.min(u32::MAX as usize) as u32).to_le_bytes());
+    v.extend_from_slice(&(skipped_existing.min(u32::MAX as usize) as u32).to_le_bytes());
+    v.extend_from_slice(&(user_scope_skipped.min(u32::MAX as usize) as u32).to_le_bytes());
+    v.extend_from_slice(&(error_count.min(u32::MAX as usize) as u32).to_le_bytes());
+    v
+}
+
+/// Per-predecessor outcome of a [`SecretsStore::migrate_secrets`] copy-forward.
+#[derive(Debug, Clone)]
+pub struct PredecessorMigration {
+    /// The predecessor delegate key this row describes.
+    pub predecessor: DelegateKey,
+    /// Local-scope secrets newly written under the successor (value was absent).
+    pub copied: usize,
+    /// Local-scope secrets already present under the successor and left
+    /// untouched (`overwrite = false`, first writer wins).
+    pub skipped_existing: usize,
+    /// User/hosted-scope secrets the predecessor holds that were DELIBERATELY
+    /// not migrated (the per-user DEK is not derivable at rest). Observability
+    /// for the Local-only carve-out; not an error.
+    pub user_scope_skipped: usize,
+    /// `true` when a prior `(predecessor, successor)` marker short-circuited the
+    /// copy (one-shot idempotence / anti-resurrection), so no copy ran this call
+    /// and the counts above are all 0.
+    pub already_migrated: bool,
+    /// Non-fatal per-secret / marker errors, recorded rather than propagated so
+    /// registration never fails because a predecessor's data was partly
+    /// unreadable. Each entry is a non-secret description (bs58 hash + cause).
+    pub errors: Vec<String>,
+}
+
+impl PredecessorMigration {
+    fn new(predecessor: DelegateKey) -> Self {
+        Self {
+            predecessor,
+            copied: 0,
+            skipped_existing: 0,
+            user_scope_skipped: 0,
+            already_migrated: false,
+            errors: Vec::new(),
+        }
+    }
+}
+
+/// Aggregate outcome of a [`SecretsStore::migrate_secrets`] copy-forward — one
+/// [`PredecessorMigration`] per predecessor, in the order supplied.
+#[derive(Debug, Clone)]
+pub struct MigrationReport {
+    /// The successor delegate key everything was copied into.
+    pub successor: DelegateKey,
+    pub per_predecessor: Vec<PredecessorMigration>,
+}
+
+impl MigrationReport {
+    /// Total Local-scope secrets newly copied across all predecessors.
+    pub fn total_copied(&self) -> usize {
+        self.per_predecessor.iter().map(|p| p.copied).sum()
+    }
+    /// Total Local-scope secrets already present under the successor.
+    pub fn total_skipped_existing(&self) -> usize {
+        self.per_predecessor
+            .iter()
+            .map(|p| p.skipped_existing)
+            .sum()
+    }
+    /// Total User/hosted-scope secrets not migrated (Local-only carve-out).
+    pub fn total_user_scope_skipped(&self) -> usize {
+        self.per_predecessor
+            .iter()
+            .map(|p| p.user_scope_skipped)
+            .sum()
+    }
+    /// Total non-fatal errors recorded across all predecessors.
+    pub fn total_errors(&self) -> usize {
+        self.per_predecessor.iter().map(|p| p.errors.len()).sum()
+    }
+}
+
+/// Decoded copy-forward AUDIT marker (the redb `MIGRATION_MARKER_TABLE` value
+/// for one `(predecessor, successor)` pair). Written by
+/// [`SecretsStore::migrate_secrets`]; readable for audit and tests. Presence of
+/// the row alone is the idempotence / anti-resurrection gate — these fields are
+/// the recorded audit fact, not part of the gate decision.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MigrationMarker {
+    /// Schema version of the blob ([`MIGRATION_MARKER_VERSION`] when written).
+    pub version: u8,
+    /// The originating web-app contract id recorded at migration time (a
+    /// consent-primary-v1 audit fact), or `None` if the registration carried no
+    /// contract origin.
+    pub origin_contract: Option<[u8; 32]>,
+    /// Counts snapshotted at migration time (see [`PredecessorMigration`]).
+    pub copied: u32,
+    pub skipped_existing: u32,
+    pub user_scope_skipped: u32,
+    pub error_count: u32,
+}
+
+impl MigrationMarker {
+    /// Decode a marker blob. Returns `None` if the blob is shorter than the v1
+    /// layout; any trailing bytes beyond the known fields are ignored so a
+    /// future writer can append fields without breaking this reader.
+    pub fn decode(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() < 50 {
+            return None;
+        }
+        let version = bytes[0];
+        let has_origin = bytes[1] != 0;
+        let origin_arr: [u8; 32] = bytes[2..34].try_into().ok()?;
+        let origin_contract = has_origin.then_some(origin_arr);
+        let copied = u32::from_le_bytes(bytes[34..38].try_into().ok()?);
+        let skipped_existing = u32::from_le_bytes(bytes[38..42].try_into().ok()?);
+        let user_scope_skipped = u32::from_le_bytes(bytes[42..46].try_into().ok()?);
+        let error_count = u32::from_le_bytes(bytes[46..50].try_into().ok()?);
+        Some(Self {
+            version,
+            origin_contract,
+            copied,
+            skipped_existing,
+            user_scope_skipped,
+            error_count,
+        })
+    }
 }
 
 /// A single decrypted secret gathered by [`SecretsStore::export_scope_entries`].
@@ -7653,5 +8114,391 @@ mod test {
             "B's secret must remain readable after A's reclaim"
         );
         Ok(())
+    }
+
+    // ============ #4117: delegate secret copy-forward (migrate_secrets) ============
+
+    /// Happy path: a Local secret written under a predecessor delegate's DERIVED
+    /// DEK (the true at-rest path, no client `register_delegate`) is copied
+    /// forward and is readable under the SUCCESSOR's distinct derived DEK — which
+    /// a raw byte copy could not achieve — while the predecessor's copy is left
+    /// intact (no-delete invariant).
+    #[tokio::test]
+    async fn migrate_copies_local_secret_forward_readable_under_successor()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let secrets_dir = temp_dir.path().join("s");
+        std::fs::create_dir_all(&secrets_dir)?;
+        let db = create_test_db(temp_dir.path()).await;
+        let mut store = SecretsStore::new(secrets_dir, Default::default(), db)?;
+
+        // Same params, different code == an ABI bump that mints a new key.
+        let pred = Delegate::from((&vec![0].into(), &vec![1].into()));
+        let succ = Delegate::from((&vec![0].into(), &vec![2].into()));
+        assert_ne!(
+            pred.key().encode(),
+            succ.key().encode(),
+            "predecessor and successor must be distinct on-disk namespaces"
+        );
+
+        let secret_id = SecretsId::new(b"room:alice".to_vec());
+        let plaintext = b"user-profile-blob".to_vec();
+        store.store_secret(
+            pred.key(),
+            &secret_id,
+            SecretScope::Local,
+            Zeroizing::new(plaintext.clone()),
+        )?;
+
+        let report = store.migrate_secrets(
+            std::slice::from_ref(pred.key()),
+            succ.key(),
+            Some([0x11; 32]),
+        );
+        assert_eq!(report.total_copied(), 1);
+        assert_eq!(report.total_skipped_existing(), 0);
+        assert_eq!(
+            report.total_errors(),
+            0,
+            "unexpected errors: {:?}",
+            report.per_predecessor
+        );
+        assert!(!report.per_predecessor[0].already_migrated);
+
+        // Readable under the successor DEK (re-encrypted, not byte-copied).
+        let got = store.get_secret(succ.key(), &secret_id, SecretScope::Local)?;
+        assert_eq!(got.to_vec(), plaintext);
+
+        // Predecessor untouched, still readable.
+        let pred_still = store.get_secret(pred.key(), &secret_id, SecretScope::Local)?;
+        assert_eq!(pred_still.to_vec(), plaintext);
+        Ok(())
+    }
+
+    /// The one-shot marker makes re-migration a no-op AND prevents resurrection:
+    /// a secret the user deletes from the successor after migration is NOT
+    /// re-created when the delegate re-registers (which apps do on every start).
+    #[tokio::test]
+    async fn migrate_is_one_shot_and_prevents_resurrection()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let secrets_dir = temp_dir.path().join("s");
+        std::fs::create_dir_all(&secrets_dir)?;
+        let db = create_test_db(temp_dir.path()).await;
+        let mut store = SecretsStore::new(secrets_dir, Default::default(), db)?;
+
+        let pred = Delegate::from((&vec![0].into(), &vec![1].into()));
+        let succ = Delegate::from((&vec![0].into(), &vec![2].into()));
+        let secret_id = SecretsId::new(b"room:bob".to_vec());
+        store.store_secret(
+            pred.key(),
+            &secret_id,
+            SecretScope::Local,
+            Zeroizing::new(b"v1".to_vec()),
+        )?;
+
+        let report1 = store.migrate_secrets(std::slice::from_ref(pred.key()), succ.key(), None);
+        assert_eq!(report1.total_copied(), 1);
+        assert!(!report1.per_predecessor[0].already_migrated);
+
+        // The user deletes the migrated secret from the successor.
+        store.remove_secret(succ.key(), &secret_id, SecretScope::Local)?;
+        assert!(
+            store
+                .get_secret(succ.key(), &secret_id, SecretScope::Local)
+                .is_err()
+        );
+
+        // Re-registration re-runs the copy — the marker must short-circuit it, so
+        // the deleted secret stays deleted.
+        let report2 = store.migrate_secrets(std::slice::from_ref(pred.key()), succ.key(), None);
+        assert!(
+            report2.per_predecessor[0].already_migrated,
+            "second migration must be gated by the marker"
+        );
+        assert_eq!(report2.total_copied(), 0);
+        assert!(
+            store
+                .get_secret(succ.key(), &secret_id, SecretScope::Local)
+                .is_err(),
+            "a user-deleted secret must NOT be resurrected by re-registration"
+        );
+        Ok(())
+    }
+
+    /// `overwrite = false`: a value the successor already holds for the same
+    /// secret id is preserved (first writer wins); the predecessor's differing
+    /// value does not clobber it, and the copy is reported as skipped.
+    #[tokio::test]
+    async fn migrate_overwrite_false_preserves_successor_existing_value()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let secrets_dir = temp_dir.path().join("s");
+        std::fs::create_dir_all(&secrets_dir)?;
+        let db = create_test_db(temp_dir.path()).await;
+        let mut store = SecretsStore::new(secrets_dir, Default::default(), db)?;
+
+        let pred = Delegate::from((&vec![0].into(), &vec![1].into()));
+        let succ = Delegate::from((&vec![0].into(), &vec![2].into()));
+        let secret_id = SecretsId::new(b"room:carol".to_vec());
+
+        store.store_secret(
+            pred.key(),
+            &secret_id,
+            SecretScope::Local,
+            Zeroizing::new(b"predecessor-value".to_vec()),
+        )?;
+        store.store_secret(
+            succ.key(),
+            &secret_id,
+            SecretScope::Local,
+            Zeroizing::new(b"successor-own-value".to_vec()),
+        )?;
+
+        let report = store.migrate_secrets(std::slice::from_ref(pred.key()), succ.key(), None);
+        assert_eq!(report.total_copied(), 0);
+        assert_eq!(report.total_skipped_existing(), 1);
+
+        // The successor's own value survives — the predecessor did not overwrite.
+        let got = store.get_secret(succ.key(), &secret_id, SecretScope::Local)?;
+        assert_eq!(got.to_vec(), b"successor-own-value".to_vec());
+        Ok(())
+    }
+
+    /// User/hosted-scope secrets are never migrated (the per-user DEK is not
+    /// derivable at rest): only the Local secret is copied, the User secret is
+    /// counted as skipped, no User secret is created under the successor, and the
+    /// predecessor's User secret is left intact.
+    #[tokio::test]
+    async fn migrate_skips_and_counts_user_scope_secrets() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let temp_dir = tempfile::tempdir()?;
+        let secrets_dir = temp_dir.path().join("s");
+        std::fs::create_dir_all(&secrets_dir)?;
+        let db = create_test_db(temp_dir.path()).await;
+        let mut store = SecretsStore::new(secrets_dir, Default::default(), db)?;
+
+        let pred = Delegate::from((&vec![0].into(), &vec![1].into()));
+        let succ = Delegate::from((&vec![0].into(), &vec![2].into()));
+
+        let local_id = SecretsId::new(b"local".to_vec());
+        let user_secret_id = SecretsId::new(b"per-user".to_vec());
+        let alice = UserId::new([0xAA; 32]);
+        let alice_dek = user_dek(0xA1);
+
+        store.store_secret(
+            pred.key(),
+            &local_id,
+            SecretScope::Local,
+            Zeroizing::new(b"local-value".to_vec()),
+        )?;
+        store.store_secret(
+            pred.key(),
+            &user_secret_id,
+            SecretScope::User {
+                id: &alice,
+                dek_secret: &alice_dek,
+            },
+            Zeroizing::new(b"alice-value".to_vec()),
+        )?;
+
+        let report = store.migrate_secrets(std::slice::from_ref(pred.key()), succ.key(), None);
+        assert_eq!(report.total_copied(), 1, "only the Local secret is copied");
+        assert_eq!(report.total_user_scope_skipped(), 1);
+        assert_eq!(report.total_errors(), 0);
+
+        // Local secret arrived under the successor.
+        assert!(
+            store
+                .get_secret(succ.key(), &local_id, SecretScope::Local)
+                .is_ok()
+        );
+        // No User-scope secret was created under the successor.
+        assert!(
+            store
+                .get_secret(
+                    succ.key(),
+                    &user_secret_id,
+                    SecretScope::User {
+                        id: &alice,
+                        dek_secret: &alice_dek,
+                    },
+                )
+                .is_err(),
+            "user-scope secret must NOT be migrated to the successor"
+        );
+        // Predecessor's User secret is untouched.
+        assert!(
+            store
+                .get_secret(
+                    pred.key(),
+                    &user_secret_id,
+                    SecretScope::User {
+                        id: &alice,
+                        dek_secret: &alice_dek,
+                    },
+                )
+                .is_ok(),
+            "predecessor's user-scope secret must remain intact"
+        );
+        Ok(())
+    }
+
+    /// An unknown / absent predecessor is a clean no-op (no error), but still
+    /// records the one-shot marker so a later re-registration short-circuits.
+    #[tokio::test]
+    async fn migrate_unknown_predecessor_is_clean_noop() -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let secrets_dir = temp_dir.path().join("s");
+        std::fs::create_dir_all(&secrets_dir)?;
+        let db = create_test_db(temp_dir.path()).await;
+        let mut store = SecretsStore::new(secrets_dir, Default::default(), db)?;
+
+        // Never had any secrets on this node.
+        let unknown = Delegate::from((&vec![9].into(), &vec![9].into()));
+        let succ = Delegate::from((&vec![0].into(), &vec![2].into()));
+
+        let report = store.migrate_secrets(std::slice::from_ref(unknown.key()), succ.key(), None);
+        assert_eq!(report.total_copied(), 0);
+        assert_eq!(report.total_errors(), 0);
+        assert!(!report.per_predecessor[0].already_migrated);
+
+        // One-shot: a second call is gated by the marker written above.
+        let report2 = store.migrate_secrets(std::slice::from_ref(unknown.key()), succ.key(), None);
+        assert!(report2.per_predecessor[0].already_migrated);
+        Ok(())
+    }
+
+    /// Multiple predecessors all feed the same successor, in order; each yields
+    /// its own report row.
+    #[tokio::test]
+    async fn migrate_multiple_predecessors() -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let secrets_dir = temp_dir.path().join("s");
+        std::fs::create_dir_all(&secrets_dir)?;
+        let db = create_test_db(temp_dir.path()).await;
+        let mut store = SecretsStore::new(secrets_dir, Default::default(), db)?;
+
+        let pred1 = Delegate::from((&vec![0].into(), &vec![1].into()));
+        let pred2 = Delegate::from((&vec![0].into(), &vec![2].into()));
+        let succ = Delegate::from((&vec![0].into(), &vec![3].into()));
+
+        let id_a = SecretsId::new(b"a".to_vec());
+        let id_b = SecretsId::new(b"b".to_vec());
+        store.store_secret(
+            pred1.key(),
+            &id_a,
+            SecretScope::Local,
+            Zeroizing::new(b"va".to_vec()),
+        )?;
+        store.store_secret(
+            pred2.key(),
+            &id_b,
+            SecretScope::Local,
+            Zeroizing::new(b"vb".to_vec()),
+        )?;
+
+        let report = store.migrate_secrets(
+            &[pred1.key().clone(), pred2.key().clone()],
+            succ.key(),
+            None,
+        );
+        assert_eq!(report.per_predecessor.len(), 2);
+        assert_eq!(report.total_copied(), 2);
+        assert!(
+            store
+                .get_secret(succ.key(), &id_a, SecretScope::Local)
+                .is_ok()
+        );
+        assert!(
+            store
+                .get_secret(succ.key(), &id_b, SecretScope::Local)
+                .is_ok()
+        );
+        Ok(())
+    }
+
+    /// A delegate listed as its own predecessor is a no-op and writes no marker
+    /// (there is nothing to gate), so it never reports `already_migrated`.
+    #[tokio::test]
+    async fn migrate_self_predecessor_is_noop() -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let secrets_dir = temp_dir.path().join("s");
+        std::fs::create_dir_all(&secrets_dir)?;
+        let db = create_test_db(temp_dir.path()).await;
+        let mut store = SecretsStore::new(secrets_dir, Default::default(), db)?;
+
+        let d = Delegate::from((&vec![0].into(), &vec![1].into()));
+        store.store_secret(
+            d.key(),
+            &SecretsId::new(b"x".to_vec()),
+            SecretScope::Local,
+            Zeroizing::new(b"v".to_vec()),
+        )?;
+
+        let report = store.migrate_secrets(std::slice::from_ref(d.key()), d.key(), None);
+        assert_eq!(report.total_copied(), 0);
+        assert_eq!(report.total_errors(), 0);
+        assert!(!report.per_predecessor[0].already_migrated);
+
+        // No marker was written for the self case, so a repeat is still not gated.
+        let report2 = store.migrate_secrets(std::slice::from_ref(d.key()), d.key(), None);
+        assert!(!report2.per_predecessor[0].already_migrated);
+        Ok(())
+    }
+
+    /// The redb marker round-trips through the store/get API and decodes back to
+    /// the audit fields, and a different `(predecessor, successor)` pair is
+    /// independent.
+    #[tokio::test]
+    async fn migration_marker_redb_round_trip() -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let db = create_test_db(temp_dir.path()).await;
+
+        let pred = DelegateKey::new([1u8; 32], CodeHash::from(&[2u8; 32]));
+        let succ = DelegateKey::new([3u8; 32], CodeHash::from(&[4u8; 32]));
+
+        assert!(db.get_migration_marker(&pred, &succ)?.is_none());
+
+        let value = encode_migration_marker(Some([9u8; 32]), 5, 2, 1, 0);
+        db.store_migration_marker(&pred, &succ, &value)?;
+
+        let got = db
+            .get_migration_marker(&pred, &succ)?
+            .expect("marker present");
+        let marker = MigrationMarker::decode(&got).expect("decodes");
+        assert_eq!(marker.version, MIGRATION_MARKER_VERSION);
+        assert_eq!(marker.origin_contract, Some([9u8; 32]));
+        assert_eq!(marker.copied, 5);
+        assert_eq!(marker.skipped_existing, 2);
+        assert_eq!(marker.user_scope_skipped, 1);
+        assert_eq!(marker.error_count, 0);
+
+        // The reversed pair is a distinct key with no marker.
+        assert!(db.get_migration_marker(&succ, &pred)?.is_none());
+        Ok(())
+    }
+
+    /// Marker codec: `None` origin round-trips, a too-short blob decodes to
+    /// `None`, and trailing bytes are tolerated (forward compatibility).
+    #[test]
+    fn migration_marker_codec_edge_cases() {
+        let v = encode_migration_marker(None, 0, 0, 0, 3);
+        let m = MigrationMarker::decode(&v).expect("decodes");
+        assert_eq!(m.origin_contract, None);
+        assert_eq!(m.error_count, 3);
+
+        assert!(
+            MigrationMarker::decode(&v[..10]).is_none(),
+            "a truncated blob must not decode"
+        );
+
+        let mut extended = v.clone();
+        extended.extend_from_slice(&[0xFFu8; 8]);
+        assert_eq!(
+            MigrationMarker::decode(&extended).expect("decodes with trailing bytes"),
+            m,
+            "trailing bytes beyond the known layout must be ignored"
+        );
     }
 }

--- a/crates/core/src/wasm_runtime/secrets_store/store.rs
+++ b/crates/core/src/wasm_runtime/secrets_store/store.rs
@@ -3121,23 +3121,56 @@ const MIGRATE_MARKER_KEY_PREFIX: &[u8] = b"\0freenet-migrate/v1/pred-done:";
 /// migration. `MIGRATE_MARKER_KEY_PREFIX` is a subset of this namespace.
 const MIGRATE_RESERVED_NAMESPACE_PREFIX: &[u8] = b"\0freenet-migrate/";
 
-/// The app-side two-phase INTENT marker prefix (`freenet-migrate` `pred-wip:`).
+/// The app-side two-phase INTENT marker prefix (`freenet-migrate` `v1/pred-wip:`).
 /// The node never WRITES this (it seals atomically, so it only ever writes the
-/// `pred-done:` completion marker), but a predecessor an app-side migration
+/// `v1/pred-done:` completion marker), but a predecessor an app-side migration
 /// touched may hold one, and it is a legal reserved shape.
 const MIGRATE_WIP_KEY_PREFIX: &[u8] = b"\0freenet-migrate/v1/pred-wip:";
 
-/// The ONLY legal secret-key shapes under the reserved
-/// [`MIGRATE_RESERVED_NAMESPACE_PREFIX`]: a `pred-done:` or `pred-wip:` prefix
-/// followed by EXACTLY a 32-byte delegate key. `store_secret` REJECTS any other
+/// LEGACY generation-keyed completion marker prefix (freenet-migrate 0.3-era),
+/// still written by the retained `import_secrets_once` API: MARKER_NS ++
+/// `done:` ++ `<gen decimal>`. Source: freenet-migrate `delegate.rs` DONE_PREFIX.
+const MIGRATE_LEGACY_DONE_PREFIX: &[u8] = b"\0freenet-migrate/done:";
+/// LEGACY generation-keyed in-progress marker prefix (0.3-era): MARKER_NS ++
+/// `wip:` ++ `<gen decimal>`. Source: freenet-migrate `delegate.rs` WIP_PREFIX.
+const MIGRATE_LEGACY_WIP_PREFIX: &[u8] = b"\0freenet-migrate/wip:";
+/// Upper bound on the `<gen decimal>` legacy suffix length (a generation counter
+/// fits well within a `u64`'s 20 decimal digits). Bounds the accepted key length
+/// so a client cannot pad a legacy-shaped key with an unbounded digit string.
+const MAX_LEGACY_GEN_DIGITS: usize = 20;
+
+/// The legal secret-key shapes under the reserved
+/// [`MIGRATE_RESERVED_NAMESPACE_PREFIX`]. `store_secret` REJECTS any other
 /// reserved-namespace key (#4117 P2a), so a client cannot pad the reserved
 /// namespace with arbitrary keys to bloat the reserved-hash table or shadow a
-/// real marker.
+/// real marker. The FULL legal matrix (pinned by
+/// `reserved_marker_shape_matrix_is_stable`, mirrored in the freenet-migrate
+/// crate) is:
+///   - v1 per-predecessor:  `\0freenet-migrate/v1/pred-done:` / `…/v1/pred-wip:`
+///     followed by EXACTLY a 32-byte delegate key;
+///   - legacy generation-keyed: `\0freenet-migrate/done:` / `…/wip:` followed by
+///     a NON-EMPTY, ≤ [`MAX_LEGACY_GEN_DIGITS`] ASCII-decimal generation.
 fn is_legal_reserved_marker_key(raw: &[u8]) -> bool {
-    (raw.len() == MIGRATE_MARKER_KEY_PREFIX.len() + 32
+    // v1 per-predecessor markers: prefix + exactly a 32-byte delegate key.
+    let v1 = (raw.len() == MIGRATE_MARKER_KEY_PREFIX.len() + 32
         && raw.starts_with(MIGRATE_MARKER_KEY_PREFIX))
         || (raw.len() == MIGRATE_WIP_KEY_PREFIX.len() + 32
-            && raw.starts_with(MIGRATE_WIP_KEY_PREFIX))
+            && raw.starts_with(MIGRATE_WIP_KEY_PREFIX));
+    if v1 {
+        return true;
+    }
+    // Legacy generation-keyed markers: prefix + a non-empty bounded decimal
+    // generation suffix (`gen` is a reserved keyword, hence `gen_suffix`).
+    for prefix in [MIGRATE_LEGACY_DONE_PREFIX, MIGRATE_LEGACY_WIP_PREFIX] {
+        if let Some(gen_suffix) = raw.strip_prefix(prefix)
+            && !gen_suffix.is_empty()
+            && gen_suffix.len() <= MAX_LEGACY_GEN_DIGITS
+            && gen_suffix.iter().all(u8::is_ascii_digit)
+        {
+            return true;
+        }
+    }
+    false
 }
 
 /// Build the `SecretsId` of the "predecessor migrated" marker recorded under the
@@ -9911,7 +9944,7 @@ mod test {
             "a reserved key with a wrong-length suffix must be rejected"
         );
 
-        // Legal pred-done: + 32 bytes → accepted.
+        // Legal v1 pred-done: + 32 bytes → accepted.
         let mut legal = b"\0freenet-migrate/v1/pred-done:".to_vec();
         legal.extend_from_slice(&[0xCDu8; 32]);
         let legal_id = SecretsId::new(legal);
@@ -9924,7 +9957,22 @@ mod test {
                     Zeroizing::new(b"1".to_vec())
                 )
                 .is_ok(),
-            "a legal marker key must be accepted"
+            "a legal v1 marker key must be accepted"
+        );
+
+        // Legal LEGACY generation-keyed marker (done:<gen decimal>) → accepted
+        // (the crate's retained import_secrets_once still writes these).
+        let legacy_id = SecretsId::new(b"\0freenet-migrate/done:42".to_vec());
+        assert!(
+            store
+                .store_secret(
+                    d.key(),
+                    &legacy_id,
+                    SecretScope::Local,
+                    Zeroizing::new(b"1".to_vec())
+                )
+                .is_ok(),
+            "a legal legacy generation-keyed marker must be accepted"
         );
 
         // An ordinary (non-reserved) user key → accepted.
@@ -9941,6 +9989,51 @@ mod test {
             "an ordinary user key must be accepted"
         );
         Ok(())
+    }
+
+    /// The FULL legal reserved-namespace shape matrix (#4117 P2a), MIRRORING the
+    /// `freenet-migrate` crate: v1 per-predecessor `pred-done:`/`pred-wip:` + 32
+    /// bytes, AND legacy generation-keyed `done:`/`wip:` + a bounded ASCII-decimal
+    /// generation. Everything else in the namespace is rejected. Pinned so a
+    /// future crate marker shape that core does not accept trips CI here.
+    #[test]
+    fn reserved_marker_shape_matrix_is_stable() {
+        let key32 = |prefix: &[u8]| {
+            let mut k = prefix.to_vec();
+            k.extend_from_slice(&[0xCDu8; 32]);
+            k
+        };
+        // ACCEPT — v1 per-predecessor + exactly 32 bytes.
+        assert!(is_legal_reserved_marker_key(&key32(
+            b"\0freenet-migrate/v1/pred-done:"
+        )));
+        assert!(is_legal_reserved_marker_key(&key32(
+            b"\0freenet-migrate/v1/pred-wip:"
+        )));
+        // ACCEPT — legacy generation-keyed + non-empty decimal.
+        assert!(is_legal_reserved_marker_key(b"\0freenet-migrate/done:0"));
+        assert!(is_legal_reserved_marker_key(b"\0freenet-migrate/done:42"));
+        assert!(is_legal_reserved_marker_key(b"\0freenet-migrate/wip:7"));
+        assert!(is_legal_reserved_marker_key(
+            b"\0freenet-migrate/done:18446744073709551615"
+        )); // u64::MAX, 20 digits
+
+        // REJECT — v1 wrong suffix length.
+        let mut short = b"\0freenet-migrate/v1/pred-done:".to_vec();
+        short.extend_from_slice(&[0xCDu8; 8]);
+        assert!(!is_legal_reserved_marker_key(&short));
+        // REJECT — legacy empty gen / non-digit gen / over-long gen.
+        assert!(!is_legal_reserved_marker_key(b"\0freenet-migrate/done:"));
+        assert!(!is_legal_reserved_marker_key(b"\0freenet-migrate/done:abc"));
+        assert!(!is_legal_reserved_marker_key(
+            b"\0freenet-migrate/done:123456789012345678901"
+        )); // 21 digits > cap
+        // REJECT — foreign sub-prefix / bare namespace.
+        assert!(!is_legal_reserved_marker_key(b"\0freenet-migrate/attacker"));
+        assert!(!is_legal_reserved_marker_key(b"\0freenet-migrate/"));
+        // A non-reserved user key is not a "marker" (handled separately at the
+        // store_secret gate; is_legal only judges reserved-namespace keys).
+        assert!(!is_legal_reserved_marker_key(b"room:alice"));
     }
 
     /// Byte-exact pin of the crate-format marker key + value, MIRRORING the

--- a/crates/core/src/wasm_runtime/secrets_store/store.rs
+++ b/crates/core/src/wasm_runtime/secrets_store/store.rs
@@ -3134,9 +3134,14 @@ const MIGRATE_LEGACY_DONE_PREFIX: &[u8] = b"\0freenet-migrate/done:";
 /// LEGACY generation-keyed in-progress marker prefix (0.3-era): MARKER_NS ++
 /// `wip:` ++ `<gen decimal>`. Source: freenet-migrate `delegate.rs` WIP_PREFIX.
 const MIGRATE_LEGACY_WIP_PREFIX: &[u8] = b"\0freenet-migrate/wip:";
-/// Upper bound on the `<gen decimal>` legacy suffix length (a generation counter
-/// fits well within a `u64`'s 20 decimal digits). Bounds the accepted key length
-/// so a client cannot pad a legacy-shaped key with an unbounded digit string.
+/// Upper bound on the `<gen decimal>` legacy suffix length. The crate writes a
+/// `u32` generation (confirmed against freenet-migrate 0.4.0 `import_secrets_once`:
+/// `generation.to_string()` where `generation: u32`), whose decimal form is at
+/// most 10 digits (`u32::MAX` = 4294967295). The `20` here is a deliberate SAFE
+/// SUPERSET (a `u64`'s worth of digits): it never rejects a legitimate crate
+/// marker (an 11–20-digit value can't be a valid `u32` gen anyway, and the crate
+/// ignores an unparseable gen), while still bounding the suffix so a client
+/// cannot pad a legacy-shaped key with an unbounded digit string.
 const MAX_LEGACY_GEN_DIGITS: usize = 20;
 
 /// The legal secret-key shapes under the reserved
@@ -3150,6 +3155,20 @@ const MAX_LEGACY_GEN_DIGITS: usize = 20;
 ///     followed by EXACTLY a 32-byte delegate key;
 ///   - legacy generation-keyed: `\0freenet-migrate/done:` / `…/wip:` followed by
 ///     a NON-EMPTY, ≤ [`MAX_LEGACY_GEN_DIGITS`] ASCII-decimal generation.
+///
+/// SHAPE-EVOLUTION LAW. This whitelist is deliberately an ENFORCEMENT list, not
+/// just documentation: it keeps the reserved namespace strictly protocol-defined
+/// (a foreign reserved key is refused rather than silently absorbed). The cost is
+/// a deploy-ordering obligation identical to the wire-variant law: any FUTURE
+/// marker shape (e.g. a hypothetical `\0freenet-migrate/v2/…`) MUST ship node-side
+/// acceptance HERE, in a RELEASED node, BEFORE any crate version writes it
+/// (crate publish → node merge → node release → only then the crate emits the new
+/// shape). If that ordering is ever violated, the failure mode is SAFE and LOUD,
+/// never silent: an old node rejects the unknown marker write with a store error,
+/// which degrades that one migration to a visible Incomplete-retry — the crate
+/// re-attempts once the node is upgraded — rather than diverging silently. Both
+/// repos byte-pin this matrix (`reserved_marker_shape_matrix_is_stable` here; the
+/// mirror crate-side), so any drift trips CI on both sides.
 fn is_legal_reserved_marker_key(raw: &[u8]) -> bool {
     // v1 per-predecessor markers: prefix + exactly a 32-byte delegate key.
     let v1 = (raw.len() == MIGRATE_MARKER_KEY_PREFIX.len() + 32

--- a/crates/core/src/wasm_runtime/secrets_store/store.rs
+++ b/crates/core/src/wasm_runtime/secrets_store/store.rs
@@ -2281,27 +2281,51 @@ impl SecretsStore {
     /// count of User-scope blobs a predecessor holds is recorded in the report
     /// (`user_scope_skipped`) as observability for that carve-out.
     ///
-    /// **No-delete invariant.** Predecessor data is only ever read, never
-    /// deleted or mutated. `overwrite = false` on the successor side means an
-    /// existing successor value (one it wrote itself, or one an earlier
-    /// predecessor already supplied) is preserved — first writer wins.
+    /// **No-delete invariant + order semantics.** Predecessor data is only ever
+    /// read, never deleted or mutated. `overwrite = false` on the successor side
+    /// means an existing successor value (one it wrote itself, or one an
+    /// EARLIER predecessor in the list already supplied) is preserved — FIRST
+    /// WRITER WINS. Predecessors are processed strictly in the supplied order, so
+    /// **callers MUST pass `predecessors` newest-first**: the node-side copy is
+    /// therefore *union-with-newest-precedence* (the newest generation that holds
+    /// a given key supplies its value; older generations only fill keys the newer
+    /// ones lacked). NOTE (v1 wire limit): the wire carries only a
+    /// `Vec<DelegateKey>` with no generation/policy metadata, so delete-by-absence
+    /// (a newer generation having *dropped* a key the older one had) is NOT
+    /// preserved node-side — a value present in ANY listed predecessor is copied
+    /// unless a newer one already supplied that key. The app-side fallback layers
+    /// its own newest-snapshot-wins / stop-at-first-data-bearing policy on top;
+    /// that is app-side only, not promised here.
     ///
-    /// **One-shot / anti-resurrection.** Each `(predecessor, successor)` pair is
-    /// gated by a persistent marker (redb `MIGRATION_MARKER_TABLE`). The marker
-    /// — NOT deletion — is what prevents resurrection: once a pair has migrated,
-    /// it never migrates again, so a secret the user DELETES from the successor
-    /// after migration cannot reappear when the delegate re-registers (which
-    /// apps do routinely, e.g. on every startup). The marker is written even
-    /// after partial per-secret errors, precisely so a retry cannot reopen that
-    /// window; per-secret read/import failures indicate genuine on-disk
-    /// corruption (the node wrote every blob it reads) that a retry would not
-    /// fix, and are logged loudly instead.
+    /// **Enumeration carry-over.** For each copied secret, the predecessor's
+    /// enumeration-registry raw key is registered under the successor so
+    /// `list_secret_keys` (e.g. River's `room:<vk>` room discovery) still works
+    /// after a rebuild. Bound: a secret with no predecessor registry entry
+    /// (pre-#4355 or cap-evicted) migrates its VALUE but stays unenumerable until
+    /// re-stored. See [`Self::copy_enumeration_registry_forward`].
+    ///
+    /// **One-shot / anti-resurrection, sealed only on a CLEAN copy.** Each
+    /// `(predecessor, successor)` pair is gated by TWO markers: a node-local redb
+    /// row (`MIGRATION_MARKER_TABLE`, rich audit) and a crate-format marker
+    /// SECRET under the successor ([`MIGRATE_MARKER_KEY_PREFIX`]) that the
+    /// app-side `freenet-migrate` fallback also reads/writes — so a node
+    /// registration and an app-side migration never double-copy the same pair.
+    /// A marker — NOT deletion — is what prevents resurrection: once a pair has
+    /// migrated, it never migrates again, so a secret the user DELETES from the
+    /// successor cannot reappear when the delegate re-registers (which apps do on
+    /// every startup). Both markers are written ONLY when the copy is FULLY clean
+    /// (enumeration succeeded AND every read/import succeeded). A partial copy is
+    /// deliberately left UNSEALED so a later registration (or the app-side
+    /// fallback) can complete it — safe because `overwrite = false` never
+    /// re-copies an already-present secret, and a sealed-but-incomplete pair
+    /// could never be completed.
     ///
     /// **Never fails registration.** All errors (an absent predecessor, an
-    /// unreadable blob, even a failed marker write) are recorded in the returned
+    /// unreadable blob, a failed marker write) are recorded in the returned
     /// [`MigrationReport`] and logged; this function returns a report, never an
     /// `Err`, so the caller registers the successor regardless. An unknown /
-    /// absent predecessor is a clean no-op.
+    /// absent predecessor is a clean no-op (and IS sealed, so it is not
+    /// re-walked).
     ///
     /// `origin_contract` is the 32-byte id of the web-app contract that drove
     /// the registration, when known. It is recorded verbatim in the marker as a
@@ -2337,16 +2361,20 @@ impl SecretsStore {
                 continue;
             }
 
-            // 1. One-shot marker gate. Presence means this exact
-            //    (predecessor, successor) copy already ran; never re-run it.
-            //    Fail CLOSED on a read anomaly: treat it as "already migrated"
-            //    so a corrupt/unreadable marker can never reopen the
-            //    resurrection window by re-copying a user-deleted secret.
+            // 1. Idempotence gate — skip if this (predecessor, successor) pair
+            //    already migrated, by EITHER path. Two checks because the redb
+            //    row is node-local (invisible to the app-side freenet-migrate
+            //    fallback) while the crate-format marker secret under the
+            //    successor is the SHARED cross-path gate both sides read/write:
+            //    (a) node-local redb audit row — fast, carries origin + counts;
+            //        a read anomaly fails CLOSED (treat as migrated) so a corrupt
+            //        marker can never reopen the resurrection window.
+            //    (b) crate-format marker secret — written by a prior node OR
+            //        app-side migration. Since a marker is written ONLY on a
+            //        fully-clean copy (step 6), its presence always means
+            //        "completed", never "partial".
             match self.db.get_migration_marker(predecessor, successor) {
                 Ok(Some(bytes)) => {
-                    // Surface the prior migration's recorded audit fact so a
-                    // repeated registration (apps re-register on every start) is
-                    // observable rather than a silent no-op.
                     if let Some(prior) = MigrationMarker::decode(&bytes) {
                         tracing::debug!(
                             predecessor = %predecessor.encode(),
@@ -2355,7 +2383,7 @@ impl SecretsStore {
                             prior_skipped_existing = prior.skipped_existing,
                             prior_user_scope_skipped = prior.user_scope_skipped,
                             prior_errors = prior.error_count,
-                            "delegate secret copy-forward: already migrated; skipping"
+                            "delegate secret copy-forward: already migrated (redb marker); skipping"
                         );
                     }
                     pm.already_migrated = true;
@@ -2368,7 +2396,7 @@ impl SecretsStore {
                         predecessor = %predecessor.encode(),
                         successor = %successor.encode(),
                         error = %e,
-                        "delegate secret copy-forward: marker read failed; skipping copy (fail-closed)"
+                        "delegate secret copy-forward: redb marker read failed; skipping copy (fail-closed)"
                     );
                     pm.already_migrated = true;
                     pm.errors.push(format!("marker read failed: {e}"));
@@ -2376,13 +2404,26 @@ impl SecretsStore {
                     continue;
                 }
             }
+            let marker_id = pred_done_marker_secret_id(predecessor);
+            if self
+                .get_secret(successor, &marker_id, SecretScope::Local)
+                .is_ok()
+            {
+                tracing::debug!(
+                    predecessor = %predecessor.encode(),
+                    successor = %successor.encode(),
+                    "delegate secret copy-forward: already migrated (crate-format marker); skipping"
+                );
+                pm.already_migrated = true;
+                report.per_predecessor.push(pm);
+                continue;
+            }
 
             // 2. Enumerate the predecessor's Local-scope secrets from disk. An
             //    absent predecessor directory yields nothing (clean no-op for an
-            //    unknown predecessor, which still records the marker below); any
-            //    other read error means we could not even list the predecessor,
-            //    so nothing is copied and NO marker is written (step 5) — a later
-            //    re-registration then retries a genuinely transient I/O failure.
+            //    unknown predecessor). Any other read error means we could not
+            //    even list the predecessor: nothing is copied and NO marker is
+            //    sealed (step 6), so a later re-registration retries.
             let mut hashes: Vec<SecretKey> = Vec::new();
             let enumeration_ok =
                 match self.walk_predecessor_local_secrets(predecessor, |h| hashes.push(h)) {
@@ -2400,9 +2441,23 @@ impl SecretsStore {
                 };
 
             // 3. Read each secret under the predecessor's Local DEK, re-encrypt
-            //    under the successor's Local DEK (overwrite = false → first
-            //    writer wins). A per-secret failure is recorded, never fatal.
+            //    under the successor's Local DEK (`overwrite = false` → first
+            //    writer wins ACROSS predecessors, so callers MUST pass
+            //    predecessors newest-first; see the method rustdoc). A per-secret
+            //    failure is recorded and un-seals this predecessor (step 6). We
+            //    also collect the hashes now present under the successor (freshly
+            //    copied OR already there) to drive the enumeration-registry copy.
+            let mut copy_error = false;
+            let mut present_hashes: HashSet<SecretKey> = HashSet::new();
+            // Coordination-marker secrets (the reserved `freenet-migrate`
+            // namespace) are NEVER copied forward — they are per-generation
+            // metadata, not user data, and chain-copying them would accrete stale
+            // markers under later successors.
+            let marker_hashes = self.predecessor_marker_hashes(predecessor);
             for hash in &hashes {
+                if marker_hashes.contains(hash) {
+                    continue;
+                }
                 let encoded = bs58::encode(hash)
                     .with_alphabet(bs58::Alphabet::BITCOIN)
                     .into_string();
@@ -2415,9 +2470,16 @@ impl SecretsStore {
                             plaintext,
                             false,
                         ) {
-                            Ok(true) => pm.copied += 1,
-                            Ok(false) => pm.skipped_existing += 1,
+                            Ok(true) => {
+                                pm.copied += 1;
+                                present_hashes.insert(*hash);
+                            }
+                            Ok(false) => {
+                                pm.skipped_existing += 1;
+                                present_hashes.insert(*hash);
+                            }
                             Err(e) => {
+                                copy_error = true;
                                 tracing::warn!(
                                     predecessor = %predecessor.encode(),
                                     successor = %successor.encode(),
@@ -2430,6 +2492,7 @@ impl SecretsStore {
                         }
                     }
                     Err(e) => {
+                        copy_error = true;
                         tracing::warn!(
                             predecessor = %predecessor.encode(),
                             secret = %encoded,
@@ -2441,7 +2504,31 @@ impl SecretsStore {
                 }
             }
 
-            // 4. Record (never migrate) any User/hosted-scope secrets the
+            // 4. Copy the predecessor's enumeration-registry raw keys forward for
+            //    the secrets now present under the successor, so `list_secret_keys`
+            //    (River's `room:<vk>` discovery) enumerates migrated keys.
+            //    Best-effort: enumeration degradation does NOT un-seal a copy
+            //    whose VALUES all landed — values are what correctness depends on.
+            match self.copy_enumeration_registry_forward(predecessor, successor, &present_hashes) {
+                Ok(n) if n > 0 => tracing::debug!(
+                    predecessor = %predecessor.encode(),
+                    successor = %successor.encode(),
+                    registered = n,
+                    "delegate secret copy-forward: copied enumeration-registry keys"
+                ),
+                Ok(_) => {}
+                Err(e) => {
+                    tracing::warn!(
+                        predecessor = %predecessor.encode(),
+                        error = %e,
+                        "delegate secret copy-forward: enumeration-registry copy degraded (values unaffected)"
+                    );
+                    pm.errors
+                        .push(format!("enumeration-registry copy failed: {e}"));
+                }
+            }
+
+            // 5. Record (never migrate) any User/hosted-scope secrets the
             //    predecessor holds — the per-user DEK is not derivable at rest.
             match self.count_predecessor_user_scope_secrets(predecessor) {
                 Ok(n) => pm.user_scope_skipped = n,
@@ -2450,16 +2537,44 @@ impl SecretsStore {
                     .push(format!("user-scope secret count failed: {e}")),
             }
 
-            // 5. Write the one-shot marker (audit fact), UNLESS enumeration
-            //    failed (step 2) — a failed enumeration copied nothing, so there
-            //    is no resurrection risk to gate and skipping the marker lets a
-            //    later re-registration retry a transient I/O failure. Once
-            //    enumeration succeeded the marker IS written even with per-secret
-            //    errors: those indicate on-disk corruption a retry would not fix,
-            //    and some secrets may have copied, which a retry could resurrect
-            //    after a user deletion. A marker WRITE failure leaves idempotence
-            //    non-durable — logged and recorded, but still non-fatal.
-            if enumeration_ok {
+            // 6. SEAL ONLY ON A FULLY-CLEAN COPY: enumeration succeeded AND every
+            //    read/import succeeded. A sealed marker means "completed", so the
+            //    app-side fallback and future registrations skip the pair; sealing
+            //    a PARTIAL copy would strand it forever (the app-side fallback can
+            //    never complete a sealed-but-incomplete pair). On any copy error
+            //    we write NO marker (redb OR crate-format) and let a retry
+            //    converge — safe because `overwrite = false` never re-copies an
+            //    already-present secret. Enumeration-registry degradation (step 4)
+            //    and the user-scope count (step 5) are best-effort observability
+            //    and do NOT gate the seal, though their errors still appear in
+            //    `pm.errors`.
+            let copy_clean = enumeration_ok && !copy_error;
+            if copy_clean {
+                // (a) crate-format marker secret under the successor — the shared
+                //     cross-path gate the app-side fallback reads/writes. The
+                //     data-bearing flag is b"1" iff the predecessor HAD ≥1 Local
+                //     secret now present under the successor (copied OR already
+                //     there): it drives the app's stop-at-first-data-bearing
+                //     newest-first walk, so an all-collided predecessor (had data,
+                //     nothing newly written) must still read as data-bearing, not
+                //     as empty.
+                let marker_value = pred_done_marker_value(pm.copied + pm.skipped_existing > 0);
+                if let Err(e) = self.store_secret(
+                    successor,
+                    &marker_id,
+                    SecretScope::Local,
+                    Zeroizing::new(marker_value.to_vec()),
+                ) {
+                    tracing::error!(
+                        predecessor = %predecessor.encode(),
+                        successor = %successor.encode(),
+                        error = %e,
+                        "delegate secret copy-forward: crate-format marker write failed; app-side idempotence not durable"
+                    );
+                    pm.errors
+                        .push(format!("crate-format marker write failed: {e}"));
+                }
+                // (b) node-local redb audit row (origin + counts).
                 let value = encode_migration_marker(
                     origin_contract,
                     pm.copied,
@@ -2475,7 +2590,7 @@ impl SecretsStore {
                         predecessor = %predecessor.encode(),
                         successor = %successor.encode(),
                         error = %e,
-                        "delegate secret copy-forward: failed to persist marker; idempotence not durable"
+                        "delegate secret copy-forward: redb marker write failed; node-local audit incomplete"
                     );
                     pm.errors.push(format!("marker write failed: {e}"));
                 }
@@ -2573,6 +2688,126 @@ impl SecretsStore {
         }
         Ok(count)
     }
+
+    /// Hashes of the predecessor's Local secrets that are freenet-migrate
+    /// coordination markers (raw key under [`MIGRATE_MARKER_KEY_PREFIX`]), so the
+    /// copy-forward walk can SKIP them. Markers are per-generation coordination
+    /// metadata written under a successor, NOT user secrets, and must not
+    /// chain-copy into a further successor (the reserved namespace is excluded
+    /// from copy). Best-effort: an unreadable registry yields an empty set
+    /// (markers then fall through as ordinary secrets — the degraded case), never
+    /// an error. Relies on markers being written via `store_secret` (which
+    /// registers the raw key), so their raw key is recoverable here.
+    fn predecessor_marker_hashes(&self, predecessor: &DelegateKey) -> HashSet<SecretKey> {
+        let mut out = HashSet::new();
+        if let Ok(keys) = self.read_key_registry(predecessor, &SecretScope::Local) {
+            for raw in keys {
+                if raw.starts_with(MIGRATE_MARKER_KEY_PREFIX) {
+                    out.insert(*SecretsId::new(raw).hash());
+                }
+            }
+        }
+        out
+    }
+
+    /// Copy the predecessor's Local enumeration-registry raw keys forward for the
+    /// secrets now present under the successor (`present_hashes`), so
+    /// `list_secret_keys` — e.g. River's `room:<vk>` room discovery — enumerates
+    /// migrated keys instead of returning empty after a delegate rebuild.
+    ///
+    /// Registers only keys whose value actually landed under the successor, skips
+    /// the reserved [`MIGRATE_MARKER_KEY_PREFIX`] coordination namespace, honors
+    /// the per-scope registration cap, and writes the successor registry ONCE
+    /// (not once per key). Returns the number of keys newly registered.
+    ///
+    /// BOUND: a secret with NO predecessor registry entry — stored before the
+    /// #4355 enumeration registry existed, or evicted at the per-scope cap — has
+    /// an unrecoverable raw key (the on-disk name is only its hash). Its VALUE
+    /// still migrates and is readable by `get_secret` with the known
+    /// `SecretsId`, but it stays UNENUMERABLE under the successor until the
+    /// delegate re-stores it. Best-effort: an unreadable predecessor OR successor
+    /// registry returns `Err` (enumeration degraded), never touching the
+    /// already-migrated values; a fail-safe `read_key_registry` refuses to
+    /// clobber an unreadable successor registry from empty.
+    fn copy_enumeration_registry_forward(
+        &self,
+        predecessor: &DelegateKey,
+        successor: &DelegateKey,
+        present_hashes: &HashSet<SecretKey>,
+    ) -> std::io::Result<usize> {
+        let pred_keys = self.read_key_registry(predecessor, &SecretScope::Local)?;
+        if pred_keys.is_empty() {
+            return Ok(0);
+        }
+        // Fail-safe: an unreadable successor registry must not be overwritten
+        // from empty, so a read error bails here (Err) rather than clobbering.
+        let mut succ_keys = self.read_key_registry(successor, &SecretScope::Local)?;
+        let existing: HashSet<&[u8]> = succ_keys.iter().map(|k| k.as_slice()).collect();
+        let mut to_add: Vec<Vec<u8>> = Vec::new();
+        let mut budget = self
+            .max_registered_keys_per_scope
+            .saturating_sub(succ_keys.len());
+        for raw in &pred_keys {
+            if budget == 0 {
+                break;
+            }
+            // Never enumerate the reserved coordination-marker namespace.
+            if raw.starts_with(MIGRATE_MARKER_KEY_PREFIX) {
+                continue;
+            }
+            // Only register a key whose value is actually present under the
+            // successor (freshly copied or already there).
+            if !present_hashes.contains(SecretsId::new(raw.clone()).hash()) {
+                continue;
+            }
+            if existing.contains(raw.as_slice()) {
+                continue;
+            }
+            to_add.push(raw.clone());
+            budget -= 1;
+        }
+        if to_add.is_empty() {
+            return Ok(0);
+        }
+        let added = to_add.len();
+        drop(existing);
+        succ_keys.extend(to_add);
+        let encryption = self.encryption_for_scope_read(successor, &SecretScope::Local);
+        self.write_key_registry(successor, &SecretScope::Local, &encryption, &succ_keys);
+        Ok(added)
+    }
+}
+
+/// Reserved secret-key namespace prefix for freenet-migrate copy-forward
+/// coordination markers, written as a Local secret UNDER THE SUCCESSOR.
+///
+/// This MIRRORS the public, versioned byte contract published by the app-side
+/// `freenet-migrate` crate: the app's own copy-forward fallback writes and reads
+/// the identical marker, so a marker written by either side idempotently
+/// short-circuits the other (a node registration and an app-side migration never
+/// double-copy the same `(predecessor -> successor)` pair). The bytes are pinned
+/// on BOTH sides (`pred_done_marker_key_format_is_stable` here, plus the crate's
+/// own pin test), so a drift on either side breaks CI. A secret under this
+/// reserved prefix is coordination metadata, never a user key — the app filters
+/// the whole `\0freenet-migrate/` namespace out of `list_secret_keys`/exports,
+/// and the copy-forward walk skips it so it is never enumerated forward.
+const MIGRATE_MARKER_KEY_PREFIX: &[u8] = b"\0freenet-migrate/v1/pred-done:";
+
+/// Build the `SecretsId` of the "predecessor migrated" marker recorded under the
+/// SUCCESSOR delegate: [`MIGRATE_MARKER_KEY_PREFIX`] followed by the
+/// predecessor's 32-byte delegate key (`DelegateKey::bytes()`, NOT its
+/// `code_hash`).
+fn pred_done_marker_secret_id(predecessor: &DelegateKey) -> SecretsId {
+    let mut key = Vec::with_capacity(MIGRATE_MARKER_KEY_PREFIX.len() + 32);
+    key.extend_from_slice(MIGRATE_MARKER_KEY_PREFIX);
+    key.extend_from_slice(predecessor.bytes());
+    SecretsId::new(key)
+}
+
+/// Marker VALUE per the freenet-migrate contract: `b"1"` when the predecessor
+/// was data-bearing (at least one secret was copied), else `b"0"`.
+fn pred_done_marker_value(had_data: bool) -> &'static [u8] {
+    if had_data { b"1" } else { b"0" }
 }
 
 /// On-disk schema version for the copy-forward marker blob (the redb
@@ -8500,5 +8735,310 @@ mod test {
             m,
             "trailing bytes beyond the known layout must be ignored"
         );
+    }
+
+    /// Enumeration carries forward: after migration, `list_secret_keys` on the
+    /// successor returns the predecessor's raw keys (River's `room:<vk>`
+    /// discovery must keep working across a delegate rebuild).
+    #[tokio::test]
+    async fn migrate_carries_enumeration_registry_forward() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let temp_dir = tempfile::tempdir()?;
+        let secrets_dir = temp_dir.path().join("s");
+        std::fs::create_dir_all(&secrets_dir)?;
+        let db = create_test_db(temp_dir.path()).await;
+        let mut store = SecretsStore::new(secrets_dir, Default::default(), db)?;
+
+        let pred = Delegate::from((&vec![0].into(), &vec![1].into()));
+        let succ = Delegate::from((&vec![0].into(), &vec![2].into()));
+        for k in [b"room:alice".to_vec(), b"room:bob".to_vec()] {
+            store.store_secret(
+                pred.key(),
+                &SecretsId::new(k),
+                SecretScope::Local,
+                Zeroizing::new(b"v".to_vec()),
+            )?;
+        }
+
+        // Successor enumerates nothing yet.
+        assert!(
+            store
+                .list_secret_keys(succ.key(), SecretScope::Local, b"room:")
+                .is_empty()
+        );
+
+        let report = store.migrate_secrets(std::slice::from_ref(pred.key()), succ.key(), None);
+        assert_eq!(report.total_copied(), 2);
+
+        let mut keys = store.list_secret_keys(succ.key(), SecretScope::Local, b"room:");
+        keys.sort();
+        assert_eq!(
+            keys,
+            vec![b"room:alice".to_vec(), b"room:bob".to_vec()],
+            "migrated room keys must be enumerable under the successor"
+        );
+        Ok(())
+    }
+
+    /// First-writer-wins in the SUPPLIED (newest-first) order: when two
+    /// predecessors hold the same secret id with different values, the FIRST
+    /// listed (newest) supplies the value; the later (older) is skipped.
+    #[tokio::test]
+    async fn migrate_first_writer_wins_under_supplied_order()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let secrets_dir = temp_dir.path().join("s");
+        std::fs::create_dir_all(&secrets_dir)?;
+        let db = create_test_db(temp_dir.path()).await;
+        let mut store = SecretsStore::new(secrets_dir, Default::default(), db)?;
+
+        let newer = Delegate::from((&vec![0].into(), &vec![1].into()));
+        let older = Delegate::from((&vec![0].into(), &vec![2].into()));
+        let succ = Delegate::from((&vec![0].into(), &vec![3].into()));
+        let sid = SecretsId::new(b"room:shared".to_vec());
+        store.store_secret(
+            newer.key(),
+            &sid,
+            SecretScope::Local,
+            Zeroizing::new(b"NEW".to_vec()),
+        )?;
+        store.store_secret(
+            older.key(),
+            &sid,
+            SecretScope::Local,
+            Zeroizing::new(b"OLD".to_vec()),
+        )?;
+
+        // Supplied newest-first: newer wins, older collides (skipped).
+        let report = store.migrate_secrets(
+            &[newer.key().clone(), older.key().clone()],
+            succ.key(),
+            None,
+        );
+        assert_eq!(
+            report.per_predecessor[0].copied, 1,
+            "newer supplies the value"
+        );
+        assert_eq!(
+            report.per_predecessor[1].skipped_existing, 1,
+            "older collides and is skipped"
+        );
+        let got = store.get_secret(succ.key(), &sid, SecretScope::Local)?;
+        assert_eq!(
+            got.to_vec(),
+            b"NEW".to_vec(),
+            "the newest (first-supplied) predecessor's value wins"
+        );
+        Ok(())
+    }
+
+    /// The crate-format marker secret is written under the successor with the
+    /// data-bearing flag, and a FRESH store (no redb marker, e.g. the app-side
+    /// path or another process) sees ONLY that on-disk marker and still
+    /// short-circuits — proving the shared cross-path gate.
+    #[tokio::test]
+    async fn migrate_writes_crate_format_marker_and_gates_cross_path()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let secrets_dir = temp_dir.path().join("s");
+        std::fs::create_dir_all(&secrets_dir)?;
+        let db = create_test_db(temp_dir.path()).await;
+        let mut store = SecretsStore::new(secrets_dir.clone(), Default::default(), db)?;
+
+        let pred = Delegate::from((&vec![0].into(), &vec![1].into()));
+        let succ = Delegate::from((&vec![0].into(), &vec![2].into()));
+        let sid = SecretsId::new(b"room:x".to_vec());
+        store.store_secret(
+            pred.key(),
+            &sid,
+            SecretScope::Local,
+            Zeroizing::new(b"v".to_vec()),
+        )?;
+
+        store.migrate_secrets(std::slice::from_ref(pred.key()), succ.key(), None);
+
+        // Marker secret exists under the successor with value b"1" (data-bearing).
+        let marker_id = pred_done_marker_secret_id(pred.key());
+        let marker = store.get_secret(succ.key(), &marker_id, SecretScope::Local)?;
+        assert_eq!(marker.to_vec(), b"1".to_vec());
+
+        // A SECOND store with a FRESH redb db but the SAME secrets_dir (so it
+        // sees the on-disk marker + the same KEK) must short-circuit purely on
+        // the crate-format marker.
+        let db2_dir = temp_dir.path().join("db2");
+        std::fs::create_dir_all(&db2_dir)?;
+        let db2 = create_test_db(&db2_dir).await;
+        let mut store2 = SecretsStore::new(secrets_dir, Default::default(), db2)?;
+        let report2 = store2.migrate_secrets(std::slice::from_ref(pred.key()), succ.key(), None);
+        assert!(
+            report2.per_predecessor[0].already_migrated,
+            "the crate-format marker alone must gate a fresh store (cross-path idempotence)"
+        );
+        assert_eq!(report2.total_copied(), 0);
+        Ok(())
+    }
+
+    /// A clean but EMPTY predecessor (or unknown one) seals with the NoData flag
+    /// b"0", so the app's stop-at-first-data-bearing walk skips past it.
+    #[tokio::test]
+    async fn migrate_empty_predecessor_marker_is_nodata() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let temp_dir = tempfile::tempdir()?;
+        let secrets_dir = temp_dir.path().join("s");
+        std::fs::create_dir_all(&secrets_dir)?;
+        let db = create_test_db(temp_dir.path()).await;
+        let mut store = SecretsStore::new(secrets_dir, Default::default(), db)?;
+
+        let unknown = Delegate::from((&vec![9].into(), &vec![9].into()));
+        let succ = Delegate::from((&vec![0].into(), &vec![2].into()));
+
+        store.migrate_secrets(std::slice::from_ref(unknown.key()), succ.key(), None);
+        let marker_id = pred_done_marker_secret_id(unknown.key());
+        let marker = store.get_secret(succ.key(), &marker_id, SecretScope::Local)?;
+        assert_eq!(
+            marker.to_vec(),
+            b"0".to_vec(),
+            "empty predecessor => NoData"
+        );
+        Ok(())
+    }
+
+    /// SEAL ONLY ON CLEAN: a per-secret read failure (a corrupted predecessor
+    /// blob) un-seals the copy — NO marker is written, and a later registration
+    /// is NOT gated (retryable), so the app-side fallback can still complete it.
+    #[tokio::test]
+    async fn migrate_partial_error_does_not_seal() -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let secrets_dir = temp_dir.path().join("s");
+        std::fs::create_dir_all(&secrets_dir)?;
+        let db = create_test_db(temp_dir.path()).await;
+        let mut store = SecretsStore::new(secrets_dir.clone(), Default::default(), db)?;
+
+        let pred = Delegate::from((&vec![0].into(), &vec![1].into()));
+        let succ = Delegate::from((&vec![0].into(), &vec![2].into()));
+        let sid = SecretsId::new(b"room:corrupt".to_vec());
+        store.store_secret(
+            pred.key(),
+            &sid,
+            SecretScope::Local,
+            Zeroizing::new(b"v".to_vec()),
+        )?;
+
+        // Corrupt the on-disk blob so read_secret_by_hash fails to decrypt.
+        let blob_path = secrets_dir.join(pred.key().encode()).join(sid.encode());
+        std::fs::write(&blob_path, b"not-a-valid-ciphertext-blob")?;
+
+        let report = store.migrate_secrets(std::slice::from_ref(pred.key()), succ.key(), None);
+        assert!(
+            report.total_errors() >= 1,
+            "the corrupted blob must be recorded as an error"
+        );
+
+        // NOT sealed: no crate-format marker under the successor.
+        let marker_id = pred_done_marker_secret_id(pred.key());
+        assert!(
+            store
+                .get_secret(succ.key(), &marker_id, SecretScope::Local)
+                .is_err(),
+            "a partial copy must not write a marker"
+        );
+
+        // Re-registration is NOT gated — the pair stays retryable.
+        let report2 = store.migrate_secrets(std::slice::from_ref(pred.key()), succ.key(), None);
+        assert!(
+            !report2.per_predecessor[0].already_migrated,
+            "an unsealed partial copy must remain retryable"
+        );
+        Ok(())
+    }
+
+    /// Coordination markers are NOT chain-copied: after P1 -> S1 (which writes a
+    /// marker under S1), migrating S1 -> S2 copies S1's real secret but NOT the
+    /// P1 marker, so the reserved namespace does not accrete down the chain.
+    #[tokio::test]
+    async fn migrate_does_not_chain_copy_markers() -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let secrets_dir = temp_dir.path().join("s");
+        std::fs::create_dir_all(&secrets_dir)?;
+        let db = create_test_db(temp_dir.path()).await;
+        let mut store = SecretsStore::new(secrets_dir, Default::default(), db)?;
+
+        let p1 = Delegate::from((&vec![0].into(), &vec![1].into()));
+        let s1 = Delegate::from((&vec![0].into(), &vec![2].into()));
+        let s2 = Delegate::from((&vec![0].into(), &vec![3].into()));
+        let sid = SecretsId::new(b"room:z".to_vec());
+        store.store_secret(
+            p1.key(),
+            &sid,
+            SecretScope::Local,
+            Zeroizing::new(b"v".to_vec()),
+        )?;
+
+        // P1 -> S1: writes a marker for P1 under S1.
+        store.migrate_secrets(std::slice::from_ref(p1.key()), s1.key(), None);
+        assert!(
+            store
+                .get_secret(
+                    s1.key(),
+                    &pred_done_marker_secret_id(p1.key()),
+                    SecretScope::Local
+                )
+                .is_ok(),
+            "P1 marker present under S1"
+        );
+
+        // S1 -> S2: copies S1's real secret but NOT the P1 marker.
+        store.migrate_secrets(std::slice::from_ref(s1.key()), s2.key(), None);
+        assert!(
+            store.get_secret(s2.key(), &sid, SecretScope::Local).is_ok(),
+            "the real secret chain-copies to S2"
+        );
+        assert!(
+            store
+                .get_secret(
+                    s2.key(),
+                    &pred_done_marker_secret_id(p1.key()),
+                    SecretScope::Local
+                )
+                .is_err(),
+            "the P1 coordination marker must NOT chain-copy into S2"
+        );
+        // S2 does carry its own S1 marker (the S1 -> S2 migration).
+        assert!(
+            store
+                .get_secret(
+                    s2.key(),
+                    &pred_done_marker_secret_id(s1.key()),
+                    SecretScope::Local
+                )
+                .is_ok(),
+            "S2 carries the S1 marker for the S1 -> S2 migration"
+        );
+        Ok(())
+    }
+
+    /// Byte-exact pin of the crate-format marker key + value, MIRRORING the
+    /// public `freenet-migrate` contract. A drift here (or in the crate) breaks
+    /// the shared marker and is caught by CI on whichever side changed.
+    #[test]
+    fn pred_done_marker_key_format_is_stable() {
+        assert_eq!(
+            MIGRATE_MARKER_KEY_PREFIX,
+            b"\0freenet-migrate/v1/pred-done:"
+        );
+
+        let pred = DelegateKey::new([7u8; 32], CodeHash::from(&[9u8; 32]));
+        let sid = pred_done_marker_secret_id(&pred);
+        // Raw key = prefix ++ the 32-byte delegate KEY (never the code_hash).
+        let mut expected = b"\0freenet-migrate/v1/pred-done:".to_vec();
+        expected.extend_from_slice(&[7u8; 32]);
+        assert_eq!(
+            sid.key(),
+            expected.as_slice(),
+            "marker key must be prefix ++ predecessor.bytes() (32-byte key, not code_hash)"
+        );
+
+        assert_eq!(pred_done_marker_value(true), b"1");
+        assert_eq!(pred_done_marker_value(false), b"0");
     }
 }

--- a/crates/core/src/wasm_runtime/secrets_store/store.rs
+++ b/crates/core/src/wasm_runtime/secrets_store/store.rs
@@ -4,7 +4,7 @@
 //! and the `#[cfg(test)]` test module.
 
 use std::{
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     fs,
     io::Write,
     path::{Path, PathBuf},
@@ -829,6 +829,25 @@ impl SecretsStore {
         // Reuses the same `encryption` (scope DEK) already derived above.
         self.register_key(delegate, &scope, &encryption, key);
 
+        // #4117 (finding 4a): durably record reserved-namespace coordination
+        // markers (`\0freenet-migrate/…`) in a registry-INDEPENDENT set, so
+        // copy-forward can exclude them even at/above the `.keys` registration
+        // cap or with an unreadable registry. Covers this node's `pred-done:`
+        // markers AND the app-side `pred-wip:`/`pred-done:` markers, since both
+        // are written through this path. Local scope only (markers are Local).
+        // Best-effort like `register_key`: on failure the registry-based union
+        // below the cap still covers it.
+        if matches!(scope, SecretScope::Local)
+            && key.key().starts_with(MIGRATE_RESERVED_NAMESPACE_PREFIX)
+            && let Err(e) = self.db.add_reserved_marker_hash(delegate, key.hash())
+        {
+            tracing::warn!(
+                delegate = %delegate.encode(),
+                error = %e,
+                "failed to durably record reserved-marker hash; copy-forward exclusion falls back to the .keys registry"
+            );
+        }
+
         // Charge the REAL `.keys` registry delta this write produced. Stat-after
         // minus the captured stat-before; folds into the same per-user counter.
         // Doing it from the real on-disk size (not the projection) keeps the
@@ -1186,23 +1205,30 @@ impl SecretsStore {
 
     /// Encrypt `keys` and atomically write the registry file for the scope,
     /// reusing the same `[VERSION_V1][nonce][AEAD]` layout, per-write random
-    /// nonce, owner-only perms, and tmp+rename discipline as the secret
-    /// values. Best-effort: a failure here is logged and swallowed — the
-    /// secret VALUE write has already committed, and a stale/absent registry
-    /// only degrades future enumeration, never the value's readability.
+    /// nonce, owner-only perms, and tmp+rename discipline as the secret values.
+    ///
+    /// Returns `Err` on a genuine persistence failure (encrypt, mkdir, or
+    /// write/rename). The `store_secret`/`register_key`/`deregister_key` callers
+    /// treat this as best-effort (a stale/absent registry only degrades future
+    /// enumeration, never a value's readability) and ignore the error after the
+    /// internal log; the copy-forward enumeration copy (#4117 P1) PROPAGATES it,
+    /// because a sealed migration whose enumeration silently failed would leave
+    /// River-style discovery empty forever.
     fn write_key_registry(
         &self,
         delegate: &DelegateKey,
         scope: &SecretScope<'_>,
         encryption: &Encryption,
         keys: &[Vec<u8>],
-    ) {
+    ) -> std::io::Result<()> {
         let scope_path = self.scope_dir(delegate, scope);
         let path = scope_path.join(KEY_REGISTRY_FILE);
 
         if keys.is_empty() {
             // Nothing left to enumerate; remove the registry so a future read
-            // sees a clean empty scope instead of an empty-list blob.
+            // sees a clean empty scope instead of an empty-list blob. Clearing
+            // is best-effort (a stale empty registry is harmless), so a remove
+            // failure is logged but still reported Ok.
             match fs::remove_file(&path) {
                 Ok(()) => {}
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
@@ -1210,7 +1236,7 @@ impl SecretsStore {
                     tracing::warn!(path = %path.display(), error = %e, "failed to clear key registry")
                 }
             }
-            return;
+            return Ok(());
         }
 
         let plaintext = encode_secret_key_list(keys.iter().map(|k| k.as_slice()));
@@ -1219,7 +1245,7 @@ impl SecretsStore {
             Ok(a) => a,
             Err(e) => {
                 tracing::warn!(error = %e, "failed to encrypt key registry");
-                return;
+                return Err(std::io::Error::other(format!("encrypt key registry: {e}")));
             }
         };
         let mut blob = Vec::with_capacity(HEADER_LEN + aead.len());
@@ -1229,7 +1255,7 @@ impl SecretsStore {
 
         if let Err(e) = fs::create_dir_all(&scope_path) {
             tracing::warn!(path = %scope_path.display(), error = %e, "failed to create scope dir for key registry");
-            return;
+            return Err(e);
         }
         if let Err(e) = ensure_owner_only_tree(&self.base_path, &scope_path) {
             tracing::warn!(path = %scope_path.display(), error = %e, "chmod scope dir tree failed (key registry)");
@@ -1262,7 +1288,9 @@ impl SecretsStore {
             if let Err(rm_err) = fs::remove_file(&tmp_path) {
                 tracing::debug!(path = %tmp_path.display(), error = %rm_err, "tmp registry cleanup failed (harmless)");
             }
+            return Err(e);
         }
+        Ok(())
     }
 
     /// Register `key`'s raw bytes in the scope's enumeration registry. Called
@@ -1316,7 +1344,11 @@ impl SecretsStore {
             return;
         }
         keys.push(key.key().to_vec());
-        self.write_key_registry(delegate, scope, encryption, &keys);
+        // Best-effort (advisory registry, already logged internally on failure):
+        // the secret VALUE + index are already durably committed. The named
+        // underscore binding consumes the `#[must_use]` result without a bare
+        // `let _` (clippy::let_underscore_must_use).
+        let _registry_write = self.write_key_registry(delegate, scope, encryption, &keys);
     }
 
     /// Drop `key` from the scope's enumeration registry. Called after
@@ -1347,7 +1379,9 @@ impl SecretsStore {
             return;
         }
         let encryption = self.encryption_for_scope_read(delegate, scope);
-        self.write_key_registry(delegate, scope, &encryption, &keys);
+        // Best-effort (advisory registry, already logged internally on failure).
+        // Named underscore binding avoids clippy::let_underscore_must_use.
+        let _registry_write = self.write_key_registry(delegate, scope, &encryption, &keys);
     }
 
     /// Enumerate the raw keys of every secret stored under `scope` whose key
@@ -1371,6 +1405,11 @@ impl SecretsStore {
         // the cause loudly and, critically, did NOT overwrite the on-disk blob
         // — so a later call can still recover the full set once it is readable.
         let mut keys = self.read_key_registry(delegate, &scope).unwrap_or_default();
+        // Defense-in-depth (#4117 L2): never surface the reserved
+        // `\0freenet-migrate/` coordination namespace to a delegate. These are
+        // node/app copy-forward markers, not user keys — a consumer must never
+        // see them even if one slipped into the enumeration registry.
+        keys.retain(|k| !k.starts_with(MIGRATE_RESERVED_NAMESPACE_PREFIX));
         if !prefix.is_empty() {
             keys.retain(|k| k.starts_with(prefix));
         }
@@ -2105,6 +2144,9 @@ impl SecretsStore {
         let mut entries: Vec<ExportSecretEntry> = Vec::new();
         let mut total_bytes: usize = 0;
         let mut count: usize = 0;
+        // Per-delegate cache of reserved-namespace marker hashes, so the export
+        // filter (#4117 L2) costs at most one DB read per delegate.
+        let mut reserved_cache: HashMap<DelegateKey, HashSet<SecretKey>> = HashMap::new();
         // The visit closure can't return a Result, so it stashes a terminal
         // outcome here and Breaks; we surface it after the walk.
         let mut bail: Option<ExportScopeError> = None;
@@ -2121,6 +2163,20 @@ impl SecretsStore {
                     limit: max_count,
                 });
                 return ControlFlow::Break(());
+            }
+            // Defense-in-depth (#4117 L2): never export the reserved
+            // `\0freenet-migrate/` coordination namespace — markers are node
+            // infrastructure, not user secrets. Skipped AFTER the count check so
+            // the DoS count bound stays consistent with the cheap pre-check.
+            let reserved = reserved_cache.entry(delegate.clone()).or_insert_with(|| {
+                self.db
+                    .get_reserved_marker_hashes(&delegate)
+                    .unwrap_or_default()
+                    .into_iter()
+                    .collect()
+            });
+            if reserved.contains(&secret_hash) {
+                return ControlFlow::Continue(());
             }
             let plaintext = match self.read_secret_by_hash(&delegate, &secret_hash, &scope) {
                 Ok(p) => p,
@@ -2320,18 +2376,31 @@ impl SecretsStore {
     /// re-copies an already-present secret, and a sealed-but-incomplete pair
     /// could never be completed.
     ///
-    /// **Never fails registration.** All errors (an absent predecessor, an
-    /// unreadable blob, a failed marker write) are recorded in the returned
-    /// [`MigrationReport`] and logged; this function returns a report, never an
-    /// `Err`, so the caller registers the successor regardless. An unknown /
-    /// absent predecessor is a clean no-op (and IS sealed, so it is not
-    /// re-walked).
+    /// **H1 SAME-ORIGIN GATE (`origin_contract`).** `origin_contract` is the
+    /// 32-byte id of the web-app contract driving the registration (or `None` for
+    /// a loopback/CLI/Admin registration). A predecessor's Local secrets are
+    /// copied ONLY IF `origin_contract` is among that predecessor's DURABLY
+    /// recorded registration origins (see
+    /// [`Self::record_delegate_registration_origin`]), or both are the Admin/None
+    /// class. This is a real authorization control, NOT an audit fact: a
+    /// predecessor key is public-derivable and a malicious web-app IS the client,
+    /// so client-side "consent" cannot gate this — without the same-origin check a
+    /// hostile app could name an unrelated victim delegate as a predecessor and
+    /// exfiltrate its secrets. An origin MISMATCH refuses the copy (no copy, no
+    /// seal, `origin_refused` in the report) but does NOT fail registration.
+    /// GRANDFATHER: a predecessor with no recorded origin (registered before this
+    /// release) is allowed and flagged `grandfathered`; the window narrows as
+    /// active delegates re-register on app load. `origin_contract` is also
+    /// recorded in the redb audit row.
     ///
-    /// `origin_contract` is the 32-byte id of the web-app contract that drove
-    /// the registration, when known. It is recorded verbatim in the marker as a
-    /// consent-primary-v1 AUDIT FACT (the client gates on user consent; the node
-    /// records the origin). Durable origin-binding authorization is a filed
-    /// follow-up, not enforced here.
+    /// **Never fails registration.** All errors (an unreadable blob, a failed
+    /// marker write, an origin-lookup failure) are recorded in the returned
+    /// [`MigrationReport`] and logged; this function returns a report, never an
+    /// `Err`, so the caller registers the successor regardless. An ABSENT
+    /// predecessor (one this node never held — no on-disk directory) is a clean
+    /// no-op that writes NO marker and NO redb row, so it is cheaply re-checked on
+    /// the next registration (and picked up if its secrets arrive later); this
+    /// also denies a client the ability to drive marker writes with bogus keys.
     ///
     /// Runs synchronously on the caller (the contract loop, via the
     /// `RegisterDelegateWithPredecessors` handler), mirroring the on-loop write
@@ -2419,6 +2488,77 @@ impl SecretsStore {
                 continue;
             }
 
+            // 1b. ABSENT predecessor (M1): if this node never held the predecessor
+            //     (no on-disk directory), there is nothing to migrate — write NO
+            //     marker files and NO redb row. Sealing an absent predecessor is
+            //     what let a malicious client drive ~10^6 marker/index writes with
+            //     bogus keys; the re-check on re-registration is cheap, and a
+            //     predecessor whose secrets arrive later is picked up then.
+            if !self.base_path.join(predecessor.encode()).is_dir() {
+                tracing::debug!(
+                    predecessor = %predecessor.encode(),
+                    successor = %successor.encode(),
+                    "delegate secret copy-forward: predecessor not held on this node; nothing to migrate"
+                );
+                report.per_predecessor.push(pm);
+                continue;
+            }
+
+            // 1c. H1 SAME-ORIGIN GATE. A malicious web-app IS the client, and a
+            //     predecessor delegate key is public-derivable, so client-side
+            //     "consent" is no control: without this gate a hostile app could
+            //     register a delegate naming an unrelated victim delegate as a
+            //     predecessor and exfiltrate its Local secrets. Copy P ONLY IF the
+            //     registering request's origin is among P's DURABLY-recorded
+            //     registration origins (or both are the Admin/None class). A
+            //     mismatch refuses the copy (no copy, no seal) but does NOT fail
+            //     registration. GRANDFATHER: a predecessor with NO recorded origin
+            //     (registered before this release) is allowed but flagged — the
+            //     window narrows as active delegates re-register on app load, and
+            //     failing closed would instead strand every existing user's first
+            //     post-release upgrade.
+            match self.db.get_delegate_origins(predecessor) {
+                Ok(None) => {
+                    pm.grandfathered = true;
+                    tracing::warn!(
+                        predecessor = %predecessor.encode(),
+                        successor = %successor.encode(),
+                        "delegate secret copy-forward: predecessor has no recorded origin; allowing under grandfather clause (pre-release delegate)"
+                    );
+                }
+                Ok(Some((has_admin_none, origins))) => {
+                    let allowed = match origin_contract {
+                        Some(current) => origins.iter().any(|o| o == &current),
+                        None => has_admin_none,
+                    };
+                    if !allowed {
+                        pm.origin_refused = true;
+                        tracing::warn!(
+                            predecessor = %predecessor.encode(),
+                            successor = %successor.encode(),
+                            "delegate secret copy-forward: origin mismatch; refusing copy (registering origin is not among the predecessor's recorded origins)"
+                        );
+                        report.per_predecessor.push(pm);
+                        continue;
+                    }
+                }
+                Err(e) => {
+                    // Fail CLOSED: a same-origin check we cannot evaluate must not
+                    // default to allowing cross-origin access. No copy, no seal;
+                    // a retry re-evaluates once the store is readable again.
+                    pm.origin_refused = true;
+                    tracing::error!(
+                        predecessor = %predecessor.encode(),
+                        successor = %successor.encode(),
+                        error = %e,
+                        "delegate secret copy-forward: origin lookup failed; refusing copy (fail-closed)"
+                    );
+                    pm.errors.push(format!("origin lookup failed: {e}"));
+                    report.per_predecessor.push(pm);
+                    continue;
+                }
+            }
+
             // 2. Enumerate the predecessor's Local-scope secrets from disk. An
             //    absent predecessor directory yields nothing (clean no-op for an
             //    unknown predecessor). Any other read error means we could not
@@ -2475,8 +2615,35 @@ impl SecretsStore {
                                 present_hashes.insert(*hash);
                             }
                             Ok(false) => {
-                                pm.skipped_existing += 1;
-                                present_hashes.insert(*hash);
+                                // A collision (overwrite=false left the existing
+                                // successor blob). Count it "present" ONLY if it
+                                // actually DECRYPTS under the successor DEK (#4117
+                                // P1). A corrupt / wrong-DEK successor blob would
+                                // otherwise be counted as a successful migration
+                                // and SEALED, making a broken secret un-retryable.
+                                // An unreadable collision = per-secret error =
+                                // unsealed, so a retry (or the app-side fallback)
+                                // can recover it.
+                                match self.read_secret_by_hash(successor, hash, &SecretScope::Local)
+                                {
+                                    Ok(_) => {
+                                        pm.skipped_existing += 1;
+                                        present_hashes.insert(*hash);
+                                    }
+                                    Err(e) => {
+                                        copy_error = true;
+                                        tracing::warn!(
+                                            predecessor = %predecessor.encode(),
+                                            successor = %successor.encode(),
+                                            secret = %encoded,
+                                            error = %e,
+                                            "delegate secret copy-forward: existing successor blob does not decrypt; treating collision as an error (unsealed)"
+                                        );
+                                        pm.errors.push(format!(
+                                            "unreadable successor collision {encoded}: {e}"
+                                        ));
+                                    }
+                                }
                             }
                             Err(e) => {
                                 copy_error = true;
@@ -2506,9 +2673,11 @@ impl SecretsStore {
 
             // 4. Copy the predecessor's enumeration-registry raw keys forward for
             //    the secrets now present under the successor, so `list_secret_keys`
-            //    (River's `room:<vk>` discovery) enumerates migrated keys.
-            //    Best-effort: enumeration degradation does NOT un-seal a copy
-            //    whose VALUES all landed — values are what correctness depends on.
+            //    (River's `room:<vk>` discovery) enumerates migrated keys. A
+            //    failure here UN-SEALS the pair (#4117 P1): a sealed migration
+            //    whose enumeration copy silently failed would leave discovery
+            //    empty forever, and the pair could never be retried to fix it.
+            let mut registry_error = false;
             match self.copy_enumeration_registry_forward(predecessor, successor, &present_hashes) {
                 Ok(n) if n > 0 => tracing::debug!(
                     predecessor = %predecessor.encode(),
@@ -2518,10 +2687,11 @@ impl SecretsStore {
                 ),
                 Ok(_) => {}
                 Err(e) => {
+                    registry_error = true;
                     tracing::warn!(
                         predecessor = %predecessor.encode(),
                         error = %e,
-                        "delegate secret copy-forward: enumeration-registry copy degraded (values unaffected)"
+                        "delegate secret copy-forward: enumeration-registry copy failed; un-sealing so a retry can restore discovery"
                     );
                     pm.errors
                         .push(format!("enumeration-registry copy failed: {e}"));
@@ -2548,51 +2718,82 @@ impl SecretsStore {
             //    and the user-scope count (step 5) are best-effort observability
             //    and do NOT gate the seal, though their errors still appear in
             //    `pm.errors`.
-            let copy_clean = enumeration_ok && !copy_error;
+            let copy_clean = enumeration_ok && !copy_error && !registry_error;
             if copy_clean {
-                // (a) crate-format marker secret under the successor — the shared
-                //     cross-path gate the app-side fallback reads/writes. The
-                //     data-bearing flag is b"1" iff the predecessor HAD ≥1 Local
-                //     secret now present under the successor (copied OR already
-                //     there): it drives the app's stop-at-first-data-bearing
-                //     newest-first walk, so an all-collided predecessor (had data,
-                //     nothing newly written) must still read as data-bearing, not
-                //     as empty.
+                // Marker ORDER is load-bearing (#4117 P1): the crate-format marker
+                // secret is the SHARED cross-path gate the app-side fallback reads.
+                // Write + durably VERIFY it FIRST; only then the redb audit row. If
+                // the crate-format marker cannot be written+read back, the pair is
+                // left FULLY unsealed (no redb row either) — otherwise the node
+                // would believe the pair complete while the app saw no marker and
+                // could re-copy (resurrecting a user-deleted secret), and a redb
+                // recreation would lose the only gate.
+                //
+                // The data-bearing flag is b"1" iff the predecessor HAD ≥1 Local
+                // secret now present under the successor (copied OR already there):
+                // it drives the app's stop-at-first-data-bearing newest-first walk,
+                // so an all-collided predecessor (had data, nothing newly written)
+                // must still read as data-bearing, not as empty.
                 let marker_value = pred_done_marker_value(pm.copied + pm.skipped_existing > 0);
-                if let Err(e) = self.store_secret(
+                let marker_written = match self.store_secret(
                     successor,
                     &marker_id,
                     SecretScope::Local,
                     Zeroizing::new(marker_value.to_vec()),
                 ) {
-                    tracing::error!(
-                        predecessor = %predecessor.encode(),
-                        successor = %successor.encode(),
-                        error = %e,
-                        "delegate secret copy-forward: crate-format marker write failed; app-side idempotence not durable"
+                    Ok(()) => {
+                        // Durably verify it reads back before sealing the redb row.
+                        if self
+                            .get_secret(successor, &marker_id, SecretScope::Local)
+                            .is_ok()
+                        {
+                            true
+                        } else {
+                            tracing::error!(
+                                predecessor = %predecessor.encode(),
+                                successor = %successor.encode(),
+                                "delegate secret copy-forward: crate-format marker not readable after write; leaving pair fully unsealed"
+                            );
+                            pm.errors
+                                .push("crate-format marker not durable".to_string());
+                            false
+                        }
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            predecessor = %predecessor.encode(),
+                            successor = %successor.encode(),
+                            error = %e,
+                            "delegate secret copy-forward: crate-format marker write failed; leaving pair fully unsealed"
+                        );
+                        pm.errors
+                            .push(format!("crate-format marker write failed: {e}"));
+                        false
+                    }
+                };
+
+                // Only seal the node-local redb audit row once the SHARED marker
+                // is durable — never seal redb-only.
+                if marker_written {
+                    let value = encode_migration_marker(
+                        origin_contract,
+                        pm.copied,
+                        pm.skipped_existing,
+                        pm.user_scope_skipped,
+                        pm.errors.len(),
                     );
-                    pm.errors
-                        .push(format!("crate-format marker write failed: {e}"));
-                }
-                // (b) node-local redb audit row (origin + counts).
-                let value = encode_migration_marker(
-                    origin_contract,
-                    pm.copied,
-                    pm.skipped_existing,
-                    pm.user_scope_skipped,
-                    pm.errors.len(),
-                );
-                if let Err(e) = self
-                    .db
-                    .store_migration_marker(predecessor, successor, &value)
-                {
-                    tracing::error!(
-                        predecessor = %predecessor.encode(),
-                        successor = %successor.encode(),
-                        error = %e,
-                        "delegate secret copy-forward: redb marker write failed; node-local audit incomplete"
-                    );
-                    pm.errors.push(format!("marker write failed: {e}"));
+                    if let Err(e) = self
+                        .db
+                        .store_migration_marker(predecessor, successor, &value)
+                    {
+                        tracing::error!(
+                            predecessor = %predecessor.encode(),
+                            successor = %successor.encode(),
+                            error = %e,
+                            "delegate secret copy-forward: redb marker write failed; node-local audit incomplete (crate-format marker is durable, so idempotence holds)"
+                        );
+                        pm.errors.push(format!("marker write failed: {e}"));
+                    }
                 }
             }
 
@@ -2600,6 +2801,28 @@ impl SecretsStore {
         }
 
         report
+    }
+
+    /// Durably record that `delegate` was registered under web-app contract
+    /// `origin` (or the Admin/None class when `origin` is `None`), for the H1
+    /// same-origin copy-forward gate (#4117). Called on EVERY successful
+    /// delegate registration (both `RegisterDelegate` and
+    /// `RegisterDelegateWithPredecessors`). Idempotent; best-effort (a failure
+    /// is logged and returned — the caller registers the delegate regardless,
+    /// but a missing record means a FUTURE migration naming this delegate as a
+    /// predecessor falls into the grandfather clause rather than a strict match).
+    pub fn record_delegate_registration_origin(
+        &self,
+        delegate: &DelegateKey,
+        origin: Option<[u8; 32]>,
+    ) {
+        if let Err(e) = self.db.record_delegate_origin(delegate, origin) {
+            tracing::warn!(
+                delegate = %delegate.encode(),
+                error = %e,
+                "failed to durably record delegate registration origin (H1 same-origin gate)"
+            );
+        }
     }
 
     /// Enumerate the Local-scope secret hashes `predecessor` holds on disk: the
@@ -2694,12 +2917,24 @@ impl SecretsStore {
     /// — both this node's `pred-done:` markers AND the app-side `pred-wip:`
     /// markers), so the copy-forward walk can SKIP them. They are per-generation
     /// coordination metadata, NOT user secrets, and must not chain-copy into a
-    /// further successor. Best-effort: an unreadable registry yields an empty set
-    /// (markers then fall through as ordinary secrets — the degraded case), never
-    /// an error. Relies on markers being written via `store_secret` (which
-    /// registers the raw key), so their raw key is recoverable here.
+    /// further successor.
+    ///
+    /// AUTHORITATIVE source is the durable, uncapped
+    /// [`RESERVED_MARKER_HASHES_TABLE`](crate::contract::storages::redb) recorded
+    /// at `store_secret` time (#4117 finding 4a) — registry-independent, so it
+    /// works even at/above the `.keys` registration cap or with an unreadable
+    /// registry, where a registry-only check would MISS a marker and let it
+    /// chain-copy as user data. The `.keys` registry scan is UNIONED in as a
+    /// below-cap belt-and-suspenders (e.g. a marker durably recorded on a node
+    /// that predated the table). Both are best-effort; a read failure narrows the
+    /// set but never errors.
     fn predecessor_reserved_marker_hashes(&self, predecessor: &DelegateKey) -> HashSet<SecretKey> {
         let mut out = HashSet::new();
+        // Authoritative, uncapped, registry-independent.
+        if let Ok(hashes) = self.db.get_reserved_marker_hashes(predecessor) {
+            out.extend(hashes);
+        }
+        // Belt-and-suspenders: registered markers below the enumeration cap.
         if let Ok(keys) = self.read_key_registry(predecessor, &SecretScope::Local) {
             for raw in keys {
                 if raw.starts_with(MIGRATE_RESERVED_NAMESPACE_PREFIX) {
@@ -2773,7 +3008,10 @@ impl SecretsStore {
         drop(existing);
         succ_keys.extend(to_add);
         let encryption = self.encryption_for_scope_read(successor, &SecretScope::Local);
-        self.write_key_registry(successor, &SecretScope::Local, &encryption, &succ_keys);
+        // PROPAGATE a registry-write failure (#4117 P1): a sealed migration whose
+        // enumeration copy silently failed would leave `list_secret_keys`
+        // (River room discovery) empty forever.
+        self.write_key_registry(successor, &SecretScope::Local, &encryption, &succ_keys)?;
         Ok(added)
     }
 }
@@ -2869,6 +3107,18 @@ pub struct PredecessorMigration {
     /// copy (one-shot idempotence / anti-resurrection), so no copy ran this call
     /// and the counts above are all 0.
     pub already_migrated: bool,
+    /// `true` when the H1 same-origin gate REFUSED the copy: the registering
+    /// request's web-app origin is not among this predecessor's recorded
+    /// registration origins, so nothing was copied and nothing sealed. A
+    /// legitimate registration from a recorded origin (or the operator via the
+    /// Admin/None class) can still migrate it later.
+    pub origin_refused: bool,
+    /// `true` when the copy was ALLOWED under the H1 grandfather clause: the
+    /// predecessor has NO recorded registration origin (it was registered before
+    /// this release), so the same-origin gate could not be evaluated and the copy
+    /// proceeded. The audit records this; the exposure window narrows as active
+    /// delegates re-register (recording their origin) on app load.
+    pub grandfathered: bool,
     /// Non-fatal per-secret / marker errors, recorded rather than propagated so
     /// registration never fails because a predecessor's data was partly
     /// unreadable. Each entry is a non-secret description (bs58 hash + cause).
@@ -2883,6 +3133,8 @@ impl PredecessorMigration {
             skipped_existing: 0,
             user_scope_skipped: 0,
             already_migrated: false,
+            origin_refused: false,
+            grandfathered: false,
             errors: Vec::new(),
         }
     }
@@ -8591,17 +8843,21 @@ mod test {
         Ok(())
     }
 
-    /// An unknown / absent predecessor is a clean no-op (no error), but still
-    /// records the one-shot marker so a later re-registration short-circuits.
+    /// An unknown / ABSENT predecessor (never held on this node) is a clean
+    /// no-op that writes NO marker (M1): nothing to migrate → nothing to seal, so
+    /// a later re-registration re-checks cheaply (and would pick it up if its
+    /// secrets arrived). This also denies a client the ability to drive marker
+    /// writes with bogus keys.
     #[tokio::test]
-    async fn migrate_unknown_predecessor_is_clean_noop() -> Result<(), Box<dyn std::error::Error>> {
+    async fn migrate_absent_predecessor_is_noop_and_not_sealed()
+    -> Result<(), Box<dyn std::error::Error>> {
         let temp_dir = tempfile::tempdir()?;
         let secrets_dir = temp_dir.path().join("s");
         std::fs::create_dir_all(&secrets_dir)?;
         let db = create_test_db(temp_dir.path()).await;
         let mut store = SecretsStore::new(secrets_dir, Default::default(), db)?;
 
-        // Never had any secrets on this node.
+        // Never had any secrets on this node (no on-disk directory).
         let unknown = Delegate::from((&vec![9].into(), &vec![9].into()));
         let succ = Delegate::from((&vec![0].into(), &vec![2].into()));
 
@@ -8610,9 +8866,20 @@ mod test {
         assert_eq!(report.total_errors(), 0);
         assert!(!report.per_predecessor[0].already_migrated);
 
-        // One-shot: a second call is gated by the marker written above.
+        // NOT sealed: no crate-format marker under the successor for the absent
+        // predecessor, and a second call is still NOT gated (retryable).
+        let marker_id = pred_done_marker_secret_id(unknown.key());
+        assert!(
+            store
+                .get_secret(succ.key(), &marker_id, SecretScope::Local)
+                .is_err(),
+            "an absent predecessor must not be sealed"
+        );
         let report2 = store.migrate_secrets(std::slice::from_ref(unknown.key()), succ.key(), None);
-        assert!(report2.per_predecessor[0].already_migrated);
+        assert!(
+            !report2.per_predecessor[0].already_migrated,
+            "an absent predecessor stays retryable (no marker written)"
+        );
         Ok(())
     }
 
@@ -8890,8 +9157,11 @@ mod test {
         Ok(())
     }
 
-    /// A clean but EMPTY predecessor (or unknown one) seals with the NoData flag
-    /// b"0", so the app's stop-at-first-data-bearing walk skips past it.
+    /// A clean but EMPTY predecessor that this node DID hold (its on-disk
+    /// directory exists, but it has no real secrets) seals with the NoData flag
+    /// b"0", so the app's stop-at-first-data-bearing walk skips past it. (An
+    /// ABSENT predecessor — no directory — is not sealed at all; see
+    /// `migrate_absent_predecessor_is_noop_and_not_sealed`.)
     #[tokio::test]
     async fn migrate_empty_predecessor_marker_is_nodata() -> Result<(), Box<dyn std::error::Error>>
     {
@@ -8899,18 +9169,22 @@ mod test {
         let secrets_dir = temp_dir.path().join("s");
         std::fs::create_dir_all(&secrets_dir)?;
         let db = create_test_db(temp_dir.path()).await;
-        let mut store = SecretsStore::new(secrets_dir, Default::default(), db)?;
+        let mut store = SecretsStore::new(secrets_dir.clone(), Default::default(), db)?;
 
-        let unknown = Delegate::from((&vec![9].into(), &vec![9].into()));
+        let pred = Delegate::from((&vec![9].into(), &vec![9].into()));
         let succ = Delegate::from((&vec![0].into(), &vec![2].into()));
 
-        store.migrate_secrets(std::slice::from_ref(unknown.key()), succ.key(), None);
-        let marker_id = pred_done_marker_secret_id(unknown.key());
+        // The predecessor directory EXISTS (this node held it) but has no real
+        // secrets — e.g. every secret was removed. Create the empty dir directly.
+        std::fs::create_dir_all(secrets_dir.join(pred.key().encode()))?;
+
+        store.migrate_secrets(std::slice::from_ref(pred.key()), succ.key(), None);
+        let marker_id = pred_done_marker_secret_id(pred.key());
         let marker = store.get_secret(succ.key(), &marker_id, SecretScope::Local)?;
         assert_eq!(
             marker.to_vec(),
             b"0".to_vec(),
-            "empty predecessor => NoData"
+            "empty (but held) predecessor => NoData"
         );
         Ok(())
     }
@@ -9094,6 +9368,237 @@ mod test {
         assert!(
             !reserved.contains(&wip_raw),
             "the WIP key must not be enumerable under the successor"
+        );
+        Ok(())
+    }
+
+    /// KNOWN LIMITATION (#4117 M2, pinned): seal-only-on-fully-clean has a
+    /// side effect — a PERMANENTLY corrupt/unreadable predecessor blob keeps the
+    /// pair unsealed forever, so its healthy co-resident secrets are re-copied on
+    /// every registration, and a healthy secret the user DELETED from the
+    /// successor is RESURRECTED each time. This is a deliberate v1 tradeoff
+    /// (pair-level sealing; per-secret sealing needs a crate-contract evolution —
+    /// tracked as freenet-core#4909) and is SYMMETRIC with the app-side
+    /// path, which has the same pair-level semantics. This test documents the
+    /// behavior so a future change to it is a conscious decision.
+    #[tokio::test]
+    async fn migrate_unsealed_pair_resurrects_deleted_healthy_secret_known_limitation()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let secrets_dir = temp_dir.path().join("s");
+        std::fs::create_dir_all(&secrets_dir)?;
+        let db = create_test_db(temp_dir.path()).await;
+        let mut store = SecretsStore::new(secrets_dir.clone(), Default::default(), db)?;
+
+        let pred = Delegate::from((&vec![0].into(), &vec![1].into()));
+        let succ = Delegate::from((&vec![0].into(), &vec![2].into()));
+        let healthy = SecretsId::new(b"room:healthy".to_vec());
+        let broken = SecretsId::new(b"room:broken".to_vec());
+        store.store_secret(
+            pred.key(),
+            &healthy,
+            SecretScope::Local,
+            Zeroizing::new(b"keep".to_vec()),
+        )?;
+        store.store_secret(
+            pred.key(),
+            &broken,
+            SecretScope::Local,
+            Zeroizing::new(b"x".to_vec()),
+        )?;
+        // Corrupt the predecessor's `broken` blob so its READ fails → the pair
+        // can never be fully clean → never seals.
+        let broken_blob = secrets_dir.join(pred.key().encode()).join(broken.encode());
+        std::fs::write(&broken_blob, b"corrupt")?;
+
+        // First migration: healthy copies, broken errors → unsealed.
+        let r1 = store.migrate_secrets(std::slice::from_ref(pred.key()), succ.key(), None);
+        assert!(r1.total_errors() >= 1);
+        assert!(
+            store
+                .get_secret(succ.key(), &healthy, SecretScope::Local)
+                .is_ok()
+        );
+
+        // The user DELETES the healthy secret from the successor.
+        store.remove_secret(succ.key(), &healthy, SecretScope::Local)?;
+        assert!(
+            store
+                .get_secret(succ.key(), &healthy, SecretScope::Local)
+                .is_err()
+        );
+
+        // Re-registration re-runs the copy. Because the pair never sealed (broken
+        // still corrupt), the deleted-but-healthy secret is RESURRECTED — the
+        // documented v1 limitation.
+        store.migrate_secrets(std::slice::from_ref(pred.key()), succ.key(), None);
+        assert!(
+            store
+                .get_secret(succ.key(), &healthy, SecretScope::Local)
+                .is_ok(),
+            "KNOWN v1 LIMITATION: an unsealed pair resurrects a deleted healthy secret"
+        );
+        Ok(())
+    }
+
+    /// H1 same-origin gate: a copy proceeds only when the registering origin
+    /// matches a predecessor's recorded origin; a mismatch refuses (no copy, no
+    /// seal); a predecessor with no recorded origin is grandfathered.
+    #[tokio::test]
+    async fn migrate_origin_gate_match_mismatch_and_grandfather()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let secrets_dir = temp_dir.path().join("s");
+        std::fs::create_dir_all(&secrets_dir)?;
+        let db = create_test_db(temp_dir.path()).await;
+        let mut store = SecretsStore::new(secrets_dir, Default::default(), db)?;
+
+        let pred = Delegate::from((&vec![0].into(), &vec![1].into()));
+        let succ = Delegate::from((&vec![0].into(), &vec![2].into()));
+        let sid = SecretsId::new(b"room:a".to_vec());
+        store.store_secret(
+            pred.key(),
+            &sid,
+            SecretScope::Local,
+            Zeroizing::new(b"v".to_vec()),
+        )?;
+
+        let origin_a = [0x11u8; 32];
+        store.record_delegate_registration_origin(pred.key(), Some(origin_a));
+
+        // MISMATCH: a different registering origin is refused.
+        let other = [0x22u8; 32];
+        let report =
+            store.migrate_secrets(std::slice::from_ref(pred.key()), succ.key(), Some(other));
+        assert!(
+            report.per_predecessor[0].origin_refused,
+            "mismatch must refuse"
+        );
+        assert_eq!(report.total_copied(), 0);
+        assert!(
+            store
+                .get_secret(succ.key(), &sid, SecretScope::Local)
+                .is_err(),
+            "an origin mismatch must copy nothing"
+        );
+
+        // MATCH: the recorded origin is allowed and copies.
+        let report2 =
+            store.migrate_secrets(std::slice::from_ref(pred.key()), succ.key(), Some(origin_a));
+        assert!(!report2.per_predecessor[0].origin_refused);
+        assert_eq!(report2.total_copied(), 1);
+        assert!(
+            store
+                .get_secret(succ.key(), &sid, SecretScope::Local)
+                .is_ok()
+        );
+
+        // GRANDFATHER: a predecessor with NO recorded origin is allowed + flagged.
+        let pred2 = Delegate::from((&vec![0].into(), &vec![3].into()));
+        let succ2 = Delegate::from((&vec![0].into(), &vec![4].into()));
+        let sid2 = SecretsId::new(b"room:b".to_vec());
+        store.store_secret(
+            pred2.key(),
+            &sid2,
+            SecretScope::Local,
+            Zeroizing::new(b"v".to_vec()),
+        )?;
+        let report3 =
+            store.migrate_secrets(std::slice::from_ref(pred2.key()), succ2.key(), Some(other));
+        assert!(
+            report3.per_predecessor[0].grandfathered,
+            "a predecessor with no recorded origin is grandfathered"
+        );
+        assert_eq!(report3.total_copied(), 1);
+        Ok(())
+    }
+
+    /// H1 Admin/None class: a predecessor registered with no origin (loopback /
+    /// CLI) is migratable by a loopback (`None`) registration, but a web-app
+    /// (`Some`) registration is refused.
+    #[tokio::test]
+    async fn migrate_origin_gate_admin_class() -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let secrets_dir = temp_dir.path().join("s");
+        std::fs::create_dir_all(&secrets_dir)?;
+        let db = create_test_db(temp_dir.path()).await;
+        let mut store = SecretsStore::new(secrets_dir, Default::default(), db)?;
+
+        let pred = Delegate::from((&vec![0].into(), &vec![1].into()));
+        let sid = SecretsId::new(b"room:a".to_vec());
+        store.store_secret(
+            pred.key(),
+            &sid,
+            SecretScope::Local,
+            Zeroizing::new(b"v".to_vec()),
+        )?;
+        // Recorded as Admin/None (a loopback registration).
+        store.record_delegate_registration_origin(pred.key(), None);
+
+        // A loopback (None) registration → allowed (both Admin/None class), NOT
+        // grandfathered (there IS a record).
+        let succ = Delegate::from((&vec![0].into(), &vec![2].into()));
+        let report = store.migrate_secrets(std::slice::from_ref(pred.key()), succ.key(), None);
+        assert!(!report.per_predecessor[0].origin_refused);
+        assert!(!report.per_predecessor[0].grandfathered);
+        assert_eq!(report.total_copied(), 1);
+
+        // A web-app (Some) registration against an Admin-only record → refused.
+        let succ2 = Delegate::from((&vec![0].into(), &vec![3].into()));
+        let report2 = store.migrate_secrets(
+            std::slice::from_ref(pred.key()),
+            succ2.key(),
+            Some([0x55u8; 32]),
+        );
+        assert!(report2.per_predecessor[0].origin_refused);
+        assert_eq!(report2.total_copied(), 0);
+        Ok(())
+    }
+
+    /// P1: a collision whose existing successor blob does NOT decrypt is treated
+    /// as a per-secret error (not a successful skip), so the pair is NOT sealed
+    /// and stays retryable — a corrupt successor secret can never masquerade as a
+    /// completed migration.
+    #[tokio::test]
+    async fn migrate_corrupt_collision_is_error_and_unsealed()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let secrets_dir = temp_dir.path().join("s");
+        std::fs::create_dir_all(&secrets_dir)?;
+        let db = create_test_db(temp_dir.path()).await;
+        let mut store = SecretsStore::new(secrets_dir.clone(), Default::default(), db)?;
+
+        let pred = Delegate::from((&vec![0].into(), &vec![1].into()));
+        let succ = Delegate::from((&vec![0].into(), &vec![2].into()));
+        let sid = SecretsId::new(b"room:c".to_vec());
+        store.store_secret(
+            pred.key(),
+            &sid,
+            SecretScope::Local,
+            Zeroizing::new(b"good".to_vec()),
+        )?;
+        // The successor already has the SAME secret id (a collision), then its
+        // on-disk blob is corrupted so it no longer decrypts.
+        store.store_secret(
+            succ.key(),
+            &sid,
+            SecretScope::Local,
+            Zeroizing::new(b"succ".to_vec()),
+        )?;
+        let succ_blob = secrets_dir.join(succ.key().encode()).join(sid.encode());
+        std::fs::write(&succ_blob, b"corrupt-not-decryptable")?;
+
+        let report = store.migrate_secrets(std::slice::from_ref(pred.key()), succ.key(), None);
+        assert!(
+            report.total_errors() >= 1,
+            "a non-decrypting collision must be recorded as an error"
+        );
+        let marker_id = pred_done_marker_secret_id(pred.key());
+        assert!(
+            store
+                .get_secret(succ.key(), &marker_id, SecretScope::Local)
+                .is_err(),
+            "a corrupt collision must leave the pair unsealed"
         );
         Ok(())
     }

--- a/crates/core/src/wasm_runtime/secrets_store/store.rs
+++ b/crates/core/src/wasm_runtime/secrets_store/store.rs
@@ -2866,26 +2866,39 @@ impl SecretsStore {
     /// the H1 same-origin copy-forward gate (#4117). FIRST-WRITER-WINS: a record
     /// is written only if none exists, and is NEVER modified afterward — an
     /// attacker who re-registers a victim's public WASM later cannot add itself.
-    /// Called on EVERY successful registration; best-effort (a persistence
-    /// failure is logged, and — critically — leaves NO record, so a future
-    /// migration naming this delegate as a predecessor fails CLOSED with
-    /// NoProvenance rather than being silently allowed; the next registration
-    /// retries the record).
+    /// Called on EVERY registration, BEFORE the delegate is registered.
+    ///
+    /// # Errors
+    /// Returns `Err` only if the record could not be DURABLY persisted. The
+    /// caller MUST fail the whole registration in that case
+    /// (persistence-succeeds-before-usable): a registered-but-recordless delegate
+    /// has an empty first-writer slot that a later — possibly attacker —
+    /// registration could claim, so leaving it usable is the exact vulnerability
+    /// this gate exists to prevent. `Ok(())` covers both a freshly-written record
+    /// AND an already-present one (an idempotent re-registration); neither is an
+    /// error.
     pub fn record_delegate_registration_origin(
         &self,
         delegate: &DelegateKey,
         origin: Option<[u8; 32]>,
-    ) {
+    ) -> Result<(), SecretStoreError> {
         match self
             .db
             .record_delegate_origin_first_writer(delegate, origin)
         {
-            Ok(_wrote) => {}
-            Err(e) => tracing::warn!(
-                delegate = %delegate.encode(),
-                error = %e,
-                "failed to record delegate first-registration origin (H1 gate fails closed until the next registration retries)"
-            ),
+            // Ok(true) wrote the first-writer record; Ok(false) means one already
+            // existed (idempotent re-registration) — both are success.
+            Ok(_wrote) => Ok(()),
+            Err(e) => {
+                tracing::warn!(
+                    delegate = %delegate.encode(),
+                    error = %e,
+                    "failed to durably record delegate first-registration origin (H1 gate); the caller must fail the registration so no usable-but-unowned delegate is left"
+                );
+                Err(SecretStoreError::IO(std::io::Error::other(format!(
+                    "could not durably record delegate first-registration origin (H1 gate): {e}"
+                ))))
+            }
         }
     }
 
@@ -3134,15 +3147,41 @@ const MIGRATE_LEGACY_DONE_PREFIX: &[u8] = b"\0freenet-migrate/done:";
 /// LEGACY generation-keyed in-progress marker prefix (0.3-era): MARKER_NS ++
 /// `wip:` ++ `<gen decimal>`. Source: freenet-migrate `delegate.rs` WIP_PREFIX.
 const MIGRATE_LEGACY_WIP_PREFIX: &[u8] = b"\0freenet-migrate/wip:";
-/// Upper bound on the `<gen decimal>` legacy suffix length. The crate writes a
-/// `u32` generation (confirmed against freenet-migrate 0.4.0 `import_secrets_once`:
-/// `generation.to_string()` where `generation: u32`), whose decimal form is at
-/// most 10 digits (`u32::MAX` = 4294967295). The `20` here is a deliberate SAFE
-/// SUPERSET (a `u64`'s worth of digits): it never rejects a legitimate crate
-/// marker (an 11–20-digit value can't be a valid `u32` gen anyway, and the crate
-/// ignores an unparseable gen), while still bounding the suffix so a client
-/// cannot pad a legacy-shaped key with an unbounded digit string.
-const MAX_LEGACY_GEN_DIGITS: usize = 20;
+/// Maximum decimal digits in a canonical `u32` generation suffix
+/// (`u32::MAX` = 4294967295 = 10 digits). The legacy `done:`/`wip:` markers
+/// (freenet-migrate 0.3-era `import_secrets_once`, confirmed against 0.4.0)
+/// encode a `u32` generation via `generation.to_string()`, so the ONLY legal
+/// suffixes are the CANONICAL decimal forms of a `u32` — see
+/// [`is_canonical_u32_decimal`]. Enforcing exactly that (rather than the earlier
+/// ≤20-digit `u64` superset) refuses non-canonical duplicates (`"00"`, `"01"`)
+/// and overflow forms (`"4294967296"`) the crate never writes, so a client
+/// cannot squat the reserved namespace with a legacy-shaped-but-illegal key.
+const MAX_LEGACY_GEN_DIGITS: usize = 10;
+
+/// True iff `s` is the CANONICAL decimal encoding of a `u32` — exactly the suffix
+/// set the crate's `generation.to_string()` (`generation: u32`) can produce:
+/// non-empty, ASCII digits only, no leading zeros (except the single digit
+/// `"0"`), at most [`MAX_LEGACY_GEN_DIGITS`] digits, and numerically `≤ u32::MAX`.
+/// Rejects `""`, `"00"`, `"01"`, `"4294967296"` (overflow within 10 digits), and
+/// any 11+-digit run — none of which the crate ever writes.
+fn is_canonical_u32_decimal(s: &[u8]) -> bool {
+    if s.is_empty() || s.len() > MAX_LEGACY_GEN_DIGITS {
+        return false;
+    }
+    if !s.iter().all(u8::is_ascii_digit) {
+        return false;
+    }
+    // Leading zero is non-canonical: only the single digit "0" is legal.
+    if s.len() > 1 && s[0] == b'0' {
+        return false;
+    }
+    // All-digits + len ≤ 10 guarantees valid UTF-8; the parse is the numeric
+    // bound that rejects the 10-digit overflow window (e.g. "4294967296").
+    std::str::from_utf8(s)
+        .ok()
+        .and_then(|t| t.parse::<u32>().ok())
+        .is_some()
+}
 
 /// The legal secret-key shapes under the reserved
 /// [`MIGRATE_RESERVED_NAMESPACE_PREFIX`]. `store_secret` REJECTS any other
@@ -3154,7 +3193,7 @@ const MAX_LEGACY_GEN_DIGITS: usize = 20;
 ///   - v1 per-predecessor:  `\0freenet-migrate/v1/pred-done:` / `…/v1/pred-wip:`
 ///     followed by EXACTLY a 32-byte delegate key;
 ///   - legacy generation-keyed: `\0freenet-migrate/done:` / `…/wip:` followed by
-///     a NON-EMPTY, ≤ [`MAX_LEGACY_GEN_DIGITS`] ASCII-decimal generation.
+///     a CANONICAL `u32` decimal generation (see [`is_canonical_u32_decimal`]).
 ///
 /// SHAPE-EVOLUTION LAW. This whitelist is deliberately an ENFORCEMENT list, not
 /// just documentation: it keeps the reserved namespace strictly protocol-defined
@@ -3178,13 +3217,11 @@ fn is_legal_reserved_marker_key(raw: &[u8]) -> bool {
     if v1 {
         return true;
     }
-    // Legacy generation-keyed markers: prefix + a non-empty bounded decimal
+    // Legacy generation-keyed markers: prefix + a CANONICAL u32 decimal
     // generation suffix (`gen` is a reserved keyword, hence `gen_suffix`).
     for prefix in [MIGRATE_LEGACY_DONE_PREFIX, MIGRATE_LEGACY_WIP_PREFIX] {
         if let Some(gen_suffix) = raw.strip_prefix(prefix)
-            && !gen_suffix.is_empty()
-            && gen_suffix.len() <= MAX_LEGACY_GEN_DIGITS
-            && gen_suffix.iter().all(u8::is_ascii_digit)
+            && is_canonical_u32_decimal(gen_suffix)
         {
             return true;
         }
@@ -8806,7 +8843,9 @@ mod test {
             Zeroizing::new(plaintext.clone()),
         )?;
 
-        store.record_delegate_registration_origin(pred.key(), Some(TEST_ORIGIN));
+        store
+            .record_delegate_registration_origin(pred.key(), Some(TEST_ORIGIN))
+            .unwrap();
         let report = store.migrate_secrets(
             std::slice::from_ref(pred.key()),
             succ.key(),
@@ -8854,7 +8893,9 @@ mod test {
             Zeroizing::new(b"v1".to_vec()),
         )?;
 
-        store.record_delegate_registration_origin(pred.key(), Some(TEST_ORIGIN));
+        store
+            .record_delegate_registration_origin(pred.key(), Some(TEST_ORIGIN))
+            .unwrap();
         let report1 = store.migrate_secrets(
             std::slice::from_ref(pred.key()),
             succ.key(),
@@ -8921,7 +8962,9 @@ mod test {
             Zeroizing::new(b"successor-own-value".to_vec()),
         )?;
 
-        store.record_delegate_registration_origin(pred.key(), Some(TEST_ORIGIN));
+        store
+            .record_delegate_registration_origin(pred.key(), Some(TEST_ORIGIN))
+            .unwrap();
         let report = store.migrate_secrets(
             std::slice::from_ref(pred.key()),
             succ.key(),
@@ -8973,7 +9016,9 @@ mod test {
             Zeroizing::new(b"alice-value".to_vec()),
         )?;
 
-        store.record_delegate_registration_origin(pred.key(), Some(TEST_ORIGIN));
+        store
+            .record_delegate_registration_origin(pred.key(), Some(TEST_ORIGIN))
+            .unwrap();
         let report = store.migrate_secrets(
             std::slice::from_ref(pred.key()),
             succ.key(),
@@ -9089,8 +9134,12 @@ mod test {
             Zeroizing::new(b"vb".to_vec()),
         )?;
 
-        store.record_delegate_registration_origin(pred1.key(), Some(TEST_ORIGIN));
-        store.record_delegate_registration_origin(pred2.key(), Some(TEST_ORIGIN));
+        store
+            .record_delegate_registration_origin(pred1.key(), Some(TEST_ORIGIN))
+            .unwrap();
+        store
+            .record_delegate_registration_origin(pred2.key(), Some(TEST_ORIGIN))
+            .unwrap();
         let report = store.migrate_secrets(
             &[pred1.key().clone(), pred2.key().clone()],
             succ.key(),
@@ -9225,7 +9274,9 @@ mod test {
                 .is_empty()
         );
 
-        store.record_delegate_registration_origin(pred.key(), Some(TEST_ORIGIN));
+        store
+            .record_delegate_registration_origin(pred.key(), Some(TEST_ORIGIN))
+            .unwrap();
         let report = store.migrate_secrets(
             std::slice::from_ref(pred.key()),
             succ.key(),
@@ -9272,8 +9323,12 @@ mod test {
             Zeroizing::new(b"OLD".to_vec()),
         )?;
 
-        store.record_delegate_registration_origin(newer.key(), Some(TEST_ORIGIN));
-        store.record_delegate_registration_origin(older.key(), Some(TEST_ORIGIN));
+        store
+            .record_delegate_registration_origin(newer.key(), Some(TEST_ORIGIN))
+            .unwrap();
+        store
+            .record_delegate_registration_origin(older.key(), Some(TEST_ORIGIN))
+            .unwrap();
 
         // Supplied newest-first: newer wins, older collides (skipped).
         let report = store.migrate_secrets(
@@ -9321,7 +9376,9 @@ mod test {
             Zeroizing::new(b"v".to_vec()),
         )?;
 
-        store.record_delegate_registration_origin(pred.key(), Some(TEST_ORIGIN));
+        store
+            .record_delegate_registration_origin(pred.key(), Some(TEST_ORIGIN))
+            .unwrap();
         store.migrate_secrets(
             std::slice::from_ref(pred.key()),
             succ.key(),
@@ -9370,7 +9427,9 @@ mod test {
         // secrets — e.g. every secret was removed. Create the empty dir directly.
         std::fs::create_dir_all(secrets_dir.join(pred.key().encode()))?;
 
-        store.record_delegate_registration_origin(pred.key(), Some(TEST_ORIGIN));
+        store
+            .record_delegate_registration_origin(pred.key(), Some(TEST_ORIGIN))
+            .unwrap();
         store.migrate_secrets(
             std::slice::from_ref(pred.key()),
             succ.key(),
@@ -9411,7 +9470,9 @@ mod test {
         let blob_path = secrets_dir.join(pred.key().encode()).join(sid.encode());
         std::fs::write(&blob_path, b"not-a-valid-ciphertext-blob")?;
 
-        store.record_delegate_registration_origin(pred.key(), Some(TEST_ORIGIN));
+        store
+            .record_delegate_registration_origin(pred.key(), Some(TEST_ORIGIN))
+            .unwrap();
         let report = store.migrate_secrets(
             std::slice::from_ref(pred.key()),
             succ.key(),
@@ -9467,7 +9528,9 @@ mod test {
         )?;
 
         // P1 -> S1: writes a marker for P1 under S1.
-        store.record_delegate_registration_origin(p1.key(), Some(TEST_ORIGIN));
+        store
+            .record_delegate_registration_origin(p1.key(), Some(TEST_ORIGIN))
+            .unwrap();
         store.migrate_secrets(std::slice::from_ref(p1.key()), s1.key(), Some(TEST_ORIGIN));
         assert!(
             store
@@ -9481,7 +9544,9 @@ mod test {
         );
 
         // S1 -> S2: copies S1's real secret but NOT the P1 marker.
-        store.record_delegate_registration_origin(s1.key(), Some(TEST_ORIGIN));
+        store
+            .record_delegate_registration_origin(s1.key(), Some(TEST_ORIGIN))
+            .unwrap();
         store.migrate_secrets(std::slice::from_ref(s1.key()), s2.key(), Some(TEST_ORIGIN));
         assert!(
             store.get_secret(s2.key(), &sid, SecretScope::Local).is_ok(),
@@ -9549,7 +9614,9 @@ mod test {
             Zeroizing::new(b"1".to_vec()),
         )?;
 
-        store.record_delegate_registration_origin(pred.key(), Some(TEST_ORIGIN));
+        store
+            .record_delegate_registration_origin(pred.key(), Some(TEST_ORIGIN))
+            .unwrap();
         let report = store.migrate_secrets(
             std::slice::from_ref(pred.key()),
             succ.key(),
@@ -9624,7 +9691,9 @@ mod test {
         let broken_blob = secrets_dir.join(pred.key().encode()).join(broken.encode());
         std::fs::write(&broken_blob, b"corrupt")?;
 
-        store.record_delegate_registration_origin(pred.key(), Some(TEST_ORIGIN));
+        store
+            .record_delegate_registration_origin(pred.key(), Some(TEST_ORIGIN))
+            .unwrap();
 
         // First migration: healthy copies, broken errors → unsealed.
         let r1 = store.migrate_secrets(
@@ -9690,7 +9759,9 @@ mod test {
         )?;
 
         let origin_a = [0x11u8; 32];
-        store.record_delegate_registration_origin(pred.key(), Some(origin_a));
+        store
+            .record_delegate_registration_origin(pred.key(), Some(origin_a))
+            .unwrap();
 
         // MISMATCH: a different registering origin is refused, but there IS a
         // record for this predecessor, so it is NOT no_provenance.
@@ -9775,7 +9846,9 @@ mod test {
         )?;
         // Recorded as None-class (a loopback registration) — this does NOT
         // privilege a later None registering origin.
-        store.record_delegate_registration_origin(pred.key(), None);
+        store
+            .record_delegate_registration_origin(pred.key(), None)
+            .unwrap();
 
         // A loopback (None) registering origin → refused: None is NEVER
         // privileged, even against a None-class record. There IS a record for
@@ -9830,10 +9903,14 @@ mod test {
         )?;
 
         // The victim's origin is recorded FIRST...
-        store.record_delegate_registration_origin(pred.key(), Some(victim_origin));
+        store
+            .record_delegate_registration_origin(pred.key(), Some(victim_origin))
+            .unwrap();
         // ...then an attacker re-registers the same (public-derivable) predecessor
         // key, trying to overwrite the record. First-writer-wins: a no-op.
-        store.record_delegate_registration_origin(pred.key(), Some(attacker_origin));
+        store
+            .record_delegate_registration_origin(pred.key(), Some(attacker_origin))
+            .unwrap();
 
         // The attacker's origin does NOT satisfy the gate — the record still
         // holds the FIRST (victim's) origin, not the attacker's.
@@ -9898,7 +9975,9 @@ mod test {
         let succ_blob = secrets_dir.join(succ.key().encode()).join(sid.encode());
         std::fs::write(&succ_blob, b"corrupt-not-decryptable")?;
 
-        store.record_delegate_registration_origin(pred.key(), Some(TEST_ORIGIN));
+        store
+            .record_delegate_registration_origin(pred.key(), Some(TEST_ORIGIN))
+            .unwrap();
         let report = store.migrate_secrets(
             std::slice::from_ref(pred.key()),
             succ.key(),
@@ -10029,24 +10108,35 @@ mod test {
         assert!(is_legal_reserved_marker_key(&key32(
             b"\0freenet-migrate/v1/pred-wip:"
         )));
-        // ACCEPT — legacy generation-keyed + non-empty decimal.
-        assert!(is_legal_reserved_marker_key(b"\0freenet-migrate/done:0"));
+        // ACCEPT — legacy generation-keyed + a CANONICAL u32 decimal generation.
+        assert!(is_legal_reserved_marker_key(b"\0freenet-migrate/done:0")); // the single "0" is canonical
         assert!(is_legal_reserved_marker_key(b"\0freenet-migrate/done:42"));
         assert!(is_legal_reserved_marker_key(b"\0freenet-migrate/wip:7"));
         assert!(is_legal_reserved_marker_key(
-            b"\0freenet-migrate/done:18446744073709551615"
-        )); // u64::MAX, 20 digits
+            b"\0freenet-migrate/done:4294967295"
+        )); // u32::MAX, 10 digits
+        assert!(is_legal_reserved_marker_key(
+            b"\0freenet-migrate/wip:4294967295"
+        ));
 
         // REJECT — v1 wrong suffix length.
         let mut short = b"\0freenet-migrate/v1/pred-done:".to_vec();
         short.extend_from_slice(&[0xCDu8; 8]);
         assert!(!is_legal_reserved_marker_key(&short));
-        // REJECT — legacy empty gen / non-digit gen / over-long gen.
-        assert!(!is_legal_reserved_marker_key(b"\0freenet-migrate/done:"));
-        assert!(!is_legal_reserved_marker_key(b"\0freenet-migrate/done:abc"));
+        // REJECT — legacy gen that is not a CANONICAL u32:
+        assert!(!is_legal_reserved_marker_key(b"\0freenet-migrate/done:")); // empty
+        assert!(!is_legal_reserved_marker_key(b"\0freenet-migrate/done:abc")); // non-digit
+        assert!(!is_legal_reserved_marker_key(b"\0freenet-migrate/done:00")); // leading zero (non-canonical)
+        assert!(!is_legal_reserved_marker_key(b"\0freenet-migrate/done:01")); // leading zero (non-canonical)
         assert!(!is_legal_reserved_marker_key(
-            b"\0freenet-migrate/done:123456789012345678901"
-        )); // 21 digits > cap
+            b"\0freenet-migrate/done:4294967296"
+        )); // u32::MAX + 1 (10 digits, but overflows u32)
+        assert!(!is_legal_reserved_marker_key(
+            b"\0freenet-migrate/done:99999999999"
+        )); // 11 digits > cap
+        assert!(!is_legal_reserved_marker_key(
+            b"\0freenet-migrate/done:18446744073709551615"
+        )); // u64::MAX (20 digits) — a legacy u64 superset value, now REJECTED
         // REJECT — foreign sub-prefix / bare namespace.
         assert!(!is_legal_reserved_marker_key(b"\0freenet-migrate/attacker"));
         assert!(!is_legal_reserved_marker_key(b"\0freenet-migrate/"));

--- a/crates/core/src/wasm_runtime/secrets_store/store.rs
+++ b/crates/core/src/wasm_runtime/secrets_store/store.rs
@@ -605,6 +605,21 @@ impl SecretsStore {
         scope: SecretScope<'_>,
         plaintext: Zeroizing<Vec<u8>>,
     ) -> RuntimeResult<()> {
+        // #4117 P2a: the `\0freenet-migrate/` namespace is RESERVED for protocol
+        // coordination markers. Reject any reserved-namespace key that is not a
+        // legal marker shape (`pred-done:`/`pred-wip:` + a 32-byte key), so a
+        // client cannot pad the namespace with arbitrary keys to bloat the
+        // reserved-hash table or shadow a real marker.
+        if key.key().starts_with(MIGRATE_RESERVED_NAMESPACE_PREFIX)
+            && !is_legal_reserved_marker_key(key.key())
+        {
+            return Err(SecretStoreError::IO(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "reserved freenet-migrate namespace: only pred-done:/pred-wip: + 32-byte marker keys are permitted",
+            ))
+            .into());
+        }
+
         let scope_path = self.scope_dir(delegate, &scope);
         let secret_file_path = scope_path.join(key.encode());
         let secret_key = *key.hash();
@@ -786,6 +801,27 @@ impl SecretsStore {
             file.write_all(&ciphertext)?;
             file.sync_all()?;
         }
+
+        // #4117 P1c: record the reserved-marker hash in the durable,
+        // registry-independent table BEFORE committing the value blob (the
+        // rename below). Ordering matters: a reserved-hash entry WITHOUT a
+        // committed blob is harmless (it just excludes a hash that isn't there),
+        // but the inverse — a committed marker blob with NO reserved-hash entry,
+        // so copy-forward wouldn't exclude it and could chain-copy it as user
+        // data — is the dangerous state. Recording first makes a crash between
+        // the two land in the safe state. Local scope only (markers are Local);
+        // P2a above guarantees a reserved-namespace key here is a legal marker.
+        if matches!(scope, SecretScope::Local)
+            && key.key().starts_with(MIGRATE_RESERVED_NAMESPACE_PREFIX)
+            && let Err(e) = self.db.add_reserved_marker_hash(delegate, key.hash())
+        {
+            tracing::warn!(
+                delegate = %delegate.encode(),
+                error = %e,
+                "failed to durably record reserved-marker hash; copy-forward exclusion falls back to the .keys registry"
+            );
+        }
+
         // Atomic on POSIX (and on Rust >=1.56 Windows: MoveFileExW with
         // MOVEFILE_REPLACE_EXISTING). If this rename fails, the active
         // path still holds the old value (or is empty if it never existed)
@@ -828,25 +864,6 @@ impl SecretsStore {
         // means the key isn't enumerable yet, never that the value is lost.
         // Reuses the same `encryption` (scope DEK) already derived above.
         self.register_key(delegate, &scope, &encryption, key);
-
-        // #4117 (finding 4a): durably record reserved-namespace coordination
-        // markers (`\0freenet-migrate/…`) in a registry-INDEPENDENT set, so
-        // copy-forward can exclude them even at/above the `.keys` registration
-        // cap or with an unreadable registry. Covers this node's `pred-done:`
-        // markers AND the app-side `pred-wip:`/`pred-done:` markers, since both
-        // are written through this path. Local scope only (markers are Local).
-        // Best-effort like `register_key`: on failure the registry-based union
-        // below the cap still covers it.
-        if matches!(scope, SecretScope::Local)
-            && key.key().starts_with(MIGRATE_RESERVED_NAMESPACE_PREFIX)
-            && let Err(e) = self.db.add_reserved_marker_hash(delegate, key.hash())
-        {
-            tracing::warn!(
-                delegate = %delegate.encode(),
-                error = %e,
-                "failed to durably record reserved-marker hash; copy-forward exclusion falls back to the .keys registry"
-            );
-        }
 
         // Charge the REAL `.keys` registry delta this write produced. Stat-after
         // minus the captured stat-before; folds into the same per-user counter.
@@ -2168,14 +2185,25 @@ impl SecretsStore {
             // `\0freenet-migrate/` coordination namespace — markers are node
             // infrastructure, not user secrets. Skipped AFTER the count check so
             // the DoS count bound stays consistent with the cheap pre-check.
-            let reserved = reserved_cache.entry(delegate.clone()).or_insert_with(|| {
-                self.db
-                    .get_reserved_marker_hashes(&delegate)
-                    .unwrap_or_default()
-                    .into_iter()
-                    .collect()
-            });
-            if reserved.contains(&secret_hash) {
+            // FAIL CLOSED (#4117 P1c): a reserved-hash lookup failure aborts the
+            // export rather than risk leaking a marker (no `unwrap_or_default`).
+            if !reserved_cache.contains_key(&delegate) {
+                match self.db.get_reserved_marker_hashes(&delegate) {
+                    Ok(h) => {
+                        reserved_cache.insert(delegate.clone(), h.into_iter().collect());
+                    }
+                    Err(e) => {
+                        bail = Some(ExportScopeError::Store(SecretStoreError::IO(
+                            std::io::Error::other(format!("reserved-marker lookup failed: {e}")),
+                        )));
+                        return ControlFlow::Break(());
+                    }
+                }
+            }
+            if reserved_cache
+                .get(&delegate)
+                .is_some_and(|r| r.contains(&secret_hash))
+            {
                 return ControlFlow::Continue(());
             }
             let plaintext = match self.read_secret_by_hash(&delegate, &secret_hash, &scope) {
@@ -2376,22 +2404,23 @@ impl SecretsStore {
     /// re-copies an already-present secret, and a sealed-but-incomplete pair
     /// could never be completed.
     ///
-    /// **H1 SAME-ORIGIN GATE (`origin_contract`).** `origin_contract` is the
-    /// 32-byte id of the web-app contract driving the registration (or `None` for
-    /// a loopback/CLI/Admin registration). A predecessor's Local secrets are
-    /// copied ONLY IF `origin_contract` is among that predecessor's DURABLY
-    /// recorded registration origins (see
-    /// [`Self::record_delegate_registration_origin`]), or both are the Admin/None
-    /// class. This is a real authorization control, NOT an audit fact: a
-    /// predecessor key is public-derivable and a malicious web-app IS the client,
-    /// so client-side "consent" cannot gate this — without the same-origin check a
-    /// hostile app could name an unrelated victim delegate as a predecessor and
-    /// exfiltrate its secrets. An origin MISMATCH refuses the copy (no copy, no
-    /// seal, `origin_refused` in the report) but does NOT fail registration.
-    /// GRANDFATHER: a predecessor with no recorded origin (registered before this
-    /// release) is allowed and flagged `grandfathered`; the window narrows as
-    /// active delegates re-register on app load. `origin_contract` is also
-    /// recorded in the redb audit row.
+    /// **H1 SAME-ORIGIN GATE (`origin_contract`) — first-writer-wins, no
+    /// grandfather, None never privileged.** `origin_contract` is the 32-byte id
+    /// of the web-app contract driving the registration (or `None` for a
+    /// token-less / loopback registration). A predecessor's Local secrets are
+    /// copied ONLY IF `origin_contract` is a specific contract that EQUALS the
+    /// predecessor's FIRST-registration origin (recorded immutably on its first
+    /// registration; see [`Self::record_delegate_registration_origin`]). This is
+    /// a real authorization control, not an audit fact: a predecessor key is
+    /// public-derivable and a malicious web-app IS the client, so client consent
+    /// cannot gate it. The gate REFUSES (no copy, no seal, `origin_refused`; not a
+    /// registration failure) when: the registering origin differs from the
+    /// record; the registering origin is `None` (never privileged in v1); or the
+    /// predecessor has NO record (`no_provenance` — such legacy data migrates via
+    /// the app-side path, whose predecessor-delegate OriginPolicy is the sound
+    /// legacy authorizer). A lookup failure fails CLOSED. Because the record is
+    /// first-writer-wins, an attacker re-registering a victim's public WASM later
+    /// records nothing and can never satisfy the gate.
     ///
     /// **Never fails registration.** All errors (an unreadable blob, a failed
     /// marker write, an origin-lookup failure) are recorded in the returned
@@ -2504,39 +2533,51 @@ impl SecretsStore {
                 continue;
             }
 
-            // 1c. H1 SAME-ORIGIN GATE. A malicious web-app IS the client, and a
-            //     predecessor delegate key is public-derivable, so client-side
-            //     "consent" is no control: without this gate a hostile app could
-            //     register a delegate naming an unrelated victim delegate as a
-            //     predecessor and exfiltrate its Local secrets. Copy P ONLY IF the
-            //     registering request's origin is among P's DURABLY-recorded
-            //     registration origins (or both are the Admin/None class). A
-            //     mismatch refuses the copy (no copy, no seal) but does NOT fail
-            //     registration. GRANDFATHER: a predecessor with NO recorded origin
-            //     (registered before this release) is allowed but flagged — the
-            //     window narrows as active delegates re-register on app load, and
-            //     failing closed would instead strand every existing user's first
-            //     post-release upgrade.
+            // 1c. H1 SAME-ORIGIN GATE (first-writer-wins, no grandfather, None
+            //     never privileged). A malicious web-app IS the client and a
+            //     predecessor delegate key is public-derivable, so client consent
+            //     is no control. Copy P ONLY IF the registering request's web-app
+            //     origin equals P's FIRST-registration origin (recorded
+            //     immutably on P's first registration — an attacker re-registering
+            //     P's WASM later records nothing and can never match).
+            //     - No record → NoProvenance → REFUSE (pre-release data migrates
+            //       via the app-side path, whose predecessor-delegate OriginPolicy
+            //       is the sound legacy authorizer). A failed first-record write
+            //       leaves no record, so this also fails closed and self-heals on
+            //       the next (normally legitimate) registration.
+            //     - Registering origin is None (token-less) → REFUSE: nothing about
+            //       a token-less connection is verifiable as locally trusted, and
+            //       None is NEVER privileged in v1 (an authenticated admin
+            //       mechanism is a later addition).
+            //     - Lookup Err → REFUSE (fail-closed).
+            //     A refusal is not a registration failure.
             match self.db.get_delegate_origins(predecessor) {
                 Ok(None) => {
-                    pm.grandfathered = true;
+                    pm.origin_refused = true;
+                    pm.no_provenance = true;
                     tracing::warn!(
                         predecessor = %predecessor.encode(),
                         successor = %successor.encode(),
-                        "delegate secret copy-forward: predecessor has no recorded origin; allowing under grandfather clause (pre-release delegate)"
+                        "delegate secret copy-forward: predecessor has no recorded origin (NoProvenance); refusing (legacy data migrates via the app-side path)"
                     );
+                    report.per_predecessor.push(pm);
+                    continue;
                 }
-                Ok(Some((has_admin_none, origins))) => {
+                Ok(Some((_has_admin_none, origins))) => {
+                    // Allowed ONLY when the registering origin is a specific
+                    // contract that equals the predecessor's recorded origin. A
+                    // None registering origin, or a None-class predecessor record
+                    // (empty `origins`), never matches.
                     let allowed = match origin_contract {
                         Some(current) => origins.iter().any(|o| o == &current),
-                        None => has_admin_none,
+                        None => false,
                     };
                     if !allowed {
                         pm.origin_refused = true;
                         tracing::warn!(
                             predecessor = %predecessor.encode(),
                             successor = %successor.encode(),
-                            "delegate secret copy-forward: origin mismatch; refusing copy (registering origin is not among the predecessor's recorded origins)"
+                            "delegate secret copy-forward: origin refused (registering origin is not the predecessor's first-registration origin, or is the never-privileged None class)"
                         );
                         report.per_predecessor.push(pm);
                         continue;
@@ -2544,8 +2585,7 @@ impl SecretsStore {
                 }
                 Err(e) => {
                     // Fail CLOSED: a same-origin check we cannot evaluate must not
-                    // default to allowing cross-origin access. No copy, no seal;
-                    // a retry re-evaluates once the store is readable again.
+                    // default to allowing cross-origin access.
                     pm.origin_refused = true;
                     tracing::error!(
                         predecessor = %predecessor.encode(),
@@ -2593,7 +2633,24 @@ impl SecretsStore {
             // namespace) are NEVER copied forward — they are per-generation
             // metadata, not user data, and chain-copying them would accrete stale
             // markers under later successors and diverge from the app-side path.
-            let marker_hashes = self.predecessor_reserved_marker_hashes(predecessor);
+            // The exclusion set FAILS CLOSED (#4117 P1c): if we cannot read which
+            // hashes are markers, abort this predecessor's copy and do NOT seal,
+            // rather than risk chain-copying a marker as user data.
+            let marker_hashes = match self.predecessor_reserved_marker_hashes(predecessor) {
+                Ok(h) => h,
+                Err(e) => {
+                    tracing::error!(
+                        predecessor = %predecessor.encode(),
+                        successor = %successor.encode(),
+                        error = %e,
+                        "delegate secret copy-forward: reserved-marker lookup failed; aborting copy (fail-closed, unsealed)"
+                    );
+                    pm.errors
+                        .push(format!("reserved-marker lookup failed: {e}"));
+                    report.per_predecessor.push(pm);
+                    continue;
+                }
+            };
             for hash in &hashes {
                 if marker_hashes.contains(hash) {
                     continue;
@@ -2708,16 +2765,17 @@ impl SecretsStore {
             }
 
             // 6. SEAL ONLY ON A FULLY-CLEAN COPY: enumeration succeeded AND every
-            //    read/import succeeded. A sealed marker means "completed", so the
-            //    app-side fallback and future registrations skip the pair; sealing
-            //    a PARTIAL copy would strand it forever (the app-side fallback can
-            //    never complete a sealed-but-incomplete pair). On any copy error
-            //    we write NO marker (redb OR crate-format) and let a retry
-            //    converge — safe because `overwrite = false` never re-copies an
-            //    already-present secret. Enumeration-registry degradation (step 4)
-            //    and the user-scope count (step 5) are best-effort observability
-            //    and do NOT gate the seal, though their errors still appear in
-            //    `pm.errors`.
+            //    read/import succeeded (`!copy_error`) AND the enumeration-registry
+            //    copy succeeded (`!registry_error` — step 4 UN-SEALS on failure,
+            //    so a sealed pair never leaves `list_secret_keys`/River discovery
+            //    empty). A sealed marker means "completed", so the app-side
+            //    fallback and future registrations skip the pair; sealing a
+            //    PARTIAL copy would strand it forever. On any such error we write
+            //    NO marker (redb OR crate-format) and let a retry converge — safe
+            //    because `overwrite = false` never re-copies an already-present
+            //    secret. Only the user-scope count (step 5) is best-effort
+            //    observability that does NOT gate the seal, though its error still
+            //    appears in `pm.errors`.
             let copy_clean = enumeration_ok && !copy_error && !registry_error;
             if copy_clean {
                 // Marker ORDER is load-bearing (#4117 P1): the crate-format marker
@@ -2803,25 +2861,31 @@ impl SecretsStore {
         report
     }
 
-    /// Durably record that `delegate` was registered under web-app contract
-    /// `origin` (or the Admin/None class when `origin` is `None`), for the H1
-    /// same-origin copy-forward gate (#4117). Called on EVERY successful
-    /// delegate registration (both `RegisterDelegate` and
-    /// `RegisterDelegateWithPredecessors`). Idempotent; best-effort (a failure
-    /// is logged and returned — the caller registers the delegate regardless,
-    /// but a missing record means a FUTURE migration naming this delegate as a
-    /// predecessor falls into the grandfather clause rather than a strict match).
+    /// Durably record the origin of `delegate`'s FIRST registration (web-app
+    /// contract `origin`, or the Admin/None class when `origin` is `None`), for
+    /// the H1 same-origin copy-forward gate (#4117). FIRST-WRITER-WINS: a record
+    /// is written only if none exists, and is NEVER modified afterward — an
+    /// attacker who re-registers a victim's public WASM later cannot add itself.
+    /// Called on EVERY successful registration; best-effort (a persistence
+    /// failure is logged, and — critically — leaves NO record, so a future
+    /// migration naming this delegate as a predecessor fails CLOSED with
+    /// NoProvenance rather than being silently allowed; the next registration
+    /// retries the record).
     pub fn record_delegate_registration_origin(
         &self,
         delegate: &DelegateKey,
         origin: Option<[u8; 32]>,
     ) {
-        if let Err(e) = self.db.record_delegate_origin(delegate, origin) {
-            tracing::warn!(
+        match self
+            .db
+            .record_delegate_origin_first_writer(delegate, origin)
+        {
+            Ok(_wrote) => {}
+            Err(e) => tracing::warn!(
                 delegate = %delegate.encode(),
                 error = %e,
-                "failed to durably record delegate registration origin (H1 same-origin gate)"
-            );
+                "failed to record delegate first-registration origin (H1 gate fails closed until the next registration retries)"
+            ),
         }
     }
 
@@ -2928,13 +2992,27 @@ impl SecretsStore {
     /// below-cap belt-and-suspenders (e.g. a marker durably recorded on a node
     /// that predated the table). Both are best-effort; a read failure narrows the
     /// set but never errors.
-    fn predecessor_reserved_marker_hashes(&self, predecessor: &DelegateKey) -> HashSet<SecretKey> {
-        let mut out = HashSet::new();
-        // Authoritative, uncapped, registry-independent.
-        if let Ok(hashes) = self.db.get_reserved_marker_hashes(predecessor) {
-            out.extend(hashes);
-        }
-        // Belt-and-suspenders: registered markers below the enumeration cap.
+    fn predecessor_reserved_marker_hashes(
+        &self,
+        predecessor: &DelegateKey,
+    ) -> Result<HashSet<SecretKey>, SecretStoreError> {
+        // AUTHORITATIVE durable, uncapped, registry-independent table. A read
+        // failure FAILS CLOSED — the caller aborts the copy and un-seals —
+        // because silently treating it as "no markers" (unwrap_or_default) would
+        // let a marker chain-copy as user data (#4117 P1c).
+        let mut out: HashSet<SecretKey> = self
+            .db
+            .get_reserved_marker_hashes(predecessor)
+            .map_err(|e| {
+                SecretStoreError::IO(std::io::Error::other(format!(
+                    "reserved-marker lookup failed: {e}"
+                )))
+            })?
+            .into_iter()
+            .collect();
+        // Below-cap belt-and-suspenders: registered markers in the `.keys`
+        // registry. Best-effort (the durable table is authoritative), so a
+        // registry read failure only narrows the union, never fails.
         if let Ok(keys) = self.read_key_registry(predecessor, &SecretScope::Local) {
             for raw in keys {
                 if raw.starts_with(MIGRATE_RESERVED_NAMESPACE_PREFIX) {
@@ -2942,7 +3020,7 @@ impl SecretsStore {
                 }
             }
         }
-        out
+        Ok(out)
     }
 
     /// Copy the predecessor's Local enumeration-registry raw keys forward for the
@@ -3043,6 +3121,25 @@ const MIGRATE_MARKER_KEY_PREFIX: &[u8] = b"\0freenet-migrate/v1/pred-done:";
 /// migration. `MIGRATE_MARKER_KEY_PREFIX` is a subset of this namespace.
 const MIGRATE_RESERVED_NAMESPACE_PREFIX: &[u8] = b"\0freenet-migrate/";
 
+/// The app-side two-phase INTENT marker prefix (`freenet-migrate` `pred-wip:`).
+/// The node never WRITES this (it seals atomically, so it only ever writes the
+/// `pred-done:` completion marker), but a predecessor an app-side migration
+/// touched may hold one, and it is a legal reserved shape.
+const MIGRATE_WIP_KEY_PREFIX: &[u8] = b"\0freenet-migrate/v1/pred-wip:";
+
+/// The ONLY legal secret-key shapes under the reserved
+/// [`MIGRATE_RESERVED_NAMESPACE_PREFIX`]: a `pred-done:` or `pred-wip:` prefix
+/// followed by EXACTLY a 32-byte delegate key. `store_secret` REJECTS any other
+/// reserved-namespace key (#4117 P2a), so a client cannot pad the reserved
+/// namespace with arbitrary keys to bloat the reserved-hash table or shadow a
+/// real marker.
+fn is_legal_reserved_marker_key(raw: &[u8]) -> bool {
+    (raw.len() == MIGRATE_MARKER_KEY_PREFIX.len() + 32
+        && raw.starts_with(MIGRATE_MARKER_KEY_PREFIX))
+        || (raw.len() == MIGRATE_WIP_KEY_PREFIX.len() + 32
+            && raw.starts_with(MIGRATE_WIP_KEY_PREFIX))
+}
+
 /// Build the `SecretsId` of the "predecessor migrated" marker recorded under the
 /// SUCCESSOR delegate: [`MIGRATE_MARKER_KEY_PREFIX`] followed by the
 /// predecessor's 32-byte delegate key (`DelegateKey::bytes()`, NOT its
@@ -3108,17 +3205,17 @@ pub struct PredecessorMigration {
     /// and the counts above are all 0.
     pub already_migrated: bool,
     /// `true` when the H1 same-origin gate REFUSED the copy: the registering
-    /// request's web-app origin is not among this predecessor's recorded
-    /// registration origins, so nothing was copied and nothing sealed. A
-    /// legitimate registration from a recorded origin (or the operator via the
-    /// Admin/None class) can still migrate it later.
+    /// request's web-app origin is not the predecessor's recorded first-writer
+    /// origin (or the request/predecessor is the never-privileged Admin/None
+    /// class), so nothing was copied and nothing sealed. A legitimate
+    /// registration from the recorded origin can still migrate it.
     pub origin_refused: bool,
-    /// `true` when the copy was ALLOWED under the H1 grandfather clause: the
-    /// predecessor has NO recorded registration origin (it was registered before
-    /// this release), so the same-origin gate could not be evaluated and the copy
-    /// proceeded. The audit records this; the exposure window narrows as active
-    /// delegates re-register (recording their origin) on app load.
-    pub grandfathered: bool,
+    /// `true` when the copy was refused specifically because the predecessor has
+    /// NO recorded first-registration origin (NoProvenance) — e.g. a delegate
+    /// registered before this release. Such data migrates via the app-side
+    /// `freenet-migrate` path, whose own predecessor-delegate OriginPolicy is the
+    /// sound authorizer for legacy data. (`origin_refused` is also set.)
+    pub no_provenance: bool,
     /// Non-fatal per-secret / marker errors, recorded rather than propagated so
     /// registration never fails because a predecessor's data was partly
     /// unreadable. Each entry is a non-secret description (bs58 hash + cause).
@@ -3134,7 +3231,7 @@ impl PredecessorMigration {
             user_scope_skipped: 0,
             already_migrated: false,
             origin_refused: false,
-            grandfathered: false,
+            no_provenance: false,
             errors: Vec::new(),
         }
     }
@@ -3413,6 +3510,14 @@ mod test {
         user_activity_dir,
     };
     use super::super::user::{user_dek_secret, user_id};
+
+    /// Shared web-app origin used by the `migrate_secrets` H1 same-origin-gate
+    /// tests below (#4117). A predecessor must have this recorded as its
+    /// FIRST-registration origin (via
+    /// [`SecretsStore::record_delegate_registration_origin`]) before a
+    /// `migrate_secrets(..., Some(TEST_ORIGIN))` call is allowed to copy its
+    /// secrets forward.
+    const TEST_ORIGIN: [u8; 32] = [0x11u8; 32];
 
     async fn create_test_db(path: &std::path::Path) -> Storage {
         Storage::new(path).await.expect("failed to create test db")
@@ -8649,10 +8754,11 @@ mod test {
             Zeroizing::new(plaintext.clone()),
         )?;
 
+        store.record_delegate_registration_origin(pred.key(), Some(TEST_ORIGIN));
         let report = store.migrate_secrets(
             std::slice::from_ref(pred.key()),
             succ.key(),
-            Some([0x11; 32]),
+            Some(TEST_ORIGIN),
         );
         assert_eq!(report.total_copied(), 1);
         assert_eq!(report.total_skipped_existing(), 0);
@@ -8696,7 +8802,12 @@ mod test {
             Zeroizing::new(b"v1".to_vec()),
         )?;
 
-        let report1 = store.migrate_secrets(std::slice::from_ref(pred.key()), succ.key(), None);
+        store.record_delegate_registration_origin(pred.key(), Some(TEST_ORIGIN));
+        let report1 = store.migrate_secrets(
+            std::slice::from_ref(pred.key()),
+            succ.key(),
+            Some(TEST_ORIGIN),
+        );
         assert_eq!(report1.total_copied(), 1);
         assert!(!report1.per_predecessor[0].already_migrated);
 
@@ -8710,7 +8821,11 @@ mod test {
 
         // Re-registration re-runs the copy — the marker must short-circuit it, so
         // the deleted secret stays deleted.
-        let report2 = store.migrate_secrets(std::slice::from_ref(pred.key()), succ.key(), None);
+        let report2 = store.migrate_secrets(
+            std::slice::from_ref(pred.key()),
+            succ.key(),
+            Some(TEST_ORIGIN),
+        );
         assert!(
             report2.per_predecessor[0].already_migrated,
             "second migration must be gated by the marker"
@@ -8754,7 +8869,12 @@ mod test {
             Zeroizing::new(b"successor-own-value".to_vec()),
         )?;
 
-        let report = store.migrate_secrets(std::slice::from_ref(pred.key()), succ.key(), None);
+        store.record_delegate_registration_origin(pred.key(), Some(TEST_ORIGIN));
+        let report = store.migrate_secrets(
+            std::slice::from_ref(pred.key()),
+            succ.key(),
+            Some(TEST_ORIGIN),
+        );
         assert_eq!(report.total_copied(), 0);
         assert_eq!(report.total_skipped_existing(), 1);
 
@@ -8801,7 +8921,12 @@ mod test {
             Zeroizing::new(b"alice-value".to_vec()),
         )?;
 
-        let report = store.migrate_secrets(std::slice::from_ref(pred.key()), succ.key(), None);
+        store.record_delegate_registration_origin(pred.key(), Some(TEST_ORIGIN));
+        let report = store.migrate_secrets(
+            std::slice::from_ref(pred.key()),
+            succ.key(),
+            Some(TEST_ORIGIN),
+        );
         assert_eq!(report.total_copied(), 1, "only the Local secret is copied");
         assert_eq!(report.total_user_scope_skipped(), 1);
         assert_eq!(report.total_errors(), 0);
@@ -8912,10 +9037,12 @@ mod test {
             Zeroizing::new(b"vb".to_vec()),
         )?;
 
+        store.record_delegate_registration_origin(pred1.key(), Some(TEST_ORIGIN));
+        store.record_delegate_registration_origin(pred2.key(), Some(TEST_ORIGIN));
         let report = store.migrate_secrets(
             &[pred1.key().clone(), pred2.key().clone()],
             succ.key(),
-            None,
+            Some(TEST_ORIGIN),
         );
         assert_eq!(report.per_predecessor.len(), 2);
         assert_eq!(report.total_copied(), 2);
@@ -9046,7 +9173,12 @@ mod test {
                 .is_empty()
         );
 
-        let report = store.migrate_secrets(std::slice::from_ref(pred.key()), succ.key(), None);
+        store.record_delegate_registration_origin(pred.key(), Some(TEST_ORIGIN));
+        let report = store.migrate_secrets(
+            std::slice::from_ref(pred.key()),
+            succ.key(),
+            Some(TEST_ORIGIN),
+        );
         assert_eq!(report.total_copied(), 2);
 
         let mut keys = store.list_secret_keys(succ.key(), SecretScope::Local, b"room:");
@@ -9088,11 +9220,14 @@ mod test {
             Zeroizing::new(b"OLD".to_vec()),
         )?;
 
+        store.record_delegate_registration_origin(newer.key(), Some(TEST_ORIGIN));
+        store.record_delegate_registration_origin(older.key(), Some(TEST_ORIGIN));
+
         // Supplied newest-first: newer wins, older collides (skipped).
         let report = store.migrate_secrets(
             &[newer.key().clone(), older.key().clone()],
             succ.key(),
-            None,
+            Some(TEST_ORIGIN),
         );
         assert_eq!(
             report.per_predecessor[0].copied, 1,
@@ -9134,7 +9269,12 @@ mod test {
             Zeroizing::new(b"v".to_vec()),
         )?;
 
-        store.migrate_secrets(std::slice::from_ref(pred.key()), succ.key(), None);
+        store.record_delegate_registration_origin(pred.key(), Some(TEST_ORIGIN));
+        store.migrate_secrets(
+            std::slice::from_ref(pred.key()),
+            succ.key(),
+            Some(TEST_ORIGIN),
+        );
 
         // Marker secret exists under the successor with value b"1" (data-bearing).
         let marker_id = pred_done_marker_secret_id(pred.key());
@@ -9178,7 +9318,12 @@ mod test {
         // secrets — e.g. every secret was removed. Create the empty dir directly.
         std::fs::create_dir_all(secrets_dir.join(pred.key().encode()))?;
 
-        store.migrate_secrets(std::slice::from_ref(pred.key()), succ.key(), None);
+        store.record_delegate_registration_origin(pred.key(), Some(TEST_ORIGIN));
+        store.migrate_secrets(
+            std::slice::from_ref(pred.key()),
+            succ.key(),
+            Some(TEST_ORIGIN),
+        );
         let marker_id = pred_done_marker_secret_id(pred.key());
         let marker = store.get_secret(succ.key(), &marker_id, SecretScope::Local)?;
         assert_eq!(
@@ -9214,7 +9359,12 @@ mod test {
         let blob_path = secrets_dir.join(pred.key().encode()).join(sid.encode());
         std::fs::write(&blob_path, b"not-a-valid-ciphertext-blob")?;
 
-        let report = store.migrate_secrets(std::slice::from_ref(pred.key()), succ.key(), None);
+        store.record_delegate_registration_origin(pred.key(), Some(TEST_ORIGIN));
+        let report = store.migrate_secrets(
+            std::slice::from_ref(pred.key()),
+            succ.key(),
+            Some(TEST_ORIGIN),
+        );
         assert!(
             report.total_errors() >= 1,
             "the corrupted blob must be recorded as an error"
@@ -9230,7 +9380,11 @@ mod test {
         );
 
         // Re-registration is NOT gated — the pair stays retryable.
-        let report2 = store.migrate_secrets(std::slice::from_ref(pred.key()), succ.key(), None);
+        let report2 = store.migrate_secrets(
+            std::slice::from_ref(pred.key()),
+            succ.key(),
+            Some(TEST_ORIGIN),
+        );
         assert!(
             !report2.per_predecessor[0].already_migrated,
             "an unsealed partial copy must remain retryable"
@@ -9261,7 +9415,8 @@ mod test {
         )?;
 
         // P1 -> S1: writes a marker for P1 under S1.
-        store.migrate_secrets(std::slice::from_ref(p1.key()), s1.key(), None);
+        store.record_delegate_registration_origin(p1.key(), Some(TEST_ORIGIN));
+        store.migrate_secrets(std::slice::from_ref(p1.key()), s1.key(), Some(TEST_ORIGIN));
         assert!(
             store
                 .get_secret(
@@ -9274,7 +9429,8 @@ mod test {
         );
 
         // S1 -> S2: copies S1's real secret but NOT the P1 marker.
-        store.migrate_secrets(std::slice::from_ref(s1.key()), s2.key(), None);
+        store.record_delegate_registration_origin(s1.key(), Some(TEST_ORIGIN));
+        store.migrate_secrets(std::slice::from_ref(s1.key()), s2.key(), Some(TEST_ORIGIN));
         assert!(
             store.get_secret(s2.key(), &sid, SecretScope::Local).is_ok(),
             "the real secret chain-copies to S2"
@@ -9341,7 +9497,12 @@ mod test {
             Zeroizing::new(b"1".to_vec()),
         )?;
 
-        let report = store.migrate_secrets(std::slice::from_ref(pred.key()), succ.key(), None);
+        store.record_delegate_registration_origin(pred.key(), Some(TEST_ORIGIN));
+        let report = store.migrate_secrets(
+            std::slice::from_ref(pred.key()),
+            succ.key(),
+            Some(TEST_ORIGIN),
+        );
         // Only the real secret copies; the reserved-namespace key does not.
         assert_eq!(report.total_copied(), 1, "only the real secret copies");
         assert!(
@@ -9411,8 +9572,14 @@ mod test {
         let broken_blob = secrets_dir.join(pred.key().encode()).join(broken.encode());
         std::fs::write(&broken_blob, b"corrupt")?;
 
+        store.record_delegate_registration_origin(pred.key(), Some(TEST_ORIGIN));
+
         // First migration: healthy copies, broken errors → unsealed.
-        let r1 = store.migrate_secrets(std::slice::from_ref(pred.key()), succ.key(), None);
+        let r1 = store.migrate_secrets(
+            std::slice::from_ref(pred.key()),
+            succ.key(),
+            Some(TEST_ORIGIN),
+        );
         assert!(r1.total_errors() >= 1);
         assert!(
             store
@@ -9431,7 +9598,11 @@ mod test {
         // Re-registration re-runs the copy. Because the pair never sealed (broken
         // still corrupt), the deleted-but-healthy secret is RESURRECTED — the
         // documented v1 limitation.
-        store.migrate_secrets(std::slice::from_ref(pred.key()), succ.key(), None);
+        store.migrate_secrets(
+            std::slice::from_ref(pred.key()),
+            succ.key(),
+            Some(TEST_ORIGIN),
+        );
         assert!(
             store
                 .get_secret(succ.key(), &healthy, SecretScope::Local)
@@ -9442,10 +9613,13 @@ mod test {
     }
 
     /// H1 same-origin gate: a copy proceeds only when the registering origin
-    /// matches a predecessor's recorded origin; a mismatch refuses (no copy, no
-    /// seal); a predecessor with no recorded origin is grandfathered.
+    /// matches a predecessor's recorded origin; a mismatch refuses
+    /// (`origin_refused`, NOT `no_provenance` — the predecessor DOES have a
+    /// record, it just doesn't match); a predecessor with NO recorded origin at
+    /// all is refused as `no_provenance` (legacy data migrates via the app-side
+    /// path instead — see #4117 H1, no grandfathering in the redesigned gate).
     #[tokio::test]
-    async fn migrate_origin_gate_match_mismatch_and_grandfather()
+    async fn migrate_origin_gate_match_mismatch_and_no_provenance()
     -> Result<(), Box<dyn std::error::Error>> {
         let temp_dir = tempfile::tempdir()?;
         let secrets_dir = temp_dir.path().join("s");
@@ -9466,13 +9640,18 @@ mod test {
         let origin_a = [0x11u8; 32];
         store.record_delegate_registration_origin(pred.key(), Some(origin_a));
 
-        // MISMATCH: a different registering origin is refused.
+        // MISMATCH: a different registering origin is refused, but there IS a
+        // record for this predecessor, so it is NOT no_provenance.
         let other = [0x22u8; 32];
         let report =
             store.migrate_secrets(std::slice::from_ref(pred.key()), succ.key(), Some(other));
         assert!(
             report.per_predecessor[0].origin_refused,
             "mismatch must refuse"
+        );
+        assert!(
+            !report.per_predecessor[0].no_provenance,
+            "a mismatch against an EXISTING record must not be no_provenance"
         );
         assert_eq!(report.total_copied(), 0);
         assert!(
@@ -9493,7 +9672,9 @@ mod test {
                 .is_ok()
         );
 
-        // GRANDFATHER: a predecessor with NO recorded origin is allowed + flagged.
+        // NO PROVENANCE: a SEPARATE predecessor with NO recorded origin at all is
+        // refused — origin_refused AND no_provenance, regardless of the supplied
+        // origin. Legacy data like this migrates via the app-side path instead.
         let pred2 = Delegate::from((&vec![0].into(), &vec![3].into()));
         let succ2 = Delegate::from((&vec![0].into(), &vec![4].into()));
         let sid2 = SecretsId::new(b"room:b".to_vec());
@@ -9506,18 +9687,26 @@ mod test {
         let report3 =
             store.migrate_secrets(std::slice::from_ref(pred2.key()), succ2.key(), Some(other));
         assert!(
-            report3.per_predecessor[0].grandfathered,
-            "a predecessor with no recorded origin is grandfathered"
+            report3.per_predecessor[0].origin_refused,
+            "a predecessor with no recorded origin must be refused"
         );
-        assert_eq!(report3.total_copied(), 1);
+        assert!(
+            report3.per_predecessor[0].no_provenance,
+            "a predecessor with no recorded origin is no_provenance"
+        );
+        assert_eq!(report3.total_copied(), 0);
         Ok(())
     }
 
-    /// H1 Admin/None class: a predecessor registered with no origin (loopback /
-    /// CLI) is migratable by a loopback (`None`) registration, but a web-app
-    /// (`Some`) registration is refused.
+    /// H1 None-class: `origin_contract == None` (a token-less / loopback
+    /// registration) is NEVER privileged — not even against a predecessor whose
+    /// FIRST-registration origin was ITSELF recorded as `None`. There is no
+    /// admin/loopback bypass in the redesigned gate. Since the predecessor DOES
+    /// have a record (the None-class record), refusal here is `origin_refused`
+    /// without `no_provenance`.
     #[tokio::test]
-    async fn migrate_origin_gate_admin_class() -> Result<(), Box<dyn std::error::Error>> {
+    async fn migrate_origin_none_class_never_privileged() -> Result<(), Box<dyn std::error::Error>>
+    {
         let temp_dir = tempfile::tempdir()?;
         let secrets_dir = temp_dir.path().join("s");
         std::fs::create_dir_all(&secrets_dir)?;
@@ -9532,18 +9721,27 @@ mod test {
             SecretScope::Local,
             Zeroizing::new(b"v".to_vec()),
         )?;
-        // Recorded as Admin/None (a loopback registration).
+        // Recorded as None-class (a loopback registration) — this does NOT
+        // privilege a later None registering origin.
         store.record_delegate_registration_origin(pred.key(), None);
 
-        // A loopback (None) registration → allowed (both Admin/None class), NOT
-        // grandfathered (there IS a record).
+        // A loopback (None) registering origin → refused: None is NEVER
+        // privileged, even against a None-class record. There IS a record for
+        // this predecessor, so no_provenance is false.
         let succ = Delegate::from((&vec![0].into(), &vec![2].into()));
         let report = store.migrate_secrets(std::slice::from_ref(pred.key()), succ.key(), None);
-        assert!(!report.per_predecessor[0].origin_refused);
-        assert!(!report.per_predecessor[0].grandfathered);
-        assert_eq!(report.total_copied(), 1);
+        assert!(
+            report.per_predecessor[0].origin_refused,
+            "a None registering origin must be refused"
+        );
+        assert!(
+            !report.per_predecessor[0].no_provenance,
+            "the predecessor DOES have a record (None-class), so this is not no_provenance"
+        );
+        assert_eq!(report.total_copied(), 0);
 
-        // A web-app (Some) registration against an Admin-only record → refused.
+        // A web-app (Some) registration against a None-class record → also
+        // refused (a None-class record never matches any Some origin).
         let succ2 = Delegate::from((&vec![0].into(), &vec![3].into()));
         let report2 = store.migrate_secrets(
             std::slice::from_ref(pred.key()),
@@ -9552,6 +9750,66 @@ mod test {
         );
         assert!(report2.per_predecessor[0].origin_refused);
         assert_eq!(report2.total_copied(), 0);
+        Ok(())
+    }
+
+    /// H1 first-writer-wins is IMMUTABLE: once a delegate's FIRST-registration
+    /// origin is recorded, a later `record_delegate_registration_origin` call
+    /// (e.g. an attacker re-registering a victim's public WASM later) is a no-op
+    /// — the original (victim's) origin keeps gating copy-forward forever.
+    #[tokio::test]
+    async fn migrate_origin_first_writer_is_immutable() -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let secrets_dir = temp_dir.path().join("s");
+        std::fs::create_dir_all(&secrets_dir)?;
+        let db = create_test_db(temp_dir.path()).await;
+        let mut store = SecretsStore::new(secrets_dir, Default::default(), db)?;
+
+        let victim_origin = [0xA1u8; 32];
+        let attacker_origin = [0xEEu8; 32];
+
+        let pred = Delegate::from((&vec![0].into(), &vec![1].into()));
+        let sid = SecretsId::new(b"room:a".to_vec());
+        store.store_secret(
+            pred.key(),
+            &sid,
+            SecretScope::Local,
+            Zeroizing::new(b"v".to_vec()),
+        )?;
+
+        // The victim's origin is recorded FIRST...
+        store.record_delegate_registration_origin(pred.key(), Some(victim_origin));
+        // ...then an attacker re-registers the same (public-derivable) predecessor
+        // key, trying to overwrite the record. First-writer-wins: a no-op.
+        store.record_delegate_registration_origin(pred.key(), Some(attacker_origin));
+
+        // The attacker's origin does NOT satisfy the gate — the record still
+        // holds the FIRST (victim's) origin, not the attacker's.
+        let succ = Delegate::from((&vec![0].into(), &vec![2].into()));
+        let report = store.migrate_secrets(
+            std::slice::from_ref(pred.key()),
+            succ.key(),
+            Some(attacker_origin),
+        );
+        assert!(
+            report.per_predecessor[0].origin_refused,
+            "the attacker's origin must not satisfy the gate"
+        );
+        assert_eq!(report.total_copied(), 0);
+
+        // The victim's ORIGINAL origin still works.
+        let succ2 = Delegate::from((&vec![0].into(), &vec![3].into()));
+        let report2 = store.migrate_secrets(
+            std::slice::from_ref(pred.key()),
+            succ2.key(),
+            Some(victim_origin),
+        );
+        assert!(!report2.per_predecessor[0].origin_refused);
+        assert_eq!(
+            report2.total_copied(),
+            1,
+            "the FIRST-recorded (victim's) origin must still gate the copy"
+        );
         Ok(())
     }
 
@@ -9588,7 +9846,12 @@ mod test {
         let succ_blob = secrets_dir.join(succ.key().encode()).join(sid.encode());
         std::fs::write(&succ_blob, b"corrupt-not-decryptable")?;
 
-        let report = store.migrate_secrets(std::slice::from_ref(pred.key()), succ.key(), None);
+        store.record_delegate_registration_origin(pred.key(), Some(TEST_ORIGIN));
+        let report = store.migrate_secrets(
+            std::slice::from_ref(pred.key()),
+            succ.key(),
+            Some(TEST_ORIGIN),
+        );
         assert!(
             report.total_errors() >= 1,
             "a non-decrypting collision must be recorded as an error"
@@ -9599,6 +9862,83 @@ mod test {
                 .get_secret(succ.key(), &marker_id, SecretScope::Local)
                 .is_err(),
             "a corrupt collision must leave the pair unsealed"
+        );
+        Ok(())
+    }
+
+    /// P2a: `store_secret` REJECTS a foreign key in the reserved
+    /// `\0freenet-migrate/` namespace — only `pred-done:`/`pred-wip:` + exactly a
+    /// 32-byte key are legal — so a client cannot pad the reserved namespace to
+    /// bloat the reserved-hash table or shadow a real marker. A legal marker and
+    /// an ordinary user key are accepted.
+    #[tokio::test]
+    async fn store_secret_rejects_foreign_reserved_namespace_keys()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let secrets_dir = temp_dir.path().join("s");
+        std::fs::create_dir_all(&secrets_dir)?;
+        let db = create_test_db(temp_dir.path()).await;
+        let mut store = SecretsStore::new(secrets_dir, Default::default(), db)?;
+        let d = Delegate::from((&vec![0].into(), &vec![1].into()));
+
+        // Foreign reserved key (wrong sub-prefix) → rejected.
+        let foreign = SecretsId::new(b"\0freenet-migrate/attacker".to_vec());
+        assert!(
+            store
+                .store_secret(
+                    d.key(),
+                    &foreign,
+                    SecretScope::Local,
+                    Zeroizing::new(b"x".to_vec())
+                )
+                .is_err(),
+            "a foreign reserved-namespace key must be rejected"
+        );
+
+        // Correct prefix but WRONG suffix length (not 32 bytes) → rejected.
+        let mut wrong = b"\0freenet-migrate/v1/pred-done:".to_vec();
+        wrong.extend_from_slice(&[0xABu8; 8]);
+        let wrong_id = SecretsId::new(wrong);
+        assert!(
+            store
+                .store_secret(
+                    d.key(),
+                    &wrong_id,
+                    SecretScope::Local,
+                    Zeroizing::new(b"x".to_vec())
+                )
+                .is_err(),
+            "a reserved key with a wrong-length suffix must be rejected"
+        );
+
+        // Legal pred-done: + 32 bytes → accepted.
+        let mut legal = b"\0freenet-migrate/v1/pred-done:".to_vec();
+        legal.extend_from_slice(&[0xCDu8; 32]);
+        let legal_id = SecretsId::new(legal);
+        assert!(
+            store
+                .store_secret(
+                    d.key(),
+                    &legal_id,
+                    SecretScope::Local,
+                    Zeroizing::new(b"1".to_vec())
+                )
+                .is_ok(),
+            "a legal marker key must be accepted"
+        );
+
+        // An ordinary (non-reserved) user key → accepted.
+        let normal = SecretsId::new(b"room:alice".to_vec());
+        assert!(
+            store
+                .store_secret(
+                    d.key(),
+                    &normal,
+                    SecretScope::Local,
+                    Zeroizing::new(b"x".to_vec())
+                )
+                .is_ok(),
+            "an ordinary user key must be accepted"
         );
         Ok(())
     }


### PR DESCRIPTION
## Problem

A delegate's on-disk key is `BLAKE3(code_hash || params)`, so ANY change to the delegate's compiled WASM mints a new key, a new secret namespace, and an "empty new install" for every existing user (#4117). Delegate-backed secrets are the only reliable per-user store a sandboxed web app has, so every delegate rebuild silently wipes profiles, room keys, and settings. Interim node-side path for the graceful-upgrades workstream (#2776).

## Solution

Node-side primitive behind `DelegateRequest::RegisterDelegateWithPredecessors { delegate, cipher, nonce, predecessors: Vec<DelegateKey> }` (freenet-stdlib 0.8.4, bincode tag 3). On registration the node runs a one-shot, idempotent, **Local-scope** copy-forward of each predecessor's secret VALUES into the successor's namespace — at-rest decrypt (predecessor Local DEK) → re-encrypt (successor Local DEK). Local-only by construction: the Local DEK is `HKDF(node_KEK, delegate_key)` (at rest); the per-user DEK needs the client's `dek_secret` (not at rest).

### Security — H1 same-origin gate (first-writer-wins, no grandfather, None never privileged)

A predecessor delegate key is public-derivable and a malicious web-app IS the client, so client consent cannot gate copy-forward. The node records each delegate's registration origin on its FIRST registration only — IMMUTABLE — and copies a predecessor's secrets ONLY IF the registering request's web-app origin equals that predecessor's recorded first origin. An attacker who re-registers a victim's public WASM later records nothing and can never satisfy the gate. Refusals (report `origin_refused`; not a registration failure):
- registering origin ≠ record (mismatch);
- registering origin is `None` / token-less (never privileged in v1 — nothing about a token-less connection is verifiable as locally trusted);
- no record (`no_provenance`) — such legacy data migrates via the app-side `freenet-migrate` path, whose predecessor-delegate OriginPolicy is the sound legacy authorizer.

An origin-LOOKUP failure fails the copy CLOSED (no copy, no seal). A first-writer origin-RECORD write failure FAILS THE ENTIRE REGISTRATION (persistence-succeeds-before-usable): the record is written BEFORE the delegate is registered, and if it cannot be durably persisted nothing is registered — for BOTH `RegisterDelegate` and `RegisterDelegateWithPredecessors`. A registered-but-recordless delegate would leave a claimable first-writer slot an attacker could later name as its own and migrate the accumulated secrets through; registration already depends on delegate-store disk health, so a failing origin-record DB is a visibly sick node and the app simply retries.

### Correctness / seal discipline

Seal only on a fully-clean copy (any read/import/enumeration/marker/reserved-lookup failure leaves the pair UNSEALED so a retry or the app-side path completes it). A collision counts as present only if the existing successor blob decrypts. The shared crate-format marker (`\0freenet-migrate/v1/pred-done:`+key, `b"1"/b"0"`, byte-pinned both repos) is written + verified FIRST, then the redb audit row; any marker failure fully un-seals. An absent predecessor (no on-disk dir) writes nothing. Order: newest-first, first-writer-wins (union-with-newest-precedence); delete-by-absence is app-side only.

### Reserved namespace + amplification bounds

- The whole reserved `\0freenet-migrate/` namespace is excluded from copy-forward via a durable, INDIVIDUALLY-KEYED, capped (256/delegate) redb reserved-hashes table, recorded at `store_secret` time BEFORE the value blob's rename (P1c) — the exclusion lookup fails CLOSED (aborts copy + un-seals; export aborts). `store_secret` REJECTS any reserved-namespace key that is not one of the FOUR pinned marker shapes (P2a): v1 `…/v1/pred-done:` / `…/v1/pred-wip:` + a 32-byte delegate key, or legacy `…/done:` / `…/wip:` + a CANONICAL `u32` decimal generation (non-empty, digits only, no leading zeros except `"0"`, ≤10 digits, ≤ `u32::MAX` — exactly what the crate's `generation.to_string()` produces; non-canonical duplicates like `"00"` and overflow forms like `"4294967296"` are refused). The four-shape matrix is confirmed against freenet-migrate 0.4.0 (no fifth `migrated:` shape) and byte-pinned in both repos (`reserved_marker_shape_matrix_is_stable` node-side; the crate mirror), so any drift trips CI on both sides.
- The client predecessor list is deduped silently and the cap is enforced on the UNIQUE count (matching the docstrings): a duplicate-heavy list whose unique count is within the cap is accepted, while an over-cap UNIQUE list (>64) is REJECTED whole before registration (P2b), never truncated (truncation would strand older generations). A separate raw-length DoS sanity bound (16× the cap = 1024) rejects a giant list up front so the dedupe work itself stays bounded.
- Enumeration carry-over registers each copied secret's raw key under the successor so `list_secret_keys` (River `room:<vk>` discovery) survives a rebuild; `list_secret_keys` + export filter the reserved namespace (L2).

### Match sites

Explicit `RegisterDelegateWithPredecessors` handling at all FOUR `DelegateRequest` match sites (register+migrate handler; `client_events.rs` app-routing no-op; `node.rs` op_name; `contract.rs` initial-params).

## Deploy ordering (LAW)

stdlib publish (done: 0.8.4) → **core merge** → **core release** → only THEN may any client emit tag 3.

**Marker SHAPE-EVOLUTION corollary.** The reserved-shape whitelist (above) is an ENFORCEMENT list, not just documentation — a foreign reserved key is refused rather than silently absorbed — so it inherits the same deploy-ordering obligation as the wire variant: any FUTURE marker shape (e.g. a hypothetical `\0freenet-migrate/v2/…`) MUST ship node-side acceptance in this matrix, in a RELEASED node, BEFORE any crate version writes it. If that ordering is ever violated the failure mode is SAFE and LOUD, never silent: an old node rejects the unknown marker write with a store error, degrading that one migration to a visible Incomplete-retry — the crate re-attempts once the node is upgraded — rather than a silent divergence. This is why the matrix is byte-pinned in both repos.

## Testing

Store-level: copy readable under successor DEK; one-shot/anti-resurrection; overwrite=false; user-scope skipped; enumeration carry-over; first-writer-wins order; crate-format marker + cross-path gating; empty-but-held NoData; absent-predecessor; whole-reserved-namespace exclusion; markers not chain-copied; corrupt-collision unsealed; seal-only-on-clean; H1 (match/mismatch/no-provenance, first-writer immutability, None never privileged); origin-record-failure ABORTS registration (redb-level fault-injected backend failure surfaces as Err not a silent Ok; handler-level: both variants abort under a failing origin-record DB, register nothing, copy nothing, predecessor intact, and a healthy retry after recovery registers + copies); P2a reserved-shape rejection (all four legal shapes accepted; foreign reserved key rejected); canonical-u32 legacy-gen boundaries (`"0"` accepted; `"00"`/`"4294967296"`/11-digit/legacy-u64 rejected); M2 resurrection known-limitation pin; marker-format byte-pin; redb round-trips. Unit: `dedupe_predecessors`. Handler-level (injects a matching origin) + a real-node freenet-ping e2e demonstrating the gate REFUSING a token-less copy end-to-end. `cargo fmt` + whole-workspace `cargo clippy --locked -- -D warnings` clean.

## Known limitation / follow-ups

- **M2 (#4909)**: a permanently-corrupt blob keeps a pair unsealed, so a user-deleted healthy co-resident secret resurrects on re-registration. Deliberate v1 pair-level tradeoff (per-secret sealing needs a crate-contract evolution), symmetric with the app-side path; pinned by a known-limitation test.
- Hosted/User-scope carry-over (re-wrap-on-login) — the at-rest DEK carve-out.
- An authenticated admin migration mechanism (None-class is unprivileged in v1).
- Crate-side byte-pin of the identical four-shape matrix — deferred to the next freenet-migrate PR (0.4.0 already published), tracked with the maintainer.

Refs #2776. Closes #4117.

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014wJpXbgCrnkSKgkpmnLGwQ
