### PR TITLE
perf: reclaim the 58 MB known-good rollback binary at probation commit

### DIFF
--- a/crates/core/src/bin/commands/rollback.rs
+++ b/crates/core/src/bin/commands/rollback.rs
@@ -62,8 +62,9 @@
 //!    version as on-probation ([`begin_probation`]).
 //! 2. **Commit**: once the new version has run healthily for
 //!    [`COMMIT_HEALTHY_UPTIME_SECS`] the node clears the probation marker
-//!    ([`commit_probation`]). After that, ordinary later crashes never trigger
-//!    a rollback.
+//!    ([`commit_probation`]) and reclaims the known-good snapshot
+//!    ([`discard_known_good_at`]). After that, ordinary later crashes never
+//!    trigger a rollback.
 //! 3. **Detect + revert**: a crash during probation increments the marker's
 //!    crash counter ([`handle_post_stop`]); on the
 //!    [`ROLLBACK_CRASH_THRESHOLD`]th crash the previous binary is restored
@@ -74,6 +75,30 @@
 //!    (`commands::auto_update`) so we never loop update -> crash -> revert ->
 //!    re-update. A later, strictly-newer release (a fix) is NOT pinned and is
 //!    applied normally.
+//!
+//! ## The known-good blob lives exactly as long as the marker
+//!
+//! The retained snapshot is an UNCOMPRESSED copy of the executable (~58 MB
+//! measured on a real peer), and it is reachable ONLY through a probation
+//! marker: [`handle_post_stop_at`] returns [`PostStopOutcome::Proceed`] before
+//! looking at it when [`read_probation_at`] is `None`, and
+//! [`prepare_known_good_for_install_at`] re-captures fresh from the live binary
+//! rather than reading it in that case. Keeping it past the commit therefore
+//! bought nothing — it was dead weight for the days-to-weeks until the next
+//! update — so the commit reclaims it.
+//!
+//! The tradeoff this accepts: once probation has committed, a node that
+//! degrades LATER has no local binary to revert to and recovers by
+//! re-installing from GitHub. That is the same position as a node whose
+//! known-good capture failed (already a supported, non-fatal state — see
+//! `commands::update`), and the crash-loop class this module exists for (a bad
+//! release that wedges at boot) is unaffected, because it fires inside the
+//! probation window while the blob is still present.
+//!
+//! Not compression: adding a decode step to the one path whose failure bricks a
+//! node would weaken the integrity guarantee (the recorded SHA would cover the
+//! stored bytes, not the installed ones) for a saving that deleting the file
+//! beats outright.
 //!
 //! ## Bounded by construction (no new flap/loop)
 //!
@@ -173,6 +198,10 @@ const PROBATION_FILE: &str = "update_probation.json";
 const KNOWN_BAD_FILE: &str = "known_bad_version";
 
 /// Snapshot of the previous, known-good binary kept as the rollback target.
+///
+/// Captured by [`capture_known_good_at`] just before an install and reclaimed by
+/// [`discard_known_good_at`] when the probation marker that made it reachable is
+/// retired — its lifetime is exactly the marker's.
 const KNOWN_GOOD_BINARY_FILE: &str = "known_good_binary";
 
 /// Persisted post-update probation record.
@@ -406,6 +435,80 @@ pub(crate) fn prepare_known_good_for_install_at(
     Ok((meta, current_version.to_string()))
 }
 
+// ── Known-good reclamation ─────────────────────────────────────────────────
+
+/// Reclaim the retained known-good snapshot once the marker that made it
+/// reachable has been removed (see the module docs: the blob's lifetime is
+/// exactly the marker's, and it is ~58 MB).
+///
+/// `expected` is the integrity metadata recorded in the marker being retired.
+///
+/// This is brick-recovery state, so it only ever unlinks a file it can
+/// positively identify as the now-dead rollback target:
+///
+/// * It re-reads the marker and does NOTHING if one is present. That makes the
+///   "remove the marker FIRST, then reclaim the blob" ordering structural
+///   rather than merely documented: a caller that reclaims while still armed
+///   gets a no-op instead of an armed marker pointing at a deleted binary. It
+///   also declines when a concurrent `freenet update` has already armed the
+///   NEXT probation over this blob.
+/// * It hashes the candidate and deletes it only when size AND SHA-256 match
+///   `expected`, so a snapshot a concurrent install captured for a different
+///   generation is left alone.
+/// * It only ever considers `dir/known_good_binary`, never the
+///   `rollback_binary` path carried in the marker JSON, so a corrupt or
+///   tampered marker cannot make us unlink an arbitrary file.
+///
+/// Best-effort by construction: it returns `()`, and every failure is logged
+/// and swallowed. Reclaiming disk must never fail a probation commit or an
+/// update — a blob we fail to delete is simply overwritten by the next
+/// install's capture, which is exactly the pre-existing steady state.
+fn discard_known_good_at(dir: &Path, expected: &KnownGoodMeta) {
+    if read_probation_at(dir).is_some() {
+        // Still armed (or re-armed by a concurrent install): the blob may be a
+        // live rollback target, so leave it. Never delete while armed.
+        return;
+    }
+    let blob = dir.join(KNOWN_GOOD_BINARY_FILE);
+    if !blob.exists() {
+        return;
+    }
+    match sha256_file(&blob) {
+        Ok((size, sha256)) if size == expected.size && sha256 == expected.sha256 => {
+            match std::fs::remove_file(&blob) {
+                Ok(()) => {
+                    fsync_dir(dir);
+                    tracing::info!(
+                        bytes = size,
+                        path = %blob.display(),
+                        "Reclaimed the retained known-good rollback binary (probation is over, \
+                         nothing can read it)."
+                    );
+                }
+                Err(e) => tracing::warn!(
+                    error = %e,
+                    path = %blob.display(),
+                    "Could not reclaim the retained known-good rollback binary; it is dead \
+                     weight until the next update's capture overwrites it."
+                ),
+            }
+        }
+        Ok((size, _sha256)) => tracing::debug!(
+            size,
+            expected_size = expected.size,
+            path = %blob.display(),
+            "Retained binary is not the rollback target being retired (a concurrent install \
+             most likely re-captured it); leaving it in place."
+        ),
+        Err(e) => tracing::warn!(
+            error = %e,
+            path = %blob.display(),
+            "Could not verify the retained known-good binary before reclaiming it; leaving it \
+             in place."
+        ),
+    }
+}
+
 /// Begin (or refresh) probation for `new_version`, just installed over the live
 /// binary at `target_binary`. `previous_version` and `meta` are the label and
 /// integrity metadata of the rollback target, computed together by
