### PR TITLE
fix(contract): stop the no-subscriber-snapshot warn storm (#5040)

### DIFF
--- a/crates/core/src/contract/executor/pool_tests/subscriber_limit_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/subscriber_limit_tests.rs
@@ -370,7 +370,13 @@ async fn send_update_notification_absent_local_snapshot_does_not_warn() {
         "an ABSENT local snapshot must not WARN (nothing is owed locally); \
          captured: {logs:?}"
     );
-    // The condition is still observable, just at DEBUG.
+    // The condition remains observable at DEBUG *in debug builds only*.
+    // `release_max_level_info` (crates/core/Cargo.toml) compiles `debug!` out of
+    // release, so in a shipped binary the absent case is silent, not merely
+    // quiet. That is deliberate — it is the steady state and carries no operator
+    // action — but it means this assertion pins a line production does not
+    // emit, and a log grep can no longer tell "no subscriber registered" from
+    // "never reached". See #5040.
     assert!(
         logs.iter().any(|l| l.starts_with("DEBUG")
             && l.contains("no local subscriber")
@@ -565,8 +571,20 @@ async fn empty_shared_snapshot_warns_once_not_on_every_update() {
     let instance_id = *key.id();
 
     // Post-`retain` state: entry present, subscriber vec emptied in place.
+    //
+    // The summaries sibling is seeded NON-EMPTY on purpose. That is the shape
+    // the real cleanup leaves behind (the local failure path historically never
+    // pruned per-client summaries), and it is the shape that catches an
+    // orphaned summaries entry. Seeding an empty map instead makes the
+    // `!contains_key` assertion below pass no matter what the production code
+    // does, because a conditional `remove_if(.., is_empty)` would clear it
+    // anyway — a vacuous test that reports success without exercising the fix.
+    let dead_client = ClientId::next();
     shared_notifications.insert(instance_id, Vec::new());
-    shared_summaries.insert(instance_id, std::collections::HashMap::new());
+    shared_summaries.insert(
+        instance_id,
+        std::collections::HashMap::from([(dead_client, None)]),
+    );
 
     let (messages, guard) = install_log_capture();
 
@@ -685,5 +703,76 @@ async fn closed_subscriber_channel_drops_entry_at_point_of_loss() {
     assert!(
         !shared_summaries.contains_key(&instance_id),
         "the summaries sibling must be removed alongside it"
+    );
+}
+
+/// Regression for #5040 — the LOCAL-storage twin of the test above.
+///
+/// Review found the source fix had landed only on the shared branch while the
+/// comments and PR body claimed both. For the identical sequence the local
+/// branch emitted one extra WARN (the entry survived to the next update) and
+/// leaked the dead client's summary, because its channel-closed cleanup only
+/// ran `retain` — it never pruned `subscriber_summaries` and never dropped the
+/// emptied entry. The pooled executor is what production uses, but this branch
+/// is what the mock/simulation harness runs, so it was untested in both senses.
+#[cfg(feature = "trace")]
+#[tokio::test(flavor = "current_thread")]
+async fn closed_subscriber_channel_drops_entry_at_point_of_loss_local() {
+    let mut executor = create_executor().await;
+    let contract = test_contract(b"closed_channel_local_5040");
+    let key = contract.key();
+    let instance_id = *key.id();
+
+    // No shared storage installed, so this takes the local branch.
+    let client_id = ClientId::next();
+    let (tx, rx) = tokio::sync::mpsc::channel(SUBSCRIBER_NOTIFICATION_CHANNEL_SIZE);
+    drop(rx);
+    executor
+        .update_notifications
+        .insert(instance_id, vec![(client_id, tx)]);
+    executor.subscriber_summaries.insert(
+        instance_id,
+        std::collections::HashMap::from([(client_id, None)]),
+    );
+
+    let (messages, guard) = install_log_capture();
+
+    for state in [vec![1u8, 1, 1], vec![2u8, 2, 2]] {
+        executor
+            .upsert_contract_state(
+                key,
+                either::Either::Left(WrappedState::new(state)),
+                RelatedContracts::default(),
+                Some(contract.clone()),
+            )
+            .await
+            .expect("store contract");
+    }
+
+    drop(guard);
+
+    let logs = messages.lock().unwrap();
+    assert_eq!(
+        logs.iter()
+            .filter(|l| l.starts_with("ERROR") && l.contains("channel closed"))
+            .count(),
+        1,
+        "a closed subscriber channel must be reported once as an ERROR on the \
+         local branch too; captured: {logs:?}"
+    );
+    assert!(
+        !logs
+            .iter()
+            .any(|l| l.starts_with("WARN") && l.contains("no subscriber snapshot")),
+        "the local branch must also drop the entry at the point of loss, leaving \
+         nothing for the next update to warn about; captured: {logs:?}"
+    );
+    assert!(
+        !executor.update_notifications.contains_key(&instance_id),
+        "the local subscriber entry must be removed as it empties"
+    );
+    assert!(
+        !executor.subscriber_summaries.contains_key(&instance_id),
+        "the local summaries sibling must be removed alongside it"
     );
 }

--- a/crates/core/src/contract/executor/pool_tests/subscriber_limit_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/subscriber_limit_tests.rs
@@ -323,17 +323,23 @@ fn install_log_capture() -> (
     (messages, guard)
 }
 
-/// Regression for #4681 (partial hardening): a committed state install for a
-/// contract that has NO subscriber snapshot must emit an observable WARN
-/// (carrying the contract `instance_id`) instead of returning silently. The
-/// silent early-return was the observability gap that let a cross-node
-/// subscriber miss a committed `UpdateNotification` with nothing logged.
+/// Re-scope of #4681 by #5040: an ABSENT subscriber entry must NOT warn.
+///
+/// #4773 deliberately treated "missing" and "empty" snapshots uniformly and
+/// warned on both. In production the missing case is the ordinary steady state
+/// for any contract a node hosts for the NETWORK with no local client attached
+/// (the network mesh is fed by `broadcast_state_change`, not by this local
+/// fan-out), so nothing is undelivered. Warning on it produced 22,413 lines in
+/// one day on a single node — 96.6% of them for one zero-subscriber contract —
+/// which buried the empty-entry case that #4681 actually exists to surface.
+/// PR #4773's own reviewer note predicted this ("a follow-up could rate-limit
+/// it if it proves noisy").
 ///
 /// The mock executor has no shared storage, so this exercises the LOCAL-storage
 /// (`else`) branch — see the `_shared_*` tests below for the shared branch.
 #[cfg(feature = "trace")]
 #[tokio::test(flavor = "current_thread")]
-async fn send_update_notification_without_subscribers_emits_warn() {
+async fn send_update_notification_absent_local_snapshot_does_not_warn() {
     let mut executor = create_executor().await;
     let contract = test_contract(b"warn_no_subscribers_4681");
     let key = contract.key();
@@ -358,11 +364,19 @@ async fn send_update_notification_without_subscribers_emits_warn() {
     let logs = messages.lock().unwrap();
     let id_str = instance_id.to_string();
     assert!(
-        logs.iter().any(|l| l.starts_with("WARN")
-            && l.contains("no subscriber snapshot")
+        !logs
+            .iter()
+            .any(|l| l.starts_with("WARN") && l.contains("no subscriber snapshot")),
+        "an ABSENT local snapshot must not WARN (nothing is owed locally); \
+         captured: {logs:?}"
+    );
+    // The condition is still observable, just at DEBUG.
+    assert!(
+        logs.iter().any(|l| l.starts_with("DEBUG")
+            && l.contains("no local subscriber")
             && l.contains("local storage")
             && l.contains(&id_str)),
-        "expected a local-storage WARN naming instance_id {id_str}; captured: {logs:?}"
+        "expected a local-storage DEBUG naming instance_id {id_str}; captured: {logs:?}"
     );
 }
 
@@ -420,12 +434,14 @@ async fn send_update_notification_empty_local_snapshot_emits_warn() {
     );
 }
 
-/// Regression for #4681: the SHARED-storage branch — the exact path the issue
-/// cites (`shared_notifications.get(&instance_id) == None`). A committed update
-/// with no shared subscriber entry must emit a shared-storage WARN.
+/// Re-scope of #4681 by #5040, SHARED-storage branch: an ABSENT shared
+/// subscriber entry must NOT warn. This is the exact production path that
+/// produced the 22k/day storm (`shared_notifications.get(&instance_id) ==
+/// None` for a network-hosted contract with no local client). See the
+/// local-storage sibling above for the full rationale.
 #[cfg(feature = "trace")]
 #[tokio::test(flavor = "current_thread")]
-async fn send_update_notification_missing_shared_snapshot_emits_warn() {
+async fn send_update_notification_absent_shared_snapshot_does_not_warn() {
     let mut executor = create_executor().await;
     // Attach empty shared storage so `send_update_notification` takes the
     // shared branch instead of the local one.
@@ -456,11 +472,18 @@ async fn send_update_notification_missing_shared_snapshot_emits_warn() {
     let logs = messages.lock().unwrap();
     let id_str = instance_id.to_string();
     assert!(
-        logs.iter().any(|l| l.starts_with("WARN")
-            && l.contains("no subscriber snapshot")
+        !logs
+            .iter()
+            .any(|l| l.starts_with("WARN") && l.contains("no subscriber snapshot")),
+        "an ABSENT shared snapshot must not WARN (nothing is owed locally); \
+         captured: {logs:?}"
+    );
+    assert!(
+        logs.iter().any(|l| l.starts_with("DEBUG")
+            && l.contains("no local subscriber")
             && l.contains("shared storage")
             && l.contains(&id_str)),
-        "expected a shared-storage WARN naming instance_id {id_str}; captured: {logs:?}"
+        "expected a shared-storage DEBUG naming instance_id {id_str}; captured: {logs:?}"
     );
 }
 
@@ -509,5 +532,78 @@ async fn send_update_notification_empty_shared_snapshot_emits_warn() {
             && l.contains(&id_str)),
         "an empty (present) shared snapshot must still WARN naming instance_id \
          {id_str}; captured: {logs:?}"
+    );
+}
+
+/// Regression for #5040 — the storm itself, and the assertion that actually
+/// fails without the fix.
+///
+/// The empty-but-present entry was pruned only opportunistically (by the next
+/// `RuntimePool::remove_client` from ANY client), so until that happened EVERY
+/// committed update on the contract re-emitted the WARN. On a contract taking
+/// sustained update traffic with no local subscriber that is unbounded: the
+/// reporting node logged 22,413 lines in a day, 96.6% for one contract.
+///
+/// The loss is worth exactly one line — it is already reported per-client as an
+/// ERROR at the point of loss — so the entry is dropped when it goes empty and
+/// every subsequent update reads as ABSENT (DEBUG). Two committed updates must
+/// therefore produce ONE WARN, not two.
+#[cfg(feature = "trace")]
+#[tokio::test(flavor = "current_thread")]
+async fn empty_shared_snapshot_warns_once_not_on_every_update() {
+    let mut executor = create_executor().await;
+    let shared_notifications = std::sync::Arc::new(dashmap::DashMap::new());
+    let shared_summaries = std::sync::Arc::new(dashmap::DashMap::new());
+    executor.set_shared_notifications(
+        shared_notifications.clone(),
+        shared_summaries.clone(),
+        std::sync::Arc::new(dashmap::DashMap::new()),
+    );
+
+    let contract = test_contract(b"warn_once_5040");
+    let key = contract.key();
+    let instance_id = *key.id();
+
+    // Post-`retain` state: entry present, subscriber vec emptied in place.
+    shared_notifications.insert(instance_id, Vec::new());
+    shared_summaries.insert(instance_id, std::collections::HashMap::new());
+
+    let (messages, guard) = install_log_capture();
+
+    // Two committed updates over the same empty entry.
+    for state in [vec![1u8, 1, 1], vec![2u8, 2, 2]] {
+        executor
+            .upsert_contract_state(
+                key,
+                either::Either::Left(WrappedState::new(state)),
+                RelatedContracts::default(),
+                Some(contract.clone()),
+            )
+            .await
+            .expect("store contract");
+    }
+
+    drop(guard);
+
+    let logs = messages.lock().unwrap();
+    let warns = logs
+        .iter()
+        .filter(|l| l.starts_with("WARN") && l.contains("no subscriber snapshot"))
+        .count();
+    assert_eq!(
+        warns, 1,
+        "an emptied subscriber entry must WARN exactly once, not once per \
+         committed update (#5040); captured: {logs:?}"
+    );
+
+    // The entry (and its summaries sibling) is gone, so the next update reads
+    // as ABSENT rather than re-warning — this is what bounds the storm.
+    assert!(
+        !shared_notifications.contains_key(&instance_id),
+        "the emptied subscriber entry must be removed once observed"
+    );
+    assert!(
+        !shared_summaries.contains_key(&instance_id),
+        "the emptied summaries sibling must be removed alongside it"
     );
 }

--- a/crates/core/src/contract/executor/pool_tests/subscriber_limit_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/subscriber_limit_tests.rs
@@ -607,3 +607,83 @@ async fn empty_shared_snapshot_warns_once_not_on_every_update() {
         "the emptied summaries sibling must be removed alongside it"
     );
 }
+
+/// Regression for #5040, source half: the entry is dropped AS it empties, in
+/// the channel-closed `retain` itself, not merely when a later update happens
+/// to observe it.
+///
+/// This is the path that actually creates the empty entry in production (a
+/// subscriber's receiver goes away without a Disconnect reaching the handler).
+/// The loss is worth exactly one line and already has one: the per-client
+/// ERROR at the point of loss. Dropping the entry there means no subsequent
+/// update warns about it at all.
+#[cfg(feature = "trace")]
+#[tokio::test(flavor = "current_thread")]
+async fn closed_subscriber_channel_drops_entry_at_point_of_loss() {
+    let mut executor = create_executor().await;
+    let shared_notifications = std::sync::Arc::new(dashmap::DashMap::new());
+    let shared_summaries = std::sync::Arc::new(dashmap::DashMap::new());
+    executor.set_shared_notifications(
+        shared_notifications.clone(),
+        shared_summaries.clone(),
+        std::sync::Arc::new(dashmap::DashMap::new()),
+    );
+
+    let contract = test_contract(b"closed_channel_5040");
+    let key = contract.key();
+    let instance_id = *key.id();
+
+    // A registered subscriber whose receiver has been dropped: the notification
+    // send fails `Closed`, which is what empties the vec in place.
+    let client_id = ClientId::next();
+    let (tx, rx) = tokio::sync::mpsc::channel(SUBSCRIBER_NOTIFICATION_CHANNEL_SIZE);
+    drop(rx);
+    shared_notifications.insert(instance_id, vec![(client_id, tx)]);
+    shared_summaries.insert(
+        instance_id,
+        std::collections::HashMap::from([(client_id, None)]),
+    );
+
+    let (messages, guard) = install_log_capture();
+
+    for state in [vec![1u8, 1, 1], vec![2u8, 2, 2]] {
+        executor
+            .upsert_contract_state(
+                key,
+                either::Either::Left(WrappedState::new(state)),
+                RelatedContracts::default(),
+                Some(contract.clone()),
+            )
+            .await
+            .expect("store contract");
+    }
+
+    drop(guard);
+
+    let logs = messages.lock().unwrap();
+    // The loss is reported once, at the point of loss, naming the client.
+    assert_eq!(
+        logs.iter()
+            .filter(|l| l.starts_with("ERROR") && l.contains("channel closed"))
+            .count(),
+        1,
+        "a closed subscriber channel must be reported once as an ERROR; \
+         captured: {logs:?}"
+    );
+    // The second update must not warn: the entry was already dropped.
+    assert!(
+        !logs
+            .iter()
+            .any(|l| l.starts_with("WARN") && l.contains("no subscriber snapshot")),
+        "dropping the entry at the point of loss must leave nothing for a later \
+         update to warn about; captured: {logs:?}"
+    );
+    assert!(
+        !shared_notifications.contains_key(&instance_id),
+        "the subscriber entry must be removed as it empties"
+    );
+    assert!(
+        !shared_summaries.contains_key(&instance_id),
+        "the summaries sibling must be removed alongside it"
+    );
+}

--- a/crates/core/src/contract/executor/pool_tests/subscriber_limit_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/subscriber_limit_tests.rs
@@ -815,7 +815,9 @@ async fn closed_subscriber_channel_drops_entry_at_point_of_loss_local() {
 /// and a dead client's summary would persist for the lifetime of the contract.
 /// Also the only test asserting a live subscriber actually RECEIVES its
 /// notification, which pins that the fan-out path still works at all.
-#[cfg(feature = "trace")]
+///
+/// No `trace` gate: this asserts on map state and a delivered notification,
+/// not on captured logs.
 #[tokio::test(flavor = "current_thread")]
 async fn partial_failure_prunes_only_the_dead_subscriber_local() {
     let mut executor = create_executor().await;
@@ -891,6 +893,91 @@ async fn partial_failure_prunes_only_the_dead_subscriber_local() {
     }
 }
 
+/// The SHARED-storage twin of the partial-failure test above — the branch
+/// production actually runs (`handler.rs` wires `ContractExecutor =
+/// RuntimePool`, and every pooled executor gets shared storage).
+///
+/// Same reasoning: the shared per-client summaries prune is masked by
+/// all-or-nothing failure, because the whole-entry cleanup removes the
+/// summaries map anyway. Only a surviving subscriber exposes it.
+#[tokio::test(flavor = "current_thread")]
+async fn partial_failure_prunes_only_the_dead_subscriber_shared() {
+    let mut executor = create_executor().await;
+    let shared_notifications = std::sync::Arc::new(dashmap::DashMap::new());
+    let shared_summaries = std::sync::Arc::new(dashmap::DashMap::new());
+    executor.set_shared_notifications(
+        shared_notifications.clone(),
+        shared_summaries.clone(),
+        std::sync::Arc::new(dashmap::DashMap::new()),
+    );
+
+    let contract = test_contract(b"partial_failure_shared_5040");
+    let key = contract.key();
+    let instance_id = *key.id();
+
+    let dead_client = ClientId::next();
+    let live_client = ClientId::next();
+    let (dead_tx, dead_rx) = tokio::sync::mpsc::channel(SUBSCRIBER_NOTIFICATION_CHANNEL_SIZE);
+    let (live_tx, mut live_rx) = tokio::sync::mpsc::channel(SUBSCRIBER_NOTIFICATION_CHANNEL_SIZE);
+    drop(dead_rx);
+
+    let mut subs = vec![(dead_client, dead_tx), (live_client, live_tx)];
+    subs.sort_by_key(|(c, _)| *c);
+    shared_notifications.insert(instance_id, subs);
+    shared_summaries.insert(
+        instance_id,
+        std::collections::HashMap::from([(dead_client, None), (live_client, None)]),
+    );
+
+    executor
+        .upsert_contract_state(
+            key,
+            either::Either::Left(WrappedState::new(vec![6, 6, 6])),
+            RelatedContracts::default(),
+            Some(contract),
+        )
+        .await
+        .expect("store contract");
+
+    let notifiers = shared_notifications
+        .get(&instance_id)
+        .expect("entry must survive — a live subscriber remains");
+    assert_eq!(
+        notifiers.len(),
+        1,
+        "only the dead subscriber may be removed from the notifier list"
+    );
+    assert_eq!(
+        notifiers[0].0, live_client,
+        "the surviving subscriber must be the live one"
+    );
+    drop(notifiers);
+
+    let summaries = shared_summaries
+        .get(&instance_id)
+        .expect("summaries entry must survive alongside the notifier entry");
+    assert!(
+        !summaries.contains_key(&dead_client),
+        "the dead subscriber's summary must be pruned on the shared branch too"
+    );
+    assert!(
+        summaries.contains_key(&live_client),
+        "the live subscriber's summary must NOT be collaterally removed"
+    );
+    drop(summaries);
+
+    match live_rx.try_recv() {
+        Ok(Ok(resp)) => {
+            let as_str = format!("{resp:?}");
+            assert!(
+                as_str.contains("UpdateNotification"),
+                "the live subscriber must receive an UpdateNotification; got: {as_str}"
+            );
+        }
+        other => panic!("the live subscriber must receive its notification; got: {other:?}"),
+    }
+}
+
 /// Source-scrape pin for the #5040 TOCTOU fix in
 /// `RuntimePool::register_contract_notifier`.
 ///
@@ -913,13 +1000,22 @@ async fn partial_failure_prunes_only_the_dead_subscriber_local() {
 #[test]
 fn register_contract_notifier_takes_one_guard_for_search_and_write() {
     let src = include_str!("../runtime/pool.rs");
+    // Slice the `already_registered` STATEMENT itself, bounded by two code
+    // anchors (both unique in pool.rs), not by prose and not by a wider region.
+    //
+    // An earlier revision of this pin ended at `MAX_SUBSCRIBERS_PER_CONTRACT`,
+    // reasoning that API surface beats a comment as an anchor. It does, but
+    // that anchor sits PAST the `else` branch's own `shared_notifications`
+    // read, so the region swallowed a second, legitimate acquisition and the
+    // count assertion failed on correct code. Bounding the statement exactly
+    // is both stabler and narrower than either.
     let start = src
-        .find("fn register_contract_notifier(")
-        .expect("register_contract_notifier not found in pool.rs");
+        .find("let already_registered =")
+        .expect("`already_registered` binding not found in pool.rs");
     let after = &src[start..];
     let end = after
-        .find("// New subscriber: enforce per-contract limit")
-        .expect("new-subscriber arm anchor not found in register_contract_notifier");
+        .find("if let Some(same_channel)")
+        .expect("`if let Some(same_channel)` not found after the binding");
     let already_registered: String = after[..end]
         .chars()
         .filter(|c| !c.is_whitespace())
@@ -937,5 +1033,16 @@ fn register_contract_notifier_takes_one_guard_for_search_and_write() {
         already_registered.contains("self.shared_notifications.get_mut("),
         "the single acquisition must be a WRITE guard (`get_mut`), so the \
          binary search and the channel write happen under it"
+    );
+    // The guard alone is not the invariant — the WRITE has to still be there.
+    // Without this, deleting the refresh entirely satisfies both assertions
+    // above while leaving a reconnected client wired to its dead sender
+    // forever, receiving nothing. Unreachable behaviorally: nothing in the
+    // tree constructs a `RuntimePool`, so no test can observe it.
+    assert!(
+        already_registered.contains("channels[idx]=(cli_id,notification_ch.clone())"),
+        "the reconnect path must actually REFRESH the stored channel; without \
+         the write a reconnected client keeps its dead sender and silently \
+         receives nothing"
     );
 }

--- a/crates/core/src/contract/executor/pool_tests/subscriber_limit_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/subscriber_limit_tests.rs
@@ -438,6 +438,16 @@ async fn send_update_notification_empty_local_snapshot_emits_warn() {
         "an empty (present) local snapshot must still WARN naming instance_id \
          {id_str}; captured: {logs:?}"
     );
+    drop(logs);
+    // Deterministic, non-log discriminator. This test and its shared twin were
+    // the only two carried entirely by a positive log assertion, which is what
+    // #4927 flakes on (a dropped capture reads as a missing WARN). The entry
+    // removal is observable in the map, so a #4927-class flake can no longer
+    // turn either of them into a silent false result.
+    assert!(
+        !executor.update_notifications.contains_key(&instance_id),
+        "the emptied local entry must also be dropped"
+    );
 }
 
 /// Re-scope of #4681 by #5040, SHARED-storage branch: an ABSENT shared
@@ -538,6 +548,22 @@ async fn send_update_notification_empty_shared_snapshot_emits_warn() {
             && l.contains(&id_str)),
         "an empty (present) shared snapshot must still WARN naming instance_id \
          {id_str}; captured: {logs:?}"
+    );
+    // The corrected wording is part of the fix: the old text claimed a delivery
+    // was being dropped at this instant, when the subscriber was actually lost
+    // on an earlier update and already reported by the per-client ERROR. Pinned
+    // so a revert to the misleading phrasing fails.
+    assert!(
+        logs.iter()
+            .any(|l| l.starts_with("WARN") && l.contains("stale entry dropped")),
+        "the WARN must say the entry was stale, not that a delivery was just \
+         dropped; captured: {logs:?}"
+    );
+    drop(logs);
+    // Deterministic, non-log discriminator — see the local twin above.
+    assert!(
+        !shared_notifications.contains_key(&instance_id),
+        "the emptied shared entry must also be dropped"
     );
 }
 
@@ -774,5 +800,142 @@ async fn closed_subscriber_channel_drops_entry_at_point_of_loss_local() {
     assert!(
         !executor.subscriber_summaries.contains_key(&instance_id),
         "the local summaries sibling must be removed alongside it"
+    );
+}
+
+/// Regression for #5040: PARTIAL failure — one subscriber dies, one survives.
+///
+/// This is the only shape in which the per-client summaries prune matters, and
+/// therefore the only shape that can catch its absence. Every other test here
+/// uses all-or-nothing failure, where the whole-entry cleanup removes the
+/// summaries map anyway and so masks a missing per-client prune entirely (the
+/// prune was a surviving mutant until this test existed).
+///
+/// With a survivor present the vec stays non-empty, the entry is never dropped,
+/// and a dead client's summary would persist for the lifetime of the contract.
+/// Also the only test asserting a live subscriber actually RECEIVES its
+/// notification, which pins that the fan-out path still works at all.
+#[cfg(feature = "trace")]
+#[tokio::test(flavor = "current_thread")]
+async fn partial_failure_prunes_only_the_dead_subscriber_local() {
+    let mut executor = create_executor().await;
+    let contract = test_contract(b"partial_failure_5040");
+    let key = contract.key();
+    let instance_id = *key.id();
+
+    let dead_client = ClientId::next();
+    let live_client = ClientId::next();
+    let (dead_tx, dead_rx) = tokio::sync::mpsc::channel(SUBSCRIBER_NOTIFICATION_CHANNEL_SIZE);
+    let (live_tx, mut live_rx) = tokio::sync::mpsc::channel(SUBSCRIBER_NOTIFICATION_CHANNEL_SIZE);
+    drop(dead_rx);
+
+    // Sorted by ClientId, matching the production insert order.
+    let mut subs = vec![(dead_client, dead_tx), (live_client, live_tx)];
+    subs.sort_by_key(|(c, _)| *c);
+    executor.update_notifications.insert(instance_id, subs);
+    executor.subscriber_summaries.insert(
+        instance_id,
+        std::collections::HashMap::from([(dead_client, None), (live_client, None)]),
+    );
+
+    executor
+        .upsert_contract_state(
+            key,
+            either::Either::Left(WrappedState::new(vec![5, 5, 5])),
+            RelatedContracts::default(),
+            Some(contract),
+        )
+        .await
+        .expect("store contract");
+
+    // The dead subscriber is pruned from BOTH maps; the survivor is untouched.
+    let notifiers = executor
+        .update_notifications
+        .get(&instance_id)
+        .expect("entry must survive — a live subscriber remains");
+    assert_eq!(
+        notifiers.len(),
+        1,
+        "only the dead subscriber may be removed from the notifier list"
+    );
+    assert_eq!(
+        notifiers[0].0, live_client,
+        "the surviving subscriber must be the live one"
+    );
+
+    let summaries = executor
+        .subscriber_summaries
+        .get(&instance_id)
+        .expect("summaries entry must survive alongside the notifier entry");
+    assert!(
+        !summaries.contains_key(&dead_client),
+        "the dead subscriber's summary must be pruned — otherwise it leaks for \
+         the lifetime of the contract, which is exactly what the per-client \
+         prune exists to prevent"
+    );
+    assert!(
+        summaries.contains_key(&live_client),
+        "the live subscriber's summary must NOT be collaterally removed"
+    );
+
+    // And the survivor actually got its notification.
+    match live_rx.try_recv() {
+        Ok(Ok(resp)) => {
+            let as_str = format!("{resp:?}");
+            assert!(
+                as_str.contains("UpdateNotification"),
+                "the live subscriber must receive an UpdateNotification; got: {as_str}"
+            );
+        }
+        other => panic!("the live subscriber must receive its notification; got: {other:?}"),
+    }
+}
+
+/// Source-scrape pin for the #5040 TOCTOU fix in
+/// `RuntimePool::register_contract_notifier`.
+///
+/// Why a source pin and not a behavioral test: nothing in the suite constructs
+/// a real `RuntimePool` (its only `new` call site is production wiring in
+/// `handler.rs`, needing a Config + OpManager). Every `register_contract_notifier`
+/// test in this file builds an `Executor`, which resolves to the *other* impl
+/// — `bridged_register_contract_notifier` — so the pool path is unreachable
+/// from here and reverting the fix would leave the whole suite green.
+///
+/// The invariant: the already-registered path acquires the
+/// `shared_notifications` guard EXACTLY ONCE, doing the binary search and the
+/// channel write under that same guard. The split version computed the index
+/// under a read guard, released it, then re-acquired `get_mut` — a window in
+/// which the entry can shrink (out-of-bounds panic) or vanish entirely
+/// (silently skipped write, so the client gets a successful subscribe that
+/// never delivers — the failure mode #5040's entry-dropping introduced).
+///
+/// Whitespace-insensitive so rustfmt cannot break it.
+#[test]
+fn register_contract_notifier_takes_one_guard_for_search_and_write() {
+    let src = include_str!("../runtime/pool.rs");
+    let start = src
+        .find("fn register_contract_notifier(")
+        .expect("register_contract_notifier not found in pool.rs");
+    let after = &src[start..];
+    let end = after
+        .find("// New subscriber: enforce per-contract limit")
+        .expect("new-subscriber arm anchor not found in register_contract_notifier");
+    let already_registered: String = after[..end]
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect();
+
+    assert_eq!(
+        already_registered
+            .matches("self.shared_notifications")
+            .count(),
+        1,
+        "the already-registered path must touch `shared_notifications` exactly \
+         once; a second acquisition reopens the TOCTOU #5040 closed"
+    );
+    assert!(
+        already_registered.contains("self.shared_notifications.get_mut("),
+        "the single acquisition must be a WRITE guard (`get_mut`), so the \
+         binary search and the channel write happen under it"
     );
 }

--- a/crates/core/src/contract/executor/runtime/executor_impl.rs
+++ b/crates/core/src/contract/executor/runtime/executor_impl.rs
@@ -2530,6 +2530,23 @@ where
                              (shared storage); stale entry dropped — the subscriber was \
                              lost on an earlier update (see the prior channel-closed ERROR)"
                         );
+                    } else {
+                        // The removal DECLINED: a client registered between the
+                        // snapshot above and this call, so the entry is no
+                        // longer empty. This update is not delivered to them
+                        // (the snapshot predates their arrival); the next
+                        // committed update is.
+                        //
+                        // Logged rather than left silent: a registered
+                        // subscriber, a committed update, and zero log evidence
+                        // is precisely the #4681 shape this callsite exists to
+                        // make visible.
+                        tracing::debug!(
+                            %instance_id,
+                            "send_update_notification: subscriber registered concurrently with \
+                             the stale-entry cleanup; this update was not delivered to it, the \
+                             next one will be"
+                        );
                     }
                     return Ok(());
                 }
@@ -2779,11 +2796,16 @@ where
                 .get(&instance_id)
                 .is_some_and(|notifiers| notifiers.is_empty());
             if lost_subscriber_entry {
+                // Captured BEFORE the removal, matching the shared arm — both
+                // branches must report the same thing under the same field name
+                // (the count at the moment of observation, INCLUDING the entry
+                // being dropped).
+                let registered_contracts = self.update_notifications.len();
                 self.update_notifications.remove(&instance_id);
                 self.subscriber_summaries.remove(&instance_id);
                 tracing::warn!(
                     %instance_id,
-                    registered_contracts = self.update_notifications.len(),
+                    registered_contracts,
                     "send_update_notification: no subscriber snapshot for contract \
                      (local storage); update notification not delivered"
                 );

--- a/crates/core/src/contract/executor/runtime/executor_impl.rs
+++ b/crates/core/src/contract/executor/runtime/executor_impl.rs
@@ -2440,22 +2440,60 @@ where
                     .get(&instance_id)
                     .map_or_else(Vec::new, |notifiers| notifiers.value().clone());
 
-            // #4681: a committed update found no LIVE subscriber for this
-            // contract — either no map entry at all, OR an empty subscriber vec
-            // left behind by the channel-closed cleanup below (`retain` removes
-            // the last dead subscriber but leaves the emptied entry in the map,
-            // so the next committed update snapshots `Some([])`). Both cases are
-            // fully silent drops for a contract that may have had a registered
-            // subscriber, so surface them with a WARN (instance + total
-            // registered-contract count) instead of returning silently — a
-            // notification dropped for a registered subscriber is never invisible.
+            // #4681, re-scoped by #5040: an empty snapshot is TWO distinct
+            // states, and only one of them is an anomaly.
+            //
+            // * ABSENT entry — no local client is subscribed: either none ever
+            //   was, or the last one disconnected cleanly (`RuntimePool::
+            //   remove_client` drops the entry outright). This is the NORMAL
+            //   steady state for a contract this node hosts for the NETWORK:
+            //   the network mesh is fed by `broadcast_state_change`, not by
+            //   this local fan-out, so nothing is undelivered and nothing is
+            //   lost. Warning per occurrence made a routine fact read as a
+            //   dropped notification and buried the real signal below — one
+            //   production node logged 22,413 of these in a single day, 96.6%
+            //   of them for one zero-subscriber contract (#5040). PR #4773's
+            //   own reviewer note predicted exactly this ("fires on the commit
+            //   path for contracts with zero local subscribers (common on
+            //   relays/gateways) ... a follow-up could rate-limit it if it
+            //   proves noisy").
+            //
+            // * PRESENT but EMPTY — a subscriber's channel closed without a
+            //   Disconnect reaching the handler, so the failure `retain` below
+            //   emptied the vec in place. That loss is already reported at the
+            //   point of loss (one ERROR per closed channel, naming the client),
+            //   so this is a backstop: it is reported ONCE and the stale entry
+            //   (with its already-emptied summaries sibling) is dropped, rather
+            //   than re-warning on every committed update forever. The `retain`
+            //   below now also removes the entry as it empties, which is the
+            //   real source fix; this arm catches anything that still slips
+            //   through. Both adopt the "drop the entry when it goes empty"
+            //   convention the interest/subscriber maps already use
+            //   (`interest.rs`, `hosting.rs`: `remove_if(.., |_, v| v.is_empty())`).
+            //
+            // `remove_if` re-checks emptiness under the map lock, so a
+            // subscriber registering between the snapshot above and this call is
+            // never removed.
             if notifiers_snapshot.is_empty() {
-                tracing::warn!(
-                    %instance_id,
-                    registered_contracts = shared_notifications.len(),
-                    "send_update_notification: no subscriber snapshot for contract \
-                     (shared storage); update notification not delivered"
-                );
+                let lost_subscriber_entry = shared_notifications
+                    .remove_if(&instance_id, |_, notifiers| notifiers.is_empty())
+                    .is_some();
+                if lost_subscriber_entry {
+                    shared_summaries.remove_if(&instance_id, |_, s| s.is_empty());
+                    tracing::warn!(
+                        %instance_id,
+                        registered_contracts = shared_notifications.len(),
+                        "send_update_notification: no subscriber snapshot for contract \
+                         (shared storage); update notification not delivered"
+                    );
+                } else {
+                    tracing::debug!(
+                        %instance_id,
+                        registered_contracts = shared_notifications.len(),
+                        "send_update_notification: no local subscriber for contract \
+                         (shared storage); nothing to deliver locally"
+                    );
+                }
                 return Ok(());
             }
 
@@ -2541,12 +2579,23 @@ where
                 if let Some(mut notifiers) = shared_notifications.get_mut(&instance_id) {
                     notifiers.retain(|(c, _)| !failures.contains(c));
                 }
+                // Drop the entry AS it empties rather than leaving `Some([])`
+                // behind (#5040). The stale empty entry was otherwise pruned
+                // only opportunistically (by the next `RuntimePool::
+                // remove_client` from any client), so until then every
+                // committed update re-warned on it and it inflated the
+                // `registered_contracts` count in that warning. The loss
+                // itself is already reported above, one ERROR per closed
+                // channel. Separate statement so the `get_mut` guard is
+                // released before `remove_if` takes the same shard lock.
+                shared_notifications.remove_if(&instance_id, |_, n| n.is_empty());
 
                 if let Some(mut contract_summaries) = shared_summaries.get_mut(&instance_id) {
                     for failed_client in &failures {
                         contract_summaries.remove(failed_client);
                     }
                 }
+                shared_summaries.remove_if(&instance_id, |_, s| s.is_empty());
 
                 // Decrement per-client subscription counters for failed clients
                 if let Some(shared_client_counts) = &self.shared_client_counts {
@@ -2657,17 +2706,36 @@ where
                 }
             }
         } else {
-            // #4681: mirror the shared-storage observability for the local
-            // (non-pool) executor — a committed update with no LIVE subscriber
-            // for this contract (no map entry at all, OR an empty subscriber vec
-            // left behind by the channel-closed cleanup above) must not vanish
-            // silently.
-            tracing::warn!(
-                %instance_id,
-                registered_contracts = self.update_notifications.len(),
-                "send_update_notification: no subscriber snapshot for contract \
-                 (local storage); update notification not delivered"
-            );
+            // #4681, re-scoped by #5040: mirror the shared-storage branch's
+            // absent-vs-empty split (see the rationale there). Reached when the
+            // entry is absent (no local subscriber — the ordinary case, and not
+            // a drop) OR present-but-empty (a subscriber was lost, already
+            // reported per-client as an ERROR above). The emptied entry and its
+            // summaries sibling are removed together — the fan-out arm above
+            // indexes `subscriber_summaries` on the strength of
+            // `update_notifications` having an entry, so the two must stay
+            // paired.
+            let lost_subscriber_entry = self
+                .update_notifications
+                .get(&instance_id)
+                .is_some_and(|notifiers| notifiers.is_empty());
+            if lost_subscriber_entry {
+                self.update_notifications.remove(&instance_id);
+                self.subscriber_summaries.remove(&instance_id);
+                tracing::warn!(
+                    %instance_id,
+                    registered_contracts = self.update_notifications.len(),
+                    "send_update_notification: no subscriber snapshot for contract \
+                     (local storage); update notification not delivered"
+                );
+            } else {
+                tracing::debug!(
+                    %instance_id,
+                    registered_contracts = self.update_notifications.len(),
+                    "send_update_notification: no local subscriber for contract \
+                     (local storage); nothing to deliver locally"
+                );
+            }
         }
         Ok(())
     }

