### PR TITLE
perf(secrets): skip no-op snapshots and cap history by bytes

### DIFF
--- a/crates/core/src/bin/commands/secrets_cmd.rs
+++ b/crates/core/src/bin/commands/secrets_cmd.rs
@@ -751,10 +751,18 @@ async fn snapshot_restore(args: SnapshotRestoreArgs) -> Result<()> {
             // Bound the history (incl. the reversibility snapshot just
             // added), matching the node runtime's default retention.
             // Best-effort: the restore has already succeeded.
+            //
+            // The per-secret BYTE budget is deliberately not applied here,
+            // exactly as in `SecretsStore::restore_snapshot`: an operator
+            // running `snapshot-restore` is mid-recovery and often walking
+            // versions one at a time, so this is the worst moment to delete
+            // history — the budget could evict several older versions,
+            // including the one just restored from, as a side effect of the
+            // reversibility snapshot. Count tiers and `max_age` still apply.
             let snap_dir = snapshot_dir_for_encoded(&delegate_dir, &args.secret);
             thin_snapshots(
                 &snap_dir,
-                &RetentionPolicy::default(),
+                &RetentionPolicy::default().without_byte_budget(),
                 std::time::SystemTime::now(),
             );
             println!(

--- a/crates/core/src/bin/commands/secrets_cmd.rs
+++ b/crates/core/src/bin/commands/secrets_cmd.rs
@@ -1504,6 +1504,66 @@ mod tests {
         assert!(count >= 2, "expected reversibility snapshot, got {count}");
     }
 
+    /// `snapshot-restore` must NOT apply the per-secret byte budget. An
+    /// operator running it is mid-recovery, often walking versions one at a
+    /// time, so this is the worst moment to garbage-collect: with the budget
+    /// applied, the reversibility snapshot the restore itself adds would push
+    /// an already-over-budget history over the limit and evict older
+    /// versions, including the one just restored FROM.
+    #[tokio::test]
+    async fn snapshot_restore_does_not_apply_byte_budget() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let now_ms = (std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64)
+            - 60_000;
+        // Four 1 MiB snapshots: 4 MiB of history against the 3 MiB default
+        // budget, so applying the budget here would visibly evict.
+        const MIB: usize = 1024 * 1024;
+        seed_snapshot(
+            dir.path(),
+            "D",
+            "S",
+            b"current",
+            now_ms - 4000,
+            &vec![1u8; MIB],
+        );
+        let snap_dir = dir.path().join("D").join(".snapshots").join("S");
+        for (i, stamp) in [now_ms - 3000, now_ms - 2000, now_ms - 1000]
+            .into_iter()
+            .enumerate()
+        {
+            std::fs::write(
+                snap_dir.join(format!("{stamp:020}")),
+                vec![2u8 + i as u8; MIB],
+            )
+            .unwrap();
+        }
+        assert_eq!(std::fs::read_dir(&snap_dir).unwrap().count(), 4);
+
+        snapshot_restore(restore_args(dir.path(), "D", "S", now_ms - 4000, true))
+            .await
+            .expect("restore must succeed");
+
+        // 4 seeded + 1 reversibility snapshot, none evicted.
+        assert_eq!(
+            std::fs::read_dir(&snap_dir).unwrap().count(),
+            5,
+            "restore must not evict history for the byte budget"
+        );
+        // The snapshot restored FROM is still there, so the operator can keep
+        // walking versions.
+        assert!(
+            snap_dir.join(format!("{:020}", now_ms - 4000)).exists(),
+            "the snapshot just restored from must survive"
+        );
+        assert_eq!(
+            std::fs::read(dir.path().join("D").join("S")).unwrap(),
+            vec![1u8; MIB]
+        );
+    }
+
     #[tokio::test]
     async fn snapshot_restore_unknown_timestamp_errors() {
         let dir = tempfile::tempdir().expect("tempdir");

--- a/crates/core/src/wasm_runtime/secret_snapshots.rs
+++ b/crates/core/src/wasm_runtime/secret_snapshots.rs
@@ -85,18 +85,22 @@ pub const DEFAULT_MAX_SNAPSHOT_BYTES_PER_SECRET: u64 = 3 * 1024 * 1024;
 /// want. Three is the smallest count that gives a real walk-back window, and
 /// it is cheap where it binds:
 ///
-/// - At the default 3 MiB budget the floor is INERT for any secret up to
-///   1 MiB, because three of those versions already fit inside the budget.
-///   It only takes effect for the genuinely large values (a ~1 MiB River
-///   room state and up) — exactly the case where the budget is aggressive
-///   and a one-entry history would be thinnest.
+/// - At the default 3 MiB budget the floor is INERT for any secret UNDER
+///   ~1 MiB, because three of those versions already fit inside the budget.
+///   Precisely: a snapshot costs `HEADER_LEN + plaintext + TAG_LEN` = 41
+///   bytes of overhead, so three fit iff `3 x (n + 41) <= 3_145_728`, i.e.
+///   plaintext `n <= 1_048_535` bytes. At exactly 1 MiB (1_048_576) the
+///   floor already binds. So it takes effect only for the genuinely large
+///   values (a ~1 MiB River room state and up) — exactly the case where the
+///   budget is aggressive and a one-entry history would be thinnest.
 /// - Worst case it retains `3 x largest_snapshot` rather than an unbounded
 ///   count, so it cannot reintroduce the version-count blowup this budget
 ///   exists to fix.
 ///
-/// Deliberately not 5 (matching `keep_last`): that would make the floor bind
-/// for every secret over ~600 KiB and raise the worst case to 5x, buying two
-/// more versions of the values that cost the most to keep.
+/// Deliberately not 5 (matching `keep_last`): by the same arithmetic that
+/// would bind for every secret over ~614 KiB (`n > 629_104`) and raise the
+/// worst case to 5x, buying two more versions of the values that cost the
+/// most to keep.
 ///
 /// Note this floor is what makes the budget's guarantee "at most
 /// `max(max_total_bytes, 3 x largest snapshot)`", not a hard byte cap.
@@ -166,6 +170,19 @@ pub struct RetentionPolicy {
     /// Applied to the size the entries actually occupy on disk, so it bounds
     /// disk directly rather than proxying it through a version count.
     ///
+    /// **Beware the `0` asymmetry when constructing this directly.**
+    /// `Some(0)` here is the MOST aggressive budget there is — zero bytes
+    /// allowed, so eviction runs until it hits the floor. Setting
+    /// [`SNAPSHOT_BUDGET_ENV`] to the string `"0"` means the OPPOSITE:
+    /// [`parse_snapshot_budget`] maps it to `None`, i.e. no budget at all.
+    /// The env spelling is the operator-facing "turn this off" switch (an
+    /// operator typing `0` means "no limit", not "limit of nothing"), while
+    /// the field is the internal numeric bound and `Some(0)` is its natural
+    /// extreme. Tests rely on the aggressive `Some(0)` reading. If you add a
+    /// constructor that takes a byte count from anywhere operator-facing,
+    /// route it through [`parse_snapshot_budget`] rather than wrapping it in
+    /// `Some` yourself.
+    ///
     /// **This clause is RETROACTIVE.** Unlike the count tiers, which a node
     /// upgrading into them satisfies gradually, the first thinning pass after
     /// this field starts being set collapses an existing over-budget history
@@ -218,11 +235,6 @@ pub fn parse_snapshot_budget(raw: Option<&str>) -> Option<u64> {
     }
 }
 
-/// [`parse_snapshot_budget`] applied to the live process environment.
-fn snapshot_budget_from_env() -> Option<u64> {
-    parse_snapshot_budget(std::env::var(SNAPSHOT_BUDGET_ENV).ok().as_deref())
-}
-
 impl Default for RetentionPolicy {
     /// Default: keep the last 5 snapshots, plus one per minute for the last
     /// 10 minutes, one per hour for the last 24 hours, one per day for the
@@ -234,10 +246,12 @@ impl Default for RetentionPolicy {
     /// `max(budget, MIN_SNAPSHOTS_KEPT_UNDER_BUDGET x largest snapshot)` of
     /// disk.
     ///
-    /// Reads [`SNAPSHOT_BUDGET_ENV`] for the byte budget, mirroring how
-    /// `SecretsStore::new` reads `FREENET_DISABLE_SECRET_SNAPSHOTS`. Every
-    /// other field is a compile-time constant, so this is the only reason
-    /// two `default()` values can differ within a process.
+    /// PURE: every field is a compile-time constant, so two `default()`
+    /// values are always identical. The operator override lives in
+    /// [`RetentionPolicy::from_env`], deliberately NOT here — a `Default`
+    /// impl that read `environ` would make every `SecretsStore` construction
+    /// a `getenv`, which is a data race against any `setenv` in the same
+    /// process (and unit tests are exactly where `setenv` happens).
     fn default() -> Self {
         const MIN: u64 = 60;
         const HOUR: u64 = 60 * MIN;
@@ -278,30 +292,85 @@ impl Default for RetentionPolicy {
             // Bounds the DISK the count tiers above would otherwise leave
             // unbounded: 62 versions is cheap for a small secret and ~62 MiB
             // for a ~1 MiB one. See the constant's docs for the sizing, and
-            // `SNAPSHOT_BUDGET_ENV` for the operator override.
-            max_total_bytes: snapshot_budget_from_env(),
+            // `Self::from_env` for the operator override.
+            max_total_bytes: Some(DEFAULT_MAX_SNAPSHOT_BYTES_PER_SECRET),
         }
     }
 }
 
 impl RetentionPolicy {
+    /// [`Self::default`] with the byte budget taken from a raw
+    /// [`SNAPSHOT_BUDGET_ENV`] string, per [`parse_snapshot_budget`].
+    ///
+    /// Split out from [`Self::from_env`] so the override is testable without
+    /// touching process-global `environ`: `setenv` races every concurrent
+    /// `getenv` in the process, and in a lib-test binary those `getenv`s are
+    /// other tests constructing stores. Tests call this; only `from_env`
+    /// reads the environment.
+    pub fn with_budget_from(raw: Option<&str>) -> Self {
+        Self {
+            max_total_bytes: parse_snapshot_budget(raw),
+            ..Self::default()
+        }
+    }
+
+    /// [`Self::default`] with the operator's [`SNAPSHOT_BUDGET_ENV`] override
+    /// applied.
+    ///
+    /// This is the ONLY place in this module that reads the environment, and
+    /// it has no test that mutates `environ` — see [`Self::with_budget_from`]
+    /// for why. Production stores are built from this (see
+    /// `SecretsStore::new`); anything that thins with a real byte budget
+    /// should use it rather than [`Self::default`], or the operator's
+    /// override silently stops applying.
+    pub fn from_env() -> Self {
+        Self::with_budget_from(std::env::var(SNAPSHOT_BUDGET_ENV).ok().as_deref())
+    }
+
     /// This policy with the byte budget removed; the count tiers and
     /// `max_age` are untouched.
     ///
     /// Used by the RECOVERY path (`SecretsStore::restore_snapshot` and
     /// `freenet secrets snapshot-restore`). A restore is what an operator
-    /// runs when they are trying to get a value back, often walking versions
-    /// one at a time, and it is the worst possible moment to garbage-collect
-    /// history: applying the budget there could evict several older versions
-    /// — including the one just restored FROM — as a side effect of the
-    /// reversibility snapshot the restore itself adds. The budget is a
-    /// disk-pressure heuristic, and a manual restore is not disk pressure.
+    /// runs when they are trying to get a value back, and it is the worst
+    /// possible moment to garbage-collect history: applying the budget there
+    /// could evict several older versions — including the one just restored
+    /// FROM — as a side effect of the reversibility snapshot the restore
+    /// itself adds. The budget is a disk-pressure heuristic, and a manual
+    /// restore is not disk pressure.
     ///
     /// This is not an unbounded cleanup exemption: `max_age` still applies at
-    /// the restore, so every entry keeps a finite lifetime, and the next
-    /// ordinary `store_secret` for that secret applies the budget in full.
-    /// The effect is that this PR leaves the restore path's thinning
-    /// behaviour byte-for-byte what it was before the budget existed.
+    /// the restore, so every entry keeps a finite lifetime, and the exemption
+    /// is per-CALL, not a property stamped on the history.
+    ///
+    /// # How long the exemption actually holds
+    ///
+    /// Be precise about this, because the two restore entry points differ:
+    ///
+    /// - **`freenet secrets snapshot-restore` (the operator-facing path):**
+    ///   the exemption holds for as long as the operator needs. The CLI
+    ///   requires the node to be STOPPED (see `docs/secrets-at-rest.md`), so
+    ///   no delegate write can intervene, and an operator can list, restore,
+    ///   inspect, and restore again across the full retained history.
+    ///
+    /// - **`SecretsStore::restore_snapshot` (the in-process API):** the
+    ///   exemption lasts only until the next `store_secret` for that secret.
+    ///   `store_secret` thins with the FULL policy on every call — it is
+    ///   gated on whether snapshots are enabled, not on whether this
+    ///   particular write took a snapshot — so a live node whose delegate
+    ///   touches that secret collapses the restored history to the floor,
+    ///   including on one of the identical re-writes that skip snapshotting.
+    ///   Do NOT read this method as buying a working window on a live node.
+    ///   (Today that API has no production callers; it is exercised by tests
+    ///   and available to embedders.)
+    ///
+    /// Gating `store_secret`'s thin on `needs_snapshot` — i.e. not
+    /// garbage-collecting on a write that adds nothing to the history —
+    /// would widen the live-node window. It is deliberately NOT done here:
+    /// it is a real semantic change to when reclaim happens, the supported
+    /// recovery procedure is the stopped-node CLI where it buys nothing, and
+    /// a write that skips its snapshot still leaves a history that the
+    /// operator's configured budget says is too large.
     pub fn without_byte_budget(&self) -> Self {
         Self {
             max_total_bytes: None,
@@ -1217,53 +1286,55 @@ mod tests {
         }
     }
 
-    /// `RetentionPolicy::default()` must actually CONSULT the environment
-    /// rather than hardcoding the constant. This is the wiring pin for the
-    /// operator override; the parsing itself is covered above.
+    /// The operator override must flow through to the policy. Pure: takes
+    /// the raw env string rather than touching process-global `environ`, so
+    /// nothing here races the `getenv` in `RetentionPolicy::from_env`.
     #[test]
-    fn default_policy_reads_the_budget_env() {
-        use std::sync::Mutex as StdMutex;
-        // Serializes this test against its own re-entry only; the real
-        // cross-test isolation is nextest's per-process model (see the
-        // SAFETY notes below). The override value is deliberately a LARGE
-        // finite budget, so a concurrent `default()` under a plain
-        // multi-threaded `cargo test` sees a still-bounded policy rather
-        // than an unbounded or 0-byte one.
-        static ENV_GUARD: StdMutex<()> = StdMutex::new(());
-        let _g = ENV_GUARD.lock().unwrap_or_else(|p| p.into_inner());
+    fn with_budget_from_applies_the_override() {
+        // Unset behaves exactly like `default()`.
+        assert_eq!(
+            RetentionPolicy::with_budget_from(None).max_total_bytes,
+            Some(DEFAULT_MAX_SNAPSHOT_BYTES_PER_SECRET)
+        );
+        // An explicit byte count is honoured...
+        assert_eq!(
+            RetentionPolicy::with_budget_from(Some("7340032")).max_total_bytes,
+            Some(7 * 1024 * 1024)
+        );
+        // ...an explicit `0` disables the budget...
+        assert_eq!(
+            RetentionPolicy::with_budget_from(Some("0")).max_total_bytes,
+            None
+        );
+        // ...and garbage degrades to the bounded default.
+        assert_eq!(
+            RetentionPolicy::with_budget_from(Some("three megabytes")).max_total_bytes,
+            Some(DEFAULT_MAX_SNAPSHOT_BYTES_PER_SECRET)
+        );
+    }
 
-        let prev = std::env::var(SNAPSHOT_BUDGET_ENV).ok();
+    /// The override must change only the budget — a policy built from an
+    /// env value keeps every count tier and the age cap.
+    #[test]
+    fn with_budget_from_touches_only_the_budget() {
+        let d = RetentionPolicy::default();
+        let overridden = RetentionPolicy::with_budget_from(Some("4096"));
+        assert_eq!(overridden.max_total_bytes, Some(4096));
+        assert_eq!(overridden.keep_last, d.keep_last);
+        assert_eq!(overridden.max_age, d.max_age);
+        assert_eq!(overridden.buckets, d.buckets);
+    }
 
-        // SAFETY: `set_var`/`remove_var` are unsound only under CONCURRENT
-        // env access. CI runs these lib tests under `cargo nextest`, which
-        // executes each test in its own process, so nothing else mutates
-        // `environ` while this test runs; the prior value is restored at the
-        // end. (`ENV_GUARD` only serializes this test against its own
-        // re-entry, so under a plain multi-threaded `cargo test` this is
-        // best-effort — nextest's per-process isolation is the guarantee.)
-        unsafe { std::env::remove_var(SNAPSHOT_BUDGET_ENV) };
+    /// `default()` is PURE — no environment read. If it ever starts
+    /// consulting `environ` again, every `SecretsStore` construction becomes
+    /// a `getenv` racing any `setenv` in the process.
+    #[test]
+    fn default_policy_is_pure() {
         assert_eq!(
             RetentionPolicy::default().max_total_bytes,
             Some(DEFAULT_MAX_SNAPSHOT_BYTES_PER_SECRET),
-            "unset env must yield the built-in default"
+            "default() must be the built-in constant, independent of the environment"
         );
-
-        // SAFETY: as above — nextest runs this test in its own process; the
-        // prior value is restored below.
-        unsafe { std::env::set_var(SNAPSHOT_BUDGET_ENV, "7340032") };
-        assert_eq!(
-            RetentionPolicy::default().max_total_bytes,
-            Some(7 * 1024 * 1024),
-            "default() must read the operator override, not a hardcoded constant"
-        );
-
-        // SAFETY: as above — restoring the environment to its prior state.
-        unsafe {
-            match prev {
-                Some(v) => std::env::set_var(SNAPSHOT_BUDGET_ENV, v),
-                None => std::env::remove_var(SNAPSHOT_BUDGET_ENV),
-            }
-        }
     }
 
     // ===== recovery-path exemption =====
@@ -1298,10 +1369,7 @@ mod tests {
     #[test]
     fn default_policy_bounds_bytes_per_secret() {
         let p = RetentionPolicy::default();
-        // Read the budget off the policy rather than the constant: under a
-        // plain multi-threaded `cargo test`, `default_policy_reads_the_budget_env`
-        // may have the override set. It only ever sets a LARGE FINITE value,
-        // so the bound below still holds and stays non-vacuous.
+        // `default()` is pure (no environment read), so this is deterministic.
         let budget = p
             .max_total_bytes
             .expect("default policy must carry a byte budget");

--- a/crates/core/src/wasm_runtime/secret_snapshots.rs
+++ b/crates/core/src/wasm_runtime/secret_snapshots.rs
@@ -1,13 +1,18 @@
 //! Tiered retention thinning for delegate secret snapshots.
 //!
 //! Each `(delegate, secret_id)` pair has its own snapshot history. Before a
-//! `store_secret` overwrites an existing value, the previous ciphertext is
-//! moved into a `.snapshots/{secret_id}/{epoch_ms}` file. Retention is then
-//! thinned per the policy below: recent history stays dense, older history
-//! is sampled at progressively coarser intervals (minute / hour / day /
-//! week / month), and an absolute `max_age` cap drops anything older
-//! regardless of which clause selected it. Worst case ~62 entries per
-//! secret in steady state.
+//! `store_secret` overwrites an existing value with DIFFERENT content, the
+//! previous ciphertext is moved into a `.snapshots/{secret_id}/{epoch_ms}`
+//! file. (A write that leaves the plaintext unchanged is skipped — see
+//! `SecretsStore::active_plaintext_matches` — since a second, differently-
+//! nonced copy of a value we already hold buys no recovery.) Retention is
+//! then thinned per the policy below: recent history stays dense, older
+//! history is sampled at progressively coarser intervals (minute / hour /
+//! day / week / month), an absolute `max_age` cap drops anything older
+//! regardless of which clause selected it, and a per-secret
+//! `max_total_bytes` budget drops the oldest survivors until the retained
+//! history fits on disk. Worst case ~62 entries per secret in steady state,
+//! and at most ~`max_total_bytes` of disk for any one secret.
 //!
 //! Snapshots are encrypted with whatever cipher the delegate had configured
 //! when the snapshot was taken; without that cipher the bytes are useless.
@@ -47,6 +52,42 @@ pub const SNAPSHOT_NAME_WIDTH: usize = 20;
 /// caller can log instead of silently overwriting an existing snapshot.
 const MAX_SNAPSHOT_COLLISION_SUFFIX: u32 = 1024;
 
+/// Default per-secret byte budget for retained snapshot history
+/// ([`RetentionPolicy::max_total_bytes`]).
+///
+/// The count-based tiers alone are unbounded in BYTES: ~62 retained
+/// versions costs a few hundred KiB for a small secret and ~62 MiB for a
+/// ~1 MiB one. Measured on a production peer, 130 MB of snapshots guarded
+/// 6.8 MB of live secrets (19x), and a SINGLE ~1 MiB River room-state
+/// secret accounted for 30.7 MB of that across 34 versions.
+///
+/// 3 MiB is the compromise:
+/// - Small secrets (bytes to low-KiB) never come near it, so they keep the
+///   full tiered history — deep history is nearly free there, and it is
+///   where an operator most plausibly wants to walk back several versions.
+/// - A ~1 MiB room state gets ~3 versions instead of ~30, which still
+///   covers the case snapshots exist for (undo an accidental or buggy
+///   overwrite) at a tenth of the disk.
+/// - Even at the cap, one secret's history is ~2x the ENTIRE live secret
+///   footprint of a measured production gateway (1.6 MB), so the budget is
+///   generous in absolute terms.
+///
+/// Note this is a PER-SECRET bound, so a node's total snapshot footprint is
+/// still `keys x 3 MiB` in the worst case; bounding the aggregate would need
+/// a cross-secret sweep, which is deliberately out of scope here.
+pub const DEFAULT_MAX_SNAPSHOT_BYTES_PER_SECRET: u64 = 3 * 1024 * 1024;
+
+/// Floor on how many snapshots the byte budget is allowed to leave behind.
+///
+/// The budget evicts oldest-first, but it must never empty the history: the
+/// newest snapshot is the value that the most recent write overwrote, i.e.
+/// exactly what "undo the last write" needs. So a single secret larger than
+/// the whole budget keeps one version and exceeds the budget, rather than
+/// silently having no recoverable history at all. Deleting user data to
+/// satisfy a disk heuristic is the failure mode this floor exists to
+/// prevent.
+const MIN_SNAPSHOTS_KEPT_UNDER_BUDGET: usize = 1;
+
 /// One tier of a [`RetentionPolicy`]: aim to keep one snapshot per
 /// `interval` of clock time, up to `max_count` snapshots in this tier.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -70,11 +111,17 @@ pub struct SnapshotMetadata {
 
 /// Tiered retention policy. The first `keep_last` snapshots (by recency) are
 /// kept regardless of bucket coverage; each bucket independently selects
-/// representatives at its own granularity; and `max_age` is an absolute
-/// upper bound that drops snapshots older than the threshold even if a
-/// recency or bucket clause would otherwise keep them. The absolute cap
-/// satisfies the cleanup-exemption rule in AGENTS.md: every retained
-/// entry has a finite lifetime.
+/// representatives at its own granularity; `max_age` is an absolute upper
+/// bound that drops snapshots older than the threshold even if a recency or
+/// bucket clause would otherwise keep them; and `max_total_bytes` is a
+/// per-secret disk budget that drops the oldest survivors of all of the
+/// above until the retained history fits. The absolute age cap satisfies the
+/// cleanup-exemption rule in AGENTS.md: every retained entry has a finite
+/// lifetime.
+///
+/// Every clause is subtractive: the count tiers propose a keep-set, and
+/// `max_age` / `max_total_bytes` only ever remove from it. Nothing here can
+/// resurrect a snapshot another clause dropped.
 #[derive(Debug, Clone)]
 pub struct RetentionPolicy {
     pub keep_last: usize,
@@ -85,6 +132,16 @@ pub struct RetentionPolicy {
     /// `Some(d)` drops snapshots older than `now - d` regardless of which
     /// clause would have kept them.
     pub max_age: Option<Duration>,
+    /// Upper bound, in bytes, on the total on-disk size of the snapshots
+    /// retained for ONE secret. `None` disables the budget (the count tiers
+    /// then bound the number of versions but not their size, which is what
+    /// let a ~1 MiB secret accumulate ~30 MiB of history). `Some(n)` drops
+    /// the OLDEST otherwise-retained snapshots until the rest fit in `n`,
+    /// never going below [`MIN_SNAPSHOTS_KEPT_UNDER_BUDGET`].
+    ///
+    /// Applied to the size the entries actually occupy on disk, so it bounds
+    /// disk directly rather than proxying it through a version count.
+    pub max_total_bytes: Option<u64>,
 }
 
 impl Default for RetentionPolicy {
@@ -92,8 +149,10 @@ impl Default for RetentionPolicy {
     /// 10 minutes, one per hour for the last 24 hours, one per day for the
     /// last week, one per week for the last 4 weeks, one per month for the
     /// last 12 months, with an absolute 2-year ceiling so stale snapshots
-    /// from secrets that stopped being written eventually age out. Worst
-    /// case ~62 entries per secret in steady state.
+    /// from secrets that stopped being written eventually age out, and a
+    /// [`DEFAULT_MAX_SNAPSHOT_BYTES_PER_SECRET`] disk budget on top. Worst
+    /// case ~62 entries per secret in steady state, and never more than the
+    /// byte budget (plus the one-snapshot floor) of disk.
     fn default() -> Self {
         const MIN: u64 = 60;
         const HOUR: u64 = 60 * MIN;
@@ -131,6 +190,10 @@ impl Default for RetentionPolicy {
             // ciphertext from secrets the user stopped writing to ages
             // out instead of lingering forever.
             max_age: Some(Duration::from_secs(2 * YEAR)),
+            // Bounds the DISK the count tiers above would otherwise leave
+            // unbounded: 62 versions is cheap for a small secret and ~62 MiB
+            // for a ~1 MiB one. See the constant's docs for the sizing.
+            max_total_bytes: Some(DEFAULT_MAX_SNAPSHOT_BYTES_PER_SECRET),
         }
     }
 }
@@ -184,6 +247,51 @@ impl RetentionPolicy {
                     .map(|age| age <= max_age)
                     .unwrap_or(true)
             });
+        }
+
+        keep
+    }
+
+    /// [`Self::select_keep`] plus the [`Self::max_total_bytes`] disk budget.
+    ///
+    /// `entries` is `(timestamp, size_bytes)` sorted ASCENDING by timestamp
+    /// (same contract as `select_keep`'s `timestamps`); the returned indices
+    /// are into `entries`. Everything `select_keep` already dropped stays
+    /// dropped — the budget only ever removes MORE, so a snapshot excluded
+    /// by `max_age` can never be resurrected by having spare byte budget.
+    ///
+    /// Eviction order is OLDEST-first, because the newest snapshot is the
+    /// value the most recent write replaced and is what an operator undoing
+    /// a bad overwrite reaches for. The floor at
+    /// [`MIN_SNAPSHOTS_KEPT_UNDER_BUDGET`] means a secret whose single
+    /// version is larger than the whole budget keeps that version and
+    /// overshoots the budget, rather than being left with no history: the
+    /// budget is a disk heuristic and must never be the reason user data
+    /// stops being recoverable.
+    pub fn select_keep_within_budget(
+        &self,
+        now: SystemTime,
+        entries: &[(SystemTime, u64)],
+    ) -> BTreeSet<usize> {
+        let timestamps: Vec<SystemTime> = entries.iter().map(|(ts, _)| *ts).collect();
+        let mut keep = self.select_keep(now, &timestamps);
+
+        let Some(budget) = self.max_total_bytes else {
+            return keep;
+        };
+
+        let mut total = keep
+            .iter()
+            .fold(0u64, |acc, &i| acc.saturating_add(entries[i].1));
+        // `BTreeSet<usize>` iterates ascending, and `entries` is sorted
+        // oldest-first, so this walks candidates from oldest to newest.
+        let oldest_first: Vec<usize> = keep.iter().copied().collect();
+        for i in oldest_first {
+            if total <= budget || keep.len() <= MIN_SNAPSHOTS_KEPT_UNDER_BUDGET {
+                break;
+            }
+            keep.remove(&i);
+            total = total.saturating_sub(entries[i].1);
         }
 
         keep
@@ -245,16 +353,17 @@ pub fn next_snapshot_path(snap_dir: &Path) -> std::io::Result<PathBuf> {
     ))
 }
 
-/// Apply the retention policy to a snapshot directory: delete any file
-/// whose timestamp is not selected by `policy` relative to `now`. Files
-/// whose names don't parse as `{epoch_ms}` (with optional `.{counter}`
-/// suffix) and non-regular-file entries are left untouched.
+/// Apply the retention policy to a snapshot directory: delete any file the
+/// `policy` does not select relative to `now`, counting both its timestamp
+/// (count tiers + `max_age`) and its on-disk size (`max_total_bytes`).
+/// Files whose names don't parse as `{epoch_ms}` (with optional
+/// `.{counter}` suffix) and non-regular-file entries are left untouched.
 ///
 /// Best-effort: I/O errors during enumeration or unlink are logged but
 /// do not propagate, since thinning is a maintenance operation that must
 /// never fail the primary write path.
 pub fn thin_snapshots(snap_dir: &Path, policy: &RetentionPolicy, now: SystemTime) {
-    let mut entries: Vec<(SystemTime, PathBuf)> = match fs::read_dir(snap_dir) {
+    let mut entries: Vec<(SystemTime, u64, PathBuf)> = match fs::read_dir(snap_dir) {
         Ok(rd) => rd
             .filter_map(|res| match res {
                 Ok(entry) => Some(entry),
@@ -274,7 +383,21 @@ pub fn thin_snapshots(snap_dir: &Path, policy: &RetentionPolicy, now: SystemTime
                 }
                 let path = entry.path();
                 let stamp = parse_snapshot_stamp(&path)?;
-                Some((UNIX_EPOCH + Duration::from_millis(stamp), path))
+                // A stat failure is charged as 0 bytes: it makes the entry
+                // free against `max_total_bytes`, so it is RETAINED and some
+                // other (measurable) entry is evicted instead. Erring toward
+                // keeping is the right default for a best-effort disk
+                // heuristic operating on user data.
+                let size = match entry.metadata() {
+                    Ok(md) => md.len(),
+                    Err(err) => {
+                        tracing::debug!(
+                            "failed to stat snapshot {path:?}: {err}; charging 0 bytes"
+                        );
+                        0
+                    }
+                };
+                Some((UNIX_EPOCH + Duration::from_millis(stamp), size, path))
             })
             .collect(),
         Err(err) => {
@@ -282,11 +405,16 @@ pub fn thin_snapshots(snap_dir: &Path, policy: &RetentionPolicy, now: SystemTime
             return;
         }
     };
-    entries.sort_by_key(|(ts, _)| *ts);
+    // Total order, not just by timestamp: same-millisecond collision entries
+    // share a stamp, and the byte budget evicts oldest-first, so the tie has
+    // to break deterministically. Names are fixed-width zero-padded, so
+    // lexicographic path order is `(stamp, suffix)` order with the
+    // unsuffixed entry first — the same order `list_snapshots` reports.
+    entries.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.2.cmp(&b.2)));
 
-    let timestamps: Vec<SystemTime> = entries.iter().map(|(t, _)| *t).collect();
-    let keep = policy.select_keep(now, &timestamps);
-    for (i, (_, path)) in entries.iter().enumerate() {
+    let sized: Vec<(SystemTime, u64)> = entries.iter().map(|(t, s, _)| (*t, *s)).collect();
+    let keep = policy.select_keep_within_budget(now, &sized);
+    for (i, (_, _, path)) in entries.iter().enumerate() {
         if !keep.contains(&i) {
             if let Err(err) = fs::remove_file(path) {
                 tracing::warn!("failed to thin snapshot {path:?}: {err}");
@@ -568,6 +696,7 @@ mod tests {
             keep_last: 3,
             buckets: vec![],
             max_age: None,
+            max_total_bytes: None,
         };
         let now = SystemTime::now();
         // Five very-old snapshots: only the trailing 3 should survive.
@@ -587,6 +716,7 @@ mod tests {
                 max_count: 10,
             }],
             max_age: None,
+            max_total_bytes: None,
         };
         let now = SystemTime::now();
         let ts: Vec<_> = (0..600).map(|i| t(now, 599 - i)).collect();
@@ -604,6 +734,7 @@ mod tests {
                 max_count: 10,
             }],
             max_age: None,
+            max_total_bytes: None,
         };
         let now = SystemTime::now();
         let ts: Vec<_> = (0..1000).map(|_| t(now, 5)).collect();
@@ -642,6 +773,7 @@ mod tests {
                 max_count: 5,
             }],
             max_age: None,
+            max_total_bytes: None,
         };
         let now = SystemTime::now();
         let ts = vec![now + Duration::from_secs(120), t(now, 30)];
@@ -661,6 +793,7 @@ mod tests {
             keep_last: 5,
             buckets: vec![],
             max_age: Some(Duration::from_secs(60)),
+            max_total_bytes: None,
         };
         let now = SystemTime::now();
         // 5 snapshots, all 1 hour old. keep_last=5 would normally keep all,
@@ -681,6 +814,7 @@ mod tests {
             keep_last: 1,
             buckets: vec![],
             max_age: Some(Duration::from_secs(60)),
+            max_total_bytes: None,
         };
         let now = SystemTime::now();
         let ts = vec![now + Duration::from_secs(120)];
@@ -696,6 +830,7 @@ mod tests {
             keep_last: 10,
             buckets: vec![],
             max_age: Some(Duration::from_secs(120)),
+            max_total_bytes: None,
         };
         let now = SystemTime::now();
         // 3 fresh (within 2 min), 3 stale (> 2 min). keep_last=10 selects
@@ -714,6 +849,219 @@ mod tests {
             vec![3, 4, 5],
             "only fresh entries should remain"
         );
+    }
+
+    // ===== per-secret byte budget (`max_total_bytes`) =====
+
+    /// Helper: a policy that keeps everything by count, so the tests below
+    /// isolate the byte budget from the tiering.
+    fn budget_only(max_total_bytes: Option<u64>) -> RetentionPolicy {
+        RetentionPolicy {
+            keep_last: usize::MAX,
+            buckets: vec![],
+            max_age: None,
+            max_total_bytes,
+        }
+    }
+
+    #[test]
+    fn byte_budget_evicts_oldest_first() {
+        let now = SystemTime::now();
+        // Four 100-byte snapshots, budget 250 => the two newest fit.
+        let entries: Vec<(SystemTime, u64)> =
+            (0..4).map(|i| (t(now, 400 - i * 100), 100u64)).collect();
+        let keep = budget_only(Some(250)).select_keep_within_budget(now, &entries);
+        assert_eq!(
+            keep.into_iter().collect::<Vec<_>>(),
+            vec![2, 3],
+            "budget must drop the OLDEST entries and keep the newest"
+        );
+    }
+
+    #[test]
+    fn byte_budget_none_keeps_everything() {
+        let now = SystemTime::now();
+        let entries: Vec<(SystemTime, u64)> = (0..4)
+            .map(|i| (t(now, 400 - i * 100), 10_000_000u64))
+            .collect();
+        let keep = budget_only(None).select_keep_within_budget(now, &entries);
+        assert_eq!(keep.len(), 4, "no budget => count tiers alone decide");
+    }
+
+    #[test]
+    fn byte_budget_never_empties_the_history() {
+        // A single snapshot far larger than the whole budget is KEPT: the
+        // budget is a disk heuristic and must never be why a value stops
+        // being recoverable.
+        let now = SystemTime::now();
+        let entries = vec![(t(now, 10), 50_000_000u64)];
+        let keep = budget_only(Some(1024)).select_keep_within_budget(now, &entries);
+        assert_eq!(keep.into_iter().collect::<Vec<_>>(), vec![0]);
+    }
+
+    #[test]
+    fn byte_budget_zero_still_keeps_the_newest() {
+        // Degenerate budget: floor at one entry, and it must be the newest
+        // (the value the last write overwrote).
+        let now = SystemTime::now();
+        let entries: Vec<(SystemTime, u64)> =
+            (0..5).map(|i| (t(now, 500 - i * 100), 100u64)).collect();
+        let keep = budget_only(Some(0)).select_keep_within_budget(now, &entries);
+        assert_eq!(keep.into_iter().collect::<Vec<_>>(), vec![4]);
+    }
+
+    #[test]
+    fn byte_budget_exactly_at_budget_keeps_all() {
+        // Boundary: total == budget is NOT over budget.
+        let now = SystemTime::now();
+        let entries: Vec<(SystemTime, u64)> =
+            (0..4).map(|i| (t(now, 400 - i * 100), 100u64)).collect();
+        let keep = budget_only(Some(400)).select_keep_within_budget(now, &entries);
+        assert_eq!(keep.len(), 4);
+        // One byte less and the oldest goes.
+        let keep = budget_only(Some(399)).select_keep_within_budget(now, &entries);
+        assert_eq!(keep.into_iter().collect::<Vec<_>>(), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn byte_budget_empty_input_keeps_nothing() {
+        let now = SystemTime::now();
+        assert!(
+            budget_only(Some(1024))
+                .select_keep_within_budget(now, &[])
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn byte_budget_only_subtracts_never_resurrects() {
+        // An entry dropped by `max_age` must stay dropped even though there
+        // is plenty of byte budget left over.
+        let p = RetentionPolicy {
+            keep_last: 10,
+            buckets: vec![],
+            max_age: Some(Duration::from_secs(120)),
+            max_total_bytes: Some(u64::MAX),
+        };
+        let now = SystemTime::now();
+        let entries = vec![
+            (t(now, 1000), 1u64), // stale
+            (t(now, 500), 1),     // stale
+            (t(now, 30), 1),      // fresh
+        ];
+        let keep = p.select_keep_within_budget(now, &entries);
+        assert_eq!(keep.into_iter().collect::<Vec<_>>(), vec![2]);
+    }
+
+    #[test]
+    fn byte_budget_counts_only_entries_the_tiers_kept() {
+        // Entries the count tiers already dropped must not consume budget:
+        // keep_last=2 leaves two 100-byte entries, which fit a 250 budget
+        // even though the eight dropped ones would have blown it.
+        let p = RetentionPolicy {
+            keep_last: 2,
+            buckets: vec![],
+            max_age: None,
+            max_total_bytes: Some(250),
+        };
+        let now = SystemTime::now();
+        let entries: Vec<(SystemTime, u64)> =
+            (0..10).map(|i| (t(now, 1000 - i * 10), 100u64)).collect();
+        let keep = p.select_keep_within_budget(now, &entries);
+        assert_eq!(keep.into_iter().collect::<Vec<_>>(), vec![8, 9]);
+    }
+
+    #[test]
+    fn byte_budget_saturates_on_overflowing_sizes() {
+        // Pathological sizes must not panic on overflow in debug builds.
+        let now = SystemTime::now();
+        let entries = vec![(t(now, 30), u64::MAX), (t(now, 20), u64::MAX)];
+        let keep = budget_only(Some(1024)).select_keep_within_budget(now, &entries);
+        assert_eq!(keep.into_iter().collect::<Vec<_>>(), vec![1]);
+    }
+
+    /// The DEFAULT policy must bound bytes, not just version count. This is
+    /// the behavioral pin on `DEFAULT_MAX_SNAPSHOT_BYTES_PER_SECRET` being
+    /// wired into `RetentionPolicy::default()`.
+    #[test]
+    fn default_policy_bounds_bytes_per_secret() {
+        let p = RetentionPolicy::default();
+        let now = SystemTime::now();
+        // 40 versions of a ~1 MiB secret written one minute apart: the count
+        // tiers alone would keep dozens (~40 MiB).
+        let size = 1024 * 1024u64;
+        let entries: Vec<(SystemTime, u64)> =
+            (0..40).map(|i| (t(now, (39 - i) * 60), size)).collect();
+        let keep = p.select_keep_within_budget(now, &entries);
+        let total: u64 = keep.iter().map(|&i| entries[i].1).sum();
+        assert!(
+            total <= DEFAULT_MAX_SNAPSHOT_BYTES_PER_SECRET,
+            "default policy must bound per-secret snapshot bytes; kept {} entries = {total} bytes",
+            keep.len()
+        );
+        assert!(
+            !keep.is_empty(),
+            "default policy must still retain recoverable history"
+        );
+        // Sanity: the count tiers on their own really would have kept far more.
+        let timestamps: Vec<SystemTime> = entries.iter().map(|(ts, _)| *ts).collect();
+        assert!(
+            p.select_keep(now, &timestamps).len() > keep.len(),
+            "test is vacuous unless the byte budget is what trimmed the set"
+        );
+    }
+
+    #[test]
+    fn thin_snapshots_enforces_byte_budget() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let now_ms = recent_ms();
+        // Five 1000-byte snapshots, one second apart.
+        for i in 0..5u64 {
+            write_snapshot(dir.path(), now_ms - (5 - i) * 1000, &vec![b'x'; 1000]);
+        }
+        let policy = RetentionPolicy {
+            keep_last: usize::MAX,
+            buckets: vec![],
+            max_age: None,
+            max_total_bytes: Some(2500),
+        };
+        thin_snapshots(dir.path(), &policy, SystemTime::now());
+
+        let remaining = list_snapshots(dir.path()).expect("list");
+        assert_eq!(
+            remaining.len(),
+            2,
+            "2500 bytes fits exactly two 1000B files"
+        );
+        // And it kept the NEWEST two.
+        assert_eq!(
+            remaining.iter().map(|m| m.timestamp_ms).collect::<Vec<_>>(),
+            vec![now_ms - 2000, now_ms - 1000]
+        );
+    }
+
+    #[test]
+    fn thin_snapshots_byte_budget_keeps_one_oversized_snapshot() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let now_ms = recent_ms();
+        write_snapshot(dir.path(), now_ms - 2000, &vec![b'a'; 5000]);
+        write_snapshot(dir.path(), now_ms - 1000, &vec![b'b'; 5000]);
+        let policy = RetentionPolicy {
+            keep_last: usize::MAX,
+            buckets: vec![],
+            max_age: None,
+            max_total_bytes: Some(100),
+        };
+        thin_snapshots(dir.path(), &policy, SystemTime::now());
+
+        let remaining = list_snapshots(dir.path()).expect("list");
+        assert_eq!(
+            remaining.len(),
+            1,
+            "the floor keeps exactly one even when it busts the budget"
+        );
+        assert_eq!(remaining[0].timestamp_ms, now_ms - 1000, "newest survives");
+        assert_eq!(fs::read(&remaining[0].path).unwrap(), vec![b'b'; 5000]);
     }
 
     #[test]
@@ -796,6 +1144,7 @@ mod tests {
                 max_count: 0,
             }],
             max_age: None,
+            max_total_bytes: None,
         };
         let now = SystemTime::now();
         let ts: Vec<_> = (0..10).map(|i| t(now, i)).collect();

--- a/crates/core/src/wasm_runtime/secret_snapshots.rs
+++ b/crates/core/src/wasm_runtime/secret_snapshots.rs
@@ -1337,6 +1337,48 @@ mod tests {
         );
     }
 
+    /// The environment read must live in exactly one place: `from_env` does
+    /// it, `Default` does not.
+    ///
+    /// SOURCE pin, because neither half is behaviourally observable without
+    /// a `setenv` — and removing `setenv` from this binary is the whole
+    /// point (a `getenv`/`setenv` race is UB, and `Default` is reached from
+    /// every `SecretsStore` construction). Needles are assembled with
+    /// `concat!` so this test's own source cannot satisfy them, and each
+    /// block is sliced out before searching so the negative assertion cannot
+    /// be tripped by unrelated code.
+    #[test]
+    fn env_read_lives_only_in_from_env() {
+        let src = include_str!("secret_snapshots.rs");
+        let slice_from = |key: &str, end: &str| -> String {
+            let start = src
+                .find(key)
+                .unwrap_or_else(|| panic!("source must still contain {key:?}"));
+            let rest = &src[start..];
+            let len = rest
+                .find(end)
+                .unwrap_or_else(|| panic!("no terminator {end:?} after {key:?}"));
+            rest[..len].to_string()
+        };
+
+        // `from_env` MUST read the environment — it is the only thing it does.
+        let from_env_body = slice_from(concat!("pub fn from_env()", " -> Self {"), "\n    }\n");
+        assert!(
+            from_env_body.contains(concat!("std::env::", "var(SNAPSHOT_BUDGET_ENV)")),
+            "from_env must read SNAPSHOT_BUDGET_ENV, otherwise the operator \
+             override is dead code; body was:\n{from_env_body}"
+        );
+
+        // `Default` MUST NOT: it is reached from every SecretsStore
+        // construction, so a getenv there races any setenv in the process.
+        let default_impl = slice_from(concat!("impl Default for ", "RetentionPolicy"), "\n}\n");
+        assert!(
+            !default_impl.contains(concat!("env::", "var")),
+            "Default for RetentionPolicy must stay pure — no environment read. \
+             Put the override in from_env instead; impl was:\n{default_impl}"
+        );
+    }
+
     // ===== recovery-path exemption =====
 
     #[test]

--- a/crates/core/src/wasm_runtime/secret_snapshots.rs
+++ b/crates/core/src/wasm_runtime/secret_snapshots.rs
@@ -79,14 +79,38 @@ pub const DEFAULT_MAX_SNAPSHOT_BYTES_PER_SECRET: u64 = 3 * 1024 * 1024;
 
 /// Floor on how many snapshots the byte budget is allowed to leave behind.
 ///
-/// The budget evicts oldest-first, but it must never empty the history: the
-/// newest snapshot is the value that the most recent write overwrote, i.e.
-/// exactly what "undo the last write" needs. So a single secret larger than
-/// the whole budget keeps one version and exceeds the budget, rather than
-/// silently having no recoverable history at all. Deleting user data to
-/// satisfy a disk heuristic is the failure mode this floor exists to
-/// prevent.
-const MIN_SNAPSHOTS_KEPT_UNDER_BUDGET: usize = 1;
+/// The budget evicts oldest-first, but it must never collapse the history to
+/// a single entry: one survivor only supports "undo the last write", with no
+/// room to walk back when the operator does not yet know which version they
+/// want. Three is the smallest count that gives a real walk-back window, and
+/// it is cheap where it binds:
+///
+/// - At the default 3 MiB budget the floor is INERT for any secret up to
+///   1 MiB, because three of those versions already fit inside the budget.
+///   It only takes effect for the genuinely large values (a ~1 MiB River
+///   room state and up) — exactly the case where the budget is aggressive
+///   and a one-entry history would be thinnest.
+/// - Worst case it retains `3 x largest_snapshot` rather than an unbounded
+///   count, so it cannot reintroduce the version-count blowup this budget
+///   exists to fix.
+///
+/// Deliberately not 5 (matching `keep_last`): that would make the floor bind
+/// for every secret over ~600 KiB and raise the worst case to 5x, buying two
+/// more versions of the values that cost the most to keep.
+///
+/// Note this floor is what makes the budget's guarantee "at most
+/// `max(max_total_bytes, 3 x largest snapshot)`", not a hard byte cap.
+const MIN_SNAPSHOTS_KEPT_UNDER_BUDGET: usize = 3;
+
+/// Environment variable overriding [`DEFAULT_MAX_SNAPSHOT_BYTES_PER_SECRET`],
+/// in bytes. Parsed by [`parse_snapshot_budget`].
+///
+/// Exists because the budget is the one retention clause that can DELETE
+/// pre-existing history on upgrade (see [`RetentionPolicy::max_total_bytes`]),
+/// and the only other snapshot knob,
+/// `FREENET_DISABLE_SECRET_SNAPSHOTS`, points the wrong way for an operator
+/// who wants MORE history rather than none.
+pub const SNAPSHOT_BUDGET_ENV: &str = "FREENET_SECRET_SNAPSHOT_BYTES_PER_SECRET";
 
 /// One tier of a [`RetentionPolicy`]: aim to keep one snapshot per
 /// `interval` of clock time, up to `max_count` snapshots in this tier.
@@ -141,7 +165,62 @@ pub struct RetentionPolicy {
     ///
     /// Applied to the size the entries actually occupy on disk, so it bounds
     /// disk directly rather than proxying it through a version count.
+    ///
+    /// **This clause is RETROACTIVE.** Unlike the count tiers, which a node
+    /// upgrading into them satisfies gradually, the first thinning pass after
+    /// this field starts being set collapses an existing over-budget history
+    /// down to the budget in one go, and those deletions are irreversible.
+    /// That is intended (it is how the ~30 MiB histories get reclaimed) but it
+    /// is a one-way door, so it is documented for operators in
+    /// `docs/secrets-at-rest.md` and overridable via [`SNAPSHOT_BUDGET_ENV`].
+    /// It is also why [`Self::without_byte_budget`] exists: the RECOVERY path
+    /// deliberately does not apply it.
     pub max_total_bytes: Option<u64>,
+}
+
+/// Resolve the per-secret byte budget from a raw [`SNAPSHOT_BUDGET_ENV`]
+/// value.
+///
+/// - absent, empty, or whitespace-only → the built-in default (treated as
+///   "operator said nothing").
+/// - `0` → `None`, i.e. the budget is DISABLED and only the count tiers and
+///   `max_age` bound the history. This is the escape hatch for an operator
+///   who wants the pre-budget behavior back.
+/// - any other valid `u64` → that many bytes.
+/// - unparseable → the built-in default, with a warning.
+///
+/// Degrade-safe in one direction on purpose: a malformed value falls back to
+/// the bounded default rather than to "unlimited" (which would silently
+/// re-open the disk blowup) or to "0 bytes" (which would silently shrink
+/// every history to the floor). Only an explicit, well-formed `0` disables
+/// the budget.
+pub fn parse_snapshot_budget(raw: Option<&str>) -> Option<u64> {
+    let Some(raw) = raw else {
+        return Some(DEFAULT_MAX_SNAPSHOT_BYTES_PER_SECRET);
+    };
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Some(DEFAULT_MAX_SNAPSHOT_BYTES_PER_SECRET);
+    }
+    match trimmed.parse::<u64>() {
+        // Explicit opt-out: count tiers + max_age still bound the history.
+        Ok(0) => None,
+        Ok(bytes) => Some(bytes),
+        Err(err) => {
+            tracing::warn!(
+                env = SNAPSHOT_BUDGET_ENV,
+                value = %trimmed,
+                error = %err,
+                "unparseable snapshot byte budget; falling back to the default"
+            );
+            Some(DEFAULT_MAX_SNAPSHOT_BYTES_PER_SECRET)
+        }
+    }
+}
+
+/// [`parse_snapshot_budget`] applied to the live process environment.
+fn snapshot_budget_from_env() -> Option<u64> {
+    parse_snapshot_budget(std::env::var(SNAPSHOT_BUDGET_ENV).ok().as_deref())
 }
 
 impl Default for RetentionPolicy {
@@ -151,8 +230,14 @@ impl Default for RetentionPolicy {
     /// last 12 months, with an absolute 2-year ceiling so stale snapshots
     /// from secrets that stopped being written eventually age out, and a
     /// [`DEFAULT_MAX_SNAPSHOT_BYTES_PER_SECRET`] disk budget on top. Worst
-    /// case ~62 entries per secret in steady state, and never more than the
-    /// byte budget (plus the one-snapshot floor) of disk.
+    /// case ~62 entries per secret in steady state, and never more than
+    /// `max(budget, MIN_SNAPSHOTS_KEPT_UNDER_BUDGET x largest snapshot)` of
+    /// disk.
+    ///
+    /// Reads [`SNAPSHOT_BUDGET_ENV`] for the byte budget, mirroring how
+    /// `SecretsStore::new` reads `FREENET_DISABLE_SECRET_SNAPSHOTS`. Every
+    /// other field is a compile-time constant, so this is the only reason
+    /// two `default()` values can differ within a process.
     fn default() -> Self {
         const MIN: u64 = 60;
         const HOUR: u64 = 60 * MIN;
@@ -192,13 +277,38 @@ impl Default for RetentionPolicy {
             max_age: Some(Duration::from_secs(2 * YEAR)),
             // Bounds the DISK the count tiers above would otherwise leave
             // unbounded: 62 versions is cheap for a small secret and ~62 MiB
-            // for a ~1 MiB one. See the constant's docs for the sizing.
-            max_total_bytes: Some(DEFAULT_MAX_SNAPSHOT_BYTES_PER_SECRET),
+            // for a ~1 MiB one. See the constant's docs for the sizing, and
+            // `SNAPSHOT_BUDGET_ENV` for the operator override.
+            max_total_bytes: snapshot_budget_from_env(),
         }
     }
 }
 
 impl RetentionPolicy {
+    /// This policy with the byte budget removed; the count tiers and
+    /// `max_age` are untouched.
+    ///
+    /// Used by the RECOVERY path (`SecretsStore::restore_snapshot` and
+    /// `freenet secrets snapshot-restore`). A restore is what an operator
+    /// runs when they are trying to get a value back, often walking versions
+    /// one at a time, and it is the worst possible moment to garbage-collect
+    /// history: applying the budget there could evict several older versions
+    /// — including the one just restored FROM — as a side effect of the
+    /// reversibility snapshot the restore itself adds. The budget is a
+    /// disk-pressure heuristic, and a manual restore is not disk pressure.
+    ///
+    /// This is not an unbounded cleanup exemption: `max_age` still applies at
+    /// the restore, so every entry keeps a finite lifetime, and the next
+    /// ordinary `store_secret` for that secret applies the budget in full.
+    /// The effect is that this PR leaves the restore path's thinning
+    /// behaviour byte-for-byte what it was before the budget existed.
+    pub fn without_byte_budget(&self) -> Self {
+        Self {
+            max_total_bytes: None,
+            ..self.clone()
+        }
+    }
+
     /// Given `timestamps` sorted ascending, return the indices to KEEP.
     /// Indices not in the returned set should be deleted.
     ///
@@ -363,7 +473,21 @@ pub fn next_snapshot_path(snap_dir: &Path) -> std::io::Result<PathBuf> {
 /// do not propagate, since thinning is a maintenance operation that must
 /// never fail the primary write path.
 pub fn thin_snapshots(snap_dir: &Path, policy: &RetentionPolicy, now: SystemTime) {
-    let mut entries: Vec<(SystemTime, u64, PathBuf)> = match fs::read_dir(snap_dir) {
+    /// One candidate entry for a thinning pass.
+    struct Candidate {
+        timestamp: SystemTime,
+        /// Collision-suffix ordering key for entries sharing `timestamp`.
+        /// `(0, 0)` for the unsuffixed file, `(1, n)` for `.n` — the exact
+        /// key [`list_snapshots`] sorts by. NUMERIC on purpose: sorting the
+        /// file names as text puts `.10` before `.9`, which would let the
+        /// byte budget evict the numerically-newest entry of a
+        /// same-millisecond burst and keep an older sibling.
+        suffix_key: (u8, u32),
+        size_bytes: u64,
+        path: PathBuf,
+    }
+
+    let mut entries: Vec<Candidate> = match fs::read_dir(snap_dir) {
         Ok(rd) => rd
             .filter_map(|res| match res {
                 Ok(entry) => Some(entry),
@@ -382,13 +506,13 @@ pub fn thin_snapshots(snap_dir: &Path, policy: &RetentionPolicy, now: SystemTime
                     return None;
                 }
                 let path = entry.path();
-                let stamp = parse_snapshot_stamp(&path)?;
+                let (stamp, suffix) = parse_snapshot_name(&path)?;
                 // A stat failure is charged as 0 bytes: it makes the entry
                 // free against `max_total_bytes`, so it is RETAINED and some
                 // other (measurable) entry is evicted instead. Erring toward
                 // keeping is the right default for a best-effort disk
                 // heuristic operating on user data.
-                let size = match entry.metadata() {
+                let size_bytes = match entry.metadata() {
                     Ok(md) => md.len(),
                     Err(err) => {
                         tracing::debug!(
@@ -397,7 +521,15 @@ pub fn thin_snapshots(snap_dir: &Path, policy: &RetentionPolicy, now: SystemTime
                         0
                     }
                 };
-                Some((UNIX_EPOCH + Duration::from_millis(stamp), size, path))
+                Some(Candidate {
+                    timestamp: UNIX_EPOCH + Duration::from_millis(stamp),
+                    suffix_key: match suffix {
+                        None => (0, 0),
+                        Some(n) => (1, n),
+                    },
+                    size_bytes,
+                    path,
+                })
             })
             .collect(),
         Err(err) => {
@@ -407,17 +539,24 @@ pub fn thin_snapshots(snap_dir: &Path, policy: &RetentionPolicy, now: SystemTime
     };
     // Total order, not just by timestamp: same-millisecond collision entries
     // share a stamp, and the byte budget evicts oldest-first, so the tie has
-    // to break deterministically. Names are fixed-width zero-padded, so
-    // lexicographic path order is `(stamp, suffix)` order with the
-    // unsuffixed entry first — the same order `list_snapshots` reports.
-    entries.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.2.cmp(&b.2)));
+    // to break deterministically — in the SAME order `list_snapshots` and the
+    // restore disambiguation use, so "the newest snapshot" names the same
+    // entry everywhere.
+    entries.sort_by(|a, b| {
+        a.timestamp
+            .cmp(&b.timestamp)
+            .then_with(|| a.suffix_key.cmp(&b.suffix_key))
+    });
 
-    let sized: Vec<(SystemTime, u64)> = entries.iter().map(|(t, s, _)| (*t, *s)).collect();
+    let sized: Vec<(SystemTime, u64)> = entries
+        .iter()
+        .map(|c| (c.timestamp, c.size_bytes))
+        .collect();
     let keep = policy.select_keep_within_budget(now, &sized);
-    for (i, (_, _, path)) in entries.iter().enumerate() {
+    for (i, candidate) in entries.iter().enumerate() {
         if !keep.contains(&i) {
-            if let Err(err) = fs::remove_file(path) {
-                tracing::warn!("failed to thin snapshot {path:?}: {err}");
+            if let Err(err) = fs::remove_file(&candidate.path) {
+                tracing::warn!("failed to thin snapshot {:?}: {err}", candidate.path);
             }
         }
     }
@@ -477,17 +616,17 @@ pub fn list_snapshots(snap_dir: &Path) -> std::io::Result<Vec<SnapshotMetadata>>
     Ok(out)
 }
 
-/// Parse a snapshot file name back into its epoch-millis timestamp.
+/// Parse a snapshot file name back into its epoch-millis timestamp and
+/// optional numeric collision suffix.
+///
 /// Accepts only `{digits}` or `{digits}.{digits}`; any other shape
 /// (including `42.tmp`, `foo`, `1.2.3`, etc.) returns `None` so stray
 /// files in the snapshot directory are not mistaken for snapshots.
-pub(crate) fn parse_snapshot_stamp(path: &Path) -> Option<u64> {
-    parse_snapshot_name(path).map(|(ts, _)| ts)
-}
-
-/// Like [`parse_snapshot_stamp`] but also returns the optional numeric
-/// collision suffix. Surfaced through [`SnapshotMetadata`] so callers
-/// can disambiguate multiple writes that landed in the same millisecond.
+///
+/// The suffix is surfaced through [`SnapshotMetadata`] so callers can
+/// disambiguate multiple writes that landed in the same millisecond, and
+/// [`thin_snapshots`] orders on it so its eviction agrees with what
+/// [`list_snapshots`] reports.
 pub(crate) fn parse_snapshot_name(path: &Path) -> Option<(u64, Option<u32>)> {
     let name = path.file_name()?.to_str()?;
     let (stamp_part, suffix_part) = match name.split_once('.') {
@@ -867,15 +1006,35 @@ mod tests {
     #[test]
     fn byte_budget_evicts_oldest_first() {
         let now = SystemTime::now();
-        // Four 100-byte snapshots, budget 250 => the two newest fit.
+        // Eight 100-byte snapshots, budget 450 => the four newest fit. Sized
+        // so the answer is the BUDGET's, not the floor's.
         let entries: Vec<(SystemTime, u64)> =
-            (0..4).map(|i| (t(now, 400 - i * 100), 100u64)).collect();
-        let keep = budget_only(Some(250)).select_keep_within_budget(now, &entries);
+            (0..8).map(|i| (t(now, 800 - i * 100), 100u64)).collect();
+        let keep = budget_only(Some(450)).select_keep_within_budget(now, &entries);
         assert_eq!(
             keep.into_iter().collect::<Vec<_>>(),
-            vec![2, 3],
+            vec![4, 5, 6, 7],
             "budget must drop the OLDEST entries and keep the newest"
         );
+    }
+
+    /// The floor stops eviction at [`MIN_SNAPSHOTS_KEPT_UNDER_BUDGET`] even
+    /// when the survivors blow the budget wide open. A disk heuristic must
+    /// never be the reason an operator has no version to walk back to.
+    #[test]
+    fn byte_budget_floor_keeps_three_over_budget() {
+        let now = SystemTime::now();
+        // Ten 1 MiB snapshots against a 1-byte budget.
+        let entries: Vec<(SystemTime, u64)> = (0..10)
+            .map(|i| (t(now, (10 - i) * 100), 1024 * 1024u64))
+            .collect();
+        let keep = budget_only(Some(1)).select_keep_within_budget(now, &entries);
+        assert_eq!(
+            keep.iter().copied().collect::<Vec<_>>(),
+            vec![7, 8, 9],
+            "floor must retain the three NEWEST entries, not just any three"
+        );
+        assert_eq!(keep.len(), MIN_SNAPSHOTS_KEPT_UNDER_BUDGET);
     }
 
     #[test]
@@ -900,14 +1059,14 @@ mod tests {
     }
 
     #[test]
-    fn byte_budget_zero_still_keeps_the_newest() {
-        // Degenerate budget: floor at one entry, and it must be the newest
-        // (the value the last write overwrote).
+    fn byte_budget_zero_still_keeps_the_floor() {
+        // Degenerate budget: floor's worth of entries survive, and they are
+        // the newest (the values the last writes overwrote).
         let now = SystemTime::now();
         let entries: Vec<(SystemTime, u64)> =
             (0..5).map(|i| (t(now, 500 - i * 100), 100u64)).collect();
         let keep = budget_only(Some(0)).select_keep_within_budget(now, &entries);
-        assert_eq!(keep.into_iter().collect::<Vec<_>>(), vec![4]);
+        assert_eq!(keep.into_iter().collect::<Vec<_>>(), vec![2, 3, 4]);
     }
 
     #[test]
@@ -915,12 +1074,12 @@ mod tests {
         // Boundary: total == budget is NOT over budget.
         let now = SystemTime::now();
         let entries: Vec<(SystemTime, u64)> =
-            (0..4).map(|i| (t(now, 400 - i * 100), 100u64)).collect();
-        let keep = budget_only(Some(400)).select_keep_within_budget(now, &entries);
-        assert_eq!(keep.len(), 4);
-        // One byte less and the oldest goes.
-        let keep = budget_only(Some(399)).select_keep_within_budget(now, &entries);
-        assert_eq!(keep.into_iter().collect::<Vec<_>>(), vec![1, 2, 3]);
+            (0..5).map(|i| (t(now, 500 - i * 100), 100u64)).collect();
+        let keep = budget_only(Some(500)).select_keep_within_budget(now, &entries);
+        assert_eq!(keep.len(), 5);
+        // One byte less and exactly one entry — the oldest — goes.
+        let keep = budget_only(Some(499)).select_keep_within_budget(now, &entries);
+        assert_eq!(keep.into_iter().collect::<Vec<_>>(), vec![1, 2, 3, 4]);
     }
 
     #[test]
@@ -974,10 +1133,163 @@ mod tests {
     #[test]
     fn byte_budget_saturates_on_overflowing_sizes() {
         // Pathological sizes must not panic on overflow in debug builds.
+        //
+        // The running total saturates at `u64::MAX`, so subtracting the first
+        // evicted entry's size takes it straight to 0 and the loop stops
+        // early. Saturation therefore makes the budget UNDER-evict (keep
+        // more), never over-evict — the correct direction for a disk
+        // heuristic operating on user data. Only reachable with sizes summing
+        // past 2^64 bytes, i.e. never in practice; what is asserted here is
+        // the absence of a panic and the safe failure direction, not an exact
+        // survivor set (which would be pinning the artifact).
         let now = SystemTime::now();
-        let entries = vec![(t(now, 30), u64::MAX), (t(now, 20), u64::MAX)];
+        let entries: Vec<(SystemTime, u64)> =
+            (0..5).map(|i| (t(now, 500 - i * 100), u64::MAX)).collect();
         let keep = budget_only(Some(1024)).select_keep_within_budget(now, &entries);
-        assert_eq!(keep.into_iter().collect::<Vec<_>>(), vec![1]);
+        assert!(
+            keep.len() >= MIN_SNAPSHOTS_KEPT_UNDER_BUDGET,
+            "saturation must never evict below the floor; kept {}",
+            keep.len()
+        );
+        assert!(
+            keep.contains(&4),
+            "the newest entry must survive regardless"
+        );
+    }
+
+    // ===== `SNAPSHOT_BUDGET_ENV` parsing =====
+
+    #[test]
+    fn budget_env_absent_or_blank_uses_the_default() {
+        for raw in [None, Some(""), Some("   "), Some("\t\n")] {
+            assert_eq!(
+                parse_snapshot_budget(raw),
+                Some(DEFAULT_MAX_SNAPSHOT_BYTES_PER_SECRET),
+                "raw={raw:?} must fall back to the default budget"
+            );
+        }
+    }
+
+    #[test]
+    fn budget_env_zero_disables_the_budget() {
+        // The escape hatch for an operator who wants the pre-budget
+        // behaviour back: count tiers + max_age only.
+        assert_eq!(parse_snapshot_budget(Some("0")), None);
+        assert_eq!(parse_snapshot_budget(Some("  0  ")), None);
+    }
+
+    #[test]
+    fn budget_env_accepts_explicit_byte_counts() {
+        assert_eq!(parse_snapshot_budget(Some("1")), Some(1));
+        assert_eq!(parse_snapshot_budget(Some("12345678")), Some(12_345_678));
+        assert_eq!(parse_snapshot_budget(Some(" 4096 ")), Some(4096));
+        assert_eq!(
+            parse_snapshot_budget(Some(&u64::MAX.to_string())),
+            Some(u64::MAX)
+        );
+        // `u64::from_str` accepts a leading `+`, and "+5" is an unambiguous
+        // way of writing 5 bytes, so it is honoured rather than rejected.
+        assert_eq!(parse_snapshot_budget(Some("+5")), Some(5));
+    }
+
+    /// Garbage must degrade to the DEFAULT, never to "unlimited" (which
+    /// would silently re-open the disk blowup) and never to "0 bytes"
+    /// (which would silently shrink every history to the floor).
+    #[test]
+    fn budget_env_garbage_degrades_to_the_default() {
+        for raw in [
+            "abc",
+            "-1",
+            "3.5",
+            "3MiB",
+            "1_000",
+            "0x10",
+            "99999999999999999999999", // overflows u64
+            "5 bytes",
+            "",
+            " 3 MiB",
+        ] {
+            assert_eq!(
+                parse_snapshot_budget(Some(raw)),
+                Some(DEFAULT_MAX_SNAPSHOT_BYTES_PER_SECRET),
+                "raw={raw:?} must degrade to the default budget"
+            );
+        }
+    }
+
+    /// `RetentionPolicy::default()` must actually CONSULT the environment
+    /// rather than hardcoding the constant. This is the wiring pin for the
+    /// operator override; the parsing itself is covered above.
+    #[test]
+    fn default_policy_reads_the_budget_env() {
+        use std::sync::Mutex as StdMutex;
+        // Serializes this test against its own re-entry only; the real
+        // cross-test isolation is nextest's per-process model (see the
+        // SAFETY notes below). The override value is deliberately a LARGE
+        // finite budget, so a concurrent `default()` under a plain
+        // multi-threaded `cargo test` sees a still-bounded policy rather
+        // than an unbounded or 0-byte one.
+        static ENV_GUARD: StdMutex<()> = StdMutex::new(());
+        let _g = ENV_GUARD.lock().unwrap_or_else(|p| p.into_inner());
+
+        let prev = std::env::var(SNAPSHOT_BUDGET_ENV).ok();
+
+        // SAFETY: `set_var`/`remove_var` are unsound only under CONCURRENT
+        // env access. CI runs these lib tests under `cargo nextest`, which
+        // executes each test in its own process, so nothing else mutates
+        // `environ` while this test runs; the prior value is restored at the
+        // end. (`ENV_GUARD` only serializes this test against its own
+        // re-entry, so under a plain multi-threaded `cargo test` this is
+        // best-effort — nextest's per-process isolation is the guarantee.)
+        unsafe { std::env::remove_var(SNAPSHOT_BUDGET_ENV) };
+        assert_eq!(
+            RetentionPolicy::default().max_total_bytes,
+            Some(DEFAULT_MAX_SNAPSHOT_BYTES_PER_SECRET),
+            "unset env must yield the built-in default"
+        );
+
+        // SAFETY: as above — nextest runs this test in its own process; the
+        // prior value is restored below.
+        unsafe { std::env::set_var(SNAPSHOT_BUDGET_ENV, "7340032") };
+        assert_eq!(
+            RetentionPolicy::default().max_total_bytes,
+            Some(7 * 1024 * 1024),
+            "default() must read the operator override, not a hardcoded constant"
+        );
+
+        // SAFETY: as above — restoring the environment to its prior state.
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var(SNAPSHOT_BUDGET_ENV, v),
+                None => std::env::remove_var(SNAPSHOT_BUDGET_ENV),
+            }
+        }
+    }
+
+    // ===== recovery-path exemption =====
+
+    #[test]
+    fn without_byte_budget_drops_only_the_budget() {
+        let p = RetentionPolicy::default();
+        let stripped = p.without_byte_budget();
+        assert_eq!(stripped.max_total_bytes, None);
+        assert_eq!(stripped.keep_last, p.keep_last);
+        assert_eq!(stripped.max_age, p.max_age);
+        assert_eq!(stripped.buckets, p.buckets);
+        // And it is what makes the selection budget-free.
+        let now = SystemTime::now();
+        let entries: Vec<(SystemTime, u64)> = (0..5)
+            .map(|i| (t(now, 500 - i * 100), 10 * 1024 * 1024u64))
+            .collect();
+        assert_eq!(
+            stripped.select_keep_within_budget(now, &entries).len(),
+            5,
+            "50 MiB of history must survive when the budget is stripped"
+        );
+        assert!(
+            p.select_keep_within_budget(now, &entries).len() < 5,
+            "test is vacuous unless the un-stripped policy would have evicted"
+        );
     }
 
     /// The DEFAULT policy must bound bytes, not just version count. This is
@@ -986,6 +1298,13 @@ mod tests {
     #[test]
     fn default_policy_bounds_bytes_per_secret() {
         let p = RetentionPolicy::default();
+        // Read the budget off the policy rather than the constant: under a
+        // plain multi-threaded `cargo test`, `default_policy_reads_the_budget_env`
+        // may have the override set. It only ever sets a LARGE FINITE value,
+        // so the bound below still holds and stays non-vacuous.
+        let budget = p
+            .max_total_bytes
+            .expect("default policy must carry a byte budget");
         let now = SystemTime::now();
         // 40 versions of a ~1 MiB secret written one minute apart: the count
         // tiers alone would keep dozens (~40 MiB).
@@ -995,7 +1314,7 @@ mod tests {
         let keep = p.select_keep_within_budget(now, &entries);
         let total: u64 = keep.iter().map(|&i| entries[i].1).sum();
         assert!(
-            total <= DEFAULT_MAX_SNAPSHOT_BYTES_PER_SECRET,
+            total <= budget,
             "default policy must bound per-secret snapshot bytes; kept {} entries = {total} bytes",
             keep.len()
         );
@@ -1011,57 +1330,112 @@ mod tests {
         );
     }
 
+    /// Policy that keeps everything by count, so filesystem-level tests
+    /// isolate the byte budget from the tiering.
+    fn fs_budget_only(max_total_bytes: Option<u64>) -> RetentionPolicy {
+        RetentionPolicy {
+            keep_last: usize::MAX,
+            buckets: vec![],
+            max_age: None,
+            max_total_bytes,
+        }
+    }
+
     #[test]
     fn thin_snapshots_enforces_byte_budget() {
         let dir = tempfile::tempdir().expect("tempdir");
         let now_ms = recent_ms();
-        // Five 1000-byte snapshots, one second apart.
-        for i in 0..5u64 {
-            write_snapshot(dir.path(), now_ms - (5 - i) * 1000, &vec![b'x'; 1000]);
+        // Eight 1000-byte snapshots, one second apart. Budget 4500 keeps the
+        // newest four — comfortably above the floor, so this pins the BUDGET.
+        for i in 0..8u64 {
+            write_snapshot(dir.path(), now_ms - (8 - i) * 1000, &vec![b'x'; 1000]);
         }
-        let policy = RetentionPolicy {
-            keep_last: usize::MAX,
-            buckets: vec![],
-            max_age: None,
-            max_total_bytes: Some(2500),
-        };
-        thin_snapshots(dir.path(), &policy, SystemTime::now());
+        thin_snapshots(dir.path(), &fs_budget_only(Some(4500)), SystemTime::now());
 
         let remaining = list_snapshots(dir.path()).expect("list");
         assert_eq!(
             remaining.len(),
-            2,
-            "2500 bytes fits exactly two 1000B files"
+            4,
+            "4500 bytes fits exactly four 1000B files"
         );
-        // And it kept the NEWEST two.
         assert_eq!(
             remaining.iter().map(|m| m.timestamp_ms).collect::<Vec<_>>(),
-            vec![now_ms - 2000, now_ms - 1000]
+            vec![now_ms - 4000, now_ms - 3000, now_ms - 2000, now_ms - 1000],
+            "the NEWEST four survive"
         );
     }
 
     #[test]
-    fn thin_snapshots_byte_budget_keeps_one_oversized_snapshot() {
+    fn thin_snapshots_byte_budget_stops_at_the_floor() {
         let dir = tempfile::tempdir().expect("tempdir");
         let now_ms = recent_ms();
-        write_snapshot(dir.path(), now_ms - 2000, &vec![b'a'; 5000]);
-        write_snapshot(dir.path(), now_ms - 1000, &vec![b'b'; 5000]);
-        let policy = RetentionPolicy {
-            keep_last: usize::MAX,
-            buckets: vec![],
-            max_age: None,
-            max_total_bytes: Some(100),
-        };
-        thin_snapshots(dir.path(), &policy, SystemTime::now());
+        // Five 5000-byte snapshots against a 100-byte budget: the floor, not
+        // the budget, decides how many survive.
+        for i in 0..5u64 {
+            write_snapshot(
+                dir.path(),
+                now_ms - (5 - i) * 1000,
+                &vec![b'a' + i as u8; 5000],
+            );
+        }
+        thin_snapshots(dir.path(), &fs_budget_only(Some(100)), SystemTime::now());
 
         let remaining = list_snapshots(dir.path()).expect("list");
         assert_eq!(
             remaining.len(),
-            1,
-            "the floor keeps exactly one even when it busts the budget"
+            MIN_SNAPSHOTS_KEPT_UNDER_BUDGET,
+            "the floor keeps its minimum even when that busts the budget"
         );
-        assert_eq!(remaining[0].timestamp_ms, now_ms - 1000, "newest survives");
-        assert_eq!(fs::read(&remaining[0].path).unwrap(), vec![b'b'; 5000]);
+        let newest = remaining.last().expect("floor keeps at least one");
+        assert_eq!(newest.timestamp_ms, now_ms - 1000, "newest survives");
+        assert_eq!(fs::read(&newest.path).unwrap(), vec![b'a' + 4; 5000]);
+    }
+
+    /// A single snapshot larger than the whole budget is still retained: the
+    /// budget must never leave a secret with no recoverable history.
+    #[test]
+    fn thin_snapshots_byte_budget_keeps_a_lone_oversized_snapshot() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let now_ms = recent_ms();
+        write_snapshot(dir.path(), now_ms - 1000, &vec![b'b'; 50_000]);
+        thin_snapshots(dir.path(), &fs_budget_only(Some(100)), SystemTime::now());
+
+        let remaining = list_snapshots(dir.path()).expect("list");
+        assert_eq!(remaining.len(), 1, "history must never be emptied");
+        assert_eq!(fs::read(&remaining[0].path).unwrap(), vec![b'b'; 50_000]);
+    }
+
+    /// Same-millisecond collision entries must be ordered NUMERICALLY by
+    /// suffix, not lexicographically by file name: text order puts `.10`
+    /// before `.9`, which would let the budget evict the numerically-newest
+    /// entry of a burst and keep an older sibling.
+    #[test]
+    fn thin_snapshots_orders_collision_suffixes_numerically() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let stamp = recent_ms();
+        let base = format!("{stamp:0width$}", width = SNAPSHOT_NAME_WIDTH);
+        // Unsuffixed plus `.0` ..= `.10` — twelve entries in one millisecond.
+        fs::write(dir.path().join(&base), b"unsuffixed").unwrap();
+        for n in 0..=10u32 {
+            fs::write(dir.path().join(format!("{base}.{n}")), format!("body-{n}")).unwrap();
+        }
+
+        // Budget 0 => only the floor survives, and it must be the three
+        // NUMERICALLY newest: `.8`, `.9`, `.10`.
+        thin_snapshots(dir.path(), &fs_budget_only(Some(0)), SystemTime::now());
+
+        let remaining = list_snapshots(dir.path()).expect("list");
+        assert_eq!(
+            remaining.iter().map(|m| m.suffix).collect::<Vec<_>>(),
+            vec![Some(8), Some(9), Some(10)],
+            "lexicographic ordering would have kept .1/.10 and dropped .9"
+        );
+    }
+
+    /// The stamp half of [`parse_snapshot_name`], which is all the
+    /// timestamp-ordering callers need.
+    fn parse_snapshot_stamp(path: &Path) -> Option<u64> {
+        parse_snapshot_name(path).map(|(ts, _)| ts)
     }
 
     #[test]

--- a/crates/core/src/wasm_runtime/secrets_store/store.rs
+++ b/crates/core/src/wasm_runtime/secrets_store/store.rs
@@ -364,7 +364,11 @@ impl SecretsStore {
             },
             legacy_migration_encryption,
             secrets,
-            retention: RetentionPolicy::default(),
+            // `from_env`, NOT `default`: the per-secret byte budget is
+            // operator-overridable via `SNAPSHOT_BUDGET_ENV`, and `default`
+            // is deliberately pure. Pinned by
+            // `secrets_store_new_uses_env_aware_retention`.
+            retention: RetentionPolicy::from_env(),
             snapshots_enabled: std::env::var_os(DISABLE_SNAPSHOTS_ENV).is_none(),
             max_registered_keys_per_scope: MAX_REGISTERED_KEYS_PER_SCOPE,
             // Quota OFF by default. Production opts in via `with_user_quota`
@@ -4646,6 +4650,38 @@ mod test {
             "no snapshot should exist after a single write"
         );
         Ok(())
+    }
+
+    /// `SecretsStore::new` must build its retention from
+    /// `RetentionPolicy::from_env()`, not `::default()` — otherwise the
+    /// operator's `FREENET_SECRET_SNAPSHOT_BYTES_PER_SECRET` override
+    /// silently stops applying.
+    ///
+    /// This is a SOURCE pin rather than a behavioural one, which is a
+    /// deliberate trade. The two constructors differ only in whether they
+    /// consult `environ`, so observing the difference at runtime means a
+    /// test that calls `setenv` — and `setenv` races every concurrent
+    /// `getenv` in the process, which in a lib-test binary means every other
+    /// test constructing a store. A source scrape catches the same mutation
+    /// with no data race. The parsing and the `with_budget_from` wiring are
+    /// pinned behaviourally in `secret_snapshots`.
+    #[test]
+    fn secrets_store_new_uses_env_aware_retention() {
+        // Split so the needle cannot match this test's own source, which is
+        // part of the same `include_str!`.
+        let needle = concat!("RetentionPolicy", "::from_env()");
+        // Match against whitespace-stripped source so a rustfmt reflow of the
+        // call cannot silently disarm the pin.
+        let src: String = include_str!("store.rs")
+            .chars()
+            .filter(|c| !c.is_whitespace())
+            .collect();
+        let stripped_needle: String = needle.chars().filter(|c| !c.is_whitespace()).collect();
+        assert!(
+            src.contains(&stripped_needle),
+            "SecretsStore::new must construct its retention via {needle}; using \
+             RetentionPolicy::default() there drops the operator byte-budget override"
+        );
     }
 
     // ===== snapshot-on-write is content-gated =====

--- a/crates/core/src/wasm_runtime/secrets_store/store.rs
+++ b/crates/core/src/wasm_runtime/secrets_store/store.rs
@@ -4652,35 +4652,46 @@ mod test {
         Ok(())
     }
 
-    /// `SecretsStore::new` must build its retention from
-    /// `RetentionPolicy::from_env()`, not `::default()` — otherwise the
-    /// operator's `FREENET_SECRET_SNAPSHOT_BYTES_PER_SECRET` override
-    /// silently stops applying.
+    /// `SecretsStore::new` must build its retention from the env-aware
+    /// constructor, not the pure one — otherwise the operator's
+    /// `FREENET_SECRET_SNAPSHOT_BYTES_PER_SECRET` override silently stops
+    /// applying.
     ///
-    /// This is a SOURCE pin rather than a behavioural one, which is a
-    /// deliberate trade. The two constructors differ only in whether they
-    /// consult `environ`, so observing the difference at runtime means a
-    /// test that calls `setenv` — and `setenv` races every concurrent
-    /// `getenv` in the process, which in a lib-test binary means every other
-    /// test constructing a store. A source scrape catches the same mutation
-    /// with no data race. The parsing and the `with_budget_from` wiring are
-    /// pinned behaviourally in `secret_snapshots`.
+    /// This is a SOURCE pin rather than a behavioural one, deliberately. The
+    /// two constructors differ only in whether they consult `environ`, so
+    /// observing the difference at runtime means a test that calls `setenv`
+    /// — and `setenv` races every concurrent `getenv` in the process, which
+    /// in a lib-test binary means every other test constructing a store. A
+    /// source scrape catches the same mutation with no data race. The
+    /// parsing and the override wiring are pinned behaviourally in
+    /// `secret_snapshots`.
+    ///
+    /// TWO-SIDED on purpose: the earlier one-sided version of this test
+    /// silently passed under its own mutation, because the doc comment
+    /// above it spelled the needle out in full and the scrape matched
+    /// itself. Every needle here is assembled with `concat!` so it cannot
+    /// appear verbatim anywhere in this file, and the negative assertion
+    /// fails independently if the call is swapped back.
     #[test]
     fn secrets_store_new_uses_env_aware_retention() {
-        // Split so the needle cannot match this test's own source, which is
-        // part of the same `include_str!`.
-        let needle = concat!("RetentionPolicy", "::from_env()");
-        // Match against whitespace-stripped source so a rustfmt reflow of the
-        // call cannot silently disarm the pin.
+        // Whitespace-stripped so a rustfmt reflow cannot disarm the pin.
         let src: String = include_str!("store.rs")
             .chars()
             .filter(|c| !c.is_whitespace())
             .collect();
-        let stripped_needle: String = needle.chars().filter(|c| !c.is_whitespace()).collect();
+        let required = concat!("retention:RetentionPolicy::", "from_env()");
+        let forbidden = concat!("retention:RetentionPolicy::", "default()");
         assert!(
-            src.contains(&stripped_needle),
-            "SecretsStore::new must construct its retention via {needle}; using \
-             RetentionPolicy::default() there drops the operator byte-budget override"
+            src.contains(required),
+            "SecretsStore::new must build its retention from the env-aware \
+             constructor ({required}); the pure one drops the operator \
+             byte-budget override"
+        );
+        assert!(
+            !src.contains(forbidden),
+            "SecretsStore::new must not build its retention from the pure \
+             constructor ({forbidden}); that drops the operator byte-budget \
+             override"
         );
     }
 

--- a/crates/core/src/wasm_runtime/secrets_store/store.rs
+++ b/crates/core/src/wasm_runtime/secrets_store/store.rs
@@ -1689,10 +1689,24 @@ impl SecretsStore {
         // intact for a clean retry instead of having already pruned source
         // snapshots. Thinning touches only `.snapshots/`; a failure here
         // self-corrects on the next write.
+        //
+        // WITHOUT the byte budget: a restore is a RECOVERY operation, and
+        // an operator walking back through versions is the worst moment to
+        // garbage-collect. Applying the budget here would let the
+        // reversibility snapshot the restore just added push several older
+        // versions — possibly including the one just restored FROM — over
+        // the limit and delete them. The count tiers and `max_age` still
+        // apply, so nothing is exempt indefinitely, and the next ordinary
+        // `store_secret` enforces the budget in full. See
+        // `RetentionPolicy::without_byte_budget`.
         if self.snapshots_enabled {
             let snap_dir = snapshot_dir_for(&scope_path, key);
             if snap_dir.exists() {
-                thin_snapshots(&snap_dir, &self.retention, SystemTime::now());
+                thin_snapshots(
+                    &snap_dir,
+                    &self.retention.without_byte_budget(),
+                    SystemTime::now(),
+                );
             }
         }
 
@@ -2338,9 +2352,16 @@ impl SecretsStore {
     /// caller reports it as skipped) — but the index is still reconciled
     /// (idempotent ensure) so a prior partial import that wrote the file but
     /// failed before indexing converges on retry. If `overwrite` is true, the
-    /// value is rewritten (the prior value is snapshotted first by the normal
-    /// `store_secret` write discipline) and re-indexed. Returns `Ok(true)` only
-    /// when a new value was written.
+    /// value is rewritten (the prior value is snapshotted first, on the same
+    /// tmp+fsync+rename discipline as `store_secret`) and re-indexed. Returns
+    /// `Ok(true)` only when a new value was written.
+    ///
+    /// Note the snapshot here is UNCONDITIONAL, unlike `store_secret`, which
+    /// skips it when the plaintext is unchanged. An import is an infrequent,
+    /// operator-driven migration/restore rather than the delegate write path
+    /// that made redundant snapshots expensive, and it is the point at which
+    /// foreign data lands on top of local data — so it always preserves what
+    /// it replaces.
     pub fn import_secret_by_hash(
         &mut self,
         delegate: &DelegateKey,
@@ -4856,8 +4877,10 @@ mod test {
         let mut store = SecretsStore::new(secrets_dir.clone(), Default::default(), db)?;
 
         // Generous count tiers so the BYTE budget is unambiguously what
-        // bounds the history; 40 KiB budget keeps the test fast.
-        const BUDGET: u64 = 40 * 1024;
+        // bounds the history. 60 KiB / 10 KiB values leaves room for ~5
+        // versions, comfortably above MIN_SNAPSHOTS_KEPT_UNDER_BUDGET, so a
+        // pass here means the BUDGET did the work rather than the floor.
+        const BUDGET: u64 = 60 * 1024;
         const VALUE_LEN: usize = 10 * 1024;
         store.set_retention_policy(RetentionPolicy {
             keep_last: 1000,
@@ -4888,10 +4911,14 @@ mod test {
             bytes <= BUDGET,
             "snapshot history must fit the byte budget; got {bytes} bytes in {count} files"
         );
-        // Not vacuous: the budget has to leave real, recoverable history.
+        // Not vacuous, and not merely the floor: a {BUDGET}-byte budget must
+        // hold strictly more than MIN_SNAPSHOTS_KEPT_UNDER_BUDGET versions,
+        // so this asserts the BUDGET bounded the history rather than the
+        // floor rescuing it.
         assert!(
-            count >= 3,
-            "a {BUDGET}-byte budget should hold several {VALUE_LEN}-byte versions; got {count}"
+            count > 3,
+            "a {BUDGET}-byte budget should hold more than the floor's worth of \
+             {VALUE_LEN}-byte versions; got {count}"
         );
         // And what survives is the most RECENT history: the newest snapshot
         // holds the value the last write replaced.
@@ -4910,6 +4937,89 @@ mod test {
         let recovered =
             decrypt_secret_blob(&encryption, &[], None, &blob, &secret_id.encode())?.to_vec();
         assert_eq!(recovered, vec![28u8; VALUE_LEN], "newest snapshot retained");
+        Ok(())
+    }
+
+    /// A restore is a RECOVERY operation and must NOT garbage-collect the
+    /// history the operator is walking through. `restore_snapshot` therefore
+    /// thins without the byte budget, so an over-budget history survives the
+    /// restore intact — while the next ordinary write still enforces it.
+    #[tokio::test]
+    async fn restore_snapshot_does_not_apply_byte_budget() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let temp_dir = tempfile::tempdir()?;
+        let secrets_dir = temp_dir.path().join("secrets-store-test");
+        std::fs::create_dir_all(&secrets_dir)?;
+        let db = create_test_db(temp_dir.path()).await;
+        let mut store = SecretsStore::new(secrets_dir.clone(), Default::default(), db)?;
+        let delegate = Delegate::from((&vec![45].into(), &vec![].into()));
+        let (cipher, nonce) = fresh_cipher();
+        store.register_delegate(delegate.key().clone(), cipher, nonce)?;
+        let secret_id = SecretsId::new(vec![45]);
+
+        const VALUE_LEN: usize = 4 * 1024;
+        // Build the history under a budget-free policy so the setup itself
+        // isn't what trims it.
+        let permissive = RetentionPolicy {
+            keep_last: 1000,
+            buckets: vec![],
+            max_age: None,
+            max_total_bytes: None,
+        };
+        store.set_retention_policy(permissive.clone());
+        for i in 0u8..7 {
+            store.store_secret(
+                delegate.key(),
+                &secret_id,
+                SecretScope::Local,
+                Zeroizing::new(vec![i; VALUE_LEN]),
+            )?;
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        let before = store.list_snapshots(delegate.key(), &secret_id, SecretScope::Local)?;
+        assert_eq!(before.len(), 6, "6 overwrites → 6 snapshots");
+        let oldest_ts = before[0].timestamp_ms;
+
+        // Now impose a budget so tight that applying it would collapse the
+        // history to the floor, and run the RECOVERY path.
+        store.set_retention_policy(RetentionPolicy {
+            max_total_bytes: Some(1),
+            ..permissive
+        });
+        store.restore_snapshot(delegate.key(), &secret_id, SecretScope::Local, oldest_ts)?;
+
+        let after = store.list_snapshots(delegate.key(), &secret_id, SecretScope::Local)?;
+        assert_eq!(
+            after.len(),
+            7,
+            "restore must not evict history: 6 prior + 1 reversibility snapshot"
+        );
+        // The value the operator restored FROM is still on disk, so they can
+        // keep walking versions.
+        assert!(
+            after.iter().any(|m| m.timestamp_ms == oldest_ts),
+            "the snapshot just restored from must survive the restore"
+        );
+        assert_eq!(
+            store
+                .get_secret(delegate.key(), &secret_id, SecretScope::Local)?
+                .to_vec(),
+            vec![0u8; VALUE_LEN],
+            "restore still put the oldest value back"
+        );
+
+        // Contrast: the very next ordinary write DOES apply the budget.
+        store.store_secret(
+            delegate.key(),
+            &secret_id,
+            SecretScope::Local,
+            Zeroizing::new(vec![99u8; VALUE_LEN]),
+        )?;
+        assert_eq!(
+            snapshot_count(&secrets_dir, delegate.key(), &secret_id),
+            3,
+            "a normal write must enforce the budget down to the floor"
+        );
         Ok(())
     }
 

--- a/crates/core/src/wasm_runtime/secrets_store/store.rs
+++ b/crates/core/src/wasm_runtime/secrets_store/store.rs
@@ -774,8 +774,16 @@ impl SecretsStore {
         //     inode and only `rename` makes it visible at the active path,
         //   - update index AFTER the active rename so a crash between rename
         //     and index-update still gives `get_secret` the new value.
-        if take_snapshots
+        //
+        // A write that does not CHANGE the plaintext is skipped entirely
+        // (`active_plaintext_matches`): the snapshot would be a second,
+        // differently-nonced ciphertext for a value we already hold, so it
+        // buys no recovery and cannot be deduped away later. The check is
+        // fail-safe — any doubt about what is on disk means we snapshot.
+        let needs_snapshot = take_snapshots
             && secret_file_path.exists()
+            && !self.active_plaintext_matches(&encryption, &secret_file_path, plaintext.as_slice());
+        if needs_snapshot
             && let Err(e) = self.snapshot_prior_value(&scope_path, key, &secret_file_path)
         {
             // Snapshotting is best-effort. A failure here must not block the
@@ -961,6 +969,90 @@ impl SecretsStore {
         secret_file_path: &Path,
     ) -> std::io::Result<()> {
         snapshot_active_value(delegate_path, &key.encode(), secret_file_path)
+    }
+
+    /// Does the active secret file already hold exactly `plaintext`?
+    ///
+    /// `store_secret` uses this to skip the pre-overwrite snapshot when a
+    /// write does not change the content. Snapshotting a byte-identical
+    /// value has zero recovery value, and because every write draws a FRESH
+    /// AEAD nonce, the redundant copy is a distinct ciphertext that no
+    /// byte-level dedup can ever reclaim afterwards — on a measured
+    /// production peer, hashing all 1001 snapshot files found zero duplicate
+    /// blobs despite obvious value-level repetition.
+    ///
+    /// FAIL-SAFE BY CONSTRUCTION. Every path except "decrypted the active
+    /// blob and its plaintext hashes equal" returns `false`, i.e. "assume it
+    /// changed, take the snapshot":
+    /// - the file can't be stat'd or read,
+    /// - its length differs from the length this plaintext would produce,
+    /// - it isn't in the current on-disk format,
+    /// - it doesn't decrypt under the scope DEK.
+    ///
+    /// So a corrupt, legacy, or foreign-key blob costs a redundant snapshot,
+    /// never a lost one. That asymmetry is deliberate: the failure mode we
+    /// refuse is "silently declined to preserve a value that was about to be
+    /// overwritten".
+    ///
+    /// The length check runs first and settles the common case for free: an
+    /// on-disk blob is exactly `HEADER_LEN + plaintext + TAG_LEN` bytes, so a
+    /// different plaintext length is proof of a change without reading or
+    /// decrypting anything. Only same-length candidates pay the decrypt,
+    /// which is bounded by the size of the very value this write is already
+    /// encrypting and fsync'ing.
+    ///
+    /// Unlike [`decrypt_secret_blob`], the legacy cipher/format fallback
+    /// chain is deliberately NOT consulted. A blob this node's current writer
+    /// did not produce is exactly the blob most worth preserving before it is
+    /// rewritten, and skipping the chain also keeps this off the write path's
+    /// "migrating a legacy blob" log lines.
+    fn active_plaintext_matches(
+        &self,
+        encryption: &Encryption,
+        secret_file_path: &Path,
+        plaintext: &[u8],
+    ) -> bool {
+        let expected_len = (HEADER_LEN + plaintext.len() + TAG_LEN) as u64;
+        match fs::metadata(secret_file_path) {
+            Ok(md) if md.len() == expected_len => {}
+            // Different size => different plaintext. No read, no decrypt.
+            Ok(_) => return false,
+            Err(e) => {
+                tracing::debug!(
+                    path = %secret_file_path.display(),
+                    error = %e,
+                    "could not stat active secret; snapshotting rather than assuming it is unchanged"
+                );
+                return false;
+            }
+        }
+
+        let blob = match fs::read(secret_file_path) {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::debug!(
+                    path = %secret_file_path.display(),
+                    error = %e,
+                    "could not read active secret; snapshotting rather than assuming it is unchanged"
+                );
+                return false;
+            }
+        };
+        // `expected_len` already guarantees `blob.len() >= HEADER_LEN`, but
+        // re-check so this stays correct if the length gate ever moves.
+        if blob.len() < HEADER_LEN || blob.first().copied() != Some(VERSION_V1) {
+            return false;
+        }
+        let nonce = XNonce::from_slice(&blob[1..HEADER_LEN]);
+        let Ok(existing) = encryption.cipher.decrypt(nonce, &blob[HEADER_LEN..]) else {
+            return false;
+        };
+        let existing = Zeroizing::new(existing);
+        // Compare 32-byte BLAKE3 digests rather than the plaintexts: the
+        // comparison then never short-circuits on secret bytes, and a
+        // 256-bit digest makes a false "unchanged" verdict computationally
+        // unreachable.
+        blake3::hash(existing.as_slice()) == blake3::hash(plaintext)
     }
 
     /// Remove a secret under the given `scope`. Local and User scopes are
@@ -4224,6 +4316,7 @@ mod test {
                 max_count: 1,
             }],
             max_age: None,
+            max_total_bytes: None,
         });
 
         let delegate = Delegate::from((&vec![2].into(), &vec![].into()));
@@ -4534,6 +4627,292 @@ mod test {
         Ok(())
     }
 
+    // ===== snapshot-on-write is content-gated =====
+
+    /// Count the snapshot files currently retained for `(delegate, secret)`.
+    fn snapshot_count(secrets_dir: &Path, delegate: &DelegateKey, secret_id: &SecretsId) -> usize {
+        let snap_dir = secrets_dir
+            .join(delegate.encode())
+            .join(SNAPSHOTS_DIR)
+            .join(secret_id.encode());
+        match std::fs::read_dir(&snap_dir) {
+            Ok(rd) => rd.flatten().count(),
+            Err(_) => 0,
+        }
+    }
+
+    /// Total bytes of the snapshot files retained for `(delegate, secret)`.
+    fn snapshot_bytes(secrets_dir: &Path, delegate: &DelegateKey, secret_id: &SecretsId) -> u64 {
+        let snap_dir = secrets_dir
+            .join(delegate.encode())
+            .join(SNAPSHOTS_DIR)
+            .join(secret_id.encode());
+        match std::fs::read_dir(&snap_dir) {
+            Ok(rd) => rd
+                .flatten()
+                .filter_map(|e| e.metadata().ok())
+                .map(|m| m.len())
+                .sum(),
+            Err(_) => 0,
+        }
+    }
+
+    /// Re-writing the SAME plaintext must not grow the snapshot history.
+    /// Every write draws a fresh AEAD nonce, so each redundant snapshot is a
+    /// distinct ciphertext that no byte-level dedup can reclaim later — this
+    /// is the 130MB-guarding-6.8MB blowup at its source.
+    #[tokio::test]
+    async fn store_secret_skips_snapshot_when_plaintext_unchanged()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let secrets_dir = temp_dir.path().join("secrets-store-test");
+        std::fs::create_dir_all(&secrets_dir)?;
+        let db = create_test_db(temp_dir.path()).await;
+        let mut store = SecretsStore::new(secrets_dir.clone(), Default::default(), db)?;
+        let delegate = Delegate::from((&vec![41].into(), &vec![].into()));
+        let (cipher, nonce) = fresh_cipher();
+        store.register_delegate(delegate.key().clone(), cipher, nonce)?;
+        let secret_id = SecretsId::new(vec![41]);
+
+        let write = |store: &mut SecretsStore, body: &[u8]| -> RuntimeResult<()> {
+            store.store_secret(
+                delegate.key(),
+                &secret_id,
+                SecretScope::Local,
+                Zeroizing::new(body.to_vec()),
+            )?;
+            // Distinct epoch-millis stamps so any snapshot taken is its own
+            // file rather than a collision suffix.
+            std::thread::sleep(Duration::from_millis(5));
+            Ok(())
+        };
+
+        write(&mut store, b"v1")?;
+        assert_eq!(
+            snapshot_count(&secrets_dir, delegate.key(), &secret_id),
+            0,
+            "first write has no prior value to preserve"
+        );
+
+        // Ten identical re-writes: nothing to preserve, nothing written.
+        for _ in 0..10 {
+            write(&mut store, b"v1")?;
+        }
+        assert_eq!(
+            snapshot_count(&secrets_dir, delegate.key(), &secret_id),
+            0,
+            "re-writing an identical plaintext must not create snapshots"
+        );
+
+        // A real change still snapshots the value it replaced.
+        write(&mut store, b"v2")?;
+        assert_eq!(
+            snapshot_count(&secrets_dir, delegate.key(), &secret_id),
+            1,
+            "a changed plaintext must still snapshot the prior value"
+        );
+        // ...and the snapshot holds the value that was overwritten.
+        let snap_dir = secrets_dir
+            .join(delegate.key().encode())
+            .join(SNAPSHOTS_DIR)
+            .join(secret_id.encode());
+        let snaps = list_snapshots(&snap_dir)?;
+        let encryption = store
+            .ciphers
+            .get(delegate.key())
+            .expect("cipher registered")
+            .clone();
+        let blob = std::fs::read(&snaps[0].path)?;
+        let recovered =
+            decrypt_secret_blob(&encryption, &[], None, &blob, &secret_id.encode())?.to_vec();
+        assert_eq!(recovered, b"v1".to_vec());
+
+        // Re-writing the new value is again a no-op for history.
+        for _ in 0..5 {
+            write(&mut store, b"v2")?;
+        }
+        assert_eq!(
+            snapshot_count(&secrets_dir, delegate.key(), &secret_id),
+            1,
+            "identical re-writes after a change must not grow history either"
+        );
+
+        // The active value is still readable and correct throughout.
+        assert_eq!(
+            store
+                .get_secret(delegate.key(), &secret_id, SecretScope::Local)?
+                .to_vec(),
+            b"v2".to_vec()
+        );
+        Ok(())
+    }
+
+    /// The cheap length pre-check must not be mistaken for the whole test:
+    /// a DIFFERENT plaintext of the SAME length must still snapshot.
+    #[tokio::test]
+    async fn store_secret_snapshots_same_length_different_content()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let secrets_dir = temp_dir.path().join("secrets-store-test");
+        std::fs::create_dir_all(&secrets_dir)?;
+        let db = create_test_db(temp_dir.path()).await;
+        let mut store = SecretsStore::new(secrets_dir.clone(), Default::default(), db)?;
+        let delegate = Delegate::from((&vec![42].into(), &vec![].into()));
+        let (cipher, nonce) = fresh_cipher();
+        store.register_delegate(delegate.key().clone(), cipher, nonce)?;
+        let secret_id = SecretsId::new(vec![42]);
+
+        // Same length, one byte apart.
+        for body in [b"aaaaaaaa", b"aaaaaaab", b"aaaaaaac"] {
+            store.store_secret(
+                delegate.key(),
+                &secret_id,
+                SecretScope::Local,
+                Zeroizing::new(body.to_vec()),
+            )?;
+            std::thread::sleep(Duration::from_millis(5));
+        }
+
+        assert_eq!(
+            snapshot_count(&secrets_dir, delegate.key(), &secret_id),
+            2,
+            "same-length content changes must each snapshot the prior value"
+        );
+        Ok(())
+    }
+
+    /// Fail-safe: when the active blob cannot be decrypted (corruption, a
+    /// foreign cipher, a legacy format), we must NOT conclude "unchanged".
+    /// The unreadable value is exactly the one most worth preserving.
+    #[tokio::test]
+    async fn store_secret_snapshots_when_active_blob_is_undecryptable()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let secrets_dir = temp_dir.path().join("secrets-store-test");
+        std::fs::create_dir_all(&secrets_dir)?;
+        let db = create_test_db(temp_dir.path()).await;
+        let mut store = SecretsStore::new(secrets_dir.clone(), Default::default(), db)?;
+        let delegate = Delegate::from((&vec![43].into(), &vec![].into()));
+        let (cipher, nonce) = fresh_cipher();
+        store.register_delegate(delegate.key().clone(), cipher, nonce)?;
+        let secret_id = SecretsId::new(vec![43]);
+
+        let body = b"unchanged-payload".to_vec();
+        store.store_secret(
+            delegate.key(),
+            &secret_id,
+            SecretScope::Local,
+            Zeroizing::new(body.clone()),
+        )?;
+        std::thread::sleep(Duration::from_millis(5));
+
+        // Corrupt the AEAD tag in place, preserving the blob LENGTH so the
+        // cheap pre-check passes and the decrypt is what rejects it.
+        let secret_path = secrets_dir
+            .join(delegate.key().encode())
+            .join(secret_id.encode());
+        let mut blob = std::fs::read(&secret_path)?;
+        let last = blob.len() - 1;
+        blob[last] ^= 0xff;
+        let len_before = blob.len();
+        std::fs::write(&secret_path, &blob)?;
+
+        // Write the same plaintext again: the on-disk blob is the right size
+        // but does not decrypt, so it must be snapshotted, not skipped.
+        store.store_secret(
+            delegate.key(),
+            &secret_id,
+            SecretScope::Local,
+            Zeroizing::new(body),
+        )?;
+
+        assert_eq!(
+            snapshot_count(&secrets_dir, delegate.key(), &secret_id),
+            1,
+            "an undecryptable active blob must be preserved before overwrite"
+        );
+        // The preserved bytes are the corrupt blob itself (forensics), which
+        // is only meaningful if it really was the same size as a valid one.
+        let snap_dir = secrets_dir
+            .join(delegate.key().encode())
+            .join(SNAPSHOTS_DIR)
+            .join(secret_id.encode());
+        let snaps = list_snapshots(&snap_dir)?;
+        assert_eq!(snaps[0].size_bytes, len_before as u64);
+        Ok(())
+    }
+
+    /// Snapshot history for one secret is bounded in BYTES, not just in
+    /// version count: many large distinct values must not accumulate an
+    /// unbounded history the way ~1 MiB room states did (30.7 MB / 34
+    /// versions on the measured peer).
+    #[tokio::test]
+    async fn store_secret_snapshot_history_respects_byte_budget()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let secrets_dir = temp_dir.path().join("secrets-store-test");
+        std::fs::create_dir_all(&secrets_dir)?;
+        let db = create_test_db(temp_dir.path()).await;
+        let mut store = SecretsStore::new(secrets_dir.clone(), Default::default(), db)?;
+
+        // Generous count tiers so the BYTE budget is unambiguously what
+        // bounds the history; 40 KiB budget keeps the test fast.
+        const BUDGET: u64 = 40 * 1024;
+        const VALUE_LEN: usize = 10 * 1024;
+        store.set_retention_policy(RetentionPolicy {
+            keep_last: 1000,
+            buckets: vec![],
+            max_age: None,
+            max_total_bytes: Some(BUDGET),
+        });
+
+        let delegate = Delegate::from((&vec![44].into(), &vec![].into()));
+        let (cipher, nonce) = fresh_cipher();
+        store.register_delegate(delegate.key().clone(), cipher, nonce)?;
+        let secret_id = SecretsId::new(vec![44]);
+
+        // 30 distinct 10 KiB values: ~300 KiB of history without a budget.
+        for i in 0u8..30 {
+            store.store_secret(
+                delegate.key(),
+                &secret_id,
+                SecretScope::Local,
+                Zeroizing::new(vec![i; VALUE_LEN]),
+            )?;
+            std::thread::sleep(Duration::from_millis(5));
+        }
+
+        let bytes = snapshot_bytes(&secrets_dir, delegate.key(), &secret_id);
+        let count = snapshot_count(&secrets_dir, delegate.key(), &secret_id);
+        assert!(
+            bytes <= BUDGET,
+            "snapshot history must fit the byte budget; got {bytes} bytes in {count} files"
+        );
+        // Not vacuous: the budget has to leave real, recoverable history.
+        assert!(
+            count >= 3,
+            "a {BUDGET}-byte budget should hold several {VALUE_LEN}-byte versions; got {count}"
+        );
+        // And what survives is the most RECENT history: the newest snapshot
+        // holds the value the last write replaced.
+        let snap_dir = secrets_dir
+            .join(delegate.key().encode())
+            .join(SNAPSHOTS_DIR)
+            .join(secret_id.encode());
+        let snaps = list_snapshots(&snap_dir)?;
+        let newest = snaps.last().expect("history is non-empty");
+        let encryption = store
+            .ciphers
+            .get(delegate.key())
+            .expect("cipher registered")
+            .clone();
+        let blob = std::fs::read(&newest.path)?;
+        let recovered =
+            decrypt_secret_blob(&encryption, &[], None, &blob, &secret_id.encode())?.to_vec();
+        assert_eq!(recovered, vec![28u8; VALUE_LEN], "newest snapshot retained");
+        Ok(())
+    }
+
     /// list_snapshots on a never-written secret returns an empty Vec (not an
     /// error). This mirrors `next_snapshot_path` + the missing-dir branch of
     /// `list_snapshots` in secret_snapshots.rs.
@@ -4830,6 +5209,7 @@ mod test {
             keep_last: 100,
             buckets: vec![],
             max_age: None,
+            max_total_bytes: None,
         });
 
         let delegate = Delegate::from((&vec![70].into(), &vec![].into()));
@@ -5284,6 +5664,7 @@ mod test {
             keep_last: 100,
             buckets: vec![],
             max_age: None,
+            max_total_bytes: None,
         });
 
         // Restore byte-copies legacy AEAD back to the active path.

--- a/docs/secrets-at-rest.md
+++ b/docs/secrets-at-rest.md
@@ -195,9 +195,53 @@ Retained history per secret is bounded on three axes:
 The byte budget is what keeps a large secret from turning a generous
 version count into tens of megabytes of disk — a ~1 MiB value keeps a
 handful of versions instead of ~30, while small secrets stay well under
-the budget and keep their full tiered history. It never empties a
-history: if a single version is larger than the whole budget it is
-retained anyway, so "undo the last write" always works.
+the budget and keep their full tiered history.
+
+It never empties a history. At least **three** snapshots are always kept,
+even when that exceeds the budget, so an operator always has a few
+versions to walk back through. For a secret up to 1 MiB this floor never
+comes into play (three of those versions already fit in 3 MiB); it only
+matters for the genuinely large values, where the practical bound becomes
+`max(3 MiB, 3 x the largest version)`.
+
+##### The byte budget is applied retroactively — read this before upgrading
+
+Unlike the count tiers, which a node upgrading into them satisfies
+gradually, the byte budget takes effect **all at once**: on a node that
+accumulated a large history before the budget existed, the first
+`store_secret` for a given secret after the upgrade thins that secret's
+history down to the budget in a single pass, and **those deletions are
+permanent**. On a peer where snapshots had grown to 130 MB, that is the
+intended reclaim — but it is a one-way door.
+
+If you want to keep an existing history, either copy
+`<secrets_dir>/<delegate>/.snapshots/` aside before starting the upgraded
+node, or raise/disable the budget (below) before the first write.
+
+##### Tuning or disabling the byte budget
+
+`FREENET_SECRET_SNAPSHOT_BYTES_PER_SECRET` overrides the per-secret budget,
+in bytes:
+
+| Value | Effect |
+|-------|--------|
+| unset, empty, or unparseable | 3 MiB default (an unparseable value logs a warning and keeps the default) |
+| `0` | budget **disabled** — only the count tiers and `max_age` bound the history, i.e. the pre-budget behaviour |
+| any other number | that many bytes |
+
+This is the knob for "I want more history". The separate
+`FREENET_DISABLE_SECRET_SNAPSHOTS` variable turns snapshotting off
+entirely, which is the opposite.
+
+##### Recovery is exempt
+
+`snapshot-restore` — both the CLI and the node runtime's restore path —
+thins **without** the byte budget. An operator running a restore is often
+walking back through versions one at a time, and applying the budget there
+could evict several older versions (including the one just restored from)
+as a side effect of the reversibility snapshot the restore itself adds.
+The count tiers and `max_age` still apply, and the next ordinary write
+enforces the budget in full.
 
 ### Export / import a portable secrets bundle (#4035, P3 of #4381)
 
@@ -261,8 +305,10 @@ bundle FILE, by contrast, is never written in plaintext.
 **Collision handling.** On import, a secret that already exists at the
 same delegate+id is left untouched and reported as skipped, unless
 `--overwrite` is passed (in which case the prior value is snapshotted
-first, like a normal write). `--out` on export refuses to overwrite an
-existing file.
+first). That snapshot is unconditional — unlike an ordinary delegate
+write, an import does not skip it when the content happens to match,
+because an import is where foreign data lands on top of local data.
+`--out` on export refuses to overwrite an existing file.
 
 ## File permissions (PR #4195 / issue #4141)
 

--- a/docs/secrets-at-rest.md
+++ b/docs/secrets-at-rest.md
@@ -199,10 +199,12 @@ the budget and keep their full tiered history.
 
 It never empties a history. At least **three** snapshots are always kept,
 even when that exceeds the budget, so an operator always has a few
-versions to walk back through. For a secret up to 1 MiB this floor never
-comes into play (three of those versions already fit in 3 MiB); it only
-matters for the genuinely large values, where the practical bound becomes
-`max(3 MiB, 3 x the largest version)`.
+versions to walk back through. For a secret under ~1 MiB this floor never
+comes into play — three of those versions already fit in 3 MiB (each
+snapshot costs its plaintext plus 41 bytes of header and AEAD tag, so
+three fit for plaintexts up to 1,048,535 bytes; at exactly 1 MiB the
+floor already binds). It only matters for the genuinely large values,
+where the practical bound becomes `max(3 MiB, 3 x the largest version)`.
 
 ##### The byte budget is applied retroactively — read this before upgrading
 
@@ -236,12 +238,23 @@ entirely, which is the opposite.
 ##### Recovery is exempt
 
 `snapshot-restore` — both the CLI and the node runtime's restore path —
-thins **without** the byte budget. An operator running a restore is often
-walking back through versions one at a time, and applying the budget there
-could evict several older versions (including the one just restored from)
-as a side effect of the reversibility snapshot the restore itself adds.
-The count tiers and `max_age` still apply, and the next ordinary write
-enforces the budget in full.
+thins **without** the byte budget. Applying it there could evict several
+older versions (including the one just restored from) as a side effect of
+the reversibility snapshot the restore itself adds. The count tiers and
+`max_age` still apply.
+
+How long that exemption lasts depends on which path you are on, and the
+difference matters:
+
+- **`freenet secrets snapshot-restore` (what you should be using):** it
+  lasts as long as you need. The command requires the node to be stopped,
+  so no delegate write can intervene — you can list, restore, inspect and
+  restore again across the whole retained history.
+- **The in-process `SecretsStore::restore_snapshot` API:** it lasts only
+  until the next write to that secret. An ordinary write thins with the
+  full policy, so on a *running* node a delegate touching that secret
+  collapses the restored history to the three-snapshot floor. This is one
+  more reason the supported recovery procedure stops the node first.
 
 ### Export / import a portable secrets bundle (#4035, P3 of #4381)
 

--- a/docs/secrets-at-rest.md
+++ b/docs/secrets-at-rest.md
@@ -174,6 +174,31 @@ consequence: if you restore from a snapshot older than the 2-year
 already the active secret by then) and stays reversible — the prior
 active value is captured as a fresh snapshot before the overwrite.
 
+#### What gets snapshotted, and how much history is kept
+
+A snapshot is taken only when a write actually **changes** the secret's
+plaintext. Re-writing a byte-identical value is a no-op for history: the
+snapshot would be a second copy of a value already on disk, and since
+every write draws a fresh AEAD nonce, that copy is a distinct ciphertext
+no deduplication can reclaim later. Any uncertainty about the current
+on-disk value (unreadable file, unexpected size, a blob that does not
+decrypt) falls back to taking the snapshot.
+
+Retained history per secret is bounded on three axes:
+
+| Axis | Default | Effect |
+|------|---------|--------|
+| Count tiers | last 5, then 1/min x10, 1/hour x24, 1/day x7, 1/week x4, 1/month x12 | ~62 versions in steady state |
+| `max_age` | 2 years | drops anything older, overriding the tiers |
+| `max_total_bytes` | 3 MiB | drops the OLDEST survivors until the rest fit |
+
+The byte budget is what keeps a large secret from turning a generous
+version count into tens of megabytes of disk — a ~1 MiB value keeps a
+handful of versions instead of ~30, while small secrets stay well under
+the budget and keep their full tiered history. It never empties a
+history: if a single version is larger than the whole budget it is
+retained anyway, so "undo the last write" always works.
+
 ### Export / import a portable secrets bundle (#4035, P3 of #4381)
 
 Unlike snapshot-restore, `export`/`import` move secrets BETWEEN nodes.


### PR DESCRIPTION
## Problem

Delegate secret snapshots cost far more disk than the data they guard. On a
measured production peer: **130 MB of snapshots protecting 6.8 MB of live
secrets** — a 19x ratio.

Two independent causes:

**1. Every overwrite snapshotted, even when nothing changed.** `store_secret`
called `snapshot_prior_value` on every write where the active file existed,
with no check that the content differed. Every write draws a fresh AEAD nonce,
so an identical plaintext always encrypts to a *different* ciphertext — the
redundant copies can never be reclaimed by byte-level dedup after the fact.
Hashing all 1001 snapshot files on the measured peer found **zero** duplicate
blobs, despite obvious value-level repetition: several keys had far fewer
distinct sizes than snapshots (16 snapshots / 7 distinct sizes, 30/18, 32/22),
and since AEAD ciphertext length tracks plaintext length, those are near
certainly the same value re-snapshotted.

**2. Retention was bounded in versions, not bytes.** `RetentionPolicy::default()`
keeps ~62 versions per secret (`keep_last: 5` plus minute/hour/day/week/month
tiers, 2-year `max_age`). That is a few hundred KiB for a small secret and tens
of MB for a large one. The top key on the measured peer was **30.7 MB across 34
snapshots** of a ~1 MB River room state (31 distinct sizes, so the content
really was changing — the tiers just have no idea what a version costs).

## Solution

### Part 1 — skip the snapshot when the plaintext is unchanged

`store_secret` now consults `SecretsStore::active_plaintext_matches` before
snapshotting and skips when the incoming plaintext already equals what is on
disk. Snapshotting a byte-identical value has zero recovery value.

**Where the plaintext hash lives: nowhere. It is recomputed by decrypting the
active blob.** The alternative — a hash stored alongside the value — is cheaper
per write but is new on-disk state, and it is state that *cannot* be committed
atomically with the value it describes. A crash between the value rename and
the sidecar write leaves a stale-but-present hash, and a stale hash that
happens to match the *incoming* plaintext makes us skip a snapshot for a write
that genuinely changed the value. That is the exact failure this feature exists
to prevent. Making it detectable would mean binding the sidecar to the blob's
identity (e.g. recording the active file's nonce) — more machinery guarding new
state, to save work that is already cheap. A stored plaintext hash also weakens
the at-rest posture: it is an offline guess-confirmation oracle against a
low-entropy secret for anyone who can read the disk but not the KEK, so it
would have to be keyed with the DEK to be safe. Decrypting is authoritative by
construction, adds no format, no migration, and no new confidentiality surface.

Cost is bounded and asymmetric in our favour:

- A cheap length gate runs first. An on-disk blob is exactly
  `HEADER_LEN + plaintext + TAG_LEN` bytes, so a different plaintext length is
  proof of a change with no read and no decrypt. This settles the common case
  for large, genuinely-changing values.
- Only same-length candidates pay a decrypt — of the same value this write is
  already encrypting and fsync'ing, so it is a small fraction of work we do
  anyway, and when it says "unchanged" we skip a hard-link plus later thinning.
- The comparison is over 32-byte BLAKE3 digests rather than raw plaintexts, so
  it never short-circuits on secret bytes.

**Fail-safe by construction.** The only path that returns "unchanged" is
"decrypted the active blob and the digests matched". Everything else —
unstattable file, unreadable file, unexpected size, not the current on-disk
format, decrypt failure — returns "changed" and takes the snapshot. The legacy
cipher/format fallback chain is deliberately *not* consulted: a blob this
node's current writer did not produce is exactly the one most worth preserving
before it is rewritten. A corrupt, legacy, or foreign-key blob costs a
redundant snapshot, never a lost one.

### Part 2 — bound snapshots by bytes per key

`RetentionPolicy` gains `max_total_bytes`, defaulting to **3 MiB per secret**
(`DEFAULT_MAX_SNAPSHOT_BYTES_PER_SECRET`). `thin_snapshots` now feeds file
sizes into `select_keep_within_budget`, which runs the existing tiered
selection unchanged and then drops the **oldest** survivors until the retained
set fits.

Why 3 MiB: a ~1 MiB room state keeps ~3 versions instead of ~30, which still
covers what snapshots exist for (undo an accidental or buggy overwrite) at a
tenth of the disk; small secrets never come near it, so they keep their full
tiered history where deep history is nearly free and most useful. For scale, 3
MiB for one secret is already ~2x the *entire* live secret footprint (1.6 MB)
of the production gateway I measured directly.

Design properties:

- **Tiering shape is preserved.** The budget is layered on top of
  `select_keep`, not a replacement for it.
- **Every clause is subtractive.** `max_age` and `max_total_bytes` only ever
  remove; spare byte budget can never resurrect an age-dropped snapshot.
- **Eviction is oldest-first**, because the newest snapshot is the value the
  most recent write replaced.
- **The budget never collapses a history.** `MIN_SNAPSHOTS_KEPT_UNDER_BUDGET = 3`:
  eviction stops there even when the survivors blow the budget wide open, so
  an operator always has a few versions to walk back through rather than only
  "undo the last write". It is cheap where it binds — at the 3 MiB default the
  floor is *inert* for any secret **under ~1 MiB**, because three of those
  already fit. Exactly: a snapshot costs `HEADER_LEN + plaintext + TAG_LEN`
  (41 bytes of overhead), so three fit iff plaintext `n <= 1_048_535`; at
  exactly 1 MiB the floor already binds. So it only affects the large values
  where a one-entry history would be thinnest, and the worst case is
  `3 x largest snapshot` rather than unbounded. Not 5 (matching `keep_last`):
  by the same arithmetic that would bind for every secret over ~614 KiB and
  raise the worst case to 5x. A disk heuristic must never be the reason user
  data stops being recoverable.
- **A stat failure charges 0 bytes**, so an unmeasurable entry is retained and
  a measurable one is evicted instead — erring toward keeping.
- `thin_snapshots` sorts by the **parsed** `(timestamp, suffix)` rather than
  timestamp alone, so same-millisecond collision entries evict
  deterministically and in the order `list_snapshots` and the restore
  disambiguation already use. Numeric, not lexicographic: text order puts
  `.10` before `.9`, so with 11+ snapshots inside one millisecond the budget
  could otherwise evict the numerically-newest entry and keep an older
  sibling, making "undo the last write" return a value from several writes
  back.
- **Operators can override the budget** via
  `FREENET_SECRET_SNAPSHOT_BYTES_PER_SECRET` (bytes; `0` disables it
  entirely). Degrade-safe in one direction on purpose: absent, empty, or
  unparseable falls back to the bounded default, never to "unlimited" (which
  would silently re-open the disk blowup) and never to "0 bytes" (which would
  silently shrink every history to the floor). The budget is the one retention
  clause that deletes pre-existing history on upgrade, and the only other knob
  (`FREENET_DISABLE_SECRET_SNAPSHOTS`) points the wrong way for someone who
  wants *more* history. The read lives in `RetentionPolicy::from_env()`
  alone; `Default` is pure, so constructing a policy never touches `environ`.

Neither part touches the live value. Snapshots are the only thing in scope: the
snapshot/tmp-write/fsync/rename ordering in `store_secret` is unchanged, and a
skipped snapshot changes nothing about the durability of the write itself.

### Part 3 — the budget stays off the recovery path

`RetentionPolicy::without_byte_budget()` strips the budget for both restore
call sites (`SecretsStore::restore_snapshot` and `freenet secrets
snapshot-restore`).

Without this, the budget fired during the exact operation an operator runs
when they are trying to recover. Concretely: a 2 MiB secret with 5 snapshots
(10 MiB of history), operator runs `snapshot-restore` to walk back one
version, the restore hard-links the active value as a reversibility snapshot
(6 entries, 12 MiB), and the budget then evicted down to the floor — deleting
the snapshot they had just restored *from*. One recovery command destroying
the history they were in the middle of walking is not a trade worth making
for disk.

This is not an unbounded cleanup exemption: the count tiers and `max_age`
still run at the restore, so every entry keeps a finite lifetime, and the next
ordinary `store_secret` applies the budget in full.

**How long the exemption holds differs by entry point, and the docs now say
so explicitly rather than implying a uniform window:**

- `freenet secrets snapshot-restore` — holds as long as the operator needs.
  The CLI requires the node to be **stopped**, so no delegate write can
  intervene; list, restore, inspect, restore again all work across the full
  retained history. This is the supported recovery procedure.
- `SecretsStore::restore_snapshot` (in-process API) — holds only until the
  next write to that secret. `store_secret` thins with the full policy on
  every call (gated on whether snapshots are enabled, not on whether *that*
  write took one), so a live node collapses a restored history to the floor
  as soon as its delegate touches the secret — including on one of the
  identical re-writes Part 1 taught it to skip snapshotting. That API has no
  production callers today.

Gating `store_secret`'s thin on `needs_snapshot` — not garbage-collecting on
a write that adds nothing to the history — would widen the live-node window.
**Deliberately not done here, and flagged rather than changed silently:** it
is a real semantic change to when reclaim happens, the supported procedure is
the stopped-node CLI where it buys nothing, and a write that skips its
snapshot still leaves a history the operator's configured budget calls too
large.

### The budget is retroactive — documented, not hidden

Unlike the count tiers, which a node upgrading into them satisfies gradually,
the byte budget takes effect all at once: the first `store_secret` for a given
secret after upgrade thins an over-budget history down to the budget in a
single pass, and those deletions are permanent. On the 130 MB peer that is the
intended reclaim, but it is a one-way door, so `docs/secrets-at-rest.md` now
says so explicitly, tells operators how to preserve a history they care about
(copy `.snapshots/` aside, or raise/disable the budget before the first
write), and documents the env override and the recovery exemption.

### Test isolation: no `setenv` in the test binary

The first version of the override test mutated process-global `environ` with
`set_var`/`remove_var` while `RetentionPolicy::default()` — reached from
`SecretsStore::new` on **every** store construction — called `std::env::var`.
That is a `getenv`/`setenv` data race inside one lib-test binary. CI is safe
(nextest, process per test) and there is repo precedent, but AGENTS.md
prescribes plain `cargo test`, which is also what #5023's flake repro uses —
and UB in that binary would undermine the very clean-tree-vs-branch
comparison used to rule this PR out of that flake.

Restructured so no test touches `environ` at all:

- `Default::default()` is **pure** (the built-in constant).
- `RetentionPolicy::with_budget_from(raw)` applies an override from a raw
  string — this is what the tests exercise, behaviourally.
- `RetentionPolicy::from_env()` is the single `getenv`, with no test mutating
  the environment around it.
- `SecretsStore::new` uses `from_env()`.

The three links that are only observable through `setenv` are pinned by
source scrapes over sliced blocks instead (mutations 13, 15, 16 above).

### Deliberately not in scope

- **`import_secret_by_hash` keeps snapshotting unconditionally.** It is the
  operator-driven migration/restore path, bounded by the export count cap and
  not a contributor to the measured growth. Gating it would be scope creep on a
  focused perf change.
- **The budget is per-secret, so a node's total is still `keys x 3 MiB`.**
  Bounding the aggregate needs a cross-secret sweep, which is a different
  mechanism. Noted on the constant.
- **No new operator config.** Snapshots can already be disabled wholesale via
  `FREENET_DISABLE_SECRET_SNAPSHOTS`; adding a persisted tunable would drag in
  the `ConfigArgs::build` round-trip contract for a value with no evidence yet
  that anyone needs to tune it.

## Estimated saving

On the peer where the 130 MB was measured I can only reason from the reported
per-key numbers, not re-derive: the top key alone goes from **30.7 MB to ~2.7
MB** (3 versions of ~0.9 MB) under the byte budget, and the keys reported with
16/7, 30/18 and 32/22 snapshots-to-distinct-sizes are what Part 1 removes. I
do not have that peer's full per-key distribution, so I am not going to invent
a total for it.

I *can* compute the effect exactly on the production gateway whose secrets tree
I can read (11.97 MiB of snapshots in 840 files across 112 keys, guarding 1.6
MB of live secrets — a 7.4x ratio, the same pathology at smaller scale):

| | |
|---|---|
| Byte budget @ 3 MiB | 11.97 → 10.87 MiB (its distribution is flat; largest key is 3.89 MiB) |
| Same-size repeats within a key | 656 of 840 files, 5.73 MiB — an **upper bound** on what Part 1 removes |

The two parts attack different shapes, which is the point: the budget does the
work on peers with a few large keys (the 130 MB case), Part 1 does the work on
peers with many repeatedly-rewritten keys.

## Testing

`cargo test -p freenet --lib --all-features wasm_runtime::` — 487 passed, 0
failed; `cargo test -p freenet --bin freenet --all-features snapshot_restore`
— 7 passed. `cargo fmt` clean; `cargo clippy -p freenet --lib --bins
--all-features` clean (exit 0, no warnings).

**Unrelated pre-existing flake found while testing, filed as #5023.**
`wasm_runtime::delegate::test::{test_large_secret_data,
test_store_and_retrieve_secret}` fail ~1 in 8 full-`wasm_runtime::` runs on a
loaded machine ("stored secret reads back as `None`"). Verified it reproduces
on `43eb1ea9` (main) with an otherwise-clean tree at the same rate, so it is
not from this PR: 1 failure in 12 runs on main, 1 in 12 on this branch.

New unit tests (`secret_snapshots`): oldest-first eviction, budget disabled,
never-empty floor, zero budget, exact-boundary (at budget vs one byte over),
empty input, subtractive-only vs `max_age`, budget counts only tier-kept
entries, `u64` overflow saturation, `RetentionPolicy::default()` bounds bytes
(with a vacuity guard asserting the count tiers alone would have kept more),
plus two filesystem-level `thin_snapshots` tests.

New store-level tests (`secrets_store::store`): identical re-writes create no
snapshots while a real change still does (and the snapshot decrypts to the
value it replaced); **same-length different content still snapshots** (the
length gate is a fast path, not the decision); an undecryptable active blob is
snapshotted rather than assumed unchanged; and snapshot history for one secret
stays within its byte budget while retaining several recoverable versions, the
newest of which decrypts to the value the last write replaced.

### Call-site mutation evidence

Internals surviving mutation while the *wiring* sits unpinned is a known
failure mode, so each new call site was deleted or inverted and the full
`wasm_runtime::` suite re-run. Each mutation was verified to have actually
landed on disk (non-empty `git diff`) before the run, so a silently-unapplied
mutation cannot masquerade as a passing pin.

| # | Mutation | Result |
|---|---|---|
| 1 | Delete `&& !self.active_plaintext_matches(...)` from `store_secret` — the Part 1 **call site** | RED: 1 failed — `store_secret_skips_snapshot_when_plaintext_unchanged` |
| 2 | `max_total_bytes: Some(DEFAULT_...)` → `None` in `RetentionPolicy::default()` — the Part 2 **default wiring** | RED: 1 failed — `default_policy_bounds_bytes_per_secret` |
| 3 | `select_keep_within_budget` → `select_keep` in `thin_snapshots` — the Part 2 **filesystem call site** | RED: 3 failed — `thin_snapshots_enforces_byte_budget`, `thin_snapshots_byte_budget_keeps_one_oversized_snapshot`, `store_secret_snapshot_history_respects_byte_budget` |
| 4 | Decrypt-failure branch returns `true` (unchanged) instead of `false` — the **fail-safe direction** | RED: 1 failed — `store_secret_snapshots_when_active_blob_is_undecryptable` |
| 5 | Digest comparison replaced with `true`, so the length gate alone decides | RED: **12 failed**, including `store_secret_snapshots_same_length_different_content` and 10 pre-existing snapshot tests |

Baseline immediately after reverting all five: **473 passed, 0 failed.**

The review round added four call sites and two constants; each was mutated the
same way:

| # | Mutation | Result |
|---|---|---|
| 6 | `MIN_SNAPSHOTS_KEPT_UNDER_BUDGET` 3 -> 1 (the pre-review value) | RED: 4 failed, incl. `byte_budget_floor_keeps_three_over_budget` and `restore_snapshot_does_not_apply_byte_budget` |
| 7 | `default()` hardcodes the constant instead of reading the env — the **override wiring** | RED: `default_policy_reads_the_budget_env` |
| 8 | Unparseable env value disables the budget instead of defaulting — the **degrade direction** | RED: `budget_env_garbage_degrades_to_the_default` |
| 9 | Node restore path applies the budget again — the **recovery call site** | RED: `restore_snapshot_does_not_apply_byte_budget` |
| 10 | `without_byte_budget()` becomes a no-op clone | RED: `without_byte_budget_drops_only_the_budget` + `restore_snapshot_does_not_apply_byte_budget` |
| 11 | `thin_snapshots` sorts by path again (lexicographic) | RED: `thin_snapshots_orders_collision_suffixes_numerically` |
| 12 | CLI restore path applies the budget again — the **CLI call site** | RED: `snapshot_restore_does_not_apply_byte_budget` |

Mutation 12 is the one worth calling out: the CLI call site was initially
**unpinned** — deleting `.without_byte_budget()` there left every test green,
because the CLI's `snapshot_restore` had no byte-budget coverage. That test
was added in commit 3 specifically so the mutation goes red, which it now
does.

The second review round restructured the env plumbing (see below), so its
call sites were mutated too:

| # | Mutation | Result |
|---|---|---|
| 13 | `SecretsStore::new` uses the pure constructor instead of the env-aware one | RED: `secrets_store_new_uses_env_aware_retention` |
| 14 | `with_budget_from` ignores its argument | RED: 2 failed |
| 15 | `from_env` stops reading the environment | RED: `env_read_lives_only_in_from_env` |
| 16 | `Default` starts reading the environment again | RED: `env_read_lives_only_in_from_env` |
| 17 | floor 3 → 1 (re-verified after the restructure) | RED: 4 failed |

**Mutation 13 initially passed, and that is worth recording.** The first
version of that pin split its needle with `concat!` so the test's *code*
could not match it — but the rustdoc directly above spelled
`RetentionPolicy::from_env()` out in full, and the scrape searched the whole
file, so it matched its own doc comment. Only the mutation run surfaced it.
It is now two-sided (must contain the env-aware construction, must **not**
contain the pure one) with every needle assembled from fragments that appear
nowhere verbatim.

Mutations 15 and 16 were also green at first — genuinely unpinned links.
`env_read_lives_only_in_from_env` closes them by slicing the `from_env` body
and the `Default` impl out of the source and asserting the environment read
is present in exactly the first and absent from the second.

Mutation 5's blast radius is the useful signal: with the content comparison
gone, every same-length write silently stops snapshotting and ten
*pre-existing* snapshot tests (`second_write_snapshots_prior_value`,
`burst_writes_are_thinned`, `delegates_have_disjoint_snapshot_histories`,
`restore_snapshot_replaces_active_value`, …) go red. The skip is genuinely
load-bearing rather than a check nothing observes.

Remaining low-severity review nits (no `#[non_exhaustive]` on
`RetentionPolicy`; an unenforced sorted-input precondition on
`select_keep_within_budget`) are tracked in #5022 rather than accreting here.
The third — a stale `import_bundle` doc sentence — was fixed in this PR
instead, since this PR is what made it inaccurate.

[AI-assisted - Claude]
