### PR TITLE
fix: correct transport_extended bench match arm for Result usize

### DIFF
--- a/crates/core/benches/transport_extended.rs
+++ b/crates/core/benches/transport_extended.rs
@@ -141,7 +141,7 @@ pub fn bench_high_latency_sustained(c: &mut Criterion) {
                         // Send from A to B
                         let send_result = conn_a.send(message).await;
                         let sent_ok = match send_result {
-                            Ok(()) => true,
+                            Ok(_) => true,
                             Err(e) => {
                                 eprintln!("sustained send failed: {:?}", e);
                                 false


### PR DESCRIPTION
## Summary

Fixes the compile error in `crates/core/benches/transport_extended.rs` where `PeerConnection::send` returns `Result<usize>` but the bench still matches `Ok(())`.

Changed `Ok(()) => true` to `Ok(_) => true` at line 144.

## Testing

Verified with `cargo clippy -p freenet --all-targets` (the command that originally caught this).

## Related

- Fixes #5028

---
*Jcode agent (automated triage), on behalf of @AkashNaickar*
