### PR TITLE
fix(interest): upsert delivered summaries so untracked co-hosts escape full-state broadcasts

### DIFF
--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -2810,11 +2810,23 @@ async fn handle_interest_sync_message(
                             _ => false,
                         };
 
-                        op_manager.interest_manager.update_peer_summary(
-                            &contract,
-                            &pk,
-                            their_summary,
-                        );
+                        // #4952: upsert (not update) when the peer reported a
+                        // real summary, so the ~5-min anti-entropy exchange can
+                        // seed a summary for an advertised co-host we don't
+                        // interest-track — otherwise those peers stay full-state
+                        // broadcast targets forever. A `None` report keeps the
+                        // old clear-only semantics (no entry is created just to
+                        // hold `None`).
+                        match their_summary {
+                            Some(theirs) => {
+                                op_manager
+                                    .interest_manager
+                                    .upsert_peer_summary(&contract, &pk, theirs);
+                            }
+                            None => op_manager
+                                .interest_manager
+                                .update_peer_summary(&contract, &pk, None),
+                        }
 
                         if is_stale && !stale_contracts.contains(&contract) {
                             stale_contracts.push(contract);
@@ -3946,6 +3958,37 @@ mod tests {
     /// `ResyncRequest` arm, which is already state-gated (returns early when
     /// `get_contract_state` is `None`) and is not heartbeat-driven, so it is
     /// excluded by slicing up to that arm.
+    /// #4952 pin: the `Summaries` handler must UPSERT a reported summary so
+    /// the ~5-min anti-entropy exchange can seed one for an advertised
+    /// co-host we don't interest-track (`update_peer_summary` no-ops for
+    /// untracked peers — the full-state fixed point). A `None` report keeps
+    /// the clear-only `update_` semantics: no entry is created just to hold
+    /// `None`. Matches whitespace-stripped source (rustfmt-proof).
+    #[test]
+    fn summaries_arm_upserts_reported_summary_pin() {
+        let src = include_str!("node.rs");
+        let handler_start = src
+            .find("async fn handle_interest_sync_message")
+            .expect("handle_interest_sync_message not found");
+        let handler_end = handler_start
+            + src[handler_start..]
+                .find("\nmod tests {")
+                .or_else(|| src[handler_start..].find("\n#[cfg(test)]"))
+                .expect("end of handler region not found");
+        let body: String = src[handler_start..handler_end].split_whitespace().collect();
+        assert!(
+            body.contains("upsert_peer_summary(&contract,&pk,theirs)"),
+            "Summaries arm must upsert a Some(summary) report (seeds untracked \
+             co-hosts, #4952)"
+        );
+        assert!(
+            body.contains("update_peer_summary(&contract,&pk,None"),
+            "Summaries arm must keep clear-only update semantics for a None \
+             report — creating an entry just to hold None would relabel \
+             untracked traffic as tracked without enabling deltas"
+        );
+    }
+
     #[test]
     fn interest_sync_periodic_arms_summarize_only_hosted_or_in_use_pin() {
         let src = include_str!("node.rs");

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -3418,9 +3418,12 @@ async fn handle_interest_sync_message(
             let peer_key = get_peer_key_from_addr(op_manager, source);
             if let Some(pk) = peer_key {
                 let summary = freenet_stdlib::prelude::StateSummary::from(summary_bytes);
+                // #4952: upsert — a ResyncResponse sender self-reported the
+                // summary of the full state it just shipped us; seed it even
+                // when we don't interest-track that co-host.
                 op_manager
                     .interest_manager
-                    .update_peer_summary(&key, &pk, Some(summary));
+                    .upsert_peer_summary(&key, &pk, summary);
             }
 
             // No response needed
@@ -3980,6 +3983,11 @@ mod tests {
             body.contains("upsert_peer_summary(&contract,&pk,theirs)"),
             "Summaries arm must upsert a Some(summary) report (seeds untracked \
              co-hosts, #4952)"
+        );
+        assert!(
+            !body.contains("update_peer_summary(&contract,&pk,Some"),
+            "a Some(summary) report must go through the upsert, not the \
+             untracked-no-op update path (#4952)"
         );
         assert!(
             body.contains("update_peer_summary(&contract,&pk,None"),

--- a/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
+++ b/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
@@ -24,16 +24,20 @@
 //! 4. [`PayloadArm::FullNoOurSummary`] — *our* summary is missing, so there
 //!    was nothing to diff from.
 //! 5. [`PayloadArm::FullNoTheirSummaryUntracked`] — the peer's summary is
-//!    missing AND the peer is not tracked in `interested_peers` at all, so the
-//!    cache write that would fix it is a silent no-op. Permanent.
+//!    missing AND the peer is not tracked in `interested_peers` at all. Before
+//!    #4952 the cache write that would fix it was a silent no-op (permanent
+//!    full state); since #4952 the delivery path upserts, so this arm is
+//!    transient (first send per pair) and should decay toward zero — a
+//!    persistent residual implicates the seeding/heartbeat chain instead.
 //! 6. [`PayloadArm::FullNoTheirSummaryTracked`] — the peer's summary is
 //!    missing but the peer IS tracked, so the next delivery repairs it.
 //!
 //! Arms 4-6 were a single `full_no_summary` bucket when #4922 first shipped.
 //! The 2026-07-25 measurement then found that bucket was the LARGEST single
 //! consumer of wire bytes on the network, with no way to tell a contract-handler
-//! failure (4, a load problem) from a peer-tracking gap (5, a structural bug)
-//! from ordinary cold start (6, self-healing). Those three have nothing in
+//! failure (4, a load problem) from a peer-tracking gap (5, structural until
+//! the #4952 upsert made it self-healing) from ordinary cold start (6,
+//! self-healing). Those three have nothing in
 //! common except the symptom, so the split is what makes the number actionable.
 //! The pre-split `full_no_summary_sends` / `_bytes` fields are still published
 //! as the sum of the three.

--- a/crates/core/src/node/network_bridge/broadcast_queue.rs
+++ b/crates/core/src/node/network_bridge/broadcast_queue.rs
@@ -706,7 +706,7 @@ fn record_delivery_to_interest<T: crate::util::time_source::TimeSource + Sync>(
     // #4952: this MUST be the upsert, not `update_peer_summary` — the latter
     // silently no-ops for a peer with no interest entry, which turned every
     // advertised co-host (fan-out targets come from NeighborHosting, a
-    // population that never registers protocol interest) into a full-state
+    // population frequently untracked at broadcast time) into a full-state
     // fixed point: full state on every update, forever. The upsert creates the
     // entry (capped, no demand-counter writes) so the next send is a delta.
     if let Some(summary) = our_summary {
@@ -953,17 +953,22 @@ pub(super) async fn broadcast_to_single_peer(
         //     summary as ours with no way to tell it from a real one.
         //
         //   * theirs missing -> a peer-summary CACHE gap, and the two
-        //     sub-cases are not alike. `update_peer_summary` writes through
-        //     `interested_peers`, so it is a silent no-op for a peer with no
-        //     `PeerInterest` entry for this contract. Broadcast targets come
+        //     sub-cases differ in HOW they self-heal. Broadcast targets come
         //     from `neighbor_hosting` (advertised co-hosts) since #4642 step 9
-        //     dropped the interest-manager fan-out arm, so a target that the
-        //     ~5-min InterestSync heartbeat has not registered can NEVER cache
-        //     a summary from a delivery — every broadcast to it is full state,
-        //     permanently. That is the #4442 chicken-and-egg re-opened for a
-        //     different peer population, and it is a different bug from an
-        //     ordinary cold-start peer that IS tracked and repairs itself on
-        //     the next delivery. Splitting them is the whole point.
+        //     dropped the interest-manager fan-out arm, so a target is often
+        //     untracked in `interested_peers` at broadcast time (the
+        //     heartbeat-registration chain exists — register_local_hosting →
+        //     Interests → register — but frequently hasn't fired or was
+        //     full-replace-wiped for this pair). Pre-#4952 that population
+        //     was a fixed point: the post-delivery cache write was a silent
+        //     `update_peer_summary` no-op, so every broadcast stayed full
+        //     state, permanently. Since #4952 the delivery path UPSERTS, so
+        //     untracked is transient (one full state seeds the summary) and
+        //     this arm should decay toward first-send-only levels — a
+        //     persistent residual now implicates the seeding/heartbeat chain
+        //     (e.g. an Interests full-replace wiping the pair each ~5 min),
+        //     not the old structural trap. Tracked-but-summaryless (arm 6)
+        //     repairs on the next delivery, same as before.
         //
         // `get_peer_interest` is an in-memory DashMap read — no contract
         // handler round-trip — so this classification costs nothing on a path
@@ -1546,6 +1551,93 @@ mod tests {
             "#4145: with a cached peer summary the next broadcast takes the delta \
              path (compute_delta), not another full state"
         );
+    }
+
+    /// #4952 — the untracked-co-host counterpart of the #4145 test above,
+    /// driven through the REAL production gate. The peer is a fan-out target
+    /// from `neighbor_hosting` with NO interest entry at all (not merely no
+    /// summary). Pre-#4952 the post-delivery cache write was a silent
+    /// `update_peer_summary` no-op, so this test FAILS on that code; it also
+    /// fails on the semantic dodge the source pin can't catch (e.g. re-gating
+    /// the upsert on prior tracking), because it asserts through the gate, not
+    /// the source text.
+    #[tokio::test]
+    async fn untracked_peer_delivery_seeds_interest_and_summary() {
+        let our_summary = StateSummary::from(vec![5, 6, 7, 8]);
+
+        let time_source = SharedMockTimeSource::new();
+        let manager = InterestManager::new(time_source.clone());
+        let contract = make_contract_key(11);
+        let peer = make_peer_key();
+
+        // NO register_peer_interest: an advertised co-host untracked at
+        // broadcast time — the #4952 population.
+        assert!(
+            manager.get_peer_interest(&contract, &peer).is_none(),
+            "precondition: the peer must be untracked"
+        );
+
+        let delivered = record_streaming_delivery(
+            &manager,
+            Ok(Ok(BroadcastDeliveryOutcome::Delivered)),
+            /* sent_delta */ false,
+            &contract,
+            &peer,
+            Some(&our_summary),
+            /* state_size */ 4096,
+            /* payload_size */ 4096,
+        );
+        assert!(delivered);
+
+        assert_eq!(
+            manager.get_peer_summary(&contract, &peer),
+            Some(our_summary),
+            "#4952: a delivered full-state broadcast to an UNTRACKED peer must \
+             seed the interest entry + summary, so the next broadcast is a \
+             delta — otherwise the pair is a full-state fixed point"
+        );
+    }
+
+    /// #4952 divergence guard for the untracked population: a NON-delivered
+    /// full-state send must not fabricate an interest entry carrying a summary
+    /// the peer never received (which would suppress the summary-mismatch
+    /// resend — the #4235 failure mode, now newly reachable because the
+    /// delivery path can create entries).
+    #[tokio::test]
+    async fn untracked_peer_drop_outcome_does_not_fabricate_interest() {
+        let our_summary = StateSummary::from(vec![3, 3, 3]);
+        let dropped = dropped_oneshot().await;
+        let timed_out = elapsed_timeout().await;
+        let cases: Vec<(&str, super::StreamCompletionResult)> = vec![
+            ("explicit-drop", Ok(Ok(BroadcastDeliveryOutcome::Dropped))),
+            ("dropped-oneshot", Ok(dropped)),
+            ("timeout", Err(timed_out)),
+        ];
+
+        for (name, completion) in cases {
+            let time_source = SharedMockTimeSource::new();
+            let manager = InterestManager::new(time_source.clone());
+            let contract = make_contract_key(12);
+            let peer = make_peer_key();
+
+            let delivered = record_streaming_delivery(
+                &manager,
+                completion,
+                /* sent_delta */ false,
+                &contract,
+                &peer,
+                Some(&our_summary),
+                /* state_size */ 2048,
+                /* payload_size */ 2048,
+            );
+            assert!(!delivered, "[{name}] must not classify as delivered");
+            assert!(
+                manager.get_peer_interest(&contract, &peer).is_none(),
+                "[{name}] a non-delivered send must NOT fabricate an interest \
+                 entry for an untracked peer — a summary the peer never \
+                 received would suppress the mismatch resend (#4235)"
+            );
+        }
     }
 
     /// Issue #4145 / #2763 — divergence guard preserved. The #4145 fix caches on
@@ -2317,7 +2409,8 @@ mod tests {
             collapsed.contains("get_peer_interest(&key,&peer_key)"),
             "the missing-their-summary arm must consult get_peer_interest to \
              separate an UNTRACKED peer (whose update_peer_summary write is a \
-             silent no-op, so it is stuck on full state permanently) from a \
+             silent no-op — permanent full state until the #4952 upsert; now \
+             transient, first send per pair) from a \
              TRACKED cold-start peer (which repairs itself on next delivery)"
         );
     }

--- a/crates/core/src/node/network_bridge/broadcast_queue.rs
+++ b/crates/core/src/node/network_bridge/broadcast_queue.rs
@@ -703,8 +703,14 @@ fn record_delivery_to_interest<T: crate::util::time_source::TimeSource + Sync>(
     // by those backstops rather than by an end-to-end ack here. Caching lets the
     // NEXT broadcast to this peer be a small delta instead of full state.
     // (Telemetry above still records delta-vs-full-state separately.)
+    // #4952: this MUST be the upsert, not `update_peer_summary` — the latter
+    // silently no-ops for a peer with no interest entry, which turned every
+    // advertised co-host (fan-out targets come from NeighborHosting, a
+    // population that never registers protocol interest) into a full-state
+    // fixed point: full state on every update, forever. The upsert creates the
+    // entry (capped, no demand-counter writes) so the next send is a delta.
     if let Some(summary) = our_summary {
-        interest_manager.update_peer_summary(key, peer_key, Some(summary.clone()));
+        interest_manager.upsert_peer_summary(key, peer_key, summary.clone());
     }
 }
 
@@ -1675,6 +1681,35 @@ mod tests {
     /// window); if the attribution recording is dropped, the memo's
     /// sender-side arm signal (`note_resync_request`) can never fire.
     /// See `crate::ring::delta_incompat`.
+    /// #4952 pin: the post-delivery summary cache must route through
+    /// `upsert_peer_summary`, never `update_peer_summary`. The latter is a
+    /// silent no-op for a peer with no interest entry, and fan-out targets
+    /// come from `neighbor_hosting` (advertised co-hosts) — a population that
+    /// never registers interest — so an `update_` call here re-opens the
+    /// full-state-forever fixed point that was 58% of fleet broadcast bytes.
+    /// Matches whitespace-stripped source so a rustfmt reflow can't dodge it.
+    #[test]
+    fn record_delivery_routes_summary_cache_through_upsert() {
+        let src = include_str!("broadcast_queue.rs");
+        let fn_start = src
+            .find("fn record_delivery_to_interest<")
+            .expect("record_delivery_to_interest not found");
+        let after = &src[fn_start..];
+        let fn_end = after
+            .find("\npub(super) async fn broadcast_to_single_peer(")
+            .expect("end of record_delivery_to_interest not found");
+        let body: String = after[..fn_end].split_whitespace().collect();
+        assert!(
+            body.contains("interest_manager.upsert_peer_summary(key,peer_key,summary.clone())"),
+            "post-delivery cache must upsert (create-if-absent) the peer summary"
+        );
+        assert!(
+            !body.contains("interest_manager.update_peer_summary("),
+            "update_peer_summary silently no-ops for untracked peers — the \
+             #4952 fixed point. Use upsert_peer_summary here."
+        );
+    }
+
     #[test]
     fn broadcast_to_single_peer_gates_deltas_on_incompat_memo() {
         let src = include_str!("broadcast_queue.rs");

--- a/crates/core/src/node/network_bridge/p2p_protoc/broadcast.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc/broadcast.rs
@@ -954,11 +954,14 @@ impl P2pConnManager {
                 // sender-side completion, not a receiver ack, so a lost stream
                 // tail is covered by the same two backstops.
                 // (Telemetry above still records delta-vs-full-state separately.)
+                // #4952: upsert so the sim path mirrors production
+                // (`record_delivery_to_interest`) — an untracked co-host must
+                // escape full state after one delivered broadcast in sims too.
                 if let Some(summary) = &our_summary {
-                    op_manager.interest_manager.update_peer_summary(
+                    op_manager.interest_manager.upsert_peer_summary(
                         &key,
                         &peer_key,
-                        Some(summary.clone()),
+                        summary.clone(),
                     );
                 }
             }

--- a/crates/core/src/operations/subscribe.rs
+++ b/crates/core/src/operations/subscribe.rs
@@ -653,18 +653,39 @@ pub(crate) async fn register_downstream_subscriber(
         });
 
     if let Some(peer_key) = peer_key {
-        if op_manager
+        let outcome = op_manager
             .ring
-            .add_downstream_subscriber(key, peer_key.clone())
-        {
-            let is_new_peer = op_manager
+            .add_downstream_subscriber(key, peer_key.clone());
+        if !matches!(outcome, crate::ring::AddSubscriberOutcome::Rejected) {
+            // Register protocol interest WITHOUT clobbering an existing
+            // entry's cached summary: `register_peer_interest` inserts a
+            // fresh `PeerInterest` with `summary = None`, so calling it for
+            // an already-tracked peer (every ~8-min lease renewal, or a
+            // #4952 delivery-seeded co-host formally subscribing) wiped the
+            // summary and forced the next broadcast back to full state.
+            if op_manager
                 .interest_manager
-                .register_peer_interest(key, peer_key, None, false);
-            // Only increment downstream count for genuinely new peers, not
-            // renewals. add_downstream_subscriber (hosting) returns true for
-            // both new and renewed peers, so use register_peer_interest's
-            // is_new return to avoid over-counting on renewal cycles.
-            if is_new_peer {
+                .get_peer_interest(key, &peer_key)
+                .is_some()
+            {
+                op_manager
+                    .interest_manager
+                    .refresh_peer_interest(key, &peer_key);
+            } else {
+                op_manager
+                    .interest_manager
+                    .register_peer_interest(key, peer_key, None, false);
+            }
+            // Key the demand-counter increment on HOSTING-map newness
+            // (NewAdd vs Renewal), NOT on interest-map newness: a #4952
+            // summary-upserted entry makes interest-map newness unreliable
+            // (a delivery-seeded co-host that later genuinely subscribes is
+            // not "new" there but IS new demand), and an interest entry that
+            // TTL-expired mid-lease would double-count on re-registration.
+            // The decrement side is keyed to hosting-map removal/expiry
+            // (`handle_unsubscribe_inbound`, lease sweep), so this pairing
+            // is exactly balanced.
+            if matches!(outcome, crate::ring::AddSubscriberOutcome::NewAdd) {
                 // #4359: a fresh-contract PUT whose initial broadcast found no
                 // targets is stashed by the fan-out handler. This new
                 // downstream subscriber is the first viable target — flush the
@@ -877,10 +898,17 @@ pub(crate) async fn handle_unsubscribe_inbound(
 
     if let Some(peer) = &sender_peer {
         let was_downstream = op_manager.ring.remove_downstream_subscriber(&key, peer);
-        let was_interested = op_manager.interest_manager.remove_peer_interest(&key, peer);
-        // Only decrement downstream count if the peer was actually tracked,
-        // to stay in sync with the increment in register_downstream_subscriber.
-        if was_downstream || was_interested {
+        // Interest-entry removal is unconditional cleanup, but it must NOT
+        // gate the demand decrement: the counter increments only on a
+        // hosting-map NewAdd (`register_downstream_subscriber`), so decrement
+        // only on hosting-map removal. Interest entries exist for peers that
+        // never incremented demand — heartbeat `Interests` registrations and
+        // #4952 delivery-seeded co-hosts — and a late/duplicate Unsubscribe
+        // from one of those (or from a peer the lease sweep already
+        // decremented) would otherwise steal a decrement from a real
+        // subscriber's count and under-report demand to eviction ranking.
+        let _was_interested = op_manager.interest_manager.remove_peer_interest(&key, peer);
+        if was_downstream {
             let lost_interest = op_manager
                 .interest_manager
                 .remove_downstream_subscriber(&key);

--- a/crates/core/src/operations/subscribe/tests.rs
+++ b/crates/core/src/operations/subscribe/tests.rs
@@ -112,15 +112,25 @@ fn handle_unsubscribe_inbound_preserves_legacy_branches() {
          intermediate peers stay subscribed forever"
     );
 
-    // Counter-symmetry pin: the legacy code only decremented the
-    // global downstream counter when the per-contract removal actually
-    // succeeded (was_downstream || was_interested). Re-introducing an
-    // unconditional decrement would underflow the gauge.
+    // Counter-symmetry pin (#4952 semantics): the increment fires only on a
+    // hosting-map NewAdd in `register_downstream_subscriber`, so the decrement
+    // must key on hosting-map removal ALONE. The legacy `|| was_interested`
+    // leg let interest-only entries (heartbeat registrations, #4952
+    // delivery-seeded co-hosts — which never incremented demand) steal a
+    // decrement from a real subscriber's count via a late/duplicate
+    // Unsubscribe, under-reporting demand to eviction ranking. An
+    // unconditional decrement would be worse still (gauge underflow).
     assert!(
-        body.contains("was_downstream || was_interested"),
+        body.contains("if was_downstream {"),
         "handle_unsubscribe_inbound must gate the global downstream-counter \
-         decrement on `was_downstream || was_interested` to stay in sync \
-         with `register_downstream_subscriber`'s increment"
+         decrement on hosting-map removal (`was_downstream`) ALONE to stay \
+         balanced with the NewAdd-keyed increment (#4952)"
+    );
+    assert!(
+        !body.contains("was_downstream || was_interested"),
+        "the legacy `|| was_interested` decrement leg must not return: \
+         interest entries exist for peers that never incremented demand \
+         (heartbeat registrations, #4952 delivery-seeded co-hosts)"
     );
 }
 

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -1490,9 +1490,13 @@ async fn drive_relay_broadcast_to(
         .get_peer_by_addr(sender_addr)
     {
         let sender_key = crate::ring::PeerKey::from(sender_pkl.pub_key().clone());
+        // #4952: upsert — the sender self-reported this summary, and the
+        // fan-out sender population is by definition co-hosts we often don't
+        // interest-track. Seeding here lets OUR next broadcast to them be a
+        // delta without waiting for a delivered send.
         op_manager
             .interest_manager
-            .update_peer_summary(&key, &sender_key, Some(sender_summary));
+            .upsert_peer_summary(&key, &sender_key, sender_summary);
     }
 
     let (update_data, payload_bytes) = match &payload {
@@ -2428,11 +2432,11 @@ async fn apply_streaming_broadcast(
         .get_peer_by_addr(sender_addr)
     {
         let sender_key = crate::ring::PeerKey::from(sender_pkl.pub_key().clone());
-        op_manager.interest_manager.update_peer_summary(
-            &key,
-            &sender_key,
-            Some(sender_summary.clone()),
-        );
+        // #4952: upsert — same self-reported provenance as the non-streaming
+        // BroadcastTo arm above.
+        op_manager
+            .interest_manager
+            .upsert_peer_summary(&key, &sender_key, sender_summary.clone());
     }
 
     // Step 5: dedup cache BEFORE merge (mirrors non-streaming slice A

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -25,7 +25,7 @@ use parking_lot::{Mutex, RwLock};
 use tokio_util::sync::CancellationToken;
 
 pub use hosting::{
-    AddClientSubscriptionResult, ClientDisconnectResult, SubscribeResult,
+    AddClientSubscriptionResult, AddSubscriberOutcome, ClientDisconnectResult, SubscribeResult,
     SubscribedContractSnapshot,
 };
 
@@ -3625,10 +3625,11 @@ impl Ring {
 
     // ==================== Downstream Subscriber Tracking ====================
 
-    pub fn add_downstream_subscriber(&self, contract: &ContractKey, peer: PeerKey) -> bool {
-        let outcome = self
-            .hosting_manager
-            .add_downstream_subscriber(contract, peer);
+    pub fn add_downstream_subscriber(
+        &self,
+        contract: &ContractKey,
+        peer: PeerKey,
+    ) -> crate::ring::hosting::AddSubscriberOutcome {
         // No governance demand is ingested here anymore. Benefit is a
         // LIVE SNAPSHOT read fresh each reaper tick from the hosting
         // manager's standing subscriber count (see
@@ -3645,12 +3646,15 @@ impl Ring {
         // are attacker-rotatable: without an identity layer a single
         // attacker can spin up many peers that each "subscribe", so each
         // forwarded subscriber is worth one tenth of a real local client.
-        // Caller-facing bool preserved for backward compat: Rejected
-        // → false; NewAdd or Renewal → true (the peer is tracked).
-        !matches!(
-            outcome,
-            crate::ring::hosting::AddSubscriberOutcome::Rejected
-        )
+        // The NewAdd/Renewal distinction is load-bearing for the caller
+        // (#4952 follow-through): the demand-counter increment in
+        // `register_downstream_subscriber` must key on HOSTING-map newness,
+        // not on `interested_peers` newness — summary-upserted entries make
+        // the latter unreliable (a delivery-seeded co-host that later
+        // genuinely subscribes is not "new" in the interest map but IS new
+        // demand).
+        self.hosting_manager
+            .add_downstream_subscriber(contract, peer)
     }
 
     #[allow(dead_code)] // Only used in tests
@@ -8517,11 +8521,14 @@ mod cost_pressure_seam_tests {
         // Demand: `subscribed` gains a downstream subscriber (lease outlives
         // this test's remaining ~3 virtual minutes); `read_hot` is genuinely
         // GET-read now (within the cost window of the final sweep).
-        assert!(ring.add_downstream_subscriber(
-            &subscribed,
-            crate::ring::interest::PeerKey(crate::transport::TransportPublicKey::from_bytes(
-                [9u8; 32]
-            )),
+        assert!(!matches!(
+            ring.add_downstream_subscriber(
+                &subscribed,
+                crate::ring::interest::PeerKey(crate::transport::TransportPublicKey::from_bytes(
+                    [9u8; 32]
+                )),
+            ),
+            crate::ring::hosting::AddSubscriberOutcome::Rejected
         ));
         let _ = ring.record_get_access(read_hot, 121);
 

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -663,7 +663,7 @@ impl<T: TimeSource + Sync> InterestManager<T> {
     /// the post-delivery cache in `broadcast_queue::record_delivery_to_interest`
     /// (we just delivered exactly that state to them) and the InterestSync
     /// `Summaries` handler (the peer itself reported the summary). Without it,
-    /// an advertised co-host that never registers protocol interest is a
+    /// an advertised co-host that is untracked at broadcast time is a
     /// full-state fixed point: every broadcast to it ships full state, the
     /// post-delivery summary write silently no-ops, and the next broadcast
     /// ships full state again (#4952 — 58% of fleet broadcast bytes).
@@ -695,7 +695,17 @@ impl<T: TimeSource + Sync> InterestManager<T> {
         if entry.len() >= MAX_INTERESTED_PEERS_PER_CONTRACT {
             // At cap the entry is non-empty, so no cleanup is needed; the
             // caller simply keeps sending full state to this peer (pre-upsert
-            // behavior), bounded per contract.
+            // behavior), bounded per contract. debug! (compiled out of
+            // release) rather than register_peer_interest's warn!: this runs
+            // per delivered broadcast, and the condition is near-unreachable
+            // in practice (entries require connected peers, and
+            // max_connections < the 512 cap), but a stuck-at-cap contract
+            // should be diagnosable in a dev build.
+            tracing::debug!(
+                contract = %contract,
+                limit = MAX_INTERESTED_PEERS_PER_CONTRACT,
+                "upsert_peer_summary: at interested-peer cap, peer stays untracked (full-state sends continue)"
+            );
             return false;
         }
         entry.insert(peer.clone(), PeerInterest::new(Some(summary), false, now));
@@ -2580,7 +2590,11 @@ mod tests {
     /// `get_peer_summary` returns None (the fan-out sends FULL STATE) and the
     /// post-delivery `update_peer_summary` that is supposed to fix that
     /// (#4442's fix for exactly this chicken-and-egg) silently does nothing —
-    /// so the pair never escapes to deltas. This is a fixed point, not a cold
+    /// so the pair never escapes to deltas via THIS method. This was a fixed
+    /// point until #4952 routed the delivery path (and the Summaries handler)
+    /// through `upsert_peer_summary`, which creates the entry; the no-op
+    /// semantics pinned here remain correct and load-bearing for writes of
+    /// unknown provenance. Historically it was a fixed point, not a cold
     /// start.
     ///
     /// The pre-existing broadcast-path tests all `register_peer_interest`
@@ -2720,6 +2734,23 @@ mod tests {
                 .contains(&contract),
             "a rejected upsert must leave no reverse-index zombie"
         );
+
+        // An EXISTING peer at cap must still take the update path — the
+        // get_mut-before-cap-check branch order is load-bearing: popular
+        // 512-peer contracts are exactly the #4952 population, and a
+        // register_peer_interest-shaped refactor (cap check first) would
+        // silently freeze summary refreshes for all of them.
+        let existing = make_unique_peer_key(0);
+        assert!(
+            manager.upsert_peer_summary(&contract, &existing, StateSummary::from(vec![42u8])),
+            "an already-tracked peer at cap must still update"
+        );
+        assert_eq!(
+            manager
+                .get_peer_summary(&contract, &existing)
+                .map(|s| s.as_ref().to_vec()),
+            Some(vec![42u8]),
+        );
     }
 
     /// #4952: upserting an already-tracked peer takes the update path —
@@ -2744,6 +2775,23 @@ mod tests {
             interest.summary.map(|s| s.as_ref().to_vec()),
             Some(vec![5u8])
         );
+    }
+
+    /// #4952: an upsert-created entry is ordinary interest state — the TTL
+    /// sweep removes it (entry + reverse index) with no GC exemption, per the
+    /// cleanup-exemptions-must-be-time-bounded rule.
+    #[test]
+    fn upsert_created_entry_expires_via_ttl_sweep() {
+        let (manager, time) = make_manager();
+        let contract = make_contract_key(1);
+        let peer = make_peer_key(1);
+
+        assert!(manager.upsert_peer_summary(&contract, &peer, StateSummary::from(vec![1u8])));
+        time.advance_time(INTEREST_TTL + Duration::from_secs(60));
+        manager.sweep_expired_interests();
+
+        assert!(manager.get_peer_interest(&contract, &peer).is_none());
+        assert!(!manager.get_contracts_for_peer(&peer).contains(&contract));
     }
 
     #[test]

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -654,6 +654,60 @@ impl<T: TimeSource + Sync> InterestManager<T> {
         }
     }
 
+    /// Cache a peer's known summary, creating the interest entry when absent.
+    ///
+    /// [`Self::update_peer_summary`] deliberately no-ops for an untracked peer
+    /// (pinned by `update_peer_summary_is_a_silent_noop_for_an_untracked_peer`)
+    /// so summary writes of unknown provenance cannot grow the map. This upsert
+    /// exists for the callers that KNOW the peer holds the summarized state:
+    /// the post-delivery cache in `broadcast_queue::record_delivery_to_interest`
+    /// (we just delivered exactly that state to them) and the InterestSync
+    /// `Summaries` handler (the peer itself reported the summary). Without it,
+    /// an advertised co-host that never registers protocol interest is a
+    /// full-state fixed point: every broadcast to it ships full state, the
+    /// post-delivery summary write silently no-ops, and the next broadcast
+    /// ships full state again (#4952 — 58% of fleet broadcast bytes).
+    ///
+    /// The insert respects [`MAX_INTERESTED_PEERS_PER_CONTRACT`] (returns
+    /// `false` at cap with no side writes, same shape as
+    /// [`Self::register_peer_interest`]) and creates the entry with
+    /// `is_upstream = false`. It does NOT touch the demand counters
+    /// (`downstream_subscriber_count` / `local_client_count`) that feed
+    /// eviction's demand ranking — an upserted entry is summary bookkeeping
+    /// plus fan-out of the small `Summaries` notifications, never a state
+    /// broadcast target (Source-2 removal, `update.rs::get_broadcast_targets_update`).
+    pub fn upsert_peer_summary(
+        &self,
+        contract: &ContractKey,
+        peer: &PeerKey,
+        summary: StateSummary<'static>,
+    ) -> bool {
+        let now = self.time_source.now();
+        // Hold the `interested_peers` shard guard across the `peer_contracts`
+        // and hash-index writes — same #4129/#4171 discipline as
+        // `register_peer_interest`, preventing a concurrent remover from
+        // leaving a zombie reverse-index entry.
+        let mut entry = self.interested_peers.entry(*contract).or_default();
+        if let Some(interest) = entry.get_mut(peer) {
+            interest.update_summary(Some(summary), now);
+            return true;
+        }
+        if entry.len() >= MAX_INTERESTED_PEERS_PER_CONTRACT {
+            // At cap the entry is non-empty, so no cleanup is needed; the
+            // caller simply keeps sending full state to this peer (pre-upsert
+            // behavior), bounded per contract.
+            return false;
+        }
+        entry.insert(peer.clone(), PeerInterest::new(Some(summary), false, now));
+        self.peer_contracts
+            .entry(peer.clone())
+            .or_default()
+            .insert(*contract);
+        self.index_contract_hash(contract);
+        drop(entry);
+        true
+    }
+
     /// Refresh the TTL for a peer's interest.
     pub fn refresh_peer_interest(&self, contract: &ContractKey, peer: &PeerKey) {
         let now = self.time_source.now();
@@ -2577,6 +2631,118 @@ mod tests {
             "a TRACKED peer caches the summary, so it escapes to deltas — this \
              is what makes the untracked case a distinct bug rather than cold \
              start"
+        );
+    }
+
+    /// #4952 regression: `upsert_peer_summary` closes the untracked-co-host
+    /// full-state fixed point that `update_peer_summary` (pinned no-op above)
+    /// cannot. The post-delivery cache in
+    /// `broadcast_queue::record_delivery_to_interest` routes through the
+    /// upsert, so one delivered full state seeds the summary and every later
+    /// broadcast to the same peer can be a delta.
+    #[test]
+    fn upsert_peer_summary_seeds_summary_for_untracked_peer() {
+        let (manager, _time) = make_manager();
+        let contract = make_contract_key(1);
+        let peer = make_peer_key(1);
+
+        assert!(
+            manager.get_peer_interest(&contract, &peer).is_none(),
+            "precondition: the peer must be untracked"
+        );
+
+        assert!(manager.upsert_peer_summary(&contract, &peer, StateSummary::from(vec![1u8, 2])));
+
+        assert_eq!(
+            manager
+                .get_peer_summary(&contract, &peer)
+                .map(|s| s.as_ref().to_vec()),
+            Some(vec![1u8, 2]),
+            "the upsert must CREATE the entry so the pair escapes to deltas"
+        );
+        let interest = manager
+            .get_peer_interest(&contract, &peer)
+            .expect("entry created");
+        assert!(
+            !interest.is_upstream,
+            "a delivery-seeded entry is not our upstream"
+        );
+
+        // Later deliveries keep the cached summary current.
+        assert!(manager.upsert_peer_summary(&contract, &peer, StateSummary::from(vec![9u8])));
+        assert_eq!(
+            manager
+                .get_peer_summary(&contract, &peer)
+                .map(|s| s.as_ref().to_vec()),
+            Some(vec![9u8]),
+        );
+
+        // The reverse index is maintained, so peer-disconnect cleanup works.
+        assert!(manager.get_contracts_for_peer(&peer).contains(&contract));
+        assert!(manager.remove_peer_interest(&contract, &peer));
+        assert!(manager.get_peer_summary(&contract, &peer).is_none());
+        assert!(!manager.get_contracts_for_peer(&peer).contains(&contract));
+
+        // Summary bookkeeping must not fabricate local demand (invariant 3):
+        // no local-interest entry appears as a side effect.
+        assert!(
+            !manager.has_local_interest(&contract),
+            "upsert must not create local interest / demand state"
+        );
+    }
+
+    /// #4952: at the per-contract cap the upsert must reject a NEW peer (no
+    /// amplification vector, no zombie side-writes) while still updating a
+    /// peer that is already tracked.
+    #[test]
+    fn upsert_peer_summary_respects_interested_peer_cap() {
+        let (manager, _time) = make_manager();
+        let contract = make_contract_key(1);
+
+        for i in 0..MAX_INTERESTED_PEERS_PER_CONTRACT {
+            assert!(manager.register_peer_interest(
+                &contract,
+                make_unique_peer_key(i as u32),
+                None,
+                false
+            ));
+        }
+
+        let newcomer = make_unique_peer_key(u32::MAX);
+        assert!(
+            !manager.upsert_peer_summary(&contract, &newcomer, StateSummary::from(vec![1u8])),
+            "a new peer at cap must be rejected"
+        );
+        assert!(manager.get_peer_interest(&contract, &newcomer).is_none());
+        assert!(
+            !manager
+                .get_contracts_for_peer(&newcomer)
+                .contains(&contract),
+            "a rejected upsert must leave no reverse-index zombie"
+        );
+    }
+
+    /// #4952: upserting an already-tracked peer takes the update path —
+    /// summary replaced, `is_upstream` preserved.
+    #[test]
+    fn upsert_peer_summary_updates_existing_entry_preserving_upstream_flag() {
+        let (manager, _time) = make_manager();
+        let contract = make_contract_key(1);
+        let peer = make_peer_key(1);
+
+        manager.register_peer_interest(&contract, peer.clone(), None, true);
+        assert!(manager.upsert_peer_summary(&contract, &peer, StateSummary::from(vec![5u8])));
+
+        let interest = manager
+            .get_peer_interest(&contract, &peer)
+            .expect("tracked");
+        assert!(
+            interest.is_upstream,
+            "upsert on an existing entry must not clobber the upstream flag"
+        );
+        assert_eq!(
+            interest.summary.map(|s| s.as_ref().to_vec()),
+            Some(vec![5u8])
         );
     }
 


### PR DESCRIPTION
## Problem

Post-0.2.108 fleet telemetry: `full_no_their_summary_untracked` is **58% of all broadcast bytes** (4.84GB in a ~6h window), plus 15% for the tracked variant. Deltas are 70% of sends but only 17% of bytes. Users report 20GB/6h nodes (#4952).

Mechanism: UPDATE fan-out targets come from NeighborHosting advertisements — a population that never enters `InterestManager::interested_peers`. The post-delivery summary cache (`record_delivery_to_interest`, the #4442 fix) and the InterestSync `Summaries` handler both write through `update_peer_summary`, which is deliberately get_mut-only and **silently no-ops for an untracked peer**. So an advertised co-host receives full state on every update, forever: send full → cache write no-ops → still no summary → send full again. A fixed point, not a cold start (pinned by the pre-existing `update_peer_summary_is_a_silent_noop_for_an_untracked_peer` test, which documents exactly this trap).

## Solution

New `InterestManager::upsert_peer_summary` — like `update_peer_summary` but creates the entry when absent — used at the two call sites that KNOW the peer holds the summarized state: the post-delivery cache (we just delivered them exactly that state) and the `Summaries` handler (the peer itself reported it). One delivered full state now seeds the summary; subsequent broadcasts collapse to deltas.

Safety properties, each deliberate:
- **Capped**: rejects a NEW peer at `MAX_INTERESTED_PEERS_PER_CONTRACT` with no side writes (no amplification vector, no reverse-index zombie).
- **No demand pollution**: never touches `downstream_subscriber_count` / `local_client_count` (eviction's invariant-3 demand signal is a separate, explicitly-incremented counter — verified, not derived from map membership).
- **No fan-out regrowth**: upserted entries never feed the state-broadcast target list (Source-2 removal stands, pinned in op_state_manager.rs). They do join the small `Summaries`-notification fan-out — which is beneficial (the co-host learns OUR summary and can send US deltas) and summary-sized.
- **Guard discipline**: holds the `interested_peers` shard guard across the reverse-index/hash-index writes (#4129/#4171).
- **`None` reports keep clear-only semantics** in the Summaries handler — no entry is created just to hold `None`.
- `update_peer_summary` itself is unchanged (its no-op pin still passes): writes of unknown provenance still can't grow the map.

## Testing

- 3 unit tests: seeding for an untracked peer (+ reverse-index maintenance + no local-interest side effects), cap rejection with no zombies, update-path preservation of `is_upstream`.
- 2 source-scrape pins (whitespace-stripped, rustfmt-proof): the delivery cache routes through the upsert (mutation-verified — reverting the call site fails the pin), and the Summaries arm upserts `Some`/clears `None`.
- Full interest + broadcast_queue suites: 105 passed. `cargo fmt` + `clippy -D warnings` clean.

## Expected field effect

`full_no_their_summary_untracked` should collapse to near-first-send-only levels as the fleet upgrades; fleet broadcast bytes should drop several-fold on busy contracts. Falsifier: if the arm does NOT collapse for upgraded emitter pairs, the untracked population is not delivery-reachable and this diagnosis is wrong.

Fixes #4952

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F2CFGizKUBc5hewJ5qzwJb