### PR TITLE
fix(broadcast): post-compute delta gate, plus an outbound-byte census to aim the next fix

### DIFF
--- a/crates/core/src/contract/executor/mock_runtime.rs
+++ b/crates/core/src/contract/executor/mock_runtime.rs
@@ -784,8 +784,12 @@ where
             );
         }
 
-        // Default mode: hash-based summary (32 bytes) to enable delta efficiency.
-        // With hash summaries, is_delta_efficient(32, state_size) = true when state > 64 bytes.
+        // Default mode: hash-based summary (32 bytes) — small, cheap to ship in
+        // interest syncs. (Historical note: while compute_delta still had its
+        // pre-compute is_delta_efficient gate, the 32-byte summary also kept
+        // that gate open for any state > 64 bytes; since #4923 the gate runs
+        // post-compute on the actual delta size, so summary size no longer
+        // decides delta viability.)
         let hash = blake3::hash(state.as_ref());
         Ok(StateSummary::from(hash.as_bytes().to_vec()))
     }

--- a/crates/core/src/node/network_bridge.rs
+++ b/crates/core/src/node/network_bridge.rs
@@ -20,6 +20,7 @@ pub(crate) mod broadcast_payload_mix;
 pub(crate) mod broadcast_queue;
 mod handshake;
 pub(crate) mod in_memory;
+pub(crate) mod outbound_message_mix;
 pub(crate) mod p2p_protoc;
 pub(crate) mod priority_select;
 

