### PR TITLE
fix(hosting): retract the co-host advertisement at eviction

### DIFF
--- a/crates/core/src/contract/executor/runtime/pool.rs
+++ b/crates/core/src/contract/executor/runtime/pool.rs
@@ -995,11 +995,15 @@ impl ContractExecutor for RuntimePool {
         // serve `key`, so we must stop advertising it (Fix 1, #4642 spec step 1;
         // invariant 1: advertise iff a fresh in-mesh host). `Err` (BOTH deletes
         // failed → nothing removed → still fully present) keeps the advertisement
-        // and retries. Wired HERE on the confirmed-delete path, NOT at the eviction
-        // decision, so the three guards above that DELIBERATELY skip the delete
-        // (contract re-hosted / re-subscribed / written to a newer generation in
-        // the eviction→reclaim window) also skip the retraction — a contract kept
-        // alive by that race retains BOTH its state AND its advertisement.
+        // and retries. This is the RECLAMATION-side backstop: the primary
+        // retraction fires at the eviction decision
+        // (`operations::retract_advertisement_for_evicted_contract`), because
+        // gating the advertisement on this delete succeeding let an evicted
+        // contract keep receiving and applying updates forever (#5059 — the
+        // newer-generation guard above is a guard on deleting BYTES, and a still-
+        // advertised contract keeps tripping it). The three guards above still
+        // skip THIS call, and that remains right: a contract kept alive by the
+        // re-host race was re-advertised by its own `announce_contract_hosted`.
         // Best-effort (`try_notify_node_event`), healed by the periodic re-request
         // on drop; idempotent, so a later Full retry after a Partial (or any repeat)
         // re-retracts harmlessly.

--- a/crates/core/src/node/neighbor_hosting.rs
+++ b/crates/core/src/node/neighbor_hosting.rs
@@ -181,6 +181,69 @@ impl NeighborHostingManager {
         }
     }
 
+    /// [`Self::on_contract_unhosted`] for a contract we evicted, with the
+    /// re-host check applied AFTER the removal so the two cannot interleave
+    /// into a wrong result.
+    ///
+    /// `still_hosted` is the caller's live re-host / re-subscribe check
+    /// (`is_hosting_contract || contract_in_use`). It is evaluated only once we
+    /// have already taken `key` out of `my_contracts`; when it reports the
+    /// contract is wanted again the removal is undone and `None` is returned, so
+    /// no retraction goes on the wire and the retraction counter is not
+    /// incremented for a retraction that never happened.
+    ///
+    /// # Why remove-then-check, not check-then-remove
+    ///
+    /// A concurrent re-host runs `host_contract` (the hosting-cache insert that
+    /// makes `still_hosted` true) and only THEN
+    /// `operations::announce_contract_hosted` → [`Self::on_contract_hosted`].
+    /// Because our removal happens first, every interleaving lands advertised
+    /// iff the contract is hosted:
+    ///
+    /// - re-host insert lands before our check → we observe it, undo, stay
+    ///   advertised, and its later `on_contract_hosted` is the usual
+    ///   already-present no-op;
+    /// - re-host insert lands after our check → we retract, and its later
+    ///   `on_contract_hosted` finds `my_contracts` empty for the key, so it
+    ///   re-announces (the announce is one-shot per advertised interval, and we
+    ///   just ended that interval).
+    ///
+    /// Check-then-remove has no such ordering: the announce can fire between the
+    /// check and the removal, and the removal then silently deletes it, leaving
+    /// a hosted-but-unadvertised contract that the ~5-min full-set re-request
+    /// CANNOT heal (that exchange replays `my_contracts`, which is the thing
+    /// that is wrong).
+    pub fn on_contract_unhosted_unless_rehosted(
+        &self,
+        contract_key: &ContractKey,
+        still_hosted: impl FnOnce() -> bool,
+    ) -> Option<NeighborHostingMessage> {
+        let contract_id = *contract_key.id();
+        self.my_contracts.remove(&contract_id)?;
+        if still_hosted() {
+            // Re-host / re-subscribe raced us: put the advertisement back and
+            // emit nothing. Neighbors never observed the removal.
+            self.my_contracts.insert(contract_id);
+            trace!(
+                contract = %contract_key,
+                "NEIGHBOR_HOSTING: eviction retraction skipped — contract re-hosted \
+                 or back in use"
+            );
+            return None;
+        }
+        debug!(
+            contract = %contract_key,
+            "NEIGHBOR_HOSTING: Removed contract from locally hosted (retracting advertisement \
+             for an evicted contract)"
+        );
+        crate::config::GlobalTestMetrics::record_neighbor_hosting_retraction();
+        Some(NeighborHostingMessage::HostingAnnounce {
+            added: vec![],
+            removed: vec![contract_id],
+            is_response: false,
+        })
+    }
+
     /// Process an incoming neighbor hosting message from a neighbor.
     ///
     /// Returns a [`NeighborHostingResult`] containing an optional response message
@@ -1450,6 +1513,61 @@ mod tests {
         assert!(
             manager.on_contract_unhosted(&key).is_none(),
             "repeat unhost is a no-op (idempotent) — the retry path must not re-broadcast"
+        );
+    }
+
+    /// The eviction retraction (#5059) must retract when the contract really is
+    /// gone, and must leave the advertisement exactly as it found it when a
+    /// re-host raced the decision — including when the contract was never
+    /// advertised at all, where the guard must not even be consulted.
+    #[test]
+    fn on_contract_unhosted_unless_rehosted_retracts_only_when_still_unhosted() {
+        let manager = NeighborHostingManager::new();
+        let key = test_contract_key();
+
+        // Never advertised: nothing to retract, and the guard is irrelevant.
+        assert!(
+            manager
+                .on_contract_unhosted_unless_rehosted(&key, || panic!(
+                    "the re-host guard must not be consulted for an unadvertised contract"
+                ))
+                .is_none(),
+            "an unadvertised contract yields no retraction"
+        );
+
+        manager.on_contract_hosted(&key);
+        // Re-hosted since the eviction decision: undo, emit nothing, stay advertised.
+        assert!(
+            manager
+                .on_contract_unhosted_unless_rehosted(&key, || true)
+                .is_none(),
+            "a re-hosted contract must not be retracted"
+        );
+        assert!(
+            manager.is_hosted_locally(&key),
+            "the advertisement must be restored intact when the guard fires — a \
+             hosted-but-unadvertised contract is unreachable by fan-out and the \
+             periodic full-set re-request replays this same set, so it cannot heal"
+        );
+
+        // Genuinely gone: retract, naming this contract.
+        let retraction = manager
+            .on_contract_unhosted_unless_rehosted(&key, || false)
+            .expect("an evicted contract must be retracted");
+        assert!(
+            matches!(
+                &retraction,
+                NeighborHostingMessage::HostingAnnounce { removed, added, .. }
+                    if removed == &vec![*key.id()] && added.is_empty()
+            ),
+            "the retraction must name the evicted contract, and only it: {retraction:?}"
+        );
+        assert!(!manager.is_hosted_locally(&key));
+        assert!(
+            manager
+                .on_contract_unhosted_unless_rehosted(&key, || false)
+                .is_none(),
+            "idempotent — a pending-reclamation retry must not re-broadcast"
         );
     }
 }

