### PR TITLE
feat(broadcast): instrument which fan-out arm sends full state (#3335)

### DIFF
--- a/crates/core/src/node/network_bridge.rs
+++ b/crates/core/src/node/network_bridge.rs
@@ -16,6 +16,7 @@ use tokio::sync::mpsc::{self, Receiver, Sender};
 
 use crate::message::{NetMessage, NodeEvent};
 
+pub(crate) mod broadcast_payload_mix;
 pub(crate) mod broadcast_queue;
 mod handshake;
 pub(crate) mod in_memory;

--- a/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
+++ b/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
@@ -8,7 +8,7 @@
 //! on contracts holding >= 500 KB of state, and that 97.9 % of it lands on
 //! contracts whose applies change nothing. What it could NOT determine is
 //! *why* those large states go out whole, because
-//! [`broadcast_to_single_peer`] has **three distinct paths that send FULL
+//! [`broadcast_to_single_peer`] has **four distinct paths that send FULL
 //! STATE** and none of them were separately instrumented:
 //!
 //! 1. [`PayloadArm::FullDeltaSuppressed`] — the `delta_incompat` memo is armed
@@ -42,19 +42,20 @@
 //!
 //! ## Cost
 //!
-//! One relaxed atomic add per delivered broadcast on the hot path, plus at
-//! most one bounded `DashMap` touch for per-contract attribution. Everything
-//! else happens in the aggregator task. Same shape as
-//! [`crate::transport::shadow_demand`]; the hot path only ever WRITES.
+//! One short uncontended mutex acquire per **delivered broadcast** (not per
+//! packet), covering a handful of integer adds and at most one bounded
+//! `HashMap` touch. Everything else happens in the aggregator task, and the
+//! hot path only ever WRITES. The lock is what makes a rollup a consistent
+//! snapshot; see [`PayloadMix`] for why per-field atomics were not enough.
 //!
 //! [`broadcast_to_single_peer`]: super::broadcast_queue::broadcast_to_single_peer
 
+use std::collections::HashMap;
 use std::sync::LazyLock;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
-use dashmap::DashMap;
 use freenet_stdlib::prelude::ContractInstanceId;
+use parking_lot::Mutex;
 
 use crate::node::background_task_monitor::BackgroundTaskMonitor;
 
@@ -70,8 +71,10 @@ const ROLLUP_WINDOW: Duration = Duration::from_secs(60);
 /// contract we host, so an unbounded map here would be an amplification
 /// vector (see `.claude/rules/code-style.md`, "per-key collections"). Entries
 /// beyond the cap are still counted in the per-arm totals; only their
-/// per-contract attribution is dropped, and the count of dropped contracts is
-/// reported so a truncated window is never mistaken for a complete one.
+/// per-contract attribution is dropped, and both the count and the BYTE total
+/// of those unattributed sends are reported (`attribution_dropped_sends` /
+/// `attribution_dropped_bytes`) so a truncated window is never mistaken for a
+/// complete one.
 const MAX_TRACKED_CONTRACTS: usize = 256;
 
 /// How many contracts the emitted rollup names.
@@ -139,6 +142,41 @@ impl PayloadArm {
 /// Process-wide payload-mix accumulator. See the module docs.
 pub(crate) static BROADCAST_PAYLOAD_MIX: LazyLock<PayloadMix> = LazyLock::new(PayloadMix::new);
 
+/// One rollup window's counters.
+///
+/// Every field advances together under a single lock so a rollup takes a
+/// consistent snapshot; see [`PayloadMix`].
+struct Window {
+    sends: [u64; PayloadArm::COUNT],
+    bytes: [u64; PayloadArm::COUNT],
+    /// Per-contract full-state byte attribution, bounded at
+    /// [`MAX_TRACKED_CONTRACTS`].
+    contract_full_state_bytes: HashMap<ContractInstanceId, u64>,
+    /// Full-state sends that could not be attributed to a contract because
+    /// the cap was already reached. This counts SENDS, not distinct
+    /// contracts: one over-cap contract broadcasting 1,000 times contributes
+    /// 1,000. Naming it for what it counts avoids the "1,000 contracts were
+    /// dropped" misreading; distinct-contract cardinality would need an
+    /// unbounded set, which is exactly what the cap exists to prevent.
+    attribution_dropped_sends: u64,
+    /// Bytes behind those unattributed sends. This is the field that says
+    /// how much of `full_state_bytes` the top-N list cannot account for, so
+    /// a truncated window is never mistaken for a complete one.
+    attribution_dropped_bytes: u64,
+}
+
+impl Default for Window {
+    fn default() -> Self {
+        Self {
+            sends: [0; PayloadArm::COUNT],
+            bytes: [0; PayloadArm::COUNT],
+            contract_full_state_bytes: HashMap::new(),
+            attribution_dropped_sends: 0,
+            attribution_dropped_bytes: 0,
+        }
+    }
+}
+
 /// Per-arm send/byte counters plus bounded per-contract full-state
 /// attribution.
 ///
@@ -146,24 +184,37 @@ pub(crate) static BROADCAST_PAYLOAD_MIX: LazyLock<PayloadMix> = LazyLock::new(Pa
 /// instantiate an isolated accumulator: a shared global would make the unit
 /// tests order-dependent and intermittently failing, which this repo treats
 /// as a broken test, not an acceptable one.
+///
+/// ## Why one mutex rather than per-field atomics
+///
+/// The first version used relaxed atomics plus a `DashMap`. External review
+/// caught two defects that are both really the same defect: a rollup drained
+/// the arm counters and the contract map at different instants, so (a) an
+/// increment landing between sampling a map entry and clearing it was lost
+/// outright, and (b) a single broadcast could be counted in one window for
+/// the aggregate fields and the next for the per-contract fields, leaving
+/// `top_contracts_by_full_state_bytes` unable to reconcile against
+/// `full_state_bytes`. For an accuracy-measurement feature that is a real
+/// bug, not a rounding detail.
+///
+/// A single lock covering the whole window makes record and drain atomic
+/// with respect to each other, which is the property the measurement needs.
+/// The cost is acceptable because this is per *delivered broadcast*, not per
+/// packet: an uncontended `parking_lot::Mutex` acquire is on the order of a
+/// few atomic operations, and the surrounding send path has already done WASM
+/// delta computation and a network write. Note this is the documented
+/// exception in `.claude/rules/code-style.md` to preferring `DashMap` — we
+/// need an atomic read-modify-write across MULTIPLE keys (all arms plus the
+/// contract map) in one transaction, which is precisely when a global lock is
+/// required.
 pub(crate) struct PayloadMix {
-    sends: [AtomicU64; PayloadArm::COUNT],
-    bytes: [AtomicU64; PayloadArm::COUNT],
-    /// Per-contract full-state byte attribution for the current window,
-    /// bounded at [`MAX_TRACKED_CONTRACTS`].
-    contract_full_state_bytes: DashMap<ContractInstanceId, AtomicU64>,
-    /// Contracts whose attribution was dropped this window because the cap
-    /// was already reached.
-    contracts_dropped: AtomicU64,
+    window: Mutex<Window>,
 }
 
 impl PayloadMix {
     fn new() -> Self {
         Self {
-            sends: std::array::from_fn(|_| AtomicU64::new(0)),
-            bytes: std::array::from_fn(|_| AtomicU64::new(0)),
-            contract_full_state_bytes: DashMap::new(),
-            contracts_dropped: AtomicU64::new(0),
+            window: Mutex::new(Window::default()),
         }
     }
 
@@ -179,43 +230,54 @@ impl PayloadMix {
         contract: &ContractInstanceId,
         payload_bytes: usize,
     ) {
+        let bytes = payload_bytes as u64;
         let idx = arm.index();
-        self.sends[idx].fetch_add(1, Ordering::Relaxed);
-        self.bytes[idx].fetch_add(payload_bytes as u64, Ordering::Relaxed);
+        let mut w = self.window.lock();
+        // Saturating throughout: a wrapped counter would silently report a
+        // tiny number for the heaviest contract, which is the opposite of
+        // what this measurement is for.
+        w.sends[idx] = w.sends[idx].saturating_add(1);
+        w.bytes[idx] = w.bytes[idx].saturating_add(bytes);
         if arm.is_full_state() {
-            self.attribute_full_state(contract, payload_bytes as u64);
+            if let Some(tally) = w.contract_full_state_bytes.get_mut(contract) {
+                *tally = tally.saturating_add(bytes);
+            } else if w.contract_full_state_bytes.len() < MAX_TRACKED_CONTRACTS {
+                w.contract_full_state_bytes.insert(*contract, bytes);
+            } else {
+                w.attribution_dropped_sends = w.attribution_dropped_sends.saturating_add(1);
+                w.attribution_dropped_bytes = w.attribution_dropped_bytes.saturating_add(bytes);
+            }
         }
     }
 
-    /// Add `bytes` to a contract's full-state tally, respecting the cap.
-    fn attribute_full_state(&self, contract: &ContractInstanceId, bytes: u64) {
-        if let Some(entry) = self.contract_full_state_bytes.get(contract) {
-            entry.fetch_add(bytes, Ordering::Relaxed);
-            return;
-        }
-        // `len()` is a racy read, so the cap is approximate under concurrency —
-        // acceptable for telemetry, and it can only ever overshoot by the number
-        // of threads racing here, never grow unboundedly.
-        if self.contract_full_state_bytes.len() >= MAX_TRACKED_CONTRACTS {
-            self.contracts_dropped.fetch_add(1, Ordering::Relaxed);
-            return;
-        }
-        self.contract_full_state_bytes
-            .entry(*contract)
-            .or_insert_with(|| AtomicU64::new(0))
-            .fetch_add(bytes, Ordering::Relaxed);
+    /// Atomically take the current window, leaving a fresh empty one.
+    ///
+    /// One lock acquisition covers every field, so the aggregate counters and
+    /// the per-contract tallies always describe the same set of broadcasts.
+    fn take_window(&self) -> Window {
+        std::mem::take(&mut *self.window.lock())
+    }
+}
+
+impl Window {
+    /// Per-arm `(sends, bytes)` in [`PayloadArm::ALL`] order.
+    fn arms(&self) -> Vec<(PayloadArm, u64, u64)> {
+        PayloadArm::ALL
+            .iter()
+            .map(|arm| {
+                let idx = arm.index();
+                (*arm, self.sends[idx], self.bytes[idx])
+            })
+            .collect()
     }
 
-    /// Drain the per-contract tallies, returning the top
-    /// [`TOP_CONTRACTS_REPORTED`] by full-state bytes plus the dropped count.
-    fn drain_contracts(&self) -> (Vec<(ContractInstanceId, u64)>, u64) {
+    /// The top [`TOP_CONTRACTS_REPORTED`] contracts by full-state bytes.
+    fn top_contracts(&self) -> Vec<(ContractInstanceId, u64)> {
         let mut tallies: Vec<(ContractInstanceId, u64)> = self
             .contract_full_state_bytes
             .iter()
-            .map(|e| (*e.key(), e.value().load(Ordering::Relaxed)))
+            .map(|(k, v)| (*k, *v))
             .collect();
-        self.contract_full_state_bytes.clear();
-        let dropped = self.contracts_dropped.swap(0, Ordering::Relaxed);
         // `ContractInstanceId` has no `Ord`, so tie-break on its raw bytes: the
         // reported top-N must be stable across nodes and windows, otherwise a tie
         // reorders on every rollup and looks like churn.
@@ -224,24 +286,7 @@ impl PayloadMix {
                 .then_with(|| a.0.as_bytes().cmp(b.0.as_bytes()))
         });
         tallies.truncate(TOP_CONTRACTS_REPORTED);
-        (tallies, dropped)
-    }
-
-    /// Drain the counters, returning per-arm `(sends, bytes)` in
-    /// [`PayloadArm::ALL`] order. Resets to zero so each rollup reports one
-    /// window rather than a lifetime total.
-    fn drain(&self) -> Vec<(PayloadArm, u64, u64)> {
-        PayloadArm::ALL
-            .iter()
-            .map(|arm| {
-                let idx = arm.index();
-                (
-                    *arm,
-                    self.sends[idx].swap(0, Ordering::Relaxed),
-                    self.bytes[idx].swap(0, Ordering::Relaxed),
-                )
-            })
-            .collect()
+        tallies
     }
 }
 
@@ -252,7 +297,8 @@ impl PayloadMix {
 fn payload_mix_json(
     arms: &[(PayloadArm, u64, u64)],
     contracts: &[(ContractInstanceId, u64)],
-    contracts_dropped: u64,
+    attribution_dropped_sends: u64,
+    attribution_dropped_bytes: u64,
     window_secs: u64,
 ) -> serde_json::Value {
     let mut obj = serde_json::Map::new();
@@ -295,7 +341,17 @@ fn payload_mix_json(
                 .collect(),
         ),
     );
-    obj.insert("contracts_dropped".into(), contracts_dropped.into());
+    // Sends (not distinct contracts) that missed attribution, and the bytes
+    // behind them: `attribution_dropped_bytes` is what tells an analyst how
+    // much of `full_state_bytes` the top-N list cannot account for.
+    obj.insert(
+        "attribution_dropped_sends".into(),
+        attribution_dropped_sends.into(),
+    );
+    obj.insert(
+        "attribution_dropped_bytes".into(),
+        attribution_dropped_bytes.into(),
+    );
     obj.insert("window_secs".into(), window_secs.into());
     serde_json::Value::Object(obj)
 }
@@ -304,9 +360,17 @@ fn payload_mix_json(
 ///
 /// Returns the payload so callers (and tests) can inspect what was sent.
 pub(crate) fn emit_payload_mix_rollup(local_peer_id: &str, window_secs: u64) -> serde_json::Value {
-    let arms = BROADCAST_PAYLOAD_MIX.drain();
-    let (contracts, dropped) = BROADCAST_PAYLOAD_MIX.drain_contracts();
-    let payload = payload_mix_json(&arms, &contracts, dropped, window_secs);
+    // ONE atomic take: the arm counters and the per-contract tallies describe
+    // exactly the same set of broadcasts, so the top-N list always reconciles
+    // against `full_state_bytes`.
+    let window = BROADCAST_PAYLOAD_MIX.take_window();
+    let payload = payload_mix_json(
+        &window.arms(),
+        &window.top_contracts(),
+        window.attribution_dropped_sends,
+        window.attribution_dropped_bytes,
+        window_secs,
+    );
     crate::tracing::telemetry::send_standalone_shadow_event_with_peer_id(
         "broadcast_payload_mix",
         local_peer_id,
@@ -342,21 +406,21 @@ mod tests {
         ContractInstanceId::new([byte; 32])
     }
 
-    /// Draining leaves the accumulator empty so consecutive rollups report
-    /// windows, not lifetime totals.
+    /// Taking the window leaves the accumulator empty so consecutive rollups
+    /// report windows, not lifetime totals.
     #[test]
-    fn drain_resets_the_window() {
+    fn take_window_resets_the_window() {
         let mix = PayloadMix::new();
         mix.record_delivered(PayloadArm::Delta, &contract(1), 100);
-        let first = mix.drain();
+        let first = mix.take_window().arms();
         assert_eq!(first[PayloadArm::Delta.index()].1, 1);
         assert_eq!(first[PayloadArm::Delta.index()].2, 100);
-        let second = mix.drain();
+        let second = mix.take_window().arms();
         assert!(
             second
                 .iter()
                 .all(|(_, sends, bytes)| *sends == 0 && *bytes == 0),
-            "second drain must be empty, got {second:?}"
+            "second take must be empty, got {second:?}"
         );
     }
 
@@ -371,12 +435,109 @@ mod tests {
                 mix.record_delivered(*arm, &contract(i as u8), 10);
             }
         }
-        let drained = mix.drain();
+        let drained = mix.take_window().arms();
         for (i, (arm, sends, bytes)) in drained.iter().enumerate() {
             assert_eq!(*arm, PayloadArm::ALL[i]);
             assert_eq!(*sends, i as u64 + 1, "wrong send count for {arm:?}");
             assert_eq!(*bytes, (i as u64 + 1) * 10, "wrong byte count for {arm:?}");
         }
+    }
+
+    /// The aggregate arm counters and the per-contract tallies must always
+    /// describe the SAME set of broadcasts.
+    ///
+    /// Regression for the external-review finding: the first version drained
+    /// the arm counters and the contract map at two different instants, so a
+    /// broadcast landing in between was counted in one window for
+    /// `full_state_bytes` and the next for the per-contract list (and an
+    /// increment racing the map `clear()` was lost outright). This asserts the
+    /// invariant an analyst actually relies on: the top-N list reconciles
+    /// against the full-state total.
+    #[test]
+    fn per_contract_tallies_reconcile_with_arm_totals() {
+        let mix = PayloadMix::new();
+        mix.record_delivered(PayloadArm::FullNotEfficient, &contract(1), 500);
+        mix.record_delivered(PayloadArm::FullNoSummary, &contract(2), 300);
+        mix.record_delivered(PayloadArm::FullDeltaSuppressed, &contract(1), 200);
+        mix.record_delivered(PayloadArm::Delta, &contract(3), 50); // not full state
+
+        let window = mix.take_window();
+        let full_state_total: u64 = window
+            .arms()
+            .iter()
+            .filter(|(arm, _, _)| arm.is_full_state())
+            .map(|(_, _, bytes)| bytes)
+            .sum();
+        let attributed: u64 = window.contract_full_state_bytes.values().sum();
+        assert_eq!(
+            full_state_total, 1000,
+            "full-state arm bytes should exclude the delta send"
+        );
+        assert_eq!(
+            attributed + window.attribution_dropped_bytes,
+            full_state_total,
+            "every full-state byte must be either attributed to a contract or \
+             counted as dropped attribution — otherwise the top-N list cannot \
+             be reconciled against full_state_bytes"
+        );
+        // Contract 1 accumulated across two different full-state arms.
+        assert_eq!(window.contract_full_state_bytes[&contract(1)], 700);
+        assert_eq!(window.contract_full_state_bytes[&contract(2)], 300);
+    }
+
+    /// Concurrent recorders racing a rollup must not lose or double-count
+    /// bytes: every recorded byte lands in exactly one window.
+    #[test]
+    fn concurrent_records_racing_a_rollup_conserve_bytes() {
+        use std::sync::Arc;
+
+        const THREADS: usize = 8;
+        const PER_THREAD: usize = 500;
+
+        let mix = Arc::new(PayloadMix::new());
+        let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+
+        // A rollup loop running concurrently with the writers, accumulating
+        // what it drains.
+        let drained_total = Arc::new(Mutex::new(0u64));
+        let drainer = {
+            let mix = Arc::clone(&mix);
+            let stop = Arc::clone(&stop);
+            let drained_total = Arc::clone(&drained_total);
+            std::thread::spawn(move || {
+                while !stop.load(std::sync::atomic::Ordering::Relaxed) {
+                    let w = mix.take_window();
+                    let sum: u64 = w.arms().iter().map(|(_, _, b)| b).sum();
+                    *drained_total.lock() += sum;
+                    std::thread::yield_now();
+                }
+            })
+        };
+
+        let writers: Vec<_> = (0..THREADS)
+            .map(|t| {
+                let mix = Arc::clone(&mix);
+                std::thread::spawn(move || {
+                    for _ in 0..PER_THREAD {
+                        mix.record_delivered(PayloadArm::FullNotEfficient, &contract(t as u8), 7);
+                    }
+                })
+            })
+            .collect();
+        for w in writers {
+            w.join().unwrap();
+        }
+        stop.store(true, std::sync::atomic::Ordering::Relaxed);
+        drainer.join().unwrap();
+
+        // Whatever the final drainer pass missed is still in the accumulator.
+        let leftover: u64 = mix.take_window().arms().iter().map(|(_, _, b)| b).sum();
+        let total = *drained_total.lock() + leftover;
+        assert_eq!(
+            total,
+            (THREADS * PER_THREAD * 7) as u64,
+            "bytes were lost or double-counted across a concurrent rollover"
+        );
     }
 
     /// Only full-state arms are counted as full-state bytes; a delta-heavy
@@ -390,7 +551,7 @@ mod tests {
             (PayloadArm::FullComputeFailed, 0, 0),
             (PayloadArm::FullNoSummary, 0, 0),
         ];
-        let json = payload_mix_json(&arms, &[], 0, 60);
+        let json = payload_mix_json(&arms, &[], 0, 0, 60);
         assert_eq!(json["total_bytes"], 1000);
         assert_eq!(json["full_state_bytes"], 700);
         assert_eq!(json["full_state_byte_share"], 0.7);
@@ -403,13 +564,21 @@ mod tests {
     #[test]
     fn empty_window_reports_zero_share_not_nan() {
         let arms: Vec<_> = PayloadArm::ALL.iter().map(|a| (*a, 0, 0)).collect();
-        let json = payload_mix_json(&arms, &[], 0, 60);
+        let json = payload_mix_json(&arms, &[], 0, 0, 60);
         assert_eq!(json["full_state_byte_share"], 0.0);
         assert_eq!(json["total_bytes"], 0);
     }
 
-    /// Per-contract attribution is capped, and the overflow is reported
-    /// rather than silently truncated.
+    /// Per-contract attribution is capped, and the overflow is reported as
+    /// SENDS and BYTES rather than silently truncated.
+    ///
+    /// The counter deliberately counts sends, not distinct contracts: an
+    /// external reviewer flagged that the original `contracts_dropped` name
+    /// implied cardinality while the code incremented per send, so one
+    /// over-cap contract broadcasting 1,000 times read as "1,000 contracts
+    /// dropped". Tracking true cardinality would need an unbounded set, which
+    /// is what the cap exists to prevent, so the field is named for what it
+    /// measures and paired with the byte total that makes it actionable.
     #[test]
     fn contract_attribution_is_bounded_and_reports_overflow() {
         let mix = PayloadMix::new();
@@ -417,24 +586,61 @@ mod tests {
             let mut raw = [0u8; 32];
             raw[0] = (i % 256) as u8;
             raw[1] = (i / 256) as u8;
-            mix.attribute_full_state(&ContractInstanceId::new(raw), 5);
+            mix.record_delivered(
+                PayloadArm::FullNotEfficient,
+                &ContractInstanceId::new(raw),
+                5,
+            );
         }
+        let window = mix.take_window();
         assert!(
-            mix.contract_full_state_bytes.len() <= MAX_TRACKED_CONTRACTS,
+            window.contract_full_state_bytes.len() <= MAX_TRACKED_CONTRACTS,
             "attribution map exceeded its cap: {}",
-            mix.contract_full_state_bytes.len()
+            window.contract_full_state_bytes.len()
         );
-        let (top, dropped) = mix.drain_contracts();
         assert_eq!(
-            dropped, 20,
+            window.attribution_dropped_sends, 20,
             "overflow must be reported, not dropped silently"
         );
-        assert!(top.len() <= TOP_CONTRACTS_REPORTED);
-        assert!(mix.contract_full_state_bytes.is_empty(), "drain must clear");
-        // Draining also resets the dropped counter, so the next window starts
-        // clean rather than re-reporting this window's overflow.
-        let (_, dropped_again) = mix.drain_contracts();
-        assert_eq!(dropped_again, 0, "dropped counter must reset on drain");
+        assert_eq!(
+            window.attribution_dropped_bytes, 100,
+            "the bytes behind unattributed sends must be reported too"
+        );
+        assert!(window.top_contracts().len() <= TOP_CONTRACTS_REPORTED);
+        // Taking the window resets everything, so the next window starts clean
+        // rather than re-reporting this window's overflow.
+        let next = mix.take_window();
+        assert!(next.contract_full_state_bytes.is_empty());
+        assert_eq!(next.attribution_dropped_sends, 0);
+        assert_eq!(next.attribution_dropped_bytes, 0);
+    }
+
+    /// One over-cap contract sending repeatedly inflates the SEND count, not
+    /// a contract count — the distinction the field name now makes explicit.
+    #[test]
+    fn repeated_sends_from_one_over_cap_contract_count_as_sends() {
+        let mix = PayloadMix::new();
+        for i in 0..MAX_TRACKED_CONTRACTS {
+            let mut raw = [0u8; 32];
+            raw[0] = (i % 256) as u8;
+            raw[1] = (i / 256) as u8;
+            mix.record_delivered(
+                PayloadArm::FullNotEfficient,
+                &ContractInstanceId::new(raw),
+                1,
+            );
+        }
+        // A single additional contract, broadcasting many times.
+        let mut raw = [9u8; 32];
+        raw[31] = 7;
+        let over_cap = ContractInstanceId::new(raw);
+        for _ in 0..1000 {
+            mix.record_delivered(PayloadArm::FullNotEfficient, &over_cap, 3);
+        }
+        let window = mix.take_window();
+        assert_eq!(window.attribution_dropped_sends, 1000);
+        assert_eq!(window.attribution_dropped_bytes, 3000);
+        assert!(!window.contract_full_state_bytes.contains_key(&over_cap));
     }
 
     /// Ties break deterministically on contract id so the reported top-N is
@@ -442,10 +648,10 @@ mod tests {
     #[test]
     fn top_contracts_sort_is_deterministic() {
         let mix = PayloadMix::new();
-        mix.attribute_full_state(&contract(9), 100);
-        mix.attribute_full_state(&contract(2), 100);
-        mix.attribute_full_state(&contract(5), 500);
-        let (top, _) = mix.drain_contracts();
+        mix.record_delivered(PayloadArm::FullNoSummary, &contract(9), 100);
+        mix.record_delivered(PayloadArm::FullNoSummary, &contract(2), 100);
+        mix.record_delivered(PayloadArm::FullNoSummary, &contract(5), 500);
+        let top = mix.take_window().top_contracts();
         assert_eq!(top[0].0, contract(5), "largest first");
         assert_eq!(top[1].0, contract(2), "tie broken by contract id");
         assert_eq!(top[2].0, contract(9));
@@ -456,14 +662,14 @@ mod tests {
     fn delta_sends_are_not_attributed_as_full_state() {
         let mix = PayloadMix::new();
         mix.record_delivered(PayloadArm::Delta, &contract(7), 1234);
-        let (top, _) = mix.drain_contracts();
+        let window = mix.take_window();
         assert!(
-            top.is_empty(),
-            "delta bytes leaked into full-state attribution: {top:?}"
+            window.contract_full_state_bytes.is_empty(),
+            "delta bytes leaked into full-state attribution: {:?}",
+            window.contract_full_state_bytes
         );
         // ...but the delta itself is still counted in the per-arm totals.
-        let arms = mix.drain();
-        assert_eq!(arms[PayloadArm::Delta.index()].2, 1234);
+        assert_eq!(window.arms()[PayloadArm::Delta.index()].2, 1234);
     }
 
     /// Every full-state arm attributes to the contract; this is what names
@@ -473,7 +679,7 @@ mod tests {
         for arm in PayloadArm::ALL.iter().filter(|a| a.is_full_state()) {
             let mix = PayloadMix::new();
             mix.record_delivered(*arm, &contract(3), 99);
-            let (top, _) = mix.drain_contracts();
+            let top = mix.take_window().top_contracts();
             assert_eq!(
                 top,
                 vec![(contract(3), 99)],

--- a/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
+++ b/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
@@ -51,7 +51,6 @@
 //! [`broadcast_to_single_peer`]: super::broadcast_queue::broadcast_to_single_peer
 
 use std::collections::HashMap;
-use std::sync::LazyLock;
 use std::time::Duration;
 
 use freenet_stdlib::prelude::ContractInstanceId;
@@ -140,9 +139,6 @@ impl PayloadArm {
     }
 }
 
-/// Process-wide payload-mix accumulator. See the module docs.
-pub(crate) static BROADCAST_PAYLOAD_MIX: LazyLock<PayloadMix> = LazyLock::new(PayloadMix::new);
-
 /// One rollup window's counters.
 ///
 /// Every field advances together under a single lock so a rollup takes a
@@ -185,10 +181,23 @@ impl Default for Window {
 /// Per-arm send/byte counters plus bounded per-contract full-state
 /// attribution.
 ///
-/// All state lives on the struct rather than in free statics so tests can
-/// instantiate an isolated accumulator: a shared global would make the unit
-/// tests order-dependent and intermittently failing, which this repo treats
-/// as a broken test, not an acceptable one.
+/// ## One instance PER NODE, never a process global
+///
+/// This is deliberately owned by [`OpManager`](crate::node::OpManager) rather
+/// than living in a `static`. A process-global accumulator drained by
+/// per-node aggregators is actively wrong when several `NodeP2P` instances
+/// share a process (the simulation harness): whichever node's ticker fires
+/// first would drain everyone's records and publish them under its own
+/// `local_peer_id`, while the other nodes emitted empty windows.
+///
+/// Note the sibling `shadow_demand` aggregators DO read process-global
+/// counters, but non-destructively (load + a locally-tracked delta), so N of
+/// them merely double-report. This accumulator is drained destructively, which
+/// turns the same shape into misattribution — so it does not follow that
+/// convention.
+///
+/// Keeping state on the struct also means tests instantiate an isolated
+/// accumulator instead of sharing one, so they are not order-dependent.
 ///
 /// ## Why one mutex rather than per-field atomics
 ///
@@ -217,7 +226,7 @@ pub(crate) struct PayloadMix {
 }
 
 impl PayloadMix {
-    fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             window: Mutex::new(Window::default()),
         }
@@ -383,11 +392,15 @@ fn payload_mix_json(
 /// Emit one `broadcast_payload_mix` rollup and reset the window.
 ///
 /// Returns the payload so callers (and tests) can inspect what was sent.
-pub(crate) fn emit_payload_mix_rollup(local_peer_id: &str, window_secs: u64) -> serde_json::Value {
+pub(crate) fn emit_payload_mix_rollup(
+    mix: &PayloadMix,
+    local_peer_id: &str,
+    window_secs: u64,
+) -> serde_json::Value {
     // ONE atomic take: the arm counters and the per-contract tallies describe
     // exactly the same set of broadcasts, so the top-N list always reconciles
     // against `full_state_bytes`.
-    let window = BROADCAST_PAYLOAD_MIX.take_window();
+    let window = mix.take_window();
     let payload = payload_mix_json(
         &window.arms(),
         &window.top_contracts(),
@@ -426,7 +439,11 @@ fn rollup_window_secs(elapsed: Duration) -> u64 {
 /// Always-on and cheap: it takes one lock and drains a bounded map once per
 /// [`ROLLUP_WINDOW`]. Observation only — nothing reads these counters to make
 /// a decision, and nothing on the hot path ever reads them at all.
-pub(crate) fn spawn_payload_mix_aggregator(local_peer_id: String, monitor: &BackgroundTaskMonitor) {
+pub(crate) fn spawn_payload_mix_aggregator(
+    mix: std::sync::Arc<PayloadMix>,
+    local_peer_id: String,
+    monitor: &BackgroundTaskMonitor,
+) {
     let handle = tokio::spawn(async move {
         let mut ticker = tokio::time::interval(ROLLUP_WINDOW);
         ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
@@ -440,7 +457,7 @@ pub(crate) fn spawn_payload_mix_aggregator(local_peer_id: String, monitor: &Back
             let now = tokio::time::Instant::now();
             let elapsed = now.saturating_duration_since(last_rollup);
             last_rollup = now;
-            emit_payload_mix_rollup(&local_peer_id, rollup_window_secs(elapsed));
+            emit_payload_mix_rollup(&mix, &local_peer_id, rollup_window_secs(elapsed));
         }
     });
     monitor.register("broadcast_payload_mix_aggregator", handle);

--- a/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
+++ b/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
@@ -379,20 +379,42 @@ pub(crate) fn emit_payload_mix_rollup(local_peer_id: &str, window_secs: u64) -> 
     payload
 }
 
+/// The window length to report, given the time actually elapsed since the
+/// previous rollup.
+///
+/// Reporting the nominal cadence would be wrong whenever the aggregator tick
+/// slips: `MissedTickBehavior::Delay` lets a saturated runtime stretch the
+/// real window past [`ROLLUP_WINDOW`] while broadcast workers keep recording,
+/// so a constant `window_secs` inflates every rate derived from the totals.
+/// That error is not random — it is largest exactly when the node is busiest,
+/// which is the condition this instrumentation exists to characterise.
+///
+/// Floored at 1 s so a downstream rate computation can never divide by zero.
+fn rollup_window_secs(elapsed: Duration) -> u64 {
+    (elapsed.as_secs_f64().round() as u64).max(1)
+}
+
 /// Spawn the `broadcast_payload_mix` aggregator and register it with the
 /// [`BackgroundTaskMonitor`].
 ///
-/// Always-on and cheap: it only swaps atomics and drains a bounded map once
-/// per [`ROLLUP_WINDOW`]. Observation only — nothing reads these counters to
-/// make a decision, and nothing on the hot path ever reads them at all.
+/// Always-on and cheap: it takes one lock and drains a bounded map once per
+/// [`ROLLUP_WINDOW`]. Observation only — nothing reads these counters to make
+/// a decision, and nothing on the hot path ever reads them at all.
 pub(crate) fn spawn_payload_mix_aggregator(local_peer_id: String, monitor: &BackgroundTaskMonitor) {
     let handle = tokio::spawn(async move {
         let mut ticker = tokio::time::interval(ROLLUP_WINDOW);
         ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
         ticker.tick().await; // skip the immediate first tick
+        // `tokio::time::Instant` (not `std::time::Instant`) so this reads the
+        // same clock the ticker uses and stays controllable under a paused
+        // test runtime.
+        let mut last_rollup = tokio::time::Instant::now();
         loop {
             ticker.tick().await;
-            emit_payload_mix_rollup(&local_peer_id, ROLLUP_WINDOW.as_secs());
+            let now = tokio::time::Instant::now();
+            let elapsed = now.saturating_duration_since(last_rollup);
+            last_rollup = now;
+            emit_payload_mix_rollup(&local_peer_id, rollup_window_secs(elapsed));
         }
     });
     monitor.register("broadcast_payload_mix_aggregator", handle);
@@ -491,7 +513,7 @@ mod tests {
     fn concurrent_records_racing_a_rollup_conserve_bytes() {
         use std::sync::Arc;
 
-        const THREADS: usize = 8;
+        const THREADS: usize = 4;
         const PER_THREAD: usize = 500;
 
         let mix = Arc::new(PayloadMix::new());
@@ -509,7 +531,14 @@ mod tests {
                     let w = mix.take_window();
                     let sum: u64 = w.arms().iter().map(|(_, _, b)| b).sum();
                     *drained_total.lock() += sum;
-                    std::thread::yield_now();
+                    // Sleep rather than spin. A hot loop here would burn a
+                    // whole core for the duration of the test, and the suite
+                    // runs tests in parallel — starving a timing-sensitive
+                    // test elsewhere would make THIS test the cause of a flake
+                    // somewhere else. 50 µs still yields hundreds of drains
+                    // against 2,000 records, so the rollover race is amply
+                    // exercised.
+                    std::thread::sleep(Duration::from_micros(50));
                 }
             })
         };
@@ -670,6 +699,32 @@ mod tests {
         );
         // ...but the delta itself is still counted in the per-arm totals.
         assert_eq!(window.arms()[PayloadArm::Delta.index()].2, 1234);
+    }
+
+    /// The reported window must reflect the time actually elapsed, not the
+    /// nominal cadence.
+    ///
+    /// Regression for the external-review finding: with
+    /// `MissedTickBehavior::Delay`, a saturated runtime stretches the real
+    /// window past `ROLLUP_WINDOW` while broadcast workers keep recording. A
+    /// constant `window_secs` would then inflate every derived rate, and worst
+    /// precisely when the node is busiest — the case this telemetry exists to
+    /// characterise.
+    #[test]
+    fn reported_window_tracks_actual_elapsed_not_nominal_cadence() {
+        // On-cadence tick: reports the nominal window.
+        assert_eq!(rollup_window_secs(ROLLUP_WINDOW), 60);
+        // Delayed tick: reports the LONGER real window, so a rate computed
+        // downstream divides by the right number.
+        assert_eq!(rollup_window_secs(Duration::from_secs(150)), 150);
+        assert_eq!(
+            rollup_window_secs(Duration::from_millis(90_400)),
+            90,
+            "sub-second remainder rounds to nearest"
+        );
+        // Never zero: a downstream `total / window_secs` must not divide by 0.
+        assert_eq!(rollup_window_secs(Duration::ZERO), 1);
+        assert_eq!(rollup_window_secs(Duration::from_millis(200)), 1);
     }
 
     /// Every full-state arm attributes to the contract; this is what names

--- a/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
+++ b/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
@@ -73,8 +73,9 @@ const ROLLUP_WINDOW: Duration = Duration::from_secs(60);
 /// beyond the cap are still counted in the per-arm totals; only their
 /// per-contract attribution is dropped, and both the count and the BYTE total
 /// of those unattributed sends are reported (`attribution_dropped_sends` /
-/// `attribution_dropped_bytes`) so a truncated window is never mistaken for a
-/// complete one.
+/// `attribution_dropped_bytes`) so a capped window is never mistaken for a
+/// complete one. Truncation of the reported top-N is a DIFFERENT omission,
+/// published separately as `other_contracts_bytes`.
 const MAX_TRACKED_CONTRACTS: usize = 256;
 
 /// How many contracts the emitted rollup names.
@@ -159,9 +160,13 @@ struct Window {
     /// dropped" misreading; distinct-contract cardinality would need an
     /// unbounded set, which is exactly what the cap exists to prevent.
     attribution_dropped_sends: u64,
-    /// Bytes behind those unattributed sends. This is the field that says
-    /// how much of `full_state_bytes` the top-N list cannot account for, so
-    /// a truncated window is never mistaken for a complete one.
+    /// Bytes behind those unattributed sends.
+    ///
+    /// This covers only contracts the cap refused to TRACK. Contracts that
+    /// were tracked but fell outside the reported top-N are a separate
+    /// omission, published as `other_contracts_bytes`; conflating the two made
+    /// an 11-contract window look perfectly reconciled while 10 % of its bytes
+    /// were unaccounted for.
     attribution_dropped_bytes: u64,
 }
 
@@ -297,6 +302,8 @@ impl Window {
 fn payload_mix_json(
     arms: &[(PayloadArm, u64, u64)],
     contracts: &[(ContractInstanceId, u64)],
+    tracked_full_state_bytes: u64,
+    contracts_tracked: u64,
     attribution_dropped_sends: u64,
     attribution_dropped_bytes: u64,
     window_secs: u64,
@@ -341,9 +348,26 @@ fn payload_mix_json(
                 .collect(),
         ),
     );
-    // Sends (not distinct contracts) that missed attribution, and the bytes
-    // behind them: `attribution_dropped_bytes` is what tells an analyst how
-    // much of `full_state_bytes` the top-N list cannot account for.
+    // The published schema must ADD UP, using only fields it publishes:
+    //
+    //   sum(top_contracts) + other_contracts_bytes + attribution_dropped_bytes
+    //     == full_state_bytes
+    //
+    // Two DIFFERENT kinds of omission have to be reported separately, and an
+    // earlier revision conflated them:
+    //   * `other_contracts_bytes` — contracts we DID track but that fell
+    //     outside the reported top-N. With 11..=MAX_TRACKED_CONTRACTS
+    //     contracts this is non-zero while nothing was ever dropped.
+    //   * `attribution_dropped_bytes` — contracts never tracked at all
+    //     because the cap was already full.
+    // Reporting only the second made an 11-contract window look perfectly
+    // reconciled while 10 % of its bytes were unaccounted for.
+    let top_sum: u64 = contracts.iter().map(|(_, b)| *b).sum();
+    let other_contracts_bytes = tracked_full_state_bytes.saturating_sub(top_sum);
+    obj.insert("other_contracts_bytes".into(), other_contracts_bytes.into());
+    obj.insert("contracts_tracked".into(), contracts_tracked.into());
+    // Sends (not distinct contracts) that missed attribution entirely, and the
+    // bytes behind them.
     obj.insert(
         "attribution_dropped_sends".into(),
         attribution_dropped_sends.into(),
@@ -367,6 +391,8 @@ pub(crate) fn emit_payload_mix_rollup(local_peer_id: &str, window_secs: u64) -> 
     let payload = payload_mix_json(
         &window.arms(),
         &window.top_contracts(),
+        window.contract_full_state_bytes.values().sum(),
+        window.contract_full_state_bytes.len() as u64,
         window.attribution_dropped_sends,
         window.attribution_dropped_bytes,
         window_secs,
@@ -490,21 +516,109 @@ mod tests {
             .filter(|(arm, _, _)| arm.is_full_state())
             .map(|(_, _, bytes)| bytes)
             .sum();
-        let attributed: u64 = window.contract_full_state_bytes.values().sum();
         assert_eq!(
             full_state_total, 1000,
             "full-state arm bytes should exclude the delta send"
         );
-        assert_eq!(
-            attributed + window.attribution_dropped_bytes,
-            full_state_total,
-            "every full-state byte must be either attributed to a contract or \
-             counted as dropped attribution — otherwise the top-N list cannot \
-             be reconciled against full_state_bytes"
-        );
         // Contract 1 accumulated across two different full-state arms.
         assert_eq!(window.contract_full_state_bytes[&contract(1)], 700);
         assert_eq!(window.contract_full_state_bytes[&contract(2)], 300);
+        assert_reconciles(&window);
+    }
+
+    /// The reconciliation invariant, asserted against the EMITTED JSON rather
+    /// than the in-memory window.
+    ///
+    /// This distinction is the whole point: an earlier revision checked the
+    /// internal map and passed, while the PUBLISHED schema silently failed to
+    /// add up for any window holding 11..=MAX_TRACKED_CONTRACTS contracts —
+    /// the top-N truncation dropped bytes that no emitted field accounted
+    /// for. A consumer can only use the fields actually present in the event,
+    /// so that is what the test must check.
+    fn assert_reconciles(window: &Window) {
+        let json = payload_mix_json(
+            &window.arms(),
+            &window.top_contracts(),
+            window.contract_full_state_bytes.values().sum(),
+            window.contract_full_state_bytes.len() as u64,
+            window.attribution_dropped_sends,
+            window.attribution_dropped_bytes,
+            60,
+        );
+        let top_sum: u64 = json["top_contracts_by_full_state_bytes"]
+            .as_array()
+            .expect("top contracts must be an array")
+            .iter()
+            .map(|e| e["bytes"].as_u64().expect("bytes must be a number"))
+            .sum();
+        let other = json["other_contracts_bytes"].as_u64().unwrap();
+        let dropped = json["attribution_dropped_bytes"].as_u64().unwrap();
+        let full_state = json["full_state_bytes"].as_u64().unwrap();
+        assert_eq!(
+            top_sum + other + dropped,
+            full_state,
+            "published schema must add up: sum(top_contracts) + \
+             other_contracts_bytes + attribution_dropped_bytes == \
+             full_state_bytes (got {top_sum} + {other} + {dropped} != \
+             {full_state})"
+        );
+    }
+
+    /// A window with more contracts than the top-N limit must still reconcile:
+    /// the untruncated remainder has to appear in `other_contracts_bytes`.
+    ///
+    /// Regression for the external-review finding — eleven 100-byte contracts
+    /// previously reported full_state_bytes = 1100, a top-list summing to
+    /// 1000, and zero dropped bytes.
+    #[test]
+    fn window_with_more_contracts_than_top_n_still_reconciles() {
+        let mix = PayloadMix::new();
+        for i in 0..(TOP_CONTRACTS_REPORTED + 1) {
+            mix.record_delivered(PayloadArm::FullNotEfficient, &contract(i as u8), 100);
+        }
+        let window = mix.take_window();
+        assert_reconciles(&window);
+
+        let json = payload_mix_json(
+            &window.arms(),
+            &window.top_contracts(),
+            window.contract_full_state_bytes.values().sum(),
+            window.contract_full_state_bytes.len() as u64,
+            window.attribution_dropped_sends,
+            window.attribution_dropped_bytes,
+            60,
+        );
+        assert_eq!(json["full_state_bytes"], 1100);
+        assert_eq!(
+            json["other_contracts_bytes"], 100,
+            "the 11th contract's bytes must be reported as the untruncated \
+             remainder, not silently lost"
+        );
+        assert_eq!(
+            json["attribution_dropped_bytes"], 0,
+            "nothing was DROPPED here — the cap was never reached; this is \
+             truncation, which is a different field"
+        );
+        assert_eq!(json["contracts_tracked"], 11);
+    }
+
+    /// Over-cap drops and top-N truncation are different omissions and must
+    /// reconcile together.
+    #[test]
+    fn truncation_and_over_cap_drops_reconcile_together() {
+        let mix = PayloadMix::new();
+        for i in 0..(MAX_TRACKED_CONTRACTS + 5) {
+            let mut raw = [0u8; 32];
+            raw[0] = (i % 256) as u8;
+            raw[1] = (i / 256) as u8;
+            mix.record_delivered(PayloadArm::FullNoSummary, &ContractInstanceId::new(raw), 10);
+        }
+        let window = mix.take_window();
+        assert!(
+            window.attribution_dropped_bytes > 0,
+            "cap must have been hit"
+        );
+        assert_reconciles(&window);
     }
 
     /// Concurrent recorders racing a rollup must not lose or double-count
@@ -580,7 +694,7 @@ mod tests {
             (PayloadArm::FullComputeFailed, 0, 0),
             (PayloadArm::FullNoSummary, 0, 0),
         ];
-        let json = payload_mix_json(&arms, &[], 0, 0, 60);
+        let json = payload_mix_json(&arms, &[], 0, 0, 0, 0, 60);
         assert_eq!(json["total_bytes"], 1000);
         assert_eq!(json["full_state_bytes"], 700);
         assert_eq!(json["full_state_byte_share"], 0.7);
@@ -593,7 +707,7 @@ mod tests {
     #[test]
     fn empty_window_reports_zero_share_not_nan() {
         let arms: Vec<_> = PayloadArm::ALL.iter().map(|a| (*a, 0, 0)).collect();
-        let json = payload_mix_json(&arms, &[], 0, 0, 60);
+        let json = payload_mix_json(&arms, &[], 0, 0, 0, 0, 60);
         assert_eq!(json["full_state_byte_share"], 0.0);
         assert_eq!(json["total_bytes"], 0);
     }

--- a/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
+++ b/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
@@ -1,0 +1,484 @@
+//! Which fan-out arm chose a broadcast payload, and how many bytes it put on
+//! the wire.
+//!
+//! ## Why
+//!
+//! A production measurement on 2026-07-24 (posted to #3335) found that the
+//! fleet sends ~60 GB per 3 h, that ~85 % of byte-weighted broadcast work is
+//! on contracts holding >= 500 KB of state, and that 97.9 % of it lands on
+//! contracts whose applies change nothing. What it could NOT determine is
+//! *why* those large states go out whole, because
+//! [`broadcast_to_single_peer`] has **three distinct paths that send FULL
+//! STATE** and none of them were separately instrumented:
+//!
+//! 1. [`PayloadArm::FullDeltaSuppressed`] — the `delta_incompat` memo is armed
+//!    (#4904): the contract is known to reject every delta, so full state is
+//!    sent deliberately.
+//! 2. [`PayloadArm::FullNotEfficient`] — the wire-efficiency gate
+//!    ([`crate::ring::interest::is_delta_efficient`]) refused *before*
+//!    computing anything, because the peer's summary is >= 50 % of our state
+//!    size. Note the fallback is full state, which is never smaller than the
+//!    delta the gate declined to compute.
+//! 3. [`PayloadArm::FullComputeFailed`] — the contract's WASM failed, timed
+//!    out, or answered unexpectedly.
+//! 4. [`PayloadArm::FullNoSummary`] — we hold no summary for one side of the
+//!    pair, so there is nothing to diff against (first sync, or a summary
+//!    cleared by a delta-apply failure).
+//!
+//! Those four have completely different remedies, so knowing which one emits
+//! the bytes is the difference between a targeted fix and a guess. Deltas are
+//! counted too ([`PayloadArm::Delta`]) so the mix is a ratio rather than a
+//! bare count.
+//!
+//! ## What is counted
+//!
+//! Bytes are recorded at the **real-delivery** sites only — the same points
+//! that charge [`ResourceType::BroadcastFanoutCost`][rt] — so a dropped,
+//! timed-out, or failed-to-enqueue send never inflates the mix with phantom
+//! fan-out. This deliberately mirrors the #4903 review round-3 Fix 4
+//! accounting rule; see `broadcast_queue::broadcast_to_single_peer`.
+//!
+//! [rt]: crate::topology::meter::ResourceType::BroadcastFanoutCost
+//!
+//! ## Cost
+//!
+//! One relaxed atomic add per delivered broadcast on the hot path, plus at
+//! most one bounded `DashMap` touch for per-contract attribution. Everything
+//! else happens in the aggregator task. Same shape as
+//! [`crate::transport::shadow_demand`]; the hot path only ever WRITES.
+//!
+//! [`broadcast_to_single_peer`]: super::broadcast_queue::broadcast_to_single_peer
+
+use std::sync::LazyLock;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use dashmap::DashMap;
+use freenet_stdlib::prelude::ContractInstanceId;
+
+use crate::node::background_task_monitor::BackgroundTaskMonitor;
+
+/// Rollup cadence. Broadcasts are far less frequent than packets, so this is
+/// a minute rather than the 1 Hz sampling the `shadow_demand` aggregators use;
+/// one event per minute per node is a negligible addition to the telemetry
+/// volume this is meant to explain.
+const ROLLUP_WINDOW: Duration = Duration::from_secs(60);
+
+/// Per-contract attribution cap for one window.
+///
+/// Bounded because the key is contract-controlled: any peer can fan out a
+/// contract we host, so an unbounded map here would be an amplification
+/// vector (see `.claude/rules/code-style.md`, "per-key collections"). Entries
+/// beyond the cap are still counted in the per-arm totals; only their
+/// per-contract attribution is dropped, and the count of dropped contracts is
+/// reported so a truncated window is never mistaken for a complete one.
+const MAX_TRACKED_CONTRACTS: usize = 256;
+
+/// How many contracts the emitted rollup names.
+const TOP_CONTRACTS_REPORTED: usize = 10;
+
+/// Which arm of the fan-out's payload selection produced a broadcast.
+///
+/// See the module docs for what each arm means and why the split matters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum PayloadArm {
+    /// A delta was computed and sent.
+    Delta,
+    /// Full state: the `delta_incompat` memo is armed for this contract.
+    FullDeltaSuppressed,
+    /// Full state: the wire-efficiency gate refused to compute a delta.
+    FullNotEfficient,
+    /// Full state: delta computation was attempted and failed.
+    FullComputeFailed,
+    /// Full state: no cached summary for one side of the pair.
+    FullNoSummary,
+}
+
+impl PayloadArm {
+    /// Every arm, in reporting order. Exhaustive by construction: the
+    /// `match` in [`PayloadArm::index`] fails to compile if a variant is
+    /// added without being listed here.
+    pub(crate) const ALL: [PayloadArm; 5] = [
+        PayloadArm::Delta,
+        PayloadArm::FullDeltaSuppressed,
+        PayloadArm::FullNotEfficient,
+        PayloadArm::FullComputeFailed,
+        PayloadArm::FullNoSummary,
+    ];
+
+    const COUNT: usize = Self::ALL.len();
+
+    const fn index(self) -> usize {
+        match self {
+            PayloadArm::Delta => 0,
+            PayloadArm::FullDeltaSuppressed => 1,
+            PayloadArm::FullNotEfficient => 2,
+            PayloadArm::FullComputeFailed => 3,
+            PayloadArm::FullNoSummary => 4,
+        }
+    }
+
+    /// Stable wire label. Used as the telemetry field prefix, so changing one
+    /// breaks existing dashboard queries.
+    pub(crate) const fn label(self) -> &'static str {
+        match self {
+            PayloadArm::Delta => "delta",
+            PayloadArm::FullDeltaSuppressed => "full_delta_suppressed",
+            PayloadArm::FullNotEfficient => "full_not_efficient",
+            PayloadArm::FullComputeFailed => "full_compute_failed",
+            PayloadArm::FullNoSummary => "full_no_summary",
+        }
+    }
+
+    /// Whether this arm put a whole contract state on the wire.
+    pub(crate) const fn is_full_state(self) -> bool {
+        !matches!(self, PayloadArm::Delta)
+    }
+}
+
+/// Process-wide payload-mix accumulator. See the module docs.
+pub(crate) static BROADCAST_PAYLOAD_MIX: LazyLock<PayloadMix> = LazyLock::new(PayloadMix::new);
+
+/// Per-arm send/byte counters plus bounded per-contract full-state
+/// attribution.
+///
+/// All state lives on the struct rather than in free statics so tests can
+/// instantiate an isolated accumulator: a shared global would make the unit
+/// tests order-dependent and intermittently failing, which this repo treats
+/// as a broken test, not an acceptable one.
+pub(crate) struct PayloadMix {
+    sends: [AtomicU64; PayloadArm::COUNT],
+    bytes: [AtomicU64; PayloadArm::COUNT],
+    /// Per-contract full-state byte attribution for the current window,
+    /// bounded at [`MAX_TRACKED_CONTRACTS`].
+    contract_full_state_bytes: DashMap<ContractInstanceId, AtomicU64>,
+    /// Contracts whose attribution was dropped this window because the cap
+    /// was already reached.
+    contracts_dropped: AtomicU64,
+}
+
+impl PayloadMix {
+    fn new() -> Self {
+        Self {
+            sends: std::array::from_fn(|_| AtomicU64::new(0)),
+            bytes: std::array::from_fn(|_| AtomicU64::new(0)),
+            contract_full_state_bytes: DashMap::new(),
+            contracts_dropped: AtomicU64::new(0),
+        }
+    }
+
+    /// Record one **delivered** broadcast.
+    ///
+    /// Call this only where [`ResourceType::BroadcastFanoutCost`][rt] is
+    /// charged, so the mix and the cost axis agree on what "sent" means.
+    ///
+    /// [rt]: crate::topology::meter::ResourceType::BroadcastFanoutCost
+    pub(crate) fn record_delivered(
+        &self,
+        arm: PayloadArm,
+        contract: &ContractInstanceId,
+        payload_bytes: usize,
+    ) {
+        let idx = arm.index();
+        self.sends[idx].fetch_add(1, Ordering::Relaxed);
+        self.bytes[idx].fetch_add(payload_bytes as u64, Ordering::Relaxed);
+        if arm.is_full_state() {
+            self.attribute_full_state(contract, payload_bytes as u64);
+        }
+    }
+
+    /// Add `bytes` to a contract's full-state tally, respecting the cap.
+    fn attribute_full_state(&self, contract: &ContractInstanceId, bytes: u64) {
+        if let Some(entry) = self.contract_full_state_bytes.get(contract) {
+            entry.fetch_add(bytes, Ordering::Relaxed);
+            return;
+        }
+        // `len()` is a racy read, so the cap is approximate under concurrency —
+        // acceptable for telemetry, and it can only ever overshoot by the number
+        // of threads racing here, never grow unboundedly.
+        if self.contract_full_state_bytes.len() >= MAX_TRACKED_CONTRACTS {
+            self.contracts_dropped.fetch_add(1, Ordering::Relaxed);
+            return;
+        }
+        self.contract_full_state_bytes
+            .entry(*contract)
+            .or_insert_with(|| AtomicU64::new(0))
+            .fetch_add(bytes, Ordering::Relaxed);
+    }
+
+    /// Drain the per-contract tallies, returning the top
+    /// [`TOP_CONTRACTS_REPORTED`] by full-state bytes plus the dropped count.
+    fn drain_contracts(&self) -> (Vec<(ContractInstanceId, u64)>, u64) {
+        let mut tallies: Vec<(ContractInstanceId, u64)> = self
+            .contract_full_state_bytes
+            .iter()
+            .map(|e| (*e.key(), e.value().load(Ordering::Relaxed)))
+            .collect();
+        self.contract_full_state_bytes.clear();
+        let dropped = self.contracts_dropped.swap(0, Ordering::Relaxed);
+        // `ContractInstanceId` has no `Ord`, so tie-break on its raw bytes: the
+        // reported top-N must be stable across nodes and windows, otherwise a tie
+        // reorders on every rollup and looks like churn.
+        tallies.sort_by(|a, b| {
+            b.1.cmp(&a.1)
+                .then_with(|| a.0.as_bytes().cmp(b.0.as_bytes()))
+        });
+        tallies.truncate(TOP_CONTRACTS_REPORTED);
+        (tallies, dropped)
+    }
+
+    /// Drain the counters, returning per-arm `(sends, bytes)` in
+    /// [`PayloadArm::ALL`] order. Resets to zero so each rollup reports one
+    /// window rather than a lifetime total.
+    fn drain(&self) -> Vec<(PayloadArm, u64, u64)> {
+        PayloadArm::ALL
+            .iter()
+            .map(|arm| {
+                let idx = arm.index();
+                (
+                    *arm,
+                    self.sends[idx].swap(0, Ordering::Relaxed),
+                    self.bytes[idx].swap(0, Ordering::Relaxed),
+                )
+            })
+            .collect()
+    }
+}
+
+/// Build the `broadcast_payload_mix` rollup JSON.
+///
+/// Pure so the schema is unit-testable without the telemetry sender, matching
+/// the `shadow_demand` rollup builders.
+fn payload_mix_json(
+    arms: &[(PayloadArm, u64, u64)],
+    contracts: &[(ContractInstanceId, u64)],
+    contracts_dropped: u64,
+    window_secs: u64,
+) -> serde_json::Value {
+    let mut obj = serde_json::Map::new();
+    let mut total_sends = 0u64;
+    let mut total_bytes = 0u64;
+    let mut full_state_bytes = 0u64;
+    for (arm, sends, bytes) in arms {
+        obj.insert(format!("{}_sends", arm.label()), (*sends).into());
+        obj.insert(format!("{}_bytes", arm.label()), (*bytes).into());
+        total_sends += sends;
+        total_bytes += bytes;
+        if arm.is_full_state() {
+            full_state_bytes += bytes;
+        }
+    }
+    obj.insert("total_sends".into(), total_sends.into());
+    obj.insert("total_bytes".into(), total_bytes.into());
+    obj.insert("full_state_bytes".into(), full_state_bytes.into());
+    // The headline ratio: of everything we actually put on the wire, how much
+    // was a whole state rather than a diff.
+    let full_state_share = if total_bytes == 0 {
+        0.0
+    } else {
+        full_state_bytes as f64 / total_bytes as f64
+    };
+    obj.insert(
+        "full_state_byte_share".into(),
+        serde_json::Number::from_f64(full_state_share)
+            .map(serde_json::Value::Number)
+            .unwrap_or(serde_json::Value::Null),
+    );
+    obj.insert(
+        "top_contracts_by_full_state_bytes".into(),
+        serde_json::Value::Array(
+            contracts
+                .iter()
+                .map(
+                    |(id, bytes)| serde_json::json!({ "contract": id.to_string(), "bytes": bytes }),
+                )
+                .collect(),
+        ),
+    );
+    obj.insert("contracts_dropped".into(), contracts_dropped.into());
+    obj.insert("window_secs".into(), window_secs.into());
+    serde_json::Value::Object(obj)
+}
+
+/// Emit one `broadcast_payload_mix` rollup and reset the window.
+///
+/// Returns the payload so callers (and tests) can inspect what was sent.
+pub(crate) fn emit_payload_mix_rollup(local_peer_id: &str, window_secs: u64) -> serde_json::Value {
+    let arms = BROADCAST_PAYLOAD_MIX.drain();
+    let (contracts, dropped) = BROADCAST_PAYLOAD_MIX.drain_contracts();
+    let payload = payload_mix_json(&arms, &contracts, dropped, window_secs);
+    crate::tracing::telemetry::send_standalone_shadow_event_with_peer_id(
+        "broadcast_payload_mix",
+        local_peer_id,
+        payload.clone(),
+    );
+    payload
+}
+
+/// Spawn the `broadcast_payload_mix` aggregator and register it with the
+/// [`BackgroundTaskMonitor`].
+///
+/// Always-on and cheap: it only swaps atomics and drains a bounded map once
+/// per [`ROLLUP_WINDOW`]. Observation only — nothing reads these counters to
+/// make a decision, and nothing on the hot path ever reads them at all.
+pub(crate) fn spawn_payload_mix_aggregator(local_peer_id: String, monitor: &BackgroundTaskMonitor) {
+    let handle = tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(ROLLUP_WINDOW);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        ticker.tick().await; // skip the immediate first tick
+        loop {
+            ticker.tick().await;
+            emit_payload_mix_rollup(&local_peer_id, ROLLUP_WINDOW.as_secs());
+        }
+    });
+    monitor.register("broadcast_payload_mix_aggregator", handle);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn contract(byte: u8) -> ContractInstanceId {
+        ContractInstanceId::new([byte; 32])
+    }
+
+    /// Draining leaves the accumulator empty so consecutive rollups report
+    /// windows, not lifetime totals.
+    #[test]
+    fn drain_resets_the_window() {
+        let mix = PayloadMix::new();
+        mix.record_delivered(PayloadArm::Delta, &contract(1), 100);
+        let first = mix.drain();
+        assert_eq!(first[PayloadArm::Delta.index()].1, 1);
+        assert_eq!(first[PayloadArm::Delta.index()].2, 100);
+        let second = mix.drain();
+        assert!(
+            second
+                .iter()
+                .all(|(_, sends, bytes)| *sends == 0 && *bytes == 0),
+            "second drain must be empty, got {second:?}"
+        );
+    }
+
+    /// Every arm lands in its own bucket — a mis-indexed arm would silently
+    /// attribute bytes to the wrong cause, which is the entire point of this
+    /// module.
+    #[test]
+    fn each_arm_counts_separately() {
+        let mix = PayloadMix::new();
+        for (i, arm) in PayloadArm::ALL.iter().enumerate() {
+            for _ in 0..=i {
+                mix.record_delivered(*arm, &contract(i as u8), 10);
+            }
+        }
+        let drained = mix.drain();
+        for (i, (arm, sends, bytes)) in drained.iter().enumerate() {
+            assert_eq!(*arm, PayloadArm::ALL[i]);
+            assert_eq!(*sends, i as u64 + 1, "wrong send count for {arm:?}");
+            assert_eq!(*bytes, (i as u64 + 1) * 10, "wrong byte count for {arm:?}");
+        }
+    }
+
+    /// Only full-state arms are counted as full-state bytes; a delta-heavy
+    /// node must not look like it is flooding whole states.
+    #[test]
+    fn full_state_share_excludes_deltas() {
+        let arms = vec![
+            (PayloadArm::Delta, 3, 300),
+            (PayloadArm::FullDeltaSuppressed, 0, 0),
+            (PayloadArm::FullNotEfficient, 1, 700),
+            (PayloadArm::FullComputeFailed, 0, 0),
+            (PayloadArm::FullNoSummary, 0, 0),
+        ];
+        let json = payload_mix_json(&arms, &[], 0, 60);
+        assert_eq!(json["total_bytes"], 1000);
+        assert_eq!(json["full_state_bytes"], 700);
+        assert_eq!(json["full_state_byte_share"], 0.7);
+        assert_eq!(json["delta_sends"], 3);
+        assert_eq!(json["full_not_efficient_bytes"], 700);
+    }
+
+    /// A window with no traffic must emit 0.0, not NaN — `Number::from_f64`
+    /// rejects NaN and the field would silently become null.
+    #[test]
+    fn empty_window_reports_zero_share_not_nan() {
+        let arms: Vec<_> = PayloadArm::ALL.iter().map(|a| (*a, 0, 0)).collect();
+        let json = payload_mix_json(&arms, &[], 0, 60);
+        assert_eq!(json["full_state_byte_share"], 0.0);
+        assert_eq!(json["total_bytes"], 0);
+    }
+
+    /// Per-contract attribution is capped, and the overflow is reported
+    /// rather than silently truncated.
+    #[test]
+    fn contract_attribution_is_bounded_and_reports_overflow() {
+        let mix = PayloadMix::new();
+        for i in 0..(MAX_TRACKED_CONTRACTS + 20) {
+            let mut raw = [0u8; 32];
+            raw[0] = (i % 256) as u8;
+            raw[1] = (i / 256) as u8;
+            mix.attribute_full_state(&ContractInstanceId::new(raw), 5);
+        }
+        assert!(
+            mix.contract_full_state_bytes.len() <= MAX_TRACKED_CONTRACTS,
+            "attribution map exceeded its cap: {}",
+            mix.contract_full_state_bytes.len()
+        );
+        let (top, dropped) = mix.drain_contracts();
+        assert_eq!(
+            dropped, 20,
+            "overflow must be reported, not dropped silently"
+        );
+        assert!(top.len() <= TOP_CONTRACTS_REPORTED);
+        assert!(mix.contract_full_state_bytes.is_empty(), "drain must clear");
+        // Draining also resets the dropped counter, so the next window starts
+        // clean rather than re-reporting this window's overflow.
+        let (_, dropped_again) = mix.drain_contracts();
+        assert_eq!(dropped_again, 0, "dropped counter must reset on drain");
+    }
+
+    /// Ties break deterministically on contract id so the reported top-N is
+    /// stable across nodes and windows.
+    #[test]
+    fn top_contracts_sort_is_deterministic() {
+        let mix = PayloadMix::new();
+        mix.attribute_full_state(&contract(9), 100);
+        mix.attribute_full_state(&contract(2), 100);
+        mix.attribute_full_state(&contract(5), 500);
+        let (top, _) = mix.drain_contracts();
+        assert_eq!(top[0].0, contract(5), "largest first");
+        assert_eq!(top[1].0, contract(2), "tie broken by contract id");
+        assert_eq!(top[2].0, contract(9));
+    }
+
+    /// Deltas must never be attributed to a contract's full-state tally.
+    #[test]
+    fn delta_sends_are_not_attributed_as_full_state() {
+        let mix = PayloadMix::new();
+        mix.record_delivered(PayloadArm::Delta, &contract(7), 1234);
+        let (top, _) = mix.drain_contracts();
+        assert!(
+            top.is_empty(),
+            "delta bytes leaked into full-state attribution: {top:?}"
+        );
+        // ...but the delta itself is still counted in the per-arm totals.
+        let arms = mix.drain();
+        assert_eq!(arms[PayloadArm::Delta.index()].2, 1234);
+    }
+
+    /// Every full-state arm attributes to the contract; this is what names
+    /// the offending contracts in the rollup.
+    #[test]
+    fn every_full_state_arm_attributes_to_its_contract() {
+        for arm in PayloadArm::ALL.iter().filter(|a| a.is_full_state()) {
+            let mix = PayloadMix::new();
+            mix.record_delivered(*arm, &contract(3), 99);
+            let (top, _) = mix.drain_contracts();
+            assert_eq!(
+                top,
+                vec![(contract(3), 99)],
+                "{arm:?} must attribute its full-state bytes to the contract"
+            );
+        }
+    }
+}

--- a/crates/core/src/node/network_bridge/broadcast_queue.rs
+++ b/crates/core/src/node/network_bridge/broadcast_queue.rs
@@ -20,7 +20,7 @@ use crate::node::OpManager;
 use crate::ring::PeerKeyLocation;
 use crate::transport::BroadcastDeliveryOutcome;
 
-use super::broadcast_payload_mix::{BROADCAST_PAYLOAD_MIX, PayloadArm};
+use super::broadcast_payload_mix::PayloadArm;
 use super::p2p_protoc::P2pBridge;
 
 /// Timeout for awaiting stream completion signal before releasing the permit
@@ -1095,7 +1095,9 @@ pub(super) async fn broadcast_to_single_peer(
                     );
                     // Same delivery gate as the cost axis above, so the mix and
                     // the cost axis always agree on what "sent" means (#3335).
-                    BROADCAST_PAYLOAD_MIX.record_delivered(payload_arm, key.id(), payload_size);
+                    op_manager
+                        .payload_mix
+                        .record_delivered(payload_arm, key.id(), payload_size);
                     tracing::debug!(
                         tx = %update_tx,
                         peer = %peer_addr,
@@ -1139,7 +1141,9 @@ pub(super) async fn broadcast_to_single_peer(
             );
             // Same delivery gate as the cost axis above, so the mix and the
             // cost axis always agree on what "sent" means (#3335).
-            BROADCAST_PAYLOAD_MIX.record_delivered(payload_arm, key.id(), payload_size);
+            op_manager
+                .payload_mix
+                .record_delivered(payload_arm, key.id(), payload_size);
             // Delta-incompat attribution (HQk7 resync loop): remember that we
             // just delivered a DELTA to this peer so a prompt `ResyncRequest`
             // from it can be attributed to the delta failing to apply (deltas
@@ -2159,13 +2163,34 @@ mod tests {
         // The mix is recorded at exactly the two real-delivery sites, the same
         // gate as BroadcastFanoutCost, so the two axes always agree on what
         // "sent" means. Recording up-front would count phantom fan-out.
-        let record_needle = concat!("BROADCAST_PAYLOAD_MIX", ".record_delivered(");
+        // Anchor on the call, not the receiver: rustfmt splits
+        // `op_manager.payload_mix.record_delivered(..)` across lines, so a
+        // receiver-shaped needle would be whitespace-fragile.
+        let record_needle = concat!(".record_", "delivered(payload_arm, key.id(), payload_size)");
         assert_eq!(
             body.matches(record_needle).count(),
             2,
             "payload mix must be recorded at exactly the two real-delivery \
              sites (streaming Delivered + inline send Ok) — recording up-front \
              would count dropped/failed sends as bytes on the wire"
+        );
+        // ...and it must be THIS node's accumulator, never a process global:
+        // several nodes share a process in the simulation harness and the
+        // aggregator drains destructively, so a global would let one node's
+        // ticker steal another's records.
+        assert_eq!(
+            body.matches(concat!(
+                "op_manager",
+                "\n",
+                "                        .payload_mix"
+            ))
+            .count()
+                + body
+                    .matches(concat!("op_manager", "\n                .payload_mix"))
+                    .count(),
+            2,
+            "the payload mix must be recorded on op_manager.payload_mix (the \
+             per-node accumulator), not a process-global static"
         );
 
         // The `NotEfficient` / `ComputeFailed` split is the load-bearing one:

--- a/crates/core/src/node/network_bridge/broadcast_queue.rs
+++ b/crates/core/src/node/network_bridge/broadcast_queue.rs
@@ -855,7 +855,16 @@ pub(super) async fn broadcast_to_single_peer(
     // tag is carried to the real-delivery sites below and recorded there, so
     // the mix counts bytes that actually reached the wire.
     let (payload, sent_delta, payload_arm) = match (&our_summary, &their_summary) {
-        _ if deltas_suppressed => (
+        // Scoped to the both-summaries-present case ON PURPOSE. When a summary
+        // is missing a delta was impossible regardless of the memo, so letting
+        // the suppression guard win there would credit the memo for a full
+        // state it did not cause — overstating `FullDeltaSuppressed` and
+        // undercounting `FullNoSummary`, which is exactly the distinction this
+        // instrumentation exists to draw. Behavior is unchanged either way (a
+        // missing summary falls to the `_` arm, which also sends full state and
+        // also never reaches `compute_delta`), so this is purely about
+        // attributing the bytes to the right cause.
+        (Some(_), Some(_)) if deltas_suppressed => (
             DeltaOrFullState::FullState(new_state.as_ref().to_vec()),
             false,
             PayloadArm::FullDeltaSuppressed,
@@ -1632,11 +1641,24 @@ mod tests {
              doomed delta is still computed and sent"
         );
         assert!(
-            body.contains("_ if deltas_suppressed => ("),
+            body.contains("if deltas_suppressed => ("),
             "suppression must short-circuit the payload match to FullState"
         );
-        // The guard arm must be FIRST in the payload match: Rust evaluates
-        // arms in order, so `_ if deltas_suppressed` has to precede the
+        // The guard is deliberately scoped to `(Some(_), Some(_))` rather than
+        // `_`: with a summary missing a delta was impossible anyway, so a
+        // wildcard guard would credit the memo for a full state it did not
+        // cause and skew the #3335 payload-mix attribution. Safety is
+        // unaffected — `compute_delta` lives only in the `(Some(ours),
+        // Some(theirs))` arm, so a suppressed contract cannot reach it via
+        // either path.
+        assert!(
+            body.contains("(Some(_), Some(_)) if deltas_suppressed => ("),
+            "the suppression guard must be scoped to the both-summaries-present \
+             case — a wildcard guard mis-attributes missing-summary full states \
+             to FullDeltaSuppressed (#3335 payload-mix accuracy)"
+        );
+        // The guard arm must still be FIRST in the payload match: Rust
+        // evaluates arms in order, so it has to precede the
         // `(Some(ours), Some(theirs))` compute_delta arm — otherwise a
         // suppressed contract with both summaries present would compute and
         // send the doomed delta (or, post-#4901, hit the Ok(None) converged
@@ -1644,7 +1666,7 @@ mod tests {
         // above precedes the match regardless, so only this arm-ordering
         // assertion catches a reordering regression.
         let guard_arm = body
-            .find("_ if deltas_suppressed => (")
+            .find("if deltas_suppressed => (")
             .expect("guard arm not found");
         let compute_arm = body
             .find("(Some(ours), Some(theirs)) => {")

--- a/crates/core/src/node/network_bridge/broadcast_queue.rs
+++ b/crates/core/src/node/network_bridge/broadcast_queue.rs
@@ -20,6 +20,7 @@ use crate::node::OpManager;
 use crate::ring::PeerKeyLocation;
 use crate::transport::BroadcastDeliveryOutcome;
 
+use super::broadcast_payload_mix::{BROADCAST_PAYLOAD_MIX, PayloadArm};
 use super::p2p_protoc::P2pBridge;
 
 /// Timeout for awaiting stream completion signal before releasing the permit
@@ -845,11 +846,19 @@ pub(super) async fn broadcast_to_single_peer(
         );
     }
 
-    // Compute delta if we have their summary
-    let (payload, sent_delta) = match (&our_summary, &their_summary) {
+    // Compute delta if we have their summary.
+    //
+    // Every arm below is tagged with the `PayloadArm` that produced it. The
+    // three full-state arms have completely different remedies, and until
+    // #3335 none of them were separately instrumented — the production
+    // measurement could see that large states go out whole but not why. The
+    // tag is carried to the real-delivery sites below and recorded there, so
+    // the mix counts bytes that actually reached the wire.
+    let (payload, sent_delta, payload_arm) = match (&our_summary, &their_summary) {
         _ if deltas_suppressed => (
             DeltaOrFullState::FullState(new_state.as_ref().to_vec()),
             false,
+            PayloadArm::FullDeltaSuppressed,
         ),
         (Some(ours), Some(theirs)) => {
             match op_manager
@@ -857,7 +866,11 @@ pub(super) async fn broadcast_to_single_peer(
                 .compute_delta(op_manager, &key, theirs, ours, new_state.size())
                 .await
             {
-                Ok(Some(delta)) => (DeltaOrFullState::Delta(delta.as_ref().to_vec()), true),
+                Ok(Some(delta)) => (
+                    DeltaOrFullState::Delta(delta.as_ref().to_vec()),
+                    true,
+                    PayloadArm::Delta,
+                ),
                 Ok(None) => {
                     // The contract computed an EMPTY delta against the peer's
                     // summary: the peer is logically converged despite the
@@ -884,9 +897,22 @@ pub(super) async fn broadcast_to_single_peer(
                         error = %err,
                         "Delta computation failed, falling back to full state"
                     );
+                    // Split the refusal from a genuine failure: `NotEfficient`
+                    // means no contract code ran at all — the gate declined a
+                    // delta because the peer's summary is >= 50 % of our state,
+                    // and we then send the whole state, which is never smaller.
+                    let arm = match err {
+                        crate::ring::interest::DeltaUnavailable::NotEfficient { .. } => {
+                            PayloadArm::FullNotEfficient
+                        }
+                        crate::ring::interest::DeltaUnavailable::ComputeFailed(_) => {
+                            PayloadArm::FullComputeFailed
+                        }
+                    };
                     (
                         DeltaOrFullState::FullState(new_state.as_ref().to_vec()),
                         false,
+                        arm,
                     )
                 }
             }
@@ -894,6 +920,7 @@ pub(super) async fn broadcast_to_single_peer(
         _ => (
             DeltaOrFullState::FullState(new_state.as_ref().to_vec()),
             false,
+            PayloadArm::FullNoSummary,
         ),
     };
     let payload_size = payload.size();
@@ -1057,6 +1084,9 @@ pub(super) async fn broadcast_to_single_peer(
                         crate::topology::meter::ResourceType::BroadcastFanoutCost,
                         payload_size as f64,
                     );
+                    // Same delivery gate as the cost axis above, so the mix and
+                    // the cost axis always agree on what "sent" means (#3335).
+                    BROADCAST_PAYLOAD_MIX.record_delivered(payload_arm, key.id(), payload_size);
                     tracing::debug!(
                         tx = %update_tx,
                         peer = %peer_addr,
@@ -1098,6 +1128,9 @@ pub(super) async fn broadcast_to_single_peer(
                 crate::topology::meter::ResourceType::BroadcastFanoutCost,
                 payload_size as f64,
             );
+            // Same delivery gate as the cost axis above, so the mix and the
+            // cost axis always agree on what "sent" means (#3335).
+            BROADCAST_PAYLOAD_MIX.record_delivered(payload_arm, key.id(), payload_size);
             // Delta-incompat attribution (HQk7 resync loop): remember that we
             // just delivered a DELTA to this peer so a prompt `ResyncRequest`
             // from it can be attributed to the delta failing to apply (deltas
@@ -2058,6 +2091,70 @@ mod tests {
             2,
             "each delivery-gated bytes report must charge the selected \
              payload_size (delta or full state), not the pre-delta full-state size"
+        );
+    }
+
+    /// Source-scrape pin for the payload-mix arm tagging (#3335).
+    ///
+    /// Same precedent as the cost-report pin above (the "Manually-mirrored
+    /// telemetry counters" row in `.claude/rules/bug-prevention-patterns.md`):
+    /// a refactor that drops an arm tag, or re-tags a full-state fallback as
+    /// `Delta`, silently corrupts the measurement that decides which fan-out
+    /// fix to build — and every behavioral test stays green, because the
+    /// fan-out still works. The whole point of this instrumentation is that
+    /// the four full-state causes are distinguishable, so pin that each one
+    /// is constructed exactly where it is decided.
+    #[test]
+    fn broadcast_to_single_peer_tags_every_payload_arm_pin() {
+        let src = include_str!("broadcast_queue.rs");
+        let fn_start = src
+            .find("pub(super) async fn broadcast_to_single_peer(")
+            .expect("broadcast_to_single_peer not found");
+        let after = &src[fn_start..];
+        let fn_end = after
+            .find("\nmod tests {")
+            .or_else(|| after.find("\n#[cfg(test)]"))
+            .expect("end of broadcast_to_single_peer (start of tests module) not found");
+        let body = &after[..fn_end];
+
+        // Every arm must be constructed in the selection match. A missing arm
+        // means some payload is attributed to the wrong cause (or to none).
+        for arm in [
+            "PayloadArm::Delta",
+            "PayloadArm::FullDeltaSuppressed",
+            "PayloadArm::FullNotEfficient",
+            "PayloadArm::FullComputeFailed",
+            "PayloadArm::FullNoSummary",
+        ] {
+            assert!(
+                body.contains(arm),
+                "broadcast_to_single_peer must tag the {arm} arm — an untagged \
+                 fallback makes the #3335 payload-mix measurement attribute \
+                 bytes to the wrong cause"
+            );
+        }
+
+        // The mix is recorded at exactly the two real-delivery sites, the same
+        // gate as BroadcastFanoutCost, so the two axes always agree on what
+        // "sent" means. Recording up-front would count phantom fan-out.
+        let record_needle = concat!("BROADCAST_PAYLOAD_MIX", ".record_delivered(");
+        assert_eq!(
+            body.matches(record_needle).count(),
+            2,
+            "payload mix must be recorded at exactly the two real-delivery \
+             sites (streaming Delivered + inline send Ok) — recording up-front \
+             would count dropped/failed sends as bytes on the wire"
+        );
+
+        // The `NotEfficient` / `ComputeFailed` split is the load-bearing one:
+        // the first means no contract code ran and we shipped a whole state
+        // anyway, the second means the WASM failed. Collapsing them back into
+        // one arm loses the distinction the measurement exists to make.
+        assert!(
+            body.contains("DeltaUnavailable::NotEfficient")
+                && body.contains("DeltaUnavailable::ComputeFailed"),
+            "the delta-failure arm must keep the typed NotEfficient vs \
+             ComputeFailed split — collapsing them re-blinds the measurement"
         );
     }
 }

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -162,6 +162,16 @@ pub(crate) struct OpManager {
         Arc<Mutex<std::collections::HashMap<ContractInstanceId, Vec<oneshot::Sender<()>>>>>,
     /// Neighbor hosting manager for tracking neighbor contract hosting
     pub neighbor_hosting: Arc<NeighborHostingManager>,
+    /// Fan-out payload-mix accumulator (#3335): which arm of the broadcast
+    /// payload selection put bytes on the wire, and which contracts those
+    /// full states belong to.
+    ///
+    /// Owned PER NODE rather than as a process global on purpose — several
+    /// `NodeP2P` instances share a process in the simulation harness, and the
+    /// aggregator drains this destructively, so a global would let one node's
+    /// ticker steal every other node's records and publish them under its own
+    /// peer id. See [`PayloadMix`](crate::node::network_bridge::broadcast_payload_mix::PayloadMix).
+    pub payload_mix: Arc<crate::node::network_bridge::broadcast_payload_mix::PayloadMix>,
     /// Interest manager for delta-based state synchronization.
     ///
     /// Its clock comes from the same injectable
@@ -315,6 +325,7 @@ impl Clone for OpManager {
             is_gateway: self.is_gateway,
             contract_waiters: self.contract_waiters.clone(),
             neighbor_hosting: self.neighbor_hosting.clone(),
+            payload_mix: self.payload_mix.clone(),
             interest_manager: self.interest_manager.clone(),
             broadcast_dedup_cache: self.broadcast_dedup_cache.clone(),
             update_propagation_stats: self.update_propagation_stats.clone(),
@@ -518,6 +529,9 @@ impl OpManager {
             is_gateway,
             contract_waiters,
             neighbor_hosting,
+            payload_mix: Arc::new(
+                crate::node::network_bridge::broadcast_payload_mix::PayloadMix::new(),
+            ),
             interest_manager,
             broadcast_dedup_cache: Arc::new(crate::operations::update::BroadcastDedupCache::new()),
             update_propagation_stats,

--- a/crates/core/src/node/p2p_impl.rs
+++ b/crates/core/src/node/p2p_impl.rs
@@ -849,6 +849,10 @@ impl NodeP2P {
             && !config.config.telemetry.is_test_environment
             && config.config.telemetry.iface_tx_enabled;
         let local_peer_id = config.local_peer_id_string();
+        // Cloned up front: `local_peer_id` is moved into the iface-tx spawn
+        // below, but the payload-mix aggregator is spawned later (it needs
+        // `op_manager`, which does not exist yet).
+        let payload_mix_peer_id = local_peer_id.clone();
         crate::transport::rolling_rtt_stats::spawn_aggregator(
             local_peer_id.clone(),
             &background_task_monitor,
@@ -862,14 +866,6 @@ impl NodeP2P {
             &background_task_monitor,
         );
         crate::transport::shadow_demand::spawn_outbound_class_aggregator(
-            local_peer_id.clone(),
-            &background_task_monitor,
-        );
-        // Fan-out payload-mix rollup (#3335): which arm of the payload
-        // selection put bytes on the wire (delta vs each of the four
-        // full-state fallbacks), and which contracts those full states belong
-        // to. Always-on and observation-only, same as the aggregators above.
-        crate::node::network_bridge::broadcast_payload_mix::spawn_payload_mix_aggregator(
             local_peer_id.clone(),
             &background_task_monitor,
         );
@@ -897,6 +893,19 @@ impl NodeP2P {
             &background_task_monitor,
         )?);
         op_manager.ring.attach_op_manager(&op_manager);
+
+        // Fan-out payload-mix rollup (#3335): which arm of the payload
+        // selection put bytes on the wire (delta vs each of the four
+        // full-state fallbacks), and which contracts those full states belong
+        // to. Always-on and observation-only, same as the shadow aggregators
+        // above. Spawned HERE rather than with them because it reads this
+        // node's own accumulator, which lives on `op_manager` — a process
+        // global would let one node's ticker drain another's records.
+        crate::node::network_bridge::broadcast_payload_mix::spawn_payload_mix_aggregator(
+            op_manager.payload_mix.clone(),
+            payload_mix_peer_id,
+            &background_task_monitor,
+        );
 
         let contract_handler = CH::build(ch_inbound, op_manager.clone(), ch_builder)
             .await

--- a/crates/core/src/node/p2p_impl.rs
+++ b/crates/core/src/node/p2p_impl.rs
@@ -866,7 +866,7 @@ impl NodeP2P {
             &background_task_monitor,
         );
         // Fan-out payload-mix rollup (#3335): which arm of the payload
-        // selection put bytes on the wire (delta vs each of the three
+        // selection put bytes on the wire (delta vs each of the four
         // full-state fallbacks), and which contracts those full states belong
         // to. Always-on and observation-only, same as the aggregators above.
         crate::node::network_bridge::broadcast_payload_mix::spawn_payload_mix_aggregator(

--- a/crates/core/src/node/p2p_impl.rs
+++ b/crates/core/src/node/p2p_impl.rs
@@ -865,6 +865,14 @@ impl NodeP2P {
             local_peer_id.clone(),
             &background_task_monitor,
         );
+        // Fan-out payload-mix rollup (#3335): which arm of the payload
+        // selection put bytes on the wire (delta vs each of the three
+        // full-state fallbacks), and which contracts those full states belong
+        // to. Always-on and observation-only, same as the aggregators above.
+        crate::node::network_bridge::broadcast_payload_mix::spawn_payload_mix_aggregator(
+            local_peer_id.clone(),
+            &background_task_monitor,
+        );
         if reference_ping_enabled {
             crate::transport::reference_ping::spawn_reference_ping(
                 local_peer_id.clone(),

--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -3842,7 +3842,7 @@ async fn compute_probe_reverse_delta(
 /// heal via a normal GET / anti-entropy. Kept as a pure function so the three
 /// arms are unit-testable without a live contract handler.
 fn reverse_delta_from_compute_result(
-    computed: Result<Option<StateDelta<'static>>, String>,
+    computed: Result<Option<StateDelta<'static>>, crate::ring::interest::DeltaUnavailable>,
 ) -> Option<StateDelta<'static>> {
     computed.unwrap_or(None)
 }
@@ -4383,11 +4383,25 @@ mod tests {
         // Delta inefficient or uncomputable: send nothing — the originator
         // heals via a normal GET / anti-entropy instead of receiving a
         // bloated or absent delta.
-        let inefficient =
-            reverse_delta_from_compute_result(Err("Delta not efficient for this contract".into()));
+        // Both Err variants must behave identically here: the reverse leg
+        // ships nothing whether the wire-efficiency gate refused up front or
+        // the contract's delta computation failed.
+        let inefficient = reverse_delta_from_compute_result(Err(
+            crate::ring::interest::DeltaUnavailable::NotEfficient {
+                summary_size: 600,
+                state_size: 1000,
+            },
+        ));
         assert!(
             inefficient.is_none(),
-            "Err (inefficient/uncomputable) must send NO reverse delta"
+            "Err (gate refused as inefficient) must send NO reverse delta"
+        );
+        let uncomputable = reverse_delta_from_compute_result(Err(
+            crate::ring::interest::DeltaUnavailable::ComputeFailed("wasm exploded".into()),
+        ));
+        assert!(
+            uncomputable.is_none(),
+            "Err (delta computation failed) must send NO reverse delta"
         );
     }
 

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -322,6 +322,45 @@ pub fn is_delta_efficient(summary_size: usize, state_size: usize) -> bool {
     summary_size * 2 < state_size
 }
 
+/// Why [`InterestManager::compute_delta`] could not hand back a delta.
+///
+/// Typed rather than a bare `String` so callers can tell the two cases apart:
+/// they have different remedies, and the fan-out's payload-mix telemetry
+/// ([`crate::node::network_bridge::broadcast_payload_mix`]) reports them as
+/// separate arms. Every caller falls back to sending FULL STATE, which is
+/// never smaller than the delta that was declined — see #3335.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DeltaUnavailable {
+    /// The wire-efficiency gate ([`is_delta_efficient`]) refused *before* any
+    /// delta was computed, because the peer's summary is >= 50 % of our state
+    /// size. No contract code ran.
+    NotEfficient {
+        summary_size: usize,
+        state_size: usize,
+    },
+    /// A delta was attempted and the contract handler failed — WASM error,
+    /// timeout, or an unexpected response.
+    ComputeFailed(String),
+}
+
+impl std::fmt::Display for DeltaUnavailable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            // Keep the historical prefix so existing log greps still match;
+            // the sizes are additive.
+            DeltaUnavailable::NotEfficient {
+                summary_size,
+                state_size,
+            } => write!(
+                f,
+                "Delta not efficient for this contract (summary {summary_size} B, \
+                 state {state_size} B)"
+            ),
+            DeltaUnavailable::ComputeFailed(msg) => write!(f, "{msg}"),
+        }
+    }
+}
+
 /// Decide whether a peer that reported `their_summary` is stale relative to our
 /// `our_summary` — i.e. whether the InterestSync heartbeat should heal it with
 /// our state.
@@ -1434,7 +1473,7 @@ impl<T: TimeSource + Sync> InterestManager<T> {
         their_summary: &StateSummary<'static>,
         our_summary: &StateSummary<'static>,
         our_state_size: usize,
-    ) -> Result<Option<StateDelta<'static>>, String> {
+    ) -> Result<Option<StateDelta<'static>>, DeltaUnavailable> {
         use crate::contract::ContractHandlerEvent;
 
         // Use slices directly - cache methods hash internally, no allocation needed
@@ -1454,7 +1493,10 @@ impl<T: TimeSource + Sync> InterestManager<T> {
         // Check if delta would be efficient
         // (summary > 50% of state size means delta probably won't help)
         if !is_delta_efficient(their_summary_bytes.len(), our_state_size) {
-            return Err("Delta not efficient for this contract".to_string());
+            return Err(DeltaUnavailable::NotEfficient {
+                summary_size: their_summary_bytes.len(),
+                state_size: our_state_size,
+            });
         }
 
         // Compute delta via contract handler (short timeout for broadcast path)
@@ -1484,11 +1526,17 @@ impl<T: TimeSource + Sync> InterestManager<T> {
                     Ok(Some(d))
                 }
             }
-            Ok(ContractHandlerEvent::GetDeltaResponse { delta: Err(e), .. }) => {
-                Err(format!("Delta computation failed: {}", e))
-            }
-            Ok(other) => Err(format!("Unexpected response to GetDeltaQuery: {:?}", other)),
-            Err(e) => Err(format!("Error computing delta: {}", e)),
+            Ok(ContractHandlerEvent::GetDeltaResponse { delta: Err(e), .. }) => Err(
+                DeltaUnavailable::ComputeFailed(format!("Delta computation failed: {}", e)),
+            ),
+            Ok(other) => Err(DeltaUnavailable::ComputeFailed(format!(
+                "Unexpected response to GetDeltaQuery: {:?}",
+                other
+            ))),
+            Err(e) => Err(DeltaUnavailable::ComputeFailed(format!(
+                "Error computing delta: {}",
+                e
+            ))),
         }
     }
 


### PR DESCRIPTION
## Problem

A production telemetry measurement on 2026-07-24 ([posted to #3335](https://github.com/freenet/freenet-core/issues/3335#issuecomment-5074264001)), prompted by a user reporting 4 GB of traffic in 90 minutes. Measuring one full telemetry rotation (~3 h, ~521 reporting peers, 93 % on 0.2.105) confirmed the report and showed the fleet baseline is high:

| percentile | combined rate | per day |
|---|---|---|
| median | 72 KB/s | ~6 GB |
| p90 | 255 KB/s | ~22 GB |
| p99 | 606 KB/s | ~52 GB |

81 % of outbound is bulk contract-state transfer. ~85 % of byte-weighted broadcast work is on contracts holding >= 500 KB of state, and **only 36 of 2,164 distinct contracts ever produced a real state change**.

What the measurement could **not** determine is *why* those large states go out whole. `broadcast_to_single_peer` has four distinct paths that send FULL STATE instead of a delta, none separately instrumented:

1. the `delta_incompat` memo is armed (#4904);
2. the wire-efficiency gate (`is_delta_efficient`) refused *before* computing anything, because the peer's summary is >= 50 % of our state size;
3. delta computation was attempted and failed;
4. no cached summary for one side of the pair.

Those four have different remedies, so without the split any fix is a guess. This PR closes that gap and nothing else — it is observation-only and changes no network behavior.

## Approach

Each arm is tagged where the payload is selected and recorded at the **two real-delivery sites**, the same gate that charges `BroadcastFanoutCost`, so the mix and the cost axis agree on what "sent" means and a dropped send never counts phantom bytes.

`compute_delta` returns a typed `DeltaUnavailable` instead of a bare `String`, so "the gate refused, no contract code ran" is distinguishable from "the contract failed". Its `Display` keeps the historical message prefix and adds the sizes.

A per-minute `broadcast_payload_mix` rollup reports per-arm sends and bytes, the full-state byte share, and the top contracts by full-state bytes.

**All window state lives behind a single `parking_lot::Mutex`** and is taken with one `mem::take`. This is deliberate and is the documented `.claude/rules/code-style.md` exception to preferring `DashMap`: the rollup needs an atomic read-modify-write across multiple keys (all arms plus the contract map) in one transaction, otherwise the aggregate and per-contract fields describe different sets of broadcasts. Cost is one short uncontended lock per *delivered broadcast* (not per packet), on a path that has already done WASM delta computation and a network write. `record_delivered` is a sync fn with no `.await` inside, so the guard cannot span an await point.

The published schema is designed to **add up**:

```
sum(top_contracts) + other_contracts_bytes + attribution_dropped_bytes == full_state_bytes
```

`other_contracts_bytes` covers contracts tracked but outside the reported top-N; `attribution_dropped_bytes` covers contracts the 256-entry cap refused to track at all. These are different omissions and conflating them hid a real gap (see review log below).

The simulation-only `broadcast_state_to_peers` is deliberately not instrumented; the production fan-out is the single site.

## Review log

Five rounds of external (Codex) review. **Four found real defects, all fixed:**

1. **Non-atomic window rollover.** Arm counters and the contract map drained at different instants, so an increment landing between sampling a map entry and `clear()` was lost, and one broadcast could be counted in one window for the aggregate and the next for per-contract fields. Fixed by the single-lock design above.
2. **`contracts_dropped` counted sends, not contracts.** One over-cap contract broadcasting 1,000 times read as "1,000 contracts dropped". Renamed `attribution_dropped_sends` and paired with `attribution_dropped_bytes`.
3. **The `deltas_suppressed` guard used a `_` wildcard**, so a missing-summary send was labelled memo-suppressed even though a delta was impossible anyway — overstating the memo, undercounting `FullNoSummary`. Scoped to `(Some(_), Some(_))`. Behavior unchanged; `compute_delta` lives only in the `(Some, Some)` arm, so the delta-incompat safety property holds on both paths.
4. **`window_secs` reported the nominal 60** even though `MissedTickBehavior::Delay` lets a saturated runtime stretch the real window, inflating every derived rate — worst exactly when the node is busiest. Now reports actual elapsed.
5. **The published schema didn't reconcile.** With 11..=256 contracts the top-N truncation dropped bytes no field accounted for. Added `other_contracts_bytes` + `contracts_tracked`.

Finding 5 is worth calling out: the existing reconciliation test *passed* while the bug was live, because it summed the in-memory map rather than the JSON a consumer receives. The test now asserts through `payload_mix_json`.

## Testing

- 14 unit tests: arm separation, window reset, delta-vs-full share (incl. the empty-window NaN boundary), bounded attribution with overflow reporting, deterministic tie-breaking, delta bytes never leaking into full-state attribution, actual-vs-nominal window duration, and schema reconciliation across truncation, over-cap, and both together.
- A multi-threaded `concurrent_records_racing_a_rollup_conserve_bytes` test: writer threads against a concurrent drain loop, asserting no byte is lost or double-counted across a rollover.
- Source-scrape pins: every arm is constructed, the mix is recorded at exactly the two delivery sites, the NotEfficient/ComputeFailed split survives refactors, and the suppression guard stays scoped.
- Full lib suite green (4285 passed, 0 failed). `cargo fmt` clean on the CI-pinned 1.93.0. `cargo clippy` reports nothing in any touched file. (Pre-existing clippy-1.94 lints in untouched files are a known separate follow-up.)

## Known gaps

- **The four-perspective Claude review panel did not run.** Six subagents were spawned across two attempts; every one went idle without producing a report. This PR therefore had one external model plus direct checks, not the Full-tier panel the review rule asks for on a broadcast-path change.
- **One unidentified test failure.** A single test failed once during a run sharing the machine with a concurrent clippy compile and a hot-spin loop in the new concurrency test. It did not reproduce across nine subsequent full-suite runs; the hot spin was removed. The failing test was never identified.
- **`broadcast_payload_mix` is not in the durable shadow-telemetry extractor's `EVENT_TYPES` allowlist** on nova. Raw telemetry retains ~3 days, so without that entry the data ages out before much accumulates. That script lives in the admin repo and deploys to nova, so it is not part of this PR.

Refs #3335. Overlaps #3798 (assigned to @iduartgomez), which closed the fan-out *width* gap in #4520/#4596; this is the payload *size* half. Follow-up hypothesis and the heavy contracts are in #4923.

[AI-assisted - Claude]