@@ -517,18 +620,43 @@ pub(crate) enum CommitOutcome {
 pub(crate) fn commit_probation_at(dir: &Path, current_version: &str) -> CommitOutcome {
     match read_probation_at(dir) {
         Some(state) if state.new_version == current_version => {
+            // Ordering is load-bearing and fail-safe in this direction only:
+            // drop the marker FIRST, then reclaim the blob it pointed at. A
+            // crash in between leaves an orphaned blob that the next install's
+            // capture overwrites (today's steady state, harmless); the reverse
+            // order would leave an ARMED marker advertising a rollback target
+            // that no longer exists. `discard_known_good_at` re-checks the
+            // marker, so the safe order is enforced, not just documented.
             remove_probation_at(dir);
+            discard_known_good_at(dir, &retired_meta(&state));
             CommitOutcome::Committed
         }
         Some(state) => {
             // Running a different version healthily than the marker describes:
-            // the marker can no longer protect anything, so drop it.
+            // the marker can no longer protect anything, so drop it (and the
+            // blob it was the only reader of). Same ordering rationale as above.
             remove_probation_at(dir);
+            discard_known_good_at(dir, &retired_meta(&state));
             CommitOutcome::ClearedStale {
                 marker_version: state.new_version,
             }
         }
-        None => CommitOutcome::Nothing,
+        None => {
+            // No marker means no blob we can positively identify as dead: an
+            // orphan (e.g. left by a post-stop path that removed the marker
+            // itself) is left for the next install's capture to overwrite
+            // rather than deleted on a guess.
+            CommitOutcome::Nothing
+        }
+    }
+}
+
+/// Integrity metadata of the rollback blob described by a marker we are
+/// retiring, used to identify the blob before reclaiming it.
+fn retired_meta(state: &ProbationState) -> KnownGoodMeta {
+    KnownGoodMeta {
+        size: state.rollback_size,
+        sha256: state.rollback_sha256.clone(),
     }
 }
 
@@ -1031,6 +1159,154 @@ mod tests {
         };
         assert_eq!(marker_version, "0.2.84");
         assert!(read_probation_at(dir).is_none());
+        // The stale marker was the blob's only reader, so it is reclaimed too.
+        assert!(!known_good_path(dir).exists());
+    }
+
+    #[test]
+    fn commit_reclaims_the_known_good_blob() {
+        // The ~58 MB snapshot is reachable ONLY through the probation marker,
+        // so committing (which removes the marker) must reclaim it instead of
+        // carrying it for the days-to-weeks until the next update.
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        setup_probation(dir, "0.2.84", "0.2.83");
+        assert!(known_good_path(dir).exists(), "precondition: blob captured");
+
+        assert_eq!(commit_probation_at(dir, "0.2.84"), CommitOutcome::Committed);
+
+        assert!(read_probation_at(dir).is_none());
+        assert!(
+            !known_good_path(dir).exists(),
+            "known-good blob must be reclaimed once probation commits"
+        );
+    }
+
+    #[test]
+    fn commit_with_no_marker_leaves_an_unidentifiable_blob() {
+        // Without a marker we have no recorded size/SHA to identify the blob
+        // against, so `Nothing` must not delete on a guess. (Orphans are
+        // overwritten by the next install's capture.)
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        let live = dir.join("freenet");
+        write_dummy_binary(&live, b"ORPHAN-BLOB");
+        capture_known_good_at(dir, &live).unwrap();
+
+        assert_eq!(commit_probation_at(dir, "0.2.84"), CommitOutcome::Nothing);
+
+        assert!(known_good_path(dir).exists());
+    }
+
+    #[test]
+    fn commit_leaves_a_blob_that_is_not_the_retired_rollback_target() {
+        // Race guard: a concurrent `freenet update` can capture a FRESH
+        // known-good over the same path between our marker read and our
+        // reclaim. That blob belongs to the next probation generation, so its
+        // content will not match the retired marker's meta and it must survive
+        // — deleting it would leave the next marker pointing at nothing.
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        setup_probation(dir, "0.2.84", "0.2.83");
+        // Stand in for the concurrent install's fresh capture.
+        std::fs::write(
+            known_good_path(dir),
+            b"FRESHLY-CAPTURED-BY-CONCURRENT-INSTALL",
+        )
+        .unwrap();
+
+        assert_eq!(commit_probation_at(dir, "0.2.84"), CommitOutcome::Committed);
+
+        assert_eq!(
+            std::fs::read(known_good_path(dir)).unwrap(),
+            b"FRESHLY-CAPTURED-BY-CONCURRENT-INSTALL"
+        );
+    }
+
+    #[test]
+    fn discard_known_good_refuses_while_a_probation_marker_exists() {
+        // The fail-safe ordering (remove the marker, THEN reclaim) is enforced
+        // by this guard, not merely documented: reclaiming while armed would
+        // leave a marker advertising a rollback target that no longer exists.
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        setup_probation(dir, "0.2.84", "0.2.83");
+        let armed = read_probation_at(dir).expect("armed");
+
+        discard_known_good_at(dir, &retired_meta(&armed));
+
+        assert!(
+            known_good_path(dir).exists(),
+            "must never delete the rollback target while probation is armed"
+        );
+        // And the still-armed marker can still roll back.
+        for _ in 0..ROLLBACK_CRASH_THRESHOLD - 1 {
+            handle_post_stop_at(dir, "101", "0.2.84");
+        }
+        assert!(matches!(
+            handle_post_stop_at(dir, "101", "0.2.84"),
+            PostStopOutcome::RolledBack { .. }
+        ));
+    }
+
+    #[test]
+    fn commit_succeeds_even_when_the_blob_cannot_be_verified() {
+        // Reclamation is best-effort: an unreadable blob must be left alone and
+        // must not change (or fail) the commit outcome.
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        setup_probation(dir, "0.2.84", "0.2.83");
+        // A directory at the blob path: exists, but hashing it fails.
+        std::fs::remove_file(known_good_path(dir)).unwrap();
+        std::fs::create_dir(known_good_path(dir)).unwrap();
+
+        assert_eq!(commit_probation_at(dir, "0.2.84"), CommitOutcome::Committed);
+
+        assert!(read_probation_at(dir).is_none(), "commit still happened");
+        assert!(
+            known_good_path(dir).is_dir(),
+            "an unverifiable blob is left in place, never removed on a guess"
+        );
+    }
+
+    #[test]
+    fn next_install_recaptures_a_fresh_blob_after_commit_reclaimed_it() {
+        // End-to-end: the reclaim must not break the NEXT update cycle. From a
+        // state where the blob is ABSENT (not merely stale),
+        // prepare_known_good_for_install_at has to capture the live binary
+        // fresh, label it the version being replaced, and produce a rollback
+        // target that actually restores.
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        let live = setup_probation(dir, "0.2.84", "0.2.83");
+        assert_eq!(commit_probation_at(dir, "0.2.84"), CommitOutcome::Committed);
+        assert!(!known_good_path(dir).exists(), "blob reclaimed at commit");
+        assert!(read_probation_at(dir).is_none());
+
+        // The next install snapshots the (now proven-good) 0.2.84 binary.
+        let (meta, previous) = prepare_known_good_for_install_at(dir, "0.2.84", &live).unwrap();
+        assert_eq!(previous, "0.2.84", "fresh capture is labelled 0.2.84");
+        assert_eq!(std::fs::read(known_good_path(dir)).unwrap(), b"BAD-BINARY");
+        let (size, hash) = sha256_file(&known_good_path(dir)).unwrap();
+        assert_eq!(meta.size, size);
+        assert_eq!(meta.sha256, hash);
+
+        // Arm 0.2.85 over it and confirm the fresh target really restores.
+        write_dummy_binary(&live, b"WORSE-BINARY");
+        begin_probation_at(dir, "0.2.85", &previous, &live, &meta).unwrap();
+        for _ in 0..ROLLBACK_CRASH_THRESHOLD - 1 {
+            handle_post_stop_at(dir, "101", "0.2.85");
+        }
+        let PostStopOutcome::RolledBack {
+            restored_version,
+            bad_version,
+        } = handle_post_stop_at(dir, "101", "0.2.85")
+        else {
+            panic!("expected RolledBack");
+        };
+        assert_eq!(restored_version, "0.2.84");
+        assert_eq!(bad_version, "0.2.85");
+        assert_eq!(std::fs::read(&live).unwrap(), b"BAD-BINARY");
     }
 
     #[test]

