### PR TITLE
feat(telemetry): publish the efficiency gate's inputs on the NotEfficient arm

### DIFF
--- a/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
+++ b/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
@@ -164,6 +164,9 @@ struct Window {
     /// an 11-contract window look perfectly reconciled while 10 % of its bytes
     /// were unaccounted for.
     attribution_dropped_bytes: u64,
+    /// Distribution of the efficiency gate's two INPUTS on the refusals it
+    /// caused. See [`NotEfficientSizes`].
+    not_efficient: NotEfficientSizes,
 }
 
 impl Default for Window {
@@ -174,6 +177,103 @@ impl Default for Window {
             contract_full_state_bytes: HashMap::new(),
             attribution_dropped_sends: 0,
             attribution_dropped_bytes: 0,
+            not_efficient: NotEfficientSizes::default(),
+        }
+    }
+}
+
+/// The two sizes [`is_delta_efficient`][ide] compared when it refused to
+/// compute a delta.
+///
+/// [ide]: crate::ring::interest::is_delta_efficient
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct GateSizes {
+    /// `their_summary.as_ref().len()` — the cached summary for the TARGET peer.
+    pub summary_size: usize,
+    /// The `our_state_size` argument the fan-out passed to `compute_delta`.
+    pub state_size: usize,
+}
+
+/// Aggregated gate inputs across one window's `FullNotEfficient` refusals.
+///
+/// ## Why this exists
+///
+/// The gate is `summary * 2 < state`, so it refuses when the summary is >= 50 %
+/// of the state. The 2026-07-25 measurement found `full_not_efficient` at 38 %
+/// of fleet wire bytes and 83 % of the River room's — against a room whose
+/// summary measures 33,804 B on a 251,887 B state (13.4 %), well under the
+/// threshold, and structurally so: the per-message marginal is +67 B of summary
+/// per +521 B of state, so growth moves the ratio further from the threshold,
+/// not toward it. No reachable state of that contract should trip this gate,
+/// yet the gate is where its bytes are attributed.
+///
+/// So the gate's inputs are not what anyone assumes, and this records what they
+/// actually were. `DeltaUnavailable::NotEfficient` has always carried both
+/// sizes and renders them in its `Display`, but its only consumer is a
+/// `tracing::debug!`, and `debug!` is compiled out of release builds
+/// (`max_level_info`) — which is exactly why there are zero occurrences of it
+/// in production telemetry.
+///
+/// ## Why min and max, not just a mean
+///
+/// A mean cannot separate the candidate explanations; the extremes can:
+///
+/// * `summary_min == summary_max` at some fixed value suggests a defaulted or
+///   empty summary being sized wrong, not a real one.
+/// * A `summary_max` far above any reachable summary suggests a stale or
+///   wrong-peer summary in the cache.
+/// * A `state_min` at or near zero implicates [`is_delta_efficient`][ide]'s
+///   explicit `state_size == 0` early return, which also lands on this arm even
+///   though "summary >= 50 % of state" is not the reason —
+///   [`zero_state_samples`](Self::zero_state_samples) counts that case outright.
+/// * Sizes consistent with the measured 13.4 % ratio would mean the gate is NOT
+///   refusing on these inputs and the arm is mis-attributed at the
+///   classification site instead.
+///
+/// Fixed cardinality: eight scalars per window, keyed by nothing. This is
+/// per-send data feeding a per-node rollup, so anything keyed by contract or
+/// peer would be an amplification vector.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+struct NotEfficientSizes {
+    /// Refusals recorded this window. Zero means the other fields are
+    /// meaningless and they are published as `null`.
+    samples: u64,
+    summary_sum: u64,
+    summary_min: u64,
+    summary_max: u64,
+    state_sum: u64,
+    state_min: u64,
+    state_max: u64,
+    /// Refusals where `state_size == 0`, i.e. the gate's explicit zero-state
+    /// early return rather than the ratio test. Counted separately because the
+    /// two have completely different causes and the ratio cannot distinguish
+    /// them (anything over zero state is ">= 50 %").
+    zero_state_samples: u64,
+}
+
+impl NotEfficientSizes {
+    fn record(&mut self, sizes: GateSizes) {
+        let summary = sizes.summary_size as u64;
+        let state = sizes.state_size as u64;
+        if self.samples == 0 {
+            // First sample seeds both extremes; seeding min at 0 instead would
+            // pin it there forever and report a zero-byte summary that never
+            // happened.
+            self.summary_min = summary;
+            self.summary_max = summary;
+            self.state_min = state;
+            self.state_max = state;
+        } else {
+            self.summary_min = self.summary_min.min(summary);
+            self.summary_max = self.summary_max.max(summary);
+            self.state_min = self.state_min.min(state);
+            self.state_max = self.state_max.max(state);
+        }
+        self.samples = self.samples.saturating_add(1);
+        self.summary_sum = self.summary_sum.saturating_add(summary);
+        self.state_sum = self.state_sum.saturating_add(state);
+        if state == 0 {
+            self.zero_state_samples = self.zero_state_samples.saturating_add(1);
         }
     }
 }
