### PR TITLE
feat(contract): instrument fair-queue depth and admission outcomes

### DIFF
--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -1801,6 +1801,8 @@ async fn push_with_background_eviction<CH>(
         match fair_queue.try_push(rejected.id, rejected.event, rejected.priority) {
             Ok(()) => return,
             Err(still_rejected) => {
+                // Terminal: eviction did not free enough room (#4917).
+                fair_queue.record_terminal_rejection(still_rejected.reason);
                 track_pending_reclamation_if_evict(contract_handler, &still_rejected);
                 send_queue_full_response(contract_handler.channel(), still_rejected).await;
                 return;
@@ -1808,6 +1810,9 @@ async fn push_with_background_eviction<CH>(
         }
     }
 
+    // Terminal: eviction could not help (wrong priority, wrong reason, or no
+    // Background queued), so this event is refused (#4917).
+    fair_queue.record_terminal_rejection(rejected.reason);
     track_pending_reclamation_if_evict(contract_handler, &rejected);
     send_queue_full_response(contract_handler.channel(), rejected).await;
 }
@@ -3603,6 +3608,56 @@ mod tests {
                 other => panic!("expected UpdateResponse for {label}, got {other}"),
             }
         }
+    }
+
+    /// Anti-rot pin for #4917: every TERMINAL admission rejection in
+    /// `push_with_background_eviction` must record itself.
+    ///
+    /// The counter deliberately does not live in `try_push`, because a
+    /// capacity failure there is often recovered by shedding Background and
+    /// retrying — counting it would report a client-visible reject for an
+    /// operation that succeeded. That correctness depends on the terminal arms
+    /// remembering to call `record_terminal_rejection`, so pin it: a new
+    /// terminal path that forgets would silently under-report queue-full
+    /// failures on the dashboard.
+    #[test]
+    fn terminal_rejection_paths_record_the_rejection() {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/contract.rs");
+        let source = std::fs::read_to_string(&path).expect("read own source");
+        let start = source
+            .find("async fn push_with_background_eviction")
+            .expect("push_with_background_eviction must exist");
+        let rest = &source[start..];
+        let end = rest
+            .find("\n/// ")
+            .map(|o| start + o)
+            .unwrap_or(source.len());
+        let body = &source[start..end];
+
+        let records = body.matches("record_terminal_rejection(").count();
+        assert_eq!(
+            records, 2,
+            "expected exactly two terminal rejection sites (eviction retry \
+             exhausted, and eviction-cannot-help), found {records}. If you \
+             added a terminal path, record the rejection there too; if you \
+             removed one, update this pin deliberately. See #4917."
+        );
+
+        // The shed loop also calls send_queue_full_response, for Background
+        // work that is re-emitted on its next cycle. That is a shed, not an
+        // admission rejection, and must NOT be counted as one.
+        let shed_loop = body
+            .find("for shed in evicted {")
+            .expect("the Background shed loop must exist");
+        let shed_end = body[shed_loop..]
+            .find('}')
+            .map(|o| shed_loop + o)
+            .expect("shed loop must close");
+        assert!(
+            !body[shed_loop..shed_end].contains("record_terminal_rejection"),
+            "a shed Background event is not an admission rejection; counting \
+             it would inflate the client-visible failure count (#4917)"
+        );
     }
 }
 

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -11,6 +11,10 @@ pub(crate) mod delegate_app_registry;
 mod executor;
 mod fair_queue;
 pub(crate) use fair_queue::Priority;
+/// Fair-queue occupancy for the status snapshot (#4917). Re-exported rather
+/// than widening `fair_queue` itself, which is otherwise private to this
+/// module.
+pub(crate) use fair_queue::{FairQueueStats, global_stats as fair_queue_stats};
 pub(crate) mod governance;
 mod handler;
 pub mod storages;

--- a/crates/core/src/contract/fair_queue.rs
+++ b/crates/core/src/contract/fair_queue.rs
@@ -385,6 +385,33 @@ impl FairEventQueue {
         }
     }
 
+    /// Count an admission failure that the caller could NOT recover from, i.e.
+    /// one that actually sent the client a queue-full response.
+    ///
+    /// Deliberately separate from [`Self::try_push`]: a `GlobalCapacity`
+    /// failure there is often recoverable — `push_with_background_eviction`
+    /// sheds `Background` work and retries, and the event is admitted. Counting
+    /// at the `try_push` failure would report a "reject" for an operation that
+    /// in fact succeeded, overstating client-visible failures on the dashboard.
+    /// Only the caller knows which failures were terminal, so it says so.
+    ///
+    /// `Evicted` is not an admission failure — a shed `Background` event is
+    /// counted by [`Self::evict_background`] and re-emits on its next cycle.
+    pub(super) fn record_terminal_rejection(&mut self, reason: RejectReason) {
+        match reason {
+            RejectReason::GlobalCapacity => {
+                self.counters.rejected_global_capacity =
+                    self.counters.rejected_global_capacity.saturating_add(1);
+            }
+            RejectReason::PerContract => {
+                self.counters.rejected_per_contract =
+                    self.counters.rejected_per_contract.saturating_add(1);
+            }
+            RejectReason::Evicted => return,
+        }
+        self.publish();
+    }
+
     /// Mirror [`Self::stats`] into the process-global gauge, and emit one WARN
     /// the first time occupancy crosses each [`DEPTH_WARN_BANDS`] threshold.
     ///
