### PR TITLE
fix(tracing): floor the error log at WARN regardless of RUST_LOG

### DIFF
--- a/crates/core/src/tracing/tracer.rs
+++ b/crates/core/src/tracing/tracer.rs
@@ -23,12 +23,22 @@ use tracing_subscriber::{Layer, Registry};
 /// would be a serious mistake: at 96 MiB a gateway retains 4.8 hours, so
 /// an 18:00 incident is gone by 09:00.
 ///
-/// Note that ~half of that 20.95 MB/h is redundant: `freenet.error.*` is
-/// currently a byte-for-byte duplicate of the main log (see issue #5015),
-/// because `RUST_LOG` overrides the error layer's WARN default. Fixing
-/// that halves the rate outright and would let this default come down to
-/// ~256 MiB for the same history. Until it lands, this budget cannot be
-/// reduced without costing a gateway real incident history.
+/// That 20.95 MB/h is a **pre-#5015 measurement**, and ~half of it was
+/// redundant: `freenet.error.*` duplicated the main log byte for byte
+/// because `RUST_LOG` overrode the error layer's WARN default. #5015
+/// has since landed ([`build_error_filter`]), so on nodes that set
+/// `RUST_LOG` the error family drops to its WARN+ share (~5 % of its
+/// former bytes) and the same gateway now runs at ~10.8 MB/h — 512 MiB
+/// buys it roughly two days rather than one.
+///
+/// Scope that carefully before retuning this: the duplication only ever
+/// affected nodes whose operator sets `RUST_LOG`. No install template
+/// does, so a stock install was always at the lower rate and sees no
+/// change. The halving therefore applies to gateways provisioned by
+/// `scripts/init-gateway.sh` and similar, not fleet-wide. This default
+/// is deliberately left at 512 MiB here: lowering it is a separate
+/// judgement call about how much history a gateway should keep, not a
+/// mechanical consequence of #5015.
 ///
 /// Do NOT lower this so far that the current-hour files alone can
 /// approach it. The size pass never deletes a file an appender has open,
@@ -389,6 +399,85 @@ async fn periodic_log_prune(log_dir: PathBuf) {
     }
 }
 
