### PR TITLE
fix: count database file and webapp cache in disk accounting

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -116,6 +116,9 @@ pub struct ConfigArgs {
     /// are evicted (least-valuable-first) and their on-disk state reclaimed.
     /// This bounds tracked contract state only — WASM code blobs and ReDb/
     /// SQLite database overhead are additional and not counted against it.
+    /// The separate aggregate DISK budget (`hosting-disk-pct` /
+    /// `max-hosting-disk`) does count them, including the database file's own
+    /// footprint since #5007.
     /// Default: 1 GiB.
     #[arg(long, env = "MAX_HOSTING_STORAGE")]
     pub max_hosting_storage: Option<u64>,
@@ -1206,6 +1209,9 @@ pub struct Config {
     /// are evicted (least-valuable-first) and their on-disk state reclaimed.
     /// This bounds tracked contract state only — WASM code blobs and ReDb/
     /// SQLite database overhead are additional and not counted against it.
+    /// The separate aggregate DISK budget (`hosting-disk-pct` /
+    /// `max-hosting-disk`) does count them, including the database file's own
+    /// footprint since #5007.
     ///
     /// The default is capability-relative (RAM-scaled): `clamp(total_ram / 8,
     /// 128 MiB, 1 GiB)`, so a memory-constrained host gets a proportionally

--- a/crates/core/src/contract/handler.rs
+++ b/crates/core/src/contract/handler.rs
@@ -124,12 +124,20 @@ impl ContractHandler for NetworkContractHandler {
         // This must be done before loading the cache so evictions work correctly
         let storage = executor.state_store().inner().clone();
         op_manager.ring.set_hosting_storage(storage.clone());
-        // Aggregate disk-usage tracker paths (#4683): the mode-resolved
-        // contracts dir (WASM blobs) and the relocated wasmtime compile-cache
-        // dir. Seeded lazily on the first sweep tick.
+        // Aggregate disk-usage tracker paths (#4683, #5007). This is the ONLY
+        // place the tracker learns where the node's bytes live, so a directory
+        // missing here is a directory nothing measures, bounds, or reports —
+        // which is exactly how the database file's dead space and the whole
+        // webapp cache stayed invisible until #5007. Seeded lazily on the first
+        // sweep tick. Pinned by
+        // `hosting_disk_paths_are_installed_from_the_node_config`.
         op_manager.ring.set_hosting_disk_paths(
-            config.contracts_dir(),
-            config.wasmtime_cache_dir(),
+            crate::ring::HostingDiskPaths {
+                contracts_dir: config.contracts_dir(),
+                wasmtime_cache_dir: config.wasmtime_cache_dir(),
+                db_dir: config.db_dir(),
+                webapp_cache_dir: config.ws_api.webapp_cache_dir.clone(),
+            },
             config.hosting_disk_pct,
             config.max_hosting_disk,
         );
@@ -1442,6 +1450,135 @@ pub mod test {
             "Expected NoEvHandlerResponse, got {:?}",
             result
         );
+    }
+
+    /// Call-site pin: the disk-usage tracker must be installed with all four of
+    /// the node's own directories (#4683, #5007).
+    ///
+    /// This one call is the entire boundary between "measured" and "invisible".
+    /// The tracker cannot walk a directory it was never given, so a field
+    /// dropped here — or wired to the wrong accessor — silently reproduces
+    /// exactly the two blind spots #5007 exists to close: a database whose dead
+    /// space nothing sees (~10x under-count on a production peer) and a webapp
+    /// cache nothing measures at all (1236 MiB on one machine). Both consumers
+    /// of the resulting figure, the `min(ram, disk)` eviction floor (#4683) and
+    /// the pre-write admission gate (#4702), then decide on a number that is an
+    /// order of magnitude wrong, and every other test in the tree stays green.
+    ///
+    /// Nothing else can catch it. The `HostingDiskPaths` fields are all
+    /// `PathBuf`, so the type system permits both omission (via struct-update
+    /// syntax) and transposition; and a behavioral test would have to boot a
+    /// real node with a real store, which is what this whole file's `build` path
+    /// does only in integration tests that do not assert on disk accounting.
+    ///
+    /// Read against the comment-stripped, whitespace-collapsed production half
+    /// of this file so a rustfmt re-wrap of the call cannot rot the needles, and
+    /// the needles are assembled from fragments so this test cannot match its
+    /// own source through `include_str!`.
+    #[test]
+    fn hosting_disk_paths_are_installed_from_the_node_config() {
+        let src = production_source();
+
+        let call = concat!("set_hosting_disk", "_paths(");
+        assert_eq!(
+            src.matches(call).count(),
+            1,
+            "pin guard: expected exactly one disk-paths install in this file, so \
+             this test is asserting against the wrong thing"
+        );
+        let args = call_arguments(&src, call);
+
+        for (field, accessor) in [
+            // Pre-#5007 pair. Present so the pin covers the whole struct, not
+            // only the fields the issue added.
+            (
+                concat!("contracts", "_dir:"),
+                concat!("config.contracts", "_dir()"),
+            ),
+            (
+                concat!("wasmtime_cache", "_dir:"),
+                concat!("config.wasmtime_cache", "_dir()"),
+            ),
+            // #5007 blind spot 1: the storage backend's database directory. Its
+            // measured size is the only term that can see redb's dead space.
+            (concat!("db", "_dir:"), concat!("config.db", "_dir()")),
+            // #5007 blind spot 2: the unpacked-webapp cache. Reported, not
+            // budgeted — but it has to be measured to be reported at all, and it
+            // must come from the node's OWN config, never the process-wide
+            // default, for the same reason `server.rs` threads it.
+            (
+                concat!("webapp_cache", "_dir:"),
+                concat!("config.ws_api.webapp_cache", "_dir"),
+            ),
+        ] {
+            assert!(
+                args.contains(field),
+                "the disk tracker must be installed with `{field}`; found \
+                 arguments `{args}`"
+            );
+            assert!(
+                args.contains(accessor),
+                "`{field}` must be resolved from the node's config via \
+                 `{accessor}`; found arguments `{args}`"
+            );
+        }
+
+        // The substitution template must not exist on this path at all: the
+        // process-wide webapp-cache default would measure some other node's
+        // directory (or the developer's) instead of this one's.
+        assert!(
+            !src.contains(concat!("default_webapp", "_cache_dir")),
+            "the node's disk accounting must never resolve the process-wide \
+             webapp cache default — it has to measure the directory this node \
+             actually serves from"
+        );
+    }
+
+    /// Production half of this file, comment-stripped and whitespace-collapsed,
+    /// for the source pin above.
+    ///
+    /// Cut at the test module's `mod` line, NOT at `#[cfg(test)]`: that
+    /// attribute also sits on individual test-only items earlier in this file,
+    /// so cutting there truncates the slice the pin reads and turns it vacuous
+    /// rather than red. Comments are dropped before collapsing so a `//` line
+    /// cannot run into the code below it, and whitespace is collapsed so a
+    /// rustfmt re-wrap of a call's arguments cannot rot a needle. The needle for
+    /// the cut is split so it cannot match its own source.
+    fn production_source() -> String {
+        const FULL: &str = include_str!("handler.rs");
+        let cutoff = FULL
+            .find(concat!("pub mod ", "test {"))
+            .expect("handler.rs must have a test module");
+        FULL[..cutoff]
+            .lines()
+            .map(|line| line.split("//").next().unwrap_or(""))
+            .collect::<String>()
+            .chars()
+            .filter(|c| !c.is_whitespace())
+            .collect()
+    }
+
+    /// The balanced-parenthesis argument list of the (single) call to
+    /// `call_prefix` within `src`.
+    fn call_arguments(src: &str, call_prefix: &str) -> String {
+        let start = src
+            .find(call_prefix)
+            .unwrap_or_else(|| panic!("could not find {call_prefix}"))
+            + call_prefix.len();
+        let mut depth: i32 = 1;
+        for (offset, ch) in src[start..].char_indices() {
+            match ch {
+                '(' => depth += 1,
+                ')' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return src[start..start + offset].to_string();
+                    }
+                }
+                _ => {}
+            }
+        }
+        panic!("unterminated call to {call_prefix}");
     }
 }
 

