### PR TITLE
fix(server): guard sandboxed serviceWorker reads in shell_bridge

### DIFF
--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -3498,6 +3498,45 @@ mod tests {
         );
     }
 
+    /// Reading `navigator.serviceWorker` throws a SecurityError in a sandboxed
+    /// document without 'allow-same-origin': the property exists on Navigator
+    /// (so an `'serviceWorker' in navigator` feature-check passes) but its
+    /// GETTER throws. In 0.2.107 the eager installNotifyClickListener() call
+    /// read it unguarded; the uncaught throw killed freenetBridge before its
+    /// message handlers installed and every locally-served web app hung
+    /// (#4945). All serviceWorker access must go through the try/catch
+    /// accessor.
+    #[test]
+    fn bridge_js_service_worker_reads_survive_sandboxed_navigator() {
+        assert!(
+            SHELL_BRIDGE_JS.contains("function serviceWorkerOrNull()"),
+            "the try/catch serviceWorker accessor must exist"
+        );
+        let body_start = SHELL_BRIDGE_JS
+            .find("function serviceWorkerOrNull()")
+            .unwrap();
+        let body = &SHELL_BRIDGE_JS[body_start..body_start + 400];
+        assert!(
+            body.contains("try {") && body.contains("catch"),
+            "serviceWorkerOrNull must guard the navigator.serviceWorker read with try/catch"
+        );
+        // Outside the accessor, `navigator.serviceWorker` may appear only as
+        // the (already try-guarded) register call pinned by the mobile test
+        // below — any new access must route through serviceWorkerOrNull().
+        assert_eq!(
+            SHELL_BRIDGE_JS.matches("navigator.serviceWorker").count(),
+            2,
+            "raw navigator.serviceWorker reads outside serviceWorkerOrNull() and \
+             the try-guarded register call reintroduce the #4945 sandbox crash"
+        );
+        // The `in`-operator feature check is exactly the pattern that passed in
+        // the sandbox and then blew up on read — it must not come back.
+        assert!(
+            !SHELL_BRIDGE_JS.contains("'serviceWorker' in navigator"),
+            "feature-detect by attempting the read (serviceWorkerOrNull), not via `in`"
+        );
+    }
+
     /// Mobile browsers reject the page-level `new Notification()` constructor, so
     /// the shell must show notifications via a service worker's
     /// `showNotification()`. Pin the wiring by source so a refactor can't