--- a/crates/core/src/bin/commands/rollback.rs
+++ b/crates/core/src/bin/commands/rollback.rs
@@ -79,21 +79,32 @@
 //! ## The known-good blob lives exactly as long as the marker
 //!
 //! The retained snapshot is an UNCOMPRESSED copy of the executable (~58 MB
-//! measured on a real peer), and it is reachable ONLY through a probation
-//! marker: [`handle_post_stop_at`] returns [`PostStopOutcome::Proceed`] before
-//! looking at it when [`read_probation_at`] is `None`, and
-//! [`prepare_known_good_for_install_at`] re-captures fresh from the live binary
-//! rather than reading it in that case. Keeping it past the commit therefore
-//! bought nothing — it was dead weight for the days-to-weeks until the next
-//! update — so the commit reclaims it.
+//! measured on a real peer). No AUTOMATED reader can reach it without a
+//! probation marker: [`handle_post_stop_at`] returns
+//! [`PostStopOutcome::Proceed`] before looking at it when [`read_probation_at`]
+//! is `None`, and [`prepare_known_good_for_install_at`] re-captures fresh from
+//! the live binary rather than reading it in that case. Keeping it past the
+//! commit therefore bought this module nothing — it was dead weight for the
+//! days-to-weeks until the next update — so the commit reclaims it.
 //!