@@ -238,11 +338,20 @@ impl PayloadMix {
     /// charged, so the mix and the cost axis agree on what "sent" means.
     ///
     /// [rt]: crate::topology::meter::ResourceType::BroadcastFanoutCost
+    /// `gate_sizes` carries the two inputs [`is_delta_efficient`][ide] weighed
+    /// when it refused, and is `Some` only for
+    /// [`PayloadArm::FullNotEfficient`] — the arm those inputs explain. Sizes
+    /// arriving with any other arm are ignored rather than folded in, so a
+    /// mis-wired call site cannot quietly contaminate the distribution that
+    /// exists to explain this one arm.
+    ///
+    /// [ide]: crate::ring::interest::is_delta_efficient
     pub(crate) fn record_delivered(
         &self,
         arm: PayloadArm,
         contract: &ContractInstanceId,
         payload_bytes: usize,
+        gate_sizes: Option<GateSizes>,
     ) {
         let bytes = payload_bytes as u64;
         let idx = arm.index();
@@ -252,6 +361,11 @@ impl PayloadMix {
         // what this measurement is for.
         w.sends[idx] = w.sends[idx].saturating_add(1);
         w.bytes[idx] = w.bytes[idx].saturating_add(bytes);
+        if arm == PayloadArm::FullNotEfficient {
+            if let Some(sizes) = gate_sizes {
+                w.not_efficient.record(sizes);
+            }
+        }
         if arm.is_full_state() {
             if let Some(tally) = w.contract_full_state_bytes.get_mut(contract) {
                 *tally = tally.saturating_add(bytes);
@@ -308,6 +422,7 @@ impl Window {
 ///
 /// Pure so the schema is unit-testable without the telemetry sender, matching
 /// the `shadow_demand` rollup builders.
+#[allow(clippy::too_many_arguments)]
 fn payload_mix_json(
     arms: &[(PayloadArm, u64, u64)],
     contracts: &[(ContractInstanceId, u64)],
@@ -315,6 +430,7 @@ fn payload_mix_json(
     contracts_tracked: u64,
     attribution_dropped_sends: u64,
     attribution_dropped_bytes: u64,
+    not_efficient: NotEfficientSizes,
     window_secs: u64,
 ) -> serde_json::Value {
     let mut obj = serde_json::Map::new();
@@ -385,6 +501,68 @@ fn payload_mix_json(
         "attribution_dropped_bytes".into(),
         attribution_dropped_bytes.into(),
     );
+    // The efficiency gate's own inputs on the refusals it caused (#4923).
+    // `full_not_efficient_sends` above says HOW MANY times the gate refused;
+    // these say WHAT IT SAW, which is the part that is currently invisible in
+    // release builds. See `NotEfficientSizes` for why min/max are published
+    // and not just a mean.
+    //
+    // With no samples every derived field is `null` rather than 0: a zero
+    // minimum summary is a specific and alarming claim ("the gate saw an empty
+    // summary"), and publishing it for an idle window would manufacture exactly
+    // the finding this instrumentation exists to test for.
+    obj.insert("not_efficient_samples".into(), not_efficient.samples.into());
+    obj.insert(
+        "not_efficient_zero_state_sends".into(),
+        not_efficient.zero_state_samples.into(),
+    );
+    let mean = |sum: u64| -> serde_json::Value {
+        if not_efficient.samples == 0 {
+            return serde_json::Value::Null;
+        }
+        serde_json::Number::from_f64(sum as f64 / not_efficient.samples as f64)
+            .map(serde_json::Value::Number)
+            .unwrap_or(serde_json::Value::Null)
+    };
+    let extreme = |v: u64| -> serde_json::Value {
+        if not_efficient.samples == 0 {
+            serde_json::Value::Null
+        } else {
+            v.into()
+        }
+    };
+    obj.insert(
+        "not_efficient_summary_bytes_sum".into(),
+        not_efficient.summary_sum.into(),
+    );
+    obj.insert(
+        "not_efficient_summary_bytes_mean".into(),
+        mean(not_efficient.summary_sum),
+    );
+    obj.insert(
+        "not_efficient_summary_bytes_min".into(),
+        extreme(not_efficient.summary_min),
+    );
+    obj.insert(
+        "not_efficient_summary_bytes_max".into(),
+        extreme(not_efficient.summary_max),
+    );
+    obj.insert(
+        "not_efficient_state_bytes_sum".into(),
+        not_efficient.state_sum.into(),
+    );
+    obj.insert(
+        "not_efficient_state_bytes_mean".into(),
+        mean(not_efficient.state_sum),
+    );
+    obj.insert(
+        "not_efficient_state_bytes_min".into(),
+        extreme(not_efficient.state_min),
+    );
+    obj.insert(
+        "not_efficient_state_bytes_max".into(),
+        extreme(not_efficient.state_max),
+    );
     obj.insert("window_secs".into(), window_secs.into());
     serde_json::Value::Object(obj)
 }
@@ -408,6 +586,7 @@ pub(crate) fn emit_payload_mix_rollup(
         window.contract_full_state_bytes.len() as u64,
         window.attribution_dropped_sends,
         window.attribution_dropped_bytes,
+        window.not_efficient,
         window_secs,
     );
     crate::tracing::telemetry::send_standalone_shadow_event_with_peer_id(
@@ -476,7 +655,7 @@ mod tests {
     #[test]
     fn take_window_resets_the_window() {
         let mix = PayloadMix::new();
-        mix.record_delivered(PayloadArm::Delta, &contract(1), 100);
+        mix.record_delivered(PayloadArm::Delta, &contract(1), 100, None);
         let first = mix.take_window().arms();
         assert_eq!(first[PayloadArm::Delta.index()].1, 1);
         assert_eq!(first[PayloadArm::Delta.index()].2, 100);
@@ -497,7 +676,7 @@ mod tests {
         let mix = PayloadMix::new();
         for (i, arm) in PayloadArm::ALL.iter().enumerate() {
             for _ in 0..=i {
-                mix.record_delivered(*arm, &contract(i as u8), 10);
+                mix.record_delivered(*arm, &contract(i as u8), 10, None);
             }
         }
         let drained = mix.take_window().arms();
@@ -521,10 +700,10 @@ mod tests {
     #[test]
     fn per_contract_tallies_reconcile_with_arm_totals() {
         let mix = PayloadMix::new();
-        mix.record_delivered(PayloadArm::FullNotEfficient, &contract(1), 500);
-        mix.record_delivered(PayloadArm::FullNoSummary, &contract(2), 300);
-        mix.record_delivered(PayloadArm::FullDeltaSuppressed, &contract(1), 200);
-        mix.record_delivered(PayloadArm::Delta, &contract(3), 50); // not full state
+        mix.record_delivered(PayloadArm::FullNotEfficient, &contract(1), 500, None);
+        mix.record_delivered(PayloadArm::FullNoSummary, &contract(2), 300, None);
+        mix.record_delivered(PayloadArm::FullDeltaSuppressed, &contract(1), 200, None);
+        mix.record_delivered(PayloadArm::Delta, &contract(3), 50, None); // not full state
 
         let window = mix.take_window();
         let full_state_total: u64 = window
@@ -560,6 +739,7 @@ mod tests {
             window.contract_full_state_bytes.len() as u64,
             window.attribution_dropped_sends,
             window.attribution_dropped_bytes,
+            NotEfficientSizes::default(),
             60,
         );
         let top_sum: u64 = json["top_contracts_by_full_state_bytes"]
@@ -591,7 +771,7 @@ mod tests {
     fn window_with_more_contracts_than_top_n_still_reconciles() {
         let mix = PayloadMix::new();
         for i in 0..(TOP_CONTRACTS_REPORTED + 1) {
-            mix.record_delivered(PayloadArm::FullNotEfficient, &contract(i as u8), 100);
+            mix.record_delivered(PayloadArm::FullNotEfficient, &contract(i as u8), 100, None);
         }
         let window = mix.take_window();
         assert_reconciles(&window);
@@ -603,6 +783,7 @@ mod tests {
             window.contract_full_state_bytes.len() as u64,
             window.attribution_dropped_sends,
             window.attribution_dropped_bytes,
+            NotEfficientSizes::default(),
             60,
         );
         assert_eq!(json["full_state_bytes"], 1100);
@@ -628,7 +809,12 @@ mod tests {
             let mut raw = [0u8; 32];
             raw[0] = (i % 256) as u8;
             raw[1] = (i / 256) as u8;
-            mix.record_delivered(PayloadArm::FullNoSummary, &ContractInstanceId::new(raw), 10);
+            mix.record_delivered(
+                PayloadArm::FullNoSummary,
+                &ContractInstanceId::new(raw),
+                10,
+                None,
+            );
         }
         let window = mix.take_window();
         assert!(
@@ -679,7 +865,12 @@ mod tests {
                 let mix = Arc::clone(&mix);
                 std::thread::spawn(move || {
                     for _ in 0..PER_THREAD {
-                        mix.record_delivered(PayloadArm::FullNotEfficient, &contract(t as u8), 7);
+                        mix.record_delivered(
+                            PayloadArm::FullNotEfficient,
+                            &contract(t as u8),
+                            7,
+                            None,
+                        );
                     }
                 })
             })
@@ -711,7 +902,7 @@ mod tests {
             (PayloadArm::FullComputeFailed, 0, 0),
             (PayloadArm::FullNoSummary, 0, 0),
         ];
-        let json = payload_mix_json(&arms, &[], 0, 0, 0, 0, 60);
+        let json = payload_mix_json(&arms, &[], 0, 0, 0, 0, NotEfficientSizes::default(), 60);
         assert_eq!(json["total_bytes"], 1000);
         assert_eq!(json["full_state_bytes"], 700);
         assert_eq!(json["full_state_byte_share"], 0.7);
@@ -724,7 +915,7 @@ mod tests {
     #[test]
     fn empty_window_reports_zero_share_not_nan() {
         let arms: Vec<_> = PayloadArm::ALL.iter().map(|a| (*a, 0, 0)).collect();
-        let json = payload_mix_json(&arms, &[], 0, 0, 0, 0, 60);
+        let json = payload_mix_json(&arms, &[], 0, 0, 0, 0, NotEfficientSizes::default(), 60);
         assert_eq!(json["full_state_byte_share"], 0.0);
         assert_eq!(json["total_bytes"], 0);
     }
@@ -750,6 +941,7 @@ mod tests {
                 PayloadArm::FullNotEfficient,
                 &ContractInstanceId::new(raw),
                 5,
+                None,
             );
         }
         let window = mix.take_window();
@@ -788,6 +980,7 @@ mod tests {
                 PayloadArm::FullNotEfficient,
                 &ContractInstanceId::new(raw),
                 1,
+                None,
             );
         }
         // A single additional contract, broadcasting many times.
@@ -795,7 +988,7 @@ mod tests {
         raw[31] = 7;
         let over_cap = ContractInstanceId::new(raw);
         for _ in 0..1000 {
-            mix.record_delivered(PayloadArm::FullNotEfficient, &over_cap, 3);
+            mix.record_delivered(PayloadArm::FullNotEfficient, &over_cap, 3, None);
         }
         let window = mix.take_window();
         assert_eq!(window.attribution_dropped_sends, 1000);
@@ -808,9 +1001,9 @@ mod tests {
     #[test]
     fn top_contracts_sort_is_deterministic() {
         let mix = PayloadMix::new();
-        mix.record_delivered(PayloadArm::FullNoSummary, &contract(9), 100);
-        mix.record_delivered(PayloadArm::FullNoSummary, &contract(2), 100);
-        mix.record_delivered(PayloadArm::FullNoSummary, &contract(5), 500);
+        mix.record_delivered(PayloadArm::FullNoSummary, &contract(9), 100, None);
+        mix.record_delivered(PayloadArm::FullNoSummary, &contract(2), 100, None);
+        mix.record_delivered(PayloadArm::FullNoSummary, &contract(5), 500, None);
         let top = mix.take_window().top_contracts();
         assert_eq!(top[0].0, contract(5), "largest first");
         assert_eq!(top[1].0, contract(2), "tie broken by contract id");
@@ -821,7 +1014,7 @@ mod tests {
     #[test]
     fn delta_sends_are_not_attributed_as_full_state() {
         let mix = PayloadMix::new();
-        mix.record_delivered(PayloadArm::Delta, &contract(7), 1234);
+        mix.record_delivered(PayloadArm::Delta, &contract(7), 1234, None);
         let window = mix.take_window();
         assert!(
             window.contract_full_state_bytes.is_empty(),
@@ -864,7 +1057,7 @@ mod tests {
     fn every_full_state_arm_attributes_to_its_contract() {
         for arm in PayloadArm::ALL.iter().filter(|a| a.is_full_state()) {
             let mix = PayloadMix::new();
-            mix.record_delivered(*arm, &contract(3), 99);
+            mix.record_delivered(*arm, &contract(3), 99, None);
             let top = mix.take_window().top_contracts();
             assert_eq!(
                 top,
@@ -872,5 +1065,181 @@ mod tests {
                 "{arm:?} must attribute its full-state bytes to the contract"
             );
         }
+    }
+
+    // ---- Efficiency-gate input distribution (#4923) ----
+
+    fn sizes(summary: usize, state: usize) -> GateSizes {
+        GateSizes {
+            summary_size: summary,
+            state_size: state,
+        }
+    }
+
+    fn json_of(mix: &PayloadMix) -> serde_json::Value {
+        let w = mix.take_window();
+        payload_mix_json(
+            &w.arms(),
+            &w.top_contracts(),
+            w.contract_full_state_bytes.values().sum(),
+            w.contract_full_state_bytes.len() as u64,
+            w.attribution_dropped_sends,
+            w.attribution_dropped_bytes,
+            w.not_efficient,
+            60,
+        )
+    }
+
+    /// The headline case: the gate's inputs reach the emitted event. Without
+    /// this the arm reports only how OFTEN it refused, never what it saw —
+    /// which is the state this change exists to end.
+    #[test]
+    fn not_efficient_gate_inputs_reach_the_rollup() {
+        let mix = PayloadMix::new();
+        mix.record_delivered(
+            PayloadArm::FullNotEfficient,
+            &contract(1),
+            254_000,
+            Some(sizes(33_804, 251_887)),
+        );
+        let json = json_of(&mix);
+        assert_eq!(json["not_efficient_samples"], 1);
+        assert_eq!(json["not_efficient_summary_bytes_sum"], 33_804);
+        assert_eq!(json["not_efficient_summary_bytes_min"], 33_804);
+        assert_eq!(json["not_efficient_summary_bytes_max"], 33_804);
+        assert_eq!(json["not_efficient_state_bytes_sum"], 251_887);
+        assert_eq!(json["not_efficient_state_bytes_min"], 251_887);
+        assert_eq!(json["not_efficient_state_bytes_max"], 251_887);
+        assert_eq!(json["not_efficient_summary_bytes_mean"], 33_804.0);
+        assert_eq!(json["not_efficient_state_bytes_mean"], 251_887.0);
+        assert_eq!(json["not_efficient_zero_state_sends"], 0);
+    }
+
+    /// Min and max are the whole point: a mean alone cannot separate "one
+    /// enormous stale summary" from "every summary is enormous", and those are
+    /// different bugs. Feed a deliberately bimodal window and check the
+    /// extremes survive rather than being averaged away.
+    #[test]
+    fn bimodal_gate_inputs_keep_their_extremes() {
+        let mix = PayloadMix::new();
+        for s in [1_000usize, 127_000, 2_000] {
+            mix.record_delivered(
+                PayloadArm::FullNotEfficient,
+                &contract(1),
+                10,
+                Some(sizes(s, 250_000)),
+            );
+        }
+        let json = json_of(&mix);
+        assert_eq!(json["not_efficient_samples"], 3);
+        assert_eq!(json["not_efficient_summary_bytes_min"], 1_000);
+        assert_eq!(
+            json["not_efficient_summary_bytes_max"], 127_000,
+            "the outlier summary must survive the rollup — averaging it away \
+             would hide the single most diagnostic observation"
+        );
+        assert_eq!(json["not_efficient_summary_bytes_sum"], 130_000);
+    }
+
+    /// `is_delta_efficient` returns false when `state_size == 0`, and that
+    /// refusal lands on this arm even though "summary >= 50 % of state" is not
+    /// the reason. The ratio cannot distinguish it (anything over zero state is
+    /// >= 50 %), so it is counted outright.
+    #[test]
+    fn zero_state_refusals_are_counted_separately() {
+        let mix = PayloadMix::new();
+        mix.record_delivered(
+            PayloadArm::FullNotEfficient,
+            &contract(1),
+            0,
+            Some(sizes(4_096, 0)),
+        );
+        mix.record_delivered(
+            PayloadArm::FullNotEfficient,
+            &contract(1),
+            10,
+            Some(sizes(4_096, 5_000)),
+        );
+        let json = json_of(&mix);
+        assert_eq!(json["not_efficient_samples"], 2);
+        assert_eq!(
+            json["not_efficient_zero_state_sends"], 1,
+            "a zero-state refusal has a different cause than a ratio refusal \
+             and must be countable on its own"
+        );
+        assert_eq!(json["not_efficient_state_bytes_min"], 0);
+    }
+
+    /// An idle window must publish `null`, not `0`. A zero minimum summary is a
+    /// specific and alarming claim — "the gate saw an empty summary" — and
+    /// emitting it for a window with no refusals would manufacture the very
+    /// finding this instrumentation exists to test for.
+    #[test]
+    fn window_with_no_refusals_publishes_null_not_zero() {
+        let mix = PayloadMix::new();
+        mix.record_delivered(PayloadArm::Delta, &contract(1), 100, None);
+        let json = json_of(&mix);
+        assert_eq!(json["not_efficient_samples"], 0);
+        for field in [
+            "not_efficient_summary_bytes_min",
+            "not_efficient_summary_bytes_max",
+            "not_efficient_summary_bytes_mean",
+            "not_efficient_state_bytes_min",
+            "not_efficient_state_bytes_max",
+            "not_efficient_state_bytes_mean",
+        ] {
+            assert!(
+                json[field].is_null(),
+                "{field} must be null with no samples, not a fabricated 0"
+            );
+        }
+    }
+
+    /// The sizes explain the `FullNotEfficient` arm and only that arm. A
+    /// mis-wired call site that attached them to another arm would silently
+    /// contaminate the distribution with sizes the gate never weighed.
+    #[test]
+    fn gate_sizes_are_ignored_for_other_arms() {
+        for arm in PayloadArm::ALL
+            .iter()
+            .filter(|a| **a != PayloadArm::FullNotEfficient)
+        {
+            let mix = PayloadMix::new();
+            mix.record_delivered(*arm, &contract(1), 10, Some(sizes(9_999, 10_000)));
+            let json = json_of(&mix);
+            assert_eq!(
+                json["not_efficient_samples"], 0,
+                "{arm:?} must not contribute to the efficiency-gate distribution"
+            );
+        }
+    }
+
+    /// A window is drained on emit, so a later window must not inherit the
+    /// previous one's extremes — that would smear one node's outlier across
+    /// every subsequent minute.
+    #[test]
+    fn gate_input_distribution_resets_between_windows() {
+        let mix = PayloadMix::new();
+        mix.record_delivered(
+            PayloadArm::FullNotEfficient,
+            &contract(1),
+            10,
+            Some(sizes(127_000, 250_000)),
+        );
+        let first = json_of(&mix);
+        assert_eq!(first["not_efficient_summary_bytes_max"], 127_000);
+
+        mix.record_delivered(
+            PayloadArm::FullNotEfficient,
+            &contract(1),
+            10,
+            Some(sizes(1_000, 250_000)),
+        );
+        let second = json_of(&mix);
+        assert_eq!(second["not_efficient_samples"], 1);
+        assert_eq!(
+            second["not_efficient_summary_bytes_max"], 1_000,
+            "the previous window's outlier must not carry over"
+        );
     }
 }

--- a/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
+++ b/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
@@ -249,6 +249,26 @@ struct NotEfficientSizes {
     /// two have completely different causes and the ratio cannot distinguish
     /// them (anything over zero state is ">= 50 %").
     zero_state_samples: u64,
+    /// Refusals whose recorded sizes say the gate should have PASSED:
+    /// `state_size != 0 && summary_size * 2 < state_size`.
+    ///
+    /// By [`is_delta_efficient`][ide]'s own logic this is impossible — those
+    /// are exactly the inputs it returns `true` for, which would have produced
+    /// a delta rather than this arm. **A non-zero value here is therefore
+    /// proof that the sizes reaching this arm are not the sizes the gate
+    /// evaluated**, i.e. the arm is mis-attributed at the classification site
+    /// and the efficiency gate is not the cause at all.
+    ///
+    /// That is the one candidate explanation a fix would most easily be built
+    /// in the wrong direction against, and it is the one the min/max fields
+    /// cannot settle on their own: they are computed independently across the
+    /// two dimensions, so a large `summary_max` and a small `state_min` may
+    /// come from different sends and must not be combined into a ratio. This
+    /// counter evaluates the predicate per sample, where the pair is still
+    /// together, so it is unambiguous.
+    ///
+    /// [ide]: crate::ring::interest::is_delta_efficient
+    ratio_would_have_passed: u64,
 }
 
 impl NotEfficientSizes {
@@ -274,6 +294,12 @@ impl NotEfficientSizes {
         self.state_sum = self.state_sum.saturating_add(state);
         if state == 0 {
             self.zero_state_samples = self.zero_state_samples.saturating_add(1);
+        } else if summary.saturating_mul(2) < state {
+            // Impossible per `is_delta_efficient` — see the field's rustdoc.
+            // Deliberately mirrors the gate's predicate verbatim rather than
+            // calling it, so this stays a check on the RECORDED sizes even if
+            // the gate's own definition later changes.
+            self.ratio_would_have_passed = self.ratio_would_have_passed.saturating_add(1);
         }
     }
 }
@@ -515,6 +541,12 @@ fn payload_mix_json(
     obj.insert(
         "not_efficient_zero_state_sends".into(),
         not_efficient.zero_state_samples.into(),
+    );
+    // Tripwire: must be 0. Any other value proves the sizes recorded on this
+    // arm are not the sizes the gate evaluated. See the field's rustdoc.
+    obj.insert(
+        "not_efficient_ratio_would_have_passed".into(),
+        not_efficient.ratio_would_have_passed.into(),
     );
     let mean = |sum: u64| -> serde_json::Value {
         if not_efficient.samples == 0 {
@@ -1168,6 +1200,71 @@ mod tests {
              and must be countable on its own"
         );
         assert_eq!(json["not_efficient_state_bytes_min"], 0);
+        assert_eq!(
+            json["not_efficient_ratio_would_have_passed"], 0,
+            "a zero-state refusal is the gate's explicit early return, NOT a \
+             ratio that would have passed — conflating them would point the \
+             tripwire at the wrong cause"
+        );
+    }
+
+    /// The mis-attribution tripwire. `is_delta_efficient` returns `true` for
+    /// `summary * 2 < state` with non-zero state, so such a send should have
+    /// produced a DELTA, never this arm. If it lands here anyway, the sizes
+    /// recorded are not the sizes the gate evaluated — the arm is
+    /// mis-attributed at the classification site and the gate is not the cause.
+    ///
+    /// This is the hypothesis a fix would most easily be built in the wrong
+    /// direction against, and the one the independent min/max fields cannot
+    /// settle: they may draw their extremes from different sends, so a large
+    /// `summary_max` and a small `state_min` must not be combined into a ratio.
+    /// Evaluating the predicate per sample, while the pair is still together,
+    /// is what makes it unambiguous.
+    #[test]
+    fn sizes_that_should_have_passed_the_gate_trip_the_misattribution_counter() {
+        let mix = PayloadMix::new();
+        // The River room's measured shape: 33,804 B summary on a 251,887 B
+        // state is 13.4 %, far under the 50 % threshold. The gate would have
+        // returned true, so reaching FullNotEfficient with these sizes is
+        // self-contradictory.
+        mix.record_delivered(
+            PayloadArm::FullNotEfficient,
+            &contract(1),
+            254_000,
+            Some(sizes(33_804, 251_887)),
+        );
+        let json = json_of(&mix);
+        assert_eq!(
+            json["not_efficient_ratio_would_have_passed"], 1,
+            "sizes the gate would have passed must trip the mis-attribution \
+             tripwire — that is the whole point of recording them"
+        );
+        assert_eq!(json["not_efficient_zero_state_sends"], 0);
+    }
+
+    /// The tripwire must stay silent on inputs the gate genuinely refuses,
+    /// including the exact boundary. `summary * 2 < state` is strict, so
+    /// `summary * 2 == state` is a real refusal, not a mis-attribution.
+    #[test]
+    fn genuine_refusals_including_the_boundary_do_not_trip_the_counter() {
+        for (summary, state) in [
+            (127_000usize, 250_000usize), // summary > 50 % — a real refusal
+            (125_000, 250_000),           // exactly 50 % — boundary, still refused
+        ] {
+            let mix = PayloadMix::new();
+            mix.record_delivered(
+                PayloadArm::FullNotEfficient,
+                &contract(1),
+                10,
+                Some(sizes(summary, state)),
+            );
+            let json = json_of(&mix);
+            assert_eq!(
+                json["not_efficient_ratio_would_have_passed"], 0,
+                "summary={summary} state={state} is a genuine refusal by the \
+                 gate's own predicate and must not read as mis-attribution"
+            );
+        }
     }
 
     /// An idle window must publish `null`, not `0`. A zero minimum summary is a

--- a/crates/core/src/node/network_bridge/broadcast_queue.rs
+++ b/crates/core/src/node/network_bridge/broadcast_queue.rs
@@ -20,7 +20,7 @@ use crate::node::OpManager;
 use crate::ring::PeerKeyLocation;
 use crate::transport::BroadcastDeliveryOutcome;
 
-use super::broadcast_payload_mix::PayloadArm;
+use super::broadcast_payload_mix::{GateSizes, PayloadArm};
 use super::p2p_protoc::P2pBridge;
 
 /// Timeout for awaiting stream completion signal before releasing the permit
@@ -854,7 +854,7 @@ pub(super) async fn broadcast_to_single_peer(
     // measurement could see that large states go out whole but not why. The
     // tag is carried to the real-delivery sites below and recorded there, so
     // the mix counts bytes that actually reached the wire.
-    let (payload, sent_delta, payload_arm) = match (&our_summary, &their_summary) {
+    let (payload, sent_delta, payload_arm, gate_sizes) = match (&our_summary, &their_summary) {
         // Scoped to the both-summaries-present case ON PURPOSE. When a summary
         // is missing a delta was impossible regardless of the memo, so letting
         // the suppression guard win there would credit the memo for a full
@@ -868,6 +868,7 @@ pub(super) async fn broadcast_to_single_peer(
             DeltaOrFullState::FullState(new_state.as_ref().to_vec()),
             false,
             PayloadArm::FullDeltaSuppressed,
+            None,
         ),
         (Some(ours), Some(theirs)) => {
             match op_manager
@@ -879,6 +880,7 @@ pub(super) async fn broadcast_to_single_peer(
                     DeltaOrFullState::Delta(delta.as_ref().to_vec()),
                     true,
                     PayloadArm::Delta,
+                    None,
                 ),
                 Ok(None) => {
                     // The contract computed an EMPTY delta against the peer's
@@ -910,18 +912,39 @@ pub(super) async fn broadcast_to_single_peer(
                     // means no contract code ran at all — the gate declined a
                     // delta because the peer's summary is >= 50 % of our state,
                     // and we then send the whole state, which is never smaller.
-                    let arm = match err {
-                        crate::ring::interest::DeltaUnavailable::NotEfficient { .. } => {
-                            PayloadArm::FullNotEfficient
-                        }
+                    //
+                    // Capture the gate's two INPUTS on the refusal arm (#4923).
+                    // The `debug!` above already renders them via
+                    // `DeltaUnavailable`'s Display, but `debug!` is compiled out
+                    // of release builds (`max_level_info`), so in production
+                    // they have never been observable — which is why the
+                    // measured `full_not_efficient` share cannot currently be
+                    // reconciled with the summary/state ratios the contracts
+                    // actually have. Carrying them to the delivery site (rather
+                    // than recording here) keeps the distribution gated on the
+                    // same real-delivery condition as the arm's own send and
+                    // byte counts, so the three always describe one set of
+                    // sends.
+                    let (arm, gate_sizes) = match err {
+                        crate::ring::interest::DeltaUnavailable::NotEfficient {
+                            summary_size,
+                            state_size,
+                        } => (
+                            PayloadArm::FullNotEfficient,
+                            Some(GateSizes {
+                                summary_size,
+                                state_size,
+                            }),
+                        ),
                         crate::ring::interest::DeltaUnavailable::ComputeFailed(_) => {
-                            PayloadArm::FullComputeFailed
+                            (PayloadArm::FullComputeFailed, None)
                         }
                     };
                     (
                         DeltaOrFullState::FullState(new_state.as_ref().to_vec()),
                         false,
                         arm,
+                        gate_sizes,
                     )
                 }
             }
@@ -930,6 +953,7 @@ pub(super) async fn broadcast_to_single_peer(
             DeltaOrFullState::FullState(new_state.as_ref().to_vec()),
             false,
             PayloadArm::FullNoSummary,
+            None,
         ),
     };
     let payload_size = payload.size();
@@ -1095,9 +1119,12 @@ pub(super) async fn broadcast_to_single_peer(
                     );
                     // Same delivery gate as the cost axis above, so the mix and
                     // the cost axis always agree on what "sent" means (#3335).
-                    op_manager
-                        .payload_mix
-                        .record_delivered(payload_arm, key.id(), payload_size);
+                    op_manager.payload_mix.record_delivered(
+                        payload_arm,
+                        key.id(),
+                        payload_size,
+                        gate_sizes,
+                    );
                     tracing::debug!(
                         tx = %update_tx,
                         peer = %peer_addr,
@@ -1141,9 +1168,12 @@ pub(super) async fn broadcast_to_single_peer(
             );
             // Same delivery gate as the cost axis above, so the mix and the
             // cost axis always agree on what "sent" means (#3335).
-            op_manager
-                .payload_mix
-                .record_delivered(payload_arm, key.id(), payload_size);
+            op_manager.payload_mix.record_delivered(
+                payload_arm,
+                key.id(),
+                payload_size,
+                gate_sizes,
+            );
             // Delta-incompat attribution (HQk7 resync loop): remember that we
             // just delivered a DELTA to this peer so a prompt `ResyncRequest`
             // from it can be attributed to the delta failing to apply (deltas
@@ -2166,13 +2196,19 @@ mod tests {
         // Anchor on the call, not the receiver: rustfmt splits
         // `op_manager.payload_mix.record_delivered(..)` across lines, so a
         // receiver-shaped needle would be whitespace-fragile.
-        let record_needle = concat!(".record_", "delivered(payload_arm, key.id(), payload_size)");
+        let record_needle = concat!(
+            ".record_",
+            "delivered(payload_arm, key.id(), payload_size, gate_sizes)"
+        );
         assert_eq!(
             body.matches(record_needle).count(),
             2,
             "payload mix must be recorded at exactly the two real-delivery \
              sites (streaming Delivered + inline send Ok) — recording up-front \
-             would count dropped/failed sends as bytes on the wire"
+             would count dropped/failed sends as bytes on the wire. The \
+             `gate_sizes` argument must ride along at BOTH (#4923): a site that \
+             drops it silently halves the efficiency-gate size distribution \
+             while every arm count stays correct, so nothing else would notice"
         );
         // ...and it must be THIS node's accumulator, never a process global:
         // several nodes share a process in the simulation harness and the
@@ -2202,6 +2238,72 @@ mod tests {
                 && body.contains("DeltaUnavailable::ComputeFailed"),
             "the delta-failure arm must keep the typed NotEfficient vs \
              ComputeFailed split — collapsing them re-blinds the measurement"
+        );
+    }
+
+    /// Source-scrape pin: the `NotEfficient` arm must destructure the gate's
+    /// two sizes and carry them to the delivery site (#4923).
+    ///
+    /// This is the one arm whose measured share cannot be reconciled with the
+    /// contracts' actual summary/state ratios, and the sizes that would explain
+    /// it are otherwise invisible: `DeltaUnavailable`'s `Display` renders them,
+    /// but its only consumer is a `tracing::debug!`, and `debug!` is compiled
+    /// out of release builds. A refactor that goes back to matching with `..`
+    /// would restore that blindness while every arm count stayed correct, so
+    /// no behavioral test would notice.
+    #[test]
+    fn not_efficient_arm_captures_the_gate_sizes_pin() {
+        let src = include_str!("broadcast_queue.rs");
+        let fn_start = src
+            .find("pub(super) async fn broadcast_to_single_peer(")
+            .expect("broadcast_to_single_peer not found");
+        let after = &src[fn_start..];
+        let fn_end = after
+            .find("\nmod tests {")
+            .or_else(|| after.find("\n#[cfg(test)]"))
+            .expect("end of broadcast_to_single_peer not found");
+        let body = &after[..fn_end];
+
+        // The arm must BIND the sizes, not discard them with `..`.
+        let arm_start = body
+            .find("DeltaUnavailable::NotEfficient")
+            .expect("NotEfficient arm not found");
+        let arm = &body[arm_start..];
+        let arm_end = arm
+            .find("ComputeFailed")
+            .expect("the two delta-failure arms must stay adjacent");
+        let arm = &arm[..arm_end];
+        assert!(
+            arm.contains("summary_size") && arm.contains("state_size"),
+            "the NotEfficient arm must destructure `summary_size` and \
+             `state_size` — matching with `..` discards the only evidence of \
+             what the gate actually weighed, which is the whole point of #4923"
+        );
+        assert!(
+            !arm.contains(".."),
+            "the NotEfficient arm must not use `..` — that is exactly the \
+             pattern that threw the sizes away before #4923"
+        );
+
+        // They must reach the recorder as a `GateSizes`, bound once.
+        assert_eq!(
+            body.matches(concat!("Some(", "GateSizes {")).count(),
+            1,
+            "the gate sizes must be wrapped exactly once, on the NotEfficient \
+             arm — a second construction site means some other arm is \
+             contributing sizes the gate never weighed"
+        );
+        let bind = body
+            .find("gate_sizes")
+            .expect("the fan-out must carry the gate sizes to the delivery site");
+        let record = body
+            .find(concat!(".record_", "delivered("))
+            .expect("payload mix record site not found");
+        assert!(
+            bind < record,
+            "the gate sizes must be captured at the refusal and carried to the \
+             delivery site, so the size distribution is gated on the same real \
+             delivery as the arm's send and byte counts"
         );
     }
 }

--- a/crates/core/src/node/network_bridge/broadcast_queue.rs
+++ b/crates/core/src/node/network_bridge/broadcast_queue.rs
@@ -2193,15 +2193,22 @@ mod tests {
         // The mix is recorded at exactly the two real-delivery sites, the same
         // gate as BroadcastFanoutCost, so the two axes always agree on what
         // "sent" means. Recording up-front would count phantom fan-out.
-        // Anchor on the call, not the receiver: rustfmt splits
-        // `op_manager.payload_mix.record_delivered(..)` across lines, so a
-        // receiver-shaped needle would be whitespace-fragile.
+        //
+        // Match against a WHITESPACE-STRIPPED copy of the body. rustfmt
+        // reformats this call whenever its argument list changes — it split it
+        // across five lines the moment #4923 added `gate_sizes`, and an
+        // indentation-shaped needle broke with it. A pin that fails for a
+        // formatting reason instead of a real one is worse than no pin: it
+        // trains the next person to "fix" it by loosening the assertion.
+        // Stripping whitespace makes the needle independent of how rustfmt
+        // chooses to lay the call out.
+        let squashed: String = body.chars().filter(|c| !c.is_whitespace()).collect();
         let record_needle = concat!(
             ".record_",
-            "delivered(payload_arm, key.id(), payload_size, gate_sizes)"
+            "delivered(payload_arm,key.id(),payload_size,gate_sizes"
         );
         assert_eq!(
-            body.matches(record_needle).count(),
+            squashed.matches(record_needle).count(),
             2,
             "payload mix must be recorded at exactly the two real-delivery \
              sites (streaming Delivered + inline send Ok) — recording up-front \
@@ -2215,15 +2222,9 @@ mod tests {
         // aggregator drains destructively, so a global would let one node's
         // ticker steal another's records.
         assert_eq!(
-            body.matches(concat!(
-                "op_manager",
-                "\n",
-                "                        .payload_mix"
-            ))
-            .count()
-                + body
-                    .matches(concat!("op_manager", "\n                .payload_mix"))
-                    .count(),
+            squashed
+                .matches(concat!("op_manager.payload_mix.record_", "delivered("))
+                .count(),
             2,
             "the payload mix must be recorded on op_manager.payload_mix (the \
              per-node accumulator), not a process-global static"


### PR DESCRIPTION
## Problem

The 2026-07-25 measurement on v0.2.106 (`broadcast_payload_mix`, 1,319 peers / 291 emitting / 7,621 windows, segmented on `service.version == 0.2.106`) put **full state at 95.58% of fleet wire bytes**. Within that, `full_not_efficient` is **38.1% fleet-wide** and **83.1% of the River room's** full-state bytes.

That last number does not reconcile with the room itself. `is_delta_efficient` is `summary * 2 < state` — it refuses when the summary is >= 50% of state. The room measures **33,804 B of summary against a 251,887 B state = 13.4%**, far under the threshold, and structurally so: the per-message marginal is +67 B of summary per +521 B of state, so growth moves the ratio *away* from the threshold. For the gate to refuse on a ~254 KB state, `their_summary` would have to be ~127 KB — roughly 4x anything reachable. No constructible state of this contract trips this gate, yet that is where its bytes are attributed.

Both measurements are solid, so **the gate's inputs are not what anyone assumes** — and today they cannot be checked. `DeltaUnavailable::NotEfficient` has always carried `summary_size` and `state_size` and renders them in its `Display`, but its only consumer is a `tracing::debug!` in `broadcast_queue.rs`, and **`debug!` is compiled out of release builds** (`max_level_info`). Hence zero occurrences in production telemetry. This repo has been bitten by that before.

## Solution

Record the gate's two inputs into the existing 60s `broadcast_payload_mix` rollup as fixed-cardinality aggregates: **count, sum, min and max for both sizes**, plus a separate count of `state_size == 0` refusals.

**Why min/max and not just a mean** — the extremes are what separate the candidate explanations, and a mean collapses all of them into one number:

| observation | implicates |
|---|---|
| `summary_min == summary_max` at a fixed value | a defaulted/empty summary being sized wrong |
| `summary_max` far above anything reachable | a stale or wrong-peer summary in the cache |
| `state_min` at/near 0 | `is_delta_efficient`'s explicit `state_size == 0` early return |
| sizes matching the measured 13.4% ratio | the gate is **not** refusing on these inputs — the arm is mis-attributed at the classification site |

The zero-state case gets its own counter because the ratio cannot express it: anything over zero state is trivially ">= 50%", so it lands on this arm even though the ratio is not the reason.

**A mis-attribution tripwire, `not_efficient_ratio_would_have_passed`.** The min/max fields are computed *independently* across the two dimensions, so a large `summary_max` and a small `state_min` may come from different sends and must not be combined into a ratio. That leaves the fourth row above — "the arm is mis-attributed" — unsettled, and it is the row a fix would most easily be built in the wrong direction against.

`is_delta_efficient` returns `true` for `state != 0 && summary * 2 < state`, so a send with those sizes should have produced a **delta** and can never legitimately reach this arm. Counting them is therefore a direct test of that hypothesis: **the counter must be 0**, and any other value proves the sizes reaching this arm are not the sizes the gate evaluated. It is evaluated per sample, where the pair is still together, which is exactly what the independent extremes cannot do.

Chosen over rate-limited raw exemplars, which were the other way to close the same pairing gap: exemplars answer it indirectly and cost serialization surface, while this answers it outright in one number. The predicate deliberately mirrors the gate rather than calling it, so it stays a check on the *recorded* sizes even if the gate's own definition later changes.

**Where it is recorded.** Sizes are captured at the refusal and carried to the delivery site, not recorded at the refusal, so the distribution is gated on the same real-delivery condition as the arm's existing send and byte counts — the three always describe one set of sends, which is the #4903 round-3 accounting rule this module already follows.

**An idle window publishes `null`, not `0`.** A zero minimum summary is a specific and alarming claim ("the gate saw an empty summary"), and emitting it for a window with no refusals would manufacture exactly the finding this instrumentation exists to test for.

**Cardinality:** eight scalars per window, keyed by nothing. Flat regardless of traffic — this is per-send data feeding a per-node rollup, so anything keyed by contract or peer would be an amplification vector.

**Concurrency:** no new channel, no new lock, no send of any kind. The write rides the existing per-window `parking_lot::Mutex` that `record_delivered` already takes, inside the same critical section.

Observability only. **Nothing about what is sent changes, and the gate itself is untouched** — the mechanism is not yet understood, and changing broadcast behaviour on a hypothesis during a live bandwidth incident is the wrong move.

### Why not promote the `debug!` to `info!`

That was the stated fallback, and I deliberately did not do it. The call site fires **once per refused delta send** — 84,394 sends in the measured sample — on every peer in the fleet, on exactly the path that is already saturating uplinks. An unthrottled per-send `info!` risks making the incident worse in order to observe it. The aggregate answers the same question with better statistics and lands in the event the analysis already parses. If raw exemplars are wanted too, a rate-limited sample would be the safe shape; say the word.

## Testing

Eight unit tests over the aggregate (inputs reach the rollup; bimodal extremes survive; zero-state counted separately; idle window publishes null; sizes ignored for other arms; window drains between rollups) plus a source-scrape pin that the `NotEfficient` arm destructures the sizes rather than matching with `..`.

Every one mutation-verified (13 mutations) — production change reverted, test confirmed to FAIL, restored:

| # | Mutation | Caught by |
|---|---|---|
| N1 | Recorder drops the sizes entirely | 4 aggregate tests |
| N2 | Arm guard removed, any arm pollutes the distribution | `gate_sizes_are_ignored_for_other_arms` |
| N3 | Publish `0` instead of `null` on an idle window | `window_with_no_refusals_publishes_null_not_zero` |
| N4 | Window not drained, outlier smears across windows | `gate_input_distribution_resets_between_windows` |
| N5 | `min` seeded at 0 (fabricates an empty-summary finding) | 2 aggregate tests |
| N6 | Zero-state refusals no longer counted separately | `zero_state_refusals_are_counted_separately` |
| N7 | `NotEfficient` arm back to matching with `..` | `not_efficient_arm_captures_the_gate_sizes_pin` |
| N8 | One of the two delivery sites silently drops `gate_sizes` | `broadcast_to_single_peer_tags_every_payload_arm_pin` |
| N9 | Recorder moved to a process-global static | compiler + same pin |
| N10 | Tripwire never increments | `sizes_that_should_have_passed_the_gate_trip_the_misattribution_counter` |
| N11 | Tripwire predicate inverted (fires on genuine refusals) | `genuine_refusals_including_the_boundary_do_not_trip_the_counter` |
| N12 | Strict `<` relaxed to `<=` (boundary misread as mis-attribution) | same |
| N13 | Zero-state refusals also counted as would-have-passed | `zero_state_refusals_are_counted_separately` |

### A pin I broke and repaired

Growing `record_delivered`'s argument list pushed rustfmt to split the call across five lines, which broke `broadcast_to_single_peer_tags_every_payload_arm_pin` — it matched a contiguous single-line needle, and its sibling assertion matched a literal newline plus an exact indentation width. Both now match a whitespace-stripped copy of the function body, so they are independent of rustfmt's layout choices, and both were mutation-verified to still catch what they exist to catch (N8, N9). A pin that fails on reformatting is worse than no pin: it trains the next person to loosen the assertion.

### Checks

- `cargo fmt -- --check` — clean
- `cargo clippy --locked -- -D warnings` — clean
- Full lib suites under nextest — see CI

## Scope

Parent measurement issue #3335. Builds directly on #4922 (merged, v0.2.106), whose rollup this extends. Provides the data #4923 is blocked on — it is explicit that "#4922 adds that instrumentation and should land and report before any fix here is sized", and this closes the one input #4922 does not capture.

[AI-assisted - Claude]
