### PR TITLE
fix(test): re-enable the event log for harness nodes so failure reports aren't empty

### DIFF
--- a/crates/core/src/test_utils.rs
+++ b/crates/core/src/test_utils.rs
@@ -1522,7 +1522,13 @@ impl TestContext {
     /// Get the path to a node's event log.
     pub fn event_log_path(&self, node_label: &str) -> anyhow::Result<PathBuf> {
         let node = self.node(node_label)?;
-        // Nodes run in Network mode, so they create _EVENT_LOG not _EVENT_LOG_LOCAL
+        // Nodes run in Network mode, so they create _EVENT_LOG not _EVENT_LOG_LOCAL.
+        // Network mode is also the mode where the event log is OFF by default
+        // (#4968), so the harness must opt in explicitly for this path to
+        // resolve to a file with anything in it — `#[freenet_test]` does that
+        // via `enable_event_log: Some(true)`. If that opt-in is ever dropped,
+        // this returns a path to an absent file and every failure report goes
+        // silently empty rather than failing loudly. See #4972.
         Ok(node.temp_dir_path.join("_EVENT_LOG"))
     }
 

--- a/crates/core/src/test_utils.rs
+++ b/crates/core/src/test_utils.rs
@@ -1587,26 +1587,7 @@ impl TestContext {
                     Ok(events) => {
                         writeln!(&mut report, "\nTotal events: {}", events.len()).unwrap();
 
-                        // An empty aggregation is almost never "nothing
-                        // happened" — it means the evidence source is missing,
-                        // and it reads identically to a genuinely quiet run.
-                        // Say so, or the reader silently draws the wrong
-                        // conclusion (#4972). A warning rather than an error on
-                        // purpose: `record_logs` sleeps briefly before creating
-                        // segment 0, so a fast failure legitimately has none.
-                        if events.is_empty() {
-                            writeln!(
-                                &mut report,
-                                "\n  ⚠️  NO EVENTS AGGREGATED across all nodes. This is very \
-                                 likely a missing evidence source rather than a quiet run — \
-                                 check that the event log is enabled for harness nodes \
-                                 (`enable_event_log: Some(true)`, #4972), that the test \
-                                 didn't fail before any events were written, and that \
-                                 `record_logs` could open the log. Treat assert-absence \
-                                 checks in this test as unproven."
-                            )
-                            .unwrap();
-                        }
+                        Self::warn_if_no_events(&mut report, events.len());
 
                         // Group by peer_id
                         let mut by_peer: HashMap<String, Vec<_>> = HashMap::new();
@@ -1820,6 +1801,36 @@ impl TestContext {
         Ok(report_dir)
     }
 
+    /// Append a loud warning when event aggregation came back empty.
+    ///
+    /// An empty aggregation is almost never "nothing happened" — it means the
+    /// evidence source is missing, and it reads identically to a genuinely
+    /// quiet run. Say so, or the reader silently draws the wrong conclusion
+    /// (#4972).
+    ///
+    /// Shared by the failure report AND the success summary on purpose: the
+    /// failure this guards is a test that PASSES vacuously, which never reaches
+    /// the failure report.
+    ///
+    /// A warning rather than an error deliberately: `record_logs` sleeps
+    /// briefly before creating segment 0, so a very fast test legitimately has
+    /// no segments and a hard error would be flaky.
+    fn warn_if_no_events(report: &mut String, event_count: usize) {
+        use std::fmt::Write;
+        if event_count == 0 {
+            writeln!(
+                report,
+                "\n  ⚠️  NO EVENTS AGGREGATED across all nodes. This is very likely a \
+                 missing evidence source rather than a quiet run — check that the event \
+                 log is enabled for harness nodes (`enable_event_log: Some(true)`, \
+                 #4972), that the test didn't fail before any events were written, and \
+                 that `record_logs` could open the log. Treat any assert-absence check \
+                 in this test as UNPROVEN."
+            )
+            .unwrap();
+        }
+    }
+
     pub async fn generate_success_summary(&self) -> String {
         use std::fmt::Write;
 
@@ -1834,6 +1845,14 @@ impl TestContext {
                 Ok(mut events) => {
                     writeln!(&mut report, "\n📊 Event Statistics:").unwrap();
                     writeln!(&mut report, "  Total events: {}", events.len()).unwrap();
+
+                    // This is the path that matters most for #4972: the failure
+                    // being guarded is a test that PASSES vacuously, and a
+                    // passing test with `aggregate_events = "always"` comes
+                    // through here, not through the failure report. (The macro
+                    // also does not catch panics, so an `assert!` failure skips
+                    // the failure report entirely.)
+                    Self::warn_if_no_events(&mut report, events.len());
 
                     // Count by event type
                     let mut by_type: HashMap<String, usize> = HashMap::new();

--- a/crates/core/src/test_utils.rs
+++ b/crates/core/src/test_utils.rs
@@ -1519,16 +1519,27 @@ impl TestContext {
             .collect()
     }
 
-    /// Get the path to a node's event log.
+    /// Base path for a node's event log. This is a segment *prefix*, not a file:
+    /// records live in `_EVENT_LOG.NNNNNNNNNN` segments, which is what
+    /// `read_all_events` scans for. Do not `.exists()`-check the returned path.
+    ///
+    /// Nodes run in Network mode, so the base name is `_EVENT_LOG`, not
+    /// `_EVENT_LOG_LOCAL`. Network mode is also the mode where the event log is
+    /// OFF by default (#4968), so the harness must opt in explicitly for these
+    /// segments to exist at all — `#[freenet_test]` does that via
+    /// `enable_event_log: Some(true)`.
+    ///
+    /// If that opt-in is ever dropped, this does NOT start returning a missing
+    /// path: `ConfigPathsArgs::build` writes a zero-length `_EVENT_LOG` stub
+    /// unconditionally, so the path resolves to a file that exists and is
+    /// empty. That is exactly why the breakage is silent — aggregation yields
+    /// zero events and every consumer reads that as "nothing happened" rather
+    /// than "the source is switched off". (With the opt-in present the stub is
+    /// deleted by `LogFile::migrate_legacy`, so the base path is absent while
+    /// the segments beside it hold the records — the inverse of what an
+    /// existence check would suggest.) See #4972.
     pub fn event_log_path(&self, node_label: &str) -> anyhow::Result<PathBuf> {
         let node = self.node(node_label)?;
-        // Nodes run in Network mode, so they create _EVENT_LOG not _EVENT_LOG_LOCAL.
-        // Network mode is also the mode where the event log is OFF by default
-        // (#4968), so the harness must opt in explicitly for this path to
-        // resolve to a file with anything in it — `#[freenet_test]` does that
-        // via `enable_event_log: Some(true)`. If that opt-in is ever dropped,
-        // this returns a path to an absent file and every failure report goes
-        // silently empty rather than failing loudly. See #4972.
         Ok(node.temp_dir_path.join("_EVENT_LOG"))
     }
 
@@ -1575,6 +1586,27 @@ impl TestContext {
                 match aggregator.get_all_events().await {
                     Ok(events) => {
                         writeln!(&mut report, "\nTotal events: {}", events.len()).unwrap();
+
+                        // An empty aggregation is almost never "nothing
+                        // happened" — it means the evidence source is missing,
+                        // and it reads identically to a genuinely quiet run.
+                        // Say so, or the reader silently draws the wrong
+                        // conclusion (#4972). A warning rather than an error on
+                        // purpose: `record_logs` sleeps briefly before creating
+                        // segment 0, so a fast failure legitimately has none.
+                        if events.is_empty() {
+                            writeln!(
+                                &mut report,
+                                "\n  ⚠️  NO EVENTS AGGREGATED across all nodes. This is very \
+                                 likely a missing evidence source rather than a quiet run — \
+                                 check that the event log is enabled for harness nodes \
+                                 (`enable_event_log: Some(true)`, #4972), that the test \
+                                 didn't fail before any events were written, and that \
+                                 `record_logs` could open the log. Treat assert-absence \
+                                 checks in this test as unproven."
+                            )
+                            .unwrap();
+                        }
 
                         // Group by peer_id
                         let mut by_peer: HashMap<String, Vec<_>> = HashMap::new();

--- a/crates/core/tests/operations.rs
+++ b/crates/core/tests/operations.rs
@@ -4396,24 +4396,38 @@ async fn test_client_disconnect_does_not_immediately_unsubscribe_with_recent_rea
         // while proving nothing. An empty aggregation here means the evidence
         // is missing, not that the behavior is correct.
         //
-        // Scope, so this is not over-trusted: it proves the event source is
-        // LIVE, not that unsubscribe detection specifically works. Any node
-        // activity satisfies it. That is the right target — the failure mode it
-        // guards is "the source is switched off", which is what silently
-        // disabled this test.
+        // `!events.is_empty()` alone is satisfiable by node-startup records
+        // (`Lifecycle(Startup)` is written unconditionally per node), so it
+        // would hold with 3 events and nothing subscription-related present.
+        // Also require a Subscribe event: this test's whole subject is the
+        // subscription lifecycle, so if no Subscribe was captured, an
+        // Unsubscribe would not have been captured either and the counts below
+        // prove nothing. Measured margin on healthy runs: ~140-190 events with
+        // Subscribe: 5, against the 1 required here.
         //
-        // Not flaky: by this point the test has completed a PUT, a GET, a
-        // SUBSCRIBE, and asserted that client B received an update
-        // notification, and the loop sleeps 5s before its first aggregation
-        // (which flushes every node's register first). Zero events here would
-        // itself be the bug.
-        assert!(
-            !events.is_empty(),
-            "event aggregation returned no events, so the unsubscribe assertions \
-             below would pass vacuously. Either the event log is disabled for \
-             harness nodes (see #4972 — `#[freenet_test]` must set \
-             `enable_event_log: Some(true)`) or `record_logs` failed to open it. \
-             This is a broken fixture, not a passing test."
+        // Not flaky: by this point the node has been up ~45-60s
+        // (`startup_wait_secs = 40` plus PUT/GET/subscribe/disconnect), well
+        // past `record_logs`' 200ms delay before creating segment 0, and
+        // `aggregate_events` flushes every register (blocking send + 2s reply
+        // wait) before reading, so sub-batch events are on disk.
+        //
+        // `ensure!` rather than `assert!` on purpose: it returns Err, which
+        // routes through `generate_failure_report` and so prints the NO-EVENTS
+        // warning alongside this message. A panic would bypass that report
+        // entirely, since the macro does not catch panics.
+        let subscribe_events = events
+            .iter()
+            .filter(|e| matches!(e.kind, freenet::tracing::EventKind::Subscribe(..)))
+            .count();
+        ensure!(
+            !events.is_empty() && subscribe_events > 0,
+            "event aggregation returned {} event(s) with {} Subscribe event(s), so the \
+             unsubscribe assertions below would pass vacuously. Either the event log is \
+             disabled for harness nodes (see #4972 — `#[freenet_test]` must set \
+             `enable_event_log: Some(true)`) or `record_logs` failed to open it. This is \
+             a broken fixture, not a passing test.",
+            events.len(),
+            subscribe_events
         );
 
         let unsubscribe_sent_count = events

--- a/crates/core/tests/operations.rs
+++ b/crates/core/tests/operations.rs
@@ -4389,6 +4389,21 @@ async fn test_client_disconnect_does_not_immediately_unsubscribe_with_recent_rea
         let aggregator = ctx.aggregate_events().await?;
         let events = aggregator.get_all_events().await?;
 
+        // Non-vacuity guard (#4972). The two assertions below assert the
+        // ABSENCE of an event, so they pass unconditionally whenever the event
+        // source is empty — which is exactly what happened when #4969 turned
+        // the event log off for network-mode nodes and this test kept passing
+        // while proving nothing. An empty aggregation here means the evidence
+        // is missing, not that the behavior is correct.
+        assert!(
+            !events.is_empty(),
+            "event aggregation returned no events, so the unsubscribe assertions \
+             below would pass vacuously. Either the event log is disabled for \
+             harness nodes (see #4972 — `#[freenet_test]` must set \
+             `enable_event_log: Some(true)`) or `record_logs` failed to open it. \
+             This is a broken fixture, not a passing test."
+        );
+
         let unsubscribe_sent_count = events
             .iter()
             .filter(|e| {

--- a/crates/core/tests/operations.rs
+++ b/crates/core/tests/operations.rs
@@ -4399,11 +4399,19 @@ async fn test_client_disconnect_does_not_immediately_unsubscribe_with_recent_rea
         // `!events.is_empty()` alone is satisfiable by node-startup records
         // (`Lifecycle(Startup)` is written unconditionally per node), so it
         // would hold with 3 events and nothing subscription-related present.
-        // Also require a Subscribe event: this test's whole subject is the
-        // subscription lifecycle, so if no Subscribe was captured, an
-        // Unsubscribe would not have been captured either and the counts below
-        // prove nothing. Measured margin on healthy runs: ~140-190 events with
-        // Subscribe: 5, against the 1 required here.
+        // Also require a Subscribe event, and note this is a structural
+        // requirement rather than a thematic one: `UnsubscribeSent` and
+        // `UnsubscribeReceived` are variants of `SubscribeEvent`, wrapped as
+        // `EventKind::Subscribe(..)` (see `tracing/event_kind.rs`). So this
+        // demands an event from the EXACT enum arm the two counts below look
+        // inside — if the pipeline that would carry an `UnsubscribeSent` is
+        // dead, `EventKind::Subscribe` is absent too.
+        //
+        // The margin is structural as well: the test asserts `subscribed ==
+        // true` above before reaching this loop, so a successful SUBSCRIBE
+        // (which emits `SubscribeEvent::SubscribeSuccess`) has definitely
+        // completed. Measured on healthy runs: ~140-190 events with Subscribe:
+        // 5, against the 1 required here.
         //
         // Not flaky: by this point the node has been up ~45-60s
         // (`startup_wait_secs = 40` plus PUT/GET/subscribe/disconnect), well

--- a/crates/core/tests/operations.rs
+++ b/crates/core/tests/operations.rs
@@ -4395,6 +4395,18 @@ async fn test_client_disconnect_does_not_immediately_unsubscribe_with_recent_rea
         // the event log off for network-mode nodes and this test kept passing
         // while proving nothing. An empty aggregation here means the evidence
         // is missing, not that the behavior is correct.
+        //
+        // Scope, so this is not over-trusted: it proves the event source is
+        // LIVE, not that unsubscribe detection specifically works. Any node
+        // activity satisfies it. That is the right target — the failure mode it
+        // guards is "the source is switched off", which is what silently
+        // disabled this test.
+        //
+        // Not flaky: by this point the test has completed a PUT, a GET, a
+        // SUBSCRIBE, and asserted that client B received an update
+        // notification, and the loop sleeps 5s before its first aggregation
+        // (which flushes every node's register first). Zero events here would
+        // itself be the bug.
         assert!(
             !events.is_empty(),
             "event aggregation returned no events, so the unsubscribe assertions \

--- a/crates/freenet-macros/src/codegen.rs
+++ b/crates/freenet-macros/src/codegen.rs
@@ -790,11 +790,19 @@ mod tests {
     /// node so that dropping it from only the gateway arm or only the peer arm
     /// still trips it.
     ///
-    /// The expected count is derived from `args.nodes.len()`, not hardcoded:
-    /// the invariant is "one per node", and writing the number literally would
-    /// mean a fixture that never reaches a newly-added config arm keeps passing
-    /// while that arm ships without the opt-in — the same silent-blind-spot
-    /// shape as the bug being fixed.
+    /// The expected count is derived from `args.nodes.len()` rather than
+    /// hardcoded, but be precise about what that buys: only that editing the
+    /// fixture's node count keeps working without a manual literal bump. It
+    /// does NOT cover a newly-added config arm that this two-node fixture never
+    /// reaches — verified by mutation: adding a third arm without the opt-in
+    /// leaves this test green, because both the node count and both match
+    /// counts stay at 2. Unreached-arm coverage is a property of the FIXTURE,
+    /// and no token count against a single fixture can establish it.
+    ///
+    /// That hole is closed separately by
+    /// `every_config_args_literal_in_the_source_sets_the_opt_in`, which scrapes
+    /// the source of `generate_node_setup` and so sees arms this fixture never
+    /// exercises.
     #[test]
     fn every_harness_node_enables_the_event_log() {
         let args: FreenetTestArgs = syn::parse2(quote! { nodes = ["gateway", "peer-1"] }).unwrap();
@@ -803,20 +811,15 @@ mod tests {
         let generated = generate_node_setup(&args).to_string();
         let normalized: String = generated.chars().filter(|c| !c.is_whitespace()).collect();
 
-        // Vacuity guard: prove we actually generated node-config code. Without
-        // this, a refactor that renamed or emptied `generate_node_setup` would
-        // leave the assertion below passing against an empty string.
-        assert!(
-            normalized.contains("ConfigArgs"),
-            "pin guard: generated node setup does not build ConfigArgs, so this \
-             test is asserting against the wrong thing. Generated:\n{generated}"
-        );
-        // Guard the guard: if the fixture ever stops generating one ConfigArgs
-        // per node, the count below stops meaning "one opt-in per node".
+        // Vacuity guard: if the fixture ever stops generating one ConfigArgs per
+        // node, the count below stops meaning "one opt-in per node". This also
+        // subsumes a bare "did we generate anything" check — a count of
+        // `expected` implies the literal is present.
         assert_eq!(
             normalized.matches("ConfigArgs{").count(),
             expected,
-            "pin guard: expected one ConfigArgs per node. Generated:\n{generated}"
+            "pin guard: expected one ConfigArgs per node, so this test is \
+             asserting against the wrong thing. Generated:\n{generated}"
         );
 
         let count = normalized.matches("enable_event_log:Some(true)").count();
@@ -827,6 +830,62 @@ mod tests {
              have the event log off by default (#4968) and #[freenet_test] reads \
              it back for failure reports and for assert-absence tests, so \
              dropping this silently empties both. See #4972.\nGenerated:\n{generated}"
+        );
+    }
+
+    /// Every `ConfigArgs` literal in `generate_node_setup` sets the opt-in —
+    /// including arms no fixture reaches (#4972).
+    ///
+    /// This is the guard `every_harness_node_enables_the_event_log` cannot be:
+    /// that test runs a two-node fixture, so a third config arm added later is
+    /// simply never generated and its missing opt-in stays invisible. Verified
+    /// by mutation during review — adding an unreached arm without the opt-in
+    /// left the token-count test green.
+    ///
+    /// Reading the SOURCE is what makes unreached arms visible, so this
+    /// deliberately accepts source-scrape brittleness in exchange for coverage
+    /// the token check structurally cannot provide.
+    #[test]
+    fn every_config_args_literal_in_the_source_sets_the_opt_in() {
+        let src = include_str!("codegen.rs");
+        // Cut at `mod tests` so the needles below cannot match this test's own
+        // source text (which contains both of them as string literals).
+        let prod = src.split("mod tests").next().unwrap();
+
+        let start = prod
+            .find(concat!("fn generate_", "node_setup"))
+            .expect("pin guard: generate_node_setup not found in the production slice");
+        let after = &prod[start..];
+        // Ends at the next top-level item.
+        let end = after.find("\nfn ").unwrap_or(after.len());
+        let body = &after[..end];
+
+        // Vacuity guard: prove the slice is the real function body rather than
+        // an empty or mis-sliced range, which would make the check below pass
+        // no matter what the code does.
+        assert!(
+            body.contains("NetworkArgs"),
+            "pin guard: the extracted slice does not look like generate_node_setup, \
+             so this pin proves nothing. Slice:\n{body}"
+        );
+
+        let literals = body.matches("ConfigArgs {").count();
+        let opt_ins = body
+            .matches(concat!("enable_event_log", ": Some(true)"))
+            .count();
+
+        assert!(
+            literals > 0,
+            "pin guard: no ConfigArgs literal found in generate_node_setup"
+        );
+        assert_eq!(
+            literals, opt_ins,
+            "every ConfigArgs literal in generate_node_setup must set \
+             `enable_event_log: Some(true)` — found {literals} literal(s) but \
+             {opt_ins} opt-in(s). A node-config arm without the opt-in writes no \
+             event log, which silently empties failure reports AND makes \
+             assert-absence tests pass vacuously (#4972). Unlike the token-count \
+             test, this one sees arms no fixture reaches."
         );
     }
 }

--- a/crates/freenet-macros/src/codegen.rs
+++ b/crates/freenet-macros/src/codegen.rs
@@ -833,61 +833,66 @@ mod tests {
         );
     }
 
-    /// Every `ConfigArgs` literal in `generate_node_setup` sets the opt-in —
-    /// including arms no fixture reaches (#4972).
+    /// Every `ConfigArgs` literal in this file's production code sets the
+    /// opt-in — including arms no fixture reaches (#4972).
     ///
     /// This is the guard `every_harness_node_enables_the_event_log` cannot be:
-    /// that test runs a two-node fixture, so a third config arm added later is
-    /// simply never generated and its missing opt-in stays invisible. Verified
-    /// by mutation during review — adding an unreached arm without the opt-in
-    /// left the token-count test green.
+    /// that test runs a two-node fixture, so a config arm added later is simply
+    /// never generated and its missing opt-in stays invisible. Verified by
+    /// mutation during review — adding an unreached arm without the opt-in left
+    /// the token-count test green.
     ///
-    /// Reading the SOURCE is what makes unreached arms visible, so this
-    /// deliberately accepts source-scrape brittleness in exchange for coverage
-    /// the token check structurally cannot provide.
+    /// Scoped to the whole pre-`mod tests` region rather than to
+    /// `generate_node_setup` alone. That is deliberate and was arrived at by
+    /// mutation, not taste: slicing a single function needed a name needle, an
+    /// end boundary, and a vacuity guard, and all three were defeatable. In
+    /// particular `NetworkArgs` appears in BOTH config arms, so a slice
+    /// truncated after the first one still passed its own guard while the
+    /// second arm sat outside the scrape entirely. Scanning the whole region
+    /// deletes all three mechanisms and also covers a `ConfigArgs` added in a
+    /// different function.
     ///
-    /// Scope, stated so it is not over-trusted (this file has already shipped
-    /// two comments claiming protection the code did not provide): it covers
-    /// only the body of `generate_node_setup`. A `ConfigArgs` literal added in
-    /// a DIFFERENT function is invisible to it — confirmed by mutation. That
-    /// is an accepted bound rather than an oversight, since node configs belong
-    /// in this function; if that ever stops being true, widen the slice.
+    /// If some future function legitimately needs a `ConfigArgs` without the
+    /// opt-in, this fails loudly and a human decides — the right default for a
+    /// guard whose entire job is catching a silent omission.
     #[test]
     fn every_config_args_literal_in_the_source_sets_the_opt_in() {
         let src = include_str!("codegen.rs");
         // Cut at `mod tests` so the needles below cannot match this test's own
-        // source text (which contains both of them as string literals).
+        // source text, which contains both of them as string literals.
         let prod = src.split("mod tests").next().unwrap();
 
-        let start = prod
-            .find(concat!("fn generate_", "node_setup"))
-            .expect("pin guard: generate_node_setup not found in the production slice");
-        let after = &prod[start..];
-        // Ends at the next top-level item.
-        let end = after.find("\nfn ").unwrap_or(after.len());
-        let body = &after[..end];
+        // Strip `//` lines before counting. Without this, a comment MENTIONING
+        // the opt-in satisfies the count for an arm that never sets it —
+        // demonstrated by mutation, and not hypothetical: `test_utils.rs`
+        // already carries the prose "via `enable_event_log: Some(true)`", so a
+        // developer adding an arm and bringing the surrounding comment along
+        // reproduces it. Stripping also closes the inverse cry-wolf case, where
+        // a comment containing `ConfigArgs {` inflates the literal count on
+        // correct code.
+        let code_only: String = prod
+            .lines()
+            .filter(|l| !l.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n");
 
-        // Vacuity guard: prove the slice is the real function body rather than
-        // an empty or mis-sliced range, which would make the check below pass
-        // no matter what the code does.
-        assert!(
-            body.contains("NetworkArgs"),
-            "pin guard: the extracted slice does not look like generate_node_setup, \
-             so this pin proves nothing. Slice:\n{body}"
-        );
-
-        let literals = body.matches("ConfigArgs {").count();
-        let opt_ins = body
+        let literals = code_only.matches("ConfigArgs {").count();
+        let opt_ins = code_only
             .matches(concat!("enable_event_log", ": Some(true)"))
             .count();
 
+        // Vacuity guard: a truncated or mis-cut slice yields zero literals, so
+        // this catches the case where the scrape silently stops looking at
+        // anything. (`ConfigPathsArgs {` cannot inflate the count — the char
+        // after `Config` is `P`, never `A`.)
         assert!(
             literals > 0,
-            "pin guard: no ConfigArgs literal found in generate_node_setup"
+            "pin guard: no ConfigArgs literal found in the production slice, so \
+             this pin proves nothing"
         );
         assert_eq!(
             literals, opt_ins,
-            "every ConfigArgs literal in generate_node_setup must set \
+            "every ConfigArgs literal in this file must set \
              `enable_event_log: Some(true)` — found {literals} literal(s) but \
              {opt_ins} opt-in(s). A node-config arm without the opt-in writes no \
              event log, which silently empties failure reports AND makes \

--- a/crates/freenet-macros/src/codegen.rs
+++ b/crates/freenet-macros/src/codegen.rs
@@ -845,6 +845,13 @@ mod tests {
     /// Reading the SOURCE is what makes unreached arms visible, so this
     /// deliberately accepts source-scrape brittleness in exchange for coverage
     /// the token check structurally cannot provide.
+    ///
+    /// Scope, stated so it is not over-trusted (this file has already shipped
+    /// two comments claiming protection the code did not provide): it covers
+    /// only the body of `generate_node_setup`. A `ConfigArgs` literal added in
+    /// a DIFFERENT function is invisible to it — confirmed by mutation. That
+    /// is an accepted bound rather than an oversight, since node configs belong
+    /// in this function; if that ever stops being true, widen the slice.
     #[test]
     fn every_config_args_literal_in_the_source_sets_the_opt_in() {
         let src = include_str!("codegen.rs");

--- a/crates/freenet-macros/src/codegen.rs
+++ b/crates/freenet-macros/src/codegen.rs
@@ -799,23 +799,35 @@ mod tests {
     /// counts stay at 2. Unreached-arm coverage is a property of the FIXTURE,
     /// and no token count against a single fixture can establish it.
     ///
-    /// **That hole is NOT covered anywhere.** A source-scrape guard for it was
-    /// written and then deleted: text matching cannot tell a field from prose,
-    /// so five separate mutations defeated it (opt-in named in a trailing
-    /// comment, in a block comment, in a `///` doc comment; a literal in
-    /// another function; and — worst — an innocuous production comment
-    /// containing the words `mod tests`, which truncated the scraped region
-    /// before the peer arm so the guard went green on exactly the bug it
-    /// existed to catch). A guard that looks like protection but isn't is worse
-    /// than none, because it stops the next person adding real protection.
+    /// **That hole is not covered by any test.** A source-scrape guard for it
+    /// was written and then deleted, because text matching cannot tell a field
+    /// from prose. Three mutations defeated the final version: the opt-in named
+    /// in a trailing comment, in a `/* block comment */`, and — worst — an
+    /// innocuous production comment containing the words `mod tests`, which
+    /// truncated the scraped region before the peer arm so the guard went green
+    /// on exactly the bug it existed to catch.
+    ///
+    /// Two more defeated earlier or alternative versions: a literal in another
+    /// function (beat the single-function slice, later widened), and the opt-in
+    /// in a `///` doc comment (beat a `proc_macro2` lexer variant, since `///`
+    /// becomes `#[doc = "..."]` and the phrase survives in the string literal).
+    /// Each fix drew a new shape — which is the point: the problem is the
+    /// approach, not any one bug. A guard that looks like protection but isn't
+    /// is worse than none, because it stops the next person adding real
+    /// protection.
+    ///
+    /// (`warn_if_no_events` would still surface a TOTAL runtime blackout, but
+    /// it prints rather than fails, and would not catch a partial one where
+    /// only a new arm's nodes lack the opt-in.)
     ///
     /// So: **if you add a node-config arm here, add a fixture node that reaches
-    /// it.** If that ever needs enforcing, parse rather than match
-    /// (`syn::parse_file`, walking for an `ExprStruct` whose path ends in
-    /// `ConfigArgs` — fields and doc attributes are structurally distinct
-    /// there), or better, remove the duplication so both arms build their
-    /// `ConfigArgs` through one shared helper and there is only one place to
-    /// forget.
+    /// it.** If that ever needs enforcing, parse rather than match —
+    /// `syn::parse_file`, walking for an `ExprStruct` whose path ends in
+    /// `ConfigArgs`, since fields and doc attributes are structurally distinct
+    /// there (note the walk needs manual recursion or syn's `visit` feature,
+    /// which is not currently enabled). Better still, remove the duplication so
+    /// both arms build their `ConfigArgs` through one shared helper and there
+    /// is only one place to forget.
     #[test]
     fn every_harness_node_enables_the_event_log() {
         let args: FreenetTestArgs = syn::parse2(quote! { nodes = ["gateway", "peer-1"] }).unwrap();

--- a/crates/freenet-macros/src/codegen.rs
+++ b/crates/freenet-macros/src/codegen.rs
@@ -314,6 +314,16 @@ fn generate_node_setup(args: &FreenetTestArgs) -> TokenStream {
                             transport_keypair: Some(transport_keypair),
                             ..Default::default()
                         },
+                        // Harness nodes run in Network mode, where the local
+                        // event log is OFF by default (#4968). The failure
+                        // report this macro emits reads that log back
+                        // (`generate_failure_report` -> `aggregate_events` ->
+                        // `event_log_path`), so without this opt-in the event
+                        // section of every failing test's report is silently
+                        // empty. Diagnostics are the whole point of the log in
+                        // a test, and a temp-dir node pays none of the disk
+                        // cost that made it opt-in for real peers. See #4972.
+                        enable_event_log: Some(true),
                         ..Default::default()
                     };
 
@@ -456,6 +466,16 @@ fn generate_node_setup(args: &FreenetTestArgs) -> TokenStream {
                             transport_keypair: Some(transport_keypair),
                             ..Default::default()
                         },
+                        // Harness nodes run in Network mode, where the local
+                        // event log is OFF by default (#4968). The failure
+                        // report this macro emits reads that log back
+                        // (`generate_failure_report` -> `aggregate_events` ->
+                        // `event_log_path`), so without this opt-in the event
+                        // section of every failing test's report is silently
+                        // empty. Diagnostics are the whole point of the log in
+                        // a test, and a temp-dir node pays none of the disk
+                        // cost that made it opt-in for real peers. See #4972.
+                        enable_event_log: Some(true),
                         ..Default::default()
                     };
 
@@ -747,5 +767,52 @@ fn generate_tokio_attr(args: &FreenetTestArgs) -> TokenStream {
                 #[tokio::test(flavor = #flavor)]
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quote::quote;
+
+    /// Every harness node must opt in to the local event log (#4972).
+    ///
+    /// Harness nodes run in Network mode, which is exactly the mode where the
+    /// event log is OFF by default (#4968). But this macro's failure report
+    /// reads that log back — `generate_failure_report` -> `aggregate_events`
+    /// -> `event_log_path`. Drop the opt-in and the report does not fail, it
+    /// just stops saying anything: the event section of every failing test's
+    /// report goes silently empty, which reads like "nothing interesting
+    /// happened" rather than "this diagnostic is switched off".
+    ///
+    /// Asserts against the GENERATED TOKENS rather than the source text, so
+    /// reformatting cannot quietly make it vacuous, and counts both nodes so
+    /// that dropping the opt-in from only the gateway arm or only the peer arm
+    /// still trips it.
+    #[test]
+    fn every_harness_node_enables_the_event_log() {
+        let args: FreenetTestArgs = syn::parse2(quote! { nodes = ["gateway", "peer-1"] }).unwrap();
+
+        let generated = generate_node_setup(&args).to_string();
+        let normalized: String = generated.chars().filter(|c| !c.is_whitespace()).collect();
+
+        // Vacuity guard: prove we actually generated node-config code. Without
+        // this, a refactor that renamed or emptied `generate_node_setup` would
+        // leave the assertion below passing against an empty string.
+        assert!(
+            normalized.contains("ConfigArgs"),
+            "pin guard: generated node setup does not build ConfigArgs, so this \
+             test is asserting against the wrong thing. Generated:\n{generated}"
+        );
+
+        let count = normalized.matches("enable_event_log:Some(true)").count();
+        assert_eq!(
+            count, 2,
+            "each of the 2 harness nodes must set `enable_event_log: Some(true)` \
+             (found {count}). Network-mode nodes have the event log off by \
+             default (#4968) and #[freenet_test] reads it back for failure \
+             reports, so dropping this silently empties the event section of \
+             every failing test's report. See #4972.\nGenerated:\n{generated}"
+        );
     }
 }

--- a/crates/freenet-macros/src/codegen.rs
+++ b/crates/freenet-macros/src/codegen.rs
@@ -786,12 +786,19 @@ mod tests {
     /// happened" rather than "this diagnostic is switched off".
     ///
     /// Asserts against the GENERATED TOKENS rather than the source text, so
-    /// reformatting cannot quietly make it vacuous, and counts both nodes so
-    /// that dropping the opt-in from only the gateway arm or only the peer arm
+    /// reformatting cannot quietly make it vacuous, and expects one opt-in per
+    /// node so that dropping it from only the gateway arm or only the peer arm
     /// still trips it.
+    ///
+    /// The expected count is derived from `args.nodes.len()`, not hardcoded:
+    /// the invariant is "one per node", and writing the number literally would
+    /// mean a fixture that never reaches a newly-added config arm keeps passing
+    /// while that arm ships without the opt-in — the same silent-blind-spot
+    /// shape as the bug being fixed.
     #[test]
     fn every_harness_node_enables_the_event_log() {
         let args: FreenetTestArgs = syn::parse2(quote! { nodes = ["gateway", "peer-1"] }).unwrap();
+        let expected = args.nodes.len();
 
         let generated = generate_node_setup(&args).to_string();
         let normalized: String = generated.chars().filter(|c| !c.is_whitespace()).collect();
@@ -804,15 +811,22 @@ mod tests {
             "pin guard: generated node setup does not build ConfigArgs, so this \
              test is asserting against the wrong thing. Generated:\n{generated}"
         );
+        // Guard the guard: if the fixture ever stops generating one ConfigArgs
+        // per node, the count below stops meaning "one opt-in per node".
+        assert_eq!(
+            normalized.matches("ConfigArgs{").count(),
+            expected,
+            "pin guard: expected one ConfigArgs per node. Generated:\n{generated}"
+        );
 
         let count = normalized.matches("enable_event_log:Some(true)").count();
         assert_eq!(
-            count, 2,
-            "each of the 2 harness nodes must set `enable_event_log: Some(true)` \
-             (found {count}). Network-mode nodes have the event log off by \
-             default (#4968) and #[freenet_test] reads it back for failure \
-             reports, so dropping this silently empties the event section of \
-             every failing test's report. See #4972.\nGenerated:\n{generated}"
+            count, expected,
+            "each of the {expected} harness nodes must set \
+             `enable_event_log: Some(true)` (found {count}). Network-mode nodes \
+             have the event log off by default (#4968) and #[freenet_test] reads \
+             it back for failure reports and for assert-absence tests, so \
+             dropping this silently empties both. See #4972.\nGenerated:\n{generated}"
         );
     }
 }

--- a/crates/freenet-macros/src/codegen.rs
+++ b/crates/freenet-macros/src/codegen.rs
@@ -799,10 +799,23 @@ mod tests {
     /// counts stay at 2. Unreached-arm coverage is a property of the FIXTURE,
     /// and no token count against a single fixture can establish it.
     ///
-    /// That hole is closed separately by
-    /// `every_config_args_literal_in_the_source_sets_the_opt_in`, which scrapes
-    /// the source of `generate_node_setup` and so sees arms this fixture never
-    /// exercises.
+    /// **That hole is NOT covered anywhere.** A source-scrape guard for it was
+    /// written and then deleted: text matching cannot tell a field from prose,
+    /// so five separate mutations defeated it (opt-in named in a trailing
+    /// comment, in a block comment, in a `///` doc comment; a literal in
+    /// another function; and — worst — an innocuous production comment
+    /// containing the words `mod tests`, which truncated the scraped region
+    /// before the peer arm so the guard went green on exactly the bug it
+    /// existed to catch). A guard that looks like protection but isn't is worse
+    /// than none, because it stops the next person adding real protection.
+    ///
+    /// So: **if you add a node-config arm here, add a fixture node that reaches
+    /// it.** If that ever needs enforcing, parse rather than match
+    /// (`syn::parse_file`, walking for an `ExprStruct` whose path ends in
+    /// `ConfigArgs` — fields and doc attributes are structurally distinct
+    /// there), or better, remove the duplication so both arms build their
+    /// `ConfigArgs` through one shared helper and there is only one place to
+    /// forget.
     #[test]
     fn every_harness_node_enables_the_event_log() {
         let args: FreenetTestArgs = syn::parse2(quote! { nodes = ["gateway", "peer-1"] }).unwrap();
@@ -830,74 +843,6 @@ mod tests {
              have the event log off by default (#4968) and #[freenet_test] reads \
              it back for failure reports and for assert-absence tests, so \
              dropping this silently empties both. See #4972.\nGenerated:\n{generated}"
-        );
-    }
-
-    /// Every `ConfigArgs` literal in this file's production code sets the
-    /// opt-in — including arms no fixture reaches (#4972).
-    ///
-    /// This is the guard `every_harness_node_enables_the_event_log` cannot be:
-    /// that test runs a two-node fixture, so a config arm added later is simply
-    /// never generated and its missing opt-in stays invisible. Verified by
-    /// mutation during review — adding an unreached arm without the opt-in left
-    /// the token-count test green.
-    ///
-    /// Scoped to the whole pre-`mod tests` region rather than to
-    /// `generate_node_setup` alone. That is deliberate and was arrived at by
-    /// mutation, not taste: slicing a single function needed a name needle, an
-    /// end boundary, and a vacuity guard, and all three were defeatable. In
-    /// particular `NetworkArgs` appears in BOTH config arms, so a slice
-    /// truncated after the first one still passed its own guard while the
-    /// second arm sat outside the scrape entirely. Scanning the whole region
-    /// deletes all three mechanisms and also covers a `ConfigArgs` added in a
-    /// different function.
-    ///
-    /// If some future function legitimately needs a `ConfigArgs` without the
-    /// opt-in, this fails loudly and a human decides — the right default for a
-    /// guard whose entire job is catching a silent omission.
-    #[test]
-    fn every_config_args_literal_in_the_source_sets_the_opt_in() {
-        let src = include_str!("codegen.rs");
-        // Cut at `mod tests` so the needles below cannot match this test's own
-        // source text, which contains both of them as string literals.
-        let prod = src.split("mod tests").next().unwrap();
-
-        // Strip `//` lines before counting. Without this, a comment MENTIONING
-        // the opt-in satisfies the count for an arm that never sets it —
-        // demonstrated by mutation, and not hypothetical: `test_utils.rs`
-        // already carries the prose "via `enable_event_log: Some(true)`", so a
-        // developer adding an arm and bringing the surrounding comment along
-        // reproduces it. Stripping also closes the inverse cry-wolf case, where
-        // a comment containing `ConfigArgs {` inflates the literal count on
-        // correct code.
-        let code_only: String = prod
-            .lines()
-            .filter(|l| !l.trim_start().starts_with("//"))
-            .collect::<Vec<_>>()
-            .join("\n");
-
-        let literals = code_only.matches("ConfigArgs {").count();
-        let opt_ins = code_only
-            .matches(concat!("enable_event_log", ": Some(true)"))
-            .count();
-
-        // Vacuity guard: a truncated or mis-cut slice yields zero literals, so
-        // this catches the case where the scrape silently stops looking at
-        // anything. (`ConfigPathsArgs {` cannot inflate the count — the char
-        // after `Config` is `P`, never `A`.)
-        assert!(
-            literals > 0,
-            "pin guard: no ConfigArgs literal found in the production slice, so \
-             this pin proves nothing"
-        );
-        assert_eq!(
-            literals, opt_ins,
-            "every ConfigArgs literal in this file must set \
-             `enable_event_log: Some(true)` — found {literals} literal(s) but \
-             {opt_ins} opt-in(s). A node-config arm without the opt-in writes no \
-             event log, which silently empties failure reports AND makes \
-             assert-absence tests pass vacuously (#4972). Unlike the token-count \
-             test, this one sees arms no fixture reaches."
         );
     }
 }


### PR DESCRIPTION
## Problem

#4969 made the local `_EVENT_LOG` opt-in on network-mode nodes. That is right for real peers — measured on a live 0.2.111 peer it was ~61 MiB/hour of appends and 95% of every fsync the process issued, for a forensic record nothing harvests.

Harness nodes also run in Network mode, and `#[freenet_test]` reads that log back to build its failure report:

```
generate_failure_report -> aggregate_events -> event_log_path
```

Nothing in `test_utils.rs` or `crates/freenet-macros/` set `enable_event_log` — the identifier appeared only in `config.rs` and `node.rs`. So every harness node silently stopped writing the log and **the event section of every failing integration test's report went empty**. `AggregateEventsMode::OnFailure` is the default, so this affects every `#[freenet_test]`.

The failure mode is the quiet kind: nothing errors, the report just stops saying anything. An empty event summary reads like "nothing interesting happened" rather than "this diagnostic is switched off", so the next person debugging a failing integration test loses the evidence without being told they lost it.

## Approach

`#[freenet_test]` opts in explicitly at both node-config sites (gateway and peer). A temp-dir node that lives for a single test pays none of the disk cost that justified making the log opt-in for real peers, so there's no reason to inherit that default here.

Also corrects the comment on `event_log_path`, which asserted that Network mode is *why* `_EVENT_LOG` exists. Network mode had become precisely why it wouldn't.

Considered and rejected: flipping the default back for all nodes (throws away the real per-peer win), and having the harness read `_EVENT_LOG_LOCAL` instead (that's the Local-mode path; harness nodes genuinely are Network-mode, so it would just move the mismatch).

## Testing

New `every_harness_node_enables_the_event_log` in `codegen.rs`. Three deliberate properties:

- **Asserts on the generated tokens, not source text**, so reformatting can't quietly make it vacuous.
- **Counts both nodes** (`== 2`), so dropping the opt-in from only the gateway arm or only the peer arm still trips it — not just wholesale removal.
- **Carries a vacuity guard** asserting the generated output really contains `ConfigArgs`, so a refactor that renamed or emptied `generate_node_setup` fails loudly instead of passing against an empty string.

Mutation-verified: removing the opt-in from **just the peer arm** fails the test with `left: 1, right: 2`; reverted, green again. `cargo fmt` and `cargo clippy -p freenet-macros -- -D warnings` clean.

## Scope

Diagnostics only. No production behavior change, and no effect on telemetry.freenet.org (a separate in-memory `TelemetryReporter` sink, unaffected by the gate). 0.2.112 ships #4969 as-is; this closes the harness gap alongside it.

Found while reviewing #4969 against the deploy gate for 0.2.112.

Closes #4972

[AI-assisted - Claude]