-//! The tradeoff this accepts: once probation has committed, a node that
-//! degrades LATER has no local binary to revert to and recovers by
-//! re-installing from GitHub. That is the same position as a node whose
-//! known-good capture failed (already a supported, non-fatal state — see
-//! `commands::update`), and the crash-loop class this module exists for (a bad
-//! release that wedges at boot) is unaffected, because it fires inside the
-//! probation window while the blob is still present.
+//! The tradeoff this accepts, in two parts:
+//!
+//! * **Automated.** Once probation has committed, a node that degrades LATER
+//!   has no local binary to revert to and recovers by re-installing from
+//!   GitHub. That is the same position as a node whose known-good capture
+//!   failed (already a supported, non-fatal state — see `commands::update`),
+//!   and the crash-loop class this module exists for (a bad release that wedges
+//!   at boot) is unaffected, because it fires inside the probation window while
+//!   the blob is still present.
+//! * **Manual.** An OPERATOR with shell access could always `cp` the blob back
+//!   by hand, so it doubled as an offline recovery artifact for the post-commit
+//!   degradation class — a use no code path expresses and this module never
+//!   promised, but a real one. Reclaiming the blob removes it. Note also that
+//!   the commit trigger is a bare 60 s sleep (`bin/freenet.rs`) with no health
+//!   check beyond "the process is still alive", so "committed" means less than
+//!   it sounds like. Whether that warrants keeping an offline copy (or a
+//!   stronger commit condition) is an open question for the maintainer, NOT
+//!   something the code below tries to answer.
 //!
 //! Not compression: adding a decode step to the one path whose failure bricks a
 //! node would weaken the integrity guarantee (the recorded SHA would cover the
