### PR TITLE
fix(tracing): make the local event log opt-in on network nodes and stop fsyncing it

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -197,7 +197,7 @@ pub struct ConfigArgs {
     ///
     /// Measured on a live 0.2.111 peer, writing it costs ~61 MiB/hour of
     /// appends and accounted for 95% of every fsync the process issued
-    /// (#4966). Enable it on nodes you operate and want to post-mortem.
+    /// (#4968). Enable it on nodes you operate and want to post-mortem.
     #[arg(
         long = "enable-event-log",
         env = "FREENET_ENABLE_EVENT_LOG",
@@ -563,7 +563,7 @@ impl ConfigArgs {
             // these are new fields, so a plain get_or_insert is correct.
             self.hosting_disk_pct.get_or_insert(cfg.hosting_disk_pct);
             self.max_hosting_disk.get_or_insert(cfg.max_hosting_disk);
-            // #4966. `cfg.enable_event_log` is itself an Option, so an older
+            // #4968. `cfg.enable_event_log` is itself an Option, so an older
             // config.toml with no such key merges as `None` and leaves the
             // mode-dependent default intact rather than pinning `false`.
             if let Some(persisted) = cfg.enable_event_log {
@@ -1296,7 +1296,7 @@ pub struct Config {
     /// mode-dependent default.
     ///
     /// NOT related to the telemetry that feeds telemetry.freenet.org; see the
-    /// `ConfigArgs::enable_event_log` docs (#4966).
+    /// `ConfigArgs::enable_event_log` docs (#4968).
     #[serde(
         default,
         rename = "enable-event-log",
@@ -2776,7 +2776,7 @@ impl Config {
     ///
     /// This does NOT gate the telemetry that feeds telemetry.freenet.org —
     /// that is a separate `TelemetryReporter` sink fed in-memory off the same
-    /// event stream (#4966).
+    /// event stream (#4968).
     pub fn event_log_enabled(&self) -> bool {
         self.enable_event_log
             .unwrap_or(matches!(self.mode, OperationMode::Local))
@@ -4019,7 +4019,7 @@ mod tests {
     }
 
     /// Build a `ConfigArgs` rooted at `dir` in the given mode. Shared by the
-    /// #4966 event-log default tests so each case differs only in what it sets.
+    /// #4968 event-log default tests so each case differs only in what it sets.
     fn event_log_args(dir: &std::path::Path, mode: OperationMode) -> ConfigArgs {
         ConfigArgs {
             mode: Some(mode),
@@ -4047,7 +4047,7 @@ mod tests {
         }
     }
 
-    /// #4966: a network-mode node (what end users run) must NOT write the local
+    /// #4968: a network-mode node (what end users run) must NOT write the local
     /// diagnostic event log by default. On a live 0.2.111 peer that log was
     /// ~61 MiB/hour of appends and 95% of every fsync the process issued.
     #[tokio::test]
@@ -4063,7 +4063,7 @@ mod tests {
         );
     }
 
-    /// #4966: local mode is a single-node dev mode where the log is the point,
+    /// #4968: local mode is a single-node dev mode where the log is the point,
     /// and `fdev verify-state` consumes `_EVENT_LOG_LOCAL`. It stays ON.
     #[tokio::test]
     async fn event_log_defaults_on_in_local_mode() {
@@ -4099,12 +4099,12 @@ mod tests {
         );
     }
 
-    /// Regression (#4966, the #3890/#4275 silent-revert class): building twice
+    /// Regression (#4968, the #3890/#4275 silent-revert class): building twice
     /// against the SAME config dir must not flip local mode's default off.
     ///
     /// The first build persists a `config.toml`. Because `enable_event_log` is
     /// `None` it is `skip_serializing_if`-omitted, so that file is byte-identical
-    /// in this respect to one written by a pre-#4966 release. If the merge step
+    /// in this respect to one written by a pre-#4968 release. If the merge step
     /// treated the absent key as an explicit `false`, the second build would
     /// silently strip the event log from every upgrading local-mode node and
     /// break `fdev verify-state`. It must still resolve to ON.
@@ -4124,7 +4124,7 @@ mod tests {
         assert!(
             !persisted.contains("enable-event-log"),
             "precondition: an unset event-log flag must be omitted from config.toml, \
-             otherwise this test is not exercising the pre-#4966 upgrade shape. Got:\n{persisted}"
+             otherwise this test is not exercising the pre-#4968 upgrade shape. Got:\n{persisted}"
         );
 
         let second = event_log_args(temp_dir.path(), OperationMode::Local)
@@ -4950,7 +4950,7 @@ mod tests {
             per_user_inactive_ttl_secs: 1_234_567,
             inactive_user_sweep_interval_secs: 7_200,
             module_cache_budget_bytes: 987_654_321,
-            // Non-default on purpose: the seed is Local mode, where the #4966
+            // Non-default on purpose: the seed is Local mode, where the #4968
             // default is ON, so `Some(false)` fails this test if the merge
             // drops the field (it would come back as `None`).
             enable_event_log: Some(false),
@@ -5035,7 +5035,7 @@ mod tests {
         );
         assert_eq!(
             enable_event_log, seed.enable_event_log,
-            "enable_event_log (#4966) — an explicit setting must survive the \
+            "enable_event_log (#4968) — an explicit setting must survive the \
              config.toml merge, or an operator's opt-in is silently reverted"
         );
         assert_eq!(

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -181,6 +181,31 @@ pub struct ConfigArgs {
     #[arg(long, env = "FREENET_MODULE_CACHE_BUDGET_BYTES")]
     pub module_cache_budget_bytes: Option<usize>,
 
+    /// Write the local append-only diagnostic event log (`_EVENT_LOG`).
+    ///
+    /// Default: ON in `local` mode, OFF in `network` mode. Local mode is a
+    /// single-node development mode where the log is the point (and where
+    /// `fdev verify-state` consumes `_EVENT_LOG_LOCAL`); network mode is what
+    /// end users run, where the log costs real disk for a capability nothing
+    /// currently harvests.
+    ///
+    /// This log is a PURELY LOCAL forensic record. It is NOT the telemetry that
+    /// feeds telemetry.freenet.org — that is a separate `TelemetryReporter`
+    /// sink fed in-memory off the same event stream, and it is unaffected by
+    /// this flag. Nothing in the node reads this log back to make decisions,
+    /// and `freenet service report` does not include it.
+    ///
+    /// Measured on a live 0.2.111 peer, writing it costs ~61 MiB/hour of
+    /// appends and accounted for 95% of every fsync the process issued
+    /// (#4966). Enable it on nodes you operate and want to post-mortem.
+    #[arg(
+        long = "enable-event-log",
+        env = "FREENET_ENABLE_EVENT_LOG",
+        num_args = 0..=1,
+        default_missing_value = "true"
+    )]
+    pub enable_event_log: Option<bool>,
+
     /// Seconds to wait on graceful shutdown for in-flight client
     /// PUT/GET/UPDATE/SUBSCRIBE operations to finish before tearing
     /// down peer connections. Set to 0 to disable. Default: 30s. See
@@ -265,6 +290,7 @@ impl Default for ConfigArgs {
             per_user_inactive_ttl_secs: None,
             inactive_user_sweep_interval_secs: None,
             module_cache_budget_bytes: None,
+            enable_event_log: None,
             shutdown_drain_secs: None,
             disable_auto_update: false,
             telemetry: Default::default(),
@@ -537,6 +563,12 @@ impl ConfigArgs {
             // these are new fields, so a plain get_or_insert is correct.
             self.hosting_disk_pct.get_or_insert(cfg.hosting_disk_pct);
             self.max_hosting_disk.get_or_insert(cfg.max_hosting_disk);
+            // #4966. `cfg.enable_event_log` is itself an Option, so an older
+            // config.toml with no such key merges as `None` and leaves the
+            // mode-dependent default intact rather than pinning `false`.
+            if let Some(persisted) = cfg.enable_event_log {
+                self.enable_event_log.get_or_insert(persisted);
+            }
             self.per_user_secret_quota_bytes
                 .get_or_insert(cfg.per_user_secret_quota_bytes);
             self.per_user_inactive_ttl_secs
@@ -1014,6 +1046,11 @@ impl ConfigArgs {
             max_blocking_threads: self
                 .max_blocking_threads
                 .unwrap_or_else(default_max_blocking_threads),
+            // Passed through un-resolved on purpose: `None` must stay `None` so
+            // `Config::event_log_enabled` can apply the mode-dependent default
+            // (ON in Local, OFF in Network) and an upgrading local node whose
+            // config.toml predates this key keeps its log.
+            enable_event_log: self.enable_event_log,
             max_hosting_storage: self
                 .max_hosting_storage
                 .unwrap_or_else(crate::ring::default_hosting_budget_bytes),
@@ -1241,6 +1278,32 @@ pub struct Config {
         rename = "module-cache-budget-bytes"
     )]
     pub module_cache_budget_bytes: usize,
+
+    /// Whether to write the local append-only diagnostic event log
+    /// (`_EVENT_LOG`). Resolved in [`ConfigArgs::build`], where the operation
+    /// mode is known: defaults ON in `local` mode and OFF in `network` mode,
+    /// with an explicit `--enable-event-log` / `FREENET_ENABLE_EVENT_LOG` /
+    /// `enable-event-log` setting always winning.
+    ///
+    /// Deliberately `Option<bool>` rather than `bool`: a config.toml written by
+    /// an older release has NO `enable-event-log` key, and a plain
+    /// `#[serde(default)] bool` would deserialize that absence to `false`,
+    /// indistinguishable from an operator's explicit `false`. The merge in
+    /// [`ConfigArgs::build`] would then pin that `false` forever and silently
+    /// strip the event log from upgrading `local`-mode nodes (breaking
+    /// `fdev verify-state`) — the #3890/#4275 silent-revert class. Keeping the
+    /// absence as `None` lets [`Config::event_log_enabled`] re-derive the
+    /// mode-dependent default.
+    ///
+    /// NOT related to the telemetry that feeds telemetry.freenet.org; see the
+    /// `ConfigArgs::enable_event_log` docs (#4966).
+    #[serde(
+        default,
+        rename = "enable-event-log",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub enable_event_log: Option<bool>,
+
     /// Telemetry configuration
     #[serde(flatten)]
     pub telemetry: TelemetryConfig,
@@ -2702,6 +2765,23 @@ impl Config {
         self.config_paths.event_log(self.mode)
     }
 
+    /// Whether this node should write the local append-only diagnostic event
+    /// log at [`Self::event_log`].
+    ///
+    /// Resolves the mode-dependent default: ON in `local` mode (a single-node
+    /// dev mode where the log is the point, and where `fdev verify-state`
+    /// consumes `_EVENT_LOG_LOCAL`), OFF in `network` mode (what end users
+    /// run). An explicit `--enable-event-log` flag, `FREENET_ENABLE_EVENT_LOG`
+    /// env var, or `enable-event-log` config key always wins.
+    ///
+    /// This does NOT gate the telemetry that feeds telemetry.freenet.org —
+    /// that is a separate `TelemetryReporter` sink fed in-memory off the same
+    /// event stream (#4966).
+    pub fn event_log_enabled(&self) -> bool {
+        self.enable_event_log
+            .unwrap_or(matches!(self.mode, OperationMode::Local))
+    }
+
     pub fn config_dir(&self) -> PathBuf {
         self.config_paths.config_dir()
     }
@@ -3938,6 +4018,155 @@ mod tests {
         );
     }
 
+    /// Build a `ConfigArgs` rooted at `dir` in the given mode. Shared by the
+    /// #4966 event-log default tests so each case differs only in what it sets.
+    fn event_log_args(dir: &std::path::Path, mode: OperationMode) -> ConfigArgs {
+        ConfigArgs {
+            mode: Some(mode),
+            // A non-gateway network node with no gateways is rejected by
+            // `build()`, so the network-mode cases build as a gateway. That is
+            // the realistic shape anyway: a gateway IS a network-mode node, and
+            // it is exactly the kind of node we operate and want the log on.
+            network_api: {
+                let is_network = matches!(mode, OperationMode::Network);
+                NetworkArgs {
+                    is_gateway: is_network,
+                    // A gateway must declare a public address.
+                    public_address: is_network.then(|| "203.0.113.1".parse().unwrap()),
+                    public_port: is_network.then_some(31337),
+                    skip_load_from_network: true,
+                    ..Default::default()
+                }
+            },
+            config_paths: ConfigPathsArgs {
+                config_dir: Some(dir.to_path_buf()),
+                data_dir: Some(dir.to_path_buf()),
+                log_dir: Some(dir.to_path_buf()),
+            },
+            ..Default::default()
+        }
+    }
+
+    /// #4966: a network-mode node (what end users run) must NOT write the local
+    /// diagnostic event log by default. On a live 0.2.111 peer that log was
+    /// ~61 MiB/hour of appends and 95% of every fsync the process issued.
+    #[tokio::test]
+    async fn event_log_defaults_off_in_network_mode() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let cfg = event_log_args(temp_dir.path(), OperationMode::Network)
+            .build()
+            .await
+            .unwrap();
+        assert!(
+            !cfg.event_log_enabled(),
+            "network mode must default to event log OFF"
+        );
+    }
+
+    /// #4966: local mode is a single-node dev mode where the log is the point,
+    /// and `fdev verify-state` consumes `_EVENT_LOG_LOCAL`. It stays ON.
+    #[tokio::test]
+    async fn event_log_defaults_on_in_local_mode() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let cfg = event_log_args(temp_dir.path(), OperationMode::Local)
+            .build()
+            .await
+            .unwrap();
+        assert!(
+            cfg.event_log_enabled(),
+            "local mode must default to event log ON so fdev verify-state keeps working"
+        );
+    }
+
+    /// An explicit setting overrides the mode-dependent default in BOTH
+    /// directions — on for a network node we operate, off for a local one.
+    #[tokio::test]
+    async fn event_log_explicit_setting_overrides_mode_default() {
+        let on_dir = tempfile::tempdir().unwrap();
+        let mut on = event_log_args(on_dir.path(), OperationMode::Network);
+        on.enable_event_log = Some(true);
+        assert!(
+            on.build().await.unwrap().event_log_enabled(),
+            "explicit true must enable the log on a network node"
+        );
+
+        let off_dir = tempfile::tempdir().unwrap();
+        let mut off = event_log_args(off_dir.path(), OperationMode::Local);
+        off.enable_event_log = Some(false);
+        assert!(
+            !off.build().await.unwrap().event_log_enabled(),
+            "explicit false must disable the log even in local mode"
+        );
+    }
+
+    /// Regression (#4966, the #3890/#4275 silent-revert class): building twice
+    /// against the SAME config dir must not flip local mode's default off.
+    ///
+    /// The first build persists a `config.toml`. Because `enable_event_log` is
+    /// `None` it is `skip_serializing_if`-omitted, so that file is byte-identical
+    /// in this respect to one written by a pre-#4966 release. If the merge step
+    /// treated the absent key as an explicit `false`, the second build would
+    /// silently strip the event log from every upgrading local-mode node and
+    /// break `fdev verify-state`. It must still resolve to ON.
+    #[tokio::test]
+    async fn event_log_absent_config_key_does_not_pin_local_mode_off() {
+        let temp_dir = tempfile::tempdir().unwrap();
+
+        let first = event_log_args(temp_dir.path(), OperationMode::Local)
+            .build()
+            .await
+            .unwrap();
+        assert!(first.event_log_enabled(), "precondition: first build is ON");
+
+        let persisted = tokio::fs::read_to_string(temp_dir.path().join("config.toml"))
+            .await
+            .expect("first build must persist a config.toml");
+        assert!(
+            !persisted.contains("enable-event-log"),
+            "precondition: an unset event-log flag must be omitted from config.toml, \
+             otherwise this test is not exercising the pre-#4966 upgrade shape. Got:\n{persisted}"
+        );
+
+        let second = event_log_args(temp_dir.path(), OperationMode::Local)
+            .build()
+            .await
+            .unwrap();
+        assert!(
+            second.event_log_enabled(),
+            "a config.toml with no enable-event-log key must NOT pin local mode to OFF"
+        );
+    }
+
+    /// The opposite direction of the merge: an operator who sets
+    /// `enable-event-log = true` in config.toml (rather than passing the CLI
+    /// flag every start) must have it honored on the next boot.
+    #[tokio::test]
+    async fn event_log_persisted_true_is_honored_on_reboot() {
+        let temp_dir = tempfile::tempdir().unwrap();
+
+        let mut args = event_log_args(temp_dir.path(), OperationMode::Network);
+        args.enable_event_log = Some(true);
+        assert!(args.build().await.unwrap().event_log_enabled());
+
+        let persisted = tokio::fs::read_to_string(temp_dir.path().join("config.toml"))
+            .await
+            .unwrap();
+        assert!(
+            persisted.contains("enable-event-log"),
+            "an explicit setting must be written to config.toml. Got:\n{persisted}"
+        );
+
+        // Reboot with NO CLI flag: the persisted value must survive.
+        let rebooted = event_log_args(temp_dir.path(), OperationMode::Network)
+            .build()
+            .await
+            .unwrap();
+        assert!(
+            rebooted.event_log_enabled(),
+            "enable-event-log = true in config.toml must survive a reboot without the CLI flag"
+        );
+    }
+
     /// When explicitly enabled, hosted mode resolves to `true` and survives a
     /// TOML round-trip (so it works from a config file, not just the CLI flag).
     #[tokio::test]
@@ -4607,6 +4836,7 @@ mod tests {
             per_user_inactive_ttl_secs: None,
             inactive_user_sweep_interval_secs: None,
             module_cache_budget_bytes: None,
+            enable_event_log: None,
             shutdown_drain_secs: None,
             disable_auto_update: false,
             telemetry: Default::default(),
@@ -4720,6 +4950,10 @@ mod tests {
             per_user_inactive_ttl_secs: 1_234_567,
             inactive_user_sweep_interval_secs: 7_200,
             module_cache_budget_bytes: 987_654_321,
+            // Non-default on purpose: the seed is Local mode, where the #4966
+            // default is ON, so `Some(false)` fails this test if the merge
+            // drops the field (it would come back as `None`).
+            enable_event_log: Some(false),
             telemetry: TelemetryConfig {
                 enabled: false,
                 endpoint: "http://example.invalid:4318".to_string(),
@@ -4760,6 +4994,7 @@ mod tests {
             per_user_inactive_ttl_secs,
             inactive_user_sweep_interval_secs,
             module_cache_budget_bytes,
+            enable_event_log,
             telemetry,
             shutdown_drain_secs,
             // #[serde(skip)] runtime CLI/env flag — set from --disable-auto-update
@@ -4797,6 +5032,11 @@ mod tests {
         assert_eq!(
             module_cache_budget_bytes, seed.module_cache_budget_bytes,
             "module_cache_budget_bytes"
+        );
+        assert_eq!(
+            enable_event_log, seed.enable_event_log,
+            "enable_event_log (#4966) — an explicit setting must survive the \
+             config.toml merge, or an operator's opt-in is silently reverted"
         );
         assert_eq!(
             shutdown_drain_secs, seed.shutdown_drain_secs,

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -4167,6 +4167,71 @@ mod tests {
         );
     }
 
+    /// `--enable-event-log` uses clap's `num_args = 0..=1` +
+    /// `default_missing_value` form, which is easy to get subtly wrong (a bare
+    /// flag silently parsing as `None`, or `=false` being rejected). The
+    /// identical `--hosted-mode` pattern carries the same test for that reason.
+    ///
+    /// Without this, every other event-log test would still pass while the
+    /// operator-facing flag did nothing — the tests set the field directly.
+    #[test]
+    fn enable_event_log_cli_accepts_bare_flag_and_explicit_value() {
+        use clap::Parser;
+
+        // The arg also reads FREENET_ENABLE_EVENT_LOG via clap's `env`. Clear it
+        // for the duration of this test so the runner's environment can't mask
+        // the CLI-form assertions, then restore it.
+        let saved = std::env::var_os("FREENET_ENABLE_EVENT_LOG");
+        // SAFETY: this is the only test that touches FREENET_ENABLE_EVENT_LOG,
+        // and it restores the prior value below; nextest per-process isolation
+        // means no other thread observes the transient unset.
+        unsafe {
+            std::env::remove_var("FREENET_ENABLE_EVENT_LOG");
+        }
+
+        // Absent => None, so the mode-dependent default applies.
+        let absent = ConfigArgs::try_parse_from(["freenet"]).expect("bare argv should parse");
+        assert_eq!(
+            absent.enable_event_log, None,
+            "an absent flag must stay None so the mode default can apply"
+        );
+
+        // Bare `--enable-event-log` => Some(true) via default_missing_value.
+        let bare = ConfigArgs::try_parse_from(["freenet", "--enable-event-log"])
+            .expect("bare --enable-event-log should parse");
+        assert_eq!(
+            bare.enable_event_log,
+            Some(true),
+            "bare --enable-event-log must mean Some(true)"
+        );
+
+        // `--enable-event-log=false` => Some(false), the explicit opt-out.
+        let explicit_false = ConfigArgs::try_parse_from(["freenet", "--enable-event-log=false"])
+            .expect("--enable-event-log=false should parse");
+        assert_eq!(
+            explicit_false.enable_event_log,
+            Some(false),
+            "--enable-event-log=false must mean Some(false)"
+        );
+
+        // Space-separated value form.
+        let spaced = ConfigArgs::try_parse_from(["freenet", "--enable-event-log", "true"])
+            .expect("--enable-event-log true should parse");
+        assert_eq!(
+            spaced.enable_event_log,
+            Some(true),
+            "--enable-event-log true must mean Some(true)"
+        );
+
+        // SAFETY: restoring the value captured above; same rationale as the
+        // remove_var at the top of this test.
+        unsafe {
+            if let Some(v) = saved {
+                std::env::set_var("FREENET_ENABLE_EVENT_LOG", v);
+            }
+        }
+    }
+
     /// When explicitly enabled, hosted mode resolves to `true` and survives a
     /// TOML round-trip (so it works from a config file, not just the CLI flag).
     #[tokio::test]

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -677,10 +677,25 @@ impl NodeConfig {
         let (event_register, flush_handle) = {
             use super::tracing::{DynamicRegister, TelemetryReporter};
 
-            let event_reg = EventRegister::new(self.config.event_log());
-            let flush_handle = event_reg.flush_handle();
+            let mut registers: Vec<Box<dyn NetEventRegister>> = Vec::new();
 
-            let mut registers: Vec<Box<dyn NetEventRegister>> = vec![Box::new(event_reg)];
+            // The local append-only diagnostic log (`_EVENT_LOG`) is opt-in on
+            // network nodes (#4966). Measured on a live 0.2.111 peer it cost
+            // ~61 MiB/hour of appends and accounted for 95% of every fsync the
+            // process issued, for a forensic record nothing currently harvests
+            // (no `freenet service report` path reads it; `fdev verify-state`
+            // reads the Local-mode `_EVENT_LOG_LOCAL`, which stays on by
+            // default). This gate does NOT affect the `TelemetryReporter`
+            // added below — that is a separate sink fed in-memory off the same
+            // event stream, and it is what feeds telemetry.freenet.org.
+            let flush_handle = if self.config.event_log_enabled() {
+                let event_reg = EventRegister::new(self.config.event_log());
+                let handle = event_reg.flush_handle();
+                registers.push(Box::new(event_reg));
+                handle
+            } else {
+                crate::tracing::EventFlushHandle::noop()
+            };
 
             // Add OpenTelemetry register if feature enabled
             #[cfg(feature = "trace-ot")]

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -680,7 +680,7 @@ impl NodeConfig {
             let mut registers: Vec<Box<dyn NetEventRegister>> = Vec::new();
 
             // The local append-only diagnostic log (`_EVENT_LOG`) is opt-in on
-            // network nodes (#4966). Measured on a live 0.2.111 peer it cost
+            // network nodes (#4968). Measured on a live 0.2.111 peer it cost
             // ~61 MiB/hour of appends and accounted for 95% of every fsync the
             // process issued, for a forensic record nothing currently harvests
             // (no `freenet service report` path reads it; `fdev verify-state`

--- a/crates/core/src/tracing/aof.rs
+++ b/crates/core/src/tracing/aof.rs
@@ -602,7 +602,7 @@ impl LogFile {
     /// readers see it immediately; the kernel then writes it back on its own
     /// schedule instead of one journal commit per five events.
     ///
-    /// do NOT re-add a per-batch fsync here — see #4966.
+    /// do NOT re-add a per-batch fsync here — see #4968.
     pub async fn write_all(&mut self, data: &[u8]) -> io::Result<()> {
         let _guard = FILE_LOCK.lock().await;
         let file = self.file.as_mut().unwrap();
@@ -652,7 +652,7 @@ mod tests {
         NEW_RECORDS_TS.get_or_init(SystemTime::now);
     }
 
-    /// Source pin (#4966): `write_all` must NOT fsync on every batch.
+    /// Source pin (#4968): `write_all` must NOT fsync on every batch.
     ///
     /// A `sync_all()` used to run after each `BATCH_SIZE` (5) events. Because
     /// an append also changes the file size, that forced a full filesystem
@@ -694,7 +694,7 @@ mod tests {
 
         assert!(
             !body.contains(concat!("sync", "_all")),
-            "write_all must NOT fsync per batch (#4966). Durability is already \
+            "write_all must NOT fsync per batch (#4968). Durability is already \
              covered by rotate_segment's fsync and the torn-tail truncation on \
              load; a per-batch fsync costs ~5x write amplification on every user \
              peer for a purely diagnostic log. Offending body:\n{body}"

--- a/crates/core/src/tracing/aof.rs
+++ b/crates/core/src/tracing/aof.rs
@@ -574,6 +574,35 @@ impl LogFile {
         }
     }
 
+    /// Append an encoded batch to the active segment.
+    ///
+    /// Deliberately does NOT `fsync`. The event log is a local diagnostic
+    /// record, not authoritative state: nothing in the node reads it back to
+    /// make decisions, and losing the last few records to a power cut costs
+    /// nothing. A per-batch `sync_all()` (data *and* metadata) used to run here,
+    /// and because an append also changes the file size it forced a full
+    /// filesystem journal commit every `BATCH_SIZE` (5) events. Measured on a
+    /// live 0.2.111 peer that was 95% of ALL fsyncs the process issued and the
+    /// dominant source of a 4-6x write amplification, turning ~61 MiB/hour of
+    /// logical appends into hundreds of MiB/hour of real disk writes.
+    ///
+    /// Durability that actually matters is preserved elsewhere:
+    /// [`Self::rotate_segment`] still fsyncs the active segment before closing
+    /// it, so a completed segment is on disk before the next one opens, and
+    /// [`Self::load_segment_records`] already truncates a torn tail at the last
+    /// good record offset on startup. Readers are unaffected either way —
+    /// `read_all_events` sees written bytes through the page cache immediately;
+    /// fsync is about surviving power loss, not visibility.
+    ///
+    /// It DOES still `flush`. That is not a durability barrier: `tokio::fs::File`
+    /// keeps an internal buffer and hands writes to a background pool, so
+    /// without an explicit flush the bytes may not reach the OS at all and a
+    /// reader (or `std::fs::metadata`) can observe a zero-length segment. The
+    /// flush issues the `write(2)`, putting the data in the page cache where
+    /// readers see it immediately; the kernel then writes it back on its own
+    /// schedule instead of one journal commit per five events.
+    ///
+    /// do NOT re-add a per-batch fsync here — see #4966.
     pub async fn write_all(&mut self, data: &[u8]) -> io::Result<()> {
         let _guard = FILE_LOCK.lock().await;
         let file = self.file.as_mut().unwrap();
@@ -582,8 +611,8 @@ impl LogFile {
             return Err(err);
         }
 
-        if let Err(err) = file.get_mut().sync_all().await {
-            tracing::error!("Failed syncing event log: {err}");
+        if let Err(err) = file.get_mut().flush().await {
+            tracing::error!("Failed flushing event log: {err}");
             return Err(err);
         }
         Ok(())
@@ -621,6 +650,55 @@ mod tests {
 
     fn ensure_records_ts() {
         NEW_RECORDS_TS.get_or_init(SystemTime::now);
+    }
+
+    /// Source pin (#4966): `write_all` must NOT fsync on every batch.
+    ///
+    /// A `sync_all()` used to run after each `BATCH_SIZE` (5) events. Because
+    /// an append also changes the file size, that forced a full filesystem
+    /// journal commit per batch: measured on a live 0.2.111 peer it was 95% of
+    /// every fsync the process issued and the dominant source of a 4-6x write
+    /// amplification. Durability that matters is preserved by the fsync in
+    /// `rotate_segment` (a completed segment is on disk before the next opens)
+    /// and by the torn-tail truncation on load, both of which this pin leaves
+    /// free to keep syncing.
+    ///
+    /// A behavioral test can't catch a re-added fsync (it changes only I/O
+    /// scheduling, not observable output), so the pin reads the source.
+    #[test]
+    fn write_all_does_not_fsync_per_batch() {
+        let src = include_str!("aof.rs");
+        // Cut at `mod tests`, NOT at the first `#[cfg(test)]` — there are
+        // `#[cfg(test)]` constants near the top of this file, so cutting there
+        // would drop nearly all production code and make this pin vacuous.
+        let prod = src.split("mod tests").next().unwrap();
+
+        // Built with `concat!` so this needle cannot match its own source text.
+        let sig = concat!("pub async fn ", "write_all");
+        let start = prod
+            .find(sig)
+            .expect("pin guard: write_all not found in the production slice");
+        let after = &prod[start..];
+        // The next same-level item is `pub fn encode_batch`.
+        let end = after.find("\n    pub fn ").unwrap_or(after.len());
+        let body = &after[..end];
+
+        // Vacuity guard: prove we actually extracted the real function body
+        // rather than an empty or mis-sliced range, which would make the
+        // assertion below pass no matter what the code does.
+        assert!(
+            body.contains("write_all(data)"),
+            "pin guard: the extracted slice does not contain the append call, so \
+             the extraction is wrong and this pin proves nothing. Slice:\n{body}"
+        );
+
+        assert!(
+            !body.contains(concat!("sync", "_all")),
+            "write_all must NOT fsync per batch (#4966). Durability is already \
+             covered by rotate_segment's fsync and the torn-tail truncation on \
+             load; a per-batch fsync costs ~5x write amplification on every user \
+             peer for a purely diagnostic log. Offending body:\n{body}"
+        );
     }
 
     /// Count the `Route` records the log surfaces through its public reader.

--- a/crates/core/src/tracing/register.rs
+++ b/crates/core/src/tracing/register.rs
@@ -1689,7 +1689,7 @@ pub struct EventFlushHandle {
 
 impl EventFlushHandle {
     /// A handle whose [`Self::flush`] is a no-op, for nodes running with the
-    /// event log disabled (#4966) — there is no `EventRegister` to drain.
+    /// event log disabled (#4968) — there is no `EventRegister` to drain.
     ///
     /// The receiver is dropped immediately and deliberately. `send` on a
     /// *closed* channel returns `Err` at once, so `flush` short-circuits

--- a/crates/core/src/tracing/register.rs
+++ b/crates/core/src/tracing/register.rs
@@ -1688,6 +1688,20 @@ pub struct EventFlushHandle {
 }
 
 impl EventFlushHandle {
+    /// A handle whose [`Self::flush`] is a no-op, for nodes running with the
+    /// event log disabled (#4966) — there is no `EventRegister` to drain.
+    ///
+    /// The receiver is dropped immediately and deliberately. `send` on a
+    /// *closed* channel returns `Err` at once, so `flush` short-circuits
+    /// through its `is_ok()` guard without waiting. This is NOT the
+    /// "bounded channel whose receiver is never read" anti-pattern from
+    /// `bug-prevention-patterns.md` — that one blocks forever once the buffer
+    /// fills, whereas a closed channel can never block.
+    pub fn noop() -> Self {
+        let (sender, _receiver) = mpsc::channel(1);
+        Self { sender }
+    }
+
     /// Request a flush and wait for completion
     pub async fn flush(&self) {
         let (tx, rx) = tokio::sync::oneshot::channel();


### PR DESCRIPTION
## Problem

A normal Freenet peer writes far more to disk than it needs to. Measured on a live v0.2.111 peer (Framework laptop, real NAT), `/proc/<pid>/io` showed **3.83 GB written in 1.73 h**, with block-layer writes running **4-6x** the bytes the process actually issued via `write()`.

`strace` over 60s found **52 of 55 fsyncs (95%) going to `_EVENT_LOG`** — one to redb, two to a wasm memory image. `LogFile::write_all` called `sync_all()` after every `BATCH_SIZE` (5) events; `sync_all` flushes data *and* metadata, and since an append also changes file size, each one forced a full filesystem journal commit. ~20 KiB of logical append cost ~112 KiB of real block writes.

The log also runs ~61 MiB/hour of appends on every peer. Plain text logs are only ~3.3 MiB/hour, so they are not the problem.

Full measurements in #4968.

## Approach

The event log is a purely **local** diagnostic record. It is **not** the telemetry behind telemetry.freenet.org — `TelemetryReporter` is a separate sink fed in-memory off the same event stream (`node.rs` builds a `DynamicRegister` over both), so nothing here changes what the dashboard sees.

Traced every consumer of the network-mode log before touching it:

| consumer | reads `_EVENT_LOG`? |
|---|---|
| `freenet service report` / NodeDiagnostics | no |
| `fdev verify-state` | no — reads Local-mode `_EVENT_LOG_LOCAL` |
| `event_aggregator` (`read_all_events`) | only from `test_utils.rs` |
| `examples/analyze_event_logs.rs` | manual dev tool |

So every user peer paid ~61 MiB/hour and 95% of its fsyncs for a forensic record we have never harvested.

**1. Default it OFF in network mode, ON in local mode.** Network mode is what end users run. Local mode is a single-node dev mode where the log is the point and `fdev verify-state` consumes it. `--enable-event-log` / `FREENET_ENABLE_EVENT_LOG` / `enable-event-log` turns it on for nodes we operate.

**2. Drop the per-batch fsync** so it is cheap even where enabled. Durability that matters is untouched: `rotate_segment` still fsyncs a segment before closing it, and a torn tail is already truncated at the last good record offset on load.

`write_all` still calls `flush()`. That is not a durability barrier — `tokio::fs::File` buffers internally and hands writes to a background pool, so without it the bytes may never reach the OS and a reader can observe a zero-length segment. This was caught by the existing `zero_byte_stray_segment_is_recovered` test, not by inspection.

### The one subtle bit

`Config::enable_event_log` is `Option<bool>`, not `bool`, deliberately. A `config.toml` from an older release has no such key; a `#[serde(default)] bool` would deserialize that absence to `false`, indistinguishable from an operator explicit `false`, and the merge would pin it — silently stripping the log from every upgrading **local**-mode node and breaking `fdev verify-state`. That is the #3890/#4275 silent-revert class this repo has been bitten by twice.

## Testing

New tests, each **mutation-verified** (I reintroduced the bug and confirmed the test goes red, then reverted):

| test | mutation that kills it |
|---|---|
| `event_log_defaults_off_in_network_mode` | flip the mode default to `true` |
| `event_log_defaults_on_in_local_mode` | — |
| `event_log_explicit_setting_overrides_mode_default` | — |
| `event_log_absent_config_key_does_not_pin_local_mode_off` | treat absent key as explicit `false` |
| `event_log_persisted_true_is_honored_on_reboot` | — |
| `write_all_does_not_fsync_per_batch` (source pin) | restore `sync_all()` |

Each mutation killed **exactly** its target test and nothing else.

The exhaustive `all_persisted_config_fields_round_trip_through_build` guard seeds `Some(false)` in Local mode — a genuinely non-default value, so a dropped field fails the assert rather than passing by coincidence.

The source pin exists because a re-added fsync changes only I/O scheduling, not observable output, so no behavioral test can catch it. It cuts at `mod tests` (not `#[cfg(test)]`, which would truncate before most production code and go vacuous) and asserts the extracted slice really is the function body before checking it.

- `config::` suite: 103 passed
- `tracing::` suite: 116 passed
- CI-style `cargo clippy --locked -p freenet -- -D warnings`: clean

## Risk

Behavioral change to a default that affects every user, but no wire-format or protocol change. The failure mode to watch is a node we operate silently losing its log; `--enable-event-log` is the mitigation and the round-trip test covers the persistence path.

Closes #4968

[AI-assisted - Claude]