--- a/crates/core/src/contract/executor/runtime/executor_impl.rs
+++ b/crates/core/src/contract/executor/runtime/executor_impl.rs
@@ -2430,15 +2430,28 @@ where
         let key = *key;
         let instance_id = *key.id();
 
+        // Set by the LOCAL fan-out arm when its channel-closed cleanup empties
+        // the subscriber vec. The removal itself has to happen after the
+        // if/else chain, because that arm holds `&mut` borrows of both maps for
+        // its whole body. The shared arm does the equivalent inline (it works
+        // through `Arc<DashMap>`, not `&mut self`), and leaves this false.
+        let mut local_entry_became_empty = false;
+
         if let (Some(shared_notifications), Some(shared_summaries)) = (
             self.shared_notifications.as_ref(),
             self.shared_summaries.as_ref(),
         ) {
-            // Snapshot subscribers and release the DashMap read-lock before sending
-            let notifiers_snapshot: Vec<(ClientId, mpsc::Sender<HostResult>)> =
+            // Snapshot subscribers and release the DashMap read-lock before sending.
+            // Kept as `Option` rather than collapsed to an empty Vec: ABSENT and
+            // PRESENT-but-EMPTY need different handling below, and distinguishing
+            // them here keeps the ABSENT path — the overwhelmingly common one —
+            // a pure READ. Collapsing first and re-deriving the distinction from
+            // a `remove_if` would take a shard WRITE lock on every committed
+            // update for every contract with no local subscriber.
+            let notifiers_snapshot: Option<Vec<(ClientId, mpsc::Sender<HostResult>)>> =
                 shared_notifications
                     .get(&instance_id)
-                    .map_or_else(Vec::new, |notifiers| notifiers.value().clone());
+                    .map(|notifiers| notifiers.value().clone());
 
             // #4681, re-scoped by #5040: an empty snapshot is TWO distinct
             // states, and only one of them is an anomaly.
@@ -2471,31 +2484,57 @@ where
             //   convention the interest/subscriber maps already use
             //   (`interest.rs`, `hosting.rs`: `remove_if(.., |_, v| v.is_empty())`).
             //
-            // `remove_if` re-checks emptiness under the map lock, so a
-            // subscriber registering between the snapshot above and this call is
-            // never removed.
-            if notifiers_snapshot.is_empty() {
-                let lost_subscriber_entry = shared_notifications
-                    .remove_if(&instance_id, |_, notifiers| notifiers.is_empty())
-                    .is_some();
-                if lost_subscriber_entry {
-                    shared_summaries.remove_if(&instance_id, |_, s| s.is_empty());
-                    tracing::warn!(
-                        %instance_id,
-                        registered_contracts = shared_notifications.len(),
-                        "send_update_notification: no subscriber snapshot for contract \
-                         (shared storage); update notification not delivered"
-                    );
-                } else {
+            // NOTE ON VISIBILITY: `debug!` is compiled OUT of release builds by
+            // `release_max_level_info` (see crates/core/Cargo.toml), so the
+            // ABSENT case below is deliberately INVISIBLE in production, not
+            // merely quieter. That is intended — it is the steady state and
+            // carries no operator action — but it does mean a log grep can no
+            // longer distinguish "no subscriber registered" from "never
+            // reached", which #4681 had relied on. See #5040.
+            let notifiers_snapshot = match notifiers_snapshot {
+                None => {
                     tracing::debug!(
                         %instance_id,
                         registered_contracts = shared_notifications.len(),
                         "send_update_notification: no local subscriber for contract \
                          (shared storage); nothing to deliver locally"
                     );
+                    return Ok(());
                 }
-                return Ok(());
-            }
+                Some(notifiers) if notifiers.is_empty() => {
+                    // Captured BEFORE the removal below, so the count describes
+                    // the moment of observation rather than the moment after
+                    // cleanup (which would undercount by exactly this entry).
+                    let registered_contracts = shared_notifications.len();
+                    // Gate the summaries removal on the notifications removal
+                    // actually happening: `remove_if` re-checks emptiness under
+                    // the shard lock, so if a client registered between the
+                    // snapshot above and here the entry is no longer empty, the
+                    // removal declines — and we must NOT then drop that new
+                    // client's summary. The next committed update serves them.
+                    if shared_notifications
+                        .remove_if(&instance_id, |_, notifiers| notifiers.is_empty())
+                        .is_some()
+                    {
+                        // Unconditional, NOT `remove_if(.., is_empty)`: with no
+                        // channels left under this key, every summary beneath it
+                        // belongs to a client that can no longer be notified. A
+                        // conditional removal would orphan exactly the realistic
+                        // case, because a summaries sibling is typically still
+                        // NON-empty at this point.
+                        shared_summaries.remove(&instance_id);
+                        tracing::warn!(
+                            %instance_id,
+                            registered_contracts,
+                            "send_update_notification: no subscriber snapshot for contract \
+                             (shared storage); stale entry dropped — the subscriber was \
+                             lost on an earlier update (see the prior channel-closed ERROR)"
+                        );
+                    }
+                    return Ok(());
+                }
+                Some(notifiers) => notifiers,
+            };
 
             let summaries_snapshot: HashMap<ClientId, Option<StateSummary<'static>>> =
                 shared_summaries
@@ -2579,6 +2618,11 @@ where
                 if let Some(mut notifiers) = shared_notifications.get_mut(&instance_id) {
                     notifiers.retain(|(c, _)| !failures.contains(c));
                 }
+                if let Some(mut contract_summaries) = shared_summaries.get_mut(&instance_id) {
+                    for failed_client in &failures {
+                        contract_summaries.remove(failed_client);
+                    }
+                }
                 // Drop the entry AS it empties rather than leaving `Some([])`
                 // behind (#5040). The stale empty entry was otherwise pruned
                 // only opportunistically (by the next `RuntimePool::
@@ -2586,16 +2630,20 @@ where
                 // committed update re-warned on it and it inflated the
                 // `registered_contracts` count in that warning. The loss
                 // itself is already reported above, one ERROR per closed
-                // channel. Separate statement so the `get_mut` guard is
+                // channel. Separate statement so the `get_mut` guards above are
                 // released before `remove_if` takes the same shard lock.
-                shared_notifications.remove_if(&instance_id, |_, n| n.is_empty());
-
-                if let Some(mut contract_summaries) = shared_summaries.get_mut(&instance_id) {
-                    for failed_client in &failures {
-                        contract_summaries.remove(failed_client);
-                    }
+                //
+                // Same gating as the check-site arm: the summaries sibling is
+                // dropped only when the notifications removal actually happened
+                // (so a concurrently-registered client keeps its summary), and
+                // then unconditionally (any summary under a channel-less key is
+                // dead).
+                if shared_notifications
+                    .remove_if(&instance_id, |_, notifiers| notifiers.is_empty())
+                    .is_some()
+                {
+                    shared_summaries.remove(&instance_id);
                 }
-                shared_summaries.remove_if(&instance_id, |_, s| s.is_empty());
 
                 // Decrement per-client subscription counters for failed clients
                 if let Some(shared_client_counts) = &self.shared_client_counts {
@@ -2695,6 +2743,17 @@ where
 
             if !failures.is_empty() {
                 notifiers.retain(|(c, _)| !failures.contains(c));
+                // Prune the dead clients' summaries too, mirroring the shared
+                // arm. Without this the local path leaked one summary per lost
+                // subscriber until that client's `remove_client` ran (#5040
+                // review): the shared arm did it, the local arm did not, while
+                // the comments claimed the two mirrored each other.
+                for failed_client in &failures {
+                    summaries.remove(failed_client);
+                }
+                // Defer the map-level removal: `notifiers` and `summaries` are
+                // live `&mut` borrows here. See the flag's declaration.
+                local_entry_became_empty = notifiers.is_empty();
                 // Decrement per-client subscription counters for failed clients
                 for failed_client in &failures {
                     if let Some(count) = self.client_subscription_counts.get_mut(failed_client) {
@@ -2736,6 +2795,19 @@ where
                      (local storage); nothing to deliver locally"
                 );
             }
+        }
+
+        // Deferred local-arm cleanup (see the flag's declaration): drop the
+        // entry AS it empties, so no later update finds a stale empty vec to
+        // warn about. This is the local counterpart of the shared arm's
+        // in-place removal; without it the local path relied entirely on the
+        // check-site backstop and warned once more than the shared path for the
+        // identical sequence (#5040 review). Both maps go together — the local
+        // fan-out arm indexes `subscriber_summaries` on the strength of
+        // `update_notifications` having an entry.
+        if local_entry_became_empty {
+            self.update_notifications.remove(&instance_id);
+            self.subscriber_summaries.remove(&instance_id);
         }
         Ok(())
     }

--- a/crates/core/src/contract/executor/runtime/executor_impl.rs
+++ b/crates/core/src/contract/executor/runtime/executor_impl.rs
@@ -1131,6 +1131,14 @@ where
                 );
                 // Safety: `already_registered` was derived from `self.update_notifications.get(&instance_id)`
                 // succeeding, so the entry is guaranteed to exist.
+                //
+                // This keeps the read-index / re-acquire / write shape that the
+                // `RuntimePool` twin deliberately collapsed (#5040). It is
+                // exempt, not overlooked: this map is a plain `HashMap` behind
+                // `&mut self` with no `.await` between the two lookups, so no
+                // other code can run in the window and the entry cannot vanish.
+                // The pool twin works through `Arc<DashMap>`, where that
+                // guarantee does not hold. Do NOT copy this shape there.
                 if let Some(channels) = self.update_notifications.get_mut(&instance_id) {
                     channels[idx] = (cli_id, notification_ch);
                 }
@@ -2537,10 +2545,13 @@ where
                         // (the snapshot predates their arrival); the next
                         // committed update is.
                         //
-                        // Logged rather than left silent: a registered
-                        // subscriber, a committed update, and zero log evidence
-                        // is precisely the #4681 shape this callsite exists to
-                        // make visible.
+                        // Logged rather than left silent, though note this is a
+                        // DEBUG-BUILD aid only: `release_max_level_info`
+                        // compiles it out, so in production this path is as
+                        // silent as it was. It is recorded because a registered
+                        // subscriber, a committed update, and zero evidence is
+                        // the #4681 shape, and a debug-build trace is better
+                        // than nothing while the window stays unreachable.
                         tracing::debug!(
                             %instance_id,
                             "send_update_notification: subscriber registered concurrently with \
@@ -2651,10 +2662,18 @@ where
                 // released before `remove_if` takes the same shard lock.
                 //
                 // Same gating as the check-site arm: the summaries sibling is
-                // dropped only when the notifications removal actually happened
-                // (so a concurrently-registered client keeps its summary), and
-                // then unconditionally (any summary under a channel-less key is
-                // dead).
+                // dropped only when the notifications removal actually happened,
+                // and then unconditionally (any summary under a channel-less key
+                // is dead).
+                //
+                // The gate covers a registration whose notifications-insert
+                // lands BEFORE the `remove_if`. It does NOT cover one landing
+                // entirely between the successful `remove_if` and the
+                // `shared_summaries.remove` below — registration writes the two
+                // maps in that order, so such a client ends up with a live
+                // channel and no summary. That degrades to a full-state send
+                // instead of a delta, never a fault, and it is unreachable
+                // while both paths run on the serial contract loop.
                 if shared_notifications
                     .remove_if(&instance_id, |_, notifiers| notifiers.is_empty())
                     .is_some()

--- a/crates/core/src/contract/executor/runtime/pool.rs
+++ b/crates/core/src/contract/executor/runtime/pool.rs
@@ -1060,23 +1060,35 @@ impl ContractExecutor for RuntimePool {
         // when the subscription is registered or when updates arrive.
         let owned_summary = summary.map(StateSummary::into_owned);
 
-        // Check if this client is already registered for this contract
-        let already_registered = self
-            .shared_notifications
-            .get(&instance_id)
-            .and_then(|channels| {
-                channels
-                    .binary_search_by_key(&&cli_id, |(p, _)| p)
-                    .ok()
-                    .map(|i| (i, channels[i].1.same_channel(&notification_ch)))
-            });
+        // Check if this client is already registered for this contract, and if
+        // so refresh its channel — all under ONE write guard.
+        //
+        // This used to compute the index under a read guard, release it, then
+        // re-acquire `get_mut` and write `channels[idx]`. That is a TOCTOU: the
+        // entry can change between the two acquisitions. It was masked by the
+        // serial `contract_handling` loop, but the maps are typed
+        // `Arc<DashMap>` and the failure modes are bad in both directions —
+        // before #5040 a shrunk vec meant `channels[idx]` panicked on an
+        // out-of-bounds index; once #5040 made the executor DROP an emptied
+        // entry, the re-acquired `get_mut` would instead return `None`, the
+        // update would be silently skipped, and the client would get a
+        // successful subscribe that never delivers. Doing the search and the
+        // write under a single guard removes the window entirely rather than
+        // trading one failure mode for a quieter one.
+        let already_registered =
+            self.shared_notifications
+                .get_mut(&instance_id)
+                .and_then(|mut channels| {
+                    let idx = channels.binary_search_by_key(&&cli_id, |(p, _)| p).ok()?;
+                    let same_channel = channels[idx].1.same_channel(&notification_ch);
+                    if !same_channel {
+                        channels[idx] = (cli_id, notification_ch.clone());
+                    }
+                    Some(same_channel)
+                });
 
-        if let Some((idx, same_channel)) = already_registered {
+        if let Some(same_channel) = already_registered {
             if !same_channel {
-                // Client reconnected with new channel, update it.
-                if let Some(mut channels) = self.shared_notifications.get_mut(&instance_id) {
-                    channels[idx] = (cli_id, notification_ch);
-                }
                 tracing::debug!(
                     client = %cli_id,
                     contract = %instance_id,


### PR DESCRIPTION
## Problem

`send_update_notification` logged a WARN claiming **"update notification not delivered"** on every committed update that found no local subscriber snapshot. The node in #5040 logged this **22,413 times in one day**, 96.6% of them for a single contract. The next most frequent message that day appeared 199 times.

It reads like local clients are silently losing updates. They are not. The check collapsed two different states into one:

* **ABSENT entry** — no local client is subscribed. Either none ever was, or the last one disconnected cleanly (`RuntimePool::remove_client` drops the entry outright). This is the **normal steady state** for any contract a node hosts on behalf of the network: those contracts are fed by `broadcast_state_change`, a different path, so nothing is owed to anyone locally and nothing is lost.
* **PRESENT but EMPTY** — a subscriber's channel closed without a `Disconnect` reaching the handler, so the failure `retain` emptied the vec in place. Already reported at the point of loss as one ERROR per closed channel, naming the client.

Warning on the first made a routine fact read as data loss and buried the second underneath it. PR #4773's own reviewer note predicted this:

> the WARN fires on the commit path for contracts with zero local subscribers (common on relays/gateways) ... a follow-up could rate-limit it if it proves noisy (cf. #4238).

**Rate-limiting would not have worked.** The per-callsite cap is 30/s (`util/rate_limit_layer.rs:63`, wired at `tracing/tracer.rs:547-554`, no per-callsite override) and #5040's observed peak was 27/s. The existing limiter never engaged and never would have.

Compounding it, the empty entry was pruned only opportunistically, by the next `remove_client` from *any* client. Until then every subsequent committed update re-warned on the same dead subscriber, and the stale entry inflated the `registered_contracts` count printed in the warning itself.

## Approach

Split the two states rather than silencing the callsite:

* **ABSENT → DEBUG.**
* **PRESENT but EMPTY → WARN**, keeping the greppable `no subscriber snapshot` phrase, with the text corrected: nothing is being dropped at the instant it fires, the subscriber was lost on an *earlier* update.
* **The entry is dropped as it empties**, in the channel-closed cleanup itself. The check-site removal remains a backstop. This adopts the "drop the entry when it goes empty" convention the interest/subscriber maps already use (`interest.rs:751,761`, `hosting.rs:1358,1711`).

Applied to **both** the shared-storage and local-storage branches.

The summaries sibling is dropped **only when the notifications removal actually succeeded** (so a client registering concurrently keeps its summary), and then **unconditionally** — with no channels left under that key, every summary beneath it is dead. A conditional `remove_if(.., is_empty)` orphans exactly the realistic case.

The ABSENT path is kept a pure **read**: the snapshot stays an `Option` rather than collapsing to an empty `Vec`, so the common case never takes a shard write lock.

**This is observability only.** No notification that would have been delivered before is dropped now, and network propagation is untouched.

### ⚠️ The absent case is INVISIBLE in release, not merely quieter

`crates/core/Cargo.toml:124` sets `release_max_level_info`, so `debug!` is **compiled out** of shipped binaries. An earlier revision of this PR claimed the absent case was "still observable at DEBUG"; that was **wrong** for every build users actually run, and the claim appeared in three places. All three are corrected.

This is deliberate — the absent case is the steady state and carries no operator action — but two consequences should be recorded rather than glossed:

1. A log grep can no longer distinguish "no subscriber registered" from "never reached". **#4681 is open and its named drop point is the ABSENT branch** (`None => return Ok(())`), not the empty one, and #4773 added this WARN specifically to make that grep possible. If #4681's registration race fires in production, there is again no log evidence.
2. The absent-case *rate* was an accidental early-warning signal for the update-storm class that the other half of #5040 is about. That signal is now gone from logs.

Reviewers proposed a per-node counter (surfaced through `node/network_status.rs`) as the durable replacement, which would give the rate without the storm. **Deliberately not included here** — it is a new telemetry surface and belongs with a maintainer decision rather than folded into an observability fix. Flagged for @sanity.

### Also fixed: a TOCTOU whose failure mode this change made worse

`RuntimePool::register_contract_notifier` computed a subscriber index under a read guard, released it, then re-acquired `get_mut` and wrote `channels[idx]`. Before this PR a shrunk vec meant an out-of-bounds **panic**. Once the executor started *dropping* emptied entries, the re-acquired `get_mut` would instead return `None`: the update silently skipped, the client handed a successful subscribe that never delivers, its summary orphaned and its counter left decremented.

Not reachable today (both paths run on the serial `contract_handling` loop), but the maps are typed `Arc<DashMap>` and trading a loud failure for a silent one is the wrong direction. Collapsed into a single guarded read-modify-write, which removes the window entirely.

## Testing

* Re-scoped the two #4681 tests that pinned absent → WARN; they now assert absent does **not** warn.
* Kept both empty-entry tests asserting WARN.
* Added `empty_shared_snapshot_warns_once_not_on_every_update` — two updates over an emptied entry must produce **one** warn, not two.
* Added `closed_subscriber_channel_drops_entry_at_point_of_loss` and its `_local` twin — the source half, via a real closed channel.

**Every fix mutation-verified**, because a green suite proves nothing here:

| Mutation | Result |
|---|---|
| Revert the absent/empty split | 3 tests fail; storm test reproduces it exactly (`left: 2, right: 1`) |
| Remove the shared retain-site cleanup | exactly 1 test fails, the one written for it |
| Remove the local deferred cleanup | exactly 1 test fails, the local twin |
| Make the summaries removal conditional again | exactly 1 test fails, the storm test |

`cargo clippy --locked -- -D warnings` clean; 13/13 tests pass; 100/100 repeat runs of the module with no flake.

### Note on `testing.md`

`testing.md` prescribes `#[ignore]` + an explanatory comment for genuinely-changed semantics. This PR **deliberately deviates**: it renames the two tests and inverts their assertions instead. Rationale — an `#[ignore]`d test pins nothing, whereas an inverted assertion actively pins the new behaviour and fails if warn-on-absent is reintroduced; and the history the rule wants preserved is preserved, in the rustdoc, which quotes #4773's reasoning and its reviewer note. Applying the rule literally would leave two dead ignored tests beside two live ones asserting the opposite, on the same callsite. Flagging explicitly so it is a reviewed decision, not an unnoticed rule break.

### Known-flaky helper

#4927 is open against `install_log_capture` in this file (~1/8 locally, thread-local capture). This PR grows that surface from 4 tests to 6, several asserting exact log counts. It did not reproduce in 100 consecutive runs here, and the map-state assertions in the new tests are deterministic regardless. **Not fixed here** — the proper fix is a process-global capturing layer, which touches every test in the file. If CI flakes on it, that is the fix, not a retry.

## Field verification

The build carrying this fix has been running on the node that reported #5040 since `2026-07-29T22:07:46Z`. **Zero `no subscriber snapshot` lines since**, against roughly 10,000/hour on the stock binary.

For the absent case that is true by construction. What it does establish: **zero empty-entry warns fired either**, confirming all 22,413 were the absent case rather than a mix.

## Scope

This is **one half of #5040**, so it does not close it. The other half (one contract dominating attributed contract-exec CPU) is a live design question being measured on the reporting node now. Early data already corrects the issue's own account: the eviction cycle is ~30-100 minutes, not the ~9 hours implied by "8 times over 3 days".

Refs #5040, #4681, #4773

## Review

Full-tier: four independent blind Claude lenses (code-first, skeptical/concurrency, testing, big-picture). No blockers. All majors addressed above; the counter and #4927 are the two explicit deferrals. No external model pass (opt-in per the review rule, not requested).

[AI-assisted - Claude]