@@ -446,18 +457,31 @@ pub(crate) fn prepare_known_good_for_install_at(
 /// This is brick-recovery state, so it only ever unlinks a file it can
 /// positively identify as the now-dead rollback target:
 ///
-/// * It re-reads the marker and does NOTHING if one is present. That makes the
-///   "remove the marker FIRST, then reclaim the blob" ordering structural
-///   rather than merely documented: a caller that reclaims while still armed
-///   gets a no-op instead of an armed marker pointing at a deleted binary. It
-///   also declines when a concurrent `freenet update` has already armed the
-///   NEXT probation over this blob.
 /// * It hashes the candidate and deletes it only when size AND SHA-256 match
 ///   `expected`, so a snapshot a concurrent install captured for a different
 ///   generation is left alone.
+/// * It re-checks for a probation marker in the SAME statement as the unlink,
+///   so the marker is the last thing read before the file goes away.
 /// * It only ever considers `dir/known_good_binary`, never the
 ///   `rollback_binary` path carried in the marker JSON, so a corrupt or
 ///   tampered marker cannot make us unlink an arbitrary file.
+///
+/// # What the marker re-check does and does not cover
+///
+/// It covers SEQUENTIAL misuse completely: a caller that reclaims before
+/// removing the marker gets a no-op rather than an armed marker pointing at a
+/// deleted binary, which is why `commit_probation_at` can rely on it instead of
+/// on a comment.
+///
+/// It does NOT make this safe against a truly CONCURRENT `freenet update`. Both
+/// sides are check-then-act on the same state directory with no lock, so an
+/// installer that writes its marker in the window between the re-check and the
+/// `remove_file` is still not seen. The window is now one syscall wide rather
+/// than a ~58 MB hash wide, and `begin_probation_at` closes the same race from
+/// the other end by disarming when the blob it just recorded has vanished — but
+/// a genuine sub-syscall interleaving remains open, and only a lock on the state
+/// directory would close it. Do not read this guard as "the concurrent installer
+/// case is handled".
 ///
 /// Best-effort by construction: it returns `()`, and every failure is logged
 /// and swallowed. Reclaiming disk must never fail a probation commit or an
@@ -465,8 +489,9 @@ pub(crate) fn prepare_known_good_for_install_at(
 /// install's capture, which is exactly the pre-existing steady state.
 fn discard_known_good_at(dir: &Path, expected: &KnownGoodMeta) {
     if read_probation_at(dir).is_some() {
-        // Still armed (or re-armed by a concurrent install): the blob may be a
-        // live rollback target, so leave it. Never delete while armed.
+        // Still armed (or re-armed): the blob may be a live rollback target.
+        // Cheap early-out before the hash; re-checked below, because a hash of
+        // a ~58 MB file is a very wide window to have decided anything in.
         return;
     }
     let blob = dir.join(KNOWN_GOOD_BINARY_FILE);
@@ -475,6 +500,18 @@ fn discard_known_good_at(dir: &Path, expected: &KnownGoodMeta) {
     }
     match sha256_file(&blob) {
         Ok((size, sha256)) if size == expected.size && sha256 == expected.sha256 => {
+            // Re-read the marker AFTER the hash, immediately before the unlink.
+            // The hash above is a cold ~58 MB read (seconds on slow storage);
+            // a marker armed during it must not be missed, so the decision to
+            // delete is made against the freshest possible read.
+            if read_probation_at(dir).is_some() {
+                tracing::debug!(
+                    path = %blob.display(),
+                    "A probation marker was armed while verifying the retained rollback \
+                     binary; leaving it in place."
+                );
+                return;
+            }
             match std::fs::remove_file(&blob) {
                 Ok(()) => {
                     fsync_dir(dir);
@@ -516,9 +553,11 @@ fn discard_known_good_at(dir: &Path, expected: &KnownGoodMeta) {
 /// known-bad pin, since a successful forward install means we have moved on.
 ///
 /// Returns `Err` if the probation marker could not be persisted (full /
-/// unwritable state dir). In that case the update still succeeded but the new
-/// version has NO crash-loop rollback protection, so the caller MUST surface
-/// the error rather than discard it.
+/// unwritable state dir), or if the known-good blob it names disappeared while
+/// the marker was being written (see [`discard_known_good_at`] — a concurrent
+/// probation commit can reclaim it). In both cases the update still succeeded
+/// but the new version has NO crash-loop rollback protection, so the caller
+/// MUST surface the error rather than discard it.
 pub(crate) fn begin_probation(
     new_version: &str,
     previous_version: &str,
@@ -562,8 +601,36 @@ pub(crate) fn begin_probation_at(
     // Moving forward to a new (non-pinned) version supersedes any prior
     // known-bad pin; best-effort, independent of the marker write.
     clear_known_bad_at(dir);
+    let blob = state.rollback_binary.clone();
     write_probation_at(dir, &state)
-        .context("failed to write crash-loop probation marker; the installed version has no rollback protection")
+        .context("failed to write crash-loop probation marker; the installed version has no rollback protection")?;
+
+    // Verify the rollback target still exists AFTER arming, and disarm if it
+    // does not. A concurrently-running node's probation commit can reclaim the
+    // blob (`discard_known_good_at`) in the window between the caller's
+    // `prepare_known_good_for_install` and this write — reachable in practice
+    // because the tray's "Check for Updates" runs a real install while the
+    // `freenet network` child is still up (`service/wrapper.rs`). Checking
+    // after the write, not before, is what makes this useful: it catches a
+    // reclaim that raced the write itself.
+    //
+    // An armed marker naming a binary that is not there is strictly worse than
+    // no marker: it burns the crash budget to `RollbackUnavailable` instead of
+    // restoring, and it suppresses the ordinary update flow (`handle_post_stop`
+    // returns `Proceed` with no marker, which is the #4549 forward self-heal).
+    // So we would rather ship this cycle with NO rollback protection — the same
+    // state as a failed capture, which the caller already surfaces — than with
+    // a marker that lies.
+    if !blob.exists() {
+        remove_probation_at(dir);
+        anyhow::bail!(
+            "the known-good rollback binary at {} disappeared while arming probation \
+             (most likely reclaimed by a concurrent probation commit); the installed \
+             version has no rollback protection",
+            blob.display()
+        );
+    }
+    Ok(())
 }
 
 /// Read the current probation marker, if any. A missing or unparseable marker
@@ -589,6 +656,14 @@ fn remove_probation_at(dir: &Path) {
 /// Clear probation if the running version matches the marker (it has proven
 /// healthy). A marker for a DIFFERENT version is stale (e.g. left over after a
 /// rollback or external install) and is also removed.
+///
+/// # Blocking
+///
+/// This performs blocking file I/O, including a cold read + SHA-256 of the
+/// ~58 MB known-good blob when there is a marker to retire
+/// ([`discard_known_good_at`]). Callers on a tokio runtime MUST run it via
+/// `spawn_blocking` — `bin/freenet.rs`'s commit task does, and
+/// `commit_probation_runs_on_a_blocking_thread` pins that.
 pub fn commit_probation(current_version: &str) {
     if let Some(dir) = state_dir() {
         match commit_probation_at(dir.as_path(), current_version) {
@@ -625,8 +700,9 @@ pub(crate) fn commit_probation_at(dir: &Path, current_version: &str) -> CommitOu
             // crash in between leaves an orphaned blob that the next install's
             // capture overwrites (today's steady state, harmless); the reverse
             // order would leave an ARMED marker advertising a rollback target
-            // that no longer exists. `discard_known_good_at` re-checks the
-            // marker, so the safe order is enforced, not just documented.
+            // that no longer exists. `discard_known_good_at`'s marker re-check
+            // enforces that ordering for THIS process — it does not make the
+            // reclaim safe against a concurrent `freenet update`; see its docs.
             remove_probation_at(dir);
             discard_known_good_at(dir, &retired_meta(&state));
             CommitOutcome::Committed
@@ -1224,6 +1300,77 @@ mod tests {
     }
 
     #[test]
+    fn commit_leaves_a_same_size_blob_whose_content_differs() {
+        // The size check alone is not enough: a concurrent install can capture
+        // a DIFFERENT binary that happens to be the same length. Identity has
+        // to come from the SHA-256, so this case must survive too. (Without
+        // this, mutating the guard down to a size-only comparison stays green.)
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        setup_probation(dir, "0.2.84", "0.2.83");
+        let recorded = read_probation_at(dir).unwrap();
+        // Same length as b"GOOD-BINARY", one byte different.
+        let impostor = b"GOOD-BINARZ";
+        assert_eq!(impostor.len() as u64, recorded.rollback_size);
+        std::fs::write(known_good_path(dir), impostor).unwrap();
+
+        assert_eq!(commit_probation_at(dir, "0.2.84"), CommitOutcome::Committed);
+
+        assert_eq!(std::fs::read(known_good_path(dir)).unwrap(), impostor);
+    }
+
+    #[test]
+    fn begin_probation_disarms_when_the_known_good_blob_is_missing() {
+        // The concurrent-install race from the other end: if the blob a marker
+        // names has been reclaimed by a node's probation commit while we were
+        // arming, we must NOT leave an armed marker pointing at nothing — that
+        // burns the crash budget to RollbackUnavailable and suppresses the
+        // ordinary forward-update self-heal. Disarm and surface instead.
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        let live = dir.join("freenet");
+        write_dummy_binary(&live, b"GOOD-BINARY");
+        let meta = capture_known_good_at(dir, &live).unwrap();
+        // Stand in for a concurrent commit reclaiming the blob.
+        std::fs::remove_file(known_good_path(dir)).unwrap();
+
+        let err = begin_probation_at(dir, "0.2.84", "0.2.83", &live, &meta)
+            .expect_err("must not arm a marker whose rollback target is gone");
+
+        assert!(
+            format!("{err:#}").contains("no rollback protection"),
+            "error must say the version is unprotected: {err:#}"
+        );
+        assert!(
+            read_probation_at(dir).is_none(),
+            "the lying marker must be removed, not left armed"
+        );
+        // And with no marker, a later crash falls through to the normal update
+        // flow (the #4549 forward self-heal) rather than to RollbackUnavailable.
+        assert_eq!(
+            handle_post_stop_at(dir, "101", "0.2.84"),
+            PostStopOutcome::Proceed
+        );
+    }
+
+    #[test]
+    fn begin_probation_arms_normally_when_the_blob_is_present() {
+        // Guard against the check above being over-eager: the ordinary install
+        // path (blob captured, then probation armed) must still arm.
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        let live = dir.join("freenet");
+        write_dummy_binary(&live, b"GOOD-BINARY");
+        let meta = capture_known_good_at(dir, &live).unwrap();
+
+        begin_probation_at(dir, "0.2.84", "0.2.83", &live, &meta).unwrap();
+
+        let state = read_probation_at(dir).expect("armed");
+        assert_eq!(state.new_version, "0.2.84");
+        assert_eq!(state.previous_version, "0.2.83");
+    }
+
+    #[test]
     fn discard_known_good_refuses_while_a_probation_marker_exists() {
         // The fail-safe ordering (remove the marker, THEN reclaim) is enforced
         // by this guard, not merely documented: reclaiming while armed would
@@ -1247,6 +1394,56 @@ mod tests {
             handle_post_stop_at(dir, "101", "0.2.84"),
             PostStopOutcome::RolledBack { .. }
         ));
+    }
+
+    /// Source pin: the marker re-check must sit BETWEEN the hash and the
+    /// unlink. A behavioural test cannot cover this — the difference is purely
+    /// when the read happens relative to a multi-second hash of a cold ~58 MB
+    /// file, and staging that would mean a sleep-based race, i.e. a flaky test.
+    /// So pin the ordering in the source instead. Needles are split with
+    /// `concat!` so this test cannot match its own text.
+    #[test]
+    fn discard_rechecks_the_marker_after_hashing_and_before_unlinking() {
+        let src = include_str!("rollback.rs");
+        let fn_start = src
+            .find(concat!("fn discard_", "known_good_at("))
+            .expect("discard fn present");
+        let body = &src[fn_start..];
+        let body = &body[..body.find("\n}\n").expect("fn body terminates")];
+
+        let hash_at = body
+            .find(concat!("sha256", "_file("))
+            .expect("the blob is hashed");
+        let unlink_at = body
+            .find(concat!("remove", "_file("))
+            .expect("the blob is unlinked");
+        assert!(hash_at < unlink_at, "hash must precede the unlink");
+        assert!(
+            body[hash_at..unlink_at].contains(concat!("read_", "probation_at(")),
+            "the probation marker MUST be re-read between hashing the blob and \
+             unlinking it — a marker armed during the hash would otherwise be \
+             missed, leaving an armed marker pointing at a deleted binary"
+        );
+    }
+
+    /// Source pin: the probation commit does a cold ~58 MB read + SHA-256, so
+    /// it must never run on a tokio worker thread. It fires at T+60s of the
+    /// first boot after every auto-update, on every peer, during ring
+    /// bootstrap — blocking a worker there is a fleet-wide regression.
+    /// Whitespace-stripped so rustfmt reflowing the call cannot break it.
+    #[test]
+    fn commit_probation_runs_on_a_blocking_thread() {
+        let src = include_str!("../freenet.rs");
+        let stripped: String = src.chars().filter(|c| !c.is_whitespace()).collect();
+        assert!(
+            stripped.contains(concat!(
+                "spawn_blocking(move||commands::rollback::",
+                "commit_probation(&version))"
+            )),
+            "bin/freenet.rs must call rollback::commit_probation via \
+             spawn_blocking; it performs a cold ~58 MB read + SHA-256 and would \
+             stall a runtime worker during ring bootstrap"
+        );
     }
 
     #[test]
@@ -1395,13 +1592,14 @@ mod tests {
         assert!(!is_version_pinned_bad_at(dir, "0.2.85"));
         assert!(!is_version_pinned_bad_at(dir, "0.2.83"));
 
-        // A successful forward install supersedes the pin.
+        // A successful forward install supersedes the pin. Capture a real
+        // known-good blob first, as every production caller does — arming
+        // probation now verifies its rollback target exists and refuses to
+        // record one that does not (see
+        // begin_probation_disarms_when_the_known_good_blob_is_missing).
         let live = dir.join("freenet");
         write_dummy_binary(&live, b"NEWER");
-        let meta = KnownGoodMeta {
-            size: 5,
-            sha256: "x".repeat(64),
-        };
+        let meta = capture_known_good_at(dir, &live).unwrap();
         begin_probation_at(dir, "0.2.85", "0.2.83", &live, &meta).unwrap();
         assert!(!is_version_pinned_bad_at(dir, "0.2.84"));
     }

--- a/crates/core/src/bin/freenet.rs
+++ b/crates/core/src/bin/freenet.rs
@@ -350,6 +350,14 @@ async fn run_network_node_with_signals(
     // crashes before the window elapses, the task dies with the process and the
     // probation marker stays armed (so the supervisor's post-stop `freenet
     // update` can count the crash and eventually roll back).
+    //
+    // `commit_probation` is BLOCKING file I/O, and not a trivial amount of it:
+    // committing reclaims the retained known-good binary, which means a cold
+    // read + SHA-256 of a ~58 MB file (tens of ms on NVMe, seconds on a spinning
+    // disk or a slow VM). It fires at T+60s of the first boot after every
+    // auto-update — i.e. on every peer, every release, while the ring is still
+    // bootstrapping — so it MUST NOT run on a runtime worker thread. Keep it on
+    // `spawn_blocking`; see `rollback::commit_probation`.
     let commit_probation_task = {
         let version = build_info::VERSION.to_string();
         GlobalExecutor::spawn(async move {
@@ -357,7 +365,12 @@ async fn run_network_node_with_signals(
                 commands::rollback::COMMIT_HEALTHY_UPTIME_SECS,
             ))
             .await;
-            commands::rollback::commit_probation(&version);
+            if let Err(e) =
+                tokio::task::spawn_blocking(move || commands::rollback::commit_probation(&version))
+                    .await
+            {
+                tracing::warn!(error = %e, "Auto-update probation commit task failed to run");
+            }
         })
     };
 


### PR DESCRIPTION
## Problem

Every Freenet node carries `~/.local/state/freenet/known_good_binary` — an
**uncompressed 58 MB copy of the executable** (measured on a real peer) — for
the entire days-to-weeks gap between releases, and nothing ever deletes it.

The blob is the crash-loop auto-rollback target (#4073): `freenet update`
snapshots the live binary just before overwriting it, then arms a probation
marker. It is reachable **only** through that marker:

* `handle_post_stop_at` returns `PostStopOutcome::Proceed` and never touches
  the blob when `read_probation_at` is `None`.
* `prepare_known_good_for_install_at` only consults the existing blob inside
  `if let Some(existing) = read_probation_at(dir)`; with no marker it
  re-captures fresh from the live binary.

Probation commits after 60 s of healthy uptime (`commit_probation`), which
removes the marker. From that moment the 58 MB is unreachable by any code
path — pure dead weight until the next update overwrites it.

Traced consumers (repo-wide sweep for `known_good` / `rollback_binary` across
Rust, shell, CI workflows, packaging, systemd units, the uninstaller and
`freenet service report`): `rollback.rs` only, plus `update.rs` calling
`prepare_known_good_for_install`. `service/purge.rs` deletes the whole state
directory on uninstall but never reads the blob.

## Solution

Reclaim the blob when the probation marker that made it reachable is retired.
This *removes* a resident cost rather than adding a code path — the alternative
(compressing the blob) was rejected: it would put a decode step on the one path
whose failure bricks a node, and the recorded SHA-256 would cover the stored
bytes rather than the bytes actually installed.

`commit_probation_at` now calls `discard_known_good_at` in both marker-removing
arms (`Committed` and `ClearedStale`). Because this is brick-recovery state, the
reclaim only unlinks a file it can positively identify as the dead rollback
target:

1. **Re-reads the marker and does nothing if one exists.** This makes the
   fail-safe ordering structural rather than documented — see below.
2. **Hashes the candidate; deletes only on a size + SHA-256 match** against the
   meta recorded in the marker being retired. A snapshot a concurrent
   `freenet update` captured for the *next* probation generation has different
   content and survives.
3. **Only ever considers `dir/known_good_binary`**, never the `rollback_binary`
   path carried in the marker JSON, so a corrupt marker cannot make us unlink an
   arbitrary file.

It returns `()`; every failure is logged (warn on a failed unlink or an
unverifiable blob) and swallowed, so reclamation can never fail a probation
commit or an update. A blob we fail to delete is simply overwritten by the next
install's capture — exactly today's steady state.

`CommitOutcome::Nothing` (no marker) deliberately does **not** delete: without a
marker there is no recorded size/SHA to identify the blob against, and deleting
on a guess is the wrong trade in this module. The post-stop paths in
`handle_post_stop_at` that remove the marker themselves (rollback succeeded,
stale marker, aged-out marker) also leave their blob for the next capture to
overwrite — they are the brick-recovery paths and are left untouched.

### Crash-ordering (requirement 4)

Remove the marker **first**, then reclaim the blob. The two orderings are not
symmetric:

| Crash point | Result |
|---|---|
| **Chosen:** after marker removal, before unlink | Marker gone (rollback correctly disarmed), blob orphaned. Identical to today's steady state; the next install's capture overwrites it. |
| **Rejected:** after unlink, before marker removal | An **armed** marker advertising a rollback target that no longer exists. A subsequent crash-loop burns to `RollbackUnavailable` instead of restoring. |

The guard in (1) enforces this rather than relying on comments: a caller that
reclaims while still armed gets a no-op, so the unsafe order cannot silently
ship.

### The tradeoff, stated plainly

**After probation commits, a node that degrades later has no local binary to
revert to and must recover by re-installing from GitHub.** Weigh it as:

* The crash-loop class this module exists for — a bad release that wedges at
  boot — is *unaffected*: it fires inside the 60 s probation window while the
  blob is still present.
* Post-commit, the blob was already unusable (no marker ⇒ no reader), so
  nothing that worked before stops working. This change makes the resource cost
  match the actual reachability.
* It leaves a committed node in the same position as one whose known-good
  capture failed — already a supported, non-fatal state that `commands::update`
  handles with a warning.
* Maintainer-approved tradeoff (behavior change, so flagging it explicitly per
  CONTRIBUTING.md).

### Concurrency (revised after review — the first version of this section was wrong)

The original PR claimed the concurrent-install path was "unreachable on the
auto-update path". That is true for systemd/post-stop, but **false in general**:
`service/wrapper.rs:909` runs a full `freenet update --quiet` *install* (not
`--check`) on the tray's "Check for Updates" while the `freenet network` child is
still running — it is not killed until `:917`. So on Windows/macOS a live node's
60 s commit timer and a real install genuinely overlap. Both windows are also
**second-scale, not microsecond-scale**: `replace_binary` copies 58 MB between
`prepare` and `begin_probation`, and the reclaim side is a cold 58 MB read + hash.

Two changes narrow it from both ends:

* **Re-read the marker after hashing, immediately before `remove_file`.** The
  first read is a cheap early-out; the read that the delete decision actually
  rests on is now one syscall from the unlink instead of a whole hash away.
* **`begin_probation_at` verifies the blob after writing the marker** and
  disarms (returns `Err`, which `update.rs` already surfaces as a warning) if it
  has gone. This closes the race from the installer's side regardless of
  interleaving. An armed marker naming a missing binary is *strictly worse than
  no marker*: it burns the crash budget to `RollbackUnavailable` **and**
  suppresses the ordinary forward-update self-heal (#4549) that a missing marker
  would have allowed.

What remains: both sides are still check-then-act on an unlocked state
directory, so an installer that writes its marker in the sub-syscall window
between the re-check and the unlink is not seen. Only a lock on the state
directory would close that. The rustdoc on `discard_known_good_at` says exactly
this rather than claiming the concurrent case is handled — on brick-recovery
code, a comment that overstates coverage is itself a hazard.

### Blocking I/O

`commit_probation` is blocking file I/O and now includes a cold 58 MB read +
SHA-256. It ran on a tokio worker (`GlobalExecutor::spawn` → plain
`handle.spawn`) at T+60 s of the first boot after every auto-update — on every
peer, every release, during ring bootstrap. It is now wrapped in
`tokio::task::spawn_blocking`, pinned by a whitespace-stripped source scrape of
`bin/freenet.rs`.

### What the blob was, beyond the automated readers

The module docs no longer say the blob is "reachable ONLY through a probation
marker". That holds for automated readers; it is false for an **operator with
shell access**, for whom it doubled as an offline recovery artifact for the
post-commit degradation class — a use no code path expresses and this module
never promised, but a real one. The docs now name it, and also note that the
commit trigger is a bare 60 s `sleep` with no health check beyond "the process
is still alive", so "committed" means less than it sounds like. Whether that
warrants keeping an offline copy or a stronger commit condition is flagged for
the maintainer, not decided here.

## Testing

New tests in `crates/core/src/bin/commands/rollback.rs`:

* `commit_reclaims_the_known_good_blob` — the main behavior.
* `commit_clears_stale_marker_for_other_version` (extended) — the
  `ClearedStale` arm reclaims too.
* `commit_with_no_marker_leaves_an_unidentifiable_blob` — `Nothing` never
  deletes on a guess.
* `commit_leaves_a_blob_that_is_not_the_retired_rollback_target` — the
  concurrent-fresh-capture race: content mismatch ⇒ blob survives.
* `discard_known_good_refuses_while_a_probation_marker_exists` — pins the
  fail-safe ordering, then proves the still-armed marker *still rolls back*.
* `commit_succeeds_even_when_the_blob_cannot_be_verified` — best-effort: an
  unhashable blob is left alone and the commit outcome is unchanged.
* `next_install_recaptures_a_fresh_blob_after_commit_reclaimed_it` —
  requirement 3, end-to-end from a state where the blob is **absent** (not
  merely stale): commit reclaims → the next `prepare_known_good_for_install_at`
  captures the live binary fresh and labels it correctly → arm the next
  probation → three crashes → the fresh target genuinely restores.

Added in review: `commit_leaves_a_same_size_blob_whose_content_differs`
(an 11-byte impostor against an 11-byte expected size — the original test used
38 bytes and so only exercised the *size* check),
`begin_probation_disarms_when_the_known_good_blob_is_missing`,
`begin_probation_arms_normally_when_the_blob_is_present`, and two source pins:
`discard_rechecks_the_marker_after_hashing_and_before_unlinking` and
`commit_probation_runs_on_a_blocking_thread`. The ordering pin exists because a
behavioural test for it would need a sleep-based race, i.e. a flaky test; its
needles are `concat!`-split so it cannot match its own text.

`pinned_version_is_not_reapplied_but_newer_is_allowed` armed probation from a
fabricated `KnownGoodMeta` with no blob on disk — something no production caller
does. It now captures a real blob first.

**Mutation testing — call sites and every new guard, each verified to fail
independently:**

| Mutation | Red |
|---|---|
| Delete both `discard_known_good_at(...)` calls from `commit_probation_at` | `commit_reclaims_the_known_good_blob`, `commit_clears_stale_marker_for_other_version`, `next_install_recaptures_a_fresh_blob_after_commit_reclaimed_it` |
| Remove the armed-marker early-out | `discard_known_good_refuses_while_a_probation_marker_exists` |
| Remove the post-hash re-check | `discard_rechecks_the_marker_after_hashing_and_before_unlinking` |
| **Move** the post-hash re-check above the hash (present, wrong place) | same pin — it asserts position, not existence |
| Weaken size+SHA to size-only | `commit_leaves_a_same_size_blob_whose_content_differs` |
| Drop the identity check entirely | `commit_leaves_a_blob_that_is_not_the_retired_rollback_target` |
| Remove `begin_probation_at`'s blob verification | `begin_probation_disarms_when_the_known_good_blob_is_missing` |
| Revert `spawn_blocking` to a direct call | `commit_probation_runs_on_a_blocking_thread` |

339/339 binary tests pass; `cargo fmt --check`, `clippy -p freenet --lib
--all-features` and `clippy -p freenet --bins --all-features -- -D warnings` all
clean.

[AI-assisted - Claude]
