### PR TITLE
fix: bound wasmtime compile cache by the disk budget it is charged to

### DIFF
--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -1286,13 +1286,16 @@ mod executor_pin_tests {
     #[test]
     fn from_config_with_shared_modules_wires_offload_and_budget() {
         let src = include_str!("runtime.rs");
+        // `split_once` (not `split(..).next()`, whose `expect` can never fire) so
+        // a reworded end marker fails loudly instead of silently widening the
+        // region to end-of-file, `mod tests` included.
         let body = src
-            .split("pub(crate) async fn from_config_with_shared_modules(")
-            .nth(1)
+            .split_once("pub(crate) async fn from_config_with_shared_modules(")
             .expect("from_config_with_shared_modules must exist")
-            .split("\n    pub async fn preload(")
-            .next()
-            .expect("end of from_config_with_shared_modules");
+            .1
+            .split_once("\n    pub async fn preload(")
+            .expect("end marker of from_config_with_shared_modules must exist")
+            .0;
         assert!(
             body.contains("offload_compilation: production_offload_compilation()"),
             "must set offload_compilation from the production gate"
@@ -1331,7 +1334,8 @@ mod executor_pin_tests {
     }
 
     /// Pin: `RuntimePool::new` MUST resolve the wasmtime on-disk compile-cache
-    /// soft limit from the DISK signal, and must resolve it exactly once.
+    /// soft limit from the DISK signal, prune an already-oversized cache down to
+    /// it, and thread the resolved value into every executor it builds.
     ///
     /// This is the wiring the #5014 fix lives in, and it is invisible to every
     /// unit test of the pure math: `default_wasmtime_cache_size_bytes` could be
@@ -1339,55 +1343,140 @@ mod executor_pin_tests {
     /// wrong knobs, and nothing else in the tree would notice. The needles are
     /// assembled from `concat!` fragments that appear nowhere verbatim in
     /// `pool.rs`, so the pin cannot match its own source through `include_str!`.
+    ///
+    /// Region delimiters use `split_once(..).expect(..)` rather than
+    /// `split(..).next()`: the latter is `Some` unconditionally, so its `expect`
+    /// can never fire and a reworded end marker would silently widen the region
+    /// to end-of-file (including `mod tests`) while the assertions kept passing
+    /// for the wrong reason.
     #[test]
     fn runtime_pool_resolves_compile_cache_limit_from_the_disk_signal() {
         let src = include_str!("runtime/pool.rs");
         let body = src
-            .split("pub async fn new(")
-            .nth(1)
+            .split_once("pub async fn new(")
             .expect("RuntimePool::new must exist")
-            .split("\n    /// Get the current health status")
-            .next()
-            .expect("end of RuntimePool::new");
+            .1
+            .split_once("\n    /// Get the current health status")
+            .expect("end marker of RuntimePool::new must exist")
+            .0;
         // Whitespace-collapsed so a rustfmt re-wrap of the (multi-argument) call
         // cannot silently vacate the pin.
         let collapsed = body.split_whitespace().collect::<Vec<_>>().join(" ");
 
         assert!(
-            collapsed.contains(concat!(
-                "let wasmtime_cache_size_bytes = ",
-                "crate::wasm_runtime::default_wasmtime_",
-                "cache_size_bytes("
-            )),
-            "the pool must resolve the compile-cache soft limit through the \
-             node-relative resolver"
+            collapsed.contains(concat!("crate::ring::startup_disk_", "budget_estimate(")),
+            "the pool must derive the aggregate disk budget from the filesystem \
+             before any executor exists — the tracker does not exist yet (#5014)"
         );
-        // The disk knobs are what make the bound a DISK bound. Passing the
-        // directories but not the operator's pct/cap (or vice versa) would
-        // silently fall back to a budget unrelated to this node's disk.
+        assert!(
+            collapsed.contains(concat!(
+                "let limit = crate::wasm_runtime::default_wasmtime_",
+                "cache_size_bytes(disk_budget)"
+            )),
+            "the compile-cache soft limit must be the resolver applied to THAT \
+             disk budget — passing anything else (a constant, the RAM term alone) \
+             restores the #5014 defect"
+        );
+        // The disk knobs are what make the bound a DISK bound. Binding the wrong
+        // config value to a name (or swapping the two dirs, which both type as
+        // `&Path` and so compile happily) would silently size the cache against a
+        // budget unrelated to this node's disk, so pin the bindings themselves and
+        // then the ORDER in which they reach the estimate.
         for needle in [
-            concat!("&config.contracts", "_dir()"),
-            concat!("&config.wasmtime_", "cache_dir()"),
-            concat!("config.hosting_", "disk_pct"),
-            concat!("config.max_hosting", "_disk"),
+            concat!("let contracts_dir = config.contracts", "_dir();"),
+            concat!("let compile_cache_dir = config.wasmtime_", "cache_dir();"),
+            concat!("let hosting_disk_pct = config.hosting_", "disk_pct;"),
+            concat!("let max_hosting_disk = config.max_hosting", "_disk;"),
         ] {
             assert!(
                 collapsed.contains(needle),
-                "RuntimePool::new must pass `{needle}` to the compile-cache \
+                "RuntimePool::new must bind `{needle}` for the compile-cache \
                  resolver — without it the limit stops tracking this node's disk \
                  budget (#5014)"
             );
         }
-        // Exactly once: the resolver walks the contracts dir, walks the compile
-        // cache dir, and statvfs's the mount. A second call inside `new` would
-        // mean re-measuring per executor, which both wastes startup I/O and
-        // samples a cache dir the first executor has begun writing into.
+        for needle in [
+            "&contracts_dir, &compile_cache_dir",
+            "hosting_disk_pct, max_hosting_disk",
+        ] {
+            assert!(
+                collapsed.contains(needle),
+                "the estimate's arguments must stay in order (`{needle}`): both \
+                 dirs are `&Path`, so a swap compiles and silently measures the \
+                 wrong trees"
+            );
+        }
+        // Lowering the limit does not shrink an existing cache — wasmtime reads it
+        // only on its write-path cleanup, behind an hourly lock — so without this
+        // prune the fix bounds future starts and leaves an already-wedged node
+        // wedged (#5014). It must run against the cache dir and the freshly
+        // resolved limit.
+        assert!(
+            collapsed.contains(concat!(
+                "crate::ring::prune_compile_",
+                "cache_to_limit( &compile_cache_dir, limit )"
+            )) || collapsed.contains(concat!(
+                "crate::ring::prune_compile_",
+                "cache_to_limit(&compile_cache_dir, limit)"
+            )),
+            "the pool must prune an already-oversized compile cache down to the \
+             freshly resolved limit, before the first `Cache::new`"
+        );
+        // Exactly one CALL SITE inside `new`. This is a textual count, so it does
+        // not by itself prove a single runtime invocation — the positional
+        // assertion below is what rules out the case that actually matters
+        // (re-resolving per executor). What the count buys is that a second,
+        // divergent resolution cannot be added without the pin noticing.
         assert_eq!(
             collapsed
                 .matches(concat!("default_wasmtime_", "cache_size_bytes("))
                 .count(),
             1,
-            "the compile-cache soft limit must be resolved exactly once per pool"
+            "the compile-cache soft limit must have exactly one call site in `new`"
+        );
+        // Position: the resolution must precede the FIRST executor construction.
+        // Moving it inside the `for i in 1..pool_size` loop keeps the textual
+        // count at 1 while re-walking the mount once per executor and re-sampling
+        // a cache dir the first engine has begun writing into — the very defect
+        // the count assertion reads as if it prevents.
+        let resolved_at = collapsed
+            .find(concat!("crate::ring::startup_disk_", "budget_estimate("))
+            .expect("estimate call must exist");
+        let first_executor_at = collapsed
+            .find("from_config_with_shared_modules(")
+            .expect("RuntimePool::new must build executors");
+        assert!(
+            resolved_at < first_executor_at,
+            "the disk budget must be resolved BEFORE the first executor is built: \
+             wasmtime fixes the soft limit at `Cache::new` inside that call, and a \
+             later resolution would be both inert and measured against a cache dir \
+             the engine has started writing into"
+        );
+
+        // THE load-bearing wiring edge: the resolved value must actually reach the
+        // executor constructor. Everything above can hold while this argument is a
+        // constant — the value would still be resolved, still logged, still stored
+        // on the pool struct, and the whole #5014 fix inert on every host with a
+        // fully green suite. The first call site is the one that creates the
+        // engine (and so fixes wasmtime's soft limit); the second must agree with
+        // it, since a divergence there is a silent per-executor difference.
+        let threaded = "shared_contract_index.clone(), wasmtime_cache_size_bytes";
+        assert_eq!(
+            collapsed
+                .matches("from_config_with_shared_modules(")
+                .count(),
+            2,
+            "RuntimePool::new is expected to build exactly two executor shapes \
+             (the engine-creating first one and the shared-backend rest); a third \
+             call site would be unpinned by the assertion below"
+        );
+        assert_eq!(
+            collapsed.matches(threaded).count(),
+            2,
+            "every executor `RuntimePool::new` builds must receive the RESOLVED \
+             compile-cache soft limit as its last argument — a constant there \
+             leaves the value resolved, logged and stored while the bound never \
+             reaches wasmtime (#5014)"
         );
 
         // Third call site: a replacement executor must reuse the pool's resolved
@@ -1395,12 +1484,12 @@ mod executor_pin_tests {
         // engine has been filling, and the engine's soft limit was fixed at
         // startup anyway — so a fresh measurement would be both wrong and inert.
         let replacement = src
-            .split("async fn create_replacement_executor(")
-            .nth(1)
+            .split_once("async fn create_replacement_executor(")
             .expect("create_replacement_executor must exist")
-            .split("\n    /// Return an executor to the pool, replacing it")
-            .next()
-            .expect("end of create_replacement_executor");
+            .1
+            .split_once("\n    /// Return an executor to the pool, replacing it")
+            .expect("end marker of create_replacement_executor must exist")
+            .0;
         let replacement = replacement.split_whitespace().collect::<Vec<_>>().join(" ");
         assert!(
             replacement.contains(concat!("self.wasmtime_", "cache_size_bytes")),
@@ -1419,17 +1508,22 @@ mod executor_pin_tests {
     fn runtime_pool_sizes_caches_by_byte_budget() {
         // RuntimePool::new lives in runtime/pool.rs after the split.
         let src = include_str!("runtime/pool.rs");
+        // Bounded by `new`'s end marker rather than by a fixed chunk count: the
+        // count version silently stopped covering the cache construction as soon
+        // as anything was added to the preamble, which is a pin that fails for a
+        // reason unrelated to what it guards. `split_once` (not `split(..).next()`,
+        // whose `expect` can never fire) so a reworded marker fails loudly instead
+        // of widening the region to end-of-file, `mod tests` included.
         let body = src
-            .split("pub async fn new(")
-            .nth(1)
+            .split_once("pub async fn new(")
             .expect("RuntimePool::new must exist")
-            // Take the first chunk of the function body. Whitespace is collapsed
-            // so the assertions below survive line-wrapping / reformatting of the
-            // (now multi-line, metrics-threaded, interest-predicate-threaded)
-            // cache construction.
-            .split("\n    ")
-            .take(110)
-            .collect::<String>()
+            .1
+            .split_once("\n    /// Get the current health status")
+            .expect("end marker of RuntimePool::new must exist")
+            .0
+            // Whitespace is collapsed so the assertions below survive
+            // line-wrapping / reformatting of the (now multi-line,
+            // metrics-threaded, interest-predicate-threaded) cache construction.
             .split_whitespace()
             .collect::<Vec<_>>()
             .join(" ");

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -9,7 +9,6 @@ use super::{
     ContractExecutor, ContractRequest, ContractResponse, ExecutorError, InitCheckResult,
     RequestError, Response, SLOW_INIT_THRESHOLD, STALE_INIT_THRESHOLD, StateStoreError, now_nanos,
 };
-use crate::wasm_runtime::default_wasmtime_cache_size_bytes;
 pub(crate) use contract_ops::ReclaimOutcome;
 pub use pool::RuntimePool;
 pub(crate) use pool::{ExportAdmission, ExportDone, MAX_CONCURRENT_EXPORTS};
@@ -438,6 +437,7 @@ impl Executor<Runtime> {
         inherited_origins: crate::wasm_runtime::SharedInheritedOrigins,
         shared_backend: Option<BackendEngine>,
         shared_contract_index: SharedContractIndex,
+        wasmtime_cache_size_bytes: u64,
     ) -> anyhow::Result<Self> {
         let db = shared_state_store.storage();
         // Pool executors all share ONE contract instance index (#4218), so a
@@ -462,13 +462,14 @@ impl Executor<Runtime> {
             // pin its soft-size limit (#4683) so it lives on the mount whose
             // free space sizes the disk budget and is measurable as freenet's
             // own on-disk usage. `with_directory` requires an absolute path;
-            // the data dir is absolute. The soft limit is derived from the
-            // memory the node may use rather than a flat constant, so a small or
-            // containerized node no longer gets a compile cache larger than the
-            // contract state it accelerates — see
-            // `default_wasmtime_cache_size_bytes`.
+            // the data dir is absolute. The soft limit is resolved ONCE per pool
+            // by `RuntimePool::new` (it walks the data-dir mount, so re-deriving
+            // it per executor would repeat that walk pool_size times) and
+            // threaded in here — see `default_wasmtime_cache_size_bytes`, which
+            // bounds the cache by the DISK budget it is charged against (#5014)
+            // rather than by a RAM signal that a disk-tight host does not feel.
             wasmtime_cache_dir: Some(config.wasmtime_cache_dir()),
-            wasmtime_cache_size_bytes: Some(default_wasmtime_cache_size_bytes()),
+            wasmtime_cache_size_bytes: Some(wasmtime_cache_size_bytes),
             ..RuntimeConfig::default()
         };
         let mut rt = Runtime::build_with_shared_module_caches(
@@ -1307,19 +1308,108 @@ mod executor_pin_tests {
             body.contains("Engine::create_backend_engine(&runtime_config)"),
             "backend engine must be built from the threaded runtime_config"
         );
-        // The wasmtime ON-DISK compile cache's soft limit must be derived from
-        // the memory the node may use, never re-hardcoded to a flat constant: a
-        // fixed 512 MiB let a 2 GiB-cgroup node keep a compile cache larger than
-        // its entire 256 MiB contract-state budget. Whitespace is collapsed so
-        // the pin survives a rustfmt line-wrap of the field.
+        // The wasmtime ON-DISK compile cache's soft limit must come from the
+        // value the POOL resolved (which bounds it by the disk budget the cache
+        // is charged against, #5014), never from a constant and never re-derived
+        // per executor against a cache dir the first executor's engine has
+        // already started writing into. Whitespace is collapsed so the pin
+        // survives a rustfmt line-wrap of the field.
         let collapsed = body.split_whitespace().collect::<Vec<_>>().join(" ");
         assert!(
             collapsed.contains(concat!(
-                "wasmtime_cache_size_bytes: Some(",
-                "default_wasmtime_cache_size_bytes())"
+                "wasmtime_cache_size_bytes: ",
+                "Some(wasmtime_cache_size_bytes)"
             )),
-            "the wasmtime on-disk compile-cache soft limit must come from \
-             default_wasmtime_cache_size_bytes() (node-relative), not a constant"
+            "the wasmtime on-disk compile-cache soft limit must be the threaded \
+             parameter, not a constant or a per-executor re-derivation"
+        );
+        assert!(
+            !collapsed.contains(concat!("default_wasmtime_", "cache_size_bytes(")),
+            "from_config_with_shared_modules must NOT call the resolver itself — \
+             it walks the data-dir mount and must run exactly once per pool"
+        );
+    }
+
+    /// Pin: `RuntimePool::new` MUST resolve the wasmtime on-disk compile-cache
+    /// soft limit from the DISK signal, and must resolve it exactly once.
+    ///
+    /// This is the wiring the #5014 fix lives in, and it is invisible to every
+    /// unit test of the pure math: `default_wasmtime_cache_size_bytes` could be
+    /// perfectly disk-aware while this call site passed a constant, `0`, or the
+    /// wrong knobs, and nothing else in the tree would notice. The needles are
+    /// assembled from `concat!` fragments that appear nowhere verbatim in
+    /// `pool.rs`, so the pin cannot match its own source through `include_str!`.
+    #[test]
+    fn runtime_pool_resolves_compile_cache_limit_from_the_disk_signal() {
+        let src = include_str!("runtime/pool.rs");
+        let body = src
+            .split("pub async fn new(")
+            .nth(1)
+            .expect("RuntimePool::new must exist")
+            .split("\n    /// Get the current health status")
+            .next()
+            .expect("end of RuntimePool::new");
+        // Whitespace-collapsed so a rustfmt re-wrap of the (multi-argument) call
+        // cannot silently vacate the pin.
+        let collapsed = body.split_whitespace().collect::<Vec<_>>().join(" ");
+
+        assert!(
+            collapsed.contains(concat!(
+                "let wasmtime_cache_size_bytes = ",
+                "crate::wasm_runtime::default_wasmtime_",
+                "cache_size_bytes("
+            )),
+            "the pool must resolve the compile-cache soft limit through the \
+             node-relative resolver"
+        );
+        // The disk knobs are what make the bound a DISK bound. Passing the
+        // directories but not the operator's pct/cap (or vice versa) would
+        // silently fall back to a budget unrelated to this node's disk.
+        for needle in [
+            concat!("&config.contracts", "_dir()"),
+            concat!("&config.wasmtime_", "cache_dir()"),
+            concat!("config.hosting_", "disk_pct"),
+            concat!("config.max_hosting", "_disk"),
+        ] {
+            assert!(
+                collapsed.contains(needle),
+                "RuntimePool::new must pass `{needle}` to the compile-cache \
+                 resolver — without it the limit stops tracking this node's disk \
+                 budget (#5014)"
+            );
+        }
+        // Exactly once: the resolver walks the contracts dir, walks the compile
+        // cache dir, and statvfs's the mount. A second call inside `new` would
+        // mean re-measuring per executor, which both wastes startup I/O and
+        // samples a cache dir the first executor has begun writing into.
+        assert_eq!(
+            collapsed
+                .matches(concat!("default_wasmtime_", "cache_size_bytes("))
+                .count(),
+            1,
+            "the compile-cache soft limit must be resolved exactly once per pool"
+        );
+
+        // Third call site: a replacement executor must reuse the pool's resolved
+        // value. Re-deriving there would measure a compile-cache dir the live
+        // engine has been filling, and the engine's soft limit was fixed at
+        // startup anyway — so a fresh measurement would be both wrong and inert.
+        let replacement = src
+            .split("async fn create_replacement_executor(")
+            .nth(1)
+            .expect("create_replacement_executor must exist")
+            .split("\n    /// Return an executor to the pool, replacing it")
+            .next()
+            .expect("end of create_replacement_executor");
+        let replacement = replacement.split_whitespace().collect::<Vec<_>>().join(" ");
+        assert!(
+            replacement.contains(concat!("self.wasmtime_", "cache_size_bytes")),
+            "a replacement executor must reuse the pool's resolved compile-cache \
+             soft limit"
+        );
+        assert!(
+            !replacement.contains(concat!("default_wasmtime_", "cache_size_bytes(")),
+            "a replacement executor must NOT re-derive the compile-cache soft limit"
         );
     }
 

--- a/crates/core/src/contract/executor/runtime/pool.rs
+++ b/crates/core/src/contract/executor/runtime/pool.rs
@@ -304,7 +304,7 @@ impl RuntimePool {
         // Resolved exactly once here, before any executor exists, because:
         //   * wasmtime fixes the limit at `Cache::new` (reached from the FIRST
         //     executor's `create_backend_engine`) and never re-reads it, and
-        //   * the resolver measures the data-dir mount — the contracts dir, the
+        //   * the estimate measures the data-dir mount — the contracts dir, the
         //     compile-cache dir, and free space — which is both wasteful to
         //     repeat `pool_size` times and wrong to re-sample once the first
         //     executor's engine has started writing into that cache dir.
@@ -314,17 +314,51 @@ impl RuntimePool {
         // hosting sweep cannot reclaim compile-cache bytes — so a RAM-derived
         // bound left a disk-tight, RAM-rich host able to wedge its own admission
         // gate (#5014).
-        // The two `du` walks and the `statvfs` are synchronous, but this is node
-        // startup: it runs once, before any executor exists or any request can
-        // arrive, immediately after the (also synchronous) ReDb open above.
-        let wasmtime_cache_size_bytes = crate::wasm_runtime::default_wasmtime_cache_size_bytes(
-            &config.contracts_dir(),
-            &config.wasmtime_cache_dir(),
-            config.hosting_disk_pct,
-            config.max_hosting_disk,
-        );
+        //
+        // The disk budget is estimated HERE rather than inside the resolver so
+        // that `wasm_runtime` needs no `ring` dependency: the hosting knobs are
+        // ring's, and the pool already passes these same four values to
+        // `Ring::set_hosting_disk_paths` (see `contract/handler.rs`).
+        //
+        // On `spawn_blocking`: two `du` walks, a `statvfs`, and (only when the
+        // existing cache is oversized) a bounded set of `remove_file`s. The
+        // identical walks in the 60s sweep are pushed onto a blocking thread for
+        // exactly this reason — `contracts_dir` is unbounded and non-self-pruning
+        // — and although this runs at startup, the session actor, the result
+        // router and the Ring background loops are already spawned, so it must
+        // not sit on the reactor either.
+        let contracts_dir = config.contracts_dir();
+        let compile_cache_dir = config.wasmtime_cache_dir();
+        let hosting_disk_pct = config.hosting_disk_pct;
+        let max_hosting_disk = config.max_hosting_disk;
+        let (startup_disk_budget, wasmtime_cache_size_bytes, compile_cache_reclaimed_bytes) =
+            tokio::task::spawn_blocking(move || {
+                let disk_budget = crate::ring::startup_disk_budget_estimate(
+                    &contracts_dir,
+                    &compile_cache_dir,
+                    hosting_disk_pct,
+                    max_hosting_disk,
+                );
+                let limit = crate::wasm_runtime::default_wasmtime_cache_size_bytes(disk_budget);
+                // Lowering the soft limit does NOT shrink an existing cache:
+                // wasmtime reads the limit only in its cleanup pass, that pass is
+                // reachable only from the cache-WRITE path, and it is gated behind
+                // a once-per-hour lock. A node with a stable contract-blob set
+                // performs only cache hits after a restart, so a cache written
+                // under an older, larger limit would persist indefinitely — and on
+                // the wedged node from #5014 that is self-sustaining, since a node
+                // whose admission gate is rejecting cannot take on the new
+                // contracts whose compiles would trigger a cleanup. Prune it here,
+                // before the first `Cache::new`, so a restart is a real remedy.
+                let reclaimed =
+                    crate::ring::prune_compile_cache_to_limit(&compile_cache_dir, limit);
+                (disk_budget, limit, reclaimed)
+            })
+            .await?;
         tracing::info!(
             wasmtime_cache_size_bytes,
+            startup_disk_budget_bytes = startup_disk_budget,
+            compile_cache_reclaimed_bytes,
             "Resolved wasmtime on-disk compile-cache soft limit"
         );
 

--- a/crates/core/src/contract/executor/runtime/pool.rs
+++ b/crates/core/src/contract/executor/runtime/pool.rs
@@ -63,6 +63,15 @@ pub struct RuntimePool {
     replacements_count: AtomicUsize,
     /// Shared StateStore used by all executors (ReDb uses exclusive file locking)
     shared_state_store: StateStore<Storage>,
+    /// Soft size limit for the wasmtime on-disk compile cache, resolved ONCE for
+    /// this pool by [`Self::new`] (#5014). Held so a replacement executor is
+    /// built with the same value instead of re-walking the data-dir mount.
+    ///
+    /// Resolving once is not merely an optimization: the resolver
+    /// (`default_wasmtime_cache_size_bytes`) reads the compile cache's own
+    /// on-disk size, so a per-executor re-derivation would sample a directory
+    /// that the first executor's engine has already begun writing into.
+    wasmtime_cache_size_bytes: u64,
     /// Shared notification channels for all subscribed clients.
     /// Stored at pool level to avoid race condition where subscriptions registered
     /// while an executor is checked out would be missed by that executor.
@@ -291,6 +300,34 @@ impl RuntimePool {
 
         let (_, _, _, shared_state_store) = Executor::<Runtime>::get_stores(&config).await?;
 
+        // Soft size limit for the wasmtime ON-DISK compile cache (#4683, #5014).
+        // Resolved exactly once here, before any executor exists, because:
+        //   * wasmtime fixes the limit at `Cache::new` (reached from the FIRST
+        //     executor's `create_backend_engine`) and never re-reads it, and
+        //   * the resolver measures the data-dir mount — the contracts dir, the
+        //     compile-cache dir, and free space — which is both wasteful to
+        //     repeat `pool_size` times and wrong to re-sample once the first
+        //     executor's engine has started writing into that cache dir.
+        // The limit is bounded by the aggregate DISK budget the cache is charged
+        // against, not only by RAM: `DiskUsageTracker::total_bytes()` counts the
+        // compile cache, that total gates every state/wasm admission, and the
+        // hosting sweep cannot reclaim compile-cache bytes — so a RAM-derived
+        // bound left a disk-tight, RAM-rich host able to wedge its own admission
+        // gate (#5014).
+        // The two `du` walks and the `statvfs` are synchronous, but this is node
+        // startup: it runs once, before any executor exists or any request can
+        // arrive, immediately after the (also synchronous) ReDb open above.
+        let wasmtime_cache_size_bytes = crate::wasm_runtime::default_wasmtime_cache_size_bytes(
+            &config.contracts_dir(),
+            &config.wasmtime_cache_dir(),
+            config.hosting_disk_pct,
+            config.max_hosting_disk,
+        );
+        tracing::info!(
+            wasmtime_cache_size_bytes,
+            "Resolved wasmtime on-disk compile-cache soft limit"
+        );
+
         // Create shared notification storage BEFORE creating executors
         // so we can pass references to each executor
         let shared_notifications: SharedNotifications = Arc::new(DashMap::new());
@@ -424,6 +461,7 @@ impl RuntimePool {
             shared_inherited_origins.clone(),
             None, // No shared backend yet — this executor creates the engine
             shared_contract_index.clone(),
+            wasmtime_cache_size_bytes,
         )
         .await?;
         let shared_backend_engine = first_executor.runtime.clone_backend_engine();
@@ -448,6 +486,7 @@ impl RuntimePool {
                 shared_inherited_origins.clone(),
                 Some(shared_backend_engine.clone()),
                 shared_contract_index.clone(),
+                wasmtime_cache_size_bytes,
             )
             .await?;
 
@@ -506,6 +545,7 @@ impl RuntimePool {
             checked_out: AtomicUsize::new(0),
             replacements_count: AtomicUsize::new(0),
             shared_state_store,
+            wasmtime_cache_size_bytes,
             shared_notifications,
             shared_summaries,
             shared_client_counts,
@@ -701,6 +741,11 @@ impl RuntimePool {
             self.shared_inherited_origins.clone(),
             Some(self.shared_backend_engine.clone()),
             self.shared_contract_index.clone(),
+            // Reuse the pool's resolved limit rather than re-deriving it: the
+            // shared backend engine already fixed wasmtime's soft limit at
+            // startup, and re-measuring now would sample a cache dir the engine
+            // has been writing into (#5014).
+            self.wasmtime_cache_size_bytes,
         )
         .await?;
 

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -122,6 +122,12 @@ pub(crate) use hosting::hosting_budget_for_ram;
 /// types, and the shadow-mode set-membership comparator) so the node layer can
 /// build inputs and run the shadow compare (keystone step-2, #4642).
 pub(crate) use hosting::reconcile;
+/// Start-time estimate of the aggregate disk budget (#5014), for consumers that
+/// must size themselves before the disk tracker exists — today the wasmtime
+/// on-disk compile-cache soft limit
+/// (`wasm_runtime::default_wasmtime_cache_size_bytes`), which is charged against
+/// this budget and so must be bounded by it.
+pub(crate) use hosting::startup_disk_budget_estimate;
 pub use hosting::{AccessType, RecordAccessResult};
 /// Aggregate disk-budget defaults (#4683). `config` resolves the persisted
 /// `hosting-disk-pct` / `max-hosting-disk` defaults from these so the operator-

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -122,12 +122,6 @@ pub(crate) use hosting::hosting_budget_for_ram;
 /// types, and the shadow-mode set-membership comparator) so the node layer can
 /// build inputs and run the shadow compare (keystone step-2, #4642).
 pub(crate) use hosting::reconcile;
-/// Start-time estimate of the aggregate disk budget (#5014), for consumers that
-/// must size themselves before the disk tracker exists — today the wasmtime
-/// on-disk compile-cache soft limit
-/// (`wasm_runtime::default_wasmtime_cache_size_bytes`), which is charged against
-/// this budget and so must be bounded by it.
-pub(crate) use hosting::startup_disk_budget_estimate;
 pub use hosting::{AccessType, RecordAccessResult};
 /// Aggregate disk-budget defaults (#4683). `config` resolves the persisted
 /// `hosting-disk-pct` / `max-hosting-disk` defaults from these so the operator-
@@ -136,6 +130,14 @@ pub(crate) use hosting::{DEFAULT_HOSTING_DISK_PCT, DEFAULT_MAX_HOSTING_DISK_BYTE
 /// Clamp bounds re-exported only for the config-default round-trip test.
 #[cfg(test)]
 pub(crate) use hosting::{MAX_DEFAULT_HOSTING_BUDGET_BYTES, MIN_DEFAULT_HOSTING_BUDGET_BYTES};
+/// Start-time estimate of the aggregate disk budget (#5014), for consumers that
+/// must size themselves before the disk tracker exists — today the wasmtime
+/// on-disk compile-cache soft limit
+/// (`wasm_runtime::default_wasmtime_cache_size_bytes`), which is charged against
+/// this budget and so must be bounded by it — plus the startup prune that
+/// enforces the freshly-resolved limit against a cache written under an older,
+/// larger one.
+pub(crate) use hosting::{prune_compile_cache_to_limit, startup_disk_budget_estimate};
 pub mod interest;
 mod live_tx;
 mod location;

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -76,6 +76,10 @@ use cache::{HostingCache, HostingCacheStats, disk_budget_for_clamped};
 use dashmap::{DashMap, DashSet};
 use demand::ProximityPrior;
 use disk_usage::DiskUsageTracker;
+/// Start-time disk-budget estimate (#5014), for the wasmtime compile-cache soft
+/// limit, which wasmtime fixes at `Cache::new` — before this manager's tracker
+/// is configured or seeded.
+pub(crate) use disk_usage::startup_disk_budget_estimate;
 pub(crate) use disk_usage::{DiskBudgetExceeded, DiskUsageStats};
 use freenet_stdlib::prelude::{ContractInstanceId, ContractKey};
 use parking_lot::RwLock;

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -76,11 +76,13 @@ use cache::{HostingCache, HostingCacheStats, disk_budget_for_clamped};
 use dashmap::{DashMap, DashSet};
 use demand::ProximityPrior;
 use disk_usage::DiskUsageTracker;
+pub(crate) use disk_usage::{DiskBudgetExceeded, DiskUsageStats};
 /// Start-time disk-budget estimate (#5014), for the wasmtime compile-cache soft
 /// limit, which wasmtime fixes at `Cache::new` — before this manager's tracker
-/// is configured or seeded.
-pub(crate) use disk_usage::startup_disk_budget_estimate;
-pub(crate) use disk_usage::{DiskBudgetExceeded, DiskUsageStats};
+/// is configured or seeded. Paired with the startup prune that brings an
+/// already-oversized cache under that freshly-resolved limit, since lowering the
+/// limit alone never shrinks an existing tree.
+pub(crate) use disk_usage::{prune_compile_cache_to_limit, startup_disk_budget_estimate};
 use freenet_stdlib::prelude::{ContractInstanceId, ContractKey};
 use parking_lot::RwLock;
 use std::collections::{HashMap, HashSet};
@@ -487,6 +489,11 @@ pub(crate) struct HostingManager {
     /// installs a real value (the tracker is also unseeded before then, so the
     /// gate is a no-op regardless).
     disk_budget_bytes: AtomicU64,
+
+    /// Edge-trigger latch for [`Self::warn_if_compile_cache_over_share`] (#5014),
+    /// so the "compile cache exceeds its share of the live budget" warning fires
+    /// on each crossing rather than on every 60s recompute.
+    compile_cache_over_share_warned: std::sync::atomic::AtomicBool,
 }
 
 impl HostingManager {
@@ -531,6 +538,7 @@ impl HostingManager {
             disk_pct_bits: AtomicU64::new(DEFAULT_HOSTING_DISK_PCT.to_bits()),
             max_hosting_disk_bytes: AtomicU64::new(DEFAULT_MAX_HOSTING_DISK_BYTES),
             disk_budget_bytes: AtomicU64::new(u64::MAX),
+            compile_cache_over_share_warned: std::sync::atomic::AtomicBool::new(false),
         }
     }
 
@@ -640,13 +648,13 @@ impl HostingManager {
     /// Returns the effective budget it installed (for telemetry/tests), or `None`
     /// when it was a no-op.
     pub(crate) fn recompute_effective_budget(&self, available: u64) -> Option<u64> {
-        let used = {
+        let (used, compile_cache_bytes) = {
             let guard = self.disk_tracker.read();
             let tracker = guard.as_ref()?;
             if !tracker.is_seeded() {
                 return None;
             }
-            tracker.total_bytes()
+            (tracker.total_bytes(), tracker.stats().compile_cache_bytes)
         };
         let pct = f64::from_bits(self.disk_pct_bits.load(Ordering::Relaxed));
         let cap = self.max_hosting_disk_bytes.load(Ordering::Relaxed);
@@ -657,11 +665,65 @@ impl HostingManager {
         // checks projected disk against THIS value (the aggregate bound), not the
         // effective floor installed on the cache below.
         self.disk_budget_bytes.store(disk_budget, Ordering::Relaxed);
+        self.warn_if_compile_cache_over_share(compile_cache_bytes, disk_budget);
         let effective = ram.min(disk_budget);
         // O(1) under the cache write lock; the expensive du-walk already ran
         // OUTSIDE any lock before this call.
         self.hosting_cache.write().set_budget_bytes(effective);
         Some(effective)
+    }
+
+    /// Surface the one residual hole in the #5014 bound: the compile cache
+    /// holding more than its share of the LIVE budget.
+    ///
+    /// The cache's soft limit is fixed at `Cache::new` from a budget ESTIMATED at
+    /// startup, and wasmtime offers no way to re-apply it on a live `Cache`. The
+    /// live budget, by contrast, is recomputed here every 60s. Freenet's own
+    /// writes cannot break the relation (the budget's basis is `used +
+    /// available`, invariant under moving bytes between the two on one mount),
+    /// but something OUTSIDE Freenet filling or resizing the data mount can: the
+    /// budget falls while the fixed limit does not. Past that point the wedge
+    /// #5014 closes is reachable again for the life of the process, and nothing
+    /// else reports it — the operator sees only rejected PUTs.
+    ///
+    /// Uses the same divisor the sizing rule uses, so this warns on exactly the
+    /// condition "the startup assumption no longer holds", not on a second,
+    /// drifting notion of it. The remedy is a restart, which re-derives the limit
+    /// from the shrunken mount and prunes the existing cache down to it
+    /// (`disk_usage::prune_compile_cache_to_limit`).
+    ///
+    /// Edge-triggered: a node parked in this state must not emit a warning every
+    /// 60s, and re-arming on recovery means a flapping mount reports each
+    /// crossing rather than only the first.
+    fn warn_if_compile_cache_over_share(&self, compile_cache_bytes: u64, disk_budget: u64) {
+        let over_share = compile_cache_bytes
+            .saturating_mul(crate::wasm_runtime::WASMTIME_CACHE_DISK_BUDGET_DIVISOR)
+            > disk_budget;
+        if self
+            .compile_cache_over_share_warned
+            .swap(over_share, Ordering::Relaxed)
+            == over_share
+        {
+            return;
+        }
+        if over_share {
+            tracing::warn!(
+                compile_cache_bytes,
+                disk_budget_bytes = disk_budget,
+                "wasmtime compile cache now exceeds its share of the aggregate disk \
+                 budget: the budget has shrunk since startup (something outside \
+                 Freenet is using the data mount) while the cache's soft limit is \
+                 fixed for this process. Eviction cannot reclaim compile-cache \
+                 bytes; restart the node to re-derive the limit and prune the cache \
+                 (#5014)"
+            );
+        } else {
+            tracing::info!(
+                compile_cache_bytes,
+                disk_budget_bytes = disk_budget,
+                "wasmtime compile cache is back within its share of the disk budget"
+            );
+        }
     }
 
     /// Pre-write admission gate for a state write (#4683, live since #4702): reject the write

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -7502,4 +7502,66 @@ mod tests {
             "growth over budget must still reject"
         );
     }
+
+    /// The one residual hole in the #5014 bound has to be VISIBLE (F1): the
+    /// compile cache's soft limit is fixed for the process, so an external
+    /// consumer filling the data mount drives the live budget below it and the
+    /// wedge returns with no in-process recovery. Nothing else reports that —
+    /// the operator sees only rejected PUTs.
+    ///
+    /// Asserts the latch transitions rather than captured log lines (subscriber-
+    /// capture tests are flaky here): the latch IS the emit decision, since the
+    /// helper returns early exactly when it does not change.
+    #[test]
+    fn compile_cache_over_share_warning_is_edge_triggered() {
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
+        let armed = || {
+            manager
+                .compile_cache_over_share_warned
+                .load(Ordering::Relaxed)
+        };
+
+        // Well under its share: nothing to report.
+        manager.warn_if_compile_cache_over_share(10, 1000);
+        assert!(!armed());
+        // Exactly its share is NOT over — the sizing rule caps AT a quarter.
+        manager.warn_if_compile_cache_over_share(250, 1000);
+        assert!(!armed(), "the boundary must not warn");
+        // Crossing up reports once...
+        manager.warn_if_compile_cache_over_share(300, 1000);
+        assert!(armed());
+        // ...and a node parked in this state must not warn every 60s.
+        manager.warn_if_compile_cache_over_share(400, 1000);
+        assert!(armed());
+        // Recovery re-arms, so a flapping mount reports each crossing rather
+        // than only the first.
+        manager.warn_if_compile_cache_over_share(200, 1000);
+        assert!(!armed());
+
+        // The threshold must be the SIZING rule's own divisor, not a second,
+        // drifting notion of "its share": at 1000 the boundary sits at 250, so a
+        // divisor of 2 would stay quiet here and a divisor of 8 would warn.
+        assert_eq!(crate::wasm_runtime::WASMTIME_CACHE_DISK_BUDGET_DIVISOR, 4);
+    }
+
+    /// Pin: the 60s recompute must actually CALL the over-share check. The check
+    /// is the only surfacing of the residual hole above, and dropping the call is
+    /// invisible to every test of the helper itself.
+    #[test]
+    fn recompute_effective_budget_runs_the_over_share_check() {
+        let src = include_str!("hosting.rs");
+        let body = src
+            .split_once("pub(crate) fn recompute_effective_budget(")
+            .expect("recompute_effective_budget must exist")
+            .1
+            .split_once("\n    /// Surface the one residual hole")
+            .expect("end marker of recompute_effective_budget must exist")
+            .0;
+        assert!(
+            body.contains(concat!("self.warn_if_compile_", "cache_over_share(")),
+            "recompute_effective_budget must run the over-share check — it is the \
+             only signal that the compile cache's fixed soft limit no longer fits \
+             the live budget (#5014)"
+        );
+    }
 }

--- a/crates/core/src/ring/hosting/disk_usage.rs
+++ b/crates/core/src/ring/hosting/disk_usage.rs
@@ -695,14 +695,19 @@ pub fn available_bytes(path: &Path) -> Option<u64> {
 ///
 /// It is NOT immaterial, and it bites hardest on exactly the hosts the disk term
 /// exists for. Worked example: a 16 GiB VM holding 1 GiB of contract state,
-/// 50 MiB of wasm, a 50 MiB cache and 200 MiB free. The live budget (pct = 0.5)
-/// is `0.5 × 1.3 GiB ≈ 665 MiB`, so a live-consistent disk term would be
-/// ~166 MiB; the estimate sees `50 + 50 + 200 = 300 MiB`, halves it to 150 MiB,
-/// the MIN clamp lifts that to 128 MiB, and the resolved limit is the 32 MiB
-/// floor. The error is always in the safe direction (the cache is bounded more
-/// tightly than the live budget licenses, never less), but "the bound lands
-/// where the live budget would put it" is false on a state-heavy, disk-tight
-/// host, and that is the shape most likely to hit it.
+/// 50 MiB of wasm, a 50 MiB cache and 200 MiB free.
+///
+/// * Live: `used = 1024 + 50 + 50 = 1124 MiB`, `available = 200 MiB`, so at
+///   pct = 0.5 the budget is ~662 MiB and a live-consistent disk term would be
+///   ~165 MiB.
+/// * Estimate: `used = 50 + 50 = 100 MiB`, so the basis is 300 MiB, the budget
+///   150 MiB, and the resolved limit ~37 MiB — about 4.5x under.
+///
+/// The error is always in the safe direction (the cache is bounded more tightly
+/// than the live budget licenses, never less), and the gap widens without bound
+/// as `--max-hosting-storage` rises. But "the bound lands where the live budget
+/// would put it" is false on a state-heavy, disk-tight host, and that is the
+/// shape most likely to hit it, so do not restate this omission as immaterial.
 ///
 /// The reason is the redb *row* total, not the database *file*: the file's size
 /// is a plain `metadata()` read and needs no storage layer. Adding it is a real
@@ -847,6 +852,10 @@ const COMPILE_CACHE_PRUNE_TARGET_PCT: u64 = 70;
 /// Best-effort throughout: a file that fails to delete is skipped and not
 /// counted as reclaimed, exactly like the `du` walks that measure this tree.
 pub(crate) fn prune_compile_cache_to_limit(compile_cache_dir: &Path, soft_limit: u64) -> u64 {
+    // Trigger on [`du_walk`] specifically — the same function
+    // [`DiskUsageTracker::refresh_compile_cache`] uses to charge this tree to the
+    // budget — so the prune fires on exactly the quantity the budget counts,
+    // rather than on a second notion of the cache's size.
     let total = du_walk(compile_cache_dir);
     if total <= soft_limit {
         return 0;

--- a/crates/core/src/ring/hosting/disk_usage.rs
+++ b/crates/core/src/ring/hosting/disk_usage.rs
@@ -689,10 +689,27 @@ pub fn available_bytes(path: &Path) -> Option<u64> {
 /// layer exists. Omitting it can only make the measured total SMALLER, and
 /// [`startup_disk_budget_estimate`] is monotone non-decreasing in this value, so
 /// the omission can only make the derived budget smaller — the conservative
-/// direction for a bound whose failure mode is over-allocation. It is also
-/// immaterial exactly where the bound binds: a host whose Freenet-reachable
-/// capacity is small enough for the disk term to matter cannot be holding much
-/// state in the first place.
+/// direction for a bound whose failure mode is over-allocation.
+///
+/// # How much the omission costs, stated honestly
+///
+/// It is NOT immaterial, and it bites hardest on exactly the hosts the disk term
+/// exists for. Worked example: a 16 GiB VM holding 1 GiB of contract state,
+/// 50 MiB of wasm, a 50 MiB cache and 200 MiB free. The live budget (pct = 0.5)
+/// is `0.5 × 1.3 GiB ≈ 665 MiB`, so a live-consistent disk term would be
+/// ~166 MiB; the estimate sees `50 + 50 + 200 = 300 MiB`, halves it to 150 MiB,
+/// the MIN clamp lifts that to 128 MiB, and the resolved limit is the 32 MiB
+/// floor. The error is always in the safe direction (the cache is bounded more
+/// tightly than the live budget licenses, never less), but "the bound lands
+/// where the live budget would put it" is false on a state-heavy, disk-tight
+/// host, and that is the shape most likely to hit it.
+///
+/// The reason is the redb *row* total, not the database *file*: the file's size
+/// is a plain `metadata()` read and needs no storage layer. Adding it is a real
+/// improvement and is deliberately left to the follow-up that lands
+/// `du_walk_shallow` over `db_dir` (#5033), which is where that walker comes
+/// from. Until then the estimate is documented as a lower bound, not as an
+/// approximation of the live budget.
 pub(crate) fn measure_startup_disk_used(contracts_dir: &Path, compile_cache_dir: &Path) -> u64 {
     du_walk_wasm(contracts_dir).saturating_add(du_walk(compile_cache_dir))
 }
@@ -768,6 +785,114 @@ pub(crate) fn startup_disk_budget_estimate(
         pct,
         max_hosting_disk,
     )
+}
+
+/// Percentage of the soft limit the startup prune deletes down to, matching
+/// wasmtime's own `files_total_size_limit_percent_if_deleting` default of 70
+/// (`wasmtime-internal-cache/src/config.rs`, applied in `worker.rs`).
+///
+/// Landing on the same target means the restart prune leaves the tree exactly
+/// where wasmtime's own hourly cleanup would have left it, so the two mechanisms
+/// agree on the steady state instead of fighting over it.
+const COMPILE_CACHE_PRUNE_TARGET_PCT: u64 = 70;
+
+/// Bring an already-oversized wasmtime compile cache under `soft_limit` at
+/// startup by deleting its least-recently-modified files (#5014). Returns the
+/// number of bytes reclaimed (0 when the tree already fits).
+///
+/// # Why this is needed at all
+///
+/// Lowering the soft limit does not shrink an existing cache. Wasmtime reads the
+/// limit in exactly one place — its cleanup pass — and that pass is reachable
+/// ONLY from the cache-*write* path (`handle_on_cache_update`), further gated by
+/// a once-per-`cleanup_interval` (1h default) filesystem lock. The cache-*hit*
+/// path never cleans up. So a node whose contract-blob set is stable performs
+/// only cache GETs after a restart and its pre-fix, oversized cache persists
+/// indefinitely.
+///
+/// That is precisely the node #5014 describes, and the loop is self-sustaining:
+/// its oversized cache pushes `total_bytes()` past the budget, every
+/// `admit_state_write` / `admit_wasm_write` rejects, so it cannot take on the new
+/// contracts whose compiles would produce the cache misses that would trigger a
+/// cleanup. Without this prune the fix bounds the cache on future starts and
+/// leaves an already-wedged node wedged.
+///
+/// # Why deleting these files is safe
+///
+/// The compile cache is a pure derived artifact — every entry is regenerable by
+/// recompiling the blob it was built from, and a missing entry is just a cache
+/// miss.
+///
+/// - It runs at startup, before the first `Cache::new`, so wasmtime has not
+///   opened anything under this tree.
+/// - Wasmtime reads entries with `fs::read` into a `Vec`, never `mmap`, so no
+///   live mapping can be invalidated even if the timing assumption above were
+///   ever violated.
+/// - Wasmtime `create_dir_all`s the tree again on its next write, so removing
+///   files (or the whole tree) is self-healing rather than a permanent break.
+/// - Wasmtime's own worker already does `fs::remove_file` / `remove_dir_all`
+///   against this same tree; this is the same operation on the same cadence
+///   boundary, not a new kind of access.
+///
+/// # Oldest-first, not wipe-everything
+///
+/// A full wipe is equally safe but strictly worse: every restart under a tight
+/// budget would pay a whole recompile wave. Deleting by ascending mtime down to
+/// [`COMPILE_CACHE_PRUNE_TARGET_PCT`] of the limit keeps the hot artifacts and
+/// matches what wasmtime's cleanup would itself have done. Files whose mtime is
+/// unreadable sort oldest (deleted first) — an entry we cannot even stat is the
+/// least trustworthy thing in the tree — and the path is a deterministic
+/// tiebreak so the outcome does not depend on directory iteration order.
+///
+/// Best-effort throughout: a file that fails to delete is skipped and not
+/// counted as reclaimed, exactly like the `du` walks that measure this tree.
+pub(crate) fn prune_compile_cache_to_limit(compile_cache_dir: &Path, soft_limit: u64) -> u64 {
+    let total = du_walk(compile_cache_dir);
+    if total <= soft_limit {
+        return 0;
+    }
+    let target = soft_limit
+        .saturating_mul(COMPILE_CACHE_PRUNE_TARGET_PCT)
+        .saturating_div(100);
+
+    // (mtime, path, len), sorted oldest first with the path as a deterministic
+    // tiebreak. Collected in full before any deletion so the walk cannot observe
+    // its own effects.
+    let mut entries: Vec<(std::time::SystemTime, PathBuf, u64)> = Vec::new();
+    let mut stack = vec![compile_cache_dir.to_path_buf()];
+    while let Some(path) = stack.pop() {
+        let Ok(dir_entries) = std::fs::read_dir(&path) else {
+            continue;
+        };
+        for entry in dir_entries.flatten() {
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if file_type.is_dir() {
+                stack.push(entry.path());
+            } else if file_type.is_file() {
+                let Ok(meta) = entry.metadata() else {
+                    continue;
+                };
+                let mtime = meta.modified().unwrap_or(std::time::UNIX_EPOCH);
+                entries.push((mtime, entry.path(), meta.len()));
+            }
+        }
+    }
+    entries.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+
+    let mut remaining = total;
+    let mut reclaimed = 0u64;
+    for (_, path, len) in entries {
+        if remaining <= target {
+            break;
+        }
+        if std::fs::remove_file(&path).is_ok() {
+            remaining = remaining.saturating_sub(len);
+            reclaimed = reclaimed.saturating_add(len);
+        }
+    }
+    reclaimed
 }
 
 #[cfg(test)]
@@ -1194,8 +1319,8 @@ mod tests {
 #[cfg(test)]
 mod startup_estimate_tests {
     use super::{
-        measure_startup_disk_used, startup_disk_budget_estimate,
-        startup_disk_budget_from_measurements,
+        du_walk, measure_startup_disk_used, prune_compile_cache_to_limit,
+        startup_disk_budget_estimate, startup_disk_budget_from_measurements,
     };
     use std::io::Write;
     use std::path::Path;
@@ -1262,8 +1387,15 @@ mod startup_estimate_tests {
     /// Moving `delta` bytes from `available` into `measured_used` is exactly
     /// what growing the compile cache does. If the estimate changed, each
     /// restart would re-derive a different soft limit from the previous run's
-    /// cache size and the value would oscillate. An estimate built on bare free
-    /// space (the tempting simplification) fails every line here.
+    /// cache size and the value would oscillate.
+    ///
+    /// Scope, precisely: this drives the PURE function with `measured_used` as a
+    /// parameter, so what it pins is that `disk_budget_for_clamped`'s basis is
+    /// `used + available`. It does NOT pin that `startup_disk_budget_estimate`
+    /// actually feeds it the `du` walk — a version that passed `0` there (i.e.
+    /// an estimate built on bare free space, the tempting simplification) would
+    /// pass every line here. `estimate_composes_the_measured_walk_and_the_free_space_read`
+    /// is what closes that.
     #[test]
     fn estimate_is_invariant_under_cache_growth_on_the_same_mount() {
         let capacity = 4 * GIB;
@@ -1347,29 +1479,180 @@ mod startup_estimate_tests {
         );
     }
 
-    /// The impure entry point must compose the two pure pieces on the real
-    /// filesystem. Driven with `pct = 0.0` so the expected value is the MIN
-    /// floor on every host — no dependence on the CI machine's free space, so
-    /// this cannot flake.
+    /// The impure entry point must resolve on real directories without
+    /// panicking, and honor the clamp. Driven with `pct = 0.0` so the expected
+    /// value is the MIN floor on every host — no dependence on the CI machine's
+    /// free space, so this cannot flake.
+    ///
+    /// Deliberately makes NO claim about the `du` walk: at `pct = 0.0` the
+    /// measured term is multiplied by zero, so any fixture written here would be
+    /// inert. (An earlier version of this test wrote two files and then asserted
+    /// a containment check against a function that clamps into exactly that
+    /// interval by construction — vacuous on both counts, which is the anti-
+    /// pattern this PR calls out elsewhere.) The composition is pinned by
+    /// `estimate_composes_the_measured_walk_and_the_free_space_read`.
     #[test]
-    fn estimate_composes_the_du_walk_and_the_clamp_on_a_real_dir() {
+    fn estimate_on_real_dirs_resolves_the_min_floor_at_pct_zero() {
         let dir = tempfile::tempdir().unwrap();
         let contracts = dir.path().join("contracts");
         let cache = dir.path().join("wasmtime-cache");
-        write_file(&contracts.join("a.wasm"), 4096);
-        write_file(&cache.join("artifact"), 4096);
+        std::fs::create_dir_all(&contracts).unwrap();
+        std::fs::create_dir_all(&cache).unwrap();
 
         assert_eq!(
             startup_disk_budget_estimate(&contracts, &cache, 0.0, CAP),
             128 * MIB,
             "pct=0 must resolve to the MIN floor regardless of the host's disk"
         );
-        // With a real pct the value is host-dependent, so only the invariant is
-        // assertable: it stays inside the documented clamp.
-        let live = startup_disk_budget_estimate(&contracts, &cache, 0.5, CAP);
+    }
+
+    /// Pin: [`startup_disk_budget_estimate`] must COMPOSE the two filesystem
+    /// reads it is documented to compose.
+    ///
+    /// Both inputs are helper-internals-tested and call-site-untested otherwise,
+    /// and each has a one-token mutation that compiles, keeps the whole suite
+    /// green, and defeats the #5014 fix on every host in the world:
+    ///
+    /// * `available_bytes(contracts_dir)` → `None` makes the basis `u64::MAX`, so
+    ///   the budget clamps to the operator cap and the disk term never binds —
+    ///   the bound is simply switched off.
+    /// * `measure_startup_disk_used(..)` → `0` is exactly "an estimate built on
+    ///   bare free space", the oscillation this function's rustdoc says must not
+    ///   happen.
+    /// * swapping the two `&Path` arguments compiles (both are `&Path`) and
+    ///   silently measures `*.wasm` under the cache dir plus everything under the
+    ///   contracts dir — including the redb file the term is documented to omit.
+    ///
+    /// A runtime test cannot close these host-independently: `available` is the
+    /// CI machine's real free space, so any assertion strong enough to see a
+    /// 4 KiB fixture would be reading a number another process can move.
+    #[test]
+    fn estimate_composes_the_measured_walk_and_the_free_space_read() {
+        let src = include_str!("disk_usage.rs");
+        let body = src
+            .split_once(concat!("pub(crate) fn ", "startup_disk_budget_estimate(\n"))
+            .expect("startup_disk_budget_estimate must exist")
+            .1
+            .split_once("\n}\n")
+            .expect("end marker of startup_disk_budget_estimate must exist")
+            .0;
+        let collapsed = body.split_whitespace().collect::<Vec<_>>().join(" ");
+
         assert!(
-            (128 * MIB..=CAP).contains(&live),
-            "estimate {live} escaped the [MIN, cap] clamp"
+            collapsed.contains(concat!("measure_startup_", "disk_used(")),
+            "the estimate must measure Freenet's own bytes — substituting a \
+             constant rebuilds it on bare free space, which oscillates across \
+             restarts (#5014)"
         );
+        assert!(
+            collapsed.contains("contracts_dir, compile_cache_dir"),
+            "the measured-used term's two `&Path` arguments must stay in order: a \
+             swap compiles and measures the wrong trees"
+        );
+        assert!(
+            collapsed.contains(concat!("available_", "bytes(contracts_dir)")),
+            "the estimate must read free space on the CONTRACTS mount — passing \
+             `None` (or the cache dir, a different mount in principle) silently \
+             disables the disk bound"
+        );
+    }
+
+    /// The prune is a no-op while the tree fits: wasmtime's own hourly cleanup
+    /// owns the steady state, and deleting artifacts a node is entitled to keep
+    /// would buy nothing but recompiles.
+    #[test]
+    fn prune_leaves_a_cache_that_already_fits_untouched() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = dir.path().join("wasmtime-cache");
+        write_file(&cache.join("a"), 400);
+        write_file(&cache.join("b"), 400);
+
+        assert_eq!(prune_compile_cache_to_limit(&cache, 1000), 0);
+        assert_eq!(
+            du_walk(&cache),
+            800,
+            "nothing may be deleted under the limit"
+        );
+        // Exactly at the limit is still "fits" — the trigger is strictly-greater.
+        assert_eq!(prune_compile_cache_to_limit(&cache, 800), 0);
+        assert_eq!(du_walk(&cache), 800);
+    }
+
+    /// The load-bearing behavior (#5014): an oversized cache is brought down to
+    /// wasmtime's own 70%-of-limit target, oldest first, so a node that restarts
+    /// under a newly-lowered limit stops carrying a cache sized by the old one.
+    ///
+    /// Without this the fix bounds future starts only: wasmtime reads the soft
+    /// limit exclusively in its cleanup pass, that pass is reachable only from
+    /// the cache-WRITE path, and a node with a stable contract-blob set performs
+    /// only cache hits after a restart.
+    #[test]
+    fn prune_deletes_oldest_first_down_to_the_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = dir.path().join("wasmtime-cache");
+        // Five 400-byte artifacts = 2000 bytes against a 1000-byte limit, so the
+        // target is 700 and four must go: 2000 → 1600 → 1200 → 800 → 400.
+        // Nested so the walk is exercised on a tree, not one flat directory.
+        let paths = [
+            cache.join("oldest"),
+            cache.join("sub").join("second"),
+            cache.join("third"),
+            cache.join("sub").join("fourth"),
+            cache.join("newest"),
+        ];
+        for (i, path) in paths.iter().enumerate() {
+            write_file(path, 400);
+            // Explicit mtimes: the outcome must not depend on how fast the test
+            // host writes files, nor on directory iteration order.
+            filetime::set_file_mtime(path, filetime::FileTime::from_unix_time(1000 + i as i64, 0))
+                .unwrap();
+        }
+
+        assert_eq!(prune_compile_cache_to_limit(&cache, 1000), 1600);
+        assert_eq!(
+            du_walk(&cache),
+            400,
+            "the tree must end at or below 70% of the limit"
+        );
+        assert!(
+            paths[4].exists(),
+            "the most recently used artifact must survive — a full wipe is equally \
+             safe but pays a whole recompile wave on every tight-budget restart"
+        );
+        for stale in &paths[..4] {
+            assert!(!stale.exists(), "{stale:?} should have been pruned");
+        }
+    }
+
+    /// A first-ever start has no cache dir at all, and the limit can legitimately
+    /// be tiny. Neither may panic, and a zero limit must clear the tree rather
+    /// than divide its way into leaving something behind.
+    #[test]
+    fn prune_boundaries_are_safe() {
+        assert_eq!(
+            prune_compile_cache_to_limit(Path::new("/nonexistent/cache"), 128 * MIB),
+            0,
+            "a missing cache dir is a first start, not an error"
+        );
+
+        let dir = tempfile::tempdir().unwrap();
+        let cache = dir.path().join("wasmtime-cache");
+        write_file(&cache.join("a"), 100);
+        write_file(&cache.join("b"), 100);
+        assert_eq!(prune_compile_cache_to_limit(&cache, 0), 200);
+        assert_eq!(du_walk(&cache), 0);
+
+        // u64::MAX must not overflow the `limit × 70` target computation.
+        write_file(&cache.join("c"), 100);
+        assert_eq!(prune_compile_cache_to_limit(&cache, u64::MAX), 0);
+        assert_eq!(du_walk(&cache), 100);
+    }
+
+    /// The prune target must stay wasmtime's own post-cleanup target, so the
+    /// restart prune and wasmtime's hourly cleanup agree on the steady state
+    /// instead of one repeatedly undoing the other's idea of "enough".
+    #[test]
+    fn prune_target_matches_wasmtimes_own_cleanup_target() {
+        assert_eq!(super::COMPILE_CACHE_PRUNE_TARGET_PCT, 70);
     }
 }

--- a/crates/core/src/ring/hosting/disk_usage.rs
+++ b/crates/core/src/ring/hosting/disk_usage.rs
@@ -37,6 +37,14 @@
 //!   the number of distinct compiled modules and self-pruned by wasmtime at its
 //!   soft-size limit.
 //!
+//! Of the three, the compile cache is the one the hosting sweep **cannot
+//! reclaim** — eviction sheds contract state, and wasmtime owns its cache
+//! directory. So its soft limit has to be bounded by the same disk budget it is
+//! charged against, or a disk-tight host can push `total_bytes()` past the
+//! budget with bytes nothing in the node is able to free (#5014). Wasmtime fixes
+//! that limit at `Cache::new`, before this tracker exists, which is what
+//! [`startup_disk_budget_estimate`] is for.
+//!
 //! # Seeding discipline (fail-loud)
 //!
 //! [`DiskUsageTracker::seed`] mirrors the #4561 secrets `seeded_user_total`
@@ -670,6 +678,98 @@ pub fn available_bytes(path: &Path) -> Option<u64> {
     }
 }
 
+/// Bytes Freenet already occupies on the data-dir mount, measured WITHOUT a
+/// [`DiskUsageTracker`] (#5014). Sums the same two `du`-measured terms the
+/// tracker maintains — `*.wasm` code blobs under `contracts_dir` and the
+/// relocated wasmtime compile cache — using the same walkers, so the two agree
+/// on what "Freenet's own bytes" means.
+///
+/// The tracker's THIRD term, persisted contract-state bytes, is deliberately
+/// omitted: it comes from redb rows, which are not readable before the storage
+/// layer exists. Omitting it can only make the measured total SMALLER, and
+/// [`startup_disk_budget_estimate`] is monotone non-decreasing in this value, so
+/// the omission can only make the derived budget smaller — the conservative
+/// direction for a bound whose failure mode is over-allocation. It is also
+/// immaterial exactly where the bound binds: a host whose Freenet-reachable
+/// capacity is small enough for the disk term to matter cannot be holding much
+/// state in the first place.
+pub(crate) fn measure_startup_disk_used(contracts_dir: &Path, compile_cache_dir: &Path) -> u64 {
+    du_walk_wasm(contracts_dir).saturating_add(du_walk(compile_cache_dir))
+}
+
+/// Pure clamp math behind [`startup_disk_budget_estimate`] (#5014), with the
+/// filesystem reads lifted out as parameters — the same determinism seam
+/// [`super::HostingManager::recompute_effective_budget`] uses for `available`.
+///
+/// `available: None` means the platform free-space query failed, and falls back
+/// to `u64::MAX` exactly as the live recompute does: a free-space read that
+/// cannot be trusted must not silently shrink a budget (the result then clamps
+/// to `max_hosting_disk`).
+///
+/// Delegates to [`disk_budget_for_clamped`](super::cache::disk_budget_for_clamped)
+/// with the same MIN floor and operator cap as the live budget, so the start-time
+/// estimate and the live value have exactly one implementation of the math.
+pub(crate) fn startup_disk_budget_from_measurements(
+    measured_used: u64,
+    available: Option<u64>,
+    pct: f64,
+    max_hosting_disk: u64,
+) -> u64 {
+    super::cache::disk_budget_for_clamped(
+        measured_used,
+        available.unwrap_or(u64::MAX),
+        pct,
+        super::cache::MIN_DEFAULT_HOSTING_BUDGET_BYTES,
+        max_hosting_disk,
+    )
+}
+
+/// Start-time estimate of the aggregate disk budget, for consumers that must
+/// size themselves BEFORE the [`DiskUsageTracker`] is configured and seeded
+/// (#5014).
+///
+/// # Why this exists
+///
+/// The wasmtime on-disk compile cache is charged against the aggregate disk
+/// budget ([`DiskUsageTracker::total_bytes`] sums state + wasm + compile-cache
+/// bytes, and that total gates `admit_state_write` / `admit_wasm_write`), but
+/// wasmtime fixes the cache's soft limit once, at `Cache::new` — inside
+/// `Executor::from_config_with_shared_modules`, which runs before the tracker
+/// exists. A limit derived from RAM needs nothing from disk and so left a
+/// disk-tight, RAM-rich host completely unprotected. This gives that call site
+/// the disk signal it needs at the only moment it can use it.
+///
+/// # It is an estimate, and it errs low
+///
+/// It reuses the live budget's own math ([`startup_disk_budget_from_measurements`])
+/// on the same basis — `freenet_used + available` — but its `freenet_used` term
+/// omits persisted contract state (see [`measure_startup_disk_used`]). Since
+/// `disk_budget_for_clamped` is monotone non-decreasing in `freenet_used`, the
+/// estimate is always `<=` the budget the first 60s recompute will install.
+///
+/// # Why it does NOT feed back on itself
+///
+/// The basis is `freenet_used + available`, not free space. Every byte the
+/// compile cache writes moves one byte from `available` into `freenet_used` on
+/// the SAME mount, so the sum is the mount's Freenet-reachable capacity and is
+/// invariant under the cache's own size. That is why `measure_startup_disk_used`
+/// must include the compile-cache walk: an estimate built on bare free space
+/// would shrink when the cache is full and grow when it is empty, so each
+/// restart would re-derive a different limit and the value would oscillate.
+pub(crate) fn startup_disk_budget_estimate(
+    contracts_dir: &Path,
+    compile_cache_dir: &Path,
+    pct: f64,
+    max_hosting_disk: u64,
+) -> u64 {
+    startup_disk_budget_from_measurements(
+        measure_startup_disk_used(contracts_dir, compile_cache_dir),
+        available_bytes(contracts_dir),
+        pct,
+        max_hosting_disk,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1085,5 +1185,191 @@ mod tests {
         );
         #[cfg(not(unix))]
         let _ = missing;
+    }
+}
+
+/// Tests for the start-time disk-budget estimate (#5014) — the signal the
+/// wasmtime compile-cache soft limit is sized from, resolved before the tracker
+/// exists.
+#[cfg(test)]
+mod startup_estimate_tests {
+    use super::{
+        measure_startup_disk_used, startup_disk_budget_estimate,
+        startup_disk_budget_from_measurements,
+    };
+    use std::io::Write;
+    use std::path::Path;
+
+    const MIB: u64 = 1024 * 1024;
+    const GIB: u64 = 1024 * MIB;
+    /// `DEFAULT_MAX_HOSTING_DISK_BYTES`, restated so these tests pin the value
+    /// the production caller passes rather than tracking a constant edit.
+    const CAP: u64 = 32 * GIB;
+
+    fn write_file(path: &Path, len: usize) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        let mut f = std::fs::File::create(path).unwrap();
+        f.write_all(&vec![0u8; len]).unwrap();
+    }
+
+    /// The measured-used term counts exactly the two things the live tracker
+    /// `du`-measures: `*.wasm` blobs under the contracts dir (recursively, so
+    /// the `local/` split counts) and EVERY file under the compile-cache dir
+    /// (wasmtime writes `.stats` sidecars beside its artifacts).
+    #[test]
+    fn measured_used_counts_wasm_blobs_and_the_whole_compile_cache() {
+        let dir = tempfile::tempdir().unwrap();
+        let contracts = dir.path().join("contracts");
+        let cache = dir.path().join("wasmtime-cache");
+        std::fs::create_dir_all(&contracts).unwrap();
+        std::fs::create_dir_all(&cache).unwrap();
+
+        write_file(&contracts.join("a.wasm"), 1000);
+        write_file(&contracts.join("local").join("b.wasm"), 2000);
+        // Non-wasm files in the contracts dir are NOT code blobs and must not
+        // be charged (the tracker's `du_walk_wasm` skips them).
+        write_file(&contracts.join("index.db"), 9_000);
+        // The compile cache is walked in full, sidecars included.
+        write_file(&cache.join("sub").join("artifact"), 4000);
+        write_file(&cache.join("sub").join("artifact.stats"), 8);
+
+        assert_eq!(
+            measure_startup_disk_used(&contracts, &cache),
+            1000 + 2000 + 4000 + 8,
+            "must count wasm blobs (recursively) + the entire compile-cache tree, \
+             and nothing else"
+        );
+    }
+
+    /// Missing directories contribute 0 rather than erroring — a first-ever
+    /// start has neither dir populated, and the estimate must still resolve.
+    #[test]
+    fn measured_used_is_zero_when_nothing_exists_yet() {
+        assert_eq!(
+            measure_startup_disk_used(
+                Path::new("/nonexistent/contracts"),
+                Path::new("/nonexistent/cache"),
+            ),
+            0
+        );
+    }
+
+    /// THE anti-feedback property (#5014): the estimate must not move when
+    /// bytes shift between the compile cache and free space on the same mount.
+    ///
+    /// Moving `delta` bytes from `available` into `measured_used` is exactly
+    /// what growing the compile cache does. If the estimate changed, each
+    /// restart would re-derive a different soft limit from the previous run's
+    /// cache size and the value would oscillate. An estimate built on bare free
+    /// space (the tempting simplification) fails every line here.
+    #[test]
+    fn estimate_is_invariant_under_cache_growth_on_the_same_mount() {
+        let capacity = 4 * GIB;
+        for cache_bytes in [0, 32 * MIB, 128 * MIB, 512 * MIB, 2 * GIB, capacity] {
+            let available = capacity - cache_bytes;
+            assert_eq!(
+                startup_disk_budget_from_measurements(cache_bytes, Some(available), 0.5, CAP),
+                2 * GIB,
+                "budget must depend on used+available (the mount's reachable \
+                 capacity), not on how much of it the cache currently holds"
+            );
+        }
+    }
+
+    /// Monotone non-decreasing in the measured-used term. This is what makes
+    /// omitting persisted state bytes SAFE: the estimate is then never larger
+    /// than the live budget computed from the complete total.
+    #[test]
+    fn estimate_is_monotone_in_measured_used() {
+        let available = 400 * MIB;
+        let mut previous = 0;
+        for used in [0, 1, 128 * MIB, 512 * MIB, 4 * GIB, 64 * GIB, u64::MAX] {
+            let budget = startup_disk_budget_from_measurements(used, Some(available), 0.5, CAP);
+            assert!(
+                budget >= previous,
+                "budget must not shrink as measured usage grows (used={used})"
+            );
+            previous = budget;
+        }
+        // Concretely: omitting a 300 MiB state term yields a SMALLER budget than
+        // including it, never a larger one.
+        let without_state =
+            startup_disk_budget_from_measurements(512 * MIB, Some(available), 0.5, CAP);
+        let with_state =
+            startup_disk_budget_from_measurements(512 * MIB + 300 * MIB, Some(available), 0.5, CAP);
+        assert!(without_state < with_state);
+        assert_eq!(without_state, 456 * MIB);
+    }
+
+    /// An unreadable free-space query must not silently shrink the budget: it
+    /// falls back to `u64::MAX`, which clamps to the operator cap. Same rule the
+    /// live recompute applies.
+    #[test]
+    fn unreadable_free_space_clamps_to_the_cap_not_to_zero() {
+        assert_eq!(
+            startup_disk_budget_from_measurements(0, None, 0.5, CAP),
+            CAP,
+            "a free-space read we cannot trust must degrade to cap-only"
+        );
+        // And with a smaller operator cap, to that cap.
+        assert_eq!(
+            startup_disk_budget_from_measurements(0, None, 0.5, GIB),
+            GIB
+        );
+    }
+
+    /// Boundary values: zero capacity, a pct of zero, and an absurd basis all
+    /// have to land inside the documented clamp instead of panicking, wrapping,
+    /// or returning zero. A zero-capacity mount still yields the 128 MiB MIN.
+    #[test]
+    fn estimate_boundaries_stay_inside_the_clamp() {
+        assert_eq!(
+            startup_disk_budget_from_measurements(0, Some(0), 0.5, CAP),
+            128 * MIB,
+            "an empty mount must still resolve to the MIN floor, never 0"
+        );
+        assert_eq!(
+            startup_disk_budget_from_measurements(0, Some(u64::MAX), 1.0, CAP),
+            CAP,
+            "an enormous basis must clamp to the cap, not wrap"
+        );
+        assert_eq!(
+            startup_disk_budget_from_measurements(u64::MAX, Some(u64::MAX), 1.0, CAP),
+            CAP,
+            "saturating basis: no overflow into a small budget"
+        );
+        assert_eq!(
+            startup_disk_budget_from_measurements(4 * GIB, Some(4 * GIB), 0.0, CAP),
+            128 * MIB,
+            "pct=0 collapses to the MIN floor"
+        );
+    }
+
+    /// The impure entry point must compose the two pure pieces on the real
+    /// filesystem. Driven with `pct = 0.0` so the expected value is the MIN
+    /// floor on every host — no dependence on the CI machine's free space, so
+    /// this cannot flake.
+    #[test]
+    fn estimate_composes_the_du_walk_and_the_clamp_on_a_real_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let contracts = dir.path().join("contracts");
+        let cache = dir.path().join("wasmtime-cache");
+        write_file(&contracts.join("a.wasm"), 4096);
+        write_file(&cache.join("artifact"), 4096);
+
+        assert_eq!(
+            startup_disk_budget_estimate(&contracts, &cache, 0.0, CAP),
+            128 * MIB,
+            "pct=0 must resolve to the MIN floor regardless of the host's disk"
+        );
+        // With a real pct the value is host-dependent, so only the invariant is
+        // assertable: it stays inside the documented clamp.
+        let live = startup_disk_budget_estimate(&contracts, &cache, 0.5, CAP);
+        assert!(
+            (128 * MIB..=CAP).contains(&live),
+            "estimate {live} escaped the [MIN, cap] clamp"
+        );
     }
 }

--- a/crates/core/src/wasm_runtime.rs
+++ b/crates/core/src/wasm_runtime.rs
@@ -51,7 +51,10 @@ pub(crate) use native_api::{
 #[cfg(test)]
 pub(crate) use native_api::InheritedOriginsEntry;
 pub use runtime::{ContractExecError, Runtime};
-pub(crate) use runtime::{RuntimeConfig, SharedModuleCache, default_wasmtime_cache_size_bytes};
+pub(crate) use runtime::{
+    RuntimeConfig, SharedModuleCache, WASMTIME_CACHE_DISK_BUDGET_DIVISOR,
+    default_wasmtime_cache_size_bytes,
+};
 pub use secrets_store::{
     DEFAULT_LAST_SEEN_DEBOUNCE_SECS, DEFAULT_PER_USER_INACTIVE_TTL_SECS,
     DEFAULT_PER_USER_SECRET_QUOTA_BYTES, ExportSecretEntry, MigrationReport, SecretScope,

--- a/crates/core/src/wasm_runtime/runtime.rs
+++ b/crates/core/src/wasm_runtime/runtime.rs
@@ -1699,7 +1699,10 @@ mod wasmtime_disk_cache_sizing_tests {
                 let ram_term = wasmtime_cache_size_for_ram(total_ram);
                 let disk_term = wasmtime_cache_size_for_disk_budget(disk_budget);
                 let resolved = wasmtime_cache_size_for(total_ram, disk_budget);
-                assert!(resolved <= ram_term && resolved <= disk_budget);
+                // Against `disk_term`, not `disk_budget`: the budget is 4x the
+                // term, so the weaker form would hold even if the cache were
+                // allowed three quarters of the budget.
+                assert!(resolved <= ram_term && resolved <= disk_term);
                 assert!(resolved == ram_term || resolved == disk_term);
             }
         }

--- a/crates/core/src/wasm_runtime/runtime.rs
+++ b/crates/core/src/wasm_runtime/runtime.rs
@@ -209,9 +209,10 @@ pub struct RuntimeConfig {
     /// Soft size limit (bytes) for the wasmtime compile cache (#4683). `Some`
     /// overrides wasmtime's 512 MiB default via
     /// `CacheConfig::with_files_total_size_soft_limit`; `None` keeps the default.
-    /// Production resolves it from
-    /// [`default_wasmtime_cache_size_bytes`], which scales it to the memory the
-    /// node may use instead of pinning a flat constant.
+    /// Production resolves it in `RuntimePool::new` from
+    /// [`default_wasmtime_cache_size_bytes`], which takes the smaller of a
+    /// RAM-scaled ceiling and a quarter of the aggregate DISK budget this cache
+    /// is charged against (#5014) instead of pinning a flat constant.
     pub wasmtime_cache_size_bytes: Option<u64>,
 }
 
@@ -262,9 +263,18 @@ pub struct RuntimeConfig {
 /// (`MIN_DEFAULT_MODULE_CACHE_BUDGET_BYTES`, 64 MiB), so it evicts compiled
 /// modules from RAM more often and leans on this on-disk cache *more* than a
 /// large host does. It is set equal to the hosting budget's own floor
-/// (`MIN_DEFAULT_HOSTING_BUDGET_BYTES`, also 128 MiB) so the two on-disk
-/// allowances stay consistent: the smallest node the code contemplates gets the
-/// same floor for the state it hosts and for the compiled code that serves it.
+/// (`MIN_DEFAULT_HOSTING_BUDGET_BYTES`, also 128 MiB) so the two RAM-derived
+/// allowances stay consistent at every host size.
+///
+/// # This floors the RAM TERM, not the resolved limit (#5014)
+///
+/// Since #5014 the resolved limit is `min(ram_term, disk_budget / 4)`, and the
+/// `min` is taken AFTER this clamp. So a disk-tight host legitimately resolves
+/// BELOW 128 MiB — down to 32 MiB, a quarter of the disk budget's own 128 MiB
+/// floor. That is deliberate and is the defect being fixed: a floor that ignores
+/// disk is a bound a disk-tight host cannot honor, and re-imposing one after the
+/// `min` would restore the wedge. See [`default_wasmtime_cache_size_bytes`] and
+/// `disk_term_may_fall_below_the_ram_floor`.
 pub(crate) const MIN_WASMTIME_CACHE_SIZE_BYTES: u64 = 128 * 1024 * 1024;
 
 /// Upper clamp for the node-relative wasmtime on-disk compile cache soft limit
@@ -293,9 +303,16 @@ pub(crate) const MAX_WASMTIME_CACHE_SIZE_BYTES: u64 = 512 * 1024 * 1024;
 /// set by how many distinct contract blobs the node executes, and that population
 /// is what the RAM-scaled hosting budget already bounds. Sharing the divisor
 /// makes the relationship exact instead of coincidental — with the same divisor,
-/// the same floor, and a strictly lower ceiling, the compile-cache **default**
-/// can never exceed the hosted-state **default** for the same host (pinned by
-/// `compile_cache_default_never_exceeds_hosting_default`). That is the shape of
+/// the same RAM-term floor, and a strictly lower ceiling, the compile-cache
+/// **default** can never exceed the hosted-state **default** for the same host
+/// (pinned by `compile_cache_default_never_exceeds_hosting_default`).
+///
+/// Both halves of that reasoning are about the RAM TERM. Since #5014 the
+/// resolved limit takes a `min` with a quarter of the disk budget, which only
+/// lowers it — so the ordering conclusion survives, but do not restate its
+/// premise as "the two budgets share a floor": the resolved compile-cache limit
+/// can fall to 32 MiB while the hosted-state budget sits at its own 128 MiB
+/// floor. That is the shape of
 /// the defect this replaced: on a peer under a 2 GiB cgroup the flat 512 MiB
 /// limit let the compile cache reach ~306 MB while that node's entire
 /// contract-state budget was 256 MiB.
@@ -339,13 +356,35 @@ const WASMTIME_CACHE_RAM_DIVISOR: u64 = 8;
 /// # Why 1/4
 ///
 /// It is chosen from the failure mode, not from a preference about cache size:
-/// the soft limit is the cache's WORST case between wasmtime's ~1h cleanups, so
-/// capping it at a quarter of the budget guarantees at least **75% of the
-/// aggregate budget is always held by consumers the node can actually reclaim**
-/// (contract state, which eviction sheds) or that dedupe on their own (WASM
-/// blobs, one file per `code_hash`). The steady state after a prune is
-/// `0.25 × 0.7 = 17.5%` of the budget. That headroom is what makes the wedge
-/// unreachable by construction rather than by calibration.
+/// a divisor of 1 lets the cache claim the entire budget, which IS the defect,
+/// and any divisor >= 2 buys the property that the cache never holds the
+/// majority of the budget. 4 picks a comfortable margin inside that — the steady
+/// state after a prune is `0.25 × 0.7 = 17.5%`, so the typical case leaves the
+/// budget overwhelmingly to consumers the node can act on.
+///
+/// # What the cap actually guarantees, and what it does not
+///
+/// It bounds **this cache's** contribution to the aggregate budget. Two things
+/// it must NOT be read as:
+///
+/// - It is not a bound on the cache's instantaneous footprint. Wasmtime's
+///   `update_data` writes the artifact FIRST and only then posts the cleanup
+///   notification, and the prune is gated behind a once-per-hour lock, so the
+///   real bound is `0.7 × L + (bytes written since the last cleanup)` and the
+///   tree can legitimately sit above `L` between cleanups. Freenet's
+///   distinct-blob arrival rate is low (418 artifacts against 185 live blobs on
+///   the production gateway), so the practical overshoot is small — but that is a
+///   rate argument about this workload, not a guarantee.
+/// - It is not a guarantee that the remaining 75% of the budget is reclaimable.
+///   Contract state is reclaimable (eviction sheds it) and WASM blobs dedupe on
+///   their own, but the storage term also carries redb dead space, which only the
+///   restart compaction reclaims and eviction cannot touch. The cap bounds one
+///   unreclaimable consumer; it does not make the rest of the budget reclaimable.
+///
+/// What it does buy is the thing the defect needed: the cache alone can no longer
+/// exceed the budget it is charged against, so `total_bytes() > budget` can no
+/// longer be true before a single new byte is considered — and eviction always
+/// has SOMETHING it can shed.
 ///
 /// # It changes nothing for a host with room
 ///
@@ -356,7 +395,7 @@ const WASMTIME_CACHE_RAM_DIVISOR: u64 = 8;
 /// gateway — resolves to exactly the RAM-derived value #5011 already gave it, so
 /// no node that works today has its cache slashed into a recompile-per-restart
 /// regime. Pinned by `disk_term_is_inert_on_hosts_with_room`.
-const WASMTIME_CACHE_DISK_BUDGET_DIVISOR: u64 = 4;
+pub(crate) const WASMTIME_CACHE_DISK_BUDGET_DIVISOR: u64 = 4;
 
 /// Fallback "memory the node may use" estimate (1 GiB) when the OS query fails.
 ///
@@ -406,32 +445,59 @@ const WASMTIME_CACHE_FALLBACK_TOTAL_RAM_BYTES: u64 = 1024 * 1024 * 1024;
 /// disk-tight host cannot honor. Pinned by
 /// `disk_term_may_fall_below_the_ram_floor`.
 ///
-/// # Ordering: this resolves BEFORE the disk tracker exists
+/// # Ordering: `disk_budget` is a start-time ESTIMATE, resolved by the caller
 ///
 /// Wasmtime fixes the soft limit once, at `Cache::new`, reached from
 /// `Executor::from_config_with_shared_modules` — which runs before
 /// `Ring::set_hosting_disk_paths` configures the `DiskUsageTracker` and long
 /// before the first sweep tick seeds it. So the disk budget cannot be read from
-/// the tracker; [`crate::ring::startup_disk_budget_estimate`] re-derives it from
-/// the filesystem instead, using the live budget's own clamp math on the same
-/// `freenet_used + available` basis. That estimate omits persisted state bytes
-/// (unreadable before storage exists) and is monotone in that term, so it is
-/// always `<=` the budget the first recompute installs — the cache therefore
-/// claims at most a quarter of the LIVE budget too, never more.
+/// the tracker, and `RuntimePool::new` derives it from the filesystem with
+/// [`crate::ring::startup_disk_budget_estimate`], using the live budget's own
+/// clamp math on the same `freenet_used + available` basis.
 ///
-/// # There is no live re-application path, and that is accepted here
+/// The estimate is resolved by the CALLER rather than here on purpose: the
+/// hosting-policy knobs it needs (`hosting_disk_pct`, `max_hosting_disk`, the
+/// data-dir paths) are `ring`'s business and the pool already holds all four a
+/// few lines from where it calls `Ring::set_hosting_disk_paths` with the same
+/// values. Taking the resolved budget as one `u64` keeps `wasm_runtime` free of
+/// any `ring` dependency, the direction this module already states elsewhere.
+///
+/// That estimate omits persisted state bytes (unreadable before storage exists)
+/// and is monotone in that term, so it is always `<=` the budget the first
+/// recompute installs — the cache therefore claims at most a quarter of the LIVE
+/// budget too, never more.
+///
+/// # There is no live re-application path; a RESTART is the recovery
 ///
 /// Wasmtime reads the soft limit once and offers no way to change it on a live
 /// `Cache`; rebuilding one would mean tearing down the backend engine that every
-/// pool executor shares and discarding its compiled modules. Deferred
-/// deliberately, because the quantity being bounded is slow-moving: the estimate's
-/// basis is `freenet_used + available`, the mount's Freenet-reachable capacity,
-/// which is invariant under Freenet's own writes (a byte the cache gains is a
-/// byte `available` loses on the same mount). It moves only when something
-/// outside Freenet fills or resizes the mount — and for that case the live 60s
-/// recompute already shrinks the aggregate budget and the eviction floor, while
-/// the compile cache stays bounded by the absolute figure chosen at start and
-/// pruned to 70% of it. The next restart re-derives.
+/// pool executor shares and discarding its compiled modules. So the limit is
+/// fixed for the lifetime of the process, and this is the residual hole that
+/// leaves — stated plainly rather than as a mitigation:
+///
+/// The live budget is recomputed every 60s as `clamp(pct × (used + available))`,
+/// while the cache's limit `L` does not move. Work the algebra at the margin:
+/// after the sweep has shed everything it can, the node is over budget iff
+/// `L > pct × (L + available)`, i.e. at the default pct = 0.5 iff `L >
+/// available`. So **any consumer outside Freenet that drives free space on the
+/// data mount below the compile cache's size re-creates the #5014 wedge for the
+/// rest of the process's life**, and no amount of eviction digs out.
+///
+/// What bounds that hole:
+///
+/// - It cannot be reached by Freenet's own writes. The estimate's basis is
+///   `freenet_used + available`, the mount's Freenet-reachable capacity, which is
+///   invariant under Freenet's own writes (a byte the cache gains is a byte
+///   `available` loses on the same mount). Only something outside Freenet filling
+///   or resizing the mount moves it.
+/// - It is now visible: `HostingManager::recompute_effective_budget` warns
+///   (edge-triggered) the first time `compile_cache_bytes` exceeds a quarter of
+///   the live budget, which is exactly the condition "the startup assumption no
+///   longer holds".
+/// - It is now recoverable: a restart re-derives the limit from the shrunken
+///   mount AND `ring::prune_compile_cache_to_limit` deletes the existing cache
+///   down to it, so "restart the node" is a real remedy rather than a hope that
+///   wasmtime's write-path cleanup happens to fire.
 ///
 /// # This is a SOFT limit, and the steady state is 70% of it
 ///
@@ -475,21 +541,10 @@ const WASMTIME_CACHE_FALLBACK_TOTAL_RAM_BYTES: u64 = 1024 * 1024 * 1024;
 /// caches with separate budgets; this one has no operator override today (it
 /// never had one — it was a private constant), so this derived default is its
 /// only source.
-pub(crate) fn default_wasmtime_cache_size_bytes(
-    contracts_dir: &std::path::Path,
-    compile_cache_dir: &std::path::Path,
-    hosting_disk_pct: f64,
-    max_hosting_disk: u64,
-) -> u64 {
+pub(crate) fn default_wasmtime_cache_size_bytes(disk_budget: u64) -> u64 {
     let total_ram = super::read_total_ram_bytes()
         .map(|v| v as u64)
         .unwrap_or(WASMTIME_CACHE_FALLBACK_TOTAL_RAM_BYTES);
-    let disk_budget = crate::ring::startup_disk_budget_estimate(
-        contracts_dir,
-        compile_cache_dir,
-        hosting_disk_pct,
-        max_hosting_disk,
-    );
     wasmtime_cache_size_for(total_ram, disk_budget)
 }
 
@@ -1416,38 +1471,29 @@ mod wasmtime_disk_cache_sizing_tests {
         let signal = crate::wasm_runtime::read_total_ram_bytes()
             .map(|v| v as u64)
             .unwrap_or(WASMTIME_CACHE_FALLBACK_TOTAL_RAM_BYTES);
-        let dir = tempfile::tempdir().unwrap();
-        let contracts = dir.path().join("contracts");
-        let cache = dir.path().join("wasmtime-cache");
-        std::fs::create_dir_all(&contracts).unwrap();
-        std::fs::create_dir_all(&cache).unwrap();
 
-        // `pct = 0.0` pins the disk budget to its MIN floor (128 MiB) on EVERY
-        // host, so the expected value is exact and this cannot flake on a CI
-        // machine whose free space differs from the developer's. The disk term
-        // is then 32 MiB, which is below the RAM floor — which is the whole
-        // point: the disk signal, not RAM, decides on a disk-starved host.
+        // A disk budget pinned at its own 128 MiB MIN floor yields 32 MiB on
+        // EVERY host — below the 128 MiB RAM floor, which is the whole point:
+        // the disk signal, not RAM, decides on a disk-starved host. Concrete and
+        // host-independent, so this is the assertion doing the work.
         assert_eq!(
-            default_wasmtime_cache_size_bytes(&contracts, &cache, 0.0, 32 * GIB),
-            wasmtime_cache_size_for(signal, 128 * MIB),
-            "the live reader must combine the RAM signal with the disk budget \
-             through the pure math"
-        );
-        assert_eq!(
-            default_wasmtime_cache_size_bytes(&contracts, &cache, 0.0, 32 * GIB),
+            default_wasmtime_cache_size_bytes(128 * MIB),
             32 * MIB,
             "a node whose disk budget is pinned at the 128 MiB floor gets a \
              quarter of it, NOT the 128 MiB RAM floor"
         );
-
-        // With a real pct the disk term depends on the host's mount, so only the
-        // bound is assertable — but it is the load-bearing bound: the resolved
-        // limit can never exceed the RAM term.
-        let live = default_wasmtime_cache_size_bytes(&contracts, &cache, 0.5, 32 * GIB);
-        assert!(
-            live <= wasmtime_cache_size_for_ram(signal),
-            "the RAM term must remain an upper bound ({live} > {})",
-            wasmtime_cache_size_for_ram(signal)
+        // The reader must apply the pure math to the host's RAM signal rather
+        // than carrying its own arithmetic. Give the disk term room so the RAM
+        // term is the binding one; on a host at or above the ceiling-binding
+        // point (>= 4 GiB, i.e. most CI machines) both sides still evaluate to
+        // the ceiling, so this cannot distinguish a reader that ignores RAM —
+        // `default_soft_limit_reader_derives_from_ram_and_disk_signals` is what
+        // covers that host-independently.
+        assert_eq!(
+            default_wasmtime_cache_size_bytes(u64::MAX),
+            wasmtime_cache_size_for_ram(signal),
+            "with disk unconstrained the RAM term must decide, through the pure \
+             math"
         );
     }
 
@@ -1464,29 +1510,41 @@ mod wasmtime_disk_cache_sizing_tests {
     fn default_soft_limit_reader_derives_from_ram_and_disk_signals() {
         let src = include_str!("runtime.rs");
         let body = src
-            .split(concat!(
+            .split_once(concat!(
                 "pub(crate) fn ",
-                "default_wasmtime_cache_size_bytes(\n"
+                "default_wasmtime_cache_size_bytes(disk_budget: u64) -> u64 {\n"
             ))
-            .nth(1)
             .expect("default_wasmtime_cache_size_bytes must exist")
-            .split("\n}\n")
-            .next()
-            .expect("end of default_wasmtime_cache_size_bytes");
+            .1
+            .split_once("\n}\n")
+            .expect("end marker of default_wasmtime_cache_size_bytes must exist")
+            .0;
         assert!(
             body.contains(concat!("read_total_", "ram_bytes()")),
             "the reader must consult the shared read_total_ram_bytes() signal, not \
              a second notion of machine size"
         );
+        // The `disk_budget` parameter must reach the pure math. Dropping it (or
+        // substituting `u64::MAX`, a constant, or the RAM term) compiles fine and
+        // silently restores the RAM-only bound that left a disk-tight host
+        // unprotected (#5014). The budget itself is derived by the CALLER —
+        // `RuntimePool::new`, pinned by
+        // `runtime_pool_resolves_compile_cache_limit_from_the_disk_signal` — so
+        // that `wasm_runtime` needs no `ring` dependency.
         assert!(
-            body.contains(concat!("ring::startup_", "disk_budget_estimate(")),
-            "the reader must consult the DISK budget the compile cache is charged \
-             against — a RAM-only bound leaves a disk-tight host unprotected (#5014)"
+            body.contains(concat!(
+                "wasmtime_cache_",
+                "size_for(total_ram, disk_budget)"
+            )),
+            "the reader must delegate to the pure math with BOTH signals, so the \
+             boundary behavior has exactly one implementation and the disk term \
+             cannot be silently dropped"
         );
         assert!(
-            body.contains(concat!("wasmtime_cache_", "size_for(")),
-            "the reader must delegate to the pure math so the boundary behavior \
-             has exactly one implementation"
+            !body.contains("crate::ring::"),
+            "the resolver must take the disk budget as a parameter rather than \
+             reaching into `ring`: `ring` already depends on `wasm_runtime`, so \
+             the reverse edge closes a module cycle"
         );
     }
 

--- a/crates/core/src/wasm_runtime/runtime.rs
+++ b/crates/core/src/wasm_runtime/runtime.rs
@@ -311,13 +311,52 @@ pub(crate) const MAX_WASMTIME_CACHE_SIZE_BYTES: u64 = 512 * 1024 * 1024;
 /// defaults* stay ordered at every host size. Do not restate this as a
 /// system-level invariant.
 ///
-/// Note also that a RAM signal is not the right shape for this cache's real
-/// constraint: the compile cache is charged against the aggregate **disk** budget
-/// (`DiskUsageTracker::total_bytes()` sums state + wasm + compile-cache bytes and
-/// gates `admit_state_write` / `admit_wasm_write`), so a disk-tight but RAM-rich
-/// host is not protected by any RAM-derived bound. Tracked separately in #5014;
-/// this constant narrows the exposure on RAM-poor hosts without closing it.
+/// A RAM signal is not, on its own, the right shape for this cache's real
+/// constraint: the compile cache is charged against the aggregate **disk**
+/// budget (`DiskUsageTracker::total_bytes()` sums state + wasm + compile-cache
+/// bytes and gates `admit_state_write` / `admit_wasm_write`), so a disk-tight
+/// but RAM-rich host was not protected by any RAM-derived bound (#5014). The
+/// RAM term therefore survives only as the UPPER bound — a large disk must not
+/// license an unbounded cache — and the *binding* constraint on a disk-tight
+/// host is [`WASMTIME_CACHE_DISK_BUDGET_DIVISOR`]. See
+/// [`default_wasmtime_cache_size_bytes`].
 const WASMTIME_CACHE_RAM_DIVISOR: u64 = 8;
+
+/// Fraction of the **aggregate disk budget** the on-disk compile cache may claim
+/// as its soft limit: 1/4 (#5014).
+///
+/// # Why the disk budget, and not RAM, is the binding term
+///
+/// The cache is charged against the aggregate disk budget and is NOT reclaimable
+/// by the thing that defends that budget: the hosting sweep sheds contract
+/// *state*, and `compile_cache_bytes` is outside its reach. So a cache sized
+/// from a signal unrelated to disk could occupy the whole budget on a disk-tight
+/// host, at which point `total_bytes() > budget_bytes` holds before a single new
+/// byte is considered, every `admit_state_write` / `admit_wasm_write` rejects,
+/// and eviction cannot dig out no matter how much state it sheds. Wasmtime's own
+/// prune does not rescue it either — it stops at 70% of the soft limit.
+///
+/// # Why 1/4
+///
+/// It is chosen from the failure mode, not from a preference about cache size:
+/// the soft limit is the cache's WORST case between wasmtime's ~1h cleanups, so
+/// capping it at a quarter of the budget guarantees at least **75% of the
+/// aggregate budget is always held by consumers the node can actually reclaim**
+/// (contract state, which eviction sheds) or that dedupe on their own (WASM
+/// blobs, one file per `code_hash`). The steady state after a prune is
+/// `0.25 × 0.7 = 17.5%` of the budget. That headroom is what makes the wedge
+/// unreachable by construction rather than by calibration.
+///
+/// # It changes nothing for a host with room
+///
+/// The disk term only becomes the smaller of the two when
+/// `disk_budget < 4 × ram_term`, i.e. when Freenet-reachable capacity on the data
+/// mount is under ~4 GiB for a host at the 512 MiB RAM ceiling. Every host with
+/// more disk than that — a laptop, a normally-provisioned VM, the production
+/// gateway — resolves to exactly the RAM-derived value #5011 already gave it, so
+/// no node that works today has its cache slashed into a recompile-per-restart
+/// regime. Pinned by `disk_term_is_inert_on_hosts_with_room`.
+const WASMTIME_CACHE_DISK_BUDGET_DIVISOR: u64 = 4;
 
 /// Fallback "memory the node may use" estimate (1 GiB) when the OS query fails.
 ///
@@ -327,16 +366,72 @@ const WASMTIME_CACHE_RAM_DIVISOR: u64 = 8;
 /// largest.
 const WASMTIME_CACHE_FALLBACK_TOTAL_RAM_BYTES: u64 = 1024 * 1024 * 1024;
 
-/// Default soft size limit for the wasmtime **on-disk compile cache**, scaled to
-/// the memory the node may use (host RAM, or a smaller cgroup limit when
-/// containerized — see [`read_total_ram_bytes`](super::read_total_ram_bytes))
-/// and clamped to a sane floor/ceiling.
+/// Default soft size limit for the wasmtime **on-disk compile cache**:
+/// `min(ram_term, disk_term)`, where the disk term is the binding one on the
+/// host shape that actually wedges (#5014).
 ///
-/// Returns `clamp(total_ram / WASMTIME_CACHE_RAM_DIVISOR,
-/// MIN_WASMTIME_CACHE_SIZE_BYTES, MAX_WASMTIME_CACHE_SIZE_BYTES)` — currently
-/// `clamp(total_ram / 8, 128 MiB, 512 MiB)`. It replaces a flat 512 MiB constant
-/// that applied regardless of machine size, which let a 2 GiB-cgroup node keep a
-/// compile cache larger than its whole 256 MiB contract-state budget.
+/// - **`ram_term`** = [`wasmtime_cache_size_for_ram`] — `clamp(total_ram / 8,
+///   128 MiB, 512 MiB)` against the memory the node may use (host RAM, or a
+///   smaller cgroup limit when containerized, see
+///   [`read_total_ram_bytes`](super::read_total_ram_bytes)). Kept as the UPPER
+///   bound: a host with an enormous disk must not license an unbounded cache,
+///   and the useful size of this cache is set by how many distinct contract
+///   blobs the node executes, a population the RAM-scaled hosting budget already
+///   bounds.
+/// - **`disk_term`** = [`wasmtime_cache_size_for_disk_budget`] — a quarter of the
+///   aggregate disk budget this cache is charged against.
+///
+/// # Why the disk term has to exist
+///
+/// `DiskUsageTracker::total_bytes()` sums state + wasm + **compile-cache** bytes,
+/// and that total gates `admit_state_write` / `admit_wasm_write` and feeds the
+/// eviction floor `min(ram_budget, disk_budget)`. Bounding a disk consumer by a
+/// RAM signal protects the RAM-poor host and leaves the RAM-rich, disk-tight one
+/// completely exposed: on a 16 GiB VM with 400 MiB free on the data mount, the
+/// old RAM-derived limit resolved to its 512 MiB ceiling while the disk budget
+/// was ~456 MiB, so `total_bytes()` exceeded the budget before any new state was
+/// considered, every admission rejected, and the hosting sweep could not recover
+/// because it sheds contract state and cannot touch the compile cache. With the
+/// disk term that same host resolves to ~114 MiB and keeps ~342 MiB of the
+/// budget for reclaimable consumers.
+///
+/// # The disk term may go BELOW `MIN_WASMTIME_CACHE_SIZE_BYTES`, deliberately
+///
+/// `min()` is taken after each term's own clamp, so on a host whose entire
+/// Freenet-reachable disk capacity is around a gigabyte the result lands below
+/// the 128 MiB RAM floor (its own lower bound is the disk budget's 128 MiB MIN
+/// over the divisor, i.e. 32 MiB — roughly 40 artifacts at the measured p90,
+/// 67 at the mean). Re-introducing an absolute floor here would recreate exactly
+/// the defect this closes: a floor that ignores disk is a bound that a
+/// disk-tight host cannot honor. Pinned by
+/// `disk_term_may_fall_below_the_ram_floor`.
+///
+/// # Ordering: this resolves BEFORE the disk tracker exists
+///
+/// Wasmtime fixes the soft limit once, at `Cache::new`, reached from
+/// `Executor::from_config_with_shared_modules` — which runs before
+/// `Ring::set_hosting_disk_paths` configures the `DiskUsageTracker` and long
+/// before the first sweep tick seeds it. So the disk budget cannot be read from
+/// the tracker; [`crate::ring::startup_disk_budget_estimate`] re-derives it from
+/// the filesystem instead, using the live budget's own clamp math on the same
+/// `freenet_used + available` basis. That estimate omits persisted state bytes
+/// (unreadable before storage exists) and is monotone in that term, so it is
+/// always `<=` the budget the first recompute installs — the cache therefore
+/// claims at most a quarter of the LIVE budget too, never more.
+///
+/// # There is no live re-application path, and that is accepted here
+///
+/// Wasmtime reads the soft limit once and offers no way to change it on a live
+/// `Cache`; rebuilding one would mean tearing down the backend engine that every
+/// pool executor shares and discarding its compiled modules. Deferred
+/// deliberately, because the quantity being bounded is slow-moving: the estimate's
+/// basis is `freenet_used + available`, the mount's Freenet-reachable capacity,
+/// which is invariant under Freenet's own writes (a byte the cache gains is a
+/// byte `available` loses on the same mount). It moves only when something
+/// outside Freenet fills or resizes the mount — and for that case the live 60s
+/// recompute already shrinks the aggregate budget and the eviction floor, while
+/// the compile cache stays bounded by the absolute figure chosen at start and
+/// pruned to 70% of it. The next restart re-derives.
 ///
 /// # This is a SOFT limit, and the steady state is 70% of it
 ///
@@ -348,8 +443,9 @@ const WASMTIME_CACHE_FALLBACK_TOTAL_RAM_BYTES: u64 = 1024 * 1024 * 1024;
 /// - The steady-state footprint after a prune is `soft_limit × 0.7`, not
 ///   `soft_limit`.
 /// - Between cleanups the cache may legitimately sit at the FULL soft limit, so
-///   the disk it is charged against must tolerate the un-pruned figure, not just
-///   the steady-state one.
+///   the disk it is charged against must tolerate the un-pruned figure. This is
+///   why [`WASMTIME_CACHE_DISK_BUDGET_DIVISOR`] is applied to the soft limit
+///   rather than to the steady state: 25% is the worst case, 17.5% the typical.
 ///
 /// # Margin at the smallest shape is thin, not comfortable
 ///
@@ -363,6 +459,12 @@ const WASMTIME_CACHE_FALLBACK_TOTAL_RAM_BYTES: u64 = 1024 * 1024 * 1024;
 /// deliberately — the alternative was a cache bigger than the node's entire state
 /// budget.
 ///
+/// Those figures describe the RAM term, i.e. a 2 GiB host with disk to spare. A
+/// host that is ALSO disk-tight lands lower still, down to 32 MiB at the disk
+/// budget's floor. That is the correct trade in the other direction: the cost of
+/// too small a cache is Cranelift recompiles, while the cost of too large a one
+/// on a disk-tight host was a node that could not accept a PUT at all.
+///
 /// # Which cache this is
 ///
 /// The **on-disk** cache of compiled artifacts wasmtime writes under the data
@@ -373,20 +475,56 @@ const WASMTIME_CACHE_FALLBACK_TOTAL_RAM_BYTES: u64 = 1024 * 1024 * 1024;
 /// caches with separate budgets; this one has no operator override today (it
 /// never had one — it was a private constant), so this derived default is its
 /// only source.
-pub(crate) fn default_wasmtime_cache_size_bytes() -> u64 {
+pub(crate) fn default_wasmtime_cache_size_bytes(
+    contracts_dir: &std::path::Path,
+    compile_cache_dir: &std::path::Path,
+    hosting_disk_pct: f64,
+    max_hosting_disk: u64,
+) -> u64 {
     let total_ram = super::read_total_ram_bytes()
         .map(|v| v as u64)
         .unwrap_or(WASMTIME_CACHE_FALLBACK_TOTAL_RAM_BYTES);
-    wasmtime_cache_size_for_ram(total_ram)
+    let disk_budget = crate::ring::startup_disk_budget_estimate(
+        contracts_dir,
+        compile_cache_dir,
+        hosting_disk_pct,
+        max_hosting_disk,
+    );
+    wasmtime_cache_size_for(total_ram, disk_budget)
 }
 
-/// Pure clamp math behind [`default_wasmtime_cache_size_bytes`], split out so the
-/// small-box / large-box / cgroup boundary behavior is unit-testable without
-/// depending on the test host's real RAM. Mirrors the `budget_for_ram` /
-/// `disk_budget_for_clamped` pattern used by the sibling budgets.
+/// Pure math behind [`default_wasmtime_cache_size_bytes`], split out so the
+/// small-box / large-box / cgroup / disk-tight boundary behavior is unit-testable
+/// without depending on the test host's real RAM or disk. Mirrors the
+/// `budget_for_ram` / `disk_budget_for_clamped` pattern used by the sibling
+/// budgets.
+///
+/// `min()` of the two terms, taken AFTER each has applied its own clamp — so the
+/// disk term can legitimately land below `MIN_WASMTIME_CACHE_SIZE_BYTES`. That is
+/// the point: a floor that ignores disk is unhonorable on a disk-tight host, and
+/// re-imposing one here would restore the defect.
+pub(crate) fn wasmtime_cache_size_for(total_ram: u64, disk_budget: u64) -> u64 {
+    wasmtime_cache_size_for_ram(total_ram).min(wasmtime_cache_size_for_disk_budget(disk_budget))
+}
+
+/// The RAM term: `clamp(total_ram / 8, 128 MiB, 512 MiB)`. Upper bound only —
+/// see [`WASMTIME_CACHE_RAM_DIVISOR`].
 pub(crate) fn wasmtime_cache_size_for_ram(total_ram: u64) -> u64 {
     (total_ram / WASMTIME_CACHE_RAM_DIVISOR)
         .clamp(MIN_WASMTIME_CACHE_SIZE_BYTES, MAX_WASMTIME_CACHE_SIZE_BYTES)
+}
+
+/// The disk term: the share of the aggregate disk budget the compile cache may
+/// claim, `disk_budget / WASMTIME_CACHE_DISK_BUDGET_DIVISOR` (#5014).
+///
+/// Deliberately unclamped on both ends. There is no floor because the disk
+/// budget already carries one (`MIN_DEFAULT_HOSTING_BUDGET_BYTES`, 128 MiB), so
+/// this cannot return less than 32 MiB, and adding a second, disk-blind floor is
+/// the defect being fixed. There is no ceiling because
+/// [`wasmtime_cache_size_for`] takes the `min` with the RAM term, which is
+/// already ceilinged.
+pub(crate) fn wasmtime_cache_size_for_disk_budget(disk_budget: u64) -> u64 {
+    disk_budget / WASMTIME_CACHE_DISK_BUDGET_DIVISOR
 }
 
 impl Default for RuntimeConfig {
@@ -1100,7 +1238,7 @@ mod wasmtime_disk_cache_sizing_tests {
     use super::{
         MAX_WASMTIME_CACHE_SIZE_BYTES, MIN_WASMTIME_CACHE_SIZE_BYTES,
         WASMTIME_CACHE_FALLBACK_TOTAL_RAM_BYTES, default_wasmtime_cache_size_bytes,
-        wasmtime_cache_size_for_ram,
+        wasmtime_cache_size_for, wasmtime_cache_size_for_disk_budget, wasmtime_cache_size_for_ram,
     };
     use crate::ring::hosting_budget_for_ram;
 
@@ -1278,37 +1416,235 @@ mod wasmtime_disk_cache_sizing_tests {
         let signal = crate::wasm_runtime::read_total_ram_bytes()
             .map(|v| v as u64)
             .unwrap_or(WASMTIME_CACHE_FALLBACK_TOTAL_RAM_BYTES);
+        let dir = tempfile::tempdir().unwrap();
+        let contracts = dir.path().join("contracts");
+        let cache = dir.path().join("wasmtime-cache");
+        std::fs::create_dir_all(&contracts).unwrap();
+        std::fs::create_dir_all(&cache).unwrap();
+
+        // `pct = 0.0` pins the disk budget to its MIN floor (128 MiB) on EVERY
+        // host, so the expected value is exact and this cannot flake on a CI
+        // machine whose free space differs from the developer's. The disk term
+        // is then 32 MiB, which is below the RAM floor — which is the whole
+        // point: the disk signal, not RAM, decides on a disk-starved host.
         assert_eq!(
-            default_wasmtime_cache_size_bytes(),
-            wasmtime_cache_size_for_ram(signal),
-            "the live reader must apply the pure clamp to the RAM signal"
+            default_wasmtime_cache_size_bytes(&contracts, &cache, 0.0, 32 * GIB),
+            wasmtime_cache_size_for(signal, 128 * MIB),
+            "the live reader must combine the RAM signal with the disk budget \
+             through the pure math"
+        );
+        assert_eq!(
+            default_wasmtime_cache_size_bytes(&contracts, &cache, 0.0, 32 * GIB),
+            32 * MIB,
+            "a node whose disk budget is pinned at the 128 MiB floor gets a \
+             quarter of it, NOT the 128 MiB RAM floor"
+        );
+
+        // With a real pct the disk term depends on the host's mount, so only the
+        // bound is assertable — but it is the load-bearing bound: the resolved
+        // limit can never exceed the RAM term.
+        let live = default_wasmtime_cache_size_bytes(&contracts, &cache, 0.5, 32 * GIB);
+        assert!(
+            live <= wasmtime_cache_size_for_ram(signal),
+            "the RAM term must remain an upper bound ({live} > {})",
+            wasmtime_cache_size_for_ram(signal)
         );
     }
 
-    /// Host-independent pin: the live reader must derive its value from the
-    /// shared RAM signal and delegate to the pure clamp. Fails if a future edit
-    /// re-hardcodes the limit or introduces a second notion of machine size —
-    /// the mutation a runtime assertion cannot catch on a large CI host.
+    /// Host-independent pin: the live reader must consult BOTH signals and
+    /// delegate to the pure math. Fails if a future edit re-hardcodes the limit,
+    /// drops the disk term back to a RAM-only bound (the #5014 defect), or
+    /// introduces a second notion of machine size — mutations a runtime
+    /// assertion cannot catch on a CI host whose RAM and disk are both ample.
+    ///
+    /// Needles are assembled from `concat!` fragments that appear nowhere
+    /// verbatim in this file, so the pin cannot satisfy itself by matching its
+    /// own source through `include_str!`.
     #[test]
-    fn default_soft_limit_reader_derives_from_the_ram_signal() {
+    fn default_soft_limit_reader_derives_from_ram_and_disk_signals() {
         let src = include_str!("runtime.rs");
         let body = src
-            .split("pub(crate) fn default_wasmtime_cache_size_bytes() -> u64 {")
+            .split(concat!(
+                "pub(crate) fn ",
+                "default_wasmtime_cache_size_bytes(\n"
+            ))
             .nth(1)
             .expect("default_wasmtime_cache_size_bytes must exist")
             .split("\n}\n")
             .next()
             .expect("end of default_wasmtime_cache_size_bytes");
         assert!(
-            body.contains("read_total_ram_bytes()"),
+            body.contains(concat!("read_total_", "ram_bytes()")),
             "the reader must consult the shared read_total_ram_bytes() signal, not \
              a second notion of machine size"
         );
         assert!(
-            body.contains("wasmtime_cache_size_for_ram("),
-            "the reader must delegate to the pure clamp so the boundary math has \
-             exactly one implementation"
+            body.contains(concat!("ring::startup_", "disk_budget_estimate(")),
+            "the reader must consult the DISK budget the compile cache is charged \
+             against — a RAM-only bound leaves a disk-tight host unprotected (#5014)"
         );
+        assert!(
+            body.contains(concat!("wasmtime_cache_", "size_for(")),
+            "the reader must delegate to the pure math so the boundary behavior \
+             has exactly one implementation"
+        );
+    }
+
+    /// The defect, stated as an invariant: the resolved soft limit must never
+    /// exceed a quarter of the aggregate disk budget it is charged against.
+    ///
+    /// This is what makes the wedge unreachable. `DiskUsageTracker::total_bytes()`
+    /// counts the compile cache, that total gates every state/wasm admission, and
+    /// the hosting sweep sheds contract STATE — it cannot reclaim compile-cache
+    /// bytes. So if the cache may occupy the whole budget, admission rejects
+    /// forever and eviction cannot dig out. A quarter leaves >= 75% of the budget
+    /// with consumers the node can actually reclaim.
+    #[test]
+    fn resolved_limit_never_claims_more_than_its_share_of_the_disk_budget() {
+        for total_ram in [0, GIB, 2 * GIB, 4 * GIB, 16 * GIB, 125 * GIB, u64::MAX] {
+            for disk_budget in [
+                0,
+                128 * MIB,
+                456 * MIB,
+                512 * MIB,
+                2 * GIB,
+                32 * GIB,
+                u64::MAX,
+            ] {
+                let limit = wasmtime_cache_size_for(total_ram, disk_budget);
+                // The `4` is a LITERAL on purpose. Written against
+                // `WASMTIME_CACHE_DISK_BUDGET_DIVISOR` this assertion would be
+                // self-referential — it would still pass if the divisor were
+                // mutated to 1, i.e. if the cache were allowed to claim the
+                // entire budget, which is precisely the defect.
+                assert!(
+                    limit.saturating_mul(4) <= disk_budget,
+                    "at ram={total_ram} disk_budget={disk_budget} the limit {limit} \
+                     claims more than a quarter of the budget it is charged against"
+                );
+            }
+        }
+
+        // The pre-fix behavior, shown failing that invariant at the exact shape
+        // from the report: a 16 GiB VM with 400 MiB free on the data mount, where
+        // freenet already occupies ~512 MiB, has a ~456 MiB disk budget.
+        let wedging_disk_budget = 456 * MIB;
+        let ram_only = wasmtime_cache_size_for_ram(16 * GIB);
+        assert_eq!(ram_only, 512 * MIB);
+        assert!(
+            ram_only > wedging_disk_budget,
+            "the RAM-derived limit exceeded the ENTIRE disk budget — total_bytes() \
+             was over budget before any new state was considered"
+        );
+        assert_eq!(
+            wasmtime_cache_size_for(16 * GIB, wedging_disk_budget),
+            114 * MIB,
+            "the disk-aware limit must fit inside the budget with room for the \
+             state and wasm the sweep can actually reclaim"
+        );
+    }
+
+    /// The three machine shapes this change was sized against. The first and
+    /// third must be BIT-IDENTICAL to what #5011 already gave them: a node that
+    /// works today must not have its cache slashed into a recompile-per-restart
+    /// regime just because a disk term now exists.
+    #[test]
+    fn disk_term_is_inert_on_hosts_with_room() {
+        // (a) 2 GiB-cgroup laptop, large disk: the disk budget clamps to its
+        // 32 GiB cap, so the disk term is 8 GiB and the RAM term still decides.
+        assert_eq!(wasmtime_cache_size_for(2 * GIB, 32 * GIB), 256 * MIB);
+        assert_eq!(
+            wasmtime_cache_size_for(2 * GIB, 32 * GIB),
+            wasmtime_cache_size_for_ram(2 * GIB),
+            "a RAM-poor host with disk to spare must see NO change from #5011"
+        );
+
+        // (c) 125 GiB server, 3.7 TB disk: same, at the ceiling. This is the
+        // production gateway — it keeps the 512 MiB it runs with today.
+        assert_eq!(wasmtime_cache_size_for(125 * GIB, 32 * GIB), 512 * MIB);
+        assert_eq!(
+            wasmtime_cache_size_for(125 * GIB, 32 * GIB),
+            wasmtime_cache_size_for_ram(125 * GIB),
+        );
+
+        // (b) 16 GiB VM, 400 MiB free: the ONLY one of the three that moves.
+        assert_eq!(wasmtime_cache_size_for(16 * GIB, 456 * MIB), 114 * MIB);
+        assert!(
+            wasmtime_cache_size_for(16 * GIB, 456 * MIB) < wasmtime_cache_size_for_ram(16 * GIB)
+        );
+
+        // The crossover, stated exactly: the disk term binds only when the disk
+        // budget is under 4x the RAM term. At the 512 MiB ceiling that is a
+        // 2 GiB budget, i.e. ~4 GiB of Freenet-reachable capacity on the mount.
+        assert_eq!(wasmtime_cache_size_for(16 * GIB, 2 * GIB), 512 * MIB);
+        assert_eq!(
+            wasmtime_cache_size_for(16 * GIB, 2 * GIB - 4),
+            512 * MIB - 1
+        );
+    }
+
+    /// The disk term MUST be able to fall below `MIN_WASMTIME_CACHE_SIZE_BYTES`.
+    /// Re-imposing the RAM floor after the `min` would restore the exact defect:
+    /// a floor that ignores disk is a bound a disk-tight host cannot honor.
+    ///
+    /// Its real lower bound is inherited from the disk budget's own 128 MiB MIN
+    /// clamp, so the resolved limit can never reach zero either.
+    #[test]
+    fn disk_term_may_fall_below_the_ram_floor() {
+        // A node whose entire Freenet-reachable disk capacity pins the budget to
+        // its MIN floor gets a quarter of it — a quarter of the RAM floor.
+        assert_eq!(wasmtime_cache_size_for(16 * GIB, 128 * MIB), 32 * MIB);
+        assert!(wasmtime_cache_size_for(16 * GIB, 128 * MIB) < MIN_WASMTIME_CACHE_SIZE_BYTES);
+
+        // The floor of the whole composition: the disk budget cannot be below
+        // 128 MiB (`disk_budget_for_clamped` clamps it there), so no legal input
+        // produces a zero-size, recompile-everything cache.
+        assert_eq!(wasmtime_cache_size_for_disk_budget(128 * MIB), 32 * MIB);
+        assert!(wasmtime_cache_size_for_disk_budget(128 * MIB) > 0);
+
+        // Only a budget BELOW the clamp floor — unreachable in production —
+        // degenerates further, and even then it saturates rather than panicking.
+        assert_eq!(wasmtime_cache_size_for_disk_budget(0), 0);
+        assert_eq!(wasmtime_cache_size_for(16 * GIB, 0), 0);
+    }
+
+    /// Disk-term boundaries in their own right: monotone, no overflow, and
+    /// concrete values (not expressed against the divisor constant, which would
+    /// make the assertions self-referential and survive a mutation of it).
+    #[test]
+    fn disk_term_boundaries_and_monotonicity() {
+        assert_eq!(wasmtime_cache_size_for_disk_budget(0), 0);
+        assert_eq!(wasmtime_cache_size_for_disk_budget(3), 0);
+        assert_eq!(wasmtime_cache_size_for_disk_budget(4), 1);
+        assert_eq!(wasmtime_cache_size_for_disk_budget(GIB), 256 * MIB);
+        assert_eq!(wasmtime_cache_size_for_disk_budget(32 * GIB), 8 * GIB);
+        // u64::MAX must divide, not wrap or panic.
+        assert_eq!(wasmtime_cache_size_for_disk_budget(u64::MAX), u64::MAX / 4);
+
+        let mut previous = 0;
+        for budget in [0, 128 * MIB, 456 * MIB, 2 * GIB, 32 * GIB, u64::MAX] {
+            let term = wasmtime_cache_size_for_disk_budget(budget);
+            assert!(
+                term >= previous,
+                "disk term must not shrink as the budget grows"
+            );
+            previous = term;
+        }
+    }
+
+    /// Composition sanity: the result is always exactly one of the two terms,
+    /// never some third value, and it is `min`-shaped (never larger than either).
+    #[test]
+    fn resolved_limit_is_the_smaller_of_the_two_terms() {
+        for total_ram in [0, GIB, 2 * GIB, 4 * GIB, 16 * GIB, u64::MAX] {
+            for disk_budget in [0, 128 * MIB, 456 * MIB, 2 * GIB, 32 * GIB, u64::MAX] {
+                let ram_term = wasmtime_cache_size_for_ram(total_ram);
+                let disk_term = wasmtime_cache_size_for_disk_budget(disk_budget);
+                let resolved = wasmtime_cache_size_for(total_ram, disk_budget);
+                assert!(resolved <= ram_term && resolved <= disk_budget);
+                assert!(resolved == ram_term || resolved == disk_term);
+            }
+        }
     }
 
     /// The OS-query fallback is itself a legal, conservative value: an


### PR DESCRIPTION
## Problem

The wasmtime on-disk compile cache is **charged against the aggregate disk
budget**, but the soft limit that bounded it was derived from **RAM**.

`DiskUsageTracker::total_bytes()` sums state + wasm + `compile_cache_bytes`, and
that total gates `admit_state_write` / `admit_state_update` / `admit_wasm_write`
and feeds the eviction floor `min(ram_budget, disk_budget)`. The limit came from
`default_wasmtime_cache_size_bytes()` = `clamp(total_ram / 8, 128 MiB, 512 MiB)`
(#5011) — a memory signal — so a RAM-rich but disk-tight host got no protection
at all.

That mismatch is worse than a merely loose bound, because the compile cache is
the one consumer of the disk budget the hosting sweep **cannot reclaim**: the
sweep sheds contract *state*, and wasmtime owns its cache directory. Once the
cache alone pushes `total_bytes()` past `budget_bytes`, every admission rejects
and eviction cannot dig out no matter how much state it sheds. Wasmtime's own
cleanup does not rescue it either — it prunes only to 70 % of the soft limit.

The worked example from #5014: a 16 GiB VM with 400 MiB free on the data mount
resolved the cache to its 512 MiB ceiling while the disk budget was
`0.5 × (512 MiB + 400 MiB) ≈ 456 MiB`. `total_bytes() > budget_bytes` before a
single new byte was considered, so the node could not accept a PUT, could not
store a WASM blob, and could not recover.

## Solution

Two halves. The bound stops the wedge from forming; the startup prune is what
makes it reach a node that is already in it.

### 1. Bound the limit by the budget it is charged to

Resolve the soft limit as **`min(ram_term, disk_budget / 4)`**.

- **`ram_term`** is unchanged (`clamp(total_ram / 8, 128 MiB, 512 MiB)`) and
  survives as the **upper** bound — a large disk must not license an unbounded
  cache, and the useful size of this cache is set by the distinct-contract-blob
  population the RAM-scaled hosting budget already bounds.
- **`disk_budget / 4`** is the new **binding** term on a disk-tight host.

A quarter is a *structural share*, not a fitted constant: a divisor of 1 lets the
cache claim the entire budget, which is the defect; any divisor ≥ 2 buys the
property that it never holds the majority. 4 picks a comfortable margin inside
that, and with wasmtime's 70 % prune the steady state is 17.5 %.

**What the cap does and does not guarantee.** It bounds *this cache's*
contribution, so `total_bytes() > budget` can no longer be true before a single
new byte is considered, and eviction always has something it can shed. It is
**not** a bound on the cache's instantaneous footprint (wasmtime writes the
artifact first and only then posts the cleanup notification, behind an hourly
lock, so the real bound is `0.7 × L + bytes written since the last cleanup`), and
it is **not** a guarantee that the other 75 % of the budget is reclaimable —
redb dead space inside the storage term is reclaimable only by the restart
compaction, not by eviction. An earlier revision of this description claimed
both; neither is true, and the rustdoc now says so.

### 2. Prune an oversized cache at startup

Lowering the soft limit does not shrink an existing cache. Wasmtime reads the
limit in exactly one place — its cleanup pass — and that pass is reachable **only
from the cache-WRITE path** (`handle_on_cache_update`), gated behind a
once-per-`cleanup_interval` (1 h default) filesystem lock. `handle_on_cache_get`
never cleans up. A node with a stable contract-blob set performs only cache hits
after a restart, so a cache written under the old, larger limit persists
indefinitely.

On the wedged node that is self-sustaining: its oversized cache keeps
`total_bytes()` over budget, `admit_wasm_write` rejects, so it cannot take on the
new contracts whose compiles would produce the cache misses that would trigger a
cleanup. Without a prune this PR would prevent the wedge on future starts and
leave an already-wedged node wedged — i.e. not fix the node in the issue.

`ring::prune_compile_cache_to_limit` runs in `RuntimePool::new`, before the first
`Cache::new`, and deletes oldest-first down to wasmtime's own 70 %-of-limit
target. Safe by construction: the cache is a pure derived artifact, entries are
read with `fs::read` into a `Vec` (never mmap'd), the tree is `create_dir_all`'d
again on the next write, and wasmtime's own worker already does `remove_file` /
`remove_dir_all` on the same tree. Oldest-first rather than a wipe because a wipe
is equally safe but pays a whole recompile wave on every tight-budget restart.

This is also what makes "restart the node" a real remedy for the residual hole
below, rather than a hope that wasmtime's write-path cleanup happens to fire.

### Nothing that works today gets smaller

The disk term only becomes the smaller of the two when
`disk_budget < 4 × ram_term`, i.e. Freenet-reachable capacity on the data mount
under ~4 GiB at the 512 MiB ceiling. Resolved values (using the real artifact
sizes from #5011's review: 418 artifacts, 198.8 MiB, mean 487 KiB, p50 397 KiB,
p90 811 KiB; steady state is 0.7 × the limit):

| Host | disk budget | limit | vs. #5011 |
|---|---|---|---|
| 2 GiB-cgroup laptop, large disk | 32 GiB (capped) | **256 MiB** | unchanged |
| 16 GiB VM, 400 MiB free, cache-dominated usage | ~456 MiB | **114 MiB** (~80 MiB steady, ~100 artifacts at p90) | 512 MiB → 114 MiB |
| 125 GiB server, 3.7 TB disk | 32 GiB (capped) | **512 MiB** | unchanged |

Only the disk-starved shape moves — the one that could not accept writes at all.
The middle row reproduces at 114 MiB because the issue's node had essentially all
of its ~512 MiB of Freenet usage in the compile cache; a node with the same free
space but that usage split as contract state resolves lower, because the start-
time estimate omits state (see below).

The floor of the whole composition is 32 MiB (a quarter of the disk budget's own
128 MiB MIN clamp), roughly 40 artifacts at the measured p90 and 67 at the mean.
It binds when `wasm + compile_cache + free ≤ ~256 MiB` at the default pct — note
that condition is about the terms the estimate *measures*, not about total
Freenet-reachable disk, so a node holding a lot of state can reach the floor with
more capacity than that.

### The three complications #5014 named

**Ordering.** Wasmtime fixes the soft limit once, at `Cache::new`, reached from
`from_config_with_shared_modules` — before `Ring::set_hosting_disk_paths`
configures the `DiskUsageTracker` and long before the first sweep seeds it. So
the budget cannot be read from the tracker. `ring::startup_disk_budget_estimate`
re-derives it from the filesystem, reusing the live budget's own
`disk_budget_for_clamped` math, the same `used + available` basis, the same MIN
floor, and the operator's `--hosting-disk-pct` / `--max-hosting-disk`. Its
`used` term omits persisted contract-state bytes (unreadable before storage
exists), and the math is monotone non-decreasing in that term, so the estimate is
always `≤` the budget the first 60 s recompute installs — the cache therefore
claims at most a quarter of the *live* budget too, never more.

That omission is **not immaterial**, and it bites hardest on exactly the
disk-tight hosts the disk term exists for. A 16 GiB VM holding 1 GiB of state,
50 MiB wasm, a 50 MiB cache and 200 MiB free has a live budget of ~662 MiB
(live-consistent disk term ~165 MiB), while the estimate sees `50 + 50 + 200 =
300 MiB` and resolves ~37 MiB — about 4.5× under. The direction is always safe
(bounded more tightly than the live budget licenses, never less), but the
rustdoc no longer claims the two agree. The gap is the redb *row* total, not the
database *file*, whose size is a plain `metadata()` read; folding it in is left
to the follow-up that lands `du_walk_shallow` (#5033), which is where that walker
comes from.

The limit is resolved **once per pool** in `RuntimePool::new` and threaded into
every executor, so the data-mount walk does not repeat `pool_size` times and does
not re-sample a cache dir the first executor's engine has begun writing into. The
walks and the prune run on `spawn_blocking`, matching the discipline the
identical walks follow in the 60 s sweep.

**Double-counting / feedback.** There is no loop, and the reason is worth stating
because it is not obvious. The budget's basis is `freenet_used + available`, not
free space: every byte the cache writes moves one byte from `available` into
`freenet_used` on the same mount, so the basis is the mount's Freenet-reachable
capacity and is **invariant under the cache's own size**. This is exactly why
the start-time estimate must include the compile-cache `du` walk — an estimate
built on bare free space would shrink when the cache is full and grow when it is
empty, re-deriving a different limit on every restart and oscillating
(50 → 109 → 100 MiB on the worked example).

For the same reason, the interaction with `min(ram_budget, disk_budget)` is
stable: shrinking the cache does **not** raise the disk budget (the basis does
not move) — it lowers `total_bytes()`, creating headroom under an unchanged
budget. Nothing oscillates.

**No live re-application — the residual hole, stated plainly.** Wasmtime offers
no way to change the limit on a live `Cache`; rebuilding one would mean tearing
down the backend engine every pool executor shares and discarding its compiled
modules. So the limit `L` is fixed for the life of the process while the live
budget is recomputed every 60 s. Work the algebra at the margin: after the sweep
has shed everything it can, the node is over budget iff `L > pct × (L +
available)`, i.e. at the default pct = 0.5 iff `L > available`. **Any consumer
outside Freenet that drives free space on the data mount below the cache's size
re-opens the #5014 wedge for the rest of that process's life.** An earlier
revision described the 60 s recompute as covering this case; the recompute
shrinking the budget *is* the mechanism of the hole, not a mitigation of it.

Three things bound it, and they are why this is deferred rather than fixed here:
Freenet's own writes cannot reach it (the basis is invariant under them, so it
takes an external mount-filler); `HostingManager::recompute_effective_budget` now
warns, edge-triggered, the first time `compile_cache_bytes` exceeds a quarter of
the live budget, so the condition is no longer silent; and a restart is now a
real remedy, because it re-derives the limit *and* prunes the existing cache down
to it.

### Layering

`default_wasmtime_cache_size_bytes` now takes the resolved `disk_budget` as one
`u64` instead of four hosting knobs, and `RuntimePool::new` calls
`ring::startup_disk_budget_estimate` itself. `ring` already depends on
`wasm_runtime` (`read_total_ram_bytes`, `ModuleCacheMetrics`), so the reverse
edge closed a module cycle; and the pool already passes those same four values to
`Ring::set_hosting_disk_paths` a few lines later, so the knowledge was already
sitting there.

### Hosting invariants

Invariant 3 (`.claude/rules/hosting-invariants.md`) is the only one touched, and
in the direction of restoring it. The eviction ranking, the demand signal, and
the budget formula are all unchanged. What changes is that a **non-reclaimable**
consumer of that budget is now bounded by it, so the budget the sweep defends
always has reclaimable headroom to work with. Before this change the sweep could
shed every contract it held and still be over budget — its constraint was
unsatisfiable. Invariants 1, 2, 4 and 5 are untouched (no placement, freshness,
or routing change).

Note the framing correction the reviews forced: the compile cache is **not**
genuinely non-reclaimable — `rm -rf` on that tree is safe at any time. Its
non-reclaimability was a property of the code (the sweep does not touch it), not
of the artifact, which is what makes the startup prune available and cheap.

## Testing

`wasm_runtime::runtime::wasmtime_disk_cache_sizing_tests`
- `resolved_limit_never_claims_more_than_its_share_of_the_disk_budget` — the
  invariant, over the RAM × disk-budget cross product including `u64::MAX`. The
  `× 4` is a literal, not the divisor constant, so it still fails if the divisor
  is mutated to 1.
- `disk_term_is_inert_on_hosts_with_room` — the three machine shapes, two of
  which must be bit-identical to #5011, plus the exact crossover point.
- `disk_term_may_fall_below_the_ram_floor` — the RAM floor must NOT be
  re-imposed after the `min`; re-imposing it restores the defect.
- `disk_term_boundaries_and_monotonicity`, `resolved_limit_is_the_smaller_of_the_two_terms`
  — 0, 3, 4, `u64::MAX`, monotonicity, no overflow.
- `default_soft_limit_matches_the_pure_clamp_of_this_hosts_ram_signal` — now
  pure (the resolver no longer touches the filesystem), so its concrete
  assertion is exact on every host.

`ring::hosting::disk_usage::startup_estimate_tests`
- `estimate_is_invariant_under_cache_growth_on_the_same_mount` (anti-feedback),
  `estimate_is_monotone_in_measured_used` (why omitting state is safe),
  `unreadable_free_space_clamps_to_the_cap_not_to_zero`,
  `estimate_boundaries_stay_inside_the_clamp`,
  `measured_used_counts_wasm_blobs_and_the_whole_compile_cache`,
  `measured_used_is_zero_when_nothing_exists_yet`.
- `prune_deletes_oldest_first_down_to_the_target`,
  `prune_leaves_a_cache_that_already_fits_untouched`,
  `prune_boundaries_are_safe` (missing dir, zero limit, `u64::MAX` target
  overflow), `prune_target_matches_wasmtimes_own_cleanup_target`. mtimes are set
  explicitly so the outcome cannot depend on how fast the host writes files or on
  directory iteration order.
- **Removed:** `estimate_composes_the_du_walk_and_the_clamp_on_a_real_dir` was
  vacuous. It ran at `pct = 0.0`, which multiplies the du-walk result by zero, so
  deleting both `write_file` calls changed nothing; and its second assertion was
  a containment check on a function that clamps into exactly that interval by
  construction. This PR calls out that same anti-pattern elsewhere and then
  reproduced it. Replaced by
  `estimate_composes_the_measured_walk_and_the_free_space_read` (below) plus a
  slim `estimate_on_real_dirs_resolves_the_min_floor_at_pct_zero` that claims
  only what it tests.

`ring::hosting::tests`
- `compile_cache_over_share_warning_is_edge_triggered` — the boundary does not
  warn, crossing up warns once, staying over does not re-warn, recovery re-arms.
  Asserts the latch transitions rather than captured log lines (subscriber-
  capture tests are flaky here); the latch *is* the emit decision.
- `recompute_effective_budget_runs_the_over_share_check`.

Call-site pins (the wiring is where this fix actually lives, and it is invisible
to every test of the pure math):
- `runtime_pool_resolves_compile_cache_limit_from_the_disk_signal` — the disk
  knob bindings, the argument ORDER into the estimate (both dirs are `&Path`, so
  a swap compiles), the resolver applied to that budget, the prune call, one call
  site, the resolution POSITION relative to the first executor, and — the edge
  the first round missed — that **both** `from_config_with_shared_modules` call
  sites receive the resolved value.
- `estimate_composes_the_measured_walk_and_the_free_space_read` — the other edge
  the first round missed: that `startup_disk_budget_estimate` actually composes
  `measure_startup_disk_used(contracts_dir, compile_cache_dir)` and
  `available_bytes(contracts_dir)`.
- `from_config_with_shared_modules_wires_offload_and_budget`,
  `default_soft_limit_reader_derives_from_ram_and_disk_signals` (extended to pin
  that `disk_budget` reaches the pure math and that the resolver does not reach
  into `ring`).

All region delimiters in the pins this PR touches now use
`split_once(..).expect(..)` rather than `split(..).next().expect(..)`, whose
`expect` is unreachable — a reworded end marker used to widen the region silently
to end-of-file, `mod tests` included, while the assertions kept passing for the
wrong reason. `runtime_pool_sizes_caches_by_byte_budget`'s fixed 110-chunk window
is likewise replaced by the function's end marker; the count version stopped
covering the cache construction as soon as anything was added to the preamble.

### Mutation testing

Each mutation was applied by exact string replacement, independently confirmed to
have landed (`git diff --numstat` non-empty, diff printed), the guard run, then
reverted.

| Mutation | Site | Guard | Result |
|---|---|---|---|
| first executor gets `512 MiB` instead of the resolved limit (the engine-creating one) | `RuntimePool::new` | `runtime_pool_resolves_compile_cache_limit_from_the_disk_signal` | **red** |
| loop executors get `512 MiB` instead of the resolved limit | `RuntimePool::new` | same | **red** |
| resolution moved AFTER the first executor (textual "exactly once" count stays at 1) | `RuntimePool::new` | same, positional assertion | **red** |
| the two `&Path` arguments to the estimate swapped (compiles) | `RuntimePool::new` | same | **red** |
| the startup prune removed | `RuntimePool::new` | same | **red** |
| `available_bytes(contracts_dir)` -> `None` (disables the disk bound on every host) | `startup_disk_budget_estimate` | `estimate_composes_the_measured_walk_and_the_free_space_read` | **red** |
| `measure_startup_disk_used(..)` -> `0` (the bare-free-space oscillation) | same | same | **red** |
| the two `&Path` arguments swapped inside the estimate | same | same | **red** |
| resolver drops the disk term (`disk_budget` -> `u64::MAX`), i.e. the #5014 defect itself | `default_wasmtime_cache_size_bytes` | `default_soft_limit_reader_derives_from_ram_and_disk_signals` + `default_soft_limit_matches_the_pure_clamp_of_this_hosts_ram_signal` | **red** |
| prune ignores the already-fits early return (deletes under the limit) | `prune_compile_cache_to_limit` | `prune_leaves_a_cache_that_already_fits_untouched` | **red** |
| prune target 70 -> 100 (diverges from wasmtime's own cleanup target) | same | `prune_deletes_oldest_first_down_to_the_target` | **red** |
| prune deletes NEWEST first | same | same | **red** |
| the over-share check dropped from the 60s recompute | `recompute_effective_budget` | `recompute_effective_budget_runs_the_over_share_check` | **red** |
| the over-share check uses its own divisor instead of the sizing rule's | `warn_if_compile_cache_over_share` | `compile_cache_over_share_warning_is_edge_triggered` | **red** |

14/14 caught. Nine of the fourteen are pure *wiring* mutations that every test of
the sizing math passes cleanly — which is the point: the fix lives in the call
sites. The first round of this PR shipped with the first eight rows of that list
uncovered.

Retained from the first round (re-run on this head): divisor 4 -> 1, RAM floor
re-imposed after the `min`, measured-used stops counting the compile cache,
executor re-hardcodes the limit, replacement executor re-derives instead of
reusing — all still **red**.

`cargo fmt` clean; `cargo clippy -p freenet --lib --all-features` clean; full
`cargo test -p freenet --lib --all-features` passes apart from four failures that
reproduce identically on the unmodified base commit under the same parallel load
(`test_set_own_addr_atomic_with_network_status`, `homepage_renders_dynamic_title`,
`cross_connection_median_returns_some_when_a_peer_has_inflation`,
`validate_host_function_delegate`) and all pass in isolation.

Closes #5014

[AI-assisted - Claude]