--- a/crates/core/src/server/path_handlers/assets/shell_bridge.js
+++ b/crates/core/src/server/path_handlers/assets/shell_bridge.js
@@ -674,6 +674,25 @@ function freenetBridge(authToken, userToken, hostedMode) {
   var notifySwPromise = null;
   var notifySwMsgListenerAdded = false;
 
+  // Reading the serviceWorker property off navigator THROWS a SecurityError in
+  // a sandboxed document without 'allow-same-origin' — the property EXISTS on
+  // Navigator
+  // (so an `in`-operator feature-check passes) but its getter
+  // throws. A feature-check must therefore attempt the read itself. The shell
+  // top page is not sandboxed today, but this bridge must never assume that:
+  // in 0.2.107 an unguarded read here threw during the eager
+  // installNotifyClickListener() call and killed freenetBridge before its
+  // message handlers installed, breaking every locally-served web app (#4945).
+  function serviceWorkerOrNull() {
+    try {
+      return typeof navigator !== 'undefined'
+        ? navigator.serviceWorker || null
+        : null;
+    } catch (e) {
+      return null;
+    }
+  }
+
   // Forward a worker-posted notification click to the iframe. Installed at most
   // once, and EAGERLY at shell startup (see the call below) — NOT only on lazy
   // SW registration: a persistent notification can outlive a shell reload, and
@@ -683,11 +702,12 @@ function freenetBridge(authToken, userToken, hostedMode) {
   // registered, so it doesn't require a secure context.
   function installNotifyClickListener() {
     if (notifySwMsgListenerAdded) return;
-    if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) {
+    var sw = serviceWorkerOrNull();
+    if (!sw) {
       return;
     }
     notifySwMsgListenerAdded = true;
-    navigator.serviceWorker.addEventListener('message', function (event) {
+    sw.addEventListener('message', function (event) {
       var d = event && event.data;
       if (!d || d.__freenet_notify_click__ !== true) return;
       try {
@@ -703,11 +723,7 @@ function freenetBridge(authToken, userToken, hostedMode) {
 
   function ensureNotifyServiceWorker() {
     if (notifySwPromise) return notifySwPromise;
-    if (
-      typeof navigator === 'undefined' ||
-      !('serviceWorker' in navigator) ||
-      !window.isSecureContext
-    ) {
+    if (!serviceWorkerOrNull() || !window.isSecureContext) {
       // No SW support, or an insecure (plain-http, non-localhost) origin where
       // registration would fail. This is permanent for the page, so cache it —
       // the page-level constructor path covers these (desktop) cases.
@@ -740,7 +756,8 @@ function freenetBridge(authToken, userToken, hostedMode) {
   // if unavailable within `timeoutMs`. Bounded so a slow/never-activating worker
   // never stalls a notification — the caller reports it undeliverable instead.
   function notifyRegistrationReady(timeoutMs) {
-    if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) {
+    var swContainer = serviceWorkerOrNull();
+    if (!swContainer) {
       return Promise.resolve(null);
     }
     return ensureNotifyServiceWorker().then(function (reg) {
@@ -755,7 +772,7 @@ function freenetBridge(authToken, userToken, hostedMode) {
             resolve(null);
           }
         }, timeoutMs);
-        navigator.serviceWorker.ready.then(
+        swContainer.ready.then(
           function (ready) {
             if (!settled) {
               settled = true;


### PR DESCRIPTION
## Problem

0.2.107 broke every locally-served web app (River, Delta, Atlas): pages hung at "Loading" / WebSocket connect timeout (#4945). #4937 added an eager `installNotifyClickListener()` call at the tail of `freenetBridge`. In the sandboxed iframe document (no `allow-same-origin`), reading the `serviceWorker` property off `navigator` throws a `SecurityError` — the property exists on `Navigator` (so an `in`-operator feature-check passes), but its getter throws. The uncaught throw killed the bridge before its message handlers installed, so the app inside the iframe could never complete its handshake.

## Solution

Route every serviceWorker container access through a single try/catch accessor, `serviceWorkerOrNull()`, and use it at all three read sites (`installNotifyClickListener`, `ensureNotifyServiceWorker`, `notifyRegistrationReady`). Sandboxed contexts now degrade to no-notifications instead of a dead bridge; non-sandboxed behavior is unchanged. The `register(NOTIFY_SW_URL)` call keeps its literal form (pinned by an existing test) and was already inside try/catch.

## Testing

- New pin test `bridge_js_service_worker_reads_survive_sandboxed_navigator`: asserts the accessor exists with try/catch, exactly 2 raw `navigator.serviceWorker` occurrences remain (the accessor's guarded read + the try-wrapped register call), and the `in`-operator feature-check pattern is absent. Verified it FAILS on the pre-fix file and passes post-fix.
- All 18 bridge_js pin tests pass; prettier/eslint and all 6 node asset tests pass; `cargo fmt` + `cargo clippy -D warnings` clean.
- Pre-release smoke on framework (real NATed peer): install the fixed binary and drive Playwright at the River URL to assert rooms render past "Loading your rooms..." — in progress, will report before release.

## Review note

Codex is out of credits tonight; per Ian's explicit authorization this ran a single focused adversarial Claude review pass instead of the full panel (user-impacting hotfix, minimal JS-only diff). The reviewer verified all eager bridge statements are throw-safe in sandboxed contexts, non-sandboxed behavior is byte-identical, and all existing pin needles hold.

Fixes #4945

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F2CFGizKUBc5hewJ5qzwJb