### PR TITLE
feat: add netcheck for live-network put, get and retention (#4665)

### DIFF
--- a/.github/workflows/netcheck-nightly.yml
+++ b/.github/workflows/netcheck-nightly.yml
@@ -1,0 +1,119 @@
+name: Netcheck (Nightly)
+
+# Runs netcheck against the LIVE network from the gateway host (#4665).
+#
+# Self-hosted on purpose: the check needs the gateway's loopback WebSocket API
+# and the UDP port opened there for its ephemeral peer, neither of which is
+# reachable from a cloud runner.
+#
+# The job body is deliberately thin. All the logic is in
+# scripts/netcheck-nightly.sh, which can be run by hand over ssh on the same
+# host; a workflow file cannot be tested before it reaches the default branch.
+
+on:
+  schedule:
+    # 04:00 UTC, an hour after the simulation nightly so a human reading the
+    # morning results sees them in a predictable order.
+    - cron: "0 4 * * *"
+  workflow_dispatch:
+
+# Never run two at once: they would contend for the ephemeral peer's UDP port
+# and both write the same manifest.
+concurrency:
+  group: netcheck-nightly
+  cancel-in-progress: false
+
+jobs:
+  netcheck:
+    name: Live network check
+    runs-on: self-hosted
+    # A normal run is minutes. The cap is generous because the first PUT after
+    # a release pays for WASM validation, and joining the ring is not instant.
+    # If it ever trips, something is genuinely stuck: investigate rather than
+    # raise it.
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Ensure the wasm target is present
+        # netcheck compiles the probe contract at startup. Idempotent.
+        run: rustup target add wasm32-unknown-unknown
+
+      - name: Run netcheck against the live network
+        env:
+          NETCHECK_OTLP_ENDPOINT: http://127.0.0.1:4318
+          NETCHECK_VANTAGE: nova
+        run: bash scripts/netcheck-nightly.sh
+
+      - name: Upload the run report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: netcheck-report
+          path: ~/netcheck/last-run.jsonl
+          if-no-files-found: warn
+          retention-days: 30
+
+  # Same transport as the simulation nightly: riverctl against the Freenet
+  # gateway with the shared RIVER_SIGNING_KEY, so there is one set of
+  # credentials to maintain rather than a second standalone token.
+  #
+  # Today any failure notifies. Distinguishing a real regression from a
+  # degraded retention window or an infrastructure error is the threshold
+  # work tracked in #4665, and belongs with the dashboard that can show it.
+  notify-failure:
+    name: Notify River on Failure
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: netcheck
+    if: failure() && needs.netcheck.result == 'failure'
+    continue-on-error: true
+    steps:
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.93.0
+
+      - name: Install riverctl
+        run: cargo install riverctl
+
+      - name: Send failure message to River (with exponential backoff)
+        env:
+          RIVER_SIGNING_KEY: ${{ secrets.RIVER_SIGNING_KEY }}
+        run: |
+          MESSAGE="🚨 Nightly netcheck failed against the live network - ${{ github.repository }} - ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          NODE_URL="${{ secrets.RIVER_GATEWAY_URL }}"
+          ROOM_ID="${{ secrets.RIVER_ROOM_ID }}"
+
+          max_attempts=7
+          delay=10
+          for attempt in $(seq 1 $max_attempts); do
+            echo "Attempt $attempt/$max_attempts (delay: ${delay}s)..."
+            if riverctl --node-url "$NODE_URL" message send "$ROOM_ID" "$MESSAGE" 2>&1; then
+              echo "Message sent successfully on attempt $attempt"
+              exit 0
+            fi
+            if [ "$attempt" -lt "$max_attempts" ]; then
+              echo "Failed, retrying in ${delay}s..."
+              sleep "$delay"
+              delay=$((delay * 2))
+            fi
+          done
+          echo "::warning::Failed to send River notification after $max_attempts attempts (gateway may be restarting)"
+          exit 0
+
+  notify-dev-room-failure:
+    name: Notify dev room on Failure
+    runs-on: ubuntu-latest
+    needs: netcheck
+    if: failure() && needs.netcheck.result == 'failure'
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/river-dev-notify
+        with:
+          message: "🚨 Nightly netcheck failed against the live network, ${{ github.repository }}, ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          bot-config: ${{ secrets.RIVER_DEV_BOT_CONFIG }}
+          room-id: ${{ secrets.RIVER_DEV_ROOM_ID }}
+          gateway-url: ${{ secrets.RIVER_GATEWAY_URL }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4116,6 +4116,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "netcheck"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "blake3",
+ "chrono",
+ "clap",
+ "freenet-stdlib 0.8.4",
+ "hex",
+ "rand 0.9.4",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tokio-tungstenite 0.27.0",
+ "x25519-dalek 3.0.0",
+]
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4126,6 +4126,7 @@ dependencies = [
  "freenet-stdlib 0.8.4",
  "hex",
  "rand 0.9.4",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4123,7 +4123,7 @@ dependencies = [
  "blake3",
  "chrono",
  "clap",
- "freenet-stdlib 0.8.4",
+ "freenet-stdlib 0.8.5",
  "hex",
  "rand 0.9.4",
  "reqwest 0.12.28",

--- a/crates/netcheck/Cargo.toml
+++ b/crates/netcheck/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "netcheck"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.85"
+publish = false
+description = "Synthetic end-to-end check against the live Freenet network: cross-gateway PUT/GET and multi-day retention (#4665)"
+
+[dependencies]
+anyhow = { workspace = true }
+blake3 = { workspace = true }
+chrono = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+freenet-stdlib = { workspace = true, features = ["net"] }
+hex = { workspace = true }
+rand = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true }
+tokio-tungstenite = { workspace = true }
+x25519-dalek = { workspace = true }

--- a/crates/netcheck/Cargo.toml
+++ b/crates/netcheck/Cargo.toml
@@ -14,6 +14,7 @@ clap = { workspace = true, features = ["derive"] }
 freenet-stdlib = { workspace = true, features = ["net"] }
 hex = { workspace = true }
 rand = { workspace = true }
+reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/netcheck/README.md
+++ b/crates/netcheck/README.md
@@ -1,0 +1,169 @@
+# netcheck
+
+Synthetic end-to-end check against the **live** Freenet network (issue
+#4665). It behaves like a normal client — it only talks to node WebSocket
+APIs and never links `freenet-core` — so it measures what a real user
+experiences, and it keeps working across core refactors.
+
+Each `put-get` run:
+
+1. PUTs 3 small contracts plus one ~1 MB contract through one gateway's
+   WS API.
+2. Boots an **ephemeral peer** (`freenet network` child process with an
+   empty data dir) that joins the network **through a different gateway**.
+   Having no replicas of its own, it cannot answer any of its own GETs.
+3. GETs this run's contracts through that peer and verifies byte-identity.
+4. Re-GETs contracts published by previous runs (24 h / 48 h / 7 d windows,
+   tracked in a persistent JSON manifest) and verifies their blake3 state
+   hashes.
+5. Prints one JSON line per operation on stdout and exits non-zero if
+   anything failed. No retries by design: an operation that only succeeds
+   on retry is the regression netcheck exists to surface.
+
+Scenarios are subcommands sharing the same infrastructure (client,
+ephemeral node, manifest, report); future ones (update propagation,
+subscriptions) are new modules under `src/scenarios/`.
+
+## What each check actually proves
+
+Every hop that handles a PUT stores the state locally, so a GET answered by
+the gateway the PUT went through proves only that the node can hand back a
+file it already has. That is why the getter enters through a different
+gateway — but the guarantee is narrower than it looks, and it is worth
+being precise about it:
+
+**`--gateway-spec` pins the join, not the steady-state connection set.**
+Once the ephemeral peer is in the ring, topology maintenance opens further
+connections on its own, and the gateway that handled the PUTs can be one of
+them (`--min-number-of-connections` defaults to 10, and the public index
+lists only two gateways). A local two-gateway run shows this directly: the
+peer was pinned to gateway B and reported connections to *both* B and A.
+No client-side setting can force the answering peer to be someone else, so
+netcheck records what happened instead of pretending otherwise — the
+`ephemeral_peers` field of the run report carries the addresses actually
+connected to. When `--gateway-spec` is omitted entirely, netcheck also
+warns on stderr.
+
+The practical consequence, and the way to read a run:
+
+- **Same-day PUT/GET** is a liveness and transfer check. A peer holding the
+  contract may be one hop away, so a success does not prove routing.
+- **The 24 h / 48 h / 7 d re-GETs carry the findability signal.** Those
+  contracts were published by a run that is long gone, against a topology
+  that has since changed, and nothing guarantees any currently-connected
+  peer still holds them. This is the part that regresses, and the part
+  worth alerting on.
+
+## Report format
+
+One `"event":"run"` line with the conditions of the run, then one
+`"event":"op"` line per operation:
+
+```json
+{"event":"run","run_id":"20260726-030000","gateway_ws":"ws://127.0.0.1:7509",
+ "freenet_version":"Freenet version: 0.2.106 (c707af0f786e)",
+ "pinned_gateways":["100.27.151.80:31337,c28123df…"],
+ "ephemeral_peers":["100.27.151.80:31337"]}
+{"event":"op","op":"get","age":"24h","label":"20260725-030000/small-0",…,"ok":true,"latency_ms":412}
+```
+
+`freenet_version` is what separates "the network broke" from "the release
+that landed last night broke" — without it a failure cannot be attributed
+after the fact.
+
+## Production use (nova)
+
+nova runs the primary gateway; the ephemeral peer is pinned to vega (the
+secondary) so the GETs are routed. Resolve the address and key from the
+public index rather than hardcoding them — the IP and the key can rotate:
+
+```bash
+VEGA_IP=$(getent hosts vega.locut.us | awk '{print $1}')
+VEGA_KEY=$(curl -fsS https://freenet.org/keys/public.vega.gw.pem)
+
+netcheck put-get \
+  --gateway-ws ws://127.0.0.1:7509 \
+  --gateway-spec "${VEGA_IP}:31337,${VEGA_KEY}" \
+  --freenet-bin /usr/local/bin/freenet \
+  --manifest    /home/runner/netcheck/manifest.json \
+  --ephemeral-dir /home/runner/netcheck/run \
+  --ephemeral-network-port 32177   # UDP port opened for netcheck on nova
+```
+
+`--freenet-bin` points at the **installed release** binary on purpose: the
+ephemeral peer is the measuring instrument, so it should be the same
+binary real users run. A peer built from an unreleased `main` would make
+every failure ambiguous.
+
+### Running alongside a real node
+
+netcheck is designed to be safe on a host that also runs a production
+gateway, and the guarantees are structural rather than conventional:
+
+- The ephemeral node gets its own `--config-dir`/`--data-dir` and its own
+  ports; it never reads or writes the real node's state.
+- Child processes are killed **by process handle**, never by name — there
+  is no `pkill` anywhere in this crate.
+- The node's own single-instance check is read-only and scoped to its
+  configured WS port: if the port is busy it logs and exits, it never
+  signals the other process. Keep `--ephemeral-ws-port` (default 7519)
+  away from the real node's port.
+- `--disable-auto-update` is passed to the ephemeral node: it lives for
+  minutes, and detecting a new release mid-run would make it exit 42 and
+  fail the check for a reason unrelated to the network.
+
+Two things the caller is responsible for:
+
+- **`--ephemeral-dir`.** Left unset, the node works in an anonymous temp
+  dir that is only cleaned up on a normal exit; a killed run (a cancelled
+  CI job) leaks it. The node's hosting cache is budgeted at `RAM/8` capped
+  at 1 GiB, so on a large host a leak is not small. Point it at a known
+  path and clear that path before each run.
+- **Disk headroom.** Check free space before running on a shared host and
+  skip the run rather than filling the disk out from under the real node.
+
+## Local testing, fully isolated
+
+Nothing needs the live network to exercise the code path. Two local
+gateways reproduce the nova/vega topology on one machine: PUT through A,
+join the ephemeral peer through B.
+
+Terminal A — gateway that receives the PUTs:
+
+```bash
+cargo build -p freenet
+cargo run -p netcheck -- local-gateway \
+  --freenet-bin target/debug/freenet --network-port 31338 --ws-port 7609
+```
+
+Terminal B — the gateway the getter joins through:
+
+```bash
+cargo run -p netcheck -- local-gateway \
+  --freenet-bin target/debug/freenet --network-port 31339 --ws-port 7610
+```
+
+Terminal C — netcheck, PUTting via A and getting via B:
+
+```bash
+cargo run -p netcheck -- put-get \
+  --gateway-ws ws://127.0.0.1:7609 \
+  --gateway-spec "<spec printed by terminal B>" \
+  --freenet-bin target/debug/freenet \
+  --ephemeral-network-port 31400 --ephemeral-ws-port 7519 \
+  --manifest /tmp/netcheck-manifest.json --settle-secs 5
+```
+
+To exercise the retention path, age the manifest and rerun:
+`jq '.runs[].timestamp -= 86400' manifest.json` puts the previous run in
+the 24 h window.
+
+Note: if a Freenet desktop app or node is already running on the machine,
+keep every `--ws-port` away from 7509 or the node's single-instance check
+will refuse to start.
+
+Caveat on what a local run proves: it validates the harness end to end —
+compilation, PUT, join, routed GET, manifest, report — but not the signal.
+Retention and findability on a two-node local network are trivially
+satisfied; only the live network has the storage pressure and topology
+that make those properties interesting.

--- a/crates/netcheck/README.md
+++ b/crates/netcheck/README.md
@@ -1,8 +1,8 @@
 # netcheck
 
 Synthetic end-to-end check against the **live** Freenet network (issue
-#4665). It behaves like a normal client — it only talks to node WebSocket
-APIs and never links `freenet-core` — so it measures what a real user
+#4665). It behaves like a normal client (it only talks to node WebSocket
+APIs and never links `freenet-core`) so it measures what a real user
 experiences, and it keeps working across core refactors.
 
 Each `put-get` run:
@@ -29,7 +29,7 @@ subscriptions) are new modules under `src/scenarios/`.
 Every hop that handles a PUT stores the state locally, so a GET answered by
 the gateway the PUT went through proves only that the node can hand back a
 file it already has. That is why the getter enters through a different
-gateway — but the guarantee is narrower than it looks, and it is worth
+gateway, but the guarantee is narrower than it looks, and it is worth
 being precise about it:
 
 **`--gateway-spec` pins the join, not the steady-state connection set.**
@@ -39,7 +39,7 @@ them (`--min-number-of-connections` defaults to 10, and the public index
 lists only two gateways). A local two-gateway run shows this directly: the
 peer was pinned to gateway B and reported connections to *both* B and A.
 No client-side setting can force the answering peer to be someone else, so
-netcheck records what happened instead of pretending otherwise — the
+netcheck records what happened instead of pretending otherwise: the
 `ephemeral_peers` field of the run report carries the addresses actually
 connected to. When `--gateway-spec` is omitted entirely, netcheck also
 warns on stderr.
@@ -68,14 +68,14 @@ One `"event":"run"` line with the conditions of the run, then one
 ```
 
 `freenet_version` is what separates "the network broke" from "the release
-that landed last night broke" — without it a failure cannot be attributed
+that landed last night broke". Without it a failure cannot be attributed
 after the fact.
 
 ## Production use (nova)
 
 nova runs the primary gateway; the ephemeral peer is pinned to vega (the
 secondary) so the GETs are routed. Resolve the address and key from the
-public index rather than hardcoding them — the IP and the key can rotate:
+public index rather than hardcoding them, since the IP and the key can rotate:
 
 ```bash
 VEGA_IP=$(getent hosts vega.locut.us | awk '{print $1}')
@@ -102,7 +102,7 @@ gateway, and the guarantees are structural rather than conventional:
 
 - The ephemeral node gets its own `--config-dir`/`--data-dir` and its own
   ports; it never reads or writes the real node's state.
-- Child processes are killed **by process handle**, never by name — there
+- Child processes are killed **by process handle**, never by name: there
   is no `pkill` anywhere in this crate.
 - The node's own single-instance check is read-only and scoped to its
   configured WS port: if the port is busy it logs and exits, it never
@@ -122,13 +122,26 @@ Two things the caller is responsible for:
 - **Disk headroom.** Check free space before running on a shared host and
   skip the run rather than filling the disk out from under the real node.
 
+### Nightly
+
+`scripts/netcheck-nightly.sh` is the production recipe above with both of
+those responsibilities handled, and it publishes the report through
+`netcheck emit`. `.github/workflows/netcheck-nightly.yml` runs it at 04:00
+UTC on the self-hosted runner and does nothing else: the logic lives in the
+script so it can be run by hand over ssh, which a workflow file cannot be
+until it reaches the default branch.
+
+Every path and port is overridable by environment variable
+(`NETCHECK_GATEWAY_WS`, `NETCHECK_STATE_DIR`, `NETCHECK_OTLP_ENDPOINT`, ...),
+so a second vantage point needs no edit to the script.
+
 ## Local testing, fully isolated
 
 Nothing needs the live network to exercise the code path. Two local
 gateways reproduce the nova/vega topology on one machine: PUT through A,
 join the ephemeral peer through B.
 
-Terminal A — gateway that receives the PUTs:
+Terminal A, gateway that receives the PUTs:
 
 ```bash
 cargo build -p freenet
@@ -136,14 +149,14 @@ cargo run -p netcheck -- local-gateway \
   --freenet-bin target/debug/freenet --network-port 31338 --ws-port 7609
 ```
 
-Terminal B — the gateway the getter joins through:
+Terminal B, the gateway the getter joins through:
 
 ```bash
 cargo run -p netcheck -- local-gateway \
   --freenet-bin target/debug/freenet --network-port 31339 --ws-port 7610
 ```
 
-Terminal C — netcheck, PUTting via A and getting via B:
+Terminal C, netcheck, PUTting via A and getting via B:
 
 ```bash
 cargo run -p netcheck -- put-get \
@@ -162,8 +175,8 @@ Note: if a Freenet desktop app or node is already running on the machine,
 keep every `--ws-port` away from 7509 or the node's single-instance check
 will refuse to start.
 
-Caveat on what a local run proves: it validates the harness end to end —
-compilation, PUT, join, routed GET, manifest, report — but not the signal.
+Caveat on what a local run proves: it validates the harness end to end,
+compilation, PUT, join, routed GET, manifest, report, but not the signal.
 Retention and findability on a two-node local network are trivially
 satisfied; only the live network has the storage pressure and topology
 that make those properties interesting.

--- a/crates/netcheck/src/client.rs
+++ b/crates/netcheck/src/client.rs
@@ -11,11 +11,20 @@ use freenet_stdlib::client_api::{
 use freenet_stdlib::prelude::*;
 use tokio_tungstenite::connect_async;
 
+/// URL of a node's client command endpoint.
 pub fn command_url(base_ws: &str) -> String {
     format!(
         "{}/v1/contract/command?encodingProtocol=native",
         base_ws.trim_end_matches('/')
     )
+}
+
+/// A poll interval with ±20% jitter. One check polling its own node has no
+/// herd to stampede, but several vantage points polling the same gateway
+/// would, and a nightly is exactly the kind of thing that ends up running
+/// from more than one place.
+fn jittered(base: Duration) -> Duration {
+    base.mul_f64(0.8 + rand::random::<f64>() * 0.4)
 }
 
 /// Connect to a node's websocket API, retrying while it comes up.
@@ -27,13 +36,15 @@ pub async fn connect(base_ws: &str, timeout: Duration) -> Result<WebApi> {
             Ok((stream, _)) => return Ok(WebApi::start(stream)),
             Err(e) if Instant::now() < deadline => {
                 eprintln!("ws at {base_ws} not ready yet ({e}), retrying...");
-                tokio::time::sleep(Duration::from_secs(1)).await;
+                tokio::time::sleep(jittered(Duration::from_secs(1))).await;
             }
             Err(e) => bail!("could not connect to websocket API at {url}: {e}"),
         }
     }
 }
 
+/// Close the client session. Best effort: a node that already went away needs
+/// no goodbye.
 pub async fn disconnect(client: &mut WebApi) {
     let _ = client.send(ClientRequest::Disconnect { cause: None }).await;
 }
@@ -169,6 +180,6 @@ pub async fn wait_for_ring_join(client: &mut WebApi, timeout: Duration) -> Resul
             Instant::now() < deadline,
             "ephemeral node did not join the ring within {timeout:?}"
         );
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        tokio::time::sleep(jittered(Duration::from_secs(2))).await;
     }
 }

--- a/crates/netcheck/src/client.rs
+++ b/crates/netcheck/src/client.rs
@@ -1,0 +1,174 @@
+//! Thin wrapper over the freenet-stdlib websocket client: single-attempt
+//! PUT/GET with one overall deadline each, plus ring-join polling.
+
+use std::time::{Duration, Instant};
+
+use anyhow::{Result, anyhow, bail, ensure};
+use freenet_stdlib::client_api::{
+    ClientRequest, ContractRequest, ContractResponse, HostResponse, NodeQuery, QueryResponse,
+    WebApi,
+};
+use freenet_stdlib::prelude::*;
+use tokio_tungstenite::connect_async;
+
+pub fn command_url(base_ws: &str) -> String {
+    format!(
+        "{}/v1/contract/command?encodingProtocol=native",
+        base_ws.trim_end_matches('/')
+    )
+}
+
+/// Connect to a node's websocket API, retrying while it comes up.
+pub async fn connect(base_ws: &str, timeout: Duration) -> Result<WebApi> {
+    let url = command_url(base_ws);
+    let deadline = Instant::now() + timeout;
+    loop {
+        match connect_async(&url).await {
+            Ok((stream, _)) => return Ok(WebApi::start(stream)),
+            Err(e) if Instant::now() < deadline => {
+                eprintln!("ws at {base_ws} not ready yet ({e}), retrying...");
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            }
+            Err(e) => bail!("could not connect to websocket API at {url}: {e}"),
+        }
+    }
+}
+
+pub async fn disconnect(client: &mut WebApi) {
+    let _ = client.send(ClientRequest::Disconnect { cause: None }).await;
+}
+
+/// Discard queued responses so a stale message from a previous interaction
+/// cannot be mis-attributed to the next request.
+async fn drain_stray_responses(client: &mut WebApi) {
+    loop {
+        match tokio::time::timeout(Duration::from_millis(200), client.recv()).await {
+            Ok(Ok(resp)) => eprintln!("discarding stray response: {resp:?}"),
+            Ok(Err(err)) => eprintln!("discarding stray error: {err}"),
+            Err(_) => break,
+        }
+    }
+}
+
+/// Issue a single PUT and wait for the matching response. Returns latency.
+pub async fn put(
+    client: &mut WebApi,
+    contract: ContractContainer,
+    state: WrappedState,
+    label: &str,
+    timeout: Duration,
+) -> Result<Duration> {
+    let expected_key = contract.key();
+    drain_stray_responses(client).await;
+    let started = Instant::now();
+    client
+        .send(ClientRequest::ContractOp(ContractRequest::Put {
+            contract,
+            state,
+            related_contracts: RelatedContracts::default(),
+            subscribe: false,
+            blocking_subscribe: false,
+        }))
+        .await?;
+
+    let deadline = started + timeout;
+    loop {
+        let remaining = deadline
+            .checked_duration_since(Instant::now())
+            .ok_or_else(|| anyhow!("PUT {label} timed out after {timeout:?}"))?;
+        match tokio::time::timeout(remaining, client.recv()).await {
+            Ok(Ok(HostResponse::ContractResponse(ContractResponse::PutResponse { key }))) => {
+                if key != expected_key {
+                    // Late reply to an earlier PUT that already timed out.
+                    // Failing this one on it would cascade bogus failures
+                    // through every remaining PUT.
+                    eprintln!("PUT {label}: response for different key {key}, ignoring");
+                    continue;
+                }
+                return Ok(started.elapsed());
+            }
+            Ok(Ok(other)) => eprintln!("PUT {label}: skipping unexpected response: {other:?}"),
+            Ok(Err(e)) => bail!("PUT {label}: websocket error: {e}"),
+            Err(_) => bail!("PUT {label} timed out after {timeout:?}"),
+        }
+    }
+}
+
+/// Issue a single GET and wait for the matching response within one overall
+/// deadline. Responses for other keys are skipped.
+pub async fn get(
+    client: &mut WebApi,
+    id: ContractInstanceId,
+    label: &str,
+    timeout: Duration,
+) -> Result<(ContractContainer, WrappedState, Duration)> {
+    drain_stray_responses(client).await;
+    let started = Instant::now();
+    client
+        .send(ClientRequest::ContractOp(ContractRequest::Get {
+            key: id,
+            return_contract_code: true,
+            subscribe: false,
+            blocking_subscribe: false,
+        }))
+        .await?;
+
+    let deadline = started + timeout;
+    loop {
+        let remaining = deadline
+            .checked_duration_since(Instant::now())
+            .ok_or_else(|| anyhow!("GET {label} ({id}) timed out after {timeout:?}"))?;
+        match tokio::time::timeout(remaining, client.recv()).await {
+            Ok(Ok(HostResponse::ContractResponse(ContractResponse::GetResponse {
+                key,
+                contract,
+                state,
+            }))) => {
+                if *key.id() != id {
+                    eprintln!("GET {label}: response for different key {key}, ignoring");
+                    continue;
+                }
+                let contract =
+                    contract.ok_or_else(|| anyhow!("GET {label} ({id}) returned no contract"))?;
+                return Ok((contract, state, started.elapsed()));
+            }
+            Ok(Ok(other)) => eprintln!("GET {label}: skipping unexpected response: {other:?}"),
+            Ok(Err(e)) => bail!("GET {label} ({id}): websocket error: {e}"),
+            Err(_) => bail!("GET {label} ({id}) timed out after {timeout:?}"),
+        }
+    }
+}
+
+/// Wait until the node joins the ring; returns the addresses it connected to.
+/// The report carries them: they are the only evidence of whether a GET could
+/// have been answered by the node that stored the PUTs.
+pub async fn wait_for_ring_join(client: &mut WebApi, timeout: Duration) -> Result<Vec<String>> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        client
+            .send(ClientRequest::NodeQueries(NodeQuery::ConnectedPeers))
+            .await?;
+        match tokio::time::timeout(Duration::from_secs(5), client.recv()).await {
+            Ok(Ok(HostResponse::QueryResponse(QueryResponse::ConnectedPeers { peers }))) => {
+                if !peers.is_empty() {
+                    let addrs: Vec<String> =
+                        peers.iter().map(|(_, addr)| addr.to_string()).collect();
+                    eprintln!(
+                        "ephemeral node joined the ring ({} connection(s): {})",
+                        addrs.len(),
+                        addrs.join(", ")
+                    );
+                    return Ok(addrs);
+                }
+            }
+            Ok(Ok(other)) => eprintln!("unexpected response to ConnectedPeers: {other:?}"),
+            Ok(Err(e)) => eprintln!("ConnectedPeers query error: {e}"),
+            Err(_) => eprintln!("ConnectedPeers query timed out"),
+        }
+        ensure!(
+            Instant::now() < deadline,
+            "ephemeral node did not join the ring within {timeout:?}"
+        );
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    }
+}

--- a/crates/netcheck/src/contracts.rs
+++ b/crates/netcheck/src/contracts.rs
@@ -1,0 +1,159 @@
+//! Contract generation. Reuses the `test-contract-integration` WASM (a
+//! todo-list contract) with per-run parameters so every run produces fresh
+//! contract keys. State layout mirrors the contract's expectations
+//! (`tests/test-contract-integration/src/lib.rs`).
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Arc;
+
+use anyhow::{Context, Result, bail};
+use freenet_stdlib::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+struct TodoList {
+    tasks: Vec<Task>,
+    version: u64,
+}
+
+#[derive(Serialize, Deserialize)]
+struct Task {
+    id: u64,
+    title: String,
+    description: String,
+    completed: bool,
+    priority: u8,
+}
+
+pub struct RunContract {
+    pub label: String,
+    pub contract: ContractContainer,
+    pub state: WrappedState,
+}
+
+/// Compile the contract crate to WASM and return the bytes.
+pub fn compile_contract_wasm(contract_dir: &Path) -> Result<Vec<u8>> {
+    const WASM_TARGET: &str = "wasm32-unknown-unknown";
+
+    let status = Command::new("cargo")
+        .args(["build", "--lib", "--release", "--target", WASM_TARGET])
+        // Nodes reject contracts carrying .debug_* sections; force them off
+        // even if a local cargo config enables debuginfo in release builds.
+        .env("CARGO_PROFILE_RELEASE_DEBUG", "false")
+        .env("CARGO_PROFILE_RELEASE_STRIP", "debuginfo")
+        .current_dir(contract_dir)
+        .status()
+        .with_context(|| format!("running cargo build in {}", contract_dir.display()))?;
+    if !status.success() {
+        bail!("cargo build failed for {}", contract_dir.display());
+    }
+
+    let target_dir = cargo_target_dir(contract_dir)?;
+    let name = contract_crate_name(contract_dir)?;
+    let wasm_path = target_dir
+        .join(WASM_TARGET)
+        .join("release")
+        .join(name.replace('-', "_"))
+        .with_extension("wasm");
+    std::fs::read(&wasm_path).with_context(|| format!("reading {}", wasm_path.display()))
+}
+
+fn cargo_target_dir(contract_dir: &Path) -> Result<PathBuf> {
+    let out = Command::new("cargo")
+        .args(["metadata", "--format-version", "1", "--no-deps"])
+        .current_dir(contract_dir)
+        .output()
+        .context("running cargo metadata")?;
+    if !out.status.success() {
+        bail!("cargo metadata failed in {}", contract_dir.display());
+    }
+    let meta: serde_json::Value = serde_json::from_slice(&out.stdout)?;
+    let dir = meta["target_directory"]
+        .as_str()
+        .context("cargo metadata: missing target_directory")?;
+    Ok(PathBuf::from(dir))
+}
+
+fn contract_crate_name(contract_dir: &Path) -> Result<String> {
+    let manifest = std::fs::read_to_string(contract_dir.join("Cargo.toml"))?;
+    for line in manifest.lines() {
+        if let Some(rest) = line.trim().strip_prefix("name") {
+            if let Some(name) = rest.split('"').nth(1) {
+                return Ok(name.to_string());
+            }
+        }
+    }
+    bail!(
+        "could not find package name in {}/Cargo.toml",
+        contract_dir.display()
+    )
+}
+
+/// Build this run's contracts: `small` one-task lists plus one ~1 MB list.
+pub fn build_run_contracts(wasm: &[u8], run_id: &str, small: usize) -> Result<Vec<RunContract>> {
+    let mut out = Vec::with_capacity(small + 1);
+    for i in 0..small {
+        let label = format!("small-{i}");
+        out.push(make_contract(
+            wasm,
+            run_id,
+            &label,
+            small_todo_list(run_id, &label)?,
+        )?);
+    }
+    out.push(make_contract(
+        wasm,
+        run_id,
+        "large-1MB",
+        large_todo_list(run_id)?,
+    )?);
+    Ok(out)
+}
+
+fn make_contract(wasm: &[u8], run_id: &str, label: &str, state: Vec<u8>) -> Result<RunContract> {
+    let params = Parameters::from(format!("netcheck/{run_id}/{label}").into_bytes());
+    let code = ContractCode::from(wasm.to_vec());
+    let contract = ContractContainer::Wasm(ContractWasmAPIVersion::V1(WrappedContract::new(
+        Arc::new(code),
+        params,
+    )));
+    Ok(RunContract {
+        label: label.to_string(),
+        contract,
+        state: WrappedState::from(state),
+    })
+}
+
+fn small_todo_list(run_id: &str, label: &str) -> Result<Vec<u8>> {
+    let list = TodoList {
+        tasks: vec![Task {
+            id: 1,
+            title: format!("netcheck {run_id} {label}"),
+            description: String::new(),
+            completed: false,
+            priority: 3,
+        }],
+        version: 1,
+    };
+    Ok(serde_json::to_vec(&list)?)
+}
+
+/// ~1 MB payload: enough ~200-byte tasks to reach the target size.
+fn large_todo_list(run_id: &str) -> Result<Vec<u8>> {
+    const TARGET_SIZE: usize = 1024 * 1024;
+    const APPROX_TASK_SIZE: usize = 200;
+    let tasks: Vec<Task> = (0..TARGET_SIZE / APPROX_TASK_SIZE)
+        .map(|i| Task {
+            id: i as u64,
+            title: format!("netcheck {run_id} large payload task {i}"),
+            description: format!(
+                "Task {i} of netcheck's large-payload retention check. \
+                 Filler text keeps the serialized size predictable."
+            ),
+            completed: i % 2 == 0,
+            priority: ((i % 5) + 1) as u8,
+        })
+        .collect();
+    Ok(serde_json::to_vec(&TodoList { tasks, version: 1 })?)
+}

--- a/crates/netcheck/src/emit.rs
+++ b/crates/netcheck/src/emit.rs
@@ -1,0 +1,374 @@
+//! `netcheck emit`: read a run's report and publish it to an OTLP collector.
+//!
+//! Separate from the check itself, and deliberately so: netcheck measures,
+//! this decides which failures are severe, and the collector transports. What
+//! counts as severe is deployment policy, not a property of the network.
+//!
+//! It lives in this crate rather than in a script because the translation
+//! between the report and the published schema is the kind of coupling nothing
+//! external can verify: reading the report back with [`OpReport`] and
+//! [`RunMeta`], the structs that wrote it, makes a renamed field a compile
+//! error instead of a silently missing column on a dashboard.
+
+use std::io::Read;
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+
+use crate::EmitArgs;
+use crate::report::{OpReport, RunMeta};
+use crate::scenarios::put_get;
+
+/// Dimensions whose failure is expected to happen occasionally and must not
+/// page anyone, per scenario.
+///
+/// Keyed by scenario because a dimension label means whatever its own check
+/// means by it: `put_get`'s retention windows are soft, since the hosting
+/// cache is a byte-budget LRU and evicting a contract nobody wants is correct
+/// behaviour rather than an outage. Another check reusing the label "24h"
+/// must not inherit that.
+///
+/// A scenario absent here has no soft dimensions, so any failure is hard.
+/// That is the safe default: a new check that fails, fails.
+fn soft_dimensions(scenario: &str) -> &'static [&'static str] {
+    if scenario == put_get::SCENARIO {
+        &["24h", "48h", "7d"]
+    } else {
+        &[]
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Verdict {
+    Pass,
+    /// Only soft dimensions failed. A metric, not a page.
+    Degraded,
+    /// A hard operation failed.
+    Fail,
+    /// The check never ran, so it says nothing about the network.
+    Error,
+}
+
+/// Numeric form of a dimension label, for ordering and plotting. Labels that
+/// are not a duration (a hop, a phase) have none, and the consumer falls back
+/// to showing the label as it is.
+fn dimension_secs(dimension: &str) -> Option<i64> {
+    let (value, unit) = dimension.split_at(dimension.len().checked_sub(1)?);
+    let mult = match unit {
+        "s" => 1,
+        "m" => 60,
+        "h" => 3600,
+        "d" => 86400,
+        _ => return None,
+    };
+    value.parse::<i64>().ok().map(|n| n * mult)
+}
+
+#[derive(Serialize)]
+struct CheckOp<'a> {
+    #[serde(rename = "type")]
+    kind: &'static str,
+    scenario: &'a str,
+    run_id: &'a str,
+    vantage: &'a str,
+    op: &'a str,
+    dimension: &'a str,
+    dimension_secs: Option<i64>,
+    contract_key: &'a str,
+    ok: bool,
+    latency_ms: u128,
+    bytes: usize,
+    error: Option<&'a str>,
+    extra: serde_json::Value,
+}
+
+#[derive(Serialize)]
+struct CheckRun<'a> {
+    #[serde(rename = "type")]
+    kind: &'static str,
+    scenario: &'a str,
+    run_id: &'a str,
+    vantage: &'a str,
+    duration_ms: u128,
+    verdict: Verdict,
+    ops_total: usize,
+    ops_failed: usize,
+    software_version: &'a str,
+    conditions: serde_json::Value,
+}
+
+/// A parsed report: the run line, if it was reached, plus every operation.
+#[derive(Default)]
+pub struct ParsedReport {
+    pub run: Option<RunMeta>,
+    pub ops: Vec<OpReport>,
+}
+
+pub fn parse_report(input: &str) -> ParsedReport {
+    let mut parsed = ParsedReport::default();
+    for line in input.lines() {
+        let line = line.trim();
+        if !line.starts_with('{') {
+            continue;
+        }
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        match value.get("event").and_then(|e| e.as_str()) {
+            Some("run") => {
+                if let Ok(run) = serde_json::from_value(value) {
+                    parsed.run = Some(run);
+                }
+            }
+            Some("op") => {
+                if let Ok(op) = serde_json::from_value(value) {
+                    parsed.ops.push(op);
+                }
+            }
+            _ => {}
+        }
+    }
+    parsed
+}
+
+pub fn verdict(scenario: &str, ops: &[OpReport], exit_code: i32) -> Verdict {
+    let soft = soft_dimensions(scenario);
+    let (mut hard, mut degraded) = (0usize, 0usize);
+    for op in ops.iter().filter(|o| !o.ok) {
+        if soft.contains(&op.age.as_str()) {
+            degraded += 1;
+        } else {
+            hard += 1;
+        }
+    }
+    if hard > 0 {
+        Verdict::Fail
+    } else if degraded > 0 {
+        Verdict::Degraded
+    } else if exit_code != 0 {
+        // Exited non-zero with nothing to blame it on: the check could not
+        // run at all.
+        Verdict::Error
+    } else {
+        Verdict::Pass
+    }
+}
+
+/// Attributes carry routing only, and always as strings: a consumer reading
+/// attribute values as string-or-double turns a boolean into a null. The
+/// payload belongs in the body.
+fn log_record<T: Serialize>(
+    event_type: &str,
+    vantage: &str,
+    timestamp_ns: u128,
+    body: &T,
+) -> Result<serde_json::Value> {
+    Ok(serde_json::json!({
+        "timeUnixNano": timestamp_ns.to_string(),
+        "body": { "stringValue": serde_json::to_string(body)? },
+        "attributes": [
+            { "key": "event_type", "value": { "stringValue": event_type } },
+            { "key": "vantage", "value": { "stringValue": vantage } },
+        ],
+    }))
+}
+
+pub async fn run(args: EmitArgs) -> Result<bool> {
+    let mut input = String::new();
+    std::io::stdin()
+        .read_to_string(&mut input)
+        .context("reading the report on stdin")?;
+    let parsed = parse_report(&input);
+    if parsed.run.is_none() && parsed.ops.is_empty() {
+        anyhow::bail!("no netcheck report found on stdin");
+    }
+
+    let run_meta = parsed.run.unwrap_or_default();
+    // The scenario belongs to the run, not to how this was invoked: reading it
+    // from the report means a second check cannot be filed under the first
+    // because someone forgot a flag.
+    let scenario = if run_meta.scenario.is_empty() {
+        args.scenario.clone()
+    } else {
+        run_meta.scenario.clone()
+    };
+    let run_id = if run_meta.run_id.is_empty() {
+        "unknown".to_string()
+    } else {
+        run_meta.run_id.clone()
+    };
+    let verdict = verdict(&scenario, &parsed.ops, args.exit_code);
+    let failed = parsed.ops.iter().filter(|o| !o.ok).count();
+    let now_ns = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .context("system clock before epoch")?
+        .as_nanos();
+
+    let mut records = Vec::with_capacity(parsed.ops.len() + 1);
+    for op in &parsed.ops {
+        records.push(log_record(
+            "netcheck_op",
+            &args.vantage,
+            now_ns,
+            &CheckOp {
+                kind: "netcheck_op",
+                scenario: &scenario,
+                run_id: &run_id,
+                vantage: &args.vantage,
+                op: &op.op,
+                dimension: &op.age,
+                dimension_secs: dimension_secs(&op.age),
+                contract_key: &op.key,
+                ok: op.ok,
+                latency_ms: op.latency_ms,
+                bytes: op.size,
+                error: op.error.as_deref(),
+                extra: serde_json::json!({ "label": op.label }),
+            },
+        )?);
+    }
+    records.push(log_record(
+        "netcheck_run",
+        &args.vantage,
+        now_ns,
+        &CheckRun {
+            kind: "netcheck_run",
+            scenario: &scenario,
+            run_id: &run_id,
+            vantage: &args.vantage,
+            duration_ms: run_meta.duration_ms,
+            verdict,
+            ops_total: parsed.ops.len(),
+            ops_failed: failed,
+            software_version: &run_meta.freenet_version,
+            conditions: serde_json::json!({
+                "gateway_ws": run_meta.gateway_ws,
+                "pinned_gateways": run_meta.pinned_gateways,
+                "ephemeral_peers": run_meta.ephemeral_peers,
+                "exit_code": args.exit_code,
+            }),
+        },
+    )?);
+
+    let payload = serde_json::json!({
+        "resourceLogs": [{ "scopeLogs": [{ "logRecords": records }] }]
+    });
+    eprintln!(
+        "netcheck emit: run {run_id} ({scenario}), {} operations, {failed} failed",
+        parsed.ops.len()
+    );
+
+    if args.dry_run {
+        println!("{}", serde_json::to_string_pretty(&payload)?);
+        return Ok(true);
+    }
+
+    let url = format!("{}/v1/logs", args.endpoint.trim_end_matches('/'));
+    let response = reqwest::Client::new()
+        .post(&url)
+        .json(&payload)
+        .send()
+        .await
+        .with_context(|| format!("posting to {url}"))?;
+    anyhow::ensure!(
+        response.status().is_success(),
+        "collector at {url} returned {}",
+        response.status()
+    );
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn op(op: &str, age: &str, ok: bool) -> OpReport {
+        OpReport {
+            op: op.to_string(),
+            age: age.to_string(),
+            label: "small-0".to_string(),
+            key: "abc123".to_string(),
+            ok,
+            latency_ms: 42,
+            size: 123,
+            error: (!ok).then(|| "boom".to_string()),
+        }
+    }
+
+    /// The reason this lives in the crate: a report written by `Report::push`
+    /// must parse back into the same values. Rename a field in `OpReport` and
+    /// this fails, instead of a column silently going blank downstream.
+    #[test]
+    fn a_report_round_trips_through_the_parser() {
+        let written = op("get", "7d", false);
+        let line = crate::report::op_line(&written).expect("serializes");
+        let parsed = parse_report(&line);
+        assert_eq!(parsed.ops.len(), 1);
+        let read = &parsed.ops[0];
+        assert_eq!(read.op, written.op);
+        assert_eq!(read.age, written.age);
+        assert_eq!(read.key, written.key);
+        assert_eq!(read.ok, written.ok);
+        assert_eq!(read.size, written.size);
+        assert_eq!(read.error, written.error);
+    }
+
+    #[test]
+    fn run_metadata_round_trips_and_carries_the_scenario() {
+        let written = RunMeta::new(
+            put_get::SCENARIO,
+            "20260726-030000".to_string(),
+            "ws://127.0.0.1:7509".to_string(),
+            "0.2.108".to_string(),
+            vec!["1.2.3.4:31337,ff".to_string()],
+        );
+        let parsed = parse_report(&crate::report::run_line(&written).expect("serializes"));
+        let read = parsed.run.expect("run line parsed");
+        assert_eq!(read.scenario, put_get::SCENARIO);
+        assert_eq!(read.run_id, "20260726-030000");
+        assert_eq!(read.pinned_gateways, written.pinned_gateways);
+    }
+
+    #[test]
+    fn non_report_lines_are_ignored() {
+        let parsed = parse_report("compiling netcheck\n{not json\n\nnetcheck summary: 8/8\n");
+        assert!(parsed.run.is_none());
+        assert!(parsed.ops.is_empty());
+    }
+
+    #[test]
+    fn a_hard_failure_outranks_a_soft_one() {
+        let ops = [op("get", "7d", false), op("put", "0h", false)];
+        assert_eq!(verdict(put_get::SCENARIO, &ops, 0), Verdict::Fail);
+    }
+
+    #[test]
+    fn only_soft_failures_are_degraded() {
+        let ops = [op("get", "7d", false), op("get", "0h", true)];
+        assert_eq!(verdict(put_get::SCENARIO, &ops, 0), Verdict::Degraded);
+    }
+
+    #[test]
+    fn a_clean_run_passes_and_a_failed_start_is_an_error() {
+        let ops = [op("get", "0h", true)];
+        assert_eq!(verdict(put_get::SCENARIO, &ops, 0), Verdict::Pass);
+        assert_eq!(verdict(put_get::SCENARIO, &[], 1), Verdict::Error);
+    }
+
+    /// A scenario nobody has classified must not inherit another's leniency.
+    #[test]
+    fn an_unknown_scenario_has_no_soft_dimensions() {
+        let ops = [op("get", "7d", false)];
+        assert_eq!(verdict("update_propagation", &ops, 0), Verdict::Fail);
+    }
+
+    #[test]
+    fn dimension_secs_reads_durations_and_declines_the_rest() {
+        assert_eq!(dimension_secs("0h"), Some(0));
+        assert_eq!(dimension_secs("24h"), Some(86_400));
+        assert_eq!(dimension_secs("7d"), Some(604_800));
+        assert_eq!(dimension_secs("hop-1"), None);
+        assert_eq!(dimension_secs(""), None);
+    }
+}

--- a/crates/netcheck/src/ephemeral.rs
+++ b/crates/netcheck/src/ephemeral.rs
@@ -1,0 +1,183 @@
+//! Boots the ephemeral getter node (and, for local testing, an isolated
+//! gateway) as `freenet` child processes. The ephemeral node starts from an
+//! empty data dir every run, so it cannot hold any replica and its GETs are
+//! forced to route over the network — the whole point of netcheck.
+//!
+//! The node is addressed only through its own dirs and ports, and killed by
+//! process handle, never by name: on a host that also runs a real node,
+//! netcheck must be incapable of touching it.
+
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use tokio::process::{Child, Command};
+
+use crate::LocalGatewayArgs;
+
+pub struct EphemeralNode {
+    child: Child,
+    pub ws_base: String,
+    dir: PathBuf,
+    /// Kept alive so the temp dir outlives the node when no explicit
+    /// `--ephemeral-dir` was given.
+    _tmp: Option<tempfile::TempDir>,
+}
+
+/// Version of the `freenet` binary running the ephemeral node. Recorded in
+/// the report: it separates "the network broke" from "last night's release
+/// broke", and cannot be recovered after the fact.
+pub async fn binary_version(freenet_bin: &Path) -> String {
+    match Command::new(freenet_bin).arg("--version").output().await {
+        Ok(out) => String::from_utf8_lossy(&out.stdout)
+            .lines()
+            .next()
+            .unwrap_or_default()
+            .trim()
+            .to_string(),
+        Err(e) => format!("(unknown: {e})"),
+    }
+}
+
+pub async fn spawn_ephemeral(
+    freenet_bin: &Path,
+    network_port: u16,
+    ws_port: u16,
+    gateway_specs: &[String],
+    explicit_dir: Option<&Path>,
+) -> Result<EphemeralNode> {
+    let (dir, tmp) = match explicit_dir {
+        Some(d) => {
+            std::fs::create_dir_all(d)
+                .with_context(|| format!("creating ephemeral node dir {}", d.display()))?;
+            (d.to_path_buf(), None)
+        }
+        None => {
+            let tmp = tempfile::tempdir().context("creating ephemeral node dir")?;
+            (tmp.path().to_path_buf(), Some(tmp))
+        }
+    };
+    let log = std::fs::File::create(dir.join("node.log"))?;
+
+    let mut cmd = Command::new(freenet_bin);
+    cmd.arg("network")
+        .args(["--network-port", &network_port.to_string()])
+        .args(["--ws-api-address", "127.0.0.1"])
+        .args(["--ws-api-port", &ws_port.to_string()])
+        // Lives for minutes: detecting a new release and exiting 42 mid-run
+        // would fail the check for a reason unrelated to the network.
+        .arg("--disable-auto-update")
+        .arg("--config-dir")
+        .arg(&dir)
+        .arg("--data-dir")
+        .arg(&dir);
+    // With explicit gateways the node skips the remote index and joins only
+    // through those; with none it bootstraps from the public index.
+    if !gateway_specs.is_empty() {
+        cmd.arg("--skip-load-from-network");
+        for spec in gateway_specs {
+            cmd.args(["--gateway", spec]);
+        }
+    }
+    cmd.stdout(Stdio::from(log.try_clone()?))
+        .stderr(Stdio::from(log))
+        .kill_on_drop(true);
+
+    let child = cmd
+        .spawn()
+        .with_context(|| format!("spawning {} network", freenet_bin.display()))?;
+    Ok(EphemeralNode {
+        child,
+        ws_base: format!("ws://127.0.0.1:{ws_port}"),
+        dir,
+        _tmp: tmp,
+    })
+}
+
+impl EphemeralNode {
+    /// Last lines of the node's log, for failure diagnostics.
+    pub fn log_tail(&self) -> String {
+        let path = self.dir.join("node.log");
+        match std::fs::read_to_string(&path) {
+            Ok(s) => {
+                let lines: Vec<&str> = s.lines().collect();
+                let start = lines.len().saturating_sub(40);
+                lines[start..].join("\n")
+            }
+            Err(e) => format!("(could not read node log: {e})"),
+        }
+    }
+
+    pub async fn shutdown(mut self) {
+        let _ = self.child.kill().await;
+    }
+}
+
+/// Run a local gateway in the foreground for local testing. Generates a
+/// transport keypair (the on-disk format is the hex-encoded 32-byte X25519
+/// secret) and prints the "ip:port,hex-pubkey" spec other nodes need to
+/// bootstrap against it. With `--peer-gateway` it links to another local
+/// gateway instead of running isolated.
+pub async fn run_local_gateway(args: LocalGatewayArgs) -> Result<()> {
+    let tmp;
+    let dir: &Path = match &args.dir {
+        Some(d) => {
+            std::fs::create_dir_all(d)?;
+            d
+        }
+        None => {
+            tmp = tempfile::tempdir()?;
+            tmp.path()
+        }
+    };
+
+    let secret = x25519_dalek::StaticSecret::from(rand::random::<[u8; 32]>());
+    let public = x25519_dalek::PublicKey::from(&secret);
+    let key_path = dir.join("gw-transport-keypair");
+    std::fs::write(&key_path, hex::encode(secret.to_bytes()))?;
+
+    let spec = format!(
+        "127.0.0.1:{},{}",
+        args.network_port,
+        hex::encode(public.as_bytes())
+    );
+    println!("local gateway starting.");
+    println!("  ws api:        ws://127.0.0.1:{}", args.ws_port);
+    println!("  --gateway-spec \"{spec}\"");
+    println!("run netcheck in another terminal, e.g.:");
+    println!(
+        "  cargo run -p netcheck -- put-get --gateway-spec \"{spec}\" \
+         --ephemeral-network-port 31400"
+    );
+
+    let mut cmd = Command::new(&args.freenet_bin);
+    cmd.arg("network")
+        .arg("--is-gateway")
+        .arg("--skip-load-from-network")
+        .arg("--disable-auto-update")
+        .arg("--transport-keypair")
+        .arg(&key_path)
+        .args(["--network-port", &args.network_port.to_string()])
+        .args(["--public-network-address", "127.0.0.1"])
+        .args(["--public-network-port", &args.network_port.to_string()])
+        .args(["--ws-api-address", "127.0.0.1"])
+        .args(["--ws-api-port", &args.ws_port.to_string()])
+        .arg("--config-dir")
+        .arg(dir)
+        .arg("--data-dir")
+        .arg(dir);
+    for peer in &args.peer_gateway {
+        cmd.args(["--gateway", peer]);
+    }
+
+    let status = cmd
+        .status()
+        .await
+        .with_context(|| format!("running {} network", args.freenet_bin.display()))?;
+
+    // Wait a beat so a crash-on-boot is visible before the temp dir goes away.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    anyhow::ensure!(status.success(), "local gateway exited with {status}");
+    Ok(())
+}

--- a/crates/netcheck/src/ephemeral.rs
+++ b/crates/netcheck/src/ephemeral.rs
@@ -1,7 +1,7 @@
 //! Boots the ephemeral getter node (and, for local testing, an isolated
 //! gateway) as `freenet` child processes. The ephemeral node starts from an
 //! empty data dir every run, so it cannot hold any replica and its GETs are
-//! forced to route over the network — the whole point of netcheck.
+//! forced to route over the network, the whole point of netcheck.
 //!
 //! The node is addressed only through its own dirs and ports, and killed by
 //! process handle, never by name: on a host that also runs a real node,
@@ -25,6 +25,27 @@ pub struct EphemeralNode {
     _tmp: Option<tempfile::TempDir>,
 }
 
+impl EphemeralNode {
+    /// Last lines of the node's log, for failure diagnostics.
+    pub fn log_tail(&self) -> String {
+        let path = self.dir.join("node.log");
+        match std::fs::read_to_string(&path) {
+            Ok(s) => {
+                let lines: Vec<&str> = s.lines().collect();
+                let start = lines.len().saturating_sub(40);
+                lines[start..].join("\n")
+            }
+            Err(e) => format!("(could not read node log: {e})"),
+        }
+    }
+
+    /// Kill the node by process handle. Never by name: on a host that also
+    /// runs a real node, netcheck must be incapable of touching it.
+    pub async fn shutdown(mut self) {
+        let _ = self.child.kill().await;
+    }
+}
+
 /// Version of the `freenet` binary running the ephemeral node. Recorded in
 /// the report: it separates "the network broke" from "last night's release
 /// broke", and cannot be recovered after the fact.
@@ -40,6 +61,8 @@ pub async fn binary_version(freenet_bin: &Path) -> String {
     }
 }
 
+/// Boot the ephemeral getter node. It joins through `gateway_specs` when
+/// given any, and from the public index otherwise.
 pub async fn spawn_ephemeral(
     freenet_bin: &Path,
     network_port: u16,
@@ -93,25 +116,6 @@ pub async fn spawn_ephemeral(
         dir,
         _tmp: tmp,
     })
-}
-
-impl EphemeralNode {
-    /// Last lines of the node's log, for failure diagnostics.
-    pub fn log_tail(&self) -> String {
-        let path = self.dir.join("node.log");
-        match std::fs::read_to_string(&path) {
-            Ok(s) => {
-                let lines: Vec<&str> = s.lines().collect();
-                let start = lines.len().saturating_sub(40);
-                lines[start..].join("\n")
-            }
-            Err(e) => format!("(could not read node log: {e})"),
-        }
-    }
-
-    pub async fn shutdown(mut self) {
-        let _ = self.child.kill().await;
-    }
 }
 
 /// Run a local gateway in the foreground for local testing. Generates a

--- a/crates/netcheck/src/main.rs
+++ b/crates/netcheck/src/main.rs
@@ -1,0 +1,137 @@
+//! Synthetic end-to-end check against the live Freenet network (#4665).
+//!
+//! Runs as a normal network client: PUTs contracts through one gateway's
+//! WebSocket API, then boots a fresh ephemeral peer (empty data dir, so it
+//! cannot hold any replica) that joins through a *different* gateway and
+//! GETs everything back, including contracts published by previous runs
+//! (24h / 48h / 7d retention windows). Talks only to public node APIs;
+//! never links freenet-core.
+
+mod client;
+mod contracts;
+mod ephemeral;
+mod manifest;
+mod report;
+mod scenarios;
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[command(name = "netcheck", about, version)]
+enum Cli {
+    /// Cross-gateway PUT/GET + retention scenario (the nightly run).
+    PutGet(PutGetArgs),
+    /// Run an isolated local gateway for testing netcheck on one machine.
+    /// Prints the `--gateway-spec` value to pass to `put-get`.
+    LocalGateway(LocalGatewayArgs),
+}
+
+#[derive(clap::Args, Debug)]
+pub struct PutGetArgs {
+    /// Base websocket URL of the gateway node the PUTs go through.
+    #[arg(long, default_value = "ws://127.0.0.1:7509")]
+    pub gateway_ws: String,
+
+    /// Path of the persistent manifest recording previous runs' contracts.
+    #[arg(long, default_value = "netcheck-manifest.json")]
+    pub manifest: PathBuf,
+
+    /// `freenet` binary used to boot the ephemeral getter node.
+    #[arg(long, default_value = "freenet")]
+    pub freenet_bin: PathBuf,
+
+    /// Directory of the check's contract crate (compiled to WASM at startup).
+    #[arg(long, default_value = "tests/test-contract-integration")]
+    pub contract_dir: PathBuf,
+
+    /// UDP network port for the ephemeral node (32177 is reserved on nova).
+    #[arg(long, default_value_t = 32177)]
+    pub ephemeral_network_port: u16,
+
+    /// Local websocket API port for the ephemeral node.
+    #[arg(long, default_value_t = 7519)]
+    pub ephemeral_ws_port: u16,
+
+    /// Working directory for the ephemeral node. Defaults to a temp dir that
+    /// is removed on exit; on a shared host point it at a known path so a
+    /// killed run leaves no anonymous directory behind.
+    #[arg(long)]
+    pub ephemeral_dir: Option<PathBuf>,
+
+    /// Gateway(s) the ephemeral node joins through, as "ip:port,hex-pubkey".
+    /// May be repeated. When set, the node skips the remote gateway index and
+    /// uses only these.
+    ///
+    /// In production this MUST name a gateway OTHER than the one the PUTs go
+    /// through (`--gateway-ws`): a GET answered by the node that just stored
+    /// the PUT proves transfer, not findability. Left empty, the node
+    /// bootstraps from the public index and may pick either gateway, so the
+    /// check silently degrades — the report records which peers it actually
+    /// connected to.
+    #[arg(long)]
+    pub gateway_spec: Vec<String>,
+
+    /// Number of small contracts to PUT (a ~1 MB one is always added).
+    #[arg(long, default_value_t = 3)]
+    pub small_contracts: usize,
+
+    /// Per-operation deadline, seconds. No retries by design: an operation
+    /// that only succeeds on retry is the regression netcheck exists to catch.
+    #[arg(long, default_value_t = 120)]
+    pub op_timeout_secs: u64,
+
+    /// Deadline for the ephemeral node to join the ring, seconds.
+    #[arg(long, default_value_t = 120)]
+    pub join_timeout_secs: u64,
+
+    /// Settle time between the PUTs and booting the getter node, seconds.
+    #[arg(long, default_value_t = 10)]
+    pub settle_secs: u64,
+}
+
+#[derive(clap::Args, Debug)]
+pub struct LocalGatewayArgs {
+    /// `freenet` binary to run.
+    #[arg(long, default_value = "freenet")]
+    pub freenet_bin: PathBuf,
+
+    /// UDP network port for the local gateway.
+    #[arg(long, default_value_t = 31338)]
+    pub network_port: u16,
+
+    /// Websocket API port (7509 matches put-get's --gateway-ws default).
+    #[arg(long, default_value_t = 7509)]
+    pub ws_port: u16,
+
+    /// Data/config directory. Defaults to a temp dir removed on exit.
+    #[arg(long)]
+    pub dir: Option<PathBuf>,
+
+    /// Other gateway(s) this one connects to, as "ip:port,hex-pubkey".
+    /// Two linked local gateways reproduce the production topology on one
+    /// machine: PUT through the first, join the ephemeral peer through the
+    /// second, so the GETs are actually routed instead of being answered by
+    /// the node that stored them.
+    #[arg(long)]
+    pub peer_gateway: Vec<String>,
+}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    let cli = Cli::parse();
+    let result = match cli {
+        Cli::PutGet(args) => scenarios::put_get::run(args).await,
+        Cli::LocalGateway(args) => ephemeral::run_local_gateway(args).await.map(|()| true),
+    };
+    match result {
+        Ok(true) => ExitCode::SUCCESS,
+        Ok(false) => ExitCode::FAILURE,
+        Err(e) => {
+            eprintln!("netcheck: fatal: {e:#}");
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/crates/netcheck/src/main.rs
+++ b/crates/netcheck/src/main.rs
@@ -9,6 +9,7 @@
 
 mod client;
 mod contracts;
+mod emit;
 mod ephemeral;
 mod manifest;
 mod report;
@@ -27,6 +28,34 @@ enum Cli {
     /// Run an isolated local gateway for testing netcheck on one machine.
     /// Prints the `--gateway-spec` value to pass to `put-get`.
     LocalGateway(LocalGatewayArgs),
+    /// Read a run's report on stdin and publish it to an OTLP collector.
+    Emit(EmitArgs),
+}
+
+#[derive(clap::Args, Debug)]
+pub struct EmitArgs {
+    /// Base URL of the OTLP/HTTP collector.
+    #[arg(long, default_value = "http://127.0.0.1:4318")]
+    pub endpoint: String,
+
+    /// Where the check ran from: a hostname, `ci`, a datacentre.
+    #[arg(long, default_value = "unknown")]
+    pub vantage: String,
+
+    /// Fallback only. The scenario is read from the report's run line
+    /// whenever it has one, so a check cannot be filed under another's name
+    /// because a flag was forgotten.
+    #[arg(long, default_value = "put_get")]
+    pub scenario: String,
+
+    /// The check's exit status, so a run that never started is published as
+    /// an error rather than a silent pass.
+    #[arg(long, default_value_t = 0)]
+    pub exit_code: i32,
+
+    /// Print the payload instead of sending it.
+    #[arg(long)]
+    pub dry_run: bool,
 }
 
 #[derive(clap::Args, Debug)]
@@ -125,6 +154,7 @@ async fn main() -> ExitCode {
     let result = match cli {
         Cli::PutGet(args) => scenarios::put_get::run(args).await,
         Cli::LocalGateway(args) => ephemeral::run_local_gateway(args).await.map(|()| true),
+        Cli::Emit(args) => emit::run(args).await,
     };
     match result {
         Ok(true) => ExitCode::SUCCESS,

--- a/crates/netcheck/src/main.rs
+++ b/crates/netcheck/src/main.rs
@@ -98,7 +98,7 @@ pub struct PutGetArgs {
     /// through (`--gateway-ws`): a GET answered by the node that just stored
     /// the PUT proves transfer, not findability. Left empty, the node
     /// bootstraps from the public index and may pick either gateway, so the
-    /// check silently degrades — the report records which peers it actually
+    /// check silently degrades: the report records which peers it actually
     /// connected to.
     #[arg(long)]
     pub gateway_spec: Vec<String>,

--- a/crates/netcheck/src/manifest.rs
+++ b/crates/netcheck/src/manifest.rs
@@ -42,6 +42,8 @@ pub struct ContractRecord {
 }
 
 impl Manifest {
+    /// Read the manifest, treating a missing file as an empty one: the
+    /// first night has no history to load.
     pub fn load(path: &Path) -> Result<Self> {
         match std::fs::read(path) {
             Ok(bytes) => serde_json::from_slice(&bytes)
@@ -51,6 +53,8 @@ impl Manifest {
         }
     }
 
+    /// Write via a temp file and rename, so an interrupted run cannot leave
+    /// a truncated manifest behind and lose every retention target.
     pub fn save(&self, path: &Path) -> Result<()> {
         let tmp = path.with_extension("tmp");
         std::fs::write(&tmp, serde_json::to_vec_pretty(self)?)?;

--- a/crates/netcheck/src/manifest.rs
+++ b/crates/netcheck/src/manifest.rs
@@ -1,0 +1,187 @@
+//! Persistent record of previous runs' contracts, used to pick the
+//! retention re-GET targets (24h / 48h / 7d windows).
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use freenet_stdlib::prelude::ContractInstanceId;
+use serde::{Deserialize, Serialize};
+
+/// Runs older than this are pruned; keeps the manifest a few entries long.
+const KEEP_SECS: u64 = 8 * 24 * 3600;
+
+/// Retention windows: newest run whose age falls inside the range is re-GET.
+/// Ranges are generous (±ish 25%) so a late or skipped nightly run does not
+/// silently drop the window.
+const WINDOWS: &[(&str, u64, u64)] = &[
+    ("24h", 20 * 3600, 30 * 3600),
+    ("48h", 44 * 3600, 54 * 3600),
+    ("7d", 156 * 3600, 180 * 3600),
+];
+
+#[derive(Serialize, Deserialize, Default)]
+pub struct Manifest {
+    pub runs: Vec<RunRecord>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct RunRecord {
+    pub run_id: String,
+    /// Unix epoch seconds of the run's PUT phase.
+    pub timestamp: u64,
+    pub contracts: Vec<ContractRecord>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct ContractRecord {
+    pub id: ContractInstanceId,
+    pub label: String,
+    pub size: usize,
+    /// blake3 of the PUT state; retention GETs verify against this.
+    pub state_hash: String,
+}
+
+impl Manifest {
+    pub fn load(path: &Path) -> Result<Self> {
+        match std::fs::read(path) {
+            Ok(bytes) => serde_json::from_slice(&bytes)
+                .with_context(|| format!("parsing manifest {}", path.display())),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Self::default()),
+            Err(e) => Err(e).with_context(|| format!("reading manifest {}", path.display())),
+        }
+    }
+
+    pub fn save(&self, path: &Path) -> Result<()> {
+        let tmp = path.with_extension("tmp");
+        std::fs::write(&tmp, serde_json::to_vec_pretty(self)?)?;
+        std::fs::rename(&tmp, path)?;
+        Ok(())
+    }
+
+    /// Newest run per retention window, oldest window first.
+    pub fn retention_targets(&self, now: u64) -> Vec<(&'static str, &RunRecord)> {
+        let mut out = Vec::new();
+        for &(label, min_age, max_age) in WINDOWS {
+            let hit = self
+                .runs
+                .iter()
+                .filter(|r| {
+                    let age = now.saturating_sub(r.timestamp);
+                    age >= min_age && age <= max_age
+                })
+                .max_by_key(|r| r.timestamp);
+            if let Some(run) = hit {
+                out.push((label, run));
+            }
+        }
+        out
+    }
+
+    /// Append this run and prune anything past the keep horizon.
+    pub fn record_run(&mut self, run: RunRecord, now: u64) {
+        self.runs.push(run);
+        self.runs
+            .retain(|r| now.saturating_sub(r.timestamp) <= KEEP_SECS);
+        self.runs.sort_by_key(|r| r.timestamp);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const NOW: u64 = 1_800_000_000;
+    const HOUR: u64 = 3600;
+
+    fn run_at(id: &str, age_hours: u64) -> RunRecord {
+        RunRecord {
+            run_id: id.to_string(),
+            timestamp: NOW - age_hours * HOUR,
+            contracts: Vec::new(),
+        }
+    }
+
+    fn windows(m: &Manifest) -> Vec<(&'static str, String)> {
+        m.retention_targets(NOW)
+            .into_iter()
+            .map(|(w, r)| (w, r.run_id.clone()))
+            .collect()
+    }
+
+    #[test]
+    fn empty_manifest_has_no_targets() {
+        assert!(windows(&Manifest::default()).is_empty());
+    }
+
+    #[test]
+    fn each_window_selects_its_own_run() {
+        let m = Manifest {
+            runs: vec![run_at("d1", 24), run_at("d2", 48), run_at("d7", 168)],
+        };
+        assert_eq!(
+            windows(&m),
+            vec![
+                ("24h", "d1".to_string()),
+                ("48h", "d2".to_string()),
+                ("7d", "d7".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn window_with_no_run_is_skipped_without_shifting_the_others() {
+        // Nothing in the 48h window: the 7d window must still resolve, and
+        // the 24h run must not be dragged in to fill the gap.
+        let m = Manifest {
+            runs: vec![run_at("d1", 24), run_at("d7", 168)],
+        };
+        assert_eq!(
+            windows(&m),
+            vec![("24h", "d1".to_string()), ("7d", "d7".to_string())]
+        );
+    }
+
+    #[test]
+    fn window_bounds_are_inclusive_and_exclude_just_outside() {
+        // 24h window is [20h, 30h].
+        let inside = Manifest {
+            runs: vec![run_at("lo", 20), run_at("hi", 30)],
+        };
+        // Newest wins when several runs land in one window.
+        assert_eq!(windows(&inside), vec![("24h", "lo".to_string())]);
+
+        let outside = Manifest {
+            runs: vec![run_at("too-new", 19), run_at("too-old", 31)],
+        };
+        assert!(windows(&outside).is_empty());
+    }
+
+    #[test]
+    fn newest_run_wins_inside_a_window() {
+        let m = Manifest {
+            runs: vec![run_at("older", 29), run_at("newer", 21)],
+        };
+        assert_eq!(windows(&m), vec![("24h", "newer".to_string())]);
+    }
+
+    #[test]
+    fn record_run_prunes_past_the_keep_horizon_and_keeps_order() {
+        let mut m = Manifest {
+            runs: vec![run_at("ancient", 9 * 24), run_at("week", 7 * 24)],
+        };
+        m.record_run(run_at("today", 0), NOW);
+        let ids: Vec<&str> = m.runs.iter().map(|r| r.run_id.as_str()).collect();
+        assert_eq!(ids, vec!["week", "today"], "9-day-old run must be pruned");
+    }
+
+    #[test]
+    fn a_run_still_needed_by_the_7d_window_survives_pruning() {
+        // The keep horizon must outlive the widest window (180h) or the 7d
+        // check would silently stop having anything to ask for.
+        let mut m = Manifest::default();
+        m.record_run(run_at("edge", 180 / 24), NOW);
+        m.record_run(run_at("today", 0), NOW);
+        assert_eq!(m.runs.len(), 2);
+        assert!(KEEP_SECS >= WINDOWS.last().expect("windows non-empty").2);
+    }
+}

--- a/crates/netcheck/src/report.rs
+++ b/crates/netcheck/src/report.rs
@@ -1,0 +1,112 @@
+//! Results, printed as JSON lines on stdout so the nightly workflow log is
+//! machine-parseable. Every line carries an `event` tag: one `"run"` line
+//! describing the conditions of the run, then one `"op"` line per operation.
+//! Phase 3 will additionally emit these as OTLP events to nova's collector.
+
+use serde::Serialize;
+
+/// Conditions the run happened under. Without them a failure cannot be
+/// attributed after the fact.
+#[derive(Serialize)]
+pub struct RunMeta {
+    pub event: &'static str,
+    pub run_id: String,
+    pub gateway_ws: String,
+    pub freenet_version: String,
+    pub pinned_gateways: Vec<String>,
+    pub ephemeral_peers: Vec<String>,
+}
+
+impl RunMeta {
+    pub fn new(
+        run_id: String,
+        gateway_ws: String,
+        freenet_version: String,
+        pinned_gateways: Vec<String>,
+    ) -> Self {
+        Self {
+            event: "run",
+            run_id,
+            gateway_ws,
+            freenet_version,
+            pinned_gateways,
+            ephemeral_peers: Vec::new(),
+        }
+    }
+
+    pub fn print(&self) {
+        match serde_json::to_string(self) {
+            Ok(line) => println!("{line}"),
+            Err(e) => eprintln!("run metadata serialization failed: {e}"),
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub struct OpReport {
+    pub op: &'static str,
+    /// Retention window of the target run ("0h" for this run's contracts).
+    pub age: &'static str,
+    pub label: String,
+    pub key: String,
+    pub ok: bool,
+    pub latency_ms: u128,
+    pub size: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Serialize)]
+struct TaggedOp<'a> {
+    event: &'static str,
+    #[serde(flatten)]
+    op: &'a OpReport,
+}
+
+#[derive(Default)]
+pub struct Report {
+    ops: Vec<OpReport>,
+}
+
+impl Report {
+    pub fn push(&mut self, op: OpReport) {
+        let tagged = TaggedOp {
+            event: "op",
+            op: &op,
+        };
+        match serde_json::to_string(&tagged) {
+            Ok(line) => println!("{line}"),
+            Err(e) => eprintln!("report serialization failed: {e}"),
+        }
+        if !op.ok {
+            eprintln!(
+                "FAIL {} {} {} ({}): {}",
+                op.op,
+                op.age,
+                op.label,
+                op.key,
+                op.error.as_deref().unwrap_or("unknown")
+            );
+        }
+        self.ops.push(op);
+    }
+
+    pub fn all_ok(&self) -> bool {
+        self.ops.iter().all(|o| o.ok)
+    }
+
+    pub fn print_summary(&self) {
+        let total = self.ops.len();
+        let failed = self.ops.iter().filter(|o| !o.ok).count();
+        eprintln!(
+            "netcheck summary: {}/{} operations succeeded{}",
+            total - failed,
+            total,
+            if failed > 0 {
+                " — FAILURES PRESENT"
+            } else {
+                ""
+            }
+        );
+    }
+}

--- a/crates/netcheck/src/report.rs
+++ b/crates/netcheck/src/report.rs
@@ -1,66 +1,94 @@
 //! Results, printed as JSON lines on stdout so the nightly workflow log is
 //! machine-parseable. Every line carries an `event` tag: one `"run"` line
 //! describing the conditions of the run, then one `"op"` line per operation.
-//! Phase 3 will additionally emit these as OTLP events to nova's collector.
+//!
+//! These types are both `Serialize` and `Deserialize` on purpose: `netcheck
+//! emit` reads a report back with the very structs that wrote it, so renaming
+//! a field cannot silently desynchronise the two halves.
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 /// Conditions the run happened under. Without them a failure cannot be
 /// attributed after the fact.
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize, Default)]
 pub struct RunMeta {
-    pub event: &'static str,
+    pub scenario: String,
     pub run_id: String,
     pub gateway_ws: String,
     pub freenet_version: String,
     pub pinned_gateways: Vec<String>,
     pub ephemeral_peers: Vec<String>,
+    pub duration_ms: u128,
+}
+
+#[derive(Serialize)]
+struct Tagged<'a, T> {
+    event: &'static str,
+    #[serde(flatten)]
+    inner: &'a T,
 }
 
 impl RunMeta {
     pub fn new(
+        scenario: &str,
         run_id: String,
         gateway_ws: String,
         freenet_version: String,
         pinned_gateways: Vec<String>,
     ) -> Self {
         Self {
-            event: "run",
+            scenario: scenario.to_string(),
             run_id,
             gateway_ws,
             freenet_version,
             pinned_gateways,
             ephemeral_peers: Vec::new(),
+            duration_ms: 0,
         }
     }
 
     pub fn print(&self) {
-        match serde_json::to_string(self) {
-            Ok(line) => println!("{line}"),
-            Err(e) => eprintln!("run metadata serialization failed: {e}"),
-        }
+        print_line(run_line(self), "run metadata");
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct OpReport {
-    pub op: &'static str,
-    /// Retention window of the target run ("0h" for this run's contracts).
-    pub age: &'static str,
+    pub op: String,
+    /// What was read: "0h" for this run's own contracts, otherwise the
+    /// retention window of the run that published them.
+    pub age: String,
     pub label: String,
     pub key: String,
     pub ok: bool,
     pub latency_ms: u128,
     pub size: usize,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
 }
 
-#[derive(Serialize)]
-struct TaggedOp<'a> {
-    event: &'static str,
-    #[serde(flatten)]
-    op: &'a OpReport,
+/// The exact line `RunMeta::print` writes. Public so the emitter's tests can
+/// prove a report survives the round trip through the structs that wrote it.
+pub fn run_line(run: &RunMeta) -> serde_json::Result<String> {
+    serde_json::to_string(&Tagged {
+        event: "run",
+        inner: run,
+    })
+}
+
+/// The exact line `Report::push` writes.
+pub fn op_line(op: &OpReport) -> serde_json::Result<String> {
+    serde_json::to_string(&Tagged {
+        event: "op",
+        inner: op,
+    })
+}
+
+fn print_line(line: serde_json::Result<String>, what: &str) {
+    match line {
+        Ok(line) => println!("{line}"),
+        Err(e) => eprintln!("{what} serialization failed: {e}"),
+    }
 }
 
 #[derive(Default)]
@@ -70,14 +98,7 @@ pub struct Report {
 
 impl Report {
     pub fn push(&mut self, op: OpReport) {
-        let tagged = TaggedOp {
-            event: "op",
-            op: &op,
-        };
-        match serde_json::to_string(&tagged) {
-            Ok(line) => println!("{line}"),
-            Err(e) => eprintln!("report serialization failed: {e}"),
-        }
+        print_line(op_line(&op), "report");
         if !op.ok {
             eprintln!(
                 "FAIL {} {} {} ({}): {}",
@@ -102,11 +123,7 @@ impl Report {
             "netcheck summary: {}/{} operations succeeded{}",
             total - failed,
             total,
-            if failed > 0 {
-                " — FAILURES PRESENT"
-            } else {
-                ""
-            }
+            if failed > 0 { ", FAILURES PRESENT" } else { "" }
         );
     }
 }

--- a/crates/netcheck/src/report.rs
+++ b/crates/netcheck/src/report.rs
@@ -97,6 +97,8 @@ pub struct Report {
 }
 
 impl Report {
+    /// Record an operation and print its line as it happens, so a run that
+    /// dies half way still leaves the operations it completed.
     pub fn push(&mut self, op: OpReport) {
         print_line(op_line(&op), "report");
         if !op.ok {
@@ -112,10 +114,12 @@ impl Report {
         self.ops.push(op);
     }
 
+    /// Whether every recorded operation succeeded.
     pub fn all_ok(&self) -> bool {
         self.ops.iter().all(|o| o.ok)
     }
 
+    /// One human-readable line on stderr, separate from the JSON on stdout.
     pub fn print_summary(&self) {
         let total = self.ops.len();
         let failed = self.ops.iter().filter(|o| !o.ok).count();

--- a/crates/netcheck/src/scenarios.rs
+++ b/crates/netcheck/src/scenarios.rs
@@ -1,0 +1,1 @@
+pub mod put_get;

--- a/crates/netcheck/src/scenarios/put_get.rs
+++ b/crates/netcheck/src/scenarios/put_get.rs
@@ -11,7 +11,12 @@ use crate::manifest::{ContractRecord, Manifest, RunRecord};
 use crate::report::{OpReport, Report, RunMeta};
 use crate::{PutGetArgs, client, contracts, ephemeral};
 
+/// Name this scenario publishes under. A new check is a new value here,
+/// never a new event type.
+pub const SCENARIO: &str = "put_get";
+
 pub async fn run(args: PutGetArgs) -> Result<bool> {
+    let started = std::time::Instant::now();
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .context("system clock before epoch")?
@@ -21,6 +26,7 @@ pub async fn run(args: PutGetArgs) -> Result<bool> {
 
     eprintln!("netcheck put-get: run {run_id}");
     let mut meta = RunMeta::new(
+        SCENARIO,
         run_id.clone(),
         args.gateway_ws.clone(),
         ephemeral::binary_version(&args.freenet_bin).await,
@@ -65,8 +71,8 @@ pub async fn run(args: PutGetArgs) -> Result<bool> {
         {
             Ok(latency) => {
                 report.push(OpReport {
-                    op: "put",
-                    age: "0h",
+                    op: "put".to_string(),
+                    age: "0h".to_string(),
                     label: c.label.clone(),
                     key: key.to_string(),
                     ok: true,
@@ -77,8 +83,8 @@ pub async fn run(args: PutGetArgs) -> Result<bool> {
                 put_ok.push(c);
             }
             Err(e) => report.push(OpReport {
-                op: "put",
-                age: "0h",
+                op: "put".to_string(),
+                age: "0h".to_string(),
                 label: c.label.clone(),
                 key: key.to_string(),
                 ok: false,
@@ -113,6 +119,7 @@ pub async fn run(args: PutGetArgs) -> Result<bool> {
         Ok(p) => p,
         Err(e) => {
             eprintln!("ephemeral node log tail:\n{}", node.log_tail());
+            meta.duration_ms = started.elapsed().as_millis();
             meta.print();
             node.shutdown().await;
             return Err(e.context("connecting to ephemeral node ws api"));
@@ -122,12 +129,12 @@ pub async fn run(args: PutGetArgs) -> Result<bool> {
         Ok(peers) => meta.ephemeral_peers = peers,
         Err(e) => {
             eprintln!("ephemeral node log tail:\n{}", node.log_tail());
+            meta.duration_ms = started.elapsed().as_millis();
             meta.print();
             node.shutdown().await;
             return Err(e);
         }
     }
-    meta.print();
 
     // Today's contracts: full byte-identity check against what we just PUT.
     for c in &put_ok {
@@ -210,6 +217,8 @@ pub async fn run(args: PutGetArgs) -> Result<bool> {
         manifest.save(&args.manifest)?;
     }
 
+    meta.duration_ms = started.elapsed().as_millis();
+    meta.print();
     report.print_summary();
     Ok(report.all_ok())
 }
@@ -225,8 +234,8 @@ fn push_get_report(
 ) {
     match outcome {
         Ok(latency) => report.push(OpReport {
-            op: "get",
-            age,
+            op: "get".to_string(),
+            age: age.to_string(),
             label: label.to_string(),
             key,
             ok: true,
@@ -235,8 +244,8 @@ fn push_get_report(
             error: None,
         }),
         Err(e) => report.push(OpReport {
-            op: "get",
-            age,
+            op: "get".to_string(),
+            age: age.to_string(),
             label: label.to_string(),
             key,
             ok: false,

--- a/crates/netcheck/src/scenarios/put_get.rs
+++ b/crates/netcheck/src/scenarios/put_get.rs
@@ -1,0 +1,248 @@
+//! The nightly scenario: PUT via one gateway, GET everything back via a
+//! fresh ephemeral peer joined through another, including previous runs'
+//! contracts (retention).
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result};
+use freenet_stdlib::prelude::*;
+
+use crate::manifest::{ContractRecord, Manifest, RunRecord};
+use crate::report::{OpReport, Report, RunMeta};
+use crate::{PutGetArgs, client, contracts, ephemeral};
+
+pub async fn run(args: PutGetArgs) -> Result<bool> {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("system clock before epoch")?
+        .as_secs();
+    let run_id = chrono::Utc::now().format("%Y%m%d-%H%M%S").to_string();
+    let op_timeout = Duration::from_secs(args.op_timeout_secs);
+
+    eprintln!("netcheck put-get: run {run_id}");
+    let mut meta = RunMeta::new(
+        run_id.clone(),
+        args.gateway_ws.clone(),
+        ephemeral::binary_version(&args.freenet_bin).await,
+        args.gateway_spec.clone(),
+    );
+    if args.gateway_spec.is_empty() {
+        eprintln!(
+            "WARNING: no --gateway-spec given; the ephemeral peer will bootstrap from the \
+             public index and may join through the same gateway the PUTs go through, which \
+             weakens the check to a transfer test. See `ephemeral_peers` in the run report."
+        );
+    }
+    let wasm = contracts::compile_contract_wasm(&args.contract_dir)?;
+    let run_contracts = contracts::build_run_contracts(&wasm, &run_id, args.small_contracts)?;
+    let mut manifest = Manifest::load(&args.manifest)?;
+    let retention: Vec<(&str, &RunRecord)> = manifest.retention_targets(now);
+    eprintln!(
+        "retention targets this run: {:?}",
+        retention
+            .iter()
+            .map(|(w, r)| (*w, r.run_id.as_str()))
+            .collect::<Vec<_>>()
+    );
+
+    let mut report = Report::default();
+
+    // ---- PUT phase, via the existing gateway ----
+    let mut gw = client::connect(&args.gateway_ws, Duration::from_secs(15))
+        .await
+        .context("connecting to gateway ws api")?;
+    let mut put_ok: Vec<&contracts::RunContract> = Vec::new();
+    for c in &run_contracts {
+        let key = c.contract.key();
+        match client::put(
+            &mut gw,
+            c.contract.clone(),
+            c.state.clone(),
+            &c.label,
+            op_timeout,
+        )
+        .await
+        {
+            Ok(latency) => {
+                report.push(OpReport {
+                    op: "put",
+                    age: "0h",
+                    label: c.label.clone(),
+                    key: key.to_string(),
+                    ok: true,
+                    latency_ms: latency.as_millis(),
+                    size: c.state.as_ref().len(),
+                    error: None,
+                });
+                put_ok.push(c);
+            }
+            Err(e) => report.push(OpReport {
+                op: "put",
+                age: "0h",
+                label: c.label.clone(),
+                key: key.to_string(),
+                ok: false,
+                latency_ms: op_timeout.as_millis(),
+                size: c.state.as_ref().len(),
+                error: Some(format!("{e:#}")),
+            }),
+        }
+    }
+    client::disconnect(&mut gw).await;
+
+    eprintln!(
+        "{}/{} PUTs ok; settling {}s before booting the ephemeral getter...",
+        put_ok.len(),
+        run_contracts.len(),
+        args.settle_secs
+    );
+    tokio::time::sleep(Duration::from_secs(args.settle_secs)).await;
+
+    // ---- GET phase, via a fresh ephemeral peer ----
+    let node = ephemeral::spawn_ephemeral(
+        &args.freenet_bin,
+        args.ephemeral_network_port,
+        args.ephemeral_ws_port,
+        &args.gateway_spec,
+        args.ephemeral_dir.as_deref(),
+    )
+    .await?;
+
+    let join_timeout = Duration::from_secs(args.join_timeout_secs);
+    let mut peer = match client::connect(&node.ws_base, join_timeout).await {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("ephemeral node log tail:\n{}", node.log_tail());
+            meta.print();
+            node.shutdown().await;
+            return Err(e.context("connecting to ephemeral node ws api"));
+        }
+    };
+    match client::wait_for_ring_join(&mut peer, join_timeout).await {
+        Ok(peers) => meta.ephemeral_peers = peers,
+        Err(e) => {
+            eprintln!("ephemeral node log tail:\n{}", node.log_tail());
+            meta.print();
+            node.shutdown().await;
+            return Err(e);
+        }
+    }
+    meta.print();
+
+    // Today's contracts: full byte-identity check against what we just PUT.
+    for c in &put_ok {
+        let key = c.contract.key();
+        let outcome = client::get(&mut peer, *key.id(), &c.label, op_timeout)
+            .await
+            .and_then(|(contract, state, latency)| {
+                anyhow::ensure!(
+                    contract == c.contract,
+                    "returned contract differs from what was PUT"
+                );
+                anyhow::ensure!(
+                    state == c.state,
+                    "returned state differs (got {} bytes, want {})",
+                    state.as_ref().len(),
+                    c.state.as_ref().len()
+                );
+                Ok(latency)
+            });
+        push_get_report(
+            &mut report,
+            "0h",
+            &c.label,
+            key.to_string(),
+            c.state.as_ref().len(),
+            outcome,
+            op_timeout,
+        );
+    }
+
+    // Previous runs: verify state via the recorded blake3 hash.
+    for (window, run) in &retention {
+        for rec in &run.contracts {
+            let label = format!("{}/{}", run.run_id, rec.label);
+            let outcome = client::get(&mut peer, rec.id, &label, op_timeout)
+                .await
+                .and_then(|(_contract, state, latency)| {
+                    let hash = blake3::hash(state.as_ref()).to_hex().to_string();
+                    anyhow::ensure!(
+                        hash == rec.state_hash,
+                        "state hash mismatch (got {hash}, want {})",
+                        rec.state_hash
+                    );
+                    Ok(latency)
+                });
+            push_get_report(
+                &mut report,
+                window,
+                &label,
+                rec.id.to_string(),
+                rec.size,
+                outcome,
+                op_timeout,
+            );
+        }
+    }
+
+    client::disconnect(&mut peer).await;
+    node.shutdown().await;
+
+    // Record only successfully-PUT contracts so retention runs never chase
+    // contracts that were never stored.
+    if !put_ok.is_empty() {
+        manifest.record_run(
+            RunRecord {
+                run_id,
+                timestamp: now,
+                contracts: put_ok
+                    .iter()
+                    .map(|c| ContractRecord {
+                        id: *c.contract.key().id(),
+                        label: c.label.clone(),
+                        size: c.state.as_ref().len(),
+                        state_hash: blake3::hash(c.state.as_ref()).to_hex().to_string(),
+                    })
+                    .collect(),
+            },
+            now,
+        );
+        manifest.save(&args.manifest)?;
+    }
+
+    report.print_summary();
+    Ok(report.all_ok())
+}
+
+fn push_get_report(
+    report: &mut Report,
+    age: &'static str,
+    label: &str,
+    key: String,
+    size: usize,
+    outcome: Result<Duration>,
+    op_timeout: Duration,
+) {
+    match outcome {
+        Ok(latency) => report.push(OpReport {
+            op: "get",
+            age,
+            label: label.to_string(),
+            key,
+            ok: true,
+            latency_ms: latency.as_millis(),
+            size,
+            error: None,
+        }),
+        Err(e) => report.push(OpReport {
+            op: "get",
+            age,
+            label: label.to_string(),
+            key,
+            ok: false,
+            latency_ms: op_timeout.as_millis(),
+            size,
+            error: Some(format!("{e:#}")),
+        }),
+    }
+}

--- a/scripts/netcheck-nightly.sh
+++ b/scripts/netcheck-nightly.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# Run netcheck against the live network and publish the result.
+#
+# The nightly workflow is a thin wrapper around this script. The logic lives
+# here because a workflow file cannot be exercised before it is merged
+# (GitHub only dispatches workflows present on the default branch), while this
+# can be run by hand over ssh on the host that will run it:
+#
+#     bash scripts/netcheck-nightly.sh
+#
+# Everything is overridable by environment so a manual run can point at a
+# scratch manifest without disturbing the nightly's own state.
+set -euo pipefail
+
+GATEWAY_WS="${NETCHECK_GATEWAY_WS:-ws://127.0.0.1:7509}"
+STATE_DIR="${NETCHECK_STATE_DIR:-$HOME/netcheck}"
+MANIFEST="${NETCHECK_MANIFEST:-$STATE_DIR/manifest.json}"
+RUN_DIR="${NETCHECK_RUN_DIR:-$STATE_DIR/run}"
+REPORT="${NETCHECK_REPORT:-$STATE_DIR/last-run.jsonl}"
+# UDP port opened on the gateway host for the ephemeral peer.
+EPHEMERAL_PORT="${NETCHECK_EPHEMERAL_PORT:-32177}"
+EPHEMERAL_WS_PORT="${NETCHECK_EPHEMERAL_WS_PORT:-7519}"
+FREENET_BIN="${NETCHECK_FREENET_BIN:-/usr/local/bin/freenet}"
+VANTAGE="${NETCHECK_VANTAGE:-$(hostname -s)}"
+OTLP_ENDPOINT="${NETCHECK_OTLP_ENDPOINT:-}"
+# The check shares a disk with a production node. Skipping a night is cheap;
+# filling that disk is not.
+MIN_FREE_GB="${NETCHECK_MIN_FREE_GB:-20}"
+
+log() { echo "[netcheck-nightly] $*" >&2; }
+
+mkdir -p "$STATE_DIR"
+free_gb=$(df -BG --output=avail "$STATE_DIR" 2>/dev/null | tail -1 | tr -dc '0-9')
+if [ -n "$free_gb" ] && [ "$free_gb" -lt "$MIN_FREE_GB" ]; then
+    log "only ${free_gb}G free, need ${MIN_FREE_GB}G. Skipping this run."
+    exit 0
+fi
+
+# A killed run leaves the ephemeral node's data behind, and its hosting cache
+# is budgeted at RAM/8 up to 1 GiB.
+rm -rf "$RUN_DIR"
+
+# The getter must join through a gateway that did not receive the PUTs, or the
+# GET can be answered by the node that just stored them. Resolved from the
+# public index so a rotated address or key does not silently stale this script.
+INDEX_KEY_URL="${NETCHECK_GETTER_KEY_URL:-https://freenet.org/keys/public.vega.gw.pem}"
+GETTER_HOST="${NETCHECK_GETTER_HOST:-vega.locut.us}"
+GETTER_PORT="${NETCHECK_GETTER_PORT:-31337}"
+getter_ip=$(getent hosts "$GETTER_HOST" | awk '{print $1}' | head -1)
+getter_key=$(curl -fsS --max-time 30 "$INDEX_KEY_URL" | tr -d '[:space:]')
+if [ -z "$getter_ip" ] || [ -z "$getter_key" ]; then
+    log "could not resolve the getter gateway ($GETTER_HOST / $INDEX_KEY_URL)"
+    exit 1
+fi
+log "getter joins through $GETTER_HOST ($getter_ip:$GETTER_PORT)"
+
+cargo build --release --locked -p netcheck
+NETCHECK_BIN="${CARGO_TARGET_DIR:-target}/release/netcheck"
+
+set +e
+"$NETCHECK_BIN" put-get \
+    --gateway-ws "$GATEWAY_WS" \
+    --gateway-spec "${getter_ip}:${GETTER_PORT},${getter_key}" \
+    --freenet-bin "$FREENET_BIN" \
+    --manifest "$MANIFEST" \
+    --ephemeral-dir "$RUN_DIR" \
+    --ephemeral-network-port "$EPHEMERAL_PORT" \
+    --ephemeral-ws-port "$EPHEMERAL_WS_PORT" \
+    | tee "$REPORT"
+status=${PIPESTATUS[0]}
+set -e
+
+# Publishing the result must not change the verdict: a collector that is down
+# is not a network regression.
+if [ -n "$OTLP_ENDPOINT" ]; then
+    if ! "$NETCHECK_BIN" emit \
+            --endpoint "$OTLP_ENDPOINT" \
+            --vantage "$VANTAGE" \
+            --exit-code "$status" < "$REPORT"; then
+        log "WARNING: could not publish results to $OTLP_ENDPOINT"
+    fi
+fi
+
+rm -rf "$RUN_DIR"
+log "netcheck exited with $status"
+exit "$status"


### PR DESCRIPTION
## Problem

Findability and retention regressions (content that cannot be routed to, or that stops being retrievable after a few days) surface only through production telemetry, weeks after the change that caused them. PR CI and the nightly simulations cannot see them: a simulated network has none of the storage pressure, topology or churn that make those properties interesting.

PR #4848 attempted this as a synthetic CI test. The conclusion there was that a test which never touches the real network cannot answer the question. This PR is the agreed replacement, and supersedes it.

## Solution

`crates/netcheck` is a plain network client: it speaks only the freenet-stdlib WebSocket API and never links `freenet-core`, so it measures what a real user experiences and survives core refactors.

A `put-get` run PUTs 3 small contracts plus one ~1 MB contract through one gateway, boots an ephemeral peer with an empty data dir that joins through a *different* gateway, and GETs them back verifying byte-identity. It then re-GETs contracts from previous runs (24 h / 48 h / 7 d windows, tracked in a persistent manifest) against their blake3 hashes. One JSON line per operation on stdout, non-zero exit on any failure, and no retries by design: an operation that only succeeds on retry is the regression this exists to surface.

**What each check actually proves.** `--gateway-spec` pins the join, not the steady-state connection set: ring maintenance opens further connections on its own, and the gateway that stored the PUTs can be among them. The same-day GET is therefore a liveness and transfer check, while the findability signal lives in the multi-day re-GETs, whose contracts were published by a run that is long gone against a topology that has since changed. The run report records which peers the ephemeral node actually connected to, so a degraded run is visible in the data instead of silently passing.

**Safe beside a production node**, which is the intended deployment: the ephemeral node gets its own dirs and ports, child processes are killed by handle and never by name (no `pkill` anywhere in the crate), and `--disable-auto-update` stops a release published mid-run from making it exit 42.

A second subcommand, `netcheck emit`, reads a run's report on stdin and publishes it to an OTLP collector. It belongs in this crate rather than in a script because the translation between the report and the published schema is coupling that nothing external can verify: `emit` reads the report back with `OpReport` and `RunMeta`, the very structs that wrote it, so renaming a field becomes a compile error instead of a silently missing column downstream. A test writes a report through `Report::push` and parses it back field by field to keep that guarantee honest.

The division of labour is deliberate. The check measures and does not judge; `emit` decides which failures are severe, because that is deployment policy rather than a property of the network; the collector transports. What counts as severe is per scenario (`put_get`'s retention windows are soft, since the hosting cache is a byte-budget LRU and evicting an unwanted contract is correct behaviour rather than an outage), and a scenario nobody has classified has no soft dimensions, so any failure of a new check is hard by default.

### Running it

A check nothing runs measures nothing, so the nightly ships here too. It cannot run on a cloud runner: it needs the gateway's loopback WebSocket API and the UDP port opened on that host for its ephemeral peer.

`.github/workflows/netcheck-nightly.yml` runs on the self-hosted runner at 04:00 UTC, an hour after the simulation nightly so the morning's results arrive in a predictable order. Failures notify River through the same `riverctl` and `RIVER_SIGNING_KEY` transport the simulation nightly already uses, rather than a second standalone credential.

The job body is three steps. Everything else is in `scripts/netcheck-nightly.sh`, and that split is the point: **a workflow file cannot be exercised before it reaches the default branch**, since GitHub only dispatches workflows present there. Putting the logic in a script means it can be run by hand over ssh on the same host, with the same paths and the same flags, before and after this merges.

The script also carries the two things that matter when a check shares a machine with a production node:

- It refuses to run when the disk is below a threshold. Skipping a night costs nothing; filling the gateway's disk does.
- It removes the ephemeral node's working directory before and after each run. A killed run would otherwise leave it behind, and that node's hosting cache is budgeted at RAM/8 up to 1 GiB.

The getter gateway is resolved at runtime from the public index rather than hardcoded, so a rotated address or key does not silently leave the check reading through the same gateway it wrote to. Publishing failures are logged but never change the verdict, because a collector that is down is not a network regression. Every path and port is overridable by environment variable, so a second vantage point needs no edit to the script.

## Testing

Validated end to end on two linked local gateways reproducing the production nova/vega shape, PUT through one and the ephemeral getter joined through the other: 8/8 operations, then 12/12 on a second run with the manifest aged 24 h to exercise the retention path. `cargo fmt`, `clippy -D warnings` and `cargo test` clean.

15 unit tests. Seven cover retention-window selection: inclusive bounds, newest run wins inside a window, an empty window does not borrow from its neighbour, and the prune horizon outlives the widest window (a shorter horizon would make the 7 d check silently pass forever with nothing to ask for). Eight cover `emit`: the report round trip in both directions, the four verdicts, that an unclassified scenario inherits no leniency, and dimension parsing.

The publishing path was exercised end to end against a local OTLP collector configured identically to the production one, using the output of a real netcheck run: the records arrive with every field intact and land in the dashboard's tables (companion PR in freenet-telemetry-dashboard).

Chaining two runs also exposed a real harness bug, fixed here: a late `PutResponse` from an already-timed-out operation was consumed by the next PUT's wait loop and failed it on a key mismatch, turning one slow PUT into a cascade of false failures.

The workflow file itself is unverifiable until it is on `main`, which is why the logic is in a script. The intended first step after merging is a manual run over ssh before waiting for a cron.

## Notes for the reviewer

Two things that contradict the CLI documentation but are verified by working runs:

- `--is-gateway` does accept `--gateway` entries, although the `--skip-load-from-network` help says a gateway "always runs isolated" and mentions only `--gateways` JSON.
- `--disable-auto-update` is documented for from-source deployments running ahead of a release. Used here for a node that lives for minutes, where exiting to update is pointless and would fail the check spuriously.

Today any failed run notifies River. Distinguishing a genuine regression from a retention window that degraded (expected under storage pressure, since the hosting cache is a byte-budget LRU) from an infrastructure error is threshold work that belongs with the dashboard that can show the trend, not with a boolean job status. `netcheck emit` already computes the four-way verdict; only the alerting reads it as a single bit.

The dashboard panel that renders these results is a follow-up, with its own PR in freenet-telemetry-dashboard.

## Fixes

Part of #4665. Replaces #4848.