### PR TITLE
fix(interest): stop clobbering cached summaries; add per-contract broadcast byte attribution

### DIFF
--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -2870,6 +2870,25 @@ async fn handle_interest_sync_message(
                         // broadcast targets forever. A `None` report keeps the
                         // old clear-only semantics (no entry is created just to
                         // hold `None`).
+                        //
+                        // LOAD-BEARING POSITION, not just a write: this runs
+                        // OUTSIDE the `is_stale` branch, on converged and stale
+                        // peers alike, and it is what refreshes the peer's
+                        // interest TTL here — both `set_summary` and
+                        // `clear_summary` end in `PeerInterest::refresh`. There
+                        // is no explicit `refresh_peer_interest` on this path;
+                        // the refresh is a CONSEQUENCE of the write.
+                        //
+                        // So moving this inside the staleness branch — which
+                        // reads as a pure optimisation ("why rewrite a summary
+                        // we just proved unchanged?") — silently stops
+                        // refreshing every converged peer, and they age out at
+                        // `INTEREST_TTL` while every test stays green. That is
+                        // the #3046/#3093 bug class, which has already appeared
+                        // at two other sites in this same fan-out logic (the
+                        // production and sim-only converged skips, both fixed in
+                        // #5055). Pinned by
+                        // `summaries_arm_writes_summary_outside_staleness_branch_pin`.
                         match their_summary {
                             Some(theirs) => {
                                 op_manager
@@ -4192,6 +4211,80 @@ mod tests {
             "the Summaries arm must ration WASM probes through \
              plan_staleness_probe (MAX_STALENESS_PROBES_PER_SUMMARIES cap) — \
              an uncapped probe per contract is a DoS amplification surface"
+        );
+    }
+
+    /// Source-scrape pin (#3046 / #3093): the `Summaries` arm's summary write
+    /// must stay OUTSIDE the staleness branch, because that write is what
+    /// refreshes the peer's interest TTL on this path.
+    ///
+    /// There is no explicit `refresh_peer_interest` here. `upsert_peer_summary`
+    /// and `clear_peer_summary` both end in `PeerInterest::refresh`, so the TTL
+    /// refresh is a CONSEQUENCE of writing the summary, and it currently reaches
+    /// converged and stale peers alike only because the write sits after the
+    /// verdict rather than inside it.
+    ///
+    /// That makes the obvious "optimisation" — skip the rewrite when we just
+    /// proved the summary unchanged — a silent subscriber-expiry bug: every
+    /// converged peer stops being refreshed and ages out at `INTEREST_TTL`,
+    /// with no test failing. This is the third site of a class that already
+    /// appeared twice in the fan-out logic (the production and sim-only
+    /// converged skips, both fixed in #5055), which is why it is pinned before
+    /// anyone tries it rather than after.
+    #[test]
+    fn summaries_arm_writes_summary_outside_staleness_branch_pin() {
+        let src = include_str!("node.rs");
+        let handler_start = src
+            .find("async fn handle_interest_sync_message(")
+            .expect("handle_interest_sync_message not found");
+        let summaries_off = src[handler_start..]
+            .find("InterestMessage::Summaries { entries, .. }")
+            .expect("Summaries arm not found");
+        let change_off = src[handler_start..]
+            .find("InterestMessage::ChangeInterests")
+            .expect("ChangeInterests arm not found");
+        let summaries_arm = &src[handler_start + summaries_off..handler_start + change_off];
+
+        // Both writes must be present — they are the only thing refreshing the
+        // TTL on this path.
+        let upsert_at = summaries_arm.find("upsert_peer_summary(").expect(
+            "the Summaries arm must cache the peer's reported summary via \
+             upsert_peer_summary — that write is also what refreshes the peer's \
+             interest TTL here (#4952, #3046)",
+        );
+        assert!(
+            summaries_arm.contains("clear_peer_summary("),
+            "the None-report branch must clear via clear_peer_summary — it too \
+             refreshes the TTL, so replacing it with a bare no-op stops \
+             refreshing peers that report no summary"
+        );
+
+        // The load-bearing structural fact: the write is NOT nested inside the
+        // staleness decision. `is_stale` is consumed AFTER the write; if a
+        // refactor moves the write inside an `if is_stale` block, the write
+        // (and with it the refresh) stops running for converged peers.
+        let is_stale_use = summaries_arm.find("if is_stale").expect(
+            "the Summaries arm must still branch on is_stale for the heal \
+             decision — if this moved, re-check where the summary write sits",
+        );
+        assert!(
+            upsert_at < is_stale_use,
+            "the summary write MUST precede (and sit outside) the `if is_stale` \
+             heal branch. Moving it inside skips the write — and therefore the \
+             interest-TTL refresh, which on this path is only a side effect of \
+             the write — for every CONVERGED peer, so they age out at \
+             INTEREST_TTL and silently stop receiving broadcasts (#3046/#3093). \
+             upsert at {upsert_at}, `if is_stale` at {is_stale_use}"
+        );
+
+        // And it must not be conditioned on staleness some other way.
+        let stripped: String = summaries_arm
+            .chars()
+            .filter(|c| !c.is_whitespace())
+            .collect();
+        assert!(
+            !stripped.contains("ifis_stale{op_manager.interest_manager.upsert_peer_summary("),
+            "the summary write must not be gated on is_stale — see above"
         );
     }
 

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -2666,15 +2666,15 @@ async fn handle_interest_sync_message(
                     // Only register new interest if this is a genuinely new entry;
                     // otherwise register_peer_interest would overwrite the cached
                     // summary with None, defeating delta optimization.
-                    if op_manager
+                    // One acquisition via the refresh's own bool — see
+                    // `InterestManager::refresh_peer_interest` for why the
+                    // `get_peer_interest(..).is_some()` form it replaces was both
+                    // expensive (it clones the cached summary) and racy. This runs
+                    // per shared contract per heartbeat, so the clone was not free.
+                    if !op_manager
                         .interest_manager
-                        .get_peer_interest(&contract, pk)
-                        .is_some()
+                        .refresh_peer_interest(&contract, pk)
                     {
-                        op_manager
-                            .interest_manager
-                            .refresh_peer_interest(&contract, pk);
-                    } else {
                         let is_new = op_manager.interest_manager.register_peer_interest(
                             &contract,
                             pk.clone(),
@@ -3071,14 +3071,14 @@ async fn handle_interest_sync_message(
                         // refresh-guard the `Interests` full-replace arm above uses.
                         // (Guarded wiring pinned by
                         // change_interests_arm_guards_register_with_refresh_pin.)
+                        // One acquisition via the refresh's own bool — see
+                        // `InterestManager::refresh_peer_interest` for why the
+                        // `get_peer_interest(..).is_some()` form it replaces was
+                        // both expensive (it clones the cached summary) and racy.
                         let is_new = if op_manager
                             .interest_manager
-                            .get_peer_interest(&contract, pk)
-                            .is_some()
+                            .refresh_peer_interest(&contract, pk)
                         {
-                            op_manager
-                                .interest_manager
-                                .refresh_peer_interest(&contract, pk);
                             false
                         } else {
                             op_manager.interest_manager.register_peer_interest(
@@ -4317,8 +4317,8 @@ mod tests {
     /// edge needs the upstream's own interest to lapse-and-revive (uncommon on
     /// current main, where leases renew unconditionally; load-bearing under
     /// piece-D interest-gated renewal, #4642). The arm therefore MUST guard
-    /// re-registration of an existing entry with
-    /// `get_peer_interest().is_some() -> refresh_peer_interest()`, exactly like
+    /// re-registration of an existing entry on `refresh_peer_interest()`'s own
+    /// return value (`true` = an entry existed and was refreshed), exactly like
     /// the `Interests` full-replace arm.
     ///
     /// This is the regression signal for the handler WIRING: it FAILS on the
@@ -4346,6 +4346,12 @@ mod tests {
                 .join("\n")
         }
 
+        // Match the guard SHAPE regardless of how rustfmt wraps the builder
+        // chain across lines (see `feedback_source_pins_survive_rustfmt`).
+        fn strip_whitespace(src: &str) -> String {
+            src.chars().filter(|c| !c.is_whitespace()).collect()
+        }
+
         let src = include_str!("node.rs");
 
         let handler_start = src
@@ -4365,61 +4371,55 @@ mod tests {
         let arm = strip_line_comments(&handler_src[arm_start..arm_start + arm_len]);
 
         // Structural pin (NOT mere token presence): the arm must GUARD the
-        // re-registration — look up the existing entry, and on a hit REFRESH it
-        // (preserving is_upstream + summary) rather than clobber it with a bare
-        // register. We assert the SHAPE and ORDER
-        //   get_peer_interest( .. ).is_some() -> refresh_peer_interest( .. )
-        //     -> register_peer_interest( .. )
-        // so the register can only be the else-branch fallback for a genuinely
-        // new peer, never the primary path. The pre-fix arm had a single
-        // unguarded `register_peer_interest(.., false)` and NEITHER the
-        // presence check nor the refresh call, so the first two `expect`s below
-        // trip on it.
-        let get_at = arm.find("get_peer_interest(").expect(
-            "ChangeInterests arm MUST look up the existing entry with \
-             get_peer_interest() before (re-)registering, so an existing upstream \
-             peer is not clobbered to is_upstream=false (D2)",
-        );
-        let is_some_at = arm[get_at..]
-            .find(".is_some()")
-            .map(|off| get_at + off)
-            .expect(
-                "ChangeInterests arm MUST use get_peer_interest(..).is_some() as the \
-                 presence check that gates the refresh (D2)",
-            );
-        let refresh_at = arm[is_some_at..]
-            .find("refresh_peer_interest(")
-            .map(|off| is_some_at + off)
-            .expect(
-                "ChangeInterests arm MUST refresh (not re-register) an existing entry \
-                 to preserve is_upstream + the cached summary (D2)",
-            );
-        let register_at = arm[refresh_at..]
-            .find("register_peer_interest(")
-            .map(|off| refresh_at + off)
-            .expect(
-                "ChangeInterests arm MUST still register a genuinely new peer in the \
-                 else branch (and flush the #4359 deferred broadcast)",
-            );
-
-        // The sequential slice searches already enforce
-        // get_at < is_some_at < refresh_at < register_at; assert it explicitly so
-        // a reshape that reorders (e.g. an unguarded register before the check)
-        // gets a clear message.
+        // re-registration on the refresh's OWN return value, so the register can
+        // only be the else-branch fallback for a genuinely new peer, never the
+        // primary path. Asserting the whole `refresh(..) { false } else {` shape
+        // rather than "refresh appears somewhere before register" is what makes
+        // this a wiring pin: a reverted arm that calls refresh for some unrelated
+        // reason and then registers unconditionally would satisfy mere ordering.
+        // The pre-fix arm had a single unguarded
+        // `register_peer_interest(.., false)` and no refresh at all, so the
+        // needle below is absent on it.
+        let stripped = strip_whitespace(&arm);
         assert!(
-            get_at < is_some_at && is_some_at < refresh_at && refresh_at < register_at,
-            "ChangeInterests guard must be shaped get_peer_interest().is_some() -> \
-             refresh_peer_interest(), with register_peer_interest() only as the \
-             else-branch fallback (D2)"
+            stripped.contains("refresh_peer_interest(&contract,pk){false}else{"),
+            "ChangeInterests arm MUST branch on refresh_peer_interest()'s return \
+             value — refreshing an existing entry (preserving is_upstream + the \
+             cached summary) and registering ONLY in the else branch. Arm:\n{arm}"
+        );
+        assert!(
+            stripped.contains("else{op_manager.interest_manager.register_peer_interest("),
+            "the register MUST be the else-branch fallback of that guard, not a \
+             separate statement that runs regardless (D2). Arm:\n{arm}"
         );
 
-        // Exactly ONE register in the arm — the guarded fallback. A second would
-        // mean an unguarded bare register slipped back in alongside the guard.
+        // Exactly ONE of each in the arm. A second register would mean an
+        // unguarded bare register slipped back in alongside the guard; a second
+        // refresh would mean the guard needle above matched a different call
+        // than the one gating the register.
         assert_eq!(
             arm.matches("register_peer_interest(").count(),
             1,
             "ChangeInterests arm must contain exactly one (guarded, else-branch) \
              register_peer_interest call; a second would be an unguarded clobber (D2)"
+        );
+        assert_eq!(
+            arm.matches("refresh_peer_interest(").count(),
+            1,
+            "ChangeInterests arm must contain exactly one refresh_peer_interest \
+             call — the one gating the register (D2)"
+        );
+
+        // The two-lookup `get_peer_interest(..).is_some()` form this replaced
+        // clones the cached summary (state-sized on the contracts that matter)
+        // purely to test presence, and loses the registration entirely if the
+        // entry is removed between the lookups. Reverting to it is a silent
+        // regression, so forbid it here.
+        assert!(
+            !stripped.contains("get_peer_interest(&contract,pk).is_some()"),
+            "ChangeInterests arm must not re-introduce the two-lookup \
+             get_peer_interest(..).is_some() guard: it deep-copies the cached \
+             summary just to test presence, and is not atomic with the refresh"
         );
     }
 

--- a/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
+++ b/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
@@ -235,8 +235,26 @@ struct Window {
     ///
     /// Also the input a per-contract outbound budget would be sized from
     /// (#5057): the ceiling should be chosen from the observed distribution,
-    /// not guessed.
+    /// not guessed. A distribution silently missing its tail is exactly the
+    /// wrong failure for that, which is why the cap overflow gets its own
+    /// counters ([`Window::total_attribution_dropped_sends`]) rather than
+    /// sharing the full-state ones.
     contract_total: HashMap<ContractInstanceId, (u64, u64)>,
+    /// Sends [`MAX_TRACKED_CONTRACTS`] refused to admit to `contract_total`,
+    /// and the bytes behind them. Counts SENDS, not distinct contracts — same
+    /// reading as [`Window::attribution_dropped_sends`].
+    ///
+    /// Deliberately SEPARATE from those full-state counters. `contract_total`
+    /// is written on EVERY arm, so it accumulates keys strictly faster than
+    /// `contract_full_state_bytes` and can reach the cap while the full-state
+    /// map still admits. Two consequences the schema has to be able to state:
+    /// a `Delta`-only contract's drop is invisible to `attribution_dropped_*`
+    /// (that counter is only written under `arm.is_full_state()`), and a
+    /// contract admitted to the full-state map but refused here has full-state
+    /// bytes with no total entry — a denominator smaller than its own
+    /// numerator. Sharing one pair of counters would leave both unreadable.
+    total_attribution_dropped_sends: u64,
+    total_attribution_dropped_bytes: u64,
     /// Per-contract bytes for the [`PayloadArm::FullNotEfficient`] arm ONLY.
     ///
     /// #4956: the aggregate gate-input ratio came back at 1.000 (summary size
@@ -309,6 +327,8 @@ impl Default for Window {
             bytes: [0; PayloadArm::COUNT],
             contract_full_state_bytes: HashMap::new(),
             contract_total: HashMap::new(),
+            total_attribution_dropped_sends: 0,
+            total_attribution_dropped_bytes: 0,
             contract_not_efficient_bytes: HashMap::new(),
             attribution_dropped_sends: 0,
             attribution_dropped_bytes: 0,
@@ -453,12 +473,19 @@ impl PayloadMix {
             }
         }
         // EVERY arm, not just full-state: see `contract_total`'s docs. Same cap
-        // discipline as the other maps — the key is contract-controlled.
+        // discipline as the other maps — the key is contract-controlled — but
+        // its OWN overflow counters, because this map fills faster than the
+        // full-state one and a `Delta`-only drop never reaches the
+        // `attribution_dropped_*` branch below.
         if let Some(tally) = w.contract_total.get_mut(contract) {
             tally.0 = tally.0.saturating_add(1);
             tally.1 = tally.1.saturating_add(bytes);
         } else if w.contract_total.len() < MAX_TRACKED_CONTRACTS {
             w.contract_total.insert(*contract, (1, bytes));
+        } else {
+            w.total_attribution_dropped_sends = w.total_attribution_dropped_sends.saturating_add(1);
+            w.total_attribution_dropped_bytes =
+                w.total_attribution_dropped_bytes.saturating_add(bytes);
         }
         if arm.is_full_state() {
             if let Some(tally) = w.contract_full_state_bytes.get_mut(contract) {
@@ -555,6 +582,22 @@ impl Window {
         tallies
     }
 
+    /// Everything the published schema needs about `contract_total`: the
+    /// reported top-N, how many distinct contracts were tracked, and what the
+    /// cap refused.
+    ///
+    /// Bundled rather than four more positional `u64` parameters on
+    /// [`payload_mix_json`], which already carries an adjacent run of them —
+    /// a transposed pair there would misreport silently and reconcile fine.
+    fn total_attribution(&self) -> TotalAttribution {
+        TotalAttribution {
+            contracts: self.top_contracts_total(),
+            contracts_tracked: self.contract_total.len() as u64,
+            dropped_sends: self.total_attribution_dropped_sends,
+            dropped_bytes: self.total_attribution_dropped_bytes,
+        }
+    }
+
     /// The top [`TOP_CONTRACTS_REPORTED`] contracts by full-state bytes.
     fn top_contracts(&self) -> Vec<(ContractInstanceId, u64)> {
         let mut tallies: Vec<(ContractInstanceId, u64)> = self
@@ -574,6 +617,22 @@ impl Window {
     }
 }
 
+/// The per-contract TOTAL attribution over one window, across every arm.
+///
+/// See [`Window::contract_total`] for why this exists at all, and
+/// [`Window::total_attribution_dropped_sends`] for why its cap overflow is
+/// counted separately from the full-state map's.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct TotalAttribution {
+    /// Top [`TOP_CONTRACTS_REPORTED`] as `(contract, sends, bytes)`.
+    contracts: Vec<(ContractInstanceId, u64, u64)>,
+    /// Distinct contracts the window attributed, bounded by
+    /// [`MAX_TRACKED_CONTRACTS`].
+    contracts_tracked: u64,
+    dropped_sends: u64,
+    dropped_bytes: u64,
+}
+
 /// The wire-efficiency gate's inputs over one window, for the
 /// [`PayloadArm::FullNotEfficient`] sends only.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -588,16 +647,19 @@ struct NotEfficientGateStats {
 ///
 /// Pure so the schema is unit-testable without the telemetry sender, matching
 /// the `shadow_demand` rollup builders.
-// Eight flat parameters rather than a `&Window`: the tests build `arms` and
-// the attribution totals independently to exercise reconciliation edge cases
+// Flat parameters rather than a `&Window`: the tests build `arms` and the
+// attribution totals independently to exercise reconciliation edge cases
 // (truncation vs over-cap drops) that a real `Window` cannot easily be coaxed
 // into, so taking the struct would make the schema harder to test, not easier.
+// The `contract_total` group is the exception — it is bundled in
+// [`TotalAttribution`] so its three numbers cannot be transposed against the
+// full-state run that follows them.
 #[allow(clippy::too_many_arguments)]
 fn payload_mix_json(
     arms: &[(PayloadArm, u64, u64)],
     contracts: &[(ContractInstanceId, u64)],
     not_efficient_contracts: &[(ContractInstanceId, u64)],
-    total_contracts: &[(ContractInstanceId, u64, u64)],
+    total: &TotalAttribution,
     tracked_full_state_bytes: u64,
     contracts_tracked: u64,
     attribution_dropped_sends: u64,
@@ -744,6 +806,46 @@ fn payload_mix_json(
                 .collect(),
         ),
     );
+    // #4979 / #5057: TOTAL bytes and sends per contract, across every arm. The
+    // full-state array above is a numerator with no denominator — it cannot see
+    // a contract whose entire cost sits in the `delta` arm, which is exactly the
+    // #5056 case. Ranked by bytes, since that is the axis a per-contract budget
+    // would bound.
+    obj.insert(
+        "top_contracts_by_total_bytes".into(),
+        serde_json::Value::Array(
+            total
+                .contracts
+                .iter()
+                .map(|(id, sends, bytes)| {
+                    serde_json::json!({
+                        "contract": id.to_string(),
+                        "sends": sends,
+                        "bytes": bytes,
+                    })
+                })
+                .collect(),
+        ),
+    );
+    // This map's own cap overflow, NOT folded into `attribution_dropped_*`.
+    // Those count full-state drops only, while every arm feeds `contract_total`,
+    // so it caps first: a `Delta`-only contract refused here would otherwise
+    // vanish from the schema entirely, and a contract the full-state map still
+    // admits would show full-state bytes with no total entry. #5057 sizes a
+    // per-contract budget from this distribution, so its truncated tail has to
+    // be legible rather than merely absent.
+    obj.insert(
+        "contracts_tracked_total".into(),
+        total.contracts_tracked.into(),
+    );
+    obj.insert(
+        "total_attribution_dropped_sends".into(),
+        total.dropped_sends.into(),
+    );
+    obj.insert(
+        "total_attribution_dropped_bytes".into(),
+        total.dropped_bytes.into(),
+    );
     // The published schema must ADD UP, using only fields it publishes:
     //
     //   sum(top_contracts) + other_contracts_bytes + attribution_dropped_bytes
@@ -760,26 +862,6 @@ fn payload_mix_json(
     // reconciled while 10 % of its bytes were unaccounted for.
     // #4956: which contracts the gate actually refused on. The aggregate
     // ratio says a state-sized "summary" is being fed in; this says by whom.
-    // #4979 / #5057: TOTAL bytes and sends per contract, across every arm. The
-    // full-state array above is a numerator with no denominator — it cannot see
-    // a contract whose entire cost sits in the `delta` arm, which is exactly the
-    // #5056 case. Ranked by bytes, since that is the axis a per-contract budget
-    // would bound.
-    obj.insert(
-        "top_contracts_by_total_bytes".into(),
-        serde_json::Value::Array(
-            total_contracts
-                .iter()
-                .map(|(id, sends, bytes)| {
-                    serde_json::json!({
-                        "contract": id.to_string(),
-                        "sends": sends,
-                        "bytes": bytes,
-                    })
-                })
-                .collect(),
-        ),
-    );
     obj.insert(
         "top_contracts_by_not_efficient_bytes".into(),
         serde_json::Value::Array(
@@ -825,7 +907,7 @@ pub(crate) fn emit_payload_mix_rollup(
         &window.arms(),
         &window.top_contracts(),
         &window.top_not_efficient_contracts(),
-        &window.top_contracts_total(),
+        &window.total_attribution(),
         window.contract_full_state_bytes.values().sum(),
         window.contract_full_state_bytes.len() as u64,
         window.attribution_dropped_sends,
@@ -1089,7 +1171,7 @@ mod tests {
             &window.arms(),
             &window.top_contracts(),
             &window.top_not_efficient_contracts(),
-            &window.top_contracts_total(),
+            &window.total_attribution(),
             window.contract_full_state_bytes.values().sum(),
             window.contract_full_state_bytes.len() as u64,
             window.attribution_dropped_sends,
@@ -1142,7 +1224,7 @@ mod tests {
             &window.arms(),
             &window.top_contracts(),
             &window.top_not_efficient_contracts(),
-            &window.top_contracts_total(),
+            &window.total_attribution(),
             window.contract_full_state_bytes.values().sum(),
             window.contract_full_state_bytes.len() as u64,
             window.attribution_dropped_sends,
@@ -1188,6 +1270,147 @@ mod tests {
             "cap must have been hit"
         );
         assert_reconciles(&window);
+    }
+
+    /// The total map's cap overflow must be VISIBLE, and visible separately
+    /// from the full-state map's.
+    ///
+    /// `contract_total` is written on every arm, so it fills strictly faster
+    /// than `contract_full_state_bytes`. Two failures follow if the overflow is
+    /// silent or shared:
+    ///   * a `Delta`-only contract refused by the cap disappears from the
+    ///     schema entirely — `attribution_dropped_*` is only written under
+    ///     `arm.is_full_state()`, so nothing records it; and
+    ///   * the total map can cap while the full-state map still admits, giving
+    ///     a contract full-state bytes with no total entry, i.e. a denominator
+    ///     smaller than its own numerator.
+    /// #5057 wants to size a per-contract budget from this distribution, so a
+    /// silently truncated tail is exactly the wrong failure.
+    #[test]
+    fn total_map_cap_overflow_is_reported_separately_from_full_state() {
+        let mix = PayloadMix::new();
+        let id = |i: usize| {
+            let mut raw = [0u8; 32];
+            raw[0] = (i % 256) as u8;
+            raw[1] = (i / 256) as u8;
+            ContractInstanceId::new(raw)
+        };
+
+        // Fill the total map to its cap with DELTA sends only. The full-state
+        // map stays empty, so this is the case `attribution_dropped_*` cannot
+        // see by construction.
+        for i in 0..MAX_TRACKED_CONTRACTS {
+            mix.record_delivered(PayloadArm::Delta, &id(i), 10, None, None);
+        }
+        // Three more delta sends, all refused by the cap.
+        for i in MAX_TRACKED_CONTRACTS..(MAX_TRACKED_CONTRACTS + 3) {
+            mix.record_delivered(PayloadArm::Delta, &id(i), 7, None, None);
+        }
+
+        let window = mix.take_window();
+        let total = window.total_attribution();
+
+        assert_eq!(
+            total.contracts_tracked, MAX_TRACKED_CONTRACTS as u64,
+            "the total map must be at its cap"
+        );
+        assert_eq!(
+            total.dropped_sends, 3,
+            "each refused send must be counted — a silently dropped tail is \
+             what makes the distribution unusable for sizing a budget (#5057)"
+        );
+        assert_eq!(
+            total.dropped_bytes, 21,
+            "and the bytes behind those refused sends"
+        );
+
+        // The pre-existing full-state counters must be untouched: these were
+        // Delta sends, so folding the two overflows together would invent
+        // full-state drops that never happened.
+        assert_eq!(
+            window.attribution_dropped_sends, 0,
+            "the full-state drop counter must stay zero — no full-state send \
+             was ever recorded, so a non-zero value means the two overflows \
+             were conflated"
+        );
+        assert_eq!(window.attribution_dropped_bytes, 0);
+
+        // And the schema publishes all of it.
+        let json = payload_mix_json(
+            &window.arms(),
+            &window.top_contracts(),
+            &window.top_not_efficient_contracts(),
+            &total,
+            window.contract_full_state_bytes.values().sum(),
+            window.contract_full_state_bytes.len() as u64,
+            window.attribution_dropped_sends,
+            window.attribution_dropped_bytes,
+            window.gate_stats(),
+            &window.tracked_missing(),
+            60,
+        );
+        assert_eq!(json["total_attribution_dropped_sends"], 3);
+        assert_eq!(json["total_attribution_dropped_bytes"], 21);
+        assert_eq!(
+            json["contracts_tracked_total"], MAX_TRACKED_CONTRACTS as u64,
+            "the total map's own tracked count, distinct from contracts_tracked \
+             (which counts the full-state map) — here 256 vs 0"
+        );
+        assert_eq!(
+            json["contracts_tracked"], 0,
+            "sanity: the two tracked counts really are different maps"
+        );
+    }
+
+    /// The total map can reach its cap while the full-state map still admits,
+    /// which is how a contract ends up with full-state bytes and no total
+    /// entry. The separate drop counters are what makes that legible.
+    #[test]
+    fn total_map_caps_before_full_state_map_and_says_so() {
+        let mix = PayloadMix::new();
+        let id = |i: usize| {
+            let mut raw = [0u8; 32];
+            raw[0] = (i % 256) as u8;
+            raw[1] = (i / 256) as u8;
+            ContractInstanceId::new(raw)
+        };
+
+        // Saturate the total map with deltas; the full-state map is still empty.
+        for i in 0..MAX_TRACKED_CONTRACTS {
+            mix.record_delivered(PayloadArm::Delta, &id(i), 10, None, None);
+        }
+        // A brand-new contract sends FULL STATE. The full-state map has room,
+        // so it is attributed there — but the total map is full and refuses it.
+        let newcomer = id(MAX_TRACKED_CONTRACTS + 1);
+        mix.record_delivered(PayloadArm::FullNoOurSummary, &newcomer, 5_000, None, None);
+
+        let window = mix.take_window();
+        assert!(
+            window
+                .top_contracts()
+                .iter()
+                .any(|(cid, bytes)| *cid == newcomer && *bytes == 5_000),
+            "precondition: the full-state map still had room for the newcomer"
+        );
+        assert!(
+            !window
+                .total_attribution()
+                .contracts
+                .iter()
+                .any(|(cid, _, _)| *cid == newcomer),
+            "precondition: the total map was full and refused it"
+        );
+        assert_eq!(
+            window.total_attribution().dropped_bytes,
+            5_000,
+            "a contract with full-state bytes and NO total entry must be \
+             reported as a total-map drop; otherwise the published numerator \
+             exceeds its own denominator with nothing to explain why"
+        );
+        assert_eq!(
+            window.attribution_dropped_bytes, 0,
+            "the full-state map did admit it, so nothing was dropped there"
+        );
     }
 
     /// Concurrent recorders racing a rollup must not lose or double-count
@@ -1273,7 +1496,7 @@ mod tests {
             &arms,
             &[],
             &[],
-            &[],
+            &TotalAttribution::default(),
             0,
             0,
             0,
@@ -1328,7 +1551,7 @@ mod tests {
             &window.arms(),
             &window.top_contracts(),
             &window.top_not_efficient_contracts(),
-            &window.top_contracts_total(),
+            &window.total_attribution(),
             window.contract_full_state_bytes.values().sum(),
             window.contract_full_state_bytes.len() as u64,
             window.attribution_dropped_sends,
@@ -1360,7 +1583,7 @@ mod tests {
             &window.arms(),
             &window.top_contracts(),
             &window.top_not_efficient_contracts(),
-            &window.top_contracts_total(),
+            &window.total_attribution(),
             window.contract_full_state_bytes.values().sum(),
             window.contract_full_state_bytes.len() as u64,
             window.attribution_dropped_sends,
@@ -1531,7 +1754,7 @@ mod tests {
             &window.arms(),
             &window.top_contracts(),
             &window.top_not_efficient_contracts(),
-            &window.top_contracts_total(),
+            &window.total_attribution(),
             window.contract_full_state_bytes.values().sum(),
             window.contract_full_state_bytes.len() as u64,
             window.attribution_dropped_sends,
@@ -1560,7 +1783,7 @@ mod tests {
             &window.arms(),
             &window.top_contracts(),
             &window.top_not_efficient_contracts(),
-            &window.top_contracts_total(),
+            &window.total_attribution(),
             0,
             0,
             0,
@@ -1581,7 +1804,7 @@ mod tests {
             &arms,
             &[],
             &[],
-            &[],
+            &TotalAttribution::default(),
             0,
             0,
             0,

--- a/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
+++ b/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
@@ -222,6 +222,21 @@ struct Window {
     /// Per-contract full-state byte attribution, bounded at
     /// [`MAX_TRACKED_CONTRACTS`].
     contract_full_state_bytes: HashMap<ContractInstanceId, u64>,
+    /// Per-contract TOTAL broadcast bytes and sends, across EVERY arm.
+    ///
+    /// #4979: `contract_full_state_bytes` is written only under
+    /// `arm.is_full_state()`, so it is a numerator with no denominator — it can
+    /// say a contract emitted N full-state bytes but not what share of that
+    /// contract's traffic those were, and it is blind to a contract whose cost
+    /// is entirely in the `delta` arm. That blind spot is not hypothetical:
+    /// #5056 found a contract at 55.6% of all broadcast sends whose "deltas"
+    /// are full-state-sized, and attributing it needed a natural experiment
+    /// over single-contract peers because no counter could answer directly.
+    ///
+    /// Also the input a per-contract outbound budget would be sized from
+    /// (#5057): the ceiling should be chosen from the observed distribution,
+    /// not guessed.
+    contract_total: HashMap<ContractInstanceId, (u64, u64)>,
     /// Per-contract bytes for the [`PayloadArm::FullNotEfficient`] arm ONLY.
     ///
     /// #4956: the aggregate gate-input ratio came back at 1.000 (summary size
@@ -293,6 +308,7 @@ impl Default for Window {
             sends: [0; PayloadArm::COUNT],
             bytes: [0; PayloadArm::COUNT],
             contract_full_state_bytes: HashMap::new(),
+            contract_total: HashMap::new(),
             contract_not_efficient_bytes: HashMap::new(),
             attribution_dropped_sends: 0,
             attribution_dropped_bytes: 0,
@@ -436,6 +452,14 @@ impl PayloadMix {
                 w.contract_not_efficient_bytes.insert(*contract, bytes);
             }
         }
+        // EVERY arm, not just full-state: see `contract_total`'s docs. Same cap
+        // discipline as the other maps — the key is contract-controlled.
+        if let Some(tally) = w.contract_total.get_mut(contract) {
+            tally.0 = tally.0.saturating_add(1);
+            tally.1 = tally.1.saturating_add(bytes);
+        } else if w.contract_total.len() < MAX_TRACKED_CONTRACTS {
+            w.contract_total.insert(*contract, (1, bytes));
+        }
         if arm.is_full_state() {
             if let Some(tally) = w.contract_full_state_bytes.get_mut(contract) {
                 *tally = tally.saturating_add(bytes);
@@ -512,6 +536,25 @@ impl Window {
         tallies
     }
 
+    /// The top [`TOP_CONTRACTS_REPORTED`] contracts by TOTAL broadcast bytes,
+    /// with their send counts. Ranked by bytes, since that is the axis a
+    /// budget would bound.
+    fn top_contracts_total(&self) -> Vec<(ContractInstanceId, u64, u64)> {
+        let mut tallies: Vec<(ContractInstanceId, u64, u64)> = self
+            .contract_total
+            .iter()
+            .map(|(k, (sends, bytes))| (*k, *sends, *bytes))
+            .collect();
+        // Tie-break on raw bytes for the same reason as `top_contracts`: a
+        // reported top-N that reorders on ties looks like churn.
+        tallies.sort_by(|a, b| {
+            b.2.cmp(&a.2)
+                .then_with(|| a.0.as_bytes().cmp(b.0.as_bytes()))
+        });
+        tallies.truncate(TOP_CONTRACTS_REPORTED);
+        tallies
+    }
+
     /// The top [`TOP_CONTRACTS_REPORTED`] contracts by full-state bytes.
     fn top_contracts(&self) -> Vec<(ContractInstanceId, u64)> {
         let mut tallies: Vec<(ContractInstanceId, u64)> = self
@@ -554,6 +597,7 @@ fn payload_mix_json(
     arms: &[(PayloadArm, u64, u64)],
     contracts: &[(ContractInstanceId, u64)],
     not_efficient_contracts: &[(ContractInstanceId, u64)],
+    total_contracts: &[(ContractInstanceId, u64, u64)],
     tracked_full_state_bytes: u64,
     contracts_tracked: u64,
     attribution_dropped_sends: u64,
@@ -716,6 +760,26 @@ fn payload_mix_json(
     // reconciled while 10 % of its bytes were unaccounted for.
     // #4956: which contracts the gate actually refused on. The aggregate
     // ratio says a state-sized "summary" is being fed in; this says by whom.
+    // #4979 / #5057: TOTAL bytes and sends per contract, across every arm. The
+    // full-state array above is a numerator with no denominator — it cannot see
+    // a contract whose entire cost sits in the `delta` arm, which is exactly the
+    // #5056 case. Ranked by bytes, since that is the axis a per-contract budget
+    // would bound.
+    obj.insert(
+        "top_contracts_by_total_bytes".into(),
+        serde_json::Value::Array(
+            total_contracts
+                .iter()
+                .map(|(id, sends, bytes)| {
+                    serde_json::json!({
+                        "contract": id.to_string(),
+                        "sends": sends,
+                        "bytes": bytes,
+                    })
+                })
+                .collect(),
+        ),
+    );
     obj.insert(
         "top_contracts_by_not_efficient_bytes".into(),
         serde_json::Value::Array(
@@ -761,6 +825,7 @@ pub(crate) fn emit_payload_mix_rollup(
         &window.arms(),
         &window.top_contracts(),
         &window.top_not_efficient_contracts(),
+        &window.top_contracts_total(),
         window.contract_full_state_bytes.values().sum(),
         window.contract_full_state_bytes.len() as u64,
         window.attribution_dropped_sends,
@@ -828,6 +893,63 @@ mod tests {
 
     fn contract(byte: u8) -> ContractInstanceId {
         ContractInstanceId::new([byte; 32])
+    }
+
+    /// #4979 / #5056: a contract whose entire cost sits in the `delta` arm must
+    /// still be attributable.
+    ///
+    /// `contract_full_state_bytes` is written only under `arm.is_full_state()`,
+    /// so it is structurally blind to exactly the contract found in #5056 — one
+    /// at 55.6% of all broadcast sends whose "deltas" are full-state-sized.
+    /// Attributing that needed a natural experiment over single-contract peers
+    /// because no counter could answer directly. This asserts the new total map
+    /// sees it AND that the old map does not, so the gap is pinned rather than
+    /// merely fixed.
+    #[test]
+    fn delta_only_contract_is_attributable_in_totals_but_not_full_state() {
+        let mix = PayloadMix::new();
+        // A contract that only ever sends deltas — the #5056 shape.
+        mix.record_delivered(PayloadArm::Delta, &contract(1), 25_000, None, None);
+        mix.record_delivered(PayloadArm::Delta, &contract(1), 25_000, None, None);
+        // A second contract that only ever sends full state, for contrast.
+        mix.record_delivered(
+            PayloadArm::FullNoOurSummary,
+            &contract(2),
+            1_000,
+            None,
+            None,
+        );
+
+        let w = mix.take_window();
+
+        let totals = w.top_contracts_total();
+        let delta_only = totals.iter().find(|(id, _, _)| *id == contract(1)).expect(
+            "a delta-only contract MUST appear in the total map — this is \
+                     the #5056 blind spot the map exists to close",
+        );
+        assert_eq!(delta_only.1, 2, "both sends must be counted");
+        assert_eq!(delta_only.2, 50_000, "both sends' bytes must be counted");
+
+        // And it must outrank the full-state contract, since ranking by total
+        // bytes is what a per-contract budget (#5057) would be sized from.
+        assert_eq!(
+            totals[0].0,
+            contract(1),
+            "the total map must rank by TOTAL bytes, so the expensive delta-only \
+             contract leads — ranking by full-state bytes would hide it entirely"
+        );
+
+        // The pin: the pre-existing map genuinely cannot see it.
+        assert!(
+            !w.top_contracts().iter().any(|(id, _)| *id == contract(1)),
+            "contract_full_state_bytes must remain full-state-only; if a delta \
+             contract starts appearing there, the two maps have been conflated \
+             and the full-state share becomes unreadable"
+        );
+        assert!(
+            w.top_contracts().iter().any(|(id, _)| *id == contract(2)),
+            "the full-state contract must still be attributed as before"
+        );
     }
 
     /// #4956: the refused-delta arm must be attributable to a CONTRACT, not
@@ -967,6 +1089,7 @@ mod tests {
             &window.arms(),
             &window.top_contracts(),
             &window.top_not_efficient_contracts(),
+            &window.top_contracts_total(),
             window.contract_full_state_bytes.values().sum(),
             window.contract_full_state_bytes.len() as u64,
             window.attribution_dropped_sends,
@@ -1019,6 +1142,7 @@ mod tests {
             &window.arms(),
             &window.top_contracts(),
             &window.top_not_efficient_contracts(),
+            &window.top_contracts_total(),
             window.contract_full_state_bytes.values().sum(),
             window.contract_full_state_bytes.len() as u64,
             window.attribution_dropped_sends,
@@ -1149,6 +1273,7 @@ mod tests {
             &arms,
             &[],
             &[],
+            &[],
             0,
             0,
             0,
@@ -1203,6 +1328,7 @@ mod tests {
             &window.arms(),
             &window.top_contracts(),
             &window.top_not_efficient_contracts(),
+            &window.top_contracts_total(),
             window.contract_full_state_bytes.values().sum(),
             window.contract_full_state_bytes.len() as u64,
             window.attribution_dropped_sends,
@@ -1234,6 +1360,7 @@ mod tests {
             &window.arms(),
             &window.top_contracts(),
             &window.top_not_efficient_contracts(),
+            &window.top_contracts_total(),
             window.contract_full_state_bytes.values().sum(),
             window.contract_full_state_bytes.len() as u64,
             window.attribution_dropped_sends,
@@ -1404,6 +1531,7 @@ mod tests {
             &window.arms(),
             &window.top_contracts(),
             &window.top_not_efficient_contracts(),
+            &window.top_contracts_total(),
             window.contract_full_state_bytes.values().sum(),
             window.contract_full_state_bytes.len() as u64,
             window.attribution_dropped_sends,
@@ -1432,6 +1560,7 @@ mod tests {
             &window.arms(),
             &window.top_contracts(),
             &window.top_not_efficient_contracts(),
+            &window.top_contracts_total(),
             0,
             0,
             0,
@@ -1450,6 +1579,7 @@ mod tests {
         let arms: Vec<_> = PayloadArm::ALL.iter().map(|a| (*a, 0, 0)).collect();
         let json = payload_mix_json(
             &arms,
+            &[],
             &[],
             &[],
             0,

--- a/crates/core/src/node/network_bridge/broadcast_queue.rs
+++ b/crates/core/src/node/network_bridge/broadcast_queue.rs
@@ -832,8 +832,9 @@ pub(super) async fn broadcast_to_single_peer(
                  or logically converged summaries)"
             );
             // Refresh the interest TTL even though nothing is sent (#3046,
-            // #3093). A CONVERGED peer is more interested than a diverged one,
-            // not less — skipping the payload must not expire the interest.
+            // #3093). A peer we believe is CONVERGED is not less interested
+            // than a diverged one — skipping the payload must not expire the
+            // interest.
             //
             // Only `record_delivery_to_interest` refreshed the TTL, and it runs
             // only on a delivered send, so every skip was silently aging the
@@ -844,6 +845,18 @@ pub(super) async fn broadcast_to_single_peer(
             // ANYTHING once the interest expires:
             // `test_interest_ttl_refresh_on_broadcast` caught exactly that,
             // decaying 98 → 29 → 0 broadcasts across the TTL boundary.
+            //
+            // TRADEOFF, stated honestly: `theirs` is OUR cached belief about the
+            // peer (`interested_peers`), not evidence from it. So a wedged but
+            // still-connected peer whose cached summary happens to match ours
+            // gets refreshed indefinitely, where the TTL previously reaped it.
+            // Two backstops bound that: disconnect drops the entry outright
+            // (`InterestManager::remove_peer`), and the peer's own ~5-min
+            // `Interests` heartbeat is a full REPLACE (node.rs), so an entry the
+            // peer no longer claims is removed regardless of how recently we
+            // refreshed it. TTL expiry is therefore not the mechanism that
+            // reaps a live-but-wedged peer, and using it as one costs every
+            // converged peer its updates.
             //
             // Refresh ONLY. Do not cache the summary or record delivery
             // telemetry here: nothing was delivered, and `sent_delta` has no
@@ -931,6 +944,16 @@ pub(super) async fn broadcast_to_single_peer(
                         "Skipping broadcast - contract reported empty delta \
                          (peer converged)"
                     );
+                    // Same outcome as the summaries-equal skip above — "the peer
+                    // is converged, send nothing" — so it owes the same TTL
+                    // refresh, for the same reason and with the same tradeoff.
+                    // This exit is self-limiting (the empty delta is cached, so
+                    // the next fan-out takes the `Skip` path above and refreshes
+                    // there), but a skip that ages the entry toward
+                    // `INTEREST_TTL` is the same class of bug either way.
+                    op_manager
+                        .interest_manager
+                        .refresh_peer_interest(&key, &peer_key);
                     // #4903 review P2: the summarize + delta WASM already ran,
                     // so account for the CPU it burned even though nothing is
                     // sent (no bytes). Previously this exit returned without
@@ -2342,6 +2365,86 @@ mod tests {
             2,
             "each delivery-gated bytes report must charge the selected \
              payload_size (delta or full state), not the pre-delta full-state size"
+        );
+    }
+
+    /// Source-scrape pin (#3046 / #3093): BOTH converged skips must refresh the
+    /// peer's interest TTL.
+    ///
+    /// `record_delivery_to_interest` refreshes only on a DELIVERED send, so a
+    /// peer we keep skipping — because we believe it already has our state —
+    /// ages toward `INTEREST_TTL` and is reaped, after which it receives
+    /// nothing at all. The skip is a permanent steady state for a converged
+    /// subscriber, so this is not a rare corner.
+    ///
+    /// Pinned at the source because the behavioural evidence is indirect: the
+    /// TTL decay only shows up as a broadcast count falling to zero across the
+    /// TTL boundary in a long simulation, and the empty-delta exit is
+    /// self-limiting (its verdict is cached, so the next fan-out takes the
+    /// summaries-equal exit instead) — a revert there would leave every
+    /// behavioural test green.
+    #[test]
+    fn broadcast_to_single_peer_refreshes_interest_on_every_skip_pin() {
+        let src = include_str!("broadcast_queue.rs");
+        let fn_start = src
+            .find("pub(super) async fn broadcast_to_single_peer(")
+            .expect("broadcast_to_single_peer not found");
+        let after = &src[fn_start..];
+        let fn_end = after
+            .find("\nmod tests {")
+            .or_else(|| after.find("\n#[cfg(test)]"))
+            .expect("end of broadcast_to_single_peer (start of tests module) not found");
+        let body = &after[..fn_end];
+
+        // Two skip exits (summaries-equal + empty-delta), one refresh each. The
+        // delivered path refreshes via `record_delivery_to_interest`, not here,
+        // so a third occurrence would mean a skip refresh drifted onto the send
+        // path or the delivered path grew a duplicate.
+        let refreshes = body
+            .matches("refresh_peer_interest(&key,&peer_key)")
+            .count()
+            + body
+                .matches("refresh_peer_interest(&key, &peer_key)")
+                .count();
+        assert_eq!(
+            refreshes, 2,
+            "broadcast_to_single_peer must refresh the interest TTL at BOTH \
+             converged-skip exits (summaries-equal and empty-delta) — got \
+             {refreshes}. Skipping the payload must not expire the interest."
+        );
+
+        // Bind each refresh to its own exit: the count alone would stay green
+        // if both landed in the same arm.
+        let equal_skip = body
+            .find("Skipping broadcast - peer already has our state")
+            .expect("summaries-equal skip arm not found");
+        let empty_delta_skip = body
+            .find("Skipping broadcast - contract reported empty delta")
+            .expect("empty-delta skip arm not found");
+        assert!(
+            equal_skip < empty_delta_skip,
+            "unexpected arm order; the offsets below assume summaries-equal \
+             precedes empty-delta"
+        );
+        assert!(
+            body[equal_skip..empty_delta_skip].contains("refresh_peer_interest("),
+            "the summaries-equal skip must refresh the interest TTL before it \
+             returns"
+        );
+        assert!(
+            body[empty_delta_skip..].contains("refresh_peer_interest("),
+            "the empty-delta (converged) skip must refresh the interest TTL \
+             before it returns — same outcome as the skip above, same obligation"
+        );
+
+        // A skip delivered nothing, so it must not record delivery telemetry or
+        // cache the peer's summary: `sent_delta` has no truthful value for a
+        // send that did not happen, and caching our summary for a peer we never
+        // sent to is the #2763/#4235 divergence hazard.
+        assert!(
+            !body[equal_skip..empty_delta_skip].contains("record_delivery_to_interest("),
+            "the summaries-equal skip must refresh ONLY — recording a delivery \
+             that did not happen corrupts the delta/full-state telemetry"
         );
     }
 

--- a/crates/core/src/node/network_bridge/broadcast_queue.rs
+++ b/crates/core/src/node/network_bridge/broadcast_queue.rs
@@ -831,6 +831,26 @@ pub(super) async fn broadcast_to_single_peer(
                 "Skipping broadcast - peer already has our state (byte-equal \
                  or logically converged summaries)"
             );
+            // Refresh the interest TTL even though nothing is sent (#3046,
+            // #3093). A CONVERGED peer is more interested than a diverged one,
+            // not less — skipping the payload must not expire the interest.
+            //
+            // Only `record_delivery_to_interest` refreshed the TTL, and it runs
+            // only on a delivered send, so every skip was silently aging the
+            // entry toward `INTEREST_TTL`. That was unreachable in practice
+            // while a renewal wiped the cached summary (no summary → no
+            // `theirs` → no skip). Preserving the summary across renewals makes
+            // the skip reachable, and without this the peer stops receiving
+            // ANYTHING once the interest expires:
+            // `test_interest_ttl_refresh_on_broadcast` caught exactly that,
+            // decaying 98 → 29 → 0 broadcasts across the TTL boundary.
+            //
+            // Refresh ONLY. Do not cache the summary or record delivery
+            // telemetry here: nothing was delivered, and `sent_delta` has no
+            // truthful value for a send that did not happen.
+            op_manager
+                .interest_manager
+                .refresh_peer_interest(&key, &peer_key);
             report_send_cpu(op_manager);
             return;
         }

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -4748,6 +4748,14 @@ pub(crate) mod tests {
     /// = converged) arm SKIPS instead of falling back to full state. Without
     /// this pin the behavioral broadcast simulation tests would diverge from
     /// production and silently regress the storm.
+    ///
+    /// Also pins the #3046/#3093 interest-TTL refresh on both of those skip
+    /// exits. The drift here is worse than usual: `tests/simulation_integration.rs`
+    /// is `#![cfg(feature = "simulation_tests")]`, so THIS body — not
+    /// `broadcast_queue::broadcast_to_single_peer` — is what
+    /// `test_interest_ttl_refresh_on_broadcast` actually exercises. A fix
+    /// applied only to production is therefore untested, and a sim-side revert
+    /// is invisible to production.
     #[test]
     fn broadcast_state_to_peers_uses_semantic_delta_skip() {
         // Lives in the `broadcast` submodule after the p2p_protoc.rs split.
@@ -4794,6 +4802,63 @@ pub(crate) mod tests {
             ok_none_arm.contains("continue;"),
             "the sim fan-out's Ok(None) (empty delta = converged) arm must skip \
              this peer (continue). Arm body:\n{ok_none_arm}"
+        );
+
+        // #3046/#3093: both skip exits must refresh the peer's interest TTL.
+        // The send-success arm's refresh is a third occurrence, so pin each
+        // skip to its own arm rather than counting.
+        let equal_skip = body
+            .find("Skipping broadcast - peer already has our state")
+            .expect("sim summaries-equal skip arm not found");
+        assert!(
+            equal_skip < ok_none_off,
+            "unexpected arm order; the slice below assumes the summaries-equal \
+             skip precedes the compute_delta match"
+        );
+        assert!(
+            body[equal_skip..ok_none_off].contains("refresh_peer_interest("),
+            "the sim fan-out's summaries-equal skip must refresh the interest \
+             TTL — without it the sim path ages the entry toward INTEREST_TTL on \
+             every skip and the peer eventually receives nothing. This is the \
+             body simulation_integration.rs actually runs."
+        );
+        assert!(
+            ok_none_arm.contains("refresh_peer_interest("),
+            "the sim fan-out's Ok(None) (empty delta = converged) arm must \
+             refresh the interest TTL — same converged outcome as the skip \
+             above, same obligation. Arm body:\n{ok_none_arm}"
+        );
+
+        // Anti-drift: the production body must carry the same two refreshes.
+        // These two implementations are selected by cfg and have drifted before
+        // (which is why this pin exists at all), so assert the property on both
+        // from one place — a fix landed on only one side fails here.
+        const PROD: &str = include_str!("broadcast_queue.rs");
+        let prod_start = PROD
+            .find("pub(super) async fn broadcast_to_single_peer(")
+            .expect("broadcast_to_single_peer not found");
+        let prod_after = &PROD[prod_start..];
+        let prod_end = prod_after
+            .find("\nmod tests {")
+            .or_else(|| prod_after.find("\n#[cfg(test)]"))
+            .expect("end of broadcast_to_single_peer not found");
+        let prod_body = &prod_after[..prod_end];
+        let prod_equal = prod_body
+            .find("Skipping broadcast - peer already has our state")
+            .expect("production summaries-equal skip arm not found");
+        let prod_empty = prod_body
+            .find("Skipping broadcast - contract reported empty delta")
+            .expect("production empty-delta skip arm not found");
+        assert!(prod_equal < prod_empty, "unexpected production arm order");
+        assert!(
+            prod_body[prod_equal..prod_empty].contains("refresh_peer_interest("),
+            "the production summaries-equal skip must refresh the interest TTL \
+             too — the sim and production bodies must not drift on this"
+        );
+        assert!(
+            prod_body[prod_empty..].contains("refresh_peer_interest("),
+            "the production empty-delta skip must refresh the interest TTL too \
+             — the sim and production bodies must not drift on this"
         );
     }
 

--- a/crates/core/src/node/network_bridge/p2p_protoc/broadcast.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc/broadcast.rs
@@ -723,6 +723,19 @@ impl P2pConnManager {
                         "Skipping broadcast - peer already has our state \
                          (byte-equal or logically converged summaries)"
                     );
+                    // Mirror production's converged-skip TTL refresh (#3046,
+                    // #3093). Without it the sim path ages the interest entry
+                    // toward `INTEREST_TTL` on every skip and the peer stops
+                    // receiving anything at all — and because
+                    // `simulation_integration.rs` is `#![cfg(feature =
+                    // "simulation_tests")]`, THIS is the body those tests
+                    // exercise, so a fix applied only to `broadcast_queue.rs`
+                    // is untested. See the rationale and the
+                    // belief-vs-evidence tradeoff at
+                    // `broadcast_queue::broadcast_to_single_peer`'s skip.
+                    op_manager
+                        .interest_manager
+                        .refresh_peer_interest(&key, &peer_key);
                     skipped_summary_match += 1;
                     continue;
                 }
@@ -753,6 +766,12 @@ impl P2pConnManager {
                                 "Skipping broadcast - contract reported empty \
                                  delta (peer converged)"
                             );
+                            // Same converged outcome as the skip above, so the
+                            // same TTL refresh. Mirrors production's
+                            // `Ok(None)` arm in `broadcast_to_single_peer`.
+                            op_manager
+                                .interest_manager
+                                .refresh_peer_interest(&key, &peer_key);
                             skipped_summary_match += 1;
                             continue;
                         }

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -3204,14 +3204,16 @@ where
             // would DOWNGRADE a peer that is legitimately our upstream, which is
             // the `Unsubscribe` routing target. A GET requester's interest must
             // not clear an upstream edge established by SUBSCRIBE.
+            //
+            // One acquisition, via the refresh's own bool — NOT
+            // `get_peer_interest(..).is_some()`, which clones the cached
+            // summary (state-sized on the contracts that matter) purely to test
+            // presence, and can lose the registration if the entry is removed
+            // between the two lookups.
             let is_new = if op_manager
                 .interest_manager
-                .get_peer_interest(&key, &peer_key)
-                .is_some()
+                .refresh_peer_interest(&key, &peer_key)
             {
-                op_manager
-                    .interest_manager
-                    .refresh_peer_interest(&key, &peer_key);
                 false
             } else {
                 op_manager

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -3193,9 +3193,31 @@ where
             .get_peer_by_addr(upstream_addr)
         {
             let peer_key = crate::ring::interest::PeerKey::from(pkl.pub_key);
-            let is_new = op_manager
+            // Refresh-if-present, register-if-absent (#4672). A bare
+            // `register_peer_interest` inserts a fresh `PeerInterest` over an
+            // existing entry, wiping its cached delta-sync summary and forcing
+            // the next broadcast to this peer back to full state.
+            //
+            // Plain `refresh_peer_interest` here, NOT the `_with_upstream`
+            // variant the subscribe finalizers use: this call passes
+            // `is_upstream = false`, and asserting that on an existing entry
+            // would DOWNGRADE a peer that is legitimately our upstream, which is
+            // the `Unsubscribe` routing target. A GET requester's interest must
+            // not clear an upstream edge established by SUBSCRIBE.
+            let is_new = if op_manager
                 .interest_manager
-                .register_peer_interest(&key, peer_key, None, false);
+                .get_peer_interest(&key, &peer_key)
+                .is_some()
+            {
+                op_manager
+                    .interest_manager
+                    .refresh_peer_interest(&key, &peer_key);
+                false
+            } else {
+                op_manager
+                    .interest_manager
+                    .register_peer_interest(&key, peer_key, None, false)
+            };
             if is_new {
                 // #4359 (MUST-FIX 1): a remote GET with subscribe=false still
                 // registers the requester's interest, making them a viable

--- a/crates/core/src/operations/subscribe.rs
+++ b/crates/core/src/operations/subscribe.rs
@@ -678,15 +678,14 @@ pub(crate) async fn register_downstream_subscriber(
             // an already-tracked peer (every ~8-min lease renewal, or a
             // #4952 delivery-seeded co-host formally subscribing) wiped the
             // summary and forced the next broadcast back to full state.
-            if op_manager
+            // One acquisition via the refresh's own bool — see
+            // `InterestManager::refresh_peer_interest` for why the
+            // `get_peer_interest(..).is_some()` form it replaces was both
+            // expensive (it clones the cached summary) and racy.
+            if !op_manager
                 .interest_manager
-                .get_peer_interest(key, &peer_key)
-                .is_some()
+                .refresh_peer_interest(key, &peer_key)
             {
-                op_manager
-                    .interest_manager
-                    .refresh_peer_interest(key, &peer_key);
-            } else {
                 op_manager
                     .interest_manager
                     .register_peer_interest(key, peer_key, None, false);

--- a/crates/core/src/operations/subscribe.rs
+++ b/crates/core/src/operations/subscribe.rs
@@ -523,9 +523,24 @@ pub(super) async fn finalize_originator_subscribe(
         .get_peer_by_addr(upstream_addr)
     {
         let peer_key = crate::ring::interest::PeerKey::from(pkl.pub_key);
-        let is_new = op_manager
+        // Refresh-if-present, register-if-absent. A bare `register_peer_interest`
+        // inserts a fresh `PeerInterest` over an existing entry and WIPES its
+        // cached delta-sync summary, which then reports `NeverPopulated` and
+        // forces every subsequent broadcast to this peer back to full state.
+        // Renewals reach here at `SUBSCRIPTION_RENEWAL_INTERVAL` (120s) against
+        // an 8-minute lease, so the unguarded form clobbered ~30x per subscribed
+        // contract per hour. Same guard as `node.rs`'s Interests handler and the
+        // downstream registration below.
+        let is_new = if op_manager
             .interest_manager
-            .register_peer_interest(&key, peer_key, None, true);
+            .refresh_peer_interest_with_upstream(&key, &peer_key, true)
+        {
+            false
+        } else {
+            op_manager
+                .interest_manager
+                .register_peer_interest(&key, peer_key, None, true)
+        };
         if is_new {
             // #4359 (MUST-FIX 1): this upstream peer is now a viable broadcast
             // target. If a fresh-contract PUT gave up with no targets and is
@@ -824,9 +839,19 @@ pub(super) async fn finalize_host_subscribe(
     // promptly. `is_new` marks a freshly-viable broadcast target → flush any
     // deferred fresh-contract broadcast (#4359), same as the originator.
     if let Some(peer_key) = upstream_peer {
-        let is_new = op_manager
+        // Refresh-if-present, register-if-absent — see the identical guard in
+        // `finalize_originator_subscribe`. A bare `register_peer_interest` here
+        // wipes the cached summary on every renewal.
+        let is_new = if op_manager
             .interest_manager
-            .register_peer_interest(&key, peer_key, None, true);
+            .refresh_peer_interest_with_upstream(&key, &peer_key, true)
+        {
+            false
+        } else {
+            op_manager
+                .interest_manager
+                .register_peer_interest(&key, peer_key, None, true)
+        };
         if is_new {
             op_manager.flush_pending_broadcast_on_interest(&key).await;
         }

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -883,6 +883,49 @@ impl<T: TimeSource + Sync> InterestManager<T> {
         }
     }
 
+    /// Refresh the TTL for a peer's interest **and** set its `is_upstream`
+    /// flag, preserving any cached summary.
+    ///
+    /// Exists for the subscribe paths, which must assert upstream-ness on an
+    /// entry that may already exist. Their only previous option was a bare
+    /// [`Self::register_peer_interest`], which inserts a fresh
+    /// [`PeerInterest::new`] over the existing one and therefore **wipes the
+    /// cached delta-sync summary** — the entry then reports
+    /// [`SummaryMissingReason::NeverPopulated`], which is both wrong (it WAS
+    /// populated) and expensive (every subsequent broadcast to that peer falls
+    /// back to full state until the summary is re-seeded).
+    ///
+    /// That matters at renewal cadence: `SUBSCRIPTION_RENEWAL_INTERVAL` is 120s
+    /// against an 8-minute lease, and a renewal re-registers through the same
+    /// outbound-SUBSCRIBE machinery as a client request, so an unguarded call
+    /// site clobbers roughly 30 times per subscribed contract per hour.
+    ///
+    /// Deliberately SETS `is_upstream` rather than leaving it alone: the bare
+    /// `register_peer_interest` this replaces also set it, and the flag is the
+    /// `Unsubscribe` routing target. Only the summary-preservation behaviour
+    /// changes. Do NOT "simplify" this into [`Self::refresh_peer_interest`] —
+    /// that one intentionally leaves the flag untouched, and the two call-site
+    /// families rely on the difference.
+    ///
+    /// Returns `true` if an entry existed and was updated, `false` if there was
+    /// nothing to refresh (the caller should then register).
+    pub fn refresh_peer_interest_with_upstream(
+        &self,
+        contract: &ContractKey,
+        peer: &PeerKey,
+        is_upstream: bool,
+    ) -> bool {
+        let now = self.time_source.now();
+        if let Some(mut entry) = self.interested_peers.get_mut(contract) {
+            if let Some(interest) = entry.get_mut(peer) {
+                interest.refresh(now);
+                interest.is_upstream = is_upstream;
+                return true;
+            }
+        }
+        false
+    }
+
     /// Get all peers interested in a contract.
     pub fn get_interested_peers(&self, contract: &ContractKey) -> Vec<(PeerKey, PeerInterest)> {
         let mut peers: Vec<(PeerKey, PeerInterest)> = self
@@ -2994,6 +3037,102 @@ mod tests {
     /// upsert, so one delivered full state seeds the summary and every later
     /// broadcast to the same peer can be a delta.
     #[test]
+    /// A subscribe RENEWAL must not wipe the cached delta-sync summary.
+    ///
+    /// `finalize_originator_subscribe` / `finalize_host_subscribe` previously
+    /// called a bare `register_peer_interest`, which inserts a fresh
+    /// `PeerInterest` over the existing entry. The summary was silently lost and
+    /// the entry then reported `NeverPopulated` — both wrong (it HAD been
+    /// populated) and expensive, since every subsequent broadcast to that peer
+    /// falls back to full state. Renewals run at 120s against an 8-minute lease,
+    /// so this fired ~30x per subscribed contract per hour.
+    #[test]
+    fn refresh_with_upstream_preserves_summary_and_sets_flag() {
+        let (manager, _time) = make_manager();
+        let contract = make_contract_key(1);
+        let peer = make_peer_key(1);
+
+        // A downstream entry that has since been seeded by a real delivery.
+        manager.register_peer_interest(&contract, peer.clone(), None, false);
+        assert!(manager.upsert_peer_summary(&contract, &peer, StateSummary::from(vec![7u8, 7])));
+
+        // The renewal path asserts upstream-ness on the existing entry.
+        assert!(
+            manager.refresh_peer_interest_with_upstream(&contract, &peer, true),
+            "an existing entry must report as refreshed, so the caller does not \
+             fall through to register_peer_interest"
+        );
+
+        assert_eq!(
+            manager
+                .get_peer_summary(&contract, &peer)
+                .map(|s| s.as_ref().to_vec()),
+            Some(vec![7u8, 7]),
+            "the cached summary MUST survive a renewal — losing it is the \
+             never_populated clobber this method exists to prevent"
+        );
+        let interest = manager
+            .get_peer_interest(&contract, &peer)
+            .expect("entry still present");
+        assert!(
+            interest.is_upstream,
+            "the flag must be SET, not merely left alone: it is the Unsubscribe \
+             routing target and the bare register it replaces also set it"
+        );
+        assert!(
+            interest.summary_missing_reason().is_none(),
+            "a preserved summary must not be tagged with an absence reason"
+        );
+    }
+
+    /// The absent case: nothing to refresh, so the caller must register.
+    #[test]
+    fn refresh_with_upstream_reports_false_for_untracked_peer() {
+        let (manager, _time) = make_manager();
+        let contract = make_contract_key(1);
+        let peer = make_peer_key(1);
+
+        assert!(
+            !manager.refresh_peer_interest_with_upstream(&contract, &peer, true),
+            "an untracked peer must report false so the caller registers it"
+        );
+        assert!(
+            manager.get_peer_interest(&contract, &peer).is_none(),
+            "the refresh must not create an entry as a side effect"
+        );
+    }
+
+    /// Source pin: neither subscribe finalizer may go back to a bare
+    /// `register_peer_interest` without first trying the refresh. Guarding by
+    /// convention already failed once — three sites had the guard and these two
+    /// did not, and the drift was invisible because the symptom is a bandwidth
+    /// regression rather than a broken test.
+    #[test]
+    fn subscribe_finalizers_do_not_clobber_cached_summaries() {
+        let src = include_str!("../operations/subscribe.rs");
+        let prod = &src[..src.find("\nmod tests {").unwrap_or(src.len())];
+        let stripped: String = prod.chars().filter(|c| !c.is_whitespace()).collect();
+
+        let bare = stripped
+            .matches("register_peer_interest(&key,peer_key,None,true)")
+            .count();
+        let guarded = stripped
+            .matches("refresh_peer_interest_with_upstream(&key,&peer_key,true)")
+            .count();
+
+        assert_eq!(
+            guarded, 2,
+            "both subscribe finalizers must consult refresh_peer_interest_with_upstream \
+             before registering (found {guarded})"
+        );
+        assert_eq!(
+            bare, 2,
+            "the two register calls must remain as the else-branch of that guard \
+             (found {bare}); if this changed, re-check that neither path can wipe \
+             a cached summary"
+        );
+    }
+
     fn upsert_peer_summary_seeds_summary_for_untracked_peer() {
         let (manager, _time) = make_manager();
         let contract = make_contract_key(1);

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -3036,7 +3036,6 @@ mod tests {
     /// `broadcast_queue::record_delivery_to_interest` routes through the
     /// upsert, so one delivered full state seeds the summary and every later
     /// broadcast to the same peer can be a delta.
-    #[test]
     /// A subscribe RENEWAL must not wipe the cached delta-sync summary.
     ///
     /// `finalize_originator_subscribe` / `finalize_host_subscribe` previously
@@ -3158,6 +3157,7 @@ mod tests {
         );
     }
 
+    #[test]
     fn upsert_peer_summary_seeds_summary_for_untracked_peer() {
         let (manager, _time) = make_manager();
         let contract = make_contract_key(1);

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -3133,6 +3133,31 @@ mod tests {
         );
     }
 
+    /// Same clobber, third site (#4672): the remote-GET interest registration.
+    ///
+    /// Guarded with plain `refresh_peer_interest`, NOT the `_with_upstream`
+    /// variant — this call passes `is_upstream = false`, and asserting that on
+    /// an existing entry would DOWNGRADE a peer that is legitimately our
+    /// upstream, which is the `Unsubscribe` routing target. A GET requester's
+    /// interest must not clear an upstream edge established by SUBSCRIBE.
+    #[test]
+    fn get_interest_registration_does_not_clobber_or_downgrade() {
+        let src = include_str!("../operations/get/op_ctx_task.rs");
+        let prod = &src[..src.find("\nmod tests {").unwrap_or(src.len())];
+        let stripped: String = prod.chars().filter(|c| !c.is_whitespace()).collect();
+
+        assert!(
+            stripped.contains("get_peer_interest(&key,&peer_key).is_some()"),
+            "the remote-GET registration must check for an existing entry before \
+             registering, or it wipes that entry's cached summary (#4672)"
+        );
+        assert!(
+            !stripped.contains("refresh_peer_interest_with_upstream(&key,&peer_key,false)"),
+            "must NOT assert is_upstream=false on an existing entry — that \
+             downgrades a legitimate upstream edge and breaks Unsubscribe routing"
+        );
+    }
+
     fn upsert_peer_summary_seeds_summary_for_untracked_peer() {
         let (manager, _time) = make_manager();
         let contract = make_contract_key(1);

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -873,14 +873,31 @@ impl<T: TimeSource + Sync> InterestManager<T> {
         true
     }
 
-    /// Refresh the TTL for a peer's interest.
-    pub fn refresh_peer_interest(&self, contract: &ContractKey, peer: &PeerKey) {
+    /// Refresh the TTL for a peer's interest, leaving `is_upstream` and any
+    /// cached summary untouched.
+    ///
+    /// Returns `true` if an entry existed and was refreshed, `false` if there
+    /// was nothing to refresh — so a caller can express refresh-if-present /
+    /// register-if-absent in ONE map acquisition.
+    ///
+    /// The `get_peer_interest(..).is_some()` form this return value replaces was
+    /// wrong twice over. [`Self::get_peer_interest`] returns an owned
+    /// [`PeerInterest`], so testing presence deep-copied the cached
+    /// `StateSummary` — up to ~840 KB of alloc+memcpy per call for exactly the
+    /// state-sized-summary contracts that make this path expensive — and threw
+    /// the clone away. And the two lookups are not atomic: a
+    /// [`Self::remove_peer_interest`] landing between them makes the refresh a
+    /// silent no-op *and* skips the register, so the caller's interest is never
+    /// recorded at all.
+    pub fn refresh_peer_interest(&self, contract: &ContractKey, peer: &PeerKey) -> bool {
         let now = self.time_source.now();
         if let Some(mut entry) = self.interested_peers.get_mut(contract) {
             if let Some(interest) = entry.get_mut(peer) {
                 interest.refresh(now);
+                return true;
             }
         }
+        false
     }
 
     /// Refresh the TTL for a peer's interest **and** set its `is_upstream`
@@ -3036,6 +3053,57 @@ mod tests {
     /// `broadcast_queue::record_delivery_to_interest` routes through the
     /// upsert, so one delivered full state seeds the summary and every later
     /// broadcast to the same peer can be a delta.
+    #[test]
+    fn upsert_peer_summary_seeds_summary_for_untracked_peer() {
+        let (manager, _time) = make_manager();
+        let contract = make_contract_key(1);
+        let peer = make_peer_key(1);
+
+        assert!(
+            manager.get_peer_interest(&contract, &peer).is_none(),
+            "precondition: the peer must be untracked"
+        );
+
+        assert!(manager.upsert_peer_summary(&contract, &peer, StateSummary::from(vec![1u8, 2])));
+
+        assert_eq!(
+            manager
+                .get_peer_summary(&contract, &peer)
+                .map(|s| s.as_ref().to_vec()),
+            Some(vec![1u8, 2]),
+            "the upsert must CREATE the entry so the pair escapes to deltas"
+        );
+        let interest = manager
+            .get_peer_interest(&contract, &peer)
+            .expect("entry created");
+        assert!(
+            !interest.is_upstream,
+            "a delivery-seeded entry is not our upstream"
+        );
+
+        // Later deliveries keep the cached summary current.
+        assert!(manager.upsert_peer_summary(&contract, &peer, StateSummary::from(vec![9u8])));
+        assert_eq!(
+            manager
+                .get_peer_summary(&contract, &peer)
+                .map(|s| s.as_ref().to_vec()),
+            Some(vec![9u8]),
+        );
+
+        // The reverse index is maintained, so peer-disconnect cleanup works.
+        assert!(manager.get_contracts_for_peer(&peer).contains(&contract));
+        assert!(manager.remove_peer_interest(&contract, &peer));
+        assert!(manager.get_peer_summary(&contract, &peer).is_none());
+        assert!(!manager.get_contracts_for_peer(&peer).contains(&contract));
+
+        // Summary bookkeeping must not fabricate local demand (invariant 3):
+        // no local-interest entry appears as a side effect.
+        assert!(
+            !manager.has_local_interest(&contract),
+            "upsert must not create local interest / demand state"
+        );
+    }
+
     /// A subscribe RENEWAL must not wipe the cached delta-sync summary.
     ///
     /// `finalize_originator_subscribe` / `finalize_host_subscribe` previously
@@ -3101,6 +3169,58 @@ mod tests {
         );
     }
 
+    /// The production-code slice of a source file: everything before its test
+    /// module.
+    ///
+    /// `subscribe.rs` declares its tests as `#[cfg(test)] mod tests;` — an
+    /// EXTERNAL module with no brace — so a cut at `"\nmod tests {"` finds
+    /// nothing and silently returns the whole file, test modules included.
+    /// `subscribe.rs` also has an INLINE `#[cfg(test)] mod source_pin_tests {`,
+    /// so a needle added to a future pin there would inflate the counts below
+    /// and mask a real drift. Cutting at the EARLIER of the two markers covers
+    /// both shapes (the `cfg-test-cut-disarms-source-pins` trap). Earlier, not
+    /// first-found: `#[cfg(test)]` precedes the `mod tests {` it annotates, so
+    /// preferring the brace form would leave the attribute in the "production"
+    /// slice.
+    fn prod_source(src: &str) -> String {
+        let cut = [src.find("\nmod tests {"), src.find("\n#[cfg(test)]")]
+            .into_iter()
+            .flatten()
+            .min()
+            .unwrap_or(src.len());
+        src[..cut].chars().filter(|c| !c.is_whitespace()).collect()
+    }
+
+    /// The cut above must actually cut. A fallback that silently no-ops leaves
+    /// every count below reading the test modules too, which is how a source
+    /// pin stops pinning without anyone noticing.
+    #[test]
+    fn prod_source_cut_excludes_test_modules() {
+        for (name, src) in [
+            (
+                "subscribe.rs",
+                include_str!("../operations/subscribe.rs") as &str,
+            ),
+            (
+                "get/op_ctx_task.rs",
+                include_str!("../operations/get/op_ctx_task.rs") as &str,
+            ),
+        ] {
+            let prod = prod_source(src);
+            let whole: String = src.chars().filter(|c| !c.is_whitespace()).collect();
+            assert!(
+                prod.len() < whole.len(),
+                "{name}: prod_source must exclude the test module(s); it returned \
+                 the whole file, so every count derived from it is reading test \
+                 code as production code"
+            );
+            assert!(
+                !prod.contains("#[cfg(test)]"),
+                "{name}: prod_source must cut BEFORE the first #[cfg(test)]"
+            );
+        }
+    }
+
     /// Source pin: neither subscribe finalizer may go back to a bare
     /// `register_peer_interest` without first trying the refresh. Guarding by
     /// convention already failed once — three sites had the guard and these two
@@ -3108,9 +3228,7 @@ mod tests {
     /// regression rather than a broken test.
     #[test]
     fn subscribe_finalizers_do_not_clobber_cached_summaries() {
-        let src = include_str!("../operations/subscribe.rs");
-        let prod = &src[..src.find("\nmod tests {").unwrap_or(src.len())];
-        let stripped: String = prod.chars().filter(|c| !c.is_whitespace()).collect();
+        let stripped = prod_source(include_str!("../operations/subscribe.rs"));
 
         let bare = stripped
             .matches("register_peer_interest(&key,peer_key,None,true)")
@@ -3130,6 +3248,30 @@ mod tests {
              (found {bare}); if this changed, re-check that neither path can wipe \
              a cached summary"
         );
+        // Bind each guard to its register: the counts alone would stay green if
+        // one finalizer refreshed and then registered unconditionally.
+        assert_eq!(
+            stripped
+                .matches(
+                    "refresh_peer_interest_with_upstream(&key,&peer_key,true){false}else{op_manager.interest_manager.register_peer_interest(&key,peer_key,None,true)"
+                )
+                .count(),
+            2,
+            "each subscribe finalizer's register must be the ELSE branch of its \
+             own refresh guard, not a separate unconditional statement"
+        );
+
+        // Third site, `register_downstream_subscriber`: same clobber, but with
+        // the PLAIN refresh — it registers with is_upstream=false, and
+        // asserting that on an existing entry would downgrade a real upstream.
+        assert!(
+            stripped.contains(
+                "refresh_peer_interest(key,&peer_key){op_manager.interest_manager.register_peer_interest(key,peer_key,None,false)"
+            ),
+            "register_downstream_subscriber must register only when the refresh \
+             reports no existing entry (a bare register wipes the cached summary \
+             on every lease renewal)"
+        );
     }
 
     /// Same clobber, third site (#4672): the remote-GET interest registration.
@@ -3141,70 +3283,47 @@ mod tests {
     /// interest must not clear an upstream edge established by SUBSCRIBE.
     #[test]
     fn get_interest_registration_does_not_clobber_or_downgrade() {
-        let src = include_str!("../operations/get/op_ctx_task.rs");
-        let prod = &src[..src.find("\nmod tests {").unwrap_or(src.len())];
-        let stripped: String = prod.chars().filter(|c| !c.is_whitespace()).collect();
+        let stripped = prod_source(include_str!("../operations/get/op_ctx_task.rs"));
 
+        // Bind the guard to the register rather than merely asserting both
+        // appear: the needle spans `refresh(..) { false } else { register(..) }`,
+        // so a register that runs regardless of the refresh fails here.
         assert!(
-            stripped.contains("get_peer_interest(&key,&peer_key).is_some()"),
-            "the remote-GET registration must check for an existing entry before \
-             registering, or it wipes that entry's cached summary (#4672)"
-        );
-        assert!(
-            !stripped.contains("refresh_peer_interest_with_upstream(&key,&peer_key,false)"),
-            "must NOT assert is_upstream=false on an existing entry — that \
-             downgrades a legitimate upstream edge and breaks Unsubscribe routing"
-        );
-    }
-
-    #[test]
-    fn upsert_peer_summary_seeds_summary_for_untracked_peer() {
-        let (manager, _time) = make_manager();
-        let contract = make_contract_key(1);
-        let peer = make_peer_key(1);
-
-        assert!(
-            manager.get_peer_interest(&contract, &peer).is_none(),
-            "precondition: the peer must be untracked"
+            stripped.contains(
+                "refresh_peer_interest(&key,&peer_key){false}else{op_manager.interest_manager.register_peer_interest(&key,peer_key,None,false)"
+            ),
+            "the remote-GET registration must register ONLY when the refresh \
+             reports no existing entry — otherwise it inserts a fresh \
+             PeerInterest over the existing one and wipes its cached summary \
+             (#4672)"
         );
 
-        assert!(manager.upsert_peer_summary(&contract, &peer, StateSummary::from(vec![1u8, 2])));
-
+        // Exactly one of each in the whole production file: a second, unguarded
+        // register elsewhere would leave the assertion above green while
+        // reintroducing the clobber.
         assert_eq!(
-            manager
-                .get_peer_summary(&contract, &peer)
-                .map(|s| s.as_ref().to_vec()),
-            Some(vec![1u8, 2]),
-            "the upsert must CREATE the entry so the pair escapes to deltas"
+            stripped.matches("register_peer_interest(").count(),
+            1,
+            "get/op_ctx_task.rs must contain exactly ONE register_peer_interest \
+             call — the guarded one; a second is an unguarded clobber"
         );
-        let interest = manager
-            .get_peer_interest(&contract, &peer)
-            .expect("entry created");
-        assert!(
-            !interest.is_upstream,
-            "a delivery-seeded entry is not our upstream"
-        );
-
-        // Later deliveries keep the cached summary current.
-        assert!(manager.upsert_peer_summary(&contract, &peer, StateSummary::from(vec![9u8])));
         assert_eq!(
-            manager
-                .get_peer_summary(&contract, &peer)
-                .map(|s| s.as_ref().to_vec()),
-            Some(vec![9u8]),
+            stripped.matches("refresh_peer_interest(").count(),
+            1,
+            "exactly one refresh_peer_interest call — the one gating that register"
         );
 
-        // The reverse index is maintained, so peer-disconnect cleanup works.
-        assert!(manager.get_contracts_for_peer(&peer).contains(&contract));
-        assert!(manager.remove_peer_interest(&contract, &peer));
-        assert!(manager.get_peer_summary(&contract, &peer).is_none());
-        assert!(!manager.get_contracts_for_peer(&peer).contains(&contract));
-
-        // Summary bookkeeping must not fabricate local demand (invariant 3):
-        // no local-interest entry appears as a side effect.
-        assert!(
-            !manager.has_local_interest(&contract),
-            "upsert must not create local interest / demand state"
+        // Falsifiable form of "must not downgrade": the `_with_upstream`
+        // variant must not appear here AT ALL. Using it on this path would
+        // assert is_upstream=false on an existing entry, clearing an upstream
+        // edge established by SUBSCRIBE and breaking Unsubscribe routing.
+        assert_eq!(
+            stripped
+                .matches("refresh_peer_interest_with_upstream(")
+                .count(),
+            0,
+            "the remote-GET path must use the plain refresh; the _with_upstream \
+             variant SETS the flag, and this call site's is_upstream is false"
         );
     }
 
@@ -3682,9 +3801,8 @@ mod tests {
     /// `register_peer_interest(.., is_upstream = false)` overwrites the whole
     /// `PeerInterest`, flipping `is_upstream` true -> false and wiping the
     /// cached delta-sync summary to `None`. The handler therefore guards the
-    /// re-registration of an EXISTING entry with
-    /// `get_peer_interest().is_some() -> refresh_peer_interest()`, which
-    /// preserves both.
+    /// re-registration of an EXISTING entry on `refresh_peer_interest()`'s own
+    /// return value, and the refresh preserves both.
     ///
     /// SCOPE: this exercises the InterestManager PRIMITIVES directly, so it is a
     /// characterization of the contract the guard relies on — it PASSES on the

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -6972,32 +6972,72 @@ fn test_interest_renewal() {
 ///
 /// ## Test Design
 ///
-/// Uses a minimal network (1 gateway + 2 nodes) with few contracts to
-/// isolate the TTL refresh mechanism. Virtual time spans ~1.5x INTEREST_TTL
-/// (1800s) so that without the broadcast-send TTL refresh, interest entries
-/// would expire and late-phase broadcasts would stop arriving.
+/// Asserts that a quiet fan-out is quiet because peers are CONVERGED, not
+/// because their subscriptions silently died.
 ///
-/// The test splits broadcast-received events into three phases:
-/// - **Early** (first third): baseline broadcast delivery
-/// - **Mid** (second third): crosses the TTL boundary (~1200s)
-/// - **Late** (final third): must still receive broadcasts if TTL was refreshed
+/// ## Why this does NOT count broadcasts
 ///
-/// ## What This Catches
+/// It used to assert `late_broadcasts > 0`, using broadcast VOLUME as a proxy
+/// for interest liveness. That proxy is invalid: suppressing redundant sends to
+/// converged peers is the intended bandwidth win, so volume moves in the SAME
+/// direction as the improvement and cannot discriminate "interest expired"
+/// (the bug) from "peers converged, nothing to send" (the fix working). Once
+/// subscribe renewals stopped wiping the cached delta-sync summary, the
+/// converged-skip became reachable and late-phase volume legitimately went to
+/// zero — the assertion failed on a healthy network.
 ///
-/// - Missing `refresh_peer_interest()` call in broadcast send path (p2p_protoc.rs)
-/// - TTL expiration causing silent subscriber loss
-/// - Regression of the #3093 fix
+/// It therefore asserts the property directly, via the #3046
+/// `BroadcastDeliverySummary` counters, which separate the three reasons a peer
+/// receives nothing: skipped as converged, unresolvable interest, or failed
+/// send. `send_failed == 0` and `interest_resolve_failed == 0` say nothing was
+/// lost; `skipped_summary_match > 0` says peers still held matching cached
+/// summaries; ground-truth convergence with zero diverged contracts says the
+/// skips were correct.
+///
+/// ## What this does NOT cover: #3093
+///
+/// This test cannot detect a missing broadcast-path TTL refresh, and no
+/// assertion here could. `INTEREST_TTL` is DEFINED as four heartbeats
+/// (`ring/interest.rs`: `INTEREST_TTL = INTEREST_HEARTBEAT_INTERVAL * 4`), so
+/// wherever the ~5-minute InterestSync exchange covers a (contract, peer) pair
+/// it refreshes that entry four times per TTL window and the broadcast-path
+/// refresh is not what keeps it alive. Reverting BOTH refreshes (production
+/// `broadcast_queue.rs` and the sim-only `p2p_protoc/broadcast.rs`) leaves every
+/// counter in this scenario byte-identical.
+///
+/// #3093 is carried instead by:
+/// - `broadcast_to_single_peer_refreshes_interest_on_every_skip_pin`
+///   (`broadcast_queue.rs`) and
+///   `broadcast_state_to_peers_uses_semantic_delta_skip` (`p2p_protoc.rs`),
+///   which fail immediately on either revert; and
+/// - the `InterestManager` TTL unit tests in `ring/interest.rs`, which drive
+///   expiry directly against a mock `TimeSource`.
+///
+/// ## Scope: this is a correctness check, not a regression gate
+///
+/// Measured, not assumed: reverting the #5055 renewal guards moves the numbers
+/// (sent 60 -> 108, received 127 -> 218) but does NOT trip any assertion here —
+/// `skipped_summary_match` only falls 256 -> 208, so it stays positive. Every
+/// assertion below states a property that must hold on a healthy network
+/// (nothing lost, interests resolvable, replicas agreed, skip reachable); none
+/// is a tripwire for a specific regression, and a threshold tuned to make one
+/// would be a magic number that flakes with scenario drift.
+///
+/// The regressions are gated by mutation-proven source pins instead:
+/// `subscribe_finalizers_do_not_clobber_cached_summaries` and
+/// `get_interest_registration_does_not_clobber_or_downgrade` (`ring/interest.rs`)
+/// for the renewal clobber, and the two broadcast pins above for #3093.
+///
+/// Do not "restore" a broadcast-count assertion here: it would fail on a
+/// healthy converged network and still not detect an expired interest.
 ///
 /// ## Related
 ///
-/// - Issue #3093: Interest TTL not refreshed on full-state broadcast
-/// - Issue #3107: Add isolated integration test (this test)
-/// - Issue #3141: CI & Testing Redesign
-/// - `test_interest_renewal`: Scale test covering the same mechanism
+/// - #3093 / #3107: the original TTL-refresh regression and this test
+/// - #5055: the renewal clobber, and why the volume proxy stopped working
 ///
-/// Uses `run_direct()` (paused-time single-thread runtime) for efficiency.
-/// Virtual time: 300 iterations × 6s = 1800s (~1.5× INTEREST_TTL).
-/// Wall clock: typically < 15s.
+/// Uses `run_direct()` (paused-time single-thread runtime). Virtual time:
+/// 300 iterations x 6s = 1800s (~1.5x INTEREST_TTL). Wall clock: < 15s.
 #[test_log::test]
 fn test_interest_ttl_refresh_on_broadcast() {
     const SEED: u64 = 0x3107_0BCA_0001;
@@ -7015,93 +7055,105 @@ fn test_interest_ttl_refresh_on_broadcast() {
         .run_direct()
         .assert_ok();
 
-    // Analyze broadcast-received events across three phases of virtual time.
-    // The TTL boundary is at ~1200s (INTEREST_TTL). If refresh is working,
-    // broadcasts should continue in the late phase (1200s-1800s).
-    let rt = create_runtime();
-    let (early_broadcasts, mid_broadcasts, late_broadcasts) = rt.block_on(async {
-        let logs = result.logs_handle.lock().await;
-        let log_count = logs.len();
-        let third = log_count / 3;
+    // Ground truth first: every replica agreed at the end of the run. This is
+    // what makes a quiet fan-out attributable to convergence rather than to
+    // lost delivery — "no broadcasts" plus "states agree" is the bandwidth win;
+    // "no broadcasts" plus divergence would be the bug.
+    assert!(
+        result.convergence.diverged.is_empty(),
+        "contracts diverged, so a quiet fan-out cannot be attributed to \
+         convergence: {:?}. Seed: 0x{:X}",
+        result.convergence.diverged,
+        SEED
+    );
 
-        let mut early = 0usize;
-        let mut mid = 0usize;
-        let mut late = 0usize;
-        for (i, log) in logs.iter().enumerate() {
+    // Read the #3046 delivery breakdown, which distinguishes the three reasons
+    // a peer got nothing: we skipped it (converged), we never resolved it
+    // (interest gone), or the send failed. Broadcast COUNTS cannot tell those
+    // apart; these counters are the whole point of the event.
+    fn field(dbg: &str, name: &str) -> Option<usize> {
+        let pat = format!("{name}: ");
+        let i = dbg.find(&pat)? + pat.len();
+        let rest = &dbg[i..];
+        let end = rest
+            .find(|c: char| !c.is_ascii_digit())
+            .unwrap_or(rest.len());
+        rest[..end].parse().ok()
+    }
+
+    let rt = create_runtime();
+    let (received, summaries, sent, skipped, send_failed, interest_failed) = rt.block_on(async {
+        let logs = result.logs_handle.lock().await;
+        let (mut recv, mut n, mut sent, mut skip, mut failed, mut ifailed) =
+            (0usize, 0usize, 0usize, 0usize, 0usize, 0usize);
+        for log in logs.iter() {
             if log.kind.is_update_broadcast_received() {
-                if i < third {
-                    early += 1;
-                } else if i < third * 2 {
-                    mid += 1;
-                } else {
-                    late += 1;
-                }
+                recv += 1;
+            }
+            let dbg = format!("{:?}", log.kind);
+            if dbg.contains("BroadcastDeliverySummary") {
+                n += 1;
+                sent += field(&dbg, "targets_sent").unwrap_or(0);
+                skip += field(&dbg, "skipped_summary_match").unwrap_or(0);
+                failed += field(&dbg, "send_failed").unwrap_or(0);
+                ifailed += field(&dbg, "interest_resolve_failed").unwrap_or(0);
             }
         }
-        (early, mid, late)
+        (recv, n, sent, skip, failed, ifailed)
     });
 
-    let total = early_broadcasts + mid_broadcasts + late_broadcasts;
     tracing::info!(
-        "Broadcast received events: {} total (early: {}, mid: {}, late: {})",
-        total,
-        early_broadcasts,
-        mid_broadcasts,
-        late_broadcasts
+        "fan-out over the run: {} delivery summaries, {} targets sent, {} skipped \
+         (summary match), {} send failures, {} interest-resolve failures, {} broadcasts received",
+        summaries,
+        sent,
+        skipped,
+        send_failed,
+        interest_failed,
+        received
     );
 
-    // Must have some broadcasts overall — otherwise the simulation didn't
-    // generate enough update activity to be meaningful.
+    // The simulation must actually have exercised the fan-out; otherwise every
+    // assertion below is vacuous.
     assert!(
-        total > 0,
-        "No BroadcastReceived events found in {} logged events — \
-         simulation may not be generating updates. Seed: 0x{:X}",
-        result.event_count,
-        SEED
+        summaries > 0 && received > 0,
+        "no fan-out activity ({summaries} delivery summaries, {received} broadcasts \
+         received) — the scenario stopped generating updates, so this test proves \
+         nothing. Seed: 0x{SEED:X}"
     );
 
-    // CRITICAL: Late-phase broadcasts must exist. If the TTL refresh on
-    // broadcast send is missing (regression of #3093), interest entries
-    // expire at ~1200s and no broadcasts are delivered after that point.
+    // Nothing was LOST. A converged peer receiving nothing is correct; a send
+    // that was attempted and failed is not, and the two are indistinguishable
+    // in a broadcast count.
+    assert_eq!(
+        send_failed, 0,
+        "{send_failed} broadcast sends FAILED — peers were meant to receive \
+         these and did not. Seed: 0x{SEED:X}"
+    );
+    assert_eq!(
+        interest_failed, 0,
+        "{interest_failed} fan-out targets could not be resolved to an interest \
+         entry. Seed: 0x{SEED:X}"
+    );
+
+    // The converged-skip demonstrably fired: peers still had CACHED SUMMARIES
+    // that matched ours. That is the positive evidence that quiet means
+    // converged. It also guards this PR's own change — if a subscribe renewal
+    // wiped the cached summary again, `theirs` would be absent, the skip could
+    // not fire, and this count would collapse toward zero.
     assert!(
-        late_broadcasts > 0,
-        "No BroadcastReceived events in the final third of simulation \
-         (after INTEREST_TTL boundary). Interest TTL is NOT being refreshed \
-         on broadcast send — subscriptions have silently expired. \
-         See #3093, #3107. Seed: 0x{:X}",
-        SEED
-    );
-
-    // The late/early ratio should be meaningful — at least 10% of early
-    // traffic. A drastic drop indicates partial TTL refresh failure.
-    let late_ratio = late_broadcasts as f64 / early_broadcasts.max(1) as f64;
-    tracing::info!(
-        "Late/early broadcast ratio: {:.2} ({}/{})",
-        late_ratio,
-        late_broadcasts,
-        early_broadcasts
-    );
-
-    assert!(
-        late_ratio > 0.1,
-        "Late broadcast ratio ({:.2}) dropped below 0.1 — \
-         interest TTL refresh may be partially broken. \
-         Early: {}, Mid: {}, Late: {}. See #3093, #3107. Seed: 0x{:X}",
-        late_ratio,
-        early_broadcasts,
-        mid_broadcasts,
-        late_broadcasts,
-        SEED
+        skipped > 0,
+        "the converged-skip never fired ({skipped} skips over {summaries} \
+         fan-outs). Either no peer had a cached summary — the renewal clobber \
+         this PR fixes — or the skip is not reachable. Seed: 0x{SEED:X}"
     );
 
     tracing::info!(
-        "test_interest_ttl_refresh_on_broadcast PASSED: late/early ratio {:.2}, \
-         total broadcasts: {} (early: {}, mid: {}, late: {})",
-        late_ratio,
-        total,
-        early_broadcasts,
-        mid_broadcasts,
-        late_broadcasts
+        "test_interest_ttl_refresh_on_broadcast PASSED: {} sent, {} skipped as \
+         converged, 0 failed, {} contracts converged with 0 diverged",
+        sent,
+        skipped,
+        result.convergence.converged.len()
     );
 }
 


### PR DESCRIPTION
## Problem

Three production sites replaced a peer's `PeerInterest` with a bare `register_peer_interest(.., summary: None)`, wiping the cached delta-sync summary of an already-tracked peer. The entry then reports `NeverPopulated`, which is both wrong (it HAD been populated) and expensive: every subsequent broadcast to that peer falls back to full state until the summary is re-seeded.

This fires at renewal cadence. `SUBSCRIPTION_RENEWAL_INTERVAL` is 120s against an 8-minute lease, and a renewal re-registers through the same outbound-SUBSCRIBE machinery as a client request, so an unguarded site clobbers roughly 30 times per subscribed contract per hour.

**Measured impact.** On the full retained collector corpus (0.2.111–0.2.115, ~52,350 node-hours, exact 60s-rollup counters, no sampling, residual exactly zero), `never_populated` is **89.4% of the tracked-missing arm's sends and 93.4% of its bytes — 16.46% of ALL broadcast bytes fleet-wide**, stable across every version in the window (89.8–96.2%).

Caveat, stated because it bounds the claim: `PeerInterest::new` unconditionally stamps `NeverPopulated` and `register_peer_interest` unconditionally inserts fresh, so the tag conflates "created and never seeded" with "seeded then wiped by re-registration". Both are this PR's domain, so the target holds, but the tag does not separate them and this PR does not claim it does.

This PR targets that cause only. It does **not** address the `full_no_their_summary_untracked` arm (13.8% of broadcast bytes) — the #4953 upsert that covers untracked co-hosts shipped in v0.2.113 and is already live on the fleet.

## Approach

Guard all three sites with refresh-if-present / register-if-absent:

- `subscribe.rs` — both finalizers, via `refresh_peer_interest_with_upstream` (asserts upstream-ness on an existing entry without wiping the summary).
- `subscribe.rs::register_downstream_subscriber` and `get/op_ctx_task.rs` (#4672) — via the plain refresh, deliberately NOT the `_with_upstream` variant: those pass `is_upstream = false`, and asserting that on an existing entry would downgrade a legitimate upstream edge and break `Unsubscribe` routing.

`refresh_peer_interest` now returns whether an entry existed, so the guard is one clone-free atomic call. The `get_peer_interest(..).is_some()` form it replaces deep-copied the cached `StateSummary` (up to ~840 KB for exactly the state-sized-summary contracts that make this path expensive) purely to test presence, and was not atomic with the refresh.

Two further fixes found while validating the above:

- **Converged-skip TTL refresh** (#3046/#3093). Preserving the summary makes the converged-skip reachable for the first time, and that path returned without refreshing the peer's interest TTL. Fixed in BOTH fan-out implementations — the production one and the `simulation_tests`-gated duplicate, which is the body the simulation tests actually execute.
- **Per-contract TOTAL broadcast attribution** (#4979/#5057), with its own cap-overflow counters so a `Delta`-only contract's drop cannot vanish from the schema.

## Testing

`cargo test -p freenet --lib`: 4495 passed, 0 failed.

Source pins, each mutation-tested (mutation applied, anchor verified, test confirmed red, restored):

| pin | mutation | result |
|---|---|---|
| `broadcast_to_single_peer_refreshes_interest_on_every_skip_pin` | drop either skip's refresh | red |
| `broadcast_state_to_peers_uses_semantic_delta_skip` | drop either sim skip's refresh; also drop the production one (anti-drift) | red |
| `change_interests_arm_guards_register_with_refresh_pin` | bare register / unbound guard / revert to two-lookup form | red |
| `subscribe_finalizers_do_not_clobber_cached_summaries` | unbind a finalizer's guard; revert `register_downstream_subscriber` | red |
| `get_interest_registration_does_not_clobber_or_downgrade` | bare register; second unguarded register | red |
| `summaries_arm_writes_summary_outside_staleness_branch_pin` | move the summary write inside `if is_stale`; delete it | red |
| `total_map_cap_overflow_is_reported_separately_from_full_state` | drop the overflow counters | red |

`test_interest_ttl_refresh_on_broadcast` was rewritten. It asserted `late_broadcasts > 0`, using broadcast VOLUME as a proxy for interest liveness — invalid here, because suppressing redundant sends to converged peers is the intended win, so the proxy moves in the same direction as the improvement. Bisect showed the first commit alone flips it (main 218 events / late 30 → 127 / late 0, identical for every later commit). Evidence the quiet is correct, not lost delivery: the #3046 delivery breakdown reads `targets_sent=0, send_failed=0, skipped_summary_match=66` for the late phase; ground-truth convergence is 3/3 with zero diverged on both branch and main; and main shows the same shape at a lower skip ratio. The rewrite asserts those properties directly and its scope is stated in the rustdoc — it is a correctness check, not a regression gate, and the source pins carry both #3093 and this PR's own regression.

## Fixes

Closes #4672
