### PR TITLE
feat(telemetry): split the interest_sync census arm and measure summary-identical rate

### DIFF
--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -2741,9 +2741,12 @@ async fn handle_interest_sync_message(
                 // `MAX_STALENESS_PROBES_PER_SUMMARIES` / `plan_staleness_probe`.
                 let mut staleness_probes_used = 0usize;
                 // Contracts already counted by the #4965 summary-comparison
-                // measurement in THIS message. Bounded by the message's entry
-                // count, which the transport already bounds; it holds contract
-                // ids only, no state.
+                // measurement in THIS message. Scoped to one message, so it
+                // cannot accumulate across a connection. Its size is bounded by
+                // the number of DISTINCT locally-known contracts the entries
+                // resolve to — `lookup_by_hash` only yields contracts this node
+                // already tracks, so a peer cannot grow it with unknown ids —
+                // and it holds contract ids only, no state.
                 let mut compared_contracts: std::collections::HashSet<
                     freenet_stdlib::prelude::ContractKey,
                 > = std::collections::HashSet::new();
@@ -4149,11 +4152,23 @@ mod tests {
              measurement; without it the identical/differing rollup is \
              silently always zero"
         );
+        // Structural, not presence: assert the call sits INSIDE the dedup
+        // guard's block. Two independent `contains` checks would pass a
+        // regression that kept both identifiers but moved the call out from
+        // behind the `if` — which is precisely the mutation that silently
+        // re-opens the skew. Slice from the guard to the end of its block.
+        let guard_off = summaries_arm
+            .find(concat!("compared_", "contracts.insert("))
+            .expect("the per-message dedup guard must exist in the Summaries arm");
+        let guard_block_end = summaries_arm[guard_off..]
+            .find("\n                                }")
+            .expect("dedup guard block end not found");
+        let guard_block = &summaries_arm[guard_off..guard_off + guard_block_end];
         assert!(
-            summaries_arm.contains(concat!("compared_", "contracts")),
-            "the measurement call must stay behind the per-message dedup set, \
+            guard_block.contains(concat!("record_summary", "_comparison")),
+            "the measurement call must sit INSIDE the per-message dedup guard, \
              or a peer repeating a hash can inflate the ratio that gates the \
-             wire-format decision"
+             wire-format decision. Guard block was:\n{guard_block}"
         );
 
         assert!(

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -2740,6 +2740,13 @@ async fn handle_interest_sync_message(
                 // sending novel summary bytes for every hosted contract. See
                 // `MAX_STALENESS_PROBES_PER_SUMMARIES` / `plan_staleness_probe`.
                 let mut staleness_probes_used = 0usize;
+                // Contracts already counted by the #4965 summary-comparison
+                // measurement in THIS message. Bounded by the message's entry
+                // count, which the transport already bounds; it holds contract
+                // ids only, no state.
+                let mut compared_contracts: std::collections::HashSet<
+                    freenet_stdlib::prelude::ContractKey,
+                > = std::collections::HashSet::new();
                 for entry in entries {
                     for contract in op_manager.interest_manager.lookup_by_hash(entry.hash) {
                         if !op_manager.interest_manager.has_local_interest(&contract) {
@@ -2784,9 +2791,22 @@ async fn handle_interest_sync_message(
                                 // at the send site because only the receiver can
                                 // compare, and only in this arm because a `None` on
                                 // either side is not a comparison at all.
-                                op_manager
-                                    .outbound_mix
-                                    .record_summary_comparison(contract.id(), identical);
+                                //
+                                // Counted once per contract per message: `entries`
+                                // is peer-supplied and may repeat a hash, and
+                                // without this a peer could inflate either bucket
+                                // at will — corrupting the very ratio that decides
+                                // whether the wire change is worth building. The
+                                // dedup guards ONLY the measurement; the staleness
+                                // logic below still runs per entry exactly as
+                                // before, so this changes no behavior.
+                                if compared_contracts.insert(contract) {
+                                    op_manager.outbound_mix.record_summary_comparison(
+                                        contract.id(),
+                                        ours.as_ref(),
+                                        theirs.as_ref(),
+                                    );
+                                }
                                 let delta_verdict = if identical {
                                     // Byte-identical => converged; skip the probe.
                                     None
@@ -4116,6 +4136,25 @@ mod tests {
             .find("InterestMessage::ChangeInterests")
             .expect("ChangeInterests arm not found");
         let summaries_arm = &src[handler_start + summaries_off..handler_start + change_off];
+
+        // #4965: the measurement call must stay wired into this arm. It is
+        // pure observation, so deleting it breaks no test and no behavior —
+        // the rollup would simply report zero comparisons forever, which reads
+        // as "nothing to save here" and would retire the hash-first redesign
+        // for the wrong reason. Needle split so this assertion's own source
+        // cannot satisfy the scrape.
+        assert!(
+            summaries_arm.contains(concat!("record_summary", "_comparison")),
+            "the Summaries arm must record the #4965 summary-comparison \
+             measurement; without it the identical/differing rollup is \
+             silently always zero"
+        );
+        assert!(
+            summaries_arm.contains(concat!("compared_", "contracts")),
+            "the measurement call must stay behind the per-message dedup set, \
+             or a peer repeating a hash can inflate the ratio that gates the \
+             wire-format decision"
+        );
 
         assert!(
             summaries_arm.contains("peer_summary_has_pending_state"),

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -2775,7 +2775,19 @@ async fn handle_interest_sync_message(
                         // `summary_indicates_stale_peer`.
                         let is_stale = match (our_summary.as_ref(), their_summary.as_ref()) {
                             (Some(ours), Some(theirs)) => {
-                                let delta_verdict = if ours.as_ref() == theirs.as_ref() {
+                                let identical = ours.as_ref() == theirs.as_ref();
+                                // #4965 falsifier: how often are the two sides
+                                // byte-identical? That fraction is exactly what a
+                                // hash-first `Summaries` exchange would save, since
+                                // `SummaryEntry` ships full summary bytes
+                                // unconditionally today. Recorded here rather than
+                                // at the send site because only the receiver can
+                                // compare, and only in this arm because a `None` on
+                                // either side is not a comparison at all.
+                                op_manager
+                                    .outbound_mix
+                                    .record_summary_comparison(contract.id(), identical);
+                                let delta_verdict = if identical {
                                     // Byte-identical => converged; skip the probe.
                                     None
                                 } else {

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -4152,24 +4152,23 @@ mod tests {
              measurement; without it the identical/differing rollup is \
              silently always zero"
         );
-        // Structural, not presence: assert the call sits INSIDE the dedup
-        // guard's block. Two independent `contains` checks would pass a
-        // regression that kept both identifiers but moved the call out from
-        // behind the `if` — which is precisely the mutation that silently
-        // re-opens the skew. Slice from the guard to the end of its block.
-        let guard_off = summaries_arm
-            .find(concat!("compared_", "contracts.insert("))
-            .expect("the per-message dedup guard must exist in the Summaries arm");
-        let guard_block_end = summaries_arm[guard_off..]
-            .find("\n                                }")
-            .expect("dedup guard block end not found");
-        let guard_block = &summaries_arm[guard_off..guard_off + guard_block_end];
-        assert!(
-            guard_block.contains(concat!("record_summary", "_comparison")),
-            "the measurement call must sit INSIDE the per-message dedup guard, \
-             or a peer repeating a hash can inflate the ratio that gates the \
-             wire-format decision. Guard block was:\n{guard_block}"
-        );
+        // What is deliberately NOT pinned: the per-message dedup that stops a
+        // peer inflating the ratio by repeating a hash.
+        //
+        // A structural pin for it — slice the guard's block, assert the call
+        // is inside — was written and then DELETED because mutation testing
+        // showed it GREEN when the call was moved out from behind the `if`:
+        // the sliced block ran on to a later brace that still contained the
+        // call. A presence check on the guard identifier is no better; it
+        // survives any mutation that keeps the declaration. Text matching
+        // cannot decide nesting, and a guard that looks like protection but
+        // isn't is worse than none, because it stops the next person adding
+        // real protection.
+        //
+        // So the dedup BYPASS has no coverage. Closing it needs a test that
+        // drives this handler with a duplicate entry, which needs hosted state
+        // and an executor — disproportionate for observation-only telemetry,
+        // but the gap is real and stated here rather than papered over.
 
         assert!(
             summaries_arm.contains("peer_summary_has_pending_state"),

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -2747,9 +2747,7 @@ async fn handle_interest_sync_message(
                 // resolve to — `lookup_by_hash` only yields contracts this node
                 // already tracks, so a peer cannot grow it with unknown ids —
                 // and it holds contract ids only, no state.
-                let mut compared_contracts: std::collections::HashSet<
-                    freenet_stdlib::prelude::ContractKey,
-                > = std::collections::HashSet::new();
+                let mut compared_contracts: HashSet<ContractInstanceId> = HashSet::new();
                 for entry in entries {
                     for contract in op_manager.interest_manager.lookup_by_hash(entry.hash) {
                         if !op_manager.interest_manager.has_local_interest(&contract) {
@@ -2803,13 +2801,12 @@ async fn handle_interest_sync_message(
                                 // dedup guards ONLY the measurement; the staleness
                                 // logic below still runs per entry exactly as
                                 // before, so this changes no behavior.
-                                if compared_contracts.insert(contract) {
-                                    op_manager.outbound_mix.record_summary_comparison(
-                                        contract.id(),
-                                        ours.as_ref(),
-                                        theirs.as_ref(),
-                                    );
-                                }
+                                op_manager.outbound_mix.record_summary_comparison(
+                                    contract.id(),
+                                    ours.as_ref(),
+                                    theirs.as_ref(),
+                                    &mut compared_contracts,
+                                );
                                 let delta_verdict = if identical {
                                     // Byte-identical => converged; skip the probe.
                                     None
@@ -4152,23 +4149,14 @@ mod tests {
              measurement; without it the identical/differing rollup is \
              silently always zero"
         );
-        // What is deliberately NOT pinned: the per-message dedup that stops a
-        // peer inflating the ratio by repeating a hash.
-        //
-        // A structural pin for it — slice the guard's block, assert the call
-        // is inside — was written and then DELETED because mutation testing
-        // showed it GREEN when the call was moved out from behind the `if`:
-        // the sliced block ran on to a later brace that still contained the
-        // call. A presence check on the guard identifier is no better; it
-        // survives any mutation that keeps the declaration. Text matching
-        // cannot decide nesting, and a guard that looks like protection but
-        // isn't is worse than none, because it stops the next person adding
-        // real protection.
-        //
-        // So the dedup BYPASS has no coverage. Closing it needs a test that
-        // drives this handler with a duplicate entry, which needs hosted state
-        // and an executor — disproportionate for observation-only telemetry,
-        // but the gap is real and stated here rather than papered over.
+        // The per-message dedup needs no pin: `record_summary_comparison` takes
+        // the seen-set as an argument, so there is no way to call it without
+        // deduping. That replaced a call-site `if` guard which no source pin
+        // could protect — a structural pin for it was written and deleted after
+        // mutation testing showed it green when the call was moved out from
+        // behind the guard. Making the bypass unrepresentable beat testing for
+        // it; the repeated-call behavior is covered directly in
+        // `outbound_message_mix::tests`.
 
         assert!(
             summaries_arm.contains("peer_summary_has_pending_state"),

--- a/crates/core/src/node/network_bridge/outbound_message_mix.rs
+++ b/crates/core/src/node/network_bridge/outbound_message_mix.rs
@@ -69,7 +69,7 @@
 //! [bpm]: super::broadcast_payload_mix
 //! [send]: crate::transport::peer_connection::PeerConnection::send
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 
 use freenet_stdlib::prelude::ContractInstanceId;
@@ -326,7 +326,18 @@ impl OutboundMix {
         contract: &ContractInstanceId,
         ours: &[u8],
         theirs: &[u8],
+        counted_this_message: &mut HashSet<ContractInstanceId>,
     ) {
+        // The per-message dedup lives HERE, not at the call site, for the same
+        // reason the byte comparison does: `Summaries.entries` is peer-supplied
+        // and may repeat a hash, so without it a peer can inflate either bucket
+        // at will and skew the ratio that gates the wire-format redesign.
+        // Taking the set makes bypassing it impossible rather than merely
+        // discouraged — an earlier version guarded the CALL SITE with an `if`,
+        // which mutation testing showed no source pin could protect.
+        if !counted_this_message.insert(*contract) {
+            return;
+        }
         // The comparison lives HERE rather than at the call site on purpose.
         // Passing a pre-computed `identical: bool` put the one bit this whole
         // measurement rests on outside the tested unit, where an inverted
@@ -630,10 +641,10 @@ mod tests {
         let a = test_instance_id(1);
         let b = test_instance_id(2);
 
-        mix.record_summary_comparison(&a, b"same", b"same");
-        mix.record_summary_comparison(&a, b"ours", b"theirs");
-        mix.record_summary_comparison(&b, b"ours", b"theirs");
-        mix.record_summary_comparison(&a, b"same", b"same");
+        mix.record_summary_comparison(&a, b"same", b"same", &mut HashSet::new());
+        mix.record_summary_comparison(&a, b"ours", b"theirs", &mut HashSet::new());
+        mix.record_summary_comparison(&b, b"ours", b"theirs", &mut HashSet::new());
+        mix.record_summary_comparison(&a, b"same", b"same", &mut HashSet::new());
 
         let w = mix.take_window();
         assert_eq!(w.summary_entries_identical, 2);
@@ -655,14 +666,19 @@ mod tests {
     fn differing_attribution_is_bounded_but_keeps_accruing_known_contracts() {
         let mix = OutboundMix::new();
         let tracked = test_instance_id(0);
-        mix.record_summary_comparison(&tracked, b"ours", b"theirs");
+        mix.record_summary_comparison(&tracked, b"ours", b"theirs", &mut HashSet::new());
 
         // Fill well past the cap with distinct ids.
         for i in 1..(MAX_TRACKED_CONTRACTS as u32 + 300) {
-            mix.record_summary_comparison(&test_instance_id(i), b"ours", b"theirs");
+            mix.record_summary_comparison(
+                &test_instance_id(i),
+                b"ours",
+                b"theirs",
+                &mut HashSet::new(),
+            );
         }
         // ...then hit the already-tracked one again.
-        mix.record_summary_comparison(&tracked, b"ours", b"theirs");
+        mix.record_summary_comparison(&tracked, b"ours", b"theirs", &mut HashSet::new());
 
         let w = mix.take_window();
         assert!(
@@ -697,7 +713,12 @@ mod tests {
         let n = TOP_DIFFERING_CONTRACTS_REPORTED as u32 + 5;
         for i in 1..=n {
             for _ in 0..i {
-                mix.record_summary_comparison(&test_instance_id(i), b"ours", b"theirs");
+                mix.record_summary_comparison(
+                    &test_instance_id(i),
+                    b"ours",
+                    b"theirs",
+                    &mut HashSet::new(),
+                );
             }
         }
         let w = mix.take_window();
@@ -745,10 +766,10 @@ mod tests {
         let mix = OutboundMix::new();
         let c = test_instance_id(1);
         for _ in 0..3 {
-            mix.record_summary_comparison(&c, b"same", b"same");
+            mix.record_summary_comparison(&c, b"same", b"same", &mut HashSet::new());
         }
         for _ in 0..5 {
-            mix.record_summary_comparison(&c, b"ours", b"theirs");
+            mix.record_summary_comparison(&c, b"ours", b"theirs", &mut HashSet::new());
         }
         let body = outbound_mix_json(&mix.take_window(), 60);
         assert_eq!(
@@ -765,6 +786,78 @@ mod tests {
         );
     }
 
+    /// Within ONE message a contract is counted once, however many times the
+    /// peer repeats it; across messages it counts again.
+    ///
+    /// `Summaries.entries` is peer-supplied, so without this a peer inflates
+    /// either bucket at will and skews the exact ratio that decides whether
+    /// the hash-first wire change gets built. The dedup lives inside this
+    /// function rather than behind an `if` at the call site precisely so this
+    /// property is testable — mutation testing showed no source pin could
+    /// protect a call-site guard.
+    #[test]
+    fn a_contract_is_counted_once_per_message_however_often_repeated() {
+        let mix = OutboundMix::new();
+        let c = test_instance_id(1);
+        let other = test_instance_id(2);
+
+        // One message that repeats `c` five times and names `other` once.
+        let mut first_message = HashSet::new();
+        for _ in 0..5 {
+            mix.record_summary_comparison(&c, b"ours", b"theirs", &mut first_message);
+        }
+        mix.record_summary_comparison(&other, b"same", b"same", &mut first_message);
+
+        // A second message names `c` again — a genuinely new observation.
+        let mut second_message = HashSet::new();
+        mix.record_summary_comparison(&c, b"ours", b"theirs", &mut second_message);
+
+        let w = mix.take_window();
+        assert_eq!(
+            w.summary_entries_differing, 2,
+            "five repeats in one message count once; the second message counts again"
+        );
+        assert_eq!(w.summary_entries_identical, 1);
+        assert_eq!(
+            w.differing_by_contract.get(&c).copied(),
+            Some(2),
+            "per-contract attribution must dedup the same way as the aggregate"
+        );
+    }
+
+    /// An untouched window emits the measurement fields as explicit zeros and
+    /// an empty list, rather than omitting them.
+    ///
+    /// A missing field and a zero field look identical to a naive query but
+    /// mean different things — "nothing diverged" vs "this build does not
+    /// report it". The rollup emits when idle for exactly that reason.
+    #[test]
+    fn idle_window_emits_zeroed_measurement_fields() {
+        let body = outbound_mix_json(&Window::default(), 60);
+        assert_eq!(
+            body.get("summary_entries_identical")
+                .and_then(|v| v.as_u64()),
+            Some(0)
+        );
+        assert_eq!(
+            body.get("summary_entries_differing")
+                .and_then(|v| v.as_u64()),
+            Some(0)
+        );
+        assert_eq!(
+            body.get("differing_attribution_dropped")
+                .and_then(|v| v.as_u64()),
+            Some(0)
+        );
+        assert_eq!(
+            body.get("summary_differing_contracts")
+                .and_then(|v| v.as_array())
+                .map(|a| a.len()),
+            Some(0),
+            "an idle window must emit an empty list, not omit the field"
+        );
+    }
+
     /// A capped window reports HOW MANY attributions it dropped.
     ///
     /// Without this the named list is indistinguishable from the complete set,
@@ -778,7 +871,12 @@ mod tests {
         let mix = OutboundMix::new();
         let overflow = 7u32;
         for i in 0..(MAX_TRACKED_CONTRACTS as u32 + overflow) {
-            mix.record_summary_comparison(&test_instance_id(i), b"ours", b"theirs");
+            mix.record_summary_comparison(
+                &test_instance_id(i),
+                b"ours",
+                b"theirs",
+                &mut HashSet::new(),
+            );
         }
         let w = mix.take_window();
         assert_eq!(w.differing_by_contract.len(), MAX_TRACKED_CONTRACTS);

--- a/crates/core/src/node/network_bridge/outbound_message_mix.rs
+++ b/crates/core/src/node/network_bridge/outbound_message_mix.rs
@@ -69,12 +69,27 @@
 //! [bpm]: super::broadcast_payload_mix
 //! [send]: crate::transport::peer_connection::PeerConnection::send
 
+use std::collections::HashMap;
 use std::time::Duration;
 
+use freenet_stdlib::prelude::ContractInstanceId;
 use parking_lot::Mutex;
 
-use crate::message::{NetMessage, NetMessageV1};
+use crate::message::{InterestMessage, NetMessage, NetMessageV1};
 use crate::node::background_task_monitor::BackgroundTaskMonitor;
+
+/// Per-contract attribution cap for the differing-summary map in one window.
+///
+/// Mirrors [`super::broadcast_payload_mix`]'s cap and exists for the same
+/// reason: the key is contract-controlled, so an unbounded map is an
+/// amplification surface. 256 is far above the number of contracts a node
+/// realistically diverges on in a minute, so hitting it is itself a signal.
+const MAX_TRACKED_CONTRACTS: usize = 256;
+
+/// How many differing contracts the emitted rollup names. Small on purpose:
+/// the decision this feeds is "is it a handful of contracts or everything",
+/// which the top few answer, and the aggregate counts above carry the rest.
+const TOP_DIFFERING_CONTRACTS_REPORTED: usize = 10;
 
 /// Rollup cadence, matching [`super::broadcast_payload_mix`] so the two
 /// rollups can be joined per node-minute without interpolation.
@@ -100,11 +115,24 @@ pub(crate) enum OutboundKind {
     /// [`super::broadcast_payload_mix`]. Present here so the two rollups can
     /// be cross-checked against each other.
     Update,
-    /// InterestSync: the ~5-min `Interests` / `Summaries` anti-entropy
-    /// heartbeat. The leading suspect for the unexplained remainder, because
+    /// InterestSync request leg: `Interests` and `ChangeInterests`, which
+    /// carry only `u32` contract-id hashes (4 bytes per interest).
+    ///
+    /// Split from the reply leg below because the two have wildly different
+    /// per-message costs and completely different remedies, and the combined
+    /// arm could not tell them apart — the #4965 measurement hinges on which
+    /// leg the 53-75% actually sits in.
+    InterestSyncInterests,
+    /// InterestSync reply leg: `Summaries`. The leading suspect, because
     /// `SummaryEntry::summary_bytes` ships a FULL `StateSummary` per shared
-    /// contract to every connected peer on every cycle.
-    InterestSync,
+    /// contract to every connected peer on every cycle
+    /// (`node.rs::handle_interest_sync_message`).
+    InterestSyncSummaries,
+    /// InterestSync heal leg: `ResyncRequest` / `ResyncResponse`. Separate
+    /// because `ResyncResponse` carries full contract STATE, so folding it
+    /// into the reply arm would attribute heal traffic to the heartbeat and
+    /// overstate exactly the thing being measured.
+    InterestSyncResync,
     /// NeighborHosting advertisements.
     NeighborHosting,
     /// Small control messages with no subsystem of their own: `Aborted`,
@@ -116,13 +144,15 @@ pub(crate) enum OutboundKind {
 }
 
 impl OutboundKind {
-    pub(crate) const ALL: [OutboundKind; 8] = [
+    pub(crate) const ALL: [OutboundKind; 10] = [
         OutboundKind::Connect,
         OutboundKind::Put,
         OutboundKind::Get,
         OutboundKind::Subscribe,
         OutboundKind::Update,
-        OutboundKind::InterestSync,
+        OutboundKind::InterestSyncInterests,
+        OutboundKind::InterestSyncSummaries,
+        OutboundKind::InterestSyncResync,
         OutboundKind::NeighborHosting,
         OutboundKind::Other,
     ];
@@ -134,9 +164,11 @@ impl OutboundKind {
             OutboundKind::Get => 2,
             OutboundKind::Subscribe => 3,
             OutboundKind::Update => 4,
-            OutboundKind::InterestSync => 5,
-            OutboundKind::NeighborHosting => 6,
-            OutboundKind::Other => 7,
+            OutboundKind::InterestSyncInterests => 5,
+            OutboundKind::InterestSyncSummaries => 6,
+            OutboundKind::InterestSyncResync => 7,
+            OutboundKind::NeighborHosting => 8,
+            OutboundKind::Other => 9,
         }
     }
 
@@ -150,7 +182,9 @@ impl OutboundKind {
             OutboundKind::Get => "get",
             OutboundKind::Subscribe => "subscribe",
             OutboundKind::Update => "update",
-            OutboundKind::InterestSync => "interest_sync",
+            OutboundKind::InterestSyncInterests => "interest_sync_interests",
+            OutboundKind::InterestSyncSummaries => "interest_sync_summaries",
+            OutboundKind::InterestSyncResync => "interest_sync_resync",
             OutboundKind::NeighborHosting => "neighbor_hosting",
             OutboundKind::Other => "other",
         }
@@ -165,7 +199,18 @@ impl OutboundKind {
                 NetMessageV1::Get(_) => OutboundKind::Get,
                 NetMessageV1::Subscribe(_) => OutboundKind::Subscribe,
                 NetMessageV1::Update(_) => OutboundKind::Update,
-                NetMessageV1::InterestSync { .. } => OutboundKind::InterestSync,
+                NetMessageV1::InterestSync { message } => match message {
+                    // Exhaustive on purpose, same rationale as the outer match:
+                    // a new InterestMessage variant must force a deliberate
+                    // choice rather than defaulting into whichever arm it
+                    // happens to resemble.
+                    InterestMessage::Interests { .. } | InterestMessage::ChangeInterests { .. } => {
+                        OutboundKind::InterestSyncInterests
+                    }
+                    InterestMessage::Summaries { .. } => OutboundKind::InterestSyncSummaries,
+                    InterestMessage::ResyncRequest { .. }
+                    | InterestMessage::ResyncResponse { .. } => OutboundKind::InterestSyncResync,
+                },
                 NetMessageV1::NeighborHosting { .. } => OutboundKind::NeighborHosting,
                 // Exhaustive on purpose (no `_` arm): a new protocol message
                 // must not silently join `Other` and hide its bytes inside a
@@ -181,12 +226,27 @@ impl OutboundKind {
 
 #[derive(Default)]
 struct Window {
-    msgs: [u64; 8],
-    bytes: [u64; 8],
+    msgs: [u64; 10],
+    bytes: [u64; 10],
     /// Largest single serialized message in the window, per arm. A big mean
     /// and a big max mean different things (steady load vs. one whale), and
     /// the InterestSync question specifically hinges on which it is.
-    max_bytes: [u64; 8],
+    max_bytes: [u64; 10],
+    /// InterestSync summary comparisons where both sides held a summary and
+    /// the bytes were IDENTICAL. See [`OutboundMix::record_summary_comparison`].
+    summary_entries_identical: u64,
+    /// Same, but the summary bytes DIFFERED.
+    summary_entries_differing: u64,
+    /// Which contracts the differing comparisons belonged to, bounded at
+    /// [`MAX_TRACKED_CONTRACTS`].
+    ///
+    /// Load-bearing for reading a low identical rate: "the design is wrong"
+    /// and "these three contracts serialize non-deterministically" produce the
+    /// same aggregate ratio and have completely different fixes (#4857 /
+    /// `contract-summary-determinism.md`). Only the DIFFERING side is
+    /// attributed — the identical side needs no diagnosis, and tracking it
+    /// would double the map for no decision.
+    differing_by_contract: HashMap<ContractInstanceId, u64>,
 }
 
 /// Per-message-kind outbound byte accumulator.
@@ -229,6 +289,52 @@ impl OutboundMix {
         w.max_bytes[idx] = w.max_bytes[idx].max(b);
     }
 
+    /// Record one InterestSync summary comparison — the #4965 falsifier.
+    ///
+    /// Called from `node.rs::handle_interest_sync_message` at the point where
+    /// a received `SummaryEntry` is byte-compared against our own summary for
+    /// the same contract, and ONLY when both sides hold one (a `None` on
+    /// either side is not a comparison and must not land in either bucket, or
+    /// the ratio silently absorbs "peer has no state yet").
+    ///
+    /// The ratio decides whether the hash-first redesign is worth a wire
+    /// change: `SummaryEntry` ships full summary bytes unconditionally, so
+    /// exchanging digests first saves bytes exactly on the identical
+    /// fraction. A high identical rate makes it a large win; a low one means
+    /// digests would mismatch, ship the bytes anyway, and add a round trip —
+    /// strictly worse than today.
+    ///
+    /// Lives on the outbound rollup despite being a RECEIVE-side observation,
+    /// for two reasons: it belongs in the same node-minute record as the
+    /// `interest_sync_summaries_bytes` it explains (joinable without
+    /// interpolation), and the telemetry budget has room for exactly one more
+    /// aligned rollup stream (`telemetry.rs`, `MAX_SHADOW_EVENTS_PER_SECOND`),
+    /// which this measurement does not deserve to consume.
+    pub(crate) fn record_summary_comparison(&self, contract: &ContractInstanceId, identical: bool) {
+        let mut w = self.window.lock();
+        if identical {
+            w.summary_entries_identical = w.summary_entries_identical.saturating_add(1);
+            return;
+        }
+        w.summary_entries_differing = w.summary_entries_differing.saturating_add(1);
+        // Bounded for the same reason the payload mix bounds its attribution:
+        // the key is contract-controlled, so an unbounded map here would be an
+        // amplification surface. Over the cap we keep counting the aggregate
+        // above and stop adding NEW keys — an existing key still accrues, so
+        // the top offenders (the ones worth naming) stay accurate.
+        let len = w.differing_by_contract.len();
+        match w.differing_by_contract.entry(*contract) {
+            std::collections::hash_map::Entry::Occupied(mut e) => {
+                *e.get_mut() = e.get().saturating_add(1);
+            }
+            std::collections::hash_map::Entry::Vacant(e) => {
+                if len < MAX_TRACKED_CONTRACTS {
+                    e.insert(1);
+                }
+            }
+        }
+    }
+
     /// Atomically take the current window, leaving a fresh empty one.
     fn take_window(&self) -> Window {
         std::mem::take(&mut *self.window.lock())
@@ -264,6 +370,43 @@ fn emit_outbound_mix_rollup(mix: &OutboundMix, local_peer_id: &str, window_secs:
         body.insert(format!("{stem}_bytes"), w.bytes[idx].into());
         body.insert(format!("{stem}_max_bytes"), w.max_bytes[idx].into());
     }
+
+    // #4965 falsifier. Emitted unconditionally (including as a pair of zeros)
+    // so "no comparisons happened this window" is distinguishable from "the
+    // field was dropped" — the same reason the arms above emit when idle.
+    body.insert(
+        "summary_entries_identical".into(),
+        w.summary_entries_identical.into(),
+    );
+    body.insert(
+        "summary_entries_differing".into(),
+        w.summary_entries_differing.into(),
+    );
+    // Top differing contracts by count, so a low identical rate can be read as
+    // "specific contracts are non-deterministic" vs "the design is wrong".
+    // Capped in the emitted body as well as in the map: the map bound stops
+    // unbounded GROWTH, this bound stops an unbounded RECORD.
+    let mut differing: Vec<(String, u64)> = w
+        .differing_by_contract
+        .iter()
+        .map(|(k, v)| (k.to_string(), *v))
+        .collect();
+    differing.sort_unstable_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    differing.truncate(TOP_DIFFERING_CONTRACTS_REPORTED);
+    body.insert(
+        "summary_differing_contracts".into(),
+        serde_json::Value::Array(
+            differing
+                .into_iter()
+                .map(|(key, count)| {
+                    let mut o = serde_json::Map::new();
+                    o.insert("contract".into(), key.into());
+                    o.insert("count".into(), count.into());
+                    serde_json::Value::Object(o)
+                })
+                .collect(),
+        ),
+    );
 
     // Shadow priority, matching the payload mix: one event per node-minute is
     // negligible volume, but it is observation rather than operational signal.
@@ -302,15 +445,31 @@ pub(crate) fn spawn_outbound_mix_aggregator(
 mod tests {
     use super::*;
 
+    fn test_instance_id(seed: u32) -> ContractInstanceId {
+        let mut bytes = [0u8; 32];
+        bytes[..4].copy_from_slice(&seed.to_le_bytes());
+        ContractInstanceId::new(bytes)
+    }
+
+    fn test_contract_key(seed: u32) -> freenet_stdlib::prelude::ContractKey {
+        freenet_stdlib::prelude::ContractKey::from_id_and_code(
+            test_instance_id(seed),
+            freenet_stdlib::prelude::CodeHash::new([0u8; 32]),
+        )
+    }
+
     /// Taking the window leaves the accumulator empty, so consecutive rollups
     /// report windows rather than lifetime totals.
     #[test]
     fn take_window_resets_the_window() {
         let mix = OutboundMix::new();
-        mix.record_sent(OutboundKind::InterestSync, 500);
+        mix.record_sent(OutboundKind::InterestSyncSummaries, 500);
         let first = mix.take_window();
-        assert_eq!(first.msgs[OutboundKind::InterestSync.index()], 1);
-        assert_eq!(first.bytes[OutboundKind::InterestSync.index()], 500);
+        assert_eq!(first.msgs[OutboundKind::InterestSyncSummaries.index()], 1);
+        assert_eq!(
+            first.bytes[OutboundKind::InterestSyncSummaries.index()],
+            500
+        );
         let second = mix.take_window();
         assert!(
             second.msgs.iter().all(|m| *m == 0) && second.bytes.iter().all(|b| *b == 0),
@@ -328,7 +487,7 @@ mod tests {
         let mix = OutboundMix::new();
         mix.record_sent(OutboundKind::Get, 10);
         mix.record_sent(OutboundKind::Put, 20);
-        mix.record_sent(OutboundKind::InterestSync, 30);
+        mix.record_sent(OutboundKind::InterestSyncSummaries, 30);
         mix.record_sent(OutboundKind::Get, 40);
         let w = mix.take_window();
         assert_eq!(w.bytes.iter().sum::<u64>(), 100);
@@ -347,6 +506,123 @@ mod tests {
         let w = mix.take_window();
         assert_eq!(w.max_bytes[OutboundKind::Update.index()], 900);
         assert_eq!(w.bytes[OutboundKind::Update.index()], 1050);
+    }
+
+    /// The three InterestSync legs must classify apart (#4965).
+    ///
+    /// Before the split they shared one arm, so a rollup showing "interest_sync
+    /// is 53-75% of outbound bytes" could not say whether the cost was the
+    /// cheap hash advertisement, the full-summary reply, or full-state resync
+    /// heals — three findings with three different remedies. Lumping them again
+    /// would silently restore that ambiguity while the rollup kept reporting a
+    /// plausible-looking number, so each leg is asserted individually.
+    #[test]
+    fn interest_sync_legs_classify_into_separate_arms() {
+        let wrap = |m: InterestMessage| NetMessage::V1(NetMessageV1::InterestSync { message: m });
+
+        let cases: [(InterestMessage, OutboundKind); 5] = [
+            (
+                InterestMessage::Interests { hashes: vec![1, 2] },
+                OutboundKind::InterestSyncInterests,
+            ),
+            (
+                InterestMessage::ChangeInterests {
+                    added: vec![1],
+                    removed: vec![],
+                },
+                OutboundKind::InterestSyncInterests,
+            ),
+            (
+                InterestMessage::Summaries { entries: vec![] },
+                OutboundKind::InterestSyncSummaries,
+            ),
+            (
+                InterestMessage::ResyncRequest {
+                    key: test_contract_key(7),
+                },
+                OutboundKind::InterestSyncResync,
+            ),
+            (
+                InterestMessage::ResyncResponse {
+                    key: test_contract_key(7),
+                    state_bytes: vec![],
+                    summary_bytes: vec![],
+                },
+                OutboundKind::InterestSyncResync,
+            ),
+        ];
+
+        for (msg, expected) in cases {
+            let label = format!("{msg:?}");
+            assert_eq!(
+                OutboundKind::classify(&wrap(msg)),
+                expected,
+                "wrong arm for {label}"
+            );
+        }
+    }
+
+    /// Identical and differing comparisons land in separate buckets — the
+    /// #4965 falsifier itself. If both fell in one bucket (or the boolean were
+    /// inverted) the ratio would still look like a plausible number, which is
+    /// the failure mode worth a test: it would send the design decision the
+    /// wrong way with no visible symptom.
+    #[test]
+    fn summary_comparisons_split_identical_from_differing() {
+        let mix = OutboundMix::new();
+        let a = test_instance_id(1);
+        let b = test_instance_id(2);
+
+        mix.record_summary_comparison(&a, true);
+        mix.record_summary_comparison(&a, false);
+        mix.record_summary_comparison(&b, false);
+        mix.record_summary_comparison(&a, true);
+
+        let w = mix.take_window();
+        assert_eq!(w.summary_entries_identical, 2);
+        assert_eq!(w.summary_entries_differing, 2);
+        // Only the differing side is attributed per contract.
+        assert_eq!(w.differing_by_contract.get(&a).copied(), Some(1));
+        assert_eq!(w.differing_by_contract.get(&b).copied(), Some(1));
+    }
+
+    /// The per-contract map is bounded, and an ALREADY-TRACKED contract keeps
+    /// accruing past the cap.
+    ///
+    /// Both halves matter. Without the bound the map is an amplification
+    /// surface on a contract-controlled key. Without the keep-accruing half,
+    /// the cap would silently freeze the counts of the very contracts worth
+    /// naming as soon as a burst of one-off ids filled the map — the top-N
+    /// report would then rank by "who arrived first", not by who diverges most.
+    #[test]
+    fn differing_attribution_is_bounded_but_keeps_accruing_known_contracts() {
+        let mix = OutboundMix::new();
+        let tracked = test_instance_id(0);
+        mix.record_summary_comparison(&tracked, false);
+
+        // Fill well past the cap with distinct ids.
+        for i in 1..(MAX_TRACKED_CONTRACTS as u32 + 300) {
+            mix.record_summary_comparison(&test_instance_id(i), false);
+        }
+        // ...then hit the already-tracked one again.
+        mix.record_summary_comparison(&tracked, false);
+
+        let w = mix.take_window();
+        assert!(
+            w.differing_by_contract.len() <= MAX_TRACKED_CONTRACTS,
+            "map must stay bounded, got {}",
+            w.differing_by_contract.len()
+        );
+        assert_eq!(
+            w.differing_by_contract.get(&tracked).copied(),
+            Some(2),
+            "an already-tracked contract must keep accruing past the cap"
+        );
+        // The aggregate never truncates, even though the map does.
+        assert_eq!(
+            w.summary_entries_differing,
+            MAX_TRACKED_CONTRACTS as u64 + 301
+        );
     }
 
     /// Every arm must own a distinct index and a distinct field stem, or two

--- a/crates/core/src/node/network_bridge/outbound_message_mix.rs
+++ b/crates/core/src/node/network_bridge/outbound_message_mix.rs
@@ -247,6 +247,17 @@ struct Window {
     /// attributed — the identical side needs no diagnosis, and tracking it
     /// would double the map for no decision.
     differing_by_contract: HashMap<ContractInstanceId, u64>,
+    /// Differing comparisons that could NOT be attributed because
+    /// [`Window::differing_by_contract`] was already at
+    /// [`MAX_TRACKED_CONTRACTS`].
+    ///
+    /// Mirrors `broadcast_payload_mix`'s `attribution_dropped_*`, and exists
+    /// for the same reason it does: without it a capped window is
+    /// indistinguishable from "no further contracts diverged", which is the
+    /// exact misreading this attribution was added to prevent. Non-zero also
+    /// means the named list below is a partial view, so the reader should not
+    /// treat it as the full set of offenders.
+    differing_attribution_dropped: u64,
 }
 
 /// Per-message-kind outbound byte accumulator.
@@ -310,18 +321,43 @@ impl OutboundMix {
     /// interpolation), and the telemetry budget has room for exactly one more
     /// aligned rollup stream (`telemetry.rs`, `MAX_SHADOW_EVENTS_PER_SECOND`),
     /// which this measurement does not deserve to consume.
-    pub(crate) fn record_summary_comparison(&self, contract: &ContractInstanceId, identical: bool) {
+    pub(crate) fn record_summary_comparison(
+        &self,
+        contract: &ContractInstanceId,
+        ours: &[u8],
+        theirs: &[u8],
+    ) {
+        // The comparison lives HERE rather than at the call site on purpose.
+        // Passing a pre-computed `identical: bool` put the one bit this whole
+        // measurement rests on outside the tested unit, where an inverted
+        // operand would compile, pass every test, and quietly invert the
+        // finding that gates a wire-format redesign. Taking the operands makes
+        // that failure unrepresentable instead of merely covered.
+        let identical = ours == theirs;
         let mut w = self.window.lock();
         if identical {
             w.summary_entries_identical = w.summary_entries_identical.saturating_add(1);
             return;
         }
         w.summary_entries_differing = w.summary_entries_differing.saturating_add(1);
+        let mut dropped = false;
         // Bounded for the same reason the payload mix bounds its attribution:
         // the key is contract-controlled, so an unbounded map here would be an
-        // amplification surface. Over the cap we keep counting the aggregate
-        // above and stop adding NEW keys — an existing key still accrues, so
-        // the top offenders (the ones worth naming) stay accurate.
+        // amplification surface. Over the cap the aggregate above keeps
+        // counting and an already-tracked key keeps accruing; only NEW keys are
+        // refused, and each refusal is counted.
+        //
+        // What this does NOT give you, stated plainly because the obvious
+        // reading is wrong: once the cap binds, the named set is NOT the top
+        // offenders. Slots are first-come-first-served, and arrival order is
+        // not random — `get_matching_contracts` sorts by contract id ascending
+        // (`ring/interest.rs`), so entries are processed in id order on every
+        // peer and every window. Under sustained cap pressure the same
+        // low-id contracts hold the slots and a higher-diverging high-id
+        // contract stays invisible indefinitely. Read a non-zero
+        // `differing_attribution_dropped` as "this list is a biased sample,
+        // use the aggregate"; a fair top-N would need a replace-if-larger
+        // policy, which is more machinery than this measurement warrants.
         let len = w.differing_by_contract.len();
         match w.differing_by_contract.entry(*contract) {
             std::collections::hash_map::Entry::Occupied(mut e) => {
@@ -330,8 +366,13 @@ impl OutboundMix {
             std::collections::hash_map::Entry::Vacant(e) => {
                 if len < MAX_TRACKED_CONTRACTS {
                     e.insert(1);
+                } else {
+                    dropped = true;
                 }
             }
+        }
+        if dropped {
+            w.differing_attribution_dropped = w.differing_attribution_dropped.saturating_add(1);
         }
     }
 
@@ -350,8 +391,15 @@ fn rollup_window_secs(elapsed: Duration) -> u64 {
     elapsed.as_secs().max(1)
 }
 
-fn emit_outbound_mix_rollup(mix: &OutboundMix, local_peer_id: &str, window_secs: u64) {
-    let w = mix.take_window();
+/// Build the rollup body for one drained window.
+///
+/// Split out of [`emit_outbound_mix_rollup`] and returning the `Value` so the
+/// shaping — field names, the descending sort, the top-N truncation — is
+/// directly testable, the way `broadcast_payload_mix::payload_mix_json`
+/// already is. Inlined in the emitter there was no seam: an inverted
+/// comparator would have reported the LEAST-diverging contracts as "top" and
+/// shipped silently.
+fn outbound_mix_json(w: &Window, window_secs: u64) -> serde_json::Value {
     let total_msgs: u64 = w.msgs.iter().sum();
     let total_bytes: u64 = w.bytes.iter().sum();
 
@@ -382,6 +430,10 @@ fn emit_outbound_mix_rollup(mix: &OutboundMix, local_peer_id: &str, window_secs:
         "summary_entries_differing".into(),
         w.summary_entries_differing.into(),
     );
+    body.insert(
+        "differing_attribution_dropped".into(),
+        w.differing_attribution_dropped.into(),
+    );
     // Top differing contracts by count, so a low identical rate can be read as
     // "specific contracts are non-deterministic" vs "the design is wrong".
     // Capped in the emitted body as well as in the map: the map bound stops
@@ -408,12 +460,17 @@ fn emit_outbound_mix_rollup(mix: &OutboundMix, local_peer_id: &str, window_secs:
         ),
     );
 
+    serde_json::Value::Object(body)
+}
+
+fn emit_outbound_mix_rollup(mix: &OutboundMix, local_peer_id: &str, window_secs: u64) {
+    let w = mix.take_window();
     // Shadow priority, matching the payload mix: one event per node-minute is
     // negligible volume, but it is observation rather than operational signal.
     crate::tracing::telemetry::send_standalone_shadow_event_with_peer_id(
         "outbound_message_mix",
         local_peer_id,
-        serde_json::Value::Object(body),
+        outbound_mix_json(&w, window_secs),
     );
 }
 
@@ -573,10 +630,10 @@ mod tests {
         let a = test_instance_id(1);
         let b = test_instance_id(2);
 
-        mix.record_summary_comparison(&a, true);
-        mix.record_summary_comparison(&a, false);
-        mix.record_summary_comparison(&b, false);
-        mix.record_summary_comparison(&a, true);
+        mix.record_summary_comparison(&a, b"same", b"same");
+        mix.record_summary_comparison(&a, b"ours", b"theirs");
+        mix.record_summary_comparison(&b, b"ours", b"theirs");
+        mix.record_summary_comparison(&a, b"same", b"same");
 
         let w = mix.take_window();
         assert_eq!(w.summary_entries_identical, 2);
@@ -598,14 +655,14 @@ mod tests {
     fn differing_attribution_is_bounded_but_keeps_accruing_known_contracts() {
         let mix = OutboundMix::new();
         let tracked = test_instance_id(0);
-        mix.record_summary_comparison(&tracked, false);
+        mix.record_summary_comparison(&tracked, b"ours", b"theirs");
 
         // Fill well past the cap with distinct ids.
         for i in 1..(MAX_TRACKED_CONTRACTS as u32 + 300) {
-            mix.record_summary_comparison(&test_instance_id(i), false);
+            mix.record_summary_comparison(&test_instance_id(i), b"ours", b"theirs");
         }
         // ...then hit the already-tracked one again.
-        mix.record_summary_comparison(&tracked, false);
+        mix.record_summary_comparison(&tracked, b"ours", b"theirs");
 
         let w = mix.take_window();
         assert!(
@@ -622,6 +679,83 @@ mod tests {
         assert_eq!(
             w.summary_entries_differing,
             MAX_TRACKED_CONTRACTS as u64 + 301
+        );
+    }
+
+    /// The emitted body ranks differing contracts by count, DESCENDING, and
+    /// truncates to the top N.
+    ///
+    /// Worth its own test because an inverted comparator is invisible: it
+    /// still emits a plausible, well-formed list of contracts — just the
+    /// LEAST-diverging ones, labelled as the top offenders. Nothing downstream
+    /// would flag that, and the wrong contracts would get investigated.
+    #[test]
+    fn rollup_body_ranks_differing_contracts_descending_and_truncates() {
+        let mix = OutboundMix::new();
+        // Contract i gets i differing comparisons, so the expected ranking is
+        // exactly the reverse of insertion order.
+        let n = TOP_DIFFERING_CONTRACTS_REPORTED as u32 + 5;
+        for i in 1..=n {
+            for _ in 0..i {
+                mix.record_summary_comparison(&test_instance_id(i), b"ours", b"theirs");
+            }
+        }
+        let w = mix.take_window();
+        let body = outbound_mix_json(&w, 60);
+
+        let listed = body
+            .get("summary_differing_contracts")
+            .and_then(|v| v.as_array())
+            .expect("summary_differing_contracts must be an array");
+        assert_eq!(
+            listed.len(),
+            TOP_DIFFERING_CONTRACTS_REPORTED,
+            "the list must be truncated to the top N"
+        );
+
+        let counts: Vec<u64> = listed
+            .iter()
+            .map(|e| e.get("count").and_then(|c| c.as_u64()).expect("count"))
+            .collect();
+        let mut descending = counts.clone();
+        descending.sort_unstable_by(|a, b| b.cmp(a));
+        assert_eq!(counts, descending, "counts must be ranked descending");
+        assert_eq!(
+            counts[0], n as u64,
+            "the highest-diverging contract must rank first"
+        );
+        assert_eq!(
+            *counts.last().expect("non-empty"),
+            (n - TOP_DIFFERING_CONTRACTS_REPORTED as u32 + 1) as u64,
+            "the Nth-ranked count must be the Nth largest, not the smallest"
+        );
+    }
+
+    /// A capped window reports HOW MANY attributions it dropped.
+    ///
+    /// Without this the named list is indistinguishable from the complete set,
+    /// which is the exact misreading the attribution exists to prevent — and
+    /// the sibling `broadcast_payload_mix` reports its drops for the same
+    /// reason. Under cap pressure the list is a biased sample (slots are
+    /// first-come, and entries arrive in contract-id order), so a reader needs
+    /// this number to know not to trust the ranking.
+    #[test]
+    fn capped_attribution_reports_its_drops() {
+        let mix = OutboundMix::new();
+        let overflow = 7u32;
+        for i in 0..(MAX_TRACKED_CONTRACTS as u32 + overflow) {
+            mix.record_summary_comparison(&test_instance_id(i), b"ours", b"theirs");
+        }
+        let w = mix.take_window();
+        assert_eq!(w.differing_by_contract.len(), MAX_TRACKED_CONTRACTS);
+        assert_eq!(w.differing_attribution_dropped, overflow as u64);
+
+        let body = outbound_mix_json(&w, 60);
+        assert_eq!(
+            body.get("differing_attribution_dropped")
+                .and_then(|v| v.as_u64()),
+            Some(overflow as u64),
+            "the drop count must reach the rollup, not just the window"
         );
     }
 

--- a/crates/core/src/node/network_bridge/outbound_message_mix.rs
+++ b/crates/core/src/node/network_bridge/outbound_message_mix.rs
@@ -731,6 +731,40 @@ mod tests {
         );
     }
 
+    /// The two headline counters survive the trip into the emitted body under
+    /// the RIGHT keys.
+    ///
+    /// They were only ever checked on the `Window` struct. A swapped key in
+    /// the body construction — emitting `summary_entries_differing` under the
+    /// `summary_entries_identical` name — would ship an exactly inverted ratio
+    /// to telemetry and send the hash-first decision the wrong way, with every
+    /// other test still green. Distinguishable counts (3 vs 5) so a swap
+    /// cannot pass.
+    #[test]
+    fn headline_counters_reach_the_rollup_body_under_the_right_keys() {
+        let mix = OutboundMix::new();
+        let c = test_instance_id(1);
+        for _ in 0..3 {
+            mix.record_summary_comparison(&c, b"same", b"same");
+        }
+        for _ in 0..5 {
+            mix.record_summary_comparison(&c, b"ours", b"theirs");
+        }
+        let body = outbound_mix_json(&mix.take_window(), 60);
+        assert_eq!(
+            body.get("summary_entries_identical")
+                .and_then(|v| v.as_u64()),
+            Some(3),
+            "identical count must reach the body under its own key"
+        );
+        assert_eq!(
+            body.get("summary_entries_differing")
+                .and_then(|v| v.as_u64()),
+            Some(5),
+            "differing count must reach the body under its own key"
+        );
+    }
+
     /// A capped window reports HOW MANY attributions it dropped.
     ///
     /// Without this the named list is indistinguishable from the complete set,


### PR DESCRIPTION
## Problem

`interest_sync` is 53-75% of all outbound bytes fleet-wide (~26 KB mean per heartbeat, ~3x actual contract updates) — the biggest known remaining bandwidth lever, larger than the 2.6-2.7x disk-write cut that 0.2.112 shipped. The obvious remedy is hash-first: exchange summary digests and ship `summary_bytes` only on mismatch.

Two things block deciding that, and both are measurement gaps rather than design questions.

**We can't attribute the bytes.** The census lumps the whole InterestSync family into one arm (`OutboundKind::InterestSync`), but the legs differ by orders of magnitude and have different remedies:

- `Interests` / `ChangeInterests` — 4 bytes per interest, just `u32` contract-id hashes.
- `Summaries` — a full `StateSummary` per shared contract, to every connected peer, every cycle.
- `ResyncRequest` / `ResyncResponse` — full contract **state**, i.e. heal traffic, not heartbeat.

Attributing the 53-75% to `Summaries` is currently inference from payload shapes, not measurement. And folding resync into the reply arm would attribute heal traffic to the heartbeat, overstating exactly the thing being measured.

**We can't tell whether hash-first would help at all.** It saves bytes precisely on the fraction where the two sides' summaries are byte-identical. That fraction is unmeasured, and there is real reason to think it might be low: `node.rs` carries a load-bearing comment (#4857, the 2.56M-`summarize_contract_state` storm) explaining that summaries which serialize non-deterministically produce different bytes for the *same* logical state. For any such contract a digest mismatches every time, ships the bytes anyway, and adds a round trip — strictly worse than today.

## Solution

Both measurements, as **fields on the existing per-minute `outbound_message_mix` rollup**.

Not new event streams, deliberately: there is a hard `MAX_EVENTS_PER_SECOND` per node, five aligned rollups already contend for the shadow sub-budget, and the cap leaves room for exactly one more stream (`tracing/telemetry.rs`). A new operational event would compete for a fixed per-second budget on precisely the busiest peers whose interest_sync behavior we want to read. A field on an existing rollup costs zero additional records. See #4980.

1. **Split the census arm** into `interest_sync_interests`, `interest_sync_summaries`, `interest_sync_resync`. The classify match stays exhaustive, so a new `InterestMessage` variant fails to compile rather than silently joining whichever arm it resembles.

2. **Count summary comparisons** as identical vs differing at the one place both sides' summaries exist (`node.rs::handle_interest_sync_message`), plus bounded per-contract attribution of the differing side. That last part is what makes a low rate readable: "the design is wrong" and "these three contracts serialize non-deterministically" produce the same aggregate ratio and have completely different fixes.

The per-contract map is bounded at 256 (mirroring `broadcast_payload_mix`) because the key is contract-controlled; an already-tracked contract keeps accruing past the cap, so the top-N ranks by who diverges most rather than by who arrived first.

## Scope

Observation only. Nothing reads these counters to make a decision, and there is no wire-format change — the wire change is step 2, gated on what this measures.

## Testing

- `interest_sync_legs_classify_into_separate_arms` — each of the five `InterestMessage` variants lands in its intended arm.
- `summary_comparisons_split_identical_from_differing` — the falsifier itself; an inverted boolean would still produce a plausible-looking ratio and send the design decision the wrong way with no visible symptom.
- `differing_attribution_is_bounded_but_keeps_accruing_known_contracts` — both halves: the bound, and that a known contract still accrues past it.

Mutation-verified (committed first): inverting the identical/differing branch fails 2 tests; lumping `Summaries` back into the request arm fails 1; removing the map bound fails 1.

`cargo fmt`, `cargo clippy --locked -- -D warnings` (the CI invocation) and the lib suite are clean.

## Follow-up

Step 2 — `Option<summary_digest>` on `SummaryEntry`, shipping bytes only on mismatch — is gated on this coming back with a high identical rate. Note for whoever builds it: `SummaryEntry.hash` is **not** a summary digest, it is FNV-1a of the contract instance id (`ring/interest.rs`), so hash-first needs a genuinely new field. And filtering sends against our cached `PeerInterest.summary` would be unsafe — it suppresses the heal in exactly the case the anti-entropy exists for, because every failure it heals is "our belief about a peer is wrong". A digest exchange stays safe because both sides compute it from actual state.

Refs #4965

[AI-assisted - Claude]


---

## Reading the telemetry: two things that will otherwise be misread

### The old `interest_sync_*` fields are RETIRED, not renamed

`interest_sync_msgs`, `interest_sync_bytes` and `interest_sync_max_bytes` **stop being emitted**. They are replaced by three separate stems, not aliased:

| retired | replaced by |
|---|---|
| `interest_sync_msgs` / `_bytes` / `_max_bytes` | `interest_sync_interests_*` (the `Interests` / `ChangeInterests` request leg) |
| | `interest_sync_summaries_*` (the `Summaries` reply — the suspected cost) |
| | `interest_sync_resync_*` (`ResyncRequest` / `ResyncResponse`, full state) |

**This matters for anyone re-running the #4965 baseline across the deploy boundary.** A saved query against `interest_sync_bytes` returns nothing after the upgrade, and nothing looks exactly like a fixed problem — the traffic appears to vanish when it has only been re-labelled. Sum the three new stems to compare against a pre-upgrade figure.

No in-repo consumer reads the old names (grep clean, and the live dashboard does not reference `interest_sync` at all), and the rollup itself is only about a day old from #4957, so the exposure is ad-hoc queries rather than anything checked in.

### A LOW identical rate probably means specific contracts, not a dead design

The obvious reading of a low `summary_entries_identical` ratio is "hash-first would not help, the summaries genuinely differ". Before concluding that, check `summary_differing_contracts`.

River's contract summaries have already been made deterministic — every summary type uses `BTreeSet` / `BTreeMap` rather than `HashSet` / `HashMap`: `MessagesSummary.message_ids`, `SecretsSummary.version_ids`, `DirectMessagesSummary.message_signatures`, plus `member_info`, `member` and `ban`. Each carries an explicit comment naming freenet-core#4857 and there is a dedicated `contract-summary-determinism.md` rule. That fix exists because `HashMap` iteration order made two identical logical states summarize to different bytes, causing spurious anti-entropy heals.

So the expectation is a **high** identical rate for the contracts that dominate our traffic, and a low rate only for third-party contracts that have not had the same fix.

- **Low aggregate, and `summary_differing_contracts` names a handful of non-River keys** → the protocol design is fine and hash-first is still worth building; the fix is upstream, in those contracts' summary types.
- **Low aggregate, and the differing set is broad and includes River keys** → that would falsify the determinism assumption and is the case where hash-first genuinely buys little.
- **`differing_attribution_dropped` non-zero** → the named list is a biased sample (slots are first-come, and entries arrive in contract-id order), so rank from the aggregate, not from the list.

[AI-assisted - Claude]