--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -1621,14 +1621,24 @@ pub struct HostingSnapshot {
     /// disk tracker is configured and seeded (early startup) — distinct from
     /// `Some(0)`, which means seeded-and-empty.
     pub disk_state_bytes: Option<u64>,
+    /// Measured byte size of the storage backend's database directory (#5007).
+    /// `disk_db_bytes − disk_state_bytes` is the database's dead space: bytes
+    /// the file holds that no live row accounts for, reclaimable only by the
+    /// startup compaction. Same seeded-gate semantics as `disk_state_bytes`.
+    pub disk_db_bytes: Option<u64>,
     /// Aggregate on-disk bytes used by `*.wasm` code blobs. Same
     /// seeded-gate semantics as `disk_state_bytes`.
     pub disk_wasm_bytes: Option<u64>,
     /// Aggregate on-disk bytes used by the wasmtime compile cache. Same
     /// seeded-gate semantics as `disk_state_bytes`.
     pub disk_compile_cache_bytes: Option<u64>,
-    /// Sum of `disk_state_bytes` + `disk_wasm_bytes` + `disk_compile_cache_bytes`
-    /// — the aggregate the disk budget bounds. Same seeded-gate semantics.
+    /// Measured byte size of the unpacked-webapp cache (#5007). Reported for
+    /// visibility but NOT part of `disk_total_bytes`: #5012 caps it separately
+    /// and hosting eviction has no lever on it. Same seeded-gate semantics.
+    pub disk_webapp_cache_bytes: Option<u64>,
+    /// `max(disk_state_bytes, disk_db_bytes)` + `disk_wasm_bytes` +
+    /// `disk_compile_cache_bytes` — the aggregate the disk budget bounds. Same
+    /// seeded-gate semantics.
     pub disk_total_bytes: Option<u64>,
     /// The aggregate disk budget the admission gate checks projected writes
     /// against (`HostingManager::disk_budget_bytes`, #4702). `None` while it

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -100,10 +100,6 @@ pub use connection_manager::{set_nn_lattice_enabled, set_nn_lattice_force_active
 mod connection;
 mod hosting;
 pub(crate) use broken_invariants::{BrokenInvariant, BrokenInvariantsTracker};
-/// Pre-write admission-gate rejection type (#4683, PR 3). Surfaced to the
-/// executor chokepoints so a write that would overflow the aggregate disk
-/// budget is refused before any bytes land.
-pub(crate) use hosting::DiskBudgetExceeded;
 /// The pre-A2 flat 1 GiB budget, used as the upgrade-migration sentinel in
 /// `config::ConfigArgs::build` so an upgraded node re-derives its hosting budget
 /// instead of keeping the historically-pinned default (#4565).
@@ -127,6 +123,10 @@ pub use hosting::{AccessType, RecordAccessResult};
 /// `hosting-disk-pct` / `max-hosting-disk` defaults from these so the operator-
 /// facing defaults and the in-code sizing math share one source of truth.
 pub(crate) use hosting::{DEFAULT_HOSTING_DISK_PCT, DEFAULT_MAX_HOSTING_DISK_BYTES};
+/// Pre-write admission-gate rejection type (#4683, PR 3). Surfaced to the
+/// executor chokepoints so a write that would overflow the aggregate disk
+/// budget is refused before any bytes land.
+pub(crate) use hosting::{DiskBudgetExceeded, HostingDiskPaths};
 /// Clamp bounds re-exported only for the config-default round-trip test.
 #[cfg(test)]
 pub(crate) use hosting::{MAX_DEFAULT_HOSTING_BUDGET_BYTES, MIN_DEFAULT_HOSTING_BUDGET_BYTES};
@@ -1776,14 +1776,19 @@ impl Ring {
             snapshot.hosting_local_hits_total = Some(ring.hosting_manager.local_get_serves());
             snapshot.hosting_local_misses_total = Some(ring.hosting_manager.local_get_forwards());
 
-            // Aggregate on-disk usage gauges (#4683): state (delta-tracked) +
-            // WASM blobs + wasmtime compile cache (both du-measured) + their sum.
+            // Aggregate on-disk usage gauges (#4683, #5007): logical state
+            // (delta-tracked) + the measured database file + WASM blobs +
+            // wasmtime compile cache + the measured webapp cache. `state` vs
+            // `db` is the pair that makes the #5007 under-count legible in
+            // central telemetry: their difference is the database's dead space.
             // `None` until the tracker is configured and seeded (early startup),
-            // in which case the fields stay unset. Observational only in this PR.
+            // in which case the fields stay unset.
             if let Some(disk) = ring.hosting_manager.disk_usage_stats() {
                 snapshot.hosting_disk_state_bytes = Some(disk.state_bytes);
+                snapshot.hosting_disk_db_bytes = Some(disk.db_file_bytes);
                 snapshot.hosting_disk_wasm_bytes = Some(disk.wasm_bytes);
                 snapshot.hosting_disk_compile_cache_bytes = Some(disk.compile_cache_bytes);
+                snapshot.hosting_disk_webapp_cache_bytes = Some(disk.webapp_cache_bytes);
                 snapshot.hosting_disk_total_bytes = Some(disk.total_bytes);
             }
 
@@ -3175,19 +3180,18 @@ impl Ring {
         self.hosting_manager.set_storage(storage);
     }
 
-    /// Install the aggregate disk-usage tracker's paths (#4683). Called once at
-    /// startup with the node's mode-resolved contracts dir and the relocated
-    /// wasmtime compile-cache dir. The tracker is seeded lazily on the first
-    /// sweep tick.
-    pub fn set_hosting_disk_paths(
+    /// Install the aggregate disk-usage tracker's paths (#4683, #5007). Called
+    /// once at startup with every directory the node's footprint lands in: the
+    /// mode-resolved contracts dir, the relocated wasmtime compile-cache dir,
+    /// the storage backend's database dir, and the unpacked-webapp cache. The
+    /// tracker is seeded lazily on the first sweep tick.
+    pub(crate) fn set_hosting_disk_paths(
         &self,
-        contracts_dir: std::path::PathBuf,
-        wasmtime_cache_dir: std::path::PathBuf,
+        paths: HostingDiskPaths,
         hosting_disk_pct: f64,
         max_hosting_disk: u64,
     ) {
-        self.hosting_manager
-            .configure_disk_tracker(contracts_dir, wasmtime_cache_dir);
+        self.hosting_manager.configure_disk_tracker(paths);
         // #4683 eviction-floor sizing knobs (mirrors the disk paths install; the
         // config is only reachable here). The 60s sweep's recompute reads them.
         self.hosting_manager
@@ -4223,8 +4227,10 @@ impl Ring {
         // usage.
         let disk = self.hosting_manager.disk_usage_stats();
         let disk_state_bytes = disk.map(|d| d.state_bytes);
+        let disk_db_bytes = disk.map(|d| d.db_file_bytes);
         let disk_wasm_bytes = disk.map(|d| d.wasm_bytes);
         let disk_compile_cache_bytes = disk.map(|d| d.compile_cache_bytes);
+        let disk_webapp_cache_bytes = disk.map(|d| d.webapp_cache_bytes);
         let disk_total_bytes = disk.map(|d| d.total_bytes);
         // `disk_budget_bytes` starts at `u64::MAX` until the first 60s
         // recompute installs a real value (see `HostingManager::
@@ -4241,8 +4247,10 @@ impl Ring {
             evictions_of_recently_read_total: stats.evictions_of_recently_read_total,
             contracts,
             disk_state_bytes,
+            disk_db_bytes,
             disk_wasm_bytes,
             disk_compile_cache_bytes,
+            disk_webapp_cache_bytes,
             disk_total_bytes,
             disk_budget_bytes,
         }

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -2989,14 +2989,16 @@ impl Ring {
             // Disk-usage accounting maintenance (#4683). Runs OUTSIDE any
             // hosting-cache write lock (the du-walks would stall cache readers).
             // First tick lazily seeds the tracker from the true on-disk state
-            // total; every tick re-walks the `du`-measured WASM-blob and
-            // compile-cache totals so telemetry stays fresh. Observational only
-            // in this PR — no admission/eviction decision reads these yet.
+            // total; every tick re-walks the four `du`-measured totals (WASM
+            // blobs, compile cache, the storage backend's database file and the
+            // webapp cache, #5007) so telemetry stays fresh. These feed live
+            // decisions since #4702: the eviction floor and the pre-write
+            // admission gate both read the aggregate.
             //
-            // The seed + refresh are synchronous, blocking disk I/O: a recursive
-            // `std::fs` walk of `contracts_dir` + the wasmtime cache dir on every
-            // tick, plus a one-time sync redb `load_all_hosting_metadata` on the
-            // seeding tick. `contracts_dir` is unbounded and non-self-pruning, so
+            // The seed + refresh are synchronous, blocking disk I/O: recursive
+            // `std::fs` walks of `contracts_dir`, the wasmtime cache dir and the
+            // webapp cache plus a shallow walk of `db_dir` on every tick, plus a
+            // one-time sync redb `load_all_hosting_metadata` on the seeding tick. `contracts_dir` is unbounded and non-self-pruning, so
             // on a node hosting many contracts the walk can run for a while with
             // no `.await` point. Push it onto a blocking thread so it can never
             // stall other tasks on the async reactor — the same discipline

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -658,8 +658,14 @@ impl HostingManager {
     /// The tightening happens where it should: the aggregate admission gate
     /// ([`Self::admit_state_write`]) compares the full `used` against the disk
     /// budget, so making `used` honest costs `(1 − pct)` of every newly-visible
-    /// byte in headroom. That is the mechanism that keeps a node's footprint
-    /// bounded instead of merely reclaiming it once per restart.
+    /// byte in headroom.
+    ///
+    /// That bounds what a full node ACCEPTS; it does not bound the footprint
+    /// itself. Nothing here shrinks a database file — dead space is reclaimed by
+    /// the startup compaction (#5005) and by nothing else — so a node whose file
+    /// has already grown past its budget refuses new tenants at that size rather
+    /// than returning to a smaller one. Making the figure honest is what lets an
+    /// operator see that; a runtime compaction trigger would be what fixes it.
     pub(crate) fn recompute_effective_budget(&self, available: u64) -> Option<u64> {
         let stats = {
             let guard = self.disk_tracker.read();
@@ -701,6 +707,15 @@ impl HostingManager {
     /// startup compaction (#5005) and by nothing else, so it has to be audible
     /// rather than leaving an operator to infer it from rejected writes.
     ///
+    /// It also has a consequence beyond refused PUTs that the operator cannot
+    /// see from the byte counts alone. UPDATEs to already-hosted contracts still
+    /// flow while they shrink, hold, or fit inside the dead space, but an UPDATE
+    /// whose growth exceeds the dead space is refused — and the node goes on
+    /// serving and advertising that contract with its last accepted state. The
+    /// warning names that, because a peer that answers reads with state it has
+    /// stopped merging is the failure mode `hosting-invariants.md` invariant 1
+    /// exists to forbid, and it is not visible in the disk gauges.
+    ///
     /// Edge-triggered via a stored flag, so a node that sits over budget logs
     /// once, not once per 60s sweep forever.
     ///
@@ -725,9 +740,12 @@ impl HostingManager {
                 wasm_bytes = stats.wasm_bytes,
                 compile_cache_bytes = stats.compile_cache_bytes,
                 "aggregate on-disk usage is over the disk budget; fresh PUTs \
-                 will be refused until it comes back under. Database dead space \
-                 is reclaimed only by the startup compaction, so a large \
-                 db_dead_space_bytes here needs a node restart, not eviction"
+                 will be refused until it comes back under, and an UPDATE whose \
+                 growth exceeds db_dead_space_bytes is refused while this node \
+                 keeps serving and advertising that contract at its last \
+                 accepted state. Database dead space is reclaimed only by the \
+                 startup compaction, so a large db_dead_space_bytes here needs a \
+                 node restart, not eviction"
             );
         } else {
             tracing::info!(
@@ -769,9 +787,13 @@ impl HostingManager {
     /// (fresh PUT), a shrinking or size-holding UPDATE (`new_size <= old`) is
     /// admitted unconditionally — even when the aggregate is over budget —
     /// because an UPDATE mutates an already-counted footprint and rejecting it
-    /// would stall CRDT convergence without freeing any bytes. Only genuine
-    /// growth is subjected to the aggregate bound. No-op admit when the tracker
-    /// is absent or unseeded, same as [`Self::admit_state_write`].
+    /// would stall CRDT convergence without freeing any bytes. So is growth that
+    /// fits inside the database's existing dead space, which costs no disk (see
+    /// `DiskUsageTracker::admit_state_update`): refusing it would leave the node
+    /// serving and advertising a contract whose state has stopped merging, for
+    /// zero bytes saved. Only growth that genuinely enlarges the footprint is
+    /// subjected to the aggregate bound. No-op admit when the tracker is absent
+    /// or unseeded, same as [`Self::admit_state_write`].
     pub(crate) fn admit_state_update(
         &self,
         key: &ContractKey,
@@ -991,6 +1013,17 @@ impl HostingManager {
     {
         if let Some(tracker) = self.disk_tracker.read().as_ref() {
             tracker.seed(rows);
+        }
+    }
+
+    /// Test-only: install a measured database-file size on the configured
+    /// tracker, so budget arithmetic can be driven across footprints far larger
+    /// than any fixture could materialize. See
+    /// `DiskUsageTracker::set_db_file_bytes_for_test`.
+    #[cfg(test)]
+    pub(crate) fn set_db_file_bytes_for_test(&self, bytes: u64) {
+        if let Some(tracker) = self.disk_tracker.read().as_ref() {
+            tracker.set_db_file_bytes_for_test(bytes);
         }
     }
 
@@ -7283,13 +7316,19 @@ mod tests {
     /// region, and at the cap) so the property is checked where the clamp could
     /// otherwise hide an inversion.
     ///
-    /// The extra bytes are supplied through a REAL database file rather than by
-    /// inflating the seeded row total, because the mutation this has to catch is
-    /// a recompute that treats the newly-visible non-state footprint as a charge
-    /// against the budget (`disk_budget − non_state`) instead of as part of its
-    /// basis. Driving `used` purely through state rows leaves `non_state == 0`
-    /// and the test passes under that mutation — verified, and the reason the
-    /// fixture looks like this.
+    /// The extra bytes are supplied as a measured DATABASE FILE size rather than
+    /// by inflating the seeded row total, because the mutation this has to catch
+    /// is a recompute that treats the newly-visible non-state footprint as a
+    /// charge against the budget (`disk_budget − non_state`) instead of as part
+    /// of its basis. Driving `used` purely through state rows leaves
+    /// `non_state == 0` and the test passes under that mutation — verified, and
+    /// the reason the fixture looks like this.
+    ///
+    /// The size is injected rather than materialized. It has to reach tens of
+    /// gigabytes to exercise the cap, and a sparse `set_len` file cannot stand
+    /// in: the walks charge ALLOCATED blocks, so a hole measures 0 and every
+    /// entry in the sweep below would collapse to the same `used`, making the
+    /// whole test vacuous.
     #[test]
     fn effective_budget_never_falls_as_measured_usage_rises() {
         const MIB: u64 = 1024 * 1024;
@@ -7307,28 +7346,17 @@ mod tests {
                     // state changing: 583 MB of rows in a 2.68 GB file was the
                     // production measurement.
                     for db_bytes in [0, 128 * MIB, 583 * MIB, 2680 * MIB, 40 * GIB] {
-                        let dir = tempfile::tempdir().unwrap();
-                        let db = dir.path().join("db");
-                        std::fs::create_dir_all(&db).unwrap();
-                        // Sparse: `set_len` gives the file the length the walk
-                        // measures without allocating blocks for it.
-                        std::fs::File::create(db.join("db"))
-                            .unwrap()
-                            .set_len(db_bytes)
-                            .unwrap();
-
                         let manager = HostingManager::new(ram);
                         manager.configure_disk_budget(0.5, cap);
-                        manager.configure_disk_tracker(HostingDiskPaths {
-                            contracts_dir: std::path::PathBuf::from("/nonexistent/contracts"),
-                            wasmtime_cache_dir: std::path::PathBuf::from("/nonexistent/cache"),
-                            db_dir: db,
-                            webapp_cache_dir: std::path::PathBuf::from("/nonexistent/webapp"),
-                        });
-                        manager.seed_configured_disk_tracker_for_test([(
-                            make_contract_key(1),
-                            STATE_ROWS,
-                        )]);
+                        manager.seed_disk_tracker_for_test([(make_contract_key(1), STATE_ROWS)]);
+                        manager.set_db_file_bytes_for_test(db_bytes);
+                        // The fixture is only meaningful while the injected file
+                        // dominates the live rows — that is what makes
+                        // `non_state` non-zero and the mutation visible.
+                        assert!(
+                            db_bytes == 0 || db_bytes > STATE_ROWS,
+                            "fixture must drive `used` through non-state bytes"
+                        );
 
                         let eff = manager
                             .recompute_effective_budget(available)
@@ -7427,16 +7455,35 @@ mod tests {
     /// post-growth size. Dropping any of the four calls from
     /// `refresh_disk_usage` leaves that gauge at its stale seed value and fails
     /// here.
+    ///
+    /// Sizes are whole multiples of 64 KiB and the post-growth sizes are read
+    /// back from the filesystem, because the walks charge ALLOCATED blocks: a
+    /// fixture growing a file from 11 to 1100 bytes would not move the
+    /// measurement at all on a 4 KiB-block filesystem, and the pin would pass
+    /// while measuring nothing.
     #[test]
     fn refresh_disk_usage_measures_database_and_webapp_cache() {
         use std::io::Write;
+        const CHUNK: usize = 64 * 1024;
 
         fn write_file(path: &std::path::Path, len: usize) {
             std::fs::create_dir_all(path.parent().unwrap()).unwrap();
             std::fs::File::create(path)
                 .unwrap()
-                .write_all(&vec![0u8; len])
+                .write_all(&vec![7u8; len])
                 .unwrap();
+        }
+        fn alloc(path: &std::path::Path) -> u64 {
+            let meta = std::fs::metadata(path).unwrap();
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::MetadataExt;
+                meta.blocks() * 512
+            }
+            #[cfg(not(unix))]
+            {
+                meta.len()
+            }
         }
 
         let dir = tempfile::tempdir().unwrap();
@@ -7444,12 +7491,16 @@ mod tests {
         let wasmtime = dir.path().join("wasmtime");
         let db = dir.path().join("db");
         let webapp = dir.path().join("webapp");
+        let wasm_file = contracts.join("aaaa.wasm");
+        let cache_file = wasmtime.join("mod.cache");
+        let db_file = db.join("db");
+        let webapp_file = webapp.join("aaaa").join("index.html");
 
-        // Seed-time sizes.
-        write_file(&contracts.join("aaaa.wasm"), 11);
-        write_file(&wasmtime.join("mod.cache"), 22);
-        write_file(&db.join("db"), 33);
-        write_file(&webapp.join("aaaa").join("index.html"), 44);
+        // Seed-time sizes, distinct so a transposed gauge is visible.
+        write_file(&wasm_file, CHUNK);
+        write_file(&cache_file, 2 * CHUNK);
+        write_file(&db_file, 3 * CHUNK);
+        write_file(&webapp_file, 4 * CHUNK);
 
         let manager = HostingManager::new(1024 * 1024 * 1024);
         manager.configure_disk_tracker(HostingDiskPaths {
@@ -7461,12 +7512,26 @@ mod tests {
         // A tiny logical state total inside a much larger database — the shape of
         // an under-counting node (583 MB of rows in a 2.68 GB file).
         manager.seed_configured_disk_tracker_for_test([(make_contract_key(1), 100)]);
+        let seeded = manager.disk_usage_stats().expect("seeded");
 
         // Everything grows after the seed. Only a re-measure can see this.
-        write_file(&contracts.join("aaaa.wasm"), 1100);
-        write_file(&wasmtime.join("mod.cache"), 2200);
-        write_file(&db.join("db"), 3300);
-        write_file(&webapp.join("aaaa").join("index.html"), 4400);
+        write_file(&wasm_file, 11 * CHUNK);
+        write_file(&cache_file, 22 * CHUNK);
+        write_file(&db_file, 33 * CHUNK);
+        write_file(&webapp_file, 44 * CHUNK);
+        let (wasm, cache, dbf, web) = (
+            alloc(&wasm_file),
+            alloc(&cache_file),
+            alloc(&db_file),
+            alloc(&webapp_file),
+        );
+        assert!(
+            wasm > seeded.wasm_bytes
+                && cache > seeded.compile_cache_bytes
+                && dbf > seeded.db_file_bytes
+                && web > seeded.webapp_cache_bytes,
+            "every gauge must actually grow, or a dropped refresh would be invisible"
+        );
 
         manager.refresh_disk_usage();
 
@@ -7475,21 +7540,21 @@ mod tests {
             .expect("seeded tracker reports stats");
         assert_eq!(stats.state_bytes, 100, "logical rows are delta-tracked");
         assert_eq!(
-            stats.db_file_bytes, 3300,
+            stats.db_file_bytes, dbf,
             "the sweep must RE-MEASURE the database file; without that call the \
              aggregate reverts to the logical row sum and the dead space a \
              long-running peer accumulates is invisible again (#5007)"
         );
         assert_eq!(
-            stats.webapp_cache_bytes, 4400,
+            stats.webapp_cache_bytes, web,
             "the sweep must RE-MEASURE the webapp cache; without that call those \
              bytes are invisible again (#5007)"
         );
-        assert_eq!(stats.wasm_bytes, 1100);
-        assert_eq!(stats.compile_cache_bytes, 2200);
+        assert_eq!(stats.wasm_bytes, wasm);
+        assert_eq!(stats.compile_cache_bytes, cache);
         // Budgeted aggregate = max(state, db) + wasm + compile cache. The webapp
         // cache is measured but not charged.
-        assert_eq!(stats.total_bytes, 3300 + 1100 + 2200);
+        assert_eq!(stats.total_bytes, dbf + wasm + cache);
     }
 
     /// The recompute takes only the O(1) `set_budget_bytes` cache write lock, so
@@ -7768,6 +7833,155 @@ mod tests {
                 .admit_state_update(&make_contract_key(1), 300 * MIB)
                 .is_err(),
             "growth over budget must still reject"
+        );
+    }
+
+    // --- What an over-budget node actually DOES (#5007) ----------------------
+    //
+    // The PR that made `used` honest argued that the resulting over-budget state
+    // is "narrow and bounded". That claim was pinned only by the boolean return
+    // of the log helper. These three tests pin the behavior itself: what still
+    // flows, what the eviction floor does, and how the state clears.
+
+    /// A node whose DATABASE FILE alone exceeds its disk budget still merges
+    /// UPDATEs to the contracts it hosts.
+    ///
+    /// This is the state #5007 makes reachable: the dead space is real, eviction
+    /// has no lever on it, and it will not clear before a restart. If a growing
+    /// UPDATE were refused there, the node would keep serving and advertising a
+    /// contract whose state had stopped merging — the stale host
+    /// `hosting-invariants.md` invariant 1 forbids — while freeing nothing.
+    /// Growth is the normal case for a River room, so this is not a corner.
+    #[test]
+    fn over_budget_from_dead_space_still_merges_hosted_updates() {
+        const MIB: u64 = 1024 * 1024;
+        // The production measurement: 583 MB of live rows inside a 2.68 GB file.
+        const ROWS: u64 = 583 * MIB;
+        const FILE: u64 = 2680 * MIB;
+
+        let manager = HostingManager::new(64 * 1024 * MIB);
+        manager.configure_disk_budget(0.5, DEFAULT_MAX_HOSTING_DISK_BYTES);
+        manager.seed_disk_tracker_for_test([(make_contract_key(1), ROWS)]);
+        manager.set_db_file_bytes_for_test(FILE);
+        manager.recompute_effective_budget(0);
+
+        let budget = manager.disk_budget_bytes();
+        assert!(
+            manager.disk_usage_stats().unwrap().total_bytes > budget,
+            "precondition: the file alone must put the node over budget"
+        );
+
+        // A fresh PUT is refused. That is the intended emergent refusal.
+        assert!(
+            manager.admit_state_write(&make_contract_key(2), 1).is_err(),
+            "a full node refuses new tenants"
+        );
+
+        // Shrinking and size-holding UPDATEs flow (pre-existing rule).
+        assert!(
+            manager
+                .admit_state_update(&make_contract_key(1), ROWS / 2)
+                .is_ok()
+        );
+        assert!(
+            manager
+                .admit_state_update(&make_contract_key(1), ROWS)
+                .is_ok()
+        );
+
+        // And so does growth that fits in the dead space: the file does not move,
+        // so refusing would cost convergence and save nothing.
+        assert!(
+            manager
+                .admit_state_update(&make_contract_key(1), ROWS + 100 * MIB)
+                .is_ok(),
+            "growth inside the dead space must merge on an over-budget node"
+        );
+        assert!(
+            manager
+                .admit_state_update(&make_contract_key(1), FILE)
+                .is_ok(),
+            "up to the measured file size, nothing new is written"
+        );
+
+        // Beyond the file, the growth is real and the budget applies again.
+        assert!(
+            manager
+                .admit_state_update(&make_contract_key(1), FILE + 1)
+                .is_err(),
+            "growth that enlarges the footprint stays bounded"
+        );
+    }
+
+    /// Being over budget must not make the eviction floor shed MORE than it did
+    /// while the same node was under-counting itself.
+    ///
+    /// `used` sits in the budget's own basis, so an honest (larger) figure can
+    /// only raise the installed floor. Stated as a direct comparison between two
+    /// nodes identical except for whether the database file is measured, because
+    /// "10x the usage against the same budget evicts everything" is the obvious
+    /// fear and it points the wrong way.
+    #[test]
+    fn honest_over_budget_usage_does_not_tighten_the_eviction_floor() {
+        const MIB: u64 = 1024 * 1024;
+        const GIB: u64 = 1024 * MIB;
+
+        let blind = HostingManager::new(GIB);
+        blind.configure_disk_budget(0.5, DEFAULT_MAX_HOSTING_DISK_BYTES);
+        blind.seed_disk_tracker_for_test([(make_contract_key(1), 583 * MIB)]);
+        blind.recompute_effective_budget(GIB);
+        let blind_floor = blind.hosting_budget_bytes();
+
+        let honest = HostingManager::new(GIB);
+        honest.configure_disk_budget(0.5, DEFAULT_MAX_HOSTING_DISK_BYTES);
+        honest.seed_disk_tracker_for_test([(make_contract_key(1), 583 * MIB)]);
+        honest.set_db_file_bytes_for_test(2680 * MIB);
+        honest.recompute_effective_budget(GIB);
+        let honest_floor = honest.hosting_budget_bytes();
+
+        assert!(
+            honest_floor >= blind_floor,
+            "measuring the database file must not lower the eviction floor \
+             ({honest_floor} < {blind_floor})"
+        );
+
+        // And the floor is a fixed point: re-running the sweep without anything
+        // changing installs the same value, so there is no shed-then-shrink
+        // treadmill.
+        honest.recompute_effective_budget(GIB);
+        assert_eq!(honest.hosting_budget_bytes(), honest_floor);
+    }
+
+    /// The over-budget state clears when free space comes back, without a
+    /// restart and without any eviction: the budget is sized from
+    /// `used + available`, so a larger `available` lifts it back over `used`.
+    #[test]
+    fn over_budget_clears_when_free_space_grows() {
+        const MIB: u64 = 1024 * 1024;
+        const GIB: u64 = 1024 * MIB;
+
+        let manager = HostingManager::new(64 * GIB);
+        manager.configure_disk_budget(0.5, DEFAULT_MAX_HOSTING_DISK_BYTES);
+        manager.seed_disk_tracker_for_test([(make_contract_key(1), 583 * MIB)]);
+        manager.set_db_file_bytes_for_test(2680 * MIB);
+
+        manager.recompute_effective_budget(0);
+        assert!(
+            manager.disk_usage_stats().unwrap().total_bytes > manager.disk_budget_bytes(),
+            "precondition: over budget with no free space"
+        );
+        assert!(manager.admit_state_write(&make_contract_key(2), 1).is_err());
+
+        // Free space appears (the operator cleared something, or another
+        // consumer released it). Nothing about the node's own footprint changed.
+        manager.recompute_effective_budget(64 * GIB);
+        assert!(
+            manager.disk_usage_stats().unwrap().total_bytes <= manager.disk_budget_bytes(),
+            "a larger `available` must lift the budget back over `used`"
+        );
+        assert!(
+            manager.admit_state_write(&make_contract_key(2), 1).is_ok(),
+            "and fresh PUTs must be accepted again"
         );
     }
 }

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -727,8 +727,13 @@ impl HostingManager {
         if self.over_disk_budget.swap(over, Ordering::Relaxed) == over {
             return false;
         }
-        // `db_file_bytes − state_bytes` is the database's dead space: bytes the
-        // file holds that no live row accounts for.
+        // `db_file_bytes − state_bytes` is the database directory's dead space:
+        // bytes the shallow walk found that no live state row accounts for.
+        // Mostly interior redb free pages, but it also covers live non-state
+        // rows and, importantly for the advice below, an orphaned
+        // `db.backup.<timestamp>` from a schema migration
+        // (`redb.rs::backup_and_remove_database`), which nothing in the tree ever
+        // deletes and which the startup compaction cannot touch.
         let db_dead_space = stats.db_file_bytes.saturating_sub(stats.state_bytes);
         if over {
             tracing::warn!(
@@ -745,7 +750,11 @@ impl HostingManager {
                  keeps serving and advertising that contract at its last \
                  accepted state. Database dead space is reclaimed only by the \
                  startup compaction, so a large db_dead_space_bytes here needs a \
-                 node restart, not eviction"
+                 node restart, not eviction. One exception: if the database \
+                 directory still holds a db.backup.<timestamp> left by a schema \
+                 migration, those bytes are counted here, are never removed \
+                 automatically, and no restart reclaims them; delete that file \
+                 once the current database is known good"
             );
         } else {
             tracing::info!(

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -76,11 +76,11 @@ use cache::{HostingCache, HostingCacheStats, disk_budget_for_clamped};
 use dashmap::{DashMap, DashSet};
 use demand::ProximityPrior;
 use disk_usage::DiskUsageTracker;
-pub(crate) use disk_usage::{DiskBudgetExceeded, DiskUsageStats};
+pub(crate) use disk_usage::{DiskBudgetExceeded, DiskUsageStats, HostingDiskPaths};
 use freenet_stdlib::prelude::{ContractInstanceId, ContractKey};
 use parking_lot::RwLock;
 use std::collections::{HashMap, HashSet};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::Duration;
 use tokio::time::Instant;
 use tracing::{debug, info};
@@ -483,6 +483,12 @@ pub(crate) struct HostingManager {
     /// installs a real value (the tracker is also unseeded before then, so the
     /// gate is a no-op regardless).
     disk_budget_bytes: AtomicU64,
+
+    /// Whether the last [`Self::recompute_effective_budget`] found the aggregate
+    /// over the disk budget (#5007). Purely a log edge-trigger — see
+    /// [`Self::log_disk_budget_transition`] — so a node parked over budget says
+    /// so once instead of once per 60s sweep.
+    over_disk_budget: AtomicBool,
 }
 
 impl HostingManager {
@@ -527,6 +533,7 @@ impl HostingManager {
             disk_pct_bits: AtomicU64::new(DEFAULT_HOSTING_DISK_PCT.to_bits()),
             max_hosting_disk_bytes: AtomicU64::new(DEFAULT_MAX_HOSTING_DISK_BYTES),
             disk_budget_bytes: AtomicU64::new(u64::MAX),
+            over_disk_budget: AtomicBool::new(false),
         }
     }
 
@@ -602,12 +609,8 @@ impl HostingManager {
     /// Called once at startup (alongside `set_storage`), since `with_time_source`
     /// has no path access. The tracker starts unseeded; the first sweep tick
     /// seeds it lazily off the hot path.
-    pub(crate) fn configure_disk_tracker(
-        &self,
-        contracts_dir: std::path::PathBuf,
-        wasmtime_cache_dir: std::path::PathBuf,
-    ) {
-        *self.disk_tracker.write() = Some(DiskUsageTracker::new(contracts_dir, wasmtime_cache_dir));
+    pub(crate) fn configure_disk_tracker(&self, paths: HostingDiskPaths) {
+        *self.disk_tracker.write() = Some(DiskUsageTracker::new(paths));
     }
 
     /// Install the operator-configured disk-budget sizing knobs (#4683): the
@@ -635,15 +638,38 @@ impl HostingManager {
     ///
     /// Returns the effective budget it installed (for telemetry/tests), or `None`
     /// when it was a no-op.
+    ///
+    /// # Why an honest `used` cannot trigger mass eviction (#5007)
+    ///
+    /// #5007 raised `used` by up to an order of magnitude (the database file's
+    /// dead space became visible). That is safe for the eviction floor by
+    /// construction, and the property is worth stating because the obvious fear
+    /// — "10x the usage against the same budget evicts everything" — points the
+    /// wrong way here:
+    ///
+    /// `used` is in the budget's own basis (`pct * (used + available)`), not on
+    /// the other side of a comparison. `disk_budget_for_clamped` is monotonically
+    /// non-decreasing in `used`, and `min(ram, ·)` preserves that, so the
+    /// effective budget this installs can only ever RISE when `used` rises. The
+    /// cache compares its live state bytes against that budget, so a larger
+    /// `used` can never make the sweep shed more than it did before. Pinned by
+    /// `effective_budget_never_falls_as_measured_usage_rises`.
+    ///
+    /// The tightening happens where it should: the aggregate admission gate
+    /// ([`Self::admit_state_write`]) compares the full `used` against the disk
+    /// budget, so making `used` honest costs `(1 − pct)` of every newly-visible
+    /// byte in headroom. That is the mechanism that keeps a node's footprint
+    /// bounded instead of merely reclaiming it once per restart.
     pub(crate) fn recompute_effective_budget(&self, available: u64) -> Option<u64> {
-        let used = {
+        let stats = {
             let guard = self.disk_tracker.read();
             let tracker = guard.as_ref()?;
             if !tracker.is_seeded() {
                 return None;
             }
-            tracker.total_bytes()
+            tracker.stats()
         };
+        let used = stats.total_bytes;
         let pct = f64::from_bits(self.disk_pct_bits.load(Ordering::Relaxed));
         let cap = self.max_hosting_disk_bytes.load(Ordering::Relaxed);
         let ram = self.ram_budget_bytes.load(Ordering::Relaxed);
@@ -653,11 +679,58 @@ impl HostingManager {
         // checks projected disk against THIS value (the aggregate bound), not the
         // effective floor installed on the cache below.
         self.disk_budget_bytes.store(disk_budget, Ordering::Relaxed);
+        self.log_disk_budget_transition(&stats, disk_budget);
         let effective = ram.min(disk_budget);
         // O(1) under the cache write lock; the expensive du-walk already ran
         // OUTSIDE any lock before this call.
         self.hosting_cache.write().set_budget_bytes(effective);
         Some(effective)
+    }
+
+    /// Log the aggregate crossing into or out of its disk budget, on the edge
+    /// only (#5007).
+    ///
+    /// While `used > disk_budget` the admission gate refuses every fresh PUT.
+    /// That is the intended emergent refusal for a genuinely full node, and it
+    /// resolves on its own once bytes come back. But since #5007 the aggregate
+    /// includes the database file's dead space, and hosting eviction has NO
+    /// lever on that: freeing rows returns pages to redb for reuse without
+    /// shrinking the file, so a node whose dead space alone exceeds its budget
+    /// stays refusing PUTs however much it sheds. That state is reclaimed by the
+    /// startup compaction (#5005) and by nothing else, so it has to be audible
+    /// rather than leaving an operator to infer it from rejected writes.
+    ///
+    /// Edge-triggered via a stored flag, so a node that sits over budget logs
+    /// once, not once per 60s sweep forever.
+    fn log_disk_budget_transition(&self, stats: &DiskUsageStats, disk_budget: u64) {
+        let over = stats.total_bytes > disk_budget;
+        if self.over_disk_budget.swap(over, Ordering::Relaxed) == over {
+            return;
+        }
+        // `db_file_bytes − state_bytes` is the database's dead space: bytes the
+        // file holds that no live row accounts for.
+        let db_dead_space = stats.db_file_bytes.saturating_sub(stats.state_bytes);
+        if over {
+            tracing::warn!(
+                total_bytes = stats.total_bytes,
+                disk_budget_bytes = disk_budget,
+                state_bytes = stats.state_bytes,
+                db_file_bytes = stats.db_file_bytes,
+                db_dead_space_bytes = db_dead_space,
+                wasm_bytes = stats.wasm_bytes,
+                compile_cache_bytes = stats.compile_cache_bytes,
+                "aggregate on-disk usage is over the disk budget; fresh PUTs \
+                 will be refused until it comes back under. Database dead space \
+                 is reclaimed only by the startup compaction, so a large \
+                 db_dead_space_bytes here needs a node restart, not eviction"
+            );
+        } else {
+            tracing::info!(
+                total_bytes = stats.total_bytes,
+                disk_budget_bytes = disk_budget,
+                "aggregate on-disk usage is back under the disk budget"
+            );
+        }
     }
 
     /// Pre-write admission gate for a state write (#4683, live since #4702): reject the write
@@ -852,12 +925,23 @@ impl HostingManager {
         self.disk_tracker.read().as_ref()?.available_bytes()
     }
 
-    /// Re-walk the WASM-blob and compile-cache totals. Called on the telemetry
-    /// cadence (the 60s sweep) since both are `du`-measured, not delta-tracked.
+    /// Re-measure every `du`-measured disk gauge: WASM blobs, the wasmtime
+    /// compile cache, the storage backend's database file (#5007) and the
+    /// unpacked-webapp cache (#5007). Called on the telemetry cadence (the 60s
+    /// sweep) since none of the four is delta-trackable.
+    ///
+    /// The database measurement is not optional decoration: it is the ONLY term
+    /// that can see the database's dead space, which is what made the aggregate
+    /// under-count the real footprint ~10x (#5007). Dropping it here would
+    /// silently restore that under-count with every other test still green,
+    /// which is why `refresh_disk_usage_measures_database_and_webapp_cache`
+    /// pins this call site rather than only the tracker internals.
     pub(crate) fn refresh_disk_usage(&self) {
         if let Some(tracker) = self.disk_tracker.read().as_ref() {
             tracker.refresh_wasm();
             tracker.refresh_compile_cache();
+            tracker.refresh_db_file();
+            tracker.refresh_webapp_cache();
         }
     }
 
@@ -881,10 +965,24 @@ impl HostingManager {
     where
         I: IntoIterator<Item = (ContractKey, u64)>,
     {
-        self.configure_disk_tracker(
-            std::path::PathBuf::from("/nonexistent/contracts"),
-            std::path::PathBuf::from("/nonexistent/cache"),
-        );
+        self.configure_disk_tracker(HostingDiskPaths {
+            contracts_dir: std::path::PathBuf::from("/nonexistent/contracts"),
+            wasmtime_cache_dir: std::path::PathBuf::from("/nonexistent/cache"),
+            db_dir: std::path::PathBuf::from("/nonexistent/db"),
+            webapp_cache_dir: std::path::PathBuf::from("/nonexistent/webapp"),
+        });
+        self.seed_configured_disk_tracker_for_test(rows);
+    }
+
+    /// Test-only: seed the ALREADY-configured disk tracker, leaving its paths
+    /// alone. Unlike [`Self::seed_disk_tracker_for_test`] this does not swap in
+    /// nonexistent directories, so a test can point the tracker at real temp
+    /// dirs and then exercise the measurement path.
+    #[cfg(test)]
+    pub(crate) fn seed_configured_disk_tracker_for_test<I>(&self, rows: I)
+    where
+        I: IntoIterator<Item = (ContractKey, u64)>,
+    {
         if let Some(tracker) = self.disk_tracker.read().as_ref() {
             tracker.seed(rows);
         }
@@ -7152,12 +7250,141 @@ mod tests {
         assert_eq!(manager.hosting_budget_bytes(), GIB);
 
         // Tracker configured but NOT seeded → still None.
-        manager.configure_disk_tracker(
-            std::path::PathBuf::from("/nonexistent/contracts"),
-            std::path::PathBuf::from("/nonexistent/cache"),
-        );
+        manager.configure_disk_tracker(HostingDiskPaths {
+            contracts_dir: std::path::PathBuf::from("/nonexistent/contracts"),
+            wasmtime_cache_dir: std::path::PathBuf::from("/nonexistent/cache"),
+            db_dir: std::path::PathBuf::from("/nonexistent/db"),
+            webapp_cache_dir: std::path::PathBuf::from("/nonexistent/webapp"),
+        });
         assert_eq!(manager.recompute_effective_budget(0), None);
         assert_eq!(manager.hosting_budget_bytes(), GIB);
+    }
+
+    // --- Honest disk accounting (#5007) --------------------------------------
+
+    /// Making `used` honest CANNOT make the eviction floor shed more.
+    ///
+    /// This is the safety property behind #5007. Raising the measured footprint
+    /// by up to 10x sounds like it should push every node straight into
+    /// eviction, and it would if `used` sat on the compared side of the floor.
+    /// It does not: `used` is in the budget's own basis
+    /// (`clamp(pct * (used + available), MIN, cap)`), which is monotonically
+    /// non-decreasing in `used`, and `min(ram, ·)` preserves that. So the budget
+    /// installed on the cache — which is what the over-budget sweep compares
+    /// live state bytes against — can only rise.
+    ///
+    /// Swept across the whole shape of the clamp (below MIN, in the linear
+    /// region, and at the cap) so the property is checked where the clamp could
+    /// otherwise hide an inversion.
+    #[test]
+    fn effective_budget_never_falls_as_measured_usage_rises() {
+        const MIB: u64 = 1024 * 1024;
+        const GIB: u64 = 1024 * 1024 * 1024;
+
+        for available in [0, 64 * MIB, 2 * GIB, 100 * GIB] {
+            for ram in [64 * MIB, GIB, 8 * GIB] {
+                let mut previous: Option<u64> = None;
+                // Ascending measured usage: what #5007 does is move a node from
+                // an early entry in this list to a later one.
+                for used in [0, 128 * MIB, 583 * MIB, 2680 * MIB, 32 * GIB] {
+                    let manager = HostingManager::new(ram);
+                    manager.configure_disk_budget(0.5, DEFAULT_MAX_HOSTING_DISK_BYTES);
+                    manager.seed_disk_tracker_for_test([(make_contract_key(1), used)]);
+                    let eff = manager
+                        .recompute_effective_budget(available)
+                        .expect("seeded → recompute runs");
+                    if let Some(prev) = previous {
+                        assert!(
+                            eff >= prev,
+                            "effective budget fell from {prev} to {eff} when measured \
+                             usage rose to {used} (ram={ram}, available={available}); \
+                             honest accounting must never tighten the eviction floor"
+                        );
+                    }
+                    previous = Some(eff);
+                }
+            }
+        }
+    }
+
+    /// Call-site pin: the 60s sweep's disk-usage refresh must re-measure the
+    /// database file and the webapp cache, not just the two gauges that existed
+    /// before #5007.
+    ///
+    /// The tracker-internal `refresh_db_file` / `refresh_webapp_cache` can be
+    /// perfectly correct and perfectly tested while nothing on the sweep path
+    /// ever calls them — in which case `db_file_bytes` freezes at its seed-time
+    /// value, a long-running node's growing dead space stays invisible, and the
+    /// ~10x under-count is silently back with every unit test still green.
+    ///
+    /// So the assertions are on values that only a REFRESH can produce: every
+    /// directory is grown AFTER the seed, and each gauge is checked against its
+    /// post-growth size. Dropping any of the four calls from
+    /// `refresh_disk_usage` leaves that gauge at its stale seed value and fails
+    /// here.
+    #[test]
+    fn refresh_disk_usage_measures_database_and_webapp_cache() {
+        use std::io::Write;
+
+        fn write_file(path: &std::path::Path, len: usize) {
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::File::create(path)
+                .unwrap()
+                .write_all(&vec![0u8; len])
+                .unwrap();
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let contracts = dir.path().join("contracts");
+        let wasmtime = dir.path().join("wasmtime");
+        let db = dir.path().join("db");
+        let webapp = dir.path().join("webapp");
+
+        // Seed-time sizes.
+        write_file(&contracts.join("aaaa.wasm"), 11);
+        write_file(&wasmtime.join("mod.cache"), 22);
+        write_file(&db.join("db"), 33);
+        write_file(&webapp.join("aaaa").join("index.html"), 44);
+
+        let manager = HostingManager::new(1024 * 1024 * 1024);
+        manager.configure_disk_tracker(HostingDiskPaths {
+            contracts_dir: contracts.clone(),
+            wasmtime_cache_dir: wasmtime.clone(),
+            db_dir: db.clone(),
+            webapp_cache_dir: webapp.clone(),
+        });
+        // A tiny logical state total inside a much larger database — the shape of
+        // an under-counting node (583 MB of rows in a 2.68 GB file).
+        manager.seed_configured_disk_tracker_for_test([(make_contract_key(1), 100)]);
+
+        // Everything grows after the seed. Only a re-measure can see this.
+        write_file(&contracts.join("aaaa.wasm"), 1100);
+        write_file(&wasmtime.join("mod.cache"), 2200);
+        write_file(&db.join("db"), 3300);
+        write_file(&webapp.join("aaaa").join("index.html"), 4400);
+
+        manager.refresh_disk_usage();
+
+        let stats = manager
+            .disk_usage_stats()
+            .expect("seeded tracker reports stats");
+        assert_eq!(stats.state_bytes, 100, "logical rows are delta-tracked");
+        assert_eq!(
+            stats.db_file_bytes, 3300,
+            "the sweep must RE-MEASURE the database file; without that call the \
+             aggregate reverts to the logical row sum and the dead space a \
+             long-running peer accumulates is invisible again (#5007)"
+        );
+        assert_eq!(
+            stats.webapp_cache_bytes, 4400,
+            "the sweep must RE-MEASURE the webapp cache; without that call those \
+             bytes are invisible again (#5007)"
+        );
+        assert_eq!(stats.wasm_bytes, 1100);
+        assert_eq!(stats.compile_cache_bytes, 2200);
+        // Budgeted aggregate = max(state, db) + wasm + compile cache. The webapp
+        // cache is measured but not charged.
+        assert_eq!(stats.total_bytes, 3300 + 1100 + 2200);
     }
 
     /// The recompute takes only the O(1) `set_budget_bytes` cache write lock, so
@@ -7261,10 +7488,12 @@ mod tests {
     #[test]
     fn dashboard_disk_fields_absent_while_unseeded() {
         let manager = HostingManager::new(1024 * 1024 * 1024);
-        manager.configure_disk_tracker(
-            std::path::PathBuf::from("/nonexistent/contracts"),
-            std::path::PathBuf::from("/nonexistent/cache"),
-        );
+        manager.configure_disk_tracker(HostingDiskPaths {
+            contracts_dir: std::path::PathBuf::from("/nonexistent/contracts"),
+            wasmtime_cache_dir: std::path::PathBuf::from("/nonexistent/cache"),
+            db_dir: std::path::PathBuf::from("/nonexistent/db"),
+            webapp_cache_dir: std::path::PathBuf::from("/nonexistent/webapp"),
+        });
         assert!(
             manager.disk_usage_stats().is_none(),
             "configured-but-unseeded tracker → disk_usage_stats must stay None"

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -679,7 +679,8 @@ impl HostingManager {
         // checks projected disk against THIS value (the aggregate bound), not the
         // effective floor installed on the cache below.
         self.disk_budget_bytes.store(disk_budget, Ordering::Relaxed);
-        self.log_disk_budget_transition(&stats, disk_budget);
+        // Return value is only for the edge-behavior test; the sweep just logs.
+        let _logged = self.log_disk_budget_transition(&stats, disk_budget);
         let effective = ram.min(disk_budget);
         // O(1) under the cache write lock; the expensive du-walk already ran
         // OUTSIDE any lock before this call.
@@ -702,10 +703,14 @@ impl HostingManager {
     ///
     /// Edge-triggered via a stored flag, so a node that sits over budget logs
     /// once, not once per 60s sweep forever.
-    fn log_disk_budget_transition(&self, stats: &DiskUsageStats, disk_budget: u64) {
+    ///
+    /// Returns whether this call logged a transition, so the edge behavior is
+    /// assertable (a flag that stuck would silence the signal permanently, which
+    /// looks exactly like a healthy node).
+    fn log_disk_budget_transition(&self, stats: &DiskUsageStats, disk_budget: u64) -> bool {
         let over = stats.total_bytes > disk_budget;
         if self.over_disk_budget.swap(over, Ordering::Relaxed) == over {
-            return;
+            return false;
         }
         // `db_file_bytes − state_bytes` is the database's dead space: bytes the
         // file holds that no live row accounts for.
@@ -731,6 +736,7 @@ impl HostingManager {
                 "aggregate on-disk usage is back under the disk budget"
             );
         }
+        true
     }
 
     /// Pre-write admission gate for a state write (#4683, live since #4702): reject the write
@@ -7341,6 +7347,69 @@ mod tests {
                 }
             }
         }
+    }
+
+    /// The over-budget signal fires on the EDGE, in both directions, and only on
+    /// the edge (#5007).
+    ///
+    /// This is the operable signal for the one state where the honest aggregate
+    /// can hurt: a node whose database dead space alone exceeds its budget
+    /// refuses fresh PUTs and cannot evict its way out, because freeing rows
+    /// returns pages to redb for reuse without shrinking the file. Only a
+    /// restart's compaction (#5005) clears it. Two ways to lose that signal, both
+    /// covered here: a flag that never clears (the recovery is never announced
+    /// and the next episode is silent) and a flag that never sets (60s of log
+    /// spam, which gets muted and then ignored).
+    #[test]
+    fn over_disk_budget_is_logged_on_the_edge_only() {
+        let manager = HostingManager::new(1024 * 1024 * 1024);
+        let over = DiskUsageStats {
+            state_bytes: 100,
+            db_file_bytes: 900,
+            wasm_bytes: 0,
+            compile_cache_bytes: 0,
+            webapp_cache_bytes: 0,
+            total_bytes: 900,
+        };
+        let under = DiskUsageStats {
+            total_bytes: 400,
+            ..over
+        };
+
+        // Starting state is "under", so an under-budget recompute says nothing.
+        assert!(
+            !manager.log_disk_budget_transition(&under, 500),
+            "no transition on the first under-budget observation"
+        );
+        // Crossing over logs once...
+        assert!(
+            manager.log_disk_budget_transition(&over, 500),
+            "crossing over budget must announce itself"
+        );
+        // ...and staying over stays quiet, however many sweeps run.
+        for _ in 0..5 {
+            assert!(
+                !manager.log_disk_budget_transition(&over, 500),
+                "a node parked over budget must not re-log every sweep"
+            );
+        }
+        // Coming back under logs the recovery, once.
+        assert!(
+            manager.log_disk_budget_transition(&under, 500),
+            "returning under budget must announce itself"
+        );
+        assert!(!manager.log_disk_budget_transition(&under, 500));
+
+        // The boundary matches the admission gate's inclusive-admit rule:
+        // `total == budget` is not over.
+        let exactly = DiskUsageStats {
+            total_bytes: 500,
+            ..over
+        };
+        assert!(
+            !manager.log_disk_budget_transition(&exactly, 500),
+            "total == budget is within budget, same as the admission gate"
+        );
     }
 
     /// Call-site pin: the 60s sweep's disk-usage refresh must re-measure the

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -7276,32 +7276,68 @@ mod tests {
     /// Swept across the whole shape of the clamp (below MIN, in the linear
     /// region, and at the cap) so the property is checked where the clamp could
     /// otherwise hide an inversion.
+    ///
+    /// The extra bytes are supplied through a REAL database file rather than by
+    /// inflating the seeded row total, because the mutation this has to catch is
+    /// a recompute that treats the newly-visible non-state footprint as a charge
+    /// against the budget (`disk_budget − non_state`) instead of as part of its
+    /// basis. Driving `used` purely through state rows leaves `non_state == 0`
+    /// and the test passes under that mutation — verified, and the reason the
+    /// fixture looks like this.
     #[test]
     fn effective_budget_never_falls_as_measured_usage_rises() {
         const MIB: u64 = 1024 * 1024;
         const GIB: u64 = 1024 * 1024 * 1024;
+        // A fixed, small live-row total under every database size below, so the
+        // growth is entirely in the dead space #5007 made visible.
+        const STATE_ROWS: u64 = 16 * MIB;
 
         for available in [0, 64 * MIB, 2 * GIB, 100 * GIB] {
             for ram in [64 * MIB, GIB, 8 * GIB] {
-                let mut previous: Option<u64> = None;
-                // Ascending measured usage: what #5007 does is move a node from
-                // an early entry in this list to a later one.
-                for used in [0, 128 * MIB, 583 * MIB, 2680 * MIB, 32 * GIB] {
-                    let manager = HostingManager::new(ram);
-                    manager.configure_disk_budget(0.5, DEFAULT_MAX_HOSTING_DISK_BYTES);
-                    manager.seed_disk_tracker_for_test([(make_contract_key(1), used)]);
-                    let eff = manager
-                        .recompute_effective_budget(available)
-                        .expect("seeded → recompute runs");
-                    if let Some(prev) = previous {
-                        assert!(
-                            eff >= prev,
-                            "effective budget fell from {prev} to {eff} when measured \
-                             usage rose to {used} (ram={ram}, available={available}); \
-                             honest accounting must never tighten the eviction floor"
-                        );
+                for cap in [256 * MIB, DEFAULT_MAX_HOSTING_DISK_BYTES] {
+                    let mut previous: Option<u64> = None;
+                    // Ascending measured footprint. #5007 moves a real node from
+                    // an early entry in this list to a later one WITHOUT its live
+                    // state changing: 583 MB of rows in a 2.68 GB file was the
+                    // production measurement.
+                    for db_bytes in [0, 128 * MIB, 583 * MIB, 2680 * MIB, 40 * GIB] {
+                        let dir = tempfile::tempdir().unwrap();
+                        let db = dir.path().join("db");
+                        std::fs::create_dir_all(&db).unwrap();
+                        // Sparse: `set_len` gives the file the length the walk
+                        // measures without allocating blocks for it.
+                        std::fs::File::create(db.join("db"))
+                            .unwrap()
+                            .set_len(db_bytes)
+                            .unwrap();
+
+                        let manager = HostingManager::new(ram);
+                        manager.configure_disk_budget(0.5, cap);
+                        manager.configure_disk_tracker(HostingDiskPaths {
+                            contracts_dir: std::path::PathBuf::from("/nonexistent/contracts"),
+                            wasmtime_cache_dir: std::path::PathBuf::from("/nonexistent/cache"),
+                            db_dir: db,
+                            webapp_cache_dir: std::path::PathBuf::from("/nonexistent/webapp"),
+                        });
+                        manager.seed_configured_disk_tracker_for_test([(
+                            make_contract_key(1),
+                            STATE_ROWS,
+                        )]);
+
+                        let eff = manager
+                            .recompute_effective_budget(available)
+                            .expect("seeded → recompute runs");
+                        if let Some(prev) = previous {
+                            assert!(
+                                eff >= prev,
+                                "effective budget fell from {prev} to {eff} when the \
+                                 measured database grew to {db_bytes} (ram={ram}, \
+                                 available={available}, cap={cap}); honest accounting \
+                                 must never tighten the eviction floor"
+                            );
+                        }
+                        previous = Some(eff);
                     }
-                    previous = Some(eff);
                 }
             }
         }

--- a/crates/core/src/ring/hosting/cache.rs
+++ b/crates/core/src/ring/hosting/cache.rs
@@ -139,7 +139,10 @@ const FALLBACK_TOTAL_RAM_BYTES: u64 = 1024 * 1024 * 1024;
 ///
 /// The budget tracks hosted contract **state** bytes only. WASM code blobs and
 /// ReDb/SQLite database overhead are additional and not counted against it, so
-/// this is not a hard bound on total on-disk usage.
+/// this is not a hard bound on total on-disk usage. Bounding the whole footprint
+/// is the separate aggregate DISK budget's job ([`disk_budget_for_clamped`] and
+/// `ring/hosting/disk_usage.rs`), which since #5007 measures the database file
+/// itself rather than summing logical state rows.
 pub fn default_hosting_budget_bytes() -> u64 {
     let total_ram = read_total_ram_bytes()
         .map(|v| v as u64)
@@ -692,7 +695,9 @@ pub struct HostedContract {
 /// for the network. The cache has:
 /// - Byte budget: Large contracts consume more budget. The budget is measured
 ///   in tracked contract **state** bytes only; WASM code blobs and database
-///   overhead are not counted against it.
+///   overhead are not counted against it (the aggregate disk budget in
+///   `disk_usage.rs` counts those, and since #5007 measures the database file
+///   rather than summing state rows).
 /// - Subscriber-primary eviction: when over budget the victim is chosen by
 ///   ascending `(local_subscription_count, downstream_subscriber_count,
 ///   recency_seq, key_bytes)` (see [`victim_order`] and the module docs). There

--- a/crates/core/src/ring/hosting/disk_usage.rs
+++ b/crates/core/src/ring/hosting/disk_usage.rs
@@ -86,6 +86,30 @@
 //! live `state_bytes` delta already captures the marginal cost of an in-flight
 //! write; the sweep reconciles it against ground truth once a minute.
 //!
+//! The gap between the two — `db_file_bytes − state_bytes` — is the database's
+//! dead space, and it is not merely a reporting curiosity: growth that fits
+//! inside it costs no disk at all, which is why
+//! [`DiskUsageTracker::admit_state_update`] admits such an UPDATE even on an
+//! over-budget node. Refusing it would freeze a hosted contract's state while
+//! the node kept serving and advertising it (invariant 1's stale host) in
+//! exchange for zero bytes saved.
+//!
+//! # How a file is measured (allocated, not apparent)
+//!
+//! Every walk charges a file's **allocated blocks**, not its apparent length —
+//! see [`file_disk_bytes`]. redb's file is sparse on some peers (measured:
+//! 2.56 GiB apparent against 1.71 GiB allocated on the production gateway), so
+//! charging the apparent length over-states the dominant term by up to ~50% and
+//! makes the admission gate refuse writes the disk can still take. Allocation is
+//! also the unit `available` is measured in (`statvfs` free blocks), so the two
+//! terms of the budget's basis have to agree.
+//!
+//! A walk that CANNOT read its directory keeps the gauge's previous value and
+//! warns, instead of recording 0 — see [`DiskUsageTracker::store_measurement`].
+//! Recording 0 for an unreadable database directory would silently revert the
+//! aggregate to the exact under-count this module exists to fix, and would look
+//! like a healthy small node in telemetry.
+//!
 //! # The webapp cache is reported, not budgeted (#5007)
 //!
 //! The unpacked-webapp cache (XDG cache dir, `~/.cache/freenet/webapp_cache`)
@@ -240,6 +264,16 @@ pub(crate) struct DiskUsageTracker {
     /// same sweep. REPORTED ONLY — never part of [`Self::total_bytes`]; see the
     /// module docs for why double-bounding it would be wrong.
     webapp_cache_bytes: AtomicU64,
+    /// Edge-trigger flags for "the last `du`-walk of this gauge failed", one per
+    /// measured gauge (#5007 follow-up). A failed walk keeps the gauge's
+    /// previous value and warns ONCE, instead of silently recording 0 and
+    /// reverting the aggregate to the pre-#5007 under-count. See
+    /// [`Self::store_measurement`]; separate flags so a warning about one
+    /// directory cannot suppress a warning about another.
+    wasm_measure_failed: AtomicBool,
+    compile_cache_measure_failed: AtomicBool,
+    db_file_measure_failed: AtomicBool,
+    webapp_cache_measure_failed: AtomicBool,
     /// The directories all of the above are measured from.
     paths: HostingDiskPaths,
 }
@@ -256,6 +290,10 @@ impl DiskUsageTracker {
             state_sizes: Mutex::new(HashMap::new()),
             db_file_bytes: AtomicU64::new(0),
             webapp_cache_bytes: AtomicU64::new(0),
+            wasm_measure_failed: AtomicBool::new(false),
+            compile_cache_measure_failed: AtomicBool::new(false),
+            db_file_measure_failed: AtomicBool::new(false),
+            webapp_cache_measure_failed: AtomicBool::new(false),
             paths,
         }
     }
@@ -300,21 +338,18 @@ impl DiskUsageTracker {
     }
 
     /// Snapshot all gauges for telemetry.
+    ///
+    /// `total_bytes` delegates to [`Self::total_bytes`] rather than re-deriving
+    /// the aggregate, so the budgeted formula has exactly one definition and a
+    /// future change to it cannot land in one place and not the other.
     pub(crate) fn stats(&self) -> DiskUsageStats {
-        let state_bytes = self.state_bytes.load(Ordering::Relaxed);
-        let db_file_bytes = self.db_file_bytes.load(Ordering::Relaxed);
-        let wasm_bytes = self.wasm_bytes.load(Ordering::Relaxed);
-        let compile_cache_bytes = self.compile_cache_bytes.load(Ordering::Relaxed);
         DiskUsageStats {
-            state_bytes,
-            db_file_bytes,
-            wasm_bytes,
-            compile_cache_bytes,
+            state_bytes: self.state_bytes.load(Ordering::Relaxed),
+            db_file_bytes: self.db_file_bytes.load(Ordering::Relaxed),
+            wasm_bytes: self.wasm_bytes.load(Ordering::Relaxed),
+            compile_cache_bytes: self.compile_cache_bytes.load(Ordering::Relaxed),
             webapp_cache_bytes: self.webapp_cache_bytes.load(Ordering::Relaxed),
-            total_bytes: state_bytes
-                .max(db_file_bytes)
-                .saturating_add(wasm_bytes)
-                .saturating_add(compile_cache_bytes),
+            total_bytes: self.total_bytes(),
         }
     }
 
@@ -322,8 +357,22 @@ impl DiskUsageTracker {
     /// `(contract, state_size)` pairs (the caller reads these from redb rows so
     /// this module stays storage-backend-agnostic and unit-testable). Also runs
     /// the initial WASM, compile-cache, database-file and webapp-cache
-    /// measurements, so every gauge is meaningful the moment `is_seeded` flips
-    /// (the telemetry and budget paths both gate on that flag).
+    /// measurements, so the gauges the telemetry and budget paths read are
+    /// populated by the time this returns rather than waiting for the first 60s
+    /// sweep.
+    ///
+    /// The four measurements run AFTER the `seeded` flag flips, so a concurrent
+    /// reader can briefly observe `is_seeded() == true` with the `du`-measured
+    /// gauges still 0. That window is permissive, not blocking: the admission
+    /// gate compares against `disk_budget_bytes`, which is `u64::MAX` until the
+    /// first `recompute_effective_budget`, and that recompute runs after this
+    /// seed in the same sweep iteration. The walks are deliberately not moved
+    /// ahead of the flag — they must run outside the `state_sizes` lock, and
+    /// measuring first would open the opposite window in which a WASM blob
+    /// written between the walk and the flag is missed by both the walk and the
+    /// (still-unseeded, therefore skipped) delta in
+    /// [`Self::record_wasm_write`], which is an under-count of a gate input
+    /// rather than an over-permissive gauge.
     ///
     /// Idempotent-guarded: only the FIRST call takes effect; later calls are a
     /// no-op so a racing second sweep tick cannot double-count.
@@ -598,9 +647,47 @@ impl DiskUsageTracker {
     ///
     /// Therefore this check is **growth-only**: when `new_size <= old_for_key`
     /// (the delta is non-positive) it admits unconditionally, even when the
-    /// aggregate is already over budget. Only genuine growth (`new_size >
-    /// old_for_key`) is subjected to the same projected-aggregate bound as
-    /// `admit_state_write`.
+    /// aggregate is already over budget.
+    ///
+    /// # Growth absorbed by the database's dead space is also admitted (#5007)
+    ///
+    /// Genuine growth still is not automatically a *disk* cost. redb reuses
+    /// freed pages rather than truncating, so a node carrying dead space
+    /// (`db_file_bytes − state_bytes`, the gap #5007 made visible) absorbs
+    /// growth up to that gap without the file growing by a single byte. The
+    /// honest projection of the storage term is therefore
+    /// `max(db_file_bytes, state_bytes − old + new)` — NOT
+    /// `max(db_file_bytes, state_bytes) − old + new`, which charges the delta on
+    /// top of a file that will not move.
+    ///
+    /// This matters because of what refusing costs. A rejected UPDATE aborts the
+    /// write while the node keeps the contract, keeps serving it, and keeps
+    /// advertising as a host — a copy that has dropped out of the update mesh
+    /// but still answers reads, which `hosting-invariants.md` invariant 1 says
+    /// must be impossible by construction. And for a relayed UPDATE the
+    /// rejection is fire-and-forget: no `UpdateMsg::Error`, so no peer learns.
+    /// Growth is the normal case for the flagship contract class (a River room
+    /// appends messages), and #5007 widens the over-budget population by making
+    /// `used` honest. Refusing a merge that consumes no disk would manufacture
+    /// stale hosts and buy nothing — eviction has no lever on dead space either,
+    /// so there is no shed that would have made room.
+    ///
+    /// So the bound applies only to growth that genuinely enlarges the
+    /// footprint. When the projected storage term exceeds the current one, the
+    /// increment is real and is subjected to the aggregate budget.
+    ///
+    /// Two bounded imprecisions, both self-correcting on the next 60s
+    /// re-measurement: `state_bytes` counts state payload only, so
+    /// `db_file_bytes − state_bytes` also includes live non-state rows (params,
+    /// hosting metadata, indices, B-tree overhead) and slightly over-states what
+    /// is truly reclaimable; and `db_file_bytes` is up to one sweep window
+    /// stale.
+    ///
+    /// **Residual:** growth that exceeds the dead space on an over-budget node
+    /// is still refused, and that stale-host window stays open. That case is
+    /// genuine disk exhaustion where admitting the write would overflow the
+    /// budget; closing it means de-registering hosting and re-homing the
+    /// contract's subscribers (epic #4642, piece D), not widening this gate.
     ///
     /// Read-only, same deferred-`+delta` discipline and inclusive-admit boundary
     /// as [`Self::admit_state_write`].
@@ -610,7 +697,7 @@ impl DiskUsageTracker {
         new_size: u64,
         budget_bytes: u64,
     ) -> Result<(), DiskBudgetExceeded> {
-        // Hold the delta-path lock so the `old` read and the `total` read are a
+        // Hold the delta-path lock so the `old` read and the storage reads are a
         // consistent snapshot (same rationale as `admit_state_write`).
         let sizes = self.state_sizes.lock();
         let old = sizes.get(key).copied().unwrap_or(0);
@@ -618,9 +705,25 @@ impl DiskUsageTracker {
         if new_size <= old {
             return Ok(());
         }
-        let total = self.total_bytes();
+        let state = self.state_bytes.load(Ordering::Relaxed);
+        let db_file = self.db_file_bytes.load(Ordering::Relaxed);
         drop(sizes);
-        let projected = total.saturating_sub(old).saturating_add(new_size);
+
+        let current_storage = state.max(db_file);
+        let projected_storage = state
+            .saturating_sub(old)
+            .saturating_add(new_size)
+            .max(db_file);
+        // The growth fits inside the database file that is already on disk and
+        // already counted: it costs no new bytes, so there is nothing for the
+        // budget to protect and refusing would only stall convergence.
+        if projected_storage <= current_storage {
+            return Ok(());
+        }
+
+        let projected = projected_storage
+            .saturating_add(self.wasm_bytes.load(Ordering::Relaxed))
+            .saturating_add(self.compile_cache_bytes.load(Ordering::Relaxed));
         if projected > budget_bytes {
             Err(DiskBudgetExceeded {
                 projected_bytes: projected,
@@ -654,20 +757,92 @@ impl DiskUsageTracker {
         }
     }
 
+    /// Store the result of one `du`-walk, distinguishing **"measured 0"** from
+    /// **"could not measure"** (#5007 follow-up).
+    ///
+    /// Every walk in this module used to swallow its `read_dir` error and return
+    /// 0. That is a silent regression to the pre-#5007 under-count on the term
+    /// that now dominates the aggregate: a single EACCES (a packaging or user
+    /// change), a transient EMFILE on a busy node, or the directory being
+    /// replaced would set `db_file_bytes = 0`, `max(state, 0) == state` would
+    /// revert the whole figure to exactly the number #5007 exists to fix, and
+    /// telemetry would show a perfectly plausible `hosting_disk_db_bytes: 0`
+    /// with no log to contradict it. Under EACCES it is permanent and
+    /// indistinguishable from a healthy small node.
+    ///
+    /// So a failed walk leaves the gauge at its **previous** value and warns.
+    /// This is the same fail-loud discipline the state seed already follows (see
+    /// "Seeding discipline" in the module docs) — a measurement that cannot read
+    /// the truth must surface that rather than publish an under-count.
+    ///
+    /// `NotFound` is NOT a failure: a directory that does not exist holds no
+    /// bytes, and that is the legitimate state for a store that has not been
+    /// created yet (and for unit-test trackers pointed at nonexistent paths).
+    ///
+    /// The warning is edge-triggered on a per-gauge flag, so a node whose
+    /// database directory is permanently unreadable logs once rather than once
+    /// per 60s sweep forever, and logs again if the condition recurs after a
+    /// recovery.
+    fn store_measurement(
+        &self,
+        gauge: &AtomicU64,
+        already_warned: &AtomicBool,
+        dir: &Path,
+        what: &'static str,
+        walk: fn(&Path) -> std::io::Result<u64>,
+    ) {
+        match walk(dir) {
+            Ok(bytes) => {
+                gauge.store(bytes, Ordering::Relaxed);
+                already_warned.store(false, Ordering::Relaxed);
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                gauge.store(0, Ordering::Relaxed);
+                already_warned.store(false, Ordering::Relaxed);
+            }
+            Err(err) => {
+                if !already_warned.swap(true, Ordering::Relaxed) {
+                    tracing::warn!(
+                        measurement = what,
+                        dir = %dir.display(),
+                        error = %err,
+                        retained_bytes = gauge.load(Ordering::Relaxed),
+                        "could not measure a hosting disk-usage directory; keeping \
+                         the previous measurement. Recording 0 here would silently \
+                         restore the pre-#5007 under-count and read as a healthy \
+                         small node"
+                    );
+                }
+            }
+        }
+    }
+
     /// Re-measure the on-disk WASM blob total by `du`-walking `contracts_dir`.
     /// Cheap and re-run on the telemetry cadence; deduping is inherent (each
-    /// distinct `code_hash` is one file).
+    /// distinct `code_hash` is one file). A walk that fails keeps the previous
+    /// value — see [`Self::store_measurement`].
     pub(crate) fn refresh_wasm(&self) {
-        self.wasm_bytes
-            .store(du_walk_wasm(&self.paths.contracts_dir), Ordering::Relaxed);
+        self.store_measurement(
+            &self.wasm_bytes,
+            &self.wasm_measure_failed,
+            &self.paths.contracts_dir,
+            "wasm_blobs",
+            du_walk_wasm,
+        );
     }
 
     /// Re-measure the wasmtime compile-cache total by `du`-walking its dir.
     /// Wasmtime writes the cache opaquely, so this re-walk (not a delta) is the
-    /// only way to account for it.
+    /// only way to account for it. A walk that fails keeps the previous value —
+    /// see [`Self::store_measurement`].
     pub(crate) fn refresh_compile_cache(&self) {
-        self.compile_cache_bytes
-            .store(du_walk(&self.paths.wasmtime_cache_dir), Ordering::Relaxed);
+        self.store_measurement(
+            &self.compile_cache_bytes,
+            &self.compile_cache_measure_failed,
+            &self.paths.wasmtime_cache_dir,
+            "compile_cache",
+            du_walk,
+        );
     }
 
     /// Re-measure the storage backend's database footprint (#5007).
@@ -684,9 +859,19 @@ impl DiskUsageTracker {
     /// Cheap: one `read_dir` over a directory holding a handful of entries,
     /// versus the recursive walks the wasm and compile-cache gauges already do
     /// on the same 60s cadence.
+    ///
+    /// A walk that FAILS keeps the previous value and warns rather than
+    /// recording 0: this is the dominant term, and a phantom 0 here reverts the
+    /// whole aggregate to the pre-#5007 under-count silently. See
+    /// [`Self::store_measurement`].
     pub(crate) fn refresh_db_file(&self) {
-        self.db_file_bytes
-            .store(du_walk_shallow(&self.paths.db_dir), Ordering::Relaxed);
+        self.store_measurement(
+            &self.db_file_bytes,
+            &self.db_file_measure_failed,
+            &self.paths.db_dir,
+            "database_file",
+            du_walk_shallow,
+        );
     }
 
     /// Re-measure the unpacked-webapp cache (#5007).
@@ -696,10 +881,16 @@ impl DiskUsageTracker {
     /// the blind spot (nothing measured or reported these bytes at all);
     /// charging them to the hosting budget would double-bound something #5012
     /// already caps at 64 MiB, using a lever hosting eviction does not have.
-    /// See the module docs.
+    /// See the module docs. A walk that fails keeps the previous value — see
+    /// [`Self::store_measurement`].
     pub(crate) fn refresh_webapp_cache(&self) {
-        self.webapp_cache_bytes
-            .store(du_walk(&self.paths.webapp_cache_dir), Ordering::Relaxed);
+        self.store_measurement(
+            &self.webapp_cache_bytes,
+            &self.webapp_cache_measure_failed,
+            &self.paths.webapp_cache_dir,
+            "webapp_cache",
+            du_walk,
+        );
     }
 
     /// Free bytes on the mount holding the tracked `contracts_dir` — the
@@ -710,45 +901,103 @@ impl DiskUsageTracker {
     pub(crate) fn available_bytes(&self) -> Option<u64> {
         available_bytes(&self.paths.contracts_dir)
     }
+
+    /// Test-only: install a measured database-file size directly.
+    ///
+    /// Budget arithmetic has to be exercised across footprints up to tens of
+    /// gigabytes, which no fixture can materialize on disk. It cannot be faked
+    /// with a sparse file either: since the walks measure allocated blocks, a
+    /// `set_len` file measures 0 and would make such a fixture silently vacuous.
+    #[cfg(test)]
+    pub(crate) fn set_db_file_bytes_for_test(&self, bytes: u64) {
+        self.db_file_bytes.store(bytes, Ordering::Relaxed);
+    }
 }
 
-/// Sum the byte size of every regular file **directly inside** `dir`, without
-/// descending into subdirectories (#5007).
+/// The disk a single file actually consumes: its **allocated blocks**, not its
+/// apparent length (#5007 follow-up).
+///
+/// `Metadata::len()` is what `ls` reports — the file's logical extent. For a
+/// **sparse** file that over-states consumption, because the holes occupy no
+/// blocks at all. redb's database file is sparse on some peers: measured on the
+/// production gateway (2026-07-29, stable across repeated samples),
+/// `len()` reported 2,749,370,368 bytes against 1,839,210,496 bytes actually
+/// allocated — a 910 MB / 49% over-charge on the term that now dominates the
+/// aggregate. (The same file on another peer was not sparse at all, so this
+/// varies with the peer's compaction history and cannot be corrected by a
+/// constant.) Over-charging makes the admission gate refuse writes the disk can
+/// still take: the mirror image of the under-count #5007 fixed, and no more
+/// honest.
+///
+/// Allocated blocks are also the only unit that composes with the budget's other
+/// term. The disk budget is `pct * (used + available)` where `available` is
+/// `statvfs`'s `f_bavail * f_frsize` — real free blocks. `used` has to be in the
+/// same currency, so block slack on a small file IS charged (the filesystem
+/// genuinely spent that block, and `available` already reflects it) and a hole
+/// is not. This makes the module's `du`-walk naming true: `du` reports
+/// allocation, `ls` reports length.
+///
+/// `st_blocks` is defined in 512-byte units regardless of the filesystem's own
+/// block size. Windows has no equivalent in `std`, so non-unix falls back to the
+/// apparent length.
+fn file_disk_bytes(meta: &std::fs::Metadata) -> u64 {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        meta.blocks().saturating_mul(512)
+    }
+    #[cfg(not(unix))]
+    {
+        meta.len()
+    }
+}
+
+/// Sum the allocated size of every regular file **directly inside** `dir`,
+/// without descending into subdirectories (#5007).
 ///
 /// The non-recursive counterpart to [`du_walk`], for the database directory:
 /// `db_dir` in `Network` mode contains the `local/` mode split, whose bytes
-/// belong to a different node instance and must not be charged here. Same
-/// best-effort error handling as [`du_walk`] — a missing directory or an
-/// unreadable entry contributes 0.
-fn du_walk_shallow(dir: &Path) -> u64 {
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return 0;
-    };
+/// belong to a different node instance and must not be charged here.
+///
+/// Returns `Err` when `dir` itself cannot be read. That is deliberate and is the
+/// difference between "measured 0" and "could not measure": see
+/// [`DiskUsageTracker::store_measurement`]. An individual unreadable entry
+/// inside a readable directory still contributes 0 (best effort).
+fn du_walk_shallow(dir: &Path) -> std::io::Result<u64> {
     let mut total: u64 = 0;
-    for entry in entries.flatten() {
+    for entry in std::fs::read_dir(dir)? {
+        let Ok(entry) = entry else {
+            continue;
+        };
         let Ok(file_type) = entry.file_type() else {
             continue;
         };
         if file_type.is_file() {
             if let Ok(meta) = entry.metadata() {
-                total = total.saturating_add(meta.len());
+                total = total.saturating_add(file_disk_bytes(&meta));
             }
         }
     }
-    total
+    Ok(total)
 }
 
-/// Recursively sum the byte size of every regular file under `dir`. A missing
-/// directory (not yet created) or an unreadable entry contributes 0 rather than
-/// erroring — the refresh path is best-effort telemetry, unlike the fail-loud
-/// state seed.
-fn du_walk(dir: &Path) -> u64 {
+/// Recursively sum the allocated size of every regular file under `dir`.
+///
+/// `Err` when the ROOT `dir` cannot be read (the caller keeps its previous
+/// measurement rather than recording a phantom 0); an unreadable *sub*directory
+/// or entry contributes 0, since a partial tree is still a better estimate than
+/// discarding the whole measurement.
+fn du_walk(dir: &Path) -> std::io::Result<u64> {
     let mut total: u64 = 0;
     let mut stack = vec![dir.to_path_buf()];
+    let mut at_root = true;
     while let Some(path) = stack.pop() {
-        let Ok(entries) = std::fs::read_dir(&path) else {
-            continue;
+        let entries = match std::fs::read_dir(&path) {
+            Ok(entries) => entries,
+            Err(err) if at_root => return Err(err),
+            Err(_) => continue,
         };
+        at_root = false;
         for entry in entries.flatten() {
             let Ok(file_type) = entry.file_type() else {
                 continue;
@@ -757,24 +1006,29 @@ fn du_walk(dir: &Path) -> u64 {
                 stack.push(entry.path());
             } else if file_type.is_file() {
                 if let Ok(meta) = entry.metadata() {
-                    total = total.saturating_add(meta.len());
+                    total = total.saturating_add(file_disk_bytes(&meta));
                 }
             }
         }
     }
-    total
+    Ok(total)
 }
 
 /// Like [`du_walk`] but only counts `*.wasm` files — the code-blob subset of
 /// `contracts_dir` (which also holds the `local/` mode split). Directory
 /// traversal is recursive so both the network and `local/` blobs are counted.
-fn du_walk_wasm(dir: &Path) -> u64 {
+/// Same root-vs-subtree error contract as [`du_walk`].
+fn du_walk_wasm(dir: &Path) -> std::io::Result<u64> {
     let mut total: u64 = 0;
     let mut stack = vec![dir.to_path_buf()];
+    let mut at_root = true;
     while let Some(path) = stack.pop() {
-        let Ok(entries) = std::fs::read_dir(&path) else {
-            continue;
+        let entries = match std::fs::read_dir(&path) {
+            Ok(entries) => entries,
+            Err(err) if at_root => return Err(err),
+            Err(_) => continue,
         };
+        at_root = false;
         for entry in entries.flatten() {
             let Ok(file_type) = entry.file_type() else {
                 continue;
@@ -785,13 +1039,13 @@ fn du_walk_wasm(dir: &Path) -> u64 {
                 let p = entry.path();
                 if p.extension().and_then(|e| e.to_str()) == Some("wasm") {
                     if let Ok(meta) = entry.metadata() {
-                        total = total.saturating_add(meta.len());
+                        total = total.saturating_add(file_disk_bytes(&meta));
                     }
                 }
             }
         }
     }
-    total
+    Ok(total)
 }
 
 /// Free bytes on the filesystem mount that holds `path`, as seen by an
@@ -895,13 +1149,48 @@ mod tests {
         DiskUsageTracker::new(nonexistent_paths())
     }
 
-    /// Write a file of `len` zero bytes at `path`, creating parents.
+    /// Write a file of `len` bytes at `path`, creating parents.
+    ///
+    /// The content is a cheap pseudo-random stream, not zeros, so a filesystem
+    /// with transparent compression (btrfs `compress`, ZFS) cannot collapse the
+    /// fixture to a fraction of its blocks and quietly change what the walks
+    /// measure. The walks charge ALLOCATED blocks, so fixture content matters.
     fn write_file(path: &Path, len: usize) {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent).unwrap();
         }
+        let mut state: u32 = 0x9E37_79B9;
+        let bytes: Vec<u8> = (0..len)
+            .map(|_| {
+                state = state.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+                (state >> 24) as u8
+            })
+            .collect();
         let mut f = std::fs::File::create(path).unwrap();
-        f.write_all(&vec![0u8; len]).unwrap();
+        f.write_all(&bytes).unwrap();
+    }
+
+    /// The disk `path` actually occupies, re-derived independently of the code
+    /// under test.
+    ///
+    /// Fixture files are small, so their allocated size is the filesystem's
+    /// block size rather than the byte count written; and the block size varies
+    /// by filesystem, so a hard-coded expectation would be wrong somewhere. The
+    /// walk tests below therefore assert *which files were counted*, and
+    /// [`file_disk_bytes`]'s own rule — allocated, not apparent — is pinned
+    /// separately by `sparse_file_is_charged_by_allocation_not_apparent_length`
+    /// and `block_slack_on_a_small_file_is_charged`.
+    fn alloc(path: &Path) -> u64 {
+        let meta = std::fs::metadata(path).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            meta.blocks() * 512
+        }
+        #[cfg(not(unix))]
+        {
+            meta.len()
+        }
     }
 
     #[test]
@@ -988,11 +1277,17 @@ mod tests {
             contracts_dir: contracts.clone(),
             ..nonexistent_paths()
         });
+        let blobs =
+            alloc(&contracts.join("aaaa.wasm")) + alloc(&contracts.join("local").join("bbbb.wasm"));
         t.seed(std::iter::empty());
-        assert_eq!(t.stats().wasm_bytes, 140);
+        assert_eq!(
+            t.stats().wasm_bytes,
+            blobs,
+            "both blobs counted, the non-wasm sibling not"
+        );
         // Re-walking is deduped by construction (same files) — idempotent.
         t.refresh_wasm();
-        assert_eq!(t.stats().wasm_bytes, 140);
+        assert_eq!(t.stats().wasm_bytes, blobs);
     }
 
     #[test]
@@ -1185,6 +1480,83 @@ mod tests {
         assert_eq!(err.budget_bytes, 149);
     }
 
+    /// Growth that fits inside the database's dead space is admitted even when
+    /// the node is over budget, because it costs no disk.
+    ///
+    /// redb reuses freed pages rather than truncating, so a write that keeps
+    /// total live state at or below the measured file size does not grow the
+    /// file by a byte. Refusing it would abort the merge while the node kept
+    /// serving and advertising the contract — invariant 1's stale host — and
+    /// would free nothing, since eviction has no lever on dead space either.
+    #[test]
+    fn admit_state_update_growth_absorbed_by_dead_space_is_admitted_over_budget() {
+        let t = tracker();
+        t.seed([(test_key(1), 100)]);
+        // 1000-byte file holding 100 bytes of live rows: 900 bytes of dead space.
+        t.set_db_file_bytes_for_test(1000);
+        assert_eq!(t.total_bytes(), 1000);
+
+        // Well over budget: a fresh PUT is refused, as it should be.
+        assert!(t.admit_state_write(&test_key(2), 1, 500).is_err());
+
+        // The same node must still merge a growing UPDATE that fits in the dead
+        // space: live state goes 100 → 900, the file does not move.
+        assert!(
+            t.admit_state_update(&test_key(1), 900, 500).is_ok(),
+            "growth inside the dead space costs no disk and must not be refused"
+        );
+        // Right up to the file size.
+        assert!(t.admit_state_update(&test_key(1), 1000, 500).is_ok());
+    }
+
+    /// The exemption stops exactly where the dead space does: growth that would
+    /// push live state past the measured file DOES enlarge the footprint, and is
+    /// held to the budget like any other growth.
+    #[test]
+    fn admit_state_update_growth_beyond_dead_space_is_still_bounded() {
+        let t = tracker();
+        t.seed([(test_key(1), 100)]);
+        t.set_db_file_bytes_for_test(1000);
+
+        let err = t
+            .admit_state_update(&test_key(1), 1001, 1000)
+            .expect_err("growth past the file must be charged");
+        assert_eq!(
+            err.projected_bytes, 1001,
+            "projection is max(file, state − old + new), not the file plus the delta"
+        );
+        assert_eq!(err.budget_bytes, 1000);
+        // …and is admitted when the budget has room for the real increment.
+        assert!(t.admit_state_update(&test_key(1), 1001, 1001).is_ok());
+    }
+
+    /// The projection must not charge the delta on top of a file that will not
+    /// move. Before this rule, `total − old + new` against a file-dominated
+    /// total over-charged every growing UPDATE by its full delta.
+    #[test]
+    fn admit_state_update_does_not_charge_growth_twice_against_the_file() {
+        let t = tracker();
+        t.seed([(test_key(1), 100)]);
+        t.set_db_file_bytes_for_test(1000);
+        // Budget exactly at the measured file. Growing the key by 1 byte inside
+        // 900 bytes of dead space must not be projected past it.
+        assert!(
+            t.admit_state_update(&test_key(1), 101, 1000).is_ok(),
+            "the file is the footprint; the delta lands inside it"
+        );
+    }
+
+    /// The exemption is scoped to UPDATEs. A fresh PUT on an over-budget node is
+    /// still refused: admitting new tenants is the decision the budget exists to
+    /// make, and a PUT has no already-hosted state whose merge would stall.
+    #[test]
+    fn dead_space_does_not_exempt_a_fresh_put() {
+        let t = tracker();
+        t.seed(std::iter::empty());
+        t.set_db_file_bytes_for_test(1000);
+        assert!(t.admit_state_write(&test_key(1), 1, 500).is_err());
+    }
+
     #[test]
     fn admit_state_update_is_read_only() {
         // Like admit_state_write, the growth-only check never mutates the counter.
@@ -1271,15 +1643,217 @@ mod tests {
             wasmtime_cache_dir: cache.clone(),
             ..nonexistent_paths()
         });
+        let nested = alloc(&cache.join("sub").join("mod.cache"));
         t.seed(std::iter::empty());
-        assert_eq!(t.stats().compile_cache_bytes, 512);
+        assert_eq!(
+            t.stats().compile_cache_bytes,
+            nested,
+            "the walk descends into subdirectories"
+        );
 
         // Grow the cache; a refresh must observe the new total.
         let mut g = std::fs::File::create(cache.join("mod2.cache")).unwrap();
         g.write_all(&[0u8; 88]).unwrap();
+        let both = nested + alloc(&cache.join("mod2.cache"));
         t.refresh_compile_cache();
-        assert_eq!(t.stats().compile_cache_bytes, 600);
-        assert_eq!(t.total_bytes(), 600);
+        assert_eq!(t.stats().compile_cache_bytes, both);
+        assert_eq!(t.total_bytes(), both);
+    }
+
+    // --- How a file is measured: allocation, not apparent length -------------
+
+    /// A SPARSE file must be charged for the blocks it actually occupies, not
+    /// for the length `ls` reports.
+    ///
+    /// Measured on the production gateway (2026-07-29): the redb database
+    /// reported 2,749,370,368 bytes of apparent length against 1,839,210,496
+    /// bytes allocated — a 910 MB / 49% over-charge on the term that dominates
+    /// the aggregate. Over-charging makes the admission gate refuse writes the
+    /// disk can still take, which is the same class of dishonesty as the
+    /// under-count #5007 fixed, pointing the other way. (The same file on
+    /// another peer was not sparse at all, so no constant correction exists.)
+    #[cfg(unix)]
+    #[test]
+    fn sparse_file_is_charged_by_allocation_not_apparent_length() {
+        const APPARENT: u64 = 64 * 1024 * 1024;
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("db");
+        std::fs::create_dir_all(&db).unwrap();
+        // A hole, not data: length without allocation, exactly the shape redb's
+        // file takes on the peers where this was measured.
+        std::fs::File::create(db.join("db"))
+            .unwrap()
+            .set_len(APPARENT)
+            .unwrap();
+        assert_eq!(
+            std::fs::metadata(db.join("db")).unwrap().len(),
+            APPARENT,
+            "fixture must have the large apparent length we are testing against"
+        );
+
+        let t = DiskUsageTracker::new(HostingDiskPaths {
+            db_dir: db.clone(),
+            ..nonexistent_paths()
+        });
+        t.seed(std::iter::empty());
+        let measured = t.stats().db_file_bytes;
+        assert_eq!(
+            measured,
+            alloc(&db.join("db")),
+            "the walk must report the allocated size"
+        );
+        assert!(
+            measured < APPARENT / 2,
+            "a hole occupies no disk, so charging it would over-state the \
+             dominant term (measured {measured} against {APPARENT} apparent)"
+        );
+    }
+
+    /// The other direction of the same rule: a file smaller than one filesystem
+    /// block still consumes a whole block, and the budget's `available` term
+    /// (`statvfs` free blocks) has already accounted for it. Charging the
+    /// apparent length would under-state usage against a basis measured in
+    /// blocks.
+    #[cfg(unix)]
+    #[test]
+    fn block_slack_on_a_small_file_is_charged() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("db");
+        write_file(&db.join("db"), 1);
+
+        let t = DiskUsageTracker::new(HostingDiskPaths {
+            db_dir: db.clone(),
+            ..nonexistent_paths()
+        });
+        t.seed(std::iter::empty());
+        assert_eq!(t.stats().db_file_bytes, alloc(&db.join("db")));
+        assert!(
+            t.stats().db_file_bytes > 1,
+            "a one-byte file occupies a whole block, and `available` already \
+             reflects that block being gone"
+        );
+    }
+
+    // --- A failed measurement is not a measurement of zero -------------------
+
+    /// A `du`-walk that CANNOT read its directory must keep the gauge's previous
+    /// value, not record 0.
+    ///
+    /// Recording 0 for the database directory reverts `max(state, 0) == state`
+    /// to exactly the pre-#5007 under-count, silently, with a perfectly
+    /// plausible `hosting_disk_db_bytes: 0` in telemetry and nothing to
+    /// contradict it. Under a persistent EACCES it is permanent and looks
+    /// identical to a healthy small node.
+    ///
+    /// The failure is injected by replacing the directory with a FILE (ENOTDIR),
+    /// which fails for root as well — a permissions-based fixture would silently
+    /// pass by measuring successfully when the suite runs as root.
+    #[test]
+    fn an_unreadable_database_directory_keeps_the_previous_measurement() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("db");
+        write_file(&db.join("db"), 256 * 1024);
+
+        let t = DiskUsageTracker::new(HostingDiskPaths {
+            db_dir: db.clone(),
+            ..nonexistent_paths()
+        });
+        t.seed([(test_key(1), 10)]);
+        let measured = t.stats().db_file_bytes;
+        assert!(
+            measured > 0,
+            "fixture must measure something to then retain"
+        );
+
+        // The directory becomes unreadable (ENOTDIR here; EACCES/EMFILE in
+        // production).
+        std::fs::remove_dir_all(&db).unwrap();
+        write_file(&db, 8);
+        assert!(std::fs::read_dir(&db).is_err(), "fixture must make it fail");
+
+        t.refresh_db_file();
+        assert_eq!(
+            t.stats().db_file_bytes,
+            measured,
+            "a failed measurement must not be published as zero"
+        );
+        assert_eq!(
+            t.total_bytes(),
+            measured,
+            "and so the aggregate must not collapse to the pre-#5007 row sum"
+        );
+    }
+
+    /// Same rule for the webapp cache, which is walked recursively.
+    #[test]
+    fn an_unreadable_webapp_cache_keeps_the_previous_measurement() {
+        let dir = tempfile::tempdir().unwrap();
+        let webapp = dir.path().join("webapp");
+        write_file(&webapp.join("aaaa").join("index.html"), 256 * 1024);
+
+        let t = DiskUsageTracker::new(HostingDiskPaths {
+            webapp_cache_dir: webapp.clone(),
+            ..nonexistent_paths()
+        });
+        t.seed(std::iter::empty());
+        let measured = t.stats().webapp_cache_bytes;
+        assert!(measured > 0);
+
+        std::fs::remove_dir_all(&webapp).unwrap();
+        write_file(&webapp, 8);
+        t.refresh_webapp_cache();
+        assert_eq!(t.stats().webapp_cache_bytes, measured);
+    }
+
+    /// A directory that does not exist is a legitimate measurement of zero, NOT
+    /// a failure: that is the state of a store not yet created, and of every
+    /// unit-test tracker pointed at nonexistent paths. Retaining a stale value
+    /// there would be its own kind of lie.
+    #[test]
+    fn a_missing_directory_measures_zero_rather_than_retaining() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("db");
+        write_file(&db.join("db"), 256 * 1024);
+
+        let t = DiskUsageTracker::new(HostingDiskPaths {
+            db_dir: db.clone(),
+            ..nonexistent_paths()
+        });
+        t.seed(std::iter::empty());
+        assert!(t.stats().db_file_bytes > 0);
+
+        std::fs::remove_dir_all(&db).unwrap();
+        t.refresh_db_file();
+        assert_eq!(t.stats().db_file_bytes, 0, "gone means zero, not retained");
+    }
+
+    /// A recoverable failure must not poison the gauge: once the directory is
+    /// readable again the measurement resumes.
+    #[test]
+    fn measurement_resumes_after_a_transient_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("db");
+        write_file(&db.join("db"), 256 * 1024);
+
+        let t = DiskUsageTracker::new(HostingDiskPaths {
+            db_dir: db.clone(),
+            ..nonexistent_paths()
+        });
+        t.seed(std::iter::empty());
+        let first = t.stats().db_file_bytes;
+
+        std::fs::remove_dir_all(&db).unwrap();
+        write_file(&db, 8);
+        t.refresh_db_file();
+        assert_eq!(t.stats().db_file_bytes, first);
+
+        // Readable again, and larger.
+        std::fs::remove_file(&db).unwrap();
+        write_file(&db.join("db"), 512 * 1024);
+        let grown = alloc(&db.join("db"));
+        assert!(grown > first);
+        t.refresh_db_file();
+        assert_eq!(t.stats().db_file_bytes, grown);
     }
 
     // --- Database-file measurement (#5007) -----------------------------------
@@ -1295,16 +1869,17 @@ mod tests {
         write_file(&db.join("db"), 4000);
 
         let t = DiskUsageTracker::new(HostingDiskPaths {
-            db_dir: db,
+            db_dir: db.clone(),
             ..nonexistent_paths()
         });
+        let file = alloc(&db.join("db"));
         // Logical rows total only 400 — the pre-#5007 figure.
         t.seed([(test_key(1), 300), (test_key(2), 100)]);
         assert_eq!(t.stats().state_bytes, 400, "logical rows still reported");
-        assert_eq!(t.stats().db_file_bytes, 4000);
+        assert_eq!(t.stats().db_file_bytes, file);
         assert_eq!(
             t.total_bytes(),
-            4000,
+            file,
             "aggregate must reflect the database file, not the row sum"
         );
     }
@@ -1324,11 +1899,12 @@ mod tests {
         write_file(&db.join("db"), 1000);
 
         let t = DiskUsageTracker::new(HostingDiskPaths {
-            db_dir: db,
+            db_dir: db.clone(),
             ..nonexistent_paths()
         });
+        let file = alloc(&db.join("db"));
         t.seed([(test_key(1), 600), (test_key(2), 400)]);
-        assert_eq!(t.total_bytes(), 1000);
+        assert_eq!(t.total_bytes(), file);
 
         // Shed everything. The file did not shrink, so neither does the figure.
         t.record_state_removed(&test_key(1));
@@ -1336,7 +1912,7 @@ mod tests {
         assert_eq!(t.stats().state_bytes, 0);
         assert_eq!(
             t.total_bytes(),
-            1000,
+            file,
             "shedding rows must not fictitiously reduce the measured footprint"
         );
     }
@@ -1351,16 +1927,17 @@ mod tests {
         write_file(&db.join("db"), 500);
 
         let t = DiskUsageTracker::new(HostingDiskPaths {
-            db_dir: db,
+            db_dir: db.clone(),
             ..nonexistent_paths()
         });
+        let file = alloc(&db.join("db"));
         t.seed(std::iter::empty());
-        assert_eq!(t.total_bytes(), 500, "measured file dominates while idle");
+        assert_eq!(t.total_bytes(), file, "measured file dominates while idle");
 
         // A write burst pushes live bytes past the last measurement; the file
         // must have grown at least that far, so the live figure takes over.
-        t.record_state_write(&test_key(1), 900);
-        assert_eq!(t.total_bytes(), 900);
+        t.record_state_write(&test_key(1), file + 400);
+        assert_eq!(t.total_bytes(), file + 400);
     }
 
     #[test]
@@ -1377,14 +1954,20 @@ mod tests {
         write_file(&db.join("local").join("db"), 9999);
 
         let t = DiskUsageTracker::new(HostingDiskPaths {
-            db_dir: db,
+            db_dir: db.clone(),
             ..nonexistent_paths()
         });
+        let siblings = alloc(&db.join("db")) + alloc(&db.join("db.backup"));
         t.seed(std::iter::empty());
         assert_eq!(
             t.stats().db_file_bytes,
-            125,
+            siblings,
             "shallow walk counts siblings of the database but not the local/ split"
+        );
+        assert!(
+            t.stats().db_file_bytes < siblings + alloc(&db.join("local").join("db")),
+            "the local/ split must be excluded, and the fixture must make its \
+             inclusion visible"
         );
     }
 
@@ -1409,15 +1992,19 @@ mod tests {
             db_dir: db.clone(),
             ..nonexistent_paths()
         });
+        let seeded = alloc(&db.join("db"));
         t.seed(std::iter::empty());
-        assert_eq!(t.total_bytes(), 200);
+        assert_eq!(t.total_bytes(), seeded);
 
         // The database grows (copy-on-write dead space, new pages, whatever) —
-        // the next sweep's re-measure must pick it up.
-        write_file(&db.join("db"), 1500);
+        // the next sweep's re-measure must pick it up. The growth spans several
+        // filesystem blocks so it is visible whatever the block size is.
+        write_file(&db.join("db"), 256 * 1024);
+        let grown = alloc(&db.join("db"));
+        assert!(grown > seeded, "fixture must actually grow the allocation");
         t.refresh_db_file();
-        assert_eq!(t.stats().db_file_bytes, 1500);
-        assert_eq!(t.total_bytes(), 1500);
+        assert_eq!(t.stats().db_file_bytes, grown);
+        assert_eq!(t.total_bytes(), grown);
     }
 
     #[test]
@@ -1431,18 +2018,20 @@ mod tests {
         write_file(&db.join("db"), 1000);
 
         let t = DiskUsageTracker::new(HostingDiskPaths {
-            db_dir: db,
+            db_dir: db.clone(),
             ..nonexistent_paths()
         });
+        // Budget == the measured file, so the node is exactly full.
+        let budget = alloc(&db.join("db"));
         t.seed(std::iter::empty()); // zero logical rows
         assert!(
-            t.admit_state_write(&test_key(1), 1, 1000).is_err(),
+            t.admit_state_write(&test_key(1), 1, budget).is_err(),
             "a full database must refuse a fresh PUT even with no rows tracked"
         );
         // Sanity: the same call against the pre-#5007 figure would have admitted.
         let blind = tracker();
         blind.seed(std::iter::empty());
-        assert!(blind.admit_state_write(&test_key(1), 1, 1000).is_ok());
+        assert!(blind.admit_state_write(&test_key(1), 1, budget).is_ok());
     }
 
     // --- Webapp cache: measured and reported, never budgeted (#5007) ----------
@@ -1460,12 +2049,15 @@ mod tests {
             webapp_cache_dir: webapp.clone(),
             ..nonexistent_paths()
         });
+        let seeded = alloc(&webapp.join("aaaa").join("index.html"))
+            + alloc(&webapp.join("bbbb").join("app.js"));
         t.seed(std::iter::empty());
-        assert_eq!(t.stats().webapp_cache_bytes, 500);
+        assert_eq!(t.stats().webapp_cache_bytes, seeded);
 
         write_file(&webapp.join("cccc").join("app.js"), 50);
+        let grown = seeded + alloc(&webapp.join("cccc").join("app.js"));
         t.refresh_webapp_cache();
-        assert_eq!(t.stats().webapp_cache_bytes, 550);
+        assert_eq!(t.stats().webapp_cache_bytes, grown);
     }
 
     #[test]
@@ -1480,11 +2072,13 @@ mod tests {
         write_file(&webapp.join("aaaa").join("index.html"), 4096);
 
         let t = DiskUsageTracker::new(HostingDiskPaths {
-            webapp_cache_dir: webapp,
+            webapp_cache_dir: webapp.clone(),
             ..nonexistent_paths()
         });
+        let cached = alloc(&webapp.join("aaaa").join("index.html"));
         t.seed([(test_key(1), 100)]);
-        assert_eq!(t.stats().webapp_cache_bytes, 4096, "measured");
+        assert_eq!(t.stats().webapp_cache_bytes, cached, "measured");
+        assert!(cached > 0, "fixture must have measurable bytes to exclude");
         assert_eq!(t.total_bytes(), 100, "but not budgeted");
         assert_eq!(t.stats().total_bytes, 100);
         // ...so it cannot influence the admission gate either.
@@ -1495,16 +2089,31 @@ mod tests {
     fn all_four_measured_dirs_are_read_from_their_own_path() {
         // Guards the transposition hazard `HostingDiskPaths` exists to make
         // unlikely: four same-typed paths, each of which must feed exactly one
-        // gauge. Distinct sizes make any swap visible.
+        // gauge. Distinct sizes make any swap visible — and they have to differ
+        // by whole filesystem blocks, since the walks charge allocation, so a
+        // few bytes apart would collapse to the same measurement.
+        const BLOCKS: usize = 64 * 1024;
         let dir = tempfile::tempdir().unwrap();
         let contracts = dir.path().join("contracts");
         let wasmtime = dir.path().join("wasmtime");
         let db = dir.path().join("db");
         let webapp = dir.path().join("webapp");
-        write_file(&contracts.join("aaaa.wasm"), 11);
-        write_file(&wasmtime.join("mod.cache"), 22);
-        write_file(&db.join("db"), 33);
-        write_file(&webapp.join("aaaa").join("index.html"), 44);
+        write_file(&contracts.join("aaaa.wasm"), BLOCKS);
+        write_file(&wasmtime.join("mod.cache"), 2 * BLOCKS);
+        write_file(&db.join("db"), 3 * BLOCKS);
+        write_file(&webapp.join("aaaa").join("index.html"), 4 * BLOCKS);
+        let wasm = alloc(&contracts.join("aaaa.wasm"));
+        let compile = alloc(&wasmtime.join("mod.cache"));
+        let dbf = alloc(&db.join("db"));
+        let web = alloc(&webapp.join("aaaa").join("index.html"));
+        assert_eq!(
+            [wasm, compile, dbf, web]
+                .iter()
+                .collect::<std::collections::HashSet<_>>()
+                .len(),
+            4,
+            "fixture sizes must stay distinct or a transposition would be invisible"
+        );
 
         let t = DiskUsageTracker::new(HostingDiskPaths {
             contracts_dir: contracts,
@@ -1514,12 +2123,12 @@ mod tests {
         });
         t.seed(std::iter::empty());
         let s = t.stats();
-        assert_eq!(s.wasm_bytes, 11);
-        assert_eq!(s.compile_cache_bytes, 22);
-        assert_eq!(s.db_file_bytes, 33);
-        assert_eq!(s.webapp_cache_bytes, 44);
-        // Budgeted aggregate = max(state=0, db=33) + wasm + compile cache.
-        assert_eq!(s.total_bytes, 33 + 11 + 22);
+        assert_eq!(s.wasm_bytes, wasm);
+        assert_eq!(s.compile_cache_bytes, compile);
+        assert_eq!(s.db_file_bytes, dbf);
+        assert_eq!(s.webapp_cache_bytes, web);
+        // Budgeted aggregate = max(state=0, db) + wasm + compile cache.
+        assert_eq!(s.total_bytes, dbf + wasm + compile);
     }
 
     /// `available_bytes` on a real, existing mount returns a plausible positive

--- a/crates/core/src/ring/hosting/disk_usage.rs
+++ b/crates/core/src/ring/hosting/disk_usage.rs
@@ -22,13 +22,8 @@
 //!
 //! Three independently-measured consumers, summed by [`DiskUsageTracker::total_bytes`]:
 //!
-//! - **Hosted contract state** — the exact byte total of persisted contract
-//!   state. Seeded once by summing every row's
-//!   [`HostingMetadata::size_bytes`](crate::contract::storages::HostingMetadata)
-//!   and thereafter maintained by signed deltas at the executor's state-write
-//!   chokepoints (via [`super::HostingManager::record_state_write`]) and at
-//!   reclamation (via [`super::HostingManager::record_state_removed`]). A small
-//!   per-key size index makes the delta exact without re-reading the DB.
+//! - **Storage-backend footprint** — `max(state_bytes, db_file_bytes)`, see
+//!   "Logical state vs the database file" below.
 //! - **WASM code blobs** — the `*.wasm` files under `contracts_dir`. Re-walked
 //!   (`du`) on seed and on each telemetry refresh; blobs dedupe by `code_hash`
 //!   so a re-PUT of already-stored code adds nothing.
@@ -36,6 +31,85 @@
 //!   delta-tracked; it is re-walked on each telemetry refresh. Cheap: bounded by
 //!   the number of distinct compiled modules and self-pruned by wasmtime at its
 //!   soft-size limit.
+//!
+//! A fourth consumer, the **unpacked-webapp cache**, is measured and REPORTED
+//! but deliberately excluded from the budgeted aggregate — see "The webapp
+//! cache is reported, not budgeted".
+//!
+//! # Logical state vs the database file (#5007)
+//!
+//! Until #5007 the storage term was the *logical* state total alone: the sum of
+//! every hosted contract's serialized state bytes, seeded from
+//! [`HostingMetadata::size_bytes`](crate::contract::storages::HostingMetadata)
+//! rows and thereafter maintained by signed deltas at the executor's state-write
+//! chokepoints (via [`super::HostingManager::record_state_write`]) and at
+//! reclamation (via [`super::HostingManager::record_state_removed`]). A small
+//! per-key size index makes those deltas exact without re-reading the DB.
+//!
+//! That figure under-counted the real footprint by roughly **10x** on a
+//! long-lived peer: redb is copy-on-write and only ever truncates *trailing*
+//! free space, so the interior dead space a busy node accumulates is invisible
+//! to any row-level accounting. Measured on a production peer (2026-07): 583 MB
+//! reported against 2.68 GB actually occupied.
+//!
+//! So the storage term is now `max(state_bytes, db_file_bytes)`, where
+//! `db_file_bytes` is a **measurement** of the database directory taken on the
+//! existing 60s sweep ([`DiskUsageTracker::refresh_db_file`]). The two halves
+//! answer different questions and the `max` is what makes them compose:
+//!
+//! - `db_file_bytes` is exact but stale by up to one sweep window, and it is the
+//!   only thing that can see dead space. It dominates in steady state.
+//! - `state_bytes` is live and exact at the write chokepoint. It dominates only
+//!   when a burst of writes within one sweep window has already pushed live
+//!   bytes past the last measured file size — in which case the file must have
+//!   grown at least that far, so the `max` is still a sound lower bound.
+//!
+//! Two properties follow, both load-bearing:
+//!
+//! 1. **Eviction cannot fictitiously shrink the figure.** Deleting rows frees
+//!    redb pages for *reuse* without shrinking the file, so a decomposition like
+//!    `state + (file − state)` would let a shedding node watch its own overhead
+//!    term inflate to exactly cancel the state it just freed — an eviction
+//!    treadmill that never converges. Under `max`, shedding state simply leaves
+//!    the figure at the measured file size, which is the truth.
+//! 2. **An unmeasured database degrades to the pre-#5007 behavior.**
+//!    `db_file_bytes` is 0 until the first measurement (and stays 0 for a
+//!    tracker configured with no database directory, e.g. unit tests), and
+//!    `max(state, 0) == state`.
+//!
+//! The measurement is periodic rather than delta-tracked because a file length
+//! is not something a write chokepoint can compute: redb extends the file when
+//! it needs a new page, not per row, so a per-write `metadata()` would be a
+//! syscall on the PUT hot path (under the `state_sizes` lock, which
+//! [`DiskUsageTracker::admit_state_write`] holds across
+//! [`DiskUsageTracker::total_bytes`]) in exchange for no extra accuracy. The
+//! live `state_bytes` delta already captures the marginal cost of an in-flight
+//! write; the sweep reconciles it against ground truth once a minute.
+//!
+//! # The webapp cache is reported, not budgeted (#5007)
+//!
+//! The unpacked-webapp cache (XDG cache dir, `~/.cache/freenet/webapp_cache`)
+//! was also entirely absent — measured at 1236 MiB / 82 entries on one peer.
+//! [`DiskUsageTracker::refresh_webapp_cache`] now measures it on the same sweep
+//! and [`DiskUsageStats::webapp_cache_bytes`] reports it, but it is NOT part of
+//! [`DiskUsageTracker::total_bytes`]. Three reasons, all of which have to hold:
+//!
+//! - **It is already bounded.** `WEBAPP_CACHE_MAX_BYTES` (64 MiB, #5012) is a
+//!   hard LRU cap. Charging a hard-capped 64 MiB against a hosting budget whose
+//!   own floor is 128 MiB would spend up to half a small node's entire hosting
+//!   allowance re-bounding something already bounded.
+//! - **Hosting eviction cannot act on it.** The eviction sweep sheds hosted
+//!   contracts; it has no lever on webapp entries. Charging a term the
+//!   enforcement mechanism cannot move is the same failure shape as charging
+//!   redb dead space, and it is why property 1 above matters.
+//! - **It may not even be on the same mount.** The disk budget's basis is
+//!   `used + available` where `available` is a `statvfs` of the *contracts-dir*
+//!   mount. XDG cache and XDG data are the same mount on the standard layout but
+//!   are not required to be, so folding cache bytes into that basis can be
+//!   dimensionally wrong.
+//!
+//! Visibility was the actual defect for these bytes: nothing measured or
+//! reported them. That is fixed; double-bounding them is not.
 //!
 //! # Seeding discipline (fail-loud)
 //!
@@ -80,6 +154,28 @@ impl std::fmt::Display for DiskBudgetExceeded {
     }
 }
 
+/// The four directories the aggregate disk-usage tracker measures (#4683,
+/// #5007).
+///
+/// A struct rather than four positional parameters because all four are
+/// `PathBuf`: a transposed pair would compile, type-check, and silently
+/// mis-account (the webapp cache measured as the database, say). Named fields
+/// make the one production call site — `contract/handler.rs` — say what it
+/// means, and give its pin test an unambiguous needle.
+#[derive(Debug, Clone)]
+pub(crate) struct HostingDiskPaths {
+    /// Mode-resolved `contracts_dir`, holding the `*.wasm` code blobs.
+    pub contracts_dir: PathBuf,
+    /// Relocated wasmtime compile-cache dir (on the data-dir mount).
+    pub wasmtime_cache_dir: PathBuf,
+    /// Mode-resolved `db_dir`, holding the storage backend's database file
+    /// (`db` for redb, `freenet.db` for sqlite) plus any sidecars.
+    pub db_dir: PathBuf,
+    /// Unpacked-webapp cache root (XDG cache dir). Measured and reported, NOT
+    /// charged against the hosting budget — see the module docs.
+    pub webapp_cache_dir: PathBuf,
+}
+
 /// Point-in-time on-disk usage gauges, one snapshot for telemetry.
 ///
 /// Aggregate scalars only, emitted on the existing `RouterSnapshot` cadence
@@ -88,12 +184,21 @@ impl std::fmt::Display for DiskBudgetExceeded {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub(crate) struct DiskUsageStats {
     /// Persisted contract-state bytes (delta-tracked, seeded from redb rows).
+    /// The *logical* total: `db_file_bytes − state_bytes` is the database's dead
+    /// space, which is why both are reported separately (#5007).
     pub state_bytes: u64,
+    /// Measured byte size of the storage backend's database directory (#5007).
+    /// 0 before the first sweep measurement.
+    pub db_file_bytes: u64,
     /// On-disk WASM code blob bytes (`du` of `contracts_dir/*.wasm`).
     pub wasm_bytes: u64,
     /// Wasmtime compile-cache bytes (`du` of the relocated cache dir).
     pub compile_cache_bytes: u64,
-    /// Sum of the three above — the aggregate the disk budget bounds.
+    /// Measured byte size of the unpacked-webapp cache (#5007). REPORTED ONLY —
+    /// deliberately excluded from `total_bytes`; see the module docs.
+    pub webapp_cache_bytes: u64,
+    /// `max(state_bytes, db_file_bytes) + wasm_bytes + compile_cache_bytes` —
+    /// the aggregate the disk budget bounds. Excludes `webapp_cache_bytes`.
     pub total_bytes: u64,
 }
 
@@ -125,24 +230,33 @@ pub(crate) struct DiskUsageTracker {
     /// reopen that race and turn the counter into a load-bearing under-count
     /// now that the admission gate reads it (#4702).
     state_sizes: Mutex<HashMap<ContractKey, u64>>,
-    /// Directory holding `*.wasm` code blobs (mode-resolved `contracts_dir`).
-    contracts_dir: PathBuf,
-    /// Relocated wasmtime compile-cache directory (on the data-dir mount).
-    compile_cache_dir: PathBuf,
+    /// Measured byte size of the storage backend's database directory (#5007).
+    /// Refreshed by a shallow walk on the 60s sweep, never delta-tracked (a file
+    /// length is not computable at a write chokepoint). 0 until the first
+    /// measurement, which makes [`Self::total_bytes`] degrade exactly to the
+    /// pre-#5007 logical-state sum.
+    db_file_bytes: AtomicU64,
+    /// Measured byte size of the unpacked-webapp cache (#5007). Refreshed on the
+    /// same sweep. REPORTED ONLY — never part of [`Self::total_bytes`]; see the
+    /// module docs for why double-bounding it would be wrong.
+    webapp_cache_bytes: AtomicU64,
+    /// The directories all of the above are measured from.
+    paths: HostingDiskPaths,
 }
 
 impl DiskUsageTracker {
     /// Create an unseeded tracker. All counters start at zero; call
     /// [`Self::seed`] once before the counts are meaningful.
-    pub(crate) fn new(contracts_dir: PathBuf, compile_cache_dir: PathBuf) -> Self {
+    pub(crate) fn new(paths: HostingDiskPaths) -> Self {
         Self {
             state_bytes: AtomicU64::new(0),
             wasm_bytes: AtomicU64::new(0),
             compile_cache_bytes: AtomicU64::new(0),
             seeded: AtomicBool::new(false),
             state_sizes: Mutex::new(HashMap::new()),
-            contracts_dir,
-            compile_cache_dir,
+            db_file_bytes: AtomicU64::new(0),
+            webapp_cache_bytes: AtomicU64::new(0),
+            paths,
         }
     }
 
@@ -151,16 +265,36 @@ impl DiskUsageTracker {
         self.seeded.load(Ordering::Acquire)
     }
 
-    /// Aggregate on-disk bytes = state + wasm + compile-cache. The value the
-    /// disk budget bounds. Cheap (three atomic loads).
+    /// The storage backend's real on-disk footprint (#5007):
+    /// `max(state_bytes, db_file_bytes)`.
+    ///
+    /// Neither term alone is right. `db_file_bytes` is the only one that can see
+    /// the database's dead space but is stale by up to one sweep window;
+    /// `state_bytes` is live and exact at the write chokepoint but blind to
+    /// everything except serialized row payloads. Taking the larger keeps the
+    /// measured file as the floor (so shedding rows can never fictitiously
+    /// shrink the figure — redb reuses freed pages rather than truncating) while
+    /// still tracking a within-window write burst that has already pushed live
+    /// bytes past the last measurement. See the module docs.
+    fn storage_bytes(&self) -> u64 {
+        self.state_bytes
+            .load(Ordering::Relaxed)
+            .max(self.db_file_bytes.load(Ordering::Relaxed))
+    }
+
+    /// Aggregate on-disk bytes = storage footprint + wasm + compile-cache. The
+    /// value the disk budget bounds. Cheap (four atomic loads).
     ///
     /// Read live by the eviction floor
     /// ([`super::HostingManager::recompute_effective_budget`]) and the pre-write
     /// admission gate ([`Self::admit_state_write`]), both wired in #4702, plus the
     /// telemetry snapshot path.
+    ///
+    /// Excludes the webapp cache on purpose (#5007) — it is measured and
+    /// reported via [`Self::stats`], but hosting eviction has no lever on it and
+    /// #5012 already caps it. See the module docs.
     pub(crate) fn total_bytes(&self) -> u64 {
-        self.state_bytes
-            .load(Ordering::Relaxed)
+        self.storage_bytes()
             .saturating_add(self.wasm_bytes.load(Ordering::Relaxed))
             .saturating_add(self.compile_cache_bytes.load(Ordering::Relaxed))
     }
@@ -168,13 +302,17 @@ impl DiskUsageTracker {
     /// Snapshot all gauges for telemetry.
     pub(crate) fn stats(&self) -> DiskUsageStats {
         let state_bytes = self.state_bytes.load(Ordering::Relaxed);
+        let db_file_bytes = self.db_file_bytes.load(Ordering::Relaxed);
         let wasm_bytes = self.wasm_bytes.load(Ordering::Relaxed);
         let compile_cache_bytes = self.compile_cache_bytes.load(Ordering::Relaxed);
         DiskUsageStats {
             state_bytes,
+            db_file_bytes,
             wasm_bytes,
             compile_cache_bytes,
+            webapp_cache_bytes: self.webapp_cache_bytes.load(Ordering::Relaxed),
             total_bytes: state_bytes
+                .max(db_file_bytes)
                 .saturating_add(wasm_bytes)
                 .saturating_add(compile_cache_bytes),
         }
@@ -183,7 +321,9 @@ impl DiskUsageTracker {
     /// Seed the state-bytes counter and per-key size index from an exact list of
     /// `(contract, state_size)` pairs (the caller reads these from redb rows so
     /// this module stays storage-backend-agnostic and unit-testable). Also runs
-    /// the initial WASM + compile-cache `du`-walks.
+    /// the initial WASM, compile-cache, database-file and webapp-cache
+    /// measurements, so every gauge is meaningful the moment `is_seeded` flips
+    /// (the telemetry and budget paths both gate on that flag).
     ///
     /// Idempotent-guarded: only the FIRST call takes effect; later calls are a
     /// no-op so a racing second sweep tick cannot double-count.
@@ -250,10 +390,10 @@ impl DiskUsageTracker {
         self.state_bytes.store(total, Ordering::Relaxed);
         drop(sizes);
 
-        self.wasm_bytes
-            .store(du_walk_wasm(&self.contracts_dir), Ordering::Relaxed);
-        self.compile_cache_bytes
-            .store(du_walk(&self.compile_cache_dir), Ordering::Relaxed);
+        self.refresh_wasm();
+        self.refresh_compile_cache();
+        self.refresh_db_file();
+        self.refresh_webapp_cache();
     }
 
     /// Apply a state-write at a chokepoint: set `key`'s tracked size to
@@ -519,7 +659,7 @@ impl DiskUsageTracker {
     /// distinct `code_hash` is one file).
     pub(crate) fn refresh_wasm(&self) {
         self.wasm_bytes
-            .store(du_walk_wasm(&self.contracts_dir), Ordering::Relaxed);
+            .store(du_walk_wasm(&self.paths.contracts_dir), Ordering::Relaxed);
     }
 
     /// Re-measure the wasmtime compile-cache total by `du`-walking its dir.
@@ -527,7 +667,39 @@ impl DiskUsageTracker {
     /// only way to account for it.
     pub(crate) fn refresh_compile_cache(&self) {
         self.compile_cache_bytes
-            .store(du_walk(&self.compile_cache_dir), Ordering::Relaxed);
+            .store(du_walk(&self.paths.wasmtime_cache_dir), Ordering::Relaxed);
+    }
+
+    /// Re-measure the storage backend's database footprint (#5007).
+    ///
+    /// A **shallow** walk of `db_dir`, not a recursive one, and that is
+    /// deliberate: in `Network` mode `db_dir` is `<data>/db`, which *contains*
+    /// the `local/` subtree belonging to the other operation mode. Those bytes
+    /// are not this node's storage and must not be charged to its budget. The
+    /// shallow walk still picks up every file the backend itself writes beside
+    /// the database — redb's `db` plus any `.backup` left by a version
+    /// migration, sqlite's `freenet.db` plus its `-wal`/`-shm` sidecars — so it
+    /// is backend-agnostic where a hardcoded filename would not be.
+    ///
+    /// Cheap: one `read_dir` over a directory holding a handful of entries,
+    /// versus the recursive walks the wasm and compile-cache gauges already do
+    /// on the same 60s cadence.
+    pub(crate) fn refresh_db_file(&self) {
+        self.db_file_bytes
+            .store(du_walk_shallow(&self.paths.db_dir), Ordering::Relaxed);
+    }
+
+    /// Re-measure the unpacked-webapp cache (#5007).
+    ///
+    /// Recursive: the cache is a tree of unpacked bundles. REPORTED ONLY — the
+    /// result never enters [`Self::total_bytes`]. Measuring it is the fix for
+    /// the blind spot (nothing measured or reported these bytes at all);
+    /// charging them to the hosting budget would double-bound something #5012
+    /// already caps at 64 MiB, using a lever hosting eviction does not have.
+    /// See the module docs.
+    pub(crate) fn refresh_webapp_cache(&self) {
+        self.webapp_cache_bytes
+            .store(du_walk(&self.paths.webapp_cache_dir), Ordering::Relaxed);
     }
 
     /// Free bytes on the mount holding the tracked `contracts_dir` — the
@@ -536,8 +708,34 @@ impl DiskUsageTracker {
     /// dir shares the data-dir mount, which is where all tracked bytes (state,
     /// wasm, relocated compile cache) land, so it is the correct mount to probe.
     pub(crate) fn available_bytes(&self) -> Option<u64> {
-        available_bytes(&self.contracts_dir)
+        available_bytes(&self.paths.contracts_dir)
     }
+}
+
+/// Sum the byte size of every regular file **directly inside** `dir`, without
+/// descending into subdirectories (#5007).
+///
+/// The non-recursive counterpart to [`du_walk`], for the database directory:
+/// `db_dir` in `Network` mode contains the `local/` mode split, whose bytes
+/// belong to a different node instance and must not be charged here. Same
+/// best-effort error handling as [`du_walk`] — a missing directory or an
+/// unreadable entry contributes 0.
+fn du_walk_shallow(dir: &Path) -> u64 {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return 0;
+    };
+    let mut total: u64 = 0;
+    for entry in entries.flatten() {
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if file_type.is_file() {
+            if let Ok(meta) = entry.metadata() {
+                total = total.saturating_add(meta.len());
+            }
+        }
+    }
+    total
 }
 
 /// Recursively sum the byte size of every regular file under `dir`. A missing
@@ -682,12 +880,28 @@ mod tests {
         ContractKey::from_id_and_code(instance, code)
     }
 
+    /// Paths that all resolve to nothing, so every `du`-walk contributes 0.
+    fn nonexistent_paths() -> HostingDiskPaths {
+        HostingDiskPaths {
+            contracts_dir: PathBuf::from("/nonexistent/contracts"),
+            wasmtime_cache_dir: PathBuf::from("/nonexistent/cache"),
+            db_dir: PathBuf::from("/nonexistent/db"),
+            webapp_cache_dir: PathBuf::from("/nonexistent/webapp"),
+        }
+    }
+
     fn tracker() -> DiskUsageTracker {
         // Nonexistent dirs → du-walks contribute 0, isolating state-delta math.
-        DiskUsageTracker::new(
-            PathBuf::from("/nonexistent/contracts"),
-            PathBuf::from("/nonexistent/cache"),
-        )
+        DiskUsageTracker::new(nonexistent_paths())
+    }
+
+    /// Write a file of `len` zero bytes at `path`, creating parents.
+    fn write_file(path: &Path, len: usize) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        let mut f = std::fs::File::create(path).unwrap();
+        f.write_all(&vec![0u8; len]).unwrap();
     }
 
     #[test]
@@ -770,7 +984,10 @@ mod tests {
         let mut junk = std::fs::File::create(contracts.join("index.db")).unwrap();
         junk.write_all(&[0u8; 1000]).unwrap();
 
-        let t = DiskUsageTracker::new(contracts.clone(), dir.path().join("cache"));
+        let t = DiskUsageTracker::new(HostingDiskPaths {
+            contracts_dir: contracts.clone(),
+            ..nonexistent_paths()
+        });
         t.seed(std::iter::empty());
         assert_eq!(t.stats().wasm_bytes, 140);
         // Re-walking is deduped by construction (same files) — idempotent.
@@ -1050,7 +1267,10 @@ mod tests {
         let mut f = std::fs::File::create(cache.join("sub").join("mod.cache")).unwrap();
         f.write_all(&[0u8; 512]).unwrap();
 
-        let t = DiskUsageTracker::new(dir.path().join("contracts"), cache.clone());
+        let t = DiskUsageTracker::new(HostingDiskPaths {
+            wasmtime_cache_dir: cache.clone(),
+            ..nonexistent_paths()
+        });
         t.seed(std::iter::empty());
         assert_eq!(t.stats().compile_cache_bytes, 512);
 
@@ -1060,6 +1280,246 @@ mod tests {
         t.refresh_compile_cache();
         assert_eq!(t.stats().compile_cache_bytes, 600);
         assert_eq!(t.total_bytes(), 600);
+    }
+
+    // --- Database-file measurement (#5007) -----------------------------------
+
+    #[test]
+    fn db_file_size_supersedes_logical_state_rows() {
+        // The reported bug: the tracker summed logical state rows and was blind
+        // to the database's own footprint, under-counting ~10x on a production
+        // peer (583 MB reported vs 2.68 GB occupied). With the file measured,
+        // the aggregate reflects the file, not the rows.
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("db");
+        write_file(&db.join("db"), 4000);
+
+        let t = DiskUsageTracker::new(HostingDiskPaths {
+            db_dir: db,
+            ..nonexistent_paths()
+        });
+        // Logical rows total only 400 — the pre-#5007 figure.
+        t.seed([(test_key(1), 300), (test_key(2), 100)]);
+        assert_eq!(t.stats().state_bytes, 400, "logical rows still reported");
+        assert_eq!(t.stats().db_file_bytes, 4000);
+        assert_eq!(
+            t.total_bytes(),
+            4000,
+            "aggregate must reflect the database file, not the row sum"
+        );
+    }
+
+    #[test]
+    fn evicting_state_cannot_shrink_the_aggregate_below_the_measured_file() {
+        // The property that keeps eviction from chasing its own tail. redb frees
+        // pages for REUSE and never truncates interior dead space, so a
+        // decomposition that re-derived "overhead" as `file − state` would
+        // inflate the overhead by exactly what eviction just freed, leaving the
+        // aggregate pinned above budget no matter how much the node sheds. Under
+        // `max(state, file)` the aggregate simply stays at the measured file
+        // size — which is the truth, and is a fixed point rather than a
+        // treadmill.
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("db");
+        write_file(&db.join("db"), 1000);
+
+        let t = DiskUsageTracker::new(HostingDiskPaths {
+            db_dir: db,
+            ..nonexistent_paths()
+        });
+        t.seed([(test_key(1), 600), (test_key(2), 400)]);
+        assert_eq!(t.total_bytes(), 1000);
+
+        // Shed everything. The file did not shrink, so neither does the figure.
+        t.record_state_removed(&test_key(1));
+        t.record_state_removed(&test_key(2));
+        assert_eq!(t.stats().state_bytes, 0);
+        assert_eq!(
+            t.total_bytes(),
+            1000,
+            "shedding rows must not fictitiously reduce the measured footprint"
+        );
+    }
+
+    #[test]
+    fn within_window_state_growth_exceeds_a_stale_db_measurement() {
+        // The other half of the `max`: the file measurement is up to one sweep
+        // window stale, so a burst of writes must still be visible to the
+        // admission gate before the next measurement lands.
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("db");
+        write_file(&db.join("db"), 500);
+
+        let t = DiskUsageTracker::new(HostingDiskPaths {
+            db_dir: db,
+            ..nonexistent_paths()
+        });
+        t.seed(std::iter::empty());
+        assert_eq!(t.total_bytes(), 500, "measured file dominates while idle");
+
+        // A write burst pushes live bytes past the last measurement; the file
+        // must have grown at least that far, so the live figure takes over.
+        t.record_state_write(&test_key(1), 900);
+        assert_eq!(t.total_bytes(), 900);
+    }
+
+    #[test]
+    fn db_measurement_is_shallow_and_skips_the_other_mode_split() {
+        // `db_dir` in Network mode contains the `local/` subtree, whose bytes
+        // belong to a different node instance. A recursive walk would charge
+        // them here.
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("db");
+        write_file(&db.join("db"), 100);
+        // Sidecars/backups written beside the database DO count (sqlite's
+        // `-wal`, redb's migration `.backup`).
+        write_file(&db.join("db.backup"), 25);
+        write_file(&db.join("local").join("db"), 9999);
+
+        let t = DiskUsageTracker::new(HostingDiskPaths {
+            db_dir: db,
+            ..nonexistent_paths()
+        });
+        t.seed(std::iter::empty());
+        assert_eq!(
+            t.stats().db_file_bytes,
+            125,
+            "shallow walk counts siblings of the database but not the local/ split"
+        );
+    }
+
+    #[test]
+    fn absent_db_measurement_degrades_to_the_logical_row_sum() {
+        // Backward-compat floor: a tracker with no readable database directory
+        // (unit tests, a node whose store has not been created yet) behaves
+        // exactly as it did before #5007. `max(state, 0) == state`.
+        let t = tracker();
+        t.seed([(test_key(1), 700)]);
+        assert_eq!(t.stats().db_file_bytes, 0);
+        assert_eq!(t.total_bytes(), 700);
+    }
+
+    #[test]
+    fn refresh_db_file_observes_growth_between_sweeps() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("db");
+        write_file(&db.join("db"), 200);
+
+        let t = DiskUsageTracker::new(HostingDiskPaths {
+            db_dir: db.clone(),
+            ..nonexistent_paths()
+        });
+        t.seed(std::iter::empty());
+        assert_eq!(t.total_bytes(), 200);
+
+        // The database grows (copy-on-write dead space, new pages, whatever) —
+        // the next sweep's re-measure must pick it up.
+        write_file(&db.join("db"), 1500);
+        t.refresh_db_file();
+        assert_eq!(t.stats().db_file_bytes, 1500);
+        assert_eq!(t.total_bytes(), 1500);
+    }
+
+    #[test]
+    fn admission_gate_charges_the_database_file_not_just_the_rows() {
+        // The consumer that made the under-count load-bearing (#4702). With a
+        // 1000-byte database and a 1000-byte budget the node is exactly full,
+        // so any fresh PUT must be refused — even though the logical rows say
+        // there is a full budget's worth of headroom.
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("db");
+        write_file(&db.join("db"), 1000);
+
+        let t = DiskUsageTracker::new(HostingDiskPaths {
+            db_dir: db,
+            ..nonexistent_paths()
+        });
+        t.seed(std::iter::empty()); // zero logical rows
+        assert!(
+            t.admit_state_write(&test_key(1), 1, 1000).is_err(),
+            "a full database must refuse a fresh PUT even with no rows tracked"
+        );
+        // Sanity: the same call against the pre-#5007 figure would have admitted.
+        let blind = tracker();
+        blind.seed(std::iter::empty());
+        assert!(blind.admit_state_write(&test_key(1), 1, 1000).is_ok());
+    }
+
+    // --- Webapp cache: measured and reported, never budgeted (#5007) ----------
+
+    #[test]
+    fn webapp_cache_is_measured_and_reported() {
+        // The second blind spot: these bytes were not measured at all (1236 MiB
+        // across 82 entries on a real peer). They are now.
+        let dir = tempfile::tempdir().unwrap();
+        let webapp = dir.path().join("webapp_cache");
+        write_file(&webapp.join("aaaa").join("index.html"), 300);
+        write_file(&webapp.join("bbbb").join("app.js"), 200);
+
+        let t = DiskUsageTracker::new(HostingDiskPaths {
+            webapp_cache_dir: webapp.clone(),
+            ..nonexistent_paths()
+        });
+        t.seed(std::iter::empty());
+        assert_eq!(t.stats().webapp_cache_bytes, 500);
+
+        write_file(&webapp.join("cccc").join("app.js"), 50);
+        t.refresh_webapp_cache();
+        assert_eq!(t.stats().webapp_cache_bytes, 550);
+    }
+
+    #[test]
+    fn webapp_cache_never_enters_the_budgeted_aggregate() {
+        // Visibility without enforcement. #5012 already caps this directory at
+        // 64 MiB with its own LRU, hosting eviction has no lever on it, and it
+        // may sit on a different mount than the one the budget's free-space term
+        // measures. Charging it here would double-bound it AND reintroduce the
+        // "over budget with nothing to shed" shape.
+        let dir = tempfile::tempdir().unwrap();
+        let webapp = dir.path().join("webapp_cache");
+        write_file(&webapp.join("aaaa").join("index.html"), 4096);
+
+        let t = DiskUsageTracker::new(HostingDiskPaths {
+            webapp_cache_dir: webapp,
+            ..nonexistent_paths()
+        });
+        t.seed([(test_key(1), 100)]);
+        assert_eq!(t.stats().webapp_cache_bytes, 4096, "measured");
+        assert_eq!(t.total_bytes(), 100, "but not budgeted");
+        assert_eq!(t.stats().total_bytes, 100);
+        // ...so it cannot influence the admission gate either.
+        assert!(t.admit_state_write(&test_key(2), 100, 200).is_ok());
+    }
+
+    #[test]
+    fn all_four_measured_dirs_are_read_from_their_own_path() {
+        // Guards the transposition hazard `HostingDiskPaths` exists to make
+        // unlikely: four same-typed paths, each of which must feed exactly one
+        // gauge. Distinct sizes make any swap visible.
+        let dir = tempfile::tempdir().unwrap();
+        let contracts = dir.path().join("contracts");
+        let wasmtime = dir.path().join("wasmtime");
+        let db = dir.path().join("db");
+        let webapp = dir.path().join("webapp");
+        write_file(&contracts.join("aaaa.wasm"), 11);
+        write_file(&wasmtime.join("mod.cache"), 22);
+        write_file(&db.join("db"), 33);
+        write_file(&webapp.join("aaaa").join("index.html"), 44);
+
+        let t = DiskUsageTracker::new(HostingDiskPaths {
+            contracts_dir: contracts,
+            wasmtime_cache_dir: wasmtime,
+            db_dir: db,
+            webapp_cache_dir: webapp,
+        });
+        t.seed(std::iter::empty());
+        let s = t.stats();
+        assert_eq!(s.wasm_bytes, 11);
+        assert_eq!(s.compile_cache_bytes, 22);
+        assert_eq!(s.db_file_bytes, 33);
+        assert_eq!(s.webapp_cache_bytes, 44);
+        // Budgeted aggregate = max(state=0, db=33) + wasm + compile cache.
+        assert_eq!(s.total_bytes, 33 + 11 + 22);
     }
 
     /// `available_bytes` on a real, existing mount returns a plausible positive

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -231,17 +231,24 @@ pub(crate) struct RouterSnapshotInfo {
     /// until the ring is built. Per-node aggregate scalars.
     pub hosting_evicted_unread_total: Option<u64>,
     pub hosting_evicted_unread_age_secs_sum: Option<u64>,
-    /// Aggregate on-disk usage gauges (#4683), populated by `Ring` from the
-    /// `HostingManager`'s `DiskUsageTracker` on the snapshot cadence.
-    /// `hosting_disk_state_bytes` is the delta-tracked persisted-state total;
-    /// `hosting_disk_wasm_bytes` is the `du`-measured WASM-blob total;
-    /// `hosting_disk_compile_cache_bytes` is the relocated wasmtime compile-cache
-    /// total; `hosting_disk_total_bytes` is their sum — the aggregate the future
-    /// disk budget will bound. `None` until the tracker is configured and seeded
-    /// (early startup). Per-node aggregate scalars.
+    /// Aggregate on-disk usage gauges (#4683, #5007), populated by `Ring` from
+    /// the `HostingManager`'s `DiskUsageTracker` on the snapshot cadence.
+    /// `hosting_disk_state_bytes` is the delta-tracked *logical* state total;
+    /// `hosting_disk_db_bytes` is the measured size of the storage backend's
+    /// database directory (their difference is the database's dead space, the
+    /// ~10x under-count #5007 fixed); `hosting_disk_wasm_bytes` is the
+    /// `du`-measured WASM-blob total; `hosting_disk_compile_cache_bytes` is the
+    /// relocated wasmtime compile-cache total; `hosting_disk_total_bytes` is
+    /// `max(state, db) + wasm + compile_cache` — the aggregate the disk budget
+    /// bounds. `hosting_disk_webapp_cache_bytes` is the unpacked-webapp cache,
+    /// reported but deliberately NOT part of the budgeted total (#5012 caps it
+    /// separately; see `ring/hosting/disk_usage.rs`). `None` until the tracker
+    /// is configured and seeded (early startup). Per-node aggregate scalars.
     pub hosting_disk_state_bytes: Option<u64>,
+    pub hosting_disk_db_bytes: Option<u64>,
     pub hosting_disk_wasm_bytes: Option<u64>,
     pub hosting_disk_compile_cache_bytes: Option<u64>,
+    pub hosting_disk_webapp_cache_bytes: Option<u64>,
     pub hosting_disk_total_bytes: Option<u64>,
     /// OOM-valve falsifier (subscriber-primary hosting rework, #4642): monotonic
     /// count of evictions performed under genuine RAM overflow (counted by
@@ -1349,8 +1356,10 @@ impl Router {
             // Aggregate on-disk usage gauges, populated by Ring from the
             // DiskUsageTracker on the snapshot cadence (#4683).
             hosting_disk_state_bytes: None,
+            hosting_disk_db_bytes: None,
             hosting_disk_wasm_bytes: None,
             hosting_disk_compile_cache_bytes: None,
+            hosting_disk_webapp_cache_bytes: None,
             hosting_disk_total_bytes: None,
             hosting_oom_valve_evictions_total: None,
             hosting_subscribed_evictions_total: None,

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -2591,8 +2591,10 @@ mod tests {
             evictions_of_recently_read_total: 0,
             contracts: vec![mk_hosted_entry("A", 1.0, false)],
             disk_state_bytes: None,
+            disk_db_bytes: None,
             disk_wasm_bytes: None,
             disk_compile_cache_bytes: None,
+            disk_webapp_cache_bytes: None,
             disk_total_bytes: None,
             disk_budget_bytes: None,
         };
@@ -2631,9 +2633,14 @@ mod tests {
             budget_evictions_total: 0,
             evictions_of_recently_read_total: 0,
             contracts: vec![mk_hosted_entry("A", 1.0, false)],
-            disk_state_bytes: Some(100 * 1024 * 1024),
+            // #5007: the database file is far bigger than the live rows — the
+            // gap is dead space, and `disk_total_bytes` is built on the file
+            // (100 MB), not the rows (40 MB).
+            disk_state_bytes: Some(40 * 1024 * 1024),
+            disk_db_bytes: Some(100 * 1024 * 1024),
             disk_wasm_bytes: Some(20 * 1024 * 1024),
             disk_compile_cache_bytes: Some(5 * 1024 * 1024),
+            disk_webapp_cache_bytes: Some(7 * 1024 * 1024),
             disk_total_bytes: Some(125 * 1024 * 1024),
             disk_budget_bytes: Some(500 * 1024 * 1024),
         };
@@ -2654,10 +2661,25 @@ mod tests {
         );
         // Breakdown surfaced in the title tooltip.
         assert!(
-            html.contains("State: 100.0 MB")
+            html.contains("State (logical): 40.0 MB")
                 && html.contains("WASM: 20.0 MB")
                 && html.contains("Compile cache: 5.0 MB"),
             "per-component breakdown in tooltip — got:\n{html}"
+        );
+        // #5007: the tooltip must separate the LOGICAL row total from the
+        // MEASURED database size and name the gap. That gap is the whole bug —
+        // an operator seeing only "state: 40 MB" against 125 MB of disk used
+        // has no way to tell where the rest went, or that a restart (startup
+        // compaction) is what reclaims it.
+        assert!(
+            html.contains("Database file: 100.0 MB (dead space: 60.0 MB)"),
+            "tooltip must show the measured database size and its dead space — got:\n{html}"
+        );
+        // And the webapp cache must be visible AND marked as excluded, so "disk
+        // used" not moving when it grows reads as deliberate.
+        assert!(
+            html.contains("Webapp cache: 7.0 MB (not budgeted)"),
+            "tooltip must report the webapp cache and mark it unbudgeted — got:\n{html}"
         );
         assert!(
             html.contains("min(RAM budget, disk budget)"),

--- a/crates/core/src/server/home_page/cards.rs
+++ b/crates/core/src/server/home_page/cards.rs
@@ -1319,6 +1319,12 @@ pub fn build_hosting_card(snap: &Option<network_status::NetworkStatusSnapshot>) 
     // operator can only clear with a restart (startup compaction, #5005). The
     // webapp cache is shown too, marked as excluded, so "disk used" not moving
     // when it grows reads as deliberate rather than as another blind spot.
+    //
+    // The parts deliberately do NOT sum to the tile above them: state bytes live
+    // INSIDE the database file, so the aggregate takes the larger of the two
+    // rather than adding them. The tooltip says so, because an operator who
+    // adds the numbers up and gets a different answer has no way to tell a
+    // display bug from the `max` rule.
     let disk_breakdown_title = match (
         h.disk_state_bytes,
         h.disk_db_bytes,
@@ -1327,8 +1333,11 @@ pub fn build_hosting_card(snap: &Option<network_status::NetworkStatusSnapshot>) 
         h.disk_webapp_cache_bytes,
     ) {
         (Some(state), Some(db), Some(wasm), Some(cache), Some(webapp)) => format!(
-            "State (logical): {state} · Database file: {db} (dead space: {dead}) · \
-             WASM: {wasm} · Compile cache: {cache} · Webapp cache: {webapp} (not budgeted)",
+            "Disk used counts the LARGER of state and database file (state lives \
+             inside the file), plus WASM and compile cache — so these parts do not \
+             sum to it. State (logical): {state} · Database file: {db} \
+             (dead space: {dead}) · WASM: {wasm} · Compile cache: {cache} · \
+             Webapp cache: {webapp} (not budgeted)",
             state = format_bytes(state),
             db = format_bytes(db),
             dead = format_bytes(db.saturating_sub(state)),

--- a/crates/core/src/server/home_page/cards.rs
+++ b/crates/core/src/server/home_page/cards.rs
@@ -1313,16 +1313,28 @@ pub fn build_hosting_card(snap: &Option<network_status::NetworkStatusSnapshot>) 
         Some(total) => format_bytes(total),
         None => MEASURING.to_string(),
     };
+    // #5007: the breakdown shows the LOGICAL state total next to the MEASURED
+    // database size, because their difference is the database's dead space —
+    // the term that made the old accounting under-count ~10x and the one an
+    // operator can only clear with a restart (startup compaction, #5005). The
+    // webapp cache is shown too, marked as excluded, so "disk used" not moving
+    // when it grows reads as deliberate rather than as another blind spot.
     let disk_breakdown_title = match (
         h.disk_state_bytes,
+        h.disk_db_bytes,
         h.disk_wasm_bytes,
         h.disk_compile_cache_bytes,
+        h.disk_webapp_cache_bytes,
     ) {
-        (Some(state), Some(wasm), Some(cache)) => format!(
-            "State: {state} · WASM: {wasm} · Compile cache: {cache}",
+        (Some(state), Some(db), Some(wasm), Some(cache), Some(webapp)) => format!(
+            "State (logical): {state} · Database file: {db} (dead space: {dead}) · \
+             WASM: {wasm} · Compile cache: {cache} · Webapp cache: {webapp} (not budgeted)",
             state = format_bytes(state),
+            db = format_bytes(db),
+            dead = format_bytes(db.saturating_sub(state)),
             wasm = format_bytes(wasm),
             cache = format_bytes(cache),
+            webapp = format_bytes(webapp),
         ),
         _ => "Disk tracker not yet seeded".to_string(),
     };

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -152,9 +152,12 @@ fn try_acquire_cache_lock(
 /// unpacked webapp is a few hundred KB to a few MB, so the budget keeps roughly
 /// the last 15-30 distinct webapps the user actually browsed — far more than a
 /// browsing session touches — while cutting >90% of the observed footprint.
-/// These bytes are additionally invisible to the node's disk accounting: the
-/// cache lives under the XDG *cache* dir, whereas `ring/hosting/disk_usage.rs`
-/// only walks `contracts_dir` + `wasmtime_cache_dir`, so nothing else bounds it.
+/// This LRU cap is the only thing that bounds these bytes. Since #5007
+/// `ring/hosting/disk_usage.rs` also measures and reports the cache, but it
+/// deliberately does NOT charge it against the hosting disk budget (hosting
+/// eviction has no lever on webapp entries, and the cache may sit on a different
+/// mount than the one the budget's free-space term measures) — see that module's
+/// "The webapp cache is reported, not budgeted".
 const WEBAPP_CACHE_MAX_BYTES: u64 = 64 * 1024 * 1024;
 
 /// How long an entry is protected from eviction after this process last served

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -2314,12 +2314,20 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                     serde_json::json!(snapshot.hosting_disk_state_bytes),
                 );
                 obj.insert(
+                    "hosting_disk_db_bytes".to_string(),
+                    serde_json::json!(snapshot.hosting_disk_db_bytes),
+                );
+                obj.insert(
                     "hosting_disk_wasm_bytes".to_string(),
                     serde_json::json!(snapshot.hosting_disk_wasm_bytes),
                 );
                 obj.insert(
                     "hosting_disk_compile_cache_bytes".to_string(),
                     serde_json::json!(snapshot.hosting_disk_compile_cache_bytes),
+                );
+                obj.insert(
+                    "hosting_disk_webapp_cache_bytes".to_string(),
+                    serde_json::json!(snapshot.hosting_disk_webapp_cache_bytes),
                 );
                 obj.insert(
                     "hosting_disk_total_bytes".to_string(),
@@ -2827,15 +2835,22 @@ mod tests {
         let mut info = crate::router::RouterSnapshotInfo::arbitrary(&mut u)
             .expect("construct RouterSnapshotInfo for test");
         info.hosting_disk_state_bytes = Some(401);
+        info.hosting_disk_db_bytes = Some(431);
         info.hosting_disk_wasm_bytes = Some(409);
         info.hosting_disk_compile_cache_bytes = Some(419);
-        info.hosting_disk_total_bytes = Some(1229);
+        info.hosting_disk_webapp_cache_bytes = Some(433);
+        info.hosting_disk_total_bytes = Some(1259);
         let json = event_kind_to_json(&EventKind::RouterSnapshot(Box::new(info)));
         for (key, want) in [
             ("hosting_disk_state_bytes", 401),
+            // #5007: the database measurement and the webapp cache are the two
+            // gauges that were entirely absent. Without them in the OTLP body
+            // there is no way to see the dead-space gap from central telemetry.
+            ("hosting_disk_db_bytes", 431),
             ("hosting_disk_wasm_bytes", 409),
             ("hosting_disk_compile_cache_bytes", 419),
-            ("hosting_disk_total_bytes", 1229),
+            ("hosting_disk_webapp_cache_bytes", 433),
+            ("hosting_disk_total_bytes", 1259),
         ] {
             assert_eq!(json[key], want, "{key} must reach the OTLP body");
         }


### PR DESCRIPTION
## Problem

`DiskUsageTracker` summed **logical** contract-state rows and walked only `contracts_dir` + `wasmtime_cache_dir`. Two blind spots followed, both measured on production peers:

- **Database dead space.** redb is copy-on-write and only truncates *trailing* free space, so the interior dead space a busy node accumulates is invisible to any row-level accounting. A peer reported **583 MB** while occupying **2.68 GB** — a ~10x under-count.
- **The webapp cache.** It lives under the XDG *cache* dir, outside the walked set: **1236 MiB / 82 entries** on one machine, 325 MB / 61 on another. Nothing measured or reported those bytes.

Both feed the `min(ram, disk)` eviction floor (#4683) and the pre-write admission gate (#4702), so both have been deciding on a number an order of magnitude wrong.

This is the structural half of the disk-reduction effort. The six preceding PRs are one-time reclaims and they do not hold: the nova gateway compacted 2.59 GB → 1.41 GB and was back at **2.81 GB ten hours later**, because nothing could see it happening.

## Solution

**The storage term becomes `max(state_bytes, db_file_bytes)`**, with the database directory measured on the existing 60s sweep.

*Why `max` and not `state + (file − state)`.* Freeing rows returns pages to redb for **reuse** without shrinking the file, so a derived "overhead" term would inflate by exactly what eviction just freed — the aggregate would stay pinned above budget however much the node shed, an eviction treadmill that never converges. Under `max` the aggregate rests at the measured file size, which is the truth and a fixed point. Two more properties fall out: an unmeasured database degrades to the old behavior (`max(state, 0) == state`), and a within-window write burst that has outrun the last measurement is still visible to the gate.

*Why periodic and not delta-tracked.* A file length is not computable at a write chokepoint: redb extends the file when it needs a page, not per row. A per-write `metadata()` would be a syscall on the PUT hot path — under the `state_sizes` lock, which `admit_state_write` holds across `total_bytes()` — in exchange for no extra accuracy, since the live `state_bytes` delta already captures the marginal cost of an in-flight write. Staleness costs at most one sweep of growth in the admitting direction, which is the same exposure the wasm gauge already accepts.

**The webapp cache is measured and reported, but not budgeted.** #5012 already caps it at a hard 64 MiB; charging that against a hosting budget whose own floor is 128 MiB would spend up to half a small node's allowance re-bounding something already bounded. Hosting eviction has no lever on it either, so charging it reproduces the treadmill shape above. And it need not share the mount whose free space the budget's basis measures (XDG cache vs XDG data). Visibility was the actual defect for these bytes; double-bounding is not the fix.

### Measurement is allocation, not apparent length

The walks charge **allocated blocks** (`st_blocks * 512`, `du` semantics), not `metadata().len()`.

`len()` is what `ls` reports, and for a sparse file it over-states consumption. redb's file **is** sparse on some peers — measured on the nova gateway (2026-07-29, stable across repeated samples):

```
apparent (metadata().len) = 2,749,370,368   (2.56 GiB)
allocated (st_blocks*512) = 1,839,210,496   (1.71 GiB)
```

A **910 MB / 49% over-charge** on the term this PR makes dominant. The same file on the Framework laptop is not sparse at all (`size == allocated`), so this varies with each peer's compaction history and no constant correction exists. Over-charging makes the admission gate refuse writes the disk can still take: the mirror image of the under-count this PR fixes, and no more honest.

Allocation is also the only unit that composes with the budget's other term. The budget is `pct * (used + available)` where `available` is `statvfs`'s `f_bavail * f_frsize` — real free blocks. `used` has to be the same currency, so all four walks were converted rather than just the database one: block slack on a small file **is** charged (the filesystem spent that block, and `available` already reflects it) and a hole is not. Non-unix has no `st_blocks` in `std` and falls back to `len()`.

### A failed measurement is not a measurement of zero

Every walk used to swallow its `read_dir` error and return 0, and the refresh stored that unconditionally. One EACCES (a packaging or user change), a transient EMFILE, or the directory being replaced set `db_file_bytes = 0`; `max(state, 0) == state` reverted the whole aggregate to exactly the pre-#5007 under-count; and telemetry showed a plausible `hosting_disk_db_bytes: 0` with no log to contradict it. Under a persistent EACCES it was permanent and indistinguishable from a healthy small node — silently reintroducing the bug this PR exists to fix, on the term it exists to make visible.

A failed walk now keeps the gauge's **previous** value and warns, edge-triggered per gauge so a permanently-unreadable directory logs once rather than once a minute. This is the same fail-loud discipline the state seed already follows. A directory that does not **exist** is still a legitimate zero (a store not yet created), not a failure.

### An UPDATE absorbed by dead space is not a disk cost

The growth-only gate refused *any* growing UPDATE on an over-budget node. That was wrong in the case that matters: redb reuses freed pages, so a write that keeps live state at or under the measured file size does not grow the file by a byte. Refusing it aborted the merge while the node kept the contract, kept serving it, and kept advertising as a host — a copy that has dropped out of the update mesh but still answers reads, which `hosting-invariants.md` invariant 1 says must be impossible by construction. For a relayed UPDATE the rejection is fire-and-forget, so no peer learns. Growth is the normal case for the flagship contract class (a River room appends messages), and making `used` honest widens the at-risk population.

The projection is now `max(db_file_bytes, state_bytes − old + new)` — the honest storage term — instead of `max(db_file_bytes, state_bytes) − old + new`, which charged the delta on top of a file that will not move. Growth that fits inside the dead space is admitted; growth that genuinely enlarges the footprint is bounded exactly as before; a fresh PUT is still refused, because admitting new tenants is the decision the budget exists to make and a PUT has no already-hosted state whose merge would stall.

Two bounded imprecisions, both self-correcting within one sweep: `state_bytes` counts state payload only, so `db_file − state` also includes live non-state rows and slightly over-states what is reclaimable; and `db_file` is up to one sweep window stale.

**Residual, stated plainly:** growth that *exceeds* the dead space on an over-budget node is still refused, and the stale-host window stays open for that case. That is genuine disk exhaustion, where admitting would overflow the budget. Closing it means de-registering hosting and re-homing the contract's subscribers — epic #4642 piece D — not widening this gate. The edge-triggered over-budget warning now names the consequence, since it is not visible in the byte counts.

### Rollout: this cannot trigger mass eviction

The obvious fear — 10x the usage against an unchanged budget evicts everything — points the wrong way here. `used` sits in the budget's **own basis** (`clamp(pct * (used + available), MIN, cap)`), not on the other side of a comparison. That is monotonically non-decreasing in `used`, and `min(ram, ·)` preserves it, so the effective budget installed on the cache can only ever **rise**. No ramp is needed for the eviction floor, and `effective_budget_never_falls_as_measured_usage_rises` pins it across the whole shape of the clamp.

The tightening lands on the aggregate **admission gate**, which is where it belongs: it compares `used` against the budget, so each newly-visible byte costs `(1 − pct)` of headroom. That bounds what a full node **accepts**; it does not bound the footprint. Nothing here shrinks a database file — dead space is reclaimed by the startup compaction (#5005) and by nothing else — so a node already past its budget refuses new tenants at that size rather than returning to a smaller one. Making the figure honest is what lets an operator see that; a runtime compaction trigger is what would fix it.

When does a node land over budget? Whichever of the three clamp regions binds:

- in the linear region at `pct = 0.5`, when its own footprint exceeds its remaining free space;
- at the **32 GiB cap** (`DEFAULT_MAX_HOSTING_DISK_BYTES`), whenever its footprint exceeds 32 GiB regardless of how much disk is free — a node with 40 GB used and 500 GB free is over budget;
- the **128 MiB floor** only ever raises the budget, so it cannot put a node over.

Refusing new contracts there is a hard **storage ceiling**, which is the clause `hosting-invariants.md` sanctions ("storage is a minor term plus a hard ceiling"). It is **not** invariant 3's emergent refusal — that means a newcomer entering the eviction ranking and losing, whereas this is an at-capacity refusal on a resource axis and the contract never enters the ranking. The earlier draft of this description cited the wrong clause.

### Hosting invariants touched

- **Invariant 1** (a served copy is fresh). The dead-space exemption above is what keeps this PR from widening the stale-host failure class; the residual case is stated rather than papered over.
- **Invariant 3** (eviction is one demand-ordered decision, budget sized by the scarcest local resource). Preserved: the ordering is untouched, no new eviction input, no pin, no valve. Only the *measurement* of the disk resource changes, and the monotonicity property above proves the floor cannot tighten. The admission gate is justified by the hard-ceiling clause, not by invariant 3's emergent refusal.
- **Byte-only-eviction anti-pattern.** Not re-introduced: this makes an existing *capacity* measurement honest; it does not make bytes an eviction signal.

## Testing

27 new tests. The properties, not just the arithmetic:

- `evicting_state_cannot_shrink_the_aggregate_below_the_measured_file` — the fixed-point property that rules out the eviction treadmill.
- `within_window_state_growth_exceeds_a_stale_db_measurement` — the other half of the `max`.
- `db_measurement_is_shallow_and_skips_the_other_mode_split` — `db_dir` in Network mode contains `local/`, whose bytes belong to a different node instance; siblings of the database (sqlite `-wal`, redb `.backup`) still count.
- `absent_db_measurement_degrades_to_the_logical_row_sum` — backward-compat floor.
- `admission_gate_charges_the_database_file_not_just_the_rows` — the consumer that made the under-count load-bearing.
- `sparse_file_is_charged_by_allocation_not_apparent_length` / `block_slack_on_a_small_file_is_charged` — both directions of the measurement unit.
- `an_unreadable_database_directory_keeps_the_previous_measurement`, `an_unreadable_webapp_cache_keeps_the_previous_measurement`, `measurement_resumes_after_a_transient_failure` — a failed walk is not a zero, and does not poison the gauge afterwards.
- `a_missing_directory_measures_zero_rather_than_retaining` — and the over-correction is not made either.
- `admit_state_update_growth_absorbed_by_dead_space_is_admitted_over_budget`, `..._growth_beyond_dead_space_is_still_bounded`, `..._does_not_charge_growth_twice_against_the_file`, `dead_space_does_not_exempt_a_fresh_put` — the four corners of the growth gate.
- `over_budget_from_dead_space_still_merges_hosted_updates`, `honest_over_budget_usage_does_not_tighten_the_eviction_floor`, `over_budget_clears_when_free_space_grows` — what the node actually **does** in the adverse state, which was previously asserted only in prose and pinned only by a `bool`.
- `webapp_cache_never_enters_the_budgeted_aggregate` + `webapp_cache_is_measured_and_reported` — the reported-not-budgeted split, both directions.
- `all_four_measured_dirs_are_read_from_their_own_path` — the transposition hazard `HostingDiskPaths` exists to make unlikely.
- `effective_budget_never_falls_as_measured_usage_rises` — the no-mass-eviction property.
- `over_disk_budget_is_logged_on_the_edge_only` — both ways of losing the operable signal.

**Call sites were mutation-tested, not just internals.** Each mutation confirmed red on the tests listed:

| # | Mutation | Caught by |
|---|---|---|
| 1 | drop both new refreshes from the sweep | `refresh_disk_usage_measures_database_and_webapp_cache` |
| 1b | drop only the webapp refresh | same |
| 2 | `db_dir: config.contracts_dir()` (wrong accessor) | `hosting_disk_paths_are_installed_from_the_node_config` |
| 3 | `webapp_cache_dir: default_webapp_cache_dir()` (process-wide) | same, via the accessor assert (see note below) |
| 4 | delete the whole install call | same (pin guard) |
| 5 | revert `total_bytes` to the row sum | 5 disk_usage tests |
| 6 | charge the webapp cache to the aggregate | `webapp_cache_never_enters_the_budgeted_aggregate` |
| 7 | budget deducts non-state footprint (the rejected design) | `effective_budget_never_falls_as_measured_usage_rises` |
| 8 | drop the over-budget signal call | `-D warnings` dead-code gate |
| 9 | `file_disk_bytes` returns `len()` (apparent size) | the two measurement tests + 9 walk tests |
| 10 | a failed walk stores 0 (the old behavior) | the three retention tests |
| 11 | growth gate reverts to `total − old + new`, no exemption | the three growth-gate tests + `over_budget_from_dead_space_still_merges_hosted_updates` |

A precision note on mutation 3, since the table used to leave it ambiguous. Two assertions in that test would trip under it: the loop's accessor assert (`config.ws_api.webapp_cache_dir` is no longer in the extracted arguments) and the negative guard (`!src.contains("default_webapp_cache_dir")`, since the substituted symbol would now appear in the production slice). The loop runs first, so the accessor assert is what actually reports; the guard is never reached. The guard on its own **cannot** go red from production code being *deleted* — it is a forward guard against reintroducing the process-wide default, which is what its own code comment says. Credit for catching mutation 3 belongs to the accessor assert.

Mutation 7 initially **passed** — the monotonicity fixture drove `used` purely through state rows, leaving the non-state footprint at zero, so the rejected deduct design was invisible to it. That is the exact inversion the test exists to forbid. Fixed in `cc6069a2`, and re-confirmed red after the fixture was rewritten (see below). Committed before mutating so nothing was lost to the revert.

### The measurement fix silently un-armed two existing tests

Worth stating on its own, because it is the failure mode this series keeps hitting: **a change that makes measurement more correct disarmed the tests guarding it, and every one of them stayed green.**

Switching the walks from apparent length to allocated blocks invalidated two fixtures that had been written in bytes:

- `effective_budget_never_falls_as_measured_usage_rises` drove `used` through a **sparse** `set_len` file. A hole allocates nothing, so every entry in its sweep — `0`, `128 MiB`, `583 MiB`, `2680 MiB`, `40 GiB` — collapsed to the same measured `used` of 0. The "never falls" assertion then compared a constant against itself. It passed, asserting nothing, and would have gone on passing.
- `refresh_disk_usage_measures_database_and_webapp_cache` — the **call-site pin**, the one test standing between this PR and a silently-dropped `refresh_db_file` — grew its fixtures from 11 to 1100 bytes. Neither size moves an allocation-based measurement on a 4 KiB-block filesystem, so the pin would have passed while measuring nothing at all.

Both are fixed and both were re-confirmed red under their mutations (7 and 1 in the table above). The monotonicity fixture now injects the database size through a `#[cfg(test)]` setter, which also lets it reach the 32 GiB cap that no on-disk fixture could materialize; the call-site pin grows by whole 64 KiB chunks and reads the post-growth sizes back from the filesystem rather than assuming them.

**Rule for anyone adding a fixture to this module: think in blocks, not bytes.** A file's contribution is `st_blocks * 512`. Sub-block sizes are indistinguishable from each other, sparse files contribute nothing regardless of length, and a filesystem with transparent compression can collapse a run of zeros — which is why the test helper writes a pseudo-random stream. Assert against a size read back from the filesystem, not against the byte count you wrote.

Four of the new tests pass **before** their fix as well as after, and are stated as such rather than as regression pins: `a_missing_directory_measures_zero_rather_than_retaining` and `dead_space_does_not_exempt_a_fresh_put` guard against over-correcting in the opposite direction, and `honest_over_budget_usage_does_not_tighten_the_eviction_floor` / `over_budget_clears_when_free_space_grows` cover behavior that was correct but unpinned.

The source pin reads a comment-stripped, whitespace-collapsed slice of the production half of `handler.rs` (so a rustfmt re-wrap cannot rot a needle) and assembles every needle from `concat!` fragments appearing nowhere verbatim, so it cannot match its own source through `include_str!`.

`cargo fmt` clean; `cargo clippy -p freenet --lib --all-features` clean; 4478 lib tests pass.

## Also in this PR

- `DiskUsageStats::total_bytes` delegates to `total_bytes()` instead of re-deriving the aggregate, so the budgeted formula has one definition.
- The home-page tooltip says its parts do not sum to the tile above them, because state bytes live *inside* the database file and the aggregate takes the larger of the two — an operator who adds them up and gets a different number had no way to tell a display bug from the `max` rule.
- Two comments this work invalidated: `path_handlers.rs` still said the accounting walks only `contracts_dir` + `wasmtime_cache_dir`, and the sweep comment in `ring.rs` still said the gauges were "observational only" (untrue since #4702).
- The over-budget warning's remediation advice named only the startup compaction. That is wrong for one case the shallow walk deliberately counts: redb's schema migration renames the old database to `db.backup.<timestamp>` (`redb.rs::backup_and_remove_database`), nothing ever deletes it, and no restart reclaims it. The warning now names the file and the remedy. This is complementary to reporting true dead space from the backend's own in-use byte count, not a substitute for it: in-use bytes tell an operator how much the *live database* would give back to a compaction, whereas an orphaned migration backup is a separate file that no compaction can ever touch and only `rm` reclaims. Both land in the same `log_disk_budget_transition` warning, so if the final diff shows them together they are additive edits and neither supersedes the other: the figure should come from `db_file - db_in_use`, and the migration-backup clause still has to be there, because that backup file is counted by the shallow walk but is not part of the live database's in-use bytes.
- `seed()`'s rustdoc no longer claims every gauge is populated the instant `is_seeded` flips. It is not — the walks run just after the flag — and the doc now says why that window is permissive rather than blocking, and why moving the walks ahead of the flag would trade it for a worse one.

Closes #5007

[AI-assisted - Claude]