--- a/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
+++ b/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
@@ -210,6 +210,15 @@ struct Window {
     /// Per-contract full-state byte attribution, bounded at
     /// [`MAX_TRACKED_CONTRACTS`].
     contract_full_state_bytes: HashMap<ContractInstanceId, u64>,
+    /// Per-contract bytes for the [`PayloadArm::FullNotEfficient`] arm ONLY.
+    ///
+    /// #4956: the aggregate gate-input ratio came back at 1.000 (summary size
+    /// == state size, max 839 KB each), which means some contract is feeding
+    /// state-sized bytes in as a "summary". `contract_full_state_bytes` mixes
+    /// every full-state arm together, so it cannot say WHICH contract, and the
+    /// culprit stayed unidentifiable. This narrows it to the one arm that
+    /// matters.
+    contract_not_efficient_bytes: HashMap<ContractInstanceId, u64>,
     /// Full-state sends that could not be attributed to a contract because
     /// the cap was already reached. This counts SENDS, not distinct
     /// contracts: one over-cap contract broadcasting 1,000 times contributes
@@ -259,6 +268,7 @@ impl Default for Window {
             sends: [0; PayloadArm::COUNT],
             bytes: [0; PayloadArm::COUNT],
             contract_full_state_bytes: HashMap::new(),
+            contract_not_efficient_bytes: HashMap::new(),
             attribution_dropped_sends: 0,
             attribution_dropped_bytes: 0,
             not_efficient_summary_bytes_sum: 0,
@@ -360,6 +370,16 @@ impl PayloadMix {
         // what this measurement is for.
         w.sends[idx] = w.sends[idx].saturating_add(1);
         w.bytes[idx] = w.bytes[idx].saturating_add(bytes);
+        if arm == PayloadArm::FullNotEfficient {
+            // Same cap discipline as the wider map: the key is
+            // contract-controlled, so it must not grow unbounded. Overflow is
+            // covered by the existing attribution_dropped_* counters below.
+            if let Some(tally) = w.contract_not_efficient_bytes.get_mut(contract) {
+                *tally = tally.saturating_add(bytes);
+            } else if w.contract_not_efficient_bytes.len() < MAX_TRACKED_CONTRACTS {
+                w.contract_not_efficient_bytes.insert(*contract, bytes);
+            }
+        }
         if arm.is_full_state() {
             if let Some(tally) = w.contract_full_state_bytes.get_mut(contract) {
                 *tally = tally.saturating_add(bytes);
@@ -403,6 +423,23 @@ impl Window {
         }
     }
 
+    /// The top [`TOP_CONTRACTS_REPORTED`] contracts in the
+    /// [`PayloadArm::FullNotEfficient`] arm, i.e. the ones whose delta the
+    /// gate refused. Same stable ordering as [`Self::top_contracts`].
+    fn top_not_efficient_contracts(&self) -> Vec<(ContractInstanceId, u64)> {
+        let mut tallies: Vec<(ContractInstanceId, u64)> = self
+            .contract_not_efficient_bytes
+            .iter()
+            .map(|(k, v)| (*k, *v))
+            .collect();
+        tallies.sort_by(|a, b| {
+            b.1.cmp(&a.1)
+                .then_with(|| a.0.as_bytes().cmp(b.0.as_bytes()))
+        });
+        tallies.truncate(TOP_CONTRACTS_REPORTED);
+        tallies
+    }
+
     /// The top [`TOP_CONTRACTS_REPORTED`] contracts by full-state bytes.
     fn top_contracts(&self) -> Vec<(ContractInstanceId, u64)> {
         let mut tallies: Vec<(ContractInstanceId, u64)> = self
@@ -444,6 +481,7 @@ struct NotEfficientGateStats {
 fn payload_mix_json(
     arms: &[(PayloadArm, u64, u64)],
     contracts: &[(ContractInstanceId, u64)],
+    not_efficient_contracts: &[(ContractInstanceId, u64)],
     tracked_full_state_bytes: u64,
     contracts_tracked: u64,
     attribution_dropped_sends: u64,
@@ -560,6 +598,19 @@ fn payload_mix_json(
     //     because the cap was already full.
     // Reporting only the second made an 11-contract window look perfectly
     // reconciled while 10 % of its bytes were unaccounted for.
+    // #4956: which contracts the gate actually refused on. The aggregate
+    // ratio says a state-sized "summary" is being fed in; this says by whom.
+    obj.insert(
+        "top_contracts_by_not_efficient_bytes".into(),
+        serde_json::Value::Array(
+            not_efficient_contracts
+                .iter()
+                .map(
+                    |(id, bytes)| serde_json::json!({ "contract": id.to_string(), "bytes": bytes }),
+                )
+                .collect(),
+        ),
+    );
     let top_sum: u64 = contracts.iter().map(|(_, b)| *b).sum();
     let other_contracts_bytes = tracked_full_state_bytes.saturating_sub(top_sum);
     obj.insert("other_contracts_bytes".into(), other_contracts_bytes.into());
@@ -593,6 +644,7 @@ pub(crate) fn emit_payload_mix_rollup(
     let payload = payload_mix_json(
         &window.arms(),
         &window.top_contracts(),
+        &window.top_not_efficient_contracts(),
         window.contract_full_state_bytes.values().sum(),
         window.contract_full_state_bytes.len() as u64,
         window.attribution_dropped_sends,
@@ -659,6 +711,42 @@ mod tests {
 
     fn contract(byte: u8) -> ContractInstanceId {
         ContractInstanceId::new([byte; 32])
+    }
+
+    /// #4956: the refused-delta arm must be attributable to a CONTRACT, not
+    /// just counted in aggregate. The aggregate gate ratio proved a
+    /// state-sized "summary" is being fed in; without this the culprit stays
+    /// anonymous. Only `FullNotEfficient` may land in the narrow map — a
+    /// different full-state arm sharing it would re-create the ambiguity.
+    #[test]
+    fn not_efficient_bytes_are_attributed_to_their_contract() {
+        let mix = PayloadMix::new();
+        mix.record_delivered(
+            PayloadArm::FullNotEfficient,
+            &contract(7),
+            600,
+            Some((600, 600)),
+        );
+        mix.record_delivered(
+            PayloadArm::FullNotEfficient,
+            &contract(7),
+            400,
+            Some((400, 400)),
+        );
+        // A different full-state arm must NOT pollute the narrow map.
+        mix.record_delivered(
+            PayloadArm::FullNoTheirSummaryUntracked,
+            &contract(8),
+            999,
+            None,
+        );
+        let w = mix.take_window();
+        let top = w.top_not_efficient_contracts();
+        assert_eq!(top.len(), 1, "only the refused arm belongs here: {top:?}");
+        assert_eq!(top[0].0, contract(7));
+        assert_eq!(top[0].1, 1000, "per-contract bytes must accumulate");
+        // The wider map still sees both, so the two views stay consistent.
+        assert_eq!(w.contract_full_state_bytes[&contract(8)], 999);
     }
 
     /// Taking the window leaves the accumulator empty so consecutive rollups
@@ -751,6 +839,7 @@ mod tests {
         let json = payload_mix_json(
             &window.arms(),
             &window.top_contracts(),
+            &window.top_not_efficient_contracts(),
             window.contract_full_state_bytes.values().sum(),
             window.contract_full_state_bytes.len() as u64,
             window.attribution_dropped_sends,
@@ -795,6 +884,7 @@ mod tests {
         let json = payload_mix_json(
             &window.arms(),
             &window.top_contracts(),
+            &window.top_not_efficient_contracts(),
             window.contract_full_state_bytes.values().sum(),
             window.contract_full_state_bytes.len() as u64,
             window.attribution_dropped_sends,
@@ -918,7 +1008,17 @@ mod tests {
             (PayloadArm::FullComputeFailed, 0, 0),
             (PayloadArm::FullNoTheirSummaryUntracked, 0, 0),
         ];
-        let json = payload_mix_json(&arms, &[], 0, 0, 0, 0, NotEfficientGateStats::default(), 60);
+        let json = payload_mix_json(
+            &arms,
+            &[],
+            &[],
+            0,
+            0,
+            0,
+            0,
+            NotEfficientGateStats::default(),
+            60,
+        );
         assert_eq!(json["total_bytes"], 1000);
         assert_eq!(json["full_state_bytes"], 700);
         assert_eq!(json["full_state_byte_share"], 0.7);
@@ -961,6 +1061,7 @@ mod tests {
         let json = payload_mix_json(
             &window.arms(),
             &window.top_contracts(),
+            &window.top_not_efficient_contracts(),
             window.contract_full_state_bytes.values().sum(),
             window.contract_full_state_bytes.len() as u64,
             window.attribution_dropped_sends,
@@ -1022,6 +1123,7 @@ mod tests {
         let json = payload_mix_json(
             &window.arms(),
             &window.top_contracts(),
+            &window.top_not_efficient_contracts(),
             window.contract_full_state_bytes.values().sum(),
             window.contract_full_state_bytes.len() as u64,
             window.attribution_dropped_sends,
@@ -1048,6 +1150,7 @@ mod tests {
         let json = payload_mix_json(
             &window.arms(),
             &window.top_contracts(),
+            &window.top_not_efficient_contracts(),
             0,
             0,
             0,
@@ -1063,7 +1166,17 @@ mod tests {
     #[test]
     fn empty_window_reports_zero_share_not_nan() {
         let arms: Vec<_> = PayloadArm::ALL.iter().map(|a| (*a, 0, 0)).collect();
-        let json = payload_mix_json(&arms, &[], 0, 0, 0, 0, NotEfficientGateStats::default(), 60);
+        let json = payload_mix_json(
+            &arms,
+            &[],
+            &[],
+            0,
+            0,
+            0,
+            0,
+            NotEfficientGateStats::default(),
+            60,
+        );
         assert_eq!(json["full_state_byte_share"], 0.0);
         assert_eq!(json["total_bytes"], 0);
     }

--- a/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
+++ b/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
@@ -14,11 +14,14 @@
 //! 1. [`PayloadArm::FullDeltaSuppressed`] — the `delta_incompat` memo is armed
 //!    (#4904): the contract is known to reject every delta, so full state is
 //!    sent deliberately.
-//! 2. [`PayloadArm::FullNotEfficient`] — the wire-efficiency gate
-//!    ([`crate::ring::interest::is_delta_efficient`]) refused *before*
-//!    computing anything, because the peer's summary is >= 50 % of our state
-//!    size. Note the fallback is full state, which is never smaller than the
-//!    delta the gate declined to compute.
+//! 2. [`PayloadArm::FullNotEfficient`] — the delta WAS computed but came back
+//!    not smaller than our full state, so full state is the (equal or
+//!    smaller) optimal payload. Until #4923 this arm instead meant the
+//!    pre-compute [`crate::ring::interest::is_delta_efficient`] summary-size
+//!    gate refused before computing anything — a fallback that was never
+//!    smaller than the delta it declined, and 41 % of all wire bytes in the
+//!    2026-07-24 measurement. Interpret pre-/post-#4923 telemetry for this
+//!    arm accordingly.
 //! 3. [`PayloadArm::FullComputeFailed`] — the contract's WASM failed, timed
 //!    out, or answered unexpectedly.
 //! 4. [`PayloadArm::FullNoOurSummary`] — *our* summary is missing, so there
@@ -106,7 +109,8 @@ pub(crate) enum PayloadArm {
     Delta,
     /// Full state: the `delta_incompat` memo is armed for this contract.
     FullDeltaSuppressed,
-    /// Full state: the wire-efficiency gate refused to compute a delta.
+    /// Full state: the computed delta was not smaller than the full state
+    /// (post-#4923; previously: the pre-compute gate refused to compute one).
     FullNotEfficient,
     /// Full state: delta computation was attempted and failed.
     FullComputeFailed,
@@ -221,21 +225,28 @@ struct Window {
     /// an 11-contract window look perfectly reconciled while 10 % of its bytes
     /// were unaccounted for.
     attribution_dropped_bytes: u64,
-    /// The wire-efficiency gate's actual INPUTS, summed and maxed over the
+    /// The efficiency gate's observed INPUTS, summed and maxed over the
     /// window's [`PayloadArm::FullNotEfficient`] sends.
     ///
     /// `DeltaUnavailable::NotEfficient` has always carried `summary_size` and
     /// `state_size`, but its only consumer was a `tracing::debug!`, which is
     /// compiled out in release (`max_level_info`) — so in production the gate
-    /// refused deltas with nobody able to see on what. That matters because
-    /// the field measurement and the assumed inputs disagree: the gate refuses
-    /// only when `summary * 2 >= state`, yet the contracts observed tripping it
-    /// are ones whose summaries are believed to be a small fraction of state.
-    /// One of those two beliefs is wrong; these four numbers say which.
+    /// refused deltas with nobody able to see on what. Both sizes are the
+    /// real observed values at refusal time.
     ///
-    /// Sum + max rather than a histogram: the mean ratio answers "is the gate
-    /// firing on genuinely summary-heavy contracts", and the maxima bound the
-    /// worst case, at four `u64`s instead of a bucket array.
+    /// Semantics shifted with #4923 and the split is exactly what these
+    /// numbers field-validate. PRE-#4923 a refusal fired when
+    /// `summary * 2 >= state` without computing anything, so the ratio
+    /// restated the trigger. POST-#4923 a refusal means the contract's
+    /// COMPUTED delta was not smaller than the state, so `FullNotEfficient`
+    /// sends should collapse to the rare genuinely-incompressible cases —
+    /// and the summary:state ratio now tells whether the OLD proxy would
+    /// have refused sends the new gate happily serves as deltas (the
+    /// wire-vs-CPU inversion the fix removes).
+    ///
+    /// Sum + max rather than a histogram: the mean ratio answers "were these
+    /// genuinely summary-heavy contracts", and the maxima bound the worst
+    /// case, at four `u64`s instead of a bucket array.
     not_efficient_summary_bytes_sum: u64,
     not_efficient_state_bytes_sum: u64,
     not_efficient_summary_bytes_max: u64,
@@ -972,16 +983,17 @@ mod tests {
         assert_eq!(json["full_no_summary_sends"], 4);
     }
 
-    /// The wire-efficiency gate's inputs are reported, so `full_not_efficient`
+    /// The efficiency gate's inputs are reported, so `full_not_efficient`
     /// stops being a black box.
     ///
-    /// This is the arm with a measured contradiction behind it: the gate only
-    /// refuses when `summary * 2 >= state`, yet it fires hardest on contracts
-    /// whose summaries are believed to be a small fraction of state. The mean
-    /// ratio is what settles which of those two beliefs is wrong. The sizes
-    /// were always carried by `DeltaUnavailable::NotEfficient` and always
-    /// thrown away, because its only reader was a `debug!` that is compiled
-    /// out in release builds.
+    /// The sizes were always carried by `DeltaUnavailable::NotEfficient` and
+    /// always thrown away, because its only reader was a `debug!` that is
+    /// compiled out in release builds. Post-#4923 the refusal is post-compute
+    /// (the COMPUTED delta was not smaller than the state), and the reported
+    /// summary:state ratio is what field-validates that change: it says
+    /// whether the sends the old `summary * 2 >= state` proxy refused were
+    /// genuinely summary-heavy, and the arm's volume says how rare a
+    /// genuinely incompressible delta actually is.
     #[test]
     fn not_efficient_reports_the_gate_inputs_it_refused_on() {
         let mix = PayloadMix::new();

--- a/crates/core/src/node/network_bridge/broadcast_queue.rs
+++ b/crates/core/src/node/network_bridge/broadcast_queue.rs
@@ -213,13 +213,13 @@ pub(super) struct SummaryPair<'a> {
 /// finding): a contract whose `summarize_state` serializes
 /// non-deterministically (HashMap/HashSet iteration order, per-process
 /// `RandomState`) yields different summary bytes for the SAME logical state on
-/// different peers. The byte compare then never skips, `compute_delta` either
-/// returns an empty delta (which the pre-fix arm "fell back" from by sending
-/// FULL STATE) or is refused outright by the `is_delta_efficient` gate on
-/// big-summary contracts — so a fully-converged pair re-flooded full state on
-/// every heartbeat-driven sync and every fan-out (the nondeterministic-summary
-/// heal storm; e.g. the `Eumk9HNQ` contract that "healed" hard while its state
-/// never changed).
+/// different peers. The byte compare then never skips, and `compute_delta`
+/// either returned an empty delta (which the pre-fix arm "fell back" from by
+/// sending FULL STATE) or — before #4923 removed the pre-compute
+/// `is_delta_efficient` gate — was refused outright on big-summary contracts,
+/// so a fully-converged pair re-flooded full state on every heartbeat-driven
+/// sync and every fan-out (the nondeterministic-summary heal storm; e.g. the
+/// `Eumk9HNQ` contract that "healed" hard while its state never changed).
 ///
 /// This helper reuses the #4894 machinery: byte-equal summaries short-circuit
 /// to [`FanoutSendPlan::Skip`]; byte-differing summaries consult the shared
@@ -284,13 +284,13 @@ pub(super) fn plan_fanout_send<T: crate::util::time_source::TimeSource + Sync>(
 /// fan-out pass can issue. Probe results land in the shared delta cache, so
 /// repeated fan-outs for an unchanged pair cost no further WASM.
 ///
-/// Note the probe deliberately bypasses the [`is_delta_efficient`] wire gate
-/// (see `peer_summary_has_pending_state`): staleness detection wants the
-/// semantic answer even for big-summary contracts, because the alternative it
+/// Note the probe deliberately has no notion of delta SIZE (see
+/// `peer_summary_has_pending_state`): staleness detection wants only the
+/// semantic answer (empty vs non-empty delta), because the alternative it
 /// replaces is a spurious FULL-STATE send on every fan-out — strictly more
-/// expensive than one delta computation.
-///
-/// [`is_delta_efficient`]: crate::ring::interest::is_delta_efficient
+/// expensive than one delta computation. (`compute_delta` shares the same
+/// always-compute behavior since #4923; it additionally refuses to RETURN a
+/// delta that is not smaller than full state.)
 pub(super) async fn fanout_send_needed(
     op_manager: &OpManager,
     key: &ContractKey,
@@ -861,21 +861,24 @@ pub(super) async fn broadcast_to_single_peer(
     // tag is carried to the real-delivery sites below and recorded there, so
     // the mix counts bytes that actually reached the wire.
     // Gate inputs for the `FullNotEfficient` arm, carried to the delivery site
-    // so the payload-mix rollup can report what the wire-efficiency gate
-    // actually refused on. `DeltaUnavailable::NotEfficient` has always carried
-    // these, but its only reader was a `debug!` — compiled out in release — so
-    // in production the refusals were unattributable. See #3335.
+    // so the payload-mix rollup can report the real (summary_size, state_size)
+    // each refusal was observed under. `DeltaUnavailable::NotEfficient` has
+    // always carried these, but its only reader was a `debug!` — compiled out
+    // in release — so in production the refusals were unattributable. Since
+    // #4923 the refusal itself is POST-compute (the computed delta was not
+    // smaller than the state), so the ratio of these two inputs field-checks
+    // the old pre-compute proxy rather than restating the trigger. See #3335.
     let mut not_efficient_gate_inputs: Option<(usize, usize)> = None;
     let (payload, sent_delta, payload_arm) = match (&our_summary, &their_summary) {
         // Scoped to the both-summaries-present case ON PURPOSE. When a summary
         // is missing a delta was impossible regardless of the memo, so letting
         // the suppression guard win there would credit the memo for a full
         // state it did not cause — overstating `FullDeltaSuppressed` and
-        // undercounting `FullNoSummary`, which is exactly the distinction this
-        // instrumentation exists to draw. Behavior is unchanged either way (a
-        // missing summary falls to the `_` arm, which also sends full state and
-        // also never reaches `compute_delta`), so this is purely about
-        // attributing the bytes to the right cause.
+        // undercounting the no-summary arms, which is exactly the distinction
+        // this instrumentation exists to draw. Behavior is unchanged either way
+        // (a missing summary falls to the no-summary arms below, which also
+        // send full state and also never reach `compute_delta`), so this is
+        // purely about attributing the bytes to the right cause.
         (Some(_), Some(_)) if deltas_suppressed => (
             DeltaOrFullState::FullState(new_state.as_ref().to_vec()),
             false,
@@ -919,9 +922,10 @@ pub(super) async fn broadcast_to_single_peer(
                         "Delta computation failed, falling back to full state"
                     );
                     // Split the refusal from a genuine failure: `NotEfficient`
-                    // means no contract code ran at all — the gate declined a
-                    // delta because the peer's summary is >= 50 % of our state,
-                    // and we then send the whole state, which is never smaller.
+                    // means the contract DID compute a delta but it was not
+                    // smaller than our full state (post-#4923 semantics), so
+                    // the full state sent here is the genuinely optimal
+                    // payload — equal or fewer bytes than the refused delta.
                     let arm = match err {
                         crate::ring::interest::DeltaUnavailable::NotEfficient {
                             summary_size,
@@ -1944,10 +1948,11 @@ mod tests {
     // (HashMap/HashSet order) yields different bytes for the SAME logical
     // state across peers, so the byte compare never skipped; the delta path
     // then either returned an empty delta (which the pre-fix arm answered by
-    // sending FULL STATE) or was refused by the `is_delta_efficient` gate on
-    // big-summary contracts — so a fully-converged pair re-flooded full state
-    // on every fan-out (contracts like `Eumk9HNQ` healing hard while their
-    // state never changed). These tests exercise the cache-only decision core
+    // sending FULL STATE) or — before #4923 removed the pre-compute
+    // `is_delta_efficient` gate — was refused outright on big-summary
+    // contracts, so a fully-converged pair re-flooded full state on every
+    // fan-out (contracts like `Eumk9HNQ` healing hard while their state never
+    // changed). These tests exercise the cache-only decision core
     // `plan_fanout_send`; the wiring is pinned by
     // `fanout_path_uses_semantic_delta_skip_pin`.
 

--- a/crates/core/src/node/network_bridge/outbound_message_mix.rs
+++ b/crates/core/src/node/network_bridge/outbound_message_mix.rs
@@ -248,12 +248,11 @@ fn emit_outbound_mix_rollup(mix: &OutboundMix, local_peer_id: &str, window_secs:
     let w = mix.take_window();
     let total_msgs: u64 = w.msgs.iter().sum();
     let total_bytes: u64 = w.bytes.iter().sum();
-    if total_msgs == 0 {
-        // Still emit: a silent node is a data point (it distinguishes "no
-        // traffic" from "telemetry stopped"), and the payload mix emits when
-        // idle too, so the two stay joinable per node-minute.
-    }
 
+    // Emitted unconditionally, including for an idle window: a silent node is
+    // a data point (it distinguishes "no traffic" from "telemetry stopped"),
+    // and the payload mix emits when idle too, so the two stay joinable per
+    // node-minute.
     let mut body = serde_json::Map::new();
     body.insert("window_secs".into(), window_secs.into());
     body.insert("total_msgs".into(), total_msgs.into());

--- a/crates/core/src/node/network_bridge/outbound_message_mix.rs
+++ b/crates/core/src/node/network_bridge/outbound_message_mix.rs
@@ -1,0 +1,363 @@
+//! Where a node's outbound bytes actually go, split by message kind.
+//!
+//! ## Why
+//!
+//! Every bandwidth fix through 0.2.109 was aimed by
+//! [`broadcast_payload_mix`][bpm], which measures ONE thing: the payload the
+//! update fan-out chose. A 2026-07-26 measurement (#4956) paired that rollup
+//! against `resource_utilization`'s `cumulative_bytes_sent` — the process's
+//! real outbound total — across 544 peers on 0.2.108 and found:
+//!
+//! | | |
+//! |---|---|
+//! | real bytes sent | median 299 MB/h, mean 707 MB/h per node |
+//! | broadcast payload | median 61 MB/h, mean 189 MB/h per node |
+//! | payload as share of real | **median 14.7 %, aggregate 26.7 %** |
+//!
+//! So roughly **three quarters of what a node sends was invisible** to the
+//! instrumentation being used to aim the fixes. The candidates for that
+//! remainder — GET/PUT/SUBSCRIBE payloads, the ~5-min InterestSync
+//! `Summaries` exchange (which ships a full `StateSummary` per shared
+//! contract to every connected peer), CONNECT/NAT traffic, and transport
+//! framing plus retransmits — differ by orders of magnitude in cost and have
+//! completely different remedies. Guessing between them is how the previous
+//! round mis-prioritised.
+//!
+//! This rollup answers it by construction rather than by inference: it counts
+//! bytes by [`OutboundKind`] at the one place every non-stream `NetMessage`
+//! is written to a connection, so the arms SUM to the node's message traffic
+//! instead of sampling a slice of it. Comparing that sum against
+//! `cumulative_bytes_sent` over the same window then attributes the residual
+//! to transport overhead (headers, ACKs, retransmits) — a number nothing
+//! currently reports.
+//!
+//! ## What is counted
+//!
+//! Bytes are the **serialized `NetMessage` length**, recorded after
+//! [`PeerConnection::send`][send] has serialized it and handed it to the
+//! transport. That is the payload the transport was asked to move, NOT the
+//! on-wire total: it excludes per-packet framing, ACKs and retransmits. The
+//! gap between this sum and `cumulative_bytes_sent` is exactly that overhead,
+//! which is the point — it is reported as a residual rather than silently
+//! folded into a message arm.
+//!
+//! Operations-level STREAM bytes are deliberately NOT counted here. They do
+//! not pass through this call site (they go out via `send_stream` /
+//! `outbound_stream`), and they already have their own accounting through
+//! `transfer_completed`. Double-counting them would break the "arms sum to
+//! message traffic" property this module exists to provide.
+//!
+//! [bpm]: super::broadcast_payload_mix
+//! [send]: crate::transport::peer_connection::PeerConnection::send
+
+use std::time::Duration;
+
+use parking_lot::Mutex;
+
+use crate::message::{NetMessage, NetMessageV1};
+use crate::node::background_task_monitor::BackgroundTaskMonitor;
+
+/// Rollup cadence, matching [`super::broadcast_payload_mix`] so the two
+/// rollups can be joined per node-minute without interpolation.
+const ROLLUP_WINDOW: Duration = Duration::from_secs(60);
+
+/// Which kind of message put these bytes on the wire.
+///
+/// Deliberately coarse — one arm per protocol family, not per message
+/// variant. The question this answers is "which SUBSYSTEM is spending the
+/// bandwidth", and a finer split would multiply the arms without changing
+/// which remedy applies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum OutboundKind {
+    /// CONNECT: joining, NAT traversal, topology maintenance.
+    Connect,
+    /// PUT, including the summary-first probe/reconcile legs.
+    Put,
+    /// GET, including responses that serve state to a requester.
+    Get,
+    /// SUBSCRIBE / UNSUBSCRIBE.
+    Subscribe,
+    /// UPDATE, which carries the broadcast fan-out measured in detail by
+    /// [`super::broadcast_payload_mix`]. Present here so the two rollups can
+    /// be cross-checked against each other.
+    Update,
+    /// InterestSync: the ~5-min `Interests` / `Summaries` anti-entropy
+    /// heartbeat. The leading suspect for the unexplained remainder, because
+    /// `SummaryEntry::summary_bytes` ships a FULL `StateSummary` per shared
+    /// contract to every connected peer on every cycle.
+    InterestSync,
+    /// NeighborHosting advertisements.
+    NeighborHosting,
+    /// Small control messages with no subsystem of their own: `Aborted`,
+    /// `ReadyState`, `SubscribeHint`. [`OutboundKind::classify`] matches
+    /// these EXPLICITLY rather than via a catch-all, so a newly added
+    /// protocol message fails to compile instead of quietly landing here and
+    /// hiding its bytes in a bucket nobody investigates.
+    Other,
+}
+
+impl OutboundKind {
+    pub(crate) const ALL: [OutboundKind; 8] = [
+        OutboundKind::Connect,
+        OutboundKind::Put,
+        OutboundKind::Get,
+        OutboundKind::Subscribe,
+        OutboundKind::Update,
+        OutboundKind::InterestSync,
+        OutboundKind::NeighborHosting,
+        OutboundKind::Other,
+    ];
+
+    const fn index(self) -> usize {
+        match self {
+            OutboundKind::Connect => 0,
+            OutboundKind::Put => 1,
+            OutboundKind::Get => 2,
+            OutboundKind::Subscribe => 3,
+            OutboundKind::Update => 4,
+            OutboundKind::InterestSync => 5,
+            OutboundKind::NeighborHosting => 6,
+            OutboundKind::Other => 7,
+        }
+    }
+
+    /// Telemetry field stem. The emitted rollup publishes `<stem>_msgs` and
+    /// `<stem>_bytes`, matching the `_sends`/`_bytes` convention the payload
+    /// mix already uses.
+    const fn stem(self) -> &'static str {
+        match self {
+            OutboundKind::Connect => "connect",
+            OutboundKind::Put => "put",
+            OutboundKind::Get => "get",
+            OutboundKind::Subscribe => "subscribe",
+            OutboundKind::Update => "update",
+            OutboundKind::InterestSync => "interest_sync",
+            OutboundKind::NeighborHosting => "neighbor_hosting",
+            OutboundKind::Other => "other",
+        }
+    }
+
+    /// Classify a message without inspecting its contents.
+    pub(crate) fn classify(msg: &NetMessage) -> Self {
+        match msg {
+            NetMessage::V1(v1) => match v1 {
+                NetMessageV1::Connect(_) => OutboundKind::Connect,
+                NetMessageV1::Put(_) => OutboundKind::Put,
+                NetMessageV1::Get(_) => OutboundKind::Get,
+                NetMessageV1::Subscribe(_) => OutboundKind::Subscribe,
+                NetMessageV1::Update(_) => OutboundKind::Update,
+                NetMessageV1::InterestSync { .. } => OutboundKind::InterestSync,
+                NetMessageV1::NeighborHosting { .. } => OutboundKind::NeighborHosting,
+                // Exhaustive on purpose (no `_` arm): a new protocol message
+                // must not silently join `Other` and hide its bytes inside a
+                // bucket nobody investigates. Adding a variant should break
+                // this match and force a deliberate choice.
+                NetMessageV1::Aborted(_)
+                | NetMessageV1::ReadyState { .. }
+                | NetMessageV1::SubscribeHint { .. } => OutboundKind::Other,
+            },
+        }
+    }
+}
+
+#[derive(Default)]
+struct Window {
+    msgs: [u64; 8],
+    bytes: [u64; 8],
+    /// Largest single serialized message in the window, per arm. A big mean
+    /// and a big max mean different things (steady load vs. one whale), and
+    /// the InterestSync question specifically hinges on which it is.
+    max_bytes: [u64; 8],
+}
+
+/// Per-message-kind outbound byte accumulator.
+///
+/// One `parking_lot::Mutex` covering the whole window, for the same reason
+/// [`super::broadcast_payload_mix::PayloadMix`] uses one: a rollup must be a
+/// consistent snapshot, so record and drain have to be atomic with respect to
+/// each other. Per-field atomics would let a drain land mid-update and report
+/// arms that never coexisted.
+///
+/// Cost is one uncontended lock acquire plus three integer updates per
+/// message sent. This IS a hotter path than the payload mix (every message,
+/// not every delivered broadcast), so it is deliberately kept to integer work
+/// with no allocation, no map insert, and no formatting — everything else
+/// happens in the aggregator task.
+pub(crate) struct OutboundMix {
+    window: Mutex<Window>,
+}
+
+impl OutboundMix {
+    pub(crate) fn new() -> Self {
+        Self {
+            window: Mutex::new(Window::default()),
+        }
+    }
+
+    /// Record one serialized message handed to the transport.
+    ///
+    /// `bytes` is the serialized `NetMessage` length, not the on-wire size —
+    /// see the module docs on what the residual against
+    /// `cumulative_bytes_sent` means.
+    pub(crate) fn record_sent(&self, kind: OutboundKind, bytes: usize) {
+        let b = bytes as u64;
+        let idx = kind.index();
+        let mut w = self.window.lock();
+        // Saturating throughout: a wrapped counter would report a tiny number
+        // for the heaviest arm, the exact opposite of the measurement's point.
+        w.msgs[idx] = w.msgs[idx].saturating_add(1);
+        w.bytes[idx] = w.bytes[idx].saturating_add(b);
+        w.max_bytes[idx] = w.max_bytes[idx].max(b);
+    }
+
+    /// Atomically take the current window, leaving a fresh empty one.
+    fn take_window(&self) -> Window {
+        std::mem::take(&mut *self.window.lock())
+    }
+}
+
+/// Clamp a measured elapsed span to a sane `window_secs` for the rollup.
+///
+/// Mirrors the payload mix: a stalled runtime can stretch the real window
+/// well past [`ROLLUP_WINDOW`], and reporting the nominal 60 s there would
+/// silently inflate every derived per-second rate.
+fn rollup_window_secs(elapsed: Duration) -> u64 {
+    elapsed.as_secs().max(1)
+}
+
+fn emit_outbound_mix_rollup(mix: &OutboundMix, local_peer_id: &str, window_secs: u64) {
+    let w = mix.take_window();
+    let total_msgs: u64 = w.msgs.iter().sum();
+    let total_bytes: u64 = w.bytes.iter().sum();
+    if total_msgs == 0 {
+        // Still emit: a silent node is a data point (it distinguishes "no
+        // traffic" from "telemetry stopped"), and the payload mix emits when
+        // idle too, so the two stay joinable per node-minute.
+    }
+
+    let mut body = serde_json::Map::new();
+    body.insert("window_secs".into(), window_secs.into());
+    body.insert("total_msgs".into(), total_msgs.into());
+    body.insert("total_bytes".into(), total_bytes.into());
+    for kind in OutboundKind::ALL {
+        let idx = kind.index();
+        let stem = kind.stem();
+        body.insert(format!("{stem}_msgs"), w.msgs[idx].into());
+        body.insert(format!("{stem}_bytes"), w.bytes[idx].into());
+        body.insert(format!("{stem}_max_bytes"), w.max_bytes[idx].into());
+    }
+
+    // Shadow priority, matching the payload mix: one event per node-minute is
+    // negligible volume, but it is observation rather than operational signal.
+    crate::tracing::telemetry::send_standalone_shadow_event_with_peer_id(
+        "outbound_message_mix",
+        local_peer_id,
+        serde_json::Value::Object(body),
+    );
+}
+
+/// Spawn the per-minute rollup emitter.
+///
+/// Observation only — nothing reads these counters to make a decision.
+pub(crate) fn spawn_outbound_mix_aggregator(
+    mix: std::sync::Arc<OutboundMix>,
+    local_peer_id: String,
+    monitor: &BackgroundTaskMonitor,
+) {
+    let handle = tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(ROLLUP_WINDOW);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        ticker.tick().await; // skip the immediate first tick
+        let mut last_rollup = tokio::time::Instant::now();
+        loop {
+            ticker.tick().await;
+            let now = tokio::time::Instant::now();
+            let elapsed = now.saturating_duration_since(last_rollup);
+            last_rollup = now;
+            emit_outbound_mix_rollup(&mix, &local_peer_id, rollup_window_secs(elapsed));
+        }
+    });
+    monitor.register("outbound_message_mix_aggregator", handle);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Taking the window leaves the accumulator empty, so consecutive rollups
+    /// report windows rather than lifetime totals.
+    #[test]
+    fn take_window_resets_the_window() {
+        let mix = OutboundMix::new();
+        mix.record_sent(OutboundKind::InterestSync, 500);
+        let first = mix.take_window();
+        assert_eq!(first.msgs[OutboundKind::InterestSync.index()], 1);
+        assert_eq!(first.bytes[OutboundKind::InterestSync.index()], 500);
+        let second = mix.take_window();
+        assert!(
+            second.msgs.iter().all(|m| *m == 0) && second.bytes.iter().all(|b| *b == 0),
+            "second take must be empty"
+        );
+    }
+
+    /// The arms must partition the traffic: every recorded byte lands in
+    /// exactly one arm, so the sum is the node's message total. This is the
+    /// property that makes the residual against `cumulative_bytes_sent`
+    /// interpretable as transport overhead rather than as "some arm we
+    /// forgot".
+    #[test]
+    fn arms_partition_recorded_bytes() {
+        let mix = OutboundMix::new();
+        mix.record_sent(OutboundKind::Get, 10);
+        mix.record_sent(OutboundKind::Put, 20);
+        mix.record_sent(OutboundKind::InterestSync, 30);
+        mix.record_sent(OutboundKind::Get, 40);
+        let w = mix.take_window();
+        assert_eq!(w.bytes.iter().sum::<u64>(), 100);
+        assert_eq!(w.msgs.iter().sum::<u64>(), 4);
+        assert_eq!(w.bytes[OutboundKind::Get.index()], 50);
+    }
+
+    /// `max_bytes` tracks the largest single message, which is what
+    /// distinguishes a steady stream from one whale.
+    #[test]
+    fn max_bytes_tracks_the_largest_single_message() {
+        let mix = OutboundMix::new();
+        mix.record_sent(OutboundKind::Update, 100);
+        mix.record_sent(OutboundKind::Update, 900);
+        mix.record_sent(OutboundKind::Update, 50);
+        let w = mix.take_window();
+        assert_eq!(w.max_bytes[OutboundKind::Update.index()], 900);
+        assert_eq!(w.bytes[OutboundKind::Update.index()], 1050);
+    }
+
+    /// Every arm must own a distinct index and a distinct field stem, or two
+    /// arms would silently share a counter / overwrite each other's JSON key.
+    #[test]
+    fn arms_have_unique_indices_and_stems() {
+        let mut idxs: Vec<usize> = OutboundKind::ALL.iter().map(|k| k.index()).collect();
+        idxs.sort_unstable();
+        idxs.dedup();
+        assert_eq!(idxs.len(), OutboundKind::ALL.len(), "duplicate arm index");
+        assert_eq!(
+            *idxs.last().expect("non-empty"),
+            OutboundKind::ALL.len() - 1,
+            "indices must be dense so the fixed-size arrays cover them"
+        );
+
+        let mut stems: Vec<&str> = OutboundKind::ALL.iter().map(|k| k.stem()).collect();
+        stems.sort_unstable();
+        stems.dedup();
+        assert_eq!(stems.len(), OutboundKind::ALL.len(), "duplicate field stem");
+    }
+
+    /// A stalled runtime must not report the nominal 60 s for a longer real
+    /// window, and a sub-second window must not report zero (which would make
+    /// every derived rate a division by zero).
+    #[test]
+    fn rollup_window_secs_is_clamped_to_the_real_elapsed_span() {
+        assert_eq!(rollup_window_secs(Duration::from_millis(10)), 1);
+        assert_eq!(rollup_window_secs(Duration::from_secs(60)), 60);
+        assert_eq!(rollup_window_secs(Duration::from_secs(300)), 300);
+    }
+}

--- a/crates/core/src/node/network_bridge/outbound_message_mix.rs
+++ b/crates/core/src/node/network_bridge/outbound_message_mix.rs
@@ -41,11 +41,30 @@
 //! which is the point — it is reported as a residual rather than silently
 //! folded into a message arm.
 //!
-//! Operations-level STREAM bytes are deliberately NOT counted here. They do
-//! not pass through this call site (they go out via `send_stream` /
-//! `outbound_stream`), and they already have their own accounting through
-//! `transfer_completed`. Double-counting them would break the "arms sum to
-//! message traffic" property this module exists to provide.
+//! ### Relationship to `transfer_completed` — do NOT sum the two
+//!
+//! There are two different kinds of "stream" here and conflating them
+//! produces a double count:
+//!
+//! * **Operations-level streams** (`send_stream` / `StreamId::next_operations`,
+//!   used for full-state broadcast and large op payloads) do NOT reach this
+//!   call site and are NOT counted here. They are covered by
+//!   `transfer_completed`.
+//! * **Transport-level streams** are just a big `NetMessage`: anything over
+//!   `MAX_DATA_SIZE` (~1.2 KB) that goes through [`PeerConnection::send`][send]
+//!   is fragmented by `outbound_stream`. Those messages DO pass through this
+//!   call site, so their bytes ARE counted here — deliberately, since that
+//!   population includes the delta broadcasts. They ALSO emit
+//!   `transfer_completed`.
+//!
+//! So this rollup and `transfer_completed` OVERLAP on transport-level streams.
+//! Each is internally consistent; adding them together is not. Use this
+//! rollup for "which subsystem spent the bytes" and `transfer_completed` for
+//! per-transfer transport behaviour.
+//!
+//! The arms here still partition *message* traffic (every non-stream-op
+//! `NetMessage` lands in exactly one arm), which is the property the residual
+//! against `cumulative_bytes_sent` relies on.
 //!
 //! [bpm]: super::broadcast_payload_mix
 //! [send]: crate::transport::peer_connection::PeerConnection::send

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -2975,17 +2975,33 @@ enum ProtocolStatus {
 async fn handle_peer_channel_message(
     conn: &mut Box<dyn PeerConnectionApi>,
     msg: Either<NetMessage, ConnEvent>,
+    outbound_mix: &crate::node::network_bridge::outbound_message_mix::OutboundMix,
 ) -> Result<(), TransportError> {
     match msg {
         Left(msg) => {
             tracing::debug!(to=%conn.remote_addr() ,"Sending message to peer. Msg: {msg}");
-            if let Err(error) = conn.send_message(msg).await {
-                tracing::error!(
-                    to = %conn.remote_addr(),
-                    ?error,
-                    "[CONN_LIFECYCLE] Failed to send message to peer"
-                );
-                return Err(error);
+            // Classify BEFORE the send moves `msg`. Classification only reads
+            // the enum discriminant, so it costs nothing on this hot path.
+            let kind =
+                crate::node::network_bridge::outbound_message_mix::OutboundKind::classify(&msg);
+            match conn.send_message(msg).await {
+                Ok(serialized_len) => {
+                    // #4956: attribute the bytes to the message kind that
+                    // produced them. `send_message` returns the length it
+                    // already computed, so nothing is serialized twice.
+                    // Recorded only on a successful hand-off to the transport,
+                    // matching the payload mix's real-delivery accounting rule
+                    // so a failed send never inflates the census.
+                    outbound_mix.record_sent(kind, serialized_len);
+                }
+                Err(error) => {
+                    tracing::error!(
+                        to = %conn.remote_addr(),
+                        ?error,
+                        "[CONN_LIFECYCLE] Failed to send message to peer"
+                    );
+                    return Err(error);
+                }
             }
             tracing::debug!(
                 to = %conn.remote_addr(),
@@ -3113,11 +3129,12 @@ async fn drain_pending_before_shutdown(
     rx: &mut PeerConnChannelRecv,
     conn: &mut Box<dyn PeerConnectionApi>,
     remote_addr: SocketAddr,
+    outbound_mix: &crate::node::network_bridge::outbound_message_mix::OutboundMix,
 ) -> usize {
     let mut drained = 0;
     while let Ok(msg) = rx.try_recv() {
         // Best-effort send - connection may already be degraded
-        if let Err(e) = handle_peer_channel_message(conn, msg).await {
+        if let Err(e) = handle_peer_channel_message(conn, msg, outbound_mix).await {
             tracing::debug!(
                 to = %remote_addr,
                 ?e,
@@ -3154,6 +3171,7 @@ async fn peer_connection_listener(
     peer_addr: SocketAddr,
     conn_events: Sender<ConnEvent>,
     connection_id: u64,
+    outbound_mix: std::sync::Arc<crate::node::network_bridge::outbound_message_mix::OutboundMix>,
 ) {
     let remote_addr = conn.remote_addr();
     tracing::debug!(
@@ -3182,7 +3200,9 @@ async fn peer_connection_listener(
             match rx.try_recv() {
                 Ok(msg) => {
                     drained += 1;
-                    if let Err(error) = handle_peer_channel_message(&mut conn, msg).await {
+                    if let Err(error) =
+                        handle_peer_channel_message(&mut conn, msg, &outbound_mix).await
+                    {
                         if error.is_transient_send_failure() {
                             tracing::warn!(
                                 to = %remote_addr,
@@ -3197,7 +3217,13 @@ async fn peer_connection_listener(
                             );
                             // Drain any messages that arrived after our try_recv() but before
                             // handle_peer_channel_message returned an error
-                            drain_pending_before_shutdown(&mut rx, &mut conn, remote_addr).await;
+                            drain_pending_before_shutdown(
+                                &mut rx,
+                                &mut conn,
+                                remote_addr,
+                                &outbound_mix,
+                            )
+                            .await;
                             notify_transport_closed(
                                 &conn_events,
                                 remote_addr,
@@ -3237,7 +3263,7 @@ async fn peer_connection_listener(
             msg = rx.recv() => {
                 match msg {
                     Some(msg) => {
-                        if let Err(error) = handle_peer_channel_message(&mut conn, msg).await {
+                        if let Err(error) = handle_peer_channel_message(&mut conn, msg, &outbound_mix).await {
                             if error.is_transient_send_failure() {
                                 tracing::warn!(
                                     to = %remote_addr,
@@ -3251,7 +3277,7 @@ async fn peer_connection_listener(
                                     "[CONN_LIFECYCLE] Connection closed after channel command"
                                 );
                                 // Drain any messages that arrived while we were processing this one
-                                drain_pending_before_shutdown(&mut rx, &mut conn, remote_addr).await;
+                                drain_pending_before_shutdown(&mut rx, &mut conn, remote_addr, &outbound_mix).await;
                                 notify_transport_closed(&conn_events, remote_addr, error, connection_id).await;
                                 return;
                             }
@@ -3300,7 +3326,7 @@ async fn peer_connection_listener(
                                 );
                                 // Drain pending messages - they may still be sendable even if
                                 // the conn_events channel is closed
-                                drain_pending_before_shutdown(&mut rx, &mut conn, remote_addr).await;
+                                drain_pending_before_shutdown(&mut rx, &mut conn, remote_addr, &outbound_mix).await;
                                 return;
                             }
                         }
@@ -3311,7 +3337,7 @@ async fn peer_connection_listener(
                                 "[CONN_LIFECYCLE] Failed to deserialize inbound message; closing connection"
                             );
                             // Drain pending outbound messages before closing - they may still succeed
-                            drain_pending_before_shutdown(&mut rx, &mut conn, remote_addr).await;
+                            drain_pending_before_shutdown(&mut rx, &mut conn, remote_addr, &outbound_mix).await;
                             let transport_error = TransportError::Other(anyhow!(
                                 "Failed to deserialize inbound message from {remote_addr}: {error:?}"
                             ));
@@ -3338,7 +3364,7 @@ async fn peer_connection_listener(
                         // CRITICAL: Drain pending outbound messages before exiting.
                         // Messages may have been queued to the channel while we were
                         // waiting in select!, and they would be lost without this drain.
-                        drain_pending_before_shutdown(&mut rx, &mut conn, remote_addr).await;
+                        drain_pending_before_shutdown(&mut rx, &mut conn, remote_addr, &outbound_mix).await;
                         notify_transport_closed(&conn_events, remote_addr, error, connection_id).await;
                         return;
                     }

--- a/crates/core/src/node/network_bridge/p2p_protoc/connection_lifecycle.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc/connection_lifecycle.rs
@@ -1078,8 +1078,17 @@ impl P2pConnManager {
         // Use tokio::spawn directly instead of GlobalExecutor::spawn.
         // GlobalExecutor::spawn uses Handle::try_current().spawn() which doesn't
         // reliably poll tasks in certain test contexts (see issue #2709).
+        let outbound_mix = self.bridge.op_manager.outbound_mix.clone();
         tokio::spawn(async move {
-            peer_connection_listener(rx, connection, peer_addr, conn_events, conn_id).await;
+            peer_connection_listener(
+                rx,
+                connection,
+                peer_addr,
+                conn_events,
+                conn_id,
+                outbound_mix,
+            )
+            .await;
         });
         // Yield to allow the spawned peer_connection_listener task to start.
         // This is important because on some runtimes (especially in tests with boxed_local

--- a/crates/core/src/node/network_bridge/priority_select/tests.rs
+++ b/crates/core/src/node/network_bridge/priority_select/tests.rs
@@ -2791,12 +2791,12 @@ impl crate::transport::PeerConnectionApi for MockPeerConnection {
         _msg: crate::message::NetMessage,
     ) -> std::pin::Pin<
         Box<
-            dyn std::future::Future<Output = Result<(), crate::transport::TransportError>>
+            dyn std::future::Future<Output = Result<usize, crate::transport::TransportError>>
                 + Send
                 + '_,
         >,
     > {
-        Box::pin(async { Ok(()) })
+        Box::pin(async { Ok(0) })
     }
 
     fn recv(

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -172,6 +172,10 @@ pub(crate) struct OpManager {
     /// ticker steal every other node's records and publish them under its own
     /// peer id. See [`PayloadMix`](crate::node::network_bridge::broadcast_payload_mix::PayloadMix).
     pub payload_mix: Arc<crate::node::network_bridge::broadcast_payload_mix::PayloadMix>,
+    /// Outbound bytes by message kind (#4956). Per-`OpManager` rather than a
+    /// global so simulation runs, which host many nodes in one process, keep
+    /// each node's census separate.
+    pub outbound_mix: Arc<crate::node::network_bridge::outbound_message_mix::OutboundMix>,
     /// Interest manager for delta-based state synchronization.
     ///
     /// Its clock comes from the same injectable
@@ -326,6 +330,7 @@ impl Clone for OpManager {
             contract_waiters: self.contract_waiters.clone(),
             neighbor_hosting: self.neighbor_hosting.clone(),
             payload_mix: self.payload_mix.clone(),
+            outbound_mix: self.outbound_mix.clone(),
             interest_manager: self.interest_manager.clone(),
             broadcast_dedup_cache: self.broadcast_dedup_cache.clone(),
             update_propagation_stats: self.update_propagation_stats.clone(),
@@ -529,6 +534,9 @@ impl OpManager {
             is_gateway,
             contract_waiters,
             neighbor_hosting,
+            outbound_mix: Arc::new(
+                crate::node::network_bridge::outbound_message_mix::OutboundMix::new(),
+            ),
             payload_mix: Arc::new(
                 crate::node::network_bridge::broadcast_payload_mix::PayloadMix::new(),
             ),

--- a/crates/core/src/node/p2p_impl.rs
+++ b/crates/core/src/node/p2p_impl.rs
@@ -903,6 +903,19 @@ impl NodeP2P {
         // global would let one node's ticker drain another's records.
         crate::node::network_bridge::broadcast_payload_mix::spawn_payload_mix_aggregator(
             op_manager.payload_mix.clone(),
+            payload_mix_peer_id.clone(),
+            &background_task_monitor,
+        );
+
+        // Outbound message-kind census (#4956): the payload mix above covers
+        // only update fan-out, which a paired measurement against
+        // `resource_utilization` found to be roughly a quarter of what a node
+        // actually sends. This one covers every non-stream message, so the
+        // arms SUM to the node's message traffic and the residual against
+        // `cumulative_bytes_sent` names the transport overhead instead of
+        // hiding it. Same per-`op_manager` reasoning as above.
+        crate::node::network_bridge::outbound_message_mix::spawn_outbound_mix_aggregator(
+            op_manager.outbound_mix.clone(),
             payload_mix_peer_id,
             &background_task_monitor,
         );

--- a/crates/core/src/operations/put.rs
+++ b/crates/core/src/operations/put.rs
@@ -548,8 +548,10 @@ mod messages {
             ///
             /// `Some(D_rev)` only when `holder_found == true`, the holder is
             /// genuinely ahead, AND the reverse delta passes the SAME
-            /// efficiency gate the forward delta uses (`compute_delta` /
-            /// `is_delta_efficient`). `None` when no holder was found, when
+            /// post-compute efficiency gate the forward delta uses
+            /// (`compute_delta`, #4923: refused only when the computed delta
+            /// is not smaller than the holder's state). `None` when no
+            /// holder was found, when
             /// the originator is already current (empty delta), or when the
             /// reverse delta would be inefficient / uncomputable — in the
             /// last two the originator falls back to healing via a normal

--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -3772,9 +3772,9 @@ async fn relay_probe_send_response(
 /// mirror of the originator's forward delta — the holder already has both
 /// inputs (the originator's summary arrived on the `ProbeRequest`, and it has
 /// its own state) — so it reuses `InterestManager::compute_delta`, and
-/// therefore the SAME `is_delta_efficient` gate the forward leg uses (a
-/// summary-size proxy for delta size: the delta is skipped when the
-/// originator's summary is ≥ ~50% of the holder's state size).
+/// therefore the SAME post-compute efficiency gate the forward leg uses
+/// (#4923: the delta is always computed, and refused only when the ACTUAL
+/// delta is not smaller than the holder's state size).
 ///
 /// Returns `None` (skip the reverse leg — the originator heals via a normal
 /// GET / anti-entropy rather than receiving a bloated or absent delta) when:
@@ -4353,8 +4353,8 @@ mod tests {
     /// - `Ok(Some)` → ship the delta (holder ahead),
     /// - `Ok(None)` (originator already current — contract returned an empty
     ///   delta) → ship NOTHING,
-    /// - `Err` (delta inefficient / uncomputable — SAME gate as the forward
-    ///   leg) → ship NOTHING.
+    /// - `Err` (computed delta not smaller than full state / uncomputable —
+    ///   SAME post-compute gate as the forward leg, #4923) → ship NOTHING.
     ///
     /// The two `None` arms are the "originator already current / heal via a
     /// normal GET or anti-entropy" fallback: the reconcile must not emit a
@@ -4384,8 +4384,8 @@ mod tests {
         // heals via a normal GET / anti-entropy instead of receiving a
         // bloated or absent delta.
         // Both Err variants must behave identically here: the reverse leg
-        // ships nothing whether the wire-efficiency gate refused up front or
-        // the contract's delta computation failed.
+        // ships nothing whether the post-compute gate refused an oversized
+        // delta (#4923) or the contract's delta computation failed.
         let inefficient = reverse_delta_from_compute_result(Err(
             crate::ring::interest::DeltaUnavailable::NotEfficient {
                 summary_size: 600,
@@ -4394,7 +4394,8 @@ mod tests {
         ));
         assert!(
             inefficient.is_none(),
-            "Err (gate refused as inefficient) must send NO reverse delta"
+            "Err (computed delta not smaller than full state) must send NO \
+             reverse delta"
         );
         let uncomputable = reverse_delta_from_compute_result(Err(
             crate::ring::interest::DeltaUnavailable::ComputeFailed("wasm exploded".into()),

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -1589,8 +1589,18 @@ impl Ring {
                 }
             }
 
-            crate::tracing::telemetry::send_standalone_event(
+            // #4956: tag with the local peer so this can be JOINED per-peer
+            // against `resource_utilization` / `outbound_message_mix`. Without
+            // it the event reports fleet-wide distributions only, which is why
+            // the InterestSync cost hypothesis could not be confirmed by
+            // correlation and had to stay an estimate.
+            crate::tracing::telemetry::send_standalone_event_with_peer_id(
                 "interest_heartbeat_cycle",
+                &op_manager
+                    .ring
+                    .connection_manager
+                    .own_location()
+                    .to_string(),
                 serde_json::json!({
                     "peers_sent": peers_sent,
                     "interest_hashes": hashes.len(),

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -4411,6 +4411,51 @@ mod tests {
         );
     }
 
+    /// Boundary pin for the documented tie-break: the gate is `>=`, so a delta
+    /// EXACTLY the size of our state loses the tie and refuses. Sending full
+    /// state is preferred at equal bytes because it costs the receiver no
+    /// delta-apply. The sibling tests only cover strictly-smaller (accepted)
+    /// and strictly-larger (refused), which leaves an off-by-one in the
+    /// comparison operator (`>` instead of `>=`) undetected.
+    #[tokio::test(flavor = "current_thread")]
+    async fn equal_sized_delta_returns_not_efficient() {
+        let our_state_size = 8usize;
+        let equal_delta = vec![3u8; 8]; // exactly our_state_size
+        let (op_manager, queries_served, _guards) =
+            op_manager_with_mock_delta_handler("post_gate_equal_delta", equal_delta).await;
+
+        let key = make_contract_key(103);
+        let their_summary = StateSummary::from(vec![4u8]);
+        let our_summary = StateSummary::from(vec![5u8, 5]);
+
+        let result = op_manager
+            .interest_manager
+            .compute_delta(
+                &op_manager,
+                &key,
+                &their_summary,
+                &our_summary,
+                our_state_size,
+            )
+            .await;
+
+        assert_eq!(
+            result,
+            Err(DeltaUnavailable::NotEfficient {
+                summary_size: their_summary.as_ref().len(),
+                state_size: our_state_size,
+            }),
+            "a delta exactly the size of the state must lose the tie (the gate \
+             is `>=`): full state is preferred at equal bytes because it costs \
+             the receiver no delta-apply"
+        );
+        assert_eq!(
+            queries_served.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "the contract must still have been consulted exactly once"
+        );
+    }
+
     /// Converged-peer companion to the incident pin: with the SAME oversized
     /// peer summary the pre-compute gate used to refuse before the contract
     /// could report an EMPTY delta, so a logically-converged peer was

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -310,6 +310,18 @@ pub fn contract_hash(contract: &ContractKey) -> u32 {
     hash
 }
 
+/// How much smaller full state must be before the post-compute gate
+/// ([`InterestManager::gate_delta_size`]) abandons a computed delta for it.
+///
+/// Switching payload kinds is not free: a delta keeps the receiver's
+/// peer-summary cache warm and keeps fan-out off the full-state path that
+/// #4233 / #4956 are about. Below this margin the byte win is a rounding
+/// error and not worth those costs — at 1 KiB, a small CRDT contract whose
+/// delta marginally exceeds its state keeps sending deltas, while the
+/// poisoned-summary population this gate targets (state-sized deltas at
+/// 550-840 KB) still refuses by a wide margin.
+const MIN_FULL_STATE_SAVING_BYTES: usize = 1024;
+
 /// Heuristic: would a delta *probably* be efficient compared to sending full
 /// state, judging only by the peer's summary size?
 ///
@@ -1654,23 +1666,45 @@ impl<T: TimeSource + Sync> InterestManager<T> {
     }
 
     /// Post-compute wire-efficiency gate (#4923): hand back the computed
-    /// (non-empty) delta only when it is strictly smaller than our full state;
-    /// otherwise refuse with [`DeltaUnavailable::NotEfficient`] so the
-    /// caller's full-state fallback — equal or smaller bytes, and no
-    /// delta-apply on the receiver — is taken as the genuinely optimal
-    /// payload. `>=` on purpose: a delta exactly the size of the state loses
-    /// the tie (full state is simpler and immune to delta-apply failures).
+    /// (non-empty) delta unless full state would be smaller by at least
+    /// [`MIN_FULL_STATE_SAVING_BYTES`], in which case refuse with
+    /// [`DeltaUnavailable::NotEfficient`] so the caller's full-state fallback
+    /// is taken as the genuinely cheaper payload.
+    ///
+    /// The margin is load-bearing, not slop. A bare `delta.len() >=
+    /// state_size` comparison is byte-optimal but behaviorally wrong at small
+    /// sizes: a 144-byte delta against a 136-byte state would flip the payload
+    /// to full state to save EIGHT bytes, and doing that for every small
+    /// contract re-creates the full-state fan-out shape that #4233 exists to
+    /// prevent (`test_sustained_update_fanout_no_full_state_storm` pins
+    /// `delta_sends > full_state_sends` and catches exactly this). Deltas are
+    /// also what keeps a receiver's peer-summary cache warm, so trading them
+    /// away for a rounding error is a bad deal even ignoring the pin.
+    ///
+    /// So the rule is: prefer the delta by default, and switch to full state
+    /// only when that genuinely saves bandwidth worth the switch. The
+    /// pathological case this gate exists for — a contract whose summary (and
+    /// therefore delta) is state-sized, the #4956 poisoned-summary population
+    /// running at 550-840 KB — clears a 1 KiB margin by orders of magnitude.
+    ///
+    /// Note for callers whose fallback is NOT full state: a refusal here means
+    /// the summary-first PUT reverse leg
+    /// (`put::op_ctx_task::reverse_delta_from_compute_result`) ships NOTHING,
+    /// not full state, and the originator heals later via GET/anti-entropy.
+    /// That asymmetry predates this change (the old pre-compute gate refused
+    /// the same way) but the margin makes it much rarer.
     fn gate_delta_size(
         delta: StateDelta<'static>,
         summary_size: usize,
         our_state_size: usize,
     ) -> Result<Option<StateDelta<'static>>, DeltaUnavailable> {
-        if delta.as_ref().len() >= our_state_size {
+        if delta.as_ref().len() >= our_state_size.saturating_add(MIN_FULL_STATE_SAVING_BYTES) {
             tracing::trace!(
                 delta_size = delta.as_ref().len(),
                 state_size = our_state_size,
-                "Computed delta is not smaller than full state — caller \
-                 should send full state"
+                margin = MIN_FULL_STATE_SAVING_BYTES,
+                "Computed delta exceeds full state by more than the switch \
+                 margin — caller should send full state"
             );
             Err(DeltaUnavailable::NotEfficient {
                 summary_size,
@@ -4357,7 +4391,9 @@ mod tests {
     /// cache — same refusal, zero additional contract queries.
     #[tokio::test(flavor = "current_thread")]
     async fn oversized_computed_delta_returns_not_efficient() {
-        let oversized_delta = vec![9u8; 10]; // 10 bytes vs a 4-byte state
+        // Must exceed the state by more than MIN_FULL_STATE_SAVING_BYTES for
+        // the switch to full state to be worth making.
+        let oversized_delta = vec![9u8; 4 + MIN_FULL_STATE_SAVING_BYTES + 1];
         let (op_manager, queries_served, _guards) =
             op_manager_with_mock_delta_handler("post_gate_oversized_delta", oversized_delta).await;
 
@@ -4411,24 +4447,29 @@ mod tests {
         );
     }
 
-    /// Boundary pin for the documented tie-break: the gate is `>=`, so a delta
-    /// EXACTLY the size of our state loses the tie and refuses. Sending full
-    /// state is preferred at equal bytes because it costs the receiver no
-    /// delta-apply. The sibling tests only cover strictly-smaller (accepted)
-    /// and strictly-larger (refused), which leaves an off-by-one in the
-    /// comparison operator (`>` instead of `>=`) undetected.
+    /// Boundary pin for the switch margin. A delta merely EQUAL to (or a few
+    /// bytes larger than) our state must still be SHIPPED: flipping to full
+    /// state there buys nothing and re-creates the #4233 full-state fan-out
+    /// shape for every small contract. Only a delta that clears
+    /// `state + MIN_FULL_STATE_SAVING_BYTES` refuses.
+    ///
+    /// The 144-vs-136 case is the real one observed in
+    /// `test_summary_first_put_holder_found_ships_delta`: a bare `>=`
+    /// comparison abandoned the delta to save 8 bytes and broke both the
+    /// summary-first PUT reverse leg and the storm pin.
     #[tokio::test(flavor = "current_thread")]
-    async fn equal_sized_delta_returns_not_efficient() {
-        let our_state_size = 8usize;
-        let equal_delta = vec![3u8; 8]; // exactly our_state_size
-        let (op_manager, queries_served, _guards) =
-            op_manager_with_mock_delta_handler("post_gate_equal_delta", equal_delta).await;
+    async fn delta_slightly_larger_than_state_is_still_shipped() {
+        let our_state_size = 136usize;
+        let slightly_larger = vec![3u8; 144]; // the observed real-world pair
+        let (op_manager, _queries_served, _guards) =
+            op_manager_with_mock_delta_handler("post_gate_margin_delta", slightly_larger.clone())
+                .await;
 
         let key = make_contract_key(103);
         let their_summary = StateSummary::from(vec![4u8]);
         let our_summary = StateSummary::from(vec![5u8, 5]);
 
-        let result = op_manager
+        let delta = op_manager
             .interest_manager
             .compute_delta(
                 &op_manager,
@@ -4437,22 +4478,58 @@ mod tests {
                 &our_summary,
                 our_state_size,
             )
-            .await;
+            .await
+            .expect(
+                "a delta only 8 bytes larger than the state must NOT be \
+                 refused — switching to full state to save 8 bytes is the \
+                 #4233 full-state fan-out shape",
+            )
+            .expect("the contract returned a non-empty delta");
+        assert_eq!(delta.as_ref(), slightly_larger.as_slice());
+    }
 
+    /// The exact refusal threshold: `state + MIN_FULL_STATE_SAVING_BYTES` is
+    /// the first size that loses. One byte under it must still ship, so an
+    /// off-by-one in the margin comparison is caught in both directions.
+    #[tokio::test(flavor = "current_thread")]
+    async fn delta_at_margin_threshold_refuses_but_one_byte_under_ships() {
+        let our_state_size = 100usize;
+        let key = make_contract_key(104);
+        let their_summary = StateSummary::from(vec![4u8]);
+        let our_summary = StateSummary::from(vec![5u8, 5]);
+
+        // One byte UNDER the threshold: still shipped.
+        let under = vec![1u8; 100 + MIN_FULL_STATE_SAVING_BYTES - 1];
+        let (op_under, _q, _g) =
+            op_manager_with_mock_delta_handler("post_gate_margin_under", under).await;
+        assert!(
+            op_under
+                .interest_manager
+                .compute_delta(
+                    &op_under,
+                    &key,
+                    &their_summary,
+                    &our_summary,
+                    our_state_size
+                )
+                .await
+                .is_ok(),
+            "one byte under the switch margin must still ship the delta"
+        );
+
+        // Exactly AT the threshold: refused.
+        let at = vec![1u8; 100 + MIN_FULL_STATE_SAVING_BYTES];
+        let (op_at, _q2, _g2) = op_manager_with_mock_delta_handler("post_gate_margin_at", at).await;
         assert_eq!(
-            result,
+            op_at
+                .interest_manager
+                .compute_delta(&op_at, &key, &their_summary, &our_summary, our_state_size)
+                .await,
             Err(DeltaUnavailable::NotEfficient {
                 summary_size: their_summary.as_ref().len(),
                 state_size: our_state_size,
             }),
-            "a delta exactly the size of the state must lose the tie (the gate \
-             is `>=`): full state is preferred at equal bytes because it costs \
-             the receiver no delta-apply"
-        );
-        assert_eq!(
-            queries_served.load(std::sync::atomic::Ordering::SeqCst),
-            1,
-            "the contract must still have been consulted exactly once"
+            "a delta at state + MIN_FULL_STATE_SAVING_BYTES must refuse"
         );
     }
 

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -310,11 +310,25 @@ pub fn contract_hash(contract: &ContractKey) -> u32 {
     hash
 }
 
-/// Check if a delta would be efficient compared to sending full state.
+/// Heuristic: would a delta *probably* be efficient compared to sending full
+/// state, judging only by the peer's summary size?
 ///
 /// Returns true if summary size is less than 50% of state size.
 ///
+/// History (#4923): this used to be a PRE-compute gate inside
+/// [`InterestManager::compute_delta`] — a refusal to even ask the contract for
+/// a delta when the peer's summary was large. That inverted the trade-off:
+/// the fallback to a refused delta is sending FULL STATE, which is never
+/// smaller than the delta the gate declined to compute, and in production the
+/// resulting full-state sends were 41% of ALL network wire bytes (87.4% for
+/// the hottest contract). `compute_delta` now always computes and gates on
+/// the ACTUAL delta size afterwards, so this summary-size proxy has no
+/// production caller. It is deliberately kept (not deleted) as the documented
+/// wire-efficiency heuristic with its unit tests — do not re-wire it as a
+/// pre-compute refusal.
+///
 /// This is a standalone function to avoid requiring type parameters when called.
+#[cfg_attr(not(test), allow(dead_code))]
 pub fn is_delta_efficient(summary_size: usize, state_size: usize) -> bool {
     if state_size == 0 {
         return false;
@@ -331,9 +345,17 @@ pub fn is_delta_efficient(summary_size: usize, state_size: usize) -> bool {
 /// never smaller than the delta that was declined — see #3335.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DeltaUnavailable {
-    /// The wire-efficiency gate ([`is_delta_efficient`]) refused *before* any
-    /// delta was computed, because the peer's summary is >= 50 % of our state
-    /// size. No contract code ran.
+    /// The delta WAS computed (or found cached) but is not smaller than our
+    /// full state, so the caller's full-state fallback is the genuinely
+    /// optimal payload (equal or smaller bytes, and no delta-apply on the
+    /// receiver).
+    ///
+    /// History (#4923): this variant used to mean the [`is_delta_efficient`]
+    /// summary-size proxy refused *before* any delta was computed ("no
+    /// contract code ran"). That pre-compute refusal is gone — the gate now
+    /// runs POST-compute on the actual delta size. The variant name and
+    /// field shape are unchanged on purpose: the #4938 payload-mix telemetry
+    /// keys off them.
     NotEfficient {
         summary_size: usize,
         state_size: usize,
@@ -1464,9 +1486,9 @@ impl<T: TimeSource + Sync> InterestManager<T> {
     /// (`BROADCAST_CH_TIMEOUT`) `GetQuery` against the contract handler,
     /// returning the stored state's `size()` or `None` if it can't be read.
     /// Used by the summary-first PUT reverse leg to feed
-    /// [`compute_delta`](Self::compute_delta)'s efficiency gate with the
-    /// holder's own state size (the holder-side mirror of the originator's
-    /// `merged_value.size()`).
+    /// [`compute_delta`](Self::compute_delta)'s post-compute efficiency check
+    /// with the holder's own state size (the holder-side mirror of the
+    /// originator's `merged_value.size()`).
     pub async fn get_contract_state_size(
         &self,
         op_manager: &crate::node::OpManager,
@@ -1520,16 +1542,29 @@ impl<T: TimeSource + Sync> InterestManager<T> {
     /// Compute a state delta for a peer given their cached summary.
     ///
     /// Uses the contract handler to compute the delta via the contract's
-    /// `get_state_delta` method. Results are cached to avoid recomputation
+    /// `get_state_delta` method (bounded by `BROADCAST_CH_TIMEOUT`). Results
+    /// are cached (keyed by contract + both summaries) to avoid recomputation
     /// for peers with the same summary.
     ///
     /// Returns `Ok(None)` when the contract returns an empty delta (zero bytes),
     /// meaning the peer's state is logically equivalent to ours despite differing
     /// summary bytes (e.g., due to non-deterministic serialization order).
     ///
+    /// Returns [`DeltaUnavailable::NotEfficient`] when the COMPUTED delta is
+    /// not smaller than our full state (`delta.len() >= our_state_size`), so
+    /// the caller's full-state fallback is genuinely optimal. Until #4923 this
+    /// refusal fired BEFORE computing anything, off the [`is_delta_efficient`]
+    /// summary-size proxy (`summary * 2 >= state`) — but the fallback to a
+    /// refused delta is sending FULL STATE, which is never smaller than the
+    /// delta that was declined, so the pre-compute gate could only ever trade
+    /// one bounded WASM call for strictly more wire bytes. In production that
+    /// arm was 41% of ALL network wire bytes. The gate now runs post-compute,
+    /// on the real delta size, on both the cache-hit and fresh-compute paths.
+    ///
     /// # Arguments
     /// * `our_summary` - Our current state summary (used for cache key)
-    /// * `our_state_size` - Size of our current state (for efficiency check)
+    /// * `our_state_size` - Size of our current state (for the post-compute
+    ///   efficiency check)
     pub async fn compute_delta(
         &self,
         op_manager: &crate::node::OpManager,
@@ -1551,19 +1586,20 @@ impl<T: TimeSource + Sync> InterestManager<T> {
                 return Ok(None);
             }
             tracing::trace!(contract = %key, "Using cached delta");
-            return Ok(Some(cached));
+            // The post-compute wire gate applies to cached deltas too: an
+            // oversized delta cached here (or by the staleness probe, which
+            // shares this cache and never gates) must produce the same
+            // NotEfficient refusal a fresh computation would — otherwise a
+            // cache hit would hand the caller a payload larger than the full
+            // state it exists to avoid.
+            return Self::gate_delta_size(cached, their_summary_bytes.len(), our_state_size);
         }
 
-        // Check if delta would be efficient
-        // (summary > 50% of state size means delta probably won't help)
-        if !is_delta_efficient(their_summary_bytes.len(), our_state_size) {
-            return Err(DeltaUnavailable::NotEfficient {
-                summary_size: their_summary_bytes.len(),
-                state_size: our_state_size,
-            });
-        }
-
-        // Compute delta via contract handler (short timeout for broadcast path)
+        // Compute delta via contract handler (short timeout for broadcast
+        // path). No pre-compute size gate here — see the method docs (#4923):
+        // refusing to compute forces a full-state send that is never smaller
+        // than the delta being declined, so the only correct place to judge
+        // efficiency is on the ACTUAL computed delta, below.
         match op_manager
             .notify_contract_handler_with_timeout(
                 ContractHandlerEvent::GetDeltaQuery {
@@ -1585,9 +1621,22 @@ impl<T: TimeSource + Sync> InterestManager<T> {
                     );
                     Ok(None)
                 } else {
-                    // Cache the result (includes contract key to prevent cross-contract pollution)
+                    // Cache the result (includes contract key to prevent
+                    // cross-contract pollution) BEFORE the size gate, even when
+                    // the delta is oversized — deliberately:
+                    // 1. `cached_staleness_verdict` maps any NON-EMPTY cached
+                    //    delta to "peer is stale", which is correct here: an
+                    //    oversized delta is still a genuine divergence, so the
+                    //    fan-out must still send (it will just send full state).
+                    //    Not caching would instead force the staleness path
+                    //    back through a WASM probe.
+                    // 2. Memoization: the next compute_delta for the same
+                    //    (contract, summaries) pair hits the cache above and
+                    //    re-applies the same gate — a consistent NotEfficient
+                    //    verdict with zero further WASM work, instead of
+                    //    re-running the contract on every fan-out target.
                     self.cache_delta(key, their_summary_bytes, our_summary_bytes, d.clone());
-                    Ok(Some(d))
+                    Self::gate_delta_size(d, their_summary_bytes.len(), our_state_size)
                 }
             }
             Ok(ContractHandlerEvent::GetDeltaResponse { delta: Err(e), .. }) => Err(
@@ -1601,6 +1650,34 @@ impl<T: TimeSource + Sync> InterestManager<T> {
                 "Error computing delta: {}",
                 e
             ))),
+        }
+    }
+
+    /// Post-compute wire-efficiency gate (#4923): hand back the computed
+    /// (non-empty) delta only when it is strictly smaller than our full state;
+    /// otherwise refuse with [`DeltaUnavailable::NotEfficient`] so the
+    /// caller's full-state fallback — equal or smaller bytes, and no
+    /// delta-apply on the receiver — is taken as the genuinely optimal
+    /// payload. `>=` on purpose: a delta exactly the size of the state loses
+    /// the tie (full state is simpler and immune to delta-apply failures).
+    fn gate_delta_size(
+        delta: StateDelta<'static>,
+        summary_size: usize,
+        our_state_size: usize,
+    ) -> Result<Option<StateDelta<'static>>, DeltaUnavailable> {
+        if delta.as_ref().len() >= our_state_size {
+            tracing::trace!(
+                delta_size = delta.as_ref().len(),
+                state_size = our_state_size,
+                "Computed delta is not smaller than full state — caller \
+                 should send full state"
+            );
+            Err(DeltaUnavailable::NotEfficient {
+                summary_size,
+                state_size: our_state_size,
+            })
+        } else {
+            Ok(Some(delta))
         }
     }
 
@@ -1636,11 +1713,14 @@ impl<T: TimeSource + Sync> InterestManager<T> {
     /// comparison via [`summary_indicates_stale_peer`]).
     ///
     /// Unlike [`compute_delta`](Self::compute_delta) this deliberately does NOT
-    /// apply the wire-efficiency gate ([`is_delta_efficient`]): staleness
-    /// detection wants the semantic answer even for contracts where a delta
-    /// would be larger than full state, because the alternative it replaces is a
-    /// spurious FULL-STATE heal on every heartbeat — strictly more expensive
-    /// than one delta computation.
+    /// apply the post-compute wire-efficiency gate: staleness detection wants
+    /// the semantic answer (empty vs non-empty) regardless of the delta's
+    /// SIZE, because the alternative it replaces is a spurious FULL-STATE heal
+    /// on every heartbeat — strictly more expensive than one delta
+    /// computation. (Since #4923 `compute_delta` also always runs the
+    /// contract; the remaining difference is only that it refuses to RETURN a
+    /// delta that is not smaller than full state, while this probe has no
+    /// notion of size at all.)
     ///
     /// Steady-state cost: the result rides the SAME delta cache as
     /// `compute_delta` (keyed by contract + both summary hashes). Note that
@@ -2245,6 +2325,12 @@ mod tests {
         assert!(hashes.contains(&contract_hash(&contract2)));
     }
 
+    /// Pins the [`is_delta_efficient`] heuristic itself. Since #4923 the
+    /// function is no longer consulted by `compute_delta` (the efficiency
+    /// gate moved POST-compute, onto the actual delta size — see
+    /// `oversized_computed_delta_returns_not_efficient`); it is kept as the
+    /// documented summary-size heuristic, and these assertions pin its
+    /// boundary behavior.
     #[test]
     fn test_delta_efficiency_check() {
         // Small summary relative to state - efficient
@@ -2864,10 +2950,15 @@ mod tests {
 
     #[test]
     fn test_delta_vs_full_state_decision() {
-        // This test verifies the decision logic for when to send delta vs full state.
-        // The decision is based on:
+        // This test verifies the inputs to the delta-vs-full-state decision:
         // 1. Whether we have peer's summary (None = full state)
-        // 2. Whether delta is efficient (summary < 50% of state size)
+        // 2. The is_delta_efficient summary-size heuristic's boundaries.
+        //
+        // NOTE (#4923): the heuristic is no longer a pre-compute refusal in
+        // `compute_delta` — a large summary now still gets a real delta
+        // computed, and only a delta that is not smaller than the full state
+        // is refused (post-compute). The assertions below pin the heuristic
+        // function itself, not the (removed) gate wiring.
 
         let (manager, _time) = make_manager();
         let contract = make_contract_key(1);
@@ -4098,6 +4189,256 @@ mod tests {
         assert_eq!(
             manager.cached_staleness_verdict(&contract, theirs.as_ref(), ours.as_ref()),
             Some(true)
+        );
+    }
+
+    // ---- Post-compute efficiency gate (#4923) ------------------------------
+    //
+    // Production incident: `compute_delta` refused to even ASK the contract
+    // for a delta whenever the peer's summary was >= 50% of our state size
+    // (the pre-compute `is_delta_efficient` gate), and every caller answers
+    // that refusal by sending FULL STATE — which is never smaller than the
+    // delta that was declined. On the live network that arm was 41% of ALL
+    // wire bytes (87.4% for the hottest contract), flat over time. The gate
+    // now runs POST-compute, on the actual delta size. These tests drive the
+    // real `compute_delta` against a real `OpManager` whose contract-handler
+    // side is a mock responder task, so the whole path (cache lookup →
+    // `GetDeltaQuery` → post-compute gate) is exercised.
+
+    /// Build a real `OpManager` backed by a temp-dir `Config` (mirrors
+    /// `summarize_delta_cache_tests::build_op_manager`) and spawn a mock
+    /// contract handler that answers every `GetDeltaQuery` with
+    /// `delta_bytes`, counting the queries it serves. The returned guard
+    /// bundle keeps the other channel receivers + task monitor alive for the
+    /// whole test (dropping them mid-run would tear down the OpManager's
+    /// channels).
+    async fn op_manager_with_mock_delta_handler(
+        id: &str,
+        delta_bytes: Vec<u8>,
+    ) -> (
+        std::sync::Arc<crate::node::OpManager>,
+        std::sync::Arc<std::sync::atomic::AtomicUsize>,
+        Box<dyn std::any::Any>,
+    ) {
+        use crate::contract::ContractHandlerEvent;
+
+        let config_args = crate::config::ConfigArgs {
+            id: Some(id.to_string()),
+            mode: Some(crate::contract::OperationMode::Local),
+            ..Default::default()
+        };
+        let node_config =
+            crate::node::NodeConfig::new(config_args.build().await.expect("build Config"))
+                .await
+                .expect("build NodeConfig");
+
+        let (notification_rx, notification_tx) = crate::node::event_loop_notification_channel();
+        let (ops_ch_channel, mut ch_channel, wait_for_event) =
+            crate::contract::contract_handler_channel();
+        let connection_manager = crate::ring::ConnectionManager::new(&node_config);
+        let (result_router_tx, result_router_rx) = tokio::sync::mpsc::channel(100);
+        let task_monitor = crate::node::background_task_monitor::BackgroundTaskMonitor::new();
+
+        let op_manager = std::sync::Arc::new(
+            crate::node::OpManager::new(
+                notification_tx,
+                ops_ch_channel,
+                &node_config,
+                crate::tracing::DynamicRegister::new(vec![]),
+                connection_manager,
+                result_router_tx,
+                &task_monitor,
+            )
+            .expect("build OpManager"),
+        );
+        op_manager.ring.attach_op_manager(&op_manager);
+
+        // The mock contract handler: serve `delta_bytes` for every
+        // GetDeltaQuery, exactly as a real handler would after running the
+        // contract's `get_state_delta`.
+        let queries_served = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let counter = queries_served.clone();
+        let responder = tokio::spawn(async move {
+            while let Ok((id, ev, _priority)) = ch_channel.recv_from_sender().await {
+                if let ContractHandlerEvent::GetDeltaQuery { key, .. } = ev {
+                    counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    let sent = ch_channel
+                        .send_to_sender(
+                            id,
+                            ContractHandlerEvent::GetDeltaResponse {
+                                key,
+                                delta: Ok(StateDelta::from(delta_bytes.clone())),
+                            },
+                        )
+                        .await;
+                    if sent.is_err() {
+                        // The querying side dropped (test teardown) — stop.
+                        break;
+                    }
+                }
+            }
+        });
+
+        let guards: Box<dyn std::any::Any> = Box::new((
+            notification_rx,
+            wait_for_event,
+            result_router_rx,
+            task_monitor,
+            responder,
+        ));
+        (op_manager, queries_served, guards)
+    }
+
+    /// THE incident pin (#4923): a peer whose cached summary is large (here
+    /// state-sized, so the removed pre-compute gate would refuse outright:
+    /// `1000 * 2 >= 1000`) must no longer force a full-state fallback when
+    /// the contract's ACTUAL delta is small. Pre-fix this returned
+    /// `Err(NotEfficient)` without running any contract code, and the caller
+    /// (`broadcast_to_single_peer`) shipped the entire state — 41% of all
+    /// network wire bytes in production. Post-fix the delta is computed and
+    /// returned.
+    #[tokio::test(flavor = "current_thread")]
+    async fn oversized_peer_summary_no_longer_forces_full_state_when_delta_is_small() {
+        let small_delta = vec![42u8, 43, 44]; // 3 bytes vs a 1000-byte state
+        let (op_manager, queries_served, _guards) =
+            op_manager_with_mock_delta_handler("post_gate_incident_pin", small_delta.clone()).await;
+
+        let key = make_contract_key(101);
+        let our_state_size = 1000usize;
+        // State-sized peer summary: the exact shape production saw for the
+        // hot contract (their_summary.len() * 2 >= our_state_size).
+        let their_summary = StateSummary::from(vec![7u8; 1000]);
+        let our_summary = StateSummary::from(vec![1u8, 2, 3]);
+
+        let result = op_manager
+            .interest_manager
+            .compute_delta(
+                &op_manager,
+                &key,
+                &their_summary,
+                &our_summary,
+                our_state_size,
+            )
+            .await;
+
+        let delta = result
+            .expect(
+                "an oversized peer summary must no longer refuse the delta \
+                 pre-compute — the fallback (full state) is never smaller than \
+                 the delta being declined (#4923)",
+            )
+            .expect("the contract returned a non-empty delta");
+        assert_eq!(
+            delta.as_ref(),
+            small_delta.as_slice(),
+            "the computed small delta must be handed back verbatim"
+        );
+        assert_eq!(
+            queries_served.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "the contract handler must have been consulted exactly once"
+        );
+        // The result is memoized in the shared delta cache.
+        assert!(
+            op_manager
+                .interest_manager
+                .get_cached_delta(&key, their_summary.as_ref(), our_summary.as_ref())
+                .is_some(),
+            "the computed delta must be cached for subsequent fan-out targets"
+        );
+    }
+
+    /// The post-compute gate: a delta that comes back NOT smaller than our
+    /// full state still yields `NotEfficient` — so the caller's full-state
+    /// fallback is taken exactly when it is genuinely optimal. Also pins the
+    /// deliberate cache interaction: the oversized delta IS cached (so
+    /// `cached_staleness_verdict` still reports genuine divergence and no
+    /// WASM re-runs), and a second `compute_delta` call answers from the
+    /// cache — same refusal, zero additional contract queries.
+    #[tokio::test(flavor = "current_thread")]
+    async fn oversized_computed_delta_returns_not_efficient() {
+        let oversized_delta = vec![9u8; 10]; // 10 bytes vs a 4-byte state
+        let (op_manager, queries_served, _guards) =
+            op_manager_with_mock_delta_handler("post_gate_oversized_delta", oversized_delta).await;
+
+        let key = make_contract_key(102);
+        let our_state_size = 4usize;
+        // Small peer summary: the OLD pre-compute gate would have let this
+        // through (1 * 2 < 4), so this failure mode is reachable only via the
+        // post-compute check.
+        let their_summary = StateSummary::from(vec![5u8]);
+        let our_summary = StateSummary::from(vec![6u8, 6, 6]);
+
+        for pass in 1..=2u32 {
+            let result = op_manager
+                .interest_manager
+                .compute_delta(
+                    &op_manager,
+                    &key,
+                    &their_summary,
+                    &our_summary,
+                    our_state_size,
+                )
+                .await;
+            assert_eq!(
+                result,
+                Err(DeltaUnavailable::NotEfficient {
+                    summary_size: their_summary.as_ref().len(),
+                    state_size: our_state_size,
+                }),
+                "pass {pass}: a computed delta >= full state must refuse with \
+                 NotEfficient so the caller's full-state fallback is optimal"
+            );
+        }
+        assert_eq!(
+            queries_served.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "the second call must be served from the delta cache (memoized \
+             refusal), not a second WASM run"
+        );
+        // The oversized delta is cached ON PURPOSE: it is still a genuine
+        // divergence, so the staleness machinery must keep reporting "peer is
+        // stale" (the fan-out then heals with full state).
+        assert_eq!(
+            op_manager.interest_manager.cached_staleness_verdict(
+                &key,
+                their_summary.as_ref(),
+                our_summary.as_ref()
+            ),
+            Some(true),
+            "an oversized (non-empty) cached delta must still read as genuine \
+             divergence for the staleness verdict"
+        );
+    }
+
+    /// Converged-peer companion to the incident pin: with the SAME oversized
+    /// peer summary the pre-compute gate used to refuse before the contract
+    /// could report an EMPTY delta, so a logically-converged peer was
+    /// re-flooded with full state. Post-#4923 the empty delta is seen and
+    /// `Ok(None)` lets the caller skip the send entirely.
+    #[tokio::test(flavor = "current_thread")]
+    async fn oversized_peer_summary_with_empty_delta_reports_converged() {
+        let (op_manager, queries_served, _guards) =
+            op_manager_with_mock_delta_handler("post_gate_empty_delta", Vec::new()).await;
+
+        let key = make_contract_key(103);
+        let their_summary = StateSummary::from(vec![8u8; 1000]); // state-sized
+        let our_summary = StateSummary::from(vec![4u8, 2]);
+
+        let result = op_manager
+            .interest_manager
+            .compute_delta(&op_manager, &key, &their_summary, &our_summary, 1000)
+            .await;
+        assert_eq!(
+            result,
+            Ok(None),
+            "an empty delta behind an oversized peer summary must report \
+             converged (skip), not NotEfficient (full-state re-flood)"
+        );
+        assert_eq!(
+            queries_served.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "the contract must have been consulted for the verdict"
         );
     }
 }

--- a/crates/core/src/transport.rs
+++ b/crates/core/src/transport.rs
@@ -645,10 +645,19 @@ pub(crate) trait PeerConnectionApi: Send {
     /// Sends a network message to the remote peer.
     ///
     /// The message is serialized and sent over the transport connection.
+    ///
+    /// Returns the SERIALIZED length of the message. Callers use it to
+    /// attribute outbound bytes by message kind
+    /// ([`outbound_message_mix`][omm]) without serializing a second time just
+    /// to measure. It is the payload the transport was asked to move, not the
+    /// on-wire total (no framing, ACKs or retransmits) — see that module for
+    /// what the difference means.
+    ///
+    /// [omm]: crate::node::network_bridge::outbound_message_mix
     fn send_message(
         &mut self,
         msg: NetMessage,
-    ) -> std::pin::Pin<Box<dyn Future<Output = Result<(), TransportError>> + Send + '_>>;
+    ) -> std::pin::Pin<Box<dyn Future<Output = Result<usize, TransportError>> + Send + '_>>;
 
     /// Receives raw bytes from the remote peer.
     ///

--- a/crates/core/src/transport/peer_connection.rs
+++ b/crates/core/src/transport/peer_connection.rs
@@ -709,7 +709,15 @@ impl<S: super::Socket, T: TimeSource> PeerConnection<S, T> {
     }
 
     #[instrument(name = "peer_connection", skip_all)]
-    pub async fn send<D>(&mut self, data: D) -> Result
+    /// Serialize `data` and hand it to the transport.
+    ///
+    /// Returns the SERIALIZED byte length, so callers that already know the
+    /// message kind can attribute outbound bytes without a second
+    /// serialization pass just to measure it (see
+    /// [`outbound_message_mix`][omm]).
+    ///
+    /// [omm]: crate::node::network_bridge::outbound_message_mix
+    pub async fn send<D>(&mut self, data: D) -> Result<usize>
     where
         D: Serialize + Send + std::fmt::Debug,
     {
@@ -723,15 +731,18 @@ impl<S: super::Socket, T: TimeSource> PeerConnection<S, T> {
                 total_size_bytes = data.len(),
                 "Sending as stream"
             );
+            let len = data.len();
             self.outbound_stream(data).await;
+            return Ok(len);
         } else {
             tracing::trace!(
                 peer_addr = %self.remote_conn.remote_addr,
                 "Sending as short message"
             );
+            let len = data.len();
             self.outbound_short_message(data).await?;
+            return Ok(len);
         }
-        Ok(())
     }
 
     #[instrument(name = "peer_connection", skip(self))]
@@ -2413,7 +2424,7 @@ impl<S: super::Socket> super::PeerConnectionApi for PeerConnection<S> {
         &mut self,
         msg: crate::message::NetMessage,
     ) -> std::pin::Pin<
-        Box<dyn futures::Future<Output = Result<(), super::TransportError>> + Send + '_>,
+        Box<dyn futures::Future<Output = Result<usize, super::TransportError>> + Send + '_>,
     > {
         Box::pin(async move { self.send(msg).await })
     }


### PR DESCRIPTION
## Problem

`is_delta_efficient` (`summary_size * 2 < state_size`) runs as a **pre-compute** gate inside `compute_delta`: when a peer's cached summary is >= 50% of our state size, we refuse to ask the contract for a delta at all and send **full state** instead.

That trade is backwards, and the existing code comment on `DeltaUnavailable` already says so:

> Every caller falls back to sending FULL STATE, which is never smaller than the delta that was declined.

On the broadcast path the peer's summary is already sitting in our local interest cache. Its size is not a wire cost at fan-out time. The only wire question is "delta or full state", and refusing to compute the delta answers that question by sending the larger of the two. A large summary is a poor proxy for a large delta: a 500 KB room with a 500 KB summary still has a ~200 byte delta when one message is appended.

### Measured cost

From a ~15 min fleet window on 0.2.108 (634 peers, `broadcast_payload_mix` rollups, see #4956 for full method):

| arm | sends | bytes | share of broadcast bytes | mean |
|---|---|---|---|---|
| `full_not_efficient` | 2,120 | 0.81 GB | 6.8% | 372 KB |

Those 2,120 sends put 372 KB on the wire each because the gate declined to compute a delta. The rollup also reports the gate's own inputs, and the aggregate summary/state ratio for this arm is **0.999** — these are contracts whose summary is essentially the same size as their state, so the pre-compute proxy refuses ~100% of the time for them, permanently.

Share rises to roughly **11%** of broadcast bytes once 0.2.109 (#4953) collapses the `full_no_their_summary_untracked` arm.

## Approach

Move the gate to **after** computation and judge the real artifact:

- `compute_delta` no longer consults `is_delta_efficient` before calling the contract.
- A new `gate_delta_size` returns `DeltaUnavailable::NotEfficient` only when `delta.len() >= our_state_size`, so the caller's full-state fallback is taken exactly when it is genuinely the smaller payload.
- The gate is applied on the **cache-hit path too**, so a delta cached by the staleness probe (which never gates) cannot hand a caller a payload larger than the full state it exists to avoid.
- Oversized deltas are still **cached** on purpose: `cached_staleness_verdict` maps any non-empty cached delta to "peer is stale", which stays correct (the peer really has diverged, we just answer with full state), and it memoizes the refusal so the next fan-out target for the same summary pair costs no further WASM.

`is_delta_efficient` is kept, documented as a heuristic with no production caller, with its unit tests intact and a `do not re-wire this as a pre-compute refusal` note. `DeltaUnavailable::NotEfficient` keeps its name and fields because the #4938 payload-mix telemetry keys off them — the arm now means "computed, and not smaller than full state" rather than "refused before computing".

### Cost

Removing a pre-compute refusal means the contract's `get_state_delta` now runs for that population. That is **+0.76%** more delta computations (2,120 against the 279,864 the `delta` arm already performs in the same window), bounded by `BROADCAST_CH_TIMEOUT` and memoized by the existing delta cache. Given #4861 made WASM CPU a real eviction axis this was worth checking; it is noise.

## Testing

- Full `cargo test -p freenet --lib` suite.
- `interest.rs` gains direct coverage for the post-compute gate: delta smaller than state passes through, delta >= state refuses, and the cache-hit path applies the same verdict as a fresh compute.
- `is_delta_efficient`'s own unit tests are retained to pin the heuristic's behavior even though it has no production caller.

## Notes

This branch originated in the 0.2.107-0.2.109 bandwidth session as `fix/delta-gate-post-compute` and was set aside as marginal after being weighed against `full_delta_suppressed` (0.5% of bytes). That was the wrong arm — the change targets `full_not_efficient`. Rebased onto 0.2.109 `main` and re-measured here.

Do not release this until 0.2.109's field validation has a clean window, so the `untracked` collapse can be measured without a second broadcast change confounding it. The arms are instrumented separately, so review and merge can proceed.

Refs #4956

[AI-assisted - Claude]
