### PR TITLE
feat: surface cost-pressure eviction decisions for field diagnosis

### DIFF
--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -1612,6 +1612,18 @@ pub struct HostingSnapshot {
     /// times). Should stay near zero; a rising value means the demand estimate
     /// is mis-ordering the working set (the #4338 miscalibration symptom).
     pub evictions_of_recently_read_total: u64,
+    /// Monotonic count of COST-PRESSURE evictions (cost-aware eviction,
+    /// #4861): zero-demand contracts shed because their attributed update-work
+    /// (WASM CPU / broadcast fan-out / broadcast message count) dominated the
+    /// node's total on a cost axis, independently of the byte budget. Disjoint
+    /// from [`Self::budget_evictions_total`].
+    ///
+    /// Surfaced here because the local dashboard is the only hosting-counter
+    /// view an operator gets ON the box, with no telemetry collector in the
+    /// loop — the gap that left the 2026-07-25 vega storm undiagnosable. The
+    /// same counter reaches central telemetry as
+    /// `RouterSnapshot::hosting_cost_evictions_total`.
+    pub cost_evictions_total: u64,
     /// Per-contract Greedy-Dual rows in EVICTION order (the next victim under
     /// budget pressure is first). May be truncated by the renderer; the full
     /// count is `contract_count`.

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -4234,6 +4234,7 @@ impl Ring {
             contract_count: stats.contract_count,
             budget_evictions_total: stats.budget_evictions_total,
             evictions_of_recently_read_total: stats.evictions_of_recently_read_total,
+            cost_evictions_total: stats.cost_evictions_total,
             contracts,
             disk_state_bytes,
             disk_wasm_bytes,

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -8710,3 +8710,71 @@ pub(crate) enum RingError {
     #[error("Peer has not joined the network yet (no ring location established)")]
     PeerNotJoined,
 }
+
+#[cfg(test)]
+mod dashboard_hosting_counter_source_tests {
+    //! Source-scrape pin for the dashboard hosting-counter mapping.
+    //!
+    //! `.claude/rules/bug-prevention-patterns.md` calls out "manually-mirrored
+    //! telemetry counters / dashboard providers" as a recurring silent-rot
+    //! pattern (#4009, #4010): a counter is wired to a card once, a later
+    //! refactor re-points or drops the mapping line, and the tile keeps
+    //! rendering a plausible-looking number from the wrong source with every
+    //! test still green.
+    //!
+    //! `dashboard_hosting_snapshot` is only reachable from `p2p_impl.rs`'s
+    //! provider registration and needs a live `Ring` to exercise, which this
+    //! suite has no scaffolding for. So — mirroring the other `*_source_tests`
+    //! modules in this file — pin the mapping in source instead.
+
+    /// Production source only: everything before the first top-level test
+    /// module. This module is itself `#[cfg(test)]` and declared last, so the
+    /// needles below cannot match this file's own test text.
+    fn production_source() -> &'static str {
+        const FULL: &str = include_str!("ring.rs");
+        let cutoff = FULL
+            .find("\n#[cfg(test)]\nmod ")
+            .expect("ring.rs must have a top-level #[cfg(test)] mod section");
+        &FULL[..cutoff]
+    }
+
+    #[test]
+    fn dashboard_hosting_snapshot_maps_each_eviction_counter_from_its_own_source() {
+        // Whitespace-stripped so a rustfmt reflow of the struct literal cannot
+        // silently vacate the pin.
+        let src: String = production_source()
+            .chars()
+            .filter(|c| !c.is_whitespace())
+            .collect();
+
+        // Each counter must come from the IDENTICALLY-named field on `stats`.
+        // Cross-wiring any two (the #4009/#4010 failure) breaks the matching
+        // needle. Needles are split so they do not appear contiguously in this
+        // file's own source.
+        for (counter, needle) in [
+            (
+                "cost_evictions_total",
+                concat!("cost_evictions_total:stats.", "cost_evictions_total,"),
+            ),
+            (
+                "budget_evictions_total",
+                concat!("budget_evictions_total:stats.", "budget_evictions_total,"),
+            ),
+            (
+                "evictions_of_recently_read_total",
+                concat!(
+                    "evictions_of_recently_read_total:stats.",
+                    "evictions_of_recently_read_total,"
+                ),
+            ),
+        ] {
+            assert!(
+                src.contains(needle),
+                "`dashboard_hosting_snapshot` must map {counter} from \
+                 `stats.{counter}` — the local dashboard is the only \
+                 hosting-counter view an operator gets with no telemetry \
+                 collector in the loop, so a cross-wired tile is silent"
+            );
+        }
+    }
+}

--- a/crates/core/src/ring/hosting/cache.rs
+++ b/crates/core/src/ring/hosting/cache.rs
@@ -761,6 +761,14 @@ pub struct HostingCache<T: TimeSource> {
     /// #4861). Only [`Self::evict_cost_pressure`] increments it. See
     /// [`HostingCacheStats::cost_evictions_total`].
     cost_evictions_total: u64,
+    /// Time of the last cost-pressure decision summary, for the rate limit in
+    /// [`Self::log_cost_decision`]. Observability only — never read by the
+    /// eviction decision.
+    last_cost_decision_log_at: Option<Instant>,
+    /// Digest of the last logged cost-pressure decision, so a CHANGE in the
+    /// decision surfaces within one sweep instead of waiting out
+    /// [`COST_DECISION_LOG_INTERVAL`]. Observability only.
+    last_cost_decision_digest: Option<u64>,
     /// Time source for testability
     time_source: T,
 }
@@ -987,6 +995,216 @@ pub(crate) fn cost_eviction_candidate(
     local_subs == 0 && downstream_subs == 0 && !recently_accessed && attributed_rate > 0.0
 }
 
+// -----------------------------------------------------------------------------
+// Cost-pressure decision OBSERVABILITY (no behavior change)
+// -----------------------------------------------------------------------------
+//
+// Everything below classifies and reports a decision the sweep has already
+// made. None of it is an input to the decision: `evict_cost_pressure` sheds
+// exactly the contracts it shed before, in the same order. The motivation is a
+// field incident (vega, 2026-07-25): a gateway sat in a sustained update storm
+// for ~7 hours while cost-pressure eviction never fired once, and from outside
+// the process there was no way to tell WHICH of three mutually-exclusive causes
+// held — the axis was under its floor, the offender was immune by design
+// (subscribed / recently read), or the meter was not attributing the work to
+// any hosted contract at all. Those need completely different fixes. Before
+// this, the ONLY log on the path fired on a successful eviction, so the
+// "nothing happened" case — the interesting one — was silent.
+
+/// Minimum spacing between periodic cost-pressure decision summaries.
+///
+/// The production sweep that drives [`HostingCache::evict_cost_pressure`] runs
+/// every 60s (`Ring::GET_SUBSCRIPTION_SWEEP_INTERVAL`), so logging every sweep
+/// would add ~60 `info!` lines/hour/node to gateways already emitting ~8 MB/hour
+/// (the #4259 log-volume budget). One heartbeat per this interval — plus an
+/// immediate line whenever the DECISION ITSELF changes, see
+/// [`cost_decision_digest`] — costs ~12 lines/hour in steady state while still
+/// surfacing a state change within one sweep.
+pub(crate) const COST_DECISION_LOG_INTERVAL: Duration = Duration::from_secs(300);
+
+/// Why the highest-attributed-cost hosted contract on a cost axis was NOT shed.
+///
+/// OBSERVABILITY ONLY. [`classify_cost_rejection`] returning `None` is exactly
+/// the condition under which [`HostingCache::evict_cost_pressure`] sheds a
+/// contract, which is what makes this a faithful explanation rather than a
+/// second, drift-prone copy of the policy (pinned by
+/// `cost_reject_classification_matches_eviction_decision`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum CostRejectReason {
+    /// No positive attributed rate on this axis — covers zero, negatives, and
+    /// NaN (all fail `attributed_rate > 0.0`). Reported ahead of
+    /// [`Self::UnderShare`] because "the meter attributed nothing to this
+    /// contract" and "the contract holds less than the share" are DIFFERENT
+    /// diagnoses with different fixes.
+    ZeroRate,
+    /// Attributed rate did not exceed `COST_SHARE_THRESHOLD × total_rate`.
+    UnderShare,
+    /// A LOCAL client subscription (invariant 3's top demand tier). Immune by
+    /// candidacy, not by ranking.
+    HasLocalSubs,
+    /// A DOWNSTREAM subscriber (forwarded demand). Immune by candidacy.
+    HasDownstreamSubs,
+    /// A genuine GET/PUT within the cost window, or a local-client access
+    /// within the reconciliation renewal lease — the read-but-never-subscribed
+    /// class invariant 3 protects.
+    RecentlyAccessed,
+}
+
+impl CostRejectReason {
+    /// Stable operator-facing token (the grep target in the summary line).
+    ///
+    /// Exhaustive on purpose — no catch-all arm — so a future reason cannot
+    /// silently render as an existing one (`.claude/rules/code-style.md`:
+    /// outcome-classifying matches must not use `_ =>`).
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::ZeroRate => "zero_rate",
+            Self::UnderShare => "under_share",
+            Self::HasLocalSubs => "has_local_subs",
+            Self::HasDownstreamSubs => "has_downstream_subs",
+            Self::RecentlyAccessed => "recently_accessed",
+        }
+    }
+}
+
+impl std::fmt::Display for CostRejectReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Classify why a contract was not shed by cost pressure on one axis, or
+/// `None` when it WAS (i.e. it cleared every gate).
+///
+/// Precedence mirrors the order the sweep applies its gates — rate share
+/// first (the cheap pre-filter), then the candidacy terms in invariant 3's
+/// demand order (local subscriptions, downstream subscribers, recent genuine
+/// access) — with the single refinement described on
+/// [`CostRejectReason::ZeroRate`].
+///
+/// Pure function of the same five inputs the decision uses, so it can be unit
+/// tested exhaustively without a cache.
+pub(crate) fn classify_cost_rejection(
+    local_subs: usize,
+    downstream_subs: usize,
+    attributed_rate: f64,
+    share_cutoff: f64,
+    recently_accessed: bool,
+) -> Option<CostRejectReason> {
+    // NaN-safe and written without `!(a > b)` so clippy's
+    // `neg_cmp_op_on_partial_ord` stays quiet: NaN and any non-positive rate
+    // both land here, exactly as they fail `cost_eviction_candidate`.
+    if attributed_rate.is_nan() || attributed_rate <= 0.0 {
+        return Some(CostRejectReason::ZeroRate);
+    }
+    if attributed_rate <= share_cutoff {
+        return Some(CostRejectReason::UnderShare);
+    }
+    if local_subs > 0 {
+        return Some(CostRejectReason::HasLocalSubs);
+    }
+    if downstream_subs > 0 {
+        return Some(CostRejectReason::HasDownstreamSubs);
+    }
+    if recently_accessed {
+        return Some(CostRejectReason::RecentlyAccessed);
+    }
+    None
+}
+
+/// The highest-attributed-cost hosted contract on one axis, with the outcome
+/// the sweep reached for it.
+#[derive(Debug, Clone)]
+pub(crate) struct CostTopOffender {
+    pub key: ContractKey,
+    /// Its attributed rate in the axis's units per second.
+    pub rate: f64,
+    /// `rate / total_rate` — its share of the node's attributed work on this
+    /// axis, the quantity [`COST_SHARE_THRESHOLD`] is compared against.
+    pub share: f64,
+    /// `None` when this contract was shed; otherwise the gate that saved it.
+    pub rejected: Option<CostRejectReason>,
+}
+
+/// The cost-pressure decision for ONE axis on ONE sweep.
+///
+/// Observability only: built FROM the decision pass (never from a second read
+/// of the same state that could reach a different conclusion) and consumed
+/// solely by [`HostingCache::log_cost_decision`] and its tests.
+#[derive(Debug, Clone)]
+pub(crate) struct CostAxisDecision {
+    /// Axis name, e.g. `"broadcast_messages_per_sec"`.
+    pub axis: &'static str,
+    /// Node-total attributed rate across all contracts.
+    pub total_rate: f64,
+    /// The absolute floor below which the axis never triggers.
+    pub floor: f64,
+    /// `total_rate > floor` (NaN-safe) — whether the axis could shed at all.
+    pub armed: bool,
+    /// Highest-attributed-rate hosted contract on this axis. `None` on an
+    /// UNARMED axis (the sweep does not scan hosted contracts there, and
+    /// reporting an offender would cost a scan the decision itself never pays
+    /// — `total_rate` vs `floor` is the whole explanation in that case) and on
+    /// an armed axis with nothing hosted.
+    pub top: Option<CostTopOffender>,
+    /// Contracts shed on this axis this sweep.
+    pub evicted: usize,
+}
+
+impl std::fmt::Display for CostAxisDecision {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}: total={:.3} floor={:.3} armed={}",
+            self.axis, self.total_rate, self.floor, self.armed
+        )?;
+        match &self.top {
+            Some(top) => write!(
+                f,
+                " top={} rate={:.3} share={:.3} outcome={}",
+                top.key,
+                top.rate,
+                top.share,
+                match top.rejected {
+                    Some(reason) => reason.as_str(),
+                    None => "evicted",
+                }
+            )?,
+            None if self.armed => f.write_str(" top=none")?,
+            None => {}
+        }
+        if self.evicted > 0 {
+            write!(f, " evicted={}", self.evicted)?;
+        }
+        Ok(())
+    }
+}
+
+/// Digest of a sweep's cost-pressure decision, used to emit a summary
+/// immediately when the DECISION changes rather than waiting out
+/// [`COST_DECISION_LOG_INTERVAL`].
+///
+/// Deliberately covers only each axis's name, armed flag, and top-offender
+/// outcome — NOT the offender's identity or the rates. Rates wobble every
+/// sweep and the top offender can swap between two near-equal contracts, so
+/// including either would turn the change-trigger into a per-sweep line. Those
+/// details still appear in the next periodic summary.
+fn cost_decision_digest(decisions: &[CostAxisDecision]) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    for decision in decisions {
+        decision.axis.hash(&mut hasher);
+        decision.armed.hash(&mut hasher);
+        // `Option<Option<_>>` distinguishes no-offender / shed / rejected(why).
+        decision
+            .top
+            .as_ref()
+            .map(|top| top.rejected)
+            .hash(&mut hasher);
+    }
+    hasher.finish()
+}
+
 impl<T: TimeSource> HostingCache<T> {
     /// Create a new hosting cache with the given byte budget.
     pub fn new(budget_bytes: u64, time_source: T) -> Self {
@@ -1003,6 +1221,8 @@ impl<T: TimeSource> HostingCache<T> {
             oom_valve_evictions_total: 0,
             subscribed_evictions_total: 0,
             cost_evictions_total: 0,
+            last_cost_decision_log_at: None,
+            last_cost_decision_digest: None,
             time_source,
         }
     }
@@ -1888,65 +2108,120 @@ impl<T: TimeSource> HostingCache<T> {
     where
         G: Fn(&ContractKey) -> (usize, usize),
     {
+        self.evict_cost_pressure_observed(subscriber_counts, axes).0
+    }
+
+    /// [`Self::evict_cost_pressure`] plus the per-axis decision record it
+    /// logs.
+    ///
+    /// The record is derived from the SAME pass that makes the decision — it
+    /// never re-reads state to reach an independent conclusion — so a test can
+    /// assert the explanation and the outcome agree contract-for-contract.
+    /// Production calls the wrapper and drops the record; only the summary log
+    /// consumes it there.
+    pub(crate) fn evict_cost_pressure_observed<G>(
+        &mut self,
+        subscriber_counts: &G,
+        axes: &[CostAxisPressure],
+    ) -> (Vec<EvictedContract>, Vec<CostAxisDecision>)
+    where
+        G: Fn(&ContractKey) -> (usize, usize),
+    {
         let now = self.time_source.now();
         let mut evicted = Vec::new();
+        let mut decisions: Vec<CostAxisDecision> = Vec::with_capacity(axes.len());
         for axis in axes {
             // NaN-safe: a NaN/zero/sub-floor total never triggers the axis.
             if axis.total_rate.is_nan() || axis.total_rate <= axis.floor {
+                decisions.push(CostAxisDecision {
+                    axis: axis.axis,
+                    total_rate: axis.total_rate,
+                    floor: axis.floor,
+                    armed: false,
+                    top: None,
+                    evicted: 0,
+                });
                 continue;
             }
             let share_cutoff = COST_SHARE_THRESHOLD * axis.total_rate;
-            let mut offenders: Vec<(ContractKey, f64)> = self
-                .contracts
+            // OBSERVABILITY, same pass, no extra state reads: `top_rate` is the
+            // highest attributed rate across ALL hosted contracts (so the
+            // summary can name the offender even when it is rejected), and
+            // `probed` records the candidacy inputs of every contract that
+            // cleared the share cutoff, so the summary explains the rejection
+            // from the inputs the DECISION used rather than from a second,
+            // racy read. `probed` stays tiny by construction: the per-contract
+            // rates are a subset of `total_rate` (see
+            // `Meter::contract_cost_rates_multi`), so at most three contracts
+            // can each hold more than COST_SHARE_THRESHOLD (25%) of it.
+            let mut top_rate: Option<(ContractKey, f64)> = None;
+            let mut probed: Vec<(ContractKey, f64, usize, usize, bool)> = Vec::new();
+            for (key, entry) in self.contracts.iter() {
+                let rate = axis.rates.get(key.id()).copied().unwrap_or(0.0);
+                // Highest rate wins; equal rates fall back to the SAME
+                // ascending key-byte tiebreak the eviction sort below uses, so
+                // the reported offender is deterministic and matches the first
+                // victim when there is one. A NaN rate is skipped rather than
+                // allowed to become an unbeatable maximum (nothing compares
+                // greater than NaN); it is never a candidate anyway.
+                if !rate.is_nan()
+                    && top_rate.as_ref().is_none_or(|(top_key, top)| {
+                        rate > *top || (rate == *top && key.as_bytes() < top_key.as_bytes())
+                    })
+                {
+                    top_rate = Some((*key, rate));
+                }
+                // Cheap, highly-selective gate FIRST (#4903 review perf):
+                // only a contract whose attributed rate exceeds the share
+                // cutoff can ever be a victim, so short-circuit BEFORE the
+                // two DashMap `subscriber_counts` gets and the recency
+                // check. This filter runs under the hosting write lock on
+                // every sweep where any axis is over its floor (a busy
+                // gateway: always), across every hosted contract, so paying
+                // the subscriber lookup only for the handful over the cutoff
+                // matters. `rate <= cutoff` rejects rate == 0 and negatives;
+                // a NaN rate (defensive: meter math) is not <= cutoff so it
+                // falls through here, but `cost_eviction_candidate` then
+                // rejects it (its `attributed_rate > 0.0` is false for NaN).
+                if rate <= share_cutoff {
+                    continue;
+                }
+                let (local, downstream) = subscriber_counts(key);
+                // Recent demand by the SAME definition the rest of the
+                // system honors (review Fix 1 / invariant 3), so cost
+                // eviction can never shed a contract reconciliation
+                // still leases (an evict → re-lease churn loop):
+                //
+                // 1. A genuine GET/PUT within the cost window
+                //    (`last_genuine_access`) — read/write demand.
+                //    UPDATE churn never stamps it, so a storm contract
+                //    cannot protect itself.
+                // 2. A LOCAL-CLIENT access within the renewal lease
+                //    (`local_client_last_access` <
+                //    `SUBSCRIPTION_LEASE_DURATION`) — the exact signal
+                //    `contracts_needing_renewal` branch 3 renews on.
+                //    This covers both the 5–8-minute tail after a local
+                //    access (the lease outlives the cost window) and the
+                //    restart window: a reload stamps
+                //    `local_client_last_access = now` for locally-
+                //    accessed contracts while `last_genuine_access`
+                //    restarts at `None`, so without this clause the cost
+                //    sweep could evict a contract the reconcile loop was
+                //    still renewing.
+                let recently_accessed = entry
+                    .last_genuine_access
+                    .is_some_and(|at| now.saturating_duration_since(at) < COST_RATE_MIN_WINDOW)
+                    || entry.local_client_last_access.is_some_and(|at| {
+                        now.saturating_duration_since(at) < super::SUBSCRIPTION_LEASE_DURATION
+                    });
+                probed.push((*key, rate, local, downstream, recently_accessed));
+            }
+            let mut offenders: Vec<(ContractKey, f64)> = probed
                 .iter()
-                .filter_map(|(key, entry)| {
-                    let rate = axis.rates.get(key.id()).copied().unwrap_or(0.0);
-                    // Cheap, highly-selective gate FIRST (#4903 review perf):
-                    // only a contract whose attributed rate exceeds the share
-                    // cutoff can ever be a victim, so short-circuit BEFORE the
-                    // two DashMap `subscriber_counts` gets and the recency
-                    // check. This filter runs under the hosting write lock on
-                    // every sweep where any axis is over its floor (a busy
-                    // gateway: always), across every hosted contract, so paying
-                    // the subscriber lookup only for the handful over the cutoff
-                    // matters. `rate <= cutoff` rejects rate == 0 and negatives;
-                    // a NaN rate (defensive: meter math) is not <= cutoff so it
-                    // falls through here, but `cost_eviction_candidate` then
-                    // rejects it (its `attributed_rate > 0.0` is false for NaN).
-                    if rate <= share_cutoff {
-                        return None;
-                    }
-                    let (local, downstream) = subscriber_counts(key);
-                    // Recent demand by the SAME definition the rest of the
-                    // system honors (review Fix 1 / invariant 3), so cost
-                    // eviction can never shed a contract reconciliation
-                    // still leases (an evict → re-lease churn loop):
-                    //
-                    // 1. A genuine GET/PUT within the cost window
-                    //    (`last_genuine_access`) — read/write demand.
-                    //    UPDATE churn never stamps it, so a storm contract
-                    //    cannot protect itself.
-                    // 2. A LOCAL-CLIENT access within the renewal lease
-                    //    (`local_client_last_access` <
-                    //    `SUBSCRIPTION_LEASE_DURATION`) — the exact signal
-                    //    `contracts_needing_renewal` branch 3 renews on.
-                    //    This covers both the 5–8-minute tail after a local
-                    //    access (the lease outlives the cost window) and the
-                    //    restart window: a reload stamps
-                    //    `local_client_last_access = now` for locally-
-                    //    accessed contracts while `last_genuine_access`
-                    //    restarts at `None`, so without this clause the cost
-                    //    sweep could evict a contract the reconcile loop was
-                    //    still renewing.
-                    let recently_accessed = entry
-                        .last_genuine_access
-                        .is_some_and(|at| now.saturating_duration_since(at) < COST_RATE_MIN_WINDOW)
-                        || entry.local_client_last_access.is_some_and(|at| {
-                            now.saturating_duration_since(at) < super::SUBSCRIPTION_LEASE_DURATION
-                        });
-                    cost_eviction_candidate(local, downstream, rate, recently_accessed)
-                        .then_some((*key, rate))
+                .filter(|(_, rate, local, downstream, recently_accessed)| {
+                    cost_eviction_candidate(*local, *downstream, *rate, *recently_accessed)
                 })
+                .map(|(key, rate, ..)| (*key, *rate))
                 .collect();
             // Descending by attributed rate; key bytes break exact-rate ties
             // deterministically.
@@ -1955,6 +2230,7 @@ impl<T: TimeSource> HostingCache<T> {
                     .unwrap_or(std::cmp::Ordering::Equal)
                     .then_with(|| a.0.as_bytes().cmp(b.0.as_bytes()))
             });
+            let evicted_before_axis = evicted.len();
             for (key, rate) in offenders {
                 if let Some(entry) = self.contracts.remove(&key) {
                     self.current_bytes = self.current_bytes.saturating_sub(entry.size_bytes);
@@ -1983,8 +2259,92 @@ impl<T: TimeSource> HostingCache<T> {
                     });
                 }
             }
+            // Explain THIS axis's outcome from the inputs used above. The
+            // classification of the top offender is `None` exactly when it was
+            // shed, because `classify_cost_rejection` returns `None` under
+            // precisely the `rate > cutoff && cost_eviction_candidate(..)`
+            // condition the loop above acted on.
+            let top = top_rate.map(|(key, rate)| {
+                let rejected = match probed.iter().find(|(probed_key, ..)| *probed_key == key) {
+                    Some((_, rate, local, downstream, recently_accessed)) => {
+                        classify_cost_rejection(
+                            *local,
+                            *downstream,
+                            *rate,
+                            share_cutoff,
+                            *recently_accessed,
+                        )
+                    }
+                    // Never cleared the share cutoff, so it has no recorded
+                    // candidacy inputs — and needs none: the rate gates
+                    // (`ZeroRate` / `UnderShare`) decide it before any
+                    // subscriber or recency term is consulted.
+                    None => classify_cost_rejection(0, 0, rate, share_cutoff, false),
+                };
+                CostTopOffender {
+                    key,
+                    rate,
+                    share: rate / axis.total_rate,
+                    rejected,
+                }
+            });
+            decisions.push(CostAxisDecision {
+                axis: axis.axis,
+                total_rate: axis.total_rate,
+                floor: axis.floor,
+                armed: true,
+                top,
+                evicted: evicted.len() - evicted_before_axis,
+            });
         }
-        evicted
+        self.log_cost_decision(now, &decisions);
+        (evicted, decisions)
+    }
+
+    /// Emit the operator-facing cost-pressure decision summary, rate-limited.
+    ///
+    /// This is the field-diagnosis surface for "cost eviction never fired".
+    /// Per axis it reports the node total, the floor, whether the axis armed,
+    /// the top attributed-cost contract with its share, and — when that
+    /// contract was NOT shed — the specific gate that saved it. Without it the
+    /// three causes an operator must tell apart (axis under floor / offender
+    /// immune by design / meter not attributing the work) are
+    /// indistinguishable from outside the process, which is exactly what
+    /// blocked the 2026-07-25 vega storm diagnosis: the only log on this path
+    /// fired on a successful eviction, so a sweep that shed nothing was
+    /// silent.
+    ///
+    /// `info!`, NOT `debug!`: release builds compile out `debug!` via
+    /// `max_level_info`, so a debug line here would be invisible in exactly
+    /// the environment it exists for.
+    fn log_cost_decision(&mut self, now: Instant, decisions: &[CostAxisDecision]) {
+        if decisions.is_empty() {
+            return;
+        }
+        let digest = cost_decision_digest(decisions);
+        let due = self
+            .last_cost_decision_log_at
+            .is_none_or(|at| now.saturating_duration_since(at) >= COST_DECISION_LOG_INTERVAL);
+        if !due && self.last_cost_decision_digest == Some(digest) {
+            return;
+        }
+        self.last_cost_decision_log_at = Some(now);
+        self.last_cost_decision_digest = Some(digest);
+        // One line for all axes rather than one per axis: `tracing` field
+        // names must be static, so a rendered summary is what keeps the whole
+        // decision greppable in a single record.
+        let rendered = decisions
+            .iter()
+            .map(CostAxisDecision::to_string)
+            .collect::<Vec<_>>()
+            .join("; ");
+        tracing::info!(
+            axes_armed = decisions.iter().filter(|decision| decision.armed).count(),
+            hosted_contracts = self.contracts.len(),
+            cost_evictions_total = self.cost_evictions_total,
+            axes = %rendered,
+            "cost-pressure eviction decision (#4861)"
+        );
     }
 
     /// Load a contract entry from persisted data during startup, using an
@@ -2745,6 +3105,442 @@ mod tests {
         );
         assert!(cache.get(&small).is_some());
         assert_eq!(cache.stats().cost_evictions_total, 2);
+    }
+
+    // =========================================================================
+    // Cost-pressure decision OBSERVABILITY (no behavior change)
+    // =========================================================================
+
+    /// Every reject reason is reachable and reported for the gate that
+    /// actually saved the contract, and the accepted shape reports `None`.
+    #[test]
+    fn classify_cost_rejection_reports_each_reason() {
+        let cutoff = 25_000.0;
+
+        // Accepted: over the share cutoff, zero demand.
+        assert_eq!(
+            classify_cost_rejection(0, 0, 58_000.0, cutoff, false),
+            None,
+            "an over-share zero-demand contract is shed, so nothing rejected it"
+        );
+
+        // zero_rate — the "meter attributed nothing here" diagnosis. Covers
+        // exact zero, negatives, and NaN (all fail `attributed_rate > 0.0`).
+        for rate in [0.0, -1.0, f64::NAN] {
+            assert_eq!(
+                classify_cost_rejection(0, 0, rate, cutoff, false),
+                Some(CostRejectReason::ZeroRate),
+                "rate {rate} must classify as zero_rate"
+            );
+        }
+
+        // under_share — positive but not dominant. Includes the exact-cutoff
+        // boundary, since the share test is strict `>`.
+        assert_eq!(
+            classify_cost_rejection(0, 0, 10_000.0, cutoff, false),
+            Some(CostRejectReason::UnderShare)
+        );
+        assert_eq!(
+            classify_cost_rejection(0, 0, cutoff, cutoff, false),
+            Some(CostRejectReason::UnderShare),
+            "exactly at the cutoff is under_share (strict >)"
+        );
+
+        // has_local_subs / has_downstream_subs — immune by candidacy.
+        assert_eq!(
+            classify_cost_rejection(1, 0, 58_000.0, cutoff, false),
+            Some(CostRejectReason::HasLocalSubs)
+        );
+        assert_eq!(
+            classify_cost_rejection(0, 3, 58_000.0, cutoff, false),
+            Some(CostRejectReason::HasDownstreamSubs)
+        );
+
+        // recently_accessed — the read-but-never-subscribed class.
+        assert_eq!(
+            classify_cost_rejection(0, 0, 58_000.0, cutoff, true),
+            Some(CostRejectReason::RecentlyAccessed)
+        );
+    }
+
+    /// Precedence when several gates would reject: the summary names the gate
+    /// the sweep applies FIRST, so an operator reading it sees the same order
+    /// of reasoning the code uses. `ZeroRate` is the one deliberate refinement
+    /// (a zero rate is also under-share, but the two need different fixes).
+    #[test]
+    fn classify_cost_rejection_precedence_is_gate_order() {
+        let cutoff = 25_000.0;
+        assert_eq!(
+            classify_cost_rejection(9, 9, 0.0, cutoff, true),
+            Some(CostRejectReason::ZeroRate),
+            "no attributed cost is reported ahead of the share and demand gates"
+        );
+        assert_eq!(
+            classify_cost_rejection(9, 9, 100.0, cutoff, true),
+            Some(CostRejectReason::UnderShare),
+            "the share gate is checked before any subscriber term"
+        );
+        assert_eq!(
+            classify_cost_rejection(1, 9, 58_000.0, cutoff, true),
+            Some(CostRejectReason::HasLocalSubs),
+            "local subscriptions outrank downstream and recency (invariant 3)"
+        );
+        assert_eq!(
+            classify_cost_rejection(0, 1, 58_000.0, cutoff, true),
+            Some(CostRejectReason::HasDownstreamSubs),
+            "downstream subscribers outrank recency"
+        );
+    }
+
+    /// The pin that makes the explanation trustworthy: over a grid covering
+    /// every gate and its boundaries, `classify_cost_rejection(..) == None` is
+    /// EXACTLY the condition under which `evict_cost_pressure` sheds a
+    /// contract (`rate > share_cutoff && cost_eviction_candidate(..)`). If a
+    /// future change moves one and not the other, this fails rather than the
+    /// logs quietly lying about the policy.
+    #[test]
+    fn cost_reject_classification_matches_eviction_decision() {
+        let cutoff = 25_000.0;
+        let rates = [
+            f64::NAN,
+            f64::NEG_INFINITY,
+            -1.0,
+            0.0,
+            f64::MIN_POSITIVE,
+            1.0,
+            cutoff - 0.1,
+            cutoff,
+            cutoff + 0.1,
+            100_000.0,
+            f64::INFINITY,
+        ];
+        for &rate in &rates {
+            for local in [0usize, 1, 7] {
+                for downstream in [0usize, 1, 7] {
+                    for recent in [false, true] {
+                        // The sweep's own two gates, transcribed from
+                        // `evict_cost_pressure`: the cheap share pre-filter
+                        // (`rate <= cutoff` → skip) then candidacy. The
+                        // pre-filter is written positively here — a NaN rate
+                        // is NOT `<= cutoff`, so it survives the filter and is
+                        // rejected one line later by candidacy, exactly as in
+                        // the sweep.
+                        let clears_share_filter = rate.is_nan() || rate > cutoff;
+                        let shed = clears_share_filter
+                            && cost_eviction_candidate(local, downstream, rate, recent);
+                        let classified =
+                            classify_cost_rejection(local, downstream, rate, cutoff, recent);
+                        assert_eq!(
+                            classified.is_none(),
+                            shed,
+                            "classification disagrees with the eviction decision for \
+                             rate={rate} local={local} downstream={downstream} \
+                             recent={recent}: classified={classified:?}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /// An UNARMED axis reports the numbers that explain it — node total vs
+    /// floor — and deliberately reports no top offender: the sweep does not
+    /// scan hosted contracts on an unarmed axis, and naming one would cost a
+    /// scan the decision itself never pays.
+    #[test]
+    fn cost_decision_reports_unarmed_axis_without_scanning() {
+        let (mut cache, clock) = make_cache(1024 * 1024);
+        let only = make_key(1);
+        cache.record_access(only, 121, AccessType::Put, 1, |_| (0, 0));
+        clock.advance_time(COST_RATE_MIN_WINDOW + Duration::from_secs(1));
+
+        let axes = [cost_axis(10_000.0, 50_000.0, &[(&only, 10_000.0)])];
+        let (evicted, decisions) =
+            cache.evict_cost_pressure_observed(&|_: &ContractKey| (0, 0), &axes);
+
+        assert!(evicted.is_empty());
+        assert_eq!(decisions.len(), 1);
+        let decision = &decisions[0];
+        assert!(!decision.armed, "sub-floor total must report armed=false");
+        assert_eq!(decision.total_rate, 10_000.0);
+        assert_eq!(decision.floor, 50_000.0);
+        assert!(decision.top.is_none());
+        assert_eq!(decision.evicted, 0);
+        let rendered = decision.to_string();
+        assert!(
+            rendered.contains("armed=false") && rendered.contains("floor=50000"),
+            "the unarmed line must carry total vs floor — got: {rendered}"
+        );
+    }
+
+    /// The armed-axis summary names the top attributed-cost contract, its
+    /// share, and the specific gate that saved it — one case per reason an
+    /// operator has to be able to tell apart in the field.
+    #[test]
+    fn cost_decision_reports_top_offender_and_reject_reason() {
+        // Shared shape: one dominant contract on an armed axis, aged past the
+        // cost window so recency is not what protects it unless we say so.
+        let armed_axis =
+            |key: &ContractKey, rate: f64| [cost_axis(100_000.0, 50_000.0, &[(key, rate)])];
+
+        // 1. Shed: zero demand, dominant share → no reject reason.
+        let (mut cache, clock) = make_cache(1024 * 1024);
+        let junk = make_key(1);
+        cache.record_access(junk, 121, AccessType::Put, 1, |_| (0, 0));
+        clock.advance_time(COST_RATE_MIN_WINDOW + Duration::from_secs(1));
+        let (evicted, decisions) = cache
+            .evict_cost_pressure_observed(&|_: &ContractKey| (0, 0), &armed_axis(&junk, 58_000.0));
+        assert_eq!(evicted.len(), 1);
+        let top = decisions[0].top.as_ref().expect("armed axis names a top");
+        assert_eq!(top.key, junk);
+        assert_eq!(top.rate, 58_000.0);
+        assert!((top.share - 0.58).abs() < 1e-9);
+        assert_eq!(top.rejected, None, "it was shed, so nothing rejected it");
+        assert_eq!(decisions[0].evicted, 1);
+        assert!(
+            decisions[0].to_string().contains("outcome=evicted"),
+            "rendered: {}",
+            decisions[0]
+        );
+
+        // 2. has_local_subs.
+        let (mut cache, clock) = make_cache(1024 * 1024);
+        let local_sub = make_key(2);
+        cache.record_access(local_sub, 121, AccessType::Put, 1, |_| (0, 0));
+        clock.advance_time(COST_RATE_MIN_WINDOW + Duration::from_secs(1));
+        let (evicted, decisions) = cache.evict_cost_pressure_observed(
+            &|_: &ContractKey| (1, 0),
+            &armed_axis(&local_sub, 58_000.0),
+        );
+        assert!(evicted.is_empty());
+        assert_eq!(
+            decisions[0].top.as_ref().unwrap().rejected,
+            Some(CostRejectReason::HasLocalSubs)
+        );
+
+        // 3. has_downstream_subs.
+        let (mut cache, clock) = make_cache(1024 * 1024);
+        let downstream_sub = make_key(3);
+        cache.record_access(downstream_sub, 121, AccessType::Put, 1, |_| (0, 0));
+        clock.advance_time(COST_RATE_MIN_WINDOW + Duration::from_secs(1));
+        let (evicted, decisions) = cache.evict_cost_pressure_observed(
+            &|_: &ContractKey| (0, 2),
+            &armed_axis(&downstream_sub, 58_000.0),
+        );
+        assert!(evicted.is_empty());
+        assert_eq!(
+            decisions[0].top.as_ref().unwrap().rejected,
+            Some(CostRejectReason::HasDownstreamSubs)
+        );
+
+        // 4. recently_accessed — the never-subscribed-but-read class.
+        let (mut cache, clock) = make_cache(1024 * 1024);
+        let read_hot = make_key(4);
+        cache.record_access(read_hot, 121, AccessType::Put, 1, |_| (0, 0));
+        clock.advance_time(COST_RATE_MIN_WINDOW + Duration::from_secs(1));
+        cache.touch(&read_hot);
+        let (evicted, decisions) = cache.evict_cost_pressure_observed(
+            &|_: &ContractKey| (0, 0),
+            &armed_axis(&read_hot, 58_000.0),
+        );
+        assert!(evicted.is_empty());
+        assert_eq!(
+            decisions[0].top.as_ref().unwrap().rejected,
+            Some(CostRejectReason::RecentlyAccessed)
+        );
+
+        // 5. under_share — armed axis, but nothing dominates it.
+        let (mut cache, clock) = make_cache(1024 * 1024);
+        let a = make_key(5);
+        let b = make_key(6);
+        cache.record_access(a, 121, AccessType::Put, 1, |_| (0, 0));
+        cache.record_access(b, 121, AccessType::Put, 1, |_| (0, 0));
+        clock.advance_time(COST_RATE_MIN_WINDOW + Duration::from_secs(1));
+        let axes = [cost_axis(
+            100_000.0,
+            50_000.0,
+            &[(&a, 20_000.0), (&b, 24_000.0)],
+        )];
+        let (evicted, decisions) =
+            cache.evict_cost_pressure_observed(&|_: &ContractKey| (0, 0), &axes);
+        assert!(evicted.is_empty());
+        let top = decisions[0].top.as_ref().unwrap();
+        assert_eq!(top.key, b, "the highest-rate contract is the reported top");
+        assert_eq!(top.rejected, Some(CostRejectReason::UnderShare));
+
+        // 6. zero_rate — the axis is armed node-wide, but the meter attributes
+        //    nothing to any hosted contract. This is the diagnosis that is
+        //    otherwise indistinguishable from "everything is under share".
+        let (mut cache, clock) = make_cache(1024 * 1024);
+        let unattributed = make_key(7);
+        cache.record_access(unattributed, 121, AccessType::Put, 1, |_| (0, 0));
+        clock.advance_time(COST_RATE_MIN_WINDOW + Duration::from_secs(1));
+        let axes = [cost_axis(100_000.0, 50_000.0, &[])];
+        let (evicted, decisions) =
+            cache.evict_cost_pressure_observed(&|_: &ContractKey| (0, 0), &axes);
+        assert!(evicted.is_empty());
+        let top = decisions[0].top.as_ref().unwrap();
+        assert_eq!(top.key, unattributed);
+        assert_eq!(top.rate, 0.0);
+        assert_eq!(top.rejected, Some(CostRejectReason::ZeroRate));
+        assert!(
+            decisions[0].to_string().contains("outcome=zero_rate"),
+            "rendered: {}",
+            decisions[0]
+        );
+    }
+
+    /// The observability path must not perturb the decision. Two identical
+    /// caches, one with the summary-log rate limiter already primed (so it
+    /// stays silent) and one fresh (so it logs), shed exactly the same
+    /// contracts in the same order — proving the log gate is downstream of the
+    /// decision, not an input to it.
+    #[test]
+    fn cost_decision_logging_state_does_not_change_evictions() {
+        let scenario = |prime_log_state: bool| {
+            let (mut cache, clock) = make_cache(1024 * 1024);
+            let bigger = make_key(1);
+            let big = make_key(2);
+            let subscribed = make_key(3);
+            let quiet = make_key(4);
+            for (key, generation) in [(bigger, 1), (big, 2), (subscribed, 3), (quiet, 4)] {
+                cache.record_access(key, 121, AccessType::Put, generation, |_| (0, 0));
+            }
+            clock.advance_time(COST_RATE_MIN_WINDOW + Duration::from_secs(1));
+            if prime_log_state {
+                // Pretend a summary was just emitted with an arbitrary digest:
+                // the rate limiter is now closed for this sweep.
+                cache.last_cost_decision_log_at = Some(cache.time_source.now());
+                cache.last_cost_decision_digest = Some(0);
+            }
+            let axes = [
+                cost_axis(
+                    100_000.0,
+                    50_000.0,
+                    &[
+                        (&bigger, 45_000.0),
+                        (&big, 30_000.0),
+                        (&subscribed, 40_000.0),
+                        (&quiet, 1.0),
+                    ],
+                ),
+                cost_axis(5_000.0, 50_000.0, &[(&quiet, 5_000.0)]),
+            ];
+            let counts = |key: &ContractKey| if *key == subscribed { (0, 1) } else { (0, 0) };
+            let evicted = cache.evict_cost_pressure(&counts, &axes);
+            (
+                evicted
+                    .iter()
+                    .map(|e| (e.key, e.write_generation))
+                    .collect::<Vec<_>>(),
+                cache.stats().cost_evictions_total,
+                cache.keys_eviction_order(),
+            )
+        };
+
+        let fresh = scenario(false);
+        let primed = scenario(true);
+        assert_eq!(
+            fresh, primed,
+            "the summary-log rate-limiter state must not influence which \
+             contracts are shed, their order, or the counter"
+        );
+        // And the outcome is the independently-expected one: both super-share
+        // zero-demand contracts, descending by rate; the subscribed one and the
+        // sub-share one survive.
+        assert_eq!(
+            fresh.0.iter().map(|(key, _)| *key).collect::<Vec<_>>(),
+            vec![make_key(1), make_key(2)]
+        );
+        assert_eq!(fresh.1, 2);
+    }
+
+    /// The summary is rate-limited but change-responsive: the first sweep
+    /// emits, an identical follow-up sweep inside the interval stays silent, a
+    /// sweep whose DECISION changed emits immediately, and the periodic
+    /// heartbeat resumes once the interval elapses. Asserted through the
+    /// emit-only bookkeeping (`last_cost_decision_log_at` advances exactly
+    /// when a line is emitted) so it needs no subscriber capture.
+    #[test]
+    fn cost_decision_log_is_rate_limited_and_change_triggered() {
+        let (mut cache, clock) = make_cache(1024 * 1024);
+        let junk = make_key(1);
+        cache.record_access(junk, 121, AccessType::Put, 1, |_| (0, 0));
+        clock.advance_time(COST_RATE_MIN_WINDOW + Duration::from_secs(1));
+
+        let quiet_axis = [cost_axis(10_000.0, 50_000.0, &[(&junk, 10_000.0)])];
+        let armed_axis = [cost_axis(100_000.0, 50_000.0, &[(&junk, 10_000.0)])];
+
+        // First sweep always emits (nothing has been logged yet).
+        cache.evict_cost_pressure(&|_: &ContractKey| (0, 0), &quiet_axis);
+        let first = cache.last_cost_decision_log_at.expect("first sweep emits");
+
+        // Same decision, well inside the interval: silent.
+        clock.advance_time(Duration::from_secs(60));
+        cache.evict_cost_pressure(&|_: &ContractKey| (0, 0), &quiet_axis);
+        assert_eq!(
+            cache.last_cost_decision_log_at,
+            Some(first),
+            "an unchanged decision inside the interval must not re-log"
+        );
+
+        // The axis arms (and the top offender is now rejected under_share):
+        // the decision changed, so it is surfaced within one sweep.
+        clock.advance_time(Duration::from_secs(60));
+        cache.evict_cost_pressure(&|_: &ContractKey| (0, 0), &armed_axis);
+        let changed = cache
+            .last_cost_decision_log_at
+            .expect("a changed decision emits");
+        assert!(changed > first, "change-trigger must emit immediately");
+
+        // Unchanged again → silent until the heartbeat interval elapses.
+        clock.advance_time(Duration::from_secs(60));
+        cache.evict_cost_pressure(&|_: &ContractKey| (0, 0), &armed_axis);
+        assert_eq!(cache.last_cost_decision_log_at, Some(changed));
+        clock.advance_time(COST_DECISION_LOG_INTERVAL);
+        cache.evict_cost_pressure(&|_: &ContractKey| (0, 0), &armed_axis);
+        assert!(
+            cache
+                .last_cost_decision_log_at
+                .is_some_and(|at| at > changed),
+            "the periodic heartbeat resumes after COST_DECISION_LOG_INTERVAL"
+        );
+    }
+
+    /// Equal-rate contracts pick the same deterministic top offender the
+    /// eviction sort would pick first (ascending key bytes), so the summary
+    /// never reports a different contract than the one that was acted on.
+    #[test]
+    fn cost_decision_top_offender_tiebreak_matches_eviction_order() {
+        let (mut cache, clock) = make_cache(1024 * 1024);
+        let k1 = make_key(1);
+        let k2 = make_key(2);
+        cache.record_access(k1, 121, AccessType::Put, 1, |_| (0, 0));
+        cache.record_access(k2, 121, AccessType::Put, 2, |_| (0, 0));
+        clock.advance_time(COST_RATE_MIN_WINDOW + Duration::from_secs(1));
+        let (lower, _higher) = if k1.as_bytes() < k2.as_bytes() {
+            (k1, k2)
+        } else {
+            (k2, k1)
+        };
+        // Exactly equal rates, both over the 25% share.
+        let axes = [cost_axis(
+            100_000.0,
+            50_000.0,
+            &[(&k1, 30_000.0), (&k2, 30_000.0)],
+        )];
+        let (evicted, decisions) =
+            cache.evict_cost_pressure_observed(&|_: &ContractKey| (0, 0), &axes);
+        assert_eq!(evicted.len(), 2, "both dominate; both are shed");
+        assert_eq!(
+            evicted[0].key, lower,
+            "eviction breaks equal-rate ties by ascending key bytes"
+        );
+        assert_eq!(
+            decisions[0].top.as_ref().unwrap().key,
+            lower,
+            "the reported top offender uses the SAME tiebreak as the eviction sort"
+        );
     }
 
     #[test]

--- a/crates/core/src/ring/hosting/cache.rs
+++ b/crates/core/src/ring/hosting/cache.rs
@@ -1174,9 +1174,10 @@ pub(crate) struct CostAxisDecision {
     /// `total_rate > floor` (NaN-safe) — whether the axis could shed at all.
     pub armed: bool,
     /// How many contracts the meter attributed SUSTAINED work to on this axis
-    /// (`axis.rates.len()`) — network-wide from this node's meter, NOT
-    /// restricted to contracts this node hosts. `0` on an unarmed axis, which
-    /// is not scanned.
+    /// (`axis.rates.len()`) — METER-wide, i.e. every contract THIS NODE
+    /// attributed work to, whether or not it hosts them. Not a fleet-wide
+    /// figure: reading it as one would suggest the network is storming when
+    /// only this box is. `0` on an unarmed axis, which is not scanned.
     ///
     /// This is the field that makes "cost eviction never fired" diagnosable,
     /// because `total_rate` and the per-contract rates come from DIFFERENT
@@ -1185,7 +1186,7 @@ pub(crate) struct CostAxisDecision {
     ///
     /// | `attributed` | `offenders` | Diagnosis |
     /// |---|---|---|
-    /// | 0 | empty | No SINGLE contract is individually above the axis floor — the load is DIFFUSE and the axis armed only on the sum. Nothing here is shed-able; this is an aggregate-budget question, not a per-contract one. (A genuinely bursty contract lands here too: its above-floor run keeps resetting.) |
+    /// | 0 | empty | No contract has SUSTAINED an above-floor rate. Two different situations, so check `total_rate` across consecutive sweeps before acting: (a) DIFFUSE — many sub-floor contributors, the axis armed only on their sum, nothing here is shed-able and this is an aggregate-budget question; (b) NOT YET SUSTAINED — a real offender exists but its above-floor run is younger than `min_window / 2` (150s), or a gap reset it, so wait a sweep or two and it will appear. A steady total with no offender ever appearing is (a); a total that climbed recently is (b). |
     /// | >0 | empty | Work IS attributed to individually-expensive contracts, but this node hosts none of them. Not this node's to shed. |
     /// | >0 | non-empty, all `rejected` | The offenders are immune BY DESIGN (invariant 3) — read each `outcome`. |
     ///
@@ -1294,7 +1295,9 @@ impl std::fmt::Display for CostAxisDecision {
 /// digest, re-admitting exactly the rate wobble this function excludes. Sorting
 /// means only a real change in a real gate moves it. Hashing the whole multiset
 /// rather than just the first offender's outcome means a SECONDARY offender
-/// changing why it was spared still surfaces within one sweep.
+/// changing why it was spared still surfaces within one sweep. `attributed` is
+/// included only as a BOOLEAN (was anything attributed at all), which is the
+/// decision-table-row crossing rather than the wobbling count.
 ///
 /// The volume bound does not depend on any of this — [`HostingCache::log_cost_decision`]
 /// is called once per sweep, so the hard ceiling is one line per sweep either
@@ -1324,6 +1327,14 @@ fn cost_decision_digest(decisions: &[CostAxisDecision]) -> u64 {
             .collect();
         outcomes.sort_unstable();
         outcomes.hash(&mut hasher);
+        // Whether ANYTHING was attributed, as a boolean rather than the count.
+        // The count wobbles; the 0 <-> non-0 crossing does not, and it is the
+        // transition that flips `CostAxisDecision::attributed`'s decision table
+        // from row 1 (diffuse / not-yet-sustained: an aggregate-budget
+        // question) to row 2 (attributed, but not to anything hosted here) —
+        // two situations with completely different fixes. Without this that
+        // change waits up to COST_DECISION_LOG_INTERVAL to surface.
+        (decision.attributed > 0).hash(&mut hasher);
     }
     hasher.finish()
 }
@@ -2223,6 +2234,14 @@ impl<T: TimeSource> HostingCache<T> {
     /// `subscriber_counts(key)` is the caller's genuine-demand split, read
     /// once per candidate and captured atomically with the decision (same
     /// discipline as [`Self::evict_over_budget`]).
+    ///
+    /// SIDE EFFECT beyond eviction: every call also emits the rate-limited
+    /// operator summary and advances its bookkeeping (see
+    /// [`Self::log_cost_decision`]). This is the entry point production uses,
+    /// so the summary's ~60s cadence is this function's call cadence. The
+    /// bookkeeping is write-only with respect to the decision — it is read
+    /// solely to rate-limit the log, never to choose a victim (pinned by
+    /// `cost_decision_logging_state_does_not_change_evictions`).
     pub fn evict_cost_pressure<G>(
         &mut self,
         subscriber_counts: &G,
@@ -2285,8 +2304,10 @@ impl<T: TimeSource> HostingCache<T> {
                 let rate = axis.rates.get(key.id()).copied().unwrap_or(0.0);
                 // Highest rate wins; equal rates fall back to the SAME
                 // ascending key-byte tiebreak the eviction sort below uses, so
-                // the reported offender is deterministic and matches the first
-                // victim when there is one.
+                // the reported contract is deterministic. `top_rate` never
+                // feeds the victim path: it is consulted only in the
+                // `reported.is_empty()` fallback, which by construction means
+                // nothing cleared the cutoff, so there is no victim to match.
                 //
                 // `rate > 0.0` is a CORRECTNESS gate, not an optimization: it
                 // excludes NaN (which would otherwise be an unbeatable maximum,
@@ -2519,6 +2540,12 @@ impl<T: TimeSource> HostingCache<T> {
             .map(CostAxisDecision::to_string)
             .collect::<Vec<_>>()
             .join("; ");
+        // `axes` MUST stay the LAST field. Its value contains spaces and `=`
+        // characters, so the record only parses as key=value at all because
+        // nothing follows it; inserting a field after `axes` would silently
+        // corrupt every downstream parse. `hosted_contracts` is the
+        // POST-eviction count, since this runs after the removal loop — pair it
+        // with the per-axis `evicted=` to reconstruct the pre-sweep total.
         tracing::info!(
             axes_armed = decisions.iter().filter(|decision| decision.armed).count(),
             hosted_contracts = self.contracts.len(),
@@ -3843,9 +3870,18 @@ mod tests {
         let start = production
             .find("fn log_cost_decision")
             .expect("log_cost_decision must exist");
+        // Bound the window to THIS function. Scraping to the end of the
+        // production region would swallow every later function, which both
+        // false-REDS (a `debug!` added to any later function would trip the
+        // no-debug assertion below, with a message about the cost summary) and
+        // false-GREENS (another function's `info!` would satisfy the emit
+        // assertion even if this one were deleted).
+        let end = production[start..]
+            .find("\n    /// Load a contract entry")
+            .expect("log_cost_decision must be followed by load_persisted_entry_with_demand");
         // Whitespace-stripped so a rustfmt reflow of the macro's arguments
         // cannot vacate the needles.
-        let body: String = production[start..]
+        let body: String = production[start..start + end]
             .chars()
             .filter(|c| !c.is_whitespace())
             .collect();
@@ -3875,6 +3911,24 @@ mod tests {
         assert!(
             body.contains(concat!("\"cost-pressureeviction", "decision")),
             "the summary's grep-able message must survive"
+        );
+        // `axes` must remain the LAST field. Its value contains spaces and `=`,
+        // so the record only parses as key=value because nothing follows it.
+        // A comment alone would not survive a future field being appended.
+        let fields_start = body
+            .find(concat!("tracing::", "info!("))
+            .expect("emit exists");
+        let after_axes = body[fields_start..]
+            .find("axes=%rendered,")
+            .map(|i| &body[fields_start + i + "axes=%rendered,".len()..])
+            .expect("axes field exists");
+        let next_field_end = after_axes.find(");").unwrap_or(after_axes.len());
+        assert!(
+            !after_axes[..next_field_end].contains('='),
+            "`axes` must be the LAST field in the summary: its value contains \
+             spaces and `=`, so appending a field after it silently corrupts \
+             every downstream key=value parse — found {:?} after it",
+            &after_axes[..next_field_end]
         );
     }
 
@@ -4112,6 +4166,28 @@ mod tests {
             cache.last_cost_decision_digest, digest_local,
             "has_local_subs -> has_downstream_subs is a real gate change and \
              must surface within one sweep, not wait for the heartbeat"
+        );
+
+        // `attributed` crossing 0 -> non-0 must also re-trigger. It flips the
+        // decision table from "diffuse / not yet sustained, an aggregate-budget
+        // question" to "attributed, but not to anything hosted here" — two
+        // situations with completely different fixes, so waiting out the 300s
+        // heartbeat to learn it is the wrong trade.
+        let (mut cache, clock) = make_cache(1024 * 1024);
+        let hosted = make_key(1);
+        let elsewhere = make_key(2);
+        cache.record_access(hosted, 121, AccessType::Put, 1, |_| (0, 0));
+        clock.advance_time(COST_RATE_MIN_WINDOW + Duration::from_secs(1));
+        let nothing_attributed = [cost_axis(100_000.0, 50_000.0, &[])];
+        let attributed_elsewhere = [cost_axis(100_000.0, 50_000.0, &[(&elsewhere, 90_000.0)])];
+        cache.evict_cost_pressure(&|_: &ContractKey| (0, 0), &nothing_attributed);
+        let digest_none = cache.last_cost_decision_digest;
+        cache.evict_cost_pressure(&|_: &ContractKey| (0, 0), &attributed_elsewhere);
+        assert_ne!(
+            cache.last_cost_decision_digest, digest_none,
+            "attributed 0 -> non-0 changes the diagnosis and must surface \
+             within one sweep (both sweeps report no offender, so only the \
+             `attributed` bit distinguishes them)"
         );
     }
 

--- a/crates/core/src/ring/hosting/cache.rs
+++ b/crates/core/src/ring/hosting/cache.rs
@@ -1020,10 +1020,12 @@ pub(crate) fn cost_eviction_candidate(
 ///
 /// The HARD BOUND is one line per sweep, i.e. **60 lines/hour**, not the
 /// steady-state 12: the change-trigger fires whenever an axis whose total
-/// hovers at its floor flips `armed`, or the top offender's reject reason
-/// alternates across sweeps. At ~750 bytes for a fully-armed three-axis line
-/// that worst case is ~45 KB/hour/node against a measured ~35 MB/hour main log
-/// (0.13%), so the bound is what matters, and it is safe.
+/// hovers at its floor flips `armed`, or an offender's reject reason changes
+/// across sweeps. The line is size-bounded too: three axes, each naming at most
+/// ~3 offenders (see [`CostAxisDecision::offenders`]) at ~90 bytes apiece, so
+/// ~1.2 KB at the absolute maximum and ~450 bytes in the realistic armed case.
+/// Worst case is therefore ~70 KB/hour/node against a measured ~35 MB/hour main
+/// log (~0.2%), so the bound is what matters, and it is safe.
 ///
 /// This line is LOCAL ONLY. Nothing in the tracing-subscriber stack forwards
 /// events to the central OTLP collector — `tracing/tracer.rs` wires only
@@ -1049,15 +1051,23 @@ pub(crate) enum CostRejectReason {
     /// "this contract holds less than the share" are DIFFERENT diagnoses with
     /// different fixes.
     ///
-    /// CAUTION for anyone reading this reason in the field: a zero rate does
-    /// NOT mean "the meter attributed nothing to this contract". The axis
-    /// `total_rate` sums EVERY positive per-contract rate, while the
-    /// per-contract `rates` map is the SUSTAINED subset — a rate is only
-    /// inserted when `activity_span >= min_window / 2`
-    /// (`topology/meter.rs::contract_cost_rates_multi`). So a contract whose
-    /// work is real but bursty reads as zero here. The rendered summary
-    /// carries [`CostAxisDecision::attributed`] alongside precisely so those
-    /// cases can be told apart; see that field's docs for the decision table.
+    /// You will NOT see this reason in a log line, and that is deliberate: a
+    /// rendered offender always has a positive rate (see
+    /// [`CostAxisDecision::offenders`]), so the field-facing form of this
+    /// diagnosis is `top=none` plus [`CostAxisDecision::attributed`], not an
+    /// `outcome=zero_rate` token. The variant exists so
+    /// [`classify_cost_rejection`] stays total over its input domain, which is
+    /// what lets `cost_reject_classification_matches_eviction_decision` pin the
+    /// classifier against the sweep across every rate including zero and NaN.
+    ///
+    /// Note for anyone tempted to render it anyway: a zero rate does NOT mean
+    /// "the meter attributed nothing to this contract". The axis `total_rate`
+    /// sums EVERY positive per-contract rate, while the per-contract `rates`
+    /// map is the SUSTAINED subset — inserted only when `activity_span >=
+    /// min_window / 2` (`topology/meter.rs::contract_cost_rates_multi`), where
+    /// that span is a run ABOVE THE AXIS FLOOR rather than mere sample
+    /// continuity. A contract carrying real but individually-sub-floor load
+    /// reads as zero here.
     ZeroRate,
     /// Attributed rate did not exceed `COST_SHARE_THRESHOLD × total_rate`.
     UnderShare,
@@ -1175,13 +1185,38 @@ pub(crate) struct CostAxisDecision {
     ///
     /// | `attributed` | `offenders` | Diagnosis |
     /// |---|---|---|
-    /// | 0 | empty | Work is real but BURSTY — every contract failed the meter's sustained gate. Not a hosting problem. |
-    /// | >0 | empty | Work IS attributed, but to contracts this node does not host (or none clears 25%). Not this node's to shed. |
-    /// | >0 | non-empty, all `rejected` | The offenders are immune BY DESIGN (invariant 3) — read the per-offender `outcome`. |
+    /// | 0 | empty | No SINGLE contract is individually above the axis floor — the load is DIFFUSE and the axis armed only on the sum. Nothing here is shed-able; this is an aggregate-budget question, not a per-contract one. (A genuinely bursty contract lands here too: its above-floor run keeps resetting.) |
+    /// | >0 | empty | Work IS attributed to individually-expensive contracts, but this node hosts none of them. Not this node's to shed. |
+    /// | >0 | non-empty, all `rejected` | The offenders are immune BY DESIGN (invariant 3) — read each `outcome`. |
+    ///
+    /// The middle row cannot mean "a hosted contract is close but under 25%":
+    /// such a contract has a positive rate, so it takes the
+    /// highest-positive-rate fallback and renders with an `under_share`
+    /// outcome, making `offenders` non-empty.
+    ///
+    /// "Above the axis floor" is meant literally, and is the subtle part: the
+    /// meter's sustained gate keys on a run of samples whose rate exceeds the
+    /// axis's own node-wide floor (`RunningAverage::new_cost_sustained`,
+    /// `topology/meter.rs`), NOT on sample continuity. Twenty contracts at
+    /// 1.5 msgs/s arm the 10 msgs/s broadcast axis on their 30 msgs/s sum while
+    /// every one of them reports `attributed = 0`.
     pub attributed: usize,
-    /// Hosted contracts that cleared the share cutoff, in the SAME order the
-    /// eviction loop acted on them (descending rate, ascending key bytes), so
-    /// `offenders[0]` is the first victim when there is one.
+    /// Hosted contracts that cleared the share cutoff, sorted by the SAME
+    /// comparator the eviction loop sorts its victims with (descending rate,
+    /// ascending key bytes), so the victims among them appear in the order they
+    /// were shed.
+    ///
+    /// `offenders[0]` is the highest-rate PROBE, NOT necessarily a victim: the
+    /// eviction loop iterates the candidacy-filtered subset, so when the
+    /// highest-rate contract is immune and a lower-ranked one is shed, slot 0
+    /// holds the immune contract with its `rejected` reason and the shed one
+    /// appears below it as `outcome=evicted`. Read the outcome, not the rank.
+    ///
+    /// Every entry has a POSITIVE, non-NaN rate: the probe filter rejects NaN
+    /// and anything at or below the cutoff, and the fallback below only fires
+    /// for `rate > 0.0`. That is what bounds this vector at ~3 entries (the
+    /// per-contract rates are a subset of `total_rate`, so at most three can
+    /// each exceed 25% of it) and what makes the sort comparator a total order.
     ///
     /// When nothing cleared the cutoff this falls back to the single
     /// highest-POSITIVE-rate hosted contract, so the line still names the
@@ -1246,29 +1281,49 @@ impl std::fmt::Display for CostAxisDecision {
 /// immediately when the DECISION changes rather than waiting out
 /// [`COST_DECISION_LOG_INTERVAL`].
 ///
-/// Deliberately covers only each axis's name, armed flag, and the SEQUENCE of
+/// Deliberately covers only each axis's name, armed flag, and the MULTISET of
 /// its offenders' outcomes — NOT their identities, the rates, or
 /// [`CostAxisDecision::attributed`]. Rates wobble every sweep and the top
 /// offender can swap between two near-equal contracts, so including any of
 /// those would turn the change-trigger into a per-sweep line. Those details
 /// still appear in the next periodic summary.
 ///
-/// Hashing the outcome sequence (rather than only the first offender's) means
-/// a secondary offender changing why it was spared also surfaces within one
-/// sweep. The vector is bounded at ~3 entries, so this cannot make the digest
-/// churn: it takes a real change in a real gate to move it.
+/// The outcomes are SORTED before hashing, which is what makes that claim
+/// true. `offenders` is ordered by rate, so hashing it in order would let two
+/// near-equal contracts crossing ranks — with both gates unchanged — flip the
+/// digest, re-admitting exactly the rate wobble this function excludes. Sorting
+/// means only a real change in a real gate moves it. Hashing the whole multiset
+/// rather than just the first offender's outcome means a SECONDARY offender
+/// changing why it was spared still surfaces within one sweep.
+///
+/// The volume bound does not depend on any of this — [`HostingCache::log_cost_decision`]
+/// is called once per sweep, so the hard ceiling is one line per sweep either
+/// way (see [`COST_DECISION_LOG_INTERVAL`]). Sorting buys a quieter steady
+/// state and an honest rationale, not safety.
 fn cost_decision_digest(decisions: &[CostAxisDecision]) -> u64 {
     use std::hash::{Hash, Hasher};
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     for decision in decisions {
         decision.axis.hash(&mut hasher);
         decision.armed.hash(&mut hasher);
-        // Length + per-offender `Option<_>` distinguishes no-offender / shed /
-        // rejected(why) at each rank.
-        decision.offenders.len().hash(&mut hasher);
-        for offender in &decision.offenders {
-            offender.rejected.hash(&mut hasher);
-        }
+        // Map to a small tag so the multiset can be sorted: `0` is "shed", and
+        // each reject reason gets its own stable tag. `offenders` is bounded at
+        // ~3 entries, so the sort is trivial. The `Vec`'s own `Hash` writes the
+        // length, so a changed offender COUNT still moves the digest.
+        let mut outcomes: Vec<u8> = decision
+            .offenders
+            .iter()
+            .map(|offender| match offender.rejected {
+                None => 0,
+                Some(CostRejectReason::ZeroRate) => 1,
+                Some(CostRejectReason::UnderShare) => 2,
+                Some(CostRejectReason::HasLocalSubs) => 3,
+                Some(CostRejectReason::HasDownstreamSubs) => 4,
+                Some(CostRejectReason::RecentlyAccessed) => 5,
+            })
+            .collect();
+        outcomes.sort_unstable();
+        outcomes.hash(&mut hasher);
     }
     hasher.finish()
 }
@@ -2256,11 +2311,23 @@ impl<T: TimeSource> HostingCache<T> {
                 // every sweep where any axis is over its floor (a busy
                 // gateway: always), across every hosted contract, so paying
                 // the subscriber lookup only for the handful over the cutoff
-                // matters. `rate <= cutoff` rejects rate == 0 and negatives;
-                // a NaN rate (defensive: meter math) is not <= cutoff so it
-                // falls through here, but `cost_eviction_candidate` then
-                // rejects it (its `attributed_rate > 0.0` is false for NaN).
-                if rate <= share_cutoff {
+                // matters. `rate <= cutoff` rejects rate == 0 and negatives.
+                //
+                // NaN is rejected EXPLICITLY rather than left to fall through
+                // to `cost_eviction_candidate` (whose `attributed_rate > 0.0`
+                // is false for NaN, so the victim set is identical either way).
+                // Letting it through would corrupt the REPORTING that now reads
+                // `probed`: `NaN <= cutoff` is false, so a NaN would (a) defeat
+                // the "at most 3 contracts can exceed 25% of the total" bound
+                // that keeps `probed` — and the rendered log line — small, since
+                // every hosted contract could pass, and (b) make the
+                // `partial_cmp`-based sort below a non-total order (NaN
+                // compares `Equal` to everything via the `unwrap_or`, creating
+                // ordering cycles), whose result `slice::sort_by` leaves
+                // unspecified. The meter cannot currently produce NaN
+                // (`Meter::contract_cost_rates_multi` inserts only
+                // `per_second > 0.0`), so this is defence in depth.
+                if rate.is_nan() || rate <= share_cutoff {
                     continue;
                 }
                 let (local, downstream) = subscriber_counts(key);
@@ -2434,6 +2501,14 @@ impl<T: TimeSource> HostingCache<T> {
         if !due && self.last_cost_decision_digest == Some(digest) {
             return;
         }
+        // Bookkeeping is committed BEFORE the emit because `tracing` gives no
+        // signal about whether an event survived the subscriber's filters. The
+        // node's global limiter is 1000 events/s (`util/rate_limit_layer.rs`)
+        // against this call site's peak of one per 60s sweep, so a drop needs
+        // the whole node to be saturated — plausible during exactly the storm
+        // this line diagnoses. The cost of a drop is bounded and self-healing:
+        // that one change-transition goes unreported, and the next periodic
+        // heartbeat re-states the current decision in full.
         self.last_cost_decision_log_at = Some(now);
         self.last_cost_decision_digest = Some(digest);
         // One line for all axes rather than one per axis: `tracing` field
@@ -3378,6 +3453,12 @@ mod tests {
             rendered.contains("armed=false") && rendered.contains("floor=50000"),
             "the unarmed line must carry total vs floor — got: {rendered}"
         );
+        assert!(
+            !rendered.contains("top=") && !rendered.contains("attributed="),
+            "an unarmed axis reports NOTHING past total-vs-floor: it is never \
+             scanned, so `top=none attributed=0` would be an unearned claim \
+             about hosted contracts — got: {rendered}"
+        );
     }
 
     /// The armed-axis summary names the top attributed-cost contract, its
@@ -3726,6 +3807,284 @@ mod tests {
         assert_eq!(
             decisions[0].offenders[0].key, lower,
             "the reported top offender uses the SAME tiebreak as the eviction sort"
+        );
+    }
+
+    /// The anti-drift pin driven through the REAL sweep, not a transcription.
+    ///
+    /// `cost_reject_classification_matches_eviction_decision` compares the
+    /// classifier against a hand-copied `rate.is_nan() || rate > cutoff` gate,
+    /// so it stays green if `evict_cost_pressure`'s own share filter drifts
+    /// (e.g. `<=` becoming `<`) — the classifier and its twin would agree with
+    /// each other while both disagreed with the code. This drives the same grid
+    /// through `evict_cost_pressure_observed` and asserts the reported outcome
+    /// matches what the sweep actually did.
+    #[test]
+    fn cost_reject_classification_matches_the_real_sweep() {
+        let total = 100_000.0;
+        let cutoff = COST_SHARE_THRESHOLD * total;
+        let rates = [
+            f64::NAN,
+            f64::NEG_INFINITY,
+            -1.0,
+            0.0,
+            f64::MIN_POSITIVE,
+            1.0,
+            cutoff - 0.1,
+            cutoff,
+            cutoff + 0.1,
+            90_000.0,
+        ];
+        for &rate in &rates {
+            for local in [0usize, 1] {
+                for downstream in [0usize, 1] {
+                    for recent in [false, true] {
+                        let (mut cache, clock) = make_cache(1024 * 1024);
+                        let key = make_key(1);
+                        cache.record_access(key, 121, AccessType::Put, 1, |_| (0, 0));
+                        clock.advance_time(COST_RATE_MIN_WINDOW + Duration::from_secs(1));
+                        if recent {
+                            cache.touch(&key);
+                        }
+                        let axes = [cost_axis(total, 50_000.0, &[(&key, rate)])];
+                        let (evicted, decisions) = cache.evict_cost_pressure_observed(
+                            &|_: &ContractKey| (local, downstream),
+                            &axes,
+                        );
+
+                        let shed = evicted.len() == 1;
+                        let reported = decisions[0].offenders.first();
+                        assert_eq!(
+                            reported.is_some_and(|offender| offender.rejected.is_none()),
+                            shed,
+                            "the sweep and its own explanation disagree for rate={rate} \
+                             local={local} downstream={downstream} recent={recent}: \
+                             evicted={} reported={reported:?}",
+                            evicted.len()
+                        );
+                        // The standalone classifier agrees with both, so drift
+                        // in any one of the three is caught here.
+                        assert_eq!(
+                            classify_cost_rejection(local, downstream, rate, cutoff, recent)
+                                .is_none(),
+                            shed,
+                            "classifier disagrees with the sweep for rate={rate} \
+                             local={local} downstream={downstream} recent={recent}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /// A NaN attributed rate must not reach the reporting vector.
+    ///
+    /// NaN is not `<= cutoff`, so without the explicit guard it passes the
+    /// share pre-filter into `probed`. That was harmless while `probed` only
+    /// fed `cost_eviction_candidate` (which rejects NaN), but the reporting
+    /// pass SORTS that vector: `partial_cmp` returns `None` for NaN, the
+    /// `unwrap_or(Equal)` turns it into "equal to everything", and the result
+    /// is an ordering cycle whose sort output `slice::sort_by` leaves
+    /// unspecified. NaN also defeats the share-based bound that keeps the
+    /// vector — and the rendered line — small, since every hosted contract
+    /// could then pass.
+    #[test]
+    fn cost_decision_nan_rate_never_enters_the_report() {
+        let (mut cache, clock) = make_cache(1024 * 1024);
+        let poisoned = make_key(1);
+        let real = make_key(2);
+        for (key, generation) in [(poisoned, 1), (real, 2)] {
+            cache.record_access(key, 121, AccessType::Put, generation, |_| (0, 0));
+        }
+        clock.advance_time(COST_RATE_MIN_WINDOW + Duration::from_secs(1));
+        let axes = [cost_axis(
+            100_000.0,
+            50_000.0,
+            &[(&poisoned, f64::NAN), (&real, 60_000.0)],
+        )];
+        let (evicted, decisions) =
+            cache.evict_cost_pressure_observed(&|_: &ContractKey| (0, 0), &axes);
+
+        assert_eq!(
+            evicted.len(),
+            1,
+            "only the real offender is shed — NaN was never a candidate"
+        );
+        assert_eq!(evicted[0].key, real);
+        assert_eq!(
+            decisions[0].offenders.len(),
+            1,
+            "the NaN contract must not be reported — got {:?}",
+            decisions[0].offenders
+        );
+        assert_eq!(decisions[0].offenders[0].key, real);
+        assert!(
+            decisions[0].offenders.iter().all(|o| !o.rate.is_nan()),
+            "no reported offender may carry a NaN rate"
+        );
+        assert!(
+            !decisions[0].to_string().contains("NaN"),
+            "rendered: {}",
+            decisions[0]
+        );
+    }
+
+    /// The rank-vs-outcome distinction, and per-axis eviction attribution.
+    ///
+    /// `offenders[0]` is the highest-rate PROBE, not necessarily a victim. When
+    /// an immune contract outranks the one actually shed, the summary must
+    /// still report both — `top=` carrying the immune contract's reason and
+    /// `also=` carrying `outcome=evicted` — because an operator greps `top=`
+    /// and would otherwise conclude the shed contract had been spared.
+    ///
+    /// Also pins `evicted` as a PER-AXIS count: the second axis sheds nothing,
+    /// so reporting the running total there would show 1 instead of 0.
+    #[test]
+    fn cost_decision_top_rank_may_be_immune_while_a_lower_rank_is_shed() {
+        let (mut cache, clock) = make_cache(1024 * 1024);
+        let immune = make_key(1);
+        let shed = make_key(2);
+        for (key, generation) in [(immune, 1), (shed, 2)] {
+            cache.record_access(key, 121, AccessType::Put, generation, |_| (0, 0));
+        }
+        clock.advance_time(COST_RATE_MIN_WINDOW + Duration::from_secs(1));
+        // `immune` has the HIGHER rate but a downstream subscriber; `shed` is
+        // second by rate and zero-demand. The second axis is armed but
+        // attributes everything to the already-immune contract, so it sheds
+        // nothing.
+        let axes = [
+            cost_axis(
+                100_000.0,
+                50_000.0,
+                &[(&immune, 45_000.0), (&shed, 40_000.0)],
+            ),
+            cost_axis(80_000.0, 50_000.0, &[(&immune, 70_000.0)]),
+        ];
+        let counts = |key: &ContractKey| if *key == immune { (0, 3) } else { (0, 0) };
+        let (evicted, decisions) = cache.evict_cost_pressure_observed(&counts, &axes);
+
+        assert_eq!(evicted.len(), 1);
+        assert_eq!(evicted[0].key, shed);
+        let axis0 = &decisions[0];
+        assert_eq!(axis0.offenders.len(), 2);
+        assert_eq!(
+            axis0.offenders[0].key, immune,
+            "slot 0 is the highest RATE, even though it was not the victim"
+        );
+        assert_eq!(
+            axis0.offenders[0].rejected,
+            Some(CostRejectReason::HasDownstreamSubs)
+        );
+        assert_eq!(axis0.offenders[1].key, shed);
+        assert_eq!(
+            axis0.offenders[1].rejected, None,
+            "the lower-ranked contract is the one that was shed"
+        );
+        let rendered = axis0.to_string();
+        assert!(
+            rendered.contains("outcome=has_downstream_subs")
+                && rendered.contains("also=")
+                && rendered.contains("outcome=evicted"),
+            "both the immune top and the shed runner-up must appear: {rendered}"
+        );
+        assert_eq!(
+            decisions.iter().map(|d| d.evicted).collect::<Vec<_>>(),
+            vec![1, 0],
+            "`evicted` counts THIS axis's victims, so the second armed axis \
+             reports 0 rather than inheriting the first axis's eviction"
+        );
+    }
+
+    /// The change-trigger must fire on a REASON change and stay quiet on rate
+    /// wobble — the two properties `cost_decision_digest`'s docs claim and the
+    /// steady-state volume figure depends on.
+    ///
+    /// The rate-limit test flips `armed`, the offender count, and a reason all
+    /// at once, so deleting any single digest component still passes it. These
+    /// isolate one component at a time.
+    #[test]
+    fn cost_decision_digest_tracks_reasons_not_rates() {
+        let build = |rate: f64| {
+            let (mut cache, clock) = make_cache(1024 * 1024);
+            let key = make_key(1);
+            cache.record_access(key, 121, AccessType::Put, 1, |_| (0, 0));
+            clock.advance_time(COST_RATE_MIN_WINDOW + Duration::from_secs(1));
+            let axis = cost_axis(100_000.0, 50_000.0, &[(&key, rate)]);
+            (cache, axis)
+        };
+
+        // Rate wobble with an UNCHANGED outcome must not move the digest —
+        // otherwise the change-trigger fires every sweep and the ~12 lines/hour
+        // steady state becomes the 60/hour worst case.
+        let (mut cache, axis_a) = build(58_000.0);
+        let (_, axis_b) = build(58_500.0);
+        let immune = |_: &ContractKey| (1usize, 0usize);
+        cache.evict_cost_pressure(&immune, std::slice::from_ref(&axis_a));
+        let after_first = (
+            cache.last_cost_decision_log_at,
+            cache.last_cost_decision_digest,
+        );
+        cache.evict_cost_pressure(&immune, std::slice::from_ref(&axis_b));
+        assert_eq!(
+            (
+                cache.last_cost_decision_log_at,
+                cache.last_cost_decision_digest
+            ),
+            after_first,
+            "a different rate with the same outcome must not re-trigger the log"
+        );
+
+        // A REASON change with the same armed flag and the same offender count
+        // must re-trigger within one sweep.
+        let (mut cache, axis) = build(58_000.0);
+        cache.evict_cost_pressure(&|_: &ContractKey| (1, 0), std::slice::from_ref(&axis));
+        let digest_local = cache.last_cost_decision_digest;
+        cache.evict_cost_pressure(&|_: &ContractKey| (0, 1), std::slice::from_ref(&axis));
+        assert_ne!(
+            cache.last_cost_decision_digest, digest_local,
+            "has_local_subs -> has_downstream_subs is a real gate change and \
+             must surface within one sweep, not wait for the heartbeat"
+        );
+    }
+
+    /// Two offenders swapping RANK with both gates unchanged must not
+    /// re-trigger. `cost_decision_digest` sorts its outcome multiset precisely
+    /// so this rate-driven reshuffle does not re-admit the wobble it excludes.
+    #[test]
+    fn cost_decision_digest_ignores_offender_rank_swaps() {
+        let scenario = |rate_a: f64, rate_b: f64| {
+            let (mut cache, clock) = make_cache(1024 * 1024);
+            let a = make_key(1);
+            let b = make_key(2);
+            for (key, generation) in [(a, 1), (b, 2)] {
+                cache.record_access(key, 121, AccessType::Put, generation, |_| (0, 0));
+            }
+            clock.advance_time(COST_RATE_MIN_WINDOW + Duration::from_secs(1));
+            // `b` is spared by recency, `a` by its local subscription, so the
+            // two outcomes are DIFFERENT and an order-sensitive digest would
+            // notice the swap.
+            cache.touch(&b);
+            let axes = [cost_axis(
+                100_000.0,
+                50_000.0,
+                &[(&a, rate_a), (&b, rate_b)],
+            )];
+            let counts = |key: &ContractKey| if *key == a { (1, 0) } else { (0, 0) };
+            let (evicted, decisions) = cache.evict_cost_pressure_observed(&counts, &axes);
+            assert!(evicted.is_empty(), "both are immune in this fixture");
+            assert_eq!(decisions[0].offenders.len(), 2);
+            (
+                cost_decision_digest(&decisions),
+                decisions[0].offenders[0].key,
+            )
+        };
+
+        let (digest_a_first, top_a) = scenario(40_000.0, 35_000.0);
+        let (digest_b_first, top_b) = scenario(35_000.0, 40_000.0);
+        assert_ne!(top_a, top_b, "the fixture really does swap the ranks");
+        assert_eq!(
+            digest_a_first, digest_b_first,
+            "a rank swap with both gates unchanged is not a decision change"
         );
     }
 

--- a/crates/core/src/ring/hosting/cache.rs
+++ b/crates/core/src/ring/hosting/cache.rs
@@ -3585,9 +3585,24 @@ mod tests {
                 cost_axis(5_000.0, 50_000.0, &[(&quiet, 5_000.0)]),
             ];
             let counts = |key: &ContractKey| if *key == subscribed { (0, 1) } else { (0, 0) };
-            let before = cache.last_cost_decision_log_at;
+            // Move the clock (in BOTH branches, so the runs stay identical)
+            // before sweeping. Without this the emit signal is blind: an emit
+            // rewrites `last_cost_decision_log_at` to the same `now` it was
+            // primed with, so a summary that DID fire looks exactly like one
+            // that stayed silent. Still far inside COST_DECISION_LOG_INTERVAL,
+            // so the periodic branch does not open.
+            clock.advance_time(Duration::from_secs(1));
+            let before = (
+                cache.last_cost_decision_log_at,
+                cache.last_cost_decision_digest,
+            );
             let evicted = cache.evict_cost_pressure(&counts, &axes);
-            let emitted = cache.last_cost_decision_log_at != before;
+            // Both fields, so neither a same-timestamp nor a same-digest
+            // coincidence can disguise an emit.
+            let emitted = (
+                cache.last_cost_decision_log_at,
+                cache.last_cost_decision_digest,
+            ) != before;
             (
                 (
                     evicted

--- a/crates/core/src/ring/hosting/cache.rs
+++ b/crates/core/src/ring/hosting/cache.rs
@@ -3810,6 +3810,74 @@ mod tests {
         );
     }
 
+    /// The DELIVERABLE is the log line, so pin that it still exists.
+    ///
+    /// Every other test here asserts on `CostAxisDecision` values or on the
+    /// emit bookkeeping, all of which keep passing if the `tracing::info!` call
+    /// is deleted outright — leaving this PR's entire purpose unpinned.
+    ///
+    /// A subscriber-capture test was tried first and REJECTED as inherently
+    /// flaky, not merely inconvenient: `tracing::subscriber::set_default` is
+    /// thread-local while `tracing`'s callsite `Interest` cache is GLOBAL, so
+    /// sibling tests hitting these same callsites concurrently with no
+    /// subscriber cache them as `never` process-wide, and the `info!` macro
+    /// then short-circuits before ever consulting the capture. Measured under
+    /// `cargo test --lib cost`: 1 of 2 expected events captured, passing when
+    /// run alone. `tracing::callsite::rebuild_interest_cache()` narrows the
+    /// window but does not close it — any sibling thread can re-poison the
+    /// cache between the rebuild and the emit. A test that passes alone and
+    /// fails in the suite is a broken test, so this scrapes the source instead,
+    /// the same idiom as `ring.rs`'s `*_source_tests` modules. It cannot prove
+    /// runtime delivery, but it catches the failure mode that matters here: the
+    /// emit being deleted, downgraded to `debug!`, or stripped of its fields.
+    #[test]
+    fn log_cost_decision_still_emits_an_info_event_with_its_fields() {
+        const FULL: &str = include_str!("cache.rs");
+        // Cut at `mod tests`, NOT at a bare `#[cfg(test)]`: cutting at the
+        // attribute would stop at the first inline `#[cfg(test)]` item and
+        // could leave the scraped region empty, silently vacating this pin.
+        let cutoff = FULL
+            .find("\n#[cfg(test)]\nmod tests")
+            .expect("cache.rs must have a top-level `mod tests`");
+        let production = &FULL[..cutoff];
+        let start = production
+            .find("fn log_cost_decision")
+            .expect("log_cost_decision must exist");
+        // Whitespace-stripped so a rustfmt reflow of the macro's arguments
+        // cannot vacate the needles.
+        let body: String = production[start..]
+            .chars()
+            .filter(|c| !c.is_whitespace())
+            .collect();
+
+        assert!(
+            body.contains(concat!("tracing::", "info!(")),
+            "the cost-decision summary must still be emitted"
+        );
+        assert!(
+            !body.contains(concat!("tracing::", "debug!(")),
+            "the summary must NOT be `debug!`: release builds compile that out \
+             via max_level_info, so it would be invisible in exactly the \
+             environment it exists for"
+        );
+        for field in [
+            "axes_armed=",
+            "hosted_contracts=",
+            "cost_evictions_total=",
+            "axes=%rendered",
+        ] {
+            assert!(
+                body.contains(field),
+                "the summary lost its `{field}` field — operators grep these"
+            );
+        }
+        // Message text, whitespace-stripped like the rest of the scrape.
+        assert!(
+            body.contains(concat!("\"cost-pressureeviction", "decision")),
+            "the summary's grep-able message must survive"
+        );
+    }
+
     /// The anti-drift pin driven through the REAL sweep, not a transcription.
     ///
     /// `cost_reject_classification_matches_eviction_decision` compares the

--- a/crates/core/src/ring/hosting/cache.rs
+++ b/crates/core/src/ring/hosting/cache.rs
@@ -1014,12 +1014,24 @@ pub(crate) fn cost_eviction_candidate(
 /// Minimum spacing between periodic cost-pressure decision summaries.
 ///
 /// The production sweep that drives [`HostingCache::evict_cost_pressure`] runs
-/// every 60s (`Ring::GET_SUBSCRIPTION_SWEEP_INTERVAL`), so logging every sweep
-/// would add ~60 `info!` lines/hour/node to gateways already emitting ~8 MB/hour
-/// (the #4259 log-volume budget). One heartbeat per this interval — plus an
-/// immediate line whenever the DECISION ITSELF changes, see
-/// [`cost_decision_digest`] — costs ~12 lines/hour in steady state while still
-/// surfacing a state change within one sweep.
+/// every 60s (`Ring::GET_SUBSCRIPTION_SWEEP_INTERVAL`). One heartbeat per this
+/// interval — plus an immediate line whenever the DECISION ITSELF changes, see
+/// [`cost_decision_digest`] — costs ~12 lines/hour in steady state.
+///
+/// The HARD BOUND is one line per sweep, i.e. **60 lines/hour**, not the
+/// steady-state 12: the change-trigger fires whenever an axis whose total
+/// hovers at its floor flips `armed`, or the top offender's reject reason
+/// alternates across sweeps. At ~750 bytes for a fully-armed three-axis line
+/// that worst case is ~45 KB/hour/node against a measured ~35 MB/hour main log
+/// (0.13%), so the bound is what matters, and it is safe.
+///
+/// This line is LOCAL ONLY. Nothing in the tracing-subscriber stack forwards
+/// events to the central OTLP collector — `tracing/tracer.rs` wires only
+/// `fmt::layer()` sinks (rolling files, stderr, console), and the collector's
+/// inputs are the explicitly enumerated `EventKind` / `send_standalone_event*`
+/// set in `tracing/telemetry.rs`. So this costs the collector nothing at any
+/// fleet size; do NOT "promote" it to a telemetry event without redoing that
+/// arithmetic against a 10x-larger network.
 pub(crate) const COST_DECISION_LOG_INTERVAL: Duration = Duration::from_secs(300);
 
 /// Why the highest-attributed-cost hosted contract on a cost axis was NOT shed.
@@ -1033,9 +1045,19 @@ pub(crate) const COST_DECISION_LOG_INTERVAL: Duration = Duration::from_secs(300)
 pub(crate) enum CostRejectReason {
     /// No positive attributed rate on this axis — covers zero, negatives, and
     /// NaN (all fail `attributed_rate > 0.0`). Reported ahead of
-    /// [`Self::UnderShare`] because "the meter attributed nothing to this
-    /// contract" and "the contract holds less than the share" are DIFFERENT
-    /// diagnoses with different fixes.
+    /// [`Self::UnderShare`] because "this contract has no attributed rate" and
+    /// "this contract holds less than the share" are DIFFERENT diagnoses with
+    /// different fixes.
+    ///
+    /// CAUTION for anyone reading this reason in the field: a zero rate does
+    /// NOT mean "the meter attributed nothing to this contract". The axis
+    /// `total_rate` sums EVERY positive per-contract rate, while the
+    /// per-contract `rates` map is the SUSTAINED subset — a rate is only
+    /// inserted when `activity_span >= min_window / 2`
+    /// (`topology/meter.rs::contract_cost_rates_multi`). So a contract whose
+    /// work is real but bursty reads as zero here. The rendered summary
+    /// carries [`CostAxisDecision::attributed`] alongside precisely so those
+    /// cases can be told apart; see that field's docs for the decision table.
     ZeroRate,
     /// Attributed rate did not exceed `COST_SHARE_THRESHOLD × total_rate`.
     UnderShare,
@@ -1112,8 +1134,8 @@ pub(crate) fn classify_cost_rejection(
     None
 }
 
-/// The highest-attributed-cost hosted contract on one axis, with the outcome
-/// the sweep reached for it.
+/// One high-attributed-cost hosted contract on an axis, with the outcome the
+/// sweep reached for it.
 #[derive(Debug, Clone)]
 pub(crate) struct CostTopOffender {
     pub key: ContractKey,
@@ -1141,12 +1163,41 @@ pub(crate) struct CostAxisDecision {
     pub floor: f64,
     /// `total_rate > floor` (NaN-safe) — whether the axis could shed at all.
     pub armed: bool,
-    /// Highest-attributed-rate hosted contract on this axis. `None` on an
-    /// UNARMED axis (the sweep does not scan hosted contracts there, and
-    /// reporting an offender would cost a scan the decision itself never pays
-    /// — `total_rate` vs `floor` is the whole explanation in that case) and on
-    /// an armed axis with nothing hosted.
-    pub top: Option<CostTopOffender>,
+    /// How many contracts the meter attributed SUSTAINED work to on this axis
+    /// (`axis.rates.len()`) — network-wide from this node's meter, NOT
+    /// restricted to contracts this node hosts. `0` on an unarmed axis, which
+    /// is not scanned.
+    ///
+    /// This is the field that makes "cost eviction never fired" diagnosable,
+    /// because `total_rate` and the per-contract rates come from DIFFERENT
+    /// filters (see [`CostRejectReason::ZeroRate`]). Decision table for an
+    /// `armed=true` axis that shed nothing:
+    ///
+    /// | `attributed` | `offenders` | Diagnosis |
+    /// |---|---|---|
+    /// | 0 | empty | Work is real but BURSTY — every contract failed the meter's sustained gate. Not a hosting problem. |
+    /// | >0 | empty | Work IS attributed, but to contracts this node does not host (or none clears 25%). Not this node's to shed. |
+    /// | >0 | non-empty, all `rejected` | The offenders are immune BY DESIGN (invariant 3) — read the per-offender `outcome`. |
+    pub attributed: usize,
+    /// Hosted contracts that cleared the share cutoff, in the SAME order the
+    /// eviction loop acted on them (descending rate, ascending key bytes), so
+    /// `offenders[0]` is the first victim when there is one.
+    ///
+    /// When nothing cleared the cutoff this falls back to the single
+    /// highest-POSITIVE-rate hosted contract, so the line still names the
+    /// biggest local holder with an `under_share` outcome. Every over-cutoff
+    /// contract is reported, not just the largest: `probed` is bounded at ~3
+    /// entries by construction, and reporting only the largest would hide the
+    /// reason a storm contract ranked second was spared.
+    ///
+    /// Empty on an UNARMED axis (the sweep does not scan hosted contracts
+    /// there, and reporting an offender would cost a scan the decision itself
+    /// never pays — `total_rate` vs `floor` is the whole explanation), and on
+    /// an armed axis where no hosted contract has any positive attributed
+    /// rate. A zero-rate contract is deliberately NOT named: with every rate
+    /// at zero the "highest" is an arbitrary innocent key, and naming it sends
+    /// the operator after the wrong contract. `attributed` carries that case.
+    pub offenders: Vec<CostTopOffender>,
     /// Contracts shed on this axis this sweep.
     pub evicted: usize,
 }
@@ -1158,20 +1209,31 @@ impl std::fmt::Display for CostAxisDecision {
             "{}: total={:.3} floor={:.3} armed={}",
             self.axis, self.total_rate, self.floor, self.armed
         )?;
-        match &self.top {
-            Some(top) => write!(
+        if !self.armed {
+            // total vs floor IS the whole explanation for an unarmed axis, and
+            // it is never scanned, so there is nothing further to report.
+            return Ok(());
+        }
+        write!(f, " attributed={}", self.attributed)?;
+        // `top=` for the first (the one the eviction loop acts on first),
+        // `also=` for the rest, so the established grep target still finds the
+        // primary offender while the secondary reasons stay visible.
+        for (index, offender) in self.offenders.iter().enumerate() {
+            write!(
                 f,
-                " top={} rate={:.3} share={:.3} outcome={}",
-                top.key,
-                top.rate,
-                top.share,
-                match top.rejected {
+                " {}={} rate={:.3} share={:.3} outcome={}",
+                if index == 0 { "top" } else { "also" },
+                offender.key,
+                offender.rate,
+                offender.share,
+                match offender.rejected {
                     Some(reason) => reason.as_str(),
                     None => "evicted",
                 }
-            )?,
-            None if self.armed => f.write_str(" top=none")?,
-            None => {}
+            )?;
+        }
+        if self.offenders.is_empty() {
+            f.write_str(" top=none")?;
         }
         if self.evicted > 0 {
             write!(f, " evicted={}", self.evicted)?;
@@ -1184,23 +1246,29 @@ impl std::fmt::Display for CostAxisDecision {
 /// immediately when the DECISION changes rather than waiting out
 /// [`COST_DECISION_LOG_INTERVAL`].
 ///
-/// Deliberately covers only each axis's name, armed flag, and top-offender
-/// outcome — NOT the offender's identity or the rates. Rates wobble every
-/// sweep and the top offender can swap between two near-equal contracts, so
-/// including either would turn the change-trigger into a per-sweep line. Those
-/// details still appear in the next periodic summary.
+/// Deliberately covers only each axis's name, armed flag, and the SEQUENCE of
+/// its offenders' outcomes — NOT their identities, the rates, or
+/// [`CostAxisDecision::attributed`]. Rates wobble every sweep and the top
+/// offender can swap between two near-equal contracts, so including any of
+/// those would turn the change-trigger into a per-sweep line. Those details
+/// still appear in the next periodic summary.
+///
+/// Hashing the outcome sequence (rather than only the first offender's) means
+/// a secondary offender changing why it was spared also surfaces within one
+/// sweep. The vector is bounded at ~3 entries, so this cannot make the digest
+/// churn: it takes a real change in a real gate to move it.
 fn cost_decision_digest(decisions: &[CostAxisDecision]) -> u64 {
     use std::hash::{Hash, Hasher};
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     for decision in decisions {
         decision.axis.hash(&mut hasher);
         decision.armed.hash(&mut hasher);
-        // `Option<Option<_>>` distinguishes no-offender / shed / rejected(why).
-        decision
-            .top
-            .as_ref()
-            .map(|top| top.rejected)
-            .hash(&mut hasher);
+        // Length + per-offender `Option<_>` distinguishes no-offender / shed /
+        // rejected(why) at each rank.
+        decision.offenders.len().hash(&mut hasher);
+        for offender in &decision.offenders {
+            offender.rejected.hash(&mut hasher);
+        }
     }
     hasher.finish()
 }
@@ -2138,15 +2206,17 @@ impl<T: TimeSource> HostingCache<T> {
                     total_rate: axis.total_rate,
                     floor: axis.floor,
                     armed: false,
-                    top: None,
+                    attributed: 0,
+                    offenders: Vec::new(),
                     evicted: 0,
                 });
                 continue;
             }
             let share_cutoff = COST_SHARE_THRESHOLD * axis.total_rate;
             // OBSERVABILITY, same pass, no extra state reads: `top_rate` is the
-            // highest attributed rate across ALL hosted contracts (so the
-            // summary can name the offender even when it is rejected), and
+            // highest POSITIVE attributed rate across all hosted contracts (so
+            // the summary can still name the biggest local holder when nothing
+            // clears the cutoff), and
             // `probed` records the candidacy inputs of every contract that
             // cleared the share cutoff, so the summary explains the rejection
             // from the inputs the DECISION used rather than from a second,
@@ -2161,10 +2231,17 @@ impl<T: TimeSource> HostingCache<T> {
                 // Highest rate wins; equal rates fall back to the SAME
                 // ascending key-byte tiebreak the eviction sort below uses, so
                 // the reported offender is deterministic and matches the first
-                // victim when there is one. A NaN rate is skipped rather than
-                // allowed to become an unbeatable maximum (nothing compares
-                // greater than NaN); it is never a candidate anyway.
-                if !rate.is_nan()
+                // victim when there is one.
+                //
+                // `rate > 0.0` is a CORRECTNESS gate, not an optimization: it
+                // excludes NaN (which would otherwise be an unbeatable maximum,
+                // since nothing compares greater than NaN) AND the all-zero
+                // case. When the meter attributes nothing to anything hosted,
+                // the "highest" rate is a tie at 0.0 that the key-byte tiebreak
+                // resolves to an arbitrary INNOCENT contract — naming it in the
+                // summary points the operator at the wrong key, every heartbeat,
+                // deterministically. `attributed` reports that case instead.
+                if rate > 0.0
                     && top_rate.as_ref().is_none_or(|(top_key, top)| {
                         rate > *top || (rate == *top && key.as_bytes() < top_key.as_bytes())
                     })
@@ -2259,41 +2336,70 @@ impl<T: TimeSource> HostingCache<T> {
                     });
                 }
             }
-            // Explain THIS axis's outcome from the inputs used above. The
-            // classification of the top offender is `None` exactly when it was
-            // shed, because `classify_cost_rejection` returns `None` under
-            // precisely the `rate > cutoff && cost_eviction_candidate(..)`
-            // condition the loop above acted on.
-            let top = top_rate.map(|(key, rate)| {
-                let rejected = match probed.iter().find(|(probed_key, ..)| *probed_key == key) {
-                    Some((_, rate, local, downstream, recently_accessed)) => {
-                        classify_cost_rejection(
+            // Explain THIS axis's outcome from the inputs used above. Each
+            // classification is `None` exactly when that contract was shed,
+            // because `classify_cost_rejection` returns `None` under precisely
+            // the `rate > cutoff && cost_eviction_candidate(..)` condition the
+            // loop above acted on.
+            //
+            // EVERY over-cutoff contract is reported, not just the largest.
+            // `probed` is bounded at ~3 entries, and reporting only the largest
+            // hides the case that matters: a storm contract ranked second
+            // behind a legitimately-expensive one, where the summary would name
+            // the legitimate contract's reason and silently drop the storm
+            // contract's.
+            let mut reported: Vec<CostTopOffender> = probed
+                .iter()
+                .map(
+                    |(key, rate, local, downstream, recently_accessed)| CostTopOffender {
+                        key: *key,
+                        rate: *rate,
+                        share: rate / axis.total_rate,
+                        rejected: classify_cost_rejection(
                             *local,
                             *downstream,
                             *rate,
                             share_cutoff,
                             *recently_accessed,
-                        )
-                    }
-                    // Never cleared the share cutoff, so it has no recorded
-                    // candidacy inputs — and needs none: the rate gates
-                    // (`ZeroRate` / `UnderShare`) decide it before any
-                    // subscriber or recency term is consulted.
-                    None => classify_cost_rejection(0, 0, rate, share_cutoff, false),
-                };
-                CostTopOffender {
+                        ),
+                    },
+                )
+                .collect();
+            // Same comparator as the eviction sort above, so `reported[0]` is
+            // the contract the eviction loop acted on first.
+            reported.sort_by(|a, b| {
+                b.rate
+                    .partial_cmp(&a.rate)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+                    .then_with(|| a.key.as_bytes().cmp(b.key.as_bytes()))
+            });
+            if reported.is_empty() {
+                // Nothing cleared the share cutoff, so name the biggest local
+                // holder anyway — it is the contract an operator would ask
+                // about next. It has no recorded candidacy inputs and needs
+                // none: `top_rate` only holds rates `> 0.0`, and this branch
+                // only runs when that rate is `<= share_cutoff`, so the share
+                // gate decides it before any subscriber or recency term is
+                // consulted. `top_rate` is `None` (leaving this empty) exactly
+                // when no hosted contract has a positive attributed rate.
+                reported.extend(top_rate.map(|(key, rate)| CostTopOffender {
                     key,
                     rate,
                     share: rate / axis.total_rate,
-                    rejected,
-                }
-            });
+                    rejected: classify_cost_rejection(0, 0, rate, share_cutoff, false),
+                }));
+            }
             decisions.push(CostAxisDecision {
                 axis: axis.axis,
                 total_rate: axis.total_rate,
                 floor: axis.floor,
                 armed: true,
-                top,
+                // Meter-wide, NOT restricted to hosted contracts: `attributed
+                // > 0` with no offender is "the work is attributed, just not to
+                // anything this node hosts", which is a different diagnosis
+                // from "nothing cleared the meter's sustained gate".
+                attributed: axis.rates.len(),
+                offenders: reported,
                 evicted: evicted.len() - evicted_before_axis,
             });
         }
@@ -3264,7 +3370,8 @@ mod tests {
         assert!(!decision.armed, "sub-floor total must report armed=false");
         assert_eq!(decision.total_rate, 10_000.0);
         assert_eq!(decision.floor, 50_000.0);
-        assert!(decision.top.is_none());
+        assert!(decision.offenders.is_empty());
+        assert_eq!(decision.attributed, 0, "an unarmed axis is never scanned");
         assert_eq!(decision.evicted, 0);
         let rendered = decision.to_string();
         assert!(
@@ -3291,7 +3398,10 @@ mod tests {
         let (evicted, decisions) = cache
             .evict_cost_pressure_observed(&|_: &ContractKey| (0, 0), &armed_axis(&junk, 58_000.0));
         assert_eq!(evicted.len(), 1);
-        let top = decisions[0].top.as_ref().expect("armed axis names a top");
+        let top = decisions[0]
+            .offenders
+            .first()
+            .expect("armed axis names a top");
         assert_eq!(top.key, junk);
         assert_eq!(top.rate, 58_000.0);
         assert!((top.share - 0.58).abs() < 1e-9);
@@ -3314,7 +3424,7 @@ mod tests {
         );
         assert!(evicted.is_empty());
         assert_eq!(
-            decisions[0].top.as_ref().unwrap().rejected,
+            decisions[0].offenders[0].rejected,
             Some(CostRejectReason::HasLocalSubs)
         );
 
@@ -3329,7 +3439,7 @@ mod tests {
         );
         assert!(evicted.is_empty());
         assert_eq!(
-            decisions[0].top.as_ref().unwrap().rejected,
+            decisions[0].offenders[0].rejected,
             Some(CostRejectReason::HasDownstreamSubs)
         );
 
@@ -3345,7 +3455,7 @@ mod tests {
         );
         assert!(evicted.is_empty());
         assert_eq!(
-            decisions[0].top.as_ref().unwrap().rejected,
+            decisions[0].offenders[0].rejected,
             Some(CostRejectReason::RecentlyAccessed)
         );
 
@@ -3364,40 +3474,88 @@ mod tests {
         let (evicted, decisions) =
             cache.evict_cost_pressure_observed(&|_: &ContractKey| (0, 0), &axes);
         assert!(evicted.is_empty());
-        let top = decisions[0].top.as_ref().unwrap();
+        let top = &decisions[0].offenders[0];
         assert_eq!(top.key, b, "the highest-rate contract is the reported top");
         assert_eq!(top.rejected, Some(CostRejectReason::UnderShare));
 
-        // 6. zero_rate — the axis is armed node-wide, but the meter attributes
-        //    nothing to any hosted contract. This is the diagnosis that is
-        //    otherwise indistinguishable from "everything is under share".
+        // 6. Nothing attributed to any HOSTED contract on an armed axis. The
+        //    summary must NOT name a contract here: every hosted rate is 0.0,
+        //    so the "highest" is whichever key sorts first — an innocent
+        //    bystander that would be named in every heartbeat, deterministically.
+        //    `top=none` plus `attributed=` is the honest report, and it is what
+        //    separates the two causes an operator must tell apart.
         let (mut cache, clock) = make_cache(1024 * 1024);
         let unattributed = make_key(7);
-        cache.record_access(unattributed, 121, AccessType::Put, 1, |_| (0, 0));
+        let also_unattributed = make_key(8);
+        for key in [unattributed, also_unattributed] {
+            cache.record_access(key, 121, AccessType::Put, 1, |_| (0, 0));
+        }
         clock.advance_time(COST_RATE_MIN_WINDOW + Duration::from_secs(1));
         let axes = [cost_axis(100_000.0, 50_000.0, &[])];
         let (evicted, decisions) =
             cache.evict_cost_pressure_observed(&|_: &ContractKey| (0, 0), &axes);
         assert!(evicted.is_empty());
-        let top = decisions[0].top.as_ref().unwrap();
-        assert_eq!(top.key, unattributed);
-        assert_eq!(top.rate, 0.0);
-        assert_eq!(top.rejected, Some(CostRejectReason::ZeroRate));
         assert!(
-            decisions[0].to_string().contains("outcome=zero_rate"),
-            "rendered: {}",
-            decisions[0]
+            decisions[0].offenders.is_empty(),
+            "an all-zero-rate axis must not name an arbitrary innocent contract \
+             as the top offender — got {:?}",
+            decisions[0].offenders
+        );
+        assert_eq!(
+            decisions[0].attributed, 0,
+            "an empty rates map means the meter attributed nothing (bursty work \
+             filtered by the sustained gate, or no contract activity at all)"
+        );
+        let rendered = decisions[0].to_string();
+        assert!(
+            rendered.contains("armed=true")
+                && rendered.contains("attributed=0")
+                && rendered.contains("top=none"),
+            "the armed-but-unattributed line must read armed=true attributed=0 \
+             top=none — got: {rendered}"
+        );
+
+        // 6b. Attributed, but to a contract this node does NOT host. Same empty
+        //     offender list, but `attributed > 0` — a DIFFERENT diagnosis
+        //     ("not ours to shed") that would be indistinguishable from 6
+        //     without this field. This is the distinction `zero_rate` alone
+        //     could not express.
+        let (mut cache, clock) = make_cache(1024 * 1024);
+        let hosted = make_key(9);
+        let elsewhere = make_key(10);
+        cache.record_access(hosted, 121, AccessType::Put, 1, |_| (0, 0));
+        clock.advance_time(COST_RATE_MIN_WINDOW + Duration::from_secs(1));
+        let axes = [cost_axis(100_000.0, 50_000.0, &[(&elsewhere, 90_000.0)])];
+        let (evicted, decisions) =
+            cache.evict_cost_pressure_observed(&|_: &ContractKey| (0, 0), &axes);
+        assert!(evicted.is_empty());
+        assert!(decisions[0].offenders.is_empty());
+        assert_eq!(
+            decisions[0].attributed, 1,
+            "the meter DID attribute the work — just not to a hosted contract"
+        );
+        let rendered = decisions[0].to_string();
+        assert!(
+            rendered.contains("attributed=1") && rendered.contains("top=none"),
+            "rendered: {rendered}"
         );
     }
 
     /// The observability path must not perturb the decision. Two identical
-    /// caches, one with the summary-log rate limiter already primed (so it
-    /// stays silent) and one fresh (so it logs), shed exactly the same
-    /// contracts in the same order — proving the log gate is downstream of the
-    /// decision, not an input to it.
+    /// caches, one with the summary-log rate limiter primed to the digest this
+    /// scenario actually produces (so it genuinely stays SILENT) and one fresh
+    /// (so it genuinely LOGS), shed exactly the same contracts in the same
+    /// order — proving the log gate is downstream of the decision, not an input
+    /// to it.
+    ///
+    /// The priming digest is taken from the fresh run rather than an arbitrary
+    /// constant. Priming with, say, `Some(0)` would NOT silence the gate — the
+    /// real `DefaultHasher` digest is not 0, so the `last_digest == digest` arm
+    /// would not match and BOTH runs would log, leaving the silent branch
+    /// untested while the assertion still passed.
     #[test]
     fn cost_decision_logging_state_does_not_change_evictions() {
-        let scenario = |prime_log_state: bool| {
+        let scenario = |prime_digest: Option<u64>| {
             let (mut cache, clock) = make_cache(1024 * 1024);
             let bigger = make_key(1);
             let big = make_key(2);
@@ -3407,11 +3565,11 @@ mod tests {
                 cache.record_access(key, 121, AccessType::Put, generation, |_| (0, 0));
             }
             clock.advance_time(COST_RATE_MIN_WINDOW + Duration::from_secs(1));
-            if prime_log_state {
-                // Pretend a summary was just emitted with an arbitrary digest:
-                // the rate limiter is now closed for this sweep.
+            if let Some(digest) = prime_digest {
+                // Pretend this exact summary was just emitted: the rate limiter
+                // is now closed for this sweep (not `due`, digest unchanged).
                 cache.last_cost_decision_log_at = Some(cache.time_source.now());
-                cache.last_cost_decision_digest = Some(0);
+                cache.last_cost_decision_digest = Some(digest);
             }
             let axes = [
                 cost_axis(
@@ -3427,19 +3585,33 @@ mod tests {
                 cost_axis(5_000.0, 50_000.0, &[(&quiet, 5_000.0)]),
             ];
             let counts = |key: &ContractKey| if *key == subscribed { (0, 1) } else { (0, 0) };
+            let before = cache.last_cost_decision_log_at;
             let evicted = cache.evict_cost_pressure(&counts, &axes);
+            let emitted = cache.last_cost_decision_log_at != before;
             (
-                evicted
-                    .iter()
-                    .map(|e| (e.key, e.write_generation))
-                    .collect::<Vec<_>>(),
-                cache.stats().cost_evictions_total,
-                cache.keys_eviction_order(),
+                (
+                    evicted
+                        .iter()
+                        .map(|e| (e.key, e.write_generation))
+                        .collect::<Vec<_>>(),
+                    cache.stats().cost_evictions_total,
+                    cache.keys_eviction_order(),
+                ),
+                emitted,
+                cache.last_cost_decision_digest,
             )
         };
 
-        let fresh = scenario(false);
-        let primed = scenario(true);
+        let (fresh, fresh_emitted, fresh_digest) = scenario(None);
+        let (primed, primed_emitted, _) = scenario(fresh_digest);
+        // The two branches of the log gate were genuinely exercised — without
+        // this the test would pass with both runs logging, testing nothing.
+        assert!(fresh_emitted, "a fresh cache must emit the first summary");
+        assert!(
+            !primed_emitted,
+            "priming with the digest this sweep produces must silence the \
+             summary — otherwise the silent branch is never exercised"
+        );
         assert_eq!(
             fresh, primed,
             "the summary-log rate-limiter state must not influence which \
@@ -3537,9 +3709,63 @@ mod tests {
             "eviction breaks equal-rate ties by ascending key bytes"
         );
         assert_eq!(
-            decisions[0].top.as_ref().unwrap().key,
-            lower,
+            decisions[0].offenders[0].key, lower,
             "the reported top offender uses the SAME tiebreak as the eviction sort"
+        );
+    }
+
+    /// EVERY over-cutoff contract is explained, not just the largest.
+    ///
+    /// The failure this prevents is the realistic field shape: a legitimately
+    /// expensive subscribed contract holds the top slot, and the actual storm
+    /// contract sits second. Reporting only the top would tell the operator
+    /// `has_downstream_subs` — a true statement about the wrong contract — and
+    /// silently drop the second contract's reason, which is the one that
+    /// explains why the storm persists.
+    #[test]
+    fn cost_decision_reports_every_over_cutoff_offender() {
+        let (mut cache, clock) = make_cache(1024 * 1024);
+        let legit = make_key(1);
+        let storm = make_key(2);
+        for (key, generation) in [(legit, 1), (storm, 2)] {
+            cache.record_access(key, 121, AccessType::Put, generation, |_| (0, 0));
+        }
+        clock.advance_time(COST_RATE_MIN_WINDOW + Duration::from_secs(1));
+        // Both clear the 25% cutoff; `legit` is larger, so it takes the top
+        // slot. Each is spared by a DIFFERENT gate.
+        let axes = [cost_axis(
+            100_000.0,
+            50_000.0,
+            &[(&legit, 40_000.0), (&storm, 35_000.0)],
+        )];
+        cache.touch(&storm); // storm is spared by recency, legit by subscribers
+        let counts = |key: &ContractKey| if *key == legit { (0, 4) } else { (0, 0) };
+        let (evicted, decisions) = cache.evict_cost_pressure_observed(&counts, &axes);
+
+        assert!(evicted.is_empty(), "both are immune, so nothing is shed");
+        assert_eq!(
+            decisions[0].offenders.len(),
+            2,
+            "both over-cutoff contracts must be reported — got {:?}",
+            decisions[0].offenders
+        );
+        assert_eq!(decisions[0].offenders[0].key, legit, "descending by rate");
+        assert_eq!(
+            decisions[0].offenders[0].rejected,
+            Some(CostRejectReason::HasDownstreamSubs)
+        );
+        assert_eq!(decisions[0].offenders[1].key, storm);
+        assert_eq!(
+            decisions[0].offenders[1].rejected,
+            Some(CostRejectReason::RecentlyAccessed),
+            "the SECOND offender's reason is the one that explains the storm"
+        );
+        let rendered = decisions[0].to_string();
+        assert!(
+            rendered.contains("outcome=has_downstream_subs")
+                && rendered.contains("also=")
+                && rendered.contains("outcome=recently_accessed"),
+            "the rendered line must carry BOTH reasons — got: {rendered}"
         );
     }
 

--- a/crates/core/src/ring/hosting/cache.rs
+++ b/crates/core/src/ring/hosting/cache.rs
@@ -2453,8 +2453,11 @@ impl<T: TimeSource> HostingCache<T> {
                     },
                 )
                 .collect();
-            // Same comparator as the eviction sort above, so `reported[0]` is
-            // the contract the eviction loop acted on first.
+            // Same comparator as the eviction sort above, so the victims among
+            // these appear in the order they were shed. `reported[0]` is the
+            // highest-RATE probe, which is not necessarily a victim — an immune
+            // contract can outrank the one actually shed. See
+            // `CostAxisDecision::offenders`.
             reported.sort_by(|a, b| {
                 b.rate
                     .partial_cmp(&a.rate)

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -2505,6 +2505,46 @@ mod tests {
         }
     }
 
+    /// The cost-pressure eviction counter (#4861) must reach the local
+    /// dashboard, not only central telemetry: on a gateway the local card is
+    /// the only hosting-counter view an operator has WITHOUT a collector, and
+    /// its absence is part of why the 2026-07-25 vega storm could not be
+    /// diagnosed on the box. Zero must render as a real "0" (the trigger has
+    /// never fired) rather than being hidden.
+    #[test]
+    fn hosting_card_renders_cost_eviction_counter() {
+        use crate::node::network_status::HostingSnapshot;
+        let mut snap = base_snapshot();
+        snap.hosting = HostingSnapshot {
+            budget_bytes: 256 * 1024 * 1024,
+            used_bytes: 1024,
+            contract_count: 1,
+            cost_evictions_total: 0,
+            contracts: vec![mk_hosted_entry("A", 1.0, true)],
+            ..Default::default()
+        };
+        let html = build_hosting_card(&Some(snap));
+        assert!(
+            html.contains("Cost evictions"),
+            "cost-eviction tile label present — got:\n{html}"
+        );
+
+        let mut snap = base_snapshot();
+        snap.hosting = HostingSnapshot {
+            budget_bytes: 256 * 1024 * 1024,
+            used_bytes: 1024,
+            contract_count: 1,
+            cost_evictions_total: 42,
+            contracts: vec![mk_hosted_entry("A", 1.0, true)],
+            ..Default::default()
+        };
+        let html = build_hosting_card(&Some(snap));
+        assert!(
+            html.contains(r#"<div class="g-norm-value">42</div>"#),
+            "cost-eviction count must render — got:\n{html}"
+        );
+    }
+
     #[test]
     fn hosting_card_badges_first_eligible_row_not_lowest_score() {
         use crate::node::network_status::HostingSnapshot;
@@ -2589,6 +2629,7 @@ mod tests {
             contract_count: 1,
             budget_evictions_total: 0,
             evictions_of_recently_read_total: 0,
+            cost_evictions_total: 0,
             contracts: vec![mk_hosted_entry("A", 1.0, false)],
             disk_state_bytes: None,
             disk_wasm_bytes: None,
@@ -2630,6 +2671,7 @@ mod tests {
             contract_count: 1,
             budget_evictions_total: 0,
             evictions_of_recently_read_total: 0,
+            cost_evictions_total: 0,
             contracts: vec![mk_hosted_entry("A", 1.0, false)],
             disk_state_bytes: Some(100 * 1024 * 1024),
             disk_wasm_bytes: Some(20 * 1024 * 1024),

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -2524,9 +2524,16 @@ mod tests {
             ..Default::default()
         };
         let html = build_hosting_card(&Some(snap));
+        // Zero must render as a real "0", not be blanked out: "the cost trigger
+        // has never fired" and "the counter is missing" are different answers,
+        // and the adjacent `recently_read_value` in cards.rs does conditionally
+        // blank itself, so this is a live failure mode rather than a
+        // hypothetical. Anchored to the label so only THIS tile satisfies it.
         assert!(
-            html.contains("Cost evictions"),
-            "cost-eviction tile label present — got:\n{html}"
+            html.contains(
+                r#"<div class="g-norm-label">Cost evictions</div><div class="g-norm-value">0</div>"#
+            ),
+            "a never-fired cost trigger must render a real 0 — got:\n{html}"
         );
 
         let mut snap = base_snapshot();

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -2539,9 +2539,28 @@ mod tests {
             ..Default::default()
         };
         let html = build_hosting_card(&Some(snap));
+        // Anchored to the LABEL, not just the value: asserting on
+        // `<div class="g-norm-value">42</div>` alone would be satisfied by any
+        // other tile that happened to render 42.
         assert!(
-            html.contains(r#"<div class="g-norm-value">42</div>"#),
-            "cost-eviction count must render — got:\n{html}"
+            html.contains(
+                r#"<div class="g-norm-label">Cost evictions</div><div class="g-norm-value">42</div>"#
+            ),
+            "cost-eviction count must render in the cost-eviction tile — got:\n{html}"
+        );
+        // The #4338 demand-miscalibration alarm must stay ahead of the new
+        // tile: `.g-norms` is a 5-column grid shared by five cards, so the
+        // sixth tile wraps to its own row and that must not be this alarm.
+        let alarm = html
+            .find("Evicted w/ demand")
+            .expect("demand-miscalibration tile present");
+        let cost = html
+            .find("Cost evictions")
+            .expect("cost-eviction tile present");
+        assert!(
+            alarm < cost,
+            "the new cost tile must be appended AFTER 'Evicted w/ demand' so the \
+             alarm keeps its first-row slot"
         );
     }
 

--- a/crates/core/src/server/home_page/cards.rs
+++ b/crates/core/src/server/home_page/cards.rs
@@ -1262,6 +1262,13 @@ pub fn build_hosting_card(snap: &Option<network_status::NetworkStatusSnapshot>) 
         "0".to_string()
     };
 
+    // Cost-pressure evictions (#4861) are a SEPARATE trigger from the byte
+    // budget: a tiny-state contract burning the node's update-work capacity is
+    // shed while comfortably under `budget_bytes`. Shown as its own tile so an
+    // operator can tell "the cost trigger is firing" from "the cost trigger has
+    // never fired", which the byte-eviction tile cannot express.
+    let cost_evictions_value = h.cost_evictions_total.to_string();
+
     // Per-contract table, bounded. Rows arrive in EVICTION order (lowest
     // keep-score first); show at most MAX_ROWS. The tile carries the full count.
     //
@@ -1345,6 +1352,7 @@ pub fn build_hosting_card(snap: &Option<network_status::NetworkStatusSnapshot>) 
                     <div class="g-norm"><div class="g-norm-label">Headroom</div><div class="g-norm-value">{headroom}</div></div>
                     <div class="g-norm"><div class="g-norm-label">Hosted</div><div class="g-norm-value">{count}</div></div>
                     <div class="g-norm"><div class="g-norm-label">Budget evictions</div><div class="g-norm-value">{budget_evictions}</div></div>
+                    <div class="g-norm" title="Zero-demand contracts shed because their attributed update-work (WASM CPU, broadcast fan-out bytes, or broadcast message count) dominated this node's total on a cost axis — a separate trigger from the byte budget (#4861)."><div class="g-norm-label">Cost evictions</div><div class="g-norm-value">{cost_evictions}</div></div>
                     <div class="g-norm"><div class="g-norm-label">Evicted w/ demand</div><div class="g-norm-value">{recently_read}</div></div>
                 </div>
             </div>
@@ -1369,6 +1377,7 @@ pub fn build_hosting_card(snap: &Option<network_status::NetworkStatusSnapshot>) 
         headroom = format_bytes(headroom),
         count = h.contract_count,
         budget_evictions = h.budget_evictions_total,
+        cost_evictions = cost_evictions_value,
         recently_read = recently_read_value,
         disk_breakdown_title = html_escape(&disk_breakdown_title),
         disk_used = disk_used_value,

--- a/crates/core/src/server/home_page/cards.rs
+++ b/crates/core/src/server/home_page/cards.rs
@@ -1352,8 +1352,13 @@ pub fn build_hosting_card(snap: &Option<network_status::NetworkStatusSnapshot>) 
                     <div class="g-norm"><div class="g-norm-label">Headroom</div><div class="g-norm-value">{headroom}</div></div>
                     <div class="g-norm"><div class="g-norm-label">Hosted</div><div class="g-norm-value">{count}</div></div>
                     <div class="g-norm"><div class="g-norm-label">Budget evictions</div><div class="g-norm-value">{budget_evictions}</div></div>
-                    <div class="g-norm" title="Zero-demand contracts shed because their attributed update-work (WASM CPU, broadcast fan-out bytes, or broadcast message count) dominated this node's total on a cost axis — a separate trigger from the byte budget (#4861)."><div class="g-norm-label">Cost evictions</div><div class="g-norm-value">{cost_evictions}</div></div>
                     <div class="g-norm"><div class="g-norm-label">Evicted w/ demand</div><div class="g-norm-value">{recently_read}</div></div>
+                    <!-- APPENDED LAST on purpose: `.g-norms` is `repeat(5, 1fr)` (assets/style.css)
+                         and is shared by five cards, so it must not be widened here. A sixth tile
+                         wraps to its own row; the one that wraps should be this new counter, not
+                         "Evicted w/ demand" — that tile is the #4338 demand-miscalibration alarm
+                         and needs to stay on the first row where an operator scans. -->
+                    <div class="g-norm" title="Zero-demand contracts shed because their attributed update-work (WASM CPU, broadcast fan-out bytes, or broadcast message count) dominated this node's total on a cost axis — a separate trigger from the byte budget (#4861)."><div class="g-norm-label">Cost evictions</div><div class="g-norm-value">{cost_evictions}</div></div>
                 </div>
             </div>
             <div class="g-verdict-row">


### PR DESCRIPTION
## Problem

Cost-pressure eviction (#4861, PR #4903, shipped in 0.2.105) is effectively
**write-only in the field**. The only log on the path fires on a *successful*
eviction, so the case that actually needs diagnosing — a sweep that shed
**nothing** — is completely silent. There is no log, metric, or counter when an
axis is under its floor, when no contract clears `COST_SHARE_THRESHOLD`, or when
a would-be offender is rejected by the zero-demand candidacy gate.

The gap is structural, and holds independently of any particular incident: on
a sweep that sheds nothing, these causes are indistinguishable from outside the
process even though each needs a different fix.

- the axis is below its floor;
- an offender exists but is immune **by design** (hosting-invariant 3:
  subscribed, or recently read);
- the load is diffuse — no single contract is individually above the axis
  floor, so the axis armed only on the sum;
- a real offender exists but has not yet SUSTAINED an above-floor rate;
- the work is attributed, but to contracts this node does not host.

The original author reports this blocking a diagnosis on the `vega` gateway
around 2026-07-25 (a sustained storm during which cost eviction never fired).
I have not independently corroborated that from logs, so the case above rests
on the structural argument rather than on that incident. Relatedly, #4877
(open) lists reducing vega's hosted contract count via demand-driven eviction
as one of its options, which is a question this line would help answer.

## Solution

Make the **decision** observable. No semantic change to eviction.

**1. A pure reject-reason classifier.** `classify_cost_rejection(..)` returns
`None` under exactly the condition `evict_cost_pressure` sheds a contract, and
otherwise names the gate that saved it (`zero_rate`, `under_share`,
`has_local_subs`, `has_downstream_subs`, `recently_accessed`).

**2. A rate-limited operator summary.** One `info!` per sweep carrying, per
axis: name, `total_rate`, `floor`, whether it **armed**, how many contracts the
meter attributed sustained work to, and every hosted contract over the share
cutoff with its rate, share, and outcome.

One line, wrapped here for readability. `axes` is recorded with `%`, so its
value is rendered unquoted, and `build_cost_axes` always returns all three axes:

```
cost-pressure eviction decision (#4861) axes_armed=1 hosted_contracts=214 cost_evictions_total=0 \
  axes=exec_cpu_micros_per_sec: total=1203.400 floor=50000.000 armed=false; \
       broadcast_fanout_bytes_per_sec: total=4102.900 floor=131072.000 armed=false; \
       broadcast_messages_per_sec: total=44.100 floor=10.000 armed=true attributed=2 \
         top=<key> rate=25.600 share=0.581 outcome=has_downstream_subs \
         also=<key> rate=11.200 share=0.254 outcome=recently_accessed
```

`axes` is deliberately the LAST field — its value contains spaces and `=`, so
the record only parses as key=value because nothing follows it. That ordering is
pinned by a test, not just a comment.

`attributed` is the field that makes the "nothing fired" case diagnosable,
because `total_rate` and the per-contract rates come from **different filters**
(`Meter::contract_cost_rates_multi` sums every positive rate into the total but
inserts only the sustained subset into `rates`, where "sustained" is a run
*above the axis floor*, not sample continuity). The decision table is on
`CostAxisDecision::attributed`.

`info!`, not `debug!` — release builds compile out `debug!` via
`max_level_info`, which is why the existing `queue_full_resync_throttled` debug
lines were useless during the incident.

**3. Counter export.** `cost_evictions_total` already reaches central telemetry
via `RouterSnapshot::hosting_cost_evictions_total` (#4903). The gap was the
**local dashboard** — the only hosting-counter view an operator gets on the box
with no collector in the loop. Added as its own tile, appended after "Evicted
w/ demand" so the #4338 miscalibration alarm keeps its first-row slot in the
5-column grid.

## Telemetry load at scale

Ian's constraint: telemetry changes must not overload the collector even at 10x
the current fleet (~1,700 peers today, so budget ~17,000).

**This PR adds zero records to the central collector.** Verified two ways:

- The tracing-subscriber stack (`tracing/tracer.rs`) wires only
  `fmt::layer()` sinks — rolling files, stderr, console. There is no
  `tracing_opentelemetry` layer, no `OpenTelemetryTracingBridge`, no
  `opentelemetry_sdk` anywhere in `crates/core/src`. A plain `tracing::info!`
  therefore cannot reach the collector.
- The collector's inputs are an explicitly enumerated set: `EventKind` via
  `register_events`, plus `send_standalone_event*`. `to_otlp_logs`
  (`tracing/telemetry.rs`) builds the OTLP body from `TelemetryEvent` structs
  only, stamping `severityNumber: 9 // INFO` on each. This PR touches neither
  `router.rs` nor `telemetry.rs`.
- `HostingSnapshot` has no `Serialize` derive; it reaches only the local HTTP
  dashboard, pull-based per page load. `RouterSnapshot::hosting_cost_evictions_total`
  already existed at 1 record/300s/node and is unchanged.

Arithmetic: **0 new records/hour/node x 17,000 peers = 0 new bytes to nova.**
Strictly better than the `broadcast_payload_mix` / `outbound_message_mix` 60s
rollup pattern, which at 17,000 peers is ~567 records/s arriving at the
collector.

Residual cost is **local disk only**, hard-bounded by the 60s sweep at one line
per sweep:

| Case | lines/h | bytes/line | bytes/h/node |
|---|---|---|---|
| Steady, quiet peer (all axes unarmed) | 12 | ~370 | ~4.5 KB |
| Steady, busy gateway (one axis armed) | 12 | ~465 | ~5.6 KB |
| Worst case (digest flips every sweep) | 60 | ~1.2 KB | ~70 KB |

Against a **measured** 35.15 MB/hour main-log rate on nova (12-hour mean) that
is 0.016%-0.2%. Both tracing rate limiters (1000/s global, 30/s per-callsite)
are untouched by orders of magnitude at this callsite's 0.0167/s peak.

## Hosting invariants

`.claude/rules/hosting-invariants.md` requires any change to the eviction path
to state which invariants it touches and how it preserves them.

This touches **invariant 3** (eviction is one demand-ordered decision) only by
reading it. The ranking, the candidacy predicate, the local/downstream
subscriber tiers, the recency terms, the share threshold, the axis floors and
the cost-eviction candidacy rule are byte-identical; no eviction input is added,
removed, or reordered. What is new is an explanation derived from that same
decision pass. No new mechanism is introduced, so the "test for a new mechanism"
gate does not apply.

## Scope (CONTRIBUTING)

Flagging rather than assuming: this is titled `feat:` and adds three observable
surfaces — an operator log line, a dashboard tile, and crate-internal API
(`CostAxisDecision`, `CostTopOffender`, `CostRejectReason`,
`classify_cost_rejection`, `evict_cost_pressure_observed`). It changes no
behaviour, but it is not a bug fix either, and neither referenced issue approves
it: #4861 is closed and #4877 is a different problem. Per
`.claude/rules/`, hosting/eviction changes are Ian's sign-off. Happy to open a
tracking issue mirroring #4658's shape if a maintainer wants one on record.

## Why eviction outcomes are unchanged

- The gates, their order, the candidacy predicate, the descending-rate sort and
  its key-byte tiebreak, and the removal loop are unchanged.
- The `filter_map` became an explicit loop only so the reporting scan can reuse
  the same pass. The explanation is derived **from** the decision, never from a
  second read of the same state that could race to a different conclusion.
- The one semantic tightening is defensive: a NaN attributed rate is now
  rejected explicitly in the share pre-filter instead of falling through to
  `cost_eviction_candidate` (which also rejects it), so the victim set is
  identical. It matters because the reporting pass sorts `probed`, where a NaN
  makes the comparator a non-total order and defeats the share-based bound that
  keeps the vector — and the log line — small.
- The `#4903` review's perf property holds: the cheap `rate <= share_cutoff`
  gate still short-circuits before the two DashMap `subscriber_counts` reads and
  the recency check.
- No new time source: `TimeSource` throughout.

## Testing

15 new tests in `crates/core/src/ring/hosting/cache.rs`, one in
`server/home_page.rs`, and one source-scrape pin in `ring.rs`. Highlights:

- `cost_reject_classification_matches_eviction_decision` — grid over 11 rates
  (incl. NaN, +/-inf, MIN_POSITIVE, both cutoff boundaries) x local x downstream
  x recency, asserting the classifier agrees with the sweep's own condition.
- `cost_reject_classification_matches_the_real_sweep` — the same grid driven
  through `evict_cost_pressure_observed`, because the test above compares the
  classifier against a hand-transcribed copy of the share gate and both could
  drift together away from the code.
- `cost_decision_logging_state_does_not_change_evictions` — two identical
  caches, one with the rate limiter primed to the digest the sweep actually
  produces (so it genuinely stays silent) and one fresh, shed identical victims.
- `cost_decision_top_rank_may_be_immune_while_a_lower_rank_is_shed` — pins that
  `top=` is the highest-rate probe, not necessarily the victim, and that
  `evicted` is a per-axis count.
- `cost_decision_digest_tracks_reasons_not_rates` and
  `..._ignores_offender_rank_swaps` — the change-trigger fires on a real gate
  change and stays quiet on rate wobble, which is what the volume figure rests
  on.
- `cost_decision_nan_rate_never_enters_the_report`.
- `log_cost_decision_still_emits_an_info_event_with_its_fields` — source-scrape
  pin on the emit. A subscriber-capture test was written first and rejected as
  inherently flaky: `set_default` is thread-local while tracing's callsite
  `Interest` cache is global, so sibling tests poison it (measured: 1 of 2
  events captured under `cargo test --lib cost`, passing when run alone).
- `dashboard_hosting_counter_source_tests` — pins that each dashboard eviction
  counter is mapped from its identically-named `stats` field (the #4009/#4010
  silent-rot pattern; `dashboard_hosting_snapshot` needs a live `Ring`).

```
cargo fmt --all --check                  # clean
cargo clippy --locked -- -D warnings     # clean (CI-equivalent invocation)
cargo test -p freenet --lib              # 4347 passed, 0 failed, 25 ignored
```

Behaviour-pinning tests were mutation-verified: reverting the NaN guard, the
`rate > 0.0` top-offender gate, the multi-offender reporting, the `attributed`
field, the per-axis eviction count, the digest sort, the rate limiter, and the
emit itself (deletion and `info!`->`debug!`) each fail a specific test.

## Review

Full-tier (eviction is a high-risk surface per `.claude/rules/pr-quality.md`).
Four independent Claude lenses: skeptical/adversarial (twice — once on the
original, once on the reworked code), telemetry-load-at-scale, and testing.
Codex was not attempted: it is quota-blocked until ~2026-08-01, and per the
current review policy external models are opt-in rather than a required pass.

The second round found four diagnostic-correctness defects — all fixed here,
because a summary that misdirects an operator is worse than no summary:
`zero_rate` conflating the meter's sustained gate with "nothing attributed"; an
all-zero axis naming an arbitrary innocent contract as the top offender; only
the top offender being explained when a storm contract ranked second; and a
decision-table row describing a state that cannot occur.

Refs #4861, #4903, #4877

[AI-assisted - Claude]
