### PR TITLE
feat(telemetry): emit BroadcastComplete with the per-fan-out delta/full-state split

### DIFF
--- a/crates/core/src/contract/executor/pool_tests/non_idempotent_detector_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/non_idempotent_detector_tests.rs
@@ -213,8 +213,13 @@ fn egress_paths_gated_on_is_contract_broken() {
     let heal_gate = body
         .find("is_contract_broken")
         .expect("handle_sync_state_to_peer must gate on is_contract_broken");
+    // Anchor on the call, not the receiver: rustfmt splits
+    // `self.broadcast_queue.enqueue(..)` across lines once the argument list
+    // grows, so a receiver-shaped needle silently stops matching and this pin
+    // fails for a formatting reason rather than a real one. Same precedent as
+    // the `record_delivered` needle in broadcast_queue.rs.
     let heal_send = body
-        .find("broadcast_queue.enqueue")
+        .find(".enqueue(")
         .expect("handle_sync_state_to_peer must still enqueue the heal send");
     assert!(
         heal_gate < heal_send,

--- a/crates/core/src/node/network_bridge.rs
+++ b/crates/core/src/node/network_bridge.rs
@@ -16,6 +16,7 @@ use tokio::sync::mpsc::{self, Receiver, Sender};
 
 use crate::message::{NetMessage, NodeEvent};
 
+pub(crate) mod broadcast_fanout_tally;
 pub(crate) mod broadcast_payload_mix;
 pub(crate) mod broadcast_queue;
 mod handshake;

--- a/crates/core/src/node/network_bridge/broadcast_fanout_tally.rs
+++ b/crates/core/src/node/network_bridge/broadcast_fanout_tally.rs
@@ -1,0 +1,417 @@
+//! Per-fan-out delta-vs-full-state tally behind `UpdateEvent::BroadcastComplete`.
+//!
+//! ## Why
+//!
+//! `UpdateEvent::BroadcastComplete` has existed since #3622-era telemetry work
+//! and `telemetry.rs` has always known how to serialize it (`"type":
+//! "broadcast_complete"`, including a derived `delta_ratio`), but **nothing ever
+//! constructed it**, so the arm never fired. The same was true of
+//! [`InterestManagerStats`]: #4922 added `delta_sends` / `full_state_sends` /
+//! `delta_bytes_saved` counters to `InterestManager`, but `stats()` has no
+//! caller, so those counters were tallied in memory and never read. This module
+//! is the missing reporting half for the per-fan-out view (#4923).
+//!
+//! The gap mattered because `state_size` — the only size the update telemetry
+//! carried — logs the post-apply FULL state regardless of whether a small delta
+//! or the whole state crossed the wire. A River room reporting ~370 KB
+//! broadcast payloads against a ~320-339 KB state and a ~15 KB delta could not
+//! be explained from telemetry alone: nothing distinguished "we sent a delta"
+//! from "we sent the entire state".
+//!
+//! ## Relationship to the #4922 payload mix
+//!
+//! [`PayloadMix`] answers the same question at a coarser grain and with a finer
+//! *cause* breakdown: a 60-second per-node rollup of per-arm sends and real wire
+//! bytes, naming which of the four full-state fallbacks fired. It is the right
+//! tool for "what is this node's byte mix, and why". It deliberately does NOT
+//! carry per-fan-out identity, so it cannot answer "this particular update to
+//! this contract went out as N deltas and M full states".
+//!
+//! This tally is that second view, and only that: one event per fan-out,
+//! carrying the fan-out's transaction so it joins directly against the
+//! `BroadcastEmitted` emitted for the same fan-out. The two are complementary;
+//! neither replaces the other.
+//!
+//! ## Why a tally rather than reading the counters
+//!
+//! [`InterestManagerStats`] counters are process-lifetime monotonic totals
+//! across every contract and peer. Differencing them around a fan-out would
+//! attribute concurrently-running fan-outs (other contracts, other peers) to
+//! whichever one happened to sample last, because the production path runs one
+//! detached task per (contract, peer) with bounded concurrency. A per-fan-out
+//! accumulator is the only way to get correct attribution.
+//!
+//! To keep that from becoming a second, independently-rotting mirror — the
+//! failure mode in the "Manually-mirrored telemetry counters" row of
+//! `.claude/rules/bug-prevention-patterns.md`, and the #4009 / #4010 precedent —
+//! every tally write sits immediately next to the canonical
+//! `InterestManager::record_delta_send` / `record_full_state_send` call it
+//! shadows, and source-scrape pins in `broadcast_queue.rs` and
+//! `p2p_protoc/broadcast.rs` assert that co-location at both recording sites.
+//!
+//! [`InterestManagerStats`]: crate::ring::interest::InterestManagerStats
+//! [`PayloadMix`]: super::broadcast_payload_mix::PayloadMix
+
+use std::sync::Arc;
+
+use freenet_stdlib::prelude::ContractKey;
+use parking_lot::Mutex;
+
+use crate::message::Transaction;
+use crate::node::OpManager;
+use crate::tracing::NetEventLog;
+
+/// One fan-out's accumulated delta-vs-full-state split.
+///
+/// Returned by [`FanoutTally::finish_one`] to exactly one caller — the one that
+/// retires the last outstanding target — so a fan-out can never emit twice.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct FanoutSummary {
+    pub tx: Transaction,
+    pub key: ContractKey,
+    pub delta_sends: usize,
+    pub full_state_sends: usize,
+    pub bytes_saved: u64,
+    pub state_size: usize,
+}
+
+/// Mutable half of [`FanoutTally`], behind one lock.
+///
+/// One lock rather than per-field atomics, for the reason #4922's [`PayloadMix`]
+/// documents: the terminal read has to see the counters and the outstanding
+/// count as a single consistent snapshot, otherwise a send recorded between
+/// "decrement to zero" and "read the counters" is silently lost from the event.
+/// Cost is one uncontended acquire per *delivered broadcast* — the surrounding
+/// path has already run WASM delta computation and a network write.
+///
+/// [`PayloadMix`]: super::broadcast_payload_mix::PayloadMix
+#[derive(Debug)]
+struct TallyInner {
+    /// Targets that have not yet retired. Starts at 1 for the creation guard
+    /// (see [`FanoutTally::new`]).
+    outstanding: usize,
+    delta_sends: usize,
+    full_state_sends: usize,
+    bytes_saved: u64,
+    /// Set once the summary has been handed out, so a stray extra
+    /// [`finish_one`](FanoutTally::finish_one) can never produce a second event.
+    finished: bool,
+}
+
+/// Accumulates one fan-out's per-target payload choices.
+///
+/// Lifecycle: [`new`](Self::new) with the fan-out's target count (plus a
+/// creation guard) → per-target [`record_delta`](Self::record_delta) /
+/// [`record_full_state`](Self::record_full_state) → one
+/// [`finish_one`](Self::finish_one) per target *and* one for the creation guard.
+/// The last of those returns the [`FanoutSummary`].
+#[derive(Debug)]
+pub(crate) struct FanoutTally {
+    tx: Transaction,
+    key: ContractKey,
+    /// Size of the full post-apply state being broadcast. Reported verbatim as
+    /// the event's `state_size`.
+    state_size: usize,
+    inner: Mutex<TallyInner>,
+}
+
+impl FanoutTally {
+    /// Start a tally for a fan-out with `targets` targets, plus one **creation
+    /// guard**.
+    ///
+    /// The guard exists so a fan-out whose first target completes before the
+    /// dispatcher has finished handing out the rest cannot hit zero outstanding
+    /// early and emit a truncated event. The dispatcher retires it with its own
+    /// [`finish_one`](Self::finish_one) once every target has been dispatched.
+    ///
+    /// `targets` must equal the number of retirements the caller will actually
+    /// produce (one per [`FanoutTarget`], or zero for a caller that records
+    /// inline). Declaring more than are produced strands the tally so it never
+    /// emits; declaring fewer emits early, and the surplus retirements are
+    /// absorbed by the `finished` flag rather than emitting twice.
+    pub(crate) fn new(
+        tx: Transaction,
+        key: ContractKey,
+        state_size: usize,
+        targets: usize,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            tx,
+            key,
+            state_size,
+            inner: Mutex::new(TallyInner {
+                outstanding: targets.saturating_add(1),
+                delta_sends: 0,
+                full_state_sends: 0,
+                bytes_saved: 0,
+                finished: false,
+            }),
+        })
+    }
+
+    /// Record that a target received a DELTA.
+    ///
+    /// Mirrors [`InterestManager::record_delta_send`]'s signature on purpose:
+    /// the two are called as a pair at every recording site, and taking the same
+    /// arguments makes a divergence between them obvious on sight.
+    ///
+    /// [`InterestManager::record_delta_send`]: crate::ring::interest::InterestManager::record_delta_send
+    pub(crate) fn record_delta(&self, state_size: usize, delta_size: usize) {
+        let mut inner = self.inner.lock();
+        inner.delta_sends += 1;
+        // Saturating: a delta larger than the state would otherwise wrap into a
+        // huge "saving", inverting the very ratio this event exists to report.
+        inner.bytes_saved = inner
+            .bytes_saved
+            .saturating_add(state_size.saturating_sub(delta_size) as u64);
+    }
+
+    /// Record that a target received FULL STATE.
+    pub(crate) fn record_full_state(&self) {
+        self.inner.lock().full_state_sends += 1;
+    }
+
+    /// Retire one outstanding target (or the creation guard).
+    ///
+    /// Returns `Some` exactly once per tally, to whichever caller retires the
+    /// last outstanding entry. Every other call returns `None`.
+    pub(crate) fn finish_one(&self) -> Option<FanoutSummary> {
+        let mut inner = self.inner.lock();
+        inner.outstanding = inner.outstanding.saturating_sub(1);
+        if inner.outstanding > 0 || inner.finished {
+            return None;
+        }
+        inner.finished = true;
+        Some(FanoutSummary {
+            tx: self.tx,
+            key: self.key,
+            delta_sends: inner.delta_sends,
+            full_state_sends: inner.full_state_sends,
+            bytes_saved: inner.bytes_saved,
+            state_size: self.state_size,
+        })
+    }
+}
+
+/// Emit one `UpdateEvent::BroadcastComplete`.
+///
+/// Non-blocking: `register_events` is `try_send` internally and drops on a full
+/// channel (see `EventRegister::register_events`), so telemetry can never
+/// backpressure a broadcast. That property is what makes it safe to call this
+/// from the fan-out path at all — see `.claude/rules/channel-safety.md`.
+pub(crate) async fn emit_broadcast_complete(op_manager: &OpManager, summary: FanoutSummary) {
+    if let Some(log) = NetEventLog::update_broadcast_complete(
+        &summary.tx,
+        &op_manager.ring,
+        summary.key,
+        summary.delta_sends,
+        summary.full_state_sends,
+        summary.bytes_saved,
+        summary.state_size,
+    ) {
+        op_manager
+            .ring
+            .register_events(either::Either::Left(log))
+            .await;
+    }
+}
+
+/// RAII retirement of one fan-out target for the production `BroadcastQueue`.
+///
+/// The queue reaches its terminal states through several paths that do not
+/// share a common exit — a target is sent, or its entry is superseded by
+/// replace-on-dedup, or it is evicted when the queue is at capacity, and
+/// `broadcast_to_single_peer` itself has several early returns. Making
+/// retirement a `Drop` obligation rather than an explicit call means a future
+/// path added to the queue retires its target automatically; an explicit call
+/// would have to be remembered at each new site, and a missed one would silently
+/// strand the fan-out so its event never fired.
+///
+/// Only the production path needs this. The simulation fan-out is inline and
+/// sequential, so it drives [`FanoutTally`] directly and emits without a spawn,
+/// keeping deterministic broadcast ordering.
+#[cfg(not(feature = "simulation_tests"))]
+pub(crate) struct FanoutTarget {
+    tally: Arc<FanoutTally>,
+    op_manager: Arc<OpManager>,
+}
+
+#[cfg(not(feature = "simulation_tests"))]
+impl FanoutTarget {
+    /// Take one of `tally`'s declared targets. The caller must create exactly as
+    /// many of these as it passed to [`FanoutTally::new`].
+    pub(crate) fn new(tally: Arc<FanoutTally>, op_manager: Arc<OpManager>) -> Self {
+        Self { tally, op_manager }
+    }
+
+    /// The tally this target reports into, for the recording sites.
+    pub(crate) fn tally(&self) -> &Arc<FanoutTally> {
+        &self.tally
+    }
+}
+
+#[cfg(not(feature = "simulation_tests"))]
+impl Drop for FanoutTarget {
+    fn drop(&mut self) {
+        let Some(summary) = self.tally.finish_one() else {
+            return;
+        };
+        let op_manager = self.op_manager.clone();
+        // Fire-and-forget is correct here per `.claude/rules/code-style.md`:
+        // this is short-lived work, not a node-lifetime task, so it does not
+        // belong to the BackgroundTaskMonitor. The spawn exists only because
+        // `Drop` cannot await — the future it runs does one non-blocking
+        // `try_send` and returns. Dropping the JoinHandle is deliberate: a lost
+        // telemetry event must never be able to fail a broadcast.
+        crate::config::GlobalExecutor::spawn(async move {
+            emit_broadcast_complete(&op_manager, summary).await;
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use freenet_stdlib::prelude::{CodeHash, ContractInstanceId};
+
+    fn make_key(seed: u8) -> ContractKey {
+        ContractKey::from_id_and_code(
+            ContractInstanceId::new([seed; 32]),
+            CodeHash::new([seed.wrapping_add(1); 32]),
+        )
+    }
+
+    fn make_tx() -> Transaction {
+        Transaction::new::<crate::operations::update::UpdateMsg>()
+    }
+
+    /// The creation guard is the whole reason a fan-out whose first target
+    /// finishes before the dispatcher has handed out the rest does not emit
+    /// early. Without it, a two-target fan-out reports only the first send.
+    #[test]
+    fn creation_guard_defers_emission_until_the_dispatcher_retires_it() {
+        let tally = FanoutTally::new(make_tx(), make_key(1), 1_000, 2);
+
+        tally.record_delta(1_000, 100);
+        assert_eq!(
+            tally.finish_one(),
+            None,
+            "the creation guard must keep the tally open"
+        );
+
+        tally.record_full_state();
+        assert_eq!(tally.finish_one(), None);
+
+        let summary = tally
+            .finish_one()
+            .expect("retiring the creation guard must complete the tally");
+        assert_eq!(summary.delta_sends, 1);
+        assert_eq!(summary.full_state_sends, 1);
+        assert_eq!(summary.bytes_saved, 900);
+        assert_eq!(summary.state_size, 1_000);
+    }
+
+    #[test]
+    fn summary_is_handed_out_exactly_once() {
+        let tally = FanoutTally::new(make_tx(), make_key(2), 500, 1);
+        tally.record_delta(500, 50);
+
+        assert_eq!(tally.finish_one(), None, "guard still outstanding");
+        assert!(tally.finish_one().is_some(), "last retirement emits");
+        assert_eq!(
+            tally.finish_one(),
+            None,
+            "a stray extra retirement must not produce a second event"
+        );
+        assert_eq!(tally.finish_one(), None);
+    }
+
+    /// A fan-out that resolves every target to "already converged" still has to
+    /// complete: zero recorded sends is a real, informative observation (nothing
+    /// went on the wire), not a reason to withhold the event.
+    #[test]
+    fn fanout_with_no_recorded_sends_still_completes_with_zeroes() {
+        let tally = FanoutTally::new(make_tx(), make_key(3), 4_096, 2);
+        assert_eq!(tally.finish_one(), None);
+        assert_eq!(tally.finish_one(), None);
+
+        let summary = tally.finish_one().expect("guard retirement completes");
+        assert_eq!(summary.delta_sends, 0);
+        assert_eq!(summary.full_state_sends, 0);
+        assert_eq!(summary.bytes_saved, 0);
+        assert_eq!(summary.state_size, 4_096);
+    }
+
+    /// A fan-out with no targets at all (every candidate filtered out before
+    /// enqueue) completes on the guard alone rather than leaking. This is also
+    /// the shape the inline simulation path uses: it declares zero targets and
+    /// records against the tally directly.
+    #[test]
+    fn fanout_with_zero_targets_completes_on_the_guard() {
+        let tally = FanoutTally::new(make_tx(), make_key(4), 7, 0);
+        let summary = tally.finish_one().expect("guard alone completes the tally");
+        assert_eq!(summary.delta_sends, 0);
+        assert_eq!(summary.full_state_sends, 0);
+    }
+
+    /// `bytes_saved` is what makes the event able to distinguish a delta from a
+    /// full state at all: `state_size * sends - bytes_saved` is the real wire
+    /// total. A delta larger than the state must clamp to zero saving rather
+    /// than wrapping into a nonsense saving.
+    #[test]
+    fn oversized_delta_saves_zero_bytes_rather_than_wrapping() {
+        let tally = FanoutTally::new(make_tx(), make_key(5), 100, 1);
+        tally.record_delta(100, 250);
+        assert_eq!(tally.finish_one(), None, "guard still outstanding");
+        let summary = tally.finish_one().expect("guard retirement completes");
+        assert_eq!(summary.bytes_saved, 0);
+        assert_eq!(summary.delta_sends, 1);
+    }
+
+    #[test]
+    fn bytes_saved_accumulates_across_targets() {
+        let tally = FanoutTally::new(make_tx(), make_key(6), 1_000, 3);
+        for _ in 0..3 {
+            tally.record_delta(1_000, 200);
+            assert_eq!(tally.finish_one(), None);
+        }
+        let summary = tally.finish_one().expect("guard retirement completes");
+        assert_eq!(summary.delta_sends, 3);
+        assert_eq!(summary.bytes_saved, 2_400);
+    }
+
+    /// Concurrent retirement is the production shape: the queue spawns one
+    /// detached task per target. Exactly one of them must observe the summary,
+    /// and it must carry every increment.
+    #[test]
+    fn concurrent_targets_emit_exactly_once_with_all_sends_counted() {
+        const TARGETS: usize = 32;
+        let tally = FanoutTally::new(make_tx(), make_key(7), 1_000, TARGETS);
+
+        let completions = Arc::new(Mutex::new(Vec::new()));
+        std::thread::scope(|scope| {
+            for i in 0..TARGETS {
+                let tally = Arc::clone(&tally);
+                let completions = Arc::clone(&completions);
+                scope.spawn(move || {
+                    if i % 2 == 0 {
+                        tally.record_delta(1_000, 100);
+                    } else {
+                        tally.record_full_state();
+                    }
+                    if let Some(summary) = tally.finish_one() {
+                        completions.lock().push(summary);
+                    }
+                });
+            }
+        });
+
+        // Every target retired but the guard is still held, so nothing emitted.
+        assert!(completions.lock().is_empty());
+
+        let summary = tally.finish_one().expect("guard retirement completes");
+        assert_eq!(summary.delta_sends, TARGETS / 2);
+        assert_eq!(summary.full_state_sends, TARGETS / 2);
+        assert_eq!(summary.bytes_saved, (TARGETS / 2) as u64 * 900);
+    }
+}

--- a/crates/core/src/node/network_bridge/broadcast_queue.rs
+++ b/crates/core/src/node/network_bridge/broadcast_queue.rs
@@ -20,6 +20,7 @@ use crate::node::OpManager;
 use crate::ring::PeerKeyLocation;
 use crate::transport::BroadcastDeliveryOutcome;
 
+use super::broadcast_fanout_tally::FanoutTally;
 use super::broadcast_payload_mix::PayloadArm;
 use super::p2p_protoc::P2pBridge;
 
@@ -332,6 +333,7 @@ mod queue {
     use crate::node::OpManager;
     use crate::ring::PeerKeyLocation;
 
+    use super::super::broadcast_fanout_tally::FanoutTarget;
     use super::super::p2p_protoc::P2pBridge;
     use super::broadcast_to_single_peer;
 
@@ -361,6 +363,12 @@ mod queue {
         new_state: WrappedState,
         /// Payload size in bytes, used to select concurrency pool.
         payload_size: usize,
+        /// This target's share of its fan-out's delta-vs-full-state tally
+        /// (#4923). Retired by `Drop`, so every way an entry can leave the
+        /// queue — sent, superseded by replace-on-dedup, or evicted at
+        /// capacity — retires it without a bespoke call at each site.
+        /// `None` for a send with no fan-out to summarize.
+        fanout: Option<FanoutTarget>,
     }
 
     /// Internal queue state: FIFO ordering via VecDeque + HashMap for dedup lookup.
@@ -431,13 +439,26 @@ mod queue {
             key: ContractKey,
             target: PeerKeyLocation,
             new_state: WrappedState,
+            fanout: Option<FanoutTarget>,
         ) {
             let dedup_key = (key, target.clone());
+            // Entries whose `FanoutTarget` must be retired, collected under the
+            // lock and dropped after it is released. Retiring a target can
+            // complete its fan-out, which spawns the telemetry emission, and
+            // there is no reason to do that while holding the queue lock every
+            // broadcast contends on.
+            let mut retired: Vec<Option<FanoutTarget>> = Vec::new();
             let mut queue = self.queue.lock().await;
 
             // Replace-on-dedup: if same contract+peer exists, update state in-place
             if let Some(existing) = queue.entries.get_mut(&dedup_key) {
                 existing.new_state = new_state;
+                // The entry now carries the NEWER fan-out's state, so its send
+                // must be attributed to the newer fan-out. Swapping (rather than
+                // keeping the original) also keeps each fan-out retiring exactly
+                // as many targets as it registered: the superseded one retires
+                // here, having contributed no send for this peer.
+                retired.push(std::mem::replace(&mut existing.fanout, fanout));
                 tracing::trace!(
                     contract = %dedup_key.0,
                     peer = ?target.socket_addr(),
@@ -446,13 +467,14 @@ mod queue {
             } else {
                 // Evict oldest if at capacity
                 while queue.len() >= self.max_queue_depth {
-                    if let Some(entry) = queue.pop_front() {
+                    if let Some(mut entry) = queue.pop_front() {
                         tracing::warn!(
                             contract = %entry.key,
                             peer = ?entry.target.socket_addr(),
                             queue_depth = self.max_queue_depth,
                             "Broadcast queue full, evicted oldest entry"
                         );
+                        retired.push(entry.fanout.take());
                     } else {
                         break;
                     }
@@ -465,6 +487,7 @@ mod queue {
                         target,
                         new_state,
                         payload_size,
+                        fanout,
                     },
                 );
                 queue.order.push_back(dedup_key);
@@ -477,6 +500,7 @@ mod queue {
             crate::transport::shadow_demand::record_broadcast_queue_depth(queue.len());
 
             drop(queue);
+            drop(retired);
             self.notify.notify_one();
         }
 
@@ -540,12 +564,21 @@ mod queue {
                         tokio::spawn(async move {
                             let _permit = permit; // Held until this task completes
 
+                            // Retired when this task ends — including on an
+                            // early return inside `broadcast_to_single_peer`
+                            // (contract not hosted, peer already converged,
+                            // serialization failure), none of which record a
+                            // send. A fan-out that ends that way still emits,
+                            // with the arms it did record.
+                            let fanout = entry.fanout;
+
                             broadcast_to_single_peer(
                                 &bridge,
                                 &op_manager,
                                 entry.key,
                                 entry.new_state,
                                 entry.target,
+                                fanout.as_ref().map(|f| f.tally().as_ref()),
                             )
                             .await;
                         });
@@ -629,6 +662,7 @@ fn record_streaming_delivery<T: crate::util::time_source::TimeSource + Sync>(
     our_summary: Option<&freenet_stdlib::prelude::StateSummary<'static>>,
     state_size: usize,
     payload_size: usize,
+    fanout: Option<&FanoutTally>,
 ) -> bool {
     let delivered = streaming_completion_delivered(completion);
     if delivered {
@@ -640,6 +674,7 @@ fn record_streaming_delivery<T: crate::util::time_source::TimeSource + Sync>(
             our_summary,
             state_size,
             payload_size,
+            fanout,
         );
     }
     delivered
@@ -650,6 +685,7 @@ fn record_streaming_delivery<T: crate::util::time_source::TimeSource + Sync>(
 /// summary (on ANY delivered broadcast — delta or full state — per #4145).
 /// Factored out so both the streaming gate ([`record_streaming_delivery`]) and
 /// the non-streaming path share one body.
+#[allow(clippy::too_many_arguments)]
 fn record_delivery_to_interest<T: crate::util::time_source::TimeSource + Sync>(
     interest_manager: &crate::ring::interest::InterestManager<T>,
     sent_delta: bool,
@@ -658,13 +694,30 @@ fn record_delivery_to_interest<T: crate::util::time_source::TimeSource + Sync>(
     our_summary: Option<&freenet_stdlib::prelude::StateSummary<'static>>,
     state_size: usize,
     payload_size: usize,
+    fanout: Option<&FanoutTally>,
 ) {
     // Track delta vs full state sends for testing (PR #2763)
+    //
+    // The per-fan-out tally (#4923) is written HERE, immediately beside the
+    // canonical `InterestManager` counter it shadows, and never anywhere else.
+    // Those counters are process-lifetime totals across every contract and peer,
+    // so they cannot attribute a send to the fan-out that caused it; the tally
+    // can. Keeping the two writes adjacent is what stops the tally becoming an
+    // independently-rotting mirror — the failure mode in the
+    // "Manually-mirrored telemetry counters" row of
+    // `.claude/rules/bug-prevention-patterns.md` (#4009 / #4010). Pinned by
+    // `fanout_tally_is_recorded_beside_the_canonical_counters_pin`.
     if sent_delta {
         interest_manager.record_delta_send(state_size, payload_size);
+        if let Some(tally) = fanout {
+            tally.record_delta(state_size, payload_size);
+        }
         crate::config::GlobalTestMetrics::record_delta_send();
     } else {
         interest_manager.record_full_state_send();
+        if let Some(tally) = fanout {
+            tally.record_full_state();
+        }
         crate::config::GlobalTestMetrics::record_full_state_send();
     }
 
@@ -722,6 +775,10 @@ pub(super) async fn broadcast_to_single_peer(
     key: ContractKey,
     new_state: WrappedState,
     target: PeerKeyLocation,
+    // Per-fan-out delta-vs-full-state tally (#4923). `None` for a send that is
+    // not part of an all-subscriber fan-out (the targeted `SyncStateToPeer`
+    // heal), which has no fan-out to summarize.
+    fanout: Option<&FanoutTally>,
 ) {
     use crate::message::{DeltaOrFullState, NetMessage};
     use crate::node::network_bridge::NetworkBridge;
@@ -1071,6 +1128,7 @@ pub(super) async fn broadcast_to_single_peer(
                     our_summary.as_ref(),
                     new_state.size(),
                     payload_size,
+                    fanout,
                 );
                 // Telemetry gauge (#4440): post-dispatch outcome — a drop,
                 // dropped completion oneshot, or completion timeout is the
@@ -1167,6 +1225,7 @@ pub(super) async fn broadcast_to_single_peer(
                 our_summary.as_ref(),
                 new_state.size(),
                 payload_size,
+                fanout,
             );
         }
         res
@@ -1371,6 +1430,18 @@ mod tests {
 
             // Drive the REAL production gate. `sent_delta = true` so the summary
             // cache (`update_peer_summary`) is exercised on the delivered arm.
+            //
+            // A real tally rides along (#4923): the per-fan-out counters are
+            // written from inside this same gate, so a drop that must not
+            // refresh interest must equally not be counted as a send. A tally
+            // that counted drops would report a fan-out as having put payloads
+            // on the wire that never landed.
+            let tally = crate::node::network_bridge::broadcast_fanout_tally::FanoutTally::new(
+                crate::message::Transaction::new::<crate::operations::update::UpdateMsg>(),
+                contract,
+                1024,
+                1,
+            );
             let delivered = record_streaming_delivery(
                 &manager,
                 completion,
@@ -1380,11 +1451,30 @@ mod tests {
                 Some(&our_summary),
                 /* state_size */ 1024,
                 /* payload_size */ 64,
+                Some(&tally),
             );
             assert_eq!(
                 delivered, expect_delivered,
                 "[{name}] classification mismatch"
             );
+
+            assert_eq!(tally.finish_one(), None, "creation guard still held");
+            let summary = tally.finish_one().expect("guard retirement completes");
+            if expect_delivered {
+                assert_eq!(
+                    (summary.delta_sends, summary.full_state_sends),
+                    (1, 0),
+                    "[{name}] a real delivery MUST be counted in the fan-out tally"
+                );
+                assert_eq!(summary.bytes_saved, 1024 - 64);
+            } else {
+                assert_eq!(
+                    (summary.delta_sends, summary.full_state_sends),
+                    (0, 0),
+                    "[{name}] a dropped send MUST NOT be counted in the fan-out tally"
+                );
+                assert_eq!(summary.bytes_saved, 0);
+            }
 
             let interest = manager
                 .get_peer_interest(&contract, &peer)
@@ -1460,6 +1550,7 @@ mod tests {
             Some(&our_summary),
             /* state_size */ 4096,
             /* payload_size */ 4096,
+            None,
         );
         assert!(delivered, "a Delivered outcome must classify as delivered");
 
@@ -1524,6 +1615,7 @@ mod tests {
                 Some(&our_summary),
                 /* state_size */ 4096,
                 /* payload_size */ 4096,
+                None,
             );
             assert!(
                 !delivered,
@@ -2202,6 +2294,151 @@ mod tests {
                 && body.contains("DeltaUnavailable::ComputeFailed"),
             "the delta-failure arm must keep the typed NotEfficient vs \
              ComputeFailed split — collapsing them re-blinds the measurement"
+        );
+    }
+
+    /// Source-scrape pin for the per-fan-out tally's co-location with the
+    /// canonical `InterestManager` counters (#4923).
+    ///
+    /// The tally duplicates information the `InterestManager` counters already
+    /// hold — necessarily, because those are process-lifetime totals across
+    /// every contract and peer and cannot attribute a send to a fan-out. A
+    /// duplicate that drifts is the failure in the "Manually-mirrored telemetry
+    /// counters" row of `.claude/rules/bug-prevention-patterns.md` (#4009 /
+    /// #4010): the mirror silently rots when the path is refactored, every test
+    /// stays green, and the rot surfaces months later as a counter stuck at
+    /// zero. The defence is that the two writes are physically adjacent, so pin
+    /// exactly that — the tally write must sit inside
+    /// `record_delivery_to_interest`, in the same branch as the counter it
+    /// shadows, and nowhere else in this file.
+    #[test]
+    fn fanout_tally_is_recorded_beside_the_canonical_counters_pin() {
+        let src = include_str!("broadcast_queue.rs");
+        let fn_start = src
+            .find("fn record_delivery_to_interest<")
+            .expect("record_delivery_to_interest not found");
+        let after = &src[fn_start..];
+        let fn_end = after
+            .find("\npub(super) async fn broadcast_to_single_peer(")
+            .expect("end of record_delivery_to_interest not found");
+        let body = &after[..fn_end];
+
+        // The delta branch records BOTH, in that order.
+        let canonical_delta = body
+            .find("record_delta_send(state_size, payload_size)")
+            .expect(
+                "record_delivery_to_interest must call \
+                 InterestManager::record_delta_send — it is the canonical counter",
+            );
+        let tally_delta = body.find("record_delta(state_size, payload_size)").expect(
+            "the per-fan-out tally must record the delta send inside \
+                 record_delivery_to_interest, beside the canonical counter — a \
+                 tally written anywhere else drifts from it (#4009/#4010)",
+        );
+        assert!(
+            tally_delta > canonical_delta,
+            "the tally's delta write must sit immediately after the canonical \
+             record_delta_send, so the pair is impossible to miss when editing"
+        );
+
+        // Same for the full-state branch.
+        let canonical_full = body.find("record_full_state_send()").expect(
+            "record_delivery_to_interest must call \
+             InterestManager::record_full_state_send",
+        );
+        let tally_full = body.find("record_full_state()").expect(
+            "the per-fan-out tally must record the full-state send inside \
+             record_delivery_to_interest, beside the canonical counter",
+        );
+        assert!(
+            tally_full > canonical_full,
+            "the tally's full-state write must sit immediately after the \
+             canonical record_full_state_send"
+        );
+
+        // Both writes are gated on the delivery the canonical counters are
+        // gated on. `record_delivery_to_interest` runs only on a real delivery
+        // (streaming `Delivered` / inline send Ok), so a tally write that
+        // escaped this function would count phantom fan-out — the same mistake
+        // the #4903 review round-3 Fix 4 corrected for the cost axis.
+        //
+        // Needles are split with `concat!` so they do not appear verbatim in
+        // this test's own source, which `include_str!` pulls back in.
+        let delta_needle = concat!("tally.record_", "delta(");
+        let full_needle = concat!("tally.record_", "full_state()");
+        assert_eq!(
+            src.matches(delta_needle).count(),
+            1,
+            "the tally's delta write must appear exactly once in this file — \
+             inside record_delivery_to_interest. A second write site is the \
+             drift this pin exists to prevent; zero means it was refactored away"
+        );
+        assert_eq!(
+            src.matches(full_needle).count(),
+            1,
+            "the tally's full-state write must appear exactly once in this file"
+        );
+    }
+
+    /// Source-scrape pin: the production queue must CARRY a fan-out target
+    /// through every entry and retire it by `Drop` (#4923).
+    ///
+    /// A `BroadcastEntry` leaves the queue three ways — sent, superseded by
+    /// replace-on-dedup, or evicted at capacity — and `broadcast_to_single_peer`
+    /// itself has several early returns. If retirement were an explicit call
+    /// instead of a `Drop` obligation, any path that forgot it would strand the
+    /// fan-out so its `BroadcastComplete` never fired, silently and with no
+    /// behavioral symptom. Pin that the entry owns the target (so `Drop` covers
+    /// every exit) rather than the tally directly.
+    #[test]
+    fn broadcast_entry_owns_a_droppable_fanout_target_pin() {
+        let src = include_str!("broadcast_queue.rs");
+        let entry_start = src
+            .find("struct BroadcastEntry {")
+            .expect("BroadcastEntry not found");
+        let entry_end = src[entry_start..]
+            .find('}')
+            .expect("end of BroadcastEntry not found");
+        let entry = &src[entry_start..entry_start + entry_end];
+        assert!(
+            entry.contains("fanout: Option<FanoutTarget>"),
+            "BroadcastEntry must own an Option<FanoutTarget>, NOT an \
+             Arc<FanoutTally>: retirement has to be a Drop obligation so every \
+             queue exit path (send, replace-on-dedup, capacity eviction) retires \
+             the target without a bespoke call at each site"
+        );
+
+        // Replace-on-dedup must SWAP the target rather than leaving the old one
+        // in place: the entry now carries the newer fan-out's state, so its send
+        // belongs to the newer fan-out, and the superseded one must retire
+        // having contributed nothing for this peer.
+        assert!(
+            src.contains("std::mem::replace(&mut existing.fanout, fanout)"),
+            "replace-on-dedup must swap the entry's FanoutTarget so the send is \
+             attributed to the fan-out whose state it now carries, and the \
+             superseded fan-out retires this target"
+        );
+
+        // Retirement must happen outside the queue lock: completing a fan-out
+        // spawns the telemetry emission, and every broadcast contends on this
+        // lock.
+        let enqueue_start = src
+            .find("pub(crate) async fn enqueue(")
+            .expect("enqueue not found");
+        let enqueue = &src[enqueue_start..];
+        let drop_queue = enqueue
+            .find("drop(queue);")
+            .expect("enqueue must release the queue lock explicitly");
+        let drop_retired = enqueue.find("drop(retired);").expect(
+            "enqueue must drop superseded/evicted FanoutTargets explicitly, \
+                 after the lock",
+        );
+        assert!(
+            drop_retired > drop_queue,
+            "superseded/evicted FanoutTargets must be dropped AFTER the queue \
+             lock is released — retiring one can complete a fan-out and spawn \
+             its telemetry emission, which must not happen under the lock every \
+             broadcast contends on"
         );
     }
 }

--- a/crates/core/src/node/network_bridge/p2p_protoc/broadcast.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc/broadcast.rs
@@ -516,10 +516,47 @@ impl P2pConnManager {
         // delivery order and breaks convergence.
         #[cfg(not(feature = "simulation_tests"))]
         {
+            // One tally for this whole fan-out (#4923). It carries the SAME
+            // `update_tx` as the `BroadcastEmitted` below, which is what lets
+            // the two events be joined on `id` — `BroadcastEmitted` says how
+            // many targets were enqueued, `BroadcastComplete` says how many of
+            // them ended up receiving a delta versus the entire state.
+            //
+            // The tally is created here, before any target is registered,
+            // holding a creation guard that is retired after the loop. Without
+            // it a fast first target could complete the fan-out before the last
+            // target was even enqueued, emitting a truncated event.
+            let update_tx =
+                crate::message::Transaction::new::<crate::operations::update::UpdateMsg>();
+            let fanout = crate::node::network_bridge::broadcast_fanout_tally::FanoutTally::new(
+                update_tx,
+                key,
+                new_state.size(),
+                target_result.targets.len(),
+            );
             for target in &target_result.targets {
                 self.broadcast_queue
-                    .enqueue(key, target.clone(), new_state.clone())
+                    .enqueue(
+                        key,
+                        target.clone(),
+                        new_state.clone(),
+                        Some(
+                            crate::node::network_bridge::broadcast_fanout_tally::FanoutTarget::new(
+                                fanout.clone(),
+                                op_manager.clone(),
+                            ),
+                        ),
+                    )
                     .await;
+            }
+            // Retire the creation guard. If every target has already finished
+            // (a small fan-out can drain faster than this loop), this is the
+            // retirement that completes the tally and emits.
+            if let Some(summary) = fanout.finish_one() {
+                crate::node::network_bridge::broadcast_fanout_tally::emit_broadcast_complete(
+                    op_manager, summary,
+                )
+                .await;
             }
             // Emit broadcast emitted telemetry (issue #3622)
             //
@@ -527,13 +564,16 @@ impl P2pConnManager {
             // - Transaction ID is synthetic (not from the original update operation).
             //   BroadcastQueue creates its own TX per target, so this ID cannot be
             //   correlated with downstream BroadcastReceived/BroadcastApplied events.
+            //   It IS shared with this fan-out's `BroadcastComplete` (#4923) — the
+            //   two are emitted from this one block against the same `update_tx`,
+            //   so they join on `id` even though neither joins downstream.
             // - `broadcasted_to` = number of targets enqueued, not actual delivery
-            //   count. Actual sends are async via BroadcastQueue.
+            //   count. Actual sends are async via BroadcastQueue. `BroadcastComplete`
+            //   reports the delivered arms, so the difference between them is the
+            //   skipped/failed count.
             // - `broadcast_to` is empty to avoid cloning up to 512 PeerKeyLocations
             //   purely for telemetry. The peer list can be reconstructed from
             //   BroadcastReceived events on the receiving end.
-            let update_tx =
-                crate::message::Transaction::new::<crate::operations::update::UpdateMsg>();
             let enqueued_count = target_result.targets.len();
             if let Some(log) = NetEventLog::update_broadcast_emitted(
                 &update_tx,
@@ -623,9 +663,14 @@ impl P2pConnManager {
             1.0,
         );
 
+        // No fan-out tally (#4923): this is a targeted single-peer heal, not an
+        // all-subscriber fan-out, so there is no delta-vs-full-state mix to
+        // summarize. Its bytes are still counted by the #4922 payload mix.
         #[cfg(not(feature = "simulation_tests"))]
         {
-            self.broadcast_queue.enqueue(key, target, new_state).await;
+            self.broadcast_queue
+                .enqueue(key, target, new_state, None)
+                .await;
         }
         #[cfg(feature = "simulation_tests")]
         {
@@ -635,6 +680,7 @@ impl P2pConnManager {
                 key,
                 new_state,
                 target,
+                None,
             )
             .await;
         }
@@ -673,6 +719,21 @@ impl P2pConnManager {
             .await;
 
         let update_tx = crate::message::Transaction::new::<crate::operations::update::UpdateMsg>();
+        // Per-fan-out delta-vs-full-state tally (#4923), shared with the
+        // `BroadcastEmitted` below via `update_tx`. This path is inline and
+        // sequential, so it drives the tally directly and emits inline at the
+        // end — no `FanoutTarget` RAII and no spawn, which would perturb the
+        // deterministic broadcast ordering this whole function exists to
+        // preserve.
+        // Zero declared targets: this path records against the tally inline
+        // rather than handing out `FanoutTarget`s, so the creation guard is the
+        // only retirement and it completes the tally at the end of the fan-out.
+        let fanout = crate::node::network_bridge::broadcast_fanout_tally::FanoutTally::new(
+            update_tx,
+            key,
+            new_state.size(),
+            0,
+        );
 
         tracing::debug!(
             tx = %update_tx,
@@ -906,13 +967,23 @@ impl P2pConnManager {
             } else {
                 send_success += 1;
                 // Track delta vs full state sends for testing (PR #2763)
+                //
+                // The per-fan-out tally (#4923) is written HERE, immediately
+                // beside the canonical `InterestManager` counter it shadows —
+                // the same co-location rule the production path follows in
+                // `broadcast_queue::record_delivery_to_interest`, for the same
+                // reason (`.claude/rules/bug-prevention-patterns.md`,
+                // "Manually-mirrored telemetry counters"). Pinned by
+                // `sim_fanout_records_tally_beside_the_canonical_counters_pin`.
                 if sent_delta {
                     op_manager
                         .interest_manager
                         .record_delta_send(new_state.size(), payload_size);
+                    fanout.record_delta(new_state.size(), payload_size);
                     crate::config::GlobalTestMetrics::record_delta_send();
                 } else {
                     op_manager.interest_manager.record_full_state_send();
+                    fanout.record_full_state();
                     crate::config::GlobalTestMetrics::record_full_state_send();
                 }
 
@@ -962,6 +1033,16 @@ impl P2pConnManager {
                     );
                 }
             }
+        }
+
+        // Emit the per-fan-out delta-vs-full-state split (#4923). This path
+        // registered no targets, so the creation guard alone completes the
+        // tally and this always yields a summary.
+        if let Some(summary) = fanout.finish_one() {
+            crate::node::network_bridge::broadcast_fanout_tally::emit_broadcast_complete(
+                op_manager, summary,
+            )
+            .await;
         }
 
         // Emit broadcast emitted telemetry (issue #3622)
@@ -1045,6 +1126,111 @@ mod broadcast_fanout_cost_pin_tests {
              (fan-out dispatch + targeted stale-peer heal); dropping the message-\
              COUNT report re-opens the exact #4861 blind spot — a tiny-payload \
              storm that the byte axis cannot see"
+        );
+    }
+
+    /// Source-scrape pin: both fan-out dispatch paths must build a
+    /// `FanoutTally` and emit its summary (#4923).
+    ///
+    /// Same precedent as the cost-report pin above. A refactor that drops
+    /// either half leaves `UpdateEvent::BroadcastComplete` unconstructed again
+    /// — the exact state this change fixes, in which `telemetry.rs` serializes
+    /// a `broadcast_complete` event, four `match` sites handle the variant, and
+    /// nothing ever produces one. Nothing behavioral breaks, so only a pin
+    /// catches it.
+    #[test]
+    fn both_fanout_paths_build_and_emit_a_fanout_tally_pin() {
+        // Needles are split with `concat!` so they do not appear verbatim in
+        // this test's own source, which `include_str!` pulls back in.
+        assert_eq!(
+            BROADCAST_SRC
+                .matches(concat!("FanoutTally", "::new("))
+                .count(),
+            2,
+            "exactly two fan-out dispatch paths must build a tally: the \
+             production BroadcastQueue path and the inline simulation path. \
+             Fewer means a path stopped reporting its delta-vs-full-state split"
+        );
+        assert_eq!(
+            BROADCAST_SRC
+                .matches(concat!("emit_broadcast_", "complete("))
+                .count(),
+            2,
+            "each fan-out path must emit its tally's summary — building a tally \
+             nothing emits is precisely the #4922 shape this change closes \
+             (counters tallied in memory, never reported)"
+        );
+
+        // The production path must reuse the SAME `update_tx` for both events,
+        // which is the only thing that lets a reader join a fan-out's
+        // BroadcastEmitted (targets enqueued) to its BroadcastComplete (arms
+        // delivered). Minting a second transaction would silently break the
+        // join while both events kept flowing.
+        assert_eq!(
+            BROADCAST_SRC
+                .matches(concat!(
+                    "Transaction",
+                    "::new::<crate::operations::update::UpdateMsg>()"
+                ))
+                .count(),
+            3,
+            "expected exactly three synthetic update transactions in this file: \
+             the no-targets delivery summary, the production fan-out (shared by \
+             BroadcastEmitted and BroadcastComplete), and the simulation \
+             fan-out (likewise shared). A fourth means a path minted its own \
+             transaction and broke the emitted/complete join"
+        );
+    }
+
+    /// Source-scrape pin: the simulation fan-out records the tally beside the
+    /// canonical `InterestManager` counters (#4923).
+    ///
+    /// The production counterpart of this pin lives in
+    /// `broadcast_queue.rs::fanout_tally_is_recorded_beside_the_canonical_counters_pin`.
+    /// This path predates the shared `record_delivery_to_interest` helper and
+    /// still inlines its own copy of the recording, so it needs its own pin:
+    /// the co-location is the only thing keeping the tally from drifting away
+    /// from the counter it shadows (#4009 / #4010).
+    #[test]
+    fn sim_fanout_records_tally_beside_the_canonical_counters_pin() {
+        let fn_start = BROADCAST_SRC
+            .find("async fn broadcast_state_to_peers(")
+            .expect("broadcast_state_to_peers not found");
+        let after = &BROADCAST_SRC[fn_start..];
+        let fn_end = after
+            .find("\n#[cfg(test)]")
+            .expect("end of broadcast_state_to_peers not found");
+        let body = &after[..fn_end];
+
+        let canonical_delta = body
+            .find("record_delta_send(new_state.size(), payload_size)")
+            .expect("the simulation fan-out must call record_delta_send");
+        let tally_delta = body
+            .find(concat!(
+                "fanout.record_",
+                "delta(new_state.size(), payload_size)"
+            ))
+            .expect(
+                "the simulation fan-out must record its delta send into the \
+                 per-fan-out tally, beside the canonical counter",
+            );
+        assert!(
+            tally_delta > canonical_delta,
+            "the tally's delta write must sit immediately after the canonical \
+             record_delta_send"
+        );
+
+        let canonical_full = body
+            .find("record_full_state_send()")
+            .expect("the simulation fan-out must call record_full_state_send");
+        let tally_full = body.find(concat!("fanout.record_", "full_state()")).expect(
+            "the simulation fan-out must record its full-state send into \
+                 the per-fan-out tally, beside the canonical counter",
+        );
+        assert!(
+            tally_full > canonical_full,
+            "the tally's full-state write must sit immediately after the \
+             canonical record_full_state_send"
         );
     }
 }

--- a/crates/core/src/tracing/event_kind.rs
+++ b/crates/core/src/tracing/event_kind.rs
@@ -212,6 +212,31 @@ impl EventKind {
         )
     }
 
+    /// Returns one fan-out's delta-vs-full-state split for `BroadcastComplete`
+    /// events: `(delta_sends, full_state_sends, bytes_saved, state_size)`.
+    ///
+    /// `state_size` is the FULL post-apply state, not the wire payload;
+    /// `state_size * (delta_sends + full_state_sends) - bytes_saved` is the real
+    /// payload total the fan-out put on the wire. Accessor rather than a public
+    /// `UpdateEvent` because the enum is `pub(crate)`, matching
+    /// [`router_snapshot_summary`](Self::router_snapshot_summary).
+    pub fn broadcast_complete_summary(&self) -> Option<(usize, usize, u64, usize)> {
+        // `if let` rather than a `match` with a catch-all: this crate bans
+        // wildcard enum arms (`.claude/rules/code-style.md`) precisely so a new
+        // variant cannot be silently swallowed by a telemetry classifier.
+        let EventKind::Update(UpdateEvent::BroadcastComplete {
+            delta_sends,
+            full_state_sends,
+            bytes_saved,
+            state_size,
+            ..
+        }) = self
+        else {
+            return None;
+        };
+        Some((*delta_sends, *full_state_sends, *bytes_saved, *state_size))
+    }
+
     /// Returns router snapshot summary data for `RouterSnapshot` events.
     ///
     /// Returns `(failure_events, success_events, prediction_active)`.

--- a/crates/core/src/tracing/event_kind.rs
+++ b/crates/core/src/tracing/event_kind.rs
@@ -204,6 +204,14 @@ impl EventKind {
         )
     }
 
+    /// Returns true if this is an Update BroadcastComplete event.
+    pub fn is_update_broadcast_complete(&self) -> bool {
+        matches!(
+            self,
+            EventKind::Update(UpdateEvent::BroadcastComplete { .. })
+        )
+    }
+
     /// Returns router snapshot summary data for `RouterSnapshot` events.
     ///
     /// Returns `(failure_events, success_events, prediction_active)`.

--- a/crates/core/src/tracing/register.rs
+++ b/crates/core/src/tracing/register.rs
@@ -824,6 +824,58 @@ impl<'a> NetEventLog<'a> {
         })
     }
 
+    /// Create an Update broadcast complete event: the delta-vs-full-state split
+    /// for ONE fan-out (issue #3335, #4923).
+    ///
+    /// Emitted once per fan-out, after every per-target send has finished, and
+    /// carries the same `tx` as that fan-out's
+    /// [`update_broadcast_emitted`](Self::update_broadcast_emitted) so the two
+    /// join on `id`.
+    ///
+    /// Field semantics, because two of them are easy to misread:
+    ///
+    /// * `state_size` is the size of the FULL post-apply state that was
+    ///   broadcast — the same number [`UpdateEvent::UpdateSuccess`] and
+    ///   [`UpdateEvent::BroadcastApplied`] report, NOT the bytes that crossed
+    ///   the wire. On its own it cannot distinguish a delta from a full state,
+    ///   which is exactly the ambiguity this event exists to close.
+    /// * `bytes_saved` closes it: it is `sum(state_size - delta_size)` over the
+    ///   delta sends, so `state_size * (delta_sends + full_state_sends) -
+    ///   bytes_saved` is the real payload total this fan-out put on the wire.
+    ///
+    /// `delta_sends + full_state_sends` counts only sends that were actually
+    /// DELIVERED, so it is normally less than the fan-out's target count: a
+    /// converged peer is skipped before any payload is chosen, and a dropped or
+    /// timed-out stream is not counted as either arm. Join against
+    /// [`update_broadcast_emitted`](Self::update_broadcast_emitted)'s
+    /// `broadcasted_to` (targets enqueued) and
+    /// [`broadcast_delivery_summary`](Self::broadcast_delivery_summary) for the
+    /// skip/failure breakdown that accounts for the difference.
+    pub fn update_broadcast_complete(
+        tx: &'a Transaction,
+        ring: &'a Ring,
+        key: ContractKey,
+        delta_sends: usize,
+        full_state_sends: usize,
+        bytes_saved: u64,
+        state_size: usize,
+    ) -> Option<Self> {
+        let peer_id = Self::get_own_peer_id(ring)?;
+        Some(NetEventLog {
+            tx,
+            peer_id,
+            kind: EventKind::Update(UpdateEvent::BroadcastComplete {
+                id: *tx,
+                key,
+                delta_sends,
+                full_state_sends,
+                bytes_saved,
+                state_size,
+                timestamp: chrono::Utc::now().timestamp() as u64,
+            }),
+        })
+    }
+
     /// Create a broadcast delivery summary event with the full breakdown of
     /// why each potential target was or was not sent the broadcast (issue #3046).
     pub fn broadcast_delivery_summary(

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -4770,6 +4770,25 @@ fn test_subscription_broadcast_propagation() {
         broadcast_emitted_count
     );
 
+    // An emitted-but-empty event is the failure an event count alone cannot see:
+    // the wiring fires, the JSON is well-formed, every arm reads zero, and the
+    // delta-vs-full-state question is no better answered than before. These peers
+    // demonstrably converged on the same state above, so at least one fan-out must
+    // have recorded a real send.
+    let recorded_sends: usize = broadcast_complete
+        .iter()
+        .filter_map(|log| log.kind.broadcast_complete_summary())
+        .map(|(delta_sends, full_state_sends, _, _)| delta_sends + full_state_sends)
+        .sum();
+    assert!(
+        recorded_sends > 0,
+        "All {} BroadcastComplete events reported zero sends. The peers converged, \
+         so payloads did reach the wire — a zero total means the per-fan-out tally \
+         is no longer being written where the delta/full-state choice is made, so \
+         the event carries no information.",
+        broadcast_complete.len()
+    );
+
     tracing::info!(
         "test_subscription_broadcast_propagation PASSED: {} peers converged to same state, \
          {} BroadcastEmitted events",

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -4733,6 +4733,43 @@ fn test_subscription_broadcast_propagation() {
          This means the emission wiring from #3622 is broken."
     );
 
+    // Verify BroadcastComplete telemetry events were produced (#4923).
+    //
+    // This is the delta-vs-full-state split for a fan-out. It matters because
+    // `state_size` alone — the only size the rest of the update telemetry
+    // carries — reports the post-apply FULL state whether a small delta or the
+    // entire state crossed the wire, so nothing else in the per-fan-out event
+    // stream can tell those apart.
+    //
+    // Every fan-out emits exactly one, so this must track BroadcastEmitted
+    // one-for-one: they are emitted from the same block against the same
+    // transaction. An inequality means one of the two emissions was dropped or
+    // duplicated — including the "emitted early, before every target was
+    // dispatched" failure the tally's creation guard exists to prevent.
+    let broadcast_complete: Vec<_> = rt.block_on(async {
+        let logs = logs_handle.lock().await;
+        logs.iter()
+            .filter(|log| log.kind.is_update_broadcast_complete())
+            .cloned()
+            .collect()
+    });
+
+    assert!(
+        !broadcast_complete.is_empty(),
+        "Expected at least one UpdateEvent::BroadcastComplete telemetry event, got 0. \
+         The variant is serialized by telemetry.rs and matched in four places, so a \
+         zero count means it is being counted as live telemetry while never actually \
+         being constructed — exactly the #4923 gap."
+    );
+    assert_eq!(
+        broadcast_complete.len(),
+        broadcast_emitted_count,
+        "Expected one BroadcastComplete per BroadcastEmitted (both are emitted once \
+         per fan-out, from the same block, against the same transaction), got {} vs {}",
+        broadcast_complete.len(),
+        broadcast_emitted_count
+    );
+
     tracing::info!(
         "test_subscription_broadcast_propagation PASSED: {} peers converged to same state, \
          {} BroadcastEmitted events",


### PR DESCRIPTION
## Problem

`UpdateEvent::BroadcastComplete` is defined (`tracing/event_kind.rs:969`), matched in four places, and serialized by `tracing/telemetry.rs:1713` into a `{"type":"broadcast_complete", ..., "delta_ratio": ...}` event — but **nothing ever constructed it**, so that arm never fired. The same was true of the counters #4922 added to `InterestManager`: `delta_sends` / `full_state_sends` / `delta_bytes_saved` are incremented on every send, but `stats()` has no caller anywhere in `crates/`, so they were tallied in memory and never read.

Both read as live telemetry to anyone grepping for them. Neither produced a byte.

This matters because `state_size` — the only size the per-fan-out update telemetry carried — reports the post-apply **full** state whether a 15 KB delta or a 340 KB whole state crossed the wire. Nothing in the per-fan-out event stream could tell those apart, which is what blocked explaining a River room reporting ~370 KB broadcast payloads against a ~320-339 KB state.

## Solution

Each fan-out builds one `FanoutTally`; its per-target sends record into it; the fan-out emits one `BroadcastComplete` carrying the **same transaction** as its `BroadcastEmitted`, so the two join on `id` — `BroadcastEmitted` gives targets enqueued, `BroadcastComplete` gives the arms actually delivered.

`bytes_saved` is what closes the ambiguity: `state_size * (delta_sends + full_state_sends) - bytes_saved` is the real payload total the fan-out put on the wire.

**Per-fan-out, not cumulative.** The `InterestManagerStats` counters are process-lifetime totals across every contract and peer, so differencing them around a fan-out would attribute concurrent fan-outs to whichever sampled last (production runs one detached task per (contract, peer)). A per-fan-out accumulator is the only way to get correct attribution — so this deliberately does **not** read `stats()`, and `stats()` remains uncalled.

**Why a second tally is defensible here.** It duplicates information the canonical counters hold, which is the `.claude/rules/bug-prevention-patterns.md` "manually-mirrored telemetry counters" failure (#4009 / #4010). The defence is that every tally write sits immediately beside the canonical `record_delta_send` / `record_full_state_send` it shadows, at both recording sites, and pins assert that adjacency. There is no third write site.

**Retirement is a `Drop` obligation** (`FanoutTarget`), not an explicit call: a queue entry leaves three ways — sent, superseded by replace-on-dedup, evicted at capacity — and `broadcast_to_single_peer` has several early returns. A forgotten explicit call would strand the fan-out so its event never fired, silently and with no behavioral symptom.

**Cannot stall a broadcast.** `register_events` is `try_send` internally and drops on a full channel (#4466/#4467), so the four `.send().await`-in-a-fan-out incidents are not reachable. Superseded/evicted targets are retired *after* the queue lock is released, so completing a fan-out never spawns under the lock every broadcast contends on.

Observability only — no change to what is broadcast, to whom, or in what form.

### Relationship to #4922 (please read before reviewing scope)

#4922 is **not** just a counting half; it shipped complete in v0.2.106. Its `broadcast_payload_mix.rs` already reports per-arm sends and **real wire bytes** on a 60s per-node rollup, naming which of the four full-state fallbacks fired (`full_delta_suppressed` / `full_not_efficient` / `full_compute_failed` / `full_no_summary`) plus `top_contracts_by_full_state_bytes`.

That is the better tool for "what is this node's byte mix, and why", and **it is the measurement #4923 is blocked on** — it should be read before this PR is treated as unblocking anything. This PR adds a strictly narrower, complementary view: per-fan-out identity, which the rollup deliberately does not carry, so it cannot answer "this particular update to this contract went out as N deltas and M full states". Neither replaces the other, and the module docs say so.

## Testing

`FanoutTally` unit tests (creation guard, exactly-once emission, zero-target and zero-send fan-outs, saturating `bytes_saved`, 32-thread concurrent retirement); the tally rides the real `record_streaming_delivery` gate in the existing #4235 drop test, asserting a dropped stream is **not** counted as a send; source-scrape pins for co-location and both emission paths; and an end-to-end assertion in `test_subscription_broadcast_propagation` requiring one `BroadcastComplete` per `BroadcastEmitted` **and** a non-zero recorded send total.

Every test was mutation-verified — the production change it pins was reverted and the test confirmed to fail:

| # | Mutation | Caught by |
|---|---|---|
| M1 | Drop tally delta write in `record_delivery_to_interest` | co-location pin |
| M2 | Drop tally full-state write | co-location pin |
| M3 | `BroadcastEntry` holds `Arc<FanoutTally>` instead of `FanoutTarget` | compiler (not the pin — noted below) |
| M4 | Retire `FanoutTarget`s *under* the queue lock | queue pin |
| M5 | Replace-on-dedup keeps the stale target | queue pin |
| M6 | Remove the creation guard (emit before all targets dispatched) | 5 tally unit tests |
| M7 | Production fan-out builds the tally but never emits | emission pin |
| M8 | Simulation fan-out never emits | **simulation integration test** |
| M9 | Simulation fan-out stops writing the tally | sim pin **and** integration test |
| M10 | `BroadcastEmitted` mints its own tx (breaks the join) | emission pin |

M3 is caught by the type system rather than the pin; that assertion is belt-and-braces over a compiler-enforced property, which is stated honestly rather than claimed as pin coverage.

**Mutation testing found two real defects in my own pins**, both fixed in the second commit: two needles matched their own source (`include_str!` pulls the test module back in), so M5 initially passed against the bug. They are now split with `concat!`, matching the existing `record_delivered` precedent.

### One pre-existing test repaired

`egress_paths_gated_on_is_contract_broken` anchored on `broadcast_queue.enqueue` as one contiguous string; adding an argument made rustfmt split the call, so the needle stopped matching and the pin failed for a formatting reason rather than a real one. Re-anchored on `.enqueue(` and verified it resolves to the identical statement (gate offset 687 < enqueue offset 2651), so the ordering assertion it exists to make is intact.

### Checks

- `cargo fmt -- --check` — clean
- `cargo clippy --locked -- -D warnings` — clean
- `cargo clippy --locked -p freenet --features trace-ot -- -D warnings` — clean
- `cargo nextest run -p freenet --lib --features "simulation_tests,testing"` — 4298 passed, 0 failed
- `cargo test -p freenet --lib` — 4296 passed, 0 failed
- `test_subscription_broadcast_propagation` — passes

Note: under `cargo test --test-threads 8` with the simulation feature, three tests in files this PR does not touch (`connection_manager`, `home_page`, `rolling_rtt_stats`) fail on shared global state; they pass in isolation and under nextest, which is the runner CI uses and which `.claude/rules/testing.md` requires for exactly this reason. Flagging rather than folding a fix into this PR.

## Scope

Parent measurement issue #3335. Related: #4922 (merged, v0.2.106), #4923 (blocked on #4922's data).

[AI-assisted - Claude]
