### PR TITLE
chore: point telemetry dashboard references at telemetry.freenet.org

### DIFF
--- a/crates/core/src/server/home_page/cards.rs
+++ b/crates/core/src/server/home_page/cards.rs
@@ -644,7 +644,7 @@ pub fn build_ring_svg(
     // (x2,y2) with the control point pulled toward the SVG centre.
     // `bend_base` is the maximum bend for antipodal points; chord
     // length scales bend so short hops look flat and long hops arc
-    // through the interior. Matches the nova.locut.us:3133 ring
+    // through the interior. Matches the telemetry.freenet.org ring
     // routing visualization.
     let curve_path = |x1: f64, y1: f64, x2: f64, y2: f64, bend_base: f64| -> String {
         let dx = x2 - x1;

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -2601,7 +2601,11 @@ mod tests {
         );
         assert!(
             !html.contains("freenet.org"),
-            "shell page must not reference external origins (CORS)"
+            "shell page must not reference external origins (CORS). This is a \
+             plain substring check over the whole rendered page, including the \
+             inlined shell_bridge.js — so a COMMENT that merely mentions a \
+             freenet.org host trips it too. If that is what you hit, drop the \
+             hostname from the comment rather than loosening this assertion."
         );
         // Shell message handler must be present in bridge JS
         assert!(
@@ -4883,10 +4887,9 @@ mod tests {
     /// Telemetry dashboard linked from the Freenet River channel header,
     /// plain HTTP at the time and since moved to
     /// `https://telemetry.freenet.org/`) — the user clicked the link and
-    /// nothing happened, no
-    /// console output, no popup, no error. The localhost block stays so a
-    /// pasted `http://127.0.0.1:NNNN/` link can't be used to target services
-    /// running on the reader's machine.
+    /// nothing happened, no console output, no popup, no error. The
+    /// localhost block stays so a pasted `http://127.0.0.1:NNNN/` link
+    /// can't be used to target services running on the reader's machine.
     #[test]
     fn shell_open_url_handler_accepts_http_and_https_but_blocks_localhost() {
         let js = SHELL_BRIDGE_JS;

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -4879,9 +4879,11 @@ mod tests {
     ///
     /// The shell `open_url` handler must accept `http:` URLs in addition to
     /// `https:`. The original https-only check silently dropped clicks on
-    /// markdown links to plain-HTTP services (e.g. the Network Telemetry
-    /// dashboard `http://nova.locut.us:3133/` linked from the Freenet River
-    /// channel header) — the user clicked the link and nothing happened, no
+    /// markdown links to plain-HTTP services (the trigger was the Network
+    /// Telemetry dashboard linked from the Freenet River channel header,
+    /// plain HTTP at the time and since moved to
+    /// `https://telemetry.freenet.org/`) — the user clicked the link and
+    /// nothing happened, no
     /// console output, no popup, no error. The localhost block stays so a
     /// pasted `http://127.0.0.1:NNNN/` link can't be used to target services
     /// running on the reader's machine.

--- a/crates/core/src/server/path_handlers/assets/shell_bridge.js
+++ b/crates/core/src/server/path_handlers/assets/shell_bridge.js
@@ -1206,9 +1206,12 @@ function freenetBridge(authToken, userToken, hostedMode) {
         // is what blocks `javascript:` / `data:` / `file:` etc.
         //
         // Both http and https are accepted because user-pasted markdown
-        // links commonly target plain-HTTP self-hosted services (e.g.
-        // nova.locut.us:3133, the Freenet network telemetry dashboard,
-        // no TLS configured). Auth tokens never travel through this path
+        // links commonly target self-hosted services with no TLS
+        // configured. freenet/river#231 was exactly that: the network
+        // telemetry dashboard was plain HTTP at the time (it has since
+        // moved to https://telemetry.freenet.org/), and an https-only
+        // filter silently swallowed every click on it.
+        // Auth tokens never travel through this path
         // — the only operation is `window.open(url, '_blank',
         // 'noopener,noreferrer')` — so HTTP doesn't expose credentials.
         // See freenet/river#231.

--- a/crates/core/src/server/path_handlers/assets/shell_bridge.js
+++ b/crates/core/src/server/path_handlers/assets/shell_bridge.js
@@ -1209,12 +1209,18 @@ function freenetBridge(authToken, userToken, hostedMode) {
         // links commonly target self-hosted services with no TLS
         // configured. freenet/river#231 was exactly that: the network
         // telemetry dashboard was plain HTTP at the time (it has since
-        // moved to https://telemetry.freenet.org/), and an https-only
-        // filter silently swallowed every click on it.
-        // Auth tokens never travel through this path
+        // moved to HTTPS), and an https-only filter silently swallowed
+        // every click on it. Auth tokens never travel through this path
         // — the only operation is `window.open(url, '_blank',
         // 'noopener,noreferrer')` — so HTTP doesn't expose credentials.
         // See freenet/river#231.
+        //
+        // Do NOT name the dashboard's host here: this file is inlined
+        // verbatim into the shell page, and
+        // `shell_page_contains_iframe_and_bridge` greps the rendered page
+        // for the project's public domain and fails on ANY occurrence,
+        // comments included (external-origin / CORS guard). The live URL
+        // lives in scripts/check-endpoints.sh.
         //
         // Private networks (RFC1918 192.168/16, 10/8, 172.16-31/12 and
         // RFC4193 fc00::/7, link-local fe80::/10) are deliberately NOT

--- a/scripts/check-endpoints.sh
+++ b/scripts/check-endpoints.sh
@@ -40,7 +40,7 @@ printf "  %-30s  %s  %s\n" "--------" "----" "-------"
     check_endpoint "vega gateway (HTTP)"      "http://vega.locut.us:31337" &
     check_endpoint "river.freenet.org"        "https://river.freenet.org" &
     check_endpoint "nova telemetry health"    "http://5.9.111.215:13133/health" &
-    check_endpoint "nova telemetry dashboard" "http://nova.locut.us:3133" &
+    check_endpoint "telemetry dashboard"      "https://telemetry.freenet.org" &
     wait
 }
 


### PR DESCRIPTION
## Problem

The network telemetry dashboard now serves over HTTPS at https://telemetry.freenet.org (nova, Caddy + Let's Encrypt). The old `http://nova.locut.us:3133/` URL 301-redirects there.

Four references in this repo still pointed at the old URL. One of them matters functionally:

`scripts/check-endpoints.sh` probed `http://nova.locut.us:3133`. That now answers **301**, which still falls inside the script's `200 <= code < 400` success band — so it would have gone on reporting the dashboard green while actually testing nothing but the redirect stub.

The other three are comments, and two of them had gone false rather than merely stale: they justify accepting `http:` URLs in the shell `open_url` handler by citing the dashboard as a plain-HTTP service with "no TLS configured". Anyone re-deriving that security decision now reads a rationale whose only cited example contradicts itself.

## Solution

- `scripts/check-endpoints.sh` — probe `https://telemetry.freenet.org` (now returns a real 200).
- `shell_bridge.js` / `path_handlers.rs` — keep the `http:`-acceptance rationale intact (it is still correct for other plain-HTTP self-hosted services) and reword the dashboard mention as the historical trigger for freenet/river#231 rather than a present-tense example.
- `home_page/cards.rs` — comment referencing the dashboard's ring visualization.

No behavior change: the Rust edits are comments only, and the JS edit is a comment inside the `open_url` block.

## Testing

- `cargo test -p freenet --lib shell_open_url` — 4/4 pass, including `shell_open_url_handler_accepts_http_and_https_but_blocks_localhost`, which source-scrapes the exact JS block whose comment changed.
- `node --check shell_bridge.js` — syntax clean.
- `cargo fmt --all` — clean.
- `bash scripts/check-endpoints.sh` — dashboard row now reports `200` (previously would report `301`). The other DOWN rows are pre-existing and unrelated (UDP gateway ports that never served HTTP).

Not opened as a draft deliberately: freenet-core drafts skip the heavy CI jobs, so a draft's green is not a real signal.

[AI-assisted - Claude]