### PR TITLE
ci: point the River endpoint check at freenet.org/river/

### DIFF
--- a/scripts/check-endpoints.sh
+++ b/scripts/check-endpoints.sh
@@ -38,7 +38,11 @@ printf "  %-30s  %s  %s\n" "--------" "----" "-------"
     check_endpoint "nova gateway (HTTP)"      "http://5.9.111.215:31337" &
     check_endpoint "nova gateway (HTTPS)"     "https://freenet.org"      &
     check_endpoint "vega gateway (HTTP)"      "http://vega.locut.us:31337" &
-    check_endpoint "river.freenet.org"        "https://river.freenet.org" &
+    # Trailing slash is DELIBERATE — do not "tidy" it away. The success band
+    # above is 200 <= code < 400, and `https://freenet.org/river` (no slash)
+    # answers 301, which would report green while asserting nothing but the
+    # redirect. Only the slashed form returns a real 200.
+    check_endpoint "freenet.org/river"        "https://freenet.org/river/" &
     check_endpoint "nova telemetry health"    "http://5.9.111.215:13133/health" &
     check_endpoint "telemetry dashboard"      "https://telemetry.freenet.org" &
     wait


### PR DESCRIPTION
## Problem

`scripts/check-endpoints.sh` probed `https://river.freenet.org`, a hostname with **no DNS record** that was never meant to exist. The row reported DOWN because there was nothing to reach, not because River was down — a permanently-red row that trains readers to ignore the output.

The current URL is freenet.org/river.

## Solution

Point the check at `https://freenet.org/river/`, **with the trailing slash**, and relabel the row.

The slash is load-bearing, not cosmetic. The script's success band is `200 <= code < 400`:

| URL | code | result |
|---|---|---|
| `https://river.freenet.org` | no DNS | DOWN |
| `https://freenet.org/river` | **301** | would report **green**, asserting only that the redirect exists |
| `https://freenet.org/river/` | **200** | a real check |

The unslashed form is exactly the false-green fixed for the telemetry dashboard row in #4955, where a 301 sat inside the success band and the row stayed green while testing nothing. Dropping the slash here would silently reintroduce that bug in the same script — and it looks like harmless tidying, so it carries a guard comment explaining why it must stay.

The label moves from `river.freenet.org` to `freenet.org/river`, since the label is what a human reads when the row goes red.

## Testing

Verified live rather than assumed — all three URLs measured directly (results in the table above), then the script run end to end:

```
freenet.org/river               200   100ms
```

`bash -n scripts/check-endpoints.sh` clean. No production code touched; this is a developer health-check script.

The remaining DOWN rows (`nova gateway (HTTP)`, `vega gateway (HTTP)`) are pre-existing and unrelated — UDP gateway ports that never served HTTP.

[AI-assisted - Claude]