+/// The `RUST_LOG` directive string exactly as `EnvFilter` itself would
+/// read it: the variable's value, or the empty string when unset.
+///
+/// Split out from [`build_error_filter`] so that the filter construction
+/// stays a pure function of its input and can be tested without mutating
+/// process-global environment state (which would race across the test
+/// binary's threads).
+fn error_log_directives() -> String {
+    std::env::var(tracing_subscriber::EnvFilter::DEFAULT_ENV).unwrap_or_default()
+}
+
+/// Build the filter for the `freenet.error.*` layer: `max(WARN, RUST_LOG)`,
+/// evaluated per target.
+///
+/// The error log is meant to be a WARN-and-above **subset** of the main
+/// log, so it can be grepped as a high-signal view of what went wrong.
+/// That needs a genuine floor, and `EnvFilter::with_default_directive`
+/// is not one — it is a *fallback* that is applied only when the parsed
+/// directive string produced no directives at all. See
+/// `tracing-subscriber-0.3.23`, `src/filter/env/builder.rs`, the
+/// `if !has_dynamics && filter.statics.is_empty()` branch at the end of
+/// `Builder::from_directives`.
+///
+/// So with `RUST_LOG` set — which production sets — the `WARN` default
+/// was silently discarded and the error layer inherited `RUST_LOG`'s
+/// level: the very same level the main layer uses. The two layers then
+/// wrote identical content to two files, doubling log disk on every node
+/// (issue #5015; the nova gateway's `freenet.error.*` was 19011 INFO /
+/// 776 WARN / 93 ERROR over its first 20000 lines, and every hourly
+/// `freenet.*` / `freenet.error.*` pair was byte-for-byte identical).
+///
+/// AND-ing the env filter with a hard [`LevelFilter::WARN`] makes the
+/// level an actual floor, per target:
+///
+/// - `RUST_LOG` unset → `WARN`+, unchanged from the intended behavior;
+/// - `RUST_LOG=info` / `debug` / `trace` → still only `WARN`+;
+/// - `RUST_LOG=error` → only `ERROR`. A deliberately *more* restrictive
+///   `RUST_LOG` is honored rather than widened — this is `max(WARN, env)`,
+///   not "always at least WARN", so the floor never resurrects records the
+///   operator explicitly asked to suppress;
+/// - per-target directives (`RUST_LOG=freenet::ring=debug`) → that target
+///   at `WARN`+ only, so no INFO/DEBUG can leak into the error log through
+///   a target-scoped directive either.
+///
+/// AND-ing (rather than replacing the env filter outright with a bare
+/// `LevelFilter::WARN`) is what keeps the operator's `RUST_LOG` in force:
+/// a target they silenced stays silent in the error log too.
+///
+/// This layer deliberately does NOT inherit `build_filter`'s `moka=off` /
+/// `sqlx=error` additions. Those exist to suppress third-party INFO/DEBUG
+/// chatter from the main log; at WARN+ they are not a volume concern, and
+/// adopting them here would remove records the error log captures today.
+/// So the error log is a WARN+ subset of the main log for every freenet
+/// target, and additionally keeps moka/sqlx WARN+ that the main log
+/// suppresses.
+///
+/// The one place this change removes records from EVERY sink: because the
+/// main layer sets `moka=off` / `sqlx=error`, moka's INFO and sqlx's INFO
+/// under `RUST_LOG=info` used to reach the error log **and nowhere else**,
+/// and now reach neither. That is the intended WARN+ semantics rather than
+/// an oversight, and it is narrow — moka is the contract cache, and moka
+/// and sqlx WARN/ERROR are still retained here. Anything at WARN or above
+/// from any target still lands in this log.
+///
+/// Only the error layer is affected. The main log's filter (`build_filter`
+/// inside [`init_tracer`]) and the console layer are untouched, so nothing
+/// is lost from the main log or the journal.
+fn build_error_filter<S>(directives: &str) -> impl tracing_subscriber::layer::Filter<S> + 'static
+where
+    S: 'static,
+{
+    use tracing_subscriber::filter::FilterExt;
+
+    tracing_subscriber::EnvFilter::builder()
+        .with_default_directive(LevelFilter::WARN.into())
+        .parse_lossy(directives)
+        .and(LevelFilter::WARN)
+}
+
 pub fn init_tracer(
     level: Option<LevelFilter>,
     _endpoint: Option<String>,
@@ -583,15 +672,11 @@ pub fn init_tracer(
                     .with_writer(main_writer.clone())
                     .with_filter(filter_layer);
 
-                let error_filter = tracing_subscriber::EnvFilter::builder()
-                    .with_default_directive(LevelFilter::WARN.into())
-                    .from_env_lossy();
-
                 let error_layer = tracing_subscriber::fmt::layer()
                     .with_level(true)
                     .with_ansi(false)
                     .with_writer(error_writer.clone())
-                    .with_filter(error_filter);
+                    .with_filter(build_error_filter(&error_log_directives()));
 
                 // Add console layer if running interactively
                 if also_log_to_console {
@@ -617,15 +702,11 @@ pub fn init_tracer(
                     .with_writer(main_writer)
                     .with_filter(filter_layer);
 
-                let error_filter = tracing_subscriber::EnvFilter::builder()
-                    .with_default_directive(LevelFilter::WARN.into())
-                    .from_env_lossy();
-
                 let error_layer = tracing_subscriber::fmt::layer()
                     .with_level(true)
                     .with_ansi(false)
                     .with_writer(error_writer)
-                    .with_filter(error_filter);
+                    .with_filter(build_error_filter(&error_log_directives()));
 
                 // Add console layer if running interactively
                 if also_log_to_console {
@@ -735,6 +816,358 @@ fn init_stdout_tracer(
         tracing::subscriber::set_global_default(subscriber).expect("Error setting subscriber");
     }
     Ok(())
+}
+
+/// Regression coverage for issue #5015: `freenet.error.*` was a
+/// byte-for-byte duplicate of the main log whenever `RUST_LOG` was set.
+#[cfg(test)]
+mod error_filter_tests {
+    use super::{build_error_filter, error_log_directives};
+    use std::io;
+    use std::sync::{Arc, Mutex};
+    use tracing::level_filters::LevelFilter;
+    use tracing_subscriber::layer::{Filter, SubscriberExt};
+    use tracing_subscriber::{Layer, Registry};
+
+    /// The most permissive level the error filter will admit for the
+    /// supplied `RUST_LOG` string. `Filter::max_level_hint` on the
+    /// `And` combinator is `min(env, WARN)`, so this is a direct,
+    /// clock-free, subscriber-free read of the floor.
+    fn error_hint(directives: &str) -> Option<LevelFilter> {
+        Filter::<Registry>::max_level_hint(&build_error_filter::<Registry>(directives))
+    }
+
+    /// Documents the upstream behavior this fix works around, and keeps
+    /// the rest of this module honest: if `with_default_directive` ever
+    /// became a real floor upstream, this assertion fails and the
+    /// workaround can be revisited. It is also the non-vacuity control
+    /// for `error_filter_floors_verbose_rust_log_at_warn` — the two
+    /// differ only by the `.and(LevelFilter::WARN)` under test.
+    #[test]
+    fn env_filter_default_directive_is_a_fallback_not_a_floor() {
+        let unfloored = tracing_subscriber::EnvFilter::builder()
+            .with_default_directive(LevelFilter::WARN.into())
+            .parse_lossy("info");
+        assert_eq!(
+            unfloored.max_level_hint(),
+            Some(LevelFilter::INFO),
+            "with_default_directive(WARN) must be discarded once RUST_LOG parses to \
+             any directive — that discard is the #5015 bug"
+        );
+    }
+
+    /// With `RUST_LOG` unset the error log keeps its pre-existing
+    /// WARN+ behavior. This is the one case that was already correct;
+    /// the fix must not change it.
+    #[test]
+    fn error_filter_is_warn_when_rust_log_unset() {
+        assert_eq!(error_hint(""), Some(LevelFilter::WARN));
+    }
+
+    /// The bug proper: a verbose `RUST_LOG` must not widen the error log.
+    #[test]
+    fn error_filter_floors_verbose_rust_log_at_warn() {
+        for directives in ["info", "debug", "trace", "freenet=info", "freenet=trace"] {
+            assert_eq!(
+                error_hint(directives),
+                Some(LevelFilter::WARN),
+                "RUST_LOG={directives} must not admit anything below WARN into the error log"
+            );
+        }
+    }
+
+    /// Per-target directives must not smuggle INFO/DEBUG into the error
+    /// log through a narrower target scope.
+    #[test]
+    fn error_filter_floors_per_target_directives_at_warn() {
+        for directives in [
+            "freenet::ring=debug",
+            "info,freenet::ring=debug",
+            "freenet::ring=trace,freenet::transport=debug",
+        ] {
+            assert_eq!(
+                error_hint(directives),
+                Some(LevelFilter::WARN),
+                "RUST_LOG={directives} must not admit anything below WARN into the error log"
+            );
+        }
+    }
+
+    /// The floor is `max(WARN, RUST_LOG)`, not "always at least WARN":
+    /// an operator who deliberately asks for *less* must get less, never
+    /// more than they asked for.
+    #[test]
+    fn error_filter_honors_a_more_restrictive_rust_log() {
+        assert_eq!(
+            error_hint("error"),
+            Some(LevelFilter::ERROR),
+            "RUST_LOG=error must leave the error log at ERROR only, not widen it to WARN"
+        );
+        assert_eq!(
+            error_hint("off"),
+            Some(LevelFilter::OFF),
+            "RUST_LOG=off must silence the error log too"
+        );
+        assert_eq!(
+            error_hint("freenet=error"),
+            Some(LevelFilter::ERROR),
+            "a more restrictive per-target directive must also be honored"
+        );
+    }
+
+    /// `error_log_directives` must read exactly the variable `EnvFilter`
+    /// itself reads, so swapping `from_env_lossy()` for
+    /// `parse_lossy(error_log_directives())` is behavior-preserving on
+    /// the env-reading half.
+    #[test]
+    fn error_log_directives_reads_rust_log() {
+        assert_eq!(tracing_subscriber::EnvFilter::DEFAULT_ENV, "RUST_LOG");
+        assert_eq!(
+            error_log_directives(),
+            std::env::var("RUST_LOG").unwrap_or_default()
+        );
+    }
+
+    #[derive(Clone)]
+    struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl io::Write for CaptureWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CaptureWriter {
+        type Writer = CaptureWriter;
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    /// End-to-end proof that `Filter::enabled` (not just the level hint)
+    /// drops sub-WARN records from an error-log-shaped layer.
+    ///
+    /// Deterministic by construction: the subscriber is installed with
+    /// `tracing::subscriber::with_default` (thread-local, so parallel
+    /// tests cannot observe or perturb it), the writer is synchronous
+    /// and in-memory (no `tracing_appender` worker thread, no flush
+    /// race), no environment variable is mutated, and the event messages
+    /// are unique to this test.
+    #[test]
+    fn error_layer_writes_only_warn_and_above_under_verbose_rust_log() {
+        let sink = Arc::new(Mutex::new(Vec::new()));
+        let layer = tracing_subscriber::fmt::layer()
+            .with_level(true)
+            .with_ansi(false)
+            .with_writer(CaptureWriter(sink.clone()))
+            .with_filter(build_error_filter("debug"));
+
+        tracing::subscriber::with_default(Registry::default().with(layer), || {
+            tracing::debug!("i5015-debug-must-be-dropped");
+            tracing::info!("i5015-info-must-be-dropped");
+            tracing::warn!("i5015-warn-must-be-kept");
+            tracing::error!("i5015-error-must-be-kept");
+        });
+
+        let captured = String::from_utf8(sink.lock().unwrap().clone()).unwrap();
+        assert!(
+            !captured.contains("i5015-debug-must-be-dropped"),
+            "DEBUG leaked into the error log under RUST_LOG=debug: {captured}"
+        );
+        assert!(
+            !captured.contains("i5015-info-must-be-dropped"),
+            "INFO leaked into the error log under RUST_LOG=debug: {captured}"
+        );
+        assert!(
+            captured.contains("i5015-warn-must-be-kept"),
+            "WARN must still reach the error log: {captured}"
+        );
+        assert!(
+            captured.contains("i5015-error-must-be-kept"),
+            "ERROR must still reach the error log: {captured}"
+        );
+    }
+
+    /// A sibling layer with the main log's (unfloored) filter must be
+    /// unaffected by the error layer's WARN floor when both are attached
+    /// to the same subscriber.
+    ///
+    /// This is the hard constraint on this fix: per-layer filtering must
+    /// not let the error layer's `Interest::never` for sub-WARN callsites
+    /// short-circuit the main layer. Without this test a regression would
+    /// silently delete INFO/DEBUG from `freenet.*` — a far worse outcome
+    /// than the disk the fix saves.
+    ///
+    /// `init_tracer` builds TWO subscriber shapes and both ship, so both
+    /// are exercised via `with_global_rate_filter`:
+    ///
+    /// - `false` → `Registry.with(main).with(error)`, taken when rate
+    ///   limiting is off, i.e. debug/test builds or
+    ///   `FREENET_DISABLE_LOG_RATE_LIMIT`;
+    /// - `true` → `Registry.with(<global DynFilterFn>).with(main).with(error)`,
+    ///   which is what **release builds actually run**. The global filter
+    ///   layer sits beneath both sinks and composes `max_level_hint`
+    ///   differently, so testing only the first shape would leave the
+    ///   shipping one uncovered.
+    fn assert_error_floor_does_not_starve_main_layer(with_global_rate_filter: bool) {
+        let main_sink = Arc::new(Mutex::new(Vec::new()));
+        let error_sink = Arc::new(Mutex::new(Vec::new()));
+
+        // Built per branch: a layer's `Filter<S>` is parameterized by the
+        // subscriber it attaches to, and `S` differs between the shapes.
+        macro_rules! layers {
+            () => {
+                (
+                    tracing_subscriber::fmt::layer()
+                        .with_level(true)
+                        .with_ansi(false)
+                        .with_writer(CaptureWriter(main_sink.clone()))
+                        .with_filter(tracing_subscriber::EnvFilter::builder().parse_lossy("info")),
+                    tracing_subscriber::fmt::layer()
+                        .with_level(true)
+                        .with_ansi(false)
+                        .with_writer(CaptureWriter(error_sink.clone()))
+                        .with_filter(build_error_filter("info")),
+                )
+            };
+        }
+
+        let emit = || {
+            tracing::info!("i5015-sibling-info");
+            tracing::warn!("i5015-sibling-warn");
+        };
+
+        if with_global_rate_filter {
+            // Always-true so this isolates filter composition rather than
+            // the rate limiter's own behavior; the shape is what matters.
+            let pass_all = tracing_subscriber::filter::DynFilterFn::new(|_meta, _cx| true);
+            let (main_layer, error_layer) = layers!();
+            let subscriber = Registry::default()
+                .with(pass_all)
+                .with(main_layer)
+                .with(error_layer);
+            tracing::subscriber::with_default(subscriber, emit);
+        } else {
+            let (main_layer, error_layer) = layers!();
+            let subscriber = Registry::default().with(main_layer).with(error_layer);
+            tracing::subscriber::with_default(subscriber, emit);
+        }
+
+        let shape = if with_global_rate_filter {
+            "rate-limited (release) shape"
+        } else {
+            "plain (debug/test) shape"
+        };
+        let main = String::from_utf8(main_sink.lock().unwrap().clone()).unwrap();
+        let error = String::from_utf8(error_sink.lock().unwrap().clone()).unwrap();
+
+        assert!(
+            main.contains("i5015-sibling-info"),
+            "[{shape}] the error layer's WARN floor must not suppress INFO on the \
+             main layer: {main}"
+        );
+        assert!(
+            main.contains("i5015-sibling-warn"),
+            "[{shape}] the main layer must still receive WARN: {main}"
+        );
+        assert!(
+            !error.contains("i5015-sibling-info"),
+            "[{shape}] the error layer must still drop INFO: {error}"
+        );
+        assert!(
+            error.contains("i5015-sibling-warn"),
+            "[{shape}] the error layer must still receive WARN: {error}"
+        );
+    }
+
+    #[test]
+    fn main_layer_still_receives_info_alongside_the_floored_error_layer() {
+        assert_error_floor_does_not_starve_main_layer(false);
+    }
+
+    /// Same hard constraint, for the subscriber shape release builds
+    /// actually construct (global rate-limit filter beneath both layers).
+    #[test]
+    fn main_layer_still_receives_info_under_the_release_rate_limited_shape() {
+        assert_error_floor_does_not_starve_main_layer(true);
+    }
+
+    /// Call-site pin. The filter helper being correct is worthless if
+    /// `init_tracer` stops using it, and neither the level-hint tests nor
+    /// the capture tests above would notice: they exercise
+    /// `build_error_filter` directly, so deleting the wiring leaves them
+    /// green. This scrapes the production half of `tracer.rs` and asserts
+    /// that every error-log layer is filtered through the helper.
+    ///
+    /// Needles are matched against whitespace-stripped source so a
+    /// `rustfmt` line-wrap of a growing call cannot silently disarm the
+    /// pin, and the module marker is assembled with `concat!` so this
+    /// test's own source cannot satisfy it.
+    #[test]
+    fn init_tracer_wires_every_error_layer_through_build_error_filter() {
+        let source = include_str!("tracer.rs");
+
+        // Cut at this test module's declaration (the first one in the file)
+        // so test source, including this function, can never satisfy a
+        // production-code assertion. Deliberately NOT cut at `#[cfg(test)]`:
+        // that attribute also appears on individual items, and cutting at the
+        // first one can truncate production code and leave the pin vacuous.
+        // The anchor is this module's own declaration, spelled with
+        // `concat!` so the needle never appears contiguously in source and
+        // cannot match itself. An exact anchor also fails CLOSED: rename the
+        // module and `find` returns `None`, so the `expect` fires loudly. A
+        // looser needle (e.g. just `tests {`) would also match the prose and
+        // the `expect` string below, so a rename would silently slide the cut
+        // point down and swallow test functions into the "production" slice.
+        let cut = source.find(concat!("mod error_filter_", "tests {")).expect(
+            "the call-site pin anchors on this module's declaration; \
+             if it was renamed, update the anchor deliberately",
+        );
+        let production: String = source[..cut]
+            .chars()
+            .filter(|c| !c.is_whitespace())
+            .collect();
+
+        let count = |needle: &str| production.matches(needle).count();
+
+        let error_layers = count(".with_writer(error_writer");
+        assert_eq!(
+            error_layers, 2,
+            "expected the two error-log layers (rate-limited and plain registry); \
+             if this changed, update the pin deliberately"
+        );
+
+        // Pin the whole wiring, not just the helper's name: passing anything
+        // other than the live `RUST_LOG` would silently stop honoring a
+        // deliberately more-restrictive operator setting.
+        let floored = count(".with_filter(build_error_filter(&error_log_directives()))");
+        assert_eq!(
+            floored, error_layers,
+            "every freenet.error.* layer must be filtered through \
+             build_error_filter(&error_log_directives()); found {error_layers} error \
+             layers but {floored} floored filters (#5015)"
+        );
+
+        assert_eq!(
+            count(".and(LevelFilter::WARN)"),
+            1,
+            "the WARN floor must live in build_error_filter and nowhere else"
+        );
+
+        // `build_filter` (main + console) is the only remaining
+        // `from_env_lossy` caller. A second one means an error layer
+        // regressed to the unfloored inline shape this fix removed.
+        assert_eq!(
+            count(".from_env_lossy()"),
+            1,
+            "only the main/console filter may use from_env_lossy(); an error layer \
+             using it would inherit RUST_LOG's level again (#5015)"
+        );
+    }
 }
 
 #[cfg(test)]
@@ -955,9 +1388,18 @@ mod cleanup_tests {
     /// For contrast, this same budget is not what binds on a quiet peer:
     /// at ~1.4 MB/h a laptop peer reaches `LOG_RETENTION_HOURS` (72h)
     /// having used under 100 MiB, so its retention is decided by age.
+    ///
+    /// The rate below is deliberately the **pre-#5015** measurement, taken
+    /// while `freenet.error.*` still duplicated the main log. Post-#5015
+    /// that gateway runs at ~10.8 MB/h, so keeping the older, higher rate
+    /// makes this guard strictly more conservative: it demands the budget
+    /// hold a day at the worst rate ever observed. Do not "refresh" it to
+    /// the lower figure — that would weaken the assertion, permitting a
+    /// budget that no longer holds a day on any node still logging at the
+    /// old rate.
     #[test]
     fn default_budget_holds_a_day_of_a_busy_gateways_logs() {
-        // nova, 2026-07: 518.9 MiB over 25.97h.
+        // nova, 2026-07, pre-#5015: 518.9 MiB over 25.97h.
         const GATEWAY_BYTES_PER_HOUR: u64 = 20_950_000;
         let hours_retained = LOG_DIR_MAX_BYTES / GATEWAY_BYTES_PER_HOUR;
         assert!(


### PR DESCRIPTION
## Problem

`freenet.error.*` is supposed to be a `WARN`+ subset of the main log. **On a node whose operator sets `RUST_LOG`** it is instead a byte-for-byte duplicate of the main log, so the log directory costs twice what it should and half of any retention budget buys nothing.

`init_tracer` built the error layer's filter like this:

```rust
let error_filter = tracing_subscriber::EnvFilter::builder()
    .with_default_directive(LevelFilter::WARN.into())
    .from_env_lossy();
```

`with_default_directive` is **not** a floor — it is a fallback applied only when the parsed environment string yields no directives at all. From `tracing-subscriber-0.3.23`, `src/filter/env/builder.rs`, the end of `Builder::from_directives`:

```rust
if !has_dynamics && filter.statics.is_empty() {
    if let Some(ref default) = self.default_directive {
        filter = filter.add_directive(default.clone());
    }
}
```

So with `RUST_LOG` unset the error layer was `WARN`+ as intended, and with `RUST_LOG` set to anything the `WARN` default was discarded and the error layer inherited `RUST_LOG`'s level — the same level the main layer uses. The two layers then wrote identical content to two files.

### Who is actually affected

**Not every node — this is a no-op on a stock install.** No install template sets `RUST_LOG`:

| install path | environment it sets |
|---|---|
| `service/linux.rs` (systemd, user + system units) | `FREENET_SUPERVISED`, the fast-crash marker, `HOME` |
| `service/macos.rs` (launchd plist) | none — the plist has no `EnvironmentVariables` key |
| `service/windows.rs` | none |

On any of those, `RUST_LOG` is unset, the error layer was already `WARN`+, and this change alters nothing.

The affected population is nodes whose operator sets it:

- gateways provisioned by the repo's own `scripts/init-gateway.sh`, which exports `RUST_LOG="info,freenet=debug,freenet-stdlib=debug,fdev=debug"` at line 3;
- the ten `freenet-peer-*.service` units on nova (plus `river-moderator`, `freenet-report-server`);
- anyone who exports it by hand for debugging.

The measured gateway is one of these — its running process has `RUST_LOG=info,freenet=info,freenet-stdlib=debug,fdev=debug` (nova's deployed copy of the script has drifted from the repo's `freenet=debug`; immaterial here, since `release_max_level_info` compiles DEBUG out of release builds anyway).

### Evidence (nova gateway, measured 2026-07-29)

| family | rotating files | bytes |
|---|---:|---:|
| `freenet.*` | 27 | 267,603,367 (255.2 MiB) |
| `freenet.error.*` | 28 | 277,106,637 (264.3 MiB) |
| **directory** | 55 | **519.5 MiB over ~26 h ≈ 20.9 MB/h** |

Per-level breakdown of five consecutive sealed hourly `freenet.error.*` files — an error log carrying ~35 000 INFO lines an hour is not an error log:

| file | total bytes | INFO | WARN | ERROR | WARN+ bytes | WARN+ share |
|---|---:|---:|---:|---:|---:|---:|
| `2026-07-28-21` | 9,744,405 | 34,851 | 1,381 | 178 | 483,270 | 4.96 % |
| `2026-07-28-22` | 9,824,488 | 35,042 | 1,488 | 176 | 516,093 | 5.25 % |
| `2026-07-28-23` | 9,777,026 | 34,736 | 1,618 | 188 | 557,450 | 5.70 % |
| `2026-07-29-00` | 12,645,271 | 46,874 | 2,022 | 276 | 625,552 | 4.95 % |
| `2026-07-29-01` | 10,967,387 | 39,663 | 1,367 | 165 | 456,561 | 4.16 % |

### Expected saving, scoped

**On a `RUST_LOG`-setting node** the error family keeps ~5 % of its bytes: **264.3 MiB → ~13 MiB**, the directory goes **519.5 MiB → ~268 MiB (48 % cut)**, and the rate goes **~20.9 → ~10.8 MB/h**. 24 h of history drops from ~500 MiB to ~260 MiB, so #5010's 512 MiB budget buys that gateway roughly two days instead of one.

**On a stock install: no change.** Such a node was never paying the duplication and was always at roughly the lower rate.

This matters for whoever tunes the budget next, so #5010's `LOG_DIR_MAX_BYTES` rustdoc is updated here rather than left saying the duplication blocks lowering it. The constant itself is deliberately **not** changed — how much history a gateway should keep is a separate judgement call, not a mechanical consequence of this fix. #5010's `default_budget_holds_a_day_of_a_busy_gateways_logs` keeps its pre-fix 20.95 MB/h constant on purpose (annotated): the higher rate makes that guard strictly more conservative, and "refreshing" it to 10.8 would weaken it.

## Solution

Extract `build_error_filter(directives)` and AND the env filter with a hard `LevelFilter::WARN`, so the error layer is `max(WARN, RUST_LOG)` **evaluated per target**:

```rust
tracing_subscriber::EnvFilter::builder()
    .with_default_directive(LevelFilter::WARN.into())
    .parse_lossy(directives)
    .and(LevelFilter::WARN)
```

| `RUST_LOG` | error log before | error log after |
|---|---|---|
| unset | `WARN`+ | `WARN`+ (unchanged) |
| `info` / `debug` / `trace` | everything | `WARN`+ |
| `error` | `ERROR` only | `ERROR` only |
| `freenet::ring=debug` | that target from DEBUG up | that target at `WARN`+ |

**Why AND and not a replacement.** `max(WARN, env)` rather than "always at least WARN" is deliberate: an operator who sets a *more* restrictive `RUST_LOG` must not suddenly get **more** in the error log than they asked for. Replacing the filter with a bare `LevelFilter::WARN` would resurrect records `RUST_LOG=error` explicitly suppressed, and would ignore per-target directives entirely. AND-ing keeps the operator's directives in force and makes the error log a `WARN`+ subset of what those directives already admit.

**Nothing is lost from the main log or the journal.** Only the error layer's filter changes; `build_filter` (main log + interactive console) and the stdout/stderr fallback are untouched. Per-layer filtering is what makes this safe — `Filtered::register_callsite` accumulates each layer's `Interest` and returns `Interest::always()` rather than short-circuiting, and `Layered::max_level_hint` takes the *maximum* across layers — so the error layer's WARN floor cannot suppress INFO on the main layer.

**One narrow place records leave every sink.** `build_filter` adds `moka=off` / `sqlx=error`; the error layer deliberately does not inherit them (adopting them would drop records the error log captures today). The consequence: under `RUST_LOG=info`, moka's INFO and sqlx's INFO previously reached the error log **and nowhere else**, and now reach neither. That is the intended `WARN`+ semantics rather than an oversight, and it is narrow — moka is the contract cache, and moka/sqlx `WARN`+ is still retained. Documented on `build_error_filter`.

**OpenTelemetry layers do not share this bug.** The `trace-ot` feature builds no `tracing_subscriber` layer at all — it plugs `OTEventRegister` (`tracing/metrics_client.rs`) into the crate's own `NetEventRegister` trait and drives the OTel SDK directly, with no `EnvFilter` anywhere. `init_tracer`'s `_endpoint` parameter is unused for the same reason. The only other `EnvFilter` sites in the workspace are `test_utils.rs` (`EnvFilter::new`, deliberately independent of `RUST_LOG`) and `crates/release-agent` (a single-destination subscriber, where fallback semantics are correct). Neither has a main/error split, so neither can exhibit this failure.

**Consumers checked.** `freenet service report` collects the two families separately and size-caps each, so the main log still carries full INFO and the report spends less of its budget on duplicates; `freenet service logs --err` tails `freenet.error.*` and becomes useful for the first time; the telemetry dashboard ingests the OTel collector's `logs.jsonl`, not the text logs. Nothing depends on the error log carrying INFO.

## Testing

Nine new tests in `tracing::tracer::error_filter_tests`. No environment variable is mutated (the helper takes the directive string, so `RUST_LOG` is never poked process-globally), no wall-clock or sleeps are involved, and the capture tests install their subscriber with the **thread-local** `tracing::subscriber::with_default` plus a synchronous in-memory writer, so parallel tests can neither observe nor perturb them. Ran 20× consecutively with identical results.

- `env_filter_default_directive_is_a_fallback_not_a_floor` — pins the upstream behavior being worked around, and is the non-vacuity control for the floor test (the two differ only by the code under test).
- `error_filter_is_warn_when_rust_log_unset` — the case that was already correct stays correct.
- `error_filter_floors_verbose_rust_log_at_warn` — `info` / `debug` / `trace` / `freenet=info` / `freenet=trace`.
- `error_filter_floors_per_target_directives_at_warn` — no INFO/DEBUG leak via a target-scoped directive.
- `error_filter_honors_a_more_restrictive_rust_log` — `error`, `off`, `freenet=error` are not widened.
- `error_log_directives_reads_rust_log` — the env-reading half matches `from_env_lossy()`. Near-tautological by construction; kept as documentation of that equivalence, **not** counted as coverage.
- `error_layer_writes_only_warn_and_above_under_verbose_rust_log` — end-to-end through `Filter::enabled`, not just the level hint.
- `main_layer_still_receives_info_alongside_the_floored_error_layer` — the hard constraint, plain subscriber shape.
- `main_layer_still_receives_info_under_the_release_rate_limited_shape` — **the same constraint for the shape release builds actually run.** `init_tracer` builds two shapes: the plain `Registry.with(main).with(error)` when rate limiting is off (`!cfg!(any(test, debug_assertions))`, i.e. debug/test builds) and `Registry.with(<global DynFilterFn>).with(main).with(error)` in release. The global filter layer composes `max_level_hint` differently, so both are now exercised.
- `init_tracer_wires_every_error_layer_through_build_error_filter` — call-site pin.

### Call-site mutation evidence

A correct filter helper is worthless if `init_tracer` stops calling it, and the behavioural tests exercise `build_error_filter` directly, so deleting the wiring leaves them green. Each mutation was applied to `tracer.rs`, verified to have actually changed the file (`diff` non-empty), and the suite re-run. **Re-run in full after the rebase onto #5010:**

| mutation | tests that went red |
|---|---|
| **M1** — delete `.and(LevelFilter::WARN)` (revert the fix itself) | 6 red: both floor tests, all three capture tests, and the pin |
| **M2** — revert one call site to the pre-fix inline `EnvFilter…from_env_lossy()` | **pin only** — the other 27 stayed green |
| **M3** — call site passes `""` instead of `&error_log_directives()` | **pin only** |
| **M4** — one error layer loses its `.with_filter(...)` entirely | **pin only** |
| **M5** — rename the module the pin anchors on | **pin only**, via its `expect` — the pin fails **closed** |

M1 is the explicit "revert the filter change and watch a test go red" check, and it now reddens 6 rather than 5, confirming the new release-shape test is not vacuous. M2–M4 are why the pin exists: each re-breaks #5015 in production while every internals test stays green. M5 checks the pin's own anchor — `concat!("mod error_filter_", "tests {")`, an exact anchor that can never match its own source and that panics on a rename rather than silently sliding the cut point down and swallowing test functions into the "production" slice.

Baseline restored and re-verified green after each run. `cargo fmt --check`, `cargo clippy -p freenet --lib --all-features`, and `cargo test -p freenet --lib` (4387 passed, 0 failed) are clean on the rebased head.

### Rebase note

Rebased onto `main` after #5010 merged. One conflict in `tracer.rs`: #5010 replaced `enforce_log_dir_size_cap` with `prune_log_files` (plus `live_file_indices`, `rotating_log_family`, `LogFile`), while my commit carried the old function's text adjacent to the two new helpers. Resolved by taking **main's deletion** of `enforce_log_dir_size_cap` and keeping only the two new helpers. Nothing in the error-layer wiring conflicted, and the pin's counts were re-verified post-rebase (2 error layers / 2 floored filters / 1 `.and(LevelFilter::WARN)` / 1 `from_env_lossy`). Because conflict resolution restales review, the full mutation battery and test suite above were re-run on the rebased head rather than carried over.

Closes #5015

[AI-assisted - Claude]