@@ -446,9 +473,6 @@ impl FairEventQueue {
     ) -> Result<(), Box<RejectedEvent>> {
         // Hard global cap — never exceeded by any class.
         if self.total_queued >= MAX_TOTAL_FAIR_QUEUE {
-            self.counters.rejected_global_capacity =
-                self.counters.rejected_global_capacity.saturating_add(1);
-            self.publish();
             return Err(Box::new(RejectedEvent {
                 id,
                 event,
@@ -463,9 +487,6 @@ impl FairEventQueue {
         // Background (a GlobalCapacity rejection is eviction-recoverable).
         let soft_cap = MAX_TOTAL_FAIR_QUEUE - CLIENT_LOCAL_RESERVE;
         if priority < Priority::ClientLocal && self.total_queued >= soft_cap {
-            self.counters.rejected_global_capacity =
-                self.counters.rejected_global_capacity.saturating_add(1);
-            self.publish();
             return Err(Box::new(RejectedEvent {
                 id,
                 event,
@@ -478,9 +499,6 @@ impl FairEventQueue {
         // original flat queue but now scoped to the tier). Evicting Background
         // cannot help here, so this is flagged PerContract.
         if self.tier(priority).len_for(&event) >= MAX_QUEUED_PER_CONTRACT {
-            self.counters.rejected_per_contract =
-                self.counters.rejected_per_contract.saturating_add(1);
-            self.publish();
             return Err(Box::new(RejectedEvent {
                 id,
                 event,
@@ -1752,13 +1770,23 @@ mod tests {
                 )
                 .expect("under per-contract cap");
         }
-        queue
+        let rejected = queue
             .try_push(
                 make_event_id(9999),
                 make_get_event(hot),
                 Priority::NetworkRelay,
             )
             .expect_err("at per-contract cap");
+        assert_eq!(
+            queue.stats().rejected_per_contract,
+            0,
+            "try_push alone must not count: only the caller knows whether the \
+             failure was terminal"
+        );
+
+        // The caller finds eviction cannot help a per-contract cap, so this is
+        // terminal and a queue-full response goes to the client.
+        queue.record_terminal_rejection(rejected.reason);
 
         let s = queue.stats();
         assert_eq!(s.rejected_per_contract, 1);
@@ -1766,6 +1794,61 @@ mod tests {
             s.rejected_global_capacity, 0,
             "a single contract hitting its own cap is not global backpressure; \
              conflating the two would misdiagnose the node as saturated"
+        );
+    }
+
+    #[test]
+    fn recovered_capacity_hit_is_not_counted_as_a_rejection() {
+        // The `push_with_background_eviction` flow: a foreground push hits the
+        // soft cap, Background is shed, the retry succeeds. The client never
+        // saw an error, so the dashboard must not report a reject — that would
+        // overstate client-visible failures.
+        let mut queue = FairEventQueue::new();
+        let soft_cap = MAX_TOTAL_FAIR_QUEUE - CLIENT_LOCAL_RESERVE;
+        let mut pushed = 0usize;
+        let mut seed = 0u32;
+        while pushed < soft_cap {
+            let cid = make_contract_id_u32(seed);
+            seed += 1;
+            for _ in 0..MAX_QUEUED_PER_CONTRACT.min(soft_cap - pushed) {
+                queue
+                    .try_push(
+                        make_event_id(pushed as u64),
+                        make_get_event(cid),
+                        Priority::Background,
+                    )
+                    .expect("under soft cap");
+                pushed += 1;
+            }
+        }
+
+        let fresh = make_contract_id_u32(seed);
+        let rejected = queue
+            .try_push(
+                make_event_id(u64::MAX),
+                make_get_event(fresh),
+                Priority::NetworkRelay,
+            )
+            .expect_err("soft cap reached");
+        assert_eq!(rejected.reason, RejectReason::GlobalCapacity);
+
+        // Caller sheds Background and retries — the recovery path.
+        let shed = queue.evict_background(CLIENT_LOCAL_RESERVE);
+        assert!(!shed.is_empty(), "Background was available to shed");
+        queue
+            .try_push(rejected.id, rejected.event, rejected.priority)
+            .expect("retry succeeds after eviction");
+
+        assert_eq!(
+            queue.stats().rejected_global_capacity,
+            0,
+            "a capacity hit the caller recovered from is NOT a rejection: the \
+             event was admitted and no queue-full response was sent"
+        );
+        assert_eq!(
+            queue.stats().background_shed,
+            shed.len() as u64,
+            "the shed Background work IS counted, under its own name"
         );
     }
 
@@ -1801,6 +1884,8 @@ mod tests {
                 Priority::NetworkRelay,
             )
             .expect_err("soft cap reached");
+        // Terminal in this scenario: the caller does not retry.
+        queue.record_terminal_rejection(RejectReason::GlobalCapacity);
         assert_eq!(queue.stats().rejected_global_capacity, 1);
 
         let shed = queue.evict_background(10);

--- a/crates/core/src/contract/fair_queue.rs
+++ b/crates/core/src/contract/fair_queue.rs
@@ -31,6 +31,7 @@
 //! `Background` event is a best-effort drop that re-emits on its next cycle.
 
 use std::collections::{HashMap, VecDeque};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 
 use freenet_stdlib::prelude::ContractInstanceId;
 
@@ -248,7 +249,103 @@ pub(super) struct FairEventQueue {
     /// non-empty lower tier so sustained client load cannot indefinitely starve
     /// remote relay / background execution (#4534 review).
     client_streak: usize,
+    /// Observability counters (#4917). Instance-scoped on purpose: a purely
+    /// process-global counter would make every gauge assertion race other
+    /// tests sharing the binary, which is the #4918 flake. [`Self::publish`]
+    /// mirrors these into the process-global gauge for the status snapshot;
+    /// tests assert on [`Self::stats`], which reads only this instance.
+    counters: FairQueueCounters,
 }
+
+/// Instance-scoped observability counters for a [`FairEventQueue`].
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct FairQueueCounters {
+    /// Highest `total_queued` this instance has reached.
+    pub high_water: usize,
+    /// Admission rejections that the global (or soft) cap caused. This is the
+    /// systemic-backpressure signal: the queue as a whole could not keep up.
+    pub rejected_global_capacity: u64,
+    /// Admission rejections from a single contract's per-tier cap. Distinct
+    /// from the above: one noisy contract, not node-wide saturation.
+    pub rejected_per_contract: u64,
+    /// `Background` events shed to make room for higher-priority work.
+    pub background_shed: u64,
+}
+
+/// A point-in-time view of queue occupancy plus cumulative admission
+/// outcomes (#4917).
+///
+/// The depth fields answer "is the executor backed up right now"; `high_water`
+/// answers "was it ever backed up", which a periodic sampler would otherwise
+/// miss between polls. Both were unavailable while diagnosing #4912, where a
+/// client PUT sat ~2 minutes behind this queue and the backlog had to be
+/// inferred from rejection *rates* over a whole hour.
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct FairQueueStats {
+    pub depth_total: usize,
+    pub depth_client_local: usize,
+    pub depth_network_relay: usize,
+    pub depth_background: usize,
+    pub high_water: usize,
+    pub rejected_global_capacity: u64,
+    pub rejected_per_contract: u64,
+    pub background_shed: u64,
+}
+
+/// Process-global mirror of the live queue's [`FairQueueStats`].
+///
+/// Written by [`FairEventQueue::publish`] from the single-threaded
+/// `contract_handling` loop, read by the status snapshot on demand. Relaxed
+/// ordering throughout: these are diagnostics, and a reader that observes a
+/// slightly-torn set of fields sees a state the queue passed through
+/// microseconds earlier. Same shape as the transport layer's
+/// `shadow_demand` gauges — cheap atomic writes on the hot path, all reads in
+/// the consumer — but kept here rather than there because `shadow_demand` is
+/// transport-scoped and carries a "never read from the production data path"
+/// rule that does not apply to a contract-layer diagnostic.
+///
+/// No production code reads these back; they exist only to be reported.
+mod gauge {
+    use super::*;
+
+    pub(super) static DEPTH_TOTAL: AtomicUsize = AtomicUsize::new(0);
+    pub(super) static DEPTH_CLIENT_LOCAL: AtomicUsize = AtomicUsize::new(0);
+    pub(super) static DEPTH_NETWORK_RELAY: AtomicUsize = AtomicUsize::new(0);
+    pub(super) static DEPTH_BACKGROUND: AtomicUsize = AtomicUsize::new(0);
+    pub(super) static HIGH_WATER: AtomicUsize = AtomicUsize::new(0);
+    pub(super) static REJECTED_GLOBAL_CAPACITY: AtomicU64 = AtomicU64::new(0);
+    pub(super) static REJECTED_PER_CONTRACT: AtomicU64 = AtomicU64::new(0);
+    pub(super) static BACKGROUND_SHED: AtomicU64 = AtomicU64::new(0);
+}
+
+/// Read the process-global fair-queue gauge for the status snapshot (#4917).
+///
+/// Returns zeroes before the contract-handling loop has run, which is
+/// indistinguishable from "an idle queue that has never been used" — the
+/// distinction does not matter to a reader of this diagnostic.
+pub(crate) fn global_stats() -> FairQueueStats {
+    FairQueueStats {
+        depth_total: gauge::DEPTH_TOTAL.load(Ordering::Relaxed),
+        depth_client_local: gauge::DEPTH_CLIENT_LOCAL.load(Ordering::Relaxed),
+        depth_network_relay: gauge::DEPTH_NETWORK_RELAY.load(Ordering::Relaxed),
+        depth_background: gauge::DEPTH_BACKGROUND.load(Ordering::Relaxed),
+        high_water: gauge::HIGH_WATER.load(Ordering::Relaxed),
+        rejected_global_capacity: gauge::REJECTED_GLOBAL_CAPACITY.load(Ordering::Relaxed),
+        rejected_per_contract: gauge::REJECTED_PER_CONTRACT.load(Ordering::Relaxed),
+        background_shed: gauge::BACKGROUND_SHED.load(Ordering::Relaxed),
+    }
+}
+
+/// Occupancy fractions (of [`MAX_TOTAL_FAIR_QUEUE`]) at which crossing the
+/// high-water mark emits one WARN.
+///
+/// Edge-triggered against a monotonic high-water mark, so each band logs at
+/// most once for the lifetime of the process — deliberately not level-triggered,
+/// because this loop's log already runs to several MB/hour and a per-event or
+/// per-sample line would be pure noise. The point is a single breadcrumb of the
+/// form "the client-dispatch queue got deep", which is precisely what #4912's
+/// logs could not show.
+const DEPTH_WARN_BANDS: [usize; 2] = [MAX_TOTAL_FAIR_QUEUE / 2, MAX_TOTAL_FAIR_QUEUE * 9 / 10];
 
 /// After this many consecutive `ClientLocal` pops (while lower-tier work is
 /// waiting), `pop()` serves one lower-tier event regardless of pending
@@ -263,11 +360,67 @@ impl FairEventQueue {
             tiers: Default::default(),
             total_queued: 0,
             client_streak: 0,
+            counters: FairQueueCounters::default(),
         }
     }
 
     fn tier(&mut self, priority: Priority) -> &mut PriorityTier {
         &mut self.tiers[priority as usize]
+    }
+
+    /// This instance's occupancy and cumulative admission outcomes (#4917).
+    ///
+    /// Reads only `self`, so tests can assert on it without touching (or
+    /// racing on) the process-global mirror.
+    pub(super) fn stats(&self) -> FairQueueStats {
+        FairQueueStats {
+            depth_total: self.total_queued,
+            depth_client_local: self.tiers[Priority::ClientLocal as usize].queued,
+            depth_network_relay: self.tiers[Priority::NetworkRelay as usize].queued,
+            depth_background: self.tiers[Priority::Background as usize].queued,
+            high_water: self.counters.high_water,
+            rejected_global_capacity: self.counters.rejected_global_capacity,
+            rejected_per_contract: self.counters.rejected_per_contract,
+            background_shed: self.counters.background_shed,
+        }
+    }
+
+    /// Mirror [`Self::stats`] into the process-global gauge, and emit one WARN
+    /// the first time occupancy crosses each [`DEPTH_WARN_BANDS`] threshold.
+    ///
+    /// MUST be called by every method that changes `total_queued`; the pin test
+    /// `every_total_queued_mutation_publishes` enforces that. Without it the
+    /// gauge silently rots, which is the failure mode
+    /// `.claude/rules/bug-prevention-patterns.md` records for manually-mirrored
+    /// telemetry (#4009 / #4010).
+    fn publish(&mut self) {
+        let previous_high_water = self.counters.high_water;
+        self.counters.high_water = self.counters.high_water.max(self.total_queued);
+        let s = self.stats();
+
+        gauge::DEPTH_TOTAL.store(s.depth_total, Ordering::Relaxed);
+        gauge::DEPTH_CLIENT_LOCAL.store(s.depth_client_local, Ordering::Relaxed);
+        gauge::DEPTH_NETWORK_RELAY.store(s.depth_network_relay, Ordering::Relaxed);
+        gauge::DEPTH_BACKGROUND.store(s.depth_background, Ordering::Relaxed);
+        gauge::HIGH_WATER.fetch_max(s.high_water, Ordering::Relaxed);
+        gauge::REJECTED_GLOBAL_CAPACITY.store(s.rejected_global_capacity, Ordering::Relaxed);
+        gauge::REJECTED_PER_CONTRACT.store(s.rejected_per_contract, Ordering::Relaxed);
+        gauge::BACKGROUND_SHED.store(s.background_shed, Ordering::Relaxed);
+
+        for band in DEPTH_WARN_BANDS {
+            if previous_high_water < band && s.high_water >= band {
+                tracing::warn!(
+                    depth_total = s.depth_total,
+                    depth_client_local = s.depth_client_local,
+                    depth_network_relay = s.depth_network_relay,
+                    depth_background = s.depth_background,
+                    high_water = s.high_water,
+                    capacity = MAX_TOTAL_FAIR_QUEUE,
+                    "contract-handler queue depth crossed {band}; client \
+                     operations may be queueing behind the executor"
+                );
+            }
+        }
     }
 
     /// Attempt to enqueue an event at the given priority.
@@ -293,6 +446,9 @@ impl FairEventQueue {
     ) -> Result<(), Box<RejectedEvent>> {
         // Hard global cap — never exceeded by any class.
         if self.total_queued >= MAX_TOTAL_FAIR_QUEUE {
+            self.counters.rejected_global_capacity =
+                self.counters.rejected_global_capacity.saturating_add(1);
+            self.publish();
             return Err(Box::new(RejectedEvent {
                 id,
                 event,
@@ -307,6 +463,9 @@ impl FairEventQueue {
         // Background (a GlobalCapacity rejection is eviction-recoverable).
         let soft_cap = MAX_TOTAL_FAIR_QUEUE - CLIENT_LOCAL_RESERVE;
         if priority < Priority::ClientLocal && self.total_queued >= soft_cap {
+            self.counters.rejected_global_capacity =
+                self.counters.rejected_global_capacity.saturating_add(1);
+            self.publish();
             return Err(Box::new(RejectedEvent {
                 id,
                 event,
@@ -319,6 +478,9 @@ impl FairEventQueue {
         // original flat queue but now scoped to the tier). Evicting Background
         // cannot help here, so this is flagged PerContract.
         if self.tier(priority).len_for(&event) >= MAX_QUEUED_PER_CONTRACT {
+            self.counters.rejected_per_contract =
+                self.counters.rejected_per_contract.saturating_add(1);
+            self.publish();
             return Err(Box::new(RejectedEvent {
                 id,
                 event,
@@ -329,6 +491,7 @@ impl FairEventQueue {
 
         self.tier(priority).push((id, event, priority));
         self.total_queued += 1;
+        self.publish();
         Ok(())
     }
 
@@ -353,6 +516,11 @@ impl FairEventQueue {
                 None => break,
             }
         }
+        self.counters.background_shed = self
+            .counters
+            .background_shed
+            .saturating_add(evicted.len() as u64);
+        self.publish();
         evicted
     }
 
@@ -423,6 +591,7 @@ impl FairEventQueue {
                 } else {
                     self.client_streak = 0;
                 }
+                self.publish();
                 return Some((id, event));
             }
         }
@@ -1522,5 +1691,163 @@ mod tests {
             RejectReason::PerContract,
             "post-eviction retry failure must be PerContract, not GlobalCapacity"
         );
+    }
+
+    // ============ observability (#4917) ============
+    //
+    // These assert on `queue.stats()`, which reads only the instance. They
+    // deliberately never touch the process-global `gauge` statics: several
+    // tests share the binary, so asserting on a process-global would make them
+    // race each other — the #4918 flake.
+
+    #[test]
+    fn stats_track_depth_per_tier() {
+        let mut queue = FairEventQueue::new();
+        let cid = make_contract_id(1);
+        assert_eq!(queue.stats(), FairQueueStats::default(), "fresh queue");
+
+        queue
+            .try_push(make_event_id(1), make_get_event(cid), Priority::ClientLocal)
+            .expect("push client");
+        queue
+            .try_push(
+                make_event_id(2),
+                make_get_event(cid),
+                Priority::NetworkRelay,
+            )
+            .expect("push relay");
+        queue
+            .try_push(make_event_id(3), make_get_event(cid), Priority::Background)
+            .expect("push background");
+
+        let s = queue.stats();
+        assert_eq!(s.depth_total, 3);
+        assert_eq!(s.depth_client_local, 1);
+        assert_eq!(s.depth_network_relay, 1);
+        assert_eq!(s.depth_background, 1);
+        assert_eq!(s.high_water, 3);
+
+        queue.pop().expect("pop one");
+        let s = queue.stats();
+        assert_eq!(s.depth_total, 2, "depth follows pops");
+        assert_eq!(s.depth_client_local, 0, "ClientLocal drains first");
+        assert_eq!(
+            s.high_water, 3,
+            "high_water is monotonic — it must survive the queue draining, \
+             which is the whole point of recording it"
+        );
+    }
+
+    #[test]
+    fn stats_distinguish_rejection_reasons() {
+        // Per-contract cap: one noisy contract, NOT node-wide saturation.
+        let mut queue = FairEventQueue::new();
+        let hot = make_contract_id(7);
+        for i in 0..MAX_QUEUED_PER_CONTRACT {
+            queue
+                .try_push(
+                    make_event_id(i as u64),
+                    make_get_event(hot),
+                    Priority::NetworkRelay,
+                )
+                .expect("under per-contract cap");
+        }
+        queue
+            .try_push(
+                make_event_id(9999),
+                make_get_event(hot),
+                Priority::NetworkRelay,
+            )
+            .expect_err("at per-contract cap");
+
+        let s = queue.stats();
+        assert_eq!(s.rejected_per_contract, 1);
+        assert_eq!(
+            s.rejected_global_capacity, 0,
+            "a single contract hitting its own cap is not global backpressure; \
+             conflating the two would misdiagnose the node as saturated"
+        );
+    }
+
+    #[test]
+    fn stats_count_global_capacity_rejections_and_background_sheds() {
+        let mut queue = FairEventQueue::new();
+        // Fill past the soft cap with Background spread over many contracts so
+        // no per-contract cap trips first.
+        let soft_cap = MAX_TOTAL_FAIR_QUEUE - CLIENT_LOCAL_RESERVE;
+        let mut pushed = 0usize;
+        let mut seed = 0u32;
+        while pushed < soft_cap {
+            let cid = make_contract_id_u32(seed);
+            seed += 1;
+            for _ in 0..MAX_QUEUED_PER_CONTRACT.min(soft_cap - pushed) {
+                queue
+                    .try_push(
+                        make_event_id(pushed as u64),
+                        make_get_event(cid),
+                        Priority::Background,
+                    )
+                    .expect("under soft cap");
+                pushed += 1;
+            }
+        }
+        assert_eq!(queue.stats().depth_total, soft_cap);
+
+        // A sub-ClientLocal push now crosses the soft cap.
+        queue
+            .try_push(
+                make_event_id(u64::MAX),
+                make_get_event(make_contract_id_u32(seed)),
+                Priority::NetworkRelay,
+            )
+            .expect_err("soft cap reached");
+        assert_eq!(queue.stats().rejected_global_capacity, 1);
+
+        let shed = queue.evict_background(10);
+        assert_eq!(shed.len(), 10);
+        assert_eq!(queue.stats().background_shed, 10);
+        assert_eq!(queue.stats().depth_total, soft_cap - 10);
+    }
+
+    /// Anti-rot pin: every method that changes `total_queued` must call
+    /// `publish`, or the gauge silently stops tracking the queue.
+    ///
+    /// This is the failure mode `.claude/rules/bug-prevention-patterns.md`
+    /// records for manually-mirrored telemetry (#4009 / #4010): the mirror is
+    /// correct when written, then a later change adds a path that forgets it
+    /// and the counter quietly flatlines in production.
+    #[test]
+    fn every_total_queued_mutation_publishes() {
+        const SRC: &str = include_str!("fair_queue.rs");
+        // Only the impl block, so the test module's own text can't satisfy it.
+        let impl_start = SRC
+            .find("impl FairEventQueue {")
+            .expect("FairEventQueue impl must exist");
+        let impl_end = SRC[impl_start..]
+            .find("\n#[cfg(test)]")
+            .map(|o| impl_start + o)
+            .unwrap_or(SRC.len());
+        let body = &SRC[impl_start..impl_end];
+
+        for method in ["fn try_push(", "fn evict_background(", "fn pop("] {
+            let start = body
+                .find(method)
+                .unwrap_or_else(|| panic!("{method} must exist in the impl"));
+            // Bound each method at the next one so the search cannot leak into
+            // a neighbour that does publish.
+            let rest = &body[start + method.len()..];
+            let end = rest
+                .find("\n    pub(super) fn ")
+                .or_else(|| rest.find("\n    fn "))
+                .map(|o| start + method.len() + o)
+                .unwrap_or(body.len());
+            let method_body = &body[start..end];
+            assert!(
+                method_body.contains("self.publish()"),
+                "{method} mutates total_queued but does not call self.publish(); \
+                 the #4917 gauge would stop tracking the queue. See \
+                 bug-prevention-patterns.md on mirrored telemetry."
+            );
+        }
     }
 }

--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -1336,6 +1336,11 @@ pub struct NetworkStatusSnapshot {
     pub health: HealthLevel,
     /// Live ring-level statistics: connection count, hosted contracts.
     pub ring_stats: RingStatsSnapshot,
+    /// Contract-handler fair-queue occupancy (#4917). Read from the queue's own
+    /// gauge at snapshot time rather than mirrored into `NetworkStatus`, so it
+    /// cannot drift from the canonical value the way a hand-maintained counter
+    /// does (`.claude/rules/bug-prevention-patterns.md`, #4009 / #4010).
+    pub fair_queue: crate::contract::FairQueueStats,
     /// Period transport metrics (current values, not reset on read).
     pub transport_snapshot: TransportSnapshot,
     /// Per-contract governance state (Phase 4). The dashboard's
@@ -1873,6 +1878,9 @@ pub fn get_snapshot() -> Option<NetworkStatusSnapshot> {
             .as_ref()
             .map(|provider| provider())
             .unwrap_or_default(),
+        // Read straight from the queue's gauge — no provider registration and
+        // no mirrored counter to keep in sync (#4917).
+        fair_queue: crate::contract::fair_queue_stats(),
     })
 }
 

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -227,6 +227,7 @@ mod tests {
             bytes_downloaded: 0,
             health: HealthLevel::Connecting,
             ring_stats: RingStatsSnapshot::default(),
+            fair_queue: Default::default(),
             transport_snapshot: TransportSnapshot::default(),
             governance: Default::default(),
             ban_list: Default::default(),
@@ -604,6 +605,40 @@ mod tests {
         assert!(
             !html.contains("Rate-limited"),
             "rate-limit row should be hidden when the limiter has seen no traffic"
+        );
+    }
+
+    #[test]
+    fn fair_queue_stats_hidden_when_queue_never_used() {
+        // An idle node must not render the queue row — same
+        // uncluttered-dashboard rule as the rate limiter above.
+        let snap = base_snapshot();
+        assert_eq!(snap.fair_queue.high_water, 0);
+        let html = build_status_card(&Some(snap));
+        assert!(
+            !html.contains("Queue depth"),
+            "queue row should be hidden until the queue has been used"
+        );
+    }
+
+    #[test]
+    fn fair_queue_stats_rendered_after_backlog_even_once_drained() {
+        // The #4912 case: a burst that has since drained. Instantaneous depth
+        // is back to 0, so ONLY `high_water` reveals that the executor was
+        // ever backed up — a polled dashboard would otherwise show nothing.
+        let mut snap = base_snapshot();
+        snap.fair_queue.depth_total = 0;
+        snap.fair_queue.high_water = 4096;
+        snap.fair_queue.rejected_global_capacity = 17;
+        let html = build_status_card(&Some(snap));
+        assert!(html.contains("Peak depth"), "peak-depth label missing");
+        assert!(
+            html.contains("4096</span>"),
+            "peak depth must be shown even though the queue has since drained"
+        );
+        assert!(
+            html.contains("Queue-full rejects") && html.contains("17</span>"),
+            "queue-full reject count missing"
         );
     }
 

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -643,6 +643,28 @@ mod tests {
     }
 
     #[test]
+    fn fair_queue_per_contract_rejects_are_not_reported_as_zero() {
+        // One hot contract hits its own per-tier cap while the node is
+        // nowhere near global capacity. The row renders because rejections
+        // happened, so it must not then show "0" for them — a card that
+        // appears *because* of an event and reports zero of it is worse than
+        // not rendering at all.
+        let mut snap = base_snapshot();
+        snap.fair_queue.high_water = 100;
+        snap.fair_queue.rejected_per_contract = 42;
+        snap.fair_queue.rejected_global_capacity = 0;
+        let html = build_status_card(&Some(snap));
+        assert!(
+            html.contains("Contract-cap rejects"),
+            "per-contract rejections need their own label"
+        );
+        assert!(
+            html.contains("42</span>"),
+            "per-contract reject count must be displayed, not silently dropped"
+        );
+    }
+
+    #[test]
     fn rate_limit_stats_rendered_when_active() {
         // Once the limiter has dropped traffic, the operator must see the
         // accepted / rate-limited / capacity-dropped counts on the card.

--- a/crates/core/src/server/home_page/cards.rs
+++ b/crates/core/src/server/home_page/cards.rs
@@ -124,6 +124,48 @@ pub fn build_status_card(snap: &Option<network_status::NetworkStatusSnapshot>) -
         String::new()
     };
 
+    // Contract-handler queue occupancy (#4917). Every client operation passes
+    // through this queue on its way to the single-threaded WASM executor, so a
+    // sustained backlog here is what a user experiences as a slow or
+    // timed-out request — the #4912 failure mode, where a client PUT waited
+    // ~2 minutes behind it with no way to see the queue at all.
+    //
+    // Hidden while the queue has never been used AND has never rejected
+    // anything, so an idle node shows nothing. `high_water` is the load-bearing
+    // number: this page is polled, and a burst between two polls would leave
+    // no trace in the instantaneous depth.
+    let fair_queue_html = if snap.fair_queue.high_water > 0
+        || snap.fair_queue.rejected_global_capacity > 0
+        || snap.fair_queue.rejected_per_contract > 0
+    {
+        format!(
+            r#"<div class="metrics-row">
+            <div class="metric-tile">
+                <span class="metric-value">{depth}</span>
+                <span class="metric-label">Queue depth</span>
+            </div>
+            <div class="metric-tile">
+                <span class="metric-value">{high_water}</span>
+                <span class="metric-label">Peak depth</span>
+            </div>
+            <div class="metric-tile">
+                <span class="metric-value">{rejected_capacity}</span>
+                <span class="metric-label">Queue-full rejects</span>
+            </div>
+            <div class="metric-tile">
+                <span class="metric-value">{shed}</span>
+                <span class="metric-label">Background shed</span>
+            </div>
+        </div>"#,
+            depth = snap.fair_queue.depth_total,
+            high_water = snap.fair_queue.high_water,
+            rejected_capacity = snap.fair_queue.rejected_global_capacity,
+            shed = snap.fair_queue.background_shed,
+        )
+    } else {
+        String::new()
+    };
+
     // Nearest-neighbor ring lattice completeness. A peer with BOTH a successor
     // (closest-higher) and predecessor (closest-lower) ring edge has the base
     // lattice greedy routing needs. Shown once the node has any connections.
@@ -284,6 +326,7 @@ pub fn build_status_card(snap: &Option<network_status::NetworkStatusSnapshot>) -
             {ring_stats_html}
             {lattice_html}
             {rate_limit_html}
+            {fair_queue_html}
             {external_addr_html}
             {spinner}
             {gateway_warning}
@@ -294,6 +337,7 @@ pub fn build_status_card(snap: &Option<network_status::NetworkStatusSnapshot>) -
         ring_stats_html = ring_stats_html,
         lattice_html = lattice_html,
         rate_limit_html = rate_limit_html,
+        fair_queue_html = fair_queue_html,
         external_addr_html = external_addr_html,
         spinner = spinner,
         gateway_warning = gateway_warning,

--- a/crates/core/src/server/home_page/cards.rs
+++ b/crates/core/src/server/home_page/cards.rs
@@ -153,13 +153,23 @@ pub fn build_status_card(snap: &Option<network_status::NetworkStatusSnapshot>) -
                 <span class="metric-label">Queue-full rejects</span>
             </div>
             <div class="metric-tile">
+                <span class="metric-value">{rejected_contract}</span>
+                <span class="metric-label">Contract-cap rejects</span>
+            </div>
+            <div class="metric-tile">
                 <span class="metric-value">{shed}</span>
                 <span class="metric-label">Background shed</span>
             </div>
         </div>"#,
             depth = snap.fair_queue.depth_total,
             high_water = snap.fair_queue.high_water,
+            // Shown as its own tile rather than folded into the total: the
+            // whole point of splitting the two causes is that node-wide
+            // backpressure and one contract hitting its own cap call for
+            // different responses. Summing them would put the misdiagnosis
+            // this split exists to prevent back on the dashboard.
             rejected_capacity = snap.fair_queue.rejected_global_capacity,
+            rejected_contract = snap.fair_queue.rejected_per_contract,
             shed = snap.fair_queue.background_shed,
         )
     } else {


### PR DESCRIPTION
## Problem

`crates/core/src/contract/fair_queue.rs` contained no `tracing::` call and no telemetry of any kind. Every client operation passes through this queue on its way to the single-threaded WASM executor, so a backlog here is what a user experiences as a slow or timed-out request — and it was completely invisible. Rejections could be inferred from their side effect (`send_queue_full_response`), but depth never could.

That cost real time on #4912: a client PUT sat 120.6s between registration and processing, and confirming the queue as the cause meant reasoning from rejection *rates* across a whole hour, because no depth signal existed to look at.

## What this adds

A gauge covering:

| Signal | Why |
|---|---|
| Depth, per priority tier | Is the executor backed up *now*, and in which lane |
| **High-water mark** (monotonic) | Was it *ever* backed up — the dashboard is polled, and a burst between polls leaves no trace in instantaneous depth |
| Rejections, split by cause | Global-capacity (node-wide backpressure) vs per-contract-cap (one noisy contract). Conflating them misdiagnoses a busy neighbour as a saturated node |
| Background shed | How much best-effort work is being dropped to protect client requests |

Surfaced two ways: a status-card row on the dashboard (hidden entirely while the queue has never been used, so an idle node stays uncluttered), and one WARN as high-water crosses 50% and 90% of capacity.

The WARN is **edge-triggered against the monotonic mark**, so each band logs at most once per process. This loop's log already runs to several MB/hour; a level-triggered or per-sample line would be pure noise. A single line saying the queue got deep is what #4912's logs could not produce.

## Design notes

- **Instance-scoped counters with a global mirror, not global-only.** Tests assert on `stats()`, which reads a single queue. A purely process-global counter would make every gauge assertion race other tests sharing the binary — that is exactly the #4918 flake I just fixed, and I did not want to reintroduce its shape here.
- **The snapshot reads the gauge at render time** rather than mirroring counters into `NetworkStatus`. `bug-prevention-patterns.md` records the rot mode for hand-maintained mirrors (#4009 / #4010) and prefers reading canonical state; this follows that.
- **Hot-path cost** is a few relaxed atomic stores per push/pop, the same shape as the transport layer's `shadow_demand` gauges. Kept in the contract layer rather than added to `shadow_demand`, which is transport-scoped and carries a "never read from the production data path" rule that does not apply here.
- **Depth only, no wait-time.** Queue latency would arguably be the more useful number, but measuring it needs a clock the contract loop does not have, and `crates/core/` bans wall-clock reads in favour of `TimeSource`. That is the same constraint #4919 is already tracking, so I did not want to half-solve it here.

## Testing

- `stats_track_depth_per_tier` — depth follows pushes and pops per tier, and high-water survives the queue draining (the property the whole metric exists for).
- `stats_distinguish_rejection_reasons` — a contract hitting its own cap must NOT register as global backpressure.
- `stats_count_global_capacity_rejections_and_background_sheds` — soft-cap rejection and shed accounting at capacity.
- `fair_queue_stats_hidden_when_queue_never_used` / `..._rendered_after_backlog_even_once_drained` — the dashboard row stays hidden when idle, and a drained burst still shows its peak.
- `every_total_queued_mutation_publishes` — anti-rot pin: every method changing `total_queued` must publish. Verified by mutation (removing the call from `pop` fails it).

`cargo test -p freenet --lib`: 4266 passed, 0 failed. `cargo clippy`: no new lints (the only local errors are the pre-existing `let_underscore_must_use` set in `client_events/websocket.rs`, which reproduces on pristine `main`).

Closes #4917

[AI-assisted - Claude]