### PR TITLE
fix(test): stop unlocked test writes to the external_address global

### DIFF
--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -4484,7 +4484,7 @@ mod tests {
         op_manager
             .ring
             .connection_manager
-            .set_own_addr("127.0.0.1:14000".parse().unwrap());
+            .set_own_addr_local_for_test("127.0.0.1:14000".parse().unwrap());
 
         // Attach an EMPTY redb hosting store so `contract_state_present`
         // returns false for unknown keys (a fresh store creates the STATE
@@ -4589,7 +4589,7 @@ mod tests {
         op_manager
             .ring
             .connection_manager
-            .set_own_addr("127.0.0.1:14100".parse().unwrap());
+            .set_own_addr_local_for_test("127.0.0.1:14100".parse().unwrap());
 
         // The one contract we DO hold.
         let key = freenet_stdlib::prelude::ContractKey::from_id_and_code(
@@ -4732,7 +4732,7 @@ mod tests {
         op_manager
             .ring
             .connection_manager
-            .set_own_addr("127.0.0.1:14200".parse().unwrap());
+            .set_own_addr_local_for_test("127.0.0.1:14200".parse().unwrap());
 
         // Stand-in contract handler: flips `update_query_seen` to true if it EVER
         // receives an UpdateQuery (proof the WASM-apply path was entered),
@@ -4861,7 +4861,7 @@ mod tests {
         op_manager
             .ring
             .connection_manager
-            .set_own_addr("127.0.0.1:14300".parse().unwrap());
+            .set_own_addr_local_for_test("127.0.0.1:14300".parse().unwrap());
 
         // Stand-in contract handler: answers UpdateQuery with a SUCCESSFUL,
         // state-changed merge (mirrors the ResyncResponse arm's

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -2953,7 +2953,10 @@ mod tests {
     /// anyone's computed upstream.
     fn seed_location_and_one_connection(op_manager: &OpManager) {
         let self_addr: std::net::SocketAddr = "127.0.0.1:12000".parse().unwrap();
-        op_manager.ring.connection_manager.set_own_addr(self_addr);
+        op_manager
+            .ring
+            .connection_manager
+            .set_own_addr_local_for_test(self_addr);
         assert!(
             op_manager
                 .ring
@@ -3032,7 +3035,10 @@ mod tests {
         // Own address. The UPDATE sender is a DIFFERENT peer, so the self/sender
         // echo-skip never applies to A or B below.
         let self_addr: std::net::SocketAddr = "127.0.0.1:12000".parse().unwrap();
-        op_manager.ring.connection_manager.set_own_addr(self_addr);
+        op_manager
+            .ring
+            .connection_manager
+            .set_own_addr_local_for_test(self_addr);
         let sender_addr: std::net::SocketAddr = "127.0.0.1:20000".parse().unwrap();
 
         let key = reroot_contract_key(0x5A);

--- a/crates/core/src/operations/connect/op_ctx_task.rs
+++ b/crates/core/src/operations/connect/op_ctx_task.rs
@@ -531,6 +531,9 @@ async fn drive_client_connect_inner(
                 // diagnostics) and `own_location` (for routing).
                 // Idempotent: subsequent observations overwrite.
                 let location = Location::from_address(&address);
+                // GLOBAL-ADDR-WRITE-OK: production. A real node learning its
+                // peer-observed address is exactly what the external_address
+                // mirror is for (#4918).
                 op_manager.ring.connection_manager.set_own_addr(address);
                 op_manager
                     .ring

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -3750,7 +3750,10 @@ mod tests {
         );
         op_manager.ring.attach_op_manager(&op_manager);
         let self_addr: SocketAddr = "127.0.0.1:12000".parse().unwrap();
-        op_manager.ring.connection_manager.set_own_addr(self_addr);
+        op_manager
+            .ring
+            .connection_manager
+            .set_own_addr_local_for_test(self_addr);
 
         let handler = tokio::spawn(async move {
             while let Ok((id, ev, _priority)) = ch_channel.recv_from_sender().await {
@@ -4019,7 +4022,10 @@ mod tests {
         );
         op_manager.ring.attach_op_manager(&op_manager);
         let self_addr: SocketAddr = "127.0.0.1:12000".parse().unwrap();
-        op_manager.ring.connection_manager.set_own_addr(self_addr);
+        op_manager
+            .ring
+            .connection_manager
+            .set_own_addr_local_for_test(self_addr);
 
         let update_query_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let counter = update_query_count.clone();

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -8497,7 +8497,7 @@ mod cost_pressure_seam_tests {
         op_manager
             .ring
             .connection_manager
-            .set_own_addr("127.0.0.1:14100".parse().unwrap());
+            .set_own_addr_local_for_test("127.0.0.1:14100".parse().unwrap());
         let ring = &op_manager.ring;
 
         let junk = seam_key(1);

--- a/crates/core/src/ring/connection_manager.rs
+++ b/crates/core/src/ring/connection_manager.rs
@@ -3758,38 +3758,72 @@ mod tests {
     /// not catch a regression in CI — but this scrape runs deterministically
     /// under both runners, so it does.
     ///
-    /// The three scanned files hold `set_own_addr` calls only in test code
-    /// (production own-address writes live in `operations/` and node startup).
-    /// If a genuine production need for the mirroring setter ever arises in one
-    /// of them, this test will fail loudly — that is the intended prompt to
-    /// consider the global-state coupling, not a reason to weaken the guard.
+    /// It walks the WHOLE crate source rather than a fixed file list, and
+    /// allowlists the known-good production sites. A hardcoded list is the same
+    /// "remember to update it" fragility this fix exists to remove: the caller
+    /// inventory for this bug was wrong three times running (5 sites, then 7,
+    /// then 9 — the last two found by review), so the guard must fail CLOSED on
+    /// anything new anywhere.
     #[test]
     fn test_no_test_calls_global_set_own_addr() {
-        // Paths are relative to THIS file (`src/ring/connection_manager.rs`).
-        let files = [
-            ("node.rs", include_str!("../node.rs")),
-            ("ring.rs", include_str!("../ring.rs")),
-            (
-                "node/op_state_manager.rs",
-                include_str!("../node/op_state_manager.rs"),
-            ),
+        use std::path::Path;
+
+        // Sites that legitimately write the process-global mirror.
+        // `connect/op_ctx_task.rs` is production (a real node learning its
+        // observed address); `connection_manager.rs` is this module — the
+        // atomicity test's own call, which holds `TEST_GLOBAL_STATE_LOCK`,
+        // plus these string literals.
+        const ALLOWED: [&str; 2] = [
+            "operations/connect/op_ctx_task.rs",
+            "ring/connection_manager.rs",
         ];
         // `.set_own_addr(` requires `(` immediately after the name, so it does
         // NOT match `.set_own_addr_local_for_test(`.
         const BARE: &str = ".set_own_addr(";
-        for (name, src) in files {
-            assert!(
-                !src.contains(BARE),
-                "{name} calls the mirroring `set_own_addr`, which writes the \
-                 process-global external_address and races \
-                 test_set_own_addr_atomic_with_network_status under `cargo \
-                 test`. Use `set_own_addr_local_for_test` for tests that only \
-                 need routing to know the address, or hold \
-                 TEST_GLOBAL_STATE_LOCK if the global mirror is genuinely \
-                 required. See #4918."
-            );
-            // ...and confirm the safe helper is actually the one in use, so a
-            // future edit can't quietly drop address-setting and pass vacuously.
+
+        fn visit(dir: &Path, out: &mut Vec<String>) {
+            let entries = std::fs::read_dir(dir).expect("read crate source dir");
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    visit(&path, out);
+                } else if path.extension().is_some_and(|e| e == "rs") {
+                    let src = std::fs::read_to_string(&path).expect("read source file");
+                    if src.contains(BARE) {
+                        out.push(path.to_string_lossy().replace('\\', "/"));
+                    }
+                }
+            }
+        }
+
+        let src_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let mut hits = Vec::new();
+        visit(&src_root, &mut hits);
+
+        let unexpected: Vec<&String> = hits
+            .iter()
+            .filter(|p| !ALLOWED.iter().any(|a| p.ends_with(a)))
+            .collect();
+        assert!(
+            unexpected.is_empty(),
+            "these files call the mirroring `set_own_addr`, which writes the \
+             process-global external_address and races \
+             test_set_own_addr_atomic_with_network_status under `cargo test`: \
+             {unexpected:?}\nUse `set_own_addr_local_for_test` for tests that \
+             only need routing to know the address, or hold \
+             TEST_GLOBAL_STATE_LOCK if the global mirror is genuinely \
+             required. See #4918."
+        );
+
+        // The migrated files must still SET an address, so a future edit
+        // cannot quietly drop address-setting and pass vacuously.
+        for name in [
+            "node.rs",
+            "ring.rs",
+            "node/op_state_manager.rs",
+            "operations/update/op_ctx_task.rs",
+        ] {
+            let src = std::fs::read_to_string(src_root.join(name)).expect("read migrated file");
             assert!(
                 src.contains(".set_own_addr_local_for_test("),
                 "{name} should set own address via set_own_addr_local_for_test \

--- a/crates/core/src/ring/connection_manager.rs
+++ b/crates/core/src/ring/connection_manager.rs
@@ -1649,6 +1649,27 @@ impl ConnectionManager {
         );
     }
 
+    /// Set only the local `own_addr`, WITHOUT mirroring to the process-global
+    /// `network_status::external_address`.
+    ///
+    /// For tests that need routing to know this node's address but do not
+    /// exercise the external-address mirror. The full [`Self::set_own_addr`]
+    /// writes a `OnceLock`-backed process global shared by every test in the
+    /// binary; a test that calls it must hold
+    /// [`crate::node::network_status::TEST_GLOBAL_STATE_LOCK`], or it races the
+    /// `set_own_addr` atomicity regression test
+    /// (`test_set_own_addr_atomic_with_network_status`) under `cargo test`'s
+    /// shared-process model. Using this local-only setter sidesteps that
+    /// coupling entirely — the write never touches the global, so there is
+    /// nothing to serialize. See issue #4918.
+    ///
+    /// `test_no_test_calls_global_set_own_addr` pins that the test files which
+    /// previously raced use this helper and not the mirroring setter.
+    #[cfg(test)]
+    pub(crate) fn set_own_addr_local_for_test(&self, addr: SocketAddr) {
+        *self.own_addr.lock() = Some(addr);
+    }
+
     pub fn prune_alive_connection(&self, addr: SocketAddr) -> Option<Location> {
         self.prune_connection(addr, true)
     }
@@ -3643,10 +3664,16 @@ mod tests {
         // global races this one's `assert_eq!`. (CI's `cargo nextest` masks
         // the race with per-process isolation; `cargo test` does not.)
         //
-        // `connection_manager`'s `test_try_set_own_addr_*` tests and every
-        // test in `node::network_status` also touch this global. They are all
-        // serialized by the crate-wide `TEST_GLOBAL_STATE_LOCK`, which this
-        // test acquires below for its entire body.
+        // Other writers of this global — `connection_manager`'s
+        // `test_try_set_own_addr_*` tests and every `node::network_status`
+        // test — take the crate-wide `TEST_GLOBAL_STATE_LOCK`, which this test
+        // holds for its entire body. Tests that only need routing to know
+        // their address (resync/eviction tests in `node.rs`, `ring.rs`,
+        // `node/op_state_manager.rs`) do NOT write the global at all: they use
+        // `ConnectionManager::set_own_addr_local_for_test`, so they cannot race
+        // this assertion. `test_no_test_calls_global_set_own_addr` pins that.
+        // (Before #4918 those tests used the mirroring `set_own_addr` without
+        // the lock and flaked this test ~1 run in 3 under `cargo test`.)
         //
         // `network_status::set_external_address` is a no-op until `init()` has
         // run. `init()` is idempotent-overwrite (installs the tracker on the
@@ -3716,6 +3743,58 @@ mod tests {
         drop(_global);
         if let Some(msg) = divergence {
             panic!("{msg}");
+        }
+    }
+
+    /// Guard for #4918: tests that only need routing to know their address
+    /// must NOT call the mirroring [`ConnectionManager::set_own_addr`], which
+    /// writes the process-global `network_status::external_address` and races
+    /// `test_set_own_addr_atomic_with_network_status` unless serialized by
+    /// `TEST_GLOBAL_STATE_LOCK`.
+    ///
+    /// This is a SOURCE-SCRAPE guard on purpose. The race only manifests under
+    /// `cargo test`'s shared-process model; CI's `cargo nextest` gives every
+    /// test its own process and masks it. A behavioural test therefore could
+    /// not catch a regression in CI — but this scrape runs deterministically
+    /// under both runners, so it does.
+    ///
+    /// The three scanned files hold `set_own_addr` calls only in test code
+    /// (production own-address writes live in `operations/` and node startup).
+    /// If a genuine production need for the mirroring setter ever arises in one
+    /// of them, this test will fail loudly — that is the intended prompt to
+    /// consider the global-state coupling, not a reason to weaken the guard.
+    #[test]
+    fn test_no_test_calls_global_set_own_addr() {
+        // Paths are relative to THIS file (`src/ring/connection_manager.rs`).
+        let files = [
+            ("node.rs", include_str!("../node.rs")),
+            ("ring.rs", include_str!("../ring.rs")),
+            (
+                "node/op_state_manager.rs",
+                include_str!("../node/op_state_manager.rs"),
+            ),
+        ];
+        // `.set_own_addr(` requires `(` immediately after the name, so it does
+        // NOT match `.set_own_addr_local_for_test(`.
+        const BARE: &str = ".set_own_addr(";
+        for (name, src) in files {
+            assert!(
+                !src.contains(BARE),
+                "{name} calls the mirroring `set_own_addr`, which writes the \
+                 process-global external_address and races \
+                 test_set_own_addr_atomic_with_network_status under `cargo \
+                 test`. Use `set_own_addr_local_for_test` for tests that only \
+                 need routing to know the address, or hold \
+                 TEST_GLOBAL_STATE_LOCK if the global mirror is genuinely \
+                 required. See #4918."
+            );
+            // ...and confirm the safe helper is actually the one in use, so a
+            // future edit can't quietly drop address-setting and pass vacuously.
+            assert!(
+                src.contains(".set_own_addr_local_for_test("),
+                "{name} should set own address via set_own_addr_local_for_test \
+                 (see #4918)"
+            );
         }
     }
 

--- a/crates/core/src/ring/connection_manager.rs
+++ b/crates/core/src/ring/connection_manager.rs
@@ -3711,6 +3711,9 @@ mod tests {
                 handles.push(std::thread::spawn(move || {
                     // Align starts so the threads' critical sections overlap.
                     barrier.wait();
+                    // GLOBAL-ADDR-WRITE-OK: this test IS the mirror's
+                    // atomicity regression test, and its body holds
+                    // TEST_GLOBAL_STATE_LOCK throughout (#4918).
                     cm.set_own_addr(addr);
                 }));
             }
@@ -3758,61 +3761,77 @@ mod tests {
     /// not catch a regression in CI — but this scrape runs deterministically
     /// under both runners, so it does.
     ///
-    /// It walks the WHOLE crate source rather than a fixed file list, and
-    /// allowlists the known-good production sites. A hardcoded list is the same
-    /// "remember to update it" fragility this fix exists to remove: the caller
-    /// inventory for this bug was wrong three times running (5 sites, then 7,
-    /// then 9 — the last two found by review), so the guard must fail CLOSED on
-    /// anything new anywhere.
+    /// It walks the WHOLE crate source and checks each call site individually.
+    /// Neither a fixed file list nor a per-file allowlist is enough: both are
+    /// the same "remember to update it" fragility this fix exists to remove.
+    /// The caller inventory for this bug was wrong three times running (5 sites,
+    /// then 7, then 9 — the last two found by review), and the two files that
+    /// legitimately write the global both contain test modules, so exempting
+    /// them wholesale would let the identical race back in. Every call site
+    /// must therefore carry an explicit [`MARKER`] annotation justifying it.
     #[test]
     fn test_no_test_calls_global_set_own_addr() {
         use std::path::Path;
 
-        // Sites that legitimately write the process-global mirror.
-        // `connect/op_ctx_task.rs` is production (a real node learning its
-        // observed address); `connection_manager.rs` is this module — the
-        // atomicity test's own call, which holds `TEST_GLOBAL_STATE_LOCK`,
-        // plus these string literals.
-        const ALLOWED: [&str; 2] = [
-            "operations/connect/op_ctx_task.rs",
-            "ring/connection_manager.rs",
-        ];
-        // `.set_own_addr(` requires `(` immediately after the name, so it does
-        // NOT match `.set_own_addr_local_for_test(`.
-        const BARE: &str = ".set_own_addr(";
+        // Built at runtime so this file's own source does not contain the
+        // literal being searched for (which would match the guard itself).
+        let bare = format!(".set_own_addr{}", "(");
+        // An annotation on the call line, or anywhere in the comment block
+        // immediately above it, marks a write to the process-global mirror as
+        // deliberate and justified. The whole block is searched so a
+        // multi-line justification can lead with the marker and still read
+        // naturally.
+        const MARKER: &str = "GLOBAL-ADDR-WRITE-OK";
 
-        fn visit(dir: &Path, out: &mut Vec<String>) {
+        fn visit(dir: &Path, out: &mut Vec<(String, usize, String)>, bare: &str) {
             let entries = std::fs::read_dir(dir).expect("read crate source dir");
             for entry in entries.flatten() {
                 let path = entry.path();
                 if path.is_dir() {
-                    visit(&path, out);
+                    visit(&path, out, bare);
                 } else if path.extension().is_some_and(|e| e == "rs") {
                     let src = std::fs::read_to_string(&path).expect("read source file");
-                    if src.contains(BARE) {
-                        out.push(path.to_string_lossy().replace('\\', "/"));
+                    let lines: Vec<&str> = src.lines().collect();
+                    for (i, line) in lines.iter().enumerate() {
+                        if !line.contains(bare) {
+                            continue;
+                        }
+                        // Walk back over the contiguous comment block directly
+                        // above the call, stopping at the first non-comment
+                        // line so a marker on an unrelated earlier statement
+                        // cannot vouch for this one.
+                        let annotated = line.contains(MARKER)
+                            || lines[..i]
+                                .iter()
+                                .rev()
+                                .take_while(|l| l.trim_start().starts_with("//"))
+                                .any(|l| l.contains(MARKER));
+                        if !annotated {
+                            out.push((
+                                path.to_string_lossy().replace('\\', "/"),
+                                i + 1,
+                                line.trim().to_string(),
+                            ));
+                        }
                     }
                 }
             }
         }
 
         let src_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
-        let mut hits = Vec::new();
-        visit(&src_root, &mut hits);
+        let mut unannotated = Vec::new();
+        visit(&src_root, &mut unannotated, &bare);
 
-        let unexpected: Vec<&String> = hits
-            .iter()
-            .filter(|p| !ALLOWED.iter().any(|a| p.ends_with(a)))
-            .collect();
         assert!(
-            unexpected.is_empty(),
-            "these files call the mirroring `set_own_addr`, which writes the \
-             process-global external_address and races \
+            unannotated.is_empty(),
+            "unannotated calls to the mirroring `set_own_addr`, which writes \
+             the process-global external_address and races \
              test_set_own_addr_atomic_with_network_status under `cargo test`: \
-             {unexpected:?}\nUse `set_own_addr_local_for_test` for tests that \
-             only need routing to know the address, or hold \
-             TEST_GLOBAL_STATE_LOCK if the global mirror is genuinely \
-             required. See #4918."
+             {unannotated:#?}\nFor a test that only needs routing to know the \
+             address, use `set_own_addr_local_for_test`. If the global mirror \
+             is genuinely required, hold TEST_GLOBAL_STATE_LOCK (or be \
+             production code) and annotate the line with `{MARKER}` plus a \
+             reason. See #4918."
         );
 
         // The migrated files must still SET an address, so a future edit


### PR DESCRIPTION
## Problem

`ring::connection_manager::tests::test_set_own_addr_atomic_with_network_status` failed roughly **1 run in 3** under `cargo test -p freenet --lib`, and **0 times in 11 isolated runs** — a cross-test interference flake, not a bug in the test's own logic.

`ConnectionManager::set_own_addr` mirrors the address into the process-global `network_status::external_address`. `own_addr` is per-manager but that global is process-wide, so the atomic test's `own_addr == external_address` assertion only holds while no *other* manager writes the global. `NETWORK_STATUS` is a `OnceLock`, so once any test calls `init()` every later `set_own_addr` in the binary hits the live tracker.

Seven test call sites were writing it without holding `TEST_GLOBAL_STATE_LOCK`:

| File | Sites |
|---|---|
| `node.rs` | 4 resync tests |
| `ring.rs` | 1 storm test |
| `node/op_state_manager.rs` | `seed_location_and_one_connection` (a shared helper) + 1 test |

The test documents a "GLOBAL-STATE CONTRACT" and takes the lock, but its inventory of other writers was incomplete, so the contract read as satisfied when it wasn't.

## Approach

None of the seven reads `external_address` — they set an address only so routing knows it. The sole production reader of that global is the home-page dashboard card. So they now use a new `#[cfg(test)] set_own_addr_local_for_test`, which writes only the local field and never touches the global.

**Why not just take the lock at each site?** That was the obvious fix and I rejected it: the initial triage of this bug (in #4918) found only 5 of the 7 callers. If a careful pass misses two, the "remember to lock" contract will keep being broken by future callers. Removing the unnecessary global write is not a workaround — these tests genuinely have no business writing it — and it leaves nothing to remember.

## Testing

`test_no_test_calls_global_set_own_addr` scrapes the three files and fails if any calls the mirroring `set_own_addr`, with a message pointing at the lock requirement and this issue. It also asserts the safe helper *is* present, so an edit that silently drops address-setting can't pass vacuously.

**It is a source scrape on purpose.** The race only manifests under `cargo test`'s shared-process model; CI runs `cargo nextest`, which gives every test its own process and masks it completely. A behavioural guard therefore could never fail in CI, which is exactly why this flake survived. A scrape runs deterministically under both runners.

Verified two ways:
- **12 consecutive full-suite runs, 0 failures.** At the old ~1-in-3 rate the odds of that are under 1%.
- **Mutation:** reverting one caller to `set_own_addr` fails the guard.

Also corrected the atomic test's stale contract comment, which listed an incomplete set of writers.

Closes #4918

[AI-assisted - Claude]