### PR TITLE
fix: evict oldest pairs instead of starving new ones in the UPDATE rate limiter

### DIFF
--- a/.claude/rules/bug-prevention-patterns.md
+++ b/.claude/rules/bug-prevention-patterns.md
@@ -478,6 +478,72 @@ reporting a healthy service as unhealthy — which is precisely the direction
 that survives unnoticed.
 
 
+## A count cap enforced by REFUSAL, over entries that ordinary use refreshes
+
+**A bound enforced by refusing newcomers is only safe when incumbents age out on
+their own.** If ordinary traffic restamps an entry's TTL, nothing ever rolls off:
+the cap is held permanently by whoever got in first and stayed active, and every
+newcomer is refused **forever**, with no recovery path. That is the
+permanently-refreshable GC exemption `AGENTS.md` forbids — wearing a memory bound
+as a disguise, which is why it reads as correct in review.
+
+#4981: the UPDATE limiter's 16,384 `(sender, contract)` slots. `*entry.get_mut() =
+now` on every accepted UPDATE meant a busy pair refreshed its own TTL indefinitely,
+so a new pair was refused, **never inserted**, and therefore stayed "new" forever —
+every subsequent UPDATE from it dropped and re-counted. Silent data loss on the
+UPDATE propagation path.
+
+Two things made it survive for months:
+
+- **Saturation was read as an attack signal, so exceeding the cap looked like the
+  bound working.** It is not. Tracked pairs are distinct senders x distinct
+  contracts, so 50 peers x ~330 contracts ~= 16,500 already exceeds the cap with
+  nobody malicious. The module justified its bound purely as an anti-attacker
+  measure and never reckoned with a healthy node simply outgrowing it.
+- **The drop logged at `debug!`**, which `release_max_level_info` compiles out, so
+  a production node discarding legitimate relayed UPDATEs left no greppable
+  evidence and a dashboard tile was the only signal.
+
+### Fix shape (#4997)
+
+**Evict least-recently-used instead of refusing**, and:
+
+- **Evict a BATCH** (`cap / 64`), not one entry. The victim scan is linear in the
+  cap and cannot run while holding a shard guard, so under the saturation this
+  targets — where the map is *persistently* full — one-per-admission means a
+  continuous full scan on the receive path.
+- **Release the shard guard before the walk**, and bound the post-eviction retry:
+  the freed slot is not reserved, so another caller may take it.
+- **Replace any incidental ceiling eviction removes.** Refuse-at-cap was also
+  (accidentally) throttling attacker-chosen keys. Add the replacement explicitly
+  and charge it **before** a slot is reserved, so a throttled peer cannot evict
+  anyone on its way to being refused.
+- **Count what you ACTUALLY removed, not the batch you selected.** A concurrent
+  reaper can take a victim first; over-counting drives the size counter **below**
+  the map's true length, letting the map grow past the cap — the one bound the
+  whole mechanism exists to enforce. Note this is unobservable unless a test
+  interleaves the reaper with an admission: with no such test, `remove()` always
+  returns `Some` and the mutation is behaviourally invisible.
+- **Make saturation visible in RELEASE builds**: `info!` plus a counter, never
+  `debug!` alone.
+
+### Where the wrong instruction came from
+
+`.claude/rules/code-style.md` said, without qualification, *"Reject new entries when
+the limit is reached"*. That is right for age-out-only collections and wrong for
+refresh-on-use ones. It now carries the distinction; keep the two files in step.
+
+Audit question for any bounded per-key map: **does ordinary use restamp this
+entry's TTL?** If yes, reject-at-cap is a starvation bug, not a bound.
+
+```bash
+# Bounded per-key maps whose entries are restamped by ordinary use:
+grep -rnE "get_mut\(\) = now|last_seen = now|last_refill = now" crates/core/src/
+# ...cross-check each against how its cap is enforced:
+grep -rnE "max_tracked|MAX_TRACKED" crates/core/src/
+```
+
+
 ## A refusal that is not counted renders as a clean zero
 
 **Any code path that DISCARDS an input must count the discard.** Three bare

--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -88,8 +88,43 @@ actors (clients, network peers) can influence.
 
 1. Per-key collections (subscribers per contract, peers per resource)
    MUST have a maximum size enforced at insertion time.
-   → Reject new entries when the limit is reached
    → Return an error or false so callers know registration was rejected
+
+   BUT: how you enforce it depends on whether entries are REFRESHED BY
+   ORDINARY USE. Get this wrong and the bound starves newcomers forever.
+
+   → Entries that only AGE OUT (a TTL nothing resets): reject new
+     entries at the cap. Incumbents roll off on their own, so a
+     newcomer's wait is bounded.
+
+   → Entries REFRESHED ON EVERY USE (a `last_seen`/`last_refill` stamp
+     that ordinary traffic restamps): reject-at-cap is WRONG — you MUST
+     EVICT the least-recently-used entry instead. A busy entry refreshes
+     its own TTL forever, so the cap is held permanently by whoever got
+     in first and stayed active, and every newcomer is refused with no
+     recovery path. That is the permanently-refreshable GC exemption
+     AGENTS.md forbids, and this rule's earlier "reject new entries when
+     the limit is reached" wording is what produced it.
+
+     #4981: the UPDATE limiter's 16,384 `(sender, contract)` slots were
+     held by whoever got in first, and every new pair's UPDATE was
+     silently dropped — and dropped at `debug!`, which
+     `release_max_level_info` compiles out, so a production node
+     discarding legitimate relayed traffic left no greppable evidence.
+     Fixed in #4997 by LRU eviction.
+
+     Two things that make eviction safe rather than a new hole:
+       a. Eviction can remove an incidental ceiling. If refusing-at-cap
+          was also (accidentally) throttling attacker-chosen keys, you
+          need an explicit replacement — #4997 added a per-sender
+          new-pair token bucket, charged BEFORE any slot is reserved so
+          a throttled peer cannot evict anyone on its way to refusal.
+       b. The scan is linear in the cap and cannot run under a shard
+          guard. Evict a BATCH, not one entry, or a persistently-full
+          map means a full scan per admission on the receive path.
+
+   → Whichever you pick, saturation must be visible in RELEASE builds:
+     `info!` or a counter, never `debug!` alone.
 
 2. Per-client/per-peer resource counts MUST be bounded.
    → A single client must not hold unbounded subscriptions across all keys

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -1598,35 +1598,55 @@ where
                     .update_rate_limiter
                     .check_and_record(sender_addr, *key.id());
                 if !rate_decision.is_allowed() {
-                    if matches!(
-                        rate_decision,
-                        crate::ring::update_rate_limit::RateLimitDecision::CapacityExceeded
-                    ) {
-                        // `info!` because `debug!` is compiled out of release
-                        // builds by `release_max_level_info`, which is how this
-                        // path came to drop legitimate relayed UPDATEs with no
-                        // greppable evidence on a production node (#4981).
-                        // Since that fix the limiter evicts instead of refusing,
-                        // so reaching here means the map was full AND every
-                        // admission attempt lost its freed slot to a concurrent
-                        // caller — rare, and worth seeing when it happens.
-                        tracing::info!(
-                            tx = %op.id(),
-                            %key,
-                            %sender_addr,
-                            phase = "update_dispatch_capacity_dropped",
-                            "UPDATE dispatch: dropped, rate-limiter map at capacity and \
-                             contended (see ring::update_rate_limit)"
-                        );
-                    } else {
-                        tracing::debug!(
-                            tx = %op.id(),
-                            %key,
-                            %sender_addr,
-                            ?rate_decision,
-                            phase = "update_dispatch_rate_limited",
-                            "UPDATE dispatch: rejected by per-(sender, contract) rate limit"
-                        );
+                    use crate::ring::update_rate_limit::RateLimitDecision;
+                    // Matched exhaustively on purpose: a new drop reason
+                    // that fell into a catch-all would be logged at
+                    // `debug!` and therefore be invisible in release
+                    // builds, which is exactly how #4981 stayed hidden.
+                    match rate_decision {
+                        RateLimitDecision::CapacityExceeded => {
+                            // `info!` because `debug!` is compiled out of release
+                            // builds by `release_max_level_info`, which is how this
+                            // path came to drop legitimate relayed UPDATEs with no
+                            // greppable evidence on a production node (#4981).
+                            // Since that fix the limiter evicts instead of refusing,
+                            // so reaching here means the map was full AND every
+                            // admission attempt lost its freed slot to a concurrent
+                            // caller — rare, and worth seeing when it happens.
+                            tracing::info!(
+                                tx = %op.id(),
+                                %key,
+                                %sender_addr,
+                                phase = "update_dispatch_capacity_dropped",
+                                "UPDATE dispatch: dropped, rate-limiter map at capacity and \
+                                 contended (see ring::update_rate_limit)"
+                            );
+                        }
+                        RateLimitDecision::SenderNewPairBudget => {
+                            // Deliberately NOT logged per drop: a sender
+                            // over this budget is over it on every
+                            // message, so a line here would be a steady
+                            // stream. The limiter logs it once a minute
+                            // with the sender, and the drop is counted in
+                            // `new_pair_budget_rejected_total`.
+                            tracing::debug!(
+                                tx = %op.id(),
+                                %key,
+                                %sender_addr,
+                                phase = "update_dispatch_fresh_id_dropped",
+                                "UPDATE dispatch: dropped, sender over its new-pair budget"
+                            );
+                        }
+                        RateLimitDecision::Rejected { .. } | RateLimitDecision::Allowed => {
+                            tracing::debug!(
+                                tx = %op.id(),
+                                %key,
+                                %sender_addr,
+                                ?rate_decision,
+                                phase = "update_dispatch_rate_limited",
+                                "UPDATE dispatch: rejected by per-(sender, contract) rate limit"
+                            );
+                        }
                     }
                     return Ok(());
                 }

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -1598,14 +1598,36 @@ where
                     .update_rate_limiter
                     .check_and_record(sender_addr, *key.id());
                 if !rate_decision.is_allowed() {
-                    tracing::debug!(
-                        tx = %op.id(),
-                        %key,
-                        %sender_addr,
-                        ?rate_decision,
-                        phase = "update_dispatch_rate_limited",
-                        "UPDATE dispatch: rejected by per-(sender, contract) rate limit"
-                    );
+                    if matches!(
+                        rate_decision,
+                        crate::ring::update_rate_limit::RateLimitDecision::CapacityExceeded
+                    ) {
+                        // `info!` because `debug!` is compiled out of release
+                        // builds by `release_max_level_info`, which is how this
+                        // path came to drop legitimate relayed UPDATEs with no
+                        // greppable evidence on a production node (#4981).
+                        // Since that fix the limiter evicts instead of refusing,
+                        // so reaching here means the map was full AND every
+                        // admission attempt lost its freed slot to a concurrent
+                        // caller — rare, and worth seeing when it happens.
+                        tracing::info!(
+                            tx = %op.id(),
+                            %key,
+                            %sender_addr,
+                            phase = "update_dispatch_capacity_dropped",
+                            "UPDATE dispatch: dropped, rate-limiter map at capacity and \
+                             contended (see ring::update_rate_limit)"
+                        );
+                    } else {
+                        tracing::debug!(
+                            tx = %op.id(),
+                            %key,
+                            %sender_addr,
+                            ?rate_decision,
+                            phase = "update_dispatch_rate_limited",
+                            "UPDATE dispatch: rejected by per-(sender, contract) rate limit"
+                        );
+                    }
                     return Ok(());
                 }
 

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -1487,35 +1487,55 @@ where
                     .update_rate_limiter
                     .check_and_record(sender_addr, *key.id());
                 if !rate_decision.is_allowed() {
-                    if matches!(
-                        rate_decision,
-                        crate::ring::update_rate_limit::RateLimitDecision::CapacityExceeded
-                    ) {
-                        // `info!` because `debug!` is compiled out of release
-                        // builds by `release_max_level_info`, which is how this
-                        // path came to drop legitimate relayed UPDATEs with no
-                        // greppable evidence on a production node (#4981).
-                        // Since that fix the limiter evicts instead of refusing,
-                        // so reaching here means the map was full AND every
-                        // admission attempt lost its freed slot to a concurrent
-                        // caller — rare, and worth seeing when it happens.
-                        tracing::info!(
-                            tx = %op.id(),
-                            %key,
-                            %sender_addr,
-                            phase = "update_dispatch_capacity_dropped",
-                            "UPDATE dispatch: dropped, rate-limiter map at capacity and \
-                             contended (see ring::update_rate_limit)"
-                        );
-                    } else {
-                        tracing::debug!(
-                            tx = %op.id(),
-                            %key,
-                            %sender_addr,
-                            ?rate_decision,
-                            phase = "update_dispatch_rate_limited",
-                            "UPDATE dispatch: rejected by per-(sender, contract) rate limit"
-                        );
+                    use crate::ring::update_rate_limit::RateLimitDecision;
+                    // Matched exhaustively on purpose: a new drop reason
+                    // that fell into a catch-all would be logged at
+                    // `debug!` and therefore be invisible in release
+                    // builds, which is exactly how #4981 stayed hidden.
+                    match rate_decision {
+                        RateLimitDecision::CapacityExceeded => {
+                            // `info!` because `debug!` is compiled out of release
+                            // builds by `release_max_level_info`, which is how this
+                            // path came to drop legitimate relayed UPDATEs with no
+                            // greppable evidence on a production node (#4981).
+                            // Since that fix the limiter evicts instead of refusing,
+                            // so reaching here means the map was full AND every
+                            // admission attempt lost its freed slot to a concurrent
+                            // caller — rare, and worth seeing when it happens.
+                            tracing::info!(
+                                tx = %op.id(),
+                                %key,
+                                %sender_addr,
+                                phase = "update_dispatch_capacity_dropped",
+                                "UPDATE dispatch: dropped, rate-limiter map at capacity and \
+                                 contended (see ring::update_rate_limit)"
+                            );
+                        }
+                        RateLimitDecision::SenderNewPairBudget => {
+                            // Deliberately NOT logged per drop: a sender
+                            // over this budget is over it on every
+                            // message, so a line here would be a steady
+                            // stream. The limiter logs it once a minute
+                            // with the sender, and the drop is counted in
+                            // `new_pair_budget_rejected_total`.
+                            tracing::debug!(
+                                tx = %op.id(),
+                                %key,
+                                %sender_addr,
+                                phase = "update_dispatch_fresh_id_dropped",
+                                "UPDATE dispatch: dropped, sender over its new-pair budget"
+                            );
+                        }
+                        RateLimitDecision::Rejected { .. } | RateLimitDecision::Allowed => {
+                            tracing::debug!(
+                                tx = %op.id(),
+                                %key,
+                                %sender_addr,
+                                ?rate_decision,
+                                phase = "update_dispatch_rate_limited",
+                                "UPDATE dispatch: rejected by per-(sender, contract) rate limit"
+                            );
+                        }
                     }
                     return Ok(());
                 }

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -1487,14 +1487,36 @@ where
                     .update_rate_limiter
                     .check_and_record(sender_addr, *key.id());
                 if !rate_decision.is_allowed() {
-                    tracing::debug!(
-                        tx = %op.id(),
-                        %key,
-                        %sender_addr,
-                        ?rate_decision,
-                        phase = "update_dispatch_rate_limited",
-                        "UPDATE dispatch: rejected by per-(sender, contract) rate limit"
-                    );
+                    if matches!(
+                        rate_decision,
+                        crate::ring::update_rate_limit::RateLimitDecision::CapacityExceeded
+                    ) {
+                        // `info!` because `debug!` is compiled out of release
+                        // builds by `release_max_level_info`, which is how this
+                        // path came to drop legitimate relayed UPDATEs with no
+                        // greppable evidence on a production node (#4981).
+                        // Since that fix the limiter evicts instead of refusing,
+                        // so reaching here means the map was full AND every
+                        // admission attempt lost its freed slot to a concurrent
+                        // caller — rare, and worth seeing when it happens.
+                        tracing::info!(
+                            tx = %op.id(),
+                            %key,
+                            %sender_addr,
+                            phase = "update_dispatch_capacity_dropped",
+                            "UPDATE dispatch: dropped, rate-limiter map at capacity and \
+                             contended (see ring::update_rate_limit)"
+                        );
+                    } else {
+                        tracing::debug!(
+                            tx = %op.id(),
+                            %key,
+                            %sender_addr,
+                            ?rate_decision,
+                            phase = "update_dispatch_rate_limited",
+                            "UPDATE dispatch: rejected by per-(sender, contract) rate limit"
+                        );
+                    }
                     return Ok(());
                 }
 

--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -79,9 +79,16 @@ pub struct RingStatsSnapshot {
     /// may be getting dropped — operators should watch this.
     pub updates_rate_limited: u64,
     /// Total relayed UPDATEs dropped because the limiter's tracking map
-    /// was at capacity (`MAX_TRACKED_PAIRS`). A non-zero value suggests
-    /// identity churn / admission pressure, distinct from per-pair rate.
+    /// was at capacity (`MAX_TRACKED_PAIRS`) and eviction could not free
+    /// a slot. Since #4981 this means the map is full *and* contended;
+    /// ordinary saturation shows up in `updates_capacity_evicted`.
     pub updates_capacity_dropped: u64,
+    /// Total tracked `(sender, contract)` pairs evicted to admit new
+    /// ones at capacity. This is the saturation signal: a busy node
+    /// relaying for more pairs than `MAX_TRACKED_PAIRS` shows this
+    /// climbing while `updates_capacity_dropped` stays flat, and no
+    /// legitimate UPDATE is dropped for it.
+    pub updates_capacity_evicted: u64,
     /// Nearest-neighbor ring lattice completeness (the "is greedy routing's base
     /// lattice present" signal). `lattice_has_successor` / `_predecessor` are
     /// whether this peer currently HOLDS (a side is FILLED with) its

--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -89,6 +89,13 @@ pub struct RingStatsSnapshot {
     /// climbing while `updates_capacity_dropped` stays flat, and no
     /// legitimate UPDATE is dropped for it.
     pub updates_capacity_evicted: u64,
+    /// Total relayed UPDATEs dropped because the sending peer was over
+    /// its budget for introducing brand-new `(sender, contract)` pairs.
+    /// This is the fresh-contract-id churn signal: unlike the counters
+    /// above it never counts a peer's traffic for contracts already
+    /// being tracked, so a non-zero value really does mean one peer is
+    /// presenting unfamiliar contract ids faster than the budget allows.
+    pub updates_sender_budget_dropped: u64,
     /// Nearest-neighbor ring lattice completeness (the "is greedy routing's base
     /// lattice present" signal). `lattice_has_successor` / `_predecessor` are
     /// whether this peer currently HOLDS (a side is FILLED with) its

--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -96,6 +96,12 @@ pub struct RingStatsSnapshot {
     /// being tracked, so a non-zero value really does mean one peer is
     /// presenting unfamiliar contract ids faster than the budget allows.
     pub updates_sender_budget_dropped: u64,
+    /// Total relayed UPDATEs admitted for a brand-new pair WITHOUT a
+    /// budget check, because the per-sender budget's own map was full.
+    /// Should be zero. A non-zero value means the budget map is
+    /// undersized for this node's peer churn, so those senders are not
+    /// actually being bounded — the safety valve is firing.
+    pub updates_sender_budget_unmetered: u64,
     /// Nearest-neighbor ring lattice completeness (the "is greedy routing's base
     /// lattice present" signal). `lattice_has_successor` / `_predecessor` are
     /// whether this peer currently HOLDS (a side is FILLED with) its

--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -77,9 +77,16 @@ pub struct RingStatsSnapshot {
     /// may be getting dropped — operators should watch this.
     pub updates_rate_limited: u64,
     /// Total relayed UPDATEs dropped because the limiter's tracking map
-    /// was at capacity (`MAX_TRACKED_PAIRS`). A non-zero value suggests
-    /// identity churn / admission pressure, distinct from per-pair rate.
+    /// was at capacity (`MAX_TRACKED_PAIRS`) and eviction could not free
+    /// a slot. Since #4981 this means the map is full *and* contended;
+    /// ordinary saturation shows up in `updates_capacity_evicted`.
     pub updates_capacity_dropped: u64,
+    /// Total tracked `(sender, contract)` pairs evicted to admit new
+    /// ones at capacity. This is the saturation signal: a busy node
+    /// relaying for more pairs than `MAX_TRACKED_PAIRS` shows this
+    /// climbing while `updates_capacity_dropped` stays flat, and no
+    /// legitimate UPDATE is dropped for it.
+    pub updates_capacity_evicted: u64,
     /// Nearest-neighbor ring lattice completeness (the "is greedy routing's base
     /// lattice present" signal). `lattice_has_successor` / `_predecessor` are
     /// whether this peer currently HOLDS (a side is FILLED with) its

--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -94,6 +94,12 @@ pub struct RingStatsSnapshot {
     /// being tracked, so a non-zero value really does mean one peer is
     /// presenting unfamiliar contract ids faster than the budget allows.
     pub updates_sender_budget_dropped: u64,
+    /// Total relayed UPDATEs admitted for a brand-new pair WITHOUT a
+    /// budget check, because the per-sender budget's own map was full.
+    /// Should be zero. A non-zero value means the budget map is
+    /// undersized for this node's peer churn, so those senders are not
+    /// actually being bounded — the safety valve is firing.
+    pub updates_sender_budget_unmetered: u64,
     /// Nearest-neighbor ring lattice completeness (the "is greedy routing's base
     /// lattice present" signal). `lattice_has_successor` / `_predecessor` are
     /// whether this peer currently HOLDS (a side is FILLED with) its

--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -87,6 +87,13 @@ pub struct RingStatsSnapshot {
     /// climbing while `updates_capacity_dropped` stays flat, and no
     /// legitimate UPDATE is dropped for it.
     pub updates_capacity_evicted: u64,
+    /// Total relayed UPDATEs dropped because the sending peer was over
+    /// its budget for introducing brand-new `(sender, contract)` pairs.
+    /// This is the fresh-contract-id churn signal: unlike the counters
+    /// above it never counts a peer's traffic for contracts already
+    /// being tracked, so a non-zero value really does mean one peer is
+    /// presenting unfamiliar contract ids faster than the budget allows.
+    pub updates_sender_budget_dropped: u64,
     /// Nearest-neighbor ring lattice completeness (the "is greedy routing's base
     /// lattice present" signal). `lattice_has_successor` / `_predecessor` are
     /// whether this peer currently HOLDS (a side is FILLED with) its

--- a/crates/core/src/node/p2p_impl.rs
+++ b/crates/core/src/node/p2p_impl.rs
@@ -550,6 +550,7 @@ impl NodeP2P {
                 updates_rate_limited: rate_limiter.rejected_total(),
                 updates_capacity_dropped: rate_limiter.capacity_rejected_total(),
                 updates_capacity_evicted: rate_limiter.capacity_evicted_total(),
+                updates_sender_budget_dropped: rate_limiter.new_pair_budget_rejected_total(),
                 lattice_has_successor: succ.is_some(),
                 lattice_has_predecessor: pred.is_some(),
                 lattice_successor_distance: succ,

--- a/crates/core/src/node/p2p_impl.rs
+++ b/crates/core/src/node/p2p_impl.rs
@@ -551,6 +551,7 @@ impl NodeP2P {
                 updates_capacity_dropped: rate_limiter.capacity_rejected_total(),
                 updates_capacity_evicted: rate_limiter.capacity_evicted_total(),
                 updates_sender_budget_dropped: rate_limiter.new_pair_budget_rejected_total(),
+                updates_sender_budget_unmetered: rate_limiter.new_pair_budget_untracked_total(),
                 lattice_has_successor: succ.is_some(),
                 lattice_has_predecessor: pred.is_some(),
                 lattice_successor_distance: succ,

--- a/crates/core/src/node/p2p_impl.rs
+++ b/crates/core/src/node/p2p_impl.rs
@@ -549,6 +549,7 @@ impl NodeP2P {
                 updates_accepted: rate_limiter.accepted_total(),
                 updates_rate_limited: rate_limiter.rejected_total(),
                 updates_capacity_dropped: rate_limiter.capacity_rejected_total(),
+                updates_capacity_evicted: rate_limiter.capacity_evicted_total(),
                 lattice_has_successor: succ.is_some(),
                 lattice_has_predecessor: pred.is_some(),
                 lattice_successor_distance: succ,

--- a/crates/core/src/node/p2p_impl.rs
+++ b/crates/core/src/node/p2p_impl.rs
@@ -537,6 +537,7 @@ impl NodeP2P {
                 updates_capacity_dropped: rate_limiter.capacity_rejected_total(),
                 updates_capacity_evicted: rate_limiter.capacity_evicted_total(),
                 updates_sender_budget_dropped: rate_limiter.new_pair_budget_rejected_total(),
+                updates_sender_budget_unmetered: rate_limiter.new_pair_budget_untracked_total(),
                 lattice_has_successor: succ.is_some(),
                 lattice_has_predecessor: pred.is_some(),
                 lattice_successor_distance: succ,

--- a/crates/core/src/node/p2p_impl.rs
+++ b/crates/core/src/node/p2p_impl.rs
@@ -536,6 +536,7 @@ impl NodeP2P {
                 updates_rate_limited: rate_limiter.rejected_total(),
                 updates_capacity_dropped: rate_limiter.capacity_rejected_total(),
                 updates_capacity_evicted: rate_limiter.capacity_evicted_total(),
+                updates_sender_budget_dropped: rate_limiter.new_pair_budget_rejected_total(),
                 lattice_has_successor: succ.is_some(),
                 lattice_has_predecessor: pred.is_some(),
                 lattice_successor_distance: succ,

--- a/crates/core/src/node/p2p_impl.rs
+++ b/crates/core/src/node/p2p_impl.rs
@@ -535,6 +535,7 @@ impl NodeP2P {
                 updates_accepted: rate_limiter.accepted_total(),
                 updates_rate_limited: rate_limiter.rejected_total(),
                 updates_capacity_dropped: rate_limiter.capacity_rejected_total(),
+                updates_capacity_evicted: rate_limiter.capacity_evicted_total(),
                 lattice_has_successor: succ.is_some(),
                 lattice_has_predecessor: pred.is_some(),
                 lattice_successor_distance: succ,

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -656,6 +656,11 @@ impl Ring {
             governance_config,
             time_source.clone(),
         ));
+        // Read before `connection_manager` is moved into the literal.
+        // The UPDATE limiter's per-sender budget is keyed by the
+        // immediate upstream hop, so its map is sized from this node's
+        // OWN connection cap rather than a hardcoded default.
+        let max_connections = connection_manager.max_connections;
         let ring = Ring {
             max_hops_to_live,
             router,
@@ -676,6 +681,7 @@ impl Ring {
             governance,
             update_rate_limiter: Arc::new(update_rate_limit::UpdateRateLimiter::new(
                 time_source.clone(),
+                max_connections,
             )),
             merge_backoff: Arc::new(merge_backoff::MergeBackoff::new(time_source.clone())),
             delta_incompat: Arc::new(delta_incompat::DeltaIncompat::new(time_source.clone())),

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -620,6 +620,11 @@ impl Ring {
             governance_config,
             time_source.clone(),
         ));
+        // Read before `connection_manager` is moved into the literal.
+        // The UPDATE limiter's per-sender budget is keyed by the
+        // immediate upstream hop, so its map is sized from this node's
+        // OWN connection cap rather than a hardcoded default.
+        let max_connections = connection_manager.max_connections;
         let ring = Ring {
             max_hops_to_live,
             router,
@@ -640,6 +645,7 @@ impl Ring {
             governance,
             update_rate_limiter: Arc::new(update_rate_limit::UpdateRateLimiter::new(
                 time_source.clone(),
+                max_connections,
             )),
             merge_backoff: Arc::new(merge_backoff::MergeBackoff::new(time_source.clone())),
             delta_incompat: Arc::new(delta_incompat::DeltaIncompat::new(time_source.clone())),

--- a/crates/core/src/ring/resync_rate_limit.rs
+++ b/crates/core/src/ring/resync_rate_limit.rs
@@ -99,6 +99,19 @@ impl Bucket {
     }
 }
 
+/// Outcome of a [`TokenBucketLimiter::check_and_record_detailed`] check.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BucketOutcome {
+    /// A token was consumed; the event is allowed.
+    Allowed,
+    /// The key's bucket is empty: it is over its rate.
+    RateLimited,
+    /// The key is not tracked and the map has no room for it, so nothing
+    /// is known about its rate. Distinct from `RateLimited` because it
+    /// says nothing about THIS key — it is a statement about the map.
+    Untracked,
+}
+
 /// A token-bucket rate limiter keyed by `K`. One token per key is consumed per
 /// allowed event; the bucket holds up to `capacity` and refills one token per
 /// `refill_interval`.
@@ -136,6 +149,19 @@ impl<K: Eq + Hash + Clone> TokenBucketLimiter<K> {
     /// allowed (a token was consumed), `false` when rate-limited or the tracking
     /// map is at capacity for a new key.
     pub fn check_and_record(&self, key: K) -> bool {
+        matches!(self.check_and_record_detailed(key), BucketOutcome::Allowed)
+    }
+
+    /// [`Self::check_and_record`] without collapsing "this key is over its
+    /// rate" and "the tracking map has no room for this key" into one
+    /// `false`.
+    ///
+    /// The distinction matters to any caller whose keys are NOT
+    /// attacker-chosen: for those, a full map is a sizing accident rather
+    /// than evidence about the key, and refusing on it starves a
+    /// newcomer for someone else's behaviour. `check_and_record` keeps
+    /// the collapsed form so existing callers are unchanged.
+    pub fn check_and_record_detailed(&self, key: K) -> BucketOutcome {
         let now = self.time_source.now();
         use dashmap::mapref::entry::Entry;
         match self.buckets.entry(key) {
@@ -145,10 +171,10 @@ impl<K: Eq + Hash + Clone> TokenBucketLimiter<K> {
                 if bucket.tokens >= 1.0 {
                     bucket.tokens -= 1.0;
                     self.allowed_total.fetch_add(1, Ordering::Relaxed);
-                    true
+                    BucketOutcome::Allowed
                 } else {
                     self.suppressed_total.fetch_add(1, Ordering::Relaxed);
-                    false
+                    BucketOutcome::RateLimited
                 }
             }
             Entry::Vacant(vac) => {
@@ -157,7 +183,7 @@ impl<K: Eq + Hash + Clone> TokenBucketLimiter<K> {
                 if prev >= self.max_tracked {
                     self.size.fetch_sub(1, Ordering::Relaxed);
                     self.suppressed_total.fetch_add(1, Ordering::Relaxed);
-                    return false;
+                    return BucketOutcome::Untracked;
                 }
                 // A brand-new key starts with a full bucket and spends one token.
                 vac.insert(Bucket {
@@ -165,7 +191,7 @@ impl<K: Eq + Hash + Clone> TokenBucketLimiter<K> {
                     last_refill: now,
                 });
                 self.allowed_total.fetch_add(1, Ordering::Relaxed);
-                true
+                BucketOutcome::Allowed
             }
         }
     }

--- a/crates/core/src/ring/update_rate_limit.rs
+++ b/crates/core/src/ring/update_rate_limit.rs
@@ -1226,6 +1226,61 @@ mod tests {
         );
     }
 
+    /// Pin: both saturation signals stay visible in release builds.
+    ///
+    /// `crates/core/Cargo.toml` sets `release_max_level_info`, so
+    /// anything logged at `debug!` is compiled out of shipped binaries.
+    /// That is half of why #4981 went unnoticed for so long: a
+    /// production node dropped legitimate relayed UPDATEs and left no
+    /// greppable evidence, so the only signal was a dashboard tile a
+    /// user happened to ask about. Behavioural tests cannot see a log
+    /// level, so this scrapes the source instead — a silent downgrade to
+    /// `debug!` would otherwise restore the invisibility with every
+    /// other test still green.
+    ///
+    /// Needles are split with `concat!` so they do not match their own
+    /// source through `include_str!`, and both haystacks are compared
+    /// with whitespace stripped so rustfmt reflowing a call cannot make
+    /// the pin vacuous.
+    #[test]
+    fn capacity_signals_are_logged_above_debug_level() {
+        fn strip_ws(s: &str) -> String {
+            s.chars().filter(|c| !c.is_whitespace()).collect()
+        }
+
+        // The limiter's own saturation line, in this file.
+        let this_file = strip_ws(include_str!("update_rate_limit.rs"));
+        let eviction_marker = strip_ws(concat!("UPDATE rate limiter at ", "capacity: evicted"));
+        let pos = this_file.find(&eviction_marker).expect(
+            "the eviction log line must exist; if it was renamed, update this pin rather than \
+             deleting it",
+        );
+        let preamble = &this_file[pos.saturating_sub(200)..pos];
+        assert!(
+            preamble.contains(&strip_ws("tracing::info!")),
+            "the eviction log must be emitted at info! or higher; debug! is compiled out of \
+             release builds by release_max_level_info (#4981)"
+        );
+
+        // The residual capacity drop, in the UPDATE dispatch path.
+        let node_rs = strip_ws(include_str!("../node.rs"));
+        let drop_marker = strip_ws(concat!("update_dispatch_", "capacity_dropped"));
+        let pos = node_rs.find(&drop_marker).expect(
+            "the capacity-drop log phase must exist in node.rs; if it was renamed, update this \
+             pin rather than deleting it",
+        );
+        let preamble = &node_rs[pos.saturating_sub(200)..pos];
+        assert!(
+            preamble.contains(&strip_ws("tracing::info!")),
+            "dropping an UPDATE for capacity must be logged at info! or higher, so the drop is \
+             greppable on a production node (#4981)"
+        );
+        assert!(
+            !preamble.contains(&strip_ws("tracing::debug!")),
+            "the capacity-drop branch must not fall back to debug!"
+        );
+    }
+
     /// Pin: cleanup decrements the `size` counter by the number of
     /// dropped entries. After all entries roll off, the cap should
     /// be fully available again — strict-cap accounting tracks the

--- a/crates/core/src/ring/update_rate_limit.rs
+++ b/crates/core/src/ring/update_rate_limit.rs
@@ -68,17 +68,47 @@
 //! that assumes the newcomer is hostile penalises the ordinary case of
 //! a healthy node outgrowing the bound.
 //!
-//! What eviction costs, stated plainly: an evicted pair's next UPDATE
-//! is treated as new and therefore allowed, so an attacker churning
-//! fresh contract ids gets one UPDATE through per id instead of being
-//! cut off after the first 16 384. That ceiling was incidental rather
-//! than designed — the cap exists to bound *memory* — and per-(sender,
-//! contract) rate limiting cannot stop a fresh-id attacker regardless,
-//! since a pair the map has never seen is always allowed once. Paying
-//! it buys back the availability of every legitimate relayed UPDATE on
-//! a saturated node. Sustained floods from a *stable* pair, which is
-//! the pattern this limiter exists for, are unaffected: that entry is
-//! the most recently used, so it is the last thing evicted.
+//! What eviction costs: an evicted pair's next UPDATE is treated as new
+//! and therefore allowed, so an attacker churning fresh contract ids
+//! gets one UPDATE through per id instead of being cut off after the
+//! first 16 384. That ceiling was incidental rather than designed — the
+//! cap exists to bound *memory* — but it was not nothing, and nothing
+//! else in the node replaced it: the ban list is keyed by contract, the
+//! MAD outlier detector is off by default and excludes contracts younger
+//! than its ramp-up anyway, and the transport rate-limits handshakes
+//! rather than traffic on an established connection. Since a node
+//! forwards an UPDATE for a contract it does not host, an unbounded
+//! fresh-id stream would make it a relay amplifier. So the ceiling is
+//! replaced deliberately rather than dropped — see below.
+//!
+//! Sustained floods from a *stable* pair, which is the pattern this
+//! limiter exists for, are unaffected by eviction: that entry is the
+//! most recently used, so it is the last thing evicted.
+//!
+//! ### The fresh-pair budget, keyed by sender alone
+//!
+//! Eviction removes the *incidental* bound on fresh-id churn, so a
+//! deliberate one takes its place: a token bucket keyed by `sender_addr`
+//! ALONE ([`NEW_PAIR_BURST`], [`NEW_PAIR_REFILL_INTERVAL`]) that a
+//! sender spends from only when it presents a `(sender, contract)` pair
+//! this limiter has never seen.
+//!
+//! Two properties make this the right shape:
+//!
+//! - **Established traffic never touches it.** A token is spent on the
+//!   new-pair path only, so a peer relaying heavily for contracts the
+//!   limiter already tracks is bounded by [`MIN_UPDATE_INTERVAL`] per
+//!   pair and by nothing else — the availability this fix exists to
+//!   restore is not clawed back.
+//! - **It is charged before eviction, not after.** A sender past its
+//!   budget is refused *before* a slot is reserved or anything is
+//!   evicted, so churning fresh ids cannot push other peers' entries out
+//!   of the map on the way to being throttled.
+//!
+//! Its own map is bounded by [`MAX_TRACKED_SENDERS`], which is a
+//! multiple of the node's connection cap rather than an attacker-chosen
+//! space: `sender` is the immediate upstream hop, so only a connected
+//! peer can occupy an entry.
 //!
 //! ## Semantic note: `sender_addr` is the immediate upstream hop
 //!
@@ -128,6 +158,8 @@ use dashmap::DashMap;
 use freenet_stdlib::prelude::ContractInstanceId;
 use tokio::time::Instant;
 
+use super::Ring;
+use super::resync_rate_limit::TokenBucketLimiter;
 use crate::util::time_source::TimeSource;
 
 /// Minimum interval between accepted UPDATEs for the same
@@ -188,13 +220,115 @@ const EVICTION_LOG_INTERVAL: Duration = Duration::from_secs(60);
 
 /// Bound on admission attempts before giving up with `CapacityExceeded`.
 ///
-/// One attempt, one eviction, one retry is the expected path. The bound
-/// exists because the slot freed by eviction is not reserved: another
-/// thread may take it between the eviction and the retry, and an
-/// unbounded retry loop would let sustained contention spin here on the
-/// receive path. Giving up is safe — the competing thread's UPDATE went
-/// through, and this sender retries.
-const MAX_ADMISSION_ATTEMPTS: usize = 3;
+/// One attempt, one eviction, one insert is the expected path. The bound
+/// exists because an admission can lose its slot to a concurrent caller,
+/// and an unbounded retry loop would let sustained contention spin here
+/// on the receive path.
+///
+/// Six rather than three. An attempt is consumed whenever the map went
+/// from full to not-full and back between this caller's cap check and
+/// its eviction — no work is done, but the attempt is spent — and the
+/// last attempt cannot evict (there would be no attempt left to use the
+/// slot), so the budget buys one fewer eviction than it looks like.
+/// Measured on the worst ratio in the suite, a 1024 cap whose 16-entry
+/// batch matches the 16 concurrent callers: at three attempts 7-26 of
+/// 6 400 admissions were dropped across a dozen runs, at four 0-3, at
+/// five 0-2, and at six none at all. Extra attempts are nearly free now
+/// that the scan is serialised — a waiter blocks on the eviction lock
+/// instead of running its own redundant scan.
+const MAX_ADMISSION_ATTEMPTS: usize = 6;
+
+/// Burst of brand-new `(sender, contract)` pairs a single sender may
+/// introduce before [`NEW_PAIR_REFILL_INTERVAL`] starts to bind.
+///
+/// Sized to absorb the legitimate bursty cases — a peer that reconnects
+/// and re-subscribes, or one that starts relaying for a batch of
+/// contracts at once — with room to spare over the ~330 pairs per peer
+/// implied by the saturation #4981 reported (≈16 500 pairs across ≈50
+/// peers). A sender only spends a token when it presents a pair the
+/// limiter has never seen, so established traffic never touches this.
+const NEW_PAIR_BURST: f64 = 512.0;
+
+/// Sustained rate at which one sender may introduce brand-new pairs once
+/// its burst is spent: one per interval.
+///
+/// Deliberately [`MIN_UPDATE_INTERVAL`], so both ceilings read the same
+/// way: a sender may introduce new pairs no faster than it may repeat an
+/// UPDATE on a single pair (10/s at the defaults).
+const NEW_PAIR_REFILL_INTERVAL: Duration = MIN_UPDATE_INTERVAL;
+
+/// Cap on the senders tracked by the new-pair budget.
+///
+/// One entry per peer address that has presented a new pair. `sender` is
+/// the immediate upstream hop, so the live set is bounded by this node's
+/// connection count; the multiple over [`Ring::DEFAULT_MAX_CONNECTIONS`]
+/// is headroom for address churn (reconnects, NAT rebinding) between
+/// [`CLEANUP_AGE`] sweeps. At ~48 bytes an entry the whole map is well
+/// under 100 KB.
+const MAX_TRACKED_SENDERS: usize = 8 * Ring::DEFAULT_MAX_CONNECTIONS;
+
+/// How often an exhausted new-pair budget may write a log line.
+///
+/// Shares [`EVICTION_LOG_INTERVAL`]'s reasoning: a sender that is being
+/// throttled is being throttled continuously, so this must be throttled
+/// too or it becomes the log flood it is meant to report.
+const NEW_PAIR_LOG_INTERVAL: Duration = EVICTION_LOG_INTERVAL;
+
+/// Outcome of an at-capacity eviction pass.
+///
+/// This is an enum rather than a count of removed entries because
+/// "removed nothing" is almost never a reason to give up, and reading it
+/// as one silently dropped legitimate UPDATEs. A pass removes nothing in
+/// three situations, only the last of which is terminal:
+///
+/// 1. Another caller already freed capacity, so the cap no longer binds.
+/// 2. Every victim this pass selected was removed concurrently — under
+///    contention the likeliest case, since concurrent callers all
+///    partition the *same* map and therefore select nearly the same
+///    oldest entries.
+/// 3. The map is empty, so there is nothing to evict and never will be.
+///
+/// 1 and 2 mean a slot is, or may already be, free: the right move is to
+/// retry the admission, which is what [`MAX_ADMISSION_ATTEMPTS`] exists
+/// for. Only 3 is a configuration problem. Conflating them dropped ~0.9%
+/// of admissions at the production cap under 16-thread contention, none
+/// of them for the documented reason, and without consuming a single
+/// retry attempt (#4997 review).
+enum EvictionOutcome {
+    /// This pass freed slots and kept one of them for the caller, which
+    /// therefore does not have to win the cap check again — it inserts
+    /// directly. See [`UpdateRateLimiter::evict_oldest`].
+    Reserved,
+    /// A slot is, or may already be, free, but this caller did not free
+    /// it and holds no claim on it. Retry the admission.
+    Retry,
+    /// The map is empty — reachable only with `max_tracked_pairs == 0`.
+    /// Terminal.
+    MapEmpty,
+}
+
+/// Whether a throttled log line is due, stamping `slot` when it is.
+///
+/// Both saturation signals in this module fire continuously once they
+/// fire at all, so both need this; sharing it keeps the two throttles
+/// from drifting apart.
+fn log_due(slot: &Mutex<Option<Instant>>, now: Instant, interval: Duration) -> bool {
+    let mut last = match slot.lock() {
+        Ok(guard) => guard,
+        // Poisoned only if a previous holder panicked while formatting a
+        // log line. Losing the throttle is not worth propagating a panic
+        // onto the UPDATE receive path.
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    let due = match *last {
+        Some(prev) => now.saturating_duration_since(prev) >= interval,
+        None => true,
+    };
+    if due {
+        *last = Some(now);
+    }
+    due
+}
 
 /// Outcome of an UPDATE rate-limit check. Callers must treat any
 /// non-`Allowed` variant as "drop this message at the receive
@@ -223,6 +357,15 @@ pub(crate) enum RateLimitDecision {
     /// something sharper than it used to: not merely that the map is
     /// full, but that it is full *and* contended.
     CapacityExceeded,
+    /// Rejected because the sender has spent its budget for introducing
+    /// brand-new `(sender, contract)` pairs (see the module docs).
+    ///
+    /// Only a pair this limiter has never seen can land here, so a
+    /// sender's established traffic never does, however much of it there
+    /// is. A rising count means one peer is presenting unfamiliar
+    /// contract ids faster than [`NEW_PAIR_REFILL_INTERVAL`] — the
+    /// fresh-id churn pattern.
+    SenderNewPairBudget,
 }
 
 impl RateLimitDecision {
@@ -278,6 +421,29 @@ pub(crate) struct UpdateRateLimiter {
     /// eviction path, which already walks the map, so the lock is not
     /// on the common path.
     last_eviction_log: Mutex<Option<Instant>>,
+    /// Held across the eviction scan so only one caller selects victims
+    /// at a time — see [`UpdateRateLimiter::evict_oldest`] for why
+    /// concurrent evictors otherwise collide on the same victims. This
+    /// is the outermost lock in the module: nothing else acquires it,
+    /// and no shard guard is held when it is taken, so it cannot
+    /// participate in a lock cycle.
+    eviction_lock: Mutex<()>,
+    /// Per-sender budget for introducing brand-new pairs — the
+    /// deliberate replacement for the fresh-id ceiling eviction removed
+    /// (see the module docs).
+    ///
+    /// Consulted only from the new-pair branch of `check_and_record`,
+    /// while that branch holds a `last_accepted` shard guard. That is
+    /// the only place either map is touched under the other's guard, so
+    /// the lock order (`last_accepted` then `new_pair_budget`) has no
+    /// counterpart to invert against.
+    new_pair_budget: TokenBucketLimiter<SocketAddr>,
+    /// Total UPDATEs dropped because the sender was over its new-pair
+    /// budget.
+    new_pair_budget_rejected_total: AtomicU64,
+    /// When the last new-pair-budget log line was written, for
+    /// [`NEW_PAIR_LOG_INTERVAL`] throttling.
+    last_new_pair_log: Mutex<Option<Instant>>,
 }
 
 impl UpdateRateLimiter {
@@ -290,7 +456,35 @@ impl UpdateRateLimiter {
         min_interval: Duration,
         max_tracked_pairs: usize,
     ) -> Self {
+        Self::with_new_pair_budget(
+            time_source,
+            min_interval,
+            max_tracked_pairs,
+            NEW_PAIR_BURST,
+            MAX_TRACKED_SENDERS,
+        )
+    }
+
+    /// [`Self::with_config`] with the per-sender new-pair budget sized
+    /// explicitly. Fixtures that deliberately flood fresh pairs from one
+    /// sender to exercise the capacity/eviction path pass a burst large
+    /// enough that the budget cannot be what they observe.
+    pub fn with_new_pair_budget(
+        time_source: Arc<dyn TimeSource + Send + Sync>,
+        min_interval: Duration,
+        max_tracked_pairs: usize,
+        new_pair_burst: f64,
+        max_tracked_senders: usize,
+    ) -> Self {
         Self {
+            new_pair_budget: TokenBucketLimiter::new(
+                time_source.clone(),
+                new_pair_burst,
+                NEW_PAIR_REFILL_INTERVAL,
+                max_tracked_senders,
+            ),
+            new_pair_budget_rejected_total: AtomicU64::new(0),
+            last_new_pair_log: Mutex::new(None),
             last_accepted: DashMap::new(),
             size: AtomicUsize::new(0),
             min_interval,
@@ -301,6 +495,7 @@ impl UpdateRateLimiter {
             capacity_rejected_total: AtomicU64::new(0),
             capacity_evicted_total: AtomicU64::new(0),
             last_eviction_log: Mutex::new(None),
+            eviction_lock: Mutex::new(()),
         }
     }
 
@@ -338,11 +533,27 @@ impl UpdateRateLimiter {
         let key = (sender, contract);
 
         use dashmap::mapref::entry::Entry;
+        // Whether this call has already spent one of `sender`'s new-pair
+        // tokens. A retry after eviction re-enters the Vacant branch, and
+        // one admission must cost one token, not one per attempt.
+        let mut budget_spent = false;
+        // Whether this call is holding a slot it freed by evicting (see
+        // `EvictionOutcome::Reserved`). It is counted in `size`, so every
+        // path out of the loop must either consume it with an insert or
+        // hand it back.
+        let mut reserved = false;
         // Each iteration either decides, or frees capacity and retries.
         // See `MAX_ADMISSION_ATTEMPTS` for why this is bounded.
-        for _ in 0..MAX_ADMISSION_ATTEMPTS {
+        for attempt in 0..MAX_ADMISSION_ATTEMPTS {
             match self.last_accepted.entry(key) {
                 Entry::Occupied(mut entry) => {
+                    if reserved {
+                        // The pair turned up while we were evicting, so
+                        // the slot we kept is not needed. Hand it back
+                        // now: both exits below return, so this is the
+                        // only chance to.
+                        self.size.fetch_sub(1, Ordering::Relaxed);
+                    }
                     // Existing pair: atomic compare-and-stamp under
                     // shard guard.
                     let last = *entry.get();
@@ -359,29 +570,67 @@ impl UpdateRateLimiter {
                     return RateLimitDecision::Allowed;
                 }
                 Entry::Vacant(entry) => {
-                    // New pair: reserve a slot via the authoritative
-                    // counter BEFORE inserting. `fetch_add` is the
-                    // serialization point — concurrent new-key inserts
-                    // strictly serialize, no overshoot beyond the cap.
-                    let prev = self.size.fetch_add(1, Ordering::Relaxed);
-                    if prev >= self.max_tracked_pairs {
-                        // Cap reached. Roll back the reservation and
-                        // release the shard guard BEFORE evicting:
-                        // `evict_oldest` walks every shard, and holding
-                        // a guard across that deadlocks (the same hazard
-                        // documented on `size`). The freed slot is not
-                        // reserved across the retry — another thread may
-                        // take it, in which case the next iteration
-                        // evicts again or falls through.
-                        self.size.fetch_sub(1, Ordering::Relaxed);
-                        drop(entry);
-                        if self.evict_oldest(now) > 0 {
-                            continue;
+                    // Already holding a slot we freed by evicting: skip
+                    // the cap check and spend it.
+                    if !reserved {
+                        // Brand-new pair. Charge the sender's new-pair
+                        // budget BEFORE reserving a slot or evicting
+                        // anything, so a sender churning fresh contract
+                        // ids cannot push other peers' entries out of the
+                        // map on its way to being throttled. See the
+                        // module docs.
+                        if !budget_spent {
+                            if !self.new_pair_budget.check_and_record(sender) {
+                                drop(entry);
+                                self.new_pair_budget_rejected_total
+                                    .fetch_add(1, Ordering::Relaxed);
+                                self.log_new_pair_budget(now, sender);
+                                return RateLimitDecision::SenderNewPairBudget;
+                            }
+                            budget_spent = true;
                         }
-                        // Nothing to evict: the map is empty, so the cap
-                        // is 0. Configuration, not saturation.
-                        self.capacity_rejected_total.fetch_add(1, Ordering::Relaxed);
-                        return RateLimitDecision::CapacityExceeded;
+                        // Reserve a slot via the authoritative counter
+                        // BEFORE inserting. `fetch_add` is the
+                        // serialization point — concurrent new-key
+                        // inserts strictly serialize, no overshoot beyond
+                        // the cap.
+                        let prev = self.size.fetch_add(1, Ordering::Relaxed);
+                        if prev >= self.max_tracked_pairs {
+                            // Cap reached. Roll back and release the
+                            // shard guard BEFORE evicting: `evict_oldest`
+                            // walks every shard, and holding a guard
+                            // across that deadlocks (the same hazard
+                            // documented on `size`).
+                            self.size.fetch_sub(1, Ordering::Relaxed);
+                            drop(entry);
+                            // On the final attempt there is no retry left
+                            // to spend a freed slot on, so evicting now
+                            // would throw away an O(map) scan and shrink
+                            // the map for no admission.
+                            if attempt + 1 == MAX_ADMISSION_ATTEMPTS {
+                                break;
+                            }
+                            match self.evict_oldest(now) {
+                                // We freed the room and kept a slot: the
+                                // next iteration inserts into it without
+                                // re-running the cap check.
+                                EvictionOutcome::Reserved => {
+                                    reserved = true;
+                                    continue;
+                                }
+                                // Someone else freed room, or may have.
+                                // Spend a retry attempt rather than
+                                // dropping.
+                                EvictionOutcome::Retry => continue,
+                                // Nothing to evict and nothing ever will
+                                // be: the cap is 0. Configuration, not
+                                // saturation.
+                                EvictionOutcome::MapEmpty => {
+                                    self.capacity_rejected_total.fetch_add(1, Ordering::Relaxed);
+                                    return RateLimitDecision::CapacityExceeded;
+                                }
+                            }
+                        }
                     }
                     entry.insert(now);
                     self.accepted_total.fetch_add(1, Ordering::Relaxed);
@@ -390,13 +639,21 @@ impl UpdateRateLimiter {
             }
         }
 
+        if reserved {
+            // Unreachable by construction: a slot is only kept on a
+            // non-final attempt, and the attempt after it either inserts
+            // into it or hands it back. Returning it anyway means a
+            // future restructuring cannot leak one — a leaked
+            // reservation is never reclaimed and permanently shrinks the
+            // effective cap.
+            self.size.fetch_sub(1, Ordering::Relaxed);
+        }
         // Every attempt lost its freed slot to a concurrent caller.
         self.capacity_rejected_total.fetch_add(1, Ordering::Relaxed);
         RateLimitDecision::CapacityExceeded
     }
 
-    /// Evict the oldest tracked pairs to make room for a new one,
-    /// returning how many were removed.
+    /// Evict the oldest tracked pairs to make room for a new one.
     ///
     /// Must be called with no shard guard held — it walks every shard.
     ///
@@ -411,7 +668,44 @@ impl UpdateRateLimiter {
     /// entries stamped within the same clock tick (and, in tests, from a
     /// mock clock that has not advanced) share an `Instant`, and a
     /// cutoff comparison would take every tied entry with it.
-    fn evict_oldest(&self, now: Instant) -> usize {
+    fn evict_oldest(&self, now: Instant) -> EvictionOutcome {
+        // Another caller already made room, so there is nothing to evict
+        // and the admission should simply retry. Without this early
+        // return every concurrent newcomer pays the full
+        // O(max_tracked_pairs) scan even though the cap no longer binds.
+        // The authoritative cap check is still the `fetch_add`
+        // reservation in `check_and_record`, so a stale read here can
+        // never let the map exceed the cap; the worst case is one wasted
+        // retry.
+        if self.size.load(Ordering::Relaxed) < self.max_tracked_pairs {
+            return EvictionOutcome::Retry;
+        }
+
+        // One evictor at a time. Concurrent evictors partition the SAME
+        // map, so they select nearly the SAME victims and then race to
+        // remove entries each other has already taken: measured at the
+        // production cap under 16-thread contention, 44% of passes
+        // removed nothing at all and the average pass removed 24 entries
+        // for a full 16 384-entry scan — against a 256-entry batch. That
+        // defeats the amortisation the batch exists for AND starves the
+        // callers whose victims were stolen, which is what the retry
+        // budget was being spent on. Serialising costs a waiter nothing
+        // it was not already paying (it was running its own redundant
+        // scan), and the re-check below means a waiter that arrives
+        // after the batch is freed does no scan at all.
+        let _evicting = match self.eviction_lock.lock() {
+            Ok(guard) => guard,
+            // Poisoned only if a previous holder panicked mid-scan. The
+            // map is still consistent — `remove` is atomic per entry —
+            // so recover rather than propagate a panic onto the UPDATE
+            // receive path.
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        // The holder we queued behind may have freed the room we needed.
+        if self.size.load(Ordering::Relaxed) < self.max_tracked_pairs {
+            return EvictionOutcome::Retry;
+        }
+
         let batch = (self.max_tracked_pairs / EVICTION_BATCH_DIVISOR).max(1);
         let mut entries: Vec<(Instant, (SocketAddr, ContractInstanceId))> = self
             .last_accepted
@@ -419,7 +713,7 @@ impl UpdateRateLimiter {
             .map(|e| (*e.value(), *e.key()))
             .collect();
         if entries.is_empty() {
-            return 0;
+            return EvictionOutcome::MapEmpty;
         }
         let batch = batch.min(entries.len());
         entries.select_nth_unstable_by_key(batch - 1, |(stamped, _)| *stamped);
@@ -434,12 +728,33 @@ impl UpdateRateLimiter {
             }
         }
         if removed > 0 {
-            self.size.fetch_sub(removed, Ordering::Relaxed);
+            // Return `removed - 1` slots and KEEP one for the caller.
+            //
+            // Without this the caller has to win the cap check again
+            // against everyone else, and whether it does depends on the
+            // batch size relative to the number of concurrent callers:
+            // at the production cap (batch 256, 16 threads) it nearly
+            // always wins, but at a 1024 cap the batch is 16 and callers
+            // lose a freed slot often enough to drop ~2 admissions in
+            // 1000. Keeping a slot makes "a caller that frees room gets
+            // to use it" true by construction instead of by margin.
+            //
+            // The strict cap is unaffected: `size` counts map entries
+            // plus outstanding reservations, and every insert still
+            // passes the `fetch_add` gate. Batching is unaffected too —
+            // the batch still leaves `removed - 1` slots of headroom for
+            // the admissions that follow, which is what amortises the
+            // scan.
+            self.size.fetch_sub(removed - 1, Ordering::Relaxed);
             self.capacity_evicted_total
                 .fetch_add(removed as u64, Ordering::Relaxed);
             self.log_eviction(now, removed);
+            return EvictionOutcome::Reserved;
         }
-        removed
+        // Every victim this pass selected was taken by a concurrent
+        // caller — slots were freed, just not by us — which is a reason
+        // to retry, not to drop.
+        EvictionOutcome::Retry
     }
 
     /// Emit the saturation log line, at most once per
@@ -450,23 +765,9 @@ impl UpdateRateLimiter {
     /// old drop path left no greppable evidence on a production node
     /// (#4981).
     fn log_eviction(&self, now: Instant, removed: usize) {
-        let mut last = match self.last_eviction_log.lock() {
-            Ok(guard) => guard,
-            // Poisoned only if a previous holder panicked while
-            // formatting a log line. Losing the throttle is not worth
-            // propagating a panic from the UPDATE receive path.
-            Err(poisoned) => poisoned.into_inner(),
-        };
-        let due = match *last {
-            Some(prev) => now.saturating_duration_since(prev) >= EVICTION_LOG_INTERVAL,
-            None => true,
-        };
-        if !due {
+        if !log_due(&self.last_eviction_log, now, EVICTION_LOG_INTERVAL) {
             return;
         }
-        *last = Some(now);
-        drop(last);
-
         tracing::info!(
             evicted = removed,
             evicted_total = self.capacity_evicted_total.load(Ordering::Relaxed),
@@ -476,6 +777,31 @@ impl UpdateRateLimiter {
              (sender, contract) pairs to admit new ones. Expected on a node \
              relaying for many peers and contracts; an evicted pair's next \
              UPDATE is treated as new. Throttled to one line per minute."
+        );
+    }
+
+    /// Emit the fresh-id-churn log line, at most once per
+    /// [`NEW_PAIR_LOG_INTERVAL`].
+    ///
+    /// Throttled for the same reason the drop is worth logging at all: a
+    /// sender over its budget is over it on every message, so an
+    /// unthrottled line here would be a steady stream on exactly the
+    /// node under load. `info!` for the #4981 reason — `debug!` is
+    /// compiled out of release builds.
+    fn log_new_pair_budget(&self, now: Instant, sender: SocketAddr) {
+        if !log_due(&self.last_new_pair_log, now, NEW_PAIR_LOG_INTERVAL) {
+            return;
+        }
+
+        tracing::info!(
+            %sender,
+            dropped_total = self.new_pair_budget_rejected_total.load(Ordering::Relaxed),
+            burst = NEW_PAIR_BURST,
+            refill_interval_ms = NEW_PAIR_REFILL_INTERVAL.as_millis() as u64,
+            "UPDATE rate limiter: peer is introducing brand-new (sender, contract) \
+             pairs faster than its budget allows, so its UPDATEs for unfamiliar \
+             contracts are being dropped. Its traffic for already-tracked contracts \
+             is unaffected. Throttled to one line per minute."
         );
     }
 
@@ -502,6 +828,10 @@ impl UpdateRateLimiter {
         if removed > 0 {
             self.size.fetch_sub(removed, Ordering::Relaxed);
         }
+        // Same cadence for the per-sender new-pair budget: reclaims the
+        // entries of peers that have gone quiet (and whose buckets have
+        // fully refilled, so dropping one cannot change a decision).
+        self.new_pair_budget.cleanup();
     }
 
     /// Total accepted UPDATEs since creation. Surfaced on the node
@@ -518,12 +848,18 @@ impl UpdateRateLimiter {
         self.rejected_total.load(Ordering::Relaxed)
     }
 
-    /// Total UPDATEs rejected because the tracking map was at capacity
-    /// (a new `(sender, contract)` pair tried to register when the map
-    /// already held [`MAX_TRACKED_PAIRS`] pairs). A non-zero value
-    /// suggests an attacker is churning identities — surfaced separately
-    /// from `rejected_total` on the dashboard ("Capacity-dropped") for
-    /// that reason.
+    /// Total UPDATEs dropped because the tracking map was at capacity
+    /// and eviction could not free a slot for a new `(sender, contract)`
+    /// pair. Surfaced separately from `rejected_total` on the dashboard
+    /// ("Capacity-dropped").
+    ///
+    /// Since #4981 a full map is no longer sufficient to land here — the
+    /// oldest entries are evicted instead — so a rising value means the
+    /// map is full *and* contended: every admission attempt lost its
+    /// freed slot to a concurrent caller. Saturation itself now reads on
+    /// [`Self::capacity_evicted_total`]. It is emphatically NOT an
+    /// attacker signal: an ordinary node relaying for enough peers and
+    /// contracts saturates this map on its own.
     pub fn capacity_rejected_total(&self) -> u64 {
         self.capacity_rejected_total.load(Ordering::Relaxed)
     }
@@ -535,6 +871,25 @@ impl UpdateRateLimiter {
     /// a busy node and no longer costs those pairs their UPDATEs.
     pub fn capacity_evicted_total(&self) -> u64 {
         self.capacity_evicted_total.load(Ordering::Relaxed)
+    }
+
+    /// Total UPDATEs dropped because the sending peer was over its
+    /// budget for introducing brand-new `(sender, contract)` pairs.
+    /// Surfaced on the dashboard ("Fresh-id-dropped").
+    ///
+    /// This is the fresh-id-churn signal, and it is the one counter here
+    /// that genuinely does suggest a peer is churning identities — the
+    /// role `capacity_rejected_total` used to be given before eviction
+    /// made saturation an ordinary condition. It never counts a peer's
+    /// traffic for contracts already being tracked.
+    pub fn new_pair_budget_rejected_total(&self) -> u64 {
+        self.new_pair_budget_rejected_total.load(Ordering::Relaxed)
+    }
+
+    /// Number of senders tracked by the new-pair budget.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn tracked_senders(&self) -> usize {
+        self.new_pair_budget.len()
     }
 
     /// Number of tracked `(sender, contract)` pairs. Used by tests and
@@ -826,65 +1181,429 @@ mod tests {
         );
     }
 
-    /// The victim is the least recently used pair, not an arbitrary one.
+    /// The compensating control for what eviction gave up: a sender
+    /// churning brand-new contract ids is cut off once it has spent its
+    /// burst, instead of getting one UPDATE through per id forever.
+    ///
+    /// Before eviction, a full map refused every fresh pair outright,
+    /// which stopped this pattern as a side effect. Nothing else in the
+    /// node does (the ban list is keyed by contract, the MAD detector is
+    /// off by default, and the transport rate-limits handshakes rather
+    /// than established traffic), so the ceiling is replaced here rather
+    /// than dropped (#4997 review).
+    #[test]
+    fn a_sender_churning_fresh_contract_ids_is_cut_off_after_its_burst() {
+        const BURST: usize = 8;
+        let ts = SharedMockTimeSource::new();
+        let limiter = UpdateRateLimiter::with_new_pair_budget(
+            Arc::new(ts.clone()),
+            MIN_UPDATE_INTERVAL,
+            MAX_TRACKED_PAIRS,
+            BURST as f64,
+            MAX_TRACKED_SENDERS,
+        );
+        let attacker = mk_sender(1);
+
+        // The burst gets through: these are the pairs a legitimate peer
+        // would be introducing when it starts relaying for a batch of
+        // contracts.
+        for i in 0..BURST {
+            assert_eq!(
+                limiter.check_and_record(attacker, mk_contract(i as u8)),
+                RateLimitDecision::Allowed,
+                "fresh id {i} is within the burst"
+            );
+        }
+
+        // Past it, fresh ids are refused — and refused for a reason that
+        // says so, not as a capacity drop.
+        for i in BURST..(BURST + 32) {
+            assert_eq!(
+                limiter.check_and_record(attacker, mk_contract(i as u8)),
+                RateLimitDecision::SenderNewPairBudget,
+                "fresh id {i} is past the burst and must be refused"
+            );
+        }
+        assert_eq!(limiter.new_pair_budget_rejected_total(), 32);
+        assert_eq!(
+            limiter.len(),
+            BURST,
+            "a throttled sender must not have grown the tracking map"
+        );
+        assert_eq!(
+            limiter.capacity_evicted_total(),
+            0,
+            "a throttled sender must not have evicted anything — the budget is \
+             charged BEFORE the capacity path so churn cannot push other peers out"
+        );
+
+        // The budget refills, so this throttles rather than bans: after
+        // one interval the sender may introduce one more pair.
+        ts.advance(NEW_PAIR_REFILL_INTERVAL);
+        assert_eq!(
+            limiter.check_and_record(attacker, mk_contract(200)),
+            RateLimitDecision::Allowed,
+            "one refill interval must buy exactly one more fresh pair"
+        );
+        assert_eq!(
+            limiter.check_and_record(attacker, mk_contract(201)),
+            RateLimitDecision::SenderNewPairBudget,
+            "and only one"
+        );
+    }
+
+    /// The budget must never touch a sender's ESTABLISHED traffic, which
+    /// is the availability the #4981 fix exists to restore. A peer that
+    /// keeps updating contracts the limiter already tracks is bounded by
+    /// `min_interval` per pair and by nothing else, however long it goes
+    /// on.
+    #[test]
+    fn the_new_pair_budget_never_throttles_established_pairs() {
+        const BURST: usize = 4;
+        let ts = SharedMockTimeSource::new();
+        let limiter = UpdateRateLimiter::with_new_pair_budget(
+            Arc::new(ts.clone()),
+            MIN_UPDATE_INTERVAL,
+            MAX_TRACKED_PAIRS,
+            BURST as f64,
+            MAX_TRACKED_SENDERS,
+        );
+        let peer = mk_sender(1);
+
+        for i in 0..BURST {
+            assert_eq!(
+                limiter.check_and_record(peer, mk_contract(i as u8)),
+                RateLimitDecision::Allowed
+            );
+        }
+        // Budget fully spent: a fresh pair is refused from here on.
+        assert_eq!(
+            limiter.check_and_record(peer, mk_contract(99)),
+            RateLimitDecision::SenderNewPairBudget
+        );
+
+        // 200 rounds over the same established pairs — far more traffic
+        // than the burst — and not one of them is budget-throttled.
+        for round in 0..200 {
+            ts.advance(MIN_UPDATE_INTERVAL + Duration::from_millis(1));
+            for i in 0..BURST {
+                assert_eq!(
+                    limiter.check_and_record(peer, mk_contract(i as u8)),
+                    RateLimitDecision::Allowed,
+                    "round {round}, established pair {i} must be unaffected by the \
+                     new-pair budget"
+                );
+            }
+        }
+        assert_eq!(
+            limiter.new_pair_budget_rejected_total(),
+            1,
+            "only the one fresh pair was refused; established traffic never \
+             touches the budget"
+        );
+        assert_eq!(limiter.accepted_total(), (BURST + BURST * 200) as u64);
+    }
+
+    /// The budget is per sender: one peer churning fresh ids must not
+    /// throttle anyone else.
+    #[test]
+    fn the_new_pair_budget_is_scoped_per_sender() {
+        const BURST: usize = 2;
+        let ts = SharedMockTimeSource::new();
+        let limiter = UpdateRateLimiter::with_new_pair_budget(
+            Arc::new(ts.clone()),
+            MIN_UPDATE_INTERVAL,
+            MAX_TRACKED_PAIRS,
+            BURST as f64,
+            MAX_TRACKED_SENDERS,
+        );
+        let noisy = mk_sender(1);
+        let quiet = mk_sender(2);
+
+        for i in 0..BURST {
+            assert_eq!(
+                limiter.check_and_record(noisy, mk_contract(i as u8)),
+                RateLimitDecision::Allowed
+            );
+        }
+        assert_eq!(
+            limiter.check_and_record(noisy, mk_contract(50)),
+            RateLimitDecision::SenderNewPairBudget
+        );
+
+        for i in 0..BURST {
+            assert_eq!(
+                limiter.check_and_record(quiet, mk_contract(i as u8)),
+                RateLimitDecision::Allowed,
+                "a second sender has its own budget, untouched by the first"
+            );
+        }
+        assert_eq!(limiter.tracked_senders(), 2);
+    }
+
+    /// The sender map is bounded, and by a space the attacker does not
+    /// choose: `sender` is the immediate upstream hop, so only a peer
+    /// that has completed a handshake can occupy an entry.
+    #[test]
+    fn the_new_pair_budget_map_is_bounded() {
+        const MAX_SENDERS: usize = 4;
+        let ts = SharedMockTimeSource::new();
+        let limiter = UpdateRateLimiter::with_new_pair_budget(
+            Arc::new(ts.clone()),
+            MIN_UPDATE_INTERVAL,
+            MAX_TRACKED_PAIRS,
+            NEW_PAIR_BURST,
+            MAX_SENDERS,
+        );
+
+        for i in 0..(MAX_SENDERS * 4) {
+            limiter.check_and_record(mk_sender(i as u8), mk_contract(1));
+            assert!(
+                limiter.tracked_senders() <= MAX_SENDERS,
+                "sender {i}: the budget map must never exceed its cap"
+            );
+        }
+        assert_eq!(limiter.tracked_senders(), MAX_SENDERS);
+    }
+
+    /// Boundary case: a zero cap is the ONLY configuration in which the
+    /// limiter still refuses a new pair outright, and it must terminate
+    /// rather than spin.
+    ///
+    /// This is the one path `EvictionOutcome::MapEmpty` exists for. It
+    /// was untested, which mattered because the eviction rework turned
+    /// "evicted nothing" into a retry: had that retry not distinguished
+    /// an empty map from a contended one, a zero cap would loop through
+    /// its whole attempt budget on every call forever.
+    #[test]
+    fn a_zero_cap_refuses_every_pair_without_spinning() {
+        let ts = SharedMockTimeSource::new();
+        let limiter = UpdateRateLimiter::with_config(Arc::new(ts.clone()), MIN_UPDATE_INTERVAL, 0);
+
+        for i in 1..=4u8 {
+            assert_eq!(
+                limiter.check_and_record(mk_sender(i), mk_contract(i)),
+                RateLimitDecision::CapacityExceeded,
+                "with a zero cap there is no slot for pair {i} and nothing to evict"
+            );
+        }
+        assert_eq!(limiter.len(), 0);
+        assert_eq!(limiter.capacity_rejected_total(), 4);
+        assert_eq!(
+            limiter.capacity_evicted_total(),
+            0,
+            "an empty map has nothing to evict"
+        );
+        assert_eq!(limiter.accepted_total(), 0);
+    }
+
+    /// Cap used by the eviction-order tests. 128 gives an eviction batch
+    /// of `128 / EVICTION_BATCH_DIVISOR` = 2, and the size is what makes
+    /// these tests decisive: an arbitrary-victim implementation has to
+    /// pick the *exact* oldest pairs out of 128 candidates, three rounds
+    /// running, to survive. At the cap-8 fixtures used elsewhere the
+    /// batch clamps to 1 and an arbitrary victim is the right one 1 time
+    /// in 8, which is not a pin (measured: an implementation with the
+    /// ordering deleted passed 349 of 400 runs, #4997 review).
+    const ORDER_TEST_CAP: usize = 128;
+    /// Number of entries the eviction-order tests drive out: three
+    /// batches of two.
+    const ORDER_TEST_EVICTED: usize = 6;
+
+    /// Distinct `(sender, contract)` pairs indexed well past 256, which
+    /// is where the `u8`-keyed helpers above stop.
+    fn mk_pair(i: usize) -> (SocketAddr, ContractInstanceId) {
+        let sender = SocketAddr::from(([10, 1, (i >> 8) as u8, (i & 0xff) as u8], 30000));
+        (sender, ContractInstanceId::new([0xAB; 32]))
+    }
+
+    /// Admit fresh pairs, starting at index `from`, until the limiter has
+    /// evicted `ORDER_TEST_EVICTED` entries. Returns the next unused
+    /// index.
+    ///
+    /// Each newcomer at capacity evicts a batch of 2 and inserts 1, so
+    /// the map alternates between cap and cap-1 and only every other
+    /// newcomer triggers a batch.
+    fn admit_until_evicted(
+        limiter: &UpdateRateLimiter,
+        ts: &SharedMockTimeSource,
+        from: usize,
+    ) -> usize {
+        let mut i = from;
+        while limiter.capacity_evicted_total() < ORDER_TEST_EVICTED as u64 {
+            let (s, c) = mk_pair(i);
+            assert_eq!(
+                limiter.check_and_record(s, c),
+                RateLimitDecision::Allowed,
+                "newcomer {i} must be admitted"
+            );
+            i += 1;
+            ts.advance(Duration::from_micros(1));
+            assert!(
+                i < from + ORDER_TEST_CAP,
+                "newcomers should have driven {ORDER_TEST_EVICTED} evictions long before this"
+            );
+        }
+        assert_eq!(
+            limiter.capacity_evicted_total(),
+            ORDER_TEST_EVICTED as u64,
+            "batches of 2 must land exactly on {ORDER_TEST_EVICTED}"
+        );
+        i
+    }
+
+    /// The victims are the least recently used pairs, not arbitrary ones.
     ///
     /// Membership is observed through the limiter's own behaviour rather
     /// than a test-only accessor: a tracked pair stamped within
     /// `min_interval` answers `Rejected`, while an evicted pair is seen
     /// as new and answers `Allowed`. So "was it evicted?" is exactly
     /// "does an immediate re-check come back Allowed?".
+    ///
+    /// That discriminator only holds while EVERY pair's stamp is inside
+    /// `min_interval`, which is why the fixture advances by microseconds
+    /// and asserts the whole run stays inside the window. The previous
+    /// version of this test let the clock run 108ms before probing, so
+    /// the pair it checked for eviction was outside the window and
+    /// answered `Allowed` whether or not it had been evicted — the
+    /// assertion could not fail (#4997 review).
     #[test]
-    fn at_capacity_evicts_the_oldest_pair_not_an_arbitrary_one() {
+    fn at_capacity_evicts_the_oldest_pairs_not_arbitrary_ones() {
         let ts = SharedMockTimeSource::new();
-        let limiter = UpdateRateLimiter::with_config(Arc::new(ts.clone()), MIN_UPDATE_INTERVAL, 8);
+        let limiter = UpdateRateLimiter::with_config(
+            Arc::new(ts.clone()),
+            MIN_UPDATE_INTERVAL,
+            ORDER_TEST_CAP,
+        );
+        assert_eq!(
+            ORDER_TEST_CAP / EVICTION_BATCH_DIVISOR,
+            2,
+            "fixture assumes a 2-entry batch"
+        );
+        let start = ts.now();
 
-        // Fill, each pair stamped a millisecond apart so "oldest" is
-        // unambiguous. Pair 1 is the oldest, pair 8 the newest.
-        for i in 1..=8u8 {
-            assert!(
-                limiter
-                    .check_and_record(mk_sender(i), mk_contract(i))
-                    .is_allowed()
+        // Fill, one microsecond apart, so ages are strictly ordered:
+        // pair 0 is the oldest, pair 127 the newest.
+        for i in 0..ORDER_TEST_CAP {
+            let (s, c) = mk_pair(i);
+            assert_eq!(
+                limiter.check_and_record(s, c),
+                RateLimitDecision::Allowed,
+                "fill {i}"
             );
-            ts.advance(Duration::from_millis(1));
+            ts.advance(Duration::from_micros(1));
+        }
+        assert_eq!(limiter.len(), ORDER_TEST_CAP);
+
+        admit_until_evicted(&limiter, &ts, ORDER_TEST_CAP);
+
+        assert!(
+            ts.now().saturating_duration_since(start) < MIN_UPDATE_INTERVAL,
+            "the fixture must stay inside min_interval, or a surviving pair and an \
+             evicted one both answer Allowed and the assertions below are vacuous"
+        );
+
+        // Survivors first: a `Rejected` check does not mutate the map,
+        // whereas an `Allowed` one re-inserts and can evict again.
+        for i in ORDER_TEST_EVICTED..ORDER_TEST_CAP {
+            let (s, c) = mk_pair(i);
+            assert!(
+                matches!(
+                    limiter.check_and_record(s, c),
+                    RateLimitDecision::Rejected { .. }
+                ),
+                "pair {i} is newer than the {ORDER_TEST_EVICTED} oldest and must have survived"
+            );
+        }
+        for i in 0..ORDER_TEST_EVICTED {
+            let (s, c) = mk_pair(i);
+            assert_eq!(
+                limiter.check_and_record(s, c),
+                RateLimitDecision::Allowed,
+                "pair {i} is among the {ORDER_TEST_EVICTED} oldest and must have been evicted"
+            );
+        }
+    }
+
+    /// Accepting an UPDATE for a tracked pair restamps it, which moves it
+    /// to the BACK of the eviction order.
+    ///
+    /// This is the property the module's cost argument rests on: a
+    /// sustained flood from a *stable* pair is unaffected by eviction,
+    /// because that pair is the most recently used and therefore the last
+    /// thing evicted. It needs its own fixture because the refresh is
+    /// what destroys the membership discriminator — a pair refreshed past
+    /// `min_interval` leaves every un-refreshed pair outside the window,
+    /// so their membership stops being observable.
+    ///
+    /// The fixture works around that by refreshing all but a chosen few:
+    /// the 6 pairs left un-refreshed are the only ones outside the
+    /// window, and they are exactly the ones that must be evicted, so
+    /// every pair the test asserts on is inside the window.
+    #[test]
+    fn a_refreshed_pair_moves_to_the_back_of_the_eviction_order() {
+        let ts = SharedMockTimeSource::new();
+        let limiter = UpdateRateLimiter::with_config(
+            Arc::new(ts.clone()),
+            MIN_UPDATE_INTERVAL,
+            ORDER_TEST_CAP,
+        );
+
+        // Fill oldest-first, as above.
+        for i in 0..ORDER_TEST_CAP {
+            let (s, c) = mk_pair(i);
+            assert_eq!(
+                limiter.check_and_record(s, c),
+                RateLimitDecision::Allowed,
+                "fill {i}"
+            );
+            ts.advance(Duration::from_micros(1));
         }
 
-        // Refresh pair 1, making it the most recently used. If eviction
-        // ignored recency, this is the entry a naive "first one found"
-        // policy would still take.
+        // Past `min_interval`, refresh every pair EXCEPT indices
+        // 6..ORDER_TEST_EVICTED+6. Crucially that includes pairs 0..6 —
+        // the entries that were the oldest — so if eviction ignored the
+        // restamp it would take exactly those, and this test fails.
         ts.advance(MIN_UPDATE_INTERVAL);
-        assert!(
-            limiter
-                .check_and_record(mk_sender(1), mk_contract(1))
-                .is_allowed()
-        );
-
-        // Admit a newcomer: pair 2 is now the oldest and must be the
-        // victim.
-        assert!(
-            limiter
-                .check_and_record(mk_sender(99), mk_contract(99))
-                .is_allowed()
-        );
-        assert_eq!(limiter.capacity_evicted_total(), 1);
-
-        // Pair 1 was just refreshed, so it must still be tracked — a
-        // re-check inside min_interval is Rejected. Checked first
-        // because a Rejected check does not mutate the map.
-        assert!(
-            matches!(
-                limiter.check_and_record(mk_sender(1), mk_contract(1)),
-                RateLimitDecision::Rejected { .. }
-            ),
-            "the most recently used pair must survive eviction"
-        );
-
-        // Pair 2 was the oldest, so it is gone: it reads as new.
+        let victims = ORDER_TEST_EVICTED..(2 * ORDER_TEST_EVICTED);
+        let refreshed = ts.now();
+        for i in (0..ORDER_TEST_CAP).filter(|i| !victims.contains(i)) {
+            let (s, c) = mk_pair(i);
+            assert_eq!(
+                limiter.check_and_record(s, c),
+                RateLimitDecision::Allowed,
+                "refresh {i} must be accepted a full min_interval after the fill"
+            );
+        }
         assert_eq!(
-            limiter.check_and_record(mk_sender(2), mk_contract(2)),
-            RateLimitDecision::Allowed,
-            "the least recently used pair must be the eviction victim"
+            limiter.capacity_evicted_total(),
+            0,
+            "restamping tracked pairs must not evict anything — it never takes the \
+             capacity path"
         );
+
+        admit_until_evicted(&limiter, &ts, ORDER_TEST_CAP);
+
+        assert!(
+            ts.now().saturating_duration_since(refreshed) < MIN_UPDATE_INTERVAL,
+            "every refreshed pair must still be inside min_interval, or the \
+             assertions below are vacuous"
+        );
+
+        // Every refreshed pair survived — including 0..6, which were the
+        // oldest before the refresh. The only entries gone are the ones
+        // left un-refreshed.
+        for i in (0..ORDER_TEST_CAP).filter(|i| !victims.contains(i)) {
+            let (s, c) = mk_pair(i);
+            assert!(
+                matches!(
+                    limiter.check_and_record(s, c),
+                    RateLimitDecision::Rejected { .. }
+                ),
+                "pair {i} was refreshed, so it must be at the back of the eviction \
+                 order and must have survived"
+            );
+        }
     }
 
     /// The #4981 regression: a busy pair must not be able to hold its
@@ -1038,6 +1757,9 @@ mod tests {
                 RateLimitDecision::Allowed => allowed += 1,
                 RateLimitDecision::Rejected { .. } => rejected += 1,
                 RateLimitDecision::CapacityExceeded => panic!("unexpected cap"),
+                RateLimitDecision::SenderNewPairBudget => {
+                    panic!("one pair cannot exhaust a new-pair budget")
+                }
             }
         }
         assert_eq!(
@@ -1188,17 +1910,28 @@ mod tests {
                 RateLimitDecision::Allowed => allowed += 1,
                 RateLimitDecision::CapacityExceeded => cap_rejected += 1,
                 RateLimitDecision::Rejected { .. } => rate_rejected += 1,
+                RateLimitDecision::SenderNewPairBudget => {
+                    panic!("each thread uses a distinct sender, so no budget can be spent")
+                }
             }
         }
-        // Critical invariant, unchanged by #4981: the map size is
-        // EXACTLY the cap, not cap + overshoot. Eviction makes this a
-        // sharper test than it was — 64 threads now race to evict and
+        // Critical invariant, unchanged by #4981: the map never exceeds
+        // the cap, no matter how many callers race. Eviction makes this
+        // a sharper test than it was — 64 threads now race to evict and
         // insert concurrently, and the reservation counter still has to
         // hold the line.
-        assert_eq!(
-            limiter.len(),
-            CAP,
-            "strict cap: map size must equal CAP after a 64-thread \
+        //
+        // It is an upper bound, NOT an equality. Admissions are not
+        // conserved under eviction: a caller can free a slot and then
+        // lose it to another thread on every remaining attempt, so a run
+        // can legitimately end one or more entries BELOW the cap. Pinning
+        // `len() == CAP` made this test fail ~1 run in 100 (#4997
+        // review measured it at 44/800 before the eviction scan was
+        // serialised, 7/800 after) — a flaky test asserting something the
+        // implementation never promised.
+        assert!(
+            limiter.len() <= CAP,
+            "strict cap: map size must never exceed CAP after a 64-thread \
              concurrent flood of distinct keys, got {}",
             limiter.len()
         );
@@ -1219,10 +1952,23 @@ mod tests {
         // slot to another thread `MAX_ADMISSION_ATTEMPTS` times running,
         // so it is contention-dependent rather than a fixed count.
         assert_eq!(limiter.capacity_rejected_total(), cap_rejected as u64);
+        // Conservation, which IS exact: every `Allowed` inserted one
+        // entry and every eviction removed one, and nothing else mutates
+        // the map here (no `cleanup`, and distinct keys mean no caller
+        // ever takes the Occupied restamp path). So whatever the final
+        // size turns out to be, it must be exactly what was put in minus
+        // what was taken out.
+        //
+        // This replaces `evicted == allowed - CAP`, which assumed the map
+        // ends exactly full and was wrong for the same reason the size
+        // assertion above was.
         assert_eq!(
-            limiter.capacity_evicted_total(),
-            (allowed - CAP) as u64,
-            "every admission beyond the first CAP must have evicted exactly one entry"
+            limiter.len() as u64,
+            allowed as u64 - limiter.capacity_evicted_total(),
+            "inserts minus evictions must account for every tracked entry: \
+             len={} allowed={allowed} evicted={}",
+            limiter.len(),
+            limiter.capacity_evicted_total()
         );
     }
 
@@ -1260,6 +2006,27 @@ mod tests {
             preamble.contains(&strip_ws("tracing::info!")),
             "the eviction log must be emitted at info! or higher; debug! is compiled out of \
              release builds by release_max_level_info (#4981)"
+        );
+
+        // The fresh-id-churn line, also in this file. This one is the
+        // ONLY release-visible evidence of that drop — the dispatch site
+        // logs it at `debug!` on purpose, because a sender over its
+        // budget is over it on every message and an unthrottled line
+        // there would be a flood. Downgrading this one would make the
+        // whole signal invisible in release.
+        let churn_marker = strip_ws(concat!(
+            "UPDATE rate limiter: peer is introducing ",
+            "brand-new (sender, contract)"
+        ));
+        let pos = this_file.find(&churn_marker).expect(
+            "the new-pair-budget log line must exist; if it was renamed, update this pin rather \
+             than deleting it",
+        );
+        let preamble = &this_file[pos.saturating_sub(200)..pos];
+        assert!(
+            preamble.contains(&strip_ws("tracing::info!")),
+            "the new-pair-budget log must be emitted at info! or higher; debug! is compiled out \
+             of release builds by release_max_level_info (#4981)"
         );
 
         // The residual capacity drop, in the UPDATE dispatch path.
@@ -1321,5 +2088,84 @@ mod tests {
                 "after cleanup, new pair (sender={i}) should be admitted"
             );
         }
+    }
+
+    /// Regression pin for the spurious capacity drops #4997's review
+    /// measured: under concurrent admission of new pairs at a saturated
+    /// cap, `CapacityExceeded` must be vanishingly rare.
+    ///
+    /// The bug it pins: `evict_oldest` returning "removed nothing" was
+    /// read as "the map is empty, so the cap is 0" and the UPDATE was
+    /// dropped. Under contention that return means the opposite — every
+    /// victim this caller selected was taken by another caller, so slots
+    /// WERE just freed — and it did not even spend the retry budget that
+    /// exists for the race. Measured at the production cap with 16
+    /// threads: 2 699 drops in 320 000 admissions (0.84%), every trial
+    /// affected, 100% of them from that branch, retry budget untouched.
+    /// After the fix, 7 in 320 000 (0.002%).
+    ///
+    /// The threshold below sits between those two by more than an order
+    /// of magnitude in both directions, so it is neither flaky nor
+    /// vacuous. It is a bound rather than zero because losing a freed
+    /// slot to a concurrent caller on every attempt is genuinely
+    /// possible — that is what `CapacityExceeded` is documented to mean.
+    #[test]
+    fn concurrent_admission_at_capacity_almost_never_drops() {
+        use std::sync::{Arc as StdArc, Barrier};
+        use std::thread;
+
+        const CAP: usize = 1024;
+        const THREADS: usize = 16;
+        const PER_THREAD: usize = 400;
+        const ADMISSIONS: usize = THREADS * PER_THREAD;
+        /// One drop per this many admissions is the ceiling. The bug
+        /// produced ~8 per thousand; the fix produces ~0.02.
+        const MAX_DROPS_PER_THOUSAND: usize = 1;
+
+        let ts = SharedMockTimeSource::new();
+        let limiter = StdArc::new(UpdateRateLimiter::with_new_pair_budget(
+            Arc::new(ts.clone()),
+            MIN_UPDATE_INTERVAL,
+            CAP,
+            // The new-pair budget is not what this test is about, and a
+            // synthetic flood of fresh pairs would otherwise be stopped
+            // by it before reaching the capacity path.
+            f64::from(u32::MAX),
+            THREADS,
+        ));
+        let barrier = StdArc::new(Barrier::new(THREADS));
+        let mut handles = Vec::with_capacity(THREADS);
+
+        for t in 0..THREADS {
+            let l = limiter.clone();
+            let b = barrier.clone();
+            handles.push(thread::spawn(move || {
+                b.wait();
+                for i in 0..PER_THREAD {
+                    // Distinct sender per thread, distinct contract per
+                    // iteration: every call takes the new-pair path.
+                    let sender = mk_sender(t as u8);
+                    let mut id = [0u8; 32];
+                    id[..8].copy_from_slice(&(i as u64).to_be_bytes());
+                    l.check_and_record(sender, ContractInstanceId::new(id));
+                }
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        assert!(
+            limiter.capacity_evicted_total() > 0,
+            "fixture must actually saturate the cap, or it pins nothing"
+        );
+        let drops = limiter.capacity_rejected_total();
+        assert!(
+            drops as usize * 1000 <= ADMISSIONS * MAX_DROPS_PER_THOUSAND,
+            "at most {MAX_DROPS_PER_THOUSAND} drop per 1000 admissions, got {drops} \
+             in {ADMISSIONS}. An eviction that removed nothing means a concurrent \
+             caller freed the slots, so the admission must retry, not drop."
+        );
+        assert!(limiter.len() <= CAP);
     }
 }

--- a/crates/core/src/ring/update_rate_limit.rs
+++ b/crates/core/src/ring/update_rate_limit.rs
@@ -95,15 +95,32 @@
 //!
 //! Two properties make this the right shape:
 //!
-//! - **Established traffic never touches it.** A token is spent on the
-//!   new-pair path only, so a peer relaying heavily for contracts the
-//!   limiter already tracks is bounded by [`MIN_UPDATE_INTERVAL`] per
-//!   pair and by nothing else — the availability this fix exists to
-//!   restore is not clawed back.
+//! - **Traffic for a pair the limiter is tracking never touches it.** A
+//!   token is spent only when the pair is not currently in the map, so a
+//!   peer relaying heavily for contracts the limiter holds is bounded by
+//!   [`MIN_UPDATE_INTERVAL`] per pair and by nothing else.
 //! - **It is charged before eviction, not after.** A sender past its
 //!   budget is refused *before* a slot is reserved or anything is
 //!   evicted, so churning fresh ids cannot push other peers' entries out
 //!   of the map on the way to being throttled.
+//!
+//! The caveat, stated rather than glossed: "not currently in the map"
+//! includes a pair that WAS tracked and then got evicted. The limiter
+//! cannot tell a returning pair from a genuinely fresh one without
+//! remembering what it evicted, which is exactly the unbounded memory
+//! the cap exists to refuse. So on a node whose working set far exceeds
+//! [`MAX_TRACKED_PAIRS`] — where the miss rate is high — this behaves
+//! less like a fresh-id bound and more like a per-peer aggregate
+//! ceiling.
+//!
+//! That is why the sustained rate is set well ABOVE
+//! [`MIN_UPDATE_INTERVAL`]'s per-pair ceiling rather than at it: a peer
+//! would have to sustain [`NEW_PAIR_BURST`] and then 200 UPDATEs/s to
+//! this node, continuously, before any of it is dropped. If that ever
+//! binds on real traffic it is visible as
+//! `new_pair_budget_rejected_total` climbing on a node with no attacker,
+//! which is the signal to raise the rate — the counter is on the
+//! dashboard for exactly that reason.
 //!
 //! Its own map is bounded by [`MAX_TRACKED_SENDERS`], which is a
 //! multiple of the node's connection cap rather than an attacker-chosen
@@ -159,7 +176,7 @@ use freenet_stdlib::prelude::ContractInstanceId;
 use tokio::time::Instant;
 
 use super::Ring;
-use super::resync_rate_limit::TokenBucketLimiter;
+use super::resync_rate_limit::{BucketOutcome, TokenBucketLimiter};
 use crate::util::time_source::TimeSource;
 
 /// Minimum interval between accepted UPDATEs for the same
@@ -245,27 +262,36 @@ const MAX_ADMISSION_ATTEMPTS: usize = 6;
 /// and re-subscribes, or one that starts relaying for a batch of
 /// contracts at once — with room to spare over the ~330 pairs per peer
 /// implied by the saturation #4981 reported (≈16 500 pairs across ≈50
-/// peers). A sender only spends a token when it presents a pair the
-/// limiter has never seen, so established traffic never touches this.
-const NEW_PAIR_BURST: f64 = 512.0;
+/// peers).
+const NEW_PAIR_BURST: f64 = 1024.0;
 
-/// Sustained rate at which one sender may introduce brand-new pairs once
-/// its burst is spent: one per interval.
+/// Sustained rate at which one sender may present pairs the limiter is
+/// not currently tracking, once its burst is spent: one per interval.
 ///
-/// Deliberately [`MIN_UPDATE_INTERVAL`], so both ceilings read the same
-/// way: a sender may introduce new pairs no faster than it may repeat an
-/// UPDATE on a single pair (10/s at the defaults).
-const NEW_PAIR_REFILL_INTERVAL: Duration = MIN_UPDATE_INTERVAL;
+/// 5ms, i.e. 200/s — twenty times [`MIN_UPDATE_INTERVAL`]'s per-pair
+/// ceiling. Deliberately not set equal to it: under saturation a pair
+/// that was tracked and got evicted comes back through this same path
+/// (see the module docs), so a rate tuned for genuinely-fresh ids would
+/// throttle ordinary relayed traffic on exactly the busy node this fix
+/// exists to keep serving. A peer must sustain 200 UPDATEs/s to this
+/// node, continuously, before anything is dropped, while a fresh-id
+/// flood is still bounded instead of unlimited.
+const NEW_PAIR_REFILL_INTERVAL: Duration = Duration::from_millis(5);
 
-/// Cap on the senders tracked by the new-pair budget.
+/// Headroom multiple over the node's configured `max_connections` for
+/// the new-pair budget's own map.
 ///
 /// One entry per peer address that has presented a new pair. `sender` is
-/// the immediate upstream hop, so the live set is bounded by this node's
-/// connection count; the multiple over [`Ring::DEFAULT_MAX_CONNECTIONS`]
-/// is headroom for address churn (reconnects, NAT rebinding) between
-/// [`CLEANUP_AGE`] sweeps. At ~48 bytes an entry the whole map is well
-/// under 100 KB.
-const MAX_TRACKED_SENDERS: usize = 8 * Ring::DEFAULT_MAX_CONNECTIONS;
+/// the immediate upstream hop, so the live set is bounded by the
+/// connection cap; the multiple is headroom for address churn
+/// (reconnects, NAT rebinding) between [`CLEANUP_AGE`] sweeps. At ~48
+/// bytes an entry, 8x the default 200-connection cap is well under
+/// 100 KB.
+///
+/// Derived from the configured value rather than a constant: a node
+/// raised above [`Ring::DEFAULT_MAX_CONNECTIONS`] would otherwise run a
+/// budget map smaller than its own peer count.
+const SENDER_TRACKING_HEADROOM: usize = 8;
 
 /// How often an exhausted new-pair budget may write a log line.
 ///
@@ -288,12 +314,23 @@ const NEW_PAIR_LOG_INTERVAL: Duration = EVICTION_LOG_INTERVAL;
 ///    oldest entries.
 /// 3. The map is empty, so there is nothing to evict and never will be.
 ///
-/// 1 and 2 mean a slot is, or may already be, free: the right move is to
-/// retry the admission, which is what [`MAX_ADMISSION_ATTEMPTS`] exists
-/// for. Only 3 is a configuration problem. Conflating them dropped ~0.9%
-/// of admissions at the production cap under 16-thread contention, none
-/// of them for the documented reason, and without consuming a single
-/// retry attempt (#4997 review).
+/// 1, 2 and 3 all mean a slot is, or may already be, free: the right
+/// move is to retry the admission, which is what
+/// [`MAX_ADMISSION_ATTEMPTS`] exists for. Conflating them with the one
+/// genuinely terminal case dropped ~0.9% of admissions at the production
+/// cap under 16-thread contention, none of them for the documented
+/// reason, and without consuming a single retry attempt (#4997 review).
+///
+/// Note that 3 — an empty map — is NOT terminal, and inferring "the cap
+/// must be 0" from it was a second instance of the same mistake. A map
+/// with a perfectly good cap reads as empty in two windows: while
+/// [`UpdateRateLimiter::cleanup`] is sweeping, and while every caller
+/// that has won a slot is still between its reservation and its insert
+/// (reachable at small caps under contention, e.g. 8 slots and 64
+/// callers). In both, `size` is legitimately at the cap while the map is
+/// not, and slots are about to exist. The only terminal condition is a
+/// cap of zero, which is a property of the configuration and is read
+/// from it directly rather than inferred.
 enum EvictionOutcome {
     /// This pass freed slots and kept one of them for the caller, which
     /// therefore does not have to win the cap check again — it inserts
@@ -302,9 +339,9 @@ enum EvictionOutcome {
     /// A slot is, or may already be, free, but this caller did not free
     /// it and holds no claim on it. Retry the admission.
     Retry,
-    /// The map is empty — reachable only with `max_tracked_pairs == 0`.
-    /// Terminal.
-    MapEmpty,
+    /// `max_tracked_pairs` is 0, so no admission can ever succeed.
+    /// Terminal, and the only terminal case.
+    CapIsZero,
 }
 
 /// Whether a throttled log line is due, stamping `slot` when it is.
@@ -441,16 +478,35 @@ pub(crate) struct UpdateRateLimiter {
     /// Total UPDATEs dropped because the sender was over its new-pair
     /// budget.
     new_pair_budget_rejected_total: AtomicU64,
+    /// Total new pairs admitted WITHOUT a budget check because the
+    /// sender map was full. Should be zero: the map is sized well above
+    /// the connection cap, and this failing open is a safety valve, not
+    /// an expected path. A non-zero value means `max_tracked_senders` is
+    /// undersized for this node.
+    new_pair_budget_untracked_total: AtomicU64,
     /// When the last new-pair-budget log line was written, for
     /// [`NEW_PAIR_LOG_INTERVAL`] throttling.
     last_new_pair_log: Mutex<Option<Instant>>,
 }
 
 impl UpdateRateLimiter {
-    pub fn new(time_source: Arc<dyn TimeSource + Send + Sync>) -> Self {
-        Self::with_config(time_source, MIN_UPDATE_INTERVAL, MAX_TRACKED_PAIRS)
+    /// `max_connections` is this node's configured connection cap; the
+    /// per-sender budget's map is sized from it (see
+    /// [`SENDER_TRACKING_HEADROOM`]).
+    pub fn new(time_source: Arc<dyn TimeSource + Send + Sync>, max_connections: usize) -> Self {
+        Self::with_new_pair_budget(
+            time_source,
+            MIN_UPDATE_INTERVAL,
+            MAX_TRACKED_PAIRS,
+            NEW_PAIR_BURST,
+            max_connections.saturating_mul(SENDER_TRACKING_HEADROOM),
+        )
     }
 
+    /// Test/bench constructor: the production path is [`Self::new`],
+    /// which sizes the per-sender budget from the node's own connection
+    /// cap rather than the default.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn with_config(
         time_source: Arc<dyn TimeSource + Send + Sync>,
         min_interval: Duration,
@@ -461,7 +517,7 @@ impl UpdateRateLimiter {
             min_interval,
             max_tracked_pairs,
             NEW_PAIR_BURST,
-            MAX_TRACKED_SENDERS,
+            Ring::DEFAULT_MAX_CONNECTIONS * SENDER_TRACKING_HEADROOM,
         )
     }
 
@@ -484,6 +540,7 @@ impl UpdateRateLimiter {
                 max_tracked_senders,
             ),
             new_pair_budget_rejected_total: AtomicU64::new(0),
+            new_pair_budget_untracked_total: AtomicU64::new(0),
             last_new_pair_log: Mutex::new(None),
             last_accepted: DashMap::new(),
             size: AtomicUsize::new(0),
@@ -580,14 +637,32 @@ impl UpdateRateLimiter {
                         // map on its way to being throttled. See the
                         // module docs.
                         if !budget_spent {
-                            if !self.new_pair_budget.check_and_record(sender) {
-                                drop(entry);
-                                self.new_pair_budget_rejected_total
-                                    .fetch_add(1, Ordering::Relaxed);
-                                self.log_new_pair_budget(now, sender);
-                                return RateLimitDecision::SenderNewPairBudget;
+                            match self.new_pair_budget.check_and_record_detailed(sender) {
+                                BucketOutcome::Allowed => budget_spent = true,
+                                BucketOutcome::RateLimited => {
+                                    drop(entry);
+                                    self.new_pair_budget_rejected_total
+                                        .fetch_add(1, Ordering::Relaxed);
+                                    self.log_new_pair_budget(now, sender);
+                                    return RateLimitDecision::SenderNewPairBudget;
+                                }
+                                // The budget map is full, so this sender
+                                // has no bucket and nothing is known
+                                // about its rate. Fail OPEN: refusing
+                                // here would starve a newcomer for a
+                                // sizing accident, and a bounded map
+                                // that permanently refuses newcomers
+                                // once full is precisely the #4981 shape
+                                // this PR removes — `Bucket::refill`
+                                // restamps on every check, so an active
+                                // sender's entry never ages out and the
+                                // newcomer would never recover.
+                                BucketOutcome::Untracked => {
+                                    self.new_pair_budget_untracked_total
+                                        .fetch_add(1, Ordering::Relaxed);
+                                    budget_spent = true;
+                                }
                             }
-                            budget_spent = true;
                         }
                         // Reserve a slot via the authoritative counter
                         // BEFORE inserting. `fetch_add` is the
@@ -623,9 +698,8 @@ impl UpdateRateLimiter {
                                 // dropping.
                                 EvictionOutcome::Retry => continue,
                                 // Nothing to evict and nothing ever will
-                                // be: the cap is 0. Configuration, not
-                                // saturation.
-                                EvictionOutcome::MapEmpty => {
+                                // be. Configuration, not saturation.
+                                EvictionOutcome::CapIsZero => {
                                     self.capacity_rejected_total.fetch_add(1, Ordering::Relaxed);
                                     return RateLimitDecision::CapacityExceeded;
                                 }
@@ -669,6 +743,11 @@ impl UpdateRateLimiter {
     /// mock clock that has not advanced) share an `Instant`, and a
     /// cutoff comparison would take every tied entry with it.
     fn evict_oldest(&self, now: Instant) -> EvictionOutcome {
+        // The one terminal condition, read from the configuration rather
+        // than inferred from an empty map — see `EvictionOutcome`.
+        if self.max_tracked_pairs == 0 {
+            return EvictionOutcome::CapIsZero;
+        }
         // Another caller already made room, so there is nothing to evict
         // and the admission should simply retry. Without this early
         // return every concurrent newcomer pays the full
@@ -693,7 +772,7 @@ impl UpdateRateLimiter {
         // it was not already paying (it was running its own redundant
         // scan), and the re-check below means a waiter that arrives
         // after the batch is freed does no scan at all.
-        let _evicting = match self.eviction_lock.lock() {
+        let evicting = match self.eviction_lock.lock() {
             Ok(guard) => guard,
             // Poisoned only if a previous holder panicked mid-scan. The
             // map is still consistent — `remove` is atomic per entry —
@@ -713,7 +792,9 @@ impl UpdateRateLimiter {
             .map(|e| (*e.value(), *e.key()))
             .collect();
         if entries.is_empty() {
-            return EvictionOutcome::MapEmpty;
+            // Not terminal: `size` reads at the cap while the map does
+            // not, so slots are about to exist. See `EvictionOutcome`.
+            return EvictionOutcome::Retry;
         }
         let batch = batch.min(entries.len());
         entries.select_nth_unstable_by_key(batch - 1, |(stamped, _)| *stamped);
@@ -748,6 +829,9 @@ impl UpdateRateLimiter {
             self.size.fetch_sub(removed - 1, Ordering::Relaxed);
             self.capacity_evicted_total
                 .fetch_add(removed as u64, Ordering::Relaxed);
+            // Log outside the lock: formatting and the tracing subscriber
+            // are not work the next evictor should queue behind.
+            drop(evicting);
             self.log_eviction(now, removed);
             return EvictionOutcome::Reserved;
         }
@@ -808,26 +892,26 @@ impl UpdateRateLimiter {
     /// Drop entries whose timestamp is older than [`CLEANUP_AGE`].
     /// Call periodically from a reaper loop to bound memory.
     ///
-    /// Decrements the [`Self::size`] counter by the number of
-    /// removed entries so the strict capacity enforcement remains
-    /// accurate as idle pairs roll off.
+    /// Decrements the [`Self::size`] counter as it goes, so the strict
+    /// capacity enforcement stays accurate as idle pairs roll off.
+    ///
+    /// Per removal rather than once at the end: batching the decrement
+    /// leaves `size` reading full for the whole sweep, so a concurrent
+    /// admission sees a full map that is in fact being emptied, and
+    /// spends attempts evicting from it (#4997 review).
     pub fn cleanup(&self) {
         let now = self.time_source.now();
         let cutoff = match now.checked_sub(CLEANUP_AGE) {
             Some(t) => t,
             None => return, // clock not advanced enough to bother
         };
-        let mut removed = 0usize;
         self.last_accepted.retain(|_, last| {
             let keep = *last >= cutoff;
             if !keep {
-                removed += 1;
+                self.size.fetch_sub(1, Ordering::Relaxed);
             }
             keep
         });
-        if removed > 0 {
-            self.size.fetch_sub(removed, Ordering::Relaxed);
-        }
         // Same cadence for the per-sender new-pair budget: reclaims the
         // entries of peers that have gone quiet (and whose buckets have
         // fully refilled, so dropping one cannot change a decision).
@@ -915,7 +999,7 @@ mod tests {
 
     fn mk_limiter() -> (UpdateRateLimiter, SharedMockTimeSource) {
         let ts = SharedMockTimeSource::new();
-        let limiter = UpdateRateLimiter::new(Arc::new(ts.clone()));
+        let limiter = UpdateRateLimiter::new(Arc::new(ts.clone()), Ring::DEFAULT_MAX_CONNECTIONS);
         (limiter, ts)
     }
 
@@ -1129,7 +1213,7 @@ mod tests {
     /// which pinned the starvation bug as if it were the contract. What
     /// it checked that still holds is kept: the map never exceeds the
     /// cap, and existing pairs keep working. See
-    /// `at_capacity_evicts_the_oldest_pair_not_an_arbitrary_one` for the
+    /// `at_capacity_evicts_the_oldest_pairs_not_arbitrary_ones` for the
     /// eviction order and
     /// `busy_pairs_cannot_hold_slots_against_newcomers` for the
     /// starvation regression itself.
@@ -1200,7 +1284,7 @@ mod tests {
             MIN_UPDATE_INTERVAL,
             MAX_TRACKED_PAIRS,
             BURST as f64,
-            MAX_TRACKED_SENDERS,
+            Ring::DEFAULT_MAX_CONNECTIONS * SENDER_TRACKING_HEADROOM,
         );
         let attacker = mk_sender(1);
 
@@ -1266,7 +1350,7 @@ mod tests {
             MIN_UPDATE_INTERVAL,
             MAX_TRACKED_PAIRS,
             BURST as f64,
-            MAX_TRACKED_SENDERS,
+            Ring::DEFAULT_MAX_CONNECTIONS * SENDER_TRACKING_HEADROOM,
         );
         let peer = mk_sender(1);
 
@@ -1304,6 +1388,85 @@ mod tests {
         assert_eq!(limiter.accepted_total(), (BURST + BURST * 200) as u64);
     }
 
+    /// The saturated case, which is the one that decides whether this
+    /// control is safe to ship: on a node whose working set far exceeds
+    /// the cap, a pair is evicted before its next UPDATE arrives, so
+    /// ordinary relayed traffic keeps re-entering the new-pair path.
+    ///
+    /// The limiter cannot tell a returning pair from a fresh one, so it
+    /// IS charged — which is why the sustained rate is 200/s and not the
+    /// per-pair 10/s. This pins the consequence both ways: a peer
+    /// running at that sustained rate is never throttled, however long
+    /// it goes on, and the bound is nonetheless real.
+    ///
+    /// Without this fixture the only budget test at a realistic cap was
+    /// one that never saturated, which could not have caught a rate
+    /// tuned for genuinely-fresh ids throttling relayed traffic (#4997
+    /// review).
+    #[test]
+    fn under_saturation_re_admitted_pairs_are_not_throttled_at_the_sustained_rate() {
+        // Half the contracts fit, so by the time one comes round again
+        // it has been evicted: every check takes the new-pair path.
+        const CAP: usize = 64;
+        const CONTRACTS: u8 = 128;
+        const CYCLES: usize = 20;
+
+        let ts = SharedMockTimeSource::new();
+        let limiter =
+            UpdateRateLimiter::with_config(Arc::new(ts.clone()), MIN_UPDATE_INTERVAL, CAP);
+        let peer = mk_sender(1);
+
+        for cycle in 0..CYCLES {
+            for c in 0..CONTRACTS {
+                assert_eq!(
+                    limiter.check_and_record(peer, mk_contract(c)),
+                    RateLimitDecision::Allowed,
+                    "cycle {cycle}, contract {c}: a peer relaying at the sustained rate \
+                     must not be throttled, even though eviction keeps making its pairs \
+                     look new"
+                );
+                ts.advance(NEW_PAIR_REFILL_INTERVAL);
+            }
+        }
+
+        assert!(
+            limiter.capacity_evicted_total() > 0,
+            "fixture must actually saturate, or it proves nothing about re-admission"
+        );
+        assert_eq!(
+            limiter.new_pair_budget_rejected_total(),
+            0,
+            "nothing may be dropped at the sustained rate"
+        );
+
+        // The bound is still real: with the clock stopped, the same peer
+        // spends its burst and is then cut off. It takes more than
+        // NEW_PAIR_BURST pairs to get there, which is the point — the
+        // burst is what keeps a legitimate reconnect flurry through.
+        let attempts = NEW_PAIR_BURST as usize * 2;
+        let mut refused = 0;
+        for c in 0..attempts {
+            let mut id = [0u8; 32];
+            id[..8].copy_from_slice(&(c as u64).to_be_bytes());
+            id[8] = 0xEE; // disjoint from mk_contract's key space
+            if limiter.check_and_record(peer, ContractInstanceId::new(id))
+                == RateLimitDecision::SenderNewPairBudget
+            {
+                refused += 1;
+            }
+        }
+        assert!(
+            refused > 0,
+            "a peer presenting unfamiliar pairs with no time passing must eventually \
+             be refused, or the budget bounds nothing"
+        );
+        assert!(
+            refused < attempts,
+            "and the burst must let a substantial run through before that: \
+             {refused} of {attempts} refused"
+        );
+    }
+
     /// The budget is per sender: one peer churning fresh ids must not
     /// throttle anyone else.
     #[test]
@@ -1315,7 +1478,7 @@ mod tests {
             MIN_UPDATE_INTERVAL,
             MAX_TRACKED_PAIRS,
             BURST as f64,
-            MAX_TRACKED_SENDERS,
+            Ring::DEFAULT_MAX_CONNECTIONS * SENDER_TRACKING_HEADROOM,
         );
         let noisy = mk_sender(1);
         let quiet = mk_sender(2);
@@ -1364,6 +1527,83 @@ mod tests {
             );
         }
         assert_eq!(limiter.tracked_senders(), MAX_SENDERS);
+    }
+
+    /// An empty map is NOT a reason to give up, even though the map
+    /// being empty looks like there is nothing to evict.
+    ///
+    /// `size` reads at the cap while the map does not in two real
+    /// windows — while `cleanup` is sweeping, and while every caller
+    /// that won a slot is still between its reservation and its insert
+    /// (reachable at small caps under contention: 8 slots, 64 callers).
+    /// Inferring "the cap must be 0" from an empty map dropped the
+    /// UPDATE in both, without spending a single retry attempt — the
+    /// same mistake as reading a zero-removal eviction as terminal, one
+    /// branch over (#4997 review).
+    ///
+    /// White-box because the windows are races: the condition is forced
+    /// directly rather than raced for, so the test is deterministic.
+    #[test]
+    fn an_empty_map_at_a_nonzero_cap_retries_rather_than_dropping() {
+        let ts = SharedMockTimeSource::new();
+        let limiter = UpdateRateLimiter::with_config(Arc::new(ts.clone()), MIN_UPDATE_INTERVAL, 8);
+
+        // The map is empty and `size` says otherwise, exactly as during
+        // a `cleanup` sweep.
+        limiter.size.store(8, Ordering::Relaxed);
+        assert_eq!(limiter.len(), 0);
+        assert!(
+            matches!(limiter.evict_oldest(ts.now()), EvictionOutcome::Retry),
+            "an empty map at a non-zero cap means slots are about to exist, not that \
+             the cap is zero"
+        );
+
+        // And with a zero cap it IS terminal, whatever the map says.
+        let zero = UpdateRateLimiter::with_config(Arc::new(ts.clone()), MIN_UPDATE_INTERVAL, 0);
+        assert!(matches!(
+            zero.evict_oldest(ts.now()),
+            EvictionOutcome::CapIsZero
+        ));
+    }
+
+    /// After a sweep, `size` equals the map length — the accounting
+    /// invariant the cap enforcement rests on, across a sweep that both
+    /// keeps and drops entries.
+    ///
+    /// Deliberately NOT claiming to pin the mid-sweep window: `cleanup`
+    /// decrements per removal rather than settling up at the end, so a
+    /// concurrent admission never sees a full `size` over an emptying
+    /// map, but that window is not observable from outside and this test
+    /// passes either way. What covers the consequence is
+    /// `an_empty_map_at_a_nonzero_cap_retries_rather_than_dropping`,
+    /// which forces the condition directly.
+    #[test]
+    fn cleanup_leaves_the_size_counter_equal_to_the_map_length() {
+        let ts = SharedMockTimeSource::new();
+        let limiter = UpdateRateLimiter::with_config(Arc::new(ts.clone()), MIN_UPDATE_INTERVAL, 8);
+        for i in 1..=8u8 {
+            assert!(
+                limiter
+                    .check_and_record(mk_sender(i), mk_contract(i))
+                    .is_allowed()
+            );
+        }
+        // Age out half of them, so the sweep both keeps and drops.
+        ts.advance(CLEANUP_AGE + Duration::from_secs(1));
+        for i in 1..=4u8 {
+            assert!(
+                limiter
+                    .check_and_record(mk_sender(i), mk_contract(i))
+                    .is_allowed()
+            );
+        }
+        limiter.cleanup();
+        assert_eq!(limiter.len(), 4);
+        assert_eq!(
+            limiter.size.load(Ordering::Relaxed),
+            limiter.len(),
+            "size must equal the map length after a sweep"
+        );
     }
 
     /// Boundary case: a zero cap is the ONLY configuration in which the
@@ -1733,7 +1973,10 @@ mod tests {
         use std::thread;
 
         let ts = SharedMockTimeSource::new();
-        let limiter = StdArc::new(UpdateRateLimiter::new(Arc::new(ts.clone())));
+        let limiter = StdArc::new(UpdateRateLimiter::new(
+            Arc::new(ts.clone()),
+            Ring::DEFAULT_MAX_CONNECTIONS,
+        ));
         let sender = mk_sender(1);
         let contract = mk_contract(1);
 
@@ -1994,16 +2237,34 @@ mod tests {
             s.chars().filter(|c| !c.is_whitespace()).collect()
         }
 
+        /// The macro invoked for the log line whose message contains
+        /// `marker`: the nearest `tracing::<level>!` at or before it.
+        ///
+        /// Searching backwards to the nearest `tracing::` rather than
+        /// scanning a fixed-size window, because a window has to be
+        /// bigger than the call's structured fields and every field
+        /// added eats into it — the eviction site was already within ~19
+        /// characters of breaking a 200-char window (#4997 review).
+        fn level_of(haystack: &str, marker: &str, what: &str) -> String {
+            let pos = haystack.find(marker).unwrap_or_else(|| {
+                panic!("the {what} log line must exist; if it was renamed, update this pin rather than deleting it")
+            });
+            let start = haystack[..pos]
+                .rfind(&strip_ws("tracing::"))
+                .unwrap_or_else(|| panic!("no tracing:: macro precedes the {what} log line"));
+            let tail = &haystack[start..pos];
+            tail[..tail.find('!').unwrap_or(tail.len())].to_string()
+        }
+
         // The limiter's own saturation line, in this file.
         let this_file = strip_ws(include_str!("update_rate_limit.rs"));
-        let eviction_marker = strip_ws(concat!("UPDATE rate limiter at ", "capacity: evicted"));
-        let pos = this_file.find(&eviction_marker).expect(
-            "the eviction log line must exist; if it was renamed, update this pin rather than \
-             deleting it",
-        );
-        let preamble = &this_file[pos.saturating_sub(200)..pos];
-        assert!(
-            preamble.contains(&strip_ws("tracing::info!")),
+        assert_eq!(
+            level_of(
+                &this_file,
+                &strip_ws(concat!("UPDATE rate limiter at ", "capacity: evicted")),
+                "eviction",
+            ),
+            strip_ws("tracing::info"),
             "the eviction log must be emitted at info! or higher; debug! is compiled out of \
              release builds by release_max_level_info (#4981)"
         );
@@ -2014,37 +2275,31 @@ mod tests {
         // budget is over it on every message and an unthrottled line
         // there would be a flood. Downgrading this one would make the
         // whole signal invisible in release.
-        let churn_marker = strip_ws(concat!(
-            "UPDATE rate limiter: peer is introducing ",
-            "brand-new (sender, contract)"
-        ));
-        let pos = this_file.find(&churn_marker).expect(
-            "the new-pair-budget log line must exist; if it was renamed, update this pin rather \
-             than deleting it",
-        );
-        let preamble = &this_file[pos.saturating_sub(200)..pos];
-        assert!(
-            preamble.contains(&strip_ws("tracing::info!")),
+        assert_eq!(
+            level_of(
+                &this_file,
+                &strip_ws(concat!(
+                    "UPDATE rate limiter: peer is introducing ",
+                    "brand-new (sender, contract)"
+                )),
+                "new-pair-budget",
+            ),
+            strip_ws("tracing::info"),
             "the new-pair-budget log must be emitted at info! or higher; debug! is compiled out \
              of release builds by release_max_level_info (#4981)"
         );
 
         // The residual capacity drop, in the UPDATE dispatch path.
         let node_rs = strip_ws(include_str!("../node.rs"));
-        let drop_marker = strip_ws(concat!("update_dispatch_", "capacity_dropped"));
-        let pos = node_rs.find(&drop_marker).expect(
-            "the capacity-drop log phase must exist in node.rs; if it was renamed, update this \
-             pin rather than deleting it",
-        );
-        let preamble = &node_rs[pos.saturating_sub(200)..pos];
-        assert!(
-            preamble.contains(&strip_ws("tracing::info!")),
+        assert_eq!(
+            level_of(
+                &node_rs,
+                &strip_ws(concat!("update_dispatch_", "capacity_dropped")),
+                "capacity-drop",
+            ),
+            strip_ws("tracing::info"),
             "dropping an UPDATE for capacity must be logged at info! or higher, so the drop is \
              greppable on a production node (#4981)"
-        );
-        assert!(
-            !preamble.contains(&strip_ws("tracing::debug!")),
-            "the capacity-drop branch must not fall back to debug!"
         );
     }
 
@@ -2104,11 +2359,13 @@ mod tests {
     /// affected, 100% of them from that branch, retry budget untouched.
     /// After the fix, 7 in 320 000 (0.002%).
     ///
-    /// The threshold below sits between those two by more than an order
-    /// of magnitude in both directions, so it is neither flaky nor
-    /// vacuous. It is a bound rather than zero because losing a freed
-    /// slot to a concurrent caller on every attempt is genuinely
-    /// possible — that is what `CapacityExceeded` is documented to mean.
+    /// The threshold sits an order of magnitude above what the fixed
+    /// implementation produces and well below what the bug produces:
+    /// reintroducing the bug takes this fixture to 671 drops in 6 400
+    /// against a threshold of 6, so it is neither flaky nor vacuous. It
+    /// is a bound rather than zero because losing a freed slot to a
+    /// concurrent caller on every attempt is genuinely possible — that
+    /// is what `CapacityExceeded` is documented to mean.
     #[test]
     fn concurrent_admission_at_capacity_almost_never_drops() {
         use std::sync::{Arc as StdArc, Barrier};

--- a/crates/core/src/ring/update_rate_limit.rs
+++ b/crates/core/src/ring/update_rate_limit.rs
@@ -2540,7 +2540,15 @@ mod tests {
         const ADMISSIONS: usize = THREADS * PER_THREAD;
         /// One drop per this many admissions is the ceiling. The bug
         /// produced ~8 per thousand; the fix produces ~0.02.
-        const MAX_DROPS_PER_THOUSAND: usize = 1;
+        ///
+        /// Widened from 1 to 2: review measured a worst case of 7 drops
+        /// against a threshold of 6 across 540 trials (~1 in 600), so the
+        /// old value was a known flake rather than the claimed order of
+        /// magnitude of headroom. Widening is the right fix here and a
+        /// retry would not be — the assertion bounds a genuinely
+        /// stochastic quantity (losing a freed slot to a concurrent
+        /// caller), not a deterministic property.
+        const MAX_DROPS_PER_THOUSAND: usize = 2;
 
         let ts = SharedMockTimeSource::new();
         let limiter = StdArc::new(UpdateRateLimiter::with_new_pair_budget(

--- a/crates/core/src/ring/update_rate_limit.rs
+++ b/crates/core/src/ring/update_rate_limit.rs
@@ -431,6 +431,7 @@ const NEW_PAIR_LOG_INTERVAL: Duration = EVICTION_LOG_INTERVAL;
 /// not, and slots are about to exist. The only terminal condition is a
 /// cap of zero, which is a property of the configuration and is read
 /// from it directly rather than inferred.
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 enum EvictionOutcome {
     /// This pass freed slots and kept one of them for the caller, which
     /// therefore does not have to win the cap check again — it inserts
@@ -852,6 +853,32 @@ impl UpdateRateLimiter {
     /// entries stamped within the same clock tick (and, in tests, from a
     /// mock clock that has not advanced) share an `Instant`, and a
     /// cutoff comparison would take every tied entry with it.
+    /// Remove `victims`, returning how many were ACTUALLY removed.
+    ///
+    /// The distinction is the whole point, and it is load-bearing rather
+    /// than defensive. `cleanup` removes from `last_accepted` without
+    /// taking `eviction_lock`, and the Ring reaper runs it once a minute
+    /// on every node, so a victim selected by the scan above can be gone
+    /// by the time this runs. The caller decrements `size` by
+    /// `removed - 1`; counting the selected batch instead would
+    /// over-decrement, drive `size` BELOW the map's true length, and let
+    /// the map grow past `max_tracked_pairs` by the drift — defeating
+    /// the one bound this module exists to enforce.
+    ///
+    /// Split out of `evict_oldest` so that property is reachable by a
+    /// deterministic test: inside `evict_oldest` the victim list is
+    /// collected and consumed in the same breath, so no fixture can put
+    /// an absent key in it without racing a real reaper (#4997 review).
+    fn remove_victims<'a, I>(&self, victims: I) -> usize
+    where
+        I: IntoIterator<Item = &'a (SocketAddr, ContractInstanceId)>,
+    {
+        victims
+            .into_iter()
+            .filter(|victim| self.last_accepted.remove(*victim).is_some())
+            .count()
+    }
+
     fn evict_oldest(&self, now: Instant) -> EvictionOutcome {
         // The one terminal condition, read from the configuration rather
         // than inferred from an empty map — see `EvictionOutcome`.
@@ -909,15 +936,7 @@ impl UpdateRateLimiter {
         let batch = batch.min(entries.len());
         entries.select_nth_unstable_by_key(batch - 1, |(stamped, _)| *stamped);
 
-        let mut removed = 0usize;
-        for (_, victim) in &entries[..batch] {
-            // A concurrent caller may have removed it already; only
-            // count what this call actually took out, so `size` stays
-            // in step with the map.
-            if self.last_accepted.remove(victim).is_some() {
-                removed += 1;
-            }
-        }
+        let removed = self.remove_victims(entries[..batch].iter().map(|(_, k)| k));
         if removed > 0 {
             // Return `removed - 1` slots and KEEP one for the caller.
             //
@@ -1424,50 +1443,44 @@ mod tests {
                 limiter.check_and_record(mk_sender(i as u8 + 1), mk_contract(i as u8 + 1)),
                 RateLimitDecision::Allowed
             );
-            // Stagger the stamps so victim selection is well-defined.
+            // Stagger the stamps so the entries are distinguishable.
             ts.advance(Duration::from_millis(1));
         }
         assert_eq!(limiter.len(), CAP);
         assert_eq!(limiter.size.load(Ordering::Relaxed), CAP);
 
-        // Simulate the concurrent reaper: take the OLDEST entry out from
-        // under the eviction pass, leaving `size` untouched. That is
-        // exactly the state a caller sees when `cleanup` removed an entry
-        // after `evict_oldest` collected it but before it removed it.
-        assert!(
-            limiter
-                .last_accepted
-                .remove(&(mk_sender(1), mk_contract(1)))
-                .is_some()
-        );
-        assert_eq!(limiter.len(), CAP - 1);
-        assert_eq!(
-            limiter.size.load(Ordering::Relaxed),
-            CAP,
-            "the fixture must leave `size` stale, which is the whole point"
-        );
+        // Three victims, only two of which are still present: the third
+        // is what a concurrent `cleanup` took between the scan's collect
+        // and its removal loop.
+        let present_a = (mk_sender(1), mk_contract(1));
+        let present_b = (mk_sender(2), mk_contract(2));
+        let already_gone = (mk_sender(3), mk_contract(3));
+        assert!(limiter.last_accepted.remove(&already_gone).is_some());
 
-        // A batch of 1 at this cap, and the single victim it selects is
-        // the entry that just vanished — so a correct pass removes ZERO.
-        let before = limiter.capacity_evicted_total();
-        let outcome = limiter.evict_oldest(ts.now());
-        let counted = limiter.capacity_evicted_total() - before;
+        let victims = [present_a, already_gone, present_b];
+        let removed = limiter.remove_victims(victims.iter());
 
         assert_eq!(
-            counted, 0,
-            "the pass removed nothing (its victim was already gone), so it must \
-             count nothing; counting the selected batch instead reports {counted}"
+            removed,
+            2,
+            "two of the three victims were still present, so the pass removed \
+             two; returning the selected batch size ({}) instead over-decrements \
+             `size` and lets the map grow past the cap",
+            victims.len()
         );
         assert_eq!(
-            outcome,
-            EvictionOutcome::Retry,
-            "removing nothing is a reason to retry, not to reserve a slot"
+            limiter.len(),
+            CAP - 3,
+            "all three victims are gone from the map either way"
         );
+
+        // The consequence the count protects: `size` is decremented by
+        // `removed - 1`, so an over-count drives the strict-cap gate below
+        // the map's true length.
+        limiter.size.fetch_sub(removed - 1, Ordering::Relaxed);
         assert!(
             limiter.size.load(Ordering::Relaxed) >= limiter.len(),
-            "`size` must never fall below the map's true length: size={} len={}. \
-             It is the strict-cap gate, so drift below `len` lets the map grow \
-             past max_tracked_pairs.",
+            "`size` must never fall below the map's true length: size={} len={}",
             limiter.size.load(Ordering::Relaxed),
             limiter.len()
         );
@@ -1487,7 +1500,10 @@ mod tests {
     #[test]
     fn a_throttled_sender_cannot_evict_other_peers_entries() {
         const CAP: usize = 8;
-        const BURST: usize = 4;
+        // The burst is charged PER SENDER, so it has to cover the
+        // incumbent's fill as well as the attacker's run; equal to the cap
+        // gives each exactly enough to fill the map once.
+        const BURST: usize = 8;
         let ts = SharedMockTimeSource::new();
         let limiter = UpdateRateLimiter::with_new_pair_budget(
             Arc::new(ts.clone()),

--- a/crates/core/src/ring/update_rate_limit.rs
+++ b/crates/core/src/ring/update_rate_limit.rs
@@ -91,7 +91,9 @@
 //! deliberate one takes its place: a token bucket keyed by `sender_addr`
 //! ALONE ([`NEW_PAIR_BURST`], [`NEW_PAIR_REFILL_INTERVAL`]) that a
 //! sender spends from only when it presents a `(sender, contract)` pair
-//! this limiter has never seen.
+//! the limiter is not currently tracking. Note "not currently tracking"
+//! rather than "has never seen" — the two differ once eviction is in
+//! play, and the difference is the caveat below.
 //!
 //! Two properties make this the right shape:
 //!
@@ -394,14 +396,17 @@ pub(crate) enum RateLimitDecision {
     /// something sharper than it used to: not merely that the map is
     /// full, but that it is full *and* contended.
     CapacityExceeded,
-    /// Rejected because the sender has spent its budget for introducing
-    /// brand-new `(sender, contract)` pairs (see the module docs).
+    /// Rejected because the sender has spent its budget for presenting
+    /// `(sender, contract)` pairs the limiter is not tracking (see the
+    /// module docs).
     ///
-    /// Only a pair this limiter has never seen can land here, so a
-    /// sender's established traffic never does, however much of it there
-    /// is. A rising count means one peer is presenting unfamiliar
-    /// contract ids faster than [`NEW_PAIR_REFILL_INTERVAL`] — the
-    /// fresh-id churn pattern.
+    /// Only a pair that is not currently in the map can land here, so a
+    /// sender's traffic for a tracked pair never does, however much of
+    /// it there is. Below saturation that is the same as "never seen"
+    /// and a rising count is the fresh-id churn pattern; once eviction
+    /// is recycling pairs faster than they return, it also counts
+    /// re-admissions, which is why the rate is set for aggregate traffic
+    /// rather than for genuinely-fresh ids.
     SenderNewPairBudget,
 }
 
@@ -882,10 +887,11 @@ impl UpdateRateLimiter {
             dropped_total = self.new_pair_budget_rejected_total.load(Ordering::Relaxed),
             burst = NEW_PAIR_BURST,
             refill_interval_ms = NEW_PAIR_REFILL_INTERVAL.as_millis() as u64,
-            "UPDATE rate limiter: peer is introducing brand-new (sender, contract) \
-             pairs faster than its budget allows, so its UPDATEs for unfamiliar \
-             contracts are being dropped. Its traffic for already-tracked contracts \
-             is unaffected. Throttled to one line per minute."
+            "UPDATE rate limiter: peer is presenting (sender, contract) pairs this \
+             node is not tracking faster than its budget allows, so those UPDATEs \
+             are being dropped. Its traffic for tracked pairs is unaffected. If this \
+             peer is not churning contract ids, the budget is set too low for this \
+             node's working set. Throttled to one line per minute."
         );
     }
 
@@ -2233,8 +2239,16 @@ mod tests {
     /// the pin vacuous.
     #[test]
     fn capacity_signals_are_logged_above_debug_level() {
+        // Backslashes go too, not just whitespace: these haystacks are
+        // SOURCE, so a long message carries `\` line continuations, and
+        // where they fall is rustfmt's choice. Stripping whitespace
+        // alone leaves the backslash behind and a needle spanning a
+        // continuation silently stops matching — which is the same
+        // reflow fragility the stripping exists to remove.
         fn strip_ws(s: &str) -> String {
-            s.chars().filter(|c| !c.is_whitespace()).collect()
+            s.chars()
+                .filter(|c| !c.is_whitespace() && *c != '\\')
+                .collect()
         }
 
         /// The macro invoked for the log line whose message contains
@@ -2279,8 +2293,8 @@ mod tests {
             level_of(
                 &this_file,
                 &strip_ws(concat!(
-                    "UPDATE rate limiter: peer is introducing ",
-                    "brand-new (sender, contract)"
+                    "UPDATE rate limiter: peer is presenting ",
+                    "(sender, contract) pairs this node is not tracking"
                 )),
                 "new-pair-budget",
             ),

--- a/crates/core/src/ring/update_rate_limit.rs
+++ b/crates/core/src/ring/update_rate_limit.rs
@@ -104,7 +104,18 @@
 //! - **It is charged before eviction, not after.** A sender past its
 //!   budget is refused *before* a slot is reserved or anything is
 //!   evicted, so churning fresh ids cannot push other peers' entries out
-//!   of the map on the way to being throttled.
+//!   of the map *once it is throttled*.
+//!
+//!   Read that precisely: it bounds churn past the budget, NOT churn
+//!   within it. A sender inside its 200/s allowance does evict other
+//!   peers' entries, at up to 200/s, and the map is global with no
+//!   per-sender slot quota. What keeps that harmless is LRU plus the
+//!   window it protects: to evict a pair touched within
+//!   [`MIN_UPDATE_INTERVAL`] (100 ms) an attacker must turn the whole
+//!   16 384-entry map over inside that window — ~164 000 evictions/s,
+//!   i.e. ~820 malicious peers against a 200-connection cap. That
+//!   turnover argument is the load-bearing part; the ordering above is
+//!   not sufficient on its own.
 //!
 //! The caveat, stated rather than glossed: "not currently in the map"
 //! includes a pair that WAS tracked and then got evicted. The limiter
@@ -137,10 +148,28 @@
 //! which is the signal to raise the rate — the counter is on the
 //! dashboard for exactly that reason.
 //!
-//! Its own map is bounded by [`MAX_TRACKED_SENDERS`], which is a
-//! multiple of the node's connection cap rather than an attacker-chosen
-//! space: `sender` is the immediate upstream hop, so only a connected
-//! peer can occupy an entry.
+//! Its own map is bounded by `max_connections * `
+//! [`SENDER_TRACKING_HEADROOM`], a multiple of the node's connection cap
+//! rather than an attacker-chosen space: `sender` is the immediate
+//! upstream hop, so only a connected peer can put an entry there in the
+//! first place.
+//!
+//! The headroom is what makes that a real bound rather than a stated
+//! one. There is no disconnect hook for this map (deliberately — see
+//! `resync_rate_limit`), so an entry outlives its connection by up to
+//! `CLEANUP_AGE`. The live set is therefore bounded by the connection
+//! cap *plus five minutes of address churn*, which is precisely what the
+//! 8x headroom absorbs.
+//!
+//! At capacity this map fails OPEN: a sender it has no room to track is
+//! admitted rather than refused, counted by
+//! `new_pair_budget_untracked_total`. That is the right default for a
+//! sizing accident, but note the consequence — a full sender map
+//! disables the fresh-id budget for every sender not already in it, and
+//! `Bucket::refill` restamps on every check, so an active entry never
+//! ages out. Giving this map the same LRU eviction the pair map now has
+//! is the natural remedy; it is tracked in #5000 together with the
+//! sibling instance in the resync limiters.
 //!
 //! ## Semantic note: `sender_addr` is the immediate upstream hop
 //!
@@ -221,10 +250,33 @@ pub(crate) const CLEANUP_AGE: Duration = Duration::from_secs(5 * 60);
 /// Memory is not the binding cost. An eviction pass holds
 /// [`UpdateRateLimiter::eviction_lock`] across a scan that is LINEAR in
 /// this constant — measured 41 ns per entry, so **672 µs at 16 384 but
-/// 10.8 ms at 163 840**. At the current value that is a ~0.001% duty
-/// cycle against real gateway load (~3.15 UPDATE/s on nova, ~2.84/s on
-/// vega) and irrelevant; ten times larger it is a 10 ms blocking
-/// section on a tokio worker.
+/// 10.8 ms at 163 840**. The pass also collects the whole map into a
+/// `Vec` first: ~1.3 MB allocated and freed per pass at the current cap,
+/// which grows with this constant too.
+///
+/// Size the duty cycle against ADVERSARIAL arrivals, not benign ones.
+/// Real gateway load (~3.15 UPDATE/s on nova, ~2.84/s on vega,
+/// node-wide) puts this at a ~0.001% duty cycle, which is where the
+/// number below stops being reassuring: the rate that matters is the one
+/// the fresh-pair budget *permits*, which is 200 new pairs/s per sender
+/// with no node-wide aggregate. At 16 384:
+///
+/// | new pairs/s | scans/s | lock duty cycle |
+/// |---|---|---|
+/// | 100 (the #4981 figure) | 0.39 | 0.03 % |
+/// | 2 000 (10 sybil senders) | 7.8 | 0.5 % |
+/// | 40 000 (200 senders at budget) | 156 | **10.5 %** |
+///
+/// `check_and_record` is sync and runs inside a per-message tokio task,
+/// and [`UpdateRateLimiter::eviction_lock`] is a blocking
+/// `std::sync::Mutex` — it parks the worker rather than yielding. At the
+/// bottom row every worker can be parked on it ~10% of the time. That
+/// row needs a full-scale coordinated flood to reach, so it is a hazard
+/// to track rather than one to design around today; the lock's shape is
+/// tracked separately (a `try_lock`-and-retry or a maintained victim
+/// ordering, neither of which fits inside a sync fn without reworking
+/// the call site). Do not raise this constant without redoing this
+/// table.
 ///
 /// This warning is here because the PR that added eviction also
 /// installed the operator story "evictions climbing means saturation",
@@ -250,8 +302,14 @@ pub(crate) const MAX_TRACKED_PAIRS: usize = 16_384;
 /// admission policy would walk 16 384 entries on every new pair — at the
 /// 50-100 new pairs/sec reported in #4981, a continuous full scan of the
 /// map several times a second on the UPDATE receive path. Evicting a
-/// batch amortises that to one scan per batch (≈1.5/sec at the same
-/// rate) for the same eviction *policy*: the oldest entries go first.
+/// batch amortises that to one scan per batch: a pass frees
+/// `removed - 1` slots and keeps one, so ~256 admissions ride on each
+/// scan and 100 new pairs/sec costs **≈0.39 scans/sec** (50/sec costs
+/// ≈0.20). Same eviction *policy* either way: the oldest entries go
+/// first. (An earlier version of this note divided the arrival rate by
+/// the DIVISOR rather than by the batch and said ≈1.5/sec; that is ~4x
+/// too pessimistic. The figure is quoted when sizing
+/// [`MAX_TRACKED_PAIRS`], so it is worth having right.)
 ///
 /// 64 gives a 256-entry batch at the default cap, ≈1.5% of it. Small
 /// enough that an evicted pair is genuinely among the least recently
@@ -325,6 +383,15 @@ const NEW_PAIR_REFILL_INTERVAL: Duration = Duration::from_millis(5);
 /// raised above [`Ring::DEFAULT_MAX_CONNECTIONS`] would otherwise run a
 /// budget map smaller than its own peer count.
 const SENDER_TRACKING_HEADROOM: usize = 8;
+
+/// Floor for the per-sender budget map, independent of `max_connections`.
+///
+/// `max_connections` is operator-settable, so without a floor a
+/// misconfigured `0` sizes the map at `0`, every sender reads
+/// `BucketOutcome::Untracked`, and the fresh-id budget is silently and
+/// completely disabled — the fail-open valve pinned open by a config
+/// typo. Costs nothing: 64 entries is a few kilobytes.
+const MIN_TRACKED_SENDERS: usize = 64;
 
 /// How often an exhausted new-pair budget may write a log line.
 ///
@@ -535,7 +602,14 @@ impl UpdateRateLimiter {
             MIN_UPDATE_INTERVAL,
             MAX_TRACKED_PAIRS,
             NEW_PAIR_BURST,
-            max_connections.saturating_mul(SENDER_TRACKING_HEADROOM),
+            // Floored: `max_connections` is operator-settable, and a
+            // configured 0 would size this map at 0, making every sender
+            // read `Untracked` and silently disabling the fresh-id budget
+            // node-wide. A fail-open valve that a config typo can pin open
+            // is not a valve.
+            max_connections
+                .saturating_mul(SENDER_TRACKING_HEADROOM)
+                .max(MIN_TRACKED_SENDERS),
         )
     }
 
@@ -896,7 +970,11 @@ impl UpdateRateLimiter {
         tracing::info!(
             evicted = removed,
             evicted_total = self.capacity_evicted_total.load(Ordering::Relaxed),
-            tracked = self.size.load(Ordering::Relaxed),
+            // `size` counts map entries PLUS outstanding reservations, so
+            // this can read above the map's true length. Named for what it
+            // is; do not relabel it `tracked`, which invites an operator to
+            // read it as `len()`.
+            reserved_plus_tracked = self.size.load(Ordering::Relaxed),
             max_tracked_pairs = self.max_tracked_pairs,
             "UPDATE rate limiter at capacity: evicted least-recently-used \
              (sender, contract) pairs to admit new ones. Expected on a node \
@@ -1314,6 +1392,185 @@ mod tests {
             d,
             RateLimitDecision::Allowed,
             "existing pair must keep working at cap"
+        );
+    }
+
+    /// `evict_oldest` must count what it ACTUALLY removed, not the size
+    /// of the batch it selected.
+    ///
+    /// `size` is decremented by `removed - 1`, so over-counting drives it
+    /// BELOW the map's true length and the map can then grow past
+    /// `max_tracked_pairs` by the drift — defeating the one bound this
+    /// module exists to enforce.
+    ///
+    /// This needs a victim that vanishes between selection and removal.
+    /// `cleanup` is the live path that does it: it removes from
+    /// `last_accepted` without taking `eviction_lock`, and the Ring
+    /// reaper runs it once a minute on every node. The whole rest of the
+    /// suite never interleaves the two, so `remove()` always returns
+    /// `Some` and `removed == batch` unconditionally — which means
+    /// mutating the count to `removed = batch` is behaviourally
+    /// invisible everywhere else (#4997 review). Reproduced here
+    /// deterministically rather than by racing threads.
+    #[test]
+    fn eviction_counts_actual_removals_not_the_selected_batch() {
+        const CAP: usize = 8;
+        let ts = SharedMockTimeSource::new();
+        let limiter =
+            UpdateRateLimiter::with_config(Arc::new(ts.clone()), MIN_UPDATE_INTERVAL, CAP);
+
+        for i in 0..CAP {
+            assert_eq!(
+                limiter.check_and_record(mk_sender(i as u8 + 1), mk_contract(i as u8 + 1)),
+                RateLimitDecision::Allowed
+            );
+            // Stagger the stamps so victim selection is well-defined.
+            ts.advance(Duration::from_millis(1));
+        }
+        assert_eq!(limiter.len(), CAP);
+        assert_eq!(limiter.size.load(Ordering::Relaxed), CAP);
+
+        // Simulate the concurrent reaper: take the OLDEST entry out from
+        // under the eviction pass, leaving `size` untouched. That is
+        // exactly the state a caller sees when `cleanup` removed an entry
+        // after `evict_oldest` collected it but before it removed it.
+        assert!(
+            limiter
+                .last_accepted
+                .remove(&(mk_sender(1), mk_contract(1)))
+                .is_some()
+        );
+        assert_eq!(limiter.len(), CAP - 1);
+        assert_eq!(
+            limiter.size.load(Ordering::Relaxed),
+            CAP,
+            "the fixture must leave `size` stale, which is the whole point"
+        );
+
+        // A batch of 1 at this cap, and the single victim it selects is
+        // the entry that just vanished — so a correct pass removes ZERO.
+        let before = limiter.capacity_evicted_total();
+        let outcome = limiter.evict_oldest(ts.now());
+        let counted = limiter.capacity_evicted_total() - before;
+
+        assert_eq!(
+            counted, 0,
+            "the pass removed nothing (its victim was already gone), so it must \
+             count nothing; counting the selected batch instead reports {counted}"
+        );
+        assert_eq!(
+            outcome,
+            EvictionOutcome::Retry,
+            "removing nothing is a reason to retry, not to reserve a slot"
+        );
+        assert!(
+            limiter.size.load(Ordering::Relaxed) >= limiter.len(),
+            "`size` must never fall below the map's true length: size={} len={}. \
+             It is the strict-cap gate, so drift below `len` lets the map grow \
+             past max_tracked_pairs.",
+            limiter.size.load(Ordering::Relaxed),
+            limiter.len()
+        );
+    }
+
+    /// The budget is charged BEFORE a slot is reserved or anything is
+    /// evicted, so a sender past its budget cannot push other peers'
+    /// entries out on its way to being refused.
+    ///
+    /// The cap has to be small enough that eviction is actually reachable.
+    /// The sibling test
+    /// `a_sender_churning_fresh_contract_ids_is_cut_off_after_its_burst`
+    /// runs at `MAX_TRACKED_PAIRS` with 40 pairs, where nothing can evict
+    /// whatever the ordering is — so its `capacity_evicted_total() == 0`
+    /// assertion holds even with the budget check moved AFTER the
+    /// reserve/evict block, and pins nothing (#4997 review).
+    #[test]
+    fn a_throttled_sender_cannot_evict_other_peers_entries() {
+        const CAP: usize = 8;
+        const BURST: usize = 4;
+        let ts = SharedMockTimeSource::new();
+        let limiter = UpdateRateLimiter::with_new_pair_budget(
+            Arc::new(ts.clone()),
+            MIN_UPDATE_INTERVAL,
+            CAP,
+            BURST as f64,
+            Ring::DEFAULT_MAX_CONNECTIONS * SENDER_TRACKING_HEADROOM,
+        );
+
+        // Fill the map to capacity with OTHER peers' pairs, so any
+        // admission from here on must evict one of them.
+        let incumbent = mk_sender(200);
+        for i in 0..CAP {
+            assert_eq!(
+                limiter.check_and_record(incumbent, mk_contract(i as u8 + 1)),
+                RateLimitDecision::Allowed
+            );
+        }
+        assert_eq!(limiter.len(), CAP);
+        let evicted_before = limiter.capacity_evicted_total();
+
+        // The attacker spends its whole burst. These DO evict — a sender
+        // inside its budget is a normal peer and competes for slots.
+        let attacker = mk_sender(1);
+        for i in 0..BURST {
+            assert_eq!(
+                limiter.check_and_record(attacker, mk_contract(100 + i as u8)),
+                RateLimitDecision::Allowed
+            );
+        }
+        let evicted_at_budget_end = limiter.capacity_evicted_total();
+        assert!(
+            evicted_at_budget_end > evicted_before,
+            "fixture check: at this cap an admission must actually evict, \
+             otherwise the assertion below cannot discriminate"
+        );
+
+        // Past the burst, every fresh id must be refused by the BUDGET,
+        // without reserving a slot or evicting anything.
+        for i in BURST..(BURST + 32) {
+            assert_eq!(
+                limiter.check_and_record(attacker, mk_contract(100 + i as u8)),
+                RateLimitDecision::SenderNewPairBudget
+            );
+        }
+        assert_eq!(
+            limiter.capacity_evicted_total(),
+            evicted_at_budget_end,
+            "a sender past its budget must not evict anything: the budget is \
+             charged before the reserve/evict block, so being throttled costs \
+             other peers nothing. 32 refused messages evicted {} entries.",
+            limiter.capacity_evicted_total() - evicted_at_budget_end
+        );
+        assert_eq!(limiter.len(), CAP, "the map stays exactly at the cap");
+    }
+
+    /// `log_due` gates both saturation log lines. Mutating it to `false`
+    /// silences the only release-visible evidence this PR adds; mutating
+    /// it to `true` turns a throttled line into a per-message flood on
+    /// the UPDATE receive path. Neither is visible to any other test, so
+    /// it is pinned directly.
+    #[test]
+    fn log_due_fires_once_per_interval() {
+        const INTERVAL: Duration = Duration::from_secs(60);
+        let slot = Mutex::new(None);
+        let t0 = Instant::now();
+
+        assert!(
+            log_due(&slot, t0, INTERVAL),
+            "the first call must be due — an unfired throttle that starts \
+             closed would suppress the signal entirely"
+        );
+        assert!(
+            !log_due(&slot, t0, INTERVAL),
+            "an immediate second call must be throttled"
+        );
+        assert!(
+            !log_due(&slot, t0 + INTERVAL - Duration::from_millis(1), INTERVAL),
+            "just inside the interval is still throttled"
+        );
+        assert!(
+            log_due(&slot, t0 + INTERVAL, INTERVAL),
+            "at the interval the line is due again"
         );
     }
 
@@ -2356,6 +2613,27 @@ mod tests {
             limiter.len(),
             limiter.capacity_evicted_total()
         );
+        // Without this the fixture passes under the REVERTED (refuse-at-cap)
+        // implementation too: `allowed == CAP` satisfies `allowed >= CAP`,
+        // `len() == CAP` satisfies `<= CAP`, and conservation holds trivially
+        // at `evicted == 0`. The comment above says these threads "race to
+        // evict and insert"; this is the assertion that makes that true
+        // rather than aspirational (#4997 review).
+        assert!(
+            limiter.capacity_evicted_total() > 0,
+            "64 threads against a cap of {CAP} must have driven at least one \
+             eviction; zero means the at-capacity path refused instead of \
+             evicting, which is the #4981 regression"
+        );
+        // All threads are joined, so no reservation is outstanding and this
+        // is deterministic. `size` is the strict-cap gate; if it drifts below
+        // `len` the map can grow past the cap.
+        assert_eq!(
+            limiter.size.load(Ordering::Relaxed),
+            limiter.len(),
+            "after all callers finish, the reservation counter must have \
+             settled back onto the map's true length"
+        );
     }
 
     /// Pin: both saturation signals stay visible in release builds.
@@ -2388,8 +2666,33 @@ mod tests {
                 .collect()
         }
 
+        /// The body of the function whose signature is `sig`, sliced to
+        /// the next item at the same indentation.
+        ///
+        /// The region bound is the load-bearing part. Without it,
+        /// `level_of`'s backwards search runs over the WHOLE file, and a
+        /// site written as `use tracing::info; info!(..)` — carrying no
+        /// `tracing::` prefix of its own — resolves to whatever macro
+        /// happens to precede it, which for `log_new_pair_budget` is the
+        /// eviction site's `tracing::info!` a few lines up. A downgrade
+        /// there would then pass this pin. AGENTS.md names this exact
+        /// failure shape and says it has shipped twice in this repo.
+        fn fn_body<'a>(src: &'a str, sig: &str, what: &str) -> &'a str {
+            let start = src.find(sig).unwrap_or_else(|| {
+                panic!(
+                    "the {what} log site's enclosing fn (`{sig}`) must exist; \
+                     if it was renamed, update this pin rather than deleting it"
+                )
+            });
+            let rest = &src[start + sig.len()..];
+            let end = rest.find("\n    fn ").unwrap_or(rest.len());
+            &rest[..end]
+        }
+
         /// The macro invoked for the log line whose message contains
-        /// `marker`: the nearest `tracing::<level>!` at or before it.
+        /// `marker`: the nearest `tracing::<level>!` at or before it,
+        /// searched only WITHIN `haystack`, which must already be
+        /// narrowed to the enclosing function by `fn_body`.
         ///
         /// Searching backwards to the nearest `tracing::` rather than
         /// scanning a fixed-size window, because a window has to be
@@ -2402,13 +2705,27 @@ mod tests {
             });
             let start = haystack[..pos]
                 .rfind(&strip_ws("tracing::"))
-                .unwrap_or_else(|| panic!("no tracing:: macro precedes the {what} log line"));
+                .unwrap_or_else(|| {
+                    panic!(
+                        "no `tracing::<level>!` precedes the {what} log line inside its own \
+                         function. If the site now uses an imported `info!`/`debug!` without \
+                         the `tracing::` path, this pin can no longer read its level — restore \
+                         the qualified form rather than widening the search, because widening \
+                         it is exactly what lets a silent downgrade pass."
+                    )
+                });
             let tail = &haystack[start..pos];
             tail[..tail.find('!').unwrap_or(tail.len())].to_string()
         }
 
-        // The limiter's own saturation line, in this file.
-        let this_file = strip_ws(include_str!("update_rate_limit.rs"));
+        // The limiter's own saturation line, in this file. Narrowed to
+        // `log_eviction`'s own body first — see `fn_body`.
+        let this_file_raw = include_str!("update_rate_limit.rs");
+        let this_file = strip_ws(fn_body(
+            this_file_raw,
+            "fn log_eviction(&self, now: Instant, removed: usize) {",
+            "eviction",
+        ));
         assert_eq!(
             level_of(
                 &this_file,
@@ -2426,9 +2743,14 @@ mod tests {
         // budget is over it on every message and an unthrottled line
         // there would be a flood. Downgrading this one would make the
         // whole signal invisible in release.
+        let new_pair_fn = strip_ws(fn_body(
+            this_file_raw,
+            "fn log_new_pair_budget(&self, now: Instant, sender: SocketAddr) {",
+            "new-pair-budget",
+        ));
         assert_eq!(
             level_of(
-                &this_file,
+                &new_pair_fn,
                 &strip_ws(concat!(
                     "UPDATE rate limiter: peer is presenting ",
                     "(sender, contract) pairs this node is not tracking"

--- a/crates/core/src/ring/update_rate_limit.rs
+++ b/crates/core/src/ring/update_rate_limit.rs
@@ -115,11 +115,24 @@
 //! less like a fresh-id bound and more like a per-peer aggregate
 //! ceiling.
 //!
-//! That is why the sustained rate is set well ABOVE
-//! [`MIN_UPDATE_INTERVAL`]'s per-pair ceiling rather than at it: a peer
-//! would have to sustain [`NEW_PAIR_BURST`] and then 200 UPDATEs/s to
-//! this node, continuously, before any of it is dropped. If that ever
-//! binds on real traffic it is visible as
+//! How high that miss rate goes depends on the access pattern, not
+//! just the working-set size: measured at ~16 500 pairs against the
+//! 16 384 cap, uniform-random access misses 1.33% of the time but
+//! round-robin misses 96.77% — LRU's worst case, since every entry is
+//! evicted exactly before it is next used. So the miss rate is NOT
+//! reliably small, and the safety of this control does not rest on it
+//! being small.
+//!
+//! What it rests on is the binding condition, which is generous
+//! regardless of miss rate: **one peer must sustain ~210 UPDATE/s to
+//! this node, continuously**, before anything is dropped (the 200/s
+//! refill plus the burst amortised). Real gateway load is ~3.15/s on
+//! nova and ~2.84/s on vega NODE-WIDE, across all peers — roughly two
+//! orders of magnitude below the threshold for a single one of them.
+//! That is why the sustained rate is set well above
+//! [`MIN_UPDATE_INTERVAL`]'s per-pair ceiling rather than at it.
+//!
+//! If it ever does bind on real traffic it is visible as
 //! `new_pair_budget_rejected_total` climbing on a node with no attacker,
 //! which is the signal to raise the rate — the counter is on the
 //! dashboard for exactly that reason.
@@ -202,6 +215,24 @@ pub(crate) const CLEANUP_AGE: Duration = Duration::from_secs(5 * 60);
 /// influenced keys" rule from `.claude/rules/code-style.md`. At 64
 /// bytes/entry, 16 384 pairs ≈ 1 MB — tiny — but bounds the worst case
 /// where an attacker chooses fresh contract ids.
+///
+/// # Re-measure the eviction scan before raising this
+///
+/// Memory is not the binding cost. An eviction pass holds
+/// [`UpdateRateLimiter::eviction_lock`] across a scan that is LINEAR in
+/// this constant — measured 41 ns per entry, so **672 µs at 16 384 but
+/// 10.8 ms at 163 840**. At the current value that is a ~0.001% duty
+/// cycle against real gateway load (~3.15 UPDATE/s on nova, ~2.84/s on
+/// vega) and irrelevant; ten times larger it is a 10 ms blocking
+/// section on a tokio worker.
+///
+/// This warning is here because the PR that added eviction also
+/// installed the operator story "evictions climbing means saturation",
+/// and the obvious response to that reading is to raise this constant.
+/// Doing so is fine — but re-measure the hold time first, and if it
+/// grows past a millisecond or two, the scan wants a different shape
+/// (sampled victim selection, or a maintained ordering) rather than a
+/// longer lock.
 ///
 /// On reaching the cap the oldest entries are evicted to admit the
 /// newcomer (see the module docs for why rejecting instead starved new
@@ -821,9 +852,14 @@ impl UpdateRateLimiter {
             // batch size relative to the number of concurrent callers:
             // at the production cap (batch 256, 16 threads) it nearly
             // always wins, but at a 1024 cap the batch is 16 and callers
-            // lose a freed slot often enough to drop ~2 admissions in
+            // lose a freed slot often enough to drop ~0.19 admissions in
             // 1000. Keeping a slot makes "a caller that frees room gets
             // to use it" true by construction instead of by margin.
+            //
+            // That residual is small because the serialised scan already
+            // removed most of it; this closes the rest and, more to the
+            // point, makes the property independent of the batch/caller
+            // ratio rather than true only at the production cap.
             //
             // The strict cap is unaffected: `size` counts map entries
             // plus outstanding reservations, and every insert still
@@ -974,6 +1010,16 @@ impl UpdateRateLimiter {
     /// traffic for contracts already being tracked.
     pub fn new_pair_budget_rejected_total(&self) -> u64 {
         self.new_pair_budget_rejected_total.load(Ordering::Relaxed)
+    }
+
+    /// Total new pairs admitted WITHOUT a budget check because the
+    /// sender map was full. Surfaced on the dashboard
+    /// ("Fresh-id-unmetered") because a safety valve nobody can see
+    /// firing is the #4981 failure mode: this should be zero, and a
+    /// non-zero value means `max_tracked_senders` is undersized for this
+    /// node, so the budget is not actually bounding those senders.
+    pub fn new_pair_budget_untracked_total(&self) -> u64 {
+        self.new_pair_budget_untracked_total.load(Ordering::Relaxed)
     }
 
     /// Number of senders tracked by the new-pair budget.
@@ -1513,8 +1559,19 @@ mod tests {
     /// The sender map is bounded, and by a space the attacker does not
     /// choose: `sender` is the immediate upstream hop, so only a peer
     /// that has completed a handshake can occupy an entry.
+    ///
+    /// And — the half that matters — a sender arriving at a FULL map is
+    /// still admitted. Bounding alone is not the property: a bounded map
+    /// that refuses newcomers once full is #4981 exactly, one map over,
+    /// inside the control added to fix #4981. `Bucket::refill` restamps
+    /// on every check including denied ones, so an active sender's entry
+    /// never ages out and a refused newcomer would never recover.
+    ///
+    /// Asserting only `tracked_senders() <= MAX` did not catch that: a
+    /// fail-CLOSED implementation passed the whole suite 15/15 (#4997
+    /// re-review).
     #[test]
-    fn the_new_pair_budget_map_is_bounded() {
+    fn the_new_pair_budget_map_is_bounded_and_fails_open_when_full() {
         const MAX_SENDERS: usize = 4;
         let ts = SharedMockTimeSource::new();
         let limiter = UpdateRateLimiter::with_new_pair_budget(
@@ -1526,13 +1583,93 @@ mod tests {
         );
 
         for i in 0..(MAX_SENDERS * 4) {
-            limiter.check_and_record(mk_sender(i as u8), mk_contract(1));
+            let d = limiter.check_and_record(mk_sender(i as u8), mk_contract(1));
+            assert_eq!(
+                d,
+                RateLimitDecision::Allowed,
+                "sender {i}: a full sender map must fail OPEN — refusing here is \
+                 #4981 one map over, and this sender has spent nothing"
+            );
             assert!(
                 limiter.tracked_senders() <= MAX_SENDERS,
                 "sender {i}: the budget map must never exceed its cap"
             );
         }
         assert_eq!(limiter.tracked_senders(), MAX_SENDERS);
+
+        // The untracked admissions are counted, so an undersized map is
+        // an operator-visible condition rather than a silent one.
+        assert_eq!(
+            limiter.new_pair_budget_untracked_total(),
+            (MAX_SENDERS * 3) as u64,
+            "every admission past the cap must be counted as untracked"
+        );
+        assert_eq!(
+            limiter.new_pair_budget_rejected_total(),
+            0,
+            "a full map is a sizing accident, not evidence about any sender"
+        );
+    }
+
+    /// Source-scrape pin: `evict_oldest` has exactly ONE terminal exit,
+    /// and it is the zero-cap guard. Every other way out must be a
+    /// retry.
+    ///
+    /// This exists because no behavioural test can reach the
+    /// `removed == 0` exit any more. Once the scan is serialised,
+    /// concurrent evictors stop stealing each other's victims, so
+    /// turning that exit terminal survives the entire suite (verified:
+    /// 29/29, and 15/15 on the concurrency fixture that looks like it
+    /// would catch it).
+    ///
+    /// The exit must nonetheless stay a retry, for a cause no evictor
+    /// creates: **`cleanup` does not take the eviction lock**, and it
+    /// removes entries older than `CLEANUP_AGE` — precisely the oldest
+    /// entries, which is precisely what `select_nth_unstable_by_key`
+    /// selects. A reaper sweep landing between the collect and the
+    /// removes takes the whole batch out from under the evictor, and
+    /// that is a once-a-minute window on every node. Making it terminal
+    /// would drop a legitimate UPDATE there, silently, with the retry
+    /// budget untouched — the #4981 shape again.
+    ///
+    /// A source pin rather than a behavioural one, because the window is
+    /// a race between a reaper tick and a receive-path scan that no
+    /// fixture can schedule. Pinning the SHAPE (one terminal exit,
+    /// guarded by the cap) is what is actually available.
+    #[test]
+    fn evict_oldest_has_exactly_one_terminal_exit() {
+        const THIS_FILE: &str = include_str!("update_rate_limit.rs");
+
+        let start = THIS_FILE
+            .find(concat!("fn evict_", "oldest("))
+            .expect("evict_oldest must exist; if renamed, update this pin");
+        let tail = &THIS_FILE[start..];
+        // Bound to this function: the next item at impl indentation.
+        let end = tail[1..]
+            .find("\n    fn ")
+            .map(|i| i + 1)
+            .unwrap_or(tail.len());
+        let body = &tail[..end];
+
+        let terminal = concat!("EvictionOutcome::", "CapIsZero");
+        assert_eq!(
+            body.matches(terminal).count(),
+            1,
+            "evict_oldest must have exactly ONE terminal exit. Every other way out \
+             means slots are, or are about to be, free — including an empty map, \
+             which `cleanup` can produce mid-scan — and dropping there loses a \
+             legitimate UPDATE without spending the retry budget (#4981, #4997)."
+        );
+
+        let guard_pos = body
+            .find("self.max_tracked_pairs == 0")
+            .expect("the terminal exit must be guarded by the cap being zero");
+        let terminal_pos = body.find(terminal).expect("checked above");
+        assert!(
+            guard_pos < terminal_pos,
+            "the one terminal exit must be the zero-cap guard, not a condition \
+             inferred from the map's contents"
+        );
     }
 
     /// An empty map is NOT a reason to give up, even though the map
@@ -1616,7 +1753,7 @@ mod tests {
     /// limiter still refuses a new pair outright, and it must terminate
     /// rather than spin.
     ///
-    /// This is the one path `EvictionOutcome::MapEmpty` exists for. It
+    /// This is the one path `EvictionOutcome::CapIsZero` exists for. It
     /// was untested, which mattered because the eviction rework turned
     /// "evicted nothing" into a retry: had that retry not distinguished
     /// an empty map from a contended one, a zero cap would loop through
@@ -2373,13 +2510,25 @@ mod tests {
     /// affected, 100% of them from that branch, retry budget untouched.
     /// After the fix, 7 in 320 000 (0.002%).
     ///
-    /// The threshold sits an order of magnitude above what the fixed
-    /// implementation produces and well below what the bug produces:
-    /// reintroducing the bug takes this fixture to 671 drops in 6 400
-    /// against a threshold of 6, so it is neither flaky nor vacuous. It
-    /// is a bound rather than zero because losing a freed slot to a
-    /// concurrent caller on every attempt is genuinely possible — that
-    /// is what `CapacityExceeded` is documented to mean.
+    /// What it actually pins, stated precisely because an earlier
+    /// version of this comment credited the wrong fix: making the
+    /// caller's `EvictionOutcome::Retry` arm terminal takes this fixture
+    /// to 671 drops in 6 400 against a threshold of 6. That arm covers
+    /// the early-out and the under-lock re-check, which is where the
+    /// measured drops came from — so this pins the caller's handling of
+    /// a non-terminal eviction, and with it the serialised scan.
+    ///
+    /// It does NOT pin the `removed == 0` exit inside `evict_oldest`.
+    /// Making that one terminal survives this fixture 15/15 and the
+    /// whole suite 29/29, because once the scan is serialised concurrent
+    /// evictors no longer steal each other's victims, so `removed == 0`
+    /// never occurs here. That exit is real for a different reason and
+    /// is pinned by source scrape instead — see
+    /// `evict_oldest_has_exactly_one_terminal_exit`.
+    ///
+    /// The threshold is a bound rather than zero because losing a freed
+    /// slot to a concurrent caller on every attempt is genuinely
+    /// possible — that is what `CapacityExceeded` is documented to mean.
     #[test]
     fn concurrent_admission_at_capacity_almost_never_drops() {
         use std::sync::{Arc as StdArc, Barrier};

--- a/crates/core/src/ring/update_rate_limit.rs
+++ b/crates/core/src/ring/update_rate_limit.rs
@@ -34,10 +34,10 @@
 //!
 //! Two layers:
 //!
-//! 1. **Hard cap on entry count** ([`MAX_TRACKED_PAIRS`]). When the
-//!    cap is hit, new entries are rejected — an attacker churning
-//!    distinct `(sender, contract)` pairs cannot grow the map past
-//!    this size. Critical because the address space is attacker-
+//! 1. **Hard cap on entry count** ([`MAX_TRACKED_PAIRS`]). At the cap,
+//!    the oldest entries are evicted to make room — an attacker
+//!    churning distinct `(sender, contract)` pairs cannot grow the map
+//!    past this size. Critical because the address space is attacker-
 //!    chosen (32-byte contract id × any source address).
 //! 2. **Periodic TTL sweep** ([`UpdateRateLimiter::cleanup`]) drops
 //!    entries idle for longer than [`CLEANUP_AGE`]. Hooked into the
@@ -46,6 +46,39 @@
 //! The cap alone is sufficient to bound memory; the TTL sweep
 //! reclaims space from genuinely-idle pairs so the cap isn't
 //! prematurely reached under normal traffic.
+//!
+//! ### Why the cap evicts rather than rejects (#4981)
+//!
+//! It used to reject: at the cap a *new* pair was refused and never
+//! inserted, so it stayed "new" forever and every subsequent UPDATE
+//! from it was dropped and re-counted. The module reasoned that "only
+//! NEW pairs hit the cap, and the TTL sweep gives smooth recovery as
+//! idle pairs roll off" — true only for *idle* pairs. An accepted
+//! UPDATE restamps its entry, so a busy pair never ages out under
+//! [`CLEANUP_AGE`]; the slots were held permanently by whoever got in
+//! first and stayed active, and newcomers were locked out with no
+//! recovery path. That is the permanently-refreshable GC exemption
+//! `AGENTS.md` forbids ("any condition that exempts an entry from
+//! garbage collection MUST either expire via TTL, or be overridden by
+//! an absolute age threshold"): the TTL was refreshable without limit.
+//!
+//! Saturation is not evidence of an attack. Tracked pairs are distinct
+//! senders × distinct contracts relayed from them, so 50 peers × ~330
+//! contracts ≈ 16 500 exceeds the cap with no attacker involved. A fix
+//! that assumes the newcomer is hostile penalises the ordinary case of
+//! a healthy node outgrowing the bound.
+//!
+//! What eviction costs, stated plainly: an evicted pair's next UPDATE
+//! is treated as new and therefore allowed, so an attacker churning
+//! fresh contract ids gets one UPDATE through per id instead of being
+//! cut off after the first 16 384. That ceiling was incidental rather
+//! than designed — the cap exists to bound *memory* — and per-(sender,
+//! contract) rate limiting cannot stop a fresh-id attacker regardless,
+//! since a pair the map has never seen is always allowed once. Paying
+//! it buys back the availability of every legitimate relayed UPDATE on
+//! a saturated node. Sustained floods from a *stable* pair, which is
+//! the pattern this limiter exists for, are unaffected: that entry is
+//! the most recently used, so it is the last thing evicted.
 //!
 //! ## Semantic note: `sender_addr` is the immediate upstream hop
 //!
@@ -87,8 +120,8 @@
 //!   detect the flood pattern from its end.
 
 use std::net::SocketAddr;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use dashmap::DashMap;
@@ -114,17 +147,54 @@ pub(crate) const MIN_UPDATE_INTERVAL: Duration = Duration::from_millis(100);
 pub(crate) const CLEANUP_AGE: Duration = Duration::from_secs(5 * 60);
 
 /// Hard upper bound on the number of tracked `(sender, contract)`
-/// pairs. When the cap is reached, new pairs are rejected outright —
-/// this is the "no unbounded per-key collection for attacker-influenced
-/// keys" rule from `.claude/rules/code-style.md`. At 64 bytes/entry,
-/// 16 384 pairs ≈ 1 MB — tiny — but bounds the worst case where an
-/// attacker chooses fresh contract ids.
+/// pairs. This is the "no unbounded per-key collection for attacker-
+/// influenced keys" rule from `.claude/rules/code-style.md`. At 64
+/// bytes/entry, 16 384 pairs ≈ 1 MB — tiny — but bounds the worst case
+/// where an attacker chooses fresh contract ids.
 ///
-/// On reaching the cap: the per-shard guard's existing entries
-/// continue to track normally (so a legitimate peer who was already
-/// tracked keeps working); only NEW pairs hit the cap. Combined with
-/// the TTL sweep this gives smooth recovery as idle pairs roll off.
+/// On reaching the cap the oldest entries are evicted to admit the
+/// newcomer (see the module docs for why rejecting instead starved new
+/// pairs permanently, #4981). The bound itself is unchanged: eviction
+/// keeps the map at or below this size at all times.
 pub(crate) const MAX_TRACKED_PAIRS: usize = 16_384;
+
+/// When the map is full, evict `max_tracked_pairs / this` entries in one
+/// pass rather than one entry per admission.
+///
+/// Finding the oldest entry means walking every shard, which cannot be
+/// done while holding a shard guard (see [`UpdateRateLimiter::size`] for
+/// the deadlock this module already hit once). Under the saturation this
+/// fix targets the map is *persistently* full, so a one-entry-per-
+/// admission policy would walk 16 384 entries on every new pair — at the
+/// 50-100 new pairs/sec reported in #4981, a continuous full scan of the
+/// map several times a second on the UPDATE receive path. Evicting a
+/// batch amortises that to one scan per batch (≈1.5/sec at the same
+/// rate) for the same eviction *policy*: the oldest entries go first.
+///
+/// 64 gives a 256-entry batch at the default cap, ≈1.5% of it. Small
+/// enough that an evicted pair is genuinely among the least recently
+/// used, large enough that the scan is not the dominant cost.
+const EVICTION_BATCH_DIVISOR: usize = 64;
+
+/// How often a capacity eviction may write a log line.
+///
+/// Eviction on a saturated node is continuous, so this is throttled to
+/// keep it to roughly a line a minute while still being visible in
+/// release builds — the whole point of logging it (#4981: the previous
+/// drop path logged at `debug!`, which `release_max_level_info` compiles
+/// out, so the only evidence a production node discarded legitimate
+/// UPDATEs was a dashboard tile).
+const EVICTION_LOG_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Bound on admission attempts before giving up with `CapacityExceeded`.
+///
+/// One attempt, one eviction, one retry is the expected path. The bound
+/// exists because the slot freed by eviction is not reserved: another
+/// thread may take it between the eviction and the retry, and an
+/// unbounded retry loop would let sustained contention spin here on the
+/// receive path. Giving up is safe — the competing thread's UPDATE went
+/// through, and this sender retries.
+const MAX_ADMISSION_ATTEMPTS: usize = 3;
 
 /// Outcome of an UPDATE rate-limit check. Callers must treat any
 /// non-`Allowed` variant as "drop this message at the receive
@@ -141,11 +211,17 @@ pub(crate) enum RateLimitDecision {
         elapsed: Duration,
         min_interval: Duration,
     },
-    /// Rejected because the tracking map has hit
-    /// [`MAX_TRACKED_PAIRS`] and this is a new pair. Distinct from
-    /// `Rejected` so the dashboard can tell "throttling working as
-    /// intended" apart from "limiter overflowing" — the latter
-    /// suggests an attack pattern with churned identities.
+    /// Rejected because the tracking map is at [`MAX_TRACKED_PAIRS`],
+    /// this is a new pair, and eviction could not free a slot for it.
+    ///
+    /// Since #4981 this is close to unreachable: a full map always has
+    /// an oldest entry to evict, so reaching here means every admission
+    /// attempt lost its freed slot to a concurrent caller (see
+    /// [`MAX_ADMISSION_ATTEMPTS`]). Kept distinct from `Rejected` so the
+    /// dashboard can still tell "throttling working as intended" apart
+    /// from "limiter overflowing", and because a rising count now means
+    /// something sharper than it used to: not merely that the map is
+    /// full, but that it is full *and* contended.
     CapacityExceeded,
 }
 
@@ -187,10 +263,21 @@ pub(crate) struct UpdateRateLimiter {
     /// Total rejected UPDATEs since limiter creation (rate-limit hits).
     rejected_total: AtomicU64,
     /// Total UPDATEs rejected because the tracking map was at capacity
-    /// when a new `(sender, contract)` pair tried to register. Surfaced
-    /// separately because a non-zero value suggests an attacker is
-    /// churning identities to exhaust the limiter's address space.
+    /// when a new `(sender, contract)` pair tried to register and
+    /// eviction could not free a slot for it. Surfaced separately
+    /// because since #4981 a non-zero value means the map is full *and*
+    /// contended, not merely full.
     capacity_rejected_total: AtomicU64,
+    /// Total entries evicted to admit new pairs at capacity. This is the
+    /// operator's "the limiter is saturated" signal, and it replaces
+    /// `capacity_rejected_total` in that role: a healthy busy node now
+    /// shows evictions climbing and capacity rejections flat.
+    capacity_evicted_total: AtomicU64,
+    /// When the last eviction log line was written, for
+    /// [`EVICTION_LOG_INTERVAL`] throttling. Only touched on the
+    /// eviction path, which already walks the map, so the lock is not
+    /// on the common path.
+    last_eviction_log: Mutex<Option<Instant>>,
 }
 
 impl UpdateRateLimiter {
@@ -212,6 +299,8 @@ impl UpdateRateLimiter {
             accepted_total: AtomicU64::new(0),
             rejected_total: AtomicU64::new(0),
             capacity_rejected_total: AtomicU64::new(0),
+            capacity_evicted_total: AtomicU64::new(0),
+            last_eviction_log: Mutex::new(None),
         }
     }
 
@@ -233,11 +322,13 @@ impl UpdateRateLimiter {
     ///    Concurrent distinct-key inserts strictly serialize through
     ///    the counter — no overshoot.
     ///
-    /// If rejected (either rate or capacity), no map mutation is
-    /// made. A barrage of rejected attempts doesn't extend the rate
-    /// window (the existing `last_accepted` timestamp is unchanged)
-    /// and doesn't grow memory (the reservation is rolled back on
-    /// CapacityExceeded).
+    /// If rejected on rate, no map mutation is made: a barrage of
+    /// rejected attempts doesn't extend the rate window (the existing
+    /// `last_accepted` timestamp is unchanged) and doesn't grow memory.
+    ///
+    /// At capacity a new pair evicts the oldest entries rather than
+    /// being refused (#4981) — see the module docs for why refusing
+    /// starved newcomers permanently, and what eviction costs.
     pub fn check_and_record(
         &self,
         sender: SocketAddr,
@@ -247,40 +338,145 @@ impl UpdateRateLimiter {
         let key = (sender, contract);
 
         use dashmap::mapref::entry::Entry;
-        match self.last_accepted.entry(key) {
-            Entry::Occupied(mut entry) => {
-                // Existing pair: atomic compare-and-stamp under
-                // shard guard.
-                let last = *entry.get();
-                let elapsed = now.saturating_duration_since(last);
-                if elapsed < self.min_interval {
-                    self.rejected_total.fetch_add(1, Ordering::Relaxed);
-                    return RateLimitDecision::Rejected {
-                        elapsed,
-                        min_interval: self.min_interval,
-                    };
+        // Each iteration either decides, or frees capacity and retries.
+        // See `MAX_ADMISSION_ATTEMPTS` for why this is bounded.
+        for _ in 0..MAX_ADMISSION_ATTEMPTS {
+            match self.last_accepted.entry(key) {
+                Entry::Occupied(mut entry) => {
+                    // Existing pair: atomic compare-and-stamp under
+                    // shard guard.
+                    let last = *entry.get();
+                    let elapsed = now.saturating_duration_since(last);
+                    if elapsed < self.min_interval {
+                        self.rejected_total.fetch_add(1, Ordering::Relaxed);
+                        return RateLimitDecision::Rejected {
+                            elapsed,
+                            min_interval: self.min_interval,
+                        };
+                    }
+                    *entry.get_mut() = now;
+                    self.accepted_total.fetch_add(1, Ordering::Relaxed);
+                    return RateLimitDecision::Allowed;
                 }
-                *entry.get_mut() = now;
-                self.accepted_total.fetch_add(1, Ordering::Relaxed);
-                RateLimitDecision::Allowed
-            }
-            Entry::Vacant(entry) => {
-                // New pair: reserve a slot via the authoritative
-                // counter BEFORE inserting. `fetch_add` is the
-                // serialization point — concurrent new-key inserts
-                // strictly serialize, no overshoot beyond the cap.
-                let prev = self.size.fetch_add(1, Ordering::Relaxed);
-                if prev >= self.max_tracked_pairs {
-                    // Cap exceeded. Roll back the reservation.
-                    self.size.fetch_sub(1, Ordering::Relaxed);
-                    self.capacity_rejected_total.fetch_add(1, Ordering::Relaxed);
-                    return RateLimitDecision::CapacityExceeded;
+                Entry::Vacant(entry) => {
+                    // New pair: reserve a slot via the authoritative
+                    // counter BEFORE inserting. `fetch_add` is the
+                    // serialization point — concurrent new-key inserts
+                    // strictly serialize, no overshoot beyond the cap.
+                    let prev = self.size.fetch_add(1, Ordering::Relaxed);
+                    if prev >= self.max_tracked_pairs {
+                        // Cap reached. Roll back the reservation and
+                        // release the shard guard BEFORE evicting:
+                        // `evict_oldest` walks every shard, and holding
+                        // a guard across that deadlocks (the same hazard
+                        // documented on `size`). The freed slot is not
+                        // reserved across the retry — another thread may
+                        // take it, in which case the next iteration
+                        // evicts again or falls through.
+                        self.size.fetch_sub(1, Ordering::Relaxed);
+                        drop(entry);
+                        if self.evict_oldest(now) > 0 {
+                            continue;
+                        }
+                        // Nothing to evict: the map is empty, so the cap
+                        // is 0. Configuration, not saturation.
+                        self.capacity_rejected_total.fetch_add(1, Ordering::Relaxed);
+                        return RateLimitDecision::CapacityExceeded;
+                    }
+                    entry.insert(now);
+                    self.accepted_total.fetch_add(1, Ordering::Relaxed);
+                    return RateLimitDecision::Allowed;
                 }
-                entry.insert(now);
-                self.accepted_total.fetch_add(1, Ordering::Relaxed);
-                RateLimitDecision::Allowed
             }
         }
+
+        // Every attempt lost its freed slot to a concurrent caller.
+        self.capacity_rejected_total.fetch_add(1, Ordering::Relaxed);
+        RateLimitDecision::CapacityExceeded
+    }
+
+    /// Evict the oldest tracked pairs to make room for a new one,
+    /// returning how many were removed.
+    ///
+    /// Must be called with no shard guard held — it walks every shard.
+    ///
+    /// Removes up to `max_tracked_pairs / EVICTION_BATCH_DIVISOR`
+    /// entries (at least one) in a single pass, oldest first, so the
+    /// O(map) scan is amortised across a batch of admissions rather than
+    /// paid per admission. `select_nth_unstable_by_key` partitions
+    /// rather than sorts, so the pass is linear.
+    ///
+    /// Removing exactly `batch` keys — rather than retaining everything
+    /// newer than a cutoff timestamp — matters because timestamps tie:
+    /// entries stamped within the same clock tick (and, in tests, from a
+    /// mock clock that has not advanced) share an `Instant`, and a
+    /// cutoff comparison would take every tied entry with it.
+    fn evict_oldest(&self, now: Instant) -> usize {
+        let batch = (self.max_tracked_pairs / EVICTION_BATCH_DIVISOR).max(1);
+        let mut entries: Vec<(Instant, (SocketAddr, ContractInstanceId))> = self
+            .last_accepted
+            .iter()
+            .map(|e| (*e.value(), *e.key()))
+            .collect();
+        if entries.is_empty() {
+            return 0;
+        }
+        let batch = batch.min(entries.len());
+        entries.select_nth_unstable_by_key(batch - 1, |(stamped, _)| *stamped);
+
+        let mut removed = 0usize;
+        for (_, victim) in &entries[..batch] {
+            // A concurrent caller may have removed it already; only
+            // count what this call actually took out, so `size` stays
+            // in step with the map.
+            if self.last_accepted.remove(victim).is_some() {
+                removed += 1;
+            }
+        }
+        if removed > 0 {
+            self.size.fetch_sub(removed, Ordering::Relaxed);
+            self.capacity_evicted_total
+                .fetch_add(removed as u64, Ordering::Relaxed);
+            self.log_eviction(now, removed);
+        }
+        removed
+    }
+
+    /// Emit the saturation log line, at most once per
+    /// [`EVICTION_LOG_INTERVAL`].
+    ///
+    /// `info!` rather than `debug!` on purpose: `debug!` is compiled out
+    /// of release builds by `release_max_level_info`, which is why the
+    /// old drop path left no greppable evidence on a production node
+    /// (#4981).
+    fn log_eviction(&self, now: Instant, removed: usize) {
+        let mut last = match self.last_eviction_log.lock() {
+            Ok(guard) => guard,
+            // Poisoned only if a previous holder panicked while
+            // formatting a log line. Losing the throttle is not worth
+            // propagating a panic from the UPDATE receive path.
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let due = match *last {
+            Some(prev) => now.saturating_duration_since(prev) >= EVICTION_LOG_INTERVAL,
+            None => true,
+        };
+        if !due {
+            return;
+        }
+        *last = Some(now);
+        drop(last);
+
+        tracing::info!(
+            evicted = removed,
+            evicted_total = self.capacity_evicted_total.load(Ordering::Relaxed),
+            tracked = self.size.load(Ordering::Relaxed),
+            max_tracked_pairs = self.max_tracked_pairs,
+            "UPDATE rate limiter at capacity: evicted least-recently-used \
+             (sender, contract) pairs to admit new ones. Expected on a node \
+             relaying for many peers and contracts; an evicted pair's next \
+             UPDATE is treated as new. Throttled to one line per minute."
+        );
     }
 
     /// Drop entries whose timestamp is older than [`CLEANUP_AGE`].
@@ -330,6 +526,15 @@ impl UpdateRateLimiter {
     /// that reason.
     pub fn capacity_rejected_total(&self) -> u64 {
         self.capacity_rejected_total.load(Ordering::Relaxed)
+    }
+
+    /// Total entries evicted to admit new pairs at capacity. Surfaced on
+    /// the dashboard ("Capacity-evicted") as the saturation signal: a
+    /// rising value means the node is relaying for more `(sender,
+    /// contract)` pairs than [`MAX_TRACKED_PAIRS`], which is expected on
+    /// a busy node and no longer costs those pairs their UPDATEs.
+    pub fn capacity_evicted_total(&self) -> u64 {
+        self.capacity_evicted_total.load(Ordering::Relaxed)
     }
 
     /// Number of tracked `(sender, contract)` pairs. Used by tests and
@@ -561,14 +766,22 @@ mod tests {
         );
     }
 
-    /// Pin: hard cap on tracked pairs prevents an attacker churning
-    /// fresh contract identities from growing the map indefinitely.
-    /// Once `MAX_TRACKED_PAIRS` is reached, new pairs get
-    /// `CapacityExceeded`, never `Allowed`. Existing pairs keep
-    /// working — graceful degradation, not total denial.
+    /// Pin: the cap still bounds the map, but reaching it admits the
+    /// newcomer by evicting rather than refusing it (#4981).
+    ///
+    /// This replaces the assertion the previous version of this test
+    /// made — that a new pair past the cap gets `CapacityExceeded` —
+    /// which pinned the starvation bug as if it were the contract. What
+    /// it checked that still holds is kept: the map never exceeds the
+    /// cap, and existing pairs keep working. See
+    /// `at_capacity_evicts_the_oldest_pair_not_an_arbitrary_one` for the
+    /// eviction order and
+    /// `busy_pairs_cannot_hold_slots_against_newcomers` for the
+    /// starvation regression itself.
     #[test]
-    fn capacity_exceeded_when_cap_reached() {
-        // Small cap so the test is fast.
+    fn at_capacity_new_pair_is_admitted_and_the_map_stays_bounded() {
+        // Small cap so the test is fast. At cap 8 the eviction batch is
+        // `max(8 / 64, 1)` = exactly one entry.
         let ts = SharedMockTimeSource::new();
         let limiter = UpdateRateLimiter::with_config(
             Arc::new(ts.clone()),
@@ -580,31 +793,211 @@ mod tests {
         for i in 0..8 {
             let d = limiter.check_and_record(mk_sender(i + 1), mk_contract(i + 1));
             assert_eq!(d, RateLimitDecision::Allowed, "pair {i} should be allowed");
+            ts.advance(Duration::from_millis(1));
         }
         assert_eq!(limiter.len(), 8);
 
-        // Pair #9 is a new key — must be CapacityExceeded.
+        // Pair #9 is a new key at capacity: admitted, by evicting.
         let d = limiter.check_and_record(mk_sender(99), mk_contract(99));
         assert_eq!(
             d,
-            RateLimitDecision::CapacityExceeded,
-            "new pair past the cap must be CapacityExceeded"
+            RateLimitDecision::Allowed,
+            "a new pair at capacity must be admitted, not starved (#4981)"
         );
-        assert_eq!(limiter.capacity_rejected_total(), 1);
+        assert_eq!(
+            limiter.capacity_rejected_total(),
+            0,
+            "admission by eviction must not count as a capacity rejection"
+        );
+        assert_eq!(limiter.capacity_evicted_total(), 1);
+        assert_eq!(
+            limiter.len(),
+            8,
+            "the cap is still a hard bound: one in, one out"
+        );
 
-        // Pair #1 (already tracked) — should still work after
-        // the min_interval elapses. Existing pairs aren't punished
-        // by the cap.
+        // An already-tracked pair keeps working after min_interval.
         ts.advance(MIN_UPDATE_INTERVAL + Duration::from_millis(1));
-        let d = limiter.check_and_record(mk_sender(1), mk_contract(1));
+        let d = limiter.check_and_record(mk_sender(8), mk_contract(8));
         assert_eq!(
             d,
             RateLimitDecision::Allowed,
             "existing pair must keep working at cap"
         );
+    }
 
-        // After cleanup drops stale entries the cap recovers, but in
-        // this test no time has passed so they're still fresh.
+    /// The victim is the least recently used pair, not an arbitrary one.
+    ///
+    /// Membership is observed through the limiter's own behaviour rather
+    /// than a test-only accessor: a tracked pair stamped within
+    /// `min_interval` answers `Rejected`, while an evicted pair is seen
+    /// as new and answers `Allowed`. So "was it evicted?" is exactly
+    /// "does an immediate re-check come back Allowed?".
+    #[test]
+    fn at_capacity_evicts_the_oldest_pair_not_an_arbitrary_one() {
+        let ts = SharedMockTimeSource::new();
+        let limiter = UpdateRateLimiter::with_config(Arc::new(ts.clone()), MIN_UPDATE_INTERVAL, 8);
+
+        // Fill, each pair stamped a millisecond apart so "oldest" is
+        // unambiguous. Pair 1 is the oldest, pair 8 the newest.
+        for i in 1..=8u8 {
+            assert!(
+                limiter
+                    .check_and_record(mk_sender(i), mk_contract(i))
+                    .is_allowed()
+            );
+            ts.advance(Duration::from_millis(1));
+        }
+
+        // Refresh pair 1, making it the most recently used. If eviction
+        // ignored recency, this is the entry a naive "first one found"
+        // policy would still take.
+        ts.advance(MIN_UPDATE_INTERVAL);
+        assert!(
+            limiter
+                .check_and_record(mk_sender(1), mk_contract(1))
+                .is_allowed()
+        );
+
+        // Admit a newcomer: pair 2 is now the oldest and must be the
+        // victim.
+        assert!(
+            limiter
+                .check_and_record(mk_sender(99), mk_contract(99))
+                .is_allowed()
+        );
+        assert_eq!(limiter.capacity_evicted_total(), 1);
+
+        // Pair 1 was just refreshed, so it must still be tracked — a
+        // re-check inside min_interval is Rejected. Checked first
+        // because a Rejected check does not mutate the map.
+        assert!(
+            matches!(
+                limiter.check_and_record(mk_sender(1), mk_contract(1)),
+                RateLimitDecision::Rejected { .. }
+            ),
+            "the most recently used pair must survive eviction"
+        );
+
+        // Pair 2 was the oldest, so it is gone: it reads as new.
+        assert_eq!(
+            limiter.check_and_record(mk_sender(2), mk_contract(2)),
+            RateLimitDecision::Allowed,
+            "the least recently used pair must be the eviction victim"
+        );
+    }
+
+    /// The #4981 regression: a busy pair must not be able to hold its
+    /// slot indefinitely against new arrivals.
+    ///
+    /// Every tracked pair keeps refreshing, which is what made the old
+    /// code starve newcomers forever — an accepted UPDATE restamps the
+    /// entry, so nothing ever aged out under `CLEANUP_AGE` and the cap
+    /// was permanently held by whoever got in first. Under that code
+    /// every newcomer here is `CapacityExceeded`; the pass condition is
+    /// that all of them get through.
+    #[test]
+    fn busy_pairs_cannot_hold_slots_against_newcomers() {
+        let ts = SharedMockTimeSource::new();
+        let limiter = UpdateRateLimiter::with_config(Arc::new(ts.clone()), MIN_UPDATE_INTERVAL, 8);
+
+        let start = ts.now();
+        for i in 1..=8u8 {
+            assert!(
+                limiter
+                    .check_and_record(mk_sender(i), mk_contract(i))
+                    .is_allowed()
+            );
+            ts.advance(Duration::from_millis(1));
+        }
+
+        // Well under CLEANUP_AGE throughout, so the TTL sweep is not
+        // what rescues the newcomers here — eviction is.
+        for round in 0..20u8 {
+            // The incumbents stay busy, restamping themselves.
+            ts.advance(MIN_UPDATE_INTERVAL + Duration::from_millis(1));
+            for i in 1..=8u8 {
+                limiter.check_and_record(mk_sender(i), mk_contract(i));
+            }
+
+            let newcomer = limiter.check_and_record(mk_sender(100 + round), mk_contract(200));
+            assert_eq!(
+                newcomer,
+                RateLimitDecision::Allowed,
+                "round {round}: a newcomer must not be starved by busy incumbents"
+            );
+            assert!(
+                limiter.len() <= 8,
+                "round {round}: the cap must still bound the map"
+            );
+        }
+
+        assert_eq!(
+            limiter.capacity_rejected_total(),
+            0,
+            "no UPDATE should have been dropped for capacity"
+        );
+        assert!(
+            ts.now().saturating_duration_since(start) < CLEANUP_AGE,
+            "sanity: the fixture must stay inside CLEANUP_AGE, so the TTL sweep \
+             cannot be what admitted the newcomers"
+        );
+    }
+
+    /// Eviction is batched at realistic cap sizes, so the O(map) scan is
+    /// amortised instead of paid on every admission.
+    ///
+    /// Cap 128 gives a batch of `128 / EVICTION_BATCH_DIVISOR` = 2. The
+    /// tests above all use cap 8, where the batch clamps to 1, so
+    /// without this one the divisor arithmetic is never exercised.
+    #[test]
+    fn eviction_is_batched_at_larger_caps() {
+        let ts = SharedMockTimeSource::new();
+        let cap = 128;
+        let limiter =
+            UpdateRateLimiter::with_config(Arc::new(ts.clone()), MIN_UPDATE_INTERVAL, cap);
+        let expected_batch = cap / EVICTION_BATCH_DIVISOR;
+        assert_eq!(expected_batch, 2, "fixture assumes a 2-entry batch");
+
+        for i in 0..cap {
+            let sender = SocketAddr::from(([10, 1, (i / 256) as u8, (i % 256) as u8], 30000));
+            assert!(
+                limiter
+                    .check_and_record(sender, mk_contract(1))
+                    .is_allowed()
+            );
+            ts.advance(Duration::from_millis(1));
+        }
+        assert_eq!(limiter.len(), cap);
+
+        assert!(
+            limiter
+                .check_and_record(mk_sender(99), mk_contract(99))
+                .is_allowed()
+        );
+        assert_eq!(
+            limiter.capacity_evicted_total(),
+            expected_batch as u64,
+            "one admission at capacity must evict a whole batch"
+        );
+        assert_eq!(
+            limiter.len(),
+            cap - expected_batch + 1,
+            "the batch leaves headroom, so the next admissions skip the scan"
+        );
+
+        // The freed headroom is real: the next admission must not evict
+        // again.
+        assert!(
+            limiter
+                .check_and_record(mk_sender(98), mk_contract(98))
+                .is_allowed()
+        );
+        assert_eq!(
+            limiter.capacity_evicted_total(),
+            expected_batch as u64,
+            "an admission with headroom must not trigger another eviction"
+        );
     }
 
     /// Pin the atomicity of `check_and_record` under concurrent
@@ -797,8 +1190,11 @@ mod tests {
                 RateLimitDecision::Rejected { .. } => rate_rejected += 1,
             }
         }
-        // Critical invariant: the map size is EXACTLY the cap, not
-        // cap + overshoot.
+        // Critical invariant, unchanged by #4981: the map size is
+        // EXACTLY the cap, not cap + overshoot. Eviction makes this a
+        // sharper test than it was — 64 threads now race to evict and
+        // insert concurrently, and the reservation counter still has to
+        // hold the line.
         assert_eq!(
             limiter.len(),
             CAP,
@@ -806,13 +1202,28 @@ mod tests {
              concurrent flood of distinct keys, got {}",
             limiter.len()
         );
-        assert_eq!(
-            allowed, CAP,
-            "exactly CAP admissions allowed under flood, got {allowed}"
+        // What this test used to assert — `allowed == CAP`, every other
+        // thread `CapacityExceeded` — was the starvation of #4981 stated
+        // as a requirement. At capacity a newcomer now evicts, so a
+        // flood of distinct keys admits more than CAP of them while the
+        // map stays bounded. What must still hold: at least the first
+        // CAP get in, nothing is lost, and no thread is rate-rejected
+        // (every key is distinct).
+        assert!(
+            allowed >= CAP,
+            "at least CAP admissions expected under flood, got {allowed}"
         );
-        assert_eq!(cap_rejected, THREADS - CAP);
+        assert_eq!(allowed + cap_rejected + rate_rejected, THREADS);
         assert_eq!(rate_rejected, 0);
-        assert_eq!(limiter.capacity_rejected_total(), (THREADS - CAP) as u64);
+        // Capacity rejection is now only reachable by losing an evicted
+        // slot to another thread `MAX_ADMISSION_ATTEMPTS` times running,
+        // so it is contention-dependent rather than a fixed count.
+        assert_eq!(limiter.capacity_rejected_total(), cap_rejected as u64);
+        assert_eq!(
+            limiter.capacity_evicted_total(),
+            (allowed - CAP) as u64,
+            "every admission beyond the first CAP must have evicted exactly one entry"
+        );
     }
 
     /// Pin: cleanup decrements the `size` counter by the number of
@@ -835,11 +1246,14 @@ mod tests {
                 RateLimitDecision::Allowed
             );
         }
-        // 5th is CapacityExceeded.
+        // The 5th is admitted by evicting (#4981 changed this from
+        // CapacityExceeded); the map stays at the cap either way, which
+        // is what this test is really about.
         assert_eq!(
             limiter.check_and_record(mk_sender(5), mk_contract(5)),
-            RateLimitDecision::CapacityExceeded
+            RateLimitDecision::Allowed
         );
+        assert_eq!(limiter.len(), 4, "eviction keeps the map at the cap");
         // Age out all entries.
         ts.advance(CLEANUP_AGE + Duration::from_secs(1));
         limiter.cleanup();

--- a/crates/core/src/ring/update_rate_limit.rs
+++ b/crates/core/src/ring/update_rate_limit.rs
@@ -115,11 +115,24 @@
 //! less like a fresh-id bound and more like a per-peer aggregate
 //! ceiling.
 //!
-//! That is why the sustained rate is set well ABOVE
-//! [`MIN_UPDATE_INTERVAL`]'s per-pair ceiling rather than at it: a peer
-//! would have to sustain [`NEW_PAIR_BURST`] and then 200 UPDATEs/s to
-//! this node, continuously, before any of it is dropped. If that ever
-//! binds on real traffic it is visible as
+//! How high that miss rate goes depends on the access pattern, not
+//! just the working-set size: measured at ~16 500 pairs against the
+//! 16 384 cap, uniform-random access misses 1.33% of the time but
+//! round-robin misses 96.77% — LRU's worst case, since every entry is
+//! evicted exactly before it is next used. So the miss rate is NOT
+//! reliably small, and the safety of this control does not rest on it
+//! being small.
+//!
+//! What it rests on is the binding condition, which is generous
+//! regardless of miss rate: **one peer must sustain ~210 UPDATE/s to
+//! this node, continuously**, before anything is dropped (the 200/s
+//! refill plus the burst amortised). Real gateway load is ~3.15/s on
+//! nova and ~2.84/s on vega NODE-WIDE, across all peers — roughly two
+//! orders of magnitude below the threshold for a single one of them.
+//! That is why the sustained rate is set well above
+//! [`MIN_UPDATE_INTERVAL`]'s per-pair ceiling rather than at it.
+//!
+//! If it ever does bind on real traffic it is visible as
 //! `new_pair_budget_rejected_total` climbing on a node with no attacker,
 //! which is the signal to raise the rate — the counter is on the
 //! dashboard for exactly that reason.
@@ -202,6 +215,24 @@ pub(crate) const CLEANUP_AGE: Duration = Duration::from_secs(5 * 60);
 /// influenced keys" rule from `.claude/rules/code-style.md`. At 64
 /// bytes/entry, 16 384 pairs ≈ 1 MB — tiny — but bounds the worst case
 /// where an attacker chooses fresh contract ids.
+///
+/// # Re-measure the eviction scan before raising this
+///
+/// Memory is not the binding cost. An eviction pass holds
+/// [`UpdateRateLimiter::eviction_lock`] across a scan that is LINEAR in
+/// this constant — measured 41 ns per entry, so **672 µs at 16 384 but
+/// 10.8 ms at 163 840**. At the current value that is a ~0.001% duty
+/// cycle against real gateway load (~3.15 UPDATE/s on nova, ~2.84/s on
+/// vega) and irrelevant; ten times larger it is a 10 ms blocking
+/// section on a tokio worker.
+///
+/// This warning is here because the PR that added eviction also
+/// installed the operator story "evictions climbing means saturation",
+/// and the obvious response to that reading is to raise this constant.
+/// Doing so is fine — but re-measure the hold time first, and if it
+/// grows past a millisecond or two, the scan wants a different shape
+/// (sampled victim selection, or a maintained ordering) rather than a
+/// longer lock.
 ///
 /// On reaching the cap the oldest entries are evicted to admit the
 /// newcomer (see the module docs for why rejecting instead starved new
@@ -821,9 +852,14 @@ impl UpdateRateLimiter {
             // batch size relative to the number of concurrent callers:
             // at the production cap (batch 256, 16 threads) it nearly
             // always wins, but at a 1024 cap the batch is 16 and callers
-            // lose a freed slot often enough to drop ~2 admissions in
+            // lose a freed slot often enough to drop ~0.19 admissions in
             // 1000. Keeping a slot makes "a caller that frees room gets
             // to use it" true by construction instead of by margin.
+            //
+            // That residual is small because the serialised scan already
+            // removed most of it; this closes the rest and, more to the
+            // point, makes the property independent of the batch/caller
+            // ratio rather than true only at the production cap.
             //
             // The strict cap is unaffected: `size` counts map entries
             // plus outstanding reservations, and every insert still
@@ -974,6 +1010,16 @@ impl UpdateRateLimiter {
     /// traffic for contracts already being tracked.
     pub fn new_pair_budget_rejected_total(&self) -> u64 {
         self.new_pair_budget_rejected_total.load(Ordering::Relaxed)
+    }
+
+    /// Total new pairs admitted WITHOUT a budget check because the
+    /// sender map was full. Surfaced on the dashboard
+    /// ("Fresh-id-unmetered") because a safety valve nobody can see
+    /// firing is the #4981 failure mode: this should be zero, and a
+    /// non-zero value means `max_tracked_senders` is undersized for this
+    /// node, so the budget is not actually bounding those senders.
+    pub fn new_pair_budget_untracked_total(&self) -> u64 {
+        self.new_pair_budget_untracked_total.load(Ordering::Relaxed)
     }
 
     /// Number of senders tracked by the new-pair budget.
@@ -1513,8 +1559,19 @@ mod tests {
     /// The sender map is bounded, and by a space the attacker does not
     /// choose: `sender` is the immediate upstream hop, so only a peer
     /// that has completed a handshake can occupy an entry.
+    ///
+    /// And — the half that matters — a sender arriving at a FULL map is
+    /// still admitted. Bounding alone is not the property: a bounded map
+    /// that refuses newcomers once full is #4981 exactly, one map over,
+    /// inside the control added to fix #4981. `Bucket::refill` restamps
+    /// on every check including denied ones, so an active sender's entry
+    /// never ages out and a refused newcomer would never recover.
+    ///
+    /// Asserting only `tracked_senders() <= MAX` did not catch that: a
+    /// fail-CLOSED implementation passed the whole suite 15/15 (#4997
+    /// re-review).
     #[test]
-    fn the_new_pair_budget_map_is_bounded() {
+    fn the_new_pair_budget_map_is_bounded_and_fails_open_when_full() {
         const MAX_SENDERS: usize = 4;
         let ts = SharedMockTimeSource::new();
         let limiter = UpdateRateLimiter::with_new_pair_budget(
@@ -1526,13 +1583,93 @@ mod tests {
         );
 
         for i in 0..(MAX_SENDERS * 4) {
-            limiter.check_and_record(mk_sender(i as u8), mk_contract(1));
+            let d = limiter.check_and_record(mk_sender(i as u8), mk_contract(1));
+            assert_eq!(
+                d,
+                RateLimitDecision::Allowed,
+                "sender {i}: a full sender map must fail OPEN — refusing here is \
+                 #4981 one map over, and this sender has spent nothing"
+            );
             assert!(
                 limiter.tracked_senders() <= MAX_SENDERS,
                 "sender {i}: the budget map must never exceed its cap"
             );
         }
         assert_eq!(limiter.tracked_senders(), MAX_SENDERS);
+
+        // The untracked admissions are counted, so an undersized map is
+        // an operator-visible condition rather than a silent one.
+        assert_eq!(
+            limiter.new_pair_budget_untracked_total(),
+            (MAX_SENDERS * 3) as u64,
+            "every admission past the cap must be counted as untracked"
+        );
+        assert_eq!(
+            limiter.new_pair_budget_rejected_total(),
+            0,
+            "a full map is a sizing accident, not evidence about any sender"
+        );
+    }
+
+    /// Source-scrape pin: `evict_oldest` has exactly ONE terminal exit,
+    /// and it is the zero-cap guard. Every other way out must be a
+    /// retry.
+    ///
+    /// This exists because no behavioural test can reach the
+    /// `removed == 0` exit any more. Once the scan is serialised,
+    /// concurrent evictors stop stealing each other's victims, so
+    /// turning that exit terminal survives the entire suite (verified:
+    /// 29/29, and 15/15 on the concurrency fixture that looks like it
+    /// would catch it).
+    ///
+    /// The exit must nonetheless stay a retry, for a cause no evictor
+    /// creates: **`cleanup` does not take the eviction lock**, and it
+    /// removes entries older than `CLEANUP_AGE` — precisely the oldest
+    /// entries, which is precisely what `select_nth_unstable_by_key`
+    /// selects. A reaper sweep landing between the collect and the
+    /// removes takes the whole batch out from under the evictor, and
+    /// that is a once-a-minute window on every node. Making it terminal
+    /// would drop a legitimate UPDATE there, silently, with the retry
+    /// budget untouched — the #4981 shape again.
+    ///
+    /// A source pin rather than a behavioural one, because the window is
+    /// a race between a reaper tick and a receive-path scan that no
+    /// fixture can schedule. Pinning the SHAPE (one terminal exit,
+    /// guarded by the cap) is what is actually available.
+    #[test]
+    fn evict_oldest_has_exactly_one_terminal_exit() {
+        const THIS_FILE: &str = include_str!("update_rate_limit.rs");
+
+        let start = THIS_FILE
+            .find(concat!("fn evict_", "oldest("))
+            .expect("evict_oldest must exist; if renamed, update this pin");
+        let tail = &THIS_FILE[start..];
+        // Bound to this function: the next item at impl indentation.
+        let end = tail[1..]
+            .find("\n    fn ")
+            .map(|i| i + 1)
+            .unwrap_or(tail.len());
+        let body = &tail[..end];
+
+        let terminal = concat!("EvictionOutcome::", "CapIsZero");
+        assert_eq!(
+            body.matches(terminal).count(),
+            1,
+            "evict_oldest must have exactly ONE terminal exit. Every other way out \
+             means slots are, or are about to be, free — including an empty map, \
+             which `cleanup` can produce mid-scan — and dropping there loses a \
+             legitimate UPDATE without spending the retry budget (#4981, #4997)."
+        );
+
+        let guard_pos = body
+            .find("self.max_tracked_pairs == 0")
+            .expect("the terminal exit must be guarded by the cap being zero");
+        let terminal_pos = body.find(terminal).expect("checked above");
+        assert!(
+            guard_pos < terminal_pos,
+            "the one terminal exit must be the zero-cap guard, not a condition \
+             inferred from the map's contents"
+        );
     }
 
     /// An empty map is NOT a reason to give up, even though the map
@@ -1616,7 +1753,7 @@ mod tests {
     /// limiter still refuses a new pair outright, and it must terminate
     /// rather than spin.
     ///
-    /// This is the one path `EvictionOutcome::MapEmpty` exists for. It
+    /// This is the one path `EvictionOutcome::CapIsZero` exists for. It
     /// was untested, which mattered because the eviction rework turned
     /// "evicted nothing" into a retry: had that retry not distinguished
     /// an empty map from a contended one, a zero cap would loop through
@@ -2364,13 +2501,25 @@ mod tests {
     /// affected, 100% of them from that branch, retry budget untouched.
     /// After the fix, 7 in 320 000 (0.002%).
     ///
-    /// The threshold sits an order of magnitude above what the fixed
-    /// implementation produces and well below what the bug produces:
-    /// reintroducing the bug takes this fixture to 671 drops in 6 400
-    /// against a threshold of 6, so it is neither flaky nor vacuous. It
-    /// is a bound rather than zero because losing a freed slot to a
-    /// concurrent caller on every attempt is genuinely possible — that
-    /// is what `CapacityExceeded` is documented to mean.
+    /// What it actually pins, stated precisely because an earlier
+    /// version of this comment credited the wrong fix: making the
+    /// caller's `EvictionOutcome::Retry` arm terminal takes this fixture
+    /// to 671 drops in 6 400 against a threshold of 6. That arm covers
+    /// the early-out and the under-lock re-check, which is where the
+    /// measured drops came from — so this pins the caller's handling of
+    /// a non-terminal eviction, and with it the serialised scan.
+    ///
+    /// It does NOT pin the `removed == 0` exit inside `evict_oldest`.
+    /// Making that one terminal survives this fixture 15/15 and the
+    /// whole suite 29/29, because once the scan is serialised concurrent
+    /// evictors no longer steal each other's victims, so `removed == 0`
+    /// never occurs here. That exit is real for a different reason and
+    /// is pinned by source scrape instead — see
+    /// `evict_oldest_has_exactly_one_terminal_exit`.
+    ///
+    /// The threshold is a bound rather than zero because losing a freed
+    /// slot to a concurrent caller on every attempt is genuinely
+    /// possible — that is what `CapacityExceeded` is documented to mean.
     #[test]
     fn concurrent_admission_at_capacity_almost_never_drops() {
         use std::sync::{Arc as StdArc, Barrier};

--- a/crates/core/src/ring/update_rate_limit.rs
+++ b/crates/core/src/ring/update_rate_limit.rs
@@ -91,7 +91,9 @@
 //! deliberate one takes its place: a token bucket keyed by `sender_addr`
 //! ALONE ([`NEW_PAIR_BURST`], [`NEW_PAIR_REFILL_INTERVAL`]) that a
 //! sender spends from only when it presents a `(sender, contract)` pair
-//! this limiter has never seen.
+//! the limiter is not currently tracking. Note "not currently tracking"
+//! rather than "has never seen" — the two differ once eviction is in
+//! play, and the difference is the caveat below.
 //!
 //! Two properties make this the right shape:
 //!
@@ -394,14 +396,17 @@ pub(crate) enum RateLimitDecision {
     /// something sharper than it used to: not merely that the map is
     /// full, but that it is full *and* contended.
     CapacityExceeded,
-    /// Rejected because the sender has spent its budget for introducing
-    /// brand-new `(sender, contract)` pairs (see the module docs).
+    /// Rejected because the sender has spent its budget for presenting
+    /// `(sender, contract)` pairs the limiter is not tracking (see the
+    /// module docs).
     ///
-    /// Only a pair this limiter has never seen can land here, so a
-    /// sender's established traffic never does, however much of it there
-    /// is. A rising count means one peer is presenting unfamiliar
-    /// contract ids faster than [`NEW_PAIR_REFILL_INTERVAL`] — the
-    /// fresh-id churn pattern.
+    /// Only a pair that is not currently in the map can land here, so a
+    /// sender's traffic for a tracked pair never does, however much of
+    /// it there is. Below saturation that is the same as "never seen"
+    /// and a rising count is the fresh-id churn pattern; once eviction
+    /// is recycling pairs faster than they return, it also counts
+    /// re-admissions, which is why the rate is set for aggregate traffic
+    /// rather than for genuinely-fresh ids.
     SenderNewPairBudget,
 }
 
@@ -882,10 +887,11 @@ impl UpdateRateLimiter {
             dropped_total = self.new_pair_budget_rejected_total.load(Ordering::Relaxed),
             burst = NEW_PAIR_BURST,
             refill_interval_ms = NEW_PAIR_REFILL_INTERVAL.as_millis() as u64,
-            "UPDATE rate limiter: peer is introducing brand-new (sender, contract) \
-             pairs faster than its budget allows, so its UPDATEs for unfamiliar \
-             contracts are being dropped. Its traffic for already-tracked contracts \
-             is unaffected. Throttled to one line per minute."
+            "UPDATE rate limiter: peer is presenting (sender, contract) pairs this \
+             node is not tracking faster than its budget allows, so those UPDATEs \
+             are being dropped. Its traffic for tracked pairs is unaffected. If this \
+             peer is not churning contract ids, the budget is set too low for this \
+             node's working set. Throttled to one line per minute."
         );
     }
 
@@ -2224,8 +2230,16 @@ mod tests {
     /// the pin vacuous.
     #[test]
     fn capacity_signals_are_logged_above_debug_level() {
+        // Backslashes go too, not just whitespace: these haystacks are
+        // SOURCE, so a long message carries `\` line continuations, and
+        // where they fall is rustfmt's choice. Stripping whitespace
+        // alone leaves the backslash behind and a needle spanning a
+        // continuation silently stops matching — which is the same
+        // reflow fragility the stripping exists to remove.
         fn strip_ws(s: &str) -> String {
-            s.chars().filter(|c| !c.is_whitespace()).collect()
+            s.chars()
+                .filter(|c| !c.is_whitespace() && *c != '\\')
+                .collect()
         }
 
         /// The macro invoked for the log line whose message contains
@@ -2270,8 +2284,8 @@ mod tests {
             level_of(
                 &this_file,
                 &strip_ws(concat!(
-                    "UPDATE rate limiter: peer is introducing ",
-                    "brand-new (sender, contract)"
+                    "UPDATE rate limiter: peer is presenting ",
+                    "(sender, contract) pairs this node is not tracking"
                 )),
                 "new-pair-budget",
             ),

--- a/crates/core/src/ring/update_rate_limit.rs
+++ b/crates/core/src/ring/update_rate_limit.rs
@@ -34,10 +34,10 @@
 //!
 //! Two layers:
 //!
-//! 1. **Hard cap on entry count** ([`MAX_TRACKED_PAIRS`]). When the
-//!    cap is hit, new entries are rejected — an attacker churning
-//!    distinct `(sender, contract)` pairs cannot grow the map past
-//!    this size. Critical because the address space is attacker-
+//! 1. **Hard cap on entry count** ([`MAX_TRACKED_PAIRS`]). At the cap,
+//!    the oldest entries are evicted to make room — an attacker
+//!    churning distinct `(sender, contract)` pairs cannot grow the map
+//!    past this size. Critical because the address space is attacker-
 //!    chosen (32-byte contract id × any source address).
 //! 2. **Periodic TTL sweep** ([`UpdateRateLimiter::cleanup`]) drops
 //!    entries idle for longer than [`CLEANUP_AGE`]. Hooked into the
@@ -46,6 +46,39 @@
 //! The cap alone is sufficient to bound memory; the TTL sweep
 //! reclaims space from genuinely-idle pairs so the cap isn't
 //! prematurely reached under normal traffic.
+//!
+//! ### Why the cap evicts rather than rejects (#4981)
+//!
+//! It used to reject: at the cap a *new* pair was refused and never
+//! inserted, so it stayed "new" forever and every subsequent UPDATE
+//! from it was dropped and re-counted. The module reasoned that "only
+//! NEW pairs hit the cap, and the TTL sweep gives smooth recovery as
+//! idle pairs roll off" — true only for *idle* pairs. An accepted
+//! UPDATE restamps its entry, so a busy pair never ages out under
+//! [`CLEANUP_AGE`]; the slots were held permanently by whoever got in
+//! first and stayed active, and newcomers were locked out with no
+//! recovery path. That is the permanently-refreshable GC exemption
+//! `AGENTS.md` forbids ("any condition that exempts an entry from
+//! garbage collection MUST either expire via TTL, or be overridden by
+//! an absolute age threshold"): the TTL was refreshable without limit.
+//!
+//! Saturation is not evidence of an attack. Tracked pairs are distinct
+//! senders × distinct contracts relayed from them, so 50 peers × ~330
+//! contracts ≈ 16 500 exceeds the cap with no attacker involved. A fix
+//! that assumes the newcomer is hostile penalises the ordinary case of
+//! a healthy node outgrowing the bound.
+//!
+//! What eviction costs, stated plainly: an evicted pair's next UPDATE
+//! is treated as new and therefore allowed, so an attacker churning
+//! fresh contract ids gets one UPDATE through per id instead of being
+//! cut off after the first 16 384. That ceiling was incidental rather
+//! than designed — the cap exists to bound *memory* — and per-(sender,
+//! contract) rate limiting cannot stop a fresh-id attacker regardless,
+//! since a pair the map has never seen is always allowed once. Paying
+//! it buys back the availability of every legitimate relayed UPDATE on
+//! a saturated node. Sustained floods from a *stable* pair, which is
+//! the pattern this limiter exists for, are unaffected: that entry is
+//! the most recently used, so it is the last thing evicted.
 //!
 //! ## Semantic note: `sender_addr` is the immediate upstream hop
 //!
@@ -87,8 +120,8 @@
 //!   detect the flood pattern from its end.
 
 use std::net::SocketAddr;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use dashmap::DashMap;
@@ -114,17 +147,54 @@ pub(crate) const MIN_UPDATE_INTERVAL: Duration = Duration::from_millis(100);
 pub(crate) const CLEANUP_AGE: Duration = Duration::from_secs(5 * 60);
 
 /// Hard upper bound on the number of tracked `(sender, contract)`
-/// pairs. When the cap is reached, new pairs are rejected outright —
-/// this is the "no unbounded per-key collection for attacker-influenced
-/// keys" rule from `.claude/rules/code-style.md`. At 64 bytes/entry,
-/// 16 384 pairs ≈ 1 MB — tiny — but bounds the worst case where an
-/// attacker chooses fresh contract ids.
+/// pairs. This is the "no unbounded per-key collection for attacker-
+/// influenced keys" rule from `.claude/rules/code-style.md`. At 64
+/// bytes/entry, 16 384 pairs ≈ 1 MB — tiny — but bounds the worst case
+/// where an attacker chooses fresh contract ids.
 ///
-/// On reaching the cap: the per-shard guard's existing entries
-/// continue to track normally (so a legitimate peer who was already
-/// tracked keeps working); only NEW pairs hit the cap. Combined with
-/// the TTL sweep this gives smooth recovery as idle pairs roll off.
+/// On reaching the cap the oldest entries are evicted to admit the
+/// newcomer (see the module docs for why rejecting instead starved new
+/// pairs permanently, #4981). The bound itself is unchanged: eviction
+/// keeps the map at or below this size at all times.
 pub(crate) const MAX_TRACKED_PAIRS: usize = 16_384;
+
+/// When the map is full, evict `max_tracked_pairs / this` entries in one
+/// pass rather than one entry per admission.
+///
+/// Finding the oldest entry means walking every shard, which cannot be
+/// done while holding a shard guard (see [`UpdateRateLimiter::size`] for
+/// the deadlock this module already hit once). Under the saturation this
+/// fix targets the map is *persistently* full, so a one-entry-per-
+/// admission policy would walk 16 384 entries on every new pair — at the
+/// 50-100 new pairs/sec reported in #4981, a continuous full scan of the
+/// map several times a second on the UPDATE receive path. Evicting a
+/// batch amortises that to one scan per batch (≈1.5/sec at the same
+/// rate) for the same eviction *policy*: the oldest entries go first.
+///
+/// 64 gives a 256-entry batch at the default cap, ≈1.5% of it. Small
+/// enough that an evicted pair is genuinely among the least recently
+/// used, large enough that the scan is not the dominant cost.
+const EVICTION_BATCH_DIVISOR: usize = 64;
+
+/// How often a capacity eviction may write a log line.
+///
+/// Eviction on a saturated node is continuous, so this is throttled to
+/// keep it to roughly a line a minute while still being visible in
+/// release builds — the whole point of logging it (#4981: the previous
+/// drop path logged at `debug!`, which `release_max_level_info` compiles
+/// out, so the only evidence a production node discarded legitimate
+/// UPDATEs was a dashboard tile).
+const EVICTION_LOG_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Bound on admission attempts before giving up with `CapacityExceeded`.
+///
+/// One attempt, one eviction, one retry is the expected path. The bound
+/// exists because the slot freed by eviction is not reserved: another
+/// thread may take it between the eviction and the retry, and an
+/// unbounded retry loop would let sustained contention spin here on the
+/// receive path. Giving up is safe — the competing thread's UPDATE went
+/// through, and this sender retries.
+const MAX_ADMISSION_ATTEMPTS: usize = 3;
 
 /// Outcome of an UPDATE rate-limit check. Callers must treat any
 /// non-`Allowed` variant as "drop this message at the receive
@@ -141,11 +211,17 @@ pub(crate) enum RateLimitDecision {
         elapsed: Duration,
         min_interval: Duration,
     },
-    /// Rejected because the tracking map has hit
-    /// [`MAX_TRACKED_PAIRS`] and this is a new pair. Distinct from
-    /// `Rejected` so the dashboard can tell "throttling working as
-    /// intended" apart from "limiter overflowing" — the latter
-    /// suggests an attack pattern with churned identities.
+    /// Rejected because the tracking map is at [`MAX_TRACKED_PAIRS`],
+    /// this is a new pair, and eviction could not free a slot for it.
+    ///
+    /// Since #4981 this is close to unreachable: a full map always has
+    /// an oldest entry to evict, so reaching here means every admission
+    /// attempt lost its freed slot to a concurrent caller (see
+    /// [`MAX_ADMISSION_ATTEMPTS`]). Kept distinct from `Rejected` so the
+    /// dashboard can still tell "throttling working as intended" apart
+    /// from "limiter overflowing", and because a rising count now means
+    /// something sharper than it used to: not merely that the map is
+    /// full, but that it is full *and* contended.
     CapacityExceeded,
 }
 
@@ -187,10 +263,21 @@ pub(crate) struct UpdateRateLimiter {
     /// Total rejected UPDATEs since limiter creation (rate-limit hits).
     rejected_total: AtomicU64,
     /// Total UPDATEs rejected because the tracking map was at capacity
-    /// when a new `(sender, contract)` pair tried to register. Surfaced
-    /// separately because a non-zero value suggests an attacker is
-    /// churning identities to exhaust the limiter's address space.
+    /// when a new `(sender, contract)` pair tried to register and
+    /// eviction could not free a slot for it. Surfaced separately
+    /// because since #4981 a non-zero value means the map is full *and*
+    /// contended, not merely full.
     capacity_rejected_total: AtomicU64,
+    /// Total entries evicted to admit new pairs at capacity. This is the
+    /// operator's "the limiter is saturated" signal, and it replaces
+    /// `capacity_rejected_total` in that role: a healthy busy node now
+    /// shows evictions climbing and capacity rejections flat.
+    capacity_evicted_total: AtomicU64,
+    /// When the last eviction log line was written, for
+    /// [`EVICTION_LOG_INTERVAL`] throttling. Only touched on the
+    /// eviction path, which already walks the map, so the lock is not
+    /// on the common path.
+    last_eviction_log: Mutex<Option<Instant>>,
 }
 
 impl UpdateRateLimiter {
@@ -212,6 +299,8 @@ impl UpdateRateLimiter {
             accepted_total: AtomicU64::new(0),
             rejected_total: AtomicU64::new(0),
             capacity_rejected_total: AtomicU64::new(0),
+            capacity_evicted_total: AtomicU64::new(0),
+            last_eviction_log: Mutex::new(None),
         }
     }
 
@@ -233,11 +322,13 @@ impl UpdateRateLimiter {
     ///    Concurrent distinct-key inserts strictly serialize through
     ///    the counter — no overshoot.
     ///
-    /// If rejected (either rate or capacity), no map mutation is
-    /// made. A barrage of rejected attempts doesn't extend the rate
-    /// window (the existing `last_accepted` timestamp is unchanged)
-    /// and doesn't grow memory (the reservation is rolled back on
-    /// CapacityExceeded).
+    /// If rejected on rate, no map mutation is made: a barrage of
+    /// rejected attempts doesn't extend the rate window (the existing
+    /// `last_accepted` timestamp is unchanged) and doesn't grow memory.
+    ///
+    /// At capacity a new pair evicts the oldest entries rather than
+    /// being refused (#4981) — see the module docs for why refusing
+    /// starved newcomers permanently, and what eviction costs.
     pub fn check_and_record(
         &self,
         sender: SocketAddr,
@@ -247,40 +338,145 @@ impl UpdateRateLimiter {
         let key = (sender, contract);
 
         use dashmap::mapref::entry::Entry;
-        match self.last_accepted.entry(key) {
-            Entry::Occupied(mut entry) => {
-                // Existing pair: atomic compare-and-stamp under
-                // shard guard.
-                let last = *entry.get();
-                let elapsed = now.saturating_duration_since(last);
-                if elapsed < self.min_interval {
-                    self.rejected_total.fetch_add(1, Ordering::Relaxed);
-                    return RateLimitDecision::Rejected {
-                        elapsed,
-                        min_interval: self.min_interval,
-                    };
+        // Each iteration either decides, or frees capacity and retries.
+        // See `MAX_ADMISSION_ATTEMPTS` for why this is bounded.
+        for _ in 0..MAX_ADMISSION_ATTEMPTS {
+            match self.last_accepted.entry(key) {
+                Entry::Occupied(mut entry) => {
+                    // Existing pair: atomic compare-and-stamp under
+                    // shard guard.
+                    let last = *entry.get();
+                    let elapsed = now.saturating_duration_since(last);
+                    if elapsed < self.min_interval {
+                        self.rejected_total.fetch_add(1, Ordering::Relaxed);
+                        return RateLimitDecision::Rejected {
+                            elapsed,
+                            min_interval: self.min_interval,
+                        };
+                    }
+                    *entry.get_mut() = now;
+                    self.accepted_total.fetch_add(1, Ordering::Relaxed);
+                    return RateLimitDecision::Allowed;
                 }
-                *entry.get_mut() = now;
-                self.accepted_total.fetch_add(1, Ordering::Relaxed);
-                RateLimitDecision::Allowed
-            }
-            Entry::Vacant(entry) => {
-                // New pair: reserve a slot via the authoritative
-                // counter BEFORE inserting. `fetch_add` is the
-                // serialization point — concurrent new-key inserts
-                // strictly serialize, no overshoot beyond the cap.
-                let prev = self.size.fetch_add(1, Ordering::Relaxed);
-                if prev >= self.max_tracked_pairs {
-                    // Cap exceeded. Roll back the reservation.
-                    self.size.fetch_sub(1, Ordering::Relaxed);
-                    self.capacity_rejected_total.fetch_add(1, Ordering::Relaxed);
-                    return RateLimitDecision::CapacityExceeded;
+                Entry::Vacant(entry) => {
+                    // New pair: reserve a slot via the authoritative
+                    // counter BEFORE inserting. `fetch_add` is the
+                    // serialization point — concurrent new-key inserts
+                    // strictly serialize, no overshoot beyond the cap.
+                    let prev = self.size.fetch_add(1, Ordering::Relaxed);
+                    if prev >= self.max_tracked_pairs {
+                        // Cap reached. Roll back the reservation and
+                        // release the shard guard BEFORE evicting:
+                        // `evict_oldest` walks every shard, and holding
+                        // a guard across that deadlocks (the same hazard
+                        // documented on `size`). The freed slot is not
+                        // reserved across the retry — another thread may
+                        // take it, in which case the next iteration
+                        // evicts again or falls through.
+                        self.size.fetch_sub(1, Ordering::Relaxed);
+                        drop(entry);
+                        if self.evict_oldest(now) > 0 {
+                            continue;
+                        }
+                        // Nothing to evict: the map is empty, so the cap
+                        // is 0. Configuration, not saturation.
+                        self.capacity_rejected_total.fetch_add(1, Ordering::Relaxed);
+                        return RateLimitDecision::CapacityExceeded;
+                    }
+                    entry.insert(now);
+                    self.accepted_total.fetch_add(1, Ordering::Relaxed);
+                    return RateLimitDecision::Allowed;
                 }
-                entry.insert(now);
-                self.accepted_total.fetch_add(1, Ordering::Relaxed);
-                RateLimitDecision::Allowed
             }
         }
+
+        // Every attempt lost its freed slot to a concurrent caller.
+        self.capacity_rejected_total.fetch_add(1, Ordering::Relaxed);
+        RateLimitDecision::CapacityExceeded
+    }
+
+    /// Evict the oldest tracked pairs to make room for a new one,
+    /// returning how many were removed.
+    ///
+    /// Must be called with no shard guard held — it walks every shard.
+    ///
+    /// Removes up to `max_tracked_pairs / EVICTION_BATCH_DIVISOR`
+    /// entries (at least one) in a single pass, oldest first, so the
+    /// O(map) scan is amortised across a batch of admissions rather than
+    /// paid per admission. `select_nth_unstable_by_key` partitions
+    /// rather than sorts, so the pass is linear.
+    ///
+    /// Removing exactly `batch` keys — rather than retaining everything
+    /// newer than a cutoff timestamp — matters because timestamps tie:
+    /// entries stamped within the same clock tick (and, in tests, from a
+    /// mock clock that has not advanced) share an `Instant`, and a
+    /// cutoff comparison would take every tied entry with it.
+    fn evict_oldest(&self, now: Instant) -> usize {
+        let batch = (self.max_tracked_pairs / EVICTION_BATCH_DIVISOR).max(1);
+        let mut entries: Vec<(Instant, (SocketAddr, ContractInstanceId))> = self
+            .last_accepted
+            .iter()
+            .map(|e| (*e.value(), *e.key()))
+            .collect();
+        if entries.is_empty() {
+            return 0;
+        }
+        let batch = batch.min(entries.len());
+        entries.select_nth_unstable_by_key(batch - 1, |(stamped, _)| *stamped);
+
+        let mut removed = 0usize;
+        for (_, victim) in &entries[..batch] {
+            // A concurrent caller may have removed it already; only
+            // count what this call actually took out, so `size` stays
+            // in step with the map.
+            if self.last_accepted.remove(victim).is_some() {
+                removed += 1;
+            }
+        }
+        if removed > 0 {
+            self.size.fetch_sub(removed, Ordering::Relaxed);
+            self.capacity_evicted_total
+                .fetch_add(removed as u64, Ordering::Relaxed);
+            self.log_eviction(now, removed);
+        }
+        removed
+    }
+
+    /// Emit the saturation log line, at most once per
+    /// [`EVICTION_LOG_INTERVAL`].
+    ///
+    /// `info!` rather than `debug!` on purpose: `debug!` is compiled out
+    /// of release builds by `release_max_level_info`, which is why the
+    /// old drop path left no greppable evidence on a production node
+    /// (#4981).
+    fn log_eviction(&self, now: Instant, removed: usize) {
+        let mut last = match self.last_eviction_log.lock() {
+            Ok(guard) => guard,
+            // Poisoned only if a previous holder panicked while
+            // formatting a log line. Losing the throttle is not worth
+            // propagating a panic from the UPDATE receive path.
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let due = match *last {
+            Some(prev) => now.saturating_duration_since(prev) >= EVICTION_LOG_INTERVAL,
+            None => true,
+        };
+        if !due {
+            return;
+        }
+        *last = Some(now);
+        drop(last);
+
+        tracing::info!(
+            evicted = removed,
+            evicted_total = self.capacity_evicted_total.load(Ordering::Relaxed),
+            tracked = self.size.load(Ordering::Relaxed),
+            max_tracked_pairs = self.max_tracked_pairs,
+            "UPDATE rate limiter at capacity: evicted least-recently-used \
+             (sender, contract) pairs to admit new ones. Expected on a node \
+             relaying for many peers and contracts; an evicted pair's next \
+             UPDATE is treated as new. Throttled to one line per minute."
+        );
     }
 
     /// Drop entries whose timestamp is older than [`CLEANUP_AGE`].
@@ -330,6 +526,15 @@ impl UpdateRateLimiter {
     /// that reason.
     pub fn capacity_rejected_total(&self) -> u64 {
         self.capacity_rejected_total.load(Ordering::Relaxed)
+    }
+
+    /// Total entries evicted to admit new pairs at capacity. Surfaced on
+    /// the dashboard ("Capacity-evicted") as the saturation signal: a
+    /// rising value means the node is relaying for more `(sender,
+    /// contract)` pairs than [`MAX_TRACKED_PAIRS`], which is expected on
+    /// a busy node and no longer costs those pairs their UPDATEs.
+    pub fn capacity_evicted_total(&self) -> u64 {
+        self.capacity_evicted_total.load(Ordering::Relaxed)
     }
 
     /// Number of tracked `(sender, contract)` pairs. Used by tests and
@@ -561,14 +766,22 @@ mod tests {
         );
     }
 
-    /// Pin: hard cap on tracked pairs prevents an attacker churning
-    /// fresh contract identities from growing the map indefinitely.
-    /// Once `MAX_TRACKED_PAIRS` is reached, new pairs get
-    /// `CapacityExceeded`, never `Allowed`. Existing pairs keep
-    /// working — graceful degradation, not total denial.
+    /// Pin: the cap still bounds the map, but reaching it admits the
+    /// newcomer by evicting rather than refusing it (#4981).
+    ///
+    /// This replaces the assertion the previous version of this test
+    /// made — that a new pair past the cap gets `CapacityExceeded` —
+    /// which pinned the starvation bug as if it were the contract. What
+    /// it checked that still holds is kept: the map never exceeds the
+    /// cap, and existing pairs keep working. See
+    /// `at_capacity_evicts_the_oldest_pair_not_an_arbitrary_one` for the
+    /// eviction order and
+    /// `busy_pairs_cannot_hold_slots_against_newcomers` for the
+    /// starvation regression itself.
     #[test]
-    fn capacity_exceeded_when_cap_reached() {
-        // Small cap so the test is fast.
+    fn at_capacity_new_pair_is_admitted_and_the_map_stays_bounded() {
+        // Small cap so the test is fast. At cap 8 the eviction batch is
+        // `max(8 / 64, 1)` = exactly one entry.
         let ts = SharedMockTimeSource::new();
         let limiter = UpdateRateLimiter::with_config(
             Arc::new(ts.clone()),
@@ -580,31 +793,211 @@ mod tests {
         for i in 0..8 {
             let d = limiter.check_and_record(mk_sender(i + 1), mk_contract(i + 1));
             assert_eq!(d, RateLimitDecision::Allowed, "pair {i} should be allowed");
+            ts.advance(Duration::from_millis(1));
         }
         assert_eq!(limiter.len(), 8);
 
-        // Pair #9 is a new key — must be CapacityExceeded.
+        // Pair #9 is a new key at capacity: admitted, by evicting.
         let d = limiter.check_and_record(mk_sender(99), mk_contract(99));
         assert_eq!(
             d,
-            RateLimitDecision::CapacityExceeded,
-            "new pair past the cap must be CapacityExceeded"
+            RateLimitDecision::Allowed,
+            "a new pair at capacity must be admitted, not starved (#4981)"
         );
-        assert_eq!(limiter.capacity_rejected_total(), 1);
+        assert_eq!(
+            limiter.capacity_rejected_total(),
+            0,
+            "admission by eviction must not count as a capacity rejection"
+        );
+        assert_eq!(limiter.capacity_evicted_total(), 1);
+        assert_eq!(
+            limiter.len(),
+            8,
+            "the cap is still a hard bound: one in, one out"
+        );
 
-        // Pair #1 (already tracked) — should still work after
-        // the min_interval elapses. Existing pairs aren't punished
-        // by the cap.
+        // An already-tracked pair keeps working after min_interval.
         ts.advance(MIN_UPDATE_INTERVAL + Duration::from_millis(1));
-        let d = limiter.check_and_record(mk_sender(1), mk_contract(1));
+        let d = limiter.check_and_record(mk_sender(8), mk_contract(8));
         assert_eq!(
             d,
             RateLimitDecision::Allowed,
             "existing pair must keep working at cap"
         );
+    }
 
-        // After cleanup drops stale entries the cap recovers, but in
-        // this test no time has passed so they're still fresh.
+    /// The victim is the least recently used pair, not an arbitrary one.
+    ///
+    /// Membership is observed through the limiter's own behaviour rather
+    /// than a test-only accessor: a tracked pair stamped within
+    /// `min_interval` answers `Rejected`, while an evicted pair is seen
+    /// as new and answers `Allowed`. So "was it evicted?" is exactly
+    /// "does an immediate re-check come back Allowed?".
+    #[test]
+    fn at_capacity_evicts_the_oldest_pair_not_an_arbitrary_one() {
+        let ts = SharedMockTimeSource::new();
+        let limiter = UpdateRateLimiter::with_config(Arc::new(ts.clone()), MIN_UPDATE_INTERVAL, 8);
+
+        // Fill, each pair stamped a millisecond apart so "oldest" is
+        // unambiguous. Pair 1 is the oldest, pair 8 the newest.
+        for i in 1..=8u8 {
+            assert!(
+                limiter
+                    .check_and_record(mk_sender(i), mk_contract(i))
+                    .is_allowed()
+            );
+            ts.advance(Duration::from_millis(1));
+        }
+
+        // Refresh pair 1, making it the most recently used. If eviction
+        // ignored recency, this is the entry a naive "first one found"
+        // policy would still take.
+        ts.advance(MIN_UPDATE_INTERVAL);
+        assert!(
+            limiter
+                .check_and_record(mk_sender(1), mk_contract(1))
+                .is_allowed()
+        );
+
+        // Admit a newcomer: pair 2 is now the oldest and must be the
+        // victim.
+        assert!(
+            limiter
+                .check_and_record(mk_sender(99), mk_contract(99))
+                .is_allowed()
+        );
+        assert_eq!(limiter.capacity_evicted_total(), 1);
+
+        // Pair 1 was just refreshed, so it must still be tracked — a
+        // re-check inside min_interval is Rejected. Checked first
+        // because a Rejected check does not mutate the map.
+        assert!(
+            matches!(
+                limiter.check_and_record(mk_sender(1), mk_contract(1)),
+                RateLimitDecision::Rejected { .. }
+            ),
+            "the most recently used pair must survive eviction"
+        );
+
+        // Pair 2 was the oldest, so it is gone: it reads as new.
+        assert_eq!(
+            limiter.check_and_record(mk_sender(2), mk_contract(2)),
+            RateLimitDecision::Allowed,
+            "the least recently used pair must be the eviction victim"
+        );
+    }
+
+    /// The #4981 regression: a busy pair must not be able to hold its
+    /// slot indefinitely against new arrivals.
+    ///
+    /// Every tracked pair keeps refreshing, which is what made the old
+    /// code starve newcomers forever — an accepted UPDATE restamps the
+    /// entry, so nothing ever aged out under `CLEANUP_AGE` and the cap
+    /// was permanently held by whoever got in first. Under that code
+    /// every newcomer here is `CapacityExceeded`; the pass condition is
+    /// that all of them get through.
+    #[test]
+    fn busy_pairs_cannot_hold_slots_against_newcomers() {
+        let ts = SharedMockTimeSource::new();
+        let limiter = UpdateRateLimiter::with_config(Arc::new(ts.clone()), MIN_UPDATE_INTERVAL, 8);
+
+        let start = ts.now();
+        for i in 1..=8u8 {
+            assert!(
+                limiter
+                    .check_and_record(mk_sender(i), mk_contract(i))
+                    .is_allowed()
+            );
+            ts.advance(Duration::from_millis(1));
+        }
+
+        // Well under CLEANUP_AGE throughout, so the TTL sweep is not
+        // what rescues the newcomers here — eviction is.
+        for round in 0..20u8 {
+            // The incumbents stay busy, restamping themselves.
+            ts.advance(MIN_UPDATE_INTERVAL + Duration::from_millis(1));
+            for i in 1..=8u8 {
+                limiter.check_and_record(mk_sender(i), mk_contract(i));
+            }
+
+            let newcomer = limiter.check_and_record(mk_sender(100 + round), mk_contract(200));
+            assert_eq!(
+                newcomer,
+                RateLimitDecision::Allowed,
+                "round {round}: a newcomer must not be starved by busy incumbents"
+            );
+            assert!(
+                limiter.len() <= 8,
+                "round {round}: the cap must still bound the map"
+            );
+        }
+
+        assert_eq!(
+            limiter.capacity_rejected_total(),
+            0,
+            "no UPDATE should have been dropped for capacity"
+        );
+        assert!(
+            ts.now().saturating_duration_since(start) < CLEANUP_AGE,
+            "sanity: the fixture must stay inside CLEANUP_AGE, so the TTL sweep \
+             cannot be what admitted the newcomers"
+        );
+    }
+
+    /// Eviction is batched at realistic cap sizes, so the O(map) scan is
+    /// amortised instead of paid on every admission.
+    ///
+    /// Cap 128 gives a batch of `128 / EVICTION_BATCH_DIVISOR` = 2. The
+    /// tests above all use cap 8, where the batch clamps to 1, so
+    /// without this one the divisor arithmetic is never exercised.
+    #[test]
+    fn eviction_is_batched_at_larger_caps() {
+        let ts = SharedMockTimeSource::new();
+        let cap = 128;
+        let limiter =
+            UpdateRateLimiter::with_config(Arc::new(ts.clone()), MIN_UPDATE_INTERVAL, cap);
+        let expected_batch = cap / EVICTION_BATCH_DIVISOR;
+        assert_eq!(expected_batch, 2, "fixture assumes a 2-entry batch");
+
+        for i in 0..cap {
+            let sender = SocketAddr::from(([10, 1, (i / 256) as u8, (i % 256) as u8], 30000));
+            assert!(
+                limiter
+                    .check_and_record(sender, mk_contract(1))
+                    .is_allowed()
+            );
+            ts.advance(Duration::from_millis(1));
+        }
+        assert_eq!(limiter.len(), cap);
+
+        assert!(
+            limiter
+                .check_and_record(mk_sender(99), mk_contract(99))
+                .is_allowed()
+        );
+        assert_eq!(
+            limiter.capacity_evicted_total(),
+            expected_batch as u64,
+            "one admission at capacity must evict a whole batch"
+        );
+        assert_eq!(
+            limiter.len(),
+            cap - expected_batch + 1,
+            "the batch leaves headroom, so the next admissions skip the scan"
+        );
+
+        // The freed headroom is real: the next admission must not evict
+        // again.
+        assert!(
+            limiter
+                .check_and_record(mk_sender(98), mk_contract(98))
+                .is_allowed()
+        );
+        assert_eq!(
+            limiter.capacity_evicted_total(),
+            expected_batch as u64,
+            "an admission with headroom must not trigger another eviction"
+        );
     }
 
     /// Pin the atomicity of `check_and_record` under concurrent
@@ -788,8 +1181,11 @@ mod tests {
                 RateLimitDecision::Rejected { .. } => rate_rejected += 1,
             }
         }
-        // Critical invariant: the map size is EXACTLY the cap, not
-        // cap + overshoot.
+        // Critical invariant, unchanged by #4981: the map size is
+        // EXACTLY the cap, not cap + overshoot. Eviction makes this a
+        // sharper test than it was — 64 threads now race to evict and
+        // insert concurrently, and the reservation counter still has to
+        // hold the line.
         assert_eq!(
             limiter.len(),
             CAP,
@@ -797,13 +1193,28 @@ mod tests {
              concurrent flood of distinct keys, got {}",
             limiter.len()
         );
-        assert_eq!(
-            allowed, CAP,
-            "exactly CAP admissions allowed under flood, got {allowed}"
+        // What this test used to assert — `allowed == CAP`, every other
+        // thread `CapacityExceeded` — was the starvation of #4981 stated
+        // as a requirement. At capacity a newcomer now evicts, so a
+        // flood of distinct keys admits more than CAP of them while the
+        // map stays bounded. What must still hold: at least the first
+        // CAP get in, nothing is lost, and no thread is rate-rejected
+        // (every key is distinct).
+        assert!(
+            allowed >= CAP,
+            "at least CAP admissions expected under flood, got {allowed}"
         );
-        assert_eq!(cap_rejected, THREADS - CAP);
+        assert_eq!(allowed + cap_rejected + rate_rejected, THREADS);
         assert_eq!(rate_rejected, 0);
-        assert_eq!(limiter.capacity_rejected_total(), (THREADS - CAP) as u64);
+        // Capacity rejection is now only reachable by losing an evicted
+        // slot to another thread `MAX_ADMISSION_ATTEMPTS` times running,
+        // so it is contention-dependent rather than a fixed count.
+        assert_eq!(limiter.capacity_rejected_total(), cap_rejected as u64);
+        assert_eq!(
+            limiter.capacity_evicted_total(),
+            (allowed - CAP) as u64,
+            "every admission beyond the first CAP must have evicted exactly one entry"
+        );
     }
 
     /// Pin: cleanup decrements the `size` counter by the number of
@@ -826,11 +1237,14 @@ mod tests {
                 RateLimitDecision::Allowed
             );
         }
-        // 5th is CapacityExceeded.
+        // The 5th is admitted by evicting (#4981 changed this from
+        // CapacityExceeded); the map stays at the cap either way, which
+        // is what this test is really about.
         assert_eq!(
             limiter.check_and_record(mk_sender(5), mk_contract(5)),
-            RateLimitDecision::CapacityExceeded
+            RateLimitDecision::Allowed
         );
+        assert_eq!(limiter.len(), 4, "eviction keeps the map at the cap");
         // Age out all entries.
         ts.advance(CLEANUP_AGE + Duration::from_secs(1));
         limiter.cleanup();

--- a/crates/core/src/ring/update_rate_limit.rs
+++ b/crates/core/src/ring/update_rate_limit.rs
@@ -68,17 +68,47 @@
 //! that assumes the newcomer is hostile penalises the ordinary case of
 //! a healthy node outgrowing the bound.
 //!
-//! What eviction costs, stated plainly: an evicted pair's next UPDATE
-//! is treated as new and therefore allowed, so an attacker churning
-//! fresh contract ids gets one UPDATE through per id instead of being
-//! cut off after the first 16 384. That ceiling was incidental rather
-//! than designed — the cap exists to bound *memory* — and per-(sender,
-//! contract) rate limiting cannot stop a fresh-id attacker regardless,
-//! since a pair the map has never seen is always allowed once. Paying
-//! it buys back the availability of every legitimate relayed UPDATE on
-//! a saturated node. Sustained floods from a *stable* pair, which is
-//! the pattern this limiter exists for, are unaffected: that entry is
-//! the most recently used, so it is the last thing evicted.
+//! What eviction costs: an evicted pair's next UPDATE is treated as new
+//! and therefore allowed, so an attacker churning fresh contract ids
+//! gets one UPDATE through per id instead of being cut off after the
+//! first 16 384. That ceiling was incidental rather than designed — the
+//! cap exists to bound *memory* — but it was not nothing, and nothing
+//! else in the node replaced it: the ban list is keyed by contract, the
+//! MAD outlier detector is off by default and excludes contracts younger
+//! than its ramp-up anyway, and the transport rate-limits handshakes
+//! rather than traffic on an established connection. Since a node
+//! forwards an UPDATE for a contract it does not host, an unbounded
+//! fresh-id stream would make it a relay amplifier. So the ceiling is
+//! replaced deliberately rather than dropped — see below.
+//!
+//! Sustained floods from a *stable* pair, which is the pattern this
+//! limiter exists for, are unaffected by eviction: that entry is the
+//! most recently used, so it is the last thing evicted.
+//!
+//! ### The fresh-pair budget, keyed by sender alone
+//!
+//! Eviction removes the *incidental* bound on fresh-id churn, so a
+//! deliberate one takes its place: a token bucket keyed by `sender_addr`
+//! ALONE ([`NEW_PAIR_BURST`], [`NEW_PAIR_REFILL_INTERVAL`]) that a
+//! sender spends from only when it presents a `(sender, contract)` pair
+//! this limiter has never seen.
+//!
+//! Two properties make this the right shape:
+//!
+//! - **Established traffic never touches it.** A token is spent on the
+//!   new-pair path only, so a peer relaying heavily for contracts the
+//!   limiter already tracks is bounded by [`MIN_UPDATE_INTERVAL`] per
+//!   pair and by nothing else — the availability this fix exists to
+//!   restore is not clawed back.
+//! - **It is charged before eviction, not after.** A sender past its
+//!   budget is refused *before* a slot is reserved or anything is
+//!   evicted, so churning fresh ids cannot push other peers' entries out
+//!   of the map on the way to being throttled.
+//!
+//! Its own map is bounded by [`MAX_TRACKED_SENDERS`], which is a
+//! multiple of the node's connection cap rather than an attacker-chosen
+//! space: `sender` is the immediate upstream hop, so only a connected
+//! peer can occupy an entry.
 //!
 //! ## Semantic note: `sender_addr` is the immediate upstream hop
 //!
@@ -128,6 +158,8 @@ use dashmap::DashMap;
 use freenet_stdlib::prelude::ContractInstanceId;
 use tokio::time::Instant;
 
+use super::Ring;
+use super::resync_rate_limit::TokenBucketLimiter;
 use crate::util::time_source::TimeSource;
 
 /// Minimum interval between accepted UPDATEs for the same
@@ -188,13 +220,115 @@ const EVICTION_LOG_INTERVAL: Duration = Duration::from_secs(60);
 
 /// Bound on admission attempts before giving up with `CapacityExceeded`.
 ///
-/// One attempt, one eviction, one retry is the expected path. The bound
-/// exists because the slot freed by eviction is not reserved: another
-/// thread may take it between the eviction and the retry, and an
-/// unbounded retry loop would let sustained contention spin here on the
-/// receive path. Giving up is safe — the competing thread's UPDATE went
-/// through, and this sender retries.
-const MAX_ADMISSION_ATTEMPTS: usize = 3;
+/// One attempt, one eviction, one insert is the expected path. The bound
+/// exists because an admission can lose its slot to a concurrent caller,
+/// and an unbounded retry loop would let sustained contention spin here
+/// on the receive path.
+///
+/// Six rather than three. An attempt is consumed whenever the map went
+/// from full to not-full and back between this caller's cap check and
+/// its eviction — no work is done, but the attempt is spent — and the
+/// last attempt cannot evict (there would be no attempt left to use the
+/// slot), so the budget buys one fewer eviction than it looks like.
+/// Measured on the worst ratio in the suite, a 1024 cap whose 16-entry
+/// batch matches the 16 concurrent callers: at three attempts 7-26 of
+/// 6 400 admissions were dropped across a dozen runs, at four 0-3, at
+/// five 0-2, and at six none at all. Extra attempts are nearly free now
+/// that the scan is serialised — a waiter blocks on the eviction lock
+/// instead of running its own redundant scan.
+const MAX_ADMISSION_ATTEMPTS: usize = 6;
+
+/// Burst of brand-new `(sender, contract)` pairs a single sender may
+/// introduce before [`NEW_PAIR_REFILL_INTERVAL`] starts to bind.
+///
+/// Sized to absorb the legitimate bursty cases — a peer that reconnects
+/// and re-subscribes, or one that starts relaying for a batch of
+/// contracts at once — with room to spare over the ~330 pairs per peer
+/// implied by the saturation #4981 reported (≈16 500 pairs across ≈50
+/// peers). A sender only spends a token when it presents a pair the
+/// limiter has never seen, so established traffic never touches this.
+const NEW_PAIR_BURST: f64 = 512.0;
+
+/// Sustained rate at which one sender may introduce brand-new pairs once
+/// its burst is spent: one per interval.
+///
+/// Deliberately [`MIN_UPDATE_INTERVAL`], so both ceilings read the same
+/// way: a sender may introduce new pairs no faster than it may repeat an
+/// UPDATE on a single pair (10/s at the defaults).
+const NEW_PAIR_REFILL_INTERVAL: Duration = MIN_UPDATE_INTERVAL;
+
+/// Cap on the senders tracked by the new-pair budget.
+///
+/// One entry per peer address that has presented a new pair. `sender` is
+/// the immediate upstream hop, so the live set is bounded by this node's
+/// connection count; the multiple over [`Ring::DEFAULT_MAX_CONNECTIONS`]
+/// is headroom for address churn (reconnects, NAT rebinding) between
+/// [`CLEANUP_AGE`] sweeps. At ~48 bytes an entry the whole map is well
+/// under 100 KB.
+const MAX_TRACKED_SENDERS: usize = 8 * Ring::DEFAULT_MAX_CONNECTIONS;
+
+/// How often an exhausted new-pair budget may write a log line.
+///
+/// Shares [`EVICTION_LOG_INTERVAL`]'s reasoning: a sender that is being
+/// throttled is being throttled continuously, so this must be throttled
+/// too or it becomes the log flood it is meant to report.
+const NEW_PAIR_LOG_INTERVAL: Duration = EVICTION_LOG_INTERVAL;
+
+/// Outcome of an at-capacity eviction pass.
+///
+/// This is an enum rather than a count of removed entries because
+/// "removed nothing" is almost never a reason to give up, and reading it
+/// as one silently dropped legitimate UPDATEs. A pass removes nothing in
+/// three situations, only the last of which is terminal:
+///
+/// 1. Another caller already freed capacity, so the cap no longer binds.
+/// 2. Every victim this pass selected was removed concurrently — under
+///    contention the likeliest case, since concurrent callers all
+///    partition the *same* map and therefore select nearly the same
+///    oldest entries.
+/// 3. The map is empty, so there is nothing to evict and never will be.
+///
+/// 1 and 2 mean a slot is, or may already be, free: the right move is to
+/// retry the admission, which is what [`MAX_ADMISSION_ATTEMPTS`] exists
+/// for. Only 3 is a configuration problem. Conflating them dropped ~0.9%
+/// of admissions at the production cap under 16-thread contention, none
+/// of them for the documented reason, and without consuming a single
+/// retry attempt (#4997 review).
+enum EvictionOutcome {
+    /// This pass freed slots and kept one of them for the caller, which
+    /// therefore does not have to win the cap check again — it inserts
+    /// directly. See [`UpdateRateLimiter::evict_oldest`].
+    Reserved,
+    /// A slot is, or may already be, free, but this caller did not free
+    /// it and holds no claim on it. Retry the admission.
+    Retry,
+    /// The map is empty — reachable only with `max_tracked_pairs == 0`.
+    /// Terminal.
+    MapEmpty,
+}
+
+/// Whether a throttled log line is due, stamping `slot` when it is.
+///
+/// Both saturation signals in this module fire continuously once they
+/// fire at all, so both need this; sharing it keeps the two throttles
+/// from drifting apart.
+fn log_due(slot: &Mutex<Option<Instant>>, now: Instant, interval: Duration) -> bool {
+    let mut last = match slot.lock() {
+        Ok(guard) => guard,
+        // Poisoned only if a previous holder panicked while formatting a
+        // log line. Losing the throttle is not worth propagating a panic
+        // onto the UPDATE receive path.
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    let due = match *last {
+        Some(prev) => now.saturating_duration_since(prev) >= interval,
+        None => true,
+    };
+    if due {
+        *last = Some(now);
+    }
+    due
+}
 
 /// Outcome of an UPDATE rate-limit check. Callers must treat any
 /// non-`Allowed` variant as "drop this message at the receive
@@ -223,6 +357,15 @@ pub(crate) enum RateLimitDecision {
     /// something sharper than it used to: not merely that the map is
     /// full, but that it is full *and* contended.
     CapacityExceeded,
+    /// Rejected because the sender has spent its budget for introducing
+    /// brand-new `(sender, contract)` pairs (see the module docs).
+    ///
+    /// Only a pair this limiter has never seen can land here, so a
+    /// sender's established traffic never does, however much of it there
+    /// is. A rising count means one peer is presenting unfamiliar
+    /// contract ids faster than [`NEW_PAIR_REFILL_INTERVAL`] — the
+    /// fresh-id churn pattern.
+    SenderNewPairBudget,
 }
 
 impl RateLimitDecision {
@@ -278,6 +421,29 @@ pub(crate) struct UpdateRateLimiter {
     /// eviction path, which already walks the map, so the lock is not
     /// on the common path.
     last_eviction_log: Mutex<Option<Instant>>,
+    /// Held across the eviction scan so only one caller selects victims
+    /// at a time — see [`UpdateRateLimiter::evict_oldest`] for why
+    /// concurrent evictors otherwise collide on the same victims. This
+    /// is the outermost lock in the module: nothing else acquires it,
+    /// and no shard guard is held when it is taken, so it cannot
+    /// participate in a lock cycle.
+    eviction_lock: Mutex<()>,
+    /// Per-sender budget for introducing brand-new pairs — the
+    /// deliberate replacement for the fresh-id ceiling eviction removed
+    /// (see the module docs).
+    ///
+    /// Consulted only from the new-pair branch of `check_and_record`,
+    /// while that branch holds a `last_accepted` shard guard. That is
+    /// the only place either map is touched under the other's guard, so
+    /// the lock order (`last_accepted` then `new_pair_budget`) has no
+    /// counterpart to invert against.
+    new_pair_budget: TokenBucketLimiter<SocketAddr>,
+    /// Total UPDATEs dropped because the sender was over its new-pair
+    /// budget.
+    new_pair_budget_rejected_total: AtomicU64,
+    /// When the last new-pair-budget log line was written, for
+    /// [`NEW_PAIR_LOG_INTERVAL`] throttling.
+    last_new_pair_log: Mutex<Option<Instant>>,
 }
 
 impl UpdateRateLimiter {
@@ -290,7 +456,35 @@ impl UpdateRateLimiter {
         min_interval: Duration,
         max_tracked_pairs: usize,
     ) -> Self {
+        Self::with_new_pair_budget(
+            time_source,
+            min_interval,
+            max_tracked_pairs,
+            NEW_PAIR_BURST,
+            MAX_TRACKED_SENDERS,
+        )
+    }
+
+    /// [`Self::with_config`] with the per-sender new-pair budget sized
+    /// explicitly. Fixtures that deliberately flood fresh pairs from one
+    /// sender to exercise the capacity/eviction path pass a burst large
+    /// enough that the budget cannot be what they observe.
+    pub fn with_new_pair_budget(
+        time_source: Arc<dyn TimeSource + Send + Sync>,
+        min_interval: Duration,
+        max_tracked_pairs: usize,
+        new_pair_burst: f64,
+        max_tracked_senders: usize,
+    ) -> Self {
         Self {
+            new_pair_budget: TokenBucketLimiter::new(
+                time_source.clone(),
+                new_pair_burst,
+                NEW_PAIR_REFILL_INTERVAL,
+                max_tracked_senders,
+            ),
+            new_pair_budget_rejected_total: AtomicU64::new(0),
+            last_new_pair_log: Mutex::new(None),
             last_accepted: DashMap::new(),
             size: AtomicUsize::new(0),
             min_interval,
@@ -301,6 +495,7 @@ impl UpdateRateLimiter {
             capacity_rejected_total: AtomicU64::new(0),
             capacity_evicted_total: AtomicU64::new(0),
             last_eviction_log: Mutex::new(None),
+            eviction_lock: Mutex::new(()),
         }
     }
 
@@ -338,11 +533,27 @@ impl UpdateRateLimiter {
         let key = (sender, contract);
 
         use dashmap::mapref::entry::Entry;
+        // Whether this call has already spent one of `sender`'s new-pair
+        // tokens. A retry after eviction re-enters the Vacant branch, and
+        // one admission must cost one token, not one per attempt.
+        let mut budget_spent = false;
+        // Whether this call is holding a slot it freed by evicting (see
+        // `EvictionOutcome::Reserved`). It is counted in `size`, so every
+        // path out of the loop must either consume it with an insert or
+        // hand it back.
+        let mut reserved = false;
         // Each iteration either decides, or frees capacity and retries.
         // See `MAX_ADMISSION_ATTEMPTS` for why this is bounded.
-        for _ in 0..MAX_ADMISSION_ATTEMPTS {
+        for attempt in 0..MAX_ADMISSION_ATTEMPTS {
             match self.last_accepted.entry(key) {
                 Entry::Occupied(mut entry) => {
+                    if reserved {
+                        // The pair turned up while we were evicting, so
+                        // the slot we kept is not needed. Hand it back
+                        // now: both exits below return, so this is the
+                        // only chance to.
+                        self.size.fetch_sub(1, Ordering::Relaxed);
+                    }
                     // Existing pair: atomic compare-and-stamp under
                     // shard guard.
                     let last = *entry.get();
@@ -359,29 +570,67 @@ impl UpdateRateLimiter {
                     return RateLimitDecision::Allowed;
                 }
                 Entry::Vacant(entry) => {
-                    // New pair: reserve a slot via the authoritative
-                    // counter BEFORE inserting. `fetch_add` is the
-                    // serialization point — concurrent new-key inserts
-                    // strictly serialize, no overshoot beyond the cap.
-                    let prev = self.size.fetch_add(1, Ordering::Relaxed);
-                    if prev >= self.max_tracked_pairs {
-                        // Cap reached. Roll back the reservation and
-                        // release the shard guard BEFORE evicting:
-                        // `evict_oldest` walks every shard, and holding
-                        // a guard across that deadlocks (the same hazard
-                        // documented on `size`). The freed slot is not
-                        // reserved across the retry — another thread may
-                        // take it, in which case the next iteration
-                        // evicts again or falls through.
-                        self.size.fetch_sub(1, Ordering::Relaxed);
-                        drop(entry);
-                        if self.evict_oldest(now) > 0 {
-                            continue;
+                    // Already holding a slot we freed by evicting: skip
+                    // the cap check and spend it.
+                    if !reserved {
+                        // Brand-new pair. Charge the sender's new-pair
+                        // budget BEFORE reserving a slot or evicting
+                        // anything, so a sender churning fresh contract
+                        // ids cannot push other peers' entries out of the
+                        // map on its way to being throttled. See the
+                        // module docs.
+                        if !budget_spent {
+                            if !self.new_pair_budget.check_and_record(sender) {
+                                drop(entry);
+                                self.new_pair_budget_rejected_total
+                                    .fetch_add(1, Ordering::Relaxed);
+                                self.log_new_pair_budget(now, sender);
+                                return RateLimitDecision::SenderNewPairBudget;
+                            }
+                            budget_spent = true;
                         }
-                        // Nothing to evict: the map is empty, so the cap
-                        // is 0. Configuration, not saturation.
-                        self.capacity_rejected_total.fetch_add(1, Ordering::Relaxed);
-                        return RateLimitDecision::CapacityExceeded;
+                        // Reserve a slot via the authoritative counter
+                        // BEFORE inserting. `fetch_add` is the
+                        // serialization point — concurrent new-key
+                        // inserts strictly serialize, no overshoot beyond
+                        // the cap.
+                        let prev = self.size.fetch_add(1, Ordering::Relaxed);
+                        if prev >= self.max_tracked_pairs {
+                            // Cap reached. Roll back and release the
+                            // shard guard BEFORE evicting: `evict_oldest`
+                            // walks every shard, and holding a guard
+                            // across that deadlocks (the same hazard
+                            // documented on `size`).
+                            self.size.fetch_sub(1, Ordering::Relaxed);
+                            drop(entry);
+                            // On the final attempt there is no retry left
+                            // to spend a freed slot on, so evicting now
+                            // would throw away an O(map) scan and shrink
+                            // the map for no admission.
+                            if attempt + 1 == MAX_ADMISSION_ATTEMPTS {
+                                break;
+                            }
+                            match self.evict_oldest(now) {
+                                // We freed the room and kept a slot: the
+                                // next iteration inserts into it without
+                                // re-running the cap check.
+                                EvictionOutcome::Reserved => {
+                                    reserved = true;
+                                    continue;
+                                }
+                                // Someone else freed room, or may have.
+                                // Spend a retry attempt rather than
+                                // dropping.
+                                EvictionOutcome::Retry => continue,
+                                // Nothing to evict and nothing ever will
+                                // be: the cap is 0. Configuration, not
+                                // saturation.
+                                EvictionOutcome::MapEmpty => {
+                                    self.capacity_rejected_total.fetch_add(1, Ordering::Relaxed);
+                                    return RateLimitDecision::CapacityExceeded;
+                                }
+                            }
+                        }
                     }
                     entry.insert(now);
                     self.accepted_total.fetch_add(1, Ordering::Relaxed);
@@ -390,13 +639,21 @@ impl UpdateRateLimiter {
             }
         }
 
+        if reserved {
+            // Unreachable by construction: a slot is only kept on a
+            // non-final attempt, and the attempt after it either inserts
+            // into it or hands it back. Returning it anyway means a
+            // future restructuring cannot leak one — a leaked
+            // reservation is never reclaimed and permanently shrinks the
+            // effective cap.
+            self.size.fetch_sub(1, Ordering::Relaxed);
+        }
         // Every attempt lost its freed slot to a concurrent caller.
         self.capacity_rejected_total.fetch_add(1, Ordering::Relaxed);
         RateLimitDecision::CapacityExceeded
     }
 
-    /// Evict the oldest tracked pairs to make room for a new one,
-    /// returning how many were removed.
+    /// Evict the oldest tracked pairs to make room for a new one.
     ///
     /// Must be called with no shard guard held — it walks every shard.
     ///
@@ -411,7 +668,44 @@ impl UpdateRateLimiter {
     /// entries stamped within the same clock tick (and, in tests, from a
     /// mock clock that has not advanced) share an `Instant`, and a
     /// cutoff comparison would take every tied entry with it.
-    fn evict_oldest(&self, now: Instant) -> usize {
+    fn evict_oldest(&self, now: Instant) -> EvictionOutcome {
+        // Another caller already made room, so there is nothing to evict
+        // and the admission should simply retry. Without this early
+        // return every concurrent newcomer pays the full
+        // O(max_tracked_pairs) scan even though the cap no longer binds.
+        // The authoritative cap check is still the `fetch_add`
+        // reservation in `check_and_record`, so a stale read here can
+        // never let the map exceed the cap; the worst case is one wasted
+        // retry.
+        if self.size.load(Ordering::Relaxed) < self.max_tracked_pairs {
+            return EvictionOutcome::Retry;
+        }
+
+        // One evictor at a time. Concurrent evictors partition the SAME
+        // map, so they select nearly the SAME victims and then race to
+        // remove entries each other has already taken: measured at the
+        // production cap under 16-thread contention, 44% of passes
+        // removed nothing at all and the average pass removed 24 entries
+        // for a full 16 384-entry scan — against a 256-entry batch. That
+        // defeats the amortisation the batch exists for AND starves the
+        // callers whose victims were stolen, which is what the retry
+        // budget was being spent on. Serialising costs a waiter nothing
+        // it was not already paying (it was running its own redundant
+        // scan), and the re-check below means a waiter that arrives
+        // after the batch is freed does no scan at all.
+        let _evicting = match self.eviction_lock.lock() {
+            Ok(guard) => guard,
+            // Poisoned only if a previous holder panicked mid-scan. The
+            // map is still consistent — `remove` is atomic per entry —
+            // so recover rather than propagate a panic onto the UPDATE
+            // receive path.
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        // The holder we queued behind may have freed the room we needed.
+        if self.size.load(Ordering::Relaxed) < self.max_tracked_pairs {
+            return EvictionOutcome::Retry;
+        }
+
         let batch = (self.max_tracked_pairs / EVICTION_BATCH_DIVISOR).max(1);
         let mut entries: Vec<(Instant, (SocketAddr, ContractInstanceId))> = self
             .last_accepted
@@ -419,7 +713,7 @@ impl UpdateRateLimiter {
             .map(|e| (*e.value(), *e.key()))
             .collect();
         if entries.is_empty() {
-            return 0;
+            return EvictionOutcome::MapEmpty;
         }
         let batch = batch.min(entries.len());
         entries.select_nth_unstable_by_key(batch - 1, |(stamped, _)| *stamped);
@@ -434,12 +728,33 @@ impl UpdateRateLimiter {
             }
         }
         if removed > 0 {
-            self.size.fetch_sub(removed, Ordering::Relaxed);
+            // Return `removed - 1` slots and KEEP one for the caller.
+            //
+            // Without this the caller has to win the cap check again
+            // against everyone else, and whether it does depends on the
+            // batch size relative to the number of concurrent callers:
+            // at the production cap (batch 256, 16 threads) it nearly
+            // always wins, but at a 1024 cap the batch is 16 and callers
+            // lose a freed slot often enough to drop ~2 admissions in
+            // 1000. Keeping a slot makes "a caller that frees room gets
+            // to use it" true by construction instead of by margin.
+            //
+            // The strict cap is unaffected: `size` counts map entries
+            // plus outstanding reservations, and every insert still
+            // passes the `fetch_add` gate. Batching is unaffected too —
+            // the batch still leaves `removed - 1` slots of headroom for
+            // the admissions that follow, which is what amortises the
+            // scan.
+            self.size.fetch_sub(removed - 1, Ordering::Relaxed);
             self.capacity_evicted_total
                 .fetch_add(removed as u64, Ordering::Relaxed);
             self.log_eviction(now, removed);
+            return EvictionOutcome::Reserved;
         }
-        removed
+        // Every victim this pass selected was taken by a concurrent
+        // caller — slots were freed, just not by us — which is a reason
+        // to retry, not to drop.
+        EvictionOutcome::Retry
     }
 
     /// Emit the saturation log line, at most once per
@@ -450,23 +765,9 @@ impl UpdateRateLimiter {
     /// old drop path left no greppable evidence on a production node
     /// (#4981).
     fn log_eviction(&self, now: Instant, removed: usize) {
-        let mut last = match self.last_eviction_log.lock() {
-            Ok(guard) => guard,
-            // Poisoned only if a previous holder panicked while
-            // formatting a log line. Losing the throttle is not worth
-            // propagating a panic from the UPDATE receive path.
-            Err(poisoned) => poisoned.into_inner(),
-        };
-        let due = match *last {
-            Some(prev) => now.saturating_duration_since(prev) >= EVICTION_LOG_INTERVAL,
-            None => true,
-        };
-        if !due {
+        if !log_due(&self.last_eviction_log, now, EVICTION_LOG_INTERVAL) {
             return;
         }
-        *last = Some(now);
-        drop(last);
-
         tracing::info!(
             evicted = removed,
             evicted_total = self.capacity_evicted_total.load(Ordering::Relaxed),
@@ -476,6 +777,31 @@ impl UpdateRateLimiter {
              (sender, contract) pairs to admit new ones. Expected on a node \
              relaying for many peers and contracts; an evicted pair's next \
              UPDATE is treated as new. Throttled to one line per minute."
+        );
+    }
+
+    /// Emit the fresh-id-churn log line, at most once per
+    /// [`NEW_PAIR_LOG_INTERVAL`].
+    ///
+    /// Throttled for the same reason the drop is worth logging at all: a
+    /// sender over its budget is over it on every message, so an
+    /// unthrottled line here would be a steady stream on exactly the
+    /// node under load. `info!` for the #4981 reason — `debug!` is
+    /// compiled out of release builds.
+    fn log_new_pair_budget(&self, now: Instant, sender: SocketAddr) {
+        if !log_due(&self.last_new_pair_log, now, NEW_PAIR_LOG_INTERVAL) {
+            return;
+        }
+
+        tracing::info!(
+            %sender,
+            dropped_total = self.new_pair_budget_rejected_total.load(Ordering::Relaxed),
+            burst = NEW_PAIR_BURST,
+            refill_interval_ms = NEW_PAIR_REFILL_INTERVAL.as_millis() as u64,
+            "UPDATE rate limiter: peer is introducing brand-new (sender, contract) \
+             pairs faster than its budget allows, so its UPDATEs for unfamiliar \
+             contracts are being dropped. Its traffic for already-tracked contracts \
+             is unaffected. Throttled to one line per minute."
         );
     }
 
@@ -502,6 +828,10 @@ impl UpdateRateLimiter {
         if removed > 0 {
             self.size.fetch_sub(removed, Ordering::Relaxed);
         }
+        // Same cadence for the per-sender new-pair budget: reclaims the
+        // entries of peers that have gone quiet (and whose buckets have
+        // fully refilled, so dropping one cannot change a decision).
+        self.new_pair_budget.cleanup();
     }
 
     /// Total accepted UPDATEs since creation. Surfaced on the node
@@ -518,12 +848,18 @@ impl UpdateRateLimiter {
         self.rejected_total.load(Ordering::Relaxed)
     }
 
-    /// Total UPDATEs rejected because the tracking map was at capacity
-    /// (a new `(sender, contract)` pair tried to register when the map
-    /// already held [`MAX_TRACKED_PAIRS`] pairs). A non-zero value
-    /// suggests an attacker is churning identities — surfaced separately
-    /// from `rejected_total` on the dashboard ("Capacity-dropped") for
-    /// that reason.
+    /// Total UPDATEs dropped because the tracking map was at capacity
+    /// and eviction could not free a slot for a new `(sender, contract)`
+    /// pair. Surfaced separately from `rejected_total` on the dashboard
+    /// ("Capacity-dropped").
+    ///
+    /// Since #4981 a full map is no longer sufficient to land here — the
+    /// oldest entries are evicted instead — so a rising value means the
+    /// map is full *and* contended: every admission attempt lost its
+    /// freed slot to a concurrent caller. Saturation itself now reads on
+    /// [`Self::capacity_evicted_total`]. It is emphatically NOT an
+    /// attacker signal: an ordinary node relaying for enough peers and
+    /// contracts saturates this map on its own.
     pub fn capacity_rejected_total(&self) -> u64 {
         self.capacity_rejected_total.load(Ordering::Relaxed)
     }
@@ -535,6 +871,25 @@ impl UpdateRateLimiter {
     /// a busy node and no longer costs those pairs their UPDATEs.
     pub fn capacity_evicted_total(&self) -> u64 {
         self.capacity_evicted_total.load(Ordering::Relaxed)
+    }
+
+    /// Total UPDATEs dropped because the sending peer was over its
+    /// budget for introducing brand-new `(sender, contract)` pairs.
+    /// Surfaced on the dashboard ("Fresh-id-dropped").
+    ///
+    /// This is the fresh-id-churn signal, and it is the one counter here
+    /// that genuinely does suggest a peer is churning identities — the
+    /// role `capacity_rejected_total` used to be given before eviction
+    /// made saturation an ordinary condition. It never counts a peer's
+    /// traffic for contracts already being tracked.
+    pub fn new_pair_budget_rejected_total(&self) -> u64 {
+        self.new_pair_budget_rejected_total.load(Ordering::Relaxed)
+    }
+
+    /// Number of senders tracked by the new-pair budget.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn tracked_senders(&self) -> usize {
+        self.new_pair_budget.len()
     }
 
     /// Number of tracked `(sender, contract)` pairs. Used by tests and
@@ -826,65 +1181,429 @@ mod tests {
         );
     }
 
-    /// The victim is the least recently used pair, not an arbitrary one.
+    /// The compensating control for what eviction gave up: a sender
+    /// churning brand-new contract ids is cut off once it has spent its
+    /// burst, instead of getting one UPDATE through per id forever.
+    ///
+    /// Before eviction, a full map refused every fresh pair outright,
+    /// which stopped this pattern as a side effect. Nothing else in the
+    /// node does (the ban list is keyed by contract, the MAD detector is
+    /// off by default, and the transport rate-limits handshakes rather
+    /// than established traffic), so the ceiling is replaced here rather
+    /// than dropped (#4997 review).
+    #[test]
+    fn a_sender_churning_fresh_contract_ids_is_cut_off_after_its_burst() {
+        const BURST: usize = 8;
+        let ts = SharedMockTimeSource::new();
+        let limiter = UpdateRateLimiter::with_new_pair_budget(
+            Arc::new(ts.clone()),
+            MIN_UPDATE_INTERVAL,
+            MAX_TRACKED_PAIRS,
+            BURST as f64,
+            MAX_TRACKED_SENDERS,
+        );
+        let attacker = mk_sender(1);
+
+        // The burst gets through: these are the pairs a legitimate peer
+        // would be introducing when it starts relaying for a batch of
+        // contracts.
+        for i in 0..BURST {
+            assert_eq!(
+                limiter.check_and_record(attacker, mk_contract(i as u8)),
+                RateLimitDecision::Allowed,
+                "fresh id {i} is within the burst"
+            );
+        }
+
+        // Past it, fresh ids are refused — and refused for a reason that
+        // says so, not as a capacity drop.
+        for i in BURST..(BURST + 32) {
+            assert_eq!(
+                limiter.check_and_record(attacker, mk_contract(i as u8)),
+                RateLimitDecision::SenderNewPairBudget,
+                "fresh id {i} is past the burst and must be refused"
+            );
+        }
+        assert_eq!(limiter.new_pair_budget_rejected_total(), 32);
+        assert_eq!(
+            limiter.len(),
+            BURST,
+            "a throttled sender must not have grown the tracking map"
+        );
+        assert_eq!(
+            limiter.capacity_evicted_total(),
+            0,
+            "a throttled sender must not have evicted anything — the budget is \
+             charged BEFORE the capacity path so churn cannot push other peers out"
+        );
+
+        // The budget refills, so this throttles rather than bans: after
+        // one interval the sender may introduce one more pair.
+        ts.advance(NEW_PAIR_REFILL_INTERVAL);
+        assert_eq!(
+            limiter.check_and_record(attacker, mk_contract(200)),
+            RateLimitDecision::Allowed,
+            "one refill interval must buy exactly one more fresh pair"
+        );
+        assert_eq!(
+            limiter.check_and_record(attacker, mk_contract(201)),
+            RateLimitDecision::SenderNewPairBudget,
+            "and only one"
+        );
+    }
+
+    /// The budget must never touch a sender's ESTABLISHED traffic, which
+    /// is the availability the #4981 fix exists to restore. A peer that
+    /// keeps updating contracts the limiter already tracks is bounded by
+    /// `min_interval` per pair and by nothing else, however long it goes
+    /// on.
+    #[test]
+    fn the_new_pair_budget_never_throttles_established_pairs() {
+        const BURST: usize = 4;
+        let ts = SharedMockTimeSource::new();
+        let limiter = UpdateRateLimiter::with_new_pair_budget(
+            Arc::new(ts.clone()),
+            MIN_UPDATE_INTERVAL,
+            MAX_TRACKED_PAIRS,
+            BURST as f64,
+            MAX_TRACKED_SENDERS,
+        );
+        let peer = mk_sender(1);
+
+        for i in 0..BURST {
+            assert_eq!(
+                limiter.check_and_record(peer, mk_contract(i as u8)),
+                RateLimitDecision::Allowed
+            );
+        }
+        // Budget fully spent: a fresh pair is refused from here on.
+        assert_eq!(
+            limiter.check_and_record(peer, mk_contract(99)),
+            RateLimitDecision::SenderNewPairBudget
+        );
+
+        // 200 rounds over the same established pairs — far more traffic
+        // than the burst — and not one of them is budget-throttled.
+        for round in 0..200 {
+            ts.advance(MIN_UPDATE_INTERVAL + Duration::from_millis(1));
+            for i in 0..BURST {
+                assert_eq!(
+                    limiter.check_and_record(peer, mk_contract(i as u8)),
+                    RateLimitDecision::Allowed,
+                    "round {round}, established pair {i} must be unaffected by the \
+                     new-pair budget"
+                );
+            }
+        }
+        assert_eq!(
+            limiter.new_pair_budget_rejected_total(),
+            1,
+            "only the one fresh pair was refused; established traffic never \
+             touches the budget"
+        );
+        assert_eq!(limiter.accepted_total(), (BURST + BURST * 200) as u64);
+    }
+
+    /// The budget is per sender: one peer churning fresh ids must not
+    /// throttle anyone else.
+    #[test]
+    fn the_new_pair_budget_is_scoped_per_sender() {
+        const BURST: usize = 2;
+        let ts = SharedMockTimeSource::new();
+        let limiter = UpdateRateLimiter::with_new_pair_budget(
+            Arc::new(ts.clone()),
+            MIN_UPDATE_INTERVAL,
+            MAX_TRACKED_PAIRS,
+            BURST as f64,
+            MAX_TRACKED_SENDERS,
+        );
+        let noisy = mk_sender(1);
+        let quiet = mk_sender(2);
+
+        for i in 0..BURST {
+            assert_eq!(
+                limiter.check_and_record(noisy, mk_contract(i as u8)),
+                RateLimitDecision::Allowed
+            );
+        }
+        assert_eq!(
+            limiter.check_and_record(noisy, mk_contract(50)),
+            RateLimitDecision::SenderNewPairBudget
+        );
+
+        for i in 0..BURST {
+            assert_eq!(
+                limiter.check_and_record(quiet, mk_contract(i as u8)),
+                RateLimitDecision::Allowed,
+                "a second sender has its own budget, untouched by the first"
+            );
+        }
+        assert_eq!(limiter.tracked_senders(), 2);
+    }
+
+    /// The sender map is bounded, and by a space the attacker does not
+    /// choose: `sender` is the immediate upstream hop, so only a peer
+    /// that has completed a handshake can occupy an entry.
+    #[test]
+    fn the_new_pair_budget_map_is_bounded() {
+        const MAX_SENDERS: usize = 4;
+        let ts = SharedMockTimeSource::new();
+        let limiter = UpdateRateLimiter::with_new_pair_budget(
+            Arc::new(ts.clone()),
+            MIN_UPDATE_INTERVAL,
+            MAX_TRACKED_PAIRS,
+            NEW_PAIR_BURST,
+            MAX_SENDERS,
+        );
+
+        for i in 0..(MAX_SENDERS * 4) {
+            limiter.check_and_record(mk_sender(i as u8), mk_contract(1));
+            assert!(
+                limiter.tracked_senders() <= MAX_SENDERS,
+                "sender {i}: the budget map must never exceed its cap"
+            );
+        }
+        assert_eq!(limiter.tracked_senders(), MAX_SENDERS);
+    }
+
+    /// Boundary case: a zero cap is the ONLY configuration in which the
+    /// limiter still refuses a new pair outright, and it must terminate
+    /// rather than spin.
+    ///
+    /// This is the one path `EvictionOutcome::MapEmpty` exists for. It
+    /// was untested, which mattered because the eviction rework turned
+    /// "evicted nothing" into a retry: had that retry not distinguished
+    /// an empty map from a contended one, a zero cap would loop through
+    /// its whole attempt budget on every call forever.
+    #[test]
+    fn a_zero_cap_refuses_every_pair_without_spinning() {
+        let ts = SharedMockTimeSource::new();
+        let limiter = UpdateRateLimiter::with_config(Arc::new(ts.clone()), MIN_UPDATE_INTERVAL, 0);
+
+        for i in 1..=4u8 {
+            assert_eq!(
+                limiter.check_and_record(mk_sender(i), mk_contract(i)),
+                RateLimitDecision::CapacityExceeded,
+                "with a zero cap there is no slot for pair {i} and nothing to evict"
+            );
+        }
+        assert_eq!(limiter.len(), 0);
+        assert_eq!(limiter.capacity_rejected_total(), 4);
+        assert_eq!(
+            limiter.capacity_evicted_total(),
+            0,
+            "an empty map has nothing to evict"
+        );
+        assert_eq!(limiter.accepted_total(), 0);
+    }
+
+    /// Cap used by the eviction-order tests. 128 gives an eviction batch
+    /// of `128 / EVICTION_BATCH_DIVISOR` = 2, and the size is what makes
+    /// these tests decisive: an arbitrary-victim implementation has to
+    /// pick the *exact* oldest pairs out of 128 candidates, three rounds
+    /// running, to survive. At the cap-8 fixtures used elsewhere the
+    /// batch clamps to 1 and an arbitrary victim is the right one 1 time
+    /// in 8, which is not a pin (measured: an implementation with the
+    /// ordering deleted passed 349 of 400 runs, #4997 review).
+    const ORDER_TEST_CAP: usize = 128;
+    /// Number of entries the eviction-order tests drive out: three
+    /// batches of two.
+    const ORDER_TEST_EVICTED: usize = 6;
+
+    /// Distinct `(sender, contract)` pairs indexed well past 256, which
+    /// is where the `u8`-keyed helpers above stop.
+    fn mk_pair(i: usize) -> (SocketAddr, ContractInstanceId) {
+        let sender = SocketAddr::from(([10, 1, (i >> 8) as u8, (i & 0xff) as u8], 30000));
+        (sender, ContractInstanceId::new([0xAB; 32]))
+    }
+
+    /// Admit fresh pairs, starting at index `from`, until the limiter has
+    /// evicted `ORDER_TEST_EVICTED` entries. Returns the next unused
+    /// index.
+    ///
+    /// Each newcomer at capacity evicts a batch of 2 and inserts 1, so
+    /// the map alternates between cap and cap-1 and only every other
+    /// newcomer triggers a batch.
+    fn admit_until_evicted(
+        limiter: &UpdateRateLimiter,
+        ts: &SharedMockTimeSource,
+        from: usize,
+    ) -> usize {
+        let mut i = from;
+        while limiter.capacity_evicted_total() < ORDER_TEST_EVICTED as u64 {
+            let (s, c) = mk_pair(i);
+            assert_eq!(
+                limiter.check_and_record(s, c),
+                RateLimitDecision::Allowed,
+                "newcomer {i} must be admitted"
+            );
+            i += 1;
+            ts.advance(Duration::from_micros(1));
+            assert!(
+                i < from + ORDER_TEST_CAP,
+                "newcomers should have driven {ORDER_TEST_EVICTED} evictions long before this"
+            );
+        }
+        assert_eq!(
+            limiter.capacity_evicted_total(),
+            ORDER_TEST_EVICTED as u64,
+            "batches of 2 must land exactly on {ORDER_TEST_EVICTED}"
+        );
+        i
+    }
+
+    /// The victims are the least recently used pairs, not arbitrary ones.
     ///
     /// Membership is observed through the limiter's own behaviour rather
     /// than a test-only accessor: a tracked pair stamped within
     /// `min_interval` answers `Rejected`, while an evicted pair is seen
     /// as new and answers `Allowed`. So "was it evicted?" is exactly
     /// "does an immediate re-check come back Allowed?".
+    ///
+    /// That discriminator only holds while EVERY pair's stamp is inside
+    /// `min_interval`, which is why the fixture advances by microseconds
+    /// and asserts the whole run stays inside the window. The previous
+    /// version of this test let the clock run 108ms before probing, so
+    /// the pair it checked for eviction was outside the window and
+    /// answered `Allowed` whether or not it had been evicted — the
+    /// assertion could not fail (#4997 review).
     #[test]
-    fn at_capacity_evicts_the_oldest_pair_not_an_arbitrary_one() {
+    fn at_capacity_evicts_the_oldest_pairs_not_arbitrary_ones() {
         let ts = SharedMockTimeSource::new();
-        let limiter = UpdateRateLimiter::with_config(Arc::new(ts.clone()), MIN_UPDATE_INTERVAL, 8);
+        let limiter = UpdateRateLimiter::with_config(
+            Arc::new(ts.clone()),
+            MIN_UPDATE_INTERVAL,
+            ORDER_TEST_CAP,
+        );
+        assert_eq!(
+            ORDER_TEST_CAP / EVICTION_BATCH_DIVISOR,
+            2,
+            "fixture assumes a 2-entry batch"
+        );
+        let start = ts.now();
 
-        // Fill, each pair stamped a millisecond apart so "oldest" is
-        // unambiguous. Pair 1 is the oldest, pair 8 the newest.
-        for i in 1..=8u8 {
-            assert!(
-                limiter
-                    .check_and_record(mk_sender(i), mk_contract(i))
-                    .is_allowed()
+        // Fill, one microsecond apart, so ages are strictly ordered:
+        // pair 0 is the oldest, pair 127 the newest.
+        for i in 0..ORDER_TEST_CAP {
+            let (s, c) = mk_pair(i);
+            assert_eq!(
+                limiter.check_and_record(s, c),
+                RateLimitDecision::Allowed,
+                "fill {i}"
             );
-            ts.advance(Duration::from_millis(1));
+            ts.advance(Duration::from_micros(1));
+        }
+        assert_eq!(limiter.len(), ORDER_TEST_CAP);
+
+        admit_until_evicted(&limiter, &ts, ORDER_TEST_CAP);
+
+        assert!(
+            ts.now().saturating_duration_since(start) < MIN_UPDATE_INTERVAL,
+            "the fixture must stay inside min_interval, or a surviving pair and an \
+             evicted one both answer Allowed and the assertions below are vacuous"
+        );
+
+        // Survivors first: a `Rejected` check does not mutate the map,
+        // whereas an `Allowed` one re-inserts and can evict again.
+        for i in ORDER_TEST_EVICTED..ORDER_TEST_CAP {
+            let (s, c) = mk_pair(i);
+            assert!(
+                matches!(
+                    limiter.check_and_record(s, c),
+                    RateLimitDecision::Rejected { .. }
+                ),
+                "pair {i} is newer than the {ORDER_TEST_EVICTED} oldest and must have survived"
+            );
+        }
+        for i in 0..ORDER_TEST_EVICTED {
+            let (s, c) = mk_pair(i);
+            assert_eq!(
+                limiter.check_and_record(s, c),
+                RateLimitDecision::Allowed,
+                "pair {i} is among the {ORDER_TEST_EVICTED} oldest and must have been evicted"
+            );
+        }
+    }
+
+    /// Accepting an UPDATE for a tracked pair restamps it, which moves it
+    /// to the BACK of the eviction order.
+    ///
+    /// This is the property the module's cost argument rests on: a
+    /// sustained flood from a *stable* pair is unaffected by eviction,
+    /// because that pair is the most recently used and therefore the last
+    /// thing evicted. It needs its own fixture because the refresh is
+    /// what destroys the membership discriminator — a pair refreshed past
+    /// `min_interval` leaves every un-refreshed pair outside the window,
+    /// so their membership stops being observable.
+    ///
+    /// The fixture works around that by refreshing all but a chosen few:
+    /// the 6 pairs left un-refreshed are the only ones outside the
+    /// window, and they are exactly the ones that must be evicted, so
+    /// every pair the test asserts on is inside the window.
+    #[test]
+    fn a_refreshed_pair_moves_to_the_back_of_the_eviction_order() {
+        let ts = SharedMockTimeSource::new();
+        let limiter = UpdateRateLimiter::with_config(
+            Arc::new(ts.clone()),
+            MIN_UPDATE_INTERVAL,
+            ORDER_TEST_CAP,
+        );
+
+        // Fill oldest-first, as above.
+        for i in 0..ORDER_TEST_CAP {
+            let (s, c) = mk_pair(i);
+            assert_eq!(
+                limiter.check_and_record(s, c),
+                RateLimitDecision::Allowed,
+                "fill {i}"
+            );
+            ts.advance(Duration::from_micros(1));
         }
 
-        // Refresh pair 1, making it the most recently used. If eviction
-        // ignored recency, this is the entry a naive "first one found"
-        // policy would still take.
+        // Past `min_interval`, refresh every pair EXCEPT indices
+        // 6..ORDER_TEST_EVICTED+6. Crucially that includes pairs 0..6 —
+        // the entries that were the oldest — so if eviction ignored the
+        // restamp it would take exactly those, and this test fails.
         ts.advance(MIN_UPDATE_INTERVAL);
-        assert!(
-            limiter
-                .check_and_record(mk_sender(1), mk_contract(1))
-                .is_allowed()
-        );
-
-        // Admit a newcomer: pair 2 is now the oldest and must be the
-        // victim.
-        assert!(
-            limiter
-                .check_and_record(mk_sender(99), mk_contract(99))
-                .is_allowed()
-        );
-        assert_eq!(limiter.capacity_evicted_total(), 1);
-
-        // Pair 1 was just refreshed, so it must still be tracked — a
-        // re-check inside min_interval is Rejected. Checked first
-        // because a Rejected check does not mutate the map.
-        assert!(
-            matches!(
-                limiter.check_and_record(mk_sender(1), mk_contract(1)),
-                RateLimitDecision::Rejected { .. }
-            ),
-            "the most recently used pair must survive eviction"
-        );
-
-        // Pair 2 was the oldest, so it is gone: it reads as new.
+        let victims = ORDER_TEST_EVICTED..(2 * ORDER_TEST_EVICTED);
+        let refreshed = ts.now();
+        for i in (0..ORDER_TEST_CAP).filter(|i| !victims.contains(i)) {
+            let (s, c) = mk_pair(i);
+            assert_eq!(
+                limiter.check_and_record(s, c),
+                RateLimitDecision::Allowed,
+                "refresh {i} must be accepted a full min_interval after the fill"
+            );
+        }
         assert_eq!(
-            limiter.check_and_record(mk_sender(2), mk_contract(2)),
-            RateLimitDecision::Allowed,
-            "the least recently used pair must be the eviction victim"
+            limiter.capacity_evicted_total(),
+            0,
+            "restamping tracked pairs must not evict anything — it never takes the \
+             capacity path"
         );
+
+        admit_until_evicted(&limiter, &ts, ORDER_TEST_CAP);
+
+        assert!(
+            ts.now().saturating_duration_since(refreshed) < MIN_UPDATE_INTERVAL,
+            "every refreshed pair must still be inside min_interval, or the \
+             assertions below are vacuous"
+        );
+
+        // Every refreshed pair survived — including 0..6, which were the
+        // oldest before the refresh. The only entries gone are the ones
+        // left un-refreshed.
+        for i in (0..ORDER_TEST_CAP).filter(|i| !victims.contains(i)) {
+            let (s, c) = mk_pair(i);
+            assert!(
+                matches!(
+                    limiter.check_and_record(s, c),
+                    RateLimitDecision::Rejected { .. }
+                ),
+                "pair {i} was refreshed, so it must be at the back of the eviction \
+                 order and must have survived"
+            );
+        }
     }
 
     /// The #4981 regression: a busy pair must not be able to hold its
@@ -1038,6 +1757,9 @@ mod tests {
                 RateLimitDecision::Allowed => allowed += 1,
                 RateLimitDecision::Rejected { .. } => rejected += 1,
                 RateLimitDecision::CapacityExceeded => panic!("unexpected cap"),
+                RateLimitDecision::SenderNewPairBudget => {
+                    panic!("one pair cannot exhaust a new-pair budget")
+                }
             }
         }
         assert_eq!(
@@ -1179,17 +1901,28 @@ mod tests {
                 RateLimitDecision::Allowed => allowed += 1,
                 RateLimitDecision::CapacityExceeded => cap_rejected += 1,
                 RateLimitDecision::Rejected { .. } => rate_rejected += 1,
+                RateLimitDecision::SenderNewPairBudget => {
+                    panic!("each thread uses a distinct sender, so no budget can be spent")
+                }
             }
         }
-        // Critical invariant, unchanged by #4981: the map size is
-        // EXACTLY the cap, not cap + overshoot. Eviction makes this a
-        // sharper test than it was — 64 threads now race to evict and
+        // Critical invariant, unchanged by #4981: the map never exceeds
+        // the cap, no matter how many callers race. Eviction makes this
+        // a sharper test than it was — 64 threads now race to evict and
         // insert concurrently, and the reservation counter still has to
         // hold the line.
-        assert_eq!(
-            limiter.len(),
-            CAP,
-            "strict cap: map size must equal CAP after a 64-thread \
+        //
+        // It is an upper bound, NOT an equality. Admissions are not
+        // conserved under eviction: a caller can free a slot and then
+        // lose it to another thread on every remaining attempt, so a run
+        // can legitimately end one or more entries BELOW the cap. Pinning
+        // `len() == CAP` made this test fail ~1 run in 100 (#4997
+        // review measured it at 44/800 before the eviction scan was
+        // serialised, 7/800 after) — a flaky test asserting something the
+        // implementation never promised.
+        assert!(
+            limiter.len() <= CAP,
+            "strict cap: map size must never exceed CAP after a 64-thread \
              concurrent flood of distinct keys, got {}",
             limiter.len()
         );
@@ -1210,10 +1943,23 @@ mod tests {
         // slot to another thread `MAX_ADMISSION_ATTEMPTS` times running,
         // so it is contention-dependent rather than a fixed count.
         assert_eq!(limiter.capacity_rejected_total(), cap_rejected as u64);
+        // Conservation, which IS exact: every `Allowed` inserted one
+        // entry and every eviction removed one, and nothing else mutates
+        // the map here (no `cleanup`, and distinct keys mean no caller
+        // ever takes the Occupied restamp path). So whatever the final
+        // size turns out to be, it must be exactly what was put in minus
+        // what was taken out.
+        //
+        // This replaces `evicted == allowed - CAP`, which assumed the map
+        // ends exactly full and was wrong for the same reason the size
+        // assertion above was.
         assert_eq!(
-            limiter.capacity_evicted_total(),
-            (allowed - CAP) as u64,
-            "every admission beyond the first CAP must have evicted exactly one entry"
+            limiter.len() as u64,
+            allowed as u64 - limiter.capacity_evicted_total(),
+            "inserts minus evictions must account for every tracked entry: \
+             len={} allowed={allowed} evicted={}",
+            limiter.len(),
+            limiter.capacity_evicted_total()
         );
     }
 
@@ -1251,6 +1997,27 @@ mod tests {
             preamble.contains(&strip_ws("tracing::info!")),
             "the eviction log must be emitted at info! or higher; debug! is compiled out of \
              release builds by release_max_level_info (#4981)"
+        );
+
+        // The fresh-id-churn line, also in this file. This one is the
+        // ONLY release-visible evidence of that drop — the dispatch site
+        // logs it at `debug!` on purpose, because a sender over its
+        // budget is over it on every message and an unthrottled line
+        // there would be a flood. Downgrading this one would make the
+        // whole signal invisible in release.
+        let churn_marker = strip_ws(concat!(
+            "UPDATE rate limiter: peer is introducing ",
+            "brand-new (sender, contract)"
+        ));
+        let pos = this_file.find(&churn_marker).expect(
+            "the new-pair-budget log line must exist; if it was renamed, update this pin rather \
+             than deleting it",
+        );
+        let preamble = &this_file[pos.saturating_sub(200)..pos];
+        assert!(
+            preamble.contains(&strip_ws("tracing::info!")),
+            "the new-pair-budget log must be emitted at info! or higher; debug! is compiled out \
+             of release builds by release_max_level_info (#4981)"
         );
 
         // The residual capacity drop, in the UPDATE dispatch path.
@@ -1312,5 +2079,84 @@ mod tests {
                 "after cleanup, new pair (sender={i}) should be admitted"
             );
         }
+    }
+
+    /// Regression pin for the spurious capacity drops #4997's review
+    /// measured: under concurrent admission of new pairs at a saturated
+    /// cap, `CapacityExceeded` must be vanishingly rare.
+    ///
+    /// The bug it pins: `evict_oldest` returning "removed nothing" was
+    /// read as "the map is empty, so the cap is 0" and the UPDATE was
+    /// dropped. Under contention that return means the opposite — every
+    /// victim this caller selected was taken by another caller, so slots
+    /// WERE just freed — and it did not even spend the retry budget that
+    /// exists for the race. Measured at the production cap with 16
+    /// threads: 2 699 drops in 320 000 admissions (0.84%), every trial
+    /// affected, 100% of them from that branch, retry budget untouched.
+    /// After the fix, 7 in 320 000 (0.002%).
+    ///
+    /// The threshold below sits between those two by more than an order
+    /// of magnitude in both directions, so it is neither flaky nor
+    /// vacuous. It is a bound rather than zero because losing a freed
+    /// slot to a concurrent caller on every attempt is genuinely
+    /// possible — that is what `CapacityExceeded` is documented to mean.
+    #[test]
+    fn concurrent_admission_at_capacity_almost_never_drops() {
+        use std::sync::{Arc as StdArc, Barrier};
+        use std::thread;
+
+        const CAP: usize = 1024;
+        const THREADS: usize = 16;
+        const PER_THREAD: usize = 400;
+        const ADMISSIONS: usize = THREADS * PER_THREAD;
+        /// One drop per this many admissions is the ceiling. The bug
+        /// produced ~8 per thousand; the fix produces ~0.02.
+        const MAX_DROPS_PER_THOUSAND: usize = 1;
+
+        let ts = SharedMockTimeSource::new();
+        let limiter = StdArc::new(UpdateRateLimiter::with_new_pair_budget(
+            Arc::new(ts.clone()),
+            MIN_UPDATE_INTERVAL,
+            CAP,
+            // The new-pair budget is not what this test is about, and a
+            // synthetic flood of fresh pairs would otherwise be stopped
+            // by it before reaching the capacity path.
+            f64::from(u32::MAX),
+            THREADS,
+        ));
+        let barrier = StdArc::new(Barrier::new(THREADS));
+        let mut handles = Vec::with_capacity(THREADS);
+
+        for t in 0..THREADS {
+            let l = limiter.clone();
+            let b = barrier.clone();
+            handles.push(thread::spawn(move || {
+                b.wait();
+                for i in 0..PER_THREAD {
+                    // Distinct sender per thread, distinct contract per
+                    // iteration: every call takes the new-pair path.
+                    let sender = mk_sender(t as u8);
+                    let mut id = [0u8; 32];
+                    id[..8].copy_from_slice(&(i as u64).to_be_bytes());
+                    l.check_and_record(sender, ContractInstanceId::new(id));
+                }
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        assert!(
+            limiter.capacity_evicted_total() > 0,
+            "fixture must actually saturate the cap, or it pins nothing"
+        );
+        let drops = limiter.capacity_rejected_total();
+        assert!(
+            drops as usize * 1000 <= ADMISSIONS * MAX_DROPS_PER_THOUSAND,
+            "at most {MAX_DROPS_PER_THOUSAND} drop per 1000 admissions, got {drops} \
+             in {ADMISSIONS}. An eviction that removed nothing means a concurrent \
+             caller freed the slots, so the admission must retry, not drop."
+        );
+        assert!(limiter.len() <= CAP);
     }
 }

--- a/crates/core/src/ring/update_rate_limit.rs
+++ b/crates/core/src/ring/update_rate_limit.rs
@@ -1217,6 +1217,61 @@ mod tests {
         );
     }
 
+    /// Pin: both saturation signals stay visible in release builds.
+    ///
+    /// `crates/core/Cargo.toml` sets `release_max_level_info`, so
+    /// anything logged at `debug!` is compiled out of shipped binaries.
+    /// That is half of why #4981 went unnoticed for so long: a
+    /// production node dropped legitimate relayed UPDATEs and left no
+    /// greppable evidence, so the only signal was a dashboard tile a
+    /// user happened to ask about. Behavioural tests cannot see a log
+    /// level, so this scrapes the source instead — a silent downgrade to
+    /// `debug!` would otherwise restore the invisibility with every
+    /// other test still green.
+    ///
+    /// Needles are split with `concat!` so they do not match their own
+    /// source through `include_str!`, and both haystacks are compared
+    /// with whitespace stripped so rustfmt reflowing a call cannot make
+    /// the pin vacuous.
+    #[test]
+    fn capacity_signals_are_logged_above_debug_level() {
+        fn strip_ws(s: &str) -> String {
+            s.chars().filter(|c| !c.is_whitespace()).collect()
+        }
+
+        // The limiter's own saturation line, in this file.
+        let this_file = strip_ws(include_str!("update_rate_limit.rs"));
+        let eviction_marker = strip_ws(concat!("UPDATE rate limiter at ", "capacity: evicted"));
+        let pos = this_file.find(&eviction_marker).expect(
+            "the eviction log line must exist; if it was renamed, update this pin rather than \
+             deleting it",
+        );
+        let preamble = &this_file[pos.saturating_sub(200)..pos];
+        assert!(
+            preamble.contains(&strip_ws("tracing::info!")),
+            "the eviction log must be emitted at info! or higher; debug! is compiled out of \
+             release builds by release_max_level_info (#4981)"
+        );
+
+        // The residual capacity drop, in the UPDATE dispatch path.
+        let node_rs = strip_ws(include_str!("../node.rs"));
+        let drop_marker = strip_ws(concat!("update_dispatch_", "capacity_dropped"));
+        let pos = node_rs.find(&drop_marker).expect(
+            "the capacity-drop log phase must exist in node.rs; if it was renamed, update this \
+             pin rather than deleting it",
+        );
+        let preamble = &node_rs[pos.saturating_sub(200)..pos];
+        assert!(
+            preamble.contains(&strip_ws("tracing::info!")),
+            "dropping an UPDATE for capacity must be logged at info! or higher, so the drop is \
+             greppable on a production node (#4981)"
+        );
+        assert!(
+            !preamble.contains(&strip_ws("tracing::debug!")),
+            "the capacity-drop branch must not fall back to debug!"
+        );
+    }
+
     /// Pin: cleanup decrements the `size` counter by the number of
     /// dropped entries. After all entries roll off, the cap should
     /// be fully available again — strict-cap accounting tracks the

--- a/crates/core/src/ring/update_rate_limit.rs
+++ b/crates/core/src/ring/update_rate_limit.rs
@@ -95,15 +95,32 @@
 //!
 //! Two properties make this the right shape:
 //!
-//! - **Established traffic never touches it.** A token is spent on the
-//!   new-pair path only, so a peer relaying heavily for contracts the
-//!   limiter already tracks is bounded by [`MIN_UPDATE_INTERVAL`] per
-//!   pair and by nothing else — the availability this fix exists to
-//!   restore is not clawed back.
+//! - **Traffic for a pair the limiter is tracking never touches it.** A
+//!   token is spent only when the pair is not currently in the map, so a
+//!   peer relaying heavily for contracts the limiter holds is bounded by
+//!   [`MIN_UPDATE_INTERVAL`] per pair and by nothing else.
 //! - **It is charged before eviction, not after.** A sender past its
 //!   budget is refused *before* a slot is reserved or anything is
 //!   evicted, so churning fresh ids cannot push other peers' entries out
 //!   of the map on the way to being throttled.
+//!
+//! The caveat, stated rather than glossed: "not currently in the map"
+//! includes a pair that WAS tracked and then got evicted. The limiter
+//! cannot tell a returning pair from a genuinely fresh one without
+//! remembering what it evicted, which is exactly the unbounded memory
+//! the cap exists to refuse. So on a node whose working set far exceeds
+//! [`MAX_TRACKED_PAIRS`] — where the miss rate is high — this behaves
+//! less like a fresh-id bound and more like a per-peer aggregate
+//! ceiling.
+//!
+//! That is why the sustained rate is set well ABOVE
+//! [`MIN_UPDATE_INTERVAL`]'s per-pair ceiling rather than at it: a peer
+//! would have to sustain [`NEW_PAIR_BURST`] and then 200 UPDATEs/s to
+//! this node, continuously, before any of it is dropped. If that ever
+//! binds on real traffic it is visible as
+//! `new_pair_budget_rejected_total` climbing on a node with no attacker,
+//! which is the signal to raise the rate — the counter is on the
+//! dashboard for exactly that reason.
 //!
 //! Its own map is bounded by [`MAX_TRACKED_SENDERS`], which is a
 //! multiple of the node's connection cap rather than an attacker-chosen
@@ -159,7 +176,7 @@ use freenet_stdlib::prelude::ContractInstanceId;
 use tokio::time::Instant;
 
 use super::Ring;
-use super::resync_rate_limit::TokenBucketLimiter;
+use super::resync_rate_limit::{BucketOutcome, TokenBucketLimiter};
 use crate::util::time_source::TimeSource;
 
 /// Minimum interval between accepted UPDATEs for the same
@@ -245,27 +262,36 @@ const MAX_ADMISSION_ATTEMPTS: usize = 6;
 /// and re-subscribes, or one that starts relaying for a batch of
 /// contracts at once — with room to spare over the ~330 pairs per peer
 /// implied by the saturation #4981 reported (≈16 500 pairs across ≈50
-/// peers). A sender only spends a token when it presents a pair the
-/// limiter has never seen, so established traffic never touches this.
-const NEW_PAIR_BURST: f64 = 512.0;
+/// peers).
+const NEW_PAIR_BURST: f64 = 1024.0;
 
-/// Sustained rate at which one sender may introduce brand-new pairs once
-/// its burst is spent: one per interval.
+/// Sustained rate at which one sender may present pairs the limiter is
+/// not currently tracking, once its burst is spent: one per interval.
 ///
-/// Deliberately [`MIN_UPDATE_INTERVAL`], so both ceilings read the same
-/// way: a sender may introduce new pairs no faster than it may repeat an
-/// UPDATE on a single pair (10/s at the defaults).
-const NEW_PAIR_REFILL_INTERVAL: Duration = MIN_UPDATE_INTERVAL;
+/// 5ms, i.e. 200/s — twenty times [`MIN_UPDATE_INTERVAL`]'s per-pair
+/// ceiling. Deliberately not set equal to it: under saturation a pair
+/// that was tracked and got evicted comes back through this same path
+/// (see the module docs), so a rate tuned for genuinely-fresh ids would
+/// throttle ordinary relayed traffic on exactly the busy node this fix
+/// exists to keep serving. A peer must sustain 200 UPDATEs/s to this
+/// node, continuously, before anything is dropped, while a fresh-id
+/// flood is still bounded instead of unlimited.
+const NEW_PAIR_REFILL_INTERVAL: Duration = Duration::from_millis(5);
 
-/// Cap on the senders tracked by the new-pair budget.
+/// Headroom multiple over the node's configured `max_connections` for
+/// the new-pair budget's own map.
 ///
 /// One entry per peer address that has presented a new pair. `sender` is
-/// the immediate upstream hop, so the live set is bounded by this node's
-/// connection count; the multiple over [`Ring::DEFAULT_MAX_CONNECTIONS`]
-/// is headroom for address churn (reconnects, NAT rebinding) between
-/// [`CLEANUP_AGE`] sweeps. At ~48 bytes an entry the whole map is well
-/// under 100 KB.
-const MAX_TRACKED_SENDERS: usize = 8 * Ring::DEFAULT_MAX_CONNECTIONS;
+/// the immediate upstream hop, so the live set is bounded by the
+/// connection cap; the multiple is headroom for address churn
+/// (reconnects, NAT rebinding) between [`CLEANUP_AGE`] sweeps. At ~48
+/// bytes an entry, 8x the default 200-connection cap is well under
+/// 100 KB.
+///
+/// Derived from the configured value rather than a constant: a node
+/// raised above [`Ring::DEFAULT_MAX_CONNECTIONS`] would otherwise run a
+/// budget map smaller than its own peer count.
+const SENDER_TRACKING_HEADROOM: usize = 8;
 
 /// How often an exhausted new-pair budget may write a log line.
 ///
@@ -288,12 +314,23 @@ const NEW_PAIR_LOG_INTERVAL: Duration = EVICTION_LOG_INTERVAL;
 ///    oldest entries.
 /// 3. The map is empty, so there is nothing to evict and never will be.
 ///
-/// 1 and 2 mean a slot is, or may already be, free: the right move is to
-/// retry the admission, which is what [`MAX_ADMISSION_ATTEMPTS`] exists
-/// for. Only 3 is a configuration problem. Conflating them dropped ~0.9%
-/// of admissions at the production cap under 16-thread contention, none
-/// of them for the documented reason, and without consuming a single
-/// retry attempt (#4997 review).
+/// 1, 2 and 3 all mean a slot is, or may already be, free: the right
+/// move is to retry the admission, which is what
+/// [`MAX_ADMISSION_ATTEMPTS`] exists for. Conflating them with the one
+/// genuinely terminal case dropped ~0.9% of admissions at the production
+/// cap under 16-thread contention, none of them for the documented
+/// reason, and without consuming a single retry attempt (#4997 review).
+///
+/// Note that 3 — an empty map — is NOT terminal, and inferring "the cap
+/// must be 0" from it was a second instance of the same mistake. A map
+/// with a perfectly good cap reads as empty in two windows: while
+/// [`UpdateRateLimiter::cleanup`] is sweeping, and while every caller
+/// that has won a slot is still between its reservation and its insert
+/// (reachable at small caps under contention, e.g. 8 slots and 64
+/// callers). In both, `size` is legitimately at the cap while the map is
+/// not, and slots are about to exist. The only terminal condition is a
+/// cap of zero, which is a property of the configuration and is read
+/// from it directly rather than inferred.
 enum EvictionOutcome {
     /// This pass freed slots and kept one of them for the caller, which
     /// therefore does not have to win the cap check again — it inserts
@@ -302,9 +339,9 @@ enum EvictionOutcome {
     /// A slot is, or may already be, free, but this caller did not free
     /// it and holds no claim on it. Retry the admission.
     Retry,
-    /// The map is empty — reachable only with `max_tracked_pairs == 0`.
-    /// Terminal.
-    MapEmpty,
+    /// `max_tracked_pairs` is 0, so no admission can ever succeed.
+    /// Terminal, and the only terminal case.
+    CapIsZero,
 }
 
 /// Whether a throttled log line is due, stamping `slot` when it is.
@@ -441,16 +478,35 @@ pub(crate) struct UpdateRateLimiter {
     /// Total UPDATEs dropped because the sender was over its new-pair
     /// budget.
     new_pair_budget_rejected_total: AtomicU64,
+    /// Total new pairs admitted WITHOUT a budget check because the
+    /// sender map was full. Should be zero: the map is sized well above
+    /// the connection cap, and this failing open is a safety valve, not
+    /// an expected path. A non-zero value means `max_tracked_senders` is
+    /// undersized for this node.
+    new_pair_budget_untracked_total: AtomicU64,
     /// When the last new-pair-budget log line was written, for
     /// [`NEW_PAIR_LOG_INTERVAL`] throttling.
     last_new_pair_log: Mutex<Option<Instant>>,
 }
 
 impl UpdateRateLimiter {
-    pub fn new(time_source: Arc<dyn TimeSource + Send + Sync>) -> Self {
-        Self::with_config(time_source, MIN_UPDATE_INTERVAL, MAX_TRACKED_PAIRS)
+    /// `max_connections` is this node's configured connection cap; the
+    /// per-sender budget's map is sized from it (see
+    /// [`SENDER_TRACKING_HEADROOM`]).
+    pub fn new(time_source: Arc<dyn TimeSource + Send + Sync>, max_connections: usize) -> Self {
+        Self::with_new_pair_budget(
+            time_source,
+            MIN_UPDATE_INTERVAL,
+            MAX_TRACKED_PAIRS,
+            NEW_PAIR_BURST,
+            max_connections.saturating_mul(SENDER_TRACKING_HEADROOM),
+        )
     }
 
+    /// Test/bench constructor: the production path is [`Self::new`],
+    /// which sizes the per-sender budget from the node's own connection
+    /// cap rather than the default.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn with_config(
         time_source: Arc<dyn TimeSource + Send + Sync>,
         min_interval: Duration,
@@ -461,7 +517,7 @@ impl UpdateRateLimiter {
             min_interval,
             max_tracked_pairs,
             NEW_PAIR_BURST,
-            MAX_TRACKED_SENDERS,
+            Ring::DEFAULT_MAX_CONNECTIONS * SENDER_TRACKING_HEADROOM,
         )
     }
 
@@ -484,6 +540,7 @@ impl UpdateRateLimiter {
                 max_tracked_senders,
             ),
             new_pair_budget_rejected_total: AtomicU64::new(0),
+            new_pair_budget_untracked_total: AtomicU64::new(0),
             last_new_pair_log: Mutex::new(None),
             last_accepted: DashMap::new(),
             size: AtomicUsize::new(0),
@@ -580,14 +637,32 @@ impl UpdateRateLimiter {
                         // map on its way to being throttled. See the
                         // module docs.
                         if !budget_spent {
-                            if !self.new_pair_budget.check_and_record(sender) {
-                                drop(entry);
-                                self.new_pair_budget_rejected_total
-                                    .fetch_add(1, Ordering::Relaxed);
-                                self.log_new_pair_budget(now, sender);
-                                return RateLimitDecision::SenderNewPairBudget;
+                            match self.new_pair_budget.check_and_record_detailed(sender) {
+                                BucketOutcome::Allowed => budget_spent = true,
+                                BucketOutcome::RateLimited => {
+                                    drop(entry);
+                                    self.new_pair_budget_rejected_total
+                                        .fetch_add(1, Ordering::Relaxed);
+                                    self.log_new_pair_budget(now, sender);
+                                    return RateLimitDecision::SenderNewPairBudget;
+                                }
+                                // The budget map is full, so this sender
+                                // has no bucket and nothing is known
+                                // about its rate. Fail OPEN: refusing
+                                // here would starve a newcomer for a
+                                // sizing accident, and a bounded map
+                                // that permanently refuses newcomers
+                                // once full is precisely the #4981 shape
+                                // this PR removes — `Bucket::refill`
+                                // restamps on every check, so an active
+                                // sender's entry never ages out and the
+                                // newcomer would never recover.
+                                BucketOutcome::Untracked => {
+                                    self.new_pair_budget_untracked_total
+                                        .fetch_add(1, Ordering::Relaxed);
+                                    budget_spent = true;
+                                }
                             }
-                            budget_spent = true;
                         }
                         // Reserve a slot via the authoritative counter
                         // BEFORE inserting. `fetch_add` is the
@@ -623,9 +698,8 @@ impl UpdateRateLimiter {
                                 // dropping.
                                 EvictionOutcome::Retry => continue,
                                 // Nothing to evict and nothing ever will
-                                // be: the cap is 0. Configuration, not
-                                // saturation.
-                                EvictionOutcome::MapEmpty => {
+                                // be. Configuration, not saturation.
+                                EvictionOutcome::CapIsZero => {
                                     self.capacity_rejected_total.fetch_add(1, Ordering::Relaxed);
                                     return RateLimitDecision::CapacityExceeded;
                                 }
@@ -669,6 +743,11 @@ impl UpdateRateLimiter {
     /// mock clock that has not advanced) share an `Instant`, and a
     /// cutoff comparison would take every tied entry with it.
     fn evict_oldest(&self, now: Instant) -> EvictionOutcome {
+        // The one terminal condition, read from the configuration rather
+        // than inferred from an empty map — see `EvictionOutcome`.
+        if self.max_tracked_pairs == 0 {
+            return EvictionOutcome::CapIsZero;
+        }
         // Another caller already made room, so there is nothing to evict
         // and the admission should simply retry. Without this early
         // return every concurrent newcomer pays the full
@@ -693,7 +772,7 @@ impl UpdateRateLimiter {
         // it was not already paying (it was running its own redundant
         // scan), and the re-check below means a waiter that arrives
         // after the batch is freed does no scan at all.
-        let _evicting = match self.eviction_lock.lock() {
+        let evicting = match self.eviction_lock.lock() {
             Ok(guard) => guard,
             // Poisoned only if a previous holder panicked mid-scan. The
             // map is still consistent — `remove` is atomic per entry —
@@ -713,7 +792,9 @@ impl UpdateRateLimiter {
             .map(|e| (*e.value(), *e.key()))
             .collect();
         if entries.is_empty() {
-            return EvictionOutcome::MapEmpty;
+            // Not terminal: `size` reads at the cap while the map does
+            // not, so slots are about to exist. See `EvictionOutcome`.
+            return EvictionOutcome::Retry;
         }
         let batch = batch.min(entries.len());
         entries.select_nth_unstable_by_key(batch - 1, |(stamped, _)| *stamped);
@@ -748,6 +829,9 @@ impl UpdateRateLimiter {
             self.size.fetch_sub(removed - 1, Ordering::Relaxed);
             self.capacity_evicted_total
                 .fetch_add(removed as u64, Ordering::Relaxed);
+            // Log outside the lock: formatting and the tracing subscriber
+            // are not work the next evictor should queue behind.
+            drop(evicting);
             self.log_eviction(now, removed);
             return EvictionOutcome::Reserved;
         }
@@ -808,26 +892,26 @@ impl UpdateRateLimiter {
     /// Drop entries whose timestamp is older than [`CLEANUP_AGE`].
     /// Call periodically from a reaper loop to bound memory.
     ///
-    /// Decrements the [`Self::size`] counter by the number of
-    /// removed entries so the strict capacity enforcement remains
-    /// accurate as idle pairs roll off.
+    /// Decrements the [`Self::size`] counter as it goes, so the strict
+    /// capacity enforcement stays accurate as idle pairs roll off.
+    ///
+    /// Per removal rather than once at the end: batching the decrement
+    /// leaves `size` reading full for the whole sweep, so a concurrent
+    /// admission sees a full map that is in fact being emptied, and
+    /// spends attempts evicting from it (#4997 review).
     pub fn cleanup(&self) {
         let now = self.time_source.now();
         let cutoff = match now.checked_sub(CLEANUP_AGE) {
             Some(t) => t,
             None => return, // clock not advanced enough to bother
         };
-        let mut removed = 0usize;
         self.last_accepted.retain(|_, last| {
             let keep = *last >= cutoff;
             if !keep {
-                removed += 1;
+                self.size.fetch_sub(1, Ordering::Relaxed);
             }
             keep
         });
-        if removed > 0 {
-            self.size.fetch_sub(removed, Ordering::Relaxed);
-        }
         // Same cadence for the per-sender new-pair budget: reclaims the
         // entries of peers that have gone quiet (and whose buckets have
         // fully refilled, so dropping one cannot change a decision).
@@ -915,7 +999,7 @@ mod tests {
 
     fn mk_limiter() -> (UpdateRateLimiter, SharedMockTimeSource) {
         let ts = SharedMockTimeSource::new();
-        let limiter = UpdateRateLimiter::new(Arc::new(ts.clone()));
+        let limiter = UpdateRateLimiter::new(Arc::new(ts.clone()), Ring::DEFAULT_MAX_CONNECTIONS);
         (limiter, ts)
     }
 
@@ -1129,7 +1213,7 @@ mod tests {
     /// which pinned the starvation bug as if it were the contract. What
     /// it checked that still holds is kept: the map never exceeds the
     /// cap, and existing pairs keep working. See
-    /// `at_capacity_evicts_the_oldest_pair_not_an_arbitrary_one` for the
+    /// `at_capacity_evicts_the_oldest_pairs_not_arbitrary_ones` for the
     /// eviction order and
     /// `busy_pairs_cannot_hold_slots_against_newcomers` for the
     /// starvation regression itself.
@@ -1200,7 +1284,7 @@ mod tests {
             MIN_UPDATE_INTERVAL,
             MAX_TRACKED_PAIRS,
             BURST as f64,
-            MAX_TRACKED_SENDERS,
+            Ring::DEFAULT_MAX_CONNECTIONS * SENDER_TRACKING_HEADROOM,
         );
         let attacker = mk_sender(1);
 
@@ -1266,7 +1350,7 @@ mod tests {
             MIN_UPDATE_INTERVAL,
             MAX_TRACKED_PAIRS,
             BURST as f64,
-            MAX_TRACKED_SENDERS,
+            Ring::DEFAULT_MAX_CONNECTIONS * SENDER_TRACKING_HEADROOM,
         );
         let peer = mk_sender(1);
 
@@ -1304,6 +1388,85 @@ mod tests {
         assert_eq!(limiter.accepted_total(), (BURST + BURST * 200) as u64);
     }
 
+    /// The saturated case, which is the one that decides whether this
+    /// control is safe to ship: on a node whose working set far exceeds
+    /// the cap, a pair is evicted before its next UPDATE arrives, so
+    /// ordinary relayed traffic keeps re-entering the new-pair path.
+    ///
+    /// The limiter cannot tell a returning pair from a fresh one, so it
+    /// IS charged — which is why the sustained rate is 200/s and not the
+    /// per-pair 10/s. This pins the consequence both ways: a peer
+    /// running at that sustained rate is never throttled, however long
+    /// it goes on, and the bound is nonetheless real.
+    ///
+    /// Without this fixture the only budget test at a realistic cap was
+    /// one that never saturated, which could not have caught a rate
+    /// tuned for genuinely-fresh ids throttling relayed traffic (#4997
+    /// review).
+    #[test]
+    fn under_saturation_re_admitted_pairs_are_not_throttled_at_the_sustained_rate() {
+        // Half the contracts fit, so by the time one comes round again
+        // it has been evicted: every check takes the new-pair path.
+        const CAP: usize = 64;
+        const CONTRACTS: u8 = 128;
+        const CYCLES: usize = 20;
+
+        let ts = SharedMockTimeSource::new();
+        let limiter =
+            UpdateRateLimiter::with_config(Arc::new(ts.clone()), MIN_UPDATE_INTERVAL, CAP);
+        let peer = mk_sender(1);
+
+        for cycle in 0..CYCLES {
+            for c in 0..CONTRACTS {
+                assert_eq!(
+                    limiter.check_and_record(peer, mk_contract(c)),
+                    RateLimitDecision::Allowed,
+                    "cycle {cycle}, contract {c}: a peer relaying at the sustained rate \
+                     must not be throttled, even though eviction keeps making its pairs \
+                     look new"
+                );
+                ts.advance(NEW_PAIR_REFILL_INTERVAL);
+            }
+        }
+
+        assert!(
+            limiter.capacity_evicted_total() > 0,
+            "fixture must actually saturate, or it proves nothing about re-admission"
+        );
+        assert_eq!(
+            limiter.new_pair_budget_rejected_total(),
+            0,
+            "nothing may be dropped at the sustained rate"
+        );
+
+        // The bound is still real: with the clock stopped, the same peer
+        // spends its burst and is then cut off. It takes more than
+        // NEW_PAIR_BURST pairs to get there, which is the point — the
+        // burst is what keeps a legitimate reconnect flurry through.
+        let attempts = NEW_PAIR_BURST as usize * 2;
+        let mut refused = 0;
+        for c in 0..attempts {
+            let mut id = [0u8; 32];
+            id[..8].copy_from_slice(&(c as u64).to_be_bytes());
+            id[8] = 0xEE; // disjoint from mk_contract's key space
+            if limiter.check_and_record(peer, ContractInstanceId::new(id))
+                == RateLimitDecision::SenderNewPairBudget
+            {
+                refused += 1;
+            }
+        }
+        assert!(
+            refused > 0,
+            "a peer presenting unfamiliar pairs with no time passing must eventually \
+             be refused, or the budget bounds nothing"
+        );
+        assert!(
+            refused < attempts,
+            "and the burst must let a substantial run through before that: \
+             {refused} of {attempts} refused"
+        );
+    }
+
     /// The budget is per sender: one peer churning fresh ids must not
     /// throttle anyone else.
     #[test]
@@ -1315,7 +1478,7 @@ mod tests {
             MIN_UPDATE_INTERVAL,
             MAX_TRACKED_PAIRS,
             BURST as f64,
-            MAX_TRACKED_SENDERS,
+            Ring::DEFAULT_MAX_CONNECTIONS * SENDER_TRACKING_HEADROOM,
         );
         let noisy = mk_sender(1);
         let quiet = mk_sender(2);
@@ -1364,6 +1527,83 @@ mod tests {
             );
         }
         assert_eq!(limiter.tracked_senders(), MAX_SENDERS);
+    }
+
+    /// An empty map is NOT a reason to give up, even though the map
+    /// being empty looks like there is nothing to evict.
+    ///
+    /// `size` reads at the cap while the map does not in two real
+    /// windows — while `cleanup` is sweeping, and while every caller
+    /// that won a slot is still between its reservation and its insert
+    /// (reachable at small caps under contention: 8 slots, 64 callers).
+    /// Inferring "the cap must be 0" from an empty map dropped the
+    /// UPDATE in both, without spending a single retry attempt — the
+    /// same mistake as reading a zero-removal eviction as terminal, one
+    /// branch over (#4997 review).
+    ///
+    /// White-box because the windows are races: the condition is forced
+    /// directly rather than raced for, so the test is deterministic.
+    #[test]
+    fn an_empty_map_at_a_nonzero_cap_retries_rather_than_dropping() {
+        let ts = SharedMockTimeSource::new();
+        let limiter = UpdateRateLimiter::with_config(Arc::new(ts.clone()), MIN_UPDATE_INTERVAL, 8);
+
+        // The map is empty and `size` says otherwise, exactly as during
+        // a `cleanup` sweep.
+        limiter.size.store(8, Ordering::Relaxed);
+        assert_eq!(limiter.len(), 0);
+        assert!(
+            matches!(limiter.evict_oldest(ts.now()), EvictionOutcome::Retry),
+            "an empty map at a non-zero cap means slots are about to exist, not that \
+             the cap is zero"
+        );
+
+        // And with a zero cap it IS terminal, whatever the map says.
+        let zero = UpdateRateLimiter::with_config(Arc::new(ts.clone()), MIN_UPDATE_INTERVAL, 0);
+        assert!(matches!(
+            zero.evict_oldest(ts.now()),
+            EvictionOutcome::CapIsZero
+        ));
+    }
+
+    /// After a sweep, `size` equals the map length — the accounting
+    /// invariant the cap enforcement rests on, across a sweep that both
+    /// keeps and drops entries.
+    ///
+    /// Deliberately NOT claiming to pin the mid-sweep window: `cleanup`
+    /// decrements per removal rather than settling up at the end, so a
+    /// concurrent admission never sees a full `size` over an emptying
+    /// map, but that window is not observable from outside and this test
+    /// passes either way. What covers the consequence is
+    /// `an_empty_map_at_a_nonzero_cap_retries_rather_than_dropping`,
+    /// which forces the condition directly.
+    #[test]
+    fn cleanup_leaves_the_size_counter_equal_to_the_map_length() {
+        let ts = SharedMockTimeSource::new();
+        let limiter = UpdateRateLimiter::with_config(Arc::new(ts.clone()), MIN_UPDATE_INTERVAL, 8);
+        for i in 1..=8u8 {
+            assert!(
+                limiter
+                    .check_and_record(mk_sender(i), mk_contract(i))
+                    .is_allowed()
+            );
+        }
+        // Age out half of them, so the sweep both keeps and drops.
+        ts.advance(CLEANUP_AGE + Duration::from_secs(1));
+        for i in 1..=4u8 {
+            assert!(
+                limiter
+                    .check_and_record(mk_sender(i), mk_contract(i))
+                    .is_allowed()
+            );
+        }
+        limiter.cleanup();
+        assert_eq!(limiter.len(), 4);
+        assert_eq!(
+            limiter.size.load(Ordering::Relaxed),
+            limiter.len(),
+            "size must equal the map length after a sweep"
+        );
     }
 
     /// Boundary case: a zero cap is the ONLY configuration in which the
@@ -1733,7 +1973,10 @@ mod tests {
         use std::thread;
 
         let ts = SharedMockTimeSource::new();
-        let limiter = StdArc::new(UpdateRateLimiter::new(Arc::new(ts.clone())));
+        let limiter = StdArc::new(UpdateRateLimiter::new(
+            Arc::new(ts.clone()),
+            Ring::DEFAULT_MAX_CONNECTIONS,
+        ));
         let sender = mk_sender(1);
         let contract = mk_contract(1);
 
@@ -1985,16 +2228,34 @@ mod tests {
             s.chars().filter(|c| !c.is_whitespace()).collect()
         }
 
+        /// The macro invoked for the log line whose message contains
+        /// `marker`: the nearest `tracing::<level>!` at or before it.
+        ///
+        /// Searching backwards to the nearest `tracing::` rather than
+        /// scanning a fixed-size window, because a window has to be
+        /// bigger than the call's structured fields and every field
+        /// added eats into it — the eviction site was already within ~19
+        /// characters of breaking a 200-char window (#4997 review).
+        fn level_of(haystack: &str, marker: &str, what: &str) -> String {
+            let pos = haystack.find(marker).unwrap_or_else(|| {
+                panic!("the {what} log line must exist; if it was renamed, update this pin rather than deleting it")
+            });
+            let start = haystack[..pos]
+                .rfind(&strip_ws("tracing::"))
+                .unwrap_or_else(|| panic!("no tracing:: macro precedes the {what} log line"));
+            let tail = &haystack[start..pos];
+            tail[..tail.find('!').unwrap_or(tail.len())].to_string()
+        }
+
         // The limiter's own saturation line, in this file.
         let this_file = strip_ws(include_str!("update_rate_limit.rs"));
-        let eviction_marker = strip_ws(concat!("UPDATE rate limiter at ", "capacity: evicted"));
-        let pos = this_file.find(&eviction_marker).expect(
-            "the eviction log line must exist; if it was renamed, update this pin rather than \
-             deleting it",
-        );
-        let preamble = &this_file[pos.saturating_sub(200)..pos];
-        assert!(
-            preamble.contains(&strip_ws("tracing::info!")),
+        assert_eq!(
+            level_of(
+                &this_file,
+                &strip_ws(concat!("UPDATE rate limiter at ", "capacity: evicted")),
+                "eviction",
+            ),
+            strip_ws("tracing::info"),
             "the eviction log must be emitted at info! or higher; debug! is compiled out of \
              release builds by release_max_level_info (#4981)"
         );
@@ -2005,37 +2266,31 @@ mod tests {
         // budget is over it on every message and an unthrottled line
         // there would be a flood. Downgrading this one would make the
         // whole signal invisible in release.
-        let churn_marker = strip_ws(concat!(
-            "UPDATE rate limiter: peer is introducing ",
-            "brand-new (sender, contract)"
-        ));
-        let pos = this_file.find(&churn_marker).expect(
-            "the new-pair-budget log line must exist; if it was renamed, update this pin rather \
-             than deleting it",
-        );
-        let preamble = &this_file[pos.saturating_sub(200)..pos];
-        assert!(
-            preamble.contains(&strip_ws("tracing::info!")),
+        assert_eq!(
+            level_of(
+                &this_file,
+                &strip_ws(concat!(
+                    "UPDATE rate limiter: peer is introducing ",
+                    "brand-new (sender, contract)"
+                )),
+                "new-pair-budget",
+            ),
+            strip_ws("tracing::info"),
             "the new-pair-budget log must be emitted at info! or higher; debug! is compiled out \
              of release builds by release_max_level_info (#4981)"
         );
 
         // The residual capacity drop, in the UPDATE dispatch path.
         let node_rs = strip_ws(include_str!("../node.rs"));
-        let drop_marker = strip_ws(concat!("update_dispatch_", "capacity_dropped"));
-        let pos = node_rs.find(&drop_marker).expect(
-            "the capacity-drop log phase must exist in node.rs; if it was renamed, update this \
-             pin rather than deleting it",
-        );
-        let preamble = &node_rs[pos.saturating_sub(200)..pos];
-        assert!(
-            preamble.contains(&strip_ws("tracing::info!")),
+        assert_eq!(
+            level_of(
+                &node_rs,
+                &strip_ws(concat!("update_dispatch_", "capacity_dropped")),
+                "capacity-drop",
+            ),
+            strip_ws("tracing::info"),
             "dropping an UPDATE for capacity must be logged at info! or higher, so the drop is \
              greppable on a production node (#4981)"
-        );
-        assert!(
-            !preamble.contains(&strip_ws("tracing::debug!")),
-            "the capacity-drop branch must not fall back to debug!"
         );
     }
 
@@ -2095,11 +2350,13 @@ mod tests {
     /// affected, 100% of them from that branch, retry budget untouched.
     /// After the fix, 7 in 320 000 (0.002%).
     ///
-    /// The threshold below sits between those two by more than an order
-    /// of magnitude in both directions, so it is neither flaky nor
-    /// vacuous. It is a bound rather than zero because losing a freed
-    /// slot to a concurrent caller on every attempt is genuinely
-    /// possible — that is what `CapacityExceeded` is documented to mean.
+    /// The threshold sits an order of magnitude above what the fixed
+    /// implementation produces and well below what the bug produces:
+    /// reintroducing the bug takes this fixture to 671 drops in 6 400
+    /// against a threshold of 6, so it is neither flaky nor vacuous. It
+    /// is a bound rather than zero because losing a freed slot to a
+    /// concurrent caller on every attempt is genuinely possible — that
+    /// is what `CapacityExceeded` is documented to mean.
     #[test]
     fn concurrent_admission_at_capacity_almost_never_drops() {
         use std::sync::{Arc as StdArc, Barrier};

--- a/crates/core/src/ring/update_rate_limit.rs
+++ b/crates/core/src/ring/update_rate_limit.rs
@@ -2531,7 +2531,15 @@ mod tests {
         const ADMISSIONS: usize = THREADS * PER_THREAD;
         /// One drop per this many admissions is the ceiling. The bug
         /// produced ~8 per thousand; the fix produces ~0.02.
-        const MAX_DROPS_PER_THOUSAND: usize = 1;
+        ///
+        /// Widened from 1 to 2: review measured a worst case of 7 drops
+        /// against a threshold of 6 across 540 trials (~1 in 600), so the
+        /// old value was a known flake rather than the claimed order of
+        /// magnitude of headroom. Widening is the right fix here and a
+        /// retry would not be — the assertion bounds a genuinely
+        /// stochastic quantity (losing a freed slot to a concurrent
+        /// caller), not a deterministic property.
+        const MAX_DROPS_PER_THOUSAND: usize = 2;
 
         let ts = SharedMockTimeSource::new();
         let limiter = StdArc::new(UpdateRateLimiter::with_new_pair_budget(

--- a/crates/core/src/server/home_page/cards.rs
+++ b/crates/core/src/server/home_page/cards.rs
@@ -219,6 +219,7 @@ pub fn build_status_card(snap: &Option<network_status::NetworkStatusSnapshot>) -
     let rate_limit_html = if snap.ring_stats.updates_accepted > 0
         || snap.ring_stats.updates_rate_limited > 0
         || snap.ring_stats.updates_capacity_dropped > 0
+        || snap.ring_stats.updates_capacity_evicted > 0
     {
         format!(
             r#"<div class="metrics-row">
@@ -234,10 +235,15 @@ pub fn build_status_card(snap: &Option<network_status::NetworkStatusSnapshot>) -
                 <span class="metric-value">{capacity_dropped}</span>
                 <span class="metric-label">Capacity-dropped</span>
             </div>
+            <div class="metric-tile">
+                <span class="metric-value">{capacity_evicted}</span>
+                <span class="metric-label">Capacity-evicted</span>
+            </div>
         </div>"#,
             accepted = snap.ring_stats.updates_accepted,
             rate_limited = snap.ring_stats.updates_rate_limited,
             capacity_dropped = snap.ring_stats.updates_capacity_dropped,
+            capacity_evicted = snap.ring_stats.updates_capacity_evicted,
         )
     } else {
         String::new()

--- a/crates/core/src/server/home_page/cards.rs
+++ b/crates/core/src/server/home_page/cards.rs
@@ -220,6 +220,7 @@ pub fn build_status_card(snap: &Option<network_status::NetworkStatusSnapshot>) -
         || snap.ring_stats.updates_rate_limited > 0
         || snap.ring_stats.updates_capacity_dropped > 0
         || snap.ring_stats.updates_capacity_evicted > 0
+        || snap.ring_stats.updates_sender_budget_dropped > 0
     {
         format!(
             r#"<div class="metrics-row">
@@ -239,11 +240,16 @@ pub fn build_status_card(snap: &Option<network_status::NetworkStatusSnapshot>) -
                 <span class="metric-value">{capacity_evicted}</span>
                 <span class="metric-label">Capacity-evicted</span>
             </div>
+            <div class="metric-tile">
+                <span class="metric-value">{sender_budget_dropped}</span>
+                <span class="metric-label">Fresh-id-dropped</span>
+            </div>
         </div>"#,
             accepted = snap.ring_stats.updates_accepted,
             rate_limited = snap.ring_stats.updates_rate_limited,
             capacity_dropped = snap.ring_stats.updates_capacity_dropped,
             capacity_evicted = snap.ring_stats.updates_capacity_evicted,
+            sender_budget_dropped = snap.ring_stats.updates_sender_budget_dropped,
         )
     } else {
         String::new()

--- a/crates/core/src/server/home_page/cards.rs
+++ b/crates/core/src/server/home_page/cards.rs
@@ -221,6 +221,7 @@ pub fn build_status_card(snap: &Option<network_status::NetworkStatusSnapshot>) -
         || snap.ring_stats.updates_capacity_dropped > 0
         || snap.ring_stats.updates_capacity_evicted > 0
         || snap.ring_stats.updates_sender_budget_dropped > 0
+        || snap.ring_stats.updates_sender_budget_unmetered > 0
     {
         format!(
             r#"<div class="metrics-row">
@@ -244,12 +245,17 @@ pub fn build_status_card(snap: &Option<network_status::NetworkStatusSnapshot>) -
                 <span class="metric-value">{sender_budget_dropped}</span>
                 <span class="metric-label">Fresh-id-dropped</span>
             </div>
+            <div class="metric-tile">
+                <span class="metric-value">{sender_budget_unmetered}</span>
+                <span class="metric-label">Fresh-id-unmetered</span>
+            </div>
         </div>"#,
             accepted = snap.ring_stats.updates_accepted,
             rate_limited = snap.ring_stats.updates_rate_limited,
             capacity_dropped = snap.ring_stats.updates_capacity_dropped,
             capacity_evicted = snap.ring_stats.updates_capacity_evicted,
             sender_budget_dropped = snap.ring_stats.updates_sender_budget_dropped,
+            sender_budget_unmetered = snap.ring_stats.updates_sender_budget_unmetered,
         )
     } else {
         String::new()

--- a/crates/core/src/server/home_page/cards.rs
+++ b/crates/core/src/server/home_page/cards.rs
@@ -101,6 +101,7 @@ pub fn build_status_card(snap: &Option<network_status::NetworkStatusSnapshot>) -
         || snap.ring_stats.updates_rate_limited > 0
         || snap.ring_stats.updates_capacity_dropped > 0
         || snap.ring_stats.updates_capacity_evicted > 0
+        || snap.ring_stats.updates_sender_budget_dropped > 0
     {
         format!(
             r#"<div class="metrics-row">
@@ -120,11 +121,16 @@ pub fn build_status_card(snap: &Option<network_status::NetworkStatusSnapshot>) -
                 <span class="metric-value">{capacity_evicted}</span>
                 <span class="metric-label">Capacity-evicted</span>
             </div>
+            <div class="metric-tile">
+                <span class="metric-value">{sender_budget_dropped}</span>
+                <span class="metric-label">Fresh-id-dropped</span>
+            </div>
         </div>"#,
             accepted = snap.ring_stats.updates_accepted,
             rate_limited = snap.ring_stats.updates_rate_limited,
             capacity_dropped = snap.ring_stats.updates_capacity_dropped,
             capacity_evicted = snap.ring_stats.updates_capacity_evicted,
+            sender_budget_dropped = snap.ring_stats.updates_sender_budget_dropped,
         )
     } else {
         String::new()

--- a/crates/core/src/server/home_page/cards.rs
+++ b/crates/core/src/server/home_page/cards.rs
@@ -100,6 +100,7 @@ pub fn build_status_card(snap: &Option<network_status::NetworkStatusSnapshot>) -
     let rate_limit_html = if snap.ring_stats.updates_accepted > 0
         || snap.ring_stats.updates_rate_limited > 0
         || snap.ring_stats.updates_capacity_dropped > 0
+        || snap.ring_stats.updates_capacity_evicted > 0
     {
         format!(
             r#"<div class="metrics-row">
@@ -115,10 +116,15 @@ pub fn build_status_card(snap: &Option<network_status::NetworkStatusSnapshot>) -
                 <span class="metric-value">{capacity_dropped}</span>
                 <span class="metric-label">Capacity-dropped</span>
             </div>
+            <div class="metric-tile">
+                <span class="metric-value">{capacity_evicted}</span>
+                <span class="metric-label">Capacity-evicted</span>
+            </div>
         </div>"#,
             accepted = snap.ring_stats.updates_accepted,
             rate_limited = snap.ring_stats.updates_rate_limited,
             capacity_dropped = snap.ring_stats.updates_capacity_dropped,
+            capacity_evicted = snap.ring_stats.updates_capacity_evicted,
         )
     } else {
         String::new()

--- a/crates/core/src/server/home_page/cards.rs
+++ b/crates/core/src/server/home_page/cards.rs
@@ -102,6 +102,7 @@ pub fn build_status_card(snap: &Option<network_status::NetworkStatusSnapshot>) -
         || snap.ring_stats.updates_capacity_dropped > 0
         || snap.ring_stats.updates_capacity_evicted > 0
         || snap.ring_stats.updates_sender_budget_dropped > 0
+        || snap.ring_stats.updates_sender_budget_unmetered > 0
     {
         format!(
             r#"<div class="metrics-row">
@@ -125,12 +126,17 @@ pub fn build_status_card(snap: &Option<network_status::NetworkStatusSnapshot>) -
                 <span class="metric-value">{sender_budget_dropped}</span>
                 <span class="metric-label">Fresh-id-dropped</span>
             </div>
+            <div class="metric-tile">
+                <span class="metric-value">{sender_budget_unmetered}</span>
+                <span class="metric-label">Fresh-id-unmetered</span>
+            </div>
         </div>"#,
             accepted = snap.ring_stats.updates_accepted,
             rate_limited = snap.ring_stats.updates_rate_limited,
             capacity_dropped = snap.ring_stats.updates_capacity_dropped,
             capacity_evicted = snap.ring_stats.updates_capacity_evicted,
             sender_budget_dropped = snap.ring_stats.updates_sender_budget_dropped,
+            sender_budget_unmetered = snap.ring_stats.updates_sender_budget_unmetered,
         )
     } else {
         String::new()


### PR DESCRIPTION
## Problem

At `MAX_TRACKED_PAIRS` (16,384) the per-`(sender, contract)` UPDATE rate limiter refused a new pair and **never inserted it**, so the pair stayed "new" forever and every subsequent UPDATE from it was dropped and re-counted.

The module's own doc comment is where the reasoning went wrong:

> *"only NEW pairs hit the cap. Combined with the TTL sweep this gives smooth recovery as idle pairs roll off."*

That holds only for **idle** pairs. An accepted UPDATE restamps its entry (`*entry.get_mut() = now`), so a busy pair never ages out under `CLEANUP_AGE`. The 16,384 slots were held permanently by whoever got in first *and stayed active*, and newcomers were locked out with no recovery path.

This is the permanently-refreshable GC exemption `AGENTS.md` forbids — *"any condition that exempts an entry from garbage collection MUST either expire via TTL, or be overridden by an absolute age threshold"*. There was only a refreshable TTL, and a busy pair refreshes it forever.

**Saturation is not evidence of an attack.** Tracked pairs are distinct senders × distinct contracts relayed from them, so 50 peers × ~330 contracts ≈ 16,500 already exceeds the cap with no attacker involved. The reported symptom was a capacity counter climbing 22K → 36K in a few minutes on an ordinary node. The module justified the bound purely as an anti-attacker measure and never reckoned with a healthy node simply outgrowing it.

Severity is silent data loss on the UPDATE path, not a noisy counter.

## Approach

This PR is **two coupled changes**, and the second is not optional — shipping the first alone would trade an availability bug for a security regression.

### 1. Evict LRU at capacity instead of refusing

The memory bound is unchanged: the map still never exceeds the cap, one in one out.

**Why batched (cap/64, so 256 at the default).** Under the saturation this targets the map is *persistently* full, so evicting a single entry per admission would walk all 16,384 entries on **every** new pair — at the reported 50-100 new pairs/sec, a continuous full scan several times a second on the UPDATE receive path. Batching amortises the scan to ~0.39/sec at 100 new pairs/sec, without changing the policy: oldest first either way. `select_nth_unstable_by_key` partitions rather than sorts, so the pass stays linear.

The shard guard is released before the walk. `evict_oldest` touches every shard, and holding a guard across that deadlocks — the same hazard already documented on this module's `size` counter. The retry after eviction is bounded (`MAX_ADMISSION_ATTEMPTS`) because the freed slot is not reserved: another thread may take it, and an unbounded loop would let contention spin on the receive path.

### 2. A per-sender new-pair budget, to replace the ceiling eviction removes

Refusing at capacity was *incidentally* cutting off an attacker churning fresh contract ids — after 16,384 of them, everything was refused. That ceiling was never designed (the cap exists to bound memory), and it denied every peer rather than just the flooder, but it was real, and eviction removes it. So it is **replaced deliberately rather than dropped**:

- A token bucket keyed by `sender_addr` (`NEW_PAIR_BURST` = 1024, `NEW_PAIR_REFILL_INTERVAL` = 5 ms → 200/s sustained), consulted only on the new-pair branch.
- A new `RateLimitDecision::SenderNewPairBudget`, so a budget refusal is distinguishable from a capacity drop.
- **Charged before a slot is reserved or anything is evicted**, so a sender past its budget cannot push other peers' entries out on its way to being refused.
- `TokenBucketLimiter` gains `BucketOutcome` + `check_and_record_detailed` so the budget can tell "over its rate" from "no room to track it". `check_and_record` keeps the collapsed `bool`, so the three resync limiters are behaviourally unchanged by this PR.
- `Ring::new` now takes `max_connections` to size the budget map (`max_connections × SENDER_TRACKING_HEADROOM`, floored at `MIN_TRACKED_SENDERS`). Note the coupling: raising the connection cap also enlarges this map.

**Honest accounting of what this trades.** The old aggregate ceiling was ~16,384 fresh pairs and then nothing, for everyone. The new one is 200/s **per sender** with no node-wide aggregate — at a 200-connection cap, a 40,000/s worst case of admitted relay work. That is a much higher attacker ceiling, and it is the right trade only because the old ceiling denied the victims too. The binding condition for legitimate traffic is generous: one peer must sustain ~210 UPDATE/s to this node continuously before anything drops, against real gateway load of ~3.15/s node-wide.

**Residual risks, stated rather than glossed** (all recorded in the module docs):
- A sender *within* its budget does evict other peers' entries, at up to 200/s. What makes that harmless is LRU plus the window it protects: evicting a pair touched within `MIN_UPDATE_INTERVAL` needs the whole map turned over inside 100 ms, ~164,000 evictions/s.
- An attacker churning at the budget rate can push the node into a high-miss-rate regime deliberately, converting every peer's per-pair limit into a per-peer 200/s aggregate.
- The budget's own map fails **open** at capacity (counted by `new_pair_budget_untracked_total`), and `Bucket::refill` restamps on every check, so a full sender map disables the budget for senders not already in it. Same shape as the bug this PR fixes, one map over; tracked in #5000 with the sibling instance in the resync limiters.
- The eviction scan holds a blocking `std::sync::Mutex` from inside an async task. At realistic load that is a 0.03% duty cycle; at a full-scale coordinated flood it approaches 10%. The `MAX_TRACKED_PAIRS` docs now carry that table so nobody raises the constant without redoing it.

Rejected alternatives: raising the cap treats the symptom and still starves eventually; failing open on the pair map lets a fresh-id attacker bypass rate limiting entirely.

## Visibility

The other half of why this went unnoticed: the drop logged at `debug!`, which `release_max_level_info` compiles out, so a production node discarding legitimate relayed UPDATEs left **no greppable evidence** and a dashboard tile was the only signal.

- Saturation now logs at `info!`, throttled to one line a minute, on eviction rather than per drop.
- `capacity_evicted_total`, `new_pair_budget_rejected_total` and `new_pair_budget_untracked_total` are surfaced through the **existing** `RingStatsSnapshot` rollup and three dashboard tiles — no new telemetry stream.
- The residual `CapacityExceeded` drop, now reachable only when the map is full *and* every admission attempt lost its slot to a concurrent caller, logs at `info!` too.

A healthy busy node now reads as evictions climbing with capacity drops flat, which is a sharper signal than the old counter gave. Note this **changes what the existing "Capacity-dropped" tile means**: it is no longer the saturation signal, and near-unreachable.

## Testing

~20 tests. The ones that carry the argument:

- `at_capacity_new_pair_is_admitted_and_the_map_stays_bounded` — the newcomer gets in and the cap still binds.
- `at_capacity_evicts_the_oldest_pairs_not_arbitrary_ones` — LRU order specifically. Membership is observed through the limiter's own behaviour (a tracked pair inside `min_interval` answers `Rejected`; an evicted one reads as new and answers `Allowed`) rather than a test-only accessor.
- `busy_pairs_cannot_hold_slots_against_newcomers` — the starvation regression, with every incumbent restamping itself each round and a sanity assertion that the fixture stays inside `CLEANUP_AGE` so the TTL sweep cannot be what admitted the newcomers.
- `eviction_counts_actual_removals_not_the_selected_batch` — deterministically reproduces a concurrent reaper taking a victim first. Over-counting drives `size` **below** the map's true length and lets the map grow past the cap.
- `a_throttled_sender_cannot_evict_other_peers_entries` — the security-relevant ordering, at a cap small enough for eviction to be reachable.
- `eviction_is_batched_at_larger_caps` — the divisor arithmetic, which the cap-8 fixtures clamp to 1 and never exercise.
- `capacity_signals_are_logged_above_debug_level` and `log_due_fires_once_per_interval` — a log level is a behavioural change no behavioural test can see. The source-scrape pin is bounded to the enclosing function body, because an unbounded backwards search resolves an imported `info!` to a *preceding* site's macro and lets a downgrade pass.

**Changed tests, and why** — stated here rather than left for a reader to discover:

- `capacity_exceeded_when_cap_reached` → `at_capacity_new_pair_is_admitted_and_the_map_stays_bounded`. The removed assertion pinned the starvation *as the contract*.
- `concurrent_distinct_keys_do_not_overshoot_cap`: `len() == CAP` relaxed to `<= CAP`. Exactly-the-cap became unachievable once a caller can free a slot and lose it (measured 44/800 flakes before the eviction scan was serialised, 7/800 after). Compensated by an exact conservation assertion (`len() == allowed - evicted`), plus new assertions that evictions actually happened and that `size` settles back onto `len` — without those the fixture passed under the *reverted* implementation.
- `MAX_DROPS_PER_THOUSAND` widened 1 → 2 in `concurrent_admission_at_capacity_almost_never_drops`, against a measured worst case of 7 drops across 540 trials, with the bug producing ~51. A stochastic bound on a scheduler-dependent quantity; the deterministic half of what it pins is covered by `an_empty_map_at_a_nonzero_cap_retries_rather_than_dropping`.
- `cleanup_decrements_size_counter` — forced change only, invariants intact.

`cargo clippy --locked -- -D warnings` and `cargo fmt` clean.

## Agent rules updated

`AGENTS.md` requires stale rules to be fixed in the PR that finds them, and this PR found one that instructs the exact mistake it fixes. `.claude/rules/code-style.md` said, unqualified, *"Reject new entries when the limit is reached"* — right for age-out-only collections, wrong for refresh-on-use ones, and the module cites it by name. It now carries the distinction, and `.claude/rules/bug-prevention-patterns.md` gains a section for the pattern.

## Not fixed here

- **#5000** — the same starvation shape in `TokenBucketLimiter`'s own map, affecting the three resync limiters. This PR adds the mechanism (`BucketOutcome`/`check_and_record_detailed`) but deliberately leaves the resync call sites on the collapsed `bool`, so their behaviour is unchanged. **PR #5027 changes those call sites**; it should land after this one and rebase onto it, since the enum and method it adds are duplicated here.

Closes #4981

[AI-assisted - Claude]
