### PR TITLE
perf(update): stop re-sending the summary to peers the broadcast already covered

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -3612,6 +3612,9 @@ std::thread_local! {
     static GLOBAL_PENDING_OP_REMOVES: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
     static GLOBAL_PENDING_OP_HWM: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
     static GLOBAL_NEIGHBOR_HOSTING_UPDATES: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+    /// Recipients dropped from a proactive summary notification because they
+    /// are advertised co-hosts the broadcast already covered (#4965).
+    static GLOBAL_NOTIFICATION_COHOSTS_SKIPPED: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
     // Hosting advertisement retractions emitted on stop-hosting (eviction).
     // Advertisement-layer reliability + retraction, #4642 spec step 1.
     static GLOBAL_NEIGHBOR_HOSTING_RETRACTIONS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
@@ -3702,6 +3705,7 @@ impl GlobalTestMetrics {
         GLOBAL_PENDING_OP_REMOVES.with(|c| c.set(0));
         GLOBAL_PENDING_OP_HWM.with(|c| c.set(0));
         GLOBAL_NEIGHBOR_HOSTING_UPDATES.with(|c| c.set(0));
+        GLOBAL_NOTIFICATION_COHOSTS_SKIPPED.with(|c| c.set(0));
         GLOBAL_NEIGHBOR_HOSTING_RETRACTIONS.with(|c| c.set(0));
         GLOBAL_ANTI_STARVATION_TRIGGERS.with(|c| c.set(0));
         GLOBAL_TERMINAL_CONSULT_ATTEMPTS.with(|c| c.set(0));
@@ -3859,6 +3863,26 @@ impl GlobalTestMetrics {
 
     pub fn neighbor_hosting_updates() -> u64 {
         GLOBAL_NEIGHBOR_HOSTING_UPDATES.with(|c| c.get())
+    }
+
+    /// A proactive summary notification skipped `n` advertised co-hosts,
+    /// because the broadcast to them already carried the summary in
+    /// `sender_summary_bytes` (#4965).
+    ///
+    /// Exists because the simulation-level effect of that exclusion is NOT
+    /// visible in `delta_sends` / `full_state_sends`: measured on the co-host
+    /// mesh scenario, reverting the exclusion left both metrics bit-identical
+    /// (140 / 6), so a test asserting on them alone would pass whether or not
+    /// the change was present. This counter is the one signal that actually
+    /// moves, which is what makes
+    /// `test_cohost_mesh_update_fanout_stays_delta_dominated` a test OF the
+    /// change rather than merely a test that runs alongside it.
+    pub fn record_notification_cohosts_skipped(n: u64) {
+        GLOBAL_NOTIFICATION_COHOSTS_SKIPPED.with(|c| c.set(c.get() + n));
+    }
+
+    pub fn notification_cohosts_skipped() -> u64 {
+        GLOBAL_NOTIFICATION_COHOSTS_SKIPPED.with(|c| c.get())
     }
 
     /// A hosting advertisement retraction was emitted because this node stopped

--- a/crates/core/src/node/network_bridge/outbound_message_mix.rs
+++ b/crates/core/src/node/network_bridge/outbound_message_mix.rs
@@ -440,6 +440,17 @@ struct Window {
     /// attributed — the identical side needs no diagnosis, and tracking it
     /// would double the map for no decision.
     differing_by_contract: HashMap<ContractInstanceId, u64>,
+    /// Recipients the proactive summary notification actually sent to, summed
+    /// over the window's notifications. See
+    /// [`OutboundMix::record_notification_recipients`].
+    notification_targets_sent: u64,
+    /// Recipients it SKIPPED because they are advertised co-hosts the
+    /// broadcast already covered (#4965). Paired with
+    /// [`Window::notification_targets_sent`] deliberately: the skipped count
+    /// alone cannot say whether the exclusion is doing much or nothing, since
+    /// a window with 100 skips out of 100 and one with 100 out of 10,000 are
+    /// completely different findings.
+    notification_cohosts_skipped: u64,
     /// Differing comparisons that could NOT be attributed because
     /// [`Window::differing_by_contract`] was already at
     /// [`MAX_TRACKED_CONTRACTS`].
@@ -630,6 +641,32 @@ impl OutboundMix {
         w.summary_entries_one_sided = w.summary_entries_one_sided.saturating_add(1);
     }
 
+    /// Record one proactive summary notification's recipient split (#4965).
+    ///
+    /// `sent` is how many standalone `Summaries` messages went out; `skipped`
+    /// is how many resolved interested peers were dropped because they are
+    /// advertised co-hosts the broadcast already covered.
+    ///
+    /// This is the RELEASE-VISIBLE measurement of the #4965 exclusion. The
+    /// emitter also logs the same pair at `debug!`, which
+    /// `release_max_level_info` compiles out — so in production that log
+    /// measures nothing, and a change judged on "how many sends did we avoid"
+    /// needs a counter that survives the release build.
+    ///
+    /// Lives on the outbound rollup rather than a new event stream for the
+    /// reason the module docs give: the per-node budget is 10 events/s and
+    /// this fires on every state change. Two integers per node-minute.
+    ///
+    /// Recorded even when both are zero — an early return before the fan-out
+    /// (throttled, gated, no summary) does NOT call this, so a zero pair means
+    /// "a notification ran and found nobody", which is a different fact from
+    /// "no notification ran" and the two must stay distinguishable.
+    pub(crate) fn record_notification_recipients(&self, sent: u64, skipped: u64) {
+        let mut w = self.window.lock();
+        w.notification_targets_sent = w.notification_targets_sent.saturating_add(sent);
+        w.notification_cohosts_skipped = w.notification_cohosts_skipped.saturating_add(skipped);
+    }
+
     /// Atomically take the current window, leaving a fresh empty one.
     fn take_window(&self) -> Window {
         std::mem::take(&mut *self.window.lock())
@@ -715,6 +752,20 @@ fn outbound_mix_json(w: &Window, window_secs: u64) -> serde_json::Value {
     body.insert(
         "differing_attribution_dropped".into(),
         w.differing_attribution_dropped.into(),
+    );
+
+    // #4965 co-host exclusion, measured in the release build. Emitted
+    // unconditionally as a PAIR: `skipped` alone cannot be read (100 of 100 and
+    // 100 of 10,000 are different findings), and a dropped field must not look
+    // like a quiet window. `interest_sync_summaries_notification_bytes` above
+    // shows the EFFECT; these two show the CAUSE, on the same node-minute row.
+    body.insert(
+        "notification_targets_sent".into(),
+        w.notification_targets_sent.into(),
+    );
+    body.insert(
+        "notification_cohosts_skipped".into(),
+        w.notification_cohosts_skipped.into(),
     );
     // Top differing contracts by count, so a low identical rate can be read as
     // "specific contracts are non-deterministic" vs "the design is wrong".
@@ -1090,6 +1141,55 @@ mod tests {
                 .and_then(|v| v.as_u64()),
             Some(5),
             "differing count must reach the body under its own key"
+        );
+    }
+
+    /// The #4965 notification split accumulates and reaches the body under
+    /// its own keys.
+    ///
+    /// Distinguishable counts (4 sent vs 9 skipped, and asymmetric per call)
+    /// so a swapped key or a `sent`/`skipped` transposition in
+    /// `record_notification_recipients` cannot pass. That transposition is the
+    /// realistic mistake: the two arguments are both `u64` and the pair is the
+    /// number the change is judged on, so an inverted report would claim a
+    /// saving that never happened while every other test stayed green.
+    #[test]
+    fn notification_recipient_split_reaches_the_rollup_body_under_the_right_keys() {
+        let mix = OutboundMix::new();
+        mix.record_notification_recipients(1, 2);
+        mix.record_notification_recipients(3, 7);
+        let body = outbound_mix_json(&mix.take_window(), 60);
+        assert_eq!(
+            body.get("notification_targets_sent")
+                .and_then(|v| v.as_u64()),
+            Some(4),
+            "sent count must accumulate and reach the body under its own key"
+        );
+        assert_eq!(
+            body.get("notification_cohosts_skipped")
+                .and_then(|v| v.as_u64()),
+            Some(9),
+            "skipped count must accumulate and reach the body under its own key"
+        );
+    }
+
+    /// An idle window still reports the pair, as zeros.
+    ///
+    /// "No notification ran this window" and "this build does not report the
+    /// counter" must not look the same — a dashboard reading a missing field
+    /// as zero would conclude the exclusion is doing nothing.
+    #[test]
+    fn notification_recipient_split_is_emitted_even_when_idle() {
+        let body = outbound_mix_json(&OutboundMix::new().take_window(), 60);
+        assert_eq!(
+            body.get("notification_targets_sent")
+                .and_then(|v| v.as_u64()),
+            Some(0)
+        );
+        assert_eq!(
+            body.get("notification_cohosts_skipped")
+                .and_then(|v| v.as_u64()),
+            Some(0)
         );
     }
 

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -21,7 +21,8 @@ use crate::contract::{ContractHandlerEvent, ExecutorError, StoreResponse};
 use crate::message::{NodeEvent, Transaction};
 use crate::node::OpManager;
 use crate::ring::PeerKeyLocation;
-use std::collections::VecDeque;
+use crate::transport::TransportPublicKey;
+use std::collections::{HashSet, VecDeque};
 use std::net::SocketAddr;
 
 use dashmap::DashMap;
@@ -283,6 +284,32 @@ impl OpManager {
         let _tx = super::get::op_ctx_task::start_targeted_sub_op_get(self, instance_id, sender_pkl);
     }
 
+    /// The advertised co-hosts of a contract: peers that announced, via the
+    /// advertisement layer, that they host it.
+    ///
+    /// SINGLE SOURCE OF TRUTH for that population, deliberately shared by the
+    /// two call sites that must agree on it:
+    ///
+    /// - [`OpManager::get_broadcast_targets_update`], which broadcasts the
+    ///   state (carrying our summary in `sender_summary_bytes`) TO them, and
+    /// - [`send_proactive_summary_notification`], which EXCLUDES them from the
+    ///   standalone `Summaries` fan-out precisely because that broadcast
+    ///   already carried the summary (#4965).
+    ///
+    /// The exclusion is only sound while the excluded set is a subset of the
+    /// broadcast target set. If the two sites read different sources, or one
+    /// narrows its set and the other does not, the notification over-excludes:
+    /// a peer gets neither the broadcast nor the standalone summary, and every
+    /// unit test stays green because each site is individually correct. Sharing
+    /// the source is what makes a future narrowing apply to both.
+    ///
+    /// **If you add a filter, add it HERE, not at a call site.** That coupling
+    /// is the point of this function, and it is pinned by
+    /// `cohost_source_is_shared_between_broadcast_and_notification`.
+    pub(crate) fn advertised_cohost_pub_keys(&self, key: &ContractKey) -> Vec<TransportPublicKey> {
+        self.neighbor_hosting.neighbors_with_contract(key)
+    }
+
     /// Resolve the set of peers to broadcast a state update to.
     ///
     /// Targets are the advertised co-hosts from the proximity neighbor cache
@@ -348,7 +375,12 @@ impl OpManager {
         // advertised co-hosts — peers who announced they host this contract via
         // the advertisement layer. The former interest-manager arm (Source 2)
         // was removed in #4642 step 9; see this function's rustdoc.
-        let proximity_pub_keys = self.neighbor_hosting.neighbors_with_contract(key);
+        //
+        // Read through `advertised_cohost_pub_keys` rather than
+        // `neighbor_hosting` directly: `send_proactive_summary_notification`
+        // EXCLUDES this same set, and the shared accessor is what keeps a
+        // future narrowing from over-excluding there. See its rustdoc.
+        let proximity_pub_keys = self.advertised_cohost_pub_keys(key);
         let proximity_found = proximity_pub_keys.len();
 
         for pub_key in proximity_pub_keys {
@@ -841,6 +873,102 @@ pub(crate) async fn update_contract(
 /// consumed even in that case, so a no-summary tick still burns the
 /// contract's 100ms notification slot (acceptable: no summary means there is
 /// nothing to advertise yet, and the next state change retries).
+///
+/// # Recipient set (#4965)
+///
+/// Interested peers, MINUS the update's sender, MINUS ourselves, MINUS every
+/// **advertised co-host** of this contract. The co-host exclusion is the
+/// bandwidth fix: those peers are exactly the broadcast fan-out targets
+/// (`get_broadcast_targets_update` sources them from
+/// `neighbor_hosting::neighbors_with_contract`), and the broadcast we send
+/// them already carries this same summary in `sender_summary_bytes`, which
+/// they upsert into their cache of us on arrival
+/// (`update/op_ctx_task.rs::drive_relay_broadcast_to` step 1, and the
+/// streaming twin `apply_streaming_broadcast` step 4 — the #4952 upsert).
+/// Sending it again as a standalone `Summaries` message duplicates the
+/// summary bytes on the wire for a peer that just received them. It is NOT a
+/// pure duplicate: the `Summaries` handler ALSO compares our summary against
+/// the receiver's and heals us via a targeted `SyncStateToPeer` if we are
+/// behind (`node.rs`, `Summaries` arm), whereas the broadcast receive path
+/// only upserts (`op_ctx_task.rs`). For co-hosts that reverse probe now falls
+/// to the ~5-min heartbeat anti-entropy — the backstop invariant 1 designates
+/// for exactly this.
+///
+/// `interest_sync_summaries` is the largest outbound arm (49.8% of outbound
+/// bytes, v0.2.115). How much of it THIS emitter accounts for is NOT known:
+/// `outbound_message_mix` buckets all four `Summaries` emitters together, and
+/// the multi-entry heartbeat reply (`node.rs`, `Interests` arm) is a
+/// significant second source. #5052 adds the per-emitter counter. Do not read
+/// a specific saving into this change. See #4965.
+///
+/// The remaining recipients are the population this notification exists for:
+/// peers interested in the contract that we do NOT advertise-host toward, so
+/// our summary would otherwise only reach them on the ~5-min InterestSync
+/// heartbeat.
+///
+/// If a broadcast is dropped rather than delivered, the excluded co-host
+/// misses this summary — but it also missed the state itself, and the
+/// heartbeat anti-entropy is the designated backstop for that case. This
+/// mirrors `record_delivery_to_interest`, which likewise only seeds on a real
+/// delivery (#4235).
+///
+/// That reasoning covers the per-send skips inside `broadcast_to_single_peer`.
+/// `plan_fanout_send` skips a peer whose summary is BYTE-IDENTICAL to ours
+/// first; the cached-empty-delta verdict is the backstop for the narrower
+/// converged-but-byte-differing case (a non-deterministically-serialized
+/// summary), not the primary test. Either way the peer did not miss the STATE,
+/// only our new summary, and it already holds an equivalent one. Neither skip
+/// covers `should_broadcast_contract`, which suppresses the broadcast for the
+/// WHOLE contract — hence the gate below.
+///
+/// # Gate: `should_summarize_or_broadcast`
+///
+/// This emitter is gated on the same `(is_hosting_contract || contract_in_use)
+/// && contract_state_present` predicate as its two siblings —
+/// `broadcast_queue::should_broadcast_contract` (the fan-out) and
+/// `node::summary_if_hosted_or_in_use` (the heartbeat / churn replies). It was
+/// the one summary-emitting path #4473/#4610 left ungated.
+///
+/// Two reasons, and the first is what makes the co-host exclusion above sound:
+///
+/// 1. **The exclusion needs a broadcast behind it.** Ungated, a contract with
+///    state on disk but neither hosted nor in use (evicted from the hosting
+///    cache, no local client, no downstream subscriber — the #4440/#4473/#4610
+///    phantom population) attempted ZERO broadcasts, yet post-#4965 excluded
+///    every advertised co-host from the notification. That is exclusion with
+///    no counterpart: the co-host would get neither. Sharing the predicate
+///    makes "excluded because the broadcast covered it" true by construction
+///    rather than by coincidence.
+/// 2. **It closes a `summarize_contract_state` storm hole.** The gate's whole
+///    purpose (#4473) is to stop phantom contracts driving WASM summarize
+///    calls, and `InterestManager::get_contract_summary` below is an ungated
+///    `GetSummaryQuery`. The paragraph above — the broadcast "already issues
+///    the identical `get_contract_summary`, so whichever runs first pays the
+///    one WASM call" — holds ONLY when the broadcast actually runs, exactly
+///    the case `should_broadcast_contract` rules out. For a phantom, this path
+///    paid the full call alone.
+///
+/// What the gate does NOT do is give a co-host our summary for such a contract
+/// — the heartbeat reply reports `None` for it too, and the receiver clears its
+/// cached summary of us (`SummaryMissingReason::ClearedByNoneReport`). That is
+/// the intended #4473 policy (we advertise no summary for a contract we do not
+/// host or serve), and the gate makes all three paths agree on it instead of
+/// leaving this one emitter dissenting.
+///
+/// A peer that still broadcasts to us for such a contract is holding a stale
+/// advertisement of us. #5063 closes the main source of those — eviction now
+/// retracts the advertisement at the eviction decision
+/// (`operations::retract_advertisement_for_evicted_contract`) rather than only
+/// at reclamation — so this residual is narrow. Its retention guard is
+/// `is_hosting_contract || contract_in_use || is_subscribed`, which is this
+/// gate's predicate plus `is_subscribed`. The one population where the two
+/// still disagree is a contract held ONLY by a bare upstream network
+/// subscription: #5063 keeps its advertisement, while all three summary paths
+/// (this one, the fan-out, and the heartbeat) report nothing for it, so a
+/// co-host's broadcasts to us stay full-state. That divergence is PRE-EXISTING
+/// — the fan-out and heartbeat already behaved this way — and this gate makes
+/// the third path match them rather than introducing it. Tracked with the rest
+/// of the #4440 advertisement-hygiene work; deliberately not papered over here.
 pub(crate) async fn send_proactive_summary_notification(
     op_manager: &OpManager,
     key: &ContractKey,
@@ -854,6 +982,22 @@ pub(crate) async fn send_proactive_summary_notification(
         .interest_manager
         .should_send_summary_notification(key)
     {
+        return;
+    }
+
+    // The #4473/#4610 gate, shared with the broadcast fan-out and the
+    // heartbeat replies. Placed AFTER the throttle so a hot contract pays its
+    // synchronous state-store lookup at most 10x/sec, and BEFORE
+    // `get_contract_summary` so a phantom contract never reaches the WASM
+    // summarize. See this function's "Gate" docs for why the co-host exclusion
+    // below depends on it.
+    if !op_manager.ring.should_summarize_or_broadcast(key) {
+        tracing::debug!(
+            contract = %key,
+            "Skipping proactive summary notification — contract is neither \
+             hosted nor in use, or its state is not present (#4473 gate); the \
+             broadcast fan-out is suppressed for it too"
+        );
         return;
     }
 
@@ -899,32 +1043,37 @@ pub(crate) async fn send_proactive_summary_notification(
     let hash = contract_hash(key);
     let full_entry = SummaryEntry::from_summary(hash, Some(&summary));
 
-    // Get interested peers and send to each (excluding the sender who just sent us the update)
+    // Get interested peers and resolve them to addresses. Peers that don't
+    // resolve to a live socket address are dropped here, as before.
     let interested = op_manager.interest_manager.get_interested_peers(key);
     let self_addr = op_manager.ring.connection_manager.get_own_addr();
 
-    for (peer_key, _interest) in &interested {
-        // Resolve peer to socket address
-        let peer_addr = match op_manager
-            .ring
-            .connection_manager
-            .get_peer_by_pub_key(&peer_key.0)
-        {
-            Some(pkl) => match pkl.socket_addr() {
-                Some(addr) => addr,
-                None => continue,
-            },
-            None => continue,
-        };
+    let resolved: Vec<(TransportPublicKey, SocketAddr)> = interested
+        .iter()
+        .filter_map(|(peer_key, _interest)| {
+            let pkl = op_manager
+                .ring
+                .connection_manager
+                .get_peer_by_pub_key(&peer_key.0)?;
+            Some((peer_key.0.clone(), pkl.socket_addr()?))
+        })
+        .collect();
 
-        // Skip sender (they just gave us this data) and ourselves
-        if peer_addr == sender_addr {
-            continue;
-        }
-        if self_addr.as_ref() == Some(&peer_addr) {
-            continue;
-        }
+    // The advertised co-hosts are the broadcast fan-out targets, which already
+    // received this summary inside the broadcast. Read through the SHARED
+    // accessor `get_broadcast_targets_update` also uses — see its rustdoc for
+    // why the two sites must not read the population independently.
+    let advertised_cohosts: HashSet<TransportPublicKey> = op_manager
+        .advertised_cohost_pub_keys(key)
+        .into_iter()
+        .collect();
 
+    let ProactiveSummaryRecipients {
+        targets,
+        cohosts_skipped,
+    } = proactive_summary_targets(&resolved, &advertised_cohosts, sender_addr, self_addr);
+
+    for peer_addr in &targets {
         // FULL BYTES, deliberately — this leg does NOT ship digest-first
         // this release (#4965 review §2).
         //
@@ -954,7 +1103,7 @@ pub(crate) async fn send_proactive_summary_notification(
 
         if let Err(e) = op_manager
             .notify_node_event(NodeEvent::SendInterestMessage {
-                target: peer_addr,
+                target: *peer_addr,
                 message,
             })
             .await
@@ -968,11 +1117,101 @@ pub(crate) async fn send_proactive_summary_notification(
         }
     }
 
+    // `cohosts_skipped` comes from `proactive_summary_targets`, which counts
+    // ONLY the #4965 co-host drops. Neither `advertised_cohosts.len()` (counts
+    // co-hosts that were never interested or failed to resolve) nor
+    // `resolved.len() - targets.len()` (also counts the sender and self) is
+    // this number, and both overstate it. This is what the change is judged on.
+    //
+    // Release-visible counterpart to the `debug!` below, which `release_max_level_info`
+    // compiles out — so in production the debug line measures nothing. Folded into
+    // the existing `outbound_message_mix` rollup window rather than emitted per
+    // notification: the collector's budget is per-event-stream, and this path fires on
+    // every state change (see `outbound_message_mix` module docs).
+    op_manager
+        .outbound_mix
+        .record_notification_recipients(targets.len() as u64, cohosts_skipped as u64);
+    // Simulation-visible twin of the same number. The sim harness cannot read
+    // per-node `OutboundMix` windows, and the exclusion's effect is invisible
+    // in `delta_sends`/`full_state_sends` — see
+    // `GlobalTestMetrics::record_notification_cohosts_skipped`.
+    crate::config::GlobalTestMetrics::record_notification_cohosts_skipped(cohosts_skipped as u64);
+
     tracing::debug!(
         contract = %key,
-        peer_count = interested.len(),
+        interested = interested.len(),
+        resolved = resolved.len(),
+        cohosts_skipped,
+        advertised_cohosts = advertised_cohosts.len(),
+        peer_count = targets.len(),
         "Sent proactive summary notifications after state change"
     );
+}
+
+/// Choose which interested peers still need a standalone `Summaries`
+/// notification after a state change.
+///
+/// Split out as a pure function so the recipient-set decision is unit-testable
+/// without an `OpManager`. `.claude/rules/operations.md` ("Event emission
+/// review") requires the emitted event's recipient set to be asserted
+/// directly rather than inferred from the data layer that feeds it; the
+/// production loop is pinned to route through here by
+/// `proactive_notification_excludes_advertised_cohosts_in_production`.
+///
+/// Excludes, in order: the update's sender, ourselves, and every advertised
+/// co-host (the broadcast fan-out already delivered this summary to them —
+/// see [`send_proactive_summary_notification`]'s "Recipient set" section).
+///
+/// Returns the co-host skip count SEPARATELY rather than leaving callers to
+/// derive it as `resolved.len() - targets.len()`. That subtraction is wrong,
+/// and wrong in the direction that flatters the change: it also counts the
+/// sender and self, so it stays non-zero even with the co-host filter deleted.
+/// A metric computed that way reports a saving the code is not making, and it
+/// silently defeats any test that asserts on it — mutation testing caught
+/// exactly that here, with the simulation's `cohosts_skipped > 0` assertion
+/// still passing under a mutation that removed the entire exclusion.
+pub(crate) fn proactive_summary_targets(
+    resolved_interested: &[(TransportPublicKey, SocketAddr)],
+    advertised_cohosts: &HashSet<TransportPublicKey>,
+    sender_addr: SocketAddr,
+    self_addr: Option<SocketAddr>,
+) -> ProactiveSummaryRecipients {
+    let mut targets = Vec::with_capacity(resolved_interested.len());
+    let mut cohosts_skipped = 0usize;
+
+    for (pub_key, peer_addr) in resolved_interested {
+        // The sender just gave us this data; never notify ourselves. Both
+        // predate #4965 and are NOT co-host skips.
+        if *peer_addr == sender_addr || self_addr.as_ref() == Some(peer_addr) {
+            continue;
+        }
+        // #4965: the broadcast to this co-host already carried the summary in
+        // `sender_summary_bytes`. Counted only here, AFTER the two exclusions
+        // above, so the count is attributable to this change alone.
+        if advertised_cohosts.contains(pub_key) {
+            cohosts_skipped += 1;
+            continue;
+        }
+        targets.push(*peer_addr);
+    }
+
+    ProactiveSummaryRecipients {
+        targets,
+        cohosts_skipped,
+    }
+}
+
+/// Outcome of [`proactive_summary_targets`]: who to notify, and how many
+/// recipients the #4965 co-host exclusion removed.
+///
+/// The count is bundled with the targets rather than recomputed by callers so
+/// there is exactly one definition of "skipped because of #4965" — see that
+/// function's docs for the subtraction that looked equivalent and was not.
+pub(crate) struct ProactiveSummaryRecipients {
+    pub targets: Vec<SocketAddr>,
+    /// Peers dropped BECAUSE they are advertised co-hosts. Excludes the sender
+    /// and self, which are dropped for unrelated, pre-#4965 reasons.
+    pub cohosts_skipped: usize,
 }
 
 /// Send our current summary to the peer whose broadcast we just rejected,
@@ -2149,6 +2388,624 @@ mod tests {
             !d_body.contains("StateSummary::from("),
             "drive_client_update must never build a StateSummary from bytes \
              (#4923)"
+        );
+    }
+
+    // ── #4965: proactive summary notification recipient set ───────────────
+    //
+    // `interest_sync_summaries` is the largest outbound arm (49.8% of outbound
+    // bytes, v0.2.115). Which of its four emitters dominates is NOT measured —
+    // `outbound_message_mix` buckets them together (#5052 adds the split).
+    // What this change rests on is narrower and does not need that number:
+    // most recipients of this notification are advertised co-hosts that
+    // already received the identical summary inside the broadcast's
+    // `sender_summary_bytes`.
+
+    /// Build a `(pub_key, addr)` pair plus the matching `PeerKeyLocation`.
+    fn resolved_peer(port: u16) -> (TransportPublicKey, SocketAddr) {
+        let pkl = crate::operations::test_utils::make_peer(port);
+        (
+            pkl.pub_key.clone(),
+            pkl.socket_addr().expect("test peer has a socket addr"),
+        )
+    }
+
+    #[test]
+    fn proactive_summary_targets_excludes_advertised_cohosts() {
+        let cohost = resolved_peer(9001);
+        let non_cohost = resolved_peer(9002);
+        let interested = vec![cohost.clone(), non_cohost.clone()];
+
+        let cohosts: HashSet<TransportPublicKey> = [cohost.0.clone()].into_iter().collect();
+
+        let targets = proactive_summary_targets(
+            &interested,
+            &cohosts,
+            "127.0.0.1:9999".parse().unwrap(),
+            None,
+        )
+        .targets;
+
+        assert_eq!(
+            targets,
+            vec![non_cohost.1],
+            "an advertised co-host already got this summary in the broadcast's \
+             sender_summary_bytes (#4952); re-sending it standalone is the #4965 waste"
+        );
+    }
+
+    #[test]
+    fn proactive_summary_targets_keeps_interested_non_cohosts() {
+        let a = resolved_peer(9010);
+        let b = resolved_peer(9011);
+        let interested = vec![a.clone(), b.clone()];
+
+        // Nothing advertised: this is the population the notification exists
+        // for — peers we do NOT broadcast to, whose only other path to our
+        // summary is the ~5-min heartbeat.
+        let targets = proactive_summary_targets(
+            &interested,
+            &HashSet::new(),
+            "127.0.0.1:9999".parse().unwrap(),
+            None,
+        )
+        .targets;
+
+        assert_eq!(targets, vec![a.1, b.1]);
+    }
+
+    #[test]
+    fn proactive_summary_targets_still_excludes_sender_and_self() {
+        let sender = resolved_peer(9020);
+        let me = resolved_peer(9021);
+        let other = resolved_peer(9022);
+        let interested = vec![sender.clone(), me.clone(), other.clone()];
+
+        let targets =
+            proactive_summary_targets(&interested, &HashSet::new(), sender.1, Some(me.1)).targets;
+
+        assert_eq!(
+            targets,
+            vec![other.1],
+            "the pre-existing sender/self exclusions must survive the #4965 change"
+        );
+    }
+
+    #[test]
+    fn proactive_summary_targets_is_empty_when_every_peer_is_a_cohost() {
+        // The steady state this fix targets: every interested peer is an
+        // advertised co-host, so the broadcast covered all of them and the
+        // notification fan-out collapses to zero messages.
+        let a = resolved_peer(9030);
+        let b = resolved_peer(9031);
+        let interested = vec![a.clone(), b.clone()];
+        let cohosts: HashSet<TransportPublicKey> = [a.0.clone(), b.0.clone()].into_iter().collect();
+
+        let targets = proactive_summary_targets(
+            &interested,
+            &cohosts,
+            "127.0.0.1:9999".parse().unwrap(),
+            None,
+        )
+        .targets;
+
+        assert!(
+            targets.is_empty(),
+            "expected zero standalone notifications, got {targets:?}"
+        );
+    }
+
+    #[test]
+    fn proactive_summary_targets_handles_empty_interest_set() {
+        let targets = proactive_summary_targets(
+            &[],
+            &HashSet::new(),
+            "127.0.0.1:9999".parse().unwrap(),
+            Some("127.0.0.1:9998".parse().unwrap()),
+        )
+        .targets;
+        assert!(targets.is_empty());
+    }
+
+    #[test]
+    fn proactive_summary_targets_cohost_exclusion_is_by_pub_key_not_addr() {
+        // A co-host whose advertised entry is keyed by pub_key must be
+        // excluded even though nothing about its ADDRESS marks it — matching
+        // `get_broadcast_targets_update`, which also sources targets by
+        // pub_key from `neighbors_with_contract`.
+        let cohost = resolved_peer(9040);
+        let cohosts: HashSet<TransportPublicKey> = [cohost.0.clone()].into_iter().collect();
+
+        let targets = proactive_summary_targets(
+            &[cohost.clone()],
+            &cohosts,
+            "127.0.0.1:9999".parse().unwrap(),
+            None,
+        )
+        .targets;
+        assert!(targets.is_empty());
+
+        // Same address, different identity => not the advertised co-host.
+        let impostor = (resolved_peer(9041).0, cohost.1);
+        let targets = proactive_summary_targets(
+            &[impostor],
+            &cohosts,
+            "127.0.0.1:9999".parse().unwrap(),
+            None,
+        )
+        .targets;
+        assert_eq!(targets, vec![cohost.1]);
+    }
+
+    /// `cohosts_skipped` counts ONLY the #4965 co-host drops — not the sender,
+    /// not self.
+    ///
+    /// Found by mutation testing, not by review. The count was originally
+    /// derived at the call site as `resolved.len() - targets.len()`, which
+    /// looks equivalent and is not: it also counts the sender and self, so it
+    /// stayed non-zero with the entire co-host exclusion deleted. That made
+    /// the number report a saving the code was not making, AND it silently
+    /// defeated the simulation test whose whole job is to fail when the
+    /// exclusion is removed — that test passed under the deletion mutation.
+    ///
+    /// The scenario below is the discriminating one: the sender is ALSO
+    /// interested, so a count that includes sender/self reads 2 where the
+    /// truthful co-host count is 1.
+    #[test]
+    fn cohosts_skipped_counts_only_cohost_drops_not_sender_or_self() {
+        let sender = resolved_peer(9050);
+        let me = resolved_peer(9051);
+        let cohost = resolved_peer(9052);
+        let plain = resolved_peer(9053);
+        let interested = vec![sender.clone(), me.clone(), cohost.clone(), plain.clone()];
+        let cohosts: HashSet<TransportPublicKey> = [cohost.0.clone()].into_iter().collect();
+
+        let out = proactive_summary_targets(&interested, &cohosts, sender.1, Some(me.1));
+
+        assert_eq!(out.targets, vec![plain.1]);
+        assert_eq!(
+            out.cohosts_skipped, 1,
+            "only the advertised co-host counts; the sender and self are \
+             dropped for pre-#4965 reasons and must not inflate the saving"
+        );
+
+        // With no co-hosts advertised the count must be ZERO even though two
+        // peers were still dropped. This is the assertion the old subtraction
+        // failed, and it is what makes the simulation's `cohosts_skipped > 0`
+        // a real discriminator.
+        let out = proactive_summary_targets(&interested, &HashSet::new(), sender.1, Some(me.1));
+        assert_eq!(out.targets, vec![cohost.1, plain.1]);
+        assert_eq!(
+            out.cohosts_skipped, 0,
+            "with the exclusion inactive the co-host skip count MUST be 0 — \
+             a non-zero value here means the metric is measuring the sender/\
+             self drops and cannot detect the exclusion being removed"
+        );
+    }
+
+    /// Source pin: the production emitter must actually consult the
+    /// advertisement layer and route its recipient set through
+    /// `proactive_summary_targets`.
+    ///
+    /// Without this, someone could revert the emitter to iterating
+    /// `get_interested_peers` directly and every pure test above would stay
+    /// green — the exact failure mode `.claude/rules/operations.md` calls out
+    /// for event-emission fixes (#3791).
+    #[test]
+    fn proactive_notification_excludes_advertised_cohosts_in_production() {
+        let src = include_str!("update.rs");
+        // Cut at `mod tests` (NOT `#[cfg(test)]`, whose attribute line sits
+        // above the doc comments) so the needles can't match this test file.
+        let prod = &src[..src.find("\nmod tests {").expect("tests module not found")];
+
+        let fn_start = prod
+            .find("pub(crate) async fn send_proactive_summary_notification(")
+            .expect("send_proactive_summary_notification not found");
+        let fn_src = &prod[fn_start..];
+        // `+ 1` rebases the offset: `find` searched `fn_src[1..]`, but the
+        // slice below indexes `fn_src`. Without it the body ends one byte
+        // early — harmless today (it only drops the preceding newline, which
+        // the whitespace filter would strip anyway) but the two indices must
+        // share a base or a future edit to this boundary will cut real source.
+        let fn_end = 1 + fn_src[1..]
+            .find("\npub(crate) fn ")
+            .expect("expected proactive_summary_targets to follow the emitter");
+        // Whitespace-stripped so the pin survives rustfmt reflowing the call.
+        let body: String = fn_src[..fn_end]
+            .chars()
+            .filter(|c| !c.is_whitespace())
+            .collect();
+
+        assert!(
+            body.contains("advertised_cohost_pub_keys(key)"),
+            "the emitter MUST consult the advertisement layer — without it the \
+             co-host exclusion silently does nothing (#4965)"
+        );
+        assert!(
+            body.contains("proactive_summary_targets(&resolved,&advertised_cohosts,"),
+            "the emitter MUST route its recipient set through \
+             proactive_summary_targets so the pure tests above actually guard \
+             production (see .claude/rules/operations.md, #3791)"
+        );
+        assert!(
+            // Needle is `in&interested`, NOT `forpeer_addrin&interested`: the
+            // pre-change loop was `for (peer_key, _interest) in &interested {`,
+            // which whitespace-strips to `for(peer_key,_interest)in&interested{`.
+            // The longer needle never matched the code it claimed to guard, so
+            // it could not fail on the reversion named in its own message.
+            !body.contains("in&interested"),
+            "the emitter must not iterate the raw interested-peer set again — \
+             it must send only to the filtered `targets`"
+        );
+        assert!(
+            body.contains("ring.should_summarize_or_broadcast(key)"),
+            "the emitter MUST share the #4473/#4610 gate with the broadcast \
+             fan-out. Ungated, a contract that broadcasts to NOBODY \
+             (should_broadcast_contract false) still excludes every advertised \
+             co-host here — exclusion with no broadcast behind it, which is \
+             exactly what makes the #4965 skip unsound"
+        );
+    }
+
+    /// The co-host population must come from ONE accessor, shared with
+    /// `get_broadcast_targets_update`.
+    ///
+    /// The behavioural guard is
+    /// `notification_exclusion_is_a_subset_of_broadcast_targets`; this pin is
+    /// the cheap structural half, and it fails on the specific edit that test
+    /// cannot see coming: a second, independent read of `neighbor_hosting` at
+    /// either site, which is how the two sets drift apart in the first place.
+    #[test]
+    fn cohost_source_is_shared_between_broadcast_and_notification() {
+        let src = include_str!("update.rs");
+        let prod = &src[..src.find("\nmod tests {").expect("tests module not found")];
+        let stripped: String = prod.chars().filter(|c| !c.is_whitespace()).collect();
+
+        // Exactly one direct read of the advertisement layer in this file: the
+        // accessor itself. Any other is a site that will not follow a future
+        // narrowing of the shared source.
+        assert_eq!(
+            stripped
+                .matches("neighbor_hosting.neighbors_with_contract(")
+                .count(),
+            1,
+            "`neighbors_with_contract` must be read ONLY through \
+             `advertised_cohost_pub_keys`. A second direct read means the \
+             broadcast fan-out and the #4965 notification exclusion can drift \
+             apart, and each site stays individually correct while the peers \
+             between them get neither the broadcast nor the summary"
+        );
+        assert!(
+            stripped.contains("fnadvertised_cohost_pub_keys(&self,key:&ContractKey)"),
+            "the shared accessor must still exist"
+        );
+        // Both consumers go through it.
+        assert!(
+            stripped.contains("letproximity_pub_keys=self.advertised_cohost_pub_keys(key);"),
+            "get_broadcast_targets_update must source its targets from the \
+             shared accessor"
+        );
+        assert!(
+            stripped.contains("op_manager.advertised_cohost_pub_keys(key)"),
+            "send_proactive_summary_notification must source its exclusion set \
+             from the shared accessor"
+        );
+    }
+
+    // ── Behavioural coverage against a real OpManager ─────────────────────
+    //
+    // The pure `proactive_summary_targets` tests above prove the FILTER is
+    // right; the pins prove production calls it. Neither can see the property
+    // the #4965 skip actually rests on, which spans two functions: every peer
+    // the notification EXCLUDES must be a peer the broadcast fan-out would
+    // have reached. These tests assert that against the real emitter.
+
+    /// Build an `OpManager` whose contract handler answers `GetSummaryQuery`,
+    /// returning the event-loop notification receiver so a test can read the
+    /// `SendInterestMessage` events the emitter actually produced.
+    ///
+    /// Deliberately NOT folded into `build_summary_test_node`: that helper
+    /// hides the receiver inside its keep-alive guard, and the whole point
+    /// here is to inspect the emitted recipient set rather than infer it from
+    /// the data layer that feeds it (#3791).
+    async fn build_notification_test_node(
+        id: &str,
+    ) -> (
+        std::sync::Arc<OpManager>,
+        tokio::sync::mpsc::Receiver<
+            either::Either<crate::message::NetMessage, crate::message::NodeEvent>,
+        >,
+        Box<dyn std::any::Any>,
+    ) {
+        let config_args = crate::config::ConfigArgs {
+            id: Some(id.to_string()),
+            mode: Some(crate::contract::OperationMode::Local),
+            ..Default::default()
+        };
+        let node_config =
+            crate::node::NodeConfig::new(config_args.build().await.expect("build Config"))
+                .await
+                .expect("build NodeConfig");
+        let (notification_rx, notification_tx) = crate::node::event_loop_notification_channel();
+        let (ops_ch_channel, mut ch_channel, wait_for_event) =
+            crate::contract::contract_handler_channel();
+        let connection_manager = crate::ring::ConnectionManager::new(&node_config);
+        let (result_router_tx, result_router_rx) = tokio::sync::mpsc::channel(100);
+        let task_monitor = crate::node::background_task_monitor::BackgroundTaskMonitor::new();
+        let op_manager = std::sync::Arc::new(
+            OpManager::new(
+                notification_tx,
+                ops_ch_channel,
+                &node_config,
+                crate::tracing::DynamicRegister::new(vec![]),
+                connection_manager,
+                result_router_tx,
+                &task_monitor,
+            )
+            .expect("build OpManager"),
+        );
+        op_manager.ring.attach_op_manager(&op_manager);
+
+        let summary = StateSummary::from(vec![9u8; 32]);
+        let handler = tokio::spawn(async move {
+            while let Ok((id, ev, _priority)) = ch_channel.recv_from_sender().await {
+                let response = match ev {
+                    ContractHandlerEvent::GetSummaryQuery { key } => {
+                        ContractHandlerEvent::GetSummaryResponse {
+                            key,
+                            summary: Ok(summary.clone()),
+                        }
+                    }
+                    other => panic!("unexpected handler event: {other:?}"),
+                };
+                if ch_channel.send_to_sender(id, response).await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        // Field access rather than a destructuring pattern: the receiver's TYPE
+        // lives in the private `node::network_bridge` module and cannot be
+        // named from here, but its fields are `pub(crate)`.
+        let notifications_receiver = notification_rx.notifications_receiver;
+        let op_execution_receiver = notification_rx.op_execution_receiver;
+
+        let guard: Box<dyn std::any::Any> = Box::new((
+            handler,
+            op_execution_receiver,
+            result_router_rx,
+            task_monitor,
+            wait_for_event,
+        ));
+        (op_manager, notifications_receiver, guard)
+    }
+
+    /// Connect a peer and return `(pub_key, addr)`.
+    fn connect_peer(
+        op_manager: &OpManager,
+        port: u16,
+        loc: f64,
+    ) -> (TransportPublicKey, SocketAddr) {
+        let keypair = crate::transport::TransportKeypair::new();
+        let addr: SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
+        op_manager.ring.connection_manager.add_connection(
+            crate::ring::Location::new(loc),
+            addr,
+            keypair.public().clone(),
+            false,
+        );
+        (keypair.public().clone(), addr)
+    }
+
+    /// Make `peer` an advertised co-host of `key`, the way an inbound
+    /// `HostingAnnounce` does.
+    fn advertise_cohost(op_manager: &OpManager, peer: &TransportPublicKey, key: &ContractKey) {
+        op_manager.neighbor_hosting.handle_message(
+            peer,
+            crate::message::NeighborHostingMessage::HostingAnnounce {
+                added: vec![*key.id()],
+                removed: vec![],
+                // `is_response: true` so the handler does not try to build a
+                // reply message; we only want the cache mutation.
+                is_response: true,
+            },
+        );
+    }
+
+    /// Drain the notification channel into the `SendInterestMessage` targets.
+    fn drain_interest_targets(
+        rx: &mut tokio::sync::mpsc::Receiver<
+            either::Either<crate::message::NetMessage, crate::message::NodeEvent>,
+        >,
+    ) -> Vec<SocketAddr> {
+        let mut targets = Vec::new();
+        while let Ok(item) = rx.try_recv() {
+            if let either::Either::Right(crate::message::NodeEvent::SendInterestMessage {
+                target,
+                ..
+            }) = item
+            {
+                targets.push(target);
+            }
+        }
+        targets.sort();
+        targets
+    }
+
+    /// The load-bearing cross-function property: a peer the notification
+    /// EXCLUDES must be a peer the broadcast fan-out would have reached.
+    ///
+    /// This is what the source pins cannot express. Both sites are
+    /// individually correct today; the failure mode the review names is a
+    /// FILTER added to `get_broadcast_targets_update` (a cap, a health check,
+    /// a location predicate) that narrows the broadcast set while the
+    /// exclusion keeps using the full advertised set. The excluded peer then
+    /// gets neither the broadcast nor the standalone summary, and every
+    /// single-site test stays green. Asserting the subset relation between the
+    /// two real functions is the only thing that fails on that edit.
+    ///
+    /// # Why TWO interested co-hosts, and why you must not simplify to one
+    ///
+    /// **A set-relation assertion cannot be falsified by a fixture whose set
+    /// has one element.** With a single interested co-host, `excluded ⊆
+    /// broadcast_targets` is satisfied by almost any mutation, because there is
+    /// no second element for a narrowing to strand — the assertion reads strong
+    /// and is very nearly unfalsifiable. Two is not a richer scenario, it is
+    /// the MINIMUM CARDINALITY at which the property has any content, the same
+    /// way a commutativity test needs two distinct operands or an ordering test
+    /// two distinct keys.
+    ///
+    /// Verified: a `truncate(1)` on `get_broadcast_targets_update`'s co-host
+    /// list left the one-co-host version of this test GREEN, and fails the
+    /// two-co-host version. Adding the non-co-host (C) and the co-host-only
+    /// peer (E) keeps the two filters distinguishable from each other.
+    ///
+    /// # Why premise 1 is deliberately weak
+    ///
+    /// It asserts only that the broadcast has SOME target, not that a specific
+    /// peer is among them. **A premise that fails before the real assertion
+    /// masks which check actually caught the mutation**, so a premise should be
+    /// the weakest statement that still rules out vacuity. The strict form
+    /// ("A specifically is a target") would fire first under a narrowing
+    /// mutation and hide the fact that the subset property is what detects it.
+    #[tokio::test]
+    async fn notification_exclusion_is_a_subset_of_broadcast_targets() {
+        let (op_manager, mut rx, _guard) =
+            build_notification_test_node("notif-exclusion-subset-4965").await;
+        let key = crate::operations::test_utils::make_contract_key(11);
+        op_manager
+            .ring
+            .host_contract(key, 1024, crate::ring::AccessType::Put);
+
+        // A and B: advertised co-hosts AND interested — the excluded
+        //          population. TWO of them, deliberately: with only one, a
+        //          mutation that narrows the broadcast target set to a single
+        //          peer can happen to keep exactly the excluded one, and the
+        //          subset assertion still holds. Mutation testing caught that
+        //          — a `truncate(1)` on the broadcast targets left this test
+        //          green. With two, narrowing to one always strands the other.
+        // C: interested only — the population the notification still exists for.
+        // E: advertised co-host only — a broadcast target we never notify.
+        let (a_pk, a_addr) = connect_peer(&op_manager, 19101, 0.11);
+        let (b_pk, b_addr) = connect_peer(&op_manager, 19102, 0.12);
+        let (c_pk, c_addr) = connect_peer(&op_manager, 19103, 0.13);
+        let (e_pk, _e_addr) = connect_peer(&op_manager, 19105, 0.15);
+        let (_d_pk, sender_addr) = connect_peer(&op_manager, 19104, 0.14);
+
+        advertise_cohost(&op_manager, &a_pk, &key);
+        advertise_cohost(&op_manager, &b_pk, &key);
+        advertise_cohost(&op_manager, &e_pk, &key);
+        for pk in [&a_pk, &b_pk, &c_pk] {
+            op_manager.interest_manager.register_peer_interest(
+                &key,
+                crate::ring::PeerKey::from(pk.clone()),
+                None,
+                false,
+            );
+        }
+
+        let broadcast_targets: HashSet<SocketAddr> = op_manager
+            .get_broadcast_targets_update(&key, &sender_addr)
+            .targets
+            .iter()
+            .filter_map(|pkl| pkl.socket_addr())
+            .collect();
+
+        send_proactive_summary_notification(&op_manager, &key, sender_addr).await;
+        let notified: HashSet<SocketAddr> = drain_interest_targets(&mut rx).into_iter().collect();
+
+        // Premise 1: the scenario really produced a broadcast fan-out.
+        assert!(
+            !broadcast_targets.is_empty(),
+            "premise: the broadcast must have targets, else the subset \
+             assertion below is vacuous"
+        );
+        // Premise 2: the exclusion really excluded BOTH co-hosts and kept the
+        // non-co-host. Without this the subset assertion passes trivially on
+        // an empty set.
+        let interested_addrs: HashSet<SocketAddr> = [a_addr, b_addr, c_addr].into_iter().collect();
+        let excluded: HashSet<SocketAddr> =
+            interested_addrs.difference(&notified).copied().collect();
+        assert_eq!(
+            excluded,
+            [a_addr, b_addr].into_iter().collect::<HashSet<_>>(),
+            "both advertised co-hosts must be excluded and the non-co-host C \
+             kept; notified={notified:?}"
+        );
+
+        // The property.
+        assert!(
+            excluded.is_subset(&broadcast_targets),
+            "#4965 UNSOUND: {:?} were excluded from the standalone summary \
+             notification but are NOT broadcast targets {:?}, so nothing \
+             delivered them our summary. The exclusion is only valid while the \
+             broadcast covers every peer it drops.",
+            excluded.difference(&broadcast_targets).collect::<Vec<_>>(),
+            broadcast_targets,
+        );
+    }
+
+    /// The gate: a contract that broadcasts to NOBODY must not notify either.
+    ///
+    /// Same topology as the subset test, minus `host_contract` — so
+    /// `should_summarize_or_broadcast` is false, `should_broadcast_contract`
+    /// suppresses the whole fan-out, and (pre-gate) the emitter still ran and
+    /// still excluded every advertised co-host. That is exclusion with no
+    /// broadcast behind it: A gets neither.
+    ///
+    /// Reachable population (#4440/#4473/#4610): state on disk, evicted from
+    /// the hosting cache, no local client and no downstream subscriber.
+    #[tokio::test]
+    async fn proactive_notification_is_gated_like_the_broadcast() {
+        let (op_manager, mut rx, _guard) = build_notification_test_node("notif-gate-4473").await;
+        let key = crate::operations::test_utils::make_contract_key(12);
+        // Deliberately NOT hosted and NOT in use.
+        assert!(
+            !op_manager.ring.should_summarize_or_broadcast(&key),
+            "premise: the gate must be false, else this test proves nothing"
+        );
+
+        let (a_pk, _a_addr) = connect_peer(&op_manager, 19201, 0.21);
+        let (b_pk, _b_addr) = connect_peer(&op_manager, 19202, 0.22);
+        let (_d_pk, sender_addr) = connect_peer(&op_manager, 19203, 0.23);
+        advertise_cohost(&op_manager, &a_pk, &key);
+        op_manager.interest_manager.register_peer_interest(
+            &key,
+            crate::ring::PeerKey::from(a_pk.clone()),
+            None,
+            false,
+        );
+        op_manager.interest_manager.register_peer_interest(
+            &key,
+            crate::ring::PeerKey::from(b_pk.clone()),
+            None,
+            false,
+        );
+
+        // Premise: A really is an advertised co-host, so pre-gate this
+        // contract WOULD have excluded a real peer. Without this the emitter
+        // could be emitting nothing for an unrelated reason.
+        assert_eq!(
+            op_manager.advertised_cohost_pub_keys(&key),
+            vec![a_pk.clone()],
+            "premise: A must be an advertised co-host, else the gate is not \
+             what is suppressing the notification"
+        );
+        // The broadcast fan-out is suppressed for this contract by the SAME
+        // predicate asserted above: `broadcast_queue::should_broadcast_contract`
+        // is a one-line delegation to `ring.should_summarize_or_broadcast`,
+        // pinned there by
+        // `broadcast_single_peer_gates_summarize_on_hosted_or_in_use_pin`.
+        // It is `pub(super)` so it cannot be called from here directly.
+
+        send_proactive_summary_notification(&op_manager, &key, sender_addr).await;
+
+        assert!(
+            drain_interest_targets(&mut rx).is_empty(),
+            "a contract whose broadcast fan-out is suppressed for the WHOLE \
+             contract must not emit standalone summary notifications either — \
+             ungated, this path also pays an unbounded WASM summarize for \
+             every phantom contract, the #4473 storm the gate exists to stop"
         );
     }
 }

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -3392,6 +3392,231 @@ fn test_sustained_update_fanout_no_full_state_storm() {
     );
 }
 
+/// #4965 sibling of the star test above, on a topology where the co-host
+/// exclusion is not a no-op.
+///
+/// ## Why the star test cannot catch a regression here
+///
+/// `test_sustained_update_fanout_no_full_state_storm` is 1 gateway + 2 DIRECT
+/// subscribers. Each subscriber's only advertised co-host is the gateway — and
+/// the gateway is the update's sender, so it was ALREADY excluded from the
+/// proactive summary notification long before #4965. In that topology the new
+/// exclusion removes nobody. Any regression in it is structurally invisible
+/// there, no matter how many updates the test drives.
+///
+/// ## The topology this needs
+///
+/// 1 gateway + 3 peers, ALL subscribed, with `max_connections` wide enough for
+/// the peers to connect to each other as well as to the gateway. Every peer
+/// then hosts the contract and announces it (`HostingAnnounce`), so each peer's
+/// advertised co-host set contains the OTHER PEERS, not just the sender. When
+/// a peer applies a relayed broadcast and fires its proactive notification, the
+/// #4965 exclusion now drops real recipients — which is exactly the thing under
+/// test.
+///
+/// ## The general rule this test exists to illustrate
+///
+/// **`delta_sends`/`full_state_sends` cannot see a redundancy being removed —
+/// only a redundancy being removed *badly*.**
+///
+/// That generalises, and it is worth recognising BEFORE writing the test rather
+/// than after: **when a change removes redundancy, every downstream health
+/// metric is invariant by design.** That invariance IS the change's thesis. So
+/// health metrics can never discriminate such a change; only a counter of the
+/// removed thing can.
+///
+/// This is unusually easy to miss, because measuring a redundancy-removal with
+/// downstream health metrics yields a vacuous test AND a confirmation that the
+/// change was correct, simultaneously — the green run looks like evidence for
+/// the change when it is evidence of nothing. Anyone facing this shape should
+/// reach for a counter of the removed thing first.
+///
+/// ## The two assertions do DIFFERENT jobs — measured, not assumed
+///
+/// **`notification_cohosts_skipped > 0` is the sensitivity assertion.** It is
+/// the only signal here that responds to the change at all.
+///
+/// **`delta_sends > full_state_sends` is a safety assertion, NOT a
+/// discriminator, and the numbers say so.** A peer's broadcast to a neighbor is
+/// a delta only while it holds a cached summary for that neighbor; the
+/// standalone `Summaries` notification and the broadcast's own
+/// `sender_summary_bytes` both seed that cache, and #4965 removes the first for
+/// co-hosts on the claim that the second already covers them. The claim holds,
+/// so removing the redundant path changes nothing downstream: reverting the
+/// exclusion on this exact scenario produced **bit-identical** `delta_sends=140
+/// / full_state_sends=6`. That is the change being harmless, which is worth
+/// pinning — but a test resting on it alone would pass whether or not the
+/// feature existed.
+///
+/// So the delta-dominance assertion stays (it catches an over-exclusion that
+/// DID strand peers, which would show up as full-state fallback), and the
+/// skipped-count assertion is what makes the test fail when the exclusion is
+/// removed.
+///
+/// ## Premise checks (without these both assertions are vacuous)
+///
+/// - `neighbor_hosting_updates() > 0`: the peers really exchanged hosting
+///   advertisements. If they never did, no peer has any advertised co-host,
+///   the exclusion removes nobody, and the test degenerates into the star case
+///   it exists to improve on.
+/// - `delta_sends + full_state_sends > 0`: broadcasts actually happened.
+#[test_log::test]
+fn test_cohost_mesh_update_fanout_stays_delta_dominated() {
+    use freenet::dev_tool::{NodeLabel, ScheduledOperation, SimOperation, register_crdt_contract};
+
+    const SEED: u64 = 0x4965_0001_0001;
+    const NETWORK_NAME: &str = "i4965-cohost-mesh";
+    // Three peers so each has TWO non-sender co-hosts; with two, a peer's only
+    // co-host besides the sender is the single other peer, which makes the
+    // exclusion much thinner.
+    const PEERS: usize = 3;
+    const SUSTAINED_UPDATES: usize = 20;
+
+    GlobalTestMetrics::reset();
+    setup_deterministic_state(SEED);
+    let rt = create_runtime();
+
+    let (sim, logs_handle) = rt.block_on(async {
+        let sim = SimNetwork::new(
+            NETWORK_NAME,
+            1,     // 1 gateway (the update source)
+            PEERS, // peers that all subscribe AND co-host
+            7,     // max_htl
+            3,     // rnd_if_htl_above
+            // Wide enough that the peers connect to EACH OTHER, not just to the
+            // gateway. This is the whole point: at a narrower cap a pure star
+            // forms and every peer's only co-host is the sender, reproducing the
+            // blind spot this test exists to cover.
+            10, // max_connections
+            2,  // min_connections
+            SEED,
+        )
+        .await;
+        let logs_handle = sim.event_logs_handle();
+        (sim, logs_handle)
+    });
+
+    // CRDT contract so post-bootstrap broadcasts compute real version-aware
+    // deltas — a plain hash contract's "delta" is full state, which would make
+    // the delta/full crossover meaningless.
+    let contract = SimOperation::create_test_contract(0x49);
+    let contract_id = *contract.key().id();
+    let contract_key = contract.key();
+    register_crdt_contract(contract_id);
+
+    let initial_state = SimOperation::create_crdt_state(1, 0x10);
+    let mut operations = Vec::new();
+
+    operations.push(ScheduledOperation::new(
+        NodeLabel::gateway(NETWORK_NAME, 0),
+        SimOperation::Put {
+            contract: contract.clone(),
+            state: initial_state,
+            subscribe: true,
+        },
+    ));
+    for node_idx in 1..=PEERS {
+        operations.push(ScheduledOperation::new(
+            NodeLabel::node(NETWORK_NAME, node_idx),
+            SimOperation::Subscribe { contract_id },
+        ));
+    }
+
+    for v in 0..SUSTAINED_UPDATES {
+        let version = (v as u64) + 2;
+        operations.push(ScheduledOperation::new(
+            NodeLabel::gateway(NETWORK_NAME, 0),
+            SimOperation::Update {
+                key: contract_key,
+                data: SimOperation::create_crdt_state(version, 0x20 + v as u8),
+            },
+        ));
+    }
+
+    let result = sim.run_controlled_simulation(
+        SEED,
+        operations,
+        Duration::from_secs(240),
+        Duration::from_secs(90),
+    );
+    assert!(
+        result.turmoil_result.is_ok(),
+        "Simulation should complete: {:?}",
+        result.turmoil_result.err()
+    );
+
+    let convergence =
+        rt.block_on(async { freenet::dev_tool::check_convergence_from_logs(&logs_handle).await });
+    let delta_sends = GlobalTestMetrics::delta_sends();
+    let full_state_sends = GlobalTestMetrics::full_state_sends();
+    let hosting_updates = GlobalTestMetrics::neighbor_hosting_updates();
+    let cohosts_skipped = GlobalTestMetrics::notification_cohosts_skipped();
+
+    tracing::info!(
+        "i4965 cohost mesh: delta_sends={}, full_state_sends={}, \
+         neighbor_hosting_updates={}, cohosts_skipped={}, converged={}/{}",
+        delta_sends,
+        full_state_sends,
+        hosting_updates,
+        cohosts_skipped,
+        convergence.converged.len(),
+        convergence.total_contracts(),
+    );
+
+    // PREMISE 1: the peers really registered as each other's co-hosts. Without
+    // this the #4965 exclusion drops nobody and the assertion below is vacuous
+    // — the exact defect that makes the star test unable to guard this change.
+    assert!(
+        hosting_updates > 0,
+        "premise: no hosting advertisements were exchanged, so no peer has an \
+         advertised co-host and the #4965 exclusion is a no-op here. This test \
+         would then prove nothing about the change it guards."
+    );
+
+    // PREMISE 2: broadcasts actually happened.
+    assert!(
+        delta_sends + full_state_sends > 0,
+        "premise: no broadcasts were recorded — the fan-out scenario did not run"
+    );
+
+    // THE DISCRIMINATOR — the assertion that fails when #4965 is reverted.
+    //
+    // Verified by mutation, not assumed: with the co-host filter removed from
+    // `proactive_summary_targets`, this drops to 0 while delta_sends and
+    // full_state_sends stay bit-identical at 140/6. It is the ONLY metric here
+    // that responds to the change.
+    assert!(
+        cohosts_skipped > 0,
+        "#4965 is not doing anything on a topology built specifically to \
+         exercise it: {hosting_updates} hosting advertisements were exchanged, \
+         so peers ARE advertised co-hosts of each other, yet zero recipients \
+         were skipped. Either the exclusion was removed, or it is reading a \
+         co-host set that never matches the notification's recipients."
+    );
+
+    // SAFETY, not a discriminator (see this test's docs): reverting the
+    // exclusion leaves these two numbers unchanged, so this assertion cannot
+    // tell the change apart. It is here to catch the DAMAGING failure — an
+    // over-exclusion that strands peers, which surfaces as full-state fallback.
+    assert!(
+        delta_sends > full_state_sends,
+        "#4965 REGRESSION: co-hosting peers stopped seeding each other's \
+         summaries, so broadcasts fell back to full state: \
+         delta_sends={delta_sends} <= full_state_sends={full_state_sends}. \
+         Either the notification exclusion drops peers the broadcast does NOT \
+         cover, or the broadcast that was supposed to carry \
+         `sender_summary_bytes` never ran for them."
+    );
+
+    assert!(
+        convergence.is_converged(),
+        "#4965: peers failed to converge under sustained fan-out. \
+         {} converged, {} diverged",
+        convergence.converged.len(),
+        convergence.diverged.len(),
+    );
+}
+
 // =============================================================================
 // #4233: Event-loop liveness under wide-star sustained UPDATE fan-out
 // =============================================================================


### PR DESCRIPTION
## Problem

`outbound_message_mix` (the 0.2.110 census, #4957) now has field data on 0.2.112, and **InterestSync is 52-55% of all outbound message bytes — more than the contract updates it exists to support.**

Re-derived on two non-overlapping rotated log files, 0.2.112 only:

| file | node-h | isync MB/h/node | share | B/msg | update MB/h/node | total MB/h/node |
|---|---|---|---|---|---|---|
| `…07-28T11-32` | 3,042 | 83.0 | 54.5% | 24,215 | 61.1 | 152.4 |
| `…07-28T06-22` | 2,752 | 105.6 | 52.2% | 28,143 | 88.4 | 202.4 |

#4965 filed this measurement but attributed it to the ~5-min InterestSync heartbeat. **It is not the heartbeat.** 10.9M InterestSync messages over 3,042 node-hours is 3,594 per node-hour — roughly 15x what a 300 s cadence over ~20 connections can emit.

Bucketing 60 s windows by their UPDATE message count measures the heartbeat floor directly rather than assuming a connection count. Windows with **zero** UPDATE messages are pure heartbeat:

| updates in window | windows | upd msgs/h | isync msgs/h | isync MB/h | isync per upd |
|---|---|---|---|---|---|
| 0 | 61,451 | 0 | 482 | 16.3 | — |
| 1–5 | 30,431 | 124 | 1,322 | 54.2 | 10.63 |
| 6–20 | 19,405 | 729 | 2,104 | 62.0 | 2.89 |
| 21–100 | 39,764 | 3,030 | 4,720 | 108.0 | 1.56 |
| >100 | 22,934 | 12,894 | 15,248 | 293.1 | 1.18 |

**Pearson r(update_msgs, interest_sync_msgs) per 60 s window = 0.924** (N=173,985; 0.880 on the second file). The heartbeat is the 16.3 MB/h floor, about a fifth. The other ~80% scales with the update rate.

## Approach

The emitter is `send_proactive_summary_notification`, which fires on every successful state change and fans our full summary out to **every** peer in `get_interested_peers`, excluding only the sender and self. Its only limit is a 100 ms per-contract throttle (up to 10/s/contract), which is not a bound at fleet update rates.

Most of those recipients are advertised co-hosts — i.e. exactly the broadcast fan-out targets, which `get_broadcast_targets_update` sources from `neighbor_hosting::neighbors_with_contract`. **The broadcast already carries this same summary** in `sender_summary_bytes` (`broadcast_queue.rs:1043` streaming, `:1207` non-streaming, both from `our_summary`), and the receiver upserts it into its cache of us on arrival — `drive_relay_broadcast_to` step 1 and `apply_streaming_broadcast` step 4, the #4952 upsert. Both the delta and full-state arms carry it.

So for every co-host we were paying ~24 KB to re-send, as a standalone message, a summary that peer had received moments earlier inside the broadcast.

This PR skips advertised co-hosts in the notification fan-out. **No wire-format change, no new message.**

The notification keeps doing its real job for the population it is actually needed for: interested peers we do **not** advertise-host toward, whose only other path to our summary is the heartbeat. Those two target sets are maintained by independent mechanisms (`neighbor_hosting` vs `interest_manager`), but not disjointly in the direction that matters — `record_delivery_to_interest` upserts every successfully-delivered broadcast target into `interested_peers`, so broadcast targets are a subset of notification targets.

**Recipient set** (per `.claude/rules/operations.md`, "Event emission review"): interested peers, minus the update's sender, minus self, minus every advertised co-host. The event is `NodeEvent::SendInterestMessage { target }` — targeted, one per remaining peer, never a fan-out variant.

### Failure mode considered

If a broadcast is dropped rather than delivered, the excluded co-host misses this summary — but it also missed the state itself, and the ~5-min heartbeat anti-entropy is the designated backstop for exactly that case. This mirrors `record_delivery_to_interest`, which likewise only seeds on a real delivery (#4235).

## Expected effect

The redundant share is the ratio between the two target sets. The fleet-wide 1.5 isync-per-update *message* ratio is consistent with roughly two-thirds redundancy, but that maps UPDATE messages to fan-out targets loosely, so I am **not** claiming a precise number. A per-window counter of "notification targets that were also broadcast targets" would pin it exactly and is worth adding alongside #4979. The 0.2.110 census will measure the actual delta on the next release regardless — `interest_sync_bytes` is already reported per node-minute.

## Testing

The recipient-set decision is split into a pure `proactive_summary_targets` so the emitted event's targets are asserted **directly** rather than inferred from the data layer that feeds it — the #3791 failure mode the operations rule calls out, where a data-layer-only test stays green after the dispatch site is reverted.

Six unit tests: co-host exclusion, the non-co-host population being preserved, sender/self exclusion surviving the change, the all-co-hosts collapse to zero messages, the empty set, and that exclusion is by `pub_key` not address (matching how `get_broadcast_targets_update` sources targets).

Plus a source-scrape pin, `proactive_notification_excludes_advertised_cohosts_in_production`, holding the production emitter to consulting the advertisement layer and routing through the helper. It cuts at `mod tests` (not `#[cfg(test)]`) and matches whitespace-stripped source so it survives rustfmt and cannot match itself.

**Mutation-tested, both directions:**
- removing the `neighbors_with_contract` lookup → pin fails ("MUST consult the advertisement layer")
- keeping the lookup but bypassing the helper → pin fails ("MUST route its recipient set through proactive_summary_targets")

(The first attempt at the second mutation silently failed to apply because rustfmt had reflowed the anchor; re-run against the real source. A mutation that doesn't apply looks exactly like a passing pin.)

Full `cargo test -p freenet --lib`: **4,348 passed, 0 failed**. `cargo clippy -p freenet --lib` clean; the 10 `--all-targets` clippy errors are pre-existing on the base commit (verified) in `websocket.rs`, `op_ctx_task.rs`, `contract_store.rs` — the backlog PR #4925 covers them.

## Reviewer notes

Risk tier: **Full** — this touches the broadcast/hosting surface. Review has not been run yet; this is a draft pending that.

Hosting invariants touched: **invariant 1** (freshness as a two-layer live-fan-out + anti-entropy mechanism). The change removes a redundant metadata message only; the state fan-out is untouched and still carries the summary, so no copy becomes less fresh and no read is served from a staler copy.

**Separately noted, not fixed here:** when `our_summary` is `None`, both broadcast paths send `unwrap_or_default()` — an empty `sender_summary_bytes` — which the receiver upserts as our summary, poisoning its cache of us with an empty `StateSummary`. That is pre-existing and orthogonal (the notification path returns early in the same condition, so this PR doesn't change its exposure), but it looks worth its own issue.

Refs #4965

[AI-assisted - Claude]