--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -218,6 +218,8 @@ pub struct NetworkStatus {
     pub nat_stats: NatStats,
     /// Terminal advertisement-consult counters (hosting redesign piece C).
     pub terminal_consult_stats: TerminalConsultStats,
+    /// Eviction-retraction emission counters (#5059).
+    pub hosting_retraction_stats: HostingRetractionStats,
     /// Streamed-transfer abort counters (large-contract failure isolation).
     pub stream_abort_stats: StreamAbortStats,
     /// Relayed-operation counters (routing/hosting attribution).
@@ -396,6 +398,25 @@ pub struct TerminalConsultStats {
     pub resolved_found: u64,
     /// A consult ran but the request still ended NotFound.
     pub still_not_found: u64,
+}
+
+/// Eviction-retraction emission counters (#5059).
+///
+/// The retraction that stops co-hosts fanning updates at an evicted contract is
+/// emitted best-effort on the cap-2048 node-event channel, and the drop is logged
+/// at `debug` — which is compiled out in release builds. A dropped retraction is
+/// self-healing (the ~5-min full-set re-request replays `my_contracts`), but a
+/// node under exactly the broadcast storm #5059 describes is when that channel is
+/// most likely to be full, so without these the field cannot tell a slow heal from
+/// a failed fix. Monotonic lifetime totals; the collector differences them.
+#[derive(Default)]
+pub struct HostingRetractionStats {
+    /// Eviction retractions handed to the node-event channel.
+    pub emitted: u64,
+    /// Eviction retractions dropped because that channel refused them. Healed by
+    /// the next interest-heartbeat full-set re-request; a sustained nonzero rate
+    /// means evicted contracts stay advertised for up to one heartbeat interval.
+    pub dropped: u64,
 }
 
 /// Streamed-transfer (> 64 KB `streaming_threshold`) abort counters, aggregated
@@ -645,6 +666,7 @@ pub fn init(listening_port: u16, gateway_addrs: HashSet<SocketAddr>, version: St
         op_stats: OperationStats::default(),
         nat_stats: NatStats::default(),
         terminal_consult_stats: TerminalConsultStats::default(),
+        hosting_retraction_stats: HostingRetractionStats::default(),
         stream_abort_stats: StreamAbortStats::default(),
         relayed_op_stats: RelayedOpStats::default(),
         connect_emit_stats: ConnectEmitStats::default(),
@@ -928,6 +950,36 @@ pub fn terminal_consult_counts() -> Option<(u64, u64, u64, u64)> {
     let s = status.read().ok()?;
     let c = &s.terminal_consult_stats;
     Some((c.attempts, c.hits, c.resolved_found, c.still_not_found))
+}
+
+/// Record one eviction retraction accepted by the node-event channel (#5059).
+pub fn record_hosting_retraction_emitted() {
+    if let Some(status) = NETWORK_STATUS.get() {
+        if let Ok(mut s) = status.write() {
+            s.hosting_retraction_stats.emitted =
+                s.hosting_retraction_stats.emitted.saturating_add(1);
+        }
+    }
+}
+
+/// Record one eviction retraction the node-event channel refused (#5059). The
+/// interest-heartbeat full-set re-request heals it within one interval; a
+/// sustained rate here means evicted contracts stay advertised that long.
+pub fn record_hosting_retraction_dropped() {
+    if let Some(status) = NETWORK_STATUS.get() {
+        if let Ok(mut s) = status.write() {
+            s.hosting_retraction_stats.dropped =
+                s.hosting_retraction_stats.dropped.saturating_add(1);
+        }
+    }
+}
+
+/// `(emitted, dropped)` eviction-retraction totals for the snapshot cadence.
+pub fn hosting_retraction_counts() -> Option<(u64, u64)> {
+    let status = NETWORK_STATUS.get()?;
+    let s = status.read().ok()?;
+    let c = &s.hosting_retraction_stats;
+    Some((c.emitted, c.dropped))
 }
 
 /// Bump the fragment-progress histogram bucket for one receiver abort.

--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -352,12 +352,13 @@ pub enum ReconcileShadowSite {
 /// contracts the controller would keep alive but production merely deferred this
 /// tick — the intended per-tick reading, not a bug.
 ///
-/// `retract_diffs` CAVEAT: it measures collapse/renewal of a contract that was
-/// EVER announced, not one with a currently-live advertisement — `is_advertised`
-/// (`NeighborHostingManager::is_hosted_locally`) is effectively MONOTONIC in
-/// production today, because its only clearer (`on_contract_unhosted`) is
-/// dead/test-only until the flip wires the `Retract` action. So a nonzero
-/// `retract_diffs` reflects the missing retraction driver, as intended.
+/// `retract_diffs` CAVEAT: `is_advertised`
+/// (`NeighborHostingManager::is_hosted_locally`) IS cleared in production, by the
+/// eviction funnel (`operations::retract_advertisement_for_evicted_contract`, and
+/// the reclamation-side `on_contract_unhosted` behind it). What no on-`main`
+/// driver does is retract on COLLAPSE/RENEWAL teardown — the sites these stats
+/// shadow-compare — so a nonzero `retract_diffs` reflects that missing
+/// site-local retraction, as intended, not a live-advertisement leak.
 #[derive(Default, Clone, Copy)]
 pub struct ReconcileShadowStats {
     /// Total shadow comparisons performed at this site (the denominator — one

--- a/crates/core/src/operations.rs
+++ b/crates/core/src/operations.rs
@@ -325,39 +325,113 @@ pub(crate) async fn announce_contract_hosted(op_manager: &OpManager, key: &Contr
 /// actually gone — the confirmed-`ReclaimOutcome::Full | Partial` delete path (a
 /// `Partial` half-delete can no longer be served, so it retracts too; `Err`, with
 /// nothing deleted, does not) — i.e. AFTER the re-host / re-subscribe /
-/// newer-generation guards that would otherwise keep the contract. Wiring it there
-/// (not at the eviction *decision* in [`reclaim_evicted_contract`]) is what keeps
-/// a contract kept alive by that race both fresh AND advertised.
+/// newer-generation guards that would otherwise keep the contract.
 ///
-/// Best-effort and non-blocking (`try_notify_node_event`): unlike
-/// [`announce_contract_hosted`] (a one-shot hosting announce that MUST be
-/// delivered, hence its blocking await), a dropped retraction self-heals within
-/// one interest-heartbeat interval (~5 min) when a co-host re-requests our full
-/// hosted set and full-replaces its view of us (the piggybacked hosting
-/// re-request in `interest_heartbeat`). `on_contract_unhosted` is idempotent, so
-/// a pending-reclamation retry that reaches this after the state is already gone
-/// is a harmless no-op.
+/// This is the RECLAMATION-side retraction and it is now a backstop, not the
+/// primary one: eviction retracts at the eviction decision via
+/// [`retract_advertisement_for_evicted_contract`], because gating the
+/// advertisement on the delete succeeding let an evicted contract keep receiving
+/// and applying updates indefinitely (#5059 — read that function's doc for the
+/// loop). This path still covers a delete that reaches reclamation from anywhere
+/// the eviction funnel did not, and `on_contract_unhosted` is idempotent, so
+/// re-entering it after the advertisement is already gone is a harmless no-op.
+///
+/// Best-effort and non-blocking — see [`emit_hosting_retraction`].
 pub(crate) fn announce_contract_unhosted(op_manager: &OpManager, key: &ContractKey) {
     if let Some(retraction) = op_manager.neighbor_hosting.on_contract_unhosted(key) {
         tracing::debug!(
             %key,
             "NEIGHBOR_HOSTING: Retracting hosting advertisement to neighbors"
         );
-        if let Err(err) =
-            op_manager.try_notify_node_event(crate::message::NodeEvent::BroadcastHostingUpdate {
-                message: retraction,
-            })
-        {
-            // Best-effort by design — the periodic full-set re-request
-            // (piggybacked on `interest_heartbeat`) is the convergence backstop for
-            // a dropped retraction. Debug, not warn: benign back-pressure under load.
-            tracing::debug!(
-                contract = %key,
-                error = %err,
-                "NEIGHBOR_HOSTING: retraction broadcast dropped (best-effort; \
-                 healed by periodic full-set re-request)"
-            );
-        }
+        emit_hosting_retraction(op_manager, key, retraction);
+    }
+}
+
+/// Retract the co-host advertisement for a contract the hosting cache has just
+/// EVICTED, unless it has already been re-hosted or is back in use.
+///
+/// This is the advertisement half of eviction, and it is deliberately NOT gated on
+/// the on-disk delete succeeding. [`announce_contract_unhosted`] fires from
+/// `RuntimePool::remove_contract` on a confirmed delete, behind three guards; the
+/// third of those — "the state generation advanced since eviction" — is a guard on
+/// deleting BYTES, and using it to gate the advertisement created a self-sustaining
+/// loop (#5059):
+///
+/// 1. cost-pressure eviction sheds a zero-demand storm contract, but the
+///    advertisement stays, and co-host fan-out targets come from the advertisement
+///    (`neighbor_hosting`) with no interest check;
+/// 2. so inbound updates keep arriving and keep being applied — which is where the
+///    WASM CPU the eviction was supposed to reclaim actually goes;
+/// 3. every applied update bumps the state generation, so the deferred
+///    `EvictContract` always bails at guard 3, never reaches the retraction, and
+///    re-queues itself for a retry that bails the same way;
+/// 4. and the ~5-min full-set re-request replays `my_contracts`, actively
+///    RE-ASSERTING the phantom advertisement to every co-host.
+///
+/// Field evidence (#5040): a contract's `send_update_notification` warn ran at
+/// ~10-11/s continuously THROUGH three separate cost evictions of that contract,
+/// with no gap at any eviction timestamp.
+///
+/// Retracting here instead is what invariant 1 asks for — advertise iff a fresh
+/// in-mesh host — because eviction is exactly the moment the contract stops being
+/// one. Holding bytes on disk that no longer belong to any hosted contract is a
+/// reclamation concern, and reclamation keeps its own retries.
+///
+/// The two guards that DO mean "still a host" are re-checked, matching guards 1
+/// and 2 in `RuntimePool::remove_contract`:
+/// `is_hosting_contract` (a GET/PUT re-hosted it) and `contract_in_use` (a client
+/// or downstream subscriber re-registered). The check runs AFTER the removal — see
+/// `NeighborHostingManager::on_contract_unhosted_unless_rehosted` for why that
+/// ordering is the race-free one.
+///
+/// Idempotent: a pending-reclamation retry re-entering this is a no-op once the
+/// advertisement is gone. Best-effort emission, like its siblings.
+pub(crate) fn retract_advertisement_for_evicted_contract(
+    op_manager: &OpManager,
+    key: &ContractKey,
+) {
+    let retraction = op_manager
+        .neighbor_hosting
+        .on_contract_unhosted_unless_rehosted(key, || {
+            op_manager.ring.is_hosting_contract(key) || op_manager.ring.contract_in_use(key)
+        });
+    if let Some(retraction) = retraction {
+        tracing::debug!(
+            %key,
+            "NEIGHBOR_HOSTING: Retracting hosting advertisement for an evicted contract"
+        );
+        emit_hosting_retraction(op_manager, key, retraction);
+    }
+}
+
+/// Put a prepared `HostingAnnounce{removed}` on the wire.
+///
+/// Best-effort and non-blocking (`try_notify_node_event`): unlike
+/// [`announce_contract_hosted`] (a one-shot hosting announce that MUST be
+/// delivered, hence its blocking await), a dropped retraction self-heals within
+/// one interest-heartbeat interval (~5 min) when a co-host re-requests our full
+/// hosted set and full-replaces its view of us (the piggybacked hosting
+/// re-request in `interest_heartbeat`) — that replay is only a backstop for a
+/// dropped MESSAGE, never for a `my_contracts` entry that should not be there.
+fn emit_hosting_retraction(
+    op_manager: &OpManager,
+    key: &ContractKey,
+    retraction: crate::message::NeighborHostingMessage,
+) {
+    if let Err(err) =
+        op_manager.try_notify_node_event(crate::message::NodeEvent::BroadcastHostingUpdate {
+            message: retraction,
+        })
+    {
+        // Best-effort by design — the periodic full-set re-request
+        // (piggybacked on `interest_heartbeat`) is the convergence backstop for
+        // a dropped retraction. Debug, not warn: benign back-pressure under load.
+        tracing::debug!(
+            contract = %key,
+            error = %err,
+            "NEIGHBOR_HOSTING: retraction broadcast dropped (best-effort; \
+             healed by periodic full-set re-request)"
+        );
     }
 }
 
@@ -522,22 +596,24 @@ pub(crate) fn reclaim_evicted_contract(
             .pending_reclamation_add(key, expected_generation);
         return;
     }
-    // NOTE (Fix 1 retraction, #4642 spec step 1): the hosting-advertisement
-    // retraction is NOT emitted here at the eviction DECISION. `EvictContract` is
-    // fire-and-forget and the deletion-time guards in `RuntimePool::remove_contract`
-    // DELIBERATELY skip the delete if the contract was re-hosted / re-subscribed /
-    // written to a newer generation in the eviction→reclaim window. Retracting
-    // here would then leave the node holding fresh state it no longer advertises
-    // (an under-advertisement the periodic heartbeat cannot heal). Instead the
-    // retraction is wired on the confirmed-delete path (`ReclaimOutcome::Full |
-    // Partial`) in `RuntimePool::remove_contract`, so it fires exactly when a
-    // required on-disk half is truly gone. That single point covers every eviction
-    // funnel (GET/PUT insert
-    // eviction, the periodic sweep, and — once built — evict-to-admit). (Interest-
+    // Retract the co-host advertisement NOW, at the eviction decision — the node
+    // has stopped hosting `key`, so under invariant 1 it must stop advertising it,
+    // whether or not the bytes come off disk. Deferring this to the confirmed-delete
+    // path in `RuntimePool::remove_contract` was #5059: that path's third guard
+    // ("written since eviction") guards deleting BYTES, and a contract that keeps
+    // receiving updates BECAUSE it is still advertised keeps tripping it, so the
+    // retraction never ran and the fan-out never stopped. The two guards that
+    // genuinely mean "still a host" — re-hosted, or back in use — are re-checked
+    // inside the helper, so a contract kept alive by that race stays advertised.
+    // This covers every eviction funnel (GET/PUT insert eviction, the periodic byte
+    // and cost sweeps, and — once built — evict-to-admit); the reclamation-side
+    // `announce_contract_unhosted` remains as an idempotent backstop.
+    // (Interest-
     // gated COLLAPSE does not stop hosting on current `main`: `send_unsubscribe_
     // upstream` drops only the lease, leaving a still-fresh cached copy that must
     // keep advertising; when the reconcile-core flip makes demand-loss stop
     // hosting, that collapse-then-evict flows through this very funnel too.)
+    retract_advertisement_for_evicted_contract(op_manager, &key);
 
     // Disk reclamation after hosting-cache eviction is best-effort GC —
     // background-tier so it yields the contract loop to client/relay work (#4534).
@@ -1241,18 +1317,27 @@ mod sub_op_subscribe_pin_tests {
 
 #[cfg(test)]
 mod reclaim_retraction_pin_tests {
-    //! Pin tests for the Fix 1 retraction wiring (#4642 spec step 1). The
-    //! hosting-advertisement retraction must fire on the CONFIRMED-delete path
-    //! (`RuntimePool::remove_contract`, gated `ReclaimOutcome::Full | Partial`),
-    //! NOT at the eviction DECISION in `reclaim_evicted_contract`: the deletion-time
-    //! guards
-    //! (re-host / re-subscribe / newer-generation) may skip the delete, and a
-    //! retraction at the decision site would then leave the node holding fresh
-    //! state it no longer advertises. A future refactor — including the
-    //! reconcile-core `Retract` flip — must neither move it back to the decision
-    //! site nor drop it. (Every eviction funnels through `remove_contract`:
-    //! GET/PUT insert eviction, the periodic sweep, and — once built —
-    //! evict-to-admit.)
+    //! Pin tests for the hosting-advertisement retraction wiring (#4642 spec
+    //! step 1, #5059).
+    //!
+    //! Two retraction sites, each with its own gate, and neither may absorb the
+    //! other:
+    //!
+    //! - **Eviction decision** (`reclaim_evicted_contract`) — the PRIMARY one.
+    //!   It must retract, and it must do so through
+    //!   `retract_advertisement_for_evicted_contract`, whose gate is
+    //!   re-hosted-or-in-use. Calling the bare `announce_contract_unhosted` here
+    //!   instead would retract unconditionally and strand a contract that the
+    //!   re-host race kept alive.
+    //! - **Confirmed delete** (`RuntimePool::remove_contract`, gated
+    //!   `ReclaimOutcome::Full | Partial`) — the reclamation-side backstop.
+    //!
+    //! What must never come back is the OLD arrangement, where the delete-side
+    //! gate was the ONLY gate: its third guard ("written since eviction") guards
+    //! deleting bytes, and an evicted-but-still-advertised contract keeps
+    //! receiving updates, keeps bumping the generation, and so keeps that guard
+    //! tripped forever — the #5059 loop. A future refactor, including the
+    //! reconcile-core `Retract` flip, must keep the eviction-decision retraction.
 
     fn extract_fn_body(src: &'static str, needle: &str) -> &'static str {
         let start = src
@@ -1285,17 +1370,61 @@ mod reclaim_retraction_pin_tests {
     }
 
     #[test]
-    fn reclaim_evicted_contract_does_not_retract_at_the_decision_site() {
+    fn reclaim_evicted_contract_retracts_through_the_guarded_helper() {
         let src = include_str!("operations.rs");
-        // Runtime-compose the needle so this pin does not match itself.
+        // Runtime-compose the needles so these pins do not match themselves.
         let needle = ["fn ", "reclaim_evicted_contract("].concat();
         let body = extract_fn_body(src, &needle);
         assert!(
-            !body.contains("announce_contract_unhosted("),
-            "`reclaim_evicted_contract` must NOT retract at the eviction decision — \
-             the deletion-time guards may skip the delete, which would leave the \
-             node holding fresh state it no longer advertises. The retraction is \
-             wired on the confirmed-delete path in `RuntimePool::remove_contract`."
+            body.contains(&["retract_advertisement_for_evicted", "_contract("].concat()),
+            "`reclaim_evicted_contract` MUST retract the co-host advertisement at the \
+             eviction decision (#5059). Leaving it to the confirmed-delete path in \
+             `RuntimePool::remove_contract` means an evicted contract that keeps \
+             receiving updates keeps tripping that path's newer-generation guard, so \
+             the retraction never fires and the fan-out never stops."
+        );
+        assert!(
+            !body.contains(&["announce_contract_", "unhosted("].concat()),
+            "the eviction-decision retraction must go through \
+             `retract_advertisement_for_evicted_contract` (gated on \
+             re-hosted-or-in-use), NOT the bare `announce_contract_unhosted`, which \
+             retracts unconditionally and would strand a contract the re-host race \
+             kept alive."
+        );
+    }
+
+    /// The helper's gate must be the two guards that mean "still a host"
+    /// (`is_hosting_contract`, `contract_in_use`) — and NOT the state-generation
+    /// guard, which is what made the delete-side gate unusable for the
+    /// advertisement (#5059). A generation check creeping in here would restore
+    /// the loop.
+    #[test]
+    fn eviction_retraction_helper_gates_on_rehost_and_in_use_only() {
+        let src = include_str!("operations.rs");
+        let needle = ["fn ", "retract_advertisement_for_evicted_contract("].concat();
+        let body = extract_fn_body(src, &needle);
+        for required in ["is_hosting_contract(", "contract_in_use("] {
+            assert!(
+                body.contains(required),
+                "`retract_advertisement_for_evicted_contract` must re-check `{required}` \
+                 so a contract re-hosted or re-subscribed since the eviction decision \
+                 keeps its advertisement"
+            );
+        }
+        assert!(
+            !body.contains("state_generation("),
+            "the eviction retraction must NOT be gated on the state generation — a \
+             contract that keeps receiving updates because it is still advertised \
+             advances its generation forever, which is exactly the #5059 loop"
+        );
+        // The re-host check must run through the remove-then-check primitive, not
+        // as a plain `if` before an unconditional removal — see
+        // `NeighborHostingManager::on_contract_unhosted_unless_rehosted` for why
+        // check-then-remove loses the race against a concurrent re-host announce.
+        assert!(
+            body.contains(&["on_contract_unhosted_unless", "_rehosted("].concat()),
+            "the retraction must go through `on_contract_unhosted_unless_rehosted`, \
+             which applies the re-host check AFTER removing from `my_contracts`"
         );
     }
 

--- a/crates/core/src/operations.rs
+++ b/crates/core/src/operations.rs
@@ -377,10 +377,32 @@ pub(crate) fn announce_contract_unhosted(op_manager: &OpManager, key: &ContractK
 /// one. Holding bytes on disk that no longer belong to any hosted contract is a
 /// reclamation concern, and reclamation keeps its own retries.
 ///
-/// The two guards that DO mean "still a host" are re-checked, matching guards 1
-/// and 2 in `RuntimePool::remove_contract`:
-/// `is_hosting_contract` (a GET/PUT re-hosted it) and `contract_in_use` (a client
-/// or downstream subscriber re-registered). The check runs AFTER the removal — see
+/// Three conditions mean "still a host", and any of them keeps the
+/// advertisement:
+///
+/// - `is_hosting_contract` — a GET/PUT re-hosted it into the hosting cache.
+/// - `contract_in_use` — a client or downstream subscriber re-registered.
+///   (These two match guards 1 and 2 in `RuntimePool::remove_contract`.)
+/// - `is_subscribed` — we hold a live upstream subscription lease, so we are
+///   wired into the contract's update mesh and therefore a host under invariant
+///   1, even with no cache entry and no subscriber of our own yet.
+///
+/// The lease check is what makes the ordering guarantee below hold for the
+/// SUBSCRIBE path, whose announce is gated on the body being present ON DISK
+/// (`finalize_originator_subscribe` → `fetch_contract_if_missing` →
+/// `has_contract`), not on a hosting-cache insert. `ring.subscribe` installs the
+/// lease before both that fetch and that announce, so the lease is the signal
+/// that is reliably set first there. Without it, a contract evicted with its
+/// state still on disk and awaiting reclamation could be re-subscribed, announce,
+/// and then have the pending-reclamation retry retract it right back out — leaving
+/// the node subscribed, holding the body, and unadvertised.
+///
+/// This does not weaken the eviction retraction, because the sweep drops the lease
+/// (`ring.unsubscribe`) before calling into here. It only makes the GET/PUT
+/// insert-eviction funnels defer a lease-holding victim's retraction to the
+/// reclamation-side path, which is where it happened before this fix anyway.
+///
+/// The check runs AFTER the removal — see
 /// `NeighborHostingManager::on_contract_unhosted_unless_rehosted` for why that
 /// ordering is the race-free one.
 ///
@@ -393,7 +415,9 @@ pub(crate) fn retract_advertisement_for_evicted_contract(
     let retraction = op_manager
         .neighbor_hosting
         .on_contract_unhosted_unless_rehosted(key, || {
-            op_manager.ring.is_hosting_contract(key) || op_manager.ring.contract_in_use(key)
+            op_manager.ring.is_hosting_contract(key)
+                || op_manager.ring.contract_in_use(key)
+                || op_manager.ring.is_subscribed(key)
         });
     if let Some(retraction) = retraction {
         tracing::debug!(
@@ -426,12 +450,20 @@ fn emit_hosting_retraction(
         // Best-effort by design — the periodic full-set re-request
         // (piggybacked on `interest_heartbeat`) is the convergence backstop for
         // a dropped retraction. Debug, not warn: benign back-pressure under load.
+        //
+        // The counter, not this log, is the field signal: `debug!` compiles out
+        // in release, and a node under the #5059 broadcast storm is exactly when
+        // this cap-2048 channel is most likely to be full — so without it a slow
+        // heal and a failed fix look identical in production.
+        crate::node::network_status::record_hosting_retraction_dropped();
         tracing::debug!(
             contract = %key,
             error = %err,
             "NEIGHBOR_HOSTING: retraction broadcast dropped (best-effort; \
              healed by periodic full-set re-request)"
         );
+    } else {
+        crate::node::network_status::record_hosting_retraction_emitted();
     }
 }
 
@@ -1369,14 +1401,29 @@ mod reclaim_retraction_pin_tests {
         &src[start..end]
     }
 
+    /// `extract_fn_body` with `//` comments stripped, so a pin asserting the
+    /// ABSENCE of a call cannot be satisfied — or spuriously broken — by prose.
+    /// Both of the absence pins below name their forbidden call in the very
+    /// comment that explains why it is forbidden.
+    fn extract_fn_code(src: &'static str, needle: &str) -> String {
+        extract_fn_body(src, needle)
+            .lines()
+            .map(|line| match line.find("//") {
+                Some(idx) => &line[..idx],
+                None => line,
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
     #[test]
     fn reclaim_evicted_contract_retracts_through_the_guarded_helper() {
         let src = include_str!("operations.rs");
         // Runtime-compose the needles so these pins do not match themselves.
         let needle = ["fn ", "reclaim_evicted_contract("].concat();
-        let body = extract_fn_body(src, &needle);
+        let code = extract_fn_code(src, &needle);
         assert!(
-            body.contains(&["retract_advertisement_for_evicted", "_contract("].concat()),
+            code.contains(&["retract_advertisement_for_evicted", "_contract(op_manager"].concat()),
             "`reclaim_evicted_contract` MUST retract the co-host advertisement at the \
              eviction decision (#5059). Leaving it to the confirmed-delete path in \
              `RuntimePool::remove_contract` means an evicted contract that keeps \
@@ -1384,35 +1431,75 @@ mod reclaim_retraction_pin_tests {
              the retraction never fires and the fan-out never stops."
         );
         assert!(
-            !body.contains(&["announce_contract_", "unhosted("].concat()),
+            !code.contains(&["announce_contract_", "unhosted(op_manager"].concat()),
             "the eviction-decision retraction must go through \
-             `retract_advertisement_for_evicted_contract` (gated on \
-             re-hosted-or-in-use), NOT the bare `announce_contract_unhosted`, which \
-             retracts unconditionally and would strand a contract the re-host race \
-             kept alive."
+             `retract_advertisement_for_evicted_contract` (gated on re-hosted / \
+             in-use / subscribed), NOT the bare `announce_contract_unhosted`, which \
+             retracts unconditionally and would strand a contract that a re-host or \
+             a re-subscribe kept alive."
         );
     }
 
-    /// The helper's gate must be the two guards that mean "still a host"
-    /// (`is_hosting_contract`, `contract_in_use`) — and NOT the state-generation
-    /// guard, which is what made the delete-side gate unusable for the
-    /// advertisement (#5059). A generation check creeping in here would restore
-    /// the loop.
+    /// The emission must stay INSIDE the guard. The helper's protection is the
+    /// `on_contract_unhosted_unless_rehosted` return value; a refactor that
+    /// inlined `try_notify_node_event` at the call site — or emitted a retraction
+    /// the primitive declined to produce — would send a retraction for a contract
+    /// that is still hosted, which nothing else in this file would catch.
+    #[test]
+    fn eviction_retraction_emits_only_what_the_guard_returned() {
+        let src = include_str!("operations.rs");
+        let needle = ["fn ", "retract_advertisement_for_evicted_contract("].concat();
+        let code = extract_fn_code(src, &needle);
+        assert!(
+            code.contains(&["emit_hosting_", "retraction("].concat()),
+            "the helper must emit through `emit_hosting_retraction`"
+        );
+        assert!(
+            !code.contains("try_notify_node_event"),
+            "the helper must NOT emit the node event directly — that bypasses \
+             `emit_hosting_retraction` and invites emitting outside the guard"
+        );
+        // The emission must be reached only through the `Some(..)` arm of the
+        // guard's return, never unconditionally.
+        let guard_idx = code
+            .find(&["on_contract_unhosted_unless", "_rehosted("].concat())
+            .expect("the guard call must exist");
+        let emit_idx = code
+            .find(&["emit_hosting_", "retraction("].concat())
+            .expect("the emission must exist");
+        assert!(
+            emit_idx > guard_idx,
+            "the emission must come after the guard, not before it"
+        );
+        assert!(
+            code[guard_idx..emit_idx].contains("if let Some("),
+            "the emission must be inside the guard's `Some(..)` arm, so a declined \
+             retraction emits nothing"
+        );
+    }
+
+    /// The helper's gate must be exactly the three conditions that mean "still a
+    /// host" — in the hosting cache, in use, or holding a live upstream lease —
+    /// and NOT the state-generation guard, which is what made the delete-side gate
+    /// unusable for the advertisement (#5059). A generation check creeping in here
+    /// would restore the loop; dropping the lease check would reopen the
+    /// SUBSCRIBE-path window (that path's announce is gated on disk presence, so
+    /// the lease is the only one of the three reliably set before it).
     #[test]
     fn eviction_retraction_helper_gates_on_rehost_and_in_use_only() {
         let src = include_str!("operations.rs");
         let needle = ["fn ", "retract_advertisement_for_evicted_contract("].concat();
-        let body = extract_fn_body(src, &needle);
-        for required in ["is_hosting_contract(", "contract_in_use("] {
+        let code = extract_fn_code(src, &needle);
+        for required in ["is_hosting_contract(", "contract_in_use(", "is_subscribed("] {
             assert!(
-                body.contains(required),
+                code.contains(required),
                 "`retract_advertisement_for_evicted_contract` must re-check `{required}` \
-                 so a contract re-hosted or re-subscribed since the eviction decision \
-                 keeps its advertisement"
+                 so a contract re-hosted, re-subscribed, or holding a live upstream \
+                 lease since the eviction decision keeps its advertisement"
             );
         }
         assert!(
-            !body.contains("state_generation("),
+            !code.contains("state_generation("),
             "the eviction retraction must NOT be gated on the state generation — a \
              contract that keeps receiving updates because it is still advertised \
              advances its generation forever, which is exactly the #5059 loop"
@@ -1422,7 +1509,7 @@ mod reclaim_retraction_pin_tests {
         // `NeighborHostingManager::on_contract_unhosted_unless_rehosted` for why
         // check-then-remove loses the race against a concurrent re-host announce.
         assert!(
-            body.contains(&["on_contract_unhosted_unless", "_rehosted("].concat()),
+            code.contains(&["on_contract_unhosted_unless", "_rehosted("].concat()),
             "the retraction must go through `on_contract_unhosted_unless_rehosted`, \
              which applies the re-host check AFTER removing from `my_contracts`"
         );

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -1815,6 +1815,18 @@ impl Ring {
                 snapshot.terminal_consult_still_not_found = Some(still_not_found);
             }
 
+            // Eviction-retraction emission counters (#5059). Same hand-mirror
+            // footgun as every counter here: a new `RouterSnapshotInfo` field is
+            // invisible to the collector unless added BOTH here AND in
+            // `event_kind_to_json` (pinned by
+            // `router_snapshot_json_includes_hosting_retraction_counters`).
+            if let Some((emitted, dropped)) =
+                crate::node::network_status::hosting_retraction_counts()
+            {
+                snapshot.hosting_retractions_emitted = Some(emitted);
+                snapshot.hosting_retractions_dropped = Some(dropped);
+            }
+
             // Streamed-transfer abort counters (Group B): isolate the
             // large-contract failure class on the existing snapshot cadence.
             // Same hand-mirror footgun as the counters above — a new
@@ -8690,14 +8702,18 @@ mod cost_pressure_seam_tests {
         retracted
     }
 
-    /// Run the maintenance loop's post-sweep step for one sweep result, exactly as
-    /// `Ring::sweep_get_subscription_cache` does: every expired key goes through
-    /// `reclaim_evicted_contract`.
+    /// Run the maintenance loop's post-sweep step for one sweep result, in the
+    /// same order as `Ring::sweep_get_subscription_cache`: drop the upstream lease
+    /// for each expired key, THEN reclaim it. The order is load-bearing now that
+    /// the retraction treats a live lease as "still a host" — a helper that
+    /// skipped the unsubscribe would suppress the very retraction under test and
+    /// pass for the wrong reason.
     fn reclaim_swept(
         op_manager: &crate::node::OpManager,
         swept: crate::ring::hosting::HostingSweepResult,
     ) {
         for (key, expected_generation) in swept.expired {
+            op_manager.ring.unsubscribe(&key);
             crate::operations::reclaim_evicted_contract(op_manager, key, expected_generation);
         }
     }
@@ -8816,18 +8832,17 @@ mod cost_pressure_seam_tests {
     }
 
     /// The eviction retraction must NOT fire for a contract that is hosted again,
-    /// or wanted again, by the time it runs — the two guards that genuinely mean
-    /// "still a host" (`RuntimePool::remove_contract`'s guards 1 and 2). Retracting
-    /// either would leave a fresh, in-mesh contract unadvertised, which the ~5-min
-    /// full-set re-request cannot heal because that exchange replays the same
-    /// (wrong) `my_contracts`.
+    /// wanted again, or back in the update mesh by the time it runs — the three
+    /// conditions that genuinely mean "still a host". Retracting any of them would
+    /// leave a fresh, in-mesh contract unadvertised, which the ~5-min full-set
+    /// re-request cannot heal because that exchange replays the same (wrong)
+    /// `my_contracts`.
     ///
-    /// Both cases go through the real `reclaim_evicted_contract` funnel, but they
-    /// are stopped at different points: the re-hosted one by the retraction
-    /// helper's own guard, the in-use one by `reclaim_evicted_contract`'s
-    /// pre-existing `contract_in_use` early return (the helper re-checks it too,
-    /// for the window between that return and the removal — that re-check is
-    /// covered directly by
+    /// All three go through the real `reclaim_evicted_contract` funnel, but they
+    /// are stopped at different points: re-hosted and leased by the retraction
+    /// helper's own guard, in-use by `reclaim_evicted_contract`'s pre-existing
+    /// `contract_in_use` early return (the helper re-checks that one too, for the
+    /// window between that return and the removal — covered directly by
     /// `on_contract_unhosted_unless_rehosted_retracts_only_when_still_unhosted`).
     #[tokio::test(start_paused = true)]
     async fn eviction_retraction_skips_a_rehosted_or_in_use_contract() {
@@ -8862,8 +8877,27 @@ mod cost_pressure_seam_tests {
             "precondition: in-use but not in the hosting cache"
         );
 
+        // (3) Re-subscribed: no cache entry and no subscriber of its own, but a
+        // live upstream lease, so it IS in the update mesh. This is the SUBSCRIBE
+        // path's shape — `finalize_originator_subscribe` installs the lease, then
+        // announces on the body being present ON DISK, and the ring-level client
+        // subscription lands later from `client_events`. Without the lease check
+        // a pending-reclamation retry in that window retracts the announce right
+        // back out, leaving the node subscribed, holding the body, unadvertised.
+        let resubscribed = seam_key(6);
+        op_manager
+            .neighbor_hosting
+            .on_contract_hosted(&resubscribed);
+        ring.subscribe(resubscribed);
+        assert!(
+            !ring.is_hosting_contract(&resubscribed)
+                && !ring.contract_in_use(&resubscribed)
+                && ring.is_subscribed(&resubscribed),
+            "precondition: leased only — not cached, no subscriber of our own"
+        );
+
         let _ = drain_retracted_ids(&mut fixture);
-        for key in [rehosted, in_use] {
+        for key in [rehosted, in_use, resubscribed] {
             let generation = ring.state_generation(&key);
             crate::operations::reclaim_evicted_contract(&op_manager, key, generation);
         }
@@ -8871,7 +8905,8 @@ mod cost_pressure_seam_tests {
         let retracted = drain_retracted_ids(&mut fixture);
         assert!(
             retracted.is_empty(),
-            "neither a re-hosted nor an in-use contract may be retracted; got {retracted:?}"
+            "none of a re-hosted, in-use, or leased contract may be retracted; \
+             got {retracted:?}"
         );
         assert!(
             op_manager.neighbor_hosting.is_hosted_locally(&rehosted),
@@ -8880,6 +8915,11 @@ mod cost_pressure_seam_tests {
         assert!(
             op_manager.neighbor_hosting.is_hosted_locally(&in_use),
             "a contract back in use since the eviction decision keeps its advertisement"
+        );
+        assert!(
+            op_manager.neighbor_hosting.is_hosted_locally(&resubscribed),
+            "a contract holding a live upstream lease keeps its advertisement — it \
+             is in the update mesh, so it is a host under invariant 1"
         );
     }
 

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -8611,6 +8611,278 @@ mod cost_pressure_seam_tests {
         );
     }
 
+    /// Everything a seam test needs kept alive for its whole run: the OpManager
+    /// plus the channel ends and task monitor whose drop would tear the Ring's
+    /// background tasks down mid-test.
+    struct SeamFixture {
+        op_manager: std::sync::Arc<crate::node::OpManager>,
+        node_events: tokio::sync::mpsc::Receiver<
+            either::Either<crate::message::NetMessage, crate::message::NodeEvent>,
+        >,
+        /// The remaining channel ends and the task monitor. Never read — held
+        /// only so dropping them does not tear the Ring's background tasks down
+        /// mid-test. Boxed opaquely because several of these types are private to
+        /// their own modules.
+        _keep_alive: Box<dyn std::any::Any + Send>,
+    }
+
+    /// A real `OpManager` over a real `Ring` (production `InstantTimeSrc`, real
+    /// background tasks), with the node-event receiver handed back so a test can
+    /// assert on EMITTED events rather than on internal bookkeeping. `id`
+    /// isolates the on-disk state in its own temp dir.
+    async fn seam_fixture(id: &str) -> SeamFixture {
+        let config_args = crate::config::ConfigArgs {
+            id: Some(id.to_string()),
+            mode: Some(crate::contract::OperationMode::Local),
+            ..Default::default()
+        };
+        let node_config =
+            crate::node::NodeConfig::new(config_args.build().await.expect("build Config"))
+                .await
+                .expect("build NodeConfig");
+        let (notification_rx, notification_tx) = crate::node::event_loop_notification_channel();
+        let (ops_ch_channel, _ch_channel, _wait_for_event) =
+            crate::contract::contract_handler_channel();
+        let connection_manager = crate::ring::ConnectionManager::new(&node_config);
+        let (result_router_tx, result_router_rx) = tokio::sync::mpsc::channel(100);
+        let task_monitor = crate::node::background_task_monitor::BackgroundTaskMonitor::new();
+        let op_manager = std::sync::Arc::new(
+            crate::node::OpManager::new(
+                notification_tx,
+                ops_ch_channel,
+                &node_config,
+                crate::tracing::DynamicRegister::new(vec![]),
+                connection_manager,
+                result_router_tx,
+                &task_monitor,
+            )
+            .expect("build OpManager"),
+        );
+        op_manager.ring.attach_op_manager(&op_manager);
+        SeamFixture {
+            op_manager,
+            node_events: notification_rx.notifications_receiver,
+            _keep_alive: Box::new((
+                notification_rx.op_execution_receiver,
+                _ch_channel,
+                _wait_for_event,
+                result_router_rx,
+                task_monitor,
+            )),
+        }
+    }
+
+    /// Every contract id retracted by a `HostingAnnounce` queued on the node-event
+    /// channel so far. This is the wire-visible effect co-hosts act on: it is what
+    /// makes them drop us from their fan-out target set.
+    fn drain_retracted_ids(
+        fixture: &mut SeamFixture,
+    ) -> Vec<freenet_stdlib::prelude::ContractInstanceId> {
+        let mut retracted = Vec::new();
+        while let Ok(event) = fixture.node_events.try_recv() {
+            if let either::Either::Right(crate::message::NodeEvent::BroadcastHostingUpdate {
+                message: crate::message::NeighborHostingMessage::HostingAnnounce { removed, .. },
+            }) = event
+            {
+                retracted.extend(removed);
+            }
+        }
+        retracted
+    }
+
+    /// Run the maintenance loop's post-sweep step for one sweep result, exactly as
+    /// `Ring::sweep_get_subscription_cache` does: every expired key goes through
+    /// `reclaim_evicted_contract`.
+    fn reclaim_swept(
+        op_manager: &crate::node::OpManager,
+        swept: crate::ring::hosting::HostingSweepResult,
+    ) {
+        for (key, expected_generation) in swept.expired {
+            crate::operations::reclaim_evicted_contract(op_manager, key, expected_generation);
+        }
+    }
+
+    /// #5059: a cost-pressure eviction must RETRACT the evicted contract's co-host
+    /// advertisement, not just drop its hosting-cache entry.
+    ///
+    /// Broadcast fan-out targets are resolved from `neighbor_hosting` (advertised
+    /// co-hosts) with no interest check, so an evicted-but-still-advertised
+    /// contract keeps being sent updates and keeps applying them. That burns the
+    /// CPU the eviction was supposed to reclaim, AND it bumps the state generation
+    /// on every apply — so the deferred `EvictContract` bails at
+    /// `RuntimePool::remove_contract`'s newer-generation guard and the retraction
+    /// wired behind that guard never runs. Field evidence in #5040: the storm
+    /// contract's per-update warn ran at ~10-11/s continuously through three
+    /// separate cost evictions of it.
+    ///
+    /// The assertion is on the EMITTED EFFECT — a `BroadcastHostingUpdate`
+    /// carrying `HostingAnnounce { removed: [junk] }` — rather than on
+    /// `my_contracts`, because the wire message is what makes co-hosts stop
+    /// sending.
+    ///
+    /// Nothing in this fixture consumes the `EvictContract` event, which is the
+    /// point: it stands in for the field case where reclamation never reaches its
+    /// own retraction. Before this fix the test sees no retraction at all.
+    ///
+    /// `start_paused` for the same reason as the sibling seam test above: the
+    /// virtual clock drives the meter, the sweep, and the background tasks
+    /// together. A background hosting sweep may shed `junk` before the explicit
+    /// sweep below; either way the retraction has to reach the channel, which is
+    /// why the assertion scans everything queued rather than a single event.
+    #[tokio::test(start_paused = true)]
+    async fn cost_evicted_contract_emits_a_co_host_advertisement_retraction() {
+        use crate::topology::meter::ResourceType;
+
+        let mut fixture = seam_fixture("cost-retraction-5059").await;
+        let op_manager = fixture.op_manager.clone();
+        op_manager
+            .ring
+            .connection_manager
+            .set_own_addr_local_for_test("127.0.0.1:14101".parse().unwrap());
+        let ring = &op_manager.ring;
+
+        let junk = seam_key(1);
+        let subscribed = seam_key(2);
+
+        let _ = ring.host_contract(junk, 121, crate::ring::AccessType::Put);
+        let _ = ring.host_contract(subscribed, 121, crate::ring::AccessType::Put);
+        // Both advertised to co-hosts — the state this fix is about. Set directly
+        // (not via `announce_contract_hosted`) so the only `HostingAnnounce` the
+        // channel can carry is a retraction.
+        op_manager.neighbor_hosting.on_contract_hosted(&junk);
+        op_manager.neighbor_hosting.on_contract_hosted(&subscribed);
+        assert!(
+            op_manager.neighbor_hosting.is_hosted_locally(&junk),
+            "precondition: the storm contract is advertised to co-hosts"
+        );
+
+        tokio::time::advance(super::hosting::COST_RATE_MIN_WINDOW + Duration::from_secs(1)).await;
+        assert!(!matches!(
+            ring.add_downstream_subscriber(
+                &subscribed,
+                crate::ring::interest::PeerKey(crate::transport::TransportPublicKey::from_bytes(
+                    [9u8; 32]
+                )),
+            ),
+            crate::ring::hosting::AddSubscriberOutcome::Rejected
+        ));
+
+        // The FX2j storm profile through the production reporter, identical for
+        // both contracts so demand — not cost share — decides who is shed.
+        for _ in 0..110u32 {
+            for key in [&junk, &subscribed] {
+                ring.report_contract_resource_usage(
+                    *key.id(),
+                    ResourceType::BroadcastMessagesSent,
+                    58.0,
+                );
+            }
+            tokio::time::advance(Duration::from_millis(1600)).await;
+        }
+
+        // The background hosting sweep may have shed `junk` (and reclaimed it)
+        // during the advances above, in which case this explicit sweep finds
+        // nothing left to evict and the retraction is already queued. Either way
+        // it has to be on the channel, which is why the drain below covers the
+        // whole run rather than only the window around this call. Nothing here
+        // ever announces hosting, so every `HostingAnnounce` on the channel is a
+        // retraction.
+        reclaim_swept(&op_manager, ring.sweep_expired_hosting());
+        assert!(
+            !ring.is_hosting_contract(&junk),
+            "precondition for the assertions below: the storm contract was shed"
+        );
+
+        let retracted = drain_retracted_ids(&mut fixture);
+        assert!(
+            retracted.contains(junk.id()),
+            "the cost-evicted contract must emit a co-host advertisement retraction \
+             — without it the fan-out never stops and the eviction reclaims nothing \
+             (#5059). Retractions seen: {retracted:?}"
+        );
+        assert!(
+            !retracted.contains(subscribed.id()),
+            "a contract that was never evicted must not be retracted"
+        );
+        assert!(
+            !op_manager.neighbor_hosting.is_hosted_locally(&junk),
+            "the evicted contract must also leave the locally-advertised set, or the \
+             ~5-min full-set re-request re-asserts the phantom advertisement"
+        );
+        assert!(
+            op_manager.neighbor_hosting.is_hosted_locally(&subscribed),
+            "the surviving subscribed contract keeps its advertisement"
+        );
+    }
+
+    /// The eviction retraction must NOT fire for a contract that is hosted again,
+    /// or wanted again, by the time it runs — the two guards that genuinely mean
+    /// "still a host" (`RuntimePool::remove_contract`'s guards 1 and 2). Retracting
+    /// either would leave a fresh, in-mesh contract unadvertised, which the ~5-min
+    /// full-set re-request cannot heal because that exchange replays the same
+    /// (wrong) `my_contracts`.
+    ///
+    /// Both cases go through the real `reclaim_evicted_contract` funnel, but they
+    /// are stopped at different points: the re-hosted one by the retraction
+    /// helper's own guard, the in-use one by `reclaim_evicted_contract`'s
+    /// pre-existing `contract_in_use` early return (the helper re-checks it too,
+    /// for the window between that return and the removal — that re-check is
+    /// covered directly by
+    /// `on_contract_unhosted_unless_rehosted_retracts_only_when_still_unhosted`).
+    #[tokio::test(start_paused = true)]
+    async fn eviction_retraction_skips_a_rehosted_or_in_use_contract() {
+        let mut fixture = seam_fixture("cost-retraction-guards-5059").await;
+        let op_manager = fixture.op_manager.clone();
+        op_manager
+            .ring
+            .connection_manager
+            .set_own_addr_local_for_test("127.0.0.1:14102".parse().unwrap());
+        let ring = &op_manager.ring;
+
+        // (1) Re-hosted: present in the hosting cache when the reclaim runs.
+        let rehosted = seam_key(4);
+        let _ = ring.host_contract(rehosted, 121, crate::ring::AccessType::Put);
+        op_manager.neighbor_hosting.on_contract_hosted(&rehosted);
+
+        // (2) Back in use: absent from the hosting cache, but a downstream
+        // subscriber re-registered interest.
+        let in_use = seam_key(5);
+        op_manager.neighbor_hosting.on_contract_hosted(&in_use);
+        assert!(!matches!(
+            ring.add_downstream_subscriber(
+                &in_use,
+                crate::ring::interest::PeerKey(crate::transport::TransportPublicKey::from_bytes(
+                    [7u8; 32]
+                )),
+            ),
+            crate::ring::hosting::AddSubscriberOutcome::Rejected
+        ));
+        assert!(
+            !ring.is_hosting_contract(&in_use) && ring.contract_in_use(&in_use),
+            "precondition: in-use but not in the hosting cache"
+        );
+
+        let _ = drain_retracted_ids(&mut fixture);
+        for key in [rehosted, in_use] {
+            let generation = ring.state_generation(&key);
+            crate::operations::reclaim_evicted_contract(&op_manager, key, generation);
+        }
+
+        let retracted = drain_retracted_ids(&mut fixture);
+        assert!(
+            retracted.is_empty(),
+            "neither a re-hosted nor an in-use contract may be retracted; got {retracted:?}"
+        );
+        assert!(
+            op_manager.neighbor_hosting.is_hosted_locally(&rehosted),
+            "a contract re-hosted since the eviction decision keeps its advertisement"
+        );
+        assert!(
+            op_manager.neighbor_hosting.is_hosted_locally(&in_use),
+            "a contract back in use since the eviction decision keeps its advertisement"
+        );
+    }
+
     /// Drift guard (#4861 Codex round-3): the meter's per-axis cost floors
     /// ([`crate::topology::meter::ResourceType::cost_pressure_floor`]) and its
     /// sustained window ([`crate::topology::meter::COST_SUSTAINED_WINDOW`]) are

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -320,6 +320,17 @@ pub(crate) struct RouterSnapshotInfo {
     pub terminal_consult_hits: Option<u64>,
     pub terminal_consult_resolved_found: Option<u64>,
     pub terminal_consult_still_not_found: Option<u64>,
+    /// Eviction-retraction emission counters (#5059). The retraction is what
+    /// makes co-hosts stop fanning updates at an evicted contract, and it is
+    /// emitted best-effort on the cap-2048 node-event channel. `dropped` rising
+    /// means evicted contracts keep receiving updates for up to one
+    /// interest-heartbeat interval (~5 min) before the full-set re-request heals
+    /// it — the difference between a slow heal and a failed fix, which the
+    /// `debug!` at the drop site cannot show because it compiles out in release.
+    /// Monotonic lifetime totals; `None` until the ring's snapshot task has
+    /// populated them.
+    pub hosting_retractions_emitted: Option<u64>,
+    pub hosting_retractions_dropped: Option<u64>,
     /// Computed-upstream vs. stored-`is_upstream`-flag divergence counters
     /// (hosting redesign piece D, #4642 / #4671). `comparisons` is the
     /// denominator (one per `send_unsubscribe_upstream`), `divergences` the times
@@ -1379,6 +1390,10 @@ impl Router {
             terminal_consult_hits: None,
             terminal_consult_resolved_found: None,
             terminal_consult_still_not_found: None,
+            // Eviction-retraction emission counters (#5059), same population
+            // path as the consult counters above.
+            hosting_retractions_emitted: None,
+            hosting_retractions_dropped: None,
             // Computed-upstream vs. stored-flag divergence counters (piece D,
             // #4642 / #4671), populated by Ring from the network_status
             // singleton on the snapshot cadence.

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -2407,6 +2407,18 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                     "terminal_consult_still_not_found".to_string(),
                     serde_json::json!(snapshot.terminal_consult_still_not_found),
                 );
+                // Eviction-retraction emission counters (#5059): whether the
+                // retraction that stops co-host fan-out at an evicted contract
+                // actually reached the wire. Pinned by
+                // `router_snapshot_json_includes_hosting_retraction_counters`.
+                obj.insert(
+                    "hosting_retractions_emitted".to_string(),
+                    serde_json::json!(snapshot.hosting_retractions_emitted),
+                );
+                obj.insert(
+                    "hosting_retractions_dropped".to_string(),
+                    serde_json::json!(snapshot.hosting_retractions_dropped),
+                );
                 // Streamed-transfer abort counters (Group B), routing/hosting
                 // attribution (Group C), and connect-emit counters — same
                 // hand-mirror footgun: a new `RouterSnapshotInfo` field is
@@ -2999,6 +3011,29 @@ mod tests {
             ("terminal_consult_hits", 313),
             ("terminal_consult_resolved_found", 317),
             ("terminal_consult_still_not_found", 331),
+        ] {
+            assert_eq!(json[key], want, "{key} must reach the OTLP body");
+        }
+    }
+
+    /// Pin: the eviction-retraction counters (#5059) must reach the
+    /// hand-mirrored OTLP body — same footgun as the counters above. The
+    /// retraction is emitted best-effort on the cap-2048 node-event channel and
+    /// its drop is logged at `debug`, which compiles out in release, so these
+    /// counters are the ONLY production signal distinguishing "retraction
+    /// dropped, healing on the ~5-min heartbeat" from "the fix is not working".
+    #[test]
+    fn router_snapshot_json_includes_hosting_retraction_counters() {
+        use arbitrary::{Arbitrary, Unstructured};
+        let mut u = Unstructured::new(&[0u8; 4096]);
+        let mut info = crate::router::RouterSnapshotInfo::arbitrary(&mut u)
+            .expect("construct RouterSnapshotInfo for test");
+        info.hosting_retractions_emitted = Some(509);
+        info.hosting_retractions_dropped = Some(521);
+        let json = event_kind_to_json(&EventKind::RouterSnapshot(Box::new(info)));
+        for (key, want) in [
+            ("hosting_retractions_emitted", 509),
+            ("hosting_retractions_dropped", 521),
         ] {
             assert_eq!(json[key], want, "{key} must reach the OTLP body");
         }


### PR DESCRIPTION
## Problem

Cost-pressure eviction removed the hosting-cache entry but never retracted the
co-host advertisement, so the evicted contract kept receiving and applying
updates. The node stopped hosting it and did not stop paying for it. Fixes #5059.

The loop is self-sustaining:

1. `evict_cost_pressure` (`ring/hosting/cache.rs`) sheds a zero-demand storm
   contract. Broadcast fan-out targets are resolved from `neighbor_hosting`
   (advertised co-hosts) with **no interest check**, and nothing retracted that
   advertisement, so co-hosts keep sending.
2. Every inbound update is applied, which is where the WASM CPU goes, and each
   apply bumps the state generation.
3. The retraction was wired only on the confirmed-delete path in
   `RuntimePool::remove_contract`, behind three guards. Guard 3 —
   `state_generation != expected_generation` — is a guard on deleting **bytes**,
   and step 2 keeps it tripped, so `EvictContract` bails, re-queues itself into
   `pending_reclamation`, and bails the same way on every retry. The retraction
   never runs.
4. The ~5-minute full-set re-request (`HostingStateRequest` →
   `HostingStateResponse`) replays `my_contracts`, so the phantom advertisement is
   actively **re-asserted** to every co-host.
5. `evict_cost_pressure` iterates `self.contracts`, so the still-executing
   contract is no longer reachable by further eviction, while it keeps inflating
   `total_rate` and suppressing every other contract's share.

Field evidence from #5040: the `send_update_notification: no subscriber snapshot`
warn for one contract ran at ~10-11/s continuously **through** three separate cost
evictions of that same contract, 10,553 lines, with no gap at any eviction
timestamp.

## Approach

Retract the advertisement at the **eviction decision** — `reclaim_evicted_contract`
in `operations.rs`, the single funnel every eviction path routes through (GET/PUT
insert eviction, the periodic byte and cost sweeps, the pending-reclamation
retry).

Eviction is the moment a peer stops being a fresh in-mesh host, so under
hosting-invariant 1 it is the moment the advertisement must go, whether or not the
bytes come off disk. Holding bytes that no longer belong to a hosted contract is a
reclamation concern, and reclamation keeps its own retry queue.

The two guards that genuinely mean "still a host" are re-checked —
`is_hosting_contract` (a GET/PUT re-hosted it) and `contract_in_use` (a client or
downstream subscriber re-registered), i.e. `RuntimePool::remove_contract`'s guards
1 and 2. Guard 3 is deliberately **not** applied: it is the one that made the old
site unusable for the advertisement.

The re-host check runs **after** the removal from `my_contracts`, via the new
`NeighborHostingManager::on_contract_unhosted_unless_rehosted`. A concurrent
re-host does its hosting-cache insert and only then its
`announce_contract_hosted`, so remove-then-check lands advertised iff hosted for
every interleaving:

- the re-host insert lands before our check → we observe it, undo the removal,
  emit nothing, and its later `on_contract_hosted` is the usual no-op;
- the insert lands after our check → we retract, and its later
  `on_contract_hosted` finds the key absent and re-announces.

Check-then-remove has no such ordering: the announce can fire between check and
removal, and the removal then deletes it, leaving a hosted-but-unadvertised
contract that the periodic full-set re-request **cannot** heal, because that
exchange replays the very `my_contracts` that is wrong.

A third condition also keeps the advertisement: `is_subscribed`, a live upstream
lease. Holding one means the node is wired into the contract's update mesh, which
is what invariant 1 calls a host, cache entry or not. It is also what makes the
ordering guarantee hold for the SUBSCRIBE path, whose announce
(`finalize_originator_subscribe`) is gated on the body being present **on disk**
via `fetch_contract_if_missing` → `has_contract`, not on a hosting-cache insert.
`ring.subscribe` installs the lease before both that fetch and that announce, so
it is the one signal reliably set first there. Without it, a contract evicted with
its state still on disk and sitting in `pending_reclamation` could be
re-subscribed, announce, and then have the pending-reclamation retry retract it
straight back out — subscribed, holding the body, unadvertised until the next
renewal.

**What the lease check costs.** A zero-subscriber victim that still holds a lease,
evicted through the GET/PUT insert-eviction funnels, no longer retracts at the
decision — it defers to the reclamation-side path. That is exactly where its
retraction happened before this PR, so it is not a regression, just a case this
change does not improve. The **cost-eviction path is unaffected**: the sweep calls
`ring.unsubscribe` on every expired key before reclaiming, so the lease is already
gone by the time the guard runs, and the #5059 victim retracts at the decision as
intended.

The reclamation-side `announce_contract_unhosted` stays as an idempotent backstop.

### What this decouples

The old arrangement ran the retraction only after a confirmed delete, which
coupled "no longer advertised" to "state gone". This decouples them: between the
retraction and a successful reclaim, the node holds state that has left the update
mesh **and is still servable** — the GET local-serve path reads the store directly
with no `is_hosting_contract` gate, so a keyward-routed GET landing there gets a
copy that is no longer receiving updates. That is the stale-serve shape invariant 1
forbids. Milliseconds in the normal case, unbounded when reclamation keeps failing
or the `EvictContract` is dropped by the fair queue. Accepted as strictly better
than what it replaces — that copy was already stale in the same window before this
change, and it stayed advertised too, so it was being actively fanned to.

Tracked as **#5069**. The exposure is measurable rather than guessed:
`pending_reclamation` depth and retry age are already tracked, so it can be sized
before choosing a fix.

### Dropped-retraction visibility

The retraction rides `try_notify_node_event` on the cap-2048 node-event channel
and its drop is logged at `debug`, which compiles out in release — and a node
under exactly the #5059 broadcast storm is when that channel is most likely to be
full. Added `hosting_retractions_emitted` / `hosting_retractions_dropped`
(`network_status` → `RouterSnapshotInfo` → OTLP body, pinned by
`router_snapshot_json_includes_hosting_retraction_counters` against the
hand-mirror footgun). Without them the field cannot tell "dropped, healing on the
~5-min heartbeat" from "the fix is not working".

### Scope

Retraction only, per the issue's part 1. Part 2 (not applying updates for
contracts absent from the hosting cache) and part 3 (an eviction memory with an
escalating TTL) are **not** in this PR — part 3 in particular needs the trace of
which path re-inserts the cache entry that the issue asks for first.

The anti-re-drive machinery is untouched: no change to the renewal-lease candidacy
guard (`cache.rs`), the in-use teardown, or the `InterestManager` replay (#4734);
`torn_down_eviction_not_redriven_by_contracts_needing_renewal` still passes. No
suppression window is added, so the escalating-TTL rule in
`.claude/rules/hosting-invariants.md` does not come into play. The topology read
lock and hosting write lock are still never held together — the new checks run
after `sweep_expired_hosting_with_cost` has dropped the cache guard.

This also changes behaviour for **byte**-budget victims, which reach the same
funnel. That is the same correction: an evicted contract is not a host, so it must
not advertise. In the healthy case the only difference is that the retraction
fires slightly earlier and the reclamation-side call becomes a no-op.

## Testing

`crates/core/src/ring.rs`, `cost_pressure_seam_tests`:

- `cost_evicted_contract_emits_a_co_host_advertisement_retraction` — the
  discriminator. Drives the real chain: production reporter →
  topology meter → `hosting_cost_pressure_axes` → real
  `Ring::sweep_expired_hosting()` → eviction → `reclaim_evicted_contract`, with
  the FX2j storm profile (121 bytes, 58 targets, ~36 per-peer sends/s sustained)
  under `start_paused` virtual time. Asserts the **emitted effect** — a
  `NodeEvent::BroadcastHostingUpdate` carrying
  `HostingAnnounce { removed: [junk] }` on the node-event channel — not a
  bookkeeping change, because the wire message is what makes co-hosts stop
  sending. A subscribed contract storming at the identical rate is neither evicted
  nor retracted. Nothing in the fixture consumes `EvictContract`, which stands in
  for the field case where reclamation never reaches its own retraction; before
  the fix the test sees no retraction at all.
- `eviction_retraction_skips_a_rehosted_or_in_use_contract` — all three
  keep-guards (re-hosted, in use, holding a live upstream lease), driven through
  the real `reclaim_evicted_contract`. The lease case is the SUBSCRIBE-path shape
  described above.

**The `reclaim_swept` test helper is load-bearing, not incidental.** It previously
skipped the sweep loop's `ring.unsubscribe`. Once a live lease became a keep-guard,
a helper that skipped it would have suppressed the very retraction under test — the
discriminator would have gone green while proving nothing. It now mirrors the
loop's real order (unsubscribe, then reclaim), and the reason is stated at the
helper so a future edit does not quietly undo it.

`crates/core/src/node/neighbor_hosting.rs`:

- `on_contract_unhosted_unless_rehosted_retracts_only_when_still_unhosted` — the
  three branches of the new primitive, including that the guard is not consulted
  at all for an unadvertised contract and that a fired guard restores the
  advertisement intact.

`crates/core/src/operations.rs` source pins:

- `reclaim_evicted_contract_retracts_through_the_guarded_helper`
- `eviction_retraction_helper_gates_on_rehost_and_in_use_only`
- `eviction_retraction_emits_only_what_the_guard_returned` — the emission stays
  inside the guard's `Some(..)` arm, so a refactor cannot hoist it out.

The first two now match against a **comment-stripped** function body. That is not
only about avoiding a spurious failure when the prose changes: as written before,
the absence assertion was passing for an accidental reason — the needle required a
trailing paren and the comment naming the forbidden call happened not to have one.
It was green by luck. Stripping comments makes it green for the real reason, and
lets the comment explaining why a call is forbidden name that call.

### Mutation testing

Seven mutations, each applied to the source, run, and reverted. Six are real
mutations and every one is caught; the last is a control that must NOT be caught.

| Mutation | Killed by |
|---|---|
| Delete the `retract_advertisement_for_evicted_contract` call from `reclaim_evicted_contract` | `reclaim_evicted_contract_retracts_through_the_guarded_helper` **and** `cost_evicted_contract_emits_a_co_host_advertisement_retraction` (`Retractions seen: []`) |
| Replace that call with the bare, unguarded `announce_contract_unhosted` | the same pin (second assertion) **and** `eviction_retraction_skips_a_rehosted_or_in_use_contract` (the re-hosted contract was retracted) |
| Drop the `contract_in_use` half of the helper's gate | `eviction_retraction_helper_gates_on_rehost_and_in_use_only` (required-anchor assertion) |
| Add a `state_generation` read to the helper's gate — the #5059 regression shape | `eviction_retraction_helper_gates_on_rehost_and_in_use_only` (negative assertion) |
| Drop `is_subscribed` from the helper's gate | the same pin (anchor assertion) **and** `eviction_retraction_skips_a_rehosted_or_in_use_contract` (the leased contract got retracted) |
| Inline `try_notify_node_event` in the helper, bypassing `emit_hosting_retraction` | `eviction_retraction_emits_only_what_the_guard_returned` |
| Name the forbidden call **with** parens in the comment that explains why it is forbidden | nothing — the pin still **passes**, which is the point: it now matches against a comment-stripped body, so it can no longer break on prose (and no longer passes for the accidental reason that the comment happened to omit a paren) |

The first mutation confirms the anchors are found and the behavioural test is
the real discriminator, not the pins alone.

`cargo test -p freenet --lib`: **4476 passed, 0 failed, 25 ignored**. `cargo fmt`
and `cargo clippy -p freenet --lib` are clean.

Not added: a `run_simulation_direct` test. The strongest available evidence is the
seam test, which runs the actual production reporter → meter → sweep → funnel
chain in-process and asserts the wire event; the sender-side other half (a
`HostingAnnounce { removed }` dropping the peer from the fan-out target set) is
already covered by `test_removed_announce_converges_at_receiver`.

Closes #5059

[AI-assisted - Claude]

