### PR TITLE
fix: skip redundant queue-full resync retry when the first request landed (#4863)

### DIFF
--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -4972,10 +4972,13 @@ mod tests {
 
         // Seed the outstanding entry: WE sent a ResyncRequest to `source` for
         // `key`, so the incoming response is solicited.
-        op_manager
-            .ring
-            .outstanding_resync_requests
-            .record(*key.id(), source);
+        assert!(
+            op_manager
+                .ring
+                .outstanding_resync_requests
+                .record(*key.id(), source),
+            "seeding the outstanding entry must correlate (map is empty here)"
+        );
         assert_eq!(
             op_manager.ring.outstanding_resync_requests.len(),
             1,

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -1206,6 +1206,22 @@ async fn send_queue_full_resync_request(
         reason = "queue_full",
         "UPDATE relay: sending rate-limited ResyncRequest after queue-full drop (#4857)"
     );
+    // #4864 round-8: record the outstanding request so the matching ResyncResponse
+    // from this peer is authorized ONCE at the receive arm; an unsolicited or
+    // replayed response finds no entry and is dropped without running WASM.
+    //
+    // #4863: this MUST stay ABOVE the retry spawn below. The retry's conditional
+    // gate READS this record to decide whether the first request already landed
+    // (the receive arm consumes it on a matching ResyncResponse), so a retry task
+    // that could observe a not-yet-written record would conclude "landed" and skip
+    // the heal. Recording first makes that race structurally impossible; pinned by
+    // `queue_full_resync_retry_is_bounded_and_reservation_scoped`. Recording is a
+    // non-blocking map insert, so it does not delay the spawn (#4862 P2).
+    op_manager
+        .ring
+        .outstanding_resync_requests
+        .record(*key.id(), sender_addr);
+
     // #4862 (P2): the immediate ResyncRequest below rides a LOSSY path
     // (`notify_node_event` → event loop → `P2pBridge::try_send`), which can drop
     // it under the SAME backpressure that caused the queue-full drop. If dropped,
@@ -1222,8 +1238,11 @@ async fn send_queue_full_resync_request(
     // throttle's own clock) so it can NEVER spill into a new reservation. The
     // retries re-deliver the ONE already-authorized emit, so they do NOT
     // re-consult the per-sender throttle or the global emit cap and do NOT
-    // re-record the outstanding request (a redundant response for an
-    // already-consumed record is correctly dropped by #4864 before WASM).
+    // re-record the correlation entry recorded above.
+    //
+    // #4863: each attempt is CONDITIONAL on that correlation entry still being
+    // outstanding, so a retry fires only while the first request is NOT observed
+    // to have landed.
     //
     // #4862 P1: gate the spawn on a node-wide retry-task slot so the throttle LRU
     // evicting active reservations under key churn cannot spawn unbounded
@@ -1244,18 +1263,10 @@ async fn send_queue_full_resync_request(
         });
     }
 
-    // #4864 round-8: record the outstanding request (immediately before the emit
-    // so the round-8 pin's proximity check holds) so the matching ResyncResponse
-    // from this peer is authorized ONCE at the receive arm; an unsolicited or
-    // replayed response finds no entry and is dropped without running WASM. The
-    // #4862 trailing retry above re-sends the SAME request and relies on THIS one
-    // record — see `resend_queue_full_resync_request`.
-    op_manager
-        .ring
-        .outstanding_resync_requests
-        .record(*key.id(), sender_addr);
-
-    // Immediate (first) ResyncRequest — blocking best-effort enqueue.
+    // Immediate (first) ResyncRequest — blocking best-effort enqueue. The
+    // #4862 trailing retry above re-sends the SAME request and relies on the ONE
+    // correlation record made before the spawn — see
+    // `resend_queue_full_resync_request`.
     if let Err(e) = op_manager
         .notify_node_event(NodeEvent::SendInterestMessage {
             target: sender_addr,
@@ -1348,12 +1359,22 @@ fn jittered_resync_retry_delay(attempt: u32) -> Duration {
 /// clocks coincide and the injected stop fires first, so the floor is a no-op;
 /// it only takes effect when the injected clock stalls.
 ///
+/// Conditional (#4863): each attempt re-dispatches ONLY while the caller's
+/// request is still outstanding in the correlation map. The `ResyncResponse`
+/// receive arm consumes that entry before applying, so its absence means the
+/// heal already landed end-to-end — and re-dispatching then would make the sender
+/// clear its summary and ship FULL STATE again onto a receiver whose queue was
+/// just full (up to [`QUEUE_FULL_RESYNC_MAX_RETRIES`] redundant full-state
+/// responses per drop). The check is READ-ONLY (`is_outstanding`, never
+/// `consume`): consuming the entry here would make the genuine response look
+/// unsolicited and be dropped without applying.
+///
 /// Storm bound (#4251 / #4864 cap): this fn RE-DELIVERS the one already-authorized
 /// emit — it deliberately does NOT call `begin_resync_request` (no new
 /// reservation), does NOT consume a `resync_emit_limiter` token (no new global
-/// emit), and does NOT re-record `outstanding_resync_requests` (the initial
-/// record authorizes the eventual response once; a redundant response is dropped
-/// by #4864 before WASM). All its sends belong to the single reservation already
+/// emit), and does NOT re-record the correlation entry (the caller's one record
+/// authorizes the eventual response once; a redundant response is dropped by
+/// #4864 before WASM). All its sends belong to the single reservation already
 /// granted by the caller. Combined with the deadline stop, steady-state stays
 /// capped at one reservation (≤ `1 + MAX` sends) per (contract, peer) per window.
 ///
@@ -1436,6 +1457,49 @@ async fn resend_queue_full_resync_request(
                 return;
             }
             tokio::time::sleep(QUEUE_FULL_RESYNC_RETRY_POLL_INTERVAL).await;
+        }
+
+        // #4863: CONDITIONAL re-dispatch. Every ResyncRequest makes the sender
+        // clear its cached summary of us and re-send FULL contract state, so a
+        // BLIND retry lands up to MAX redundant full-state ResyncResponses on a
+        // receiver whose queue was full moments ago. Re-dispatch only while the
+        // request is NOT observed to have landed.
+        //
+        // The signal is the #4864 round-8 correlation record: the ResyncResponse
+        // receive arm (node.rs) require-and-CONSUMES the (contract, sender) entry
+        // before applying, so its absence is an END-TO-END confirmation — the
+        // request landed, the sender answered, and we authorized the answer. Any
+        // other reason the entry is gone (never recorded at the strict cap, or
+        // TTL-expired) means the eventual response would be dropped as
+        // unsolicited, so a re-dispatch could not heal anything either way. See
+        // `OutstandingResyncRequests::is_outstanding`.
+        //
+        // Read-only on purpose: the retry must NOT consume the entry — that
+        // authorization belongs to the receive arm, and consuming it here would
+        // make the real response look unsolicited (dropped without applying).
+        //
+        // Return, don't continue: once the heal has landed every REMAINING
+        // attempt is redundant too, and returning frees the node-wide retry slot
+        // (#4862 P1) via its RAII guard instead of holding it for the rest of the
+        // window. The residual case this cannot cover is a request that landed but
+        // whose response is still in flight — bounded by the same `1 + MAX` cap as
+        // before, never worse than the blind retry it replaces.
+        if !op_manager
+            .ring
+            .outstanding_resync_requests
+            .is_outstanding(*key.id(), sender_addr)
+        {
+            tracing::debug!(
+                tx = %incoming_tx,
+                contract = %key,
+                target = %sender_addr,
+                attempt,
+                event = "queue_full_resync_retry_skipped_landed",
+                "UPDATE relay: queue-full ResyncRequest already landed (its \
+                 ResyncResponse was consumed), skipping the redundant \
+                 full-state re-dispatch (#4863)"
+            );
+            return;
         }
 
         match op_manager.try_notify_node_event(NodeEvent::SendInterestMessage {
@@ -4510,14 +4574,26 @@ mod tests {
                 continue;
             }
             emits += 1;
-            // Look back a bounded window for the record call that authorizes the
-            // ResyncResponse this emit will provoke (fmt-robust: match the field
-            // identifier, which survives line-wrapping of the method chain).
-            let window_start = pos.saturating_sub(600);
+            // Look back to the start of the ENCLOSING production fn for the record
+            // call that authorizes the ResyncResponse this emit will provoke
+            // (fmt-robust: match the field identifier, which survives
+            // line-wrapping of the method chain).
+            //
+            // This was a fixed 600-byte lookback until #4863 moved the queue-full
+            // helper's record ABOVE the retry spawn — the retry's conditional gate
+            // reads that record, so it must exist before the task can observe it —
+            // which pushed the record out of a byte window that was always an
+            // arbitrary proxy for "same statement sequence". Scoping to the
+            // enclosing fn keeps the real guarantee (an emit is preceded by its
+            // record, on the same code path) without the brittle distance.
+            let fn_start = prod[..pos]
+                .rfind("\nasync fn ")
+                .max(prod[..pos].rfind("\nfn "))
+                .unwrap_or(0);
             assert!(
-                prod[window_start..pos].contains("outstanding_resync_requests"),
+                prod[fn_start..pos].contains("outstanding_resync_requests"),
                 "a production ResyncRequest emit at byte {pos} is NOT preceded by an \
-                 outstanding_resync_requests.record(...) within 600 bytes — the \
+                 outstanding_resync_requests.record(...) in the same fn — the \
                  receive arm would drop its response as unsolicited (#4864 round-8)"
             );
         }
@@ -5163,6 +5239,178 @@ mod tests {
         );
     }
 
+    /// Issue #4863: the #4862 trailing retry must be CONDITIONAL — it must NOT
+    /// re-dispatch once the first queue-full `ResyncRequest` is observed to have
+    /// landed. Every `ResyncRequest` makes the sender clear its cached summary
+    /// of us and re-send FULL contract state, so a blind retry lands up to
+    /// `QUEUE_FULL_RESYNC_MAX_RETRIES` redundant full-state `ResyncResponse`s on
+    /// a receiver whose queue was full moments ago — the exact amplification the
+    /// #4251 storm bound exists to avoid.
+    ///
+    /// The observed-landed signal is the #4864 round-8 correlation record: the
+    /// `ResyncResponse` receive arm (`node.rs`) require-and-CONSUMES the
+    /// `(contract, sender)` entry before applying, so the entry's absence is an
+    /// END-TO-END confirmation that the request landed, the sender answered, and
+    /// we authorized the answer.
+    ///
+    /// This drives ONE queue-full drop, then simulates the response landing
+    /// exactly the way the receive arm does (consume the record), then advances
+    /// the throttle's clock across the whole retry burst window. NO retry may
+    /// fire. It also asserts the node-wide retry slot (#4862 P1) is RELEASED on
+    /// the skip rather than burned.
+    #[tokio::test(start_paused = true)]
+    async fn queue_full_resync_retry_skipped_once_response_landed() {
+        let (op_manager, mut notification_rx, _guard) =
+            build_queue_full_test_node("queue-full-resync-4863-landed").await;
+        let key = ContractKey::from_id_and_code(
+            ContractInstanceId::new([17u8; 32]),
+            CodeHash::new([18u8; 32]),
+        );
+        let sender_addr: SocketAddr = "127.0.0.1:12700".parse().unwrap();
+
+        let r1 = drive_relay_broadcast_to(
+            &op_manager,
+            Transaction::new::<UpdateMsg>(),
+            key,
+            DeltaOrFullState::Delta(vec![1, 2, 3]),
+            Vec::new(),
+            sender_addr,
+        )
+        .await;
+        assert!(
+            r1.as_ref()
+                .err()
+                .is_some_and(|e| e.is_contract_queue_full()),
+            "expected a queue-full error from the stand-in handler, got {r1:?}"
+        );
+        assert_eq!(
+            drain_resync_targets(&mut notification_rx, key),
+            vec![sender_addr],
+            "the immediate (pre-retry) ResyncRequest must fire exactly once"
+        );
+
+        // The sender's `ResyncResponse` arrives: `node.rs`'s receive arm
+        // require-and-consumes the outstanding correlation record before applying
+        // the full state. Doing exactly that here IS the "first request landed"
+        // event, from the retry's point of view.
+        assert!(
+            op_manager
+                .ring
+                .outstanding_resync_requests
+                .consume(*key.id(), sender_addr),
+            "the helper must have recorded the outstanding request, so the \
+             matching ResyncResponse is authorized once (#4864 round-8)"
+        );
+
+        // Advance the throttle's clock across the whole retry burst (20s, under
+        // the 30s reservation deadline) — the same pacing the blind-retry test
+        // uses to observe both retries.
+        let mut retries = Vec::new();
+        for _ in 0..40 {
+            tokio::time::advance(Duration::from_millis(500)).await;
+            tokio::task::yield_now().await;
+            retries.extend(drain_resync_targets(&mut notification_rx, key));
+        }
+
+        assert!(
+            retries.is_empty(),
+            "the first ResyncRequest already landed (its ResyncResponse was \
+             received and consumed), so the trailing retry MUST NOT re-dispatch \
+             — each redundant request costs another full-state ResyncResponse \
+             onto a just-saturated receiver (#4863). Got {retries:?}"
+        );
+        assert_eq!(
+            op_manager.interest_manager.outstanding_resync_retries(),
+            0,
+            "skipping the retry must RELEASE the node-wide retry slot (the task \
+             returns and its RAII guard drops), never burn it (#4862 P1)"
+        );
+    }
+
+    /// Issue #4863 (edge case): the conditional gate is re-evaluated on EVERY
+    /// attempt, not just the first. When the `ResyncResponse` lands between
+    /// retry 1 and retry 2, retry 1 legitimately fired (nothing had landed yet)
+    /// but retry 2 MUST be skipped.
+    ///
+    /// This is the partial-heal case a first-attempt-only check would miss, and
+    /// it also proves the gate stops the burst rather than merely delaying it.
+    #[tokio::test(start_paused = true)]
+    async fn queue_full_resync_retry_stops_at_the_attempt_after_response_lands() {
+        let (op_manager, mut notification_rx, _guard) =
+            build_queue_full_test_node("queue-full-resync-4863-midburst").await;
+        let key = ContractKey::from_id_and_code(
+            ContractInstanceId::new([19u8; 32]),
+            CodeHash::new([20u8; 32]),
+        );
+        let sender_addr: SocketAddr = "127.0.0.1:12800".parse().unwrap();
+
+        let r1 = drive_relay_broadcast_to(
+            &op_manager,
+            Transaction::new::<UpdateMsg>(),
+            key,
+            DeltaOrFullState::Delta(vec![1, 2, 3]),
+            Vec::new(),
+            sender_addr,
+        )
+        .await;
+        assert!(
+            r1.as_ref()
+                .err()
+                .is_some_and(|e| e.is_contract_queue_full()),
+            "expected a queue-full error from the stand-in handler, got {r1:?}"
+        );
+        assert_eq!(
+            drain_resync_targets(&mut notification_rx, key),
+            vec![sender_addr],
+            "the immediate (pre-retry) ResyncRequest must fire exactly once"
+        );
+
+        // Nothing has landed yet → the FIRST retry must still fire (the #4857
+        // heal for a genuinely bridge-dropped request is preserved).
+        let mut retries = Vec::new();
+        for _ in 0..20 {
+            tokio::time::advance(Duration::from_millis(500)).await;
+            tokio::task::yield_now().await;
+            retries.extend(drain_resync_targets(&mut notification_rx, key));
+            if !retries.is_empty() {
+                break;
+            }
+        }
+        assert_eq!(
+            retries.len(),
+            1,
+            "with nothing landed, the first trailing retry MUST still fire \
+             (preserves the #4857 heal), got {retries:?}"
+        );
+
+        // NOW the response lands (receive arm consumes the correlation record).
+        assert!(
+            op_manager
+                .ring
+                .outstanding_resync_requests
+                .consume(*key.id(), sender_addr),
+            "the outstanding record must still be present before the response lands"
+        );
+
+        // Advance across the remaining burst window; retry 2 must be skipped.
+        for _ in 0..30 {
+            tokio::time::advance(Duration::from_millis(500)).await;
+            tokio::task::yield_now().await;
+            retries.extend(drain_resync_targets(&mut notification_rx, key));
+        }
+        assert_eq!(
+            retries.len(),
+            1,
+            "once the response lands mid-burst, every REMAINING attempt must be \
+             skipped — the gate is re-evaluated per attempt (#4863). Got {retries:?}"
+        );
+        assert_eq!(
+            op_manager.interest_manager.outstanding_resync_retries(),
+            0,
+            "the retry task must exit and free its node-wide slot (#4862 P1)"
+        );
+    }
+
     /// Issue #4857 (P2, review P2-A): the trailing retry burst is anchored to
     /// the reservation deadline on the throttle's OWN clock. If the injected
     /// clock crosses that deadline before a retry's target is reached, the retry
@@ -5257,6 +5505,16 @@ mod tests {
         // so `now >= target` and `now >= reservation_deadline` never hold and
         // only the tokio backstop can stop the task.
         let reservation_deadline = op_manager.interest_manager.now() + Duration::from_secs(30);
+
+        // This test drives the retry DIRECTLY, so it must first do what the real
+        // caller (`send_queue_full_resync_request`) does: record the outstanding
+        // request. Without it the #4863 landed-gate would short-circuit every
+        // attempt and this test would pass for the WRONG reason (skipped, not
+        // stopped by the liveness backstop).
+        op_manager
+            .ring
+            .outstanding_resync_requests
+            .record(*key.id(), sender_addr);
 
         let op_mgr = op_manager.clone();
         let handle = tokio::spawn(async move {
@@ -5381,6 +5639,14 @@ mod tests {
         // Deadline only 500ms out — much less than jittered_resync_retry_delay(1)
         // (~1.6-2.4s), so a fixed first target would exceed it.
         let reservation_deadline = op_manager.interest_manager.now() + Duration::from_millis(500);
+        // Driving the retry DIRECTLY, so record the outstanding request the way
+        // the real caller (`send_queue_full_resync_request`) does — otherwise the
+        // #4863 landed-gate skips every attempt and this test would fail for a
+        // reason unrelated to the clamp it is pinning.
+        op_manager
+            .ring
+            .outstanding_resync_requests
+            .record(*key.id(), sender_addr);
         let op_mgr = op_manager.clone();
         let handle = tokio::spawn(async move {
             resend_queue_full_resync_request(
@@ -5500,20 +5766,58 @@ mod tests {
              begin_resync_request into the retry (anchor to the window, P2-A)"
         );
 
+        // (1d) #4863: the correlation record MUST be written BEFORE the retry
+        // spawn. The retry's conditional gate READS that record to decide whether
+        // the first request already landed; a task spawned before the record
+        // exists could observe "absent", conclude "landed", and skip the heal.
+        let record = helper.find(".record(*key.id(), sender_addr)").expect(
+            "helper must record the outstanding request for receive-arm \
+             correlation (#4864 round-8)",
+        );
+        assert!(
+            record < spawn,
+            "the outstanding-request record ({record}) MUST precede the retry \
+             spawn ({spawn}) — the retry's #4863 conditional gate reads it, and a \
+             task that could observe a not-yet-written record would skip the heal"
+        );
+
         // (2) The retry body RE-DELIVERS the one already-authorized emit: it must
         // NOT re-consult the per-sender throttle (begin_resync_request), the
-        // global emit cap (resync_emit_limiter), or re-record the outstanding
-        // request (outstanding_resync_requests) — so it creates no new reservation
-        // and consumes no extra global token (storm bound #4251 / #4864 cap).
+        // global emit cap (resync_emit_limiter), re-record the correlation entry
+        // (`.record(`), or CONSUME it (`.consume(` — that one-shot authorization
+        // belongs to the receive arm; consuming it here would make the genuine
+        // ResyncResponse look unsolicited). So the retry creates no new
+        // reservation and consumes no extra global token (storm bound #4251 /
+        // #4864 cap).
         let retry = fn_body("async fn resend_queue_full_resync_request(");
         assert!(
             !retry.contains("begin_resync_request")
                 && !retry.contains("resync_emit_limiter")
-                && !retry.contains("outstanding_resync_requests"),
-            "resend_queue_full_resync_request must NOT re-consult the throttle, the \
-             global emit cap, or re-record the outstanding request — its sends \
-             belong to the caller's single granted reservation (storm bound \
-             #4251 / #4864 cap)"
+                && !retry.contains(".record(")
+                && !retry.contains(".consume("),
+            "resend_queue_full_resync_request must NOT re-consult the throttle or \
+             the global emit cap, and must neither re-record NOR consume the \
+             outstanding-request entry — its sends belong to the caller's single \
+             granted reservation, and the entry's consumption belongs to the \
+             ResyncResponse receive arm (storm bound #4251 / #4864 cap)"
+        );
+
+        // (2a) #4863: every re-dispatch is GATED on the outstanding-request entry
+        // still being present (read-only). A blind retry re-sends a request that
+        // already landed, which makes the sender clear its summary and ship FULL
+        // STATE again onto a receiver whose queue was just full.
+        let landed_gate = retry.find("is_outstanding(").expect(
+            "the retry must gate each re-dispatch on \
+             outstanding_resync_requests.is_outstanding(...) (#4863)",
+        );
+        let retry_emit = retry
+            .find("try_notify_node_event(")
+            .expect("the retry must emit via the non-blocking try_notify_node_event");
+        assert!(
+            landed_gate < retry_emit,
+            "the #4863 landed-gate ({landed_gate}) MUST be checked BEFORE the \
+             re-dispatch ({retry_emit}) — checking after would send the redundant \
+             request anyway"
         );
         assert!(
             retry.contains("in 1..=QUEUE_FULL_RESYNC_MAX_RETRIES"),

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -1217,7 +1217,14 @@ async fn send_queue_full_resync_request(
     // the heal. Recording first makes that race structurally impossible; pinned by
     // `queue_full_resync_retry_is_bounded_and_reservation_scoped`. Recording is a
     // non-blocking map insert, so it does not delay the spawn (#4862 P2).
-    op_manager
+    // `false` = the strict cap rejected a brand-new key, so the request is
+    // UNCORRELATED. The retry's gate must then fall back to unconditional
+    // re-dispatch: `is_outstanding` would read `false` forever, and reading that
+    // as "landed" would silently disable the retry node-wide while the map is
+    // full. A re-dispatch still heals when uncorrelated — the responder clears
+    // its cached summary on the ResyncRequest itself (#4857), independently of
+    // our correlation record; only the full-state ResyncResponse needs it.
+    let correlated = op_manager
         .ring
         .outstanding_resync_requests
         .record(*key.id(), sender_addr);
@@ -1258,6 +1265,7 @@ async fn send_queue_full_resync_request(
                 sender_addr,
                 incoming_tx,
                 reservation_deadline,
+                correlated,
             )
             .await;
         });
@@ -1362,12 +1370,27 @@ fn jittered_resync_retry_delay(attempt: u32) -> Duration {
 /// Conditional (#4863): each attempt re-dispatches ONLY while the caller's
 /// request is still outstanding in the correlation map. The `ResyncResponse`
 /// receive arm consumes that entry before applying, so its absence means the
-/// heal already landed end-to-end — and re-dispatching then would make the sender
-/// clear its summary and ship FULL STATE again onto a receiver whose queue was
-/// just full (up to [`QUEUE_FULL_RESYNC_MAX_RETRIES`] redundant full-state
-/// responses per drop). The check is READ-ONLY (`is_outstanding`, never
-/// `consume`): consuming the entry here would make the genuine response look
-/// unsolicited and be dropped without applying.
+/// response arrived and was AUTHORIZED (not necessarily applied — the consume
+/// precedes the apply, which can still fail). Re-dispatching then would make the
+/// sender clear its summary and ship FULL STATE again onto a receiver whose
+/// queue was just full (up to [`QUEUE_FULL_RESYNC_MAX_RETRIES`] redundant
+/// full-state responses per drop). The check is READ-ONLY (`is_outstanding`,
+/// never `consume`): consuming the entry here would make the genuine response
+/// look unsolicited and be dropped without applying.
+///
+/// The gate applies ONLY when `correlated` — see the caller. An uncorrelated
+/// request (strict-cap rejection) reads `is_outstanding == false` forever, so
+/// gating on it unconditionally would disable this retry node-wide whenever the
+/// map is full.
+///
+/// Scale note: against a peer running >= v0.2.102 the responder's own
+/// `resync_response_limiter` already caps it at ONE full-state reply per
+/// (peer, contract) per 30s, and the whole retry burst lives inside one such
+/// window — so there the redundant responses were already suppressed at the
+/// source. The amplification this gate removes is reachable against peers older
+/// than that, i.e. it shrinks as the fleet upgrades. The gate is still worth
+/// having: it also stops the redundant REQUESTS, and it is the only bound that
+/// does not depend on the remote peer's version.
 ///
 /// Storm bound (#4251 / #4864 cap): this fn RE-DELIVERS the one already-authorized
 /// emit — it deliberately does NOT call `begin_resync_request` (no new
@@ -1391,6 +1414,7 @@ async fn resend_queue_full_resync_request(
     sender_addr: SocketAddr,
     incoming_tx: Transaction,
     reservation_deadline: Instant,
+    correlated: bool,
 ) {
     // Tokio-clock liveness backstop (DST safety). The injected `reservation_deadline`
     // below is the PRIMARY stop, but if the injected clock is a DECOUPLED
@@ -1467,12 +1491,19 @@ async fn resend_queue_full_resync_request(
         //
         // The signal is the #4864 round-8 correlation record: the ResyncResponse
         // receive arm (node.rs) require-and-CONSUMES the (contract, sender) entry
-        // before applying, so its absence is an END-TO-END confirmation — the
-        // request landed, the sender answered, and we authorized the answer. Any
-        // other reason the entry is gone (never recorded at the strict cap, or
-        // TTL-expired) means the eventual response would be dropped as
-        // unsolicited, so a re-dispatch could not heal anything either way. See
-        // `OutstandingResyncRequests::is_outstanding`.
+        // before applying, so its absence means the request landed, the sender
+        // answered, and we AUTHORIZED the answer. It observes authorization, not
+        // application — the receive arm consumes before applying and the apply can
+        // still fail — so this is not an end-to-end heal confirmation. It is still
+        // the right stop signal: a redundant response would be dropped by the
+        // consume-once gate anyway, so re-dispatching cannot repair a failed apply.
+        //
+        // Gated on `correlated` (#4863 review): when the strict cap rejected the
+        // record, `is_outstanding` reads false FOREVER, and treating that as
+        // "landed" would silently disable this retry node-wide while the map is
+        // full. Uncorrelated requests fall back to unconditional re-dispatch,
+        // which still heals — the responder clears its cached summary on the
+        // ResyncRequest itself (#4857), with no dependence on our record.
         //
         // Read-only on purpose: the retry must NOT consume the entry — that
         // authorization belongs to the receive arm, and consuming it here would
@@ -1484,12 +1515,20 @@ async fn resend_queue_full_resync_request(
         // window. The residual case this cannot cover is a request that landed but
         // whose response is still in flight — bounded by the same `1 + MAX` cap as
         // before, never worse than the blind retry it replaces.
-        if !op_manager
-            .ring
-            .outstanding_resync_requests
-            .is_outstanding(*key.id(), sender_addr)
+        if correlated
+            && !op_manager
+                .ring
+                .outstanding_resync_requests
+                .is_outstanding(*key.id(), sender_addr)
         {
-            tracing::debug!(
+            // info!, not debug!: `release_max_level_info` compiles debug out of
+            // release builds, and this is the ONLY field-visible signal of the
+            // gate's decision. Both the benefit (fewer redundant full-state
+            // resends) and the main risk (a gate that wrongly skips silently
+            // loses the #4857 heal) are unfalsifiable without it. Rate is
+            // bounded by the per-(contract, peer) reservation, so this cannot
+            // become a log storm.
+            tracing::info!(
                 tx = %incoming_tx,
                 contract = %key,
                 target = %sender_addr,
@@ -1838,7 +1877,12 @@ async fn drive_relay_broadcast_to(
                     // matching ResyncResponse from this peer is authorized (once)
                     // at the receive arm; unsolicited/replayed responses are
                     // dropped without running WASM.
-                    op_manager
+                    //
+                    // The correlated/uncorrelated distinction only matters for the
+                    // queue-full retry's gate (#4863); this path has no retry, so
+                    // a strict-cap rejection just means the eventual response is
+                    // dropped as unsolicited and anti-entropy heals instead.
+                    let _correlated = op_manager
                         .ring
                         .outstanding_resync_requests
                         .record(*key.id(), sender_addr);
@@ -4586,12 +4630,34 @@ mod tests {
             // arbitrary proxy for "same statement sequence". Scoping to the
             // enclosing fn keeps the real guarantee (an emit is preceded by its
             // record, on the same code path) without the brittle distance.
-            let fn_start = prod[..pos]
-                .rfind("\nasync fn ")
-                .max(prod[..pos].rfind("\nfn "))
-                .unwrap_or(0);
+            // Anchor on the LAST fn-opening token before the emit. Must cover
+            // visibility-prefixed forms (`pub async fn`, `pub(crate) async fn`):
+            // matching only "\nasync fn "/"\nfn " would skip past a `pub` fn and
+            // anchor to an EARLIER one, whose window may contain an unrelated
+            // record — a false pass for exactly the regression this pin catches.
+            let fn_start = [
+                "\nasync fn ",
+                "\nfn ",
+                "\npub async fn ",
+                "\npub fn ",
+                "\npub(",
+            ]
+            .iter()
+            .filter_map(|kw| prod[..pos].rfind(kw))
+            .max()
+            .unwrap_or(0);
+            // Require the identifier to be part of an actual `.record(` call, not
+            // merely mentioned. #4863 added the first NON-recording use of this
+            // field (`is_outstanding`), so a bare identifier match would let a
+            // READ satisfy a pin whose entire purpose is to require a WRITE.
+            // Whitespace-stripped so rustfmt line-wrapping of the method chain
+            // cannot break the match.
+            let window: String = prod[fn_start..pos]
+                .chars()
+                .filter(|c| !c.is_whitespace())
+                .collect();
             assert!(
-                prod[fn_start..pos].contains("outstanding_resync_requests"),
+                window.contains("outstanding_resync_requests.record("),
                 "a production ResyncRequest emit at byte {pos} is NOT preceded by an \
                  outstanding_resync_requests.record(...) in the same fn — the \
                  receive arm would drop its response as unsolicited (#4864 round-8)"
@@ -5506,12 +5572,18 @@ mod tests {
         // only the tokio backstop can stop the task.
         let reservation_deadline = op_manager.interest_manager.now() + Duration::from_secs(30);
 
-        // This test drives the retry DIRECTLY, so it must first do what the real
-        // caller (`send_queue_full_resync_request`) does: record the outstanding
-        // request. Without it the #4863 landed-gate would short-circuit every
-        // attempt and this test would pass for the WRONG reason (skipped, not
-        // stopped by the liveness backstop).
-        op_manager
+        // This test drives the retry DIRECTLY, so it does what the real caller
+        // (`send_queue_full_resync_request`) does and records the outstanding
+        // request first.
+        //
+        // Note this record is INERT here, and deliberately so: the injected clock
+        // is frozen at ~0, so `now >= target` never holds and the wait loop can
+        // only exit via the tokio liveness backstop — the #4863 landed-gate below
+        // it is never reached. The record keeps the fixture faithful to the real
+        // caller (and makes the test strictly stricter if the gate ever does
+        // become reachable on this path) but it is NOT what makes this test pass,
+        // and this test does NOT cover the gate on the frozen-clock path.
+        let _correlated = op_manager
             .ring
             .outstanding_resync_requests
             .record(*key.id(), sender_addr);
@@ -5524,6 +5596,7 @@ mod tests {
                 sender_addr,
                 Transaction::new::<UpdateMsg>(),
                 reservation_deadline,
+                true,
             )
             .await;
         });
@@ -5642,8 +5715,10 @@ mod tests {
         // Driving the retry DIRECTLY, so record the outstanding request the way
         // the real caller (`send_queue_full_resync_request`) does — otherwise the
         // #4863 landed-gate skips every attempt and this test would fail for a
-        // reason unrelated to the clamp it is pinning.
-        op_manager
+        // reason unrelated to the clamp it is pinning. (Unlike the frozen-clock
+        // test, the gate IS reachable here — the 500ms deadline clamps the first
+        // target to ~250ms, which the injected clock does reach.)
+        let _correlated = op_manager
             .ring
             .outstanding_resync_requests
             .record(*key.id(), sender_addr);
@@ -5655,6 +5730,7 @@ mod tests {
                 sender_addr,
                 Transaction::new::<UpdateMsg>(),
                 reservation_deadline,
+                true,
             )
             .await;
         });
@@ -5875,6 +5951,19 @@ mod tests {
             worst_case < Duration::from_secs(30),
             "worst-case retry span {worst_case:?} must stay under the 30s \
              RESYNC_REQUEST_MIN_INTERVAL reservation window (interest.rs)"
+        );
+        // #4863: the whole retry span must ALSO stay inside the correlation
+        // entry's TTL. The conditional gate reads `is_outstanding`, which goes
+        // false once the entry expires — so a TTL at or below the retry span
+        // would silently turn the #4862 heal into a no-op for later attempts
+        // (they would read "landed" and skip) with entirely green CI. Nothing
+        // else couples these two constants, so pin the relationship here.
+        assert!(
+            worst_case < crate::ring::resync_rate_limit::OUTSTANDING_RESYNC_TTL,
+            "worst-case retry span {worst_case:?} must stay under the outstanding \
+             correlation TTL {:?} — otherwise a later attempt reads its own \
+             expired entry as 'landed' and silently skips the #4862 heal (#4863)",
+            crate::ring::resync_rate_limit::OUTSTANDING_RESYNC_TTL
         );
     }
 

--- a/crates/core/src/ring/resync_rate_limit.rs
+++ b/crates/core/src/ring/resync_rate_limit.rs
@@ -348,6 +348,33 @@ impl OutstandingResyncRequests {
         }
     }
 
+    /// Read-only: is there a NON-EXPIRED outstanding request for
+    /// `(contract, peer)`?
+    ///
+    /// Unlike [`Self::consume`] this does NOT remove the entry, so the receive
+    /// arm's one-shot authorization stays intact.
+    ///
+    /// This is the "did our `ResyncRequest` land?" signal for the queue-full
+    /// resync retry (#4863). The entry is removed exactly when a matching
+    /// `ResyncResponse` is accepted at the receive arm, so `false` means one of:
+    ///
+    /// - the response already arrived and was applied — the heal is DONE and
+    ///   re-sending the request would only make the sender clear its summary and
+    ///   ship full state again, onto a receiver whose queue was just full;
+    /// - the request was never correlated (a brand-new key dropped at the strict
+    ///   cap in [`Self::record`]) — then the eventual response would be rejected
+    ///   as unsolicited anyway, so re-sending cannot heal anything either;
+    /// - the entry expired (TTL) — same rejection, same conclusion.
+    ///
+    /// In every case a re-dispatch is pointless, so the retry skips. `true`
+    /// (request still outstanding) is the only case where a retry can help.
+    pub fn is_outstanding(&self, contract: ContractInstanceId, peer: SocketAddr) -> bool {
+        let now = self.time_source.now();
+        self.entries
+            .get(&(contract, peer))
+            .is_some_and(|emitted| now.saturating_duration_since(*emitted) <= self.ttl)
+    }
+
     /// Drop entries older than the TTL. Call from the Ring reaper so a burst of
     /// requests whose responses never arrive cannot pin memory past the TTL.
     pub fn cleanup(&self) {
@@ -423,6 +450,56 @@ mod tests {
         );
     }
 
+    /// #4863: `is_outstanding` is the queue-full retry's "did our request land?"
+    /// signal. It must be READ-ONLY (leaving the receive arm's one-shot
+    /// authorization intact), scoped per `(contract, peer)`, and TTL-aware — an
+    /// expired entry's response would be rejected anyway, so it is not a live
+    /// request.
+    #[test]
+    fn outstanding_resync_is_outstanding_is_read_only_and_ttl_aware() {
+        let ts = SharedMockTimeSource::new();
+        let m = new_outstanding_resync_requests(Arc::new(ts.clone()));
+        let c = mk_contract(1);
+        let peer = mk_peer(1);
+
+        // Nothing recorded → not outstanding.
+        assert!(!m.is_outstanding(c, peer));
+
+        m.record(c, peer);
+        assert!(m.is_outstanding(c, peer), "a fresh record is outstanding");
+
+        // Scoped per (contract, peer) — a different peer or contract is unrelated.
+        assert!(!m.is_outstanding(c, mk_peer(2)));
+        assert!(!m.is_outstanding(mk_contract(2), peer));
+
+        // READ-ONLY: repeated checks must not remove the entry, so the receive
+        // arm's require-and-consume still succeeds afterwards.
+        assert!(m.is_outstanding(c, peer));
+        assert_eq!(m.len(), 1, "is_outstanding must not remove the entry");
+        assert!(
+            m.consume(c, peer),
+            "the receive arm's one-shot authorization must survive is_outstanding"
+        );
+
+        // Once consumed (the ResyncResponse landed and was applied), the request
+        // is no longer outstanding — this is what makes the retry skip.
+        assert!(
+            !m.is_outstanding(c, peer),
+            "a consumed request must read as landed so the #4863 retry skips"
+        );
+
+        // TTL-aware: an entry past the TTL is not a live request (its response
+        // would be rejected as unsolicited, so re-dispatching cannot heal).
+        m.record(c, peer);
+        ts.advance_time(OUTSTANDING_RESYNC_TTL - Duration::from_millis(1));
+        assert!(
+            m.is_outstanding(c, peer),
+            "just under the TTL is still live"
+        );
+        ts.advance_time(Duration::from_millis(2));
+        assert!(!m.is_outstanding(c, peer), "past the TTL is not live");
+    }
+
     #[test]
     fn outstanding_resync_is_scoped_per_contract_and_peer() {
         let ts = SharedMockTimeSource::new();
@@ -487,6 +564,10 @@ mod tests {
         assert_eq!(m.len(), MAX_TRACKED_KEYS, "over-cap insert is dropped");
         // Its response is therefore treated as unsolicited.
         assert!(!m.consume(overflow_c, overflow_peer));
+        // ...and it reads as NOT outstanding, so the #4863 queue-full retry skips
+        // it: an un-correlated request's response would be dropped without
+        // applying, so re-dispatching it could not heal anything either.
+        assert!(!m.is_outstanding(overflow_c, overflow_peer));
     }
 
     #[test]

--- a/crates/core/src/ring/resync_rate_limit.rs
+++ b/crates/core/src/ring/resync_rate_limit.rs
@@ -314,20 +314,27 @@ impl OutstandingResyncRequests {
     /// response is then treated as unsolicited, so we forgo one heal that
     /// anti-entropy recovers — never a correctness loss, and the cap keeps an
     /// attacker from growing the map by inducing our emissions.
-    pub fn record(&self, contract: ContractInstanceId, target: SocketAddr) {
+    /// Returns `true` iff the request is now CORRELATED (an entry exists). A
+    /// `false` return means the strict cap rejected a brand-new key, so no
+    /// entry was stored — callers that later read [`Self::is_outstanding`] as a
+    /// "did it land?" signal MUST NOT treat that absence as "landed" (#4863).
+    #[must_use]
+    pub fn record(&self, contract: ContractInstanceId, target: SocketAddr) -> bool {
         let now = self.time_source.now();
         use dashmap::mapref::entry::Entry;
         match self.entries.entry((contract, target)) {
             Entry::Occupied(mut occ) => {
                 *occ.get_mut() = now;
+                true
             }
             Entry::Vacant(vac) => {
                 let prev = self.size.fetch_add(1, Ordering::Relaxed);
                 if prev >= self.max_tracked {
                     self.size.fetch_sub(1, Ordering::Relaxed);
-                    return;
+                    return false;
                 }
                 vac.insert(now);
+                true
             }
         }
     }
@@ -356,18 +363,35 @@ impl OutstandingResyncRequests {
     ///
     /// This is the "did our `ResyncRequest` land?" signal for the queue-full
     /// resync retry (#4863). The entry is removed exactly when a matching
-    /// `ResyncResponse` is accepted at the receive arm, so `false` means one of:
+    /// `ResyncResponse` is accepted at the receive arm.
     ///
-    /// - the response already arrived and was applied — the heal is DONE and
-    ///   re-sending the request would only make the sender clear its summary and
+    /// ONLY MEANINGFUL FOR A CORRELATED REQUEST. Callers must gate on
+    /// [`Self::record`] having returned `true`; for an UNCORRELATED request
+    /// (brand-new key rejected by the strict cap) this returns `false`
+    /// immediately and forever, which must NOT be read as "landed". A
+    /// re-dispatch still heals in that case: the responder clears its cached
+    /// summary of us on receiving the `ResyncRequest` itself (`node.rs`,
+    /// `update_peer_summary(.., None)`), which is the #4857 heal and does not
+    /// depend on our correlation record at all. Only the full-state
+    /// `ResyncResponse` needs the record. Treating the cap rejection as
+    /// "landed" would silently disable the retry node-wide while the map is
+    /// full.
+    ///
+    /// So for a correlated request `false` means one of:
+    ///
+    /// - the response arrived and was authorized at the receive arm — the
+    ///   redundant re-dispatch would only make the sender clear its summary and
     ///   ship full state again, onto a receiver whose queue was just full;
-    /// - the request was never correlated (a brand-new key dropped at the strict
-    ///   cap in [`Self::record`]) — then the eventual response would be rejected
-    ///   as unsolicited anyway, so re-sending cannot heal anything either;
-    /// - the entry expired (TTL) — same rejection, same conclusion.
+    /// - the entry expired (TTL) — unreachable inside the retry window, which
+    ///   is bounded by one reservation interval well under the TTL.
     ///
-    /// In every case a re-dispatch is pointless, so the retry skips. `true`
-    /// (request still outstanding) is the only case where a retry can help.
+    /// `true` (request still outstanding) is the case where a retry can help.
+    ///
+    /// Note this observes AUTHORIZATION, not application: the receive arm
+    /// consumes the entry BEFORE applying the state, and the apply can still
+    /// fail (including with another `ContractQueueFull`). Absence therefore
+    /// means "the response arrived and we authorized it", not "the state
+    /// merged".
     pub fn is_outstanding(&self, contract: ContractInstanceId, peer: SocketAddr) -> bool {
         let now = self.time_source.now();
         self.entries
@@ -435,7 +459,7 @@ mod tests {
         );
 
         // We emit a request → the response from that peer is authorized ONCE.
-        m.record(c, peer);
+        assert!(m.record(c, peer), "record must correlate under the cap");
         assert_eq!(m.len(), 1);
         assert!(
             m.consume(c, peer),
@@ -465,7 +489,7 @@ mod tests {
         // Nothing recorded → not outstanding.
         assert!(!m.is_outstanding(c, peer));
 
-        m.record(c, peer);
+        assert!(m.record(c, peer), "record must correlate under the cap");
         assert!(m.is_outstanding(c, peer), "a fresh record is outstanding");
 
         // Scoped per (contract, peer) — a different peer or contract is unrelated.
@@ -490,7 +514,7 @@ mod tests {
 
         // TTL-aware: an entry past the TTL is not a live request (its response
         // would be rejected as unsolicited, so re-dispatching cannot heal).
-        m.record(c, peer);
+        assert!(m.record(c, peer), "record must correlate under the cap");
         ts.advance_time(OUTSTANDING_RESYNC_TTL - Duration::from_millis(1));
         assert!(
             m.is_outstanding(c, peer),
@@ -505,7 +529,10 @@ mod tests {
         let ts = SharedMockTimeSource::new();
         let m = new_outstanding_resync_requests(Arc::new(ts.clone()));
         let c = mk_contract(1);
-        m.record(c, mk_peer(1));
+        assert!(
+            m.record(c, mk_peer(1)),
+            "record must correlate under the cap"
+        );
         // A response for the SAME contract from a DIFFERENT peer is unsolicited.
         assert!(!m.consume(c, mk_peer(2)));
         // A response for a DIFFERENT contract from the recorded peer is unsolicited.
@@ -522,7 +549,7 @@ mod tests {
         let peer = mk_peer(1);
 
         // Just UNDER the TTL → still accepted.
-        m.record(c, peer);
+        assert!(m.record(c, peer), "record must correlate under the cap");
         ts.advance_time(OUTSTANDING_RESYNC_TTL - Duration::from_millis(1));
         assert!(
             m.consume(c, peer),
@@ -530,7 +557,7 @@ mod tests {
         );
 
         // Past the TTL → the stale entry is consumed-and-REJECTED.
-        m.record(c, peer);
+        assert!(m.record(c, peer), "record must correlate under the cap");
         ts.advance_time(OUTSTANDING_RESYNC_TTL + Duration::from_millis(1));
         assert!(
             !m.consume(c, peer),
@@ -539,7 +566,10 @@ mod tests {
         assert_eq!(m.len(), 0, "a consumed (even if stale) entry is removed");
 
         // cleanup() reaps expired entries whose response never arrived.
-        m.record(mk_contract(9), mk_peer(9));
+        assert!(
+            m.record(mk_contract(9), mk_peer(9)),
+            "record must correlate under the cap"
+        );
         assert_eq!(m.len(), 1);
         ts.advance_time(OUTSTANDING_RESYNC_TTL + Duration::from_secs(1));
         m.cleanup();
@@ -554,20 +584,27 @@ mod tests {
         for i in 0..MAX_TRACKED_KEYS {
             let c = ContractInstanceId::new([(i % 256) as u8; 32]);
             let peer = SocketAddr::from(([10, (i >> 16) as u8, (i >> 8) as u8, i as u8], 40000));
-            m.record(c, peer);
+            assert!(m.record(c, peer), "under-cap record must correlate");
         }
         assert_eq!(m.len(), MAX_TRACKED_KEYS, "map fills to exactly the cap");
         // One more distinct key is dropped (fail-closed), not admitted.
         let overflow_c = ContractInstanceId::new([0xAB; 32]);
         let overflow_peer = SocketAddr::from(([172, 16, 0, 1], 41000));
-        m.record(overflow_c, overflow_peer);
+        // #4863: the over-cap record must REPORT the rejection. This bool is what
+        // stops the queue-full retry from mistaking a never-correlated request for
+        // a landed one and disabling itself node-wide while the map is full.
+        assert!(
+            !m.record(overflow_c, overflow_peer),
+            "over-cap record must report the request as UNCORRELATED so the \
+             queue-full retry falls back to unconditional re-dispatch (#4863)"
+        );
         assert_eq!(m.len(), MAX_TRACKED_KEYS, "over-cap insert is dropped");
+        // It reads as NOT outstanding — which is exactly why the retry must not
+        // gate on `is_outstanding` alone for an uncorrelated request. Assert this
+        // BEFORE the mutating `consume` below so the read is unambiguous.
+        assert!(!m.is_outstanding(overflow_c, overflow_peer));
         // Its response is therefore treated as unsolicited.
         assert!(!m.consume(overflow_c, overflow_peer));
-        // ...and it reads as NOT outstanding, so the #4863 queue-full retry skips
-        // it: an un-correlated request's response would be dropped without
-        // applying, so re-dispatching it could not heal anything either.
-        assert!(!m.is_outstanding(overflow_c, overflow_peer));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Follow-up to #4862 (the bounded trailing re-dispatch for the #4857/#4858 queue-full resync).

On a `ContractQueueFull` broadcast drop we send a rate-limited `ResyncRequest` to the sender so it clears its poisoned summary cache and re-sends. #4862 added a bounded trailing re-dispatch so that request still lands if the lossy `notify_node_event` → event loop → `P2pBridge::try_send` path drops it.

That retry is **blind**: it re-dispatches regardless of whether the first request already landed. Every `ResyncRequest` makes the sender clear its cached summary of us and re-send **full contract state**, so when the first request *did* land, each extra retry costs another full-state `ResyncResponse` — up to `QUEUE_FULL_RESYNC_MAX_RETRIES` (2) of them — landing on a receiver whose queue was full moments ago. That is amplification onto a just-saturated queue, the exact shape the #4251 storm bound exists to prevent.

## Solution

Make each retry attempt **conditional** on an observed-landed signal.

**Signal chosen: the #4864 round-8 correlation record** (`OutstandingResyncRequests`). `send_queue_full_resync_request` records `(contract, sender)` when it emits; the `ResyncResponse` receive arm in `node.rs` require-and-**consumes** that entry *before* applying the state. So the entry's absence is an **end-to-end** confirmation: the request landed, the sender answered, and we authorized the answer. Before each re-dispatch the retry asks `is_outstanding(contract, sender)`; if false it logs `queue_full_resync_retry_skipped_landed` and returns.

New read-only accessor `OutstandingResyncRequests::is_outstanding` — **never `consume`**: that one-shot authorization belongs to the receive arm, and consuming it in the retry would make the genuine `ResyncResponse` look unsolicited and be dropped without applying. Pinned by the storm-bound pin test.

`is_outstanding` is TTL-aware, matching `consume`'s acceptance predicate. Every other reason the entry can be absent leads to the same conclusion:

| Entry absent because | Would a re-dispatch help? |
|---|---|
| response arrived + applied (the common case) | No — heal is done |
| response arrived but the apply FAILED | No — the receive arm consumes before applying, and re-pulling a full state that just failed to merge is the #4861 poison-contract storm the merge backoff exists to stop |
| never recorded (brand-new key dropped at the strict `MAX_TRACKED_KEYS` cap) | No — the eventual response would be dropped as unsolicited anyway |
| TTL-expired (unreachable inside the ≤30s retry window; TTL is 60s) | No — same rejection |

**Why not the `P2pBridge::try_send` result** (the issue's option (a)): `try_send` succeeding does **not** mean the request reached the peer — the transport is UDP and the remote side can drop it too. So it is a negative-only signal, and gating retries on locally-observed drops alone would silently lose the #4857 heal in exactly the cases it exists for (sent fine locally, lost on the wire). It would also thread new cross-layer state (a bounded, TTL'd drop map) through the high-risk broadcast dispatch path. Option (b) is both simpler and strictly safer: it can only skip a retry once the heal has demonstrably completed.

**Ordering change:** the correlation record now happens **above** the retry spawn (it was between the spawn and the immediate enqueue). The retry reads that record, so a task spawned before it was written could observe "absent", conclude "landed", and skip the heal. Recording is a non-blocking map insert, so #4862 P2's requirement — spawn *before* the blocking `notify_node_event(...).await` — still holds. Pinned.

### Acceptance criteria

- **No redundant full-state `ResyncResponse` when the first request landed** — covered, with one honest residual (below).
- **#4857 heal preserved** — a genuinely dropped request leaves the record outstanding, so retries fire exactly as before (`queue_full_resync_retry_redispatches_within_reservation` still passes unchanged).
- **#4251 per-`(contract, peer)` storm bound preserved** — the retry still creates no reservation, consumes no global emit token, re-records nothing; the throttle window is untouched (it must not be released — that is the storm bound).
- **#4862 node-wide cap preserved** — and on a skip the retry slot is **released**, not burned: the task returns, dropping its RAII guard, instead of holding the slot for the rest of the window.

### Honest residual

The signal observes the **response**, not the request. A request that landed but whose `ResyncResponse` is still in flight (large state, slow WASM summarize) can still draw a retry. That window is bounded by the same `1 + MAX` per-`(contract, peer)` per-30s cap as before, and each subsequent attempt re-checks — so this is strictly fewer redundant full-state resends than the blind retry, never more. Closing it completely would need a request-level ack, which does not exist on this path.

Also unchanged (pre-existing behavior): if the *delta-failure* resync path records a new request for the same `(contract, sender)` mid-burst, the gate reads "outstanding" and a retry fires. That is the old blind behavior in a rare interleaving, not a regression.

## Testing

**Regression tests written FIRST and verified to FAIL without the fix** (both reported `Got [127.0.0.1:…, 127.0.0.1:…]` — the 2 blind retries — before the production change; both pass after):

- `queue_full_resync_retry_skipped_once_response_landed` (behavioral, `start_paused`) — one queue-full drop, then the response lands exactly the way `node.rs` does it (consume the correlation record), then the clock advances across the whole 20s burst window. **Zero** retries, and `outstanding_resync_retries() == 0` (slot released, not burned).
- `queue_full_resync_retry_stops_at_the_attempt_after_response_lands` (behavioral, edge case) — nothing landed yet, so retry 1 **must still fire** (heal preserved); the response then lands mid-burst and retry 2 must be skipped. Proves the gate is re-evaluated per attempt, not just on the first.

Unit tests for the new accessor:

- `outstanding_resync_is_outstanding_is_read_only_and_ttl_aware` — absent → false; recorded → true; scoped per `(contract, peer)`; repeated checks do **not** remove the entry (a later `consume` still succeeds); consumed → false; just-under-TTL → true, just-past-TTL → false.
- `outstanding_resync_is_strictly_capped` extended: an over-cap (never-recorded) key reads as not-outstanding, so the retry skips it.

Pin updates:

- `queue_full_resync_retry_is_bounded_and_reservation_scoped` — now also pins (a) the record precedes the retry spawn, (b) the retry contains no `.record(` **and no `.consume(`**, (c) the `is_outstanding` gate is checked **before** `try_notify_node_event`.
- `every_production_resync_request_emit_records_outstanding` — the fixed 600-byte lookback becomes an enclosing-fn lookback. The byte distance was always an arbitrary proxy; the reorder pushed the record past it. Same guarantee (an emit is preceded by its record, on the same code path), no brittle distance.
- Two pre-existing tests that call `resend_queue_full_resync_request` **directly** now record the outstanding request first, the way the real caller does. Without that, `…_terminates_when_injected_clock_frozen` would have passed for the wrong reason (skipped by the new gate rather than stopped by the liveness backstop) — a premise fix, not a weakened assertion.

`TimeSource` (`interest_manager.now()`, the injected throttle clock) and `GlobalRng` are used throughout; no new `Instant::now()`, no new `.send().await`, no new channel.

Commands run (worktree at `078d3459`):

```
cargo fmt                                    # clean
cargo clippy -- -D warnings                  # clean (the CI-exact invocation)
cargo test -p freenet --lib resync           # ok. 54 passed; 0 failed
cargo test -p freenet --lib                  # ok. 4273 passed; 0 failed; 25 ignored
cargo test -p freenet update                 # 250 passed after re-run (see note)
```

Note on `cargo test -p freenet update`: one run failed on `contract::executor::pool_tests::subscriber_limit_tests::send_update_notification_empty_local_snapshot_emits_warn`, which is unrelated to this change (executor subscriber-notification log capture, not the UPDATE resync path). It passed alone and on 6/6 subsequent identical runs, so it is order-dependent flake — filed separately as #4927 rather than papered over.

`cargo clippy --all-targets` reports 24 pre-existing `let_underscore_must_use` errors in test code across the crate (e.g. `wasm_runtime/contract_store.rs:1230`, untouched here). CI runs `cargo clippy --locked -- -D warnings` without `--all-targets`, so these are local-toolchain drift, not introduced by this PR.

Closes #4863

> Draft: concurrency + protocol-adjacent surface (Full tier). Needs a full multi-model review before ready/merge. Note that freenet-core DRAFT PRs skip the heavy Simulation and Unit&Integration CI jobs, so draft-green is a false signal — mark ready for review to get real CI.

[AI-assisted - Claude]
