### PR TITLE
build: bump freenet-stdlib to 0.8.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1866,7 +1866,7 @@ dependencies = [
  "ed25519-dalek",
  "either",
  "freenet",
- "freenet-stdlib 0.8.4",
+ "freenet-stdlib 0.8.5",
  "futures 0.3.32",
  "glob",
  "hex",
@@ -2061,7 +2061,7 @@ dependencies = [
  "flatbuffers 25.12.19",
  "flate2",
  "freenet-macros 0.1.0",
- "freenet-stdlib 0.8.4",
+ "freenet-stdlib 0.8.5",
  "freenet-test-network",
  "futures 0.3.32",
  "headers",
@@ -2179,7 +2179,7 @@ dependencies = [
  "clap",
  "freenet",
  "freenet-ping-types",
- "freenet-stdlib 0.8.4",
+ "freenet-stdlib 0.8.5",
  "freenet-test-network",
  "futures 0.3.32",
  "rand 0.9.4",
@@ -2199,7 +2199,7 @@ name = "freenet-ping-contract"
 version = "0.1.11"
 dependencies = [
  "freenet-ping-types",
- "freenet-stdlib 0.8.4",
+ "freenet-stdlib 0.8.5",
  "serde_json",
 ]
 
@@ -2209,7 +2209,7 @@ version = "0.1.11"
 dependencies = [
  "chrono",
  "clap",
- "freenet-stdlib 0.8.4",
+ "freenet-stdlib 0.8.5",
  "humantime",
  "humantime-serde",
  "serde",
@@ -2269,9 +2269,9 @@ dependencies = [
 
 [[package]]
 name = "freenet-stdlib"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffa7063130085b2319850c4407b6ae76de7b5a38cdd12e36a4684ff562cd1ceb"
+checksum = "b62aeba7634d1ae5c2d02f78db33ee40442511858275be5be2099d24a13b2559"
 dependencies = [
  "arbitrary",
  "bincode",
@@ -2333,7 +2333,7 @@ dependencies = [
  "byteorder",
  "ciborium",
  "ed25519-dalek",
- "freenet-stdlib 0.8.4",
+ "freenet-stdlib 0.8.5",
  "rand 0.9.4",
  "serde",
 ]
@@ -6715,7 +6715,7 @@ dependencies = [
 name = "test-contract-integration"
 version = "0.1.11"
 dependencies = [
- "freenet-stdlib 0.8.4",
+ "freenet-stdlib 0.8.5",
  "serde",
  "serde_json",
 ]
@@ -6725,14 +6725,14 @@ name = "test-contract-mock-aligned"
 version = "0.1.0"
 dependencies = [
  "blake3",
- "freenet-stdlib 0.8.4",
+ "freenet-stdlib 0.8.5",
 ]
 
 [[package]]
 name = "test-contract-update-nochange"
 version = "0.1.0"
 dependencies = [
- "freenet-stdlib 0.8.4",
+ "freenet-stdlib 0.8.5",
  "serde",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,6 +154,23 @@ zip = { version = "8", default-features = false, features = ["deflate", "time"] 
 # Freenet
 # 0.8.4 adds `DelegateRequest::RegisterDelegateWithPredecessors` (stdlib PR #86),
 # consumed by the #4117 delegate secret copy-forward.
+#
+# 0.8.5 fixes the FlatBuffers client-request boundary (stdlib #85/#87/#88).
+# Behaviour changes for FBS clients, none for native ones:
+#   - `ContractKey.code` must be exactly 32 bytes; a wrong length is now
+#     rejected at the boundary instead of being hashed into a key that
+#     matched nothing and failing later as "Contract not in store".
+#   - Paths that used to panic on malformed input (instance-id length,
+#     delegate key/cipher/nonce length, four union discriminants) now
+#     return errors, so a bad request no longer kills the client's
+#     connection task.
+#   - OUTBOUND: `HostResponse` now writes `related_to` as raw 32 bytes
+#     where 0.8.4 wrote base58 ASCII. This fixes browser clients (the TS
+#     SDK reads the field as raw bytes) but is a wire change in the
+#     node->client direction.
+# Exposure is FBS-only: `client_events/websocket.rs` falls back to
+# Flatbuffers when no encoding is specified, and every first-party client
+# (fdev, riverctl, River UI, the test harness) explicitly pins native.
 freenet-stdlib = "0.8.5"
 
 # Crypto (secrets-at-rest KEK + DEK derivation, see crates/core/src/config/kek.rs).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,7 +154,7 @@ zip = { version = "8", default-features = false, features = ["deflate", "time"] 
 # Freenet
 # 0.8.4 adds `DelegateRequest::RegisterDelegateWithPredecessors` (stdlib PR #86),
 # consumed by the #4117 delegate secret copy-forward.
-freenet-stdlib = "0.8.4"
+freenet-stdlib = "0.8.5"
 
 # Crypto (secrets-at-rest KEK + DEK derivation, see crates/core/src/config/kek.rs).
 # `sha2` is already declared above (workspace-wide); only `hkdf` and `keyring`

--- a/crates/core/src/server/client_api.rs
+++ b/crates/core/src/server/client_api.rs
@@ -581,7 +581,7 @@ fn redirect_to_shell_root(
 /// `key` is interpolated into a `Location` header by the caller, so
 /// validation MUST reject CRLF-bearing input here before
 /// `HeaderValue::try_from` ever sees it. The check via
-/// `ContractInstanceId::from_bytes` also rejects path-traversal-style
+/// `ContractInstanceId::from_base58` also rejects path-traversal-style
 /// inputs like `../../etc/passwd` that would point the redirect at an
 /// attacker-chosen URL on the reader's gateway.
 ///
@@ -601,7 +601,7 @@ pub(super) fn build_canonical_shell_url(
         });
     }
     let _instance_id =
-        ContractInstanceId::from_bytes(key).map_err(|err| WebSocketApiError::InvalidParam {
+        ContractInstanceId::from_base58(key).map_err(|err| WebSocketApiError::InvalidParam {
             error_cause: format!("invalid contract key in redirect target: {err}"),
         })?;
 
@@ -1203,7 +1203,7 @@ mod tests {
     }
 
     /// A valid contract key used across redirect tests. Constructed from
-    /// 32 zero bytes so `ContractInstanceId::from_bytes` accepts it.
+    /// 32 zero bytes so `ContractInstanceId::from_base58` accepts it.
     fn valid_contract_key_b58() -> String {
         use freenet_stdlib::prelude::ContractInstanceId;
         let bytes = [0u8; 32];
@@ -1291,7 +1291,7 @@ mod tests {
     /// without key validation, a crafted path containing percent-encoded
     /// CRLF would reach `HeaderValue::try_from` inside `Redirect::to`,
     /// which panics on invalid header values. Validating via
-    /// `ContractInstanceId::from_bytes` first converts this into a
+    /// `ContractInstanceId::from_base58` first converts this into a
     /// structured 4xx response.
     #[test]
     fn redirect_to_shell_root_rejects_invalid_key_instead_of_panicking() {

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -382,7 +382,7 @@ pub(super) async fn contract_home(
     sub_path: Option<&str>,
     hosted_mode: bool,
 ) -> Result<impl IntoResponse, WebSocketApiError> {
-    let instance_id = ContractInstanceId::from_bytes(&key).map_err(|err| {
+    let instance_id = ContractInstanceId::from_base58(&key).map_err(|err| {
         debug!("contract_home: Failed to parse contract key: {}", err);
         WebSocketApiError::InvalidParam {
             error_cause: format!("{err}"),
@@ -649,7 +649,7 @@ pub(super) async fn variable_content(
     );
     // compose the correct absolute path
     let instance_id =
-        ContractInstanceId::from_bytes(&key).map_err(|err| WebSocketApiError::InvalidParam {
+        ContractInstanceId::from_base58(&key).map_err(|err| WebSocketApiError::InvalidParam {
             error_cause: format!("{err}"),
         })?;
     let base_path = contract_web_path(&instance_id);
@@ -949,7 +949,7 @@ pub(super) async fn serve_sandbox_content(
     let page = sub_path.unwrap_or("index.html");
     debug!("serve_sandbox_content: serving iframe content for key: {key}, page: {page}");
     let instance_id =
-        ContractInstanceId::from_bytes(&key).map_err(|err| WebSocketApiError::InvalidParam {
+        ContractInstanceId::from_base58(&key).map_err(|err| WebSocketApiError::InvalidParam {
             error_cause: format!("{err}"),
         })?;
 


### PR DESCRIPTION
## Problem

freenet-stdlib 0.8.5 was published tonight carrying three fixes to the FlatBuffers client-request boundary. None of them reaches a user until core consumes it.

All three affect **third-party and browser clients specifically** — fdev, riverctl and the River UI all connect with `encodingProtocol=native` and never reach these decode paths. That asymmetry is why the whole class survived unnoticed for years and why first-party testing will never catch the next one.

## What it brings

- **#85** — `ContractKey`'s code hash is passed through FBS decode instead of re-hashed. `CodeHash::from_code` was being applied to a field that already holds the 32-byte hash, producing BLAKE3(BLAKE3(wasm)) — a key matching nothing. **FlatBuffers UPDATE has been 100% broken since `844880e` (Nov 2023).**
- **#87** — `WebApi::recv()` no longer discards a buffered response when the stream channel closes first. Both channels went ready simultaneously and `tokio::select!` picked at random, so the real error was replaced by a generic "channel closed" about half the time. `Stream::poll_next` had the same defect *deterministically*, dropping complete streamed responses.
- **#88** — twelve further sites on the same boundary. The worst: `ContractInstanceId::from_bytes` is a **base58 decoder** that was being applied to raw wire bytes — 200,000 sampled instance ids produced **zero** successful decodes, so every *correct* related-contract UPDATE or PUT panicked the connection task. Also the encode half (`HostResponse` wrote base58 text into a field the TypeScript SDK reads as raw bytes), length checks on delegate keys and cipher/nonce, and four union discriminants that hit `unreachable!()` on input the generated verifier accepts.

## The rename

`ContractInstanceId::from_bytes` → **`from_base58`**. The old name survives as a `#[deprecated]` delegating alias, so it isn't a breaking change — but `crates/core` builds with `-D warnings`, so **this PR would not compile without renaming the four call sites**:

- `crates/core/src/server/client_api.rs:604`
- `crates/core/src/server/path_handlers.rs:385, 652, 952`

All four are correct base58 uses. The rename exists precisely because the misleading name (its doc said "binary representation") is what caused the misuse twice, weeks apart, in the same file. Stale doc references to the old name are updated in the same files.

## Testing

`cargo check --locked -p freenet --all-targets` is clean, and **no deprecation warnings remain** — which is the check that confirms every use was renamed rather than just the ones I grepped for.

One note for reviewers running clippy locally: `main` already fails `-D warnings` with 27 errors under rustc 1.94.0. That is toolchain drift against CI's pinned 1.93.0 and predates this change — I verified it on `main` before assuming this PR caused it.

[AI-assisted - Claude]