### PR TITLE
feat(telemetry): tag why a tracked peer has no cached summary

### DIFF
--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -2823,9 +2823,11 @@ async fn handle_interest_sync_message(
                                     .interest_manager
                                     .upsert_peer_summary(&contract, &pk, theirs);
                             }
-                            None => op_manager
-                                .interest_manager
-                                .update_peer_summary(&contract, &pk, None),
+                            None => op_manager.interest_manager.clear_peer_summary(
+                                &contract,
+                                &pk,
+                                crate::ring::interest::SummaryMissingReason::ClearedByNoneReport,
+                            ),
                         }
 
                         if is_stale && !stale_contracts.contains(&contract) {
@@ -3173,9 +3175,11 @@ async fn handle_interest_sync_message(
             // Clear cached summary for this peer
             let peer_key = get_peer_key_from_addr(op_manager, source);
             if let Some(ref pk) = peer_key {
-                op_manager
-                    .interest_manager
-                    .update_peer_summary(&key, pk, None);
+                op_manager.interest_manager.clear_peer_summary(
+                    &key,
+                    pk,
+                    crate::ring::interest::SummaryMissingReason::ClearedByResync,
+                );
             }
 
             // Get PeerKeyLocation for telemetry
@@ -3990,10 +3994,13 @@ mod tests {
              untracked-no-op update path (#4952)"
         );
         assert!(
-            body.contains("update_peer_summary(&contract,&pk,None"),
-            "Summaries arm must keep clear-only update semantics for a None \
-             report — creating an entry just to hold None would relabel \
-             untracked traffic as tracked without enabling deltas"
+            body.contains("clear_peer_summary(&contract,&pk,")
+                && body.contains("SummaryMissingReason::ClearedByNoneReport"),
+            "Summaries arm must keep clear-only semantics for a None report \
+             (creating an entry just to hold None would relabel untracked \
+             traffic as tracked without enabling deltas), and must tag the \
+             clear ClearedByNoneReport so #4961 can attribute the \
+             full_no_their_summary_tracked arm to this path"
         );
     }
 
@@ -6632,22 +6639,27 @@ mod tests {
         fn resync_request_handler_clears_cached_peer_summary() {
             let arm = resync_request_arm();
             assert!(
-                arm.contains("update_peer_summary"),
-                "ResyncRequest handler no longer calls update_peer_summary. \
+                arm.contains("clear_peer_summary"),
+                "ResyncRequest handler no longer calls clear_peer_summary. \
                  #4145 caching relies on this handler clearing the sender's \
                  cached summary so a delta-apply failure forces a fresh \
                  full-state resend instead of looping on unappliable deltas."
             );
-            // The clear MUST pass `None` (clear), not a `Some(summary)` cache.
-            // Strip whitespace so the multi-line call (`op_manager\n
-            // .interest_manager\n .update_peer_summary(&key, pk, None);`)
-            // matches regardless of formatting.
+            // The clear MUST go through the tagged clear API, not a
+            // `update_peer_summary` cache-write. Strip whitespace so the
+            // multi-line call matches regardless of formatting.
             let collapsed: String = arm.chars().filter(|c| !c.is_whitespace()).collect();
             assert!(
-                collapsed.contains("update_peer_summary(&key,pk,None)"),
-                "ResyncRequest handler must clear the cached summary with \
-                 `update_peer_summary(&key, pk, None)` (the `None` clears it). \
-                 Caching a summary here instead would defeat the #4145 backstop."
+                collapsed.contains("clear_peer_summary(&key,pk,"),
+                "ResyncRequest handler must clear the cached summary via \
+                 `clear_peer_summary`. Caching a summary here instead would \
+                 defeat the #4145 backstop."
+            );
+            assert!(
+                collapsed.contains("SummaryMissingReason::ClearedByResync"),
+                "the clear must be tagged ClearedByResync — #4961 needs the \
+                 full_no_their_summary_tracked arm attributed per clear path, \
+                 and an untagged clear would silently land in another bucket"
             );
         }
 

--- a/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
+++ b/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
@@ -34,6 +34,13 @@
 //!    persistent residual implicates the seeding/heartbeat chain instead.
 //! 6. [`PayloadArm::FullNoTheirSummaryTracked`] — the peer's summary is
 //!    missing but the peer IS tracked, so the next delivery repairs it.
+//!    Measured at 26.9 % of broadcast bytes (357 KB mean) on the aged 0.2.109
+//!    fleet — the largest remaining arm — so #4961 splits it AGAIN, by
+//!    [`SummaryMissingReason`]: never seeded vs cleared by the peer's own
+//!    `None` report vs cleared by a resync or a delta-apply failure. Those
+//!    have three different fixes, published as
+//!    `tracked_missing_<reason>_{sends,bytes}` plus a
+//!    `tracked_missing_unattributed_*` residual that must stay at zero.
 //!
 //! Arms 4-6 were a single `full_no_summary` bucket when #4922 first shipped.
 //! The 2026-07-25 measurement then found that bucket was the LARGEST single

--- a/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
+++ b/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
@@ -379,9 +379,24 @@ impl PayloadMix {
         let mut w = self.window.lock();
         if arm == PayloadArm::FullNoTheirSummaryTracked {
             if let Some(reason) = missing_reason {
+                // Fallible indexing, NOT `[r]`. Adding a variant to
+                // `SummaryMissingReason` forces `index()` and `as_str()` to be
+                // updated (both are exhaustive matches) but does NOT force
+                // `ALL` to be extended, and `ALL.len()` sizes these arrays. So
+                // the plausible sequence "add variant, fix the two compile
+                // errors, forget ALL" yields an out-of-range index — which as
+                // `[r]` would PANIC inside a held mutex on the broadcast send
+                // path. Degrading to the unattributed residual instead is
+                // strictly better: the miss stays visible (the per-reason sums
+                // no longer cover the arm total) and no send path dies for a
+                // telemetry bookkeeping slip.
+                // One bounds check covers both arrays: they are declared with
+                // the same `ALL.len()` const expression, so they cannot differ.
                 let r = reason.index();
-                w.tracked_missing_sends[r] = w.tracked_missing_sends[r].saturating_add(1);
-                w.tracked_missing_bytes[r] = w.tracked_missing_bytes[r].saturating_add(bytes);
+                if r < w.tracked_missing_sends.len() {
+                    w.tracked_missing_sends[r] = w.tracked_missing_sends[r].saturating_add(1);
+                    w.tracked_missing_bytes[r] = w.tracked_missing_bytes[r].saturating_add(bytes);
+                }
             }
         }
         if arm == PayloadArm::FullNotEfficient {

--- a/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
+++ b/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
@@ -77,6 +77,7 @@ use freenet_stdlib::prelude::ContractInstanceId;
 use parking_lot::Mutex;
 
 use crate::node::background_task_monitor::BackgroundTaskMonitor;
+use crate::ring::interest::SummaryMissingReason;
 
 /// Rollup cadence. Broadcasts are far less frequent than packets, so this is
 /// a minute rather than the 1 Hz sampling the `shadow_demand` aggregators use;
@@ -260,6 +261,19 @@ struct Window {
     not_efficient_state_bytes_sum: u64,
     not_efficient_summary_bytes_max: u64,
     not_efficient_state_bytes_max: u64,
+
+    /// Why the peer had no cached summary, for the
+    /// [`PayloadArm::FullNoTheirSummaryTracked`] arm only.
+    ///
+    /// That arm was 26.9% of broadcast bytes at a 357 KB mean on the aged
+    /// 0.2.109 fleet — the largest remaining arm — but "the peer is tracked
+    /// and has no summary" has three causes with three different fixes
+    /// (never seeded / cleared by the peer's own `None` report / cleared by a
+    /// resync or delta-apply failure), and the rollup could not tell them
+    /// apart. These counters split it. Indexed by
+    /// [`SummaryMissingReason::index`]; sums to the `tracked` arm's totals.
+    tracked_missing_sends: [u64; SummaryMissingReason::ALL.len()],
+    tracked_missing_bytes: [u64; SummaryMissingReason::ALL.len()],
 }
 
 impl Default for Window {
@@ -275,6 +289,8 @@ impl Default for Window {
             not_efficient_state_bytes_sum: 0,
             not_efficient_summary_bytes_max: 0,
             not_efficient_state_bytes_max: 0,
+            tracked_missing_sends: [0; SummaryMissingReason::ALL.len()],
+            tracked_missing_bytes: [0; SummaryMissingReason::ALL.len()],
         }
     }
 }
@@ -344,16 +360,30 @@ impl PayloadMix {
     /// `arm` is [`PayloadArm::FullNotEfficient`] — the only arm for which the
     /// gate ran — and ignored otherwise, so a mis-paired call cannot corrupt
     /// the ratio.
+    ///
+    /// `missing_reason` carries why the peer had no cached summary. It is
+    /// `Some` exactly when `arm` is
+    /// [`PayloadArm::FullNoTheirSummaryTracked`] — the only arm for which a
+    /// tracked entry with an absent summary exists to read — and ignored
+    /// otherwise, same discipline as `gate_inputs`.
     pub(crate) fn record_delivered(
         &self,
         arm: PayloadArm,
         contract: &ContractInstanceId,
         payload_bytes: usize,
         gate_inputs: Option<(usize, usize)>,
+        missing_reason: Option<SummaryMissingReason>,
     ) {
         let bytes = payload_bytes as u64;
         let idx = arm.index();
         let mut w = self.window.lock();
+        if arm == PayloadArm::FullNoTheirSummaryTracked {
+            if let Some(reason) = missing_reason {
+                let r = reason.index();
+                w.tracked_missing_sends[r] = w.tracked_missing_sends[r].saturating_add(1);
+                w.tracked_missing_bytes[r] = w.tracked_missing_bytes[r].saturating_add(bytes);
+            }
+        }
         if arm == PayloadArm::FullNotEfficient {
             if let Some((summary_size, state_size)) = gate_inputs {
                 let (s, st) = (summary_size as u64, state_size as u64);
@@ -423,6 +453,22 @@ impl Window {
         }
     }
 
+    /// Per-reason `(sends, bytes)` for the tracked-but-summaryless arm, in
+    /// [`SummaryMissingReason::ALL`] order.
+    fn tracked_missing(&self) -> Vec<(SummaryMissingReason, u64, u64)> {
+        SummaryMissingReason::ALL
+            .iter()
+            .map(|reason| {
+                let idx = reason.index();
+                (
+                    *reason,
+                    self.tracked_missing_sends[idx],
+                    self.tracked_missing_bytes[idx],
+                )
+            })
+            .collect()
+    }
+
     /// The top [`TOP_CONTRACTS_REPORTED`] contracts in the
     /// [`PayloadArm::FullNotEfficient`] arm, i.e. the ones whose delta the
     /// gate refused. Same stable ordering as [`Self::top_contracts`].
@@ -487,6 +533,7 @@ fn payload_mix_json(
     attribution_dropped_sends: u64,
     attribution_dropped_bytes: u64,
     gate: NotEfficientGateStats,
+    tracked_missing: &[(SummaryMissingReason, u64, u64)],
     window_secs: u64,
 ) -> serde_json::Value {
     let mut obj = serde_json::Map::new();
@@ -555,6 +602,49 @@ fn payload_mix_json(
             .map(serde_json::Value::Number)
             .unwrap_or(serde_json::Value::Null)
         },
+    );
+
+    // #4961: split the tracked-but-summaryless arm by WHY the summary is
+    // absent. The arm was the largest remaining bandwidth consumer (26.9% of
+    // broadcast bytes at a 357 KB mean on the aged 0.2.109 fleet) and the top
+    // suspect for the 4-20s room propagation latency, but its three causes
+    // have three different fixes and were indistinguishable in the rollup.
+    let mut reason_sends = 0u64;
+    let mut reason_bytes = 0u64;
+    for (reason, sends, bytes) in tracked_missing {
+        obj.insert(
+            format!("tracked_missing_{}_sends", reason.as_str()),
+            (*sends).into(),
+        );
+        obj.insert(
+            format!("tracked_missing_{}_bytes", reason.as_str()),
+            (*bytes).into(),
+        );
+        reason_sends += sends;
+        reason_bytes += bytes;
+    }
+    // Reconciliation: the per-reason counters must account for the whole
+    // `full_no_their_summary_tracked` arm. A non-zero residual means a send
+    // reached that arm without a reason — publish it rather than let the
+    // split quietly under-count and mis-aim the fix, which is exactly the
+    // failure mode this instrumentation exists to prevent.
+    let tracked_arm_sends: u64 = arms
+        .iter()
+        .filter(|(arm, _, _)| *arm == PayloadArm::FullNoTheirSummaryTracked)
+        .map(|(_, sends, _)| *sends)
+        .sum();
+    let tracked_arm_bytes: u64 = arms
+        .iter()
+        .filter(|(arm, _, _)| *arm == PayloadArm::FullNoTheirSummaryTracked)
+        .map(|(_, _, bytes)| *bytes)
+        .sum();
+    obj.insert(
+        "tracked_missing_unattributed_sends".into(),
+        tracked_arm_sends.saturating_sub(reason_sends).into(),
+    );
+    obj.insert(
+        "tracked_missing_unattributed_bytes".into(),
+        tracked_arm_bytes.saturating_sub(reason_bytes).into(),
     );
 
     obj.insert("total_sends".into(), total_sends.into());
@@ -650,6 +740,7 @@ pub(crate) fn emit_payload_mix_rollup(
         window.attribution_dropped_sends,
         window.attribution_dropped_bytes,
         window.gate_stats(),
+        &window.tracked_missing(),
         window_secs,
     );
     crate::tracing::telemetry::send_standalone_shadow_event_with_peer_id(
@@ -726,18 +817,21 @@ mod tests {
             &contract(7),
             600,
             Some((600, 600)),
+            None,
         );
         mix.record_delivered(
             PayloadArm::FullNotEfficient,
             &contract(7),
             400,
             Some((400, 400)),
+            None,
         );
         // A different full-state arm must NOT pollute the narrow map.
         mix.record_delivered(
             PayloadArm::FullNoTheirSummaryUntracked,
             &contract(8),
             999,
+            None,
             None,
         );
         let w = mix.take_window();
@@ -754,7 +848,7 @@ mod tests {
     #[test]
     fn take_window_resets_the_window() {
         let mix = PayloadMix::new();
-        mix.record_delivered(PayloadArm::Delta, &contract(1), 100, None);
+        mix.record_delivered(PayloadArm::Delta, &contract(1), 100, None, None);
         let first = mix.take_window().arms();
         assert_eq!(first[PayloadArm::Delta.index()].1, 1);
         assert_eq!(first[PayloadArm::Delta.index()].2, 100);
@@ -775,7 +869,7 @@ mod tests {
         let mix = PayloadMix::new();
         for (i, arm) in PayloadArm::ALL.iter().enumerate() {
             for _ in 0..=i {
-                mix.record_delivered(*arm, &contract(i as u8), 10, None);
+                mix.record_delivered(*arm, &contract(i as u8), 10, None, None);
             }
         }
         let drained = mix.take_window().arms();
@@ -799,15 +893,22 @@ mod tests {
     #[test]
     fn per_contract_tallies_reconcile_with_arm_totals() {
         let mix = PayloadMix::new();
-        mix.record_delivered(PayloadArm::FullNotEfficient, &contract(1), 500, None);
+        mix.record_delivered(PayloadArm::FullNotEfficient, &contract(1), 500, None, None);
         mix.record_delivered(
             PayloadArm::FullNoTheirSummaryUntracked,
             &contract(2),
             300,
             None,
+            None,
         );
-        mix.record_delivered(PayloadArm::FullDeltaSuppressed, &contract(1), 200, None);
-        mix.record_delivered(PayloadArm::Delta, &contract(3), 50, None); // not full state
+        mix.record_delivered(
+            PayloadArm::FullDeltaSuppressed,
+            &contract(1),
+            200,
+            None,
+            None,
+        );
+        mix.record_delivered(PayloadArm::Delta, &contract(3), 50, None, None); // not full state
 
         let window = mix.take_window();
         let full_state_total: u64 = window
@@ -845,6 +946,7 @@ mod tests {
             window.attribution_dropped_sends,
             window.attribution_dropped_bytes,
             window.gate_stats(),
+            &[],
             60,
         );
         let top_sum: u64 = json["top_contracts_by_full_state_bytes"]
@@ -876,7 +978,13 @@ mod tests {
     fn window_with_more_contracts_than_top_n_still_reconciles() {
         let mix = PayloadMix::new();
         for i in 0..(TOP_CONTRACTS_REPORTED + 1) {
-            mix.record_delivered(PayloadArm::FullNotEfficient, &contract(i as u8), 100, None);
+            mix.record_delivered(
+                PayloadArm::FullNotEfficient,
+                &contract(i as u8),
+                100,
+                None,
+                None,
+            );
         }
         let window = mix.take_window();
         assert_reconciles(&window);
@@ -890,6 +998,7 @@ mod tests {
             window.attribution_dropped_sends,
             window.attribution_dropped_bytes,
             window.gate_stats(),
+            &[],
             60,
         );
         assert_eq!(json["full_state_bytes"], 1100);
@@ -919,6 +1028,7 @@ mod tests {
                 PayloadArm::FullNoTheirSummaryUntracked,
                 &ContractInstanceId::new(raw),
                 10,
+                None,
                 None,
             );
         }
@@ -976,6 +1086,7 @@ mod tests {
                             &contract(t as u8),
                             7,
                             None,
+                            None,
                         );
                     }
                 })
@@ -1017,6 +1128,7 @@ mod tests {
             0,
             0,
             NotEfficientGateStats::default(),
+            &[],
             60,
         );
         assert_eq!(json["total_bytes"], 1000);
@@ -1037,11 +1149,12 @@ mod tests {
     #[test]
     fn no_summary_split_reports_each_cause_and_the_legacy_aggregate() {
         let mix = PayloadMix::new();
-        mix.record_delivered(PayloadArm::FullNoOurSummary, &contract(1), 100, None);
+        mix.record_delivered(PayloadArm::FullNoOurSummary, &contract(1), 100, None, None);
         mix.record_delivered(
             PayloadArm::FullNoTheirSummaryUntracked,
             &contract(2),
             200,
+            None,
             None,
         );
         mix.record_delivered(
@@ -1049,11 +1162,13 @@ mod tests {
             &contract(3),
             300,
             None,
+            None,
         );
         mix.record_delivered(
             PayloadArm::FullNoTheirSummaryUntracked,
             &contract(2),
             400,
+            None,
             None,
         );
 
@@ -1067,6 +1182,7 @@ mod tests {
             window.attribution_dropped_sends,
             window.attribution_dropped_bytes,
             window.gate_stats(),
+            &[],
             60,
         );
 
@@ -1082,6 +1198,142 @@ mod tests {
              analysis script that queries `full_no_summary_bytes` by name"
         );
         assert_eq!(json["full_no_summary_sends"], 4);
+    }
+
+    /// Emit the rollup for a window built by `record_delivered`, so these
+    /// tests exercise the real recording path rather than hand-built inputs.
+    fn emit(mix: &PayloadMix) -> serde_json::Value {
+        let window = mix.take_window();
+        payload_mix_json(
+            &window.arms(),
+            &window.top_contracts(),
+            &window.top_not_efficient_contracts(),
+            window.contract_full_state_bytes.values().sum(),
+            window.contract_full_state_bytes.len() as u64,
+            window.attribution_dropped_sends,
+            window.attribution_dropped_bytes,
+            window.gate_stats(),
+            &window.tracked_missing(),
+            60,
+        )
+    }
+
+    /// #4961: the tracked arm splits by WHY the summary is absent, and the
+    /// per-reason bytes reconcile exactly against the arm total.
+    #[test]
+    fn tracked_arm_splits_by_missing_reason_and_reconciles() {
+        let mix = PayloadMix::new();
+        mix.record_delivered(
+            PayloadArm::FullNoTheirSummaryTracked,
+            &contract(1),
+            100,
+            None,
+            Some(SummaryMissingReason::NeverPopulated),
+        );
+        mix.record_delivered(
+            PayloadArm::FullNoTheirSummaryTracked,
+            &contract(2),
+            250,
+            None,
+            Some(SummaryMissingReason::ClearedByNoneReport),
+        );
+        mix.record_delivered(
+            PayloadArm::FullNoTheirSummaryTracked,
+            &contract(3),
+            30,
+            None,
+            Some(SummaryMissingReason::ClearedByResync),
+        );
+        mix.record_delivered(
+            PayloadArm::FullNoTheirSummaryTracked,
+            &contract(4),
+            7,
+            None,
+            Some(SummaryMissingReason::ClearedByDeltaApplyFailure),
+        );
+
+        let json = emit(&mix);
+        assert_eq!(json["tracked_missing_never_populated_bytes"], 100);
+        assert_eq!(json["tracked_missing_never_populated_sends"], 1);
+        assert_eq!(json["tracked_missing_none_report_bytes"], 250);
+        assert_eq!(json["tracked_missing_resync_bytes"], 30);
+        assert_eq!(json["tracked_missing_delta_apply_failed_bytes"], 7);
+
+        assert_eq!(
+            json["full_no_their_summary_tracked_bytes"], 387,
+            "the arm total must equal the sum of its reasons"
+        );
+        assert_eq!(
+            json["tracked_missing_unattributed_bytes"], 0,
+            "every tracked send carried a reason, so the residual must be zero"
+        );
+        assert_eq!(json["tracked_missing_unattributed_sends"], 0);
+    }
+
+    /// A tracked send that arrives WITHOUT a reason must surface as an
+    /// explicit residual, never be silently folded into another bucket.
+    ///
+    /// This is the guard against the failure mode that motivated the split:
+    /// a future clear path that forgets to tag itself would otherwise make
+    /// one of the four reasons look artificially small and mis-aim the fix.
+    #[test]
+    fn tracked_send_without_a_reason_is_reported_as_unattributed() {
+        let mix = PayloadMix::new();
+        mix.record_delivered(
+            PayloadArm::FullNoTheirSummaryTracked,
+            &contract(1),
+            100,
+            None,
+            Some(SummaryMissingReason::NeverPopulated),
+        );
+        // No reason — e.g. a future clear site that forgot to tag itself.
+        mix.record_delivered(
+            PayloadArm::FullNoTheirSummaryTracked,
+            &contract(2),
+            900,
+            None,
+            None,
+        );
+
+        let json = emit(&mix);
+        assert_eq!(json["tracked_missing_never_populated_bytes"], 100);
+        assert_eq!(
+            json["tracked_missing_unattributed_bytes"], 900,
+            "an untagged tracked send must be visible as a residual, not \
+             silently attributed to a reason that did not cause it"
+        );
+        assert_eq!(json["tracked_missing_unattributed_sends"], 1);
+    }
+
+    /// A reason passed on a NON-tracked arm is ignored, so a mis-paired call
+    /// cannot inflate the split — the same discipline `gate_inputs` follows.
+    #[test]
+    fn missing_reason_is_ignored_on_arms_other_than_tracked() {
+        let mix = PayloadMix::new();
+        mix.record_delivered(
+            PayloadArm::FullNoTheirSummaryUntracked,
+            &contract(1),
+            500,
+            None,
+            Some(SummaryMissingReason::NeverPopulated),
+        );
+        mix.record_delivered(
+            PayloadArm::Delta,
+            &contract(2),
+            10,
+            None,
+            Some(SummaryMissingReason::ClearedByResync),
+        );
+
+        let json = emit(&mix);
+        for reason in SummaryMissingReason::ALL {
+            assert_eq!(
+                json[format!("tracked_missing_{}_bytes", reason.as_str())],
+                0,
+                "a reason paired with a non-tracked arm must not be counted"
+            );
+        }
+        assert_eq!(json["tracked_missing_unattributed_bytes"], 0);
     }
 
     /// The efficiency gate's inputs are reported, so `full_not_efficient`
@@ -1103,16 +1355,18 @@ mod tests {
             &contract(1),
             1000,
             Some((600, 1000)),
+            None,
         );
         mix.record_delivered(
             PayloadArm::FullNotEfficient,
             &contract(1),
             2000,
             Some((1400, 2000)),
+            None,
         );
         // A non-NotEfficient arm must never contribute, even if a caller
         // mistakenly passes sizes — otherwise the ratio silently drifts.
-        mix.record_delivered(PayloadArm::Delta, &contract(1), 10, Some((99999, 1)));
+        mix.record_delivered(PayloadArm::Delta, &contract(1), 10, Some((99999, 1)), None);
 
         let window = mix.take_window();
         assert_eq!(window.gate_stats().summary_bytes_sum, 2000);
@@ -1129,6 +1383,7 @@ mod tests {
             window.attribution_dropped_sends,
             window.attribution_dropped_bytes,
             window.gate_stats(),
+            &[],
             60,
         );
         assert_eq!(json["not_efficient_summary_bytes_sum"], 2000);
@@ -1145,7 +1400,7 @@ mod tests {
     #[test]
     fn not_efficient_ratio_is_null_when_the_gate_never_fired() {
         let mix = PayloadMix::new();
-        mix.record_delivered(PayloadArm::Delta, &contract(1), 10, None);
+        mix.record_delivered(PayloadArm::Delta, &contract(1), 10, None, None);
         let window = mix.take_window();
         let json = payload_mix_json(
             &window.arms(),
@@ -1156,6 +1411,7 @@ mod tests {
             0,
             0,
             window.gate_stats(),
+            &[],
             60,
         );
         assert!(json["not_efficient_summary_to_state_bytes_ratio"].is_null());
@@ -1175,6 +1431,7 @@ mod tests {
             0,
             0,
             NotEfficientGateStats::default(),
+            &[],
             60,
         );
         assert_eq!(json["full_state_byte_share"], 0.0);
@@ -1202,6 +1459,7 @@ mod tests {
                 PayloadArm::FullNotEfficient,
                 &ContractInstanceId::new(raw),
                 5,
+                None,
                 None,
             );
         }
@@ -1242,6 +1500,7 @@ mod tests {
                 &ContractInstanceId::new(raw),
                 1,
                 None,
+                None,
             );
         }
         // A single additional contract, broadcasting many times.
@@ -1249,7 +1508,7 @@ mod tests {
         raw[31] = 7;
         let over_cap = ContractInstanceId::new(raw);
         for _ in 0..1000 {
-            mix.record_delivered(PayloadArm::FullNotEfficient, &over_cap, 3, None);
+            mix.record_delivered(PayloadArm::FullNotEfficient, &over_cap, 3, None, None);
         }
         let window = mix.take_window();
         assert_eq!(window.attribution_dropped_sends, 1000);
@@ -1267,17 +1526,20 @@ mod tests {
             &contract(9),
             100,
             None,
+            None,
         );
         mix.record_delivered(
             PayloadArm::FullNoTheirSummaryUntracked,
             &contract(2),
             100,
             None,
+            None,
         );
         mix.record_delivered(
             PayloadArm::FullNoTheirSummaryUntracked,
             &contract(5),
             500,
+            None,
             None,
         );
         let top = mix.take_window().top_contracts();
@@ -1290,7 +1552,7 @@ mod tests {
     #[test]
     fn delta_sends_are_not_attributed_as_full_state() {
         let mix = PayloadMix::new();
-        mix.record_delivered(PayloadArm::Delta, &contract(7), 1234, None);
+        mix.record_delivered(PayloadArm::Delta, &contract(7), 1234, None, None);
         let window = mix.take_window();
         assert!(
             window.contract_full_state_bytes.is_empty(),
@@ -1333,7 +1595,7 @@ mod tests {
     fn every_full_state_arm_attributes_to_its_contract() {
         for arm in PayloadArm::ALL.iter().filter(|a| a.is_full_state()) {
             let mix = PayloadMix::new();
-            mix.record_delivered(*arm, &contract(3), 99, None);
+            mix.record_delivered(*arm, &contract(3), 99, None, None);
             let top = mix.take_window().top_contracts();
             assert_eq!(
                 top,

--- a/crates/core/src/node/network_bridge/broadcast_queue.rs
+++ b/crates/core/src/node/network_bridge/broadcast_queue.rs
@@ -2361,6 +2361,20 @@ mod tests {
             );
         }
 
+        // #4961: the tracked arm must READ the reason where it is decided, not
+        // merely pass the variable along. Dropping the assignment leaves it at
+        // `None` forever, so every tracked send lands in
+        // `tracked_missing_unattributed_*` — the split still emits, still
+        // reconciles, and answers nothing. That mutation passes every other
+        // test here, so it needs its own pin.
+        assert!(
+            body.contains("tracked_missing_reason = interest.summary_missing_reason()"),
+            "the FullNoTheirSummaryTracked arm must read the peer's \
+             summary_missing_reason where the arm is decided — without it the \
+             per-reason split is uniformly unattributed and #4961 stays \
+             unanswered"
+        );
+
         // The mix is recorded at exactly the two real-delivery sites, the same
         // gate as BroadcastFanoutCost, so the two axes always agree on what
         // "sent" means. Recording up-front would count phantom fan-out.

--- a/crates/core/src/node/network_bridge/broadcast_queue.rs
+++ b/crates/core/src/node/network_bridge/broadcast_queue.rs
@@ -990,10 +990,16 @@ pub(super) async fn broadcast_to_single_peer(
                 .interest_manager
                 .get_peer_interest(&key, &peer_key)
             {
-                // The entry is tracked and (by this match arm) summaryless, so
-                // the reason tag is always readable here — #4961 needs it to
-                // tell the three clear paths apart, since they have three
-                // different fixes and this is the largest broadcast-byte arm.
+                // #4961 needs this to tell the three clear paths apart, since
+                // they have three different fixes and this is the largest
+                // broadcast-byte arm.
+                //
+                // Usually `Some`: this match arm means `their_summary` was
+                // `None`. But that was read further up, before an `.await`, so
+                // a concurrent upsert in between leaves the entry holding a
+                // summary and this reads `None`. That send is then counted in
+                // `tracked_missing_unattributed_*` rather than being charged to
+                // a cause that did not produce it.
                 tracked_missing_reason = interest.summary_missing_reason();
                 PayloadArm::FullNoTheirSummaryTracked
             } else {

--- a/crates/core/src/node/network_bridge/broadcast_queue.rs
+++ b/crates/core/src/node/network_bridge/broadcast_queue.rs
@@ -869,6 +869,9 @@ pub(super) async fn broadcast_to_single_peer(
     // smaller than the state), so the ratio of these two inputs field-checks
     // the old pre-compute proxy rather than restating the trigger. See #3335.
     let mut not_efficient_gate_inputs: Option<(usize, usize)> = None;
+    // #4961: WHY a tracked peer has no cached summary. Set only on the
+    // `FullNoTheirSummaryTracked` arm below, where the entry exists to be read.
+    let mut tracked_missing_reason: Option<crate::ring::interest::SummaryMissingReason> = None;
     let (payload, sent_delta, payload_arm) = match (&our_summary, &their_summary) {
         // Scoped to the both-summaries-present case ON PURPOSE. When a summary
         // is missing a delta was impossible regardless of the memo, so letting
@@ -983,11 +986,15 @@ pub(super) async fn broadcast_to_single_peer(
             PayloadArm::FullNoOurSummary,
         ),
         (Some(_), None) => {
-            let arm = if op_manager
+            let arm = if let Some(interest) = op_manager
                 .interest_manager
                 .get_peer_interest(&key, &peer_key)
-                .is_some()
             {
+                // The entry is tracked and (by this match arm) summaryless, so
+                // the reason tag is always readable here — #4961 needs it to
+                // tell the three clear paths apart, since they have three
+                // different fixes and this is the largest broadcast-byte arm.
+                tracked_missing_reason = interest.summary_missing_reason();
                 PayloadArm::FullNoTheirSummaryTracked
             } else {
                 PayloadArm::FullNoTheirSummaryUntracked
@@ -1167,6 +1174,7 @@ pub(super) async fn broadcast_to_single_peer(
                         key.id(),
                         payload_size,
                         not_efficient_gate_inputs,
+                        tracked_missing_reason,
                     );
                     tracing::debug!(
                         tx = %update_tx,
@@ -1216,6 +1224,7 @@ pub(super) async fn broadcast_to_single_peer(
                 key.id(),
                 payload_size,
                 not_efficient_gate_inputs,
+                tracked_missing_reason,
             );
             // Delta-incompat attribution (HQk7 resync loop): remember that we
             // just delivered a DELTA to this peer so a prompt `ResyncRequest`
@@ -2366,7 +2375,7 @@ mod tests {
         let collapsed: String = body.chars().filter(|c| !c.is_whitespace()).collect();
         let record_needle = concat!(
             ".record_",
-            "delivered(payload_arm,key.id(),payload_size,not_efficient_gate_inputs,)"
+            "delivered(payload_arm,key.id(),payload_size,not_efficient_gate_inputs,tracked_missing_reason,)"
         );
         assert_eq!(
             collapsed.matches(record_needle).count(),

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -1756,9 +1756,11 @@ async fn drive_relay_broadcast_to(
                         .get_peer_by_addr(sender_addr)
                     {
                         let sender_key = crate::ring::PeerKey::from(sender_pkl.pub_key().clone());
-                        op_manager
-                            .interest_manager
-                            .update_peer_summary(&key, &sender_key, None);
+                        op_manager.interest_manager.clear_peer_summary(
+                            &key,
+                            &sender_key,
+                            crate::ring::interest::SummaryMissingReason::ClearedByDeltaApplyFailure,
+                        );
                     }
 
                     tracing::info!(
@@ -3186,8 +3188,14 @@ mod tests {
             .find("resync_emit_limiter")
             .expect("ResyncRequest emit must be gated by resync_emit_limiter");
         let summary_clear_pos = driver_src
-            .find("update_peer_summary(&key, &sender_key, None)")
+            .find("clear_peer_summary(")
             .expect("sender summary-clear missing");
+        assert!(
+            driver_src.contains("SummaryMissingReason::ClearedByDeltaApplyFailure"),
+            "the sender summary-clear must be tagged ClearedByDeltaApplyFailure \
+             so #4961 can attribute the full_no_their_summary_tracked arm to \
+             this path"
+        );
         let resync_pos = driver_src
             .find("InterestMessage::ResyncRequest")
             .expect("ResyncRequest emission missing");

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -169,11 +169,85 @@ impl From<TransportPublicKey> for PeerKey {
     }
 }
 
+/// Why a tracked peer's cached summary is absent.
+///
+/// A tracked peer with no cached summary forces a FULL STATE broadcast
+/// (`PayloadArm::FullNoTheirSummaryTracked`). On the aged 0.2.109 fleet that
+/// arm was 26.9% of broadcast bytes at a 357 KB mean — the single largest
+/// remaining bandwidth arm and the main cause of the 4-20s propagation
+/// latency in #4961 — but the rollup could not say WHICH of the paths below
+/// produced it, and the three have completely different fixes. This tag is
+/// what makes that distinguishable; see #4961.
+///
+/// The tag is only meaningful while `summary` is `None`; read it through
+/// [`PeerInterest::summary_missing_reason`], which enforces that.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SummaryMissingReason {
+    /// The entry was created without a summary and has never had one written.
+    ///
+    /// The interest-registration chain (`register_local_hosting` → `Interests`
+    /// → `register_peer_interest`) creates entries with `summary: None`; they
+    /// stay that way until a delivery or a `Summaries` report seeds one. A
+    /// large share here means the seeding chain isn't firing (or an
+    /// `Interests` full-replace is wiping seeded entries every ~5 min).
+    NeverPopulated,
+
+    /// The peer itself reported `None` in an InterestSync `Summaries` message,
+    /// so we dropped what we had cached.
+    ///
+    /// Suspect path: we may be discarding a summary we seeded from an actual
+    /// delivery because the peer's own report raced ahead of its state write.
+    ClearedByNoneReport,
+
+    /// We received a `ResyncRequest` from the peer, which invalidates our
+    /// cached view of what they hold.
+    ClearedByResync,
+
+    /// A delta we sent failed to apply on the peer, so our cached summary for
+    /// them was provably wrong.
+    ClearedByDeltaApplyFailure,
+}
+
+impl SummaryMissingReason {
+    /// Every reason, in telemetry field order.
+    pub const ALL: [SummaryMissingReason; 4] = [
+        SummaryMissingReason::NeverPopulated,
+        SummaryMissingReason::ClearedByNoneReport,
+        SummaryMissingReason::ClearedByResync,
+        SummaryMissingReason::ClearedByDeltaApplyFailure,
+    ];
+
+    /// Dense index into a per-reason counter array.
+    pub fn index(self) -> usize {
+        match self {
+            SummaryMissingReason::NeverPopulated => 0,
+            SummaryMissingReason::ClearedByNoneReport => 1,
+            SummaryMissingReason::ClearedByResync => 2,
+            SummaryMissingReason::ClearedByDeltaApplyFailure => 3,
+        }
+    }
+
+    /// Stable label for telemetry field names.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            SummaryMissingReason::NeverPopulated => "never_populated",
+            SummaryMissingReason::ClearedByNoneReport => "none_report",
+            SummaryMissingReason::ClearedByResync => "resync",
+            SummaryMissingReason::ClearedByDeltaApplyFailure => "delta_apply_failed",
+        }
+    }
+}
+
 /// Tracking information for a peer's interest in a specific contract.
 #[derive(Clone, Debug)]
 pub struct PeerInterest {
     /// The peer's current state summary. None if interested but has no state yet.
     pub summary: Option<StateSummary<'static>>,
+
+    /// Why [`Self::summary`] is absent. Stale (and unread) whenever `summary`
+    /// is `Some` — always read it via [`Self::summary_missing_reason`], which
+    /// returns `None` in that case rather than a misleading last-clear cause.
+    summary_absence: SummaryMissingReason,
 
     /// When this interest entry was last refreshed.
     /// Used for TTL-based expiration.
@@ -186,9 +260,14 @@ pub struct PeerInterest {
 
 impl PeerInterest {
     /// Create a new peer interest entry with the given timestamp.
+    ///
+    /// A `None` summary here is [`SummaryMissingReason::NeverPopulated`] by
+    /// construction — this is the only constructor, so an entry cannot come
+    /// into existence summaryless without carrying that tag.
     pub fn new(summary: Option<StateSummary<'static>>, is_upstream: bool, now: Instant) -> Self {
         Self {
             summary,
+            summary_absence: SummaryMissingReason::NeverPopulated,
             last_refreshed: now,
             is_upstream,
         }
@@ -204,9 +283,26 @@ impl PeerInterest {
         now.saturating_duration_since(self.last_refreshed) > INTEREST_TTL
     }
 
-    /// Update the peer's summary and refresh TTL.
-    pub fn update_summary(&mut self, summary: Option<StateSummary<'static>>, now: Instant) {
-        self.summary = summary;
+    /// Why this peer has no cached summary, or `None` when one IS cached.
+    pub fn summary_missing_reason(&self) -> Option<SummaryMissingReason> {
+        self.summary.is_none().then_some(self.summary_absence)
+    }
+
+    /// Cache a summary for this peer and refresh TTL.
+    pub fn set_summary(&mut self, summary: StateSummary<'static>, now: Instant) {
+        self.summary = Some(summary);
+        self.refresh(now);
+    }
+
+    /// Drop the cached summary, recording why, and refresh TTL.
+    ///
+    /// Taking `reason` by value (rather than accepting an `Option` summary) is
+    /// deliberate: it makes an untagged clear unrepresentable, so a future
+    /// clear site cannot silently land in the `NeverPopulated` bucket and
+    /// mis-aim the next fix.
+    pub fn clear_summary(&mut self, reason: SummaryMissingReason, now: Instant) {
+        self.summary = None;
+        self.summary_absence = reason;
         self.refresh(now);
     }
 }
@@ -678,12 +774,37 @@ impl<T: TimeSource + Sync> InterestManager<T> {
         &self,
         contract: &ContractKey,
         peer: &PeerKey,
-        summary: Option<StateSummary<'static>>,
+        summary: StateSummary<'static>,
     ) {
         let now = self.time_source.now();
         if let Some(mut entry) = self.interested_peers.get_mut(contract) {
             if let Some(interest) = entry.get_mut(peer) {
-                interest.update_summary(summary, now);
+                interest.set_summary(summary, now);
+            }
+        }
+    }
+
+    /// Drop a peer's cached summary for a contract, recording why.
+    ///
+    /// Every clear MUST name its cause: a tracked peer with no cached summary
+    /// is what forces a full-state broadcast, and #4961 could not tell the
+    /// three clear paths apart in the rollup. The `reason` is surfaced on the
+    /// `FullNoTheirSummaryTracked` arm of `broadcast_payload_mix`.
+    ///
+    /// Like [`Self::update_peer_summary`], this is a silent no-op for an
+    /// untracked peer — clearing something we never cached is a no-op by
+    /// definition, and creating an entry just to hold `None` would inflate the
+    /// map from unauthenticated input.
+    pub fn clear_peer_summary(
+        &self,
+        contract: &ContractKey,
+        peer: &PeerKey,
+        reason: SummaryMissingReason,
+    ) {
+        let now = self.time_source.now();
+        if let Some(mut entry) = self.interested_peers.get_mut(contract) {
+            if let Some(interest) = entry.get_mut(peer) {
+                interest.clear_summary(reason, now);
             }
         }
     }
@@ -723,7 +844,7 @@ impl<T: TimeSource + Sync> InterestManager<T> {
         // leaving a zombie reverse-index entry.
         let mut entry = self.interested_peers.entry(*contract).or_default();
         if let Some(interest) = entry.get_mut(peer) {
-            interest.update_summary(Some(summary), now);
+            interest.set_summary(summary, now);
             return true;
         }
         if entry.len() >= MAX_INTERESTED_PEERS_PER_CONTRACT {
@@ -2145,7 +2266,7 @@ mod tests {
 
         // Update with summary
         let summary = StateSummary::from(vec![1, 2, 3]);
-        manager.update_peer_summary(&contract, &peer, Some(summary.clone()));
+        manager.update_peer_summary(&contract, &peer, summary.clone());
 
         let retrieved = manager.get_peer_summary(&contract, &peer);
         assert!(retrieved.is_some());
@@ -2598,7 +2719,7 @@ mod tests {
         assert_eq!(cached_summary.unwrap().as_ref(), summary2.as_ref());
 
         // Step 4: A sends its summary back
-        manager_b.update_peer_summary(&contract2, &peer_a, Some(summary1.clone()));
+        manager_b.update_peer_summary(&contract2, &peer_a, summary1.clone());
 
         // Verify B has A's summary
         let cached_summary = manager_b.get_peer_summary(&contract2, &peer_a);
@@ -2680,7 +2801,7 @@ mod tests {
         assert!(cached.is_some());
 
         // Simulate ResyncRequest: clear the summary
-        manager.update_peer_summary(&contract, &peer, None);
+        manager.clear_peer_summary(&contract, &peer, SummaryMissingReason::ClearedByResync);
 
         // Verify summary is now None
         let cached = manager.get_peer_summary(&contract, &peer);
@@ -2692,6 +2813,104 @@ mod tests {
                 .get_interested_peers(&contract)
                 .iter()
                 .any(|(pk, _)| pk == &peer)
+        );
+    }
+
+    /// #4961: an entry that never had a summary written reports
+    /// `NeverPopulated`, and one that HAS a summary reports no reason at all.
+    ///
+    /// The second half is the load-bearing one: `summary_absence` keeps its
+    /// last value once a summary is cached, so a naive field read would
+    /// attribute a live, summary-holding peer to whichever path last cleared
+    /// it. Only the accessor's `is_none()` guard prevents that, and that is
+    /// exactly the mis-attribution this instrumentation exists to avoid.
+    #[test]
+    fn summary_missing_reason_is_never_populated_until_cleared_and_absent_when_cached() {
+        let (manager, _time) = make_manager();
+        let contract = make_contract_key(1);
+        let peer = make_peer_key(1);
+
+        manager.register_peer_interest(&contract, peer.clone(), None, false);
+        assert_eq!(
+            manager
+                .get_peer_interest(&contract, &peer)
+                .and_then(|i: PeerInterest| i.summary_missing_reason()),
+            Some(SummaryMissingReason::NeverPopulated),
+            "a fresh summaryless entry must report NeverPopulated"
+        );
+
+        manager.update_peer_summary(&contract, &peer, StateSummary::from(vec![1u8, 2, 3]));
+        assert_eq!(
+            manager
+                .get_peer_interest(&contract, &peer)
+                .and_then(|i: PeerInterest| i.summary_missing_reason()),
+            None,
+            "a peer WITH a cached summary must report no missing-reason — \
+             reading the raw field here would mis-attribute it"
+        );
+    }
+
+    /// #4961: each clear path is distinguishable, and a re-cached summary
+    /// hides the reason again.
+    ///
+    /// Without the per-path tag the `full_no_their_summary_tracked` arm (26.9%
+    /// of broadcast bytes on the aged 0.2.109 fleet) is one number covering
+    /// three causes with three different fixes.
+    #[test]
+    fn clear_peer_summary_records_the_distinguishing_reason() {
+        let (manager, _time) = make_manager();
+        let contract = make_contract_key(1);
+        let peer = make_peer_key(1);
+        let summary = StateSummary::from(vec![1u8, 2, 3]);
+
+        for reason in SummaryMissingReason::ALL {
+            manager.register_peer_interest(&contract, peer.clone(), Some(summary.clone()), false);
+            manager.clear_peer_summary(&contract, &peer, reason);
+            assert_eq!(
+                manager
+                    .get_peer_interest(&contract, &peer)
+                    .and_then(|i: PeerInterest| i.summary_missing_reason()),
+                Some(reason),
+                "clear must record {reason:?}, not a different path's tag"
+            );
+
+            // Re-caching hides the reason; the arm no longer applies.
+            manager.update_peer_summary(&contract, &peer, summary.clone());
+            assert_eq!(
+                manager
+                    .get_peer_interest(&contract, &peer)
+                    .and_then(|i: PeerInterest| i.summary_missing_reason()),
+                None
+            );
+        }
+    }
+
+    /// Every reason has a distinct index and label — a collision would silently
+    /// merge two causes into one telemetry bucket, which is the exact failure
+    /// this split exists to prevent.
+    #[test]
+    fn summary_missing_reason_indices_and_labels_are_distinct() {
+        let indices: std::collections::HashSet<_> = SummaryMissingReason::ALL
+            .iter()
+            .map(|r| r.index())
+            .collect();
+        assert_eq!(
+            indices.len(),
+            SummaryMissingReason::ALL.len(),
+            "duplicate index would merge two causes into one counter"
+        );
+        assert!(
+            indices.iter().all(|i| *i < SummaryMissingReason::ALL.len()),
+            "index must stay in bounds of the counter array"
+        );
+        let labels: std::collections::HashSet<_> = SummaryMissingReason::ALL
+            .iter()
+            .map(|r| r.as_str())
+            .collect();
+        assert_eq!(
+            labels.len(),
+            SummaryMissingReason::ALL.len(),
+            "duplicate label would collide as a JSON field name"
         );
     }
 
@@ -2733,7 +2952,7 @@ mod tests {
             "precondition: the peer must be untracked"
         );
 
-        manager.update_peer_summary(&contract, &peer, Some(summary));
+        manager.update_peer_summary(&contract, &peer, summary);
 
         assert!(
             manager.get_peer_summary(&contract, &peer).is_none(),
@@ -2746,7 +2965,7 @@ mod tests {
 
         // And it stays that way no matter how many deliveries land.
         for _ in 0..5 {
-            manager.update_peer_summary(&contract, &peer, Some(StateSummary::from(vec![9u8])));
+            manager.update_peer_summary(&contract, &peer, StateSummary::from(vec![9u8]));
         }
         assert!(
             manager.get_peer_summary(&contract, &peer).is_none(),
@@ -2756,7 +2975,7 @@ mod tests {
 
         // Contrast: once the peer IS tracked, the very same call sticks.
         manager.register_peer_interest(&contract, peer.clone(), None, false);
-        manager.update_peer_summary(&contract, &peer, Some(StateSummary::from(vec![7u8])));
+        manager.update_peer_summary(&contract, &peer, StateSummary::from(vec![7u8]));
         assert_eq!(
             manager
                 .get_peer_summary(&contract, &peer)
@@ -2948,7 +3167,7 @@ mod tests {
 
         // Step 1: A sends ResyncRequest
         // B receives it and clears A's cached summary
-        manager_b.update_peer_summary(&contract, &peer_a, None);
+        manager_b.clear_peer_summary(&contract, &peer_a, SummaryMissingReason::ClearedByResync);
 
         // Verify B cleared A's summary
         let cached = manager_b.get_peer_summary(&contract, &peer_a);
@@ -2956,7 +3175,7 @@ mod tests {
 
         // Step 2: B sends ResyncResponse with full state and summary
         // A receives it and updates B's summary
-        manager_a.update_peer_summary(&contract, &peer_b, Some(new_summary.clone()));
+        manager_a.update_peer_summary(&contract, &peer_b, new_summary.clone());
 
         // Verify A has B's new summary
         let cached = manager_a.get_peer_summary(&contract, &peer_b);


### PR DESCRIPTION
## Problem

`full_no_their_summary_tracked` — a full-state broadcast to a peer we DO track but hold no cached summary for — is **26.9% of broadcast bytes at a 357 KB mean** on the aged 0.2.109 fleet (605 peers, 3,772 node-minutes). That makes it the single largest remaining bandwidth arm, and the leading suspect for the 4-20s propagation latency on the official River room (#4961).

The rollup cannot say *why* the summary is absent, and the three possible causes have three completely different fixes:

| cause | fix shape |
|---|---|
| entry created summaryless, never seeded | the registration/heartbeat chain isn't firing, or an `Interests` full-replace wipes it every ~5 min |
| the peer reported `None` and we discarded a summary we had seeded from a real delivery | stop discarding on an unconfirmed `None` report |
| a resync or delta-apply failure cleared it | expected; self-heals on next delivery |

Only the third is measurable today, at **~8%** of tracked sends (381 resync requests vs ~4,600 tracked sends). The other ~92% splits between the first two by an unknown ratio, so a fix aimed at either one is a guess.

That matters here specifically. In this investigation, the two times mechanism was guessed at (summary doubling; River summaries being oversized) the guess was wrong; the two times it was measured (the ops/transport stream split; gate inputs at ratio 1.000) it produced a real finding. This PR buys the measurement before spending a release on the fix.

## Approach

Tag the absence at its source rather than infer it at the send.

`PeerInterest` gains a `summary_missing_reason`, and clearing a summary now goes through `clear_peer_summary(contract, peer, reason)`. The reason is a by-value parameter, so an untagged clear is **unrepresentable** — a future clear site cannot silently land in the wrong bucket. `update_peer_summary` is correspondingly narrowed to a non-`Option` summary, so caching and clearing are distinct at the type level (the `.claude/rules/bug-prevention-patterns.md` "paired fields → let the type system forbid it" shape). The three production clear sites each name their own cause.

The reason is read at the one site that classifies the arm and reported as `tracked_missing_<reason>_{sends,bytes}` on `broadcast_payload_mix`, alongside a `tracked_missing_unattributed_*` residual.

The residual is deliberate, not defensive padding. `their_summary` is read at the top of `broadcast_to_single_peer` and the reason is read much later, past an `.await`, so a concurrent upsert between the two yields no reason. A future untagged clear would do the same. Both surface as an explicit residual instead of inflating a cause that did not produce them.

**No behavior change.** `clear_peer_summary` does exactly what `update_peer_summary(.., None)` did; everything else is counters.

## Testing

Unit tests:
- the accessor returns no reason while a summary IS cached — `summary_absence` keeps its last value once a summary is re-cached, so a raw field read would attribute a live peer to whichever path last cleared it
- each of the four clear paths is distinguishable, and re-caching hides the reason again
- indices and labels are distinct (a collision would silently merge two causes into one bucket)
- per-reason bytes reconcile exactly against the arm total
- an untagged tracked send reports as unattributed, not folded into a reason
- a reason paired with a non-tracked arm is ignored (same discipline `gate_inputs` follows)

Source pins — the three existing ones now also require the reason tag, plus a new one:
- `broadcast_to_single_peer_tags_every_payload_arm_pin` now pins that the arm **reads** the reason. Mutation-testing found this gap: replacing the assignment with a no-op left every other test green while leaving the reason at `None` forever, so all tracked sends would land in `unattributed` — the split would emit, reconcile, and answer nothing.

Mutation-verified (each mutation confirmed to fail the intended test):
1. dropping the accessor's `is_none()` guard → fails the mis-attribution test
2. folding untagged sends into `NeverPopulated` → fails the residual test
3. dropping the reason read at the classification site → fails the new pin (this one passed everything before the pin was added)

Full lib suite: 4323 passed, 0 failed. CI-shaped `cargo clippy --all-features -- -D warnings`: clean.

## What this answers

One 60s rollup window after adoption tells us which of the three paths owns the ~92%, and the fix goes into the next release aimed rather than guessed.

Refs #4961, #4952

[AI-assisted - Claude]
