### PR TITLE
perf(interest-sync): exchange summary digests before summary bytes

### DIFF
--- a/.claude/rules/ring.md
+++ b/.claude/rules/ring.md
@@ -215,7 +215,8 @@ WHEN exchanging peer lists in sync protocols (e.g., interest sync):
   → Stale peer entries cause operations to be sent to dead nodes
 
 WHEN summarizing contracts in the InterestSync heartbeat handlers
-(handle_interest_sync_message: Interests / Summaries / ChangeInterests):
+(handle_interest_sync_message: Interests / Summaries / SummaryDigests /
+SummaryRequest / ChangeInterests):
   → ONLY call get_contract_summary for contracts we host OR actively serve
     AND for which we actually hold state:
     (is_hosting_contract || contract_in_use) && contract_state_present — go

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -3659,6 +3659,11 @@ std::thread_local! {
     // for a peer pair sharing exactly ONE contract is also single-entry, so the
     // single bucket is "state-change-driven sites PLUS narrow heartbeats", not
     // a clean partition. It is directional evidence, not attribution.
+    /// Peak size of the digest arm's per-hash local-summary cache (#4965).
+    /// The observable for the RETENTION bound: the cache holds owned summary
+    /// clones, so its peak entry count is what decides whether a hostile
+    /// message can accumulate hundreds of MB.
+    static GLOBAL_SUMMARY_CACHE_PEAK: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
     static GLOBAL_SUMMARY_AGREE_SINGLE: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
     static GLOBAL_SUMMARY_AGREE_MULTI: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
     static GLOBAL_SUMMARY_MISMATCH_SINGLE: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
@@ -3715,6 +3720,7 @@ impl GlobalTestMetrics {
         GLOBAL_SUMMARY_DIGEST_MSGS.with(|c| c.set(0));
         GLOBAL_SUMMARY_FULL_MSGS.with(|c| c.set(0));
         GLOBAL_SUMMARY_FULL_BYTES.with(|c| c.set(0));
+        GLOBAL_SUMMARY_CACHE_PEAK.with(|c| c.set(0));
         GLOBAL_SUMMARY_AGREE_SINGLE.with(|c| c.set(0));
         GLOBAL_SUMMARY_AGREE_MULTI.with(|c| c.set(0));
         GLOBAL_SUMMARY_MISMATCH_SINGLE.with(|c| c.set(0));
@@ -3992,6 +3998,20 @@ impl GlobalTestMetrics {
     pub fn record_summary_full_msg(bytes: u64) {
         GLOBAL_SUMMARY_FULL_MSGS.with(|c| c.set(c.get() + 1));
         GLOBAL_SUMMARY_FULL_BYTES.with(|c| c.set(c.get() + bytes));
+    }
+
+    /// Observe the digest arm's local-summary cache size, keeping the peak.
+    ///
+    /// Records the RETENTION bound directly rather than through a proxy: the
+    /// cache holds owned summary clones, so a peak proportional to the number
+    /// of hashes a peer named — rather than to ONE hash's contract set — is
+    /// the accumulation this is here to catch.
+    pub fn note_summary_cache_size(len: usize) {
+        GLOBAL_SUMMARY_CACHE_PEAK.with(|c| c.set(c.get().max(len as u64)));
+    }
+
+    pub fn summary_cache_peak() -> u64 {
+        GLOBAL_SUMMARY_CACHE_PEAK.with(|c| c.get())
     }
 
     /// One advertised digest matched our own summary, settling that contract

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -3646,7 +3646,23 @@ std::thread_local! {
     static GLOBAL_SUMMARY_DIGEST_MSGS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
     static GLOBAL_SUMMARY_FULL_MSGS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
     static GLOBAL_SUMMARY_FULL_BYTES: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
-    static GLOBAL_SUMMARY_DIGEST_AGREEMENTS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+    // #4965 agreement rate, split by MESSAGE SHAPE rather than by emitter.
+    //
+    // The emitter tag (#5052) is `#[serde(skip)]`, so an INBOUND SummaryDigests
+    // always decodes as `Other` — the receiver, which is the only side that can
+    // judge agreement, cannot know which send site produced it. Entry count is
+    // the best available proxy and needs no wire change: the notification and
+    // rejection emitters are single-entry BY CONSTRUCTION while both reply
+    // emitters are multi-entry (see `outbound_message_mix::SummariesDetail`).
+    //
+    // Known ambiguity, stated so the number is not over-read: a heartbeat reply
+    // for a peer pair sharing exactly ONE contract is also single-entry, so the
+    // single bucket is "state-change-driven sites PLUS narrow heartbeats", not
+    // a clean partition. It is directional evidence, not attribution.
+    static GLOBAL_SUMMARY_AGREE_SINGLE: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+    static GLOBAL_SUMMARY_AGREE_MULTI: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+    static GLOBAL_SUMMARY_MISMATCH_SINGLE: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+    static GLOBAL_SUMMARY_MISMATCH_MULTI: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
     static GLOBAL_SUMMARY_BYTE_REQUESTS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
 }
 
@@ -3699,7 +3715,10 @@ impl GlobalTestMetrics {
         GLOBAL_SUMMARY_DIGEST_MSGS.with(|c| c.set(0));
         GLOBAL_SUMMARY_FULL_MSGS.with(|c| c.set(0));
         GLOBAL_SUMMARY_FULL_BYTES.with(|c| c.set(0));
-        GLOBAL_SUMMARY_DIGEST_AGREEMENTS.with(|c| c.set(0));
+        GLOBAL_SUMMARY_AGREE_SINGLE.with(|c| c.set(0));
+        GLOBAL_SUMMARY_AGREE_MULTI.with(|c| c.set(0));
+        GLOBAL_SUMMARY_MISMATCH_SINGLE.with(|c| c.set(0));
+        GLOBAL_SUMMARY_MISMATCH_MULTI.with(|c| c.set(0));
         GLOBAL_SUMMARY_BYTE_REQUESTS.with(|c| c.set(0));
     }
 
@@ -3973,9 +3992,63 @@ impl GlobalTestMetrics {
     }
 
     /// One advertised digest matched our own summary, settling that contract
-    /// with zero summary bytes exchanged. This is the 98.1% case.
-    pub fn record_summary_digest_agreement() {
-        GLOBAL_SUMMARY_DIGEST_AGREEMENTS.with(|c| c.set(c.get() + 1));
+    /// with zero summary bytes exchanged.
+    ///
+    /// `single_entry` splits by the SHAPE of the message the entry arrived in
+    /// — see the module note on why that is the best available proxy for the
+    /// send site.
+    pub fn record_summary_digest_agreement(single_entry: bool) {
+        if single_entry {
+            GLOBAL_SUMMARY_AGREE_SINGLE.with(|c| c.set(c.get() + 1));
+        } else {
+            GLOBAL_SUMMARY_AGREE_MULTI.with(|c| c.set(c.get() + 1));
+        }
+    }
+
+    /// A digest could NOT settle a contract, so its bytes must be requested.
+    ///
+    /// The denominator half of the agreement rate: without it, a low agreement
+    /// COUNT and a low exchange VOLUME look identical, and the whole question
+    /// (does the state-change-driven site agree less often than the heartbeat
+    /// one?) is about a RATE.
+    pub fn record_summary_digest_mismatch(single_entry: bool) {
+        if single_entry {
+            GLOBAL_SUMMARY_MISMATCH_SINGLE.with(|c| c.set(c.get() + 1));
+        } else {
+            GLOBAL_SUMMARY_MISMATCH_MULTI.with(|c| c.set(c.get() + 1));
+        }
+    }
+
+    /// Agreements observed in SINGLE-entry `SummaryDigests` messages.
+    ///
+    /// Proxy for the state-change-driven send sites (proactive notification,
+    /// rejection summary-back), which are single-entry by construction. This
+    /// is the population #4861 makes us care about: the proactive site fires
+    /// immediately after WE change state, so the receiver may not have applied
+    /// the update yet and could disagree far more often than the fleet-wide
+    /// 98.1% suggests — and every disagreement costs two extra messages on the
+    /// axis that caused the storm.
+    pub fn summary_digest_agreements_single() -> u64 {
+        GLOBAL_SUMMARY_AGREE_SINGLE.with(|c| c.get())
+    }
+
+    /// Agreements observed in MULTI-entry `SummaryDigests` messages — the
+    /// heartbeat / interest-churn replies.
+    pub fn summary_digest_agreements_multi() -> u64 {
+        GLOBAL_SUMMARY_AGREE_MULTI.with(|c| c.get())
+    }
+
+    pub fn summary_digest_mismatches_single() -> u64 {
+        GLOBAL_SUMMARY_MISMATCH_SINGLE.with(|c| c.get())
+    }
+
+    pub fn summary_digest_mismatches_multi() -> u64 {
+        GLOBAL_SUMMARY_MISMATCH_MULTI.with(|c| c.get())
+    }
+
+    /// Total agreements, both shapes.
+    pub fn summary_digest_agreements() -> u64 {
+        Self::summary_digest_agreements_single() + Self::summary_digest_agreements_multi()
     }
 
     /// A digest could not settle some contracts, so their bytes were
@@ -3994,10 +4067,6 @@ impl GlobalTestMetrics {
 
     pub fn summary_full_bytes() -> u64 {
         GLOBAL_SUMMARY_FULL_BYTES.with(|c| c.get())
-    }
-
-    pub fn summary_digest_agreements() -> u64 {
-        GLOBAL_SUMMARY_DIGEST_AGREEMENTS.with(|c| c.get())
     }
 
     pub fn summary_byte_requests() -> u64 {

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -3970,12 +3970,15 @@ impl GlobalTestMetrics {
     // === Hash-first summary exchange falsifiers (#4965) ===
     //
     // The claim under test is "the common case stops shipping summary bytes".
-    // These counters are fed from the FOUR sites that can construct a
-    // `Summaries`/`SummaryDigests` message — `node::summaries_reply_for_peer`,
-    // the `SummaryRequest` reply arm, and the two `operations::update`
-    // helpers — so `summary_full_bytes() == 0` means no summary byte was put
-    // on the wire by any path, not merely by the one a test happened to
-    // exercise. `hash_first_send_sites_are_all_instrumented` pins the set.
+    // These counters are fed from the TWO constructor functions that can build
+    // these messages — `node::summaries_reply_for_peer` (which chooses the
+    // encoding) and `node::full_summaries_message` (which every full-bytes
+    // path routes through, including the `operations::update` helpers, which
+    // are CALLERS rather than construction sites). So
+    // `summary_full_bytes() == 0` means no summary byte was put on the wire by
+    // any path, not merely by the one a test happened to exercise.
+    // `no_uninstrumented_full_summaries_construction` pins that no production
+    // site builds an `InterestMessage::Summaries` outside the constructor.
 
     /// A hash-first `SummaryDigests` message was emitted, advertising
     /// contracts without their summaries.

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -3641,6 +3641,13 @@ std::thread_local! {
     static GLOBAL_RESYNC_RESPONSES_SUPPRESSED_PER_PEER: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
     static GLOBAL_RESYNC_RESPONSES_SUPPRESSED_GLOBAL: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
     static GLOBAL_RESYNC_RESPONSES_UNSOLICITED: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+    // Hash-first summary exchange falsifiers (#4965). See the `record_*`
+    // rustdoc on `GlobalTestMetrics` for what each one proves.
+    static GLOBAL_SUMMARY_DIGEST_MSGS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+    static GLOBAL_SUMMARY_FULL_MSGS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+    static GLOBAL_SUMMARY_FULL_BYTES: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+    static GLOBAL_SUMMARY_DIGEST_AGREEMENTS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+    static GLOBAL_SUMMARY_BYTE_REQUESTS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
 }
 
 /// Global test metrics for tracking events across the simulation network.
@@ -3689,6 +3696,11 @@ impl GlobalTestMetrics {
         GLOBAL_RESYNC_RESPONSES_SUPPRESSED_PER_PEER.with(|c| c.set(0));
         GLOBAL_RESYNC_RESPONSES_SUPPRESSED_GLOBAL.with(|c| c.set(0));
         GLOBAL_RESYNC_RESPONSES_UNSOLICITED.with(|c| c.set(0));
+        GLOBAL_SUMMARY_DIGEST_MSGS.with(|c| c.set(0));
+        GLOBAL_SUMMARY_FULL_MSGS.with(|c| c.set(0));
+        GLOBAL_SUMMARY_FULL_BYTES.with(|c| c.set(0));
+        GLOBAL_SUMMARY_DIGEST_AGREEMENTS.with(|c| c.set(0));
+        GLOBAL_SUMMARY_BYTE_REQUESTS.with(|c| c.set(0));
     }
 
     /// Records that a ResyncRequest was received.
@@ -3934,6 +3946,62 @@ impl GlobalTestMetrics {
 
     pub fn put_probe_existing_mesh_delta_bytes() -> u64 {
         GLOBAL_PUT_PROBE_EXISTING_MESH_DELTA_BYTES.with(|c| c.get())
+    }
+
+    // === Hash-first summary exchange falsifiers (#4965) ===
+    //
+    // The claim under test is "the common case stops shipping summary bytes".
+    // These counters are fed from the FOUR sites that can construct a
+    // `Summaries`/`SummaryDigests` message — `node::summaries_reply_for_peer`,
+    // the `SummaryRequest` reply arm, and the two `operations::update`
+    // helpers — so `summary_full_bytes() == 0` means no summary byte was put
+    // on the wire by any path, not merely by the one a test happened to
+    // exercise. `hash_first_send_sites_are_all_instrumented` pins the set.
+
+    /// A hash-first `SummaryDigests` message was emitted, advertising
+    /// contracts without their summaries.
+    pub fn record_summary_digest_msg() {
+        GLOBAL_SUMMARY_DIGEST_MSGS.with(|c| c.set(c.get() + 1));
+    }
+
+    /// A full-bytes `Summaries` message was emitted: either the pre-floor
+    /// fallback, or the answer to a `SummaryRequest`. `bytes` is the total
+    /// summary payload it carries — the quantity hash-first exists to avoid.
+    pub fn record_summary_full_msg(bytes: u64) {
+        GLOBAL_SUMMARY_FULL_MSGS.with(|c| c.set(c.get() + 1));
+        GLOBAL_SUMMARY_FULL_BYTES.with(|c| c.set(c.get() + bytes));
+    }
+
+    /// One advertised digest matched our own summary, settling that contract
+    /// with zero summary bytes exchanged. This is the 98.1% case.
+    pub fn record_summary_digest_agreement() {
+        GLOBAL_SUMMARY_DIGEST_AGREEMENTS.with(|c| c.set(c.get() + 1));
+    }
+
+    /// A digest could not settle some contracts, so their bytes were
+    /// requested. Non-zero means the mismatch path ran.
+    pub fn record_summary_byte_request() {
+        GLOBAL_SUMMARY_BYTE_REQUESTS.with(|c| c.set(c.get() + 1));
+    }
+
+    pub fn summary_digest_msgs() -> u64 {
+        GLOBAL_SUMMARY_DIGEST_MSGS.with(|c| c.get())
+    }
+
+    pub fn summary_full_msgs() -> u64 {
+        GLOBAL_SUMMARY_FULL_MSGS.with(|c| c.get())
+    }
+
+    pub fn summary_full_bytes() -> u64 {
+        GLOBAL_SUMMARY_FULL_BYTES.with(|c| c.get())
+    }
+
+    pub fn summary_digest_agreements() -> u64 {
+        GLOBAL_SUMMARY_DIGEST_AGREEMENTS.with(|c| c.get())
+    }
+
+    pub fn summary_byte_requests() -> u64 {
+        GLOBAL_SUMMARY_BYTE_REQUESTS.with(|c| c.get())
     }
 }
 

--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -678,6 +678,13 @@ pub struct SummaryDigestEntry {
     /// Truncated-BLAKE3 digest of our summary BYTES for that contract, or
     /// `None` if we're interested but hold no state yet. Says *what state* we
     /// hold.
+    ///
+    /// Fixed 16 bytes, so for a summary SMALLER than ~8 bytes the digest form
+    /// is LARGER than the summary it replaces. Real summaries are orders of
+    /// magnitude bigger (~33 KB for a River room), so this is a curiosity
+    /// rather than a cost — but it means the saving is not monotonic in
+    /// summary size, and a contract with a trivially small summary should not
+    /// be expected to benefit.
     pub summary_digest: Option<crate::ring::interest::SummaryDigest>,
 }
 
@@ -685,11 +692,16 @@ impl SummaryDigestEntry {
     /// Build a digest entry from the full-bytes entry we would otherwise have
     /// sent.
     ///
-    /// This is deliberately the ONLY constructor: every digest is a pure
-    /// function of the exact `SummaryEntry` the fallback `Summaries` form
-    /// would have carried, so the two wire forms cannot describe different
-    /// state and no call site can compute a digest over something other than
-    /// the summary it is advertising. Those summaries in turn always come from
+    /// This is deliberately the only constructor PROVIDED, so every digest is
+    /// a pure function of the exact `SummaryEntry` the fallback `Summaries`
+    /// form would have carried and the two wire forms cannot describe
+    /// different state.
+    ///
+    /// It is a convention, not an invariant: the fields are `pub`, so a caller
+    /// could build the struct literally and pair a digest with an unrelated
+    /// summary. Nothing pins that today. Making the fields private would cost
+    /// the wire-format tests their literal construction, which is why the
+    /// weaker guarantee is stated rather than an enforcement implied. Those summaries in turn always come from
     /// the node's ACTUAL state (`summary_if_hosted_or_in_use` /
     /// `get_contract_summary`), never from a cached belief about a peer.
     pub fn from_entry(entry: &SummaryEntry) -> Self {

--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -494,6 +494,60 @@ pub enum InterestMessage {
         /// Sender's current state summary bytes.
         summary_bytes: Vec<u8>,
     },
+
+    // ---------------------------------------------------------------------
+    // Hash-first summary exchange (#4965).
+    //
+    // APPENDED, and any future variant must be appended too: bincode encodes
+    // the variant as its positional index, so inserting anywhere above would
+    // renumber `Summaries`/`ResyncRequest`/… and silently mis-decode every
+    // message from an older peer. `wire_variant_indices_are_frozen` pins this.
+    // ---------------------------------------------------------------------
+    /// Hash-first replacement for [`InterestMessage::Summaries`]: advertises a
+    /// *digest* of each summary instead of the summary itself.
+    ///
+    /// Sent in place of `Summaries` when — and only when — the recipient's
+    /// reported version is at or above
+    /// `crate::node::HASH_FIRST_SUMMARIES_MIN_VERSION` (an older peer cannot
+    /// deserialize this variant index and would drop the connection).
+    ///
+    /// The receiver compares each digest against a digest of **its own actual
+    /// summary**, and asks for the bytes of only the ones that differ (via
+    /// [`InterestMessage::SummaryRequest`]). Measured on the fleet, 98.1% of
+    /// summary comparisons find both sides already byte-identical (#4965), so
+    /// the overwhelmingly common case stops shipping ~33 KB per contract to
+    /// say "nothing changed".
+    SummaryDigests {
+        /// (contract_hash, summary_digest) pairs for shared contracts.
+        /// The digest is `None` if we're interested but hold no state yet —
+        /// exactly the case `SummaryEntry::summary_bytes == None` covers.
+        entries: Vec<SummaryDigestEntry>,
+        /// Which send path built this — the same non-wire (`#[serde(skip)]`)
+        /// tag [`InterestMessage::Summaries`] carries (#5052).
+        ///
+        /// The digest form REPLACES a `Summaries` at every send site, so it
+        /// must carry the same tag or a path would lose its per-emitter
+        /// attribution the moment its peer upgrades — the rollup would show
+        /// the named arm shrinking and the residual arm growing, which reads
+        /// as "hash-first saved bytes" when it actually means "we stopped
+        /// being able to see them".
+        #[serde(skip)]
+        emitter: SummariesEmitter,
+    },
+
+    /// Ask a peer for the FULL summary bytes of specific contracts.
+    ///
+    /// Sent only in reply to [`InterestMessage::SummaryDigests`], for the
+    /// entries whose advertised digest did not match our own summary's digest.
+    /// The peer answers with a plain [`InterestMessage::Summaries`], so the
+    /// mismatch path funnels back into the unchanged `Summaries` handler —
+    /// including its semantic staleness check and targeted `SyncStateToPeer`
+    /// heal. The exchange terminates there (`Summaries` never replies).
+    SummaryRequest {
+        /// Contract hashes (same `contract_hash` space as
+        /// [`InterestMessage::Interests`]) whose summary bytes we need.
+        hashes: Vec<u32>,
+    },
 }
 
 /// Which code path built an [`InterestMessage::Summaries`] — a NON-WIRE
@@ -553,6 +607,21 @@ pub enum SummariesEmitter {
     /// `operations::update::send_summary_back_on_rejection` — one entry, only
     /// when a rejected broadcast's summary already matched ours.
     Rejection,
+    /// `node::handle_interest_sync_message`, replying to a `SummaryRequest`
+    /// with the bytes a digest could not settle (#4965).
+    ///
+    /// The one full-bytes send that hash-first ADDS rather than replaces, so
+    /// it gets its own arm: folded into `InterestsReply` it would look like
+    /// the heartbeat failing to shrink, when it is the mismatch tail doing
+    /// exactly what it is supposed to do.
+    SummaryRequestReply,
+    /// The `SummaryRequest` leg itself — a bare list of contract hashes, no
+    /// summaries (#4965).
+    ///
+    /// Carries no payload worth attributing, but is tagged anyway because the
+    /// per-emitter arms must SUM to `interest_sync_summaries`; an untagged
+    /// message would open a gap between the split and the arm it splits.
+    SummaryRequest,
     /// Residual: no emitter claimed this message. The `Default`, so it is also
     /// what a decoded inbound message carries.
     ///
@@ -591,6 +660,46 @@ impl SummaryEntry {
         self.summary_bytes
             .as_ref()
             .map(|bytes| freenet_stdlib::prelude::StateSummary::from(bytes.clone()))
+    }
+}
+
+/// The hash-first counterpart of [`SummaryEntry`]: identifies a contract and
+/// describes our summary of it, without carrying the summary.
+///
+/// The two fields are DIFFERENT hashes of different things and must not be
+/// conflated — see [`crate::ring::interest::summary_digest`] for the full
+/// contrast table.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SummaryDigestEntry {
+    /// Fast FNV-1a hash of the contract INSTANCE ID — identical in meaning and
+    /// value to [`SummaryEntry::hash`]. Says *which* contract; says nothing
+    /// about its state.
+    pub hash: u32,
+    /// Truncated-BLAKE3 digest of our summary BYTES for that contract, or
+    /// `None` if we're interested but hold no state yet. Says *what state* we
+    /// hold.
+    pub summary_digest: Option<crate::ring::interest::SummaryDigest>,
+}
+
+impl SummaryDigestEntry {
+    /// Build a digest entry from the full-bytes entry we would otherwise have
+    /// sent.
+    ///
+    /// This is deliberately the ONLY constructor: every digest is a pure
+    /// function of the exact `SummaryEntry` the fallback `Summaries` form
+    /// would have carried, so the two wire forms cannot describe different
+    /// state and no call site can compute a digest over something other than
+    /// the summary it is advertising. Those summaries in turn always come from
+    /// the node's ACTUAL state (`summary_if_hosted_or_in_use` /
+    /// `get_contract_summary`), never from a cached belief about a peer.
+    pub fn from_entry(entry: &SummaryEntry) -> Self {
+        Self {
+            hash: entry.hash,
+            summary_digest: entry
+                .summary_bytes
+                .as_deref()
+                .map(crate::ring::interest::summary_digest),
+        }
     }
 }
 
@@ -963,6 +1072,12 @@ impl Display for NodeEvent {
                     } => {
                         format!("ResyncResponse({key}, {} bytes)", state_bytes.len())
                     }
+                    InterestMessage::SummaryDigests { entries, emitter } => {
+                        format!("SummaryDigests({} entries, {emitter:?})", entries.len())
+                    }
+                    InterestMessage::SummaryRequest { hashes } => {
+                        format!("SummaryRequest({} hashes)", hashes.len())
+                    }
                 };
                 write!(f, "SendInterestMessage (to: {target}, {msg_summary})")
             }
@@ -1091,6 +1206,214 @@ const _: () = {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The bincode variant index of every pre-existing `InterestMessage`
+    /// variant, frozen (#4965).
+    ///
+    /// bincode encodes an enum variant as its POSITIONAL index, so inserting a
+    /// variant anywhere but the end renumbers everything after it. That is not
+    /// a compile error and not a deserialization error either — a peer on the
+    /// old build would decode a `Summaries` as a `ChangeInterests` and act on
+    /// garbage. This is the v0.2.11 incident class, and the whole reason the
+    /// hash-first variants are APPENDED.
+    ///
+    /// bincode's default config writes the index as a little-endian u32, so
+    /// the first four bytes of a serialized `InterestMessage` are its index.
+    #[test]
+    fn interest_message_wire_variant_indices_are_frozen() {
+        use freenet_stdlib::prelude::CodeHash;
+
+        fn variant_index(msg: &InterestMessage) -> u32 {
+            let bytes = bincode::serialize(msg).expect("serialize InterestMessage");
+            u32::from_le_bytes(bytes[..4].try_into().expect("variant index prefix"))
+        }
+
+        let key = ContractKey::from_id_and_code(
+            ContractInstanceId::new([1u8; 32]),
+            CodeHash::new([2u8; 32]),
+        );
+
+        // These five indices are on the wire of every released peer. Changing
+        // any of them is a protocol break; a new variant goes at the END.
+        assert_eq!(
+            variant_index(&InterestMessage::Interests { hashes: vec![1] }),
+            0,
+            "Interests must stay variant 0"
+        );
+        assert_eq!(
+            variant_index(&InterestMessage::Summaries {
+                entries: vec![SummaryEntry {
+                    hash: 1,
+                    summary_bytes: Some(vec![9]),
+                }],
+                emitter: SummariesEmitter::Other,
+            }),
+            1,
+            "Summaries must stay variant 1"
+        );
+        assert_eq!(
+            variant_index(&InterestMessage::ChangeInterests {
+                added: vec![1],
+                removed: vec![],
+            }),
+            2,
+            "ChangeInterests must stay variant 2"
+        );
+        assert_eq!(
+            variant_index(&InterestMessage::ResyncRequest { key }),
+            3,
+            "ResyncRequest must stay variant 3"
+        );
+        assert_eq!(
+            variant_index(&InterestMessage::ResyncResponse {
+                key,
+                state_bytes: vec![1],
+                summary_bytes: vec![2],
+            }),
+            4,
+            "ResyncResponse must stay variant 4"
+        );
+
+        // The hash-first additions occupy the next two slots. Pinned so a
+        // future insertion above them is caught here rather than in
+        // production: their indices are what
+        // `HASH_FIRST_SUMMARIES_MIN_VERSION` gates on being decodable.
+        assert_eq!(
+            variant_index(&InterestMessage::SummaryDigests {
+                entries: vec![],
+                emitter: SummariesEmitter::Other,
+            }),
+            5,
+            "SummaryDigests must stay variant 5 (appended, #4965)"
+        );
+        assert_eq!(
+            variant_index(&InterestMessage::SummaryRequest { hashes: vec![] }),
+            6,
+            "SummaryRequest must stay variant 6 (appended, #4965)"
+        );
+    }
+
+    /// The hash-first variants must survive a bincode round trip intact —
+    /// including the fixed-size digest array, which is the one field whose
+    /// encoding differs in kind from anything `SummaryEntry` carries.
+    #[test]
+    fn hash_first_variants_wire_roundtrip() {
+        let digest = crate::ring::interest::summary_digest(b"a summary");
+        let msg = InterestMessage::SummaryDigests {
+            emitter: SummariesEmitter::Other,
+            entries: vec![
+                SummaryDigestEntry {
+                    hash: 0xDEAD_BEEF,
+                    summary_digest: Some(digest),
+                },
+                SummaryDigestEntry {
+                    hash: 7,
+                    summary_digest: None,
+                },
+            ],
+        };
+        let bytes = bincode::serialize(&msg).expect("serialize SummaryDigests");
+        let decoded: InterestMessage =
+            bincode::deserialize(&bytes).expect("deserialize SummaryDigests");
+        match decoded {
+            InterestMessage::SummaryDigests { entries, .. } => {
+                assert_eq!(entries.len(), 2);
+                assert_eq!(entries[0].hash, 0xDEAD_BEEF);
+                assert_eq!(entries[0].summary_digest, Some(digest));
+                assert_eq!(entries[1].hash, 7);
+                assert_eq!(
+                    entries[1].summary_digest, None,
+                    "a peer with no state must round-trip as None, not as a \
+                     zero digest — a zero digest would read as a real summary \
+                     and could accidentally 'agree'"
+                );
+            }
+            other => panic!("expected SummaryDigests, got {other:?}"),
+        }
+
+        let req = InterestMessage::SummaryRequest {
+            hashes: vec![1, 2, 3],
+        };
+        let bytes = bincode::serialize(&req).expect("serialize SummaryRequest");
+        let decoded: InterestMessage =
+            bincode::deserialize(&bytes).expect("deserialize SummaryRequest");
+        match decoded {
+            InterestMessage::SummaryRequest { hashes } => assert_eq!(hashes, vec![1, 2, 3]),
+            other => panic!("expected SummaryRequest, got {other:?}"),
+        }
+    }
+
+    /// A `SummaryDigests` message must be dramatically smaller than the
+    /// `Summaries` it replaces — that is the entire point (#4965), and a
+    /// refactor that accidentally re-attached the bytes would otherwise pass
+    /// every behavioural test in this PR while saving nothing.
+    ///
+    /// Sized against a River-scale summary (~33 KB measured in production).
+    #[test]
+    fn digest_form_is_orders_of_magnitude_smaller_than_full_bytes() {
+        let summary = vec![0xABu8; 33 * 1024];
+        let entry = SummaryEntry {
+            hash: 42,
+            summary_bytes: Some(summary),
+        };
+        let full = bincode::serialize(&InterestMessage::Summaries {
+            entries: vec![entry.clone()],
+            emitter: SummariesEmitter::Other,
+        })
+        .expect("serialize Summaries");
+        let digests = bincode::serialize(&InterestMessage::SummaryDigests {
+            entries: vec![SummaryDigestEntry::from_entry(&entry)],
+            emitter: SummariesEmitter::Other,
+        })
+        .expect("serialize SummaryDigests");
+
+        assert!(
+            digests.len() < 64,
+            "one digest entry should be a few dozen bytes, got {}",
+            digests.len()
+        );
+        assert!(
+            full.len() > 100 * digests.len(),
+            "the digest form must be >100x smaller than the bytes form \
+             ({} vs {} bytes) — if this fails, the digest is carrying the \
+             summary and the wire change saves nothing",
+            digests.len(),
+            full.len()
+        );
+    }
+
+    /// `SummaryDigestEntry::from_entry` must be a pure function of the entry it
+    /// is derived from: same contract hash, and a digest that is exactly the
+    /// digest of the bytes the fallback `Summaries` would have shipped.
+    ///
+    /// This is what makes the two wire forms interchangeable. If they could
+    /// describe different state, a digest "match" would no longer prove the
+    /// peer holds our summary, and the heal-suppression on agreement would be
+    /// unsound.
+    #[test]
+    fn digest_entry_is_derived_from_the_bytes_it_replaces() {
+        let bytes = vec![1u8, 2, 3, 4, 5];
+        let entry = SummaryEntry {
+            hash: 99,
+            summary_bytes: Some(bytes.clone()),
+        };
+        let digest_entry = SummaryDigestEntry::from_entry(&entry);
+        assert_eq!(digest_entry.hash, entry.hash);
+        assert_eq!(
+            digest_entry.summary_digest,
+            Some(crate::ring::interest::summary_digest(&bytes))
+        );
+
+        let none_entry = SummaryEntry {
+            hash: 99,
+            summary_bytes: None,
+        };
+        assert_eq!(
+            SummaryDigestEntry::from_entry(&none_entry).summary_digest,
+            None,
+            "'we hold no state' must stay distinguishable from any digest value"
+        );
+    }
 
     #[test]
     fn subscribe_hint_wire_roundtrip_and_version() {

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -2220,8 +2220,9 @@ where
 /// cycle is re-detected and synced on a later cycle.
 ///
 /// Starvation avoidance: when the stale set exceeds the cap, the emission loop
-/// starts at a random offset and wraps (see the `rotate_left` in the `Summaries`
-/// arm), so the cap window slides across the whole stale set over successive
+/// starts at a random offset and wraps (see the `rotate_left` in
+/// `emit_stale_peer_syncs`, the helper both the `Summaries` and
+/// `SummaryDigests` arms share), so the cap window slides across the whole
 /// cycles instead of always re-processing the same prefix. Without this, a
 /// contract stuck in the leading `cap` positions — e.g. one whose
 /// `SyncStateToPeer` is dropped on a full channel, lost in transit, or not
@@ -3378,6 +3379,15 @@ async fn handle_interest_sync_message(
             // assumed away — same bounded, targeted emission as `Summaries`.
             emit_stale_peer_syncs(op_manager, source, stale_contracts).await;
 
+            // A contract on the mismatch path is confirmed TWICE: once here,
+            // once again when the requested bytes arrive at the `Summaries`
+            // arm. That is idempotent for the convergence checker by
+            // construction rather than by assumption — all three consumers
+            // (`testing_impl.rs:3712`, `:6535`, `simulation_integration.rs:4682`)
+            // fold into `BTreeMap<contract, BTreeMap<peer, hash>>` via
+            // `.insert(peer_addr, hash)`, so a repeat for the same
+            // (contract, peer) overwrites with the same value — or, if our
+            // state moved in between, with the newer and more correct one.
             for (key, state_hash) in confirmed_states {
                 if let Some(event) =
                     crate::tracing::NetEventLog::state_confirmed(&op_manager.ring, key, state_hash)

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -3461,6 +3461,15 @@ async fn handle_interest_sync_message(
             // A digest-match verdict of "stale" is not expected (the predicate
             // short-circuits on equal bytes) but is honoured rather than
             // assumed away — same bounded, targeted emission as `Summaries`.
+            //
+            // ACCEPTED COST, stated plainly: because agreement provably never
+            // heals, every heal that DOES happen on this leg now costs one
+            // extra round trip — the divergence is discovered from a digest,
+            // the bytes are requested, and only then does the `Summaries` arm
+            // run its staleness probe and emit. Against a ~300 s heartbeat a
+            // sub-second RTT is not a convergence risk, but it is a real
+            // regression in heal LATENCY on the legs that ship digests, and it
+            // is the price of not shipping the summary every cycle.
             emit_stale_peer_syncs(op_manager, source, stale_contracts).await;
 
             // A contract on the mismatch path is confirmed TWICE: once here,
@@ -3488,6 +3497,16 @@ async fn handle_interest_sync_message(
                 // contract and not one summary byte crossed the wire.
                 None
             } else {
+                // This is the ONE hash-first send with no version check, and
+                // it is safe by inference rather than by gate: a
+                // `SummaryRequest` is only ever emitted in reply to a
+                // `SummaryDigests` we just decoded, and we only receive one
+                // from a peer that chose the digest encoding — which it can
+                // only do if it read OUR version as at-or-above the floor and
+                // carries the variants itself. So the sender is necessarily
+                // capable of decoding the reply. Gating here would be
+                // redundant; NOT recording the inference would leave the next
+                // reader to wonder whether it was an oversight.
                 crate::config::GlobalTestMetrics::record_summary_byte_request();
                 Some(InterestMessage::SummaryRequest {
                     hashes: request_hashes,

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -64,7 +64,7 @@ pub(crate) use network_bridge::broadcast_queue::BROADCAST_STREAM_METRICS;
 // re-export rather than a path through `network_bridge` directly. Mirrors
 // `BROADCAST_STREAM_METRICS` above.
 pub(crate) use network_bridge::p2p_protoc::{
-    HASH_FIRST_SUMMARIES_MIN_VERSION, SUMMARY_FIRST_PUT_MIN_VERSION,
+    HASH_FIRST_SHIPPED_IN, HASH_FIRST_SUMMARIES_MIN_VERSION, SUMMARY_FIRST_PUT_MIN_VERSION,
     version_supports_hash_first_summaries, version_supports_summary_first_put,
 };
 #[cfg(test)]
@@ -2270,10 +2270,45 @@ fn stale_sync_emit_budget(stale_contracts_len: usize) -> usize {
 /// the same reason: `get_matching_contracts` sorts by contract id, so a fixed
 /// prefix would starve the tail forever).
 ///
-/// 256 is deliberately far above the handful of contracts a healthy pair
-/// actually shares (and 8x the 32-contract heal budget that gates the outcome
-/// of any request), so it binds only on abuse.
-const MAX_SUMMARY_HASHES_PER_MESSAGE: usize = 256;
+/// # Why 4096, measured rather than guessed
+///
+/// This constant was 256, chosen on the assumption that "a healthy pair shares
+/// a handful of contracts". **Production telemetry says otherwise.**
+/// `hosting_contract_count` over 16,578 samples from the deployed collector:
+///
+/// | p50 | p75 | p90 | p95 | p99 | max |
+/// |-----|-----|-----|-----|-----|-----|
+/// | 417 | 698 | 825 | 976 | 2463 | 2814 |
+///
+/// **73% of samples exceed 256.** A median peer hosts 417 contracts, so the
+/// old value would have bound on the common case, not the abuse case.
+///
+/// The reason this was not obvious from the bandwidth data — and the reason
+/// the byte metrics everyone had been staring at could not have revealed it —
+/// is that **entry count is decoupled from message size**:
+/// `summary_if_hosted_or_in_use` returns `None` for any contract the responder
+/// does not host-or-serve, and a `None` entry costs ~5 bytes on the wire. A
+/// pair sharing 400 contracts of which the responder hosts a handful produces
+/// a CHEAP 400-entry message. Byte size bounds nothing here.
+///
+/// 4096 clears the observed maximum (2814) with headroom. The counter that
+/// measures this directly per message, `summaries_entries` (#5061), ships in
+/// this same release and is the ongoing field validation.
+///
+/// # What the cap is, and is not
+///
+/// It is a **backstop, not the operative bound.** The sender's entry count is
+/// naturally bounded by its own tracked set (`get_matching_contracts` iterates
+/// the responder's hash index), and the expensive receive-side work is bounded
+/// the same way: `lookup_by_hash` can only resolve contracts WE already track,
+/// so a peer cannot make us summarize something we do not have. What this cap
+/// actually bounds is a per-entry DashMap-get loop — cheap, which is why a
+/// generous value costs nothing.
+///
+/// There is no send-side chunking at this value; all three uses are
+/// receive-side (the `SummaryDigests` window and the `SummaryRequest` answer),
+/// so the constant moves them together and cannot be raised on one side only.
+const MAX_SUMMARY_HASHES_PER_MESSAGE: usize = 4096;
 
 /// Per-`Summaries`-message cap on semantic-staleness probes — the WASM
 /// `get_state_delta` calls the `Summaries` handler issues to decide, for a
@@ -2713,6 +2748,20 @@ fn classify_summary_digest(
 /// [`crate::node::HASH_FIRST_SUMMARIES_MIN_VERSION`]): the fallback is what
 /// every peer does today, so the cost of guessing wrong is bandwidth, never
 /// convergence.
+///
+/// # Only the two MULTI-ENTRY reply legs use this (#4965 review §2)
+///
+/// `InterestsReply` and `ChangeInterestsReply` route through here. The two
+/// single-entry legs — `Notification` and `Rejection` — call
+/// [`full_summaries_message`] directly and ship full bytes this release.
+///
+/// The reason is evidential, not technical: the 98.1% agreement rate that
+/// justifies hash-first was measured on a heartbeat-dominated population, and
+/// the state-change-driven legs are the population least likely to agree
+/// (their receivers may not have applied the update yet). A mismatch turns 1
+/// message into 3 for the same bytes, which is the wrong direction on the
+/// #4861 messages/s axis. Extend to those legs once the agreement counters
+/// give a field reading.
 pub(crate) fn summaries_reply_for_peer(
     op_manager: &OpManager,
     target: std::net::SocketAddr,
@@ -3039,6 +3088,11 @@ async fn handle_interest_sync_message(
                 // already tracks, so a peer cannot grow it with unknown ids —
                 // and it holds contract ids only, no state.
                 let mut compared_contracts: HashSet<ContractInstanceId> = HashSet::new();
+                // Separate dedup set from `compared_contracts`: a contract is
+                // either a two-sided comparison or a one-sided observation,
+                // never both in one message, and sharing one set would let the
+                // first kind silence the second.
+                let mut one_sided_counted: HashSet<ContractInstanceId> = HashSet::new();
                 for entry in entries {
                     for contract in op_manager.interest_manager.lookup_by_hash(entry.hash) {
                         if !op_manager.interest_manager.has_local_interest(&contract) {
@@ -3145,6 +3199,21 @@ async fn handle_interest_sync_message(
                             }
                             // One side has no summary => no basis to heal
                             // (unchanged from the prior `.zip()` semantics).
+                            //
+                            // #4965 review S2: count the WE-have-nothing /
+                            // THEY-have-something case. It was never in the
+                            // 98.1%-identical denominator (that counted only
+                            // `(Some, Some)`), and it is not neutral under
+                            // hash-first — it classifies as `NeedBytes`, so it
+                            // costs +2 messages for bytes this path delivers
+                            // immediately. Sizing it keeps the headline honest.
+                            (None, Some(_)) => {
+                                op_manager.outbound_mix.record_summary_one_sided(
+                                    contract.id(),
+                                    &mut one_sided_counted,
+                                );
+                                false
+                            }
                             _ => false,
                         };
 
@@ -3277,6 +3346,8 @@ async fn handle_interest_sync_message(
                 let single_entry = entries.len() == 1;
                 let mut seen_hashes: HashSet<u32> = HashSet::new();
                 let mut compared_contracts: HashSet<ContractInstanceId> = HashSet::new();
+                // See the sibling set in the `Summaries` arm.
+                let mut one_sided_counted: HashSet<ContractInstanceId> = HashSet::new();
                 for entry in entries {
                     if seen_hashes.len() >= MAX_SUMMARY_HASHES_PER_MESSAGE {
                         break;
@@ -3364,6 +3435,19 @@ async fn handle_interest_sync_message(
                                 crate::config::GlobalTestMetrics::record_summary_digest_mismatch(
                                     single_entry,
                                 );
+                                // #4965 review S2: separate "we hold nothing,
+                                // they do" from a genuine digest disagreement.
+                                // Only the former sat outside the 98.1%
+                                // denominator, and it is the one costing +2
+                                // messages for bytes the full-bytes path
+                                // shipped immediately (and used to seed our
+                                // peer-summary cache).
+                                if our_summary.is_none() {
+                                    op_manager.outbound_mix.record_summary_one_sided(
+                                        contract.id(),
+                                        &mut one_sided_counted,
+                                    );
+                                }
                                 needs_bytes = true;
                             }
                         }
@@ -4360,6 +4444,33 @@ mod tests {
     use super::*;
     use rstest::rstest;
 
+    /// Strip `//` comment lines from a source window before asserting on it.
+    ///
+    /// Load-bearing, not tidiness. Source-scrape pins assert that an arm CALLS
+    /// something; the identifiers they search for also appear in that arm's own
+    /// explanatory comments, so an unstripped window is satisfied by PROSE.
+    ///
+    /// Two pins in this file were vacuous for exactly this reason:
+    /// `digest_arm_shares_the_single_heal_path` (its window's comments name
+    /// `summary_indicates_stale_peer` and `record_summary_comparison`), and
+    /// `summaries_arm_uses_semantic_staleness_probe_pin` (whose CORRECT window
+    /// still carries comment mentions of `plan_staleness_probe` at node.rs:3032
+    /// and `summary_indicates_stale_peer` at :3074/:3135, alongside the real
+    /// calls at :3095/:3115/:3123/:3140).
+    ///
+    /// Note this is only ONE of the two guards a scrape pin needs. The sibling
+    /// guard is on the NEEDLE — `concat!("record_summary", "_comparison")` — so
+    /// the assertion's own source cannot satisfy its own scrape. Needle guard
+    /// and window guard defend against different self-matches; a pin wants
+    /// both. See #5076.
+    fn code_only(window: &str) -> String {
+        window
+            .lines()
+            .filter(|l| !l.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
     /// Source-level pins for the three log sites in this file that were
     /// demoted / format-fixed in PR #4252 for issue #4251.
     ///
@@ -4624,9 +4735,18 @@ mod tests {
         // the positive assertions below would have kept passing with those
         // calls deleted from `Summaries` itself.
         let next_off = src[handler_start..]
-            .find("InterestMessage::SummaryDigests { entries }")
+            // `{ entries, .. }`, matching the REAL arm at node.rs:3203. The
+            // bare `{ entries }` form appears NOWHERE in this file except this
+            // line, so `include_str!` made the needle match ITSELF: the window
+            // became 2995..4627 (~1632 lines) instead of ~208, swallowing the
+            // digest arm's own calls and this pin's rustdoc, either of which
+            // satisfies all four assertions with the true `Summaries` arm's
+            // calls deleted. A needle must be verified to resolve to the
+            // INTENDED line, not merely to resolve somewhere (#5076).
+            .find("InterestMessage::SummaryDigests { entries, .. } => {")
             .expect("SummaryDigests arm not found");
-        let summaries_arm = &src[handler_start + summaries_off..handler_start + next_off];
+        let summaries_arm =
+            &code_only(&src[handler_start + summaries_off..handler_start + next_off]);
 
         // #4965: the measurement call must stay wired into this arm. It is
         // pure observation, so deleting it breaks no test and no behavior —
@@ -8629,33 +8749,6 @@ mod tests {
                 }
                 other => panic!("expected Summaries for the one known hash, got {other:?}"),
             }
-        }
-
-        /// Strip `//` comment lines from a source window before asserting on
-        /// it.
-        ///
-        /// Load-bearing, not tidiness. These pins assert that the arm CALLS
-        /// something; the identifiers they search for also appear in the arm's
-        /// own explanatory comments, so an unstripped window is satisfied by
-        /// PROSE. `digest_arm_shares_the_single_heal_path` was exactly that:
-        /// `summary_indicates_stale_peer` and `record_summary_comparison` both
-        /// appear in comments inside its window, so deleting both calls left it
-        /// green — and the mutation is silent everywhere else, since
-        /// `record_summary_comparison` is pure observation and
-        /// `summary_indicates_stale_peer(&ours, &ours, None)` provably returns
-        /// `false`, so `let is_stale = false;` compiles and breaks nothing.
-        ///
-        /// The sibling pins already guarded the ASSERTION's own source from
-        /// self-matching (via `concat!`); this guards the SCANNED WINDOW, which
-        /// is the half that was missed. Verified by mutation: with the
-        /// predicate call replaced by `let is_stale = false;` and the prose
-        /// left intact, the pin now fails.
-        fn code_only(window: &str) -> String {
-            window
-                .lines()
-                .filter(|l| !l.trim_start().starts_with("//"))
-                .collect::<Vec<_>>()
-                .join("\n")
         }
 
         /// Source pin: production code must never construct

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -64,7 +64,8 @@ pub(crate) use network_bridge::broadcast_queue::BROADCAST_STREAM_METRICS;
 // re-export rather than a path through `network_bridge` directly. Mirrors
 // `BROADCAST_STREAM_METRICS` above.
 pub(crate) use network_bridge::p2p_protoc::{
-    SUMMARY_FIRST_PUT_MIN_VERSION, version_supports_summary_first_put,
+    HASH_FIRST_SUMMARIES_MIN_VERSION, SUMMARY_FIRST_PUT_MIN_VERSION,
+    version_supports_hash_first_summaries, version_supports_summary_first_put,
 };
 #[cfg(test)]
 pub(crate) use network_bridge::{EventLoopNotificationsReceiver, event_loop_notification_channel};
@@ -2217,6 +2218,29 @@ fn stale_sync_emit_budget(stale_contracts_len: usize) -> usize {
     stale_contracts_len.min(MAX_STALE_SYNCS_PER_SUMMARIES)
 }
 
+/// Per-message cap on how many DISTINCT contract hashes the hash-first
+/// handlers will process — both the `SummaryDigests` entries we examine and
+/// the `SummaryRequest` hashes we answer (#4965).
+///
+/// A digest entry costs the SENDER ~20 bytes and can cost the RECEIVER a
+/// `summary_if_hosted_or_in_use` round trip, which is an amplification ratio
+/// the full-bytes `Summaries` never had: there, an entry cost the sender a
+/// whole `StateSummary`. The cap restores a bound. It is per-message and per
+/// DISTINCT hash: a peer repeating one hash is deduplicated before any work,
+/// so repetition buys nothing.
+///
+/// Over-cap contracts are not dropped permanently — the ~5-min interest
+/// heartbeat re-advertises them, and the `SummaryDigests` arm rotates its
+/// starting offset when the cap binds (the same random-rotation starvation
+/// argument [`MAX_STALE_SYNCS_PER_SUMMARIES`] makes, which matters here for
+/// the same reason: `get_matching_contracts` sorts by contract id, so a fixed
+/// prefix would starve the tail forever).
+///
+/// 256 is deliberately far above the handful of contracts a healthy pair
+/// actually shares (and 8x the 32-contract heal budget that gates the outcome
+/// of any request), so it binds only on abuse.
+const MAX_SUMMARY_HASHES_PER_MESSAGE: usize = 256;
+
 /// Per-`Summaries`-message cap on semantic-staleness probes — the WASM
 /// `get_state_delta` calls the `Summaries` handler issues to decide, for a
 /// byte-differing summary, whether a peer is genuinely stale (#4857 secondary
@@ -2590,11 +2614,206 @@ fn stale_peer_sync_event(
     }
 }
 
+/// What a peer's advertised summary digest tells us about that contract.
+///
+/// Pure classification of one [`crate::message::SummaryDigestEntry`] against
+/// OUR OWN summary, factored out so the one comparison the whole hash-first
+/// exchange rests on is unit-testable without a node.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DigestVerdict {
+    /// The peer's digest equals a digest of our own summary, so we know their
+    /// summary bytes without them sending any: they are ours.
+    ///
+    /// This is the 98.1% case (#4965) and the entire point of the exchange.
+    Agree,
+    /// The peer reported no summary at all (`summary_digest: None`) — they are
+    /// interested but hold no state. Identical in meaning to a
+    /// `SummaryEntry { summary_bytes: None }`, and handled identically: clear
+    /// our cached summary for them, no heal (there is no divergence to heal
+    /// when one side has nothing).
+    PeerHasNoState,
+    /// We cannot settle this entry from the digest alone and must ask for the
+    /// bytes. Either the digests differ (real divergence, or a
+    /// non-deterministically-serialized summary), or the peer has a summary
+    /// and we do not — in which case we still need their bytes to seed the
+    /// peer-summary cache (#4952) and keep them off the full-state broadcast
+    /// path.
+    NeedBytes,
+}
+
+/// Classify one advertised digest against our own summary.
+///
+/// Both inputs come from FACT, never belief: `our_summary` is this node's
+/// actual state summary (`summary_if_hosted_or_in_use`), and `their_digest` is
+/// what the peer computed from its actual state. The cached
+/// `PeerInterest.summary` — our *belief* about the peer — is deliberately not
+/// consulted, because every failure anti-entropy exists to repair is precisely
+/// that belief being wrong.
+fn classify_summary_digest(
+    our_summary: Option<&freenet_stdlib::prelude::StateSummary<'static>>,
+    their_digest: Option<&crate::ring::interest::SummaryDigest>,
+) -> DigestVerdict {
+    match (our_summary, their_digest) {
+        (_, None) => DigestVerdict::PeerHasNoState,
+        (None, Some(_)) => DigestVerdict::NeedBytes,
+        (Some(ours), Some(theirs)) => {
+            if crate::ring::interest::summary_digest(ours.as_ref()) == *theirs {
+                DigestVerdict::Agree
+            } else {
+                DigestVerdict::NeedBytes
+            }
+        }
+    }
+}
+
+/// Choose the wire form for a `Summaries` reply aimed at `target`: the
+/// hash-first [`InterestMessage::SummaryDigests`] when the peer is new enough
+/// to decode it, otherwise the full-bytes [`InterestMessage::Summaries`].
+///
+/// The digest form is derived from the very `SummaryEntry` values we would
+/// otherwise have sent, so the two forms cannot describe different state: the
+/// digest is a pure function of the exact bytes the fallback carries. Callers
+/// therefore build entries exactly as before and let this decide the encoding.
+///
+/// Fail-closed on an unknown peer version (see
+/// [`crate::node::HASH_FIRST_SUMMARIES_MIN_VERSION`]): the fallback is what
+/// every peer does today, so the cost of guessing wrong is bandwidth, never
+/// convergence.
+pub(crate) fn summaries_reply_for_peer(
+    op_manager: &OpManager,
+    target: std::net::SocketAddr,
+    entries: Vec<crate::message::SummaryEntry>,
+    emitter: crate::message::SummariesEmitter,
+) -> crate::message::InterestMessage {
+    use crate::message::{InterestMessage, SummaryDigestEntry};
+
+    if op_manager
+        .ring
+        .connection_manager
+        .supports_hash_first_summaries(target)
+    {
+        InterestMessage::SummaryDigests {
+            entries: entries.iter().map(SummaryDigestEntry::from_entry).collect(),
+            emitter,
+        }
+    } else {
+        InterestMessage::Summaries { entries, emitter }
+    }
+}
+
+/// Emit targeted `SyncStateToPeer` heals for the contracts on which `source`
+/// was found stale, bounded by [`stale_sync_emit_budget`].
+///
+/// Extracted from the `Summaries` arm so the `SummaryDigests` arm shares the
+/// IDENTICAL heal path rather than growing a second copy that can drift. The
+/// hash-first exchange must not cost convergence, so there is exactly one
+/// implementation of "we decided this peer is stale, now fix it".
+async fn emit_stale_peer_syncs(
+    op_manager: &Arc<OpManager>,
+    source: std::net::SocketAddr,
+    mut stale_contracts: Vec<freenet_stdlib::prelude::ContractKey>,
+) {
+    // #3798 Gap 1: cap the number of SyncStateToPeer events emitted per
+    // message so a peer diverging on many contracts cannot trigger an
+    // unbounded burst in one handler call. `emit_budget` bounds *emitted*
+    // events (not loop iterations) — banned and no-local-state contracts are
+    // skipped without consuming the budget. Overflow is not dropped
+    // permanently: each later heartbeat re-derives the still-stale set from
+    // the durable summary comparison and syncs the next batch (see
+    // MAX_STALE_SYNCS_PER_SUMMARIES rustdoc for the eventual-consistency
+    // argument).
+    let total_stale = stale_contracts.len();
+    let emit_budget = stale_sync_emit_budget(total_stale);
+    // Starvation avoidance: when the stale set exceeds the cap, rotate the
+    // start of the iteration by a random offset so the cap window slides
+    // across the whole set over successive cycles. Without this, a contract
+    // stuck in the leading `cap` positions (dropped emit, lost packet, peer
+    // fails to apply) would re-consume the budget every cycle and permanently
+    // starve everything past the cap. No rotation when total_stale <= cap —
+    // every contract is emitted anyway, so the order does not matter.
+    // GlobalRng keeps this deterministic under simulation/test.
+    if total_stale > emit_budget {
+        let start = crate::config::GlobalRng::random_range(0..total_stale);
+        stale_contracts.rotate_left(start);
+    }
+    let mut emitted = 0usize;
+    for contract in stale_contracts {
+        if emitted >= emit_budget {
+            // Cap reached; the still-stale remainder (any that are not
+            // banned / have local state) is re-detected and synced on a
+            // subsequent interest-sync cycle rather than emitted now.
+            tracing::warn!(
+                stale_peer = %source,
+                total_stale,
+                emitted,
+                cap = MAX_STALE_SYNCS_PER_SUMMARIES,
+                "Stale-contract sync cap hit for Summaries message; \
+                 deferring the remainder to a later interest-sync cycle"
+            );
+            break;
+        }
+        // Phase 7 egress gate. Don't repair a stale peer's summary mismatch by
+        // pushing state for a contract we have banned — same rationale as the
+        // inbound wire-boundary drop, applied to the proactive heal path.
+        if op_manager.ring.contract_ban_list.is_banned(contract.id()) {
+            tracing::debug!(
+                %contract,
+                stale_peer = %source,
+                phase = "interest_sync_banned_skip",
+                "skipping summary-mismatch sync for banned contract"
+            );
+            continue;
+        }
+        let Some(state) = get_contract_state(op_manager, &contract).await else {
+            tracing::trace!(
+                contract = %contract,
+                "Skipping stale-peer sync — no local state available"
+            );
+            continue;
+        };
+        // Count this contract against the emit budget: it has local state and
+        // is not banned, so we are about to emit a SyncStateToPeer event for
+        // it. Increment before the emit so a channel-full drop still consumes
+        // the budget — the dropped event is retried next cycle exactly like an
+        // over-cap one.
+        emitted += 1;
+        // Fires per stale-peer detection during interest sync, which is
+        // dominant on hot contracts. Diagnostic-grade rather than
+        // user-actionable; keep accessible via RUST_LOG=…=debug.
+        tracing::debug!(
+            contract = %contract,
+            stale_peer = %source,
+            "Summary mismatch in interest sync — syncing state to stale peer"
+        );
+        // Non-blocking emit: SyncStateToPeer is best-effort gossip — if
+        // dropped, the next interest-sync round will retry. Blocking here
+        // would stack the heal path on the same notification channel the
+        // executor is trying to keep responsive (#4145 / #4234).
+        // Targeted heal: `stale_peer_sync_event` builds a `SyncStateToPeer`
+        // aimed at exactly `source`, NEVER an all-subscriber fan-out. Pinned
+        // by `stale_peer_sync_event_is_targeted_not_broadcast` (#3791/#3796).
+        if let Err(e) =
+            op_manager.try_notify_node_event(stale_peer_sync_event(contract, state, source))
+        {
+            // Best-effort by design (see comment above); log at debug to keep
+            // the caller layer in step with the helper-internal downgrade
+            // (#4238).
+            tracing::debug!(
+                contract = %contract,
+                error = %e,
+                "Failed to emit SyncStateToPeer for stale peer correction (best-effort)"
+            );
+        }
+    }
+}
+
 /// Handle incoming InterestSync messages for delta-based state synchronization.
 ///
 /// This function processes the interest exchange protocol:
 /// - `Interests`: Connection-time discovery of shared contract interests
 /// - `Summaries`: State summaries for shared contracts
+/// - `SummaryDigests`: hash-first advertisement of those same summaries (#4965)
+/// - `SummaryRequest`: the bytes-on-mismatch follow-up to `SummaryDigests`
 /// - `ChangeInterests`: Incremental interest changes
 /// - `ResyncRequest`: Request full state when delta application fails
 async fn handle_interest_sync_message(
@@ -2697,13 +2916,17 @@ async fn handle_interest_sync_message(
             if entries.is_empty() {
                 None
             } else {
-                Some(InterestMessage::Summaries {
+                // #5052: the heartbeat reply — MULTI-entry, one per shared
+                // advertised contract, on every `Interests` received. #4965
+                // is the change #5052 anticipated here: this emitter now sends
+                // DIGESTS to a capable peer, and the tag rides the full-bytes
+                // fallback so the per-emitter rollup keeps attributing it.
+                Some(summaries_reply_for_peer(
+                    op_manager,
+                    source,
                     entries,
-                    // #5052: the heartbeat reply — MULTI-entry, one per shared
-                    // advertised contract, on every `Interests` received. This
-                    // is the emitter hash-first (#4965) would change.
-                    emitter: SummariesEmitter::InterestsReply,
-                })
+                    SummariesEmitter::InterestsReply,
+                ))
             }
         }
 
@@ -2894,105 +3117,9 @@ async fn handle_interest_sync_message(
             // summary. Previously this emitted BroadcastStateChange which fanned
             // out to ALL subscribers (~28 peers), causing O(peers^2) traffic when
             // many peers reported mismatches within the same heartbeat cycle.
-            //
-            // #3798 Gap 1: cap the number of SyncStateToPeer events emitted per
-            // Summaries message so a peer diverging on many contracts cannot
-            // trigger an unbounded burst in one handler call. `emit_budget`
-            // bounds *emitted* events (not loop iterations) — banned and
-            // no-local-state contracts are skipped without consuming the
-            // budget. Overflow is not dropped permanently: each later
-            // heartbeat re-derives the still-stale set from the durable summary
-            // comparison above and syncs the next batch (see
-            // MAX_STALE_SYNCS_PER_SUMMARIES rustdoc for the eventual-consistency
-            // argument).
-            let total_stale = stale_contracts.len();
-            let emit_budget = stale_sync_emit_budget(total_stale);
-            // Starvation avoidance: when the stale set exceeds the cap, rotate
-            // the start of the iteration by a random offset so the cap window
-            // slides across the whole set over successive cycles. Without this,
-            // a contract stuck in the leading `cap` positions (dropped emit,
-            // lost packet, peer fails to apply) would re-consume the budget
-            // every cycle and permanently starve everything past the cap. No
-            // rotation when total_stale <= cap — every contract is emitted
-            // anyway, so the order does not matter. GlobalRng keeps this
-            // deterministic under simulation/test.
-            if total_stale > emit_budget {
-                let start = crate::config::GlobalRng::random_range(0..total_stale);
-                stale_contracts.rotate_left(start);
-            }
-            let mut emitted = 0usize;
-            for contract in stale_contracts {
-                if emitted >= emit_budget {
-                    // Cap reached; the still-stale remainder (any that are not
-                    // banned / have local state) is re-detected and synced on a
-                    // subsequent interest-sync cycle rather than emitted now.
-                    tracing::warn!(
-                        stale_peer = %source,
-                        total_stale,
-                        emitted,
-                        cap = MAX_STALE_SYNCS_PER_SUMMARIES,
-                        "Stale-contract sync cap hit for Summaries message; \
-                         deferring the remainder to a later interest-sync cycle"
-                    );
-                    break;
-                }
-                // Phase 7 egress gate. Don't repair a stale peer's
-                // summary mismatch by pushing state for a contract
-                // we have banned — same rationale as the inbound
-                // wire-boundary drop, applied to the proactive heal
-                // path.
-                if op_manager.ring.contract_ban_list.is_banned(contract.id()) {
-                    tracing::debug!(
-                        %contract,
-                        stale_peer = %source,
-                        phase = "interest_sync_banned_skip",
-                        "skipping summary-mismatch sync for banned contract"
-                    );
-                    continue;
-                }
-                let Some(state) = get_contract_state(op_manager, &contract).await else {
-                    tracing::trace!(
-                        contract = %contract,
-                        "Skipping stale-peer sync — no local state available"
-                    );
-                    continue;
-                };
-                // Count this contract against the emit budget: it has local
-                // state and is not banned, so we are about to emit a
-                // SyncStateToPeer event for it. Increment before the emit so a
-                // channel-full drop still consumes the budget — the dropped
-                // event is retried next cycle exactly like an over-cap one.
-                emitted += 1;
-                // Fires per stale-peer detection during interest sync, which
-                // is dominant on hot contracts. Diagnostic-grade rather than
-                // user-actionable; keep accessible via RUST_LOG=…=debug.
-                tracing::debug!(
-                    contract = %contract,
-                    stale_peer = %source,
-                    "Summary mismatch in interest sync — syncing state to stale peer"
-                );
-                // Non-blocking emit: SyncStateToPeer is best-effort
-                // gossip — if dropped, the next interest-sync round
-                // will retry. Blocking here would stack the heal
-                // path on the same notification channel the executor
-                // is trying to keep responsive (#4145 / #4234).
-                // Targeted heal: `stale_peer_sync_event` builds a
-                // `SyncStateToPeer` aimed at exactly `source`, NEVER an
-                // all-subscriber fan-out. Pinned by
-                // `stale_peer_sync_event_is_targeted_not_broadcast` (#3791/#3796).
-                if let Err(e) =
-                    op_manager.try_notify_node_event(stale_peer_sync_event(contract, state, source))
-                {
-                    // Best-effort by design (see comment above); log
-                    // at debug to keep the caller layer in step with
-                    // the helper-internal downgrade (#4238).
-                    tracing::debug!(
-                        contract = %contract,
-                        error = %e,
-                        "Failed to emit SyncStateToPeer for stale peer correction (best-effort)"
-                    );
-                }
-            }
+            // The bounded, targeted emission lives in `emit_stale_peer_syncs`,
+            // shared verbatim with the `SummaryDigests` arm.
+            emit_stale_peer_syncs(op_manager, source, stale_contracts).await;
 
             // Emit deferred StateConfirmed telemetry so the convergence
             // checker has up-to-date state hashes for CRDT-merged state.
@@ -3009,6 +3136,249 @@ async fn handle_interest_sync_message(
 
             // No response needed for Summaries
             None
+        }
+
+        InterestMessage::SummaryDigests { entries, .. } => {
+            tracing::debug!(
+                from = %source,
+                entry_count = entries.len(),
+                "Received SummaryDigests message"
+            );
+
+            // Hash-first half of the summary exchange (#4965).
+            //
+            // The peer told us what its summaries HASH to instead of shipping
+            // them. For each entry we compute OUR OWN summary from actual
+            // local state — exactly as the `Summaries` arm does — and compare.
+            //
+            // # This does not short-circuit the heal
+            //
+            // A digest match proves the peer's summary bytes EQUAL ours. That
+            // is the same input the `Summaries` arm's staleness check gets, so
+            // this arm runs that check for real rather than assuming its
+            // answer: `record_summary_comparison` is called with the operands
+            // it would have been called with, `summary_indicates_stale_peer`
+            // is invoked, and a `true` verdict lands in the SAME
+            // `emit_stale_peer_syncs` the `Summaries` arm uses. Nothing is
+            // skipped on the strength of "identical summaries are never
+            // stale"; that stays a property of the predicate, not an
+            // assumption baked in here.
+            //
+            // Everything the digest CANNOT settle — differing digests, or a
+            // peer holding state we don't — is answered with a
+            // `SummaryRequest`, and the bytes come back as a plain
+            // `Summaries` that runs the untouched original handler, including
+            // its semantic (`get_state_delta`) staleness probe. Divergence
+            // therefore costs one extra round trip (sub-second) against a
+            // ~5-min heartbeat, and is never silently dropped. If the request
+            // or its answer IS lost, the contract simply stays diverged until
+            // the next heartbeat re-advertises it — the same outcome a lost
+            // `Summaries` has today, not a new failure mode.
+            //
+            // Telemetry note: the #4965 identical/differing counters are
+            // recorded on AGREEMENT here and on ARRIVAL of the requested bytes
+            // in the `Summaries` arm, so each contract is counted exactly once
+            // per exchange. A request whose answer never arrives is the one
+            // case that goes uncounted, biasing the ratio very slightly toward
+            // "identical"; read the counters as a floor on the agreement rate,
+            // not a point estimate.
+            let peer_key = get_peer_key_from_addr(op_manager, source);
+            let mut stale_contracts = Vec::new();
+            let emit_confirmed = crate::config::SimulationIdleTimeout::is_enabled();
+            let mut confirmed_states: Vec<(freenet_stdlib::prelude::ContractKey, String)> =
+                Vec::new();
+            let mut request_hashes: Vec<u32> = Vec::new();
+
+            if let Some(pk) = peer_key {
+                // See `MAX_SUMMARY_HASHES_PER_MESSAGE`: entries are
+                // peer-supplied and cheap for the peer to fabricate, so
+                // deduplicate by hash and process a bounded window. The window
+                // starts at a random offset when the cap binds, for the same
+                // starvation reason `emit_stale_peer_syncs` rotates — a
+                // sender's entries arrive in contract-id order, so a fixed
+                // prefix would starve the tail on every cycle forever.
+                let mut entries = entries;
+                if entries.len() > MAX_SUMMARY_HASHES_PER_MESSAGE {
+                    let start = crate::config::GlobalRng::random_range(0..entries.len());
+                    entries.rotate_left(start);
+                }
+                let mut seen_hashes: HashSet<u32> = HashSet::new();
+                let mut compared_contracts: HashSet<ContractInstanceId> = HashSet::new();
+                for entry in entries {
+                    if seen_hashes.len() >= MAX_SUMMARY_HASHES_PER_MESSAGE {
+                        break;
+                    }
+                    if !seen_hashes.insert(entry.hash) {
+                        continue;
+                    }
+                    // One hash can resolve to several contracts (FNV-1a
+                    // collisions), and any one of them needing bytes is enough
+                    // to ask — but the hash goes on the request list at most
+                    // once, so the reply cannot be inflated by collisions.
+                    let mut needs_bytes = false;
+                    for contract in op_manager.interest_manager.lookup_by_hash(entry.hash) {
+                        if !op_manager.interest_manager.has_local_interest(&contract) {
+                            continue;
+                        }
+
+                        // Our ACTUAL summary, from the same gated helper the
+                        // `Summaries` arm uses (#4473). Never the cached
+                        // `PeerInterest.summary`: that is our belief about the
+                        // peer, and repairing a wrong belief is the entire job
+                        // of this exchange.
+                        let our_summary = summary_if_hosted_or_in_use(op_manager, &contract).await;
+
+                        if emit_confirmed {
+                            if let Some(ref summary) = our_summary {
+                                confirmed_states.push((contract, hex::encode(summary.as_ref())));
+                            }
+                        }
+
+                        match classify_summary_digest(
+                            our_summary.as_ref(),
+                            entry.summary_digest.as_ref(),
+                        ) {
+                            DigestVerdict::Agree => {
+                                // The digest proves their summary bytes are
+                                // ours, so hand the staleness machinery those
+                                // bytes and let it decide, exactly as the
+                                // `Summaries` arm would have.
+                                let ours = our_summary
+                                    .expect("DigestVerdict::Agree is only reachable with Some");
+                                op_manager.outbound_mix.record_summary_comparison(
+                                    contract.id(),
+                                    ours.as_ref(),
+                                    ours.as_ref(),
+                                    &mut compared_contracts,
+                                );
+                                // `None` delta verdict: there is nothing to
+                                // probe. `summary_indicates_stale_peer` sees
+                                // byte-equal summaries and never reaches the
+                                // verdict — the same path a byte-identical
+                                // `SummaryEntry` takes today.
+                                let is_stale = crate::ring::interest::summary_indicates_stale_peer(
+                                    &ours, &ours, None,
+                                );
+                                // #4952: seed the peer-summary cache so an
+                                // advertised co-host does not stay a
+                                // full-state broadcast target. Fact, not
+                                // belief: the digest established that these
+                                // bytes are what the peer holds.
+                                op_manager
+                                    .interest_manager
+                                    .upsert_peer_summary(&contract, &pk, ours);
+                                if is_stale && !stale_contracts.contains(&contract) {
+                                    stale_contracts.push(contract);
+                                }
+                            }
+                            DigestVerdict::PeerHasNoState => {
+                                // Same handling a `SummaryEntry` with
+                                // `summary_bytes: None` gets: clear-only, no
+                                // entry created just to hold `None`, no heal.
+                                op_manager.interest_manager.clear_peer_summary(
+                                    &contract,
+                                    &pk,
+                                    crate::ring::interest::SummaryMissingReason::ClearedByNoneReport,
+                                );
+                            }
+                            // Defer to the full-bytes path: the digest cannot
+                            // settle this contract, so ask for the summary and
+                            // let the untouched `Summaries` handler decide.
+                            DigestVerdict::NeedBytes => needs_bytes = true,
+                        }
+                    }
+                    if needs_bytes {
+                        request_hashes.push(entry.hash);
+                    }
+                }
+            }
+
+            // A digest-match verdict of "stale" is not expected (the predicate
+            // short-circuits on equal bytes) but is honoured rather than
+            // assumed away — same bounded, targeted emission as `Summaries`.
+            emit_stale_peer_syncs(op_manager, source, stale_contracts).await;
+
+            for (key, state_hash) in confirmed_states {
+                if let Some(event) =
+                    crate::tracing::NetEventLog::state_confirmed(&op_manager.ring, key, state_hash)
+                {
+                    op_manager
+                        .ring
+                        .register_events(either::Either::Left(event))
+                        .await;
+                }
+            }
+
+            if request_hashes.is_empty() {
+                // The 98.1% case: both sides already agree on every shared
+                // contract and not one summary byte crossed the wire.
+                None
+            } else {
+                Some(InterestMessage::SummaryRequest {
+                    hashes: request_hashes,
+                })
+            }
+        }
+
+        InterestMessage::SummaryRequest { hashes } => {
+            tracing::debug!(
+                from = %source,
+                hash_count = hashes.len(),
+                "Received SummaryRequest message"
+            );
+
+            // The peer's digest comparison could not settle these contracts,
+            // so it needs the actual bytes. Answer with a plain `Summaries` —
+            // ALWAYS the full-bytes form, NEVER the version-gated encoding
+            // chooser the other reply sites use. (The chooser is not named
+            // here on purpose: the pin test below asserts its identifier is
+            // absent from this arm, and a mention in a comment would satisfy
+            // that search and disarm the pin.)
+            //
+            // Two reasons, both load-bearing: replying with digests to a
+            // request FOR bytes would loop (request → digests → request …),
+            // and the requester has already established that a digest cannot
+            // settle these entries. `summary_request_reply_is_always_full_bytes`
+            // pins this.
+            //
+            // Disclosure and cost are identical to the `Interests` arm: the
+            // same `get_matching_contracts` filter (so only contracts we
+            // already track can be named) and the same
+            // `summary_if_hosted_or_in_use` gate. Unlike the `Interests` arm
+            // this registers no interest and removes none — a request is not
+            // an interest advertisement. Bounded by
+            // `MAX_SUMMARY_HASHES_PER_MESSAGE` on the input so a peer cannot
+            // name an arbitrarily long hash list.
+            //
+            // No separate rate limit, deliberately: a peer that wanted to
+            // force this work could already do so by spamming `Interests`,
+            // which runs the identical `get_matching_contracts` +
+            // `summary_if_hosted_or_in_use` loop AND additionally rewrites its
+            // interest registrations. This arm is strictly the cheaper of the
+            // two, so it adds no amplification surface that is not already
+            // reachable — and the summaries themselves are memoized on the
+            // state hash, so repeats do not re-enter WASM.
+            let bounded = &hashes[..hashes.len().min(MAX_SUMMARY_HASHES_PER_MESSAGE)];
+            let matching = op_manager.interest_manager.get_matching_contracts(bounded);
+            let mut entries = Vec::with_capacity(matching.len());
+            for contract in matching {
+                let hash = contract_hash(&contract);
+                let summary = summary_if_hosted_or_in_use(op_manager, &contract).await;
+                entries.push(SummaryEntry::from_summary(hash, summary.as_ref()));
+            }
+
+            if entries.is_empty() {
+                None
+            } else {
+                // #5052/#4965: the one full-bytes send hash-first ADDS rather
+                // than replaces, so it gets its own emitter arm — folded into
+                // the heartbeat reply it would look like the heartbeat failing
+                // to shrink, when it is the mismatch tail doing its job.
+                Some(InterestMessage::Summaries {
+                    entries,
+                    emitter: SummariesEmitter::SummaryRequestReply,
+                })
+            }
         }
 
         InterestMessage::ChangeInterests { added, removed } => {
@@ -3110,15 +3480,17 @@ async fn handle_interest_sync_message(
             if entries.is_empty() {
                 None
             } else {
-                Some(InterestMessage::Summaries {
+                // #5052: also multi-entry and also built by
+                // `summary_if_hosted_or_in_use`, but driven by interest CHURN
+                // rather than the heartbeat clock — a peer joining or dropping
+                // interest, not a periodic tick. Same bytes, a different thing
+                // to fix if it is the large one.
+                Some(summaries_reply_for_peer(
+                    op_manager,
+                    source,
                     entries,
-                    // #5052: also multi-entry and also built by
-                    // `summary_if_hosted_or_in_use`, but driven by interest
-                    // CHURN rather than the heartbeat clock — a peer joining or
-                    // dropping interest, not a periodic tick. Same bytes, a
-                    // different thing to fix if it is the large one.
-                    emitter: SummariesEmitter::ChangeInterestsReply,
-                })
+                    SummariesEmitter::ChangeInterestsReply,
+                ))
             }
         }
 
@@ -4114,9 +4486,13 @@ mod tests {
             .matches("summary_if_hosted_or_in_use(")
             .count();
         assert!(
-            gated_calls >= 3,
-            "expected the 3 periodic interest-sync arms to call \
-             summary_if_hosted_or_in_use, found {gated_calls}"
+            gated_calls >= 5,
+            "expected the 5 periodic interest-sync arms (Interests, Summaries, \
+             SummaryDigests, SummaryRequest, ChangeInterests) to call \
+             summary_if_hosted_or_in_use, found {gated_calls}. The hash-first \
+             arms (#4965) summarize on the same schedule as the ones they \
+             replace, so an ungated call there re-opens the #4473 storm on the \
+             hottest path in the protocol."
         );
     }
 
@@ -4149,10 +4525,17 @@ mod tests {
         let summaries_off = src[handler_start..]
             .find("InterestMessage::Summaries { entries, .. }")
             .expect("Summaries arm not found");
-        let change_off = src[handler_start..]
-            .find("InterestMessage::ChangeInterests")
-            .expect("ChangeInterests arm not found");
-        let summaries_arm = &src[handler_start + summaries_off..handler_start + change_off];
+        // End at the arm that IMMEDIATELY follows, not at a later one. When
+        // the hash-first arms (#4965) were inserted between `Summaries` and
+        // `ChangeInterests`, an end marker of `ChangeInterests` silently
+        // widened this window to cover them — and because the digest arm also
+        // calls `record_summary_comparison` and `summary_indicates_stale_peer`,
+        // the positive assertions below would have kept passing with those
+        // calls deleted from `Summaries` itself.
+        let next_off = src[handler_start..]
+            .find("InterestMessage::SummaryDigests { entries }")
+            .expect("SummaryDigests arm not found");
+        let summaries_arm = &src[handler_start + summaries_off..handler_start + next_off];
 
         // #4965: the measurement call must stay wired into this arm. It is
         // pure observation, so deleting it breaks no test and no behavior —
@@ -7544,5 +7927,747 @@ mod tests {
                  instead of a targeted SyncStateToPeer (#3791/#3796)"
             );
         }
+    }
+
+    /// Behavioural tests for the hash-first `InterestSync` exchange (#4965).
+    ///
+    /// The exchange replaces "ship every summary to every co-host every cycle"
+    /// with "ship a digest, ship the bytes only on mismatch". The properties
+    /// that matter, and that these tests pin:
+    ///
+    /// 1. A digest MATCH puts no summary bytes on the wire, yet still seeds the
+    ///    peer-summary cache and still runs the staleness check.
+    /// 2. A digest MISMATCH asks for the bytes, and the resulting `Summaries`
+    ///    runs the untouched original handler — so the targeted
+    ///    `SyncStateToPeer` heal still fires.
+    /// 3. A peer that sends no digest at all (an old peer, or one with no
+    ///    state) still converges.
+    mod hash_first_summaries {
+        use super::*;
+        use crate::contract::{ContractHandlerEvent, StoreResponse};
+        use crate::message::{InterestMessage, NodeEvent, SummaryDigestEntry, SummaryEntry};
+        use crate::ring::interest::{PeerKey, contract_hash, summary_digest};
+        use either::Either;
+        use freenet_stdlib::prelude::{
+            CodeHash, ContractInstanceId, ContractKey, StateSummary, WrappedState,
+        };
+        use std::net::SocketAddr;
+
+        /// Everything a hash-first handler test needs, kept alive together.
+        struct Harness {
+            op_manager: Arc<OpManager>,
+            notifications: crate::node::EventLoopNotificationsReceiver,
+            /// The one contract the node hosts, is locally interested in, and
+            /// can summarize.
+            key: ContractKey,
+            /// The summary the stand-in contract handler reports for `key`.
+            our_summary: Vec<u8>,
+            /// A connected peer, recorded at the hash-first version floor.
+            new_peer: SocketAddr,
+            /// A connected peer with NO recorded version (an old peer, as far
+            /// as the fail-closed gate is concerned).
+            old_peer: SocketAddr,
+            _guard: Box<dyn std::any::Any>,
+        }
+
+        impl Harness {
+            fn peer_key_of(&self, addr: SocketAddr) -> PeerKey {
+                PeerKey::from(
+                    self.op_manager
+                        .ring
+                        .connection_manager
+                        .get_peer_by_addr(addr)
+                        .expect("peer must be connected")
+                        .pub_key
+                        .clone(),
+                )
+            }
+
+            /// Every `SyncStateToPeer` heal emitted so far, as
+            /// (contract, target). This is the observable the "PRESERVE THE
+            /// HEAL" property is asserted on.
+            fn drain_heals(&mut self) -> Vec<(ContractKey, SocketAddr)> {
+                let mut out = Vec::new();
+                while let Ok(ev) = self.notifications.notifications_receiver.try_recv() {
+                    if let Either::Right(NodeEvent::SyncStateToPeer { key, target, .. }) = ev {
+                        out.push((key, target));
+                    }
+                }
+                out
+            }
+        }
+
+        /// Build a node that hosts exactly one contract with a known summary,
+        /// connected to one hash-first-capable peer and one pre-floor peer.
+        ///
+        /// `contract_state_present` returns `true` when no hosting storage is
+        /// attached, so the `should_summarize_or_broadcast` gate is satisfied
+        /// by `host_contract` alone and no redb temp dir is needed.
+        async fn build_harness(id: &str, port_base: u16, our_summary: Vec<u8>) -> Harness {
+            let config_args = crate::config::ConfigArgs {
+                id: Some(id.to_string()),
+                mode: Some(crate::contract::OperationMode::Local),
+                ..Default::default()
+            };
+            let node_config = NodeConfig::new(config_args.build().await.expect("build Config"))
+                .await
+                .expect("build NodeConfig");
+            let (notifications, notification_tx) = crate::node::event_loop_notification_channel();
+            let (ops_ch_channel, mut ch_channel, wait_for_event) =
+                crate::contract::contract_handler_channel();
+            let connection_manager = crate::ring::ConnectionManager::new(&node_config);
+            let (result_router_tx, result_router_rx) = tokio::sync::mpsc::channel(100);
+            let task_monitor = crate::node::background_task_monitor::BackgroundTaskMonitor::new();
+            let op_manager = Arc::new(
+                crate::node::OpManager::new(
+                    notification_tx,
+                    ops_ch_channel,
+                    &node_config,
+                    crate::tracing::DynamicRegister::new(vec![]),
+                    connection_manager,
+                    result_router_tx,
+                    &task_monitor,
+                )
+                .expect("build OpManager"),
+            );
+            op_manager.ring.attach_op_manager(&op_manager);
+            let self_addr: SocketAddr = format!("127.0.0.1:{port_base}").parse().unwrap();
+            op_manager
+                .ring
+                .connection_manager
+                .set_own_addr_local_for_test(self_addr);
+
+            let key = ContractKey::from_id_and_code(
+                ContractInstanceId::new([42u8; 32]),
+                CodeHash::new([43u8; 32]),
+            );
+            // Hosted + locally interested + hash-indexed, so
+            // `summary_if_hosted_or_in_use` will summarize it and
+            // `lookup_by_hash` will resolve the peer's advertised hash to it.
+            let _ = op_manager
+                .ring
+                .host_contract(key, 128, crate::ring::AccessType::Put);
+            op_manager.interest_manager.register_local_hosting(&key);
+
+            // Two connected peers, distinguished ONLY by whether a remote
+            // version was recorded — the exact production discriminator.
+            let new_peer: SocketAddr = format!("127.0.0.1:{}", port_base + 1).parse().unwrap();
+            let old_peer: SocketAddr = format!("127.0.0.1:{}", port_base + 2).parse().unwrap();
+            for (i, addr) in [new_peer, old_peer].into_iter().enumerate() {
+                let pub_key = crate::transport::TransportPublicKey::from_bytes([(i as u8) + 1; 32]);
+                assert!(
+                    op_manager.ring.connection_manager.add_connection(
+                        crate::ring::Location::new(0.1 + (i as f64) * 0.1),
+                        addr,
+                        pub_key,
+                        false,
+                    ),
+                    "test peer must be admitted to the ring"
+                );
+            }
+            op_manager
+                .ring
+                .connection_manager
+                .record_remote_version(new_peer, crate::node::HASH_FIRST_SUMMARIES_MIN_VERSION);
+
+            let summary_for_handler = our_summary.clone();
+            let handler_key = key;
+            let handler = tokio::spawn(async move {
+                while let Ok((id, ev, _priority)) = ch_channel.recv_from_sender().await {
+                    let response = match ev {
+                        ContractHandlerEvent::GetSummaryQuery { key } => {
+                            ContractHandlerEvent::GetSummaryResponse {
+                                key,
+                                summary: Ok(StateSummary::from(summary_for_handler.clone())),
+                            }
+                        }
+                        ContractHandlerEvent::GetQuery { .. } => {
+                            ContractHandlerEvent::GetResponse {
+                                key: Some(handler_key),
+                                response: Ok(StoreResponse {
+                                    state: Some(WrappedState::new(vec![1u8, 2, 3])),
+                                    contract: None,
+                                }),
+                            }
+                        }
+                        // The semantic-staleness probe (#4857): a NON-EMPTY
+                        // delta is the contract answering "yes, I hold state
+                        // this peer lacks", which is what turns a byte
+                        // mismatch into a real heal. Returning an empty delta
+                        // here would make every divergence test vacuous.
+                        ContractHandlerEvent::GetDeltaQuery { key, .. } => {
+                            ContractHandlerEvent::GetDeltaResponse {
+                                key,
+                                delta: Ok(freenet_stdlib::prelude::StateDelta::from(vec![
+                                    1u8, 2, 3,
+                                ])),
+                            }
+                        }
+                        other => panic!("unexpected handler event: {other:?}"),
+                    };
+                    if ch_channel.send_to_sender(id, response).await.is_err() {
+                        break;
+                    }
+                }
+            });
+
+            let guard: Box<dyn std::any::Any> =
+                Box::new((handler, result_router_rx, task_monitor, wait_for_event));
+            Harness {
+                op_manager,
+                notifications,
+                key,
+                our_summary,
+                new_peer,
+                old_peer,
+                _guard: guard,
+            }
+        }
+
+        /// A hash-first-capable peer asking for our interests gets DIGESTS
+        /// back; a peer whose version we don't know gets the full bytes.
+        ///
+        /// This is the backward-compatibility property stated as behaviour
+        /// rather than as a predicate: the same node, the same contract, the
+        /// same handler call — only the recorded peer version differs, and the
+        /// old peer still receives a message it can decode.
+        #[tokio::test]
+        async fn interests_reply_is_digests_only_for_capable_peers() {
+            let mut h = build_harness("hf-reply-form", 17000, vec![7u8; 64]).await;
+            let hash = contract_hash(&h.key);
+
+            let to_new = handle_interest_sync_message(
+                &h.op_manager,
+                h.new_peer,
+                InterestMessage::Interests { hashes: vec![hash] },
+            )
+            .await;
+            match to_new {
+                Some(InterestMessage::SummaryDigests { entries, .. }) => {
+                    assert_eq!(entries.len(), 1);
+                    assert_eq!(entries[0].hash, hash);
+                    assert_eq!(
+                        entries[0].summary_digest,
+                        Some(summary_digest(&h.our_summary)),
+                        "the digest must be computed from our ACTUAL summary"
+                    );
+                }
+                other => panic!("expected SummaryDigests for a capable peer, got {other:?}"),
+            }
+
+            let to_old = handle_interest_sync_message(
+                &h.op_manager,
+                h.old_peer,
+                InterestMessage::Interests { hashes: vec![hash] },
+            )
+            .await;
+            match to_old {
+                Some(InterestMessage::Summaries { entries, .. }) => {
+                    assert_eq!(entries.len(), 1);
+                    assert_eq!(
+                        entries[0].summary_bytes.as_deref(),
+                        Some(h.our_summary.as_slice()),
+                        "a peer with an unknown version must still receive the \
+                         full summary bytes — it cannot decode SummaryDigests \
+                         and would drop the connection"
+                    );
+                }
+                other => panic!("expected full Summaries for a pre-floor peer, got {other:?}"),
+            }
+
+            assert!(
+                h.drain_heals().is_empty(),
+                "answering an Interests query must not emit any heal"
+            );
+        }
+
+        /// The 98.1% case: the peer advertises a digest equal to ours.
+        ///
+        /// Asserts all three halves of "cheap AND correct":
+        /// - no `SummaryRequest` goes back, so NO summary bytes cross the wire;
+        /// - the peer-summary cache is seeded with the agreed bytes (#4952), so
+        ///   the peer does not stay a full-state broadcast target;
+        /// - no heal fires, because there is nothing to heal.
+        #[tokio::test]
+        async fn matching_digest_costs_no_bytes_and_still_seeds_the_summary_cache() {
+            let mut h = build_harness("hf-agree", 17010, vec![5u8; 128]).await;
+            let hash = contract_hash(&h.key);
+            let pk = h.peer_key_of(h.new_peer);
+
+            assert!(
+                h.op_manager
+                    .interest_manager
+                    .get_peer_summary(&h.key, &pk)
+                    .is_none(),
+                "precondition: we hold no cached summary for this peer"
+            );
+
+            let reply = handle_interest_sync_message(
+                &h.op_manager,
+                h.new_peer,
+                InterestMessage::SummaryDigests {
+                    emitter: crate::message::SummariesEmitter::Other,
+                    entries: vec![SummaryDigestEntry {
+                        hash,
+                        summary_digest: Some(summary_digest(&h.our_summary)),
+                    }],
+                },
+            )
+            .await;
+
+            assert!(
+                reply.is_none(),
+                "a digest that matches must produce NO follow-up message — not \
+                 one summary byte on the wire. Got {reply:?}"
+            );
+            assert_eq!(
+                h.op_manager
+                    .interest_manager
+                    .get_peer_summary(&h.key, &pk)
+                    .as_deref()
+                    .map(|s| s.to_vec()),
+                Some(h.our_summary.clone()),
+                "the agreed summary must still be cached for the peer (#4952): \
+                 the digest PROVED these are the bytes it holds, so skipping \
+                 the seeding would leave it a full-state broadcast target"
+            );
+            assert!(
+                h.drain_heals().is_empty(),
+                "two peers that agree must not trigger a state push"
+            );
+        }
+
+        /// A digest we cannot match must ask for the bytes — and the answer to
+        /// that request must be the FULL-BYTES `Summaries`, whose untouched
+        /// handler then emits the targeted heal.
+        ///
+        /// This is the "PRESERVE THE HEAL" property end to end: the digest
+        /// exchange defers the decision rather than making it, so divergence
+        /// still reaches exactly the same `SyncStateToPeer` it reaches today,
+        /// one round trip later.
+        #[tokio::test]
+        async fn mismatching_digest_requests_bytes_and_the_heal_still_fires() {
+            let mut h = build_harness("hf-mismatch", 17020, vec![5u8; 128]).await;
+            let hash = contract_hash(&h.key);
+
+            // Leg 1: peer advertises a digest of DIFFERENT state.
+            let reply = handle_interest_sync_message(
+                &h.op_manager,
+                h.new_peer,
+                InterestMessage::SummaryDigests {
+                    emitter: crate::message::SummariesEmitter::Other,
+                    entries: vec![SummaryDigestEntry {
+                        hash,
+                        summary_digest: Some(summary_digest(b"some other state")),
+                    }],
+                },
+            )
+            .await;
+            match &reply {
+                Some(InterestMessage::SummaryRequest { hashes }) => {
+                    assert_eq!(hashes, &vec![hash]);
+                }
+                other => panic!("a mismatching digest must request bytes, got {other:?}"),
+            }
+            assert!(
+                h.drain_heals().is_empty(),
+                "the digest leg must not heal on its own — it has not yet seen \
+                 the peer's summary, so any heal here would be guesswork"
+            );
+
+            // Leg 2: the peer answers our request. It must answer with real
+            // bytes, never with more digests (that would loop).
+            let their_summary = vec![6u8; 128];
+            let answer = handle_interest_sync_message(
+                &h.op_manager,
+                h.new_peer,
+                InterestMessage::SummaryRequest { hashes: vec![hash] },
+            )
+            .await;
+            match &answer {
+                Some(InterestMessage::Summaries { entries, .. }) => {
+                    assert_eq!(
+                        entries[0].summary_bytes.as_deref(),
+                        Some(h.our_summary.as_slice()),
+                        "a SummaryRequest must be answered with the real bytes"
+                    );
+                }
+                other => panic!(
+                    "a SummaryRequest must be answered with full-bytes Summaries \
+                     (answering with digests would loop), got {other:?}"
+                ),
+            }
+
+            // Leg 3: the peer's bytes arrive here, through the ORIGINAL
+            // handler. The heal fires exactly as it does on today's main.
+            let follow_up = handle_interest_sync_message(
+                &h.op_manager,
+                h.new_peer,
+                InterestMessage::Summaries {
+                    emitter: crate::message::SummariesEmitter::Other,
+                    entries: vec![SummaryEntry {
+                        hash,
+                        summary_bytes: Some(their_summary.clone()),
+                    }],
+                },
+            )
+            .await;
+            assert!(follow_up.is_none(), "Summaries never replies");
+            assert_eq!(
+                h.drain_heals(),
+                vec![(h.key, h.new_peer)],
+                "once the bytes arrive, the targeted SyncStateToPeer heal MUST \
+                 fire — hash-first defers the heal by one round trip, it does \
+                 not remove it"
+            );
+            let pk = h.peer_key_of(h.new_peer);
+            assert_eq!(
+                h.op_manager
+                    .interest_manager
+                    .get_peer_summary(&h.key, &pk)
+                    .as_deref()
+                    .map(|s| s.to_vec()),
+                Some(their_summary),
+                "their real summary must be cached once received"
+            );
+        }
+
+        /// Control for the test above: the same `Summaries` message, but
+        /// carrying OUR bytes, must NOT heal.
+        ///
+        /// Without this pair, `mismatching_digest_requests_bytes_and_the_heal_
+        /// still_fires` would also pass against a handler that healed
+        /// unconditionally — which would be a broadcast storm, not a fix.
+        #[tokio::test]
+        async fn identical_summary_bytes_do_not_heal() {
+            let mut h = build_harness("hf-agree-control", 17030, vec![5u8; 128]).await;
+            let hash = contract_hash(&h.key);
+
+            let reply = handle_interest_sync_message(
+                &h.op_manager,
+                h.new_peer,
+                InterestMessage::Summaries {
+                    emitter: crate::message::SummariesEmitter::Other,
+                    entries: vec![SummaryEntry {
+                        hash,
+                        summary_bytes: Some(h.our_summary.clone()),
+                    }],
+                },
+            )
+            .await;
+            assert!(reply.is_none());
+            assert!(
+                h.drain_heals().is_empty(),
+                "byte-identical summaries must never heal (that is the \
+                 property the digest-agreement path inherits)"
+            );
+        }
+
+        /// A peer that reports no state for a contract (`summary_digest: None`)
+        /// must be handled exactly like a `SummaryEntry { summary_bytes: None }`
+        /// — cached summary cleared, no bytes requested, no heal.
+        ///
+        /// Asking for bytes here would be pointless traffic (there are none),
+        /// and healing would push state at a peer that should get it through
+        /// the normal subscribe/GET flow.
+        #[tokio::test]
+        async fn peer_reporting_no_state_is_not_asked_for_bytes() {
+            let mut h = build_harness("hf-none", 17040, vec![5u8; 128]).await;
+            let hash = contract_hash(&h.key);
+            let pk = h.peer_key_of(h.new_peer);
+
+            // Seed a stale cached summary so the clear is observable.
+            h.op_manager.interest_manager.upsert_peer_summary(
+                &h.key,
+                &pk,
+                StateSummary::from(vec![9u8; 8]),
+            );
+            assert!(
+                h.op_manager
+                    .interest_manager
+                    .get_peer_summary(&h.key, &pk)
+                    .is_some(),
+                "precondition: a cached summary exists"
+            );
+
+            let reply = handle_interest_sync_message(
+                &h.op_manager,
+                h.new_peer,
+                InterestMessage::SummaryDigests {
+                    emitter: crate::message::SummariesEmitter::Other,
+                    entries: vec![SummaryDigestEntry {
+                        hash,
+                        summary_digest: None,
+                    }],
+                },
+            )
+            .await;
+
+            assert!(
+                reply.is_none(),
+                "a peer with no state has no bytes to send; requesting them \
+                 would be pure round-trip cost. Got {reply:?}"
+            );
+            assert!(
+                h.op_manager
+                    .interest_manager
+                    .get_peer_summary(&h.key, &pk)
+                    .is_none(),
+                "a None report must clear our cached summary for the peer, \
+                 same as SummaryEntry {{ summary_bytes: None }} does"
+            );
+            assert!(h.drain_heals().is_empty());
+        }
+
+        /// An unknown contract hash must not produce a request.
+        ///
+        /// Otherwise a peer could make us emit `SummaryRequest` messages for
+        /// contracts we have never heard of, and each answer would be an empty
+        /// `Summaries` — traffic amplification from nothing.
+        #[tokio::test]
+        async fn unknown_contract_hash_produces_no_request() {
+            let mut h = build_harness("hf-unknown", 17050, vec![5u8; 128]).await;
+
+            let reply = handle_interest_sync_message(
+                &h.op_manager,
+                h.new_peer,
+                InterestMessage::SummaryDigests {
+                    emitter: crate::message::SummariesEmitter::Other,
+                    entries: vec![SummaryDigestEntry {
+                        hash: contract_hash(&h.key).wrapping_add(1),
+                        summary_digest: Some(summary_digest(b"whatever")),
+                    }],
+                },
+            )
+            .await;
+
+            assert!(
+                reply.is_none(),
+                "a hash that resolves to no locally-tracked contract must be \
+                 ignored, not turned into a request. Got {reply:?}"
+            );
+            assert!(h.drain_heals().is_empty());
+        }
+
+        /// The per-message hash cap bounds both the work a peer can force and
+        /// the size of the request it can provoke.
+        ///
+        /// A digest entry is ~20 bytes for the sender and can cost the
+        /// receiver a contract round trip, an amplification ratio the
+        /// full-bytes `Summaries` never had. Duplicate hashes must be free.
+        #[tokio::test]
+        async fn digest_entries_are_deduplicated_and_capped() {
+            let h = build_harness("hf-cap", 17060, vec![5u8; 128]).await;
+            let hash = contract_hash(&h.key);
+
+            // 5,000 entries: the one real contract repeated, plus a long tail
+            // of unknown hashes.
+            let mut entries = vec![
+                SummaryDigestEntry {
+                    hash,
+                    summary_digest: Some(summary_digest(b"divergent")),
+                };
+                64
+            ];
+            for i in 0..5_000u32 {
+                entries.push(SummaryDigestEntry {
+                    hash: hash.wrapping_add(i + 1),
+                    summary_digest: Some(summary_digest(b"divergent")),
+                });
+            }
+
+            let reply = handle_interest_sync_message(
+                &h.op_manager,
+                h.new_peer,
+                InterestMessage::SummaryDigests {
+                    entries,
+                    emitter: crate::message::SummariesEmitter::Other,
+                },
+            )
+            .await;
+
+            match reply {
+                Some(InterestMessage::SummaryRequest { hashes }) => {
+                    assert!(
+                        hashes.len() <= MAX_SUMMARY_HASHES_PER_MESSAGE,
+                        "the request must stay bounded by \
+                         MAX_SUMMARY_HASHES_PER_MESSAGE, got {}",
+                        hashes.len()
+                    );
+                    assert_eq!(
+                        hashes.iter().filter(|h| **h == hash).count(),
+                        1,
+                        "a repeated hash must appear in the request at most \
+                         once — repetition must buy the sender nothing"
+                    );
+                }
+                // Legitimate: the random rotation may push the one known hash
+                // outside the processed window. The cap is what is under test.
+                None => {}
+                other => panic!("unexpected reply {other:?}"),
+            }
+        }
+
+        /// A `SummaryRequest` naming a huge hash list must not produce an
+        /// unbounded reply, and must only ever name contracts we already
+        /// track.
+        #[tokio::test]
+        async fn summary_request_reply_is_bounded_and_scoped_to_known_contracts() {
+            let h = build_harness("hf-req-bound", 17070, vec![5u8; 128]).await;
+            let hash = contract_hash(&h.key);
+            let mut hashes: Vec<u32> = (0..10_000u32).map(|i| hash.wrapping_add(i + 1)).collect();
+            hashes.insert(0, hash);
+
+            let reply = handle_interest_sync_message(
+                &h.op_manager,
+                h.new_peer,
+                InterestMessage::SummaryRequest { hashes },
+            )
+            .await;
+
+            match reply {
+                Some(InterestMessage::Summaries { entries, .. }) => {
+                    assert_eq!(
+                        entries.len(),
+                        1,
+                        "only the one contract this node actually tracks may be \
+                         answered — a peer must not be able to enumerate or \
+                         inflate the reply with hashes we know nothing about"
+                    );
+                    assert_eq!(entries[0].hash, hash);
+                }
+                other => panic!("expected Summaries for the one known hash, got {other:?}"),
+            }
+        }
+
+        /// Source pin: the `SummaryRequest` arm must build its reply as a plain
+        /// `InterestMessage::Summaries`, NEVER through
+        /// `summaries_reply_for_peer`.
+        ///
+        /// Routing it through the encoding chooser would answer a request FOR
+        /// BYTES with more digests, and the two sides would ping-pong
+        /// (digests → request → digests → …) forever. Behavioural coverage
+        /// exists above, but only for the one shape a test can construct; this
+        /// pins the decision itself.
+        #[test]
+        fn summary_request_reply_is_always_full_bytes() {
+            let src = include_str!("node.rs");
+            let arm = src
+                .find("InterestMessage::SummaryRequest { hashes } => {")
+                .expect("SummaryRequest arm not found");
+            // End at the NEXT arm, not at a later one: the arms between
+            // would drag their own `summaries_reply_for_peer` into the window
+            // and make the negative assertion below fire on innocent code.
+            let end = src[arm..]
+                .find("InterestMessage::ChangeInterests { added, removed } => {")
+                .expect("end of SummaryRequest arm not found");
+            let body = &src[arm..arm + end];
+            assert!(
+                body.contains("get_matching_contracts"),
+                "window extraction is off — the SummaryRequest arm body should \
+                 contain its get_matching_contracts lookup"
+            );
+            assert!(
+                body.contains("Some(InterestMessage::Summaries { entries })"),
+                "the SummaryRequest arm must reply with a plain full-bytes \
+                 Summaries"
+            );
+            assert!(
+                !body.contains("summaries_reply_for_peer"),
+                "the SummaryRequest arm must NOT route through \
+                 summaries_reply_for_peer: answering a request for bytes with \
+                 digests loops the exchange (digests → request → digests → …)"
+            );
+        }
+
+        /// Source pin: the `SummaryDigests` arm must reach the heal through the
+        /// SHARED `emit_stale_peer_syncs`, and must not grow its own emission.
+        ///
+        /// A second copy of the heal path is how "hash-first traded bandwidth
+        /// for convergence" happens: the copies drift, the digest arm loses a
+        /// guard (the ban check, the budget, the targeting), and nothing fails
+        /// until production.
+        #[test]
+        fn digest_arm_shares_the_single_heal_path() {
+            let src = include_str!("node.rs");
+            let arm = src
+                .find("InterestMessage::SummaryDigests { entries } => {")
+                .expect("SummaryDigests arm not found");
+            let end = src[arm..]
+                .find("InterestMessage::SummaryRequest { hashes } => {")
+                .expect("end of SummaryDigests arm not found");
+            let body = &src[arm..arm + end];
+            assert!(
+                body.contains("emit_stale_peer_syncs(op_manager, source, stale_contracts)"),
+                "the SummaryDigests arm must delegate healing to the shared \
+                 emit_stale_peer_syncs"
+            );
+            assert!(
+                !body.contains("stale_peer_sync_event("),
+                "the SummaryDigests arm must not construct heal events itself \
+                 — a second emission path drifts from the shared one and \
+                 loses its ban check / budget / targeting guards"
+            );
+            assert!(
+                !body.contains("NodeEvent::BroadcastStateChange"),
+                "a heal from the digest arm must never become an \
+                 all-subscriber fan-out (#3791/#3796)"
+            );
+            assert!(
+                body.contains("summary_indicates_stale_peer"),
+                "the SummaryDigests arm must RUN the staleness predicate on \
+                 agreement rather than assume its answer — the assumption \
+                 ('identical summaries are never stale') is a property of the \
+                 predicate, and baking it in here is how a digest match would \
+                 come to short-circuit a real heal"
+            );
+            assert!(
+                body.contains("record_summary_comparison"),
+                "the digest-agreement path must still record the #4965 \
+                 identical/differing comparison, or the telemetry that \
+                 justifies this change stops being able to measure it"
+            );
+        }
+    }
+
+    /// The pure digest classifier — the one comparison the whole exchange rests
+    /// on. Every arm is asserted, because each maps to a different wire
+    /// outcome and getting any of them backwards is silent.
+    #[test]
+    fn classify_summary_digest_covers_every_case() {
+        use freenet_stdlib::prelude::StateSummary;
+
+        let ours = StateSummary::from(vec![1u8, 2, 3]);
+        let matching = crate::ring::interest::summary_digest(&[1u8, 2, 3]);
+        let differing = crate::ring::interest::summary_digest(&[9u8, 9, 9]);
+
+        assert_eq!(
+            classify_summary_digest(Some(&ours), Some(&matching)),
+            DigestVerdict::Agree,
+            "equal digests mean the peer holds our summary — the 98.1% case"
+        );
+        assert_eq!(
+            classify_summary_digest(Some(&ours), Some(&differing)),
+            DigestVerdict::NeedBytes,
+            "differing digests must fetch the bytes so the semantic staleness \
+             probe (and the heal) can run on real data"
+        );
+        assert_eq!(
+            classify_summary_digest(None, Some(&matching)),
+            DigestVerdict::NeedBytes,
+            "we hold no summary but the peer does: we still need their bytes \
+             to seed the peer-summary cache (#4952), or they stay a full-state \
+             broadcast target forever"
+        );
+        assert_eq!(
+            classify_summary_digest(Some(&ours), None),
+            DigestVerdict::PeerHasNoState,
+            "a peer with no state is not a divergence"
+        );
+        assert_eq!(
+            classify_summary_digest(None, None),
+            DigestVerdict::PeerHasNoState,
+            "neither side holds state: nothing to exchange, nothing to heal"
+        );
     }
 }

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -3373,6 +3373,24 @@ async fn handle_interest_sync_message(
                 // message) inflating the reply, and it is independent of the
                 // per-entry dedup above.
                 let mut requested_hashes: HashSet<u32> = HashSet::new();
+                // Per-message cache of OUR summaries, keyed by contract.
+                //
+                // The root bound on the expensive operation. Pair-dedup (above)
+                // is required for correctness but removed the incidental bound
+                // hash-dedup used to provide: a peer can name ONE known hash
+                // with up to `MAX_SUMMARY_HASHES_PER_MESSAGE` distinct
+                // fabricated digests, and without this each pair would rerun
+                // `summary_if_hosted_or_in_use` — a contract-handler round trip
+                // — for every contract matching that hash, sequentially, on the
+                // loop the executor needs responsive
+                // (`.claude/rules/code-style.md`, fan-out cost).
+                //
+                // With the cache the fetch runs at most ONCE per contract per
+                // message no matter how many pairs name it.
+                let mut local_summaries: std::collections::HashMap<
+                    ContractInstanceId,
+                    Option<freenet_stdlib::prelude::StateSummary<'static>>,
+                > = std::collections::HashMap::new();
                 let mut compared_contracts: HashSet<ContractInstanceId> = HashSet::new();
                 // See the sibling set in the `Summaries` arm.
                 let mut one_sided_counted: HashSet<ContractInstanceId> = HashSet::new();
@@ -3384,6 +3402,23 @@ async fn handle_interest_sync_message(
                         break;
                     }
                     if !seen_pairs.insert((entry.hash, entry.summary_digest)) {
+                        continue;
+                    }
+                    // Once a hash is on the request list, further pairs naming
+                    // it are inert: the full-bytes `Summaries` reply we are
+                    // about to receive carries OUR summaries for ALL contracts
+                    // matching the hash, so any divergence those pairs would
+                    // have found is resolved there anyway.
+                    //
+                    // This cannot lose a heal — it defers one, to the reply
+                    // that is already on its way. What it removes is the
+                    // attacker's ability to keep the loop busy: only ONE digest
+                    // value can agree with a given local contract (the digest
+                    // IS the hash of our summary bytes), so all but one
+                    // fabricated pair mismatch, the first mismatch arms this
+                    // skip, and the hash goes inert after ~2 productive
+                    // iterations.
+                    if requested_hashes.contains(&entry.hash) {
                         continue;
                     }
                     // One hash can resolve to several contracts (FNV-1a
@@ -3401,7 +3436,19 @@ async fn handle_interest_sync_message(
                         // `PeerInterest.summary`: that is our belief about the
                         // peer, and repairing a wrong belief is the entire job
                         // of this exchange.
-                        let our_summary = summary_if_hosted_or_in_use(op_manager, &contract).await;
+                        //
+                        // Memoized per MESSAGE (see `local_summaries`): the
+                        // value cannot change while this handler runs, and
+                        // re-fetching per pair is the amplification the pair
+                        // dedup would otherwise open.
+                        if !local_summaries.contains_key(contract.id()) {
+                            let fetched = summary_if_hosted_or_in_use(op_manager, &contract).await;
+                            local_summaries.insert(*contract.id(), fetched);
+                        }
+                        let our_summary = local_summaries
+                            .get(contract.id())
+                            .expect("just inserted")
+                            .clone();
 
                         if emit_confirmed {
                             if let Some(ref summary) = our_summary {
@@ -8252,6 +8299,11 @@ mod tests {
             /// A connected peer with NO recorded version (an old peer, as far
             /// as the fail-closed gate is concerned).
             old_peer: SocketAddr,
+            /// How many `GetSummaryQuery` round trips the stand-in contract
+            /// handler has answered. The observable for the amplification
+            /// bound: it counts the EXPENSIVE operation directly, rather than
+            /// a proxy that could stay flat while the work still happened.
+            summary_queries: std::sync::Arc<std::sync::atomic::AtomicUsize>,
             _guard: Box<dyn std::any::Any>,
         }
 
@@ -8357,10 +8409,13 @@ mod tests {
 
             let summary_for_handler = our_summary.clone();
             let handler_key = key;
+            let summary_queries = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+            let queries_for_handler = std::sync::Arc::clone(&summary_queries);
             let handler = tokio::spawn(async move {
                 while let Ok((id, ev, _priority)) = ch_channel.recv_from_sender().await {
                     let response = match ev {
                         ContractHandlerEvent::GetSummaryQuery { key } => {
+                            queries_for_handler.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                             ContractHandlerEvent::GetSummaryResponse {
                                 key,
                                 summary: Ok(StateSummary::from(summary_for_handler.clone())),
@@ -8405,6 +8460,7 @@ mod tests {
                 our_summary,
                 new_peer,
                 old_peer,
+                summary_queries,
                 _guard: guard,
             }
         }
@@ -8877,6 +8933,113 @@ mod tests {
                     "the second (diverging) entry was dropped: no SummaryRequest \
                      fired, so this node will report converged forever while the \
                      peer holds different state. Got {other:?}"
+                ),
+            }
+        }
+
+        /// A peer naming ONE hash with many distinct fabricated digests must
+        /// not multiply the expensive work (codex P1 on the collision fix).
+        ///
+        /// # The amplification this bounds
+        ///
+        /// The collision fix had to dedup on `(hash, digest)` rather than on
+        /// hash alone, which was correct — but hash-dedup had been
+        /// *incidentally* bounding something else: how many times
+        /// `summary_if_hosted_or_in_use` runs. That is a contract-handler round
+        /// trip, sequential, on the loop the executor needs responsive. With
+        /// pair-dedup and no further bound, one message could name a single
+        /// known hash with up to `MAX_SUMMARY_HASHES_PER_MESSAGE` distinct
+        /// digests and force that many fetches per matching contract.
+        ///
+        /// Two mechanisms bound it:
+        ///
+        /// - a per-message summary cache, so a contract is fetched at most once
+        ///   per message however many pairs name it;
+        /// - skip-once-requested, so pairs arriving after the hash is already
+        ///   on the request list are not processed at all.
+        ///
+        /// The skip cannot lose a heal: the full-bytes reply already on its way
+        /// carries our summaries for ALL contracts matching that hash.
+        ///
+        /// # What this test does and does NOT discriminate
+        ///
+        /// Stated because the obvious reading is wrong. Mutation-tested three
+        /// ways: removing the cache alone PASSES, removing the skip alone
+        /// PASSES, removing BOTH fails at 512 fetches. So this test bounds the
+        /// CONJUNCTION, not either mechanism individually.
+        ///
+        /// That is not a defect in the test so much as a property of the fix:
+        /// each mechanism is independently sufficient for this observable. Only
+        /// one digest value can agree with a given local contract (the digest
+        /// IS the hash of our summary bytes), so the first fabricated pair
+        /// mismatches, arms the skip, and the hash goes inert — which holds the
+        /// count to ~1 even with no cache; and the cache holds it to 1 even
+        /// with no skip. They are deliberate defence in depth.
+        ///
+        /// A test that isolated one would need a scenario where the skip cannot
+        /// arm (no request fires) yet many pairs still resolve — and pair-dedup
+        /// makes that unconstructible, since all `None`-digest pairs for a hash
+        /// collapse to one. If a future change makes them separable, split this
+        /// test then.
+        #[tokio::test]
+        async fn many_digests_for_one_hash_do_not_multiply_summary_fetches() {
+            use std::sync::atomic::Ordering;
+
+            let h = build_harness("hf-amp", 17090, vec![5u8; 128]).await;
+            let hash = contract_hash(&h.key);
+
+            // 512 distinct fabricated digests, all naming the ONE hash this
+            // node tracks. Every one of them is a real, distinct pair, so
+            // pair-dedup does not collapse them.
+            let entries: Vec<SummaryDigestEntry> = (0..512u32)
+                .map(|i| SummaryDigestEntry {
+                    hash,
+                    summary_digest: Some(summary_digest(&i.to_le_bytes())),
+                })
+                .collect();
+            assert!(
+                entries.len() < MAX_SUMMARY_HASHES_PER_MESSAGE,
+                "premise: stay under the cap so the CAP is not what bounds \
+                 this — the cache and the skip must be doing the work"
+            );
+
+            let before = h.summary_queries.load(Ordering::Relaxed);
+            let reply = handle_interest_sync_message(
+                &h.op_manager,
+                h.new_peer,
+                InterestMessage::SummaryDigests {
+                    entries,
+                    emitter: crate::message::SummariesEmitter::Other,
+                },
+            )
+            .await;
+            let fetches = h.summary_queries.load(Ordering::Relaxed) - before;
+
+            // One contract matches this hash, so one fetch is the floor. The
+            // bound is what matters: NOT proportional to the 512 pairs.
+            assert!(
+                fetches <= 1,
+                "512 fabricated digests for one hash caused {fetches} summary \
+                 fetches; the per-message cache should hold it to at most one \
+                 per matching contract. A count near 512 means the cache is \
+                 gone and a peer can monopolize the contract loop with a single \
+                 message."
+            );
+
+            // And the divergence is still handled: the hash IS requested.
+            match reply {
+                Some(InterestMessage::SummaryRequest { hashes }) => {
+                    assert_eq!(
+                        hashes,
+                        vec![hash],
+                        "the hash must be requested exactly once — bounding the \
+                         work must not cost the request, and must not let 512 \
+                         pairs inflate it either"
+                    );
+                }
+                other => panic!(
+                    "fabricated digests all mismatch our summary, so the bytes \
+                     must be requested; got {other:?}"
                 ),
             }
         }

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -3263,6 +3263,17 @@ async fn handle_interest_sync_message(
                     let start = crate::config::GlobalRng::random_range(0..entries.len());
                     entries.rotate_left(start);
                 }
+                // #4965 agreement-rate proxy: single-entry messages come
+                // from the state-change-driven send sites (proactive
+                // notification, rejection summary-back) by construction, while
+                // the heartbeat / interest-churn replies are multi-entry. The
+                // emitter tag is non-wire so the receiver cannot read it; this
+                // is the closest available discriminator. Reads `entries.len()`
+                // — the length of the message the peer actually SENT. The
+                // rotation above reorders but never shortens, and the cap
+                // applies to the processing window rather than to this count,
+                // so a capped message is still classified by its true size.
+                let single_entry = entries.len() == 1;
                 let mut seen_hashes: HashSet<u32> = HashSet::new();
                 let mut compared_contracts: HashSet<ContractInstanceId> = HashSet::new();
                 for entry in entries {
@@ -3312,7 +3323,9 @@ async fn handle_interest_sync_message(
                                     ours.as_ref(),
                                     &mut compared_contracts,
                                 );
-                                crate::config::GlobalTestMetrics::record_summary_digest_agreement();
+                                crate::config::GlobalTestMetrics::record_summary_digest_agreement(
+                                    single_entry,
+                                );
                                 // `None` delta verdict: there is nothing to
                                 // probe. `summary_indicates_stale_peer` sees
                                 // byte-equal summaries and never reaches the
@@ -3346,7 +3359,12 @@ async fn handle_interest_sync_message(
                             // Defer to the full-bytes path: the digest cannot
                             // settle this contract, so ask for the summary and
                             // let the untouched `Summaries` handler decide.
-                            DigestVerdict::NeedBytes => needs_bytes = true,
+                            DigestVerdict::NeedBytes => {
+                                crate::config::GlobalTestMetrics::record_summary_digest_mismatch(
+                                    single_entry,
+                                );
+                                needs_bytes = true;
+                            }
                         }
                     }
                     if needs_bytes {
@@ -8128,10 +8146,10 @@ mod tests {
                     "test peer must be admitted to the ring"
                 );
             }
-            op_manager
-                .ring
-                .connection_manager
-                .record_remote_version(new_peer, crate::node::HASH_FIRST_SUMMARIES_MIN_VERSION);
+            op_manager.ring.connection_manager.record_remote_version(
+                new_peer,
+                Some(crate::node::HASH_FIRST_SUMMARIES_MIN_VERSION),
+            );
 
             let summary_for_handler = our_summary.clone();
             let handler_key = key;
@@ -8603,6 +8621,33 @@ mod tests {
             }
         }
 
+        /// Strip `//` comment lines from a source window before asserting on
+        /// it.
+        ///
+        /// Load-bearing, not tidiness. These pins assert that the arm CALLS
+        /// something; the identifiers they search for also appear in the arm's
+        /// own explanatory comments, so an unstripped window is satisfied by
+        /// PROSE. `digest_arm_shares_the_single_heal_path` was exactly that:
+        /// `summary_indicates_stale_peer` and `record_summary_comparison` both
+        /// appear in comments inside its window, so deleting both calls left it
+        /// green — and the mutation is silent everywhere else, since
+        /// `record_summary_comparison` is pure observation and
+        /// `summary_indicates_stale_peer(&ours, &ours, None)` provably returns
+        /// `false`, so `let is_stale = false;` compiles and breaks nothing.
+        ///
+        /// The sibling pins already guarded the ASSERTION's own source from
+        /// self-matching (via `concat!`); this guards the SCANNED WINDOW, which
+        /// is the half that was missed. Verified by mutation: with the
+        /// predicate call replaced by `let is_stale = false;` and the prose
+        /// left intact, the pin now fails.
+        fn code_only(window: &str) -> String {
+            window
+                .lines()
+                .filter(|l| !l.trim_start().starts_with("//"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        }
+
         /// Source pin: production code must never construct
         /// `InterestMessage::Summaries` directly — only through
         /// [`full_summaries_message`], which records the summary bytes it puts
@@ -8718,7 +8763,7 @@ mod tests {
             let end = src[arm..]
                 .find("InterestMessage::ChangeInterests { added, removed } => {")
                 .expect("end of SummaryRequest arm not found");
-            let body = &src[arm..arm + end];
+            let body = &code_only(&src[arm..arm + end]);
             assert!(
                 body.contains("get_matching_contracts"),
                 "window extraction is off — the SummaryRequest arm body should \
@@ -8754,7 +8799,7 @@ mod tests {
             let end = src[arm..]
                 .find("InterestMessage::SummaryRequest { hashes } => {")
                 .expect("end of SummaryDigests arm not found");
-            let body = &src[arm..arm + end];
+            let body = &code_only(&src[arm..arm + end]);
             assert!(
                 body.contains("emit_stale_peer_syncs(op_manager, source, stale_contracts)"),
                 "the SummaryDigests arm must delegate healing to the shared \

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -3349,15 +3349,41 @@ async fn handle_interest_sync_message(
                 // applies to the processing window rather than to this count,
                 // so a capped message is still classified by its true size.
                 let single_entry = entries.len() == 1;
-                let mut seen_hashes: HashSet<u32> = HashSet::new();
+                // Dedup on the (hash, digest) PAIR, not on the hash alone.
+                //
+                // The sender emits one entry per CONTRACT, and two DISTINCT
+                // contracts can collide on the 32-bit FNV-1a `contract_hash`
+                // — `lookup_by_hash` returns a Vec precisely because that
+                // happens. Deduping on hash alone dropped the second colliding
+                // entry, and that is not a lost optimisation but permanent
+                // silent divergence: with both local summaries byte-identical,
+                // the FIRST entry's digest agrees against BOTH contracts, so
+                // both record as converged while the entry carrying the
+                // genuinely-diverged digest never runs. No request fires, and
+                // every later heartbeat repeats it. The full-bytes `Summaries`
+                // arm has no such dedup, so this was a REGRESSION for the
+                // collision input class, not a pre-existing gap.
+                //
+                // Pinned by `colliding_contract_hashes_do_not_drop_the_second_entry`.
+                let mut seen_pairs: HashSet<(u32, Option<crate::ring::interest::SummaryDigest>)> =
+                    HashSet::new();
+                // Separate from the pair set: the REQUEST list stays deduped by
+                // hash, so N colliding entries still ask for their shared hash
+                // once. That bound is what stops a collision (or a crafted
+                // message) inflating the reply, and it is independent of the
+                // per-entry dedup above.
+                let mut requested_hashes: HashSet<u32> = HashSet::new();
                 let mut compared_contracts: HashSet<ContractInstanceId> = HashSet::new();
                 // See the sibling set in the `Summaries` arm.
                 let mut one_sided_counted: HashSet<ContractInstanceId> = HashSet::new();
                 for entry in entries {
-                    if seen_hashes.len() >= MAX_SUMMARY_HASHES_PER_MESSAGE {
+                    // The cap counts distinct PAIRS, matching what is actually
+                    // processed — counting distinct hashes would no longer
+                    // bound the work now that several pairs can share a hash.
+                    if seen_pairs.len() >= MAX_SUMMARY_HASHES_PER_MESSAGE {
                         break;
                     }
-                    if !seen_hashes.insert(entry.hash) {
+                    if !seen_pairs.insert((entry.hash, entry.summary_digest)) {
                         continue;
                     }
                     // One hash can resolve to several contracts (FNV-1a
@@ -3457,7 +3483,7 @@ async fn handle_interest_sync_message(
                             }
                         }
                     }
-                    if needs_bytes {
+                    if needs_bytes && requested_hashes.insert(entry.hash) {
                         request_hashes.push(entry.hash);
                     }
                 }
@@ -8706,6 +8732,153 @@ mod tests {
                  ignored, not turned into a request. Got {reply:?}"
             );
             assert!(h.drain_heals().is_empty());
+        }
+
+        /// Two DISTINCT contracts whose 32-bit `contract_hash` collides must
+        /// both be considered — dropping the second is permanent silent
+        /// divergence.
+        ///
+        /// # The bug this pins (codex P2)
+        ///
+        /// The digest arm deduplicated on `entry.hash` alone, first-wins. The
+        /// sender emits one entry per CONTRACT, so two contracts colliding on
+        /// FNV-1a produce two entries with the SAME hash and different digests
+        /// — and the second was silently dropped.
+        ///
+        /// That is not merely a missed optimisation. With both local summaries
+        /// byte-identical (two freshly-seeded contracts, say), the FIRST
+        /// entry's digest agrees against BOTH local contracts, so both are
+        /// recorded as converged; the second entry, carrying the digest of the
+        /// contract that actually diverged, never runs. No `SummaryRequest`
+        /// fires, and every subsequent heartbeat repeats the same outcome:
+        /// **permanent divergence, invisible**. That is the stale-copy class
+        /// `hosting-invariants.md` invariant 1 forbids.
+        ///
+        /// It was also a REGRESSION rather than a pre-existing gap: the
+        /// full-bytes `Summaries` arm has no such dedup and processes every
+        /// entry, so this input class worked before hash-first.
+        ///
+        /// The fix deduplicates on the `(hash, digest)` PAIR, so a same-hash
+        /// different-digest entry still runs. It then mismatches at least one
+        /// local summary, which asks for the bytes; the full-bytes reply
+        /// resolves ALL contracts for the hash and disambiguates.
+        #[tokio::test]
+        async fn colliding_contract_hashes_do_not_drop_the_second_entry() {
+            use freenet_stdlib::prelude::{CodeHash, ContractInstanceId, ContractKey};
+            use std::collections::HashMap;
+
+            // Find ANY pair of instance ids colliding under FNV-1a.
+            //
+            // Two subtleties, both learned by getting them wrong:
+            //
+            // 1. Search for an ARBITRARY colliding pair, not a collision with a
+            //    fixed key — the latter needs ~2^32 trials, the birthday bound
+            //    for a pair is ~2^16.
+            // 2. Vary MORE than 32 bits of the input. FNV-1a's per-byte step
+            //    (xor then multiply by an odd prime mod 2^32) is invertible, so
+            //    over fixed-length inputs differing only in a 4-byte window it
+            //    is a BIJECTION — distinct 32-bit prefixes provably never
+            //    collide, and a search over them runs forever finding nothing.
+            //    Spreading a multiplied counter across 8 bytes puts the domain
+            //    above 2^32 so collisions exist and appear at the birthday rate.
+            let (id_a, id_b) = {
+                let mut seen: HashMap<u32, [u8; 32]> = HashMap::new();
+                let mut found = None;
+                for i in 0u64..2_000_000 {
+                    let mut raw = [7u8; 32];
+                    // Golden-ratio multiply spreads the counter over 64 bits.
+                    raw[..8].copy_from_slice(&i.wrapping_mul(0x9E37_79B9_7F4A_7C15).to_le_bytes());
+                    let key = ContractKey::from_id_and_code(
+                        ContractInstanceId::new(raw),
+                        CodeHash::new([1u8; 32]),
+                    );
+                    let h = contract_hash(&key);
+                    if let Some(prev) = seen.insert(h, raw) {
+                        if prev != raw {
+                            found = Some((prev, raw));
+                            break;
+                        }
+                    }
+                }
+                found.expect("an FNV-1a collision must exist within 2M candidates")
+            };
+
+            let key_a = ContractKey::from_id_and_code(
+                ContractInstanceId::new(id_a),
+                CodeHash::new([1; 32]),
+            );
+            let key_b = ContractKey::from_id_and_code(
+                ContractInstanceId::new(id_b),
+                CodeHash::new([1; 32]),
+            );
+            assert_ne!(key_a, key_b, "the two contracts must be distinct");
+            assert_eq!(
+                contract_hash(&key_a),
+                contract_hash(&key_b),
+                "premise: the two contracts must COLLIDE under contract_hash, \
+                 or this test is not exercising the collision path at all"
+            );
+            let shared_hash = contract_hash(&key_a);
+
+            // Host BOTH on the node. The stand-in handler answers every
+            // GetSummaryQuery with the same bytes, so their local summaries are
+            // byte-identical — which is what lets one digest agree against both
+            // and makes the dropped entry invisible.
+            let h = build_harness("hf-collision", 17080, vec![3u8; 64]).await;
+            for k in [key_a, key_b] {
+                let _ = h
+                    .op_manager
+                    .ring
+                    .host_contract(k, 128, crate::ring::AccessType::Put);
+                h.op_manager.interest_manager.register_local_hosting(&k);
+            }
+
+            let agreeing = summary_digest(&h.our_summary);
+            let diverged = summary_digest(b"a genuinely different state");
+            assert_ne!(agreeing, diverged);
+
+            // Exactly what a peer hosting both contracts sends: one entry per
+            // CONTRACT, both carrying the same (colliding) hash.
+            let reply = handle_interest_sync_message(
+                &h.op_manager,
+                h.new_peer,
+                InterestMessage::SummaryDigests {
+                    emitter: crate::message::SummariesEmitter::Other,
+                    entries: vec![
+                        SummaryDigestEntry {
+                            hash: shared_hash,
+                            summary_digest: Some(agreeing),
+                        },
+                        SummaryDigestEntry {
+                            hash: shared_hash,
+                            summary_digest: Some(diverged),
+                        },
+                    ],
+                },
+            )
+            .await;
+
+            match reply {
+                Some(InterestMessage::SummaryRequest { hashes }) => {
+                    assert!(
+                        hashes.contains(&shared_hash),
+                        "the diverging entry must provoke a SummaryRequest for \
+                         its hash, got {hashes:?}"
+                    );
+                    assert_eq!(
+                        hashes.iter().filter(|x| **x == shared_hash).count(),
+                        1,
+                        "the hash must still appear at most ONCE — the \
+                         collision-inflation bound is independent of the \
+                         per-entry dedup and must survive the fix"
+                    );
+                }
+                other => panic!(
+                    "the second (diverging) entry was dropped: no SummaryRequest \
+                     fired, so this node will report converged forever while the \
+                     peer holds different state. Got {other:?}"
+                ),
+            }
         }
 
         /// Repeated hashes must be free: a peer that names the same contract

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -8725,7 +8725,7 @@ mod tests {
                  contain its get_matching_contracts lookup"
             );
             assert!(
-                body.contains("full_summaries_message(entries)"),
+                body.contains("full_summaries_message("),
                 "the SummaryRequest arm must reply through \
                  full_summaries_message — the instrumented full-bytes \
                  constructor"
@@ -8749,7 +8749,7 @@ mod tests {
         fn digest_arm_shares_the_single_heal_path() {
             let src = include_str!("node.rs");
             let arm = src
-                .find("InterestMessage::SummaryDigests { entries } => {")
+                .find("InterestMessage::SummaryDigests { entries, .. } => {")
                 .expect("SummaryDigests arm not found");
             let end = src[arm..]
                 .find("InterestMessage::SummaryRequest { hashes } => {")

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -3373,24 +3373,44 @@ async fn handle_interest_sync_message(
                 // message) inflating the reply, and it is independent of the
                 // per-entry dedup above.
                 let mut requested_hashes: HashSet<u32> = HashSet::new();
-                // Per-message cache of OUR summaries, keyed by contract.
+                // Cache of OUR summaries for the hash CURRENTLY being
+                // processed, keyed by contract. Cleared whenever the hash
+                // changes (see `cached_for_hash`).
                 //
-                // The root bound on the expensive operation. Pair-dedup (above)
-                // is required for correctness but removed the incidental bound
+                // It bounds the expensive operation. Pair-dedup (above) is
+                // required for correctness but removed the incidental bound
                 // hash-dedup used to provide: a peer can name ONE known hash
-                // with up to `MAX_SUMMARY_HASHES_PER_MESSAGE` distinct
-                // fabricated digests, and without this each pair would rerun
-                // `summary_if_hosted_or_in_use` — a contract-handler round trip
-                // — for every contract matching that hash, sequentially, on the
-                // loop the executor needs responsive
-                // (`.claude/rules/code-style.md`, fan-out cost).
+                // with many distinct fabricated digests, and without this each
+                // pair would rerun `summary_if_hosted_or_in_use` — a
+                // contract-handler round trip — for every contract matching
+                // that hash, sequentially, on the loop the executor needs
+                // responsive (`.claude/rules/code-style.md`, fan-out cost).
                 //
-                // With the cache the fetch runs at most ONCE per contract per
-                // message no matter how many pairs name it.
+                // PER-HASH, not per-message, and that scoping is the memory
+                // bound. These are OWNED summary clones; a message-scoped cache
+                // retains one per matched contract until the whole message
+                // finishes, so a peer naming many distinct locally-hosted
+                // hashes accumulates (matched contracts x summary size) —
+                // hundreds of MB at the cap with River-scale summaries. That is
+                // the large-value retention class `contract/executor.rs`
+                // byte-bounds its own summary cache for.
+                //
+                // Per-hash scoping costs nothing real: distinct hashes resolve
+                // to ~disjoint contract sets, so cross-hash caching never had
+                // hits to give. And within one hash the skip below holds
+                // processed pairs to ~2, so stopping the second pair from
+                // refetching is the cache's entire job — which a per-hash cache
+                // does completely. An attacker interleaving A,B,A,B to force
+                // clears gains nothing either: each hash goes inert after its
+                // first mismatch arms the skip.
+                //
+                // Retention is therefore bounded by ONE hash's contract set,
+                // with no byte-budget machinery needed.
                 let mut local_summaries: std::collections::HashMap<
                     ContractInstanceId,
                     Option<freenet_stdlib::prelude::StateSummary<'static>>,
                 > = std::collections::HashMap::new();
+                let mut cached_for_hash: Option<u32> = None;
                 let mut compared_contracts: HashSet<ContractInstanceId> = HashSet::new();
                 // See the sibling set in the `Summaries` arm.
                 let mut one_sided_counted: HashSet<ContractInstanceId> = HashSet::new();
@@ -3421,6 +3441,15 @@ async fn handle_interest_sync_message(
                     if requested_hashes.contains(&entry.hash) {
                         continue;
                     }
+                    // Drop the previous hash's summaries before touching a new
+                    // one. This is the retention bound, not an optimisation.
+                    if cached_for_hash != Some(entry.hash) {
+                        local_summaries.clear();
+                        cached_for_hash = Some(entry.hash);
+                    }
+                    crate::config::GlobalTestMetrics::note_summary_cache_size(
+                        local_summaries.len(),
+                    );
                     // One hash can resolve to several contracts (FNV-1a
                     // collisions), and any one of them needing bytes is enough
                     // to ask — but the hash goes on the request list at most
@@ -3444,6 +3473,9 @@ async fn handle_interest_sync_message(
                         if !local_summaries.contains_key(contract.id()) {
                             let fetched = summary_if_hosted_or_in_use(op_manager, &contract).await;
                             local_summaries.insert(*contract.id(), fetched);
+                            crate::config::GlobalTestMetrics::note_summary_cache_size(
+                                local_summaries.len(),
+                            );
                         }
                         let our_summary = local_summaries
                             .get(contract.id())
@@ -9042,6 +9074,91 @@ mod tests {
                      must be requested; got {other:?}"
                 ),
             }
+        }
+
+        /// Processing many DISTINCT locally-hosted hashes must not accumulate
+        /// their summaries (codex P1, round 3).
+        ///
+        /// # The retention this bounds
+        ///
+        /// The local-summary cache holds OWNED `StateSummary` clones. Scoped to
+        /// the MESSAGE, it retained one per matched contract until the whole
+        /// message finished — so a peer naming many distinct hashes it knows we
+        /// host accumulates (matched contracts x summary size). At the
+        /// per-message cap with River-scale summaries (~33 KB) that is hundreds
+        /// of MB from a single message: the large-value retention class
+        /// `contract/executor.rs` byte-bounds its own summary cache for.
+        ///
+        /// Scoping the cache to the CURRENT hash bounds retention to one hash's
+        /// contract set. This test asserts that directly through the peak cache
+        /// size, rather than through a fetch count — fetches and retention are
+        /// different quantities and only the latter is the OOM risk.
+        ///
+        /// Note the peak is asserted, not the final size: a cache that grew and
+        /// was cleared only at the END of the message would leave a final size
+        /// of ~0 while having held everything at once.
+        #[tokio::test]
+        async fn distinct_hashes_do_not_accumulate_cached_summaries() {
+            use freenet_stdlib::prelude::{CodeHash, ContractInstanceId, ContractKey};
+
+            let h = build_harness("hf-retain", 17100, vec![5u8; 128]).await;
+
+            // 64 contracts this node hosts, each with its own distinct hash.
+            let mut hashes = Vec::new();
+            for i in 0u8..64 {
+                let k = ContractKey::from_id_and_code(
+                    ContractInstanceId::new([i.wrapping_add(100); 32]),
+                    CodeHash::new([i; 32]),
+                );
+                let _ = h
+                    .op_manager
+                    .ring
+                    .host_contract(k, 128, crate::ring::AccessType::Put);
+                h.op_manager.interest_manager.register_local_hosting(&k);
+                hashes.push(contract_hash(&k));
+            }
+            hashes.sort_unstable();
+            hashes.dedup();
+            assert!(
+                hashes.len() >= 32,
+                "premise: the fixture needs many DISTINCT hashes to accumulate, \
+                 got {} — if they collided this tests the wrong thing",
+                hashes.len()
+            );
+
+            crate::config::GlobalTestMetrics::reset();
+
+            // One entry per hash, each digest divergent so every hash resolves
+            // and caches its contract's summary.
+            let entries: Vec<SummaryDigestEntry> = hashes
+                .iter()
+                .map(|hash| SummaryDigestEntry {
+                    hash: *hash,
+                    summary_digest: Some(summary_digest(b"divergent")),
+                })
+                .collect();
+
+            let _ = handle_interest_sync_message(
+                &h.op_manager,
+                h.new_peer,
+                InterestMessage::SummaryDigests {
+                    entries,
+                    emitter: crate::message::SummariesEmitter::Other,
+                },
+            )
+            .await;
+
+            let peak = crate::config::GlobalTestMetrics::summary_cache_peak();
+            assert!(
+                peak <= 4,
+                "the local-summary cache peaked at {peak} entries across \
+                 {} distinct hashes. It must be bounded by ONE hash's contract \
+                 set (1 here), not by how many hashes a peer names — a peak \
+                 tracking the hash count means owned summary clones accumulate \
+                 for the whole message, which is hundreds of MB at the cap with \
+                 real summaries.",
+                hashes.len()
+            );
         }
 
         /// Repeated hashes must be free: a peer that names the same contract

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -8660,19 +8660,26 @@ mod tests {
             assert!(h.drain_heals().is_empty());
         }
 
-        /// The per-message hash cap bounds both the work a peer can force and
-        /// the size of the request it can provoke.
+        /// Repeated hashes must be free: a peer that names the same contract
+        /// 64 times must provoke exactly ONE entry in the request.
         ///
-        /// A digest entry is ~20 bytes for the sender and can cost the
-        /// receiver a contract round trip, an amplification ratio the
-        /// full-bytes `Summaries` never had. Duplicate hashes must be free.
+        /// Entry count is deliberately kept UNDER
+        /// [`MAX_SUMMARY_HASHES_PER_MESSAGE`] so the handler's over-cap
+        /// rotation is the identity and this test is deterministic. The
+        /// over-cap behaviour is the sibling test below; separating them is
+        /// what lets BOTH have hard assertions.
+        ///
+        /// History: this test previously mixed the two concerns — 5,064
+        /// entries against a 256 cap — so its outcome depended on where the
+        /// random rotation landed, and its `None` arm was an unconditional
+        /// pass. It therefore asserted nothing in roughly 94% of runs, and
+        /// `GlobalRng` is unseeded in a plain `#[tokio::test]`, so which runs
+        /// those were varied per invocation.
         #[tokio::test]
-        async fn digest_entries_are_deduplicated_and_capped() {
-            let h = build_harness("hf-cap", 17060, vec![5u8; 128]).await;
+        async fn repeated_digest_hashes_are_deduplicated() {
+            let h = build_harness("hf-dedup", 17060, vec![5u8; 128]).await;
             let hash = contract_hash(&h.key);
 
-            // 5,000 entries: the one real contract repeated, plus a long tail
-            // of unknown hashes.
             let mut entries = vec![
                 SummaryDigestEntry {
                     hash,
@@ -8680,12 +8687,18 @@ mod tests {
                 };
                 64
             ];
-            for i in 0..5_000u32 {
+            // A short tail of unknown hashes, still well under the cap.
+            for i in 0..100u32 {
                 entries.push(SummaryDigestEntry {
                     hash: hash.wrapping_add(i + 1),
                     summary_digest: Some(summary_digest(b"divergent")),
                 });
             }
+            assert!(
+                entries.len() < MAX_SUMMARY_HASHES_PER_MESSAGE,
+                "premise: the fixture must stay under the cap so no rotation \
+                 occurs and this test is deterministic"
+            );
 
             let reply = handle_interest_sync_message(
                 &h.op_manager,
@@ -8699,22 +8712,78 @@ mod tests {
 
             match reply {
                 Some(InterestMessage::SummaryRequest { hashes }) => {
+                    assert_eq!(
+                        hashes.iter().filter(|h| **h == hash).count(),
+                        1,
+                        "a hash repeated 64 times must appear in the request \
+                         exactly once — repetition must buy the sender nothing"
+                    );
+                    assert_eq!(
+                        hashes.len(),
+                        1,
+                        "only the one locally-tracked contract may be \
+                         requested; the 100 unknown hashes resolve to nothing"
+                    );
+                }
+                other => panic!(
+                    "a divergent digest for a tracked contract must provoke a \
+                     SummaryRequest, got {other:?}"
+                ),
+            }
+        }
+
+        /// A massively over-cap digest message must stay bounded and must not
+        /// panic, and the request it provokes must never exceed the cap.
+        ///
+        /// `GlobalRng` is seeded explicitly: the handler rotates its processing
+        /// window by a random offset when the cap binds, and an unseeded
+        /// `#[tokio::test]` falls back to `rand::rng()` (config.rs), making the
+        /// outcome vary per invocation. Any test that depends on rotation or
+        /// sampling must seed.
+        #[tokio::test]
+        async fn over_cap_digest_message_stays_bounded() {
+            crate::config::GlobalRng::set_seed(0x4965_CA9);
+            let h = build_harness("hf-cap", 17065, vec![5u8; 128]).await;
+            let hash = contract_hash(&h.key);
+
+            let mut entries = Vec::new();
+            for i in 0..(MAX_SUMMARY_HASHES_PER_MESSAGE as u32 + 2_000) {
+                entries.push(SummaryDigestEntry {
+                    hash: hash.wrapping_add(i + 1),
+                    summary_digest: Some(summary_digest(b"divergent")),
+                });
+            }
+            assert!(
+                entries.len() > MAX_SUMMARY_HASHES_PER_MESSAGE,
+                "premise: the fixture must EXCEED the cap, or the bound below \
+                 is not being exercised"
+            );
+
+            let reply = handle_interest_sync_message(
+                &h.op_manager,
+                h.new_peer,
+                InterestMessage::SummaryDigests {
+                    entries,
+                    emitter: crate::message::SummariesEmitter::Other,
+                },
+            )
+            .await;
+
+            // Every hash here is unknown to this node, so nothing resolves and
+            // no request is warranted. The property under test is that an
+            // over-cap message is absorbed without panic and without
+            // manufacturing work: `lookup_by_hash` yields nothing for any of
+            // them, so the peer's 6,096 entries buy it exactly nothing.
+            match reply {
+                None => {}
+                Some(InterestMessage::SummaryRequest { hashes }) => {
                     assert!(
                         hashes.len() <= MAX_SUMMARY_HASHES_PER_MESSAGE,
                         "the request must stay bounded by \
                          MAX_SUMMARY_HASHES_PER_MESSAGE, got {}",
                         hashes.len()
                     );
-                    assert_eq!(
-                        hashes.iter().filter(|h| **h == hash).count(),
-                        1,
-                        "a repeated hash must appear in the request at most \
-                         once — repetition must buy the sender nothing"
-                    );
                 }
-                // Legitimate: the random rotation may push the one known hash
-                // outside the processed window. The cap is what is under test.
-                None => {}
                 other => panic!("unexpected reply {other:?}"),
             }
         }

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -363,6 +363,38 @@ pub struct NodeConfig {
     /// `#[serde(skip)]`; never serialized.
     #[serde(skip)]
     pub(crate) summary_first_put_floor_override: Option<(u8, u8, u16)>,
+    /// Test-only override for the hash-first summary version floor
+    /// (`HASH_FIRST_SUMMARIES_MIN_VERSION`, #4965). Threaded exactly like the
+    /// two overrides above and consulted as
+    /// `hash_first_summaries_floor_override().unwrap_or(HASH_FIRST_SUMMARIES_MIN_VERSION)`
+    /// by `ConnectionManager::supports_hash_first_summaries`.
+    ///
+    /// In production this is `None` → the real `(0, 2, 116)` floor (untouched).
+    ///
+    /// **Simulations default this to `SIM_MIGRATION_ENABLED_FLOOR` — ON — which
+    /// is the OPPOSITE of the two overrides above.** The deviation is
+    /// deliberate and is the whole reason this field exists. Those two gate
+    /// behavioural *cascades* (extra directed subscribes, extra probes) that
+    /// pile load onto unrelated sims, so they fail closed. Hash-first changes
+    /// only the ENCODING of an exchange that already runs in every sim, with
+    /// identical convergence semantics — so defaulting it ON costs unrelated
+    /// sims nothing and buys the one thing a version-gated wire change
+    /// otherwise cannot get: the whole simulation suite exercising the new
+    /// path BEFORE the release that lifts the crate version over the floor.
+    /// Without it, the first integration-level run of this code would be the
+    /// release PR itself, where a red sim could not be attributed between the
+    /// feature and the version bump.
+    ///
+    /// `SimNetwork::disable_hash_first_summaries` pins it OFF for a test that
+    /// needs the pre-0.2.116 fallback (mixed-version interop), and
+    /// `enable_hash_first_summaries` states the default explicitly at a call
+    /// site that depends on it.
+    ///
+    /// Not cfg-gated for the same reason as `subscribe_hint_floor_override`:
+    /// `node::testing_impl` sets it and is compiled unconditionally.
+    /// `#[serde(skip)]`; never serialized.
+    #[serde(skip)]
+    pub(crate) hash_first_summaries_floor_override: Option<(u8, u8, u16)>,
     /// Test-only harness flag: when set, a startup-hosted contract
     /// (`SeedHostedContract`, i.e. `append_contracts` with `subscription =
     /// true`) is registered in the neighbor-hosting advertised set so the
@@ -529,6 +561,7 @@ impl NodeConfig {
             governance_config_override: None,
             subscribe_hint_floor_override: None,
             summary_first_put_floor_override: None,
+            hash_first_summaries_floor_override: None,
             advertise_seeded_hosts: false,
             hosting_time_source_override: None,
         })
@@ -2692,13 +2725,41 @@ pub(crate) fn summaries_reply_for_peer(
         .connection_manager
         .supports_hash_first_summaries(target)
     {
+        crate::config::GlobalTestMetrics::record_summary_digest_msg();
         InterestMessage::SummaryDigests {
             entries: entries.iter().map(SummaryDigestEntry::from_entry).collect(),
             emitter,
         }
     } else {
-        InterestMessage::Summaries { entries, emitter }
+        full_summaries_message(entries, emitter)
     }
+}
+
+/// Build a full-bytes [`InterestMessage::Summaries`] and record the summary
+/// payload it puts on the wire (#4965).
+///
+/// **This is the only way production code may construct a `Summaries`**, and
+/// `no_uninstrumented_full_summaries_construction` pins that. The falsifier
+/// for this whole change is "`summary_full_bytes() == 0` means not one summary
+/// byte was sent"; a construction site that bypassed the counter would make
+/// that reading silently false rather than merely untested. Taking the
+/// recording inside the constructor makes the bypass unrepresentable instead
+/// of discouraged — the same reasoning that moved the per-message dedup inside
+/// `record_summary_comparison`.
+pub(crate) fn full_summaries_message(
+    entries: Vec<crate::message::SummaryEntry>,
+    emitter: crate::message::SummariesEmitter,
+) -> crate::message::InterestMessage {
+    // Only the summaries themselves, not the enclosing bincode framing: the
+    // framing is the same handful of bytes in both wire forms, and including
+    // it would blur the one number the falsifier rests on.
+    let payload_bytes: u64 = entries
+        .iter()
+        .filter_map(|e| e.summary_bytes.as_ref())
+        .map(|b| b.len() as u64)
+        .sum();
+    crate::config::GlobalTestMetrics::record_summary_full_msg(payload_bytes);
+    crate::message::InterestMessage::Summaries { entries, emitter }
 }
 
 /// Emit targeted `SyncStateToPeer` heals for the contracts on which `source`
@@ -3251,6 +3312,7 @@ async fn handle_interest_sync_message(
                                     ours.as_ref(),
                                     &mut compared_contracts,
                                 );
+                                crate::config::GlobalTestMetrics::record_summary_digest_agreement();
                                 // `None` delta verdict: there is nothing to
                                 // probe. `summary_indicates_stale_peer` sees
                                 // byte-equal summaries and never reaches the
@@ -3314,6 +3376,7 @@ async fn handle_interest_sync_message(
                 // contract and not one summary byte crossed the wire.
                 None
             } else {
+                crate::config::GlobalTestMetrics::record_summary_byte_request();
                 Some(InterestMessage::SummaryRequest {
                     hashes: request_hashes,
                 })
@@ -3374,10 +3437,10 @@ async fn handle_interest_sync_message(
                 // than replaces, so it gets its own emitter arm — folded into
                 // the heartbeat reply it would look like the heartbeat failing
                 // to shrink, when it is the mismatch tail doing its job.
-                Some(InterestMessage::Summaries {
+                Some(full_summaries_message(
                     entries,
-                    emitter: SummariesEmitter::SummaryRequestReply,
-                })
+                    SummariesEmitter::SummaryRequestReply,
+                ))
             }
         }
 
@@ -8540,6 +8603,100 @@ mod tests {
             }
         }
 
+        /// Source pin: production code must never construct
+        /// `InterestMessage::Summaries` directly — only through
+        /// [`full_summaries_message`], which records the summary bytes it puts
+        /// on the wire.
+        ///
+        /// The whole #4965 falsifier is the reading "`summary_full_bytes() == 0`
+        /// means not one summary byte was sent". A construction site that
+        /// bypassed the constructor would not make that reading untested — it
+        /// would make it FALSE, while every test in this PR stayed green. The
+        /// counter is the only thing standing between "we measured the win" and
+        /// "we assumed it".
+        ///
+        /// Scoped to the production halves of the two files that build these
+        /// messages, cut at their test modules so the test fixtures below
+        /// (which legitimately build `Summaries` by hand to feed the handler)
+        /// do not trip it.
+        #[test]
+        fn no_uninstrumented_full_summaries_construction() {
+            // `node.rs`'s FIRST `#[cfg(test)]` is near the top of the file, so
+            // cutting there would truncate the production code this pin exists
+            // to scan and pass vacuously. Cut at the outer `mod tests` instead.
+            let node_src = include_str!("node.rs");
+            let node_prod = &node_src[..node_src
+                .find("\n#[cfg(test)]\nmod tests {")
+                .expect("node.rs outer test module not found")];
+            assert!(
+                node_prod.contains("fn handle_interest_sync_message("),
+                "the production slice must actually contain the handler — if \
+                 this fails the cut point moved and the scan below is vacuous"
+            );
+
+            let update_src = include_str!("operations/update.rs");
+            let update_prod = &update_src[..update_src
+                .find("\n#[cfg(test)]")
+                .unwrap_or(update_src.len())];
+
+            // The constructor itself is the one legitimate construction site.
+            let ctor = node_prod
+                .find("pub(crate) fn full_summaries_message(")
+                .expect("full_summaries_message constructor not found");
+            let ctor_end = ctor
+                + node_prod[ctor..]
+                    .find("\n}\n")
+                    .expect("constructor body end not found");
+
+            for (name, src, allowed) in [
+                ("node.rs", node_prod, Some((ctor, ctor_end))),
+                ("operations/update.rs", update_prod, None),
+            ] {
+                let needle = concat!("InterestMessage::Summaries", " {");
+                let mut from = 0usize;
+                let mut constructions = 0usize;
+                while let Some(off) = src[from..].find(needle) {
+                    let at = from + off;
+                    from = at + needle.len();
+
+                    // Skip MATCH PATTERNS. `InterestMessage::Summaries { .. }`
+                    // reads identically whether it destructures or constructs,
+                    // and the handler necessarily matches on it. A pattern is
+                    // followed by `=>` after its closing brace; a construction
+                    // is not.
+                    let Some(close) = src[at..].find('}') else {
+                        continue;
+                    };
+                    let after = src[at + close + 1..].trim_start();
+                    if after.starts_with("=>") {
+                        continue;
+                    }
+
+                    constructions += 1;
+                    let inside_ctor = allowed.is_some_and(|(a, b)| at >= a && at <= b);
+                    assert!(
+                        inside_ctor,
+                        "{name} constructs `InterestMessage::Summaries` outside \
+                         `full_summaries_message` (byte offset {at}). Route it \
+                         through the constructor: an uninstrumented site makes \
+                         `summary_full_bytes() == 0` mean nothing, silently."
+                    );
+                }
+
+                // Positive control: node.rs MUST contain the one legitimate
+                // construction. Without this the scan passes vacuously if the
+                // needle or the pattern-skip ever stops matching anything.
+                if allowed.is_some() {
+                    assert_eq!(
+                        constructions, 1,
+                        "expected exactly one `InterestMessage::Summaries` \
+                         construction in {name} (inside full_summaries_message); \
+                         found {constructions}. Zero means this scan is vacuous."
+                    );
+                }
+            }
+        }
+
         /// Source pin: the `SummaryRequest` arm must build its reply as a plain
         /// `InterestMessage::Summaries`, NEVER through
         /// `summaries_reply_for_peer`.
@@ -8568,9 +8725,10 @@ mod tests {
                  contain its get_matching_contracts lookup"
             );
             assert!(
-                body.contains("Some(InterestMessage::Summaries { entries })"),
-                "the SummaryRequest arm must reply with a plain full-bytes \
-                 Summaries"
+                body.contains("full_summaries_message(entries)"),
+                "the SummaryRequest arm must reply through \
+                 full_summaries_message — the instrumented full-bytes \
+                 constructor"
             );
             assert!(
                 !body.contains("summaries_reply_for_peer"),

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -64,9 +64,14 @@ pub(crate) use network_bridge::broadcast_queue::BROADCAST_STREAM_METRICS;
 // re-export rather than a path through `network_bridge` directly. Mirrors
 // `BROADCAST_STREAM_METRICS` above.
 pub(crate) use network_bridge::p2p_protoc::{
-    HASH_FIRST_SHIPPED_IN, HASH_FIRST_SUMMARIES_MIN_VERSION, SUMMARY_FIRST_PUT_MIN_VERSION,
+    HASH_FIRST_SUMMARIES_MIN_VERSION, SUMMARY_FIRST_PUT_MIN_VERSION,
     version_supports_hash_first_summaries, version_supports_summary_first_put,
 };
+// Test-only: the release-timing marker has no runtime reader by design (see
+// its rustdoc), so re-exporting it unconditionally is an unused import in the
+// non-test build.
+#[cfg(test)]
+pub(crate) use network_bridge::p2p_protoc::HASH_FIRST_SHIPPED_IN;
 #[cfg(test)]
 pub(crate) use network_bridge::{EventLoopNotificationsReceiver, event_loop_notification_channel};
 // Re-export types for dev_tool and testing

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -4759,18 +4759,42 @@ mod tests {
         // the positive assertions below would have kept passing with those
         // calls deleted from `Summaries` itself.
         let next_off = src[handler_start..]
-            // `{ entries, .. }`, matching the REAL arm at node.rs:3203. The
-            // bare `{ entries }` form appears NOWHERE in this file except this
-            // line, so `include_str!` made the needle match ITSELF: the window
-            // became 2995..4627 (~1632 lines) instead of ~208, swallowing the
-            // digest arm's own calls and this pin's rustdoc, either of which
-            // satisfies all four assertions with the true `Summaries` arm's
-            // calls deleted. A needle must be verified to resolve to the
-            // INTENDED line, not merely to resolve somewhere (#5076).
+            // `{ entries, .. }` — the destructuring the REAL arm uses. An
+            // earlier revision searched for the bare `{ entries }` form, which
+            // appears NOWHERE in this file except the needle line itself, so
+            // `include_str!` made it match ITS OWN SOURCE: the window widened
+            // roughly eightfold, swallowing the digest arm's own calls and this
+            // pin's rustdoc, either of which satisfies all four assertions with
+            // the true `Summaries` arm's calls deleted. A needle must resolve
+            // to the INTENDED place, not merely resolve somewhere (#5076).
             .find("InterestMessage::SummaryDigests { entries, .. } => {")
             .expect("SummaryDigests arm not found");
-        let summaries_arm =
-            &code_only(&src[handler_start + summaries_off..handler_start + next_off]);
+        let window_end = handler_start + next_off;
+
+        // Hard guard against that failure recurring. If the real arm's shape
+        // ever drifts again, `find` falls through to this pin's own literal
+        // above and the window silently widens to span the test module — which
+        // is exactly how this pin was vacuous twice on this branch. Asserting
+        // the end lands in PRODUCTION code turns the recurrence into a loud
+        // failure instead of a quiet pass.
+        //
+        // Anchored on the outer `mod tests`, not the first `#[cfg(test)]`:
+        // node.rs has a `#[cfg(test)]` near the top, so that marker would put
+        // the boundary BEFORE the handler and make this assertion fire on
+        // correct code. (#5076: a scrape's own scope needs checking too.)
+        let test_mod_start = src
+            .find("\n#[cfg(test)]\nmod tests {")
+            .expect("node.rs outer test module not found");
+        assert!(
+            window_end < test_mod_start,
+            "the Summaries-arm window ends at byte {window_end}, inside the \
+             test module (starts at {test_mod_start}). The end needle has \
+             fallen through to this pin's own source again — the #5076 \
+             self-match — and the window has silently widened. Re-anchor it on \
+             the arm that immediately follows `Summaries` in production code."
+        );
+
+        let summaries_arm = &code_only(&src[handler_start + summaries_off..window_end]);
 
         // #4965: the measurement call must stay wired into this arm. It is
         // pure observation, so deleting it breaks no test and no behavior —

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -3414,6 +3414,33 @@ async fn handle_interest_sync_message(
                 let mut compared_contracts: HashSet<ContractInstanceId> = HashSet::new();
                 // See the sibling set in the `Summaries` arm.
                 let mut one_sided_counted: HashSet<ContractInstanceId> = HashSet::new();
+                // WIRE-ORDER INDEPENDENCE — the invariant this grouping exists
+                // to establish.
+                //
+                // The receiver's work must depend on the message's CONTENT, not
+                // on the order the peer chose to send it in. Take the bounded,
+                // pair-deduped set and GROUP IT BY HASH before doing any work,
+                // so every hash is visited exactly once, contiguously.
+                //
+                // This is a root-cause fix, not another patch. Three separate
+                // findings on this arm were all instances of peer-controlled
+                // ordering: with entries walked in wire order, a peer choosing
+                // an interleaving (A, B, A, B, ...) forced the per-hash cache to
+                // clear and refetch on every revisit. An earlier comment here
+                // argued that could not happen because "the skip arms after a
+                // hash's first mismatch" — that argument was WRONG and is
+                // removed: `DigestVerdict::Agree` does not set `needs_bytes`
+                // (only the `NeedBytes` arm does), so a round of non-arming
+                // entries leaves every hash live and revisitable.
+                //
+                // Grouping makes the whole class unreachable rather than
+                // patching its instances, and restores both bounds at once:
+                // <=1 fetch per contract per message (CPU) and retention <= one
+                // hash's contract set (memory). The pair dedup, the request-list
+                // hash dedup and the skip all remain — grouping does not replace
+                // them, it removes the ordering freedom they were being asked to
+                // absorb.
+                let mut bounded: Vec<crate::message::SummaryDigestEntry> = Vec::new();
                 for entry in entries {
                     // The cap counts distinct PAIRS, matching what is actually
                     // processed — counting distinct hashes would no longer
@@ -3424,25 +3451,28 @@ async fn handle_interest_sync_message(
                     if !seen_pairs.insert((entry.hash, entry.summary_digest)) {
                         continue;
                     }
+                    bounded.push(entry);
+                }
+                // Stable sort by hash: equal hashes become contiguous, and the
+                // relative order WITHIN a hash is preserved, so behaviour for a
+                // single hash is unchanged from before the grouping.
+                bounded.sort_by_key(|e| e.hash);
+
+                for entry in bounded {
                     // Once a hash is on the request list, further pairs naming
                     // it are inert: the full-bytes `Summaries` reply we are
                     // about to receive carries OUR summaries for ALL contracts
                     // matching the hash, so any divergence those pairs would
                     // have found is resolved there anyway.
                     //
-                    // This cannot lose a heal — it defers one, to the reply
-                    // that is already on its way. What it removes is the
-                    // attacker's ability to keep the loop busy: only ONE digest
-                    // value can agree with a given local contract (the digest
-                    // IS the hash of our summary bytes), so all but one
-                    // fabricated pair mismatch, the first mismatch arms this
-                    // skip, and the hash goes inert after ~2 productive
-                    // iterations.
+                    // This cannot lose a heal — it defers one, to the reply that
+                    // is already on its way.
                     if requested_hashes.contains(&entry.hash) {
                         continue;
                     }
-                    // Drop the previous hash's summaries before touching a new
-                    // one. This is the retention bound, not an optimisation.
+                    // Drop the previous hash's summaries before moving to the
+                    // next. This is the retention bound, and with the grouping
+                    // above it fires exactly once per distinct hash.
                     if cached_for_hash != Some(entry.hash) {
                         local_summaries.clear();
                         cached_for_hash = Some(entry.hash);
@@ -9158,6 +9188,118 @@ mod tests {
                  for the whole message, which is hundreds of MB at the cap with \
                  real summaries.",
                 hashes.len()
+            );
+        }
+
+        /// INTERLEAVED hashes must cost the same as grouped ones — the
+        /// receiver's work must not depend on the order the peer chose.
+        ///
+        /// # The finding this pins (codex P1, round 4)
+        ///
+        /// Three earlier findings on this arm were all the same root cause:
+        /// with entries walked in WIRE ORDER, a peer choosing an interleaving
+        /// (A, B, A, B, ...) forced the per-hash summary cache to clear and
+        /// refetch on every revisit, reopening the CPU bound the cache was
+        /// added to close.
+        ///
+        /// A prior comment argued this was impossible because "the skip arms
+        /// after a hash's first mismatch, so the hash goes inert". **That
+        /// argument was false.** `DigestVerdict::Agree` does not set
+        /// `needs_bytes` — only the `NeedBytes` arm does — so a round of
+        /// NON-ARMING entries (agreements, or a `None` digest) leaves every
+        /// hash live and revisitable. The reasoning held for mismatching pairs
+        /// and was wrongly generalised to all pairs.
+        ///
+        /// The fix groups entries by hash before any work, so ordering is not
+        /// the peer's to choose. This test asserts that property directly: the
+        /// same entries interleaved must cost ~one fetch per contract, not one
+        /// per pair.
+        #[tokio::test]
+        async fn interleaved_hashes_cost_the_same_as_grouped_ones() {
+            use freenet_stdlib::prelude::{CodeHash, ContractInstanceId, ContractKey};
+            use std::sync::atomic::Ordering;
+
+            let h = build_harness("hf-interleave", 17110, vec![5u8; 128]).await;
+
+            // 32 hosted contracts, each its own hash.
+            let mut hashes = Vec::new();
+            for i in 0u8..32 {
+                let k = ContractKey::from_id_and_code(
+                    ContractInstanceId::new([i.wrapping_add(160); 32]),
+                    CodeHash::new([i.wrapping_add(3); 32]),
+                );
+                let _ = h
+                    .op_manager
+                    .ring
+                    .host_contract(k, 128, crate::ring::AccessType::Put);
+                h.op_manager.interest_manager.register_local_hosting(&k);
+                hashes.push(contract_hash(&k));
+            }
+            hashes.sort_unstable();
+            hashes.dedup();
+            let n = hashes.len();
+            assert!(n >= 16, "premise: need many distinct hashes, got {n}");
+
+            // Three INTERLEAVED rounds, and the SHAPES matter — this is where
+            // a first attempt at this test went wrong. A round of MISMATCHING
+            // digests arms the skip on its first visit, after which the hash is
+            // inert and never revisited, so a fixture built only from
+            // fabricated digests costs ~one visit per hash even in wire order
+            // and cannot detect the bug at all.
+            //
+            // The revisitable rounds are the NON-ARMING ones: `Agree` (digest
+            // equals our summary's) and `PeerHasNoState` (`None`). Neither sets
+            // `needs_bytes`, so neither arms the skip. Pair dedup means there is
+            // exactly ONE distinct non-arming pair of each kind per hash — the
+            // agreeing digest has only one possible value, and so does `None` —
+            // which also bounds the real-world amplification to ~3 visits per
+            // hash rather than the pair count.
+            let agreeing = summary_digest(&h.our_summary);
+            let mut entries = Vec::new();
+            for hash in &hashes {
+                entries.push(SummaryDigestEntry {
+                    hash: *hash,
+                    summary_digest: Some(agreeing),
+                });
+            }
+            for hash in &hashes {
+                entries.push(SummaryDigestEntry {
+                    hash: *hash,
+                    summary_digest: None,
+                });
+            }
+            for hash in &hashes {
+                entries.push(SummaryDigestEntry {
+                    hash: *hash,
+                    summary_digest: Some(summary_digest(&hash.to_le_bytes())),
+                });
+            }
+            assert!(
+                entries.len() < MAX_SUMMARY_HASHES_PER_MESSAGE,
+                "premise: stay under the cap so the CAP is not what bounds this"
+            );
+
+            let before = h.summary_queries.load(Ordering::Relaxed);
+            let _ = handle_interest_sync_message(
+                &h.op_manager,
+                h.new_peer,
+                InterestMessage::SummaryDigests {
+                    entries,
+                    emitter: crate::message::SummariesEmitter::Other,
+                },
+            )
+            .await;
+            let fetches = h.summary_queries.load(Ordering::Relaxed) - before;
+
+            // One contract per hash, so `n` fetches is the content-determined
+            // floor. Without grouping this is ~4n (one per round per hash).
+            assert!(
+                fetches <= n,
+                "interleaving {n} hashes over 3 non-arming rounds caused \
+                 {fetches} summary \
+                 fetches; grouping should hold it to at most {n} — one per \
+                 contract. A count scaling with the ROUND COUNT means the peer's \
+                 chosen ordering still drives our work."
             );
         }
 

--- a/crates/core/src/node/network_bridge/outbound_message_mix.rs
+++ b/crates/core/src/node/network_bridge/outbound_message_mix.rs
@@ -396,18 +396,18 @@ struct Window {
     /// convention every future call site has to honour — but it is asserted
     /// anyway (`summaries_sub_arms_reconcile_with_the_parent_arm`), since a
     /// silently non-reconciling split is worse than no split.
-    summaries_msgs: [u64; 5],
-    summaries_bytes: [u64; 5],
-    summaries_max_bytes: [u64; 5],
+    summaries_msgs: [u64; SUMMARIES_ARMS.len()],
+    summaries_bytes: [u64; SUMMARIES_ARMS.len()],
+    summaries_max_bytes: [u64; SUMMARIES_ARMS.len()],
     /// Total `SummaryEntry` count across the window's messages, per sub-arm.
     /// Divided by `summaries_msgs` this gives mean entries per message, the
     /// independent check that a call site is labelled correctly — see
     /// [`SummariesDetail::entries`].
-    summaries_entries: [u64; 5],
+    summaries_entries: [u64; SUMMARIES_ARMS.len()],
     /// Largest single message's entry count, per sub-arm. Separates "every
     /// reply is moderately wide" from "one peer shares 400 contracts with us",
     /// which the mean cannot.
-    summaries_max_entries: [u64; 5],
+    summaries_max_entries: [u64; SUMMARIES_ARMS.len()],
     /// InterestSync summary comparisons where both sides held a summary and
     /// the bytes were IDENTICAL. See [`OutboundMix::record_summary_comparison`].
     summary_entries_identical: u64,
@@ -1237,7 +1237,10 @@ mod tests {
         record_summaries(&mix, SummariesEmitter::InterestsReply, 4, 200);
         record_summaries(&mix, SummariesEmitter::ChangeInterestsReply, 3, 400);
         record_summaries(&mix, SummariesEmitter::Rejection, 1, 800);
-        record_summaries(&mix, SummariesEmitter::Other, 1, 1600);
+        // #4965 legs: the full-bytes answer to a request, and the request.
+        record_summaries(&mix, SummariesEmitter::SummaryRequestReply, 2, 1600);
+        record_summaries(&mix, SummariesEmitter::SummaryRequest, 5, 3200);
+        record_summaries(&mix, SummariesEmitter::Other, 1, 6400);
 
         let w = mix.take_window();
         let bytes_of = |e| w.summaries_bytes[summaries_index(e)];
@@ -1245,7 +1248,9 @@ mod tests {
         assert_eq!(bytes_of(SummariesEmitter::InterestsReply), 200);
         assert_eq!(bytes_of(SummariesEmitter::ChangeInterestsReply), 400);
         assert_eq!(bytes_of(SummariesEmitter::Rejection), 800);
-        assert_eq!(bytes_of(SummariesEmitter::Other), 1600);
+        assert_eq!(bytes_of(SummariesEmitter::SummaryRequestReply), 1600);
+        assert_eq!(bytes_of(SummariesEmitter::SummaryRequest), 3200);
+        assert_eq!(bytes_of(SummariesEmitter::Other), 6400);
 
         for emitter in SUMMARIES_ARMS {
             assert_eq!(
@@ -1551,8 +1556,34 @@ mod tests {
 
         // file → the arms it tags, one entry per DISTINCT arm.
         let expected_arms: BTreeMap<&str, Vec<&str>> = [
-            ("node.rs", vec!["ChangeInterestsReply", "InterestsReply"]),
+            (
+                "node.rs",
+                // #4965 added SummaryRequestReply: the full-bytes answer to a
+                // `SummaryRequest`, the one full-bytes send hash-first ADDS
+                // rather than replaces.
+                vec![
+                    "ChangeInterestsReply",
+                    "InterestsReply",
+                    "SummaryRequestReply",
+                ],
+            ),
             ("operations/update.rs", vec!["Notification", "Rejection"]),
+            // The rollup's own index/stem tables name every arm. Listing them
+            // here means adding a `SummariesEmitter` variant without wiring it
+            // a telemetry stem fails this pin rather than silently reporting
+            // under a neighbouring field.
+            (
+                "node/network_bridge/outbound_message_mix.rs",
+                vec![
+                    "ChangeInterestsReply",
+                    "InterestsReply",
+                    "Notification",
+                    "Other",
+                    "Rejection",
+                    "SummaryRequest",
+                    "SummaryRequestReply",
+                ],
+            ),
         ]
         .into_iter()
         .collect();
@@ -1568,7 +1599,14 @@ mod tests {
         );
 
         let mentions = concat!("InterestMessage::", "Summaries {");
-        let tag = concat!("emitter: ", "SummariesEmitter::");
+        // Bare `SummariesEmitter::`, not `emitter: SummariesEmitter::`.
+        // #4965 centralised construction behind `node::summaries_reply_for_peer`
+        // / `full_summaries_message`, so the arm is now named as a call
+        // ARGUMENT at the emitter site rather than as a struct field. Matching
+        // only the field form would have silently found zero arms in both
+        // emitter files and passed — this pin would have gone quiet at exactly
+        // the moment it became load-bearing.
+        let tag = concat!("SummariesEmitter", "::");
 
         let mut found_files: BTreeSet<String> = Default::default();
         let mut found_arms: BTreeMap<String, Vec<String>> = Default::default();
@@ -1586,8 +1624,24 @@ mod tests {
             let Ok(src) = std::fs::read_to_string(path) else {
                 continue;
             };
-            let prod = strip_cfg_test_regions(&src);
-            if !prod.contains(mentions) {
+            // Strip COMMENT lines before scanning. An emitter site is code;
+            // prose that merely names an arm is not. Without this, a rustdoc
+            // intra-doc link (`[\`SummariesEmitter::Other\`]` in message.rs)
+            // registers as an emitter, and worse, any future doc edit that
+            // mentions an arm trips a pin about wire attribution.
+            let prod_all = strip_cfg_test_regions(&src);
+            let prod: String = prod_all
+                .lines()
+                .filter(|l| !l.trim_start().starts_with("//"))
+                .collect::<Vec<_>>()
+                .join("\n");
+            // A file counts if it CONSTRUCTS/matches the variant OR merely
+            // NAMES an arm. #4965 moved construction behind
+            // `node::summaries_reply_for_peer`, so `operations/update.rs` now
+            // only names its arms — under the old construct-only test it
+            // dropped out of scope entirely and its two emitters stopped being
+            // pinned, silently.
+            if !prod.contains(mentions) && !prod.contains(tag) {
                 continue;
             }
             found_files.insert(rel.clone());

--- a/crates/core/src/node/network_bridge/outbound_message_mix.rs
+++ b/crates/core/src/node/network_bridge/outbound_message_mix.rs
@@ -1580,13 +1580,23 @@ mod tests {
     ///      a new file touching it fails CI even before we look at tags, and
     ///   2. the arm each tagging site claims, per file.
     ///
-    /// Known limit, stated rather than papered over: (2) scrapes the literal
-    /// `emitter: SummariesEmitter::<Arm>`, so a site that assigned the tag
-    /// from a variable would escape it. (1) still catches such a site if it
-    /// lives in a new file, and a wrongly-tagged one shows up as an
-    /// entries-per-message anomaly (`entry_counts_are_recorded_per_sub_arm`)
-    /// or in the residual arm. Needles are built with `concat!` so this test's
-    /// own source cannot satisfy the scrape when the walk reaches this file.
+    /// Known limit, stated rather than papered over: (2) scrapes a literal
+    /// arm reference, so a site that computed the tag from a variable would
+    /// escape it. (1) still catches such a site if it lives in a new file, and
+    /// a wrongly-tagged one shows up as an entries-per-message anomaly
+    /// (`entry_counts_are_recorded_per_sub_arm`) or in the residual arm.
+    /// Needles are built with `concat!` so this test's own source cannot
+    /// satisfy the scrape when the walk reaches this file.
+    ///
+    /// The needle is the BARE `SummariesEmitter::<Arm>` form, not
+    /// `emitter: SummariesEmitter::<Arm>`. #4965 centralised construction
+    /// behind `node::summaries_reply_for_peer` / `full_summaries_message`, so
+    /// an emitter site now names its arm as a call ARGUMENT rather than a
+    /// struct field; the field-form needle found zero arms in both emitter
+    /// files and passed. This file is the one exception, scanned with the
+    /// ASSIGNMENT form instead, because `classify` is where `SummaryRequest`
+    /// gets its arm — that message carries no emitter field, having exactly
+    /// one possible origin.
     #[test]
     fn summaries_emitter_sites_are_pinned() {
         use crate::node::network_bridge::p2p_protoc::tests::{

--- a/crates/core/src/node/network_bridge/outbound_message_mix.rs
+++ b/crates/core/src/node/network_bridge/outbound_message_mix.rs
@@ -413,6 +413,19 @@ struct Window {
     summary_entries_identical: u64,
     /// Same, but the summary bytes DIFFERED.
     summary_entries_differing: u64,
+    /// Comparisons where exactly ONE side held a summary (#4965 review S2).
+    ///
+    /// The 98.1% identical figure has a structural hole:
+    /// [`OutboundMix::record_summary_comparison`] only fires in the
+    /// `(Some, Some)` arm, so the one-sided case was never in its denominator.
+    /// That case is NOT neutral under hash-first — it classifies as
+    /// `NeedBytes`, costing +2 messages for bytes the full-bytes path shipped
+    /// immediately AND used to seed the peer-summary cache. It is the #4473
+    /// phantom-interest shape, and its size is unmeasured.
+    ///
+    /// Counted so the post-deploy data can size it rather than leaving the
+    /// headline extrapolated over a population it never observed.
+    summary_entries_one_sided: u64,
     /// Which contracts the differing comparisons belonged to, bounded at
     /// [`MAX_TRACKED_CONTRACTS`].
     ///
@@ -581,6 +594,38 @@ impl OutboundMix {
         }
     }
 
+    /// Record a summary comparison where WE hold no summary but the PEER does
+    /// (#4965 review S2).
+    ///
+    /// Deliberately a separate method rather than a third branch inside
+    /// [`Self::record_summary_comparison`]: that function takes two byte
+    /// slices, and the whole point here is that one of them does not exist.
+    /// Forcing a caller to synthesise an empty slice would have made this
+    /// population indistinguishable from a genuine empty-summary comparison.
+    ///
+    /// Why it matters: the 98.1%-identical headline was computed over
+    /// `(Some, Some)` comparisons only, so this case was never in its
+    /// denominator — yet it is not neutral under hash-first. It classifies as
+    /// `NeedBytes`, which costs +2 messages to fetch bytes the full-bytes path
+    /// delivered immediately and used to seed our peer-summary cache. Sizing
+    /// it is the difference between a headline that generalises and one that
+    /// was extrapolated over a population it never saw.
+    ///
+    /// Shares the caller's per-message dedup set for the same reason the
+    /// two-sided counter does: `entries` is peer-supplied and may repeat a
+    /// hash, so without it a peer could inflate this bucket at will.
+    pub(crate) fn record_summary_one_sided(
+        &self,
+        contract: &ContractInstanceId,
+        counted_this_message: &mut HashSet<ContractInstanceId>,
+    ) {
+        if !counted_this_message.insert(*contract) {
+            return;
+        }
+        let mut w = self.window.lock();
+        w.summary_entries_one_sided = w.summary_entries_one_sided.saturating_add(1);
+    }
+
     /// Atomically take the current window, leaving a fresh empty one.
     fn take_window(&self) -> Window {
         std::mem::take(&mut *self.window.lock())
@@ -658,6 +703,10 @@ fn outbound_mix_json(w: &Window, window_secs: u64) -> serde_json::Value {
     body.insert(
         "summary_entries_differing".into(),
         w.summary_entries_differing.into(),
+    );
+    body.insert(
+        "summary_entries_one_sided".into(),
+        w.summary_entries_one_sided.into(),
     );
     body.insert(
         "differing_attribution_dropped".into(),

--- a/crates/core/src/node/network_bridge/outbound_message_mix.rs
+++ b/crates/core/src/node/network_bridge/outbound_message_mix.rs
@@ -284,7 +284,11 @@ const fn summaries_stem(emitter: SummariesEmitter) -> &'static str {
         SummariesEmitter::ChangeInterestsReply => "interest_sync_summaries_change_interests_reply",
         SummariesEmitter::Rejection => "interest_sync_summaries_rejection",
         SummariesEmitter::SummaryRequestReply => "interest_sync_summaries_request_reply",
-        SummariesEmitter::SummaryRequest => "interest_sync_summaries_request",
+        // `_request_leg`, NOT `_request`: the latter is a strict PREFIX of
+        // `_request_reply` below, so any dashboard glob on
+        // `interest_sync_summaries_request*` would double-count the reply into
+        // the request arm. Free to fix now, breaking once emitted.
+        SummariesEmitter::SummaryRequest => "interest_sync_summaries_request_leg",
         SummariesEmitter::Other => "interest_sync_summaries_other",
     }
 }
@@ -1595,10 +1599,12 @@ mod tests {
         // Deliberately wider than "emitters": the point is that a new file
         // touching Summaries at all is a deliberate decision.
         let expected_files: BTreeSet<&str> = [
-            "message.rs",                                  // variant + Display
-            "node.rs",                                     // both reply emitters + the receive arm
-            "node/network_bridge/outbound_message_mix.rs", // the classify choke point
-            "operations/update.rs",                        // notification + rejection emitters
+            "message.rs",           // variant + Display
+            "node.rs", // both reply emitters, the request-reply emitter, the receive arms
+            "operations/update.rs", // notification + rejection emitters
+            // Claimed via `classify`'s emitter ASSIGNMENT only; its stem
+            // tables are not counted. See the scan below.
+            "node/network_bridge/outbound_message_mix.rs",
         ]
         .into_iter()
         .collect();
@@ -1621,17 +1627,15 @@ mod tests {
             // here means adding a `SummariesEmitter` variant without wiring it
             // a telemetry stem fails this pin rather than silently reporting
             // under a neighbouring field.
+            // The rollup claims exactly the arms `classify` ASSIGNS, not the
+            // seven its stem tables name. Listing all seven made the scan
+            // claim everything unconditionally, silently disabling the
+            // orphan-arm check. `SummaryRequest` is claimed HERE rather than at
+            // a construction site because that message carries no emitter
+            // field — one possible origin, so `classify` assigns it.
             (
                 "node/network_bridge/outbound_message_mix.rs",
-                vec![
-                    "ChangeInterestsReply",
-                    "InterestsReply",
-                    "Notification",
-                    "Other",
-                    "Rejection",
-                    "SummaryRequest",
-                    "SummaryRequestReply",
-                ],
+                vec!["SummaryRequest"],
             ),
         ]
         .into_iter()
@@ -1684,6 +1688,37 @@ mod tests {
                 .filter(|l| !l.trim_start().starts_with("//"))
                 .collect::<Vec<_>>()
                 .join("\n");
+            // The rollup's own index/stem tables name every arm; counting them
+            // as claims makes the orphan-arm check vacuous. See the note on
+            // `expected_arms`.
+            if rel == "node/network_bridge/outbound_message_mix.rs" {
+                // Not simply excluded: `classify` ASSIGNS an emitter to
+                // `SummaryRequest`, which — unlike `Summaries` and
+                // `SummaryDigests` — carries no emitter field on the wire type
+                // because it has exactly one possible origin. That assignment
+                // IS the arm's wiring, so collect it with a needle matching
+                // assignment (`emitter: SummariesEmitter::`) rather than the
+                // stem/index match tables (`SummariesEmitter::X =>`), which
+                // name all seven arms and would claim everything.
+                let assign = concat!("emitter: ", "SummariesEmitter", "::");
+                let mut arms: Vec<String> = prod
+                    .match_indices(assign)
+                    .map(|(idx, _)| {
+                        prod[idx + assign.len()..]
+                            .split(|c: char| !c.is_alphanumeric() && c != '_')
+                            .next()
+                            .unwrap_or("")
+                            .to_string()
+                    })
+                    .collect();
+                arms.sort();
+                arms.dedup();
+                if !arms.is_empty() {
+                    found_arms.insert(rel.clone(), arms);
+                    found_files.insert(rel);
+                }
+                continue;
+            }
             // A file counts if it CONSTRUCTS/matches the variant OR merely
             // NAMES an arm. #4965 moved construction behind
             // `node::summaries_reply_for_peer`, so `operations/update.rs` now

--- a/crates/core/src/node/network_bridge/outbound_message_mix.rs
+++ b/crates/core/src/node/network_bridge/outbound_message_mix.rs
@@ -123,15 +123,27 @@ pub(crate) enum OutboundKind {
     /// arm could not tell them apart — the #4965 measurement hinges on which
     /// leg the 53-75% actually sits in.
     InterestSyncInterests,
-    /// InterestSync reply leg: `Summaries`. The leading suspect, because
-    /// `SummaryEntry::summary_bytes` ships a FULL `StateSummary` per shared
-    /// contract to every connected peer on every cycle
-    /// (`node.rs::handle_interest_sync_message`).
+    /// InterestSync reply leg — the WHOLE summary exchange: `Summaries`, plus
+    /// its hash-first legs `SummaryDigests` and `SummaryRequest` (#4965).
+    ///
+    /// The leading suspect, because `SummaryEntry::summary_bytes` ships a FULL
+    /// `StateSummary` per shared contract to every connected peer on every
+    /// cycle (`node.rs::handle_interest_sync_message`).
     ///
     /// Measured at 49.8% of all outbound bytes on the fleet (v0.2.115, 1,174
     /// peers), which is what makes it worth a second level of split: this arm
-    /// alone still lumps four unrelated emitters together. See
+    /// alone still lumps several unrelated emitters together. See
     /// [`SummariesEmitter`] and [`Window::summaries_bytes`].
+    ///
+    /// All THREE hash-first legs land in this one arm on purpose: #4965
+    /// replaces a single `Summaries` with up to three messages
+    /// (`SummaryDigests` -> `SummaryRequest` -> `Summaries`), so splitting them
+    /// across arms would make `interest_sync_summaries_bytes` collapse for a
+    /// trivial reason and hide the extra legs in a bucket that did not exist
+    /// before. Keeping them together makes the same field a like-for-like
+    /// before/after total for the whole mechanism — which is exactly the
+    /// falsifier: if hash-first does not shrink this number, it did not work.
+    /// The per-emitter split below still separates them.
     InterestSyncSummaries,
     /// InterestSync heal leg: `ResyncRequest` / `ResyncResponse`. Separate
     /// because `ResyncResponse` carries full contract STATE, so folding it
@@ -238,11 +250,16 @@ pub(crate) struct SummariesDetail {
 /// Kept here rather than on [`SummariesEmitter`] itself: the enum is a
 /// protocol-adjacent type, the index and the field stem are facts about this
 /// rollup's wire-to-telemetry shape.
-const SUMMARIES_ARMS: [SummariesEmitter; 5] = [
+const SUMMARIES_ARMS: [SummariesEmitter; 7] = [
     SummariesEmitter::Notification,
     SummariesEmitter::InterestsReply,
     SummariesEmitter::ChangeInterestsReply,
     SummariesEmitter::Rejection,
+    // #4965 hash-first legs. Appended so the existing arms keep their indices
+    // and a dashboard query built against the pre-#4965 rollup does not
+    // silently start reading a different arm's numbers.
+    SummariesEmitter::SummaryRequestReply,
+    SummariesEmitter::SummaryRequest,
     SummariesEmitter::Other,
 ];
 
@@ -252,7 +269,9 @@ const fn summaries_index(emitter: SummariesEmitter) -> usize {
         SummariesEmitter::InterestsReply => 1,
         SummariesEmitter::ChangeInterestsReply => 2,
         SummariesEmitter::Rejection => 3,
-        SummariesEmitter::Other => 4,
+        SummariesEmitter::SummaryRequestReply => 4,
+        SummariesEmitter::SummaryRequest => 5,
+        SummariesEmitter::Other => 6,
     }
 }
 
@@ -264,6 +283,8 @@ const fn summaries_stem(emitter: SummariesEmitter) -> &'static str {
         SummariesEmitter::InterestsReply => "interest_sync_summaries_interests_reply",
         SummariesEmitter::ChangeInterestsReply => "interest_sync_summaries_change_interests_reply",
         SummariesEmitter::Rejection => "interest_sync_summaries_rejection",
+        SummariesEmitter::SummaryRequestReply => "interest_sync_summaries_request_reply",
+        SummariesEmitter::SummaryRequest => "interest_sync_summaries_request",
         SummariesEmitter::Other => "interest_sync_summaries_other",
     }
 }
@@ -314,6 +335,28 @@ impl OutboundClass {
                         summaries: Some(SummariesDetail {
                             emitter: *emitter,
                             entries: entries.len() as u64,
+                        }),
+                    },
+                    // #4965: the digest form carries the SAME emitter tag as
+                    // the `Summaries` it replaces, so a send path keeps its
+                    // per-emitter attribution across the hash-first migration
+                    // instead of silently moving into the residual arm.
+                    InterestMessage::SummaryDigests { entries, emitter } => Self {
+                        kind: OutboundKind::InterestSyncSummaries,
+                        summaries: Some(SummariesDetail {
+                            emitter: *emitter,
+                            entries: entries.len() as u64,
+                        }),
+                    },
+                    // The bytes-on-mismatch request leg. Tagged rather than
+                    // left `plain` because the per-emitter arms must SUM to
+                    // this kind's totals; an untagged message would open a gap
+                    // between the split and the arm it splits.
+                    InterestMessage::SummaryRequest { hashes } => Self {
+                        kind: OutboundKind::InterestSyncSummaries,
+                        summaries: Some(SummariesDetail {
+                            emitter: SummariesEmitter::SummaryRequest,
+                            entries: hashes.len() as u64,
                         }),
                     },
                     InterestMessage::ResyncRequest { .. }

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -956,6 +956,54 @@ pub(crate) fn version_supports_summary_first_put(
     remote.is_some_and(|v| v >= floor)
 }
 
+/// Minimum reported peer version before this node may emit the hash-first
+/// `InterestSync` variants ([`InterestMessage::SummaryDigests`] /
+/// [`InterestMessage::SummaryRequest`], #4965).
+///
+/// # Emission gate
+///
+/// Consulted by `ConnectionManager::supports_hash_first_summaries`, which
+/// every `Summaries` send site checks before choosing the digest form:
+/// `node.rs::handle_interest_sync_message` (the `Interests`, `ChangeInterests`
+/// and `SummaryRequest` replies) and the two `operations::update` helpers
+/// (`send_proactive_summary_notification`, `send_summary_back_on_rejection`).
+/// A pre-floor peer does not carry these variant indices at all and cannot
+/// bincode-deserialize them; the decode failure DROPS the connection, so it
+/// must never receive one. Below the floor — and whenever the remote version
+/// is UNKNOWN — every site falls back to the existing full-bytes
+/// `Summaries`, which is exactly today's behaviour.
+///
+/// The variants, both send sites and the receive handlers all land together in
+/// this PR; no released version carries them inert. Per the wire-gated-floor
+/// rule in `docs/RELEASING.md` ("set the floor to exactly the release that
+/// first EMITS the feature, then freeze"), the floor is the next release after
+/// the 0.2.115 this branched from: `(0, 2, 116)`.
+///
+/// RELEASE-TIME CHECK (do NOT skip): this constant MUST equal the actual
+/// shipping version. A floor BELOW it sends an undecodable variant to peers on
+/// the release just before, churning live connections during the 0-4h
+/// staggered rollout; a floor ABOVE it silently disables the feature against
+/// fully-capable peers. Once the release ships, FREEZE it.
+pub(crate) const HASH_FIRST_SUMMARIES_MIN_VERSION: (u8, u8, u16) = (0, 2, 116);
+
+/// Pure version-gate for the hash-first summary exchange, mirroring
+/// [`version_supports_subscribe_hint`] and
+/// [`version_supports_summary_first_put`]: `true` iff `remote` is known
+/// (`Some`) AND at least `floor`.
+///
+/// Fail-closed on `None` for the reason spelled out on
+/// [`HASH_FIRST_SUMMARIES_MIN_VERSION`]: an unknown version might be a peer
+/// that drops the connection on the undecodable variant, and the fallback
+/// (send the full summary bytes) is merely today's cost, never a correctness
+/// loss. Takes an explicit `floor` so the predicate is unit-testable
+/// independent of the production constant.
+pub(crate) fn version_supports_hash_first_summaries(
+    remote: Option<(u8, u8, u16)>,
+    floor: (u8, u8, u16),
+) -> bool {
+    remote.is_some_and(|v| v >= floor)
+}
+
 /// Upper bound on the number of hosted contracts examined per new-peer
 /// migration trigger. Each examined contract may emit a best-effort
 /// non-blocking `try_send` (the SubscribeHint nudge), so an unbounded scan
@@ -3546,7 +3594,8 @@ pub(crate) mod tests {
 
     mod version_gate {
         use super::super::{
-            SUBSCRIBE_HINT_MIN_VERSION, SUMMARY_FIRST_PUT_MIN_VERSION,
+            HASH_FIRST_SUMMARIES_MIN_VERSION, SUBSCRIBE_HINT_MIN_VERSION,
+            SUMMARY_FIRST_PUT_MIN_VERSION, version_supports_hash_first_summaries,
             version_supports_subscribe_hint, version_supports_summary_first_put,
         };
 
@@ -3662,6 +3711,56 @@ pub(crate) mod tests {
             assert!(version_supports_summary_first_put(
                 Some((1, 0, 0)),
                 SF_FLOOR
+            ));
+        }
+
+        /// The hash-first summary gate (#4965), same three properties as the
+        /// summary-first PUT gate above and for the same reason: a peer that
+        /// predates `InterestMessage::SummaryDigests` cannot deserialize the
+        /// appended variant index and drops the connection.
+        ///
+        /// Covers the mixed-version rollout window explicitly: 0.2.115 is the
+        /// last release with neither variant, and during the 0-4h staggered
+        /// rollout most of the fleet is exactly there.
+        #[test]
+        fn hash_first_summaries_gate_fails_closed_and_discriminates() {
+            const HF_FLOOR: (u8, u8, u16) = (0, 2, 116);
+
+            assert!(
+                !version_supports_hash_first_summaries(None, HF_FLOOR),
+                "unknown remote version must fail CLOSED"
+            );
+            assert!(
+                !version_supports_hash_first_summaries(Some((0, 2, 115)), HF_FLOOR),
+                "0.2.115 is the last release WITHOUT the variants; a \
+                 SummaryDigests sent to it fails to decode and drops the \
+                 connection"
+            );
+            assert!(!version_supports_hash_first_summaries(
+                Some((0, 1, 40)),
+                HF_FLOOR
+            ));
+            assert!(
+                version_supports_hash_first_summaries(Some((0, 2, 116)), HF_FLOOR),
+                "the floor release carries both variants and their handlers"
+            );
+            assert!(version_supports_hash_first_summaries(
+                Some((0, 3, 0)),
+                HF_FLOOR
+            ));
+            assert!(version_supports_hash_first_summaries(
+                Some((1, 0, 0)),
+                HF_FLOOR
+            ));
+
+            // Wired to the production constant, not just the test floor.
+            assert!(!version_supports_hash_first_summaries(
+                None,
+                HASH_FIRST_SUMMARIES_MIN_VERSION
+            ));
+            assert!(version_supports_hash_first_summaries(
+                Some(HASH_FIRST_SUMMARIES_MIN_VERSION),
+                HASH_FIRST_SUMMARIES_MIN_VERSION
             ));
         }
 

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -984,6 +984,38 @@ pub(crate) fn version_supports_summary_first_put(
 /// the release just before, churning live connections during the 0-4h
 /// staggered rollout; a floor ABOVE it silently disables the feature against
 /// fully-capable peers. Once the release ships, FREEZE it.
+/// Has the hash-first exchange actually SHIPPED, and in which release?
+///
+/// `None` — not yet shipped. [`HASH_FIRST_SUMMARIES_MIN_VERSION`] is a
+/// PREDICTION about the next release, and must stay strictly ABOVE the current
+/// crate version.
+///
+/// `Some(v)` — shipped in `v`, which must EQUAL the floor, frozen thereafter.
+///
+/// # Why a marker instead of a manual release-time check
+///
+/// The floor is only correct if this PR ships in exactly the release it names.
+/// Five releases went out in the four days before this was written, so "the
+/// next release" is a moving target and `docs/RELEASING.md`'s manual check is
+/// not enough at that cadence.
+///
+/// The failure it guards is not cosmetic. If 0.2.116 ships WITHOUT this
+/// feature, the floor goes stale while every test stays green — and then a
+/// peer running the real 0.2.116 (which has no `SummaryDigests` variant index)
+/// reads as at-floor, receives a digest, fails to bincode-decode it, and the
+/// connection is CLOSED. During a 0-4h staggered rollout that is fleet-wide
+/// churn presenting as a transport fault.
+///
+/// `hash_first_floor_tracks_the_shipping_release` makes that unrepresentable:
+/// the moment a release bump raises `CARGO_PKG_VERSION` to the floor's value,
+/// the test fails until someone consciously either flips this to `Some(floor)`
+/// (we are shipping it) or raises the floor (we are not). The release cannot
+/// silently outrun the floor in either direction.
+///
+/// RELEASE-TIME ACTION: when the release carrying this feature is cut, set
+/// this to `Some(HASH_FIRST_SUMMARIES_MIN_VERSION)` and freeze both.
+pub(crate) const HASH_FIRST_SHIPPED_IN: Option<(u8, u8, u16)> = None;
+
 pub(crate) const HASH_FIRST_SUMMARIES_MIN_VERSION: (u8, u8, u16) = (0, 2, 116);
 
 /// Pure version-gate for the hash-first summary exchange, mirroring

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -979,6 +979,7 @@ pub(crate) fn version_supports_summary_first_put(
 ///   `SummaryRequest`, so it is necessarily at or above the floor.
 /// - The **`Notification` and `Rejection`** legs ship full bytes this release
 ///   (#4965 review §2), so there is no encoding choice to gate.
+///
 /// A pre-floor peer does not carry these variant indices at all and cannot
 /// bincode-deserialize them; the decode failure DROPS the connection, so it
 /// must never receive one. Below the floor — and whenever the remote version
@@ -1026,6 +1027,14 @@ pub(crate) fn version_supports_summary_first_put(
 ///
 /// RELEASE-TIME ACTION: when the release carrying this feature is cut, set
 /// this to `Some(HASH_FIRST_SUMMARIES_MIN_VERSION)` and freeze both.
+///
+/// Read only by `hash_first_floor_tracks_the_shipping_release`. It carries no
+/// runtime behaviour by design — its whole job is to make a release-time
+/// decision explicit and testable — so the non-test build sees it as dead.
+/// `allow(dead_code)` rather than deletion or a runtime reader: the constant IS
+/// the guard's input, and a runtime reader invented to satisfy the lint would
+/// be the fake dependency this codebase already avoids elsewhere.
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) const HASH_FIRST_SHIPPED_IN: Option<(u8, u8, u16)> = None;
 
 pub(crate) const HASH_FIRST_SUMMARIES_MIN_VERSION: (u8, u8, u16) = (0, 2, 116);

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -962,11 +962,23 @@ pub(crate) fn version_supports_summary_first_put(
 ///
 /// # Emission gate
 ///
-/// Consulted by `ConnectionManager::supports_hash_first_summaries`, which
-/// every `Summaries` send site checks before choosing the digest form:
-/// `node.rs::handle_interest_sync_message` (the `Interests`, `ChangeInterests`
-/// and `SummaryRequest` replies) and the two `operations::update` helpers
-/// (`send_proactive_summary_notification`, `send_summary_back_on_rejection`).
+/// Consulted by `ConnectionManager::supports_hash_first_summaries`, which the
+/// digest-capable send sites check before choosing the digest form: the
+/// `Interests` and `ChangeInterests` replies in
+/// `node.rs::handle_interest_sync_message`, both via
+/// `node::summaries_reply_for_peer`.
+///
+/// Two send sites deliberately do NOT consult it:
+///
+/// - The **`SummaryRequest` reply** is unconditionally full bytes. Routing it
+///   through the version gate would be worse than pointless — replying to a
+///   request FOR bytes with digests loops the exchange — and
+///   `summary_request_reply_is_always_full_bytes` asserts the chooser is
+///   absent from that arm. It is safe without a version check by inference:
+///   only a peer that already decoded a `SummaryDigests` can have sent us a
+///   `SummaryRequest`, so it is necessarily at or above the floor.
+/// - The **`Notification` and `Rejection`** legs ship full bytes this release
+///   (#4965 review §2), so there is no encoding choice to gate.
 /// A pre-floor peer does not carry these variant indices at all and cannot
 /// bincode-deserialize them; the decode failure DROPS the connection, so it
 /// must never receive one. Below the floor — and whenever the remote version

--- a/crates/core/src/node/network_bridge/p2p_protoc/connection_lifecycle.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc/connection_lifecycle.rs
@@ -1052,13 +1052,15 @@ impl P2pConnManager {
         // variants — e.g. the summary-first PUT probe's
         // `supports_summary_first_put` check. Keep this write paired with
         // the `self.connections.insert` above if that call site changes.
-        if let Some(version) = remote_version {
-            self.bridge
-                .op_manager
-                .ring
-                .connection_manager
-                .record_remote_version(peer_addr, version);
-        }
+        // Write the Option THROUGH — unconditionally, so a reconnection whose
+        // version is unknown (`None`, the joiner->gateway path) CLEARS any
+        // stale entry rather than leaving us believing a downgraded peer is
+        // still current. See `ConnectionManager::record_remote_version`.
+        self.bridge
+            .op_manager
+            .ring
+            .connection_manager
+            .record_remote_version(peer_addr, remote_version);
         // Only add to reverse lookup if we know the pub_key
         // For transient connections, this will be populated when identity is learned
         if let Some(ref peer) = peer_id {

--- a/crates/core/src/node/testing_impl.rs
+++ b/crates/core/src/node/testing_impl.rs
@@ -1392,6 +1392,21 @@ pub struct SimNetwork {
     /// untouched: `NodeConfig::new` sets this to `None`, which resolves to
     /// the real `SUMMARY_FIRST_PUT_MIN_VERSION`.
     summary_first_put_floor_override: Option<(u8, u8, u16)>,
+    /// Per-node hash-first summary version-floor override (#4965, see
+    /// [`SimNetwork::enable_hash_first_summaries`]).
+    ///
+    /// **Defaults to `Some(SIM_MIGRATION_ENABLED_FLOOR)` — ON — which is the
+    /// OPPOSITE of the two overrides above.** They gate behavioural cascades
+    /// that pile load onto unrelated sims, so they fail closed. Hash-first
+    /// only changes the ENCODING of the `Summaries` exchange that already
+    /// runs in every sim, with identical convergence semantics, so ON by
+    /// default costs unrelated sims nothing — and it is the only way the
+    /// suite exercises the new wire path before the release that lifts the
+    /// crate version over the production floor. Without it the first
+    /// integration-level run of a Full-tier protocol change would be the
+    /// release PR, where a red sim could not be attributed between the
+    /// feature and the version bump.
+    hash_first_summaries_floor_override: Option<(u8, u8, u16)>,
     /// Optional controllable hosting clock injected into every node's
     /// `HostingManager` (via `NodeConfig::hosting_time_source_override`). When
     /// set, hosting-cache TTL and subscription-lease eviction advance ONLY when
@@ -1585,6 +1600,12 @@ impl SimNetwork {
             // `subscribe_hint_floor_override` above: summary-first PUT is
             // genuinely opt-in per sim via `enable_summary_first_put`.
             summary_first_put_floor_override: Some(Self::SIM_MIGRATION_DISABLED_FLOOR),
+            // Fail-OPEN by default, deliberately unlike the two above (#4965).
+            // See the field's rustdoc: hash-first is an encoding change, not a
+            // load-bearing cascade, and defaulting it ON is what gives a
+            // version-gated wire change simulation coverage BEFORE the release
+            // that lifts the crate version past its floor.
+            hash_first_summaries_floor_override: Some(Self::SIM_MIGRATION_ENABLED_FLOOR),
             hosting_clock: None,
             hosting_budget_override: None,
             shared_rings: HashMap::new(),
@@ -1914,6 +1935,49 @@ impl SimNetwork {
         }
         for (builder, _) in self.nodes.iter_mut() {
             builder.config.summary_first_put_floor_override = floor;
+        }
+        self
+    }
+
+    /// State explicitly that this simulation exercises the hash-first summary
+    /// exchange (#4965) by pinning the per-node floor to the always-passing
+    /// [`Self::SIM_MIGRATION_ENABLED_FLOOR`].
+    ///
+    /// This is ALREADY the default for every `SimNetwork` (see `new_inner`),
+    /// so calling it changes nothing — it exists so a test whose premise
+    /// depends on hash-first being on says so at the call site instead of
+    /// relying on a default that a future edit could flip out from under it.
+    /// Mirrors [`disable_summary_first_put`](Self::disable_summary_first_put)'s
+    /// belt-and-suspenders rationale, in the opposite direction.
+    #[allow(dead_code)]
+    pub fn enable_hash_first_summaries(&mut self) -> &mut Self {
+        let floor = Some(Self::SIM_MIGRATION_ENABLED_FLOOR);
+        self.hash_first_summaries_floor_override = floor;
+        for (builder, _) in self.gateways.iter_mut() {
+            builder.config.hash_first_summaries_floor_override = floor;
+        }
+        for (builder, _) in self.nodes.iter_mut() {
+            builder.config.hash_first_summaries_floor_override = floor;
+        }
+        self
+    }
+
+    /// Force the hash-first summary exchange OFF for this simulation by
+    /// pinning the per-node floor to the unreachable
+    /// [`Self::SIM_MIGRATION_DISABLED_FLOOR`], so every peer falls back to the
+    /// full-bytes `InterestMessage::Summaries`.
+    ///
+    /// This is the PRE-0.2.116 fleet: it reproduces what an un-upgraded peer
+    /// does, which is what makes a mixed-version interop test possible at all.
+    #[allow(dead_code)]
+    pub fn disable_hash_first_summaries(&mut self) -> &mut Self {
+        let floor = Some(Self::SIM_MIGRATION_DISABLED_FLOOR);
+        self.hash_first_summaries_floor_override = floor;
+        for (builder, _) in self.gateways.iter_mut() {
+            builder.config.hash_first_summaries_floor_override = floor;
+        }
+        for (builder, _) in self.nodes.iter_mut() {
+            builder.config.hash_first_summaries_floor_override = floor;
         }
         self
     }
@@ -2570,6 +2634,7 @@ impl SimNetwork {
             config.governance_config_override = self.governance_config_override.clone();
             config.subscribe_hint_floor_override = self.subscribe_hint_floor_override;
             config.summary_first_put_floor_override = self.summary_first_put_floor_override;
+            config.hash_first_summaries_floor_override = self.hash_first_summaries_floor_override;
             config.hosting_time_source_override = self
                 .hosting_clock
                 .clone()
@@ -2670,6 +2735,7 @@ impl SimNetwork {
             config.governance_config_override = self.governance_config_override.clone();
             config.subscribe_hint_floor_override = self.subscribe_hint_floor_override;
             config.summary_first_put_floor_override = self.summary_first_put_floor_override;
+            config.hash_first_summaries_floor_override = self.hash_first_summaries_floor_override;
             config.hosting_time_source_override = self
                 .hosting_clock
                 .clone()

--- a/crates/core/src/node/testing_impl.rs
+++ b/crates/core/src/node/testing_impl.rs
@@ -1968,7 +1968,16 @@ impl SimNetwork {
     /// full-bytes `InterestMessage::Summaries`.
     ///
     /// This is the PRE-0.2.116 fleet: it reproduces what an un-upgraded peer
-    /// does, which is what makes a mixed-version interop test possible at all.
+    /// does.
+    ///
+    /// Note the override is per-node (`builder.config`), so a genuinely MIXED
+    /// simulation — one peer at the floor, one below — is constructible by
+    /// setting the two builders differently rather than using this helper,
+    /// which sets every node uniformly. No such test exists yet; the mixed
+    /// case that IS covered today is incidental rather than constructed: a
+    /// regular node never learns its gateway's version (the gateway's
+    /// `AckConnection` carries none), so every gateway link already runs
+    /// digests one way and full bytes the other.
     #[allow(dead_code)]
     pub fn disable_hash_first_summaries(&mut self) -> &mut Self {
         let floor = Some(Self::SIM_MIGRATION_DISABLED_FLOOR);

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -846,7 +846,7 @@ pub(crate) async fn send_proactive_summary_notification(
     key: &ContractKey,
     sender_addr: SocketAddr,
 ) {
-    use crate::message::{InterestMessage, SummariesEmitter, SummaryEntry};
+    use crate::message::{SummariesEmitter, SummaryEntry};
     use crate::ring::interest::contract_hash;
 
     // Throttle: at most one notification per contract per 100ms
@@ -990,7 +990,7 @@ pub(crate) async fn send_summary_back_on_rejection(
     target_addr: SocketAddr,
     sender_summary_bytes: Vec<u8>,
 ) {
-    use crate::message::{InterestMessage, SummariesEmitter, SummaryEntry};
+    use crate::message::{SummariesEmitter, SummaryEntry};
     use crate::ring::interest::contract_hash;
 
     // Throttle BEFORE the WASM `summarize_state` call. Even with call

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -1045,11 +1045,19 @@ pub(crate) async fn send_summary_back_on_rejection(
     // fan-out #5003 actually changes.
     //
     // #4965: this path only runs once we have ALREADY established that
-    // `our_summary == sender_summary_bytes`, so a digest is GUARANTEED to
-    // match on the receiving side, and the seeding this exists to do (their
-    // cache of us flipping `None` -> `Some`) completes from the digest alone —
-    // the receiver caches its own bytes, which the digest proved are ours.
-    // Shipping the bytes would be pure waste in the one case this is reachable.
+    // `our_summary == sender_summary_bytes`, so in the expected case the
+    // digest matches on the receiving side and the seeding this exists to do
+    // (their cache of us flipping `None` -> `Some`) completes from the digest
+    // alone — the receiver caches its own bytes, which the digest proved are
+    // ours, and shipping the bytes would be pure waste.
+    //
+    // NOT guaranteed, deliberately stated: the receiver re-derives its summary
+    // through `summary_if_hosted_or_in_use`, which returns `None` for a
+    // contract it no longer hosts or serves (#4473). It then classifies as
+    // `NeedBytes` and asks — costing one extra round trip, never a lost
+    // update. The rejection that got us here proves the peer HAD the state a
+    // moment ago, so this is a narrow race, but an absolute claim here would
+    // be wrong.
     let full_entry = SummaryEntry::from_summary(hash, Some(&our_summary));
     let message = crate::node::summaries_reply_for_peer(
         op_manager,

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -872,16 +872,22 @@ pub(crate) async fn send_proactive_summary_notification(
         return;
     };
 
-    // Build the Summaries message with our updated summary
+    // The wire form is chosen PER PEER (#4965): a peer whose reported version
+    // clears the hash-first floor gets a `SummaryDigests`, everyone else the
+    // full-bytes `Summaries`. Both are built from this one `SummaryEntry`, so
+    // the two forms can never describe different state.
+    //
+    // This is the send site that fires on every state change to every
+    // interested peer, so it is where a ~33 KB summary is most often shipped
+    // to a peer that just received the same update and therefore already
+    // agrees — the single biggest source of the bytes #4965 removes.
+    //
+    // #5052: this is also the per-state-change fan-out that #5003 targets. It
+    // is the only SINGLE-entry emitter that fans across peers, so its
+    // bytes/msgs ratio is what tells a notification apart from a heartbeat
+    // reply in the rollup; the tag rides both wire forms.
     let hash = contract_hash(key);
-    let message = InterestMessage::Summaries {
-        entries: vec![SummaryEntry::from_summary(hash, Some(&summary))],
-        // #5052: this is the per-state-change fan-out, the emitter #5003
-        // targets. It is the only SINGLE-entry emitter that fans across peers,
-        // so its bytes/msgs ratio is what tells a `summary` apart from a
-        // heartbeat reply in the rollup.
-        emitter: SummariesEmitter::Notification,
-    };
+    let full_entry = SummaryEntry::from_summary(hash, Some(&summary));
 
     // Get interested peers and send to each (excluding the sender who just sent us the update)
     let interested = op_manager.interest_manager.get_interested_peers(key);
@@ -909,10 +915,17 @@ pub(crate) async fn send_proactive_summary_notification(
             continue;
         }
 
+        let message = crate::node::summaries_reply_for_peer(
+            op_manager,
+            peer_addr,
+            vec![full_entry.clone()],
+            SummariesEmitter::Notification,
+        );
+
         if let Err(e) = op_manager
             .notify_node_event(NodeEvent::SendInterestMessage {
                 target: peer_addr,
-                message: message.clone(),
+                message,
             })
             .await
         {
@@ -1026,14 +1039,24 @@ pub(crate) async fn send_summary_back_on_rejection(
     }
 
     let hash = contract_hash(key);
-    let message = InterestMessage::Summaries {
-        entries: vec![SummaryEntry::from_summary(hash, Some(&our_summary))],
-        // #5052: same SHAPE as the notification above (single entry, real
-        // summary) but a different trigger and a much narrower gate, so it
-        // gets its own arm. Sharing one would make the notification arm look
-        // larger than the fan-out #5003 actually changes.
-        emitter: SummariesEmitter::Rejection,
-    };
+    // #5052: same SHAPE as the notification above (single entry, real summary)
+    // but a different trigger and a much narrower gate, so it gets its own
+    // arm. Sharing one would make the notification arm look larger than the
+    // fan-out #5003 actually changes.
+    //
+    // #4965: this path only runs once we have ALREADY established that
+    // `our_summary == sender_summary_bytes`, so a digest is GUARANTEED to
+    // match on the receiving side, and the seeding this exists to do (their
+    // cache of us flipping `None` -> `Some`) completes from the digest alone —
+    // the receiver caches its own bytes, which the digest proved are ours.
+    // Shipping the bytes would be pure waste in the one case this is reachable.
+    let full_entry = SummaryEntry::from_summary(hash, Some(&our_summary));
+    let message = crate::node::summaries_reply_for_peer(
+        op_manager,
+        target_addr,
+        vec![full_entry],
+        SummariesEmitter::Rejection,
+    );
 
     if let Err(e) = op_manager
         .notify_node_event(NodeEvent::SendInterestMessage {

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -915,9 +915,29 @@ pub(crate) async fn send_proactive_summary_notification(
             continue;
         }
 
-        let message = crate::node::summaries_reply_for_peer(
-            op_manager,
-            peer_addr,
+        // FULL BYTES, deliberately — this leg does NOT ship digest-first
+        // this release (#4965 review §2).
+        //
+        // The 98.1% agreement measurement that justifies hash-first comes from
+        // a heartbeat-dominated population. This site is the opposite case: it
+        // fires immediately after WE change state, so its receivers are
+        // precisely the peers least likely to have applied the update yet. A
+        // mismatch here costs 1 message -> 3 (digests, request, bytes) for the
+        // SAME bytes, and defers the heal a round trip — a bad trade on the
+        // #4861 messages/s axis if the agreement rate is materially below the
+        // heartbeat's. Nothing in the field can currently tell us: the
+        // single/multi agreement split lives in thread-local test metrics, not
+        // fleet telemetry, and there is no runtime kill-switch.
+        //
+        // #5003 makes it worse before it makes it better: it removes advertised
+        // co-hosts from this leg's recipients — exactly the peers most likely
+        // to agree.
+        //
+        // So: ship where the evidence is (the two multi-entry reply legs),
+        // extend here next release once `summaries_entries` and the agreement
+        // counters give a field reading. The emitter tag is unchanged, so the
+        // rollup keeps attributing this leg either way.
+        let message = crate::node::full_summaries_message(
             vec![full_entry.clone()],
             SummariesEmitter::Notification,
         );
@@ -1059,12 +1079,15 @@ pub(crate) async fn send_summary_back_on_rejection(
     // moment ago, so this is a narrow race, but an absolute claim here would
     // be wrong.
     let full_entry = SummaryEntry::from_summary(hash, Some(&our_summary));
-    let message = crate::node::summaries_reply_for_peer(
-        op_manager,
-        target_addr,
-        vec![full_entry],
-        SummariesEmitter::Rejection,
-    );
+    // FULL BYTES, same release-scoping as the notification leg above (#4965
+    // review §2): single-entry, state-change-driven, and outside the
+    // population the 98.1% agreement figure was measured on. The digest would
+    // very likely match here (this path only runs once the peer's summary is
+    // known equal to ours), but "very likely" on an unmeasured leg is exactly
+    // what the review declined to ship — and the saving is one summary on a
+    // path that fires ~80-130 times/hour/gateway, not a stream.
+    let message =
+        crate::node::full_summaries_message(vec![full_entry], SummariesEmitter::Rejection);
 
     if let Err(e) = op_manager
         .notify_node_event(NodeEvent::SendInterestMessage {

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -872,20 +872,30 @@ pub(crate) async fn send_proactive_summary_notification(
         return;
     };
 
-    // The wire form is chosen PER PEER (#4965): a peer whose reported version
-    // clears the hash-first floor gets a `SummaryDigests`, everyone else the
-    // full-bytes `Summaries`. Both are built from this one `SummaryEntry`, so
-    // the two forms can never describe different state.
+    // One `SummaryEntry`, built once here and reused for every interested peer
+    // in the loop below — the summary is identical for all of them, so there
+    // is nothing per-peer to compute.
     //
-    // This is the send site that fires on every state change to every
-    // interested peer, so it is where a ~33 KB summary is most often shipped
-    // to a peer that just received the same update and therefore already
-    // agrees — the single biggest source of the bytes #4965 removes.
+    // This leg ships FULL BYTES this release. Hash-first (#4965) does NOT
+    // apply here: digest-first rides the two multi-entry reply legs
+    // (`InterestsReply` / `ChangeInterestsReply`) only, and the send site 40
+    // lines below carries the evidential reasoning for why this one was left
+    // out. There is no per-peer encoding choice on this path, and no version
+    // gate is consulted.
+    //
+    // Worth stating because the opposite is the intuitive guess: this is the
+    // send site that fires on every state change to every interested peer, so
+    // it looks like the biggest available saving. It is deliberately NOT
+    // taken, because its receivers are the population least likely to have
+    // applied the update yet — the one place a digest is most likely to MISS
+    // and cost 1 message -> 3 for the same bytes. It is the strongest
+    // candidate for the NEXT release, once the agreement counters give a field
+    // reading, not a saving already banked.
     //
     // #5052: this is also the per-state-change fan-out that #5003 targets. It
     // is the only SINGLE-entry emitter that fans across peers, so its
     // bytes/msgs ratio is what tells a notification apart from a heartbeat
-    // reply in the rollup; the tag rides both wire forms.
+    // reply in the rollup.
     let hash = contract_hash(key);
     let full_entry = SummaryEntry::from_summary(hash, Some(&summary));
 

--- a/crates/core/src/ring/connection_manager.rs
+++ b/crates/core/src/ring/connection_manager.rs
@@ -1385,6 +1385,31 @@ impl ConnectionManager {
         crate::node::version_supports_summary_first_put(remote, floor)
     }
 
+    /// Whether the peer at `addr` reports a version new enough to understand
+    /// the hash-first `InterestSync` variants (`InterestMessage::SummaryDigests`
+    /// / `SummaryRequest`, #4965).
+    ///
+    /// Same shape and same fail-closed rule as
+    /// [`Self::supports_summary_first_put`]: an unknown version is treated as
+    /// unsupported, because a peer that lacks the variant index drops the
+    /// connection on the decode failure. Every caller's fallback is the
+    /// existing full-bytes `InterestMessage::Summaries`, so failing closed
+    /// costs bandwidth, never convergence.
+    ///
+    /// Deliberately has NO floor override: the gate that actually binds is
+    /// `remote_version`, which is only ever populated by the real transport
+    /// handshake (`p2p_protoc::connection_lifecycle`). An override would not
+    /// make the feature reachable anywhere the handshake does not run, so it
+    /// would be dead configuration. The receive-side handlers are unit-tested
+    /// directly against a `ConnectionManager` seeded with
+    /// [`Self::record_remote_version`] — the production mechanism.
+    pub(crate) fn supports_hash_first_summaries(&self, addr: SocketAddr) -> bool {
+        crate::node::version_supports_hash_first_summaries(
+            self.remote_version(addr),
+            crate::node::HASH_FIRST_SUMMARIES_MIN_VERSION,
+        )
+    }
+
     /// Reserve the next `window`-sized slice of the hosting set for a migration
     /// scan and advance the rotating cursor by `window`. Returns the start
     /// offset (callers should take it modulo the current hosting-set size). Over
@@ -2708,6 +2733,85 @@ mod tests {
         let at_floor_addr = make_addr(9004);
         cm.record_remote_version(at_floor_addr, crate::node::SUMMARY_FIRST_PUT_MIN_VERSION);
         assert!(cm.supports_summary_first_put(at_floor_addr));
+    }
+
+    // ============ hash-first summary version-gate tests (#4965) ============
+
+    /// The send gate for `InterestMessage::SummaryDigests` / `SummaryRequest`.
+    ///
+    /// Mirrors the summary-first PUT gate above and matters for the same
+    /// reason: a peer that predates the variants cannot bincode-deserialize
+    /// them and DROPS THE CONNECTION on the decode failure. During the 0-4h
+    /// staggered rollout most peers are pre-floor, so getting this wrong
+    /// churns live connections network-wide.
+    ///
+    /// Asserts the gate DISCRIMINATES rather than merely always-rejecting: an
+    /// unknown peer and the last pre-floor release are refused, the floor
+    /// release and anything newer are accepted.
+    #[test]
+    fn supports_hash_first_summaries_gate_discriminates_by_version() {
+        let cm = make_connection_manager(Some(make_addr(9100)), 1, 10, false);
+
+        let unknown = make_addr(9101);
+        assert!(
+            !cm.supports_hash_first_summaries(unknown),
+            "an unrecorded peer version must fail CLOSED — sending an \
+             undecodable variant to a pre-floor peer drops the connection, \
+             while the fallback merely costs the bytes we send today"
+        );
+
+        // 0.2.115 is the highest already-released version at the time this
+        // shipped and carries neither variant.
+        let pre_floor = make_addr(9102);
+        cm.record_remote_version(pre_floor, (0, 2, 115));
+        assert!(
+            !cm.supports_hash_first_summaries(pre_floor),
+            "a peer one release below the floor has no SummaryDigests variant \
+             index; it must keep receiving full-bytes Summaries"
+        );
+
+        let at_floor = make_addr(9103);
+        cm.record_remote_version(at_floor, crate::node::HASH_FIRST_SUMMARIES_MIN_VERSION);
+        assert!(
+            cm.supports_hash_first_summaries(at_floor),
+            "the floor release itself carries the variants and their handlers, \
+             so it must be accepted — otherwise the feature never activates"
+        );
+
+        let newer = make_addr(9104);
+        cm.record_remote_version(newer, (0, 3, 0));
+        assert!(
+            cm.supports_hash_first_summaries(newer),
+            "a peer above the floor must stay supported (the floor is a \
+             minimum, never an equality test)"
+        );
+    }
+
+    /// The hash-first floor must stay strictly ABOVE the last release that
+    /// shipped WITHOUT the variants.
+    ///
+    /// 0.2.115 is that release — it is the version this feature branched from,
+    /// and it carries neither `SummaryDigests` nor `SummaryRequest`. Every
+    /// peer on 0.2.115 or below drops its connection on receiving one.
+    ///
+    /// Deliberately pinned against that FROZEN constant rather than against
+    /// `CARGO_PKG_VERSION`: the floor is frozen at the first-shipping release
+    /// while the crate version keeps moving, so a comparison against the
+    /// current crate version would fail on the very next release and train the
+    /// next agent to edit the floor — the exact mistake `docs/RELEASING.md`
+    /// forbids ("set it to the first-shipping release, then freeze").
+    #[test]
+    fn hash_first_floor_stays_above_every_release_without_the_variants() {
+        /// Last release that does NOT carry the hash-first wire variants.
+        const LAST_RELEASE_WITHOUT_VARIANTS: (u8, u8, u16) = (0, 2, 115);
+        assert!(
+            crate::node::HASH_FIRST_SUMMARIES_MIN_VERSION > LAST_RELEASE_WITHOUT_VARIANTS,
+            "HASH_FIRST_SUMMARIES_MIN_VERSION ({:?}) dropped to or below \
+             {LAST_RELEASE_WITHOUT_VARIANTS:?}, a release with no \
+             SummaryDigests variant index. Emitting to those peers fails to \
+             decode and drops the connection.",
+            crate::node::HASH_FIRST_SUMMARIES_MIN_VERSION,
+        );
     }
 
     // ============ cleanup_expired_transients tests ============

--- a/crates/core/src/ring/connection_manager.rs
+++ b/crates/core/src/ring/connection_manager.rs
@@ -2883,19 +2883,100 @@ mod tests {
         );
     }
 
-    /// The hash-first floor must stay strictly ABOVE the last release that
-    /// shipped WITHOUT the variants.
+    /// The hash-first floor must track the release that actually ships it.
     ///
-    /// 0.2.115 is that release — it is the version this feature branched from,
-    /// and it carries neither `SummaryDigests` nor `SummaryRequest`. Every
-    /// peer on 0.2.115 or below drops its connection on receiving one.
+    /// Two failure directions, both fleet-wide and both silent under the
+    /// previous frozen-literal guard:
     ///
-    /// Deliberately pinned against that FROZEN constant rather than against
-    /// `CARGO_PKG_VERSION`: the floor is frozen at the first-shipping release
-    /// while the crate version keeps moving, so a comparison against the
-    /// current crate version would fail on the very next release and train the
-    /// next agent to edit the floor — the exact mistake `docs/RELEASING.md`
-    /// forbids ("set it to the first-shipping release, then freeze").
+    /// - **Floor too LOW** (a release ships at or above the floor WITHOUT the
+    ///   feature): peers on that real release read as at-floor, receive a
+    ///   `SummaryDigests` they have no variant index for, fail to
+    ///   bincode-decode, and the connection is CLOSED.
+    /// - **Floor too HIGH** (the feature ships below its own floor): the gate
+    ///   never opens and the feature is inert against fully-capable peers.
+    ///
+    /// The previous guard compared the floor against a frozen
+    /// `LAST_RELEASE_WITHOUT_VARIANTS = (0,2,115)` literal, which can only
+    /// catch the floor moving DOWN. It cannot notice the RELEASE moving up
+    /// past a floor that stayed put — the actual risk at this project's
+    /// cadence (five releases in the four days before this was written).
+    ///
+    /// This version couples the floor to `CARGO_PKG_VERSION` through
+    /// [`crate::node::HASH_FIRST_SHIPPED_IN`], so a release bump forces a
+    /// conscious decision instead of a silent drift.
+    #[test]
+    fn hash_first_floor_tracks_the_shipping_release() {
+        /// `CARGO_PKG_VERSION` of the `freenet` crate as a comparable triple.
+        /// Pre-release suffixes (`-rc1`) are dropped: they order below the
+        /// release proper, so ignoring them is the conservative direction.
+        fn crate_version() -> (u8, u8, u16) {
+            let v = env!("CARGO_PKG_VERSION");
+            let mut it = v.split('.');
+            let major = it.next().unwrap().parse().expect("major");
+            let minor = it.next().unwrap().parse().expect("minor");
+            let patch = it
+                .next()
+                .unwrap()
+                .split(['-', '+'])
+                .next()
+                .unwrap()
+                .parse()
+                .expect("patch");
+            (major, minor, patch)
+        }
+
+        let floor = crate::node::HASH_FIRST_SUMMARIES_MIN_VERSION;
+        let current = crate_version();
+
+        match crate::node::HASH_FIRST_SHIPPED_IN {
+            None => {
+                // Not shipped yet: the floor is a PREDICTION about a future
+                // release, so it must still be ahead of the crate version.
+                // This is the assertion that fires on the release bump PR.
+                assert!(
+                    floor > current,
+                    "HASH_FIRST_SUMMARIES_MIN_VERSION is {floor:?} but the crate \
+                     is already at {current:?}, and HASH_FIRST_SHIPPED_IN is \
+                     None.\n\n\
+                     The release has caught up with the floor. Decide which is \
+                     true and encode it:\n\
+                     - This release DOES carry hash-first -> set \
+                     HASH_FIRST_SHIPPED_IN = Some({floor:?}) and freeze both.\n\
+                     - It does NOT -> raise HASH_FIRST_SUMMARIES_MIN_VERSION to \
+                     the release that will.\n\n\
+                     Leaving it as-is ships a floor that peers on the real \
+                     {current:?} satisfy without carrying the SummaryDigests \
+                     variant: they cannot decode it, and the connection is \
+                     closed. See HASH_FIRST_SHIPPED_IN."
+                );
+            }
+            Some(shipped) => {
+                assert_eq!(
+                    shipped, floor,
+                    "HASH_FIRST_SHIPPED_IN ({shipped:?}) must EQUAL \
+                     HASH_FIRST_SUMMARIES_MIN_VERSION ({floor:?}). The gate opens \
+                     at the floor, so a mismatch means peers on the shipping \
+                     release either receive a variant they lack, or never \
+                     receive one they have."
+                );
+                assert!(
+                    floor <= current,
+                    "HASH_FIRST_SHIPPED_IN says the feature shipped in \
+                     {shipped:?}, but the crate is only at {current:?} — a \
+                     release cannot have shipped in the future. One of the two \
+                     is wrong."
+                );
+            }
+        }
+    }
+
+    /// Companion to the marker guard: the floor must never drop to or below a
+    /// release known NOT to carry the variants.
+    ///
+    /// Kept alongside the marker test rather than replaced by it, because the
+    /// two catch different mistakes: this one catches the floor being LOWERED
+    /// (e.g. someone "fixing" a gate that seems not to fire), the marker one
+    /// catches the RELEASE advancing past a stationary floor.
     #[test]
     fn hash_first_floor_stays_above_every_release_without_the_variants() {
         /// Last release that does NOT carry the hash-first wire variants.

--- a/crates/core/src/ring/connection_manager.rs
+++ b/crates/core/src/ring/connection_manager.rs
@@ -466,12 +466,29 @@ pub(crate) struct ConnectionManager {
     /// Populated at connection establishment
     /// (`p2p_protoc::connection_lifecycle`, the same call site that populates
     /// `P2pConnManager.connections[addr].remote_version`) via
-    /// `record_remote_version`. Never proactively removed: a stale entry can
-    /// only matter if a different peer later reconnects at the exact same
-    /// socket address with an older version, and any real reconnection at
-    /// that address overwrites the entry before it is ever consulted (lookups
-    /// only target addresses with a live connection). Unknown addresses
-    /// (`None`) fail closed in `version_supports_summary_first_put`.
+    /// `record_remote_version`, which writes the `Option` THROUGH — a `None`
+    /// clears any prior entry.
+    ///
+    /// That unconditional write is load-bearing, and the reasoning this
+    /// rustdoc used to carry was wrong. It claimed a stale entry could not
+    /// matter because "any real reconnection at that address overwrites the
+    /// entry before it is ever consulted". That holds only when the
+    /// reconnection yields `Some`. It does NOT on the joiner->gateway path,
+    /// where the gateway's `AckConnection` carries no version and the
+    /// handshake yields `None`: under the old `if let Some(version)` guard
+    /// nothing was written, so a peer that reconnected on an OLDER build kept
+    /// its stale entry, we kept believing it was current, and it received a
+    /// wire variant it could not decode — which closes the connection
+    /// (`p2p_protoc.rs`, `ConnectionError::Serialization`) and reads as a
+    /// transport fault.
+    ///
+    /// Pre-existing (`SUMMARY_FIRST_PUT_MIN_VERSION` had the same exposure),
+    /// but hash-first (#4965) changes the frequency from rare to persistent:
+    /// summary-first PUT consults the mirror only when PUTting to that peer,
+    /// while hash-first consults it on EVERY interest-sync exchange with it.
+    ///
+    /// Unknown addresses (`None`) fail closed in every
+    /// `version_supports_*` predicate.
     #[allow(clippy::type_complexity)]
     remote_version: Arc<RwLock<BTreeMap<SocketAddr, (u8, u8, u16)>>>,
     /// Test-only override for the summary-first PUT probe version floor,
@@ -1349,16 +1366,30 @@ impl ConnectionManager {
         self.subscribe_hint_floor_override
     }
 
-    /// Record the negotiated protocol version for a peer at `addr`, mirroring
-    /// `P2pConnManager.connections[addr].remote_version` so op drivers can
-    /// read it via `op_manager.ring.connection_manager`. Overwrites any prior
-    /// entry for `addr` (a fresh connection at a reused address always wins).
+    /// Record (or CLEAR) the negotiated protocol version for a peer at `addr`,
+    /// mirroring `P2pConnManager.connections[addr].remote_version` so op
+    /// drivers can read it via `op_manager.ring.connection_manager`.
+    ///
+    /// Takes the `Option` rather than a bare version, and writes it through:
+    /// `Some` overwrites, **`None` REMOVES**. A fresh connection at a reused
+    /// address always wins, including when that connection's version is
+    /// unknown — which is the whole point. Accepting only `Some` let a stale
+    /// entry outlive the connection that created it and made us send an
+    /// undecodable wire variant to a downgraded peer; see the
+    /// `remote_version` field rustdoc for the full failure.
     ///
     /// Called from `p2p_protoc::connection_lifecycle` at the same point
     /// `P2pConnManager` records `remote_version` on its own `connections`
     /// entry — keep the two writes together if that call site changes.
-    pub(crate) fn record_remote_version(&self, addr: SocketAddr, version: (u8, u8, u16)) {
-        self.remote_version.write().insert(addr, version);
+    pub(crate) fn record_remote_version(&self, addr: SocketAddr, version: Option<(u8, u8, u16)>) {
+        match version {
+            Some(v) => {
+                self.remote_version.write().insert(addr, v);
+            }
+            None => {
+                self.remote_version.write().remove(&addr);
+            }
+        }
     }
 
     /// Look up the negotiated protocol version recorded for `addr` via
@@ -2695,7 +2726,7 @@ mod tests {
         let cm = make_connection_manager(Some(make_addr(9000)), 1, 10, false);
         let addr = make_addr(9001);
         assert_eq!(cm.remote_version(addr), None);
-        cm.record_remote_version(addr, (0, 2, 94));
+        cm.record_remote_version(addr, Some((0, 2, 94)));
         assert_eq!(cm.remote_version(addr), Some((0, 2, 94)));
     }
 
@@ -2724,7 +2755,7 @@ mod tests {
         let cm = make_connection_manager(Some(make_addr(9000)), 1, 10, false);
 
         let pre_floor_addr = make_addr(9003);
-        cm.record_remote_version(pre_floor_addr, (0, 2, 80));
+        cm.record_remote_version(pre_floor_addr, Some((0, 2, 80)));
         assert!(!cm.supports_summary_first_put(pre_floor_addr));
 
         // The exact staggered-rollout boundary (#4642 step 3-bis): the probe
@@ -2735,7 +2766,7 @@ mod tests {
         // must therefore fall back to a full-state PUT and NEVER send it a
         // probe. The floor being strictly greater than 0.2.94 enforces this.
         let pre_variant_peer = make_addr(9005);
-        cm.record_remote_version(pre_variant_peer, (0, 2, 94));
+        cm.record_remote_version(pre_variant_peer, Some((0, 2, 94)));
         assert!(
             !cm.supports_summary_first_put(pre_variant_peer),
             "a 0.2.94 peer has no probe variants; a probe would fail to decode \
@@ -2746,7 +2777,10 @@ mod tests {
         // A peer at the floor (0.2.95, the first release carrying the probe
         // variants + handler) is accepted.
         let at_floor_addr = make_addr(9004);
-        cm.record_remote_version(at_floor_addr, crate::node::SUMMARY_FIRST_PUT_MIN_VERSION);
+        cm.record_remote_version(
+            at_floor_addr,
+            Some(crate::node::SUMMARY_FIRST_PUT_MIN_VERSION),
+        );
         assert!(cm.supports_summary_first_put(at_floor_addr));
     }
 
@@ -2778,7 +2812,7 @@ mod tests {
         // 0.2.115 is the highest already-released version at the time this
         // shipped and carries neither variant.
         let pre_floor = make_addr(9102);
-        cm.record_remote_version(pre_floor, (0, 2, 115));
+        cm.record_remote_version(pre_floor, Some((0, 2, 115)));
         assert!(
             !cm.supports_hash_first_summaries(pre_floor),
             "a peer one release below the floor has no SummaryDigests variant \
@@ -2786,7 +2820,10 @@ mod tests {
         );
 
         let at_floor = make_addr(9103);
-        cm.record_remote_version(at_floor, crate::node::HASH_FIRST_SUMMARIES_MIN_VERSION);
+        cm.record_remote_version(
+            at_floor,
+            Some(crate::node::HASH_FIRST_SUMMARIES_MIN_VERSION),
+        );
         assert!(
             cm.supports_hash_first_summaries(at_floor),
             "the floor release itself carries the variants and their handlers, \
@@ -2794,11 +2831,55 @@ mod tests {
         );
 
         let newer = make_addr(9104);
-        cm.record_remote_version(newer, (0, 3, 0));
+        cm.record_remote_version(newer, Some((0, 3, 0)));
         assert!(
             cm.supports_hash_first_summaries(newer),
             "a peer above the floor must stay supported (the floor is a \
              minimum, never an equality test)"
+        );
+    }
+
+    /// A reconnection whose version is UNKNOWN must CLEAR the mirror, not
+    /// leave the previous connection's version standing.
+    ///
+    /// The failure this guards is not hypothetical arithmetic. A peer
+    /// reconnects on an older build; the joiner->gateway handshake yields
+    /// `None` (the gateway's `AckConnection` carries no version); under the
+    /// old `if let Some(version)` write the stale entry survived; we kept
+    /// believing the peer was current and sent it `SummaryDigests`; it could
+    /// not decode the variant and the connection was CLOSED. The visible
+    /// symptom is connection flap that looks like a transport fault.
+    ///
+    /// Pre-existing exposure (summary-first PUT had it too), but hash-first
+    /// consults this mirror on every interest-sync exchange rather than only
+    /// when PUTting to that peer, which turns rare into persistent.
+    #[test]
+    fn unknown_version_on_reconnect_clears_the_mirror() {
+        let cm = make_connection_manager(Some(make_addr(9200)), 1, 10, false);
+        let addr = make_addr(9201);
+
+        // First connection: a current peer.
+        cm.record_remote_version(addr, Some(crate::node::HASH_FIRST_SUMMARIES_MIN_VERSION));
+        assert_eq!(
+            cm.remote_version(addr),
+            Some(crate::node::HASH_FIRST_SUMMARIES_MIN_VERSION)
+        );
+        assert!(
+            cm.supports_hash_first_summaries(addr),
+            "precondition: the peer is believed capable"
+        );
+
+        // Reconnection at the same address with an UNKNOWN version.
+        cm.record_remote_version(addr, None);
+
+        assert_eq!(
+            cm.remote_version(addr),
+            None,
+            "an unknown-version reconnection must REMOVE the stale entry - leaving it makes us send a wire variant the peer may not be able to decode, which closes the connection"
+        );
+        assert!(
+            !cm.supports_hash_first_summaries(addr),
+            "with the version cleared the gate must fail closed again, so the peer goes back to receiving full-bytes Summaries"
         );
     }
 

--- a/crates/core/src/ring/connection_manager.rs
+++ b/crates/core/src/ring/connection_manager.rs
@@ -480,6 +480,13 @@ pub(crate) struct ConnectionManager {
     /// `Some(floor)` only in a sim test that opted in via
     /// `SimNetwork::enable_summary_first_put`. See `NodeConfig`.
     summary_first_put_floor_override: Option<(u8, u8, u16)>,
+    /// Test-only override for the hash-first summary version floor (#4965),
+    /// threaded exactly like `summary_first_put_floor_override`. `None` in
+    /// production (the real `HASH_FIRST_SUMMARIES_MIN_VERSION` applies).
+    /// Simulations default it to an always-passing floor so the suite
+    /// exercises the hash-first path before the crate version reaches the
+    /// production floor. See `NodeConfig`.
+    hash_first_summaries_floor_override: Option<(u8, u8, u16)>,
     /// Rotating start offset for the per-new-peer migration scan. The scan
     /// examines at most `MIGRATION_SCAN_CAP_PER_NEW_PEER` hosted contracts per
     /// event; advancing this cursor each event makes successive events cover
@@ -610,6 +617,7 @@ impl ConnectionManager {
         // sim opted into the migration cascade.
         cm.subscribe_hint_floor_override = config.subscribe_hint_floor_override;
         cm.summary_first_put_floor_override = config.summary_first_put_floor_override;
+        cm.hash_first_summaries_floor_override = config.hash_first_summaries_floor_override;
         cm
     }
 
@@ -646,6 +654,7 @@ impl ConnectionManager {
             remote_version: Arc::new(RwLock::new(BTreeMap::new())),
             // Default off; `new(config)` overrides from config after init.
             summary_first_put_floor_override: None,
+            hash_first_summaries_floor_override: None,
             migration_scan_cursor: Arc::new(AtomicUsize::new(0)),
             transient_connections: Arc::new(DashMap::new()),
             transient_in_use: Arc::new(AtomicUsize::new(0)),
@@ -1396,18 +1405,24 @@ impl ConnectionManager {
     /// existing full-bytes `InterestMessage::Summaries`, so failing closed
     /// costs bandwidth, never convergence.
     ///
-    /// Deliberately has NO floor override: the gate that actually binds is
-    /// `remote_version`, which is only ever populated by the real transport
-    /// handshake (`p2p_protoc::connection_lifecycle`). An override would not
-    /// make the feature reachable anywhere the handshake does not run, so it
-    /// would be dead configuration. The receive-side handlers are unit-tested
-    /// directly against a `ConnectionManager` seeded with
-    /// [`Self::record_remote_version`] — the production mechanism.
+    /// Honours `NodeConfig::hash_first_summaries_floor_override` exactly like
+    /// [`Self::supports_summary_first_put`] does. Simulations run the real
+    /// transport handshake, so `remote_version` IS populated there (with the
+    /// crate version) — which is what makes the override load-bearing rather
+    /// than decorative: it is the only way the simulation suite can exercise
+    /// this path before the release that lifts the crate version over the
+    /// production floor.
+    ///
+    /// Note the asymmetry a sim test must respect: a connection carries the
+    /// version of the peer that introduced itself over it, so only one
+    /// DIRECTION of a sim peer pair may have a known version. A test that
+    /// picks the wrong direction gets `None`, fails closed, and silently
+    /// exercises the fallback instead of the feature.
     pub(crate) fn supports_hash_first_summaries(&self, addr: SocketAddr) -> bool {
-        crate::node::version_supports_hash_first_summaries(
-            self.remote_version(addr),
-            crate::node::HASH_FIRST_SUMMARIES_MIN_VERSION,
-        )
+        let floor = self
+            .hash_first_summaries_floor_override
+            .unwrap_or(crate::node::HASH_FIRST_SUMMARIES_MIN_VERSION);
+        crate::node::version_supports_hash_first_summaries(self.remote_version(addr), floor)
     }
 
     /// Reserve the next `window`-sized slice of the hosting set for a migration

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -406,6 +406,60 @@ pub fn contract_hash(contract: &ContractKey) -> u32 {
     hash
 }
 
+/// Length in bytes of a [`SummaryDigest`].
+///
+/// 16 bytes (128 bits). The digest replaces a full `StateSummary` on the wire
+/// (~33 KB for a River room), so the cost of a wide digest is a rounding
+/// error, while a narrow one would make accidental collisions — which read as
+/// "the peer agrees with us" and therefore SUPPRESS a heal — thinkable. At 128
+/// bits they are not.
+pub const SUMMARY_DIGEST_LEN: usize = 16;
+
+/// A digest of a contract's `StateSummary` **bytes**, used by the hash-first
+/// `InterestSync` exchange (#4965) to say "my summary is X" without shipping
+/// the summary itself.
+pub type SummaryDigest = [u8; SUMMARY_DIGEST_LEN];
+
+/// Digest of a contract's state-summary bytes: truncated BLAKE3.
+///
+/// # This is NOT [`contract_hash`]
+///
+/// The two hashes live next to each other on purpose, because conflating them
+/// is the obvious mistake and they answer different questions:
+///
+/// | | [`contract_hash`] | [`summary_digest`] |
+/// |---|---|---|
+/// | input | contract INSTANCE ID | the contract's state SUMMARY bytes |
+/// | answers | *which* contract | *what state* we hold of it |
+/// | changes when | never, for a given contract | every state change |
+/// | algorithm | FNV-1a, 32-bit | BLAKE3, truncated to 128-bit |
+/// | collisions | fine (extra comparisons) | must not happen (suppresses a heal) |
+///
+/// `SummaryDigestEntry` carries BOTH: `hash` identifies the contract,
+/// `summary_digest` describes our state of it.
+///
+/// # Why BLAKE3 and not a `Hasher`
+///
+/// The digest is a WIRE value compared across peers and across restarts, so it
+/// must be identical for identical bytes on every node forever.
+/// `DefaultHasher` is explicitly not stable across releases (and `RandomState`
+/// is per-process random): a digest that varies per node would make every
+/// comparison mismatch, which degrades to "always ship the bytes plus an extra
+/// round trip" — worse than not doing this at all — and re-creates the #4857
+/// storm shape where every heartbeat looks like divergence. BLAKE3 over the
+/// raw bytes has no endianness or platform freedom: the input is a byte slice
+/// and the output is a byte array, so no integer is ever serialized.
+///
+/// The truncation takes the FIRST [`SUMMARY_DIGEST_LEN`] bytes of the 32-byte
+/// BLAKE3 output, which is the standard way to shorten it (BLAKE3's output is
+/// uniformly distributed, so any fixed slice is a sound shorter digest).
+pub fn summary_digest(summary_bytes: &[u8]) -> SummaryDigest {
+    let full = blake3::hash(summary_bytes);
+    let mut digest = [0u8; SUMMARY_DIGEST_LEN];
+    digest.copy_from_slice(&full.as_bytes()[..SUMMARY_DIGEST_LEN]);
+    digest
+}
+
 /// How much smaller full state must be before the post-compute gate
 /// ([`InterestManager::gate_delta_size`]) abandons a computed delta for it.
 ///
@@ -2067,6 +2121,126 @@ mod tests {
         let time_source = SharedMockTimeSource::new();
         let manager = InterestManager::new(time_source.clone());
         (manager, time_source)
+    }
+
+    /// [`summary_digest`] must be a FIXED function of the bytes — identical on
+    /// every node, every platform, and every release (#4965).
+    ///
+    /// Pinned against a hard-coded vector, not merely "two calls agree". Two
+    /// calls agree for `DefaultHasher` too *within one process*, and it is
+    /// exactly the cross-process disagreement that would be catastrophic here:
+    /// a per-node digest makes every comparison mismatch, which degrades to
+    /// "ship the bytes AND an extra round trip" — worse than not doing this at
+    /// all — and re-creates the #4857 shape where every heartbeat looks like
+    /// divergence. Only a pinned vector catches a swap to a non-stable hasher.
+    ///
+    /// If BLAKE3 itself is ever intentionally replaced, this vector changes AND
+    /// `HASH_FIRST_SUMMARIES_MIN_VERSION` must be re-floored, because peers on
+    /// either side of the change would disagree about identical state.
+    #[test]
+    fn summary_digest_is_pinned_to_truncated_blake3() {
+        let got = summary_digest(b"freenet summary digest test vector");
+
+        // The TRUNCATION rule: first SUMMARY_DIGEST_LEN bytes, not last, not
+        // folded. This half is computed with blake3, so it moves with the
+        // implementation — the hard pin is the literal below.
+        let truncated = {
+            let full = blake3::hash(b"freenet summary digest test vector");
+            let mut d = [0u8; SUMMARY_DIGEST_LEN];
+            d.copy_from_slice(&full.as_bytes()[..SUMMARY_DIGEST_LEN]);
+            d
+        };
+        assert_eq!(
+            got, truncated,
+            "summary_digest must be the FIRST {SUMMARY_DIGEST_LEN} bytes of \
+             BLAKE3 over the raw summary bytes"
+        );
+
+        // The ALGORITHM, pinned to a literal. Verified independently of this
+        // codebase with the `b3sum` CLI:
+        //   printf 'freenet summary digest test vector' | b3sum
+        // Swapping BLAKE3 for anything else fails here even though the
+        // truncation assertion above would happily follow the swap.
+        assert_eq!(
+            hex::encode(got),
+            "c6d93b99cde492c9edc177db79b27e2b",
+            "summary_digest changed value for a fixed input — this is a WIRE \
+             change: peers on either side of it disagree about identical \
+             state. If deliberate, re-floor HASH_FIRST_SUMMARIES_MIN_VERSION."
+        );
+    }
+
+    /// Two independently constructed but byte-identical summaries must digest
+    /// identically, and any difference must change the digest.
+    ///
+    /// The first half is the property the exchange relies on for its 98.1%
+    /// win; the second is what keeps a digest match from hiding real
+    /// divergence.
+    #[test]
+    fn summary_digest_agrees_on_equal_bytes_and_differs_otherwise() {
+        // Built by different routes so no shared allocation can mask a bug.
+        let a: Vec<u8> = (0u8..64).collect();
+        let mut b = Vec::with_capacity(64);
+        for i in 0u8..64 {
+            b.push(i);
+        }
+        assert_eq!(a, b, "precondition: the two summaries are byte-identical");
+        assert_eq!(
+            summary_digest(&a),
+            summary_digest(&b),
+            "identical summary bytes MUST digest identically — two peers that \
+             agree must see a digest match"
+        );
+
+        let mut c = a.clone();
+        c[63] ^= 0x01;
+        assert_ne!(
+            summary_digest(&a),
+            summary_digest(&c),
+            "a one-bit difference must change the digest, or divergence goes \
+             undetected and the heal never fires"
+        );
+
+        assert_ne!(
+            summary_digest(b""),
+            summary_digest(&a),
+            "an empty summary must not digest like a populated one"
+        );
+    }
+
+    /// [`summary_digest`] and [`contract_hash`] answer different questions and
+    /// must not be confused: the digest tracks STATE (so it changes when state
+    /// changes) while `contract_hash` identifies a CONTRACT (so it never does).
+    ///
+    /// `SummaryDigestEntry` carries both, and overloading either one for the
+    /// other's job is the obvious way to get this wrong.
+    #[test]
+    fn summary_digest_and_contract_hash_are_different_functions() {
+        let contract = make_contract_key(1);
+        let h = contract_hash(&contract);
+
+        // Same contract, two different states → same contract hash, different
+        // digests.
+        let d1 = summary_digest(b"state one");
+        let d2 = summary_digest(b"state two");
+        assert_eq!(
+            h,
+            contract_hash(&contract),
+            "contract_hash must not depend on state"
+        );
+        assert_ne!(
+            d1, d2,
+            "summary_digest MUST depend on state — a digest that tracked the \
+             contract id instead would report 'agree' for every peer holding \
+             the contract, silently disabling every heal"
+        );
+
+        // And the digest must not be a widened contract hash.
+        assert_ne!(
+            &summary_digest(contract.id().as_bytes())[..4],
+            &h.to_le_bytes()[..],
+            "summary_digest must not reduce to contract_hash"
+        );
     }
 
     #[test]

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -36,8 +36,17 @@
 //!
 //! Additional refresh triggers:
 //! - Sending/receiving updates
-//! - Summaries exchange
+//! - Summaries exchange (the TTL refresh rides `PeerInterest::set_summary`,
+//!   so it happens wherever a summary is stored, not as a separate step)
 //! - Receiving `ChangeInterests { added }`
+//!
+//! Caveat for the hash-first exchange (#4965): a digest that AGREES stores the
+//! summary and therefore refreshes the TTL as usual, but a digest that needs
+//! bytes DEFERS both by one round trip — the refresh lands when the requested
+//! `Summaries` arrives. If that request or its reply is lost, the refresh is
+//! lost for the cycle too. Harmless at a 4x-heartbeat TTL (three consecutive
+//! losses are tolerated), but worth knowing before assuming every digest
+//! exchange refreshes.
 //!
 //! This self-healing mechanism catches forgotten cleanup and prevents zombie interests.
 

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -15257,6 +15257,266 @@ fn test_summary_first_put_reverse_delta_converges_originator() {
 }
 
 // =============================================================================
+// Hash-first summary exchange (#4965) — behavioral simulation test
+// =============================================================================
+//
+// Unlike the summary-first PUT sims above, hash-first is ON by default in every
+// simulation (`SimNetwork::SIM_MIGRATION_ENABLED_FLOOR`): it changes only the
+// ENCODING of an exchange every sim already runs, with identical convergence
+// semantics, so defaulting it on costs unrelated sims nothing and gives a
+// version-gated wire change integration coverage BEFORE the release that lifts
+// the crate version past its production floor. This test states its premise
+// explicitly at the call site anyway, so a future edit to that default cannot
+// silently make it vacuous.
+
+/// **A/B falsifier: hash-first must ship strictly fewer summary bytes without
+/// costing more messages, and without changing what the network converges to.**
+///
+/// Runs the SAME seed, topology and operations twice — once with the hash-first
+/// exchange enabled, once pinned to the pre-0.2.116 full-bytes fallback.
+///
+/// # Why this test exists
+///
+/// Everything else in this PR proves hash-first BREAKS nothing. Nothing else
+/// proves it HELPS. The whole change is justified by a bandwidth saving, and
+/// until something measures that saving end-to-end it is a hypothesis.
+///
+/// # Why bytes alone would be the wrong assertion
+///
+/// Hash-first trades bytes for messages on the mismatch path: one `Summaries`
+/// becomes `SummaryDigests` -> `SummaryRequest` -> `Summaries`. #4861
+/// established per-peer broadcast MESSAGES/s — not bytes — as the load-bearing
+/// storm signal, so a version that halved bytes while multiplying messages
+/// would regress the exact axis that caused the storm. Both are asserted.
+///
+/// # Why an absolute "zero summary bytes" assertion would be wrong
+///
+/// `RemoteConnection::remote_protoc_version` is `None` on the joiner->gateway
+/// path (the gateway's `AckConnection` carries no version), so a regular node
+/// never learns its gateway's version, fails closed, and keeps sending
+/// full-bytes `Summaries` UP to its gateway while receiving digests DOWN from
+/// it. That makes this topology a genuine mixed-encoding link — which is the
+/// production rollout shape, and convergence across it is worth having.
+#[test_log::test]
+fn test_hash_first_summaries_ships_fewer_bytes_and_still_converges() {
+    use freenet::dev_tool::{NodeLabel, ScheduledOperation, SimOperation};
+
+    const SEED: u64 = 0x4965_5F01_CAFE;
+
+    struct Run {
+        digest_msgs: u64,
+        full_msgs: u64,
+        full_bytes: u64,
+        byte_requests: u64,
+        agree_single: u64,
+        agree_multi: u64,
+        mismatch_single: u64,
+        mismatch_multi: u64,
+        hosting: Vec<String>,
+    }
+
+    impl Run {
+        /// Every message the summary exchange put on the wire, both encodings.
+        /// The #4861 axis: a byte saving bought with a message multiplication
+        /// is not a saving.
+        fn exchange_msgs(&self) -> u64 {
+            self.digest_msgs + self.full_msgs + self.byte_requests
+        }
+    }
+
+    fn run(name: &str, hash_first: bool) -> Run {
+        setup_deterministic_state(SEED);
+        let rt = create_runtime();
+
+        let gateway = NodeLabel::gateway(name, 0);
+        let node1 = NodeLabel::node(name, 1);
+
+        let contract = SimOperation::create_test_contract(0x49);
+        let contract_key = contract.key();
+        let state = SimOperation::create_test_state(0x49);
+
+        let mut sim = rt.block_on(async { SimNetwork::new(name, 1, 1, 7, 3, 10, 2, SEED).await });
+        if hash_first {
+            sim.enable_hash_first_summaries();
+        } else {
+            sim.disable_hash_first_summaries();
+        }
+
+        // Subscribe makes node1 an interested peer; the UPDATE then drives the
+        // proactive summary notification — the send site that fires on every
+        // state change to every interested peer, and the one hash-first is
+        // most meant to shrink.
+        let operations = vec![
+            ScheduledOperation::new(
+                gateway.clone(),
+                SimOperation::Put {
+                    contract: contract.clone(),
+                    state: state.clone(),
+                    subscribe: true,
+                },
+            ),
+            ScheduledOperation::new(
+                node1.clone(),
+                SimOperation::Subscribe {
+                    contract_id: *contract_key.id(),
+                },
+            ),
+            ScheduledOperation::new(
+                gateway.clone(),
+                SimOperation::Update {
+                    key: contract_key,
+                    data: SimOperation::create_test_state(0x4A),
+                },
+            ),
+        ];
+
+        let result = sim.run_controlled_simulation(
+            SEED,
+            operations,
+            Duration::from_secs(120),
+            Duration::from_secs(30),
+        );
+        assert!(
+            result.turmoil_result.is_ok(),
+            "hash-first sim ({name}) failed: {:?}",
+            result.turmoil_result.err()
+        );
+
+        // Strip the per-run network-name prefix. `NodeLabel` renders as
+        // `<network>-gateway-0`, and the two runs necessarily use DIFFERENT
+        // network names (turmoil keys its DNS on them), so comparing raw
+        // labels compares the run names and can never match. What is being
+        // compared is which ROLES converged, not what the networks were
+        // called.
+        let prefix = format!("{name}-");
+        let mut hosting: Vec<String> = result
+            .node_storages
+            .iter()
+            .filter(|(_, s)| s.get_stored_state(&contract_key).is_some())
+            .map(|(label, _)| {
+                let full = label.to_string();
+                full.strip_prefix(&prefix).unwrap_or(&full).to_string()
+            })
+            .collect();
+        hosting.sort();
+
+        Run {
+            digest_msgs: GlobalTestMetrics::summary_digest_msgs(),
+            full_msgs: GlobalTestMetrics::summary_full_msgs(),
+            full_bytes: GlobalTestMetrics::summary_full_bytes(),
+            byte_requests: GlobalTestMetrics::summary_byte_requests(),
+            agree_single: GlobalTestMetrics::summary_digest_agreements_single(),
+            agree_multi: GlobalTestMetrics::summary_digest_agreements_multi(),
+            mismatch_single: GlobalTestMetrics::summary_digest_mismatches_single(),
+            mismatch_multi: GlobalTestMetrics::summary_digest_mismatches_multi(),
+            hosting,
+        }
+    }
+
+    let on = run("hash-first-on", true);
+    let off = run("hash-first-off", false);
+
+    tracing::info!(
+        on_digest_msgs = on.digest_msgs,
+        on_full_msgs = on.full_msgs,
+        on_full_bytes = on.full_bytes,
+        on_byte_requests = on.byte_requests,
+        on_exchange_msgs = on.exchange_msgs(),
+        on_agree_single = on.agree_single,
+        on_agree_multi = on.agree_multi,
+        on_mismatch_single = on.mismatch_single,
+        on_mismatch_multi = on.mismatch_multi,
+        off_full_msgs = off.full_msgs,
+        off_full_bytes = off.full_bytes,
+        off_exchange_msgs = off.exchange_msgs(),
+        "hash-first A/B counters"
+    );
+
+    // ---- PREMISES, asserted before any conclusion is drawn ----
+    //
+    // Without these, two runs that both did the same thing produce an
+    // equal-bytes result that reads as "no regression" rather than "the test
+    // never exercised the feature". That is the vacuous-test shape.
+    assert_eq!(
+        off.digest_msgs, 0,
+        "premise: the pinned-fallback run must emit NO SummaryDigests. If it \
+         does, disable_hash_first_summaries is not taking effect and every \
+         comparison below is meaningless"
+    );
+    assert!(
+        on.digest_msgs > 0,
+        "premise: the enabled run must emit SummaryDigests. Zero means the \
+         hash-first path never ran — the exact way this test would go quiet \
+         if the sim default or the version gate changed underneath it"
+    );
+    assert!(
+        off.full_bytes > 0,
+        "premise: the fallback run must actually ship summary bytes, or there \
+         is no baseline to improve on"
+    );
+    assert!(
+        !off.hosting.is_empty(),
+        "premise: at least one peer must host the contract, or the convergence \
+         comparison is between two empty sets"
+    );
+
+    // ---- THE CLAIM ----
+    assert!(
+        on.full_bytes < off.full_bytes,
+        "hash-first must ship strictly FEWER summary bytes for identical work \
+         ({} enabled vs {} fallback). This is the entire justification for the \
+         wire change; if it does not hold, the change is not paying for itself.",
+        on.full_bytes,
+        off.full_bytes
+    );
+
+    // ---- ...WITHOUT PAYING FOR IT IN MESSAGES (#4861) ----
+    assert!(
+        on.exchange_msgs() <= off.exchange_msgs(),
+        "hash-first must not cost MORE summary-exchange messages than the \
+         fallback ({} enabled vs {} fallback). #4861 established per-peer \
+         messages/s as the load-bearing storm signal, so a byte saving bought \
+         with a message multiplication would regress the axis that caused the \
+         storm.",
+        on.exchange_msgs(),
+        off.exchange_msgs()
+    );
+
+    // ---- WHERE THE SAVING COMES FROM ----
+    assert!(
+        on.agree_single + on.agree_multi > 0,
+        "the enabled run must settle at least one contract by digest agreement \
+         — that is the mechanism; a run that saved bytes with zero agreements \
+         saved them for some other reason and this test would be measuring the \
+         wrong thing"
+    );
+    assert_eq!(
+        off.agree_single + off.agree_multi,
+        0,
+        "the fallback run cannot agree by digest — it never sends one"
+    );
+
+    // ---- CONVERGENCE IS UNAFFECTED ----
+    // Guard the normalisation itself. If `NodeLabel`'s rendering changes so the
+    // prefix no longer strips, both sides stay run-scoped and the equality
+    // below fails loudly — fine. The dangerous direction is the other one: if
+    // both sides normalised to the same constant, the comparison would pass
+    // vacuously. Requiring a recognisable role name rules that out.
+    assert!(
+        on.hosting.iter().any(|l| l.contains("gateway")),
+        "convergence labels should be role-scoped after stripping the run \
+         prefix, got {:?} — the normalisation is not doing what it claims",
+        on.hosting
+    );
+    assert_eq!(
+        on.hosting, off.hosting,
+        "the same peers must end up hosting the contract under both encodings \
+         — hash-first changes how summaries are ADVERTISED, never what the \
+         network converges to"
+    );
+}
+
+// =============================================================================
 // NEAREST-NEIGHBOR RING LATTICE — validation + regression (feat(topology)).
 //
 // The lattice SEEKS AND TIGHTENS each peer's closest connected SUCCESSOR (higher

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -15257,101 +15257,129 @@ fn test_summary_first_put_reverse_delta_converges_originator() {
 }
 
 // =============================================================================
-// Hash-first summary exchange (#4965) — behavioral simulation test
+// Hash-first summary exchange (#4965) — behavioral simulation A/B
 // =============================================================================
 //
-// Unlike the summary-first PUT sims above, hash-first is ON by default in every
-// simulation (`SimNetwork::SIM_MIGRATION_ENABLED_FLOOR`): it changes only the
-// ENCODING of an exchange every sim already runs, with identical convergence
-// semantics, so defaulting it on costs unrelated sims nothing and gives a
-// version-gated wire change integration coverage BEFORE the release that lifts
-// the crate version past its production floor. This test states its premise
-// explicitly at the call site anyway, so a future edit to that default cannot
-// silently make it vacuous.
+// Hash-first is ON by default in every simulation
+// (`SimNetwork::SIM_MIGRATION_ENABLED_FLOOR`): it changes only the ENCODING of
+// an exchange every sim already runs, with identical convergence semantics, so
+// defaulting it on costs unrelated sims nothing and gives a version-gated wire
+// change integration coverage BEFORE the release that lifts the crate version
+// past its production floor. These tests state that premise explicitly at the
+// call site anyway, so a future edit to the default cannot silently make them
+// vacuous.
+//
+// NOTE ON WHICH LEG IS EXERCISED: after the #4965 review, digest-first ships on
+// the two MULTI-ENTRY reply legs only (`InterestsReply`, `ChangeInterestsReply`)
+// — `Notification` and `Rejection` stay full-bytes. So the digests observed here
+// necessarily come from the connection-time `Interests` -> reply exchange, which
+// is the leg that matters, and NOT from the per-state-change notification.
+// `summaries_reply_for_peer` is the only path that can emit a digest, and only
+// those two legs call it.
 
-/// **A/B falsifier: hash-first must ship strictly fewer summary bytes without
-/// costing more messages, and without changing what the network converges to.**
-///
-/// Runs the SAME seed, topology and operations twice — once with the hash-first
-/// exchange enabled, once pinned to the pre-0.2.116 full-bytes fallback.
-///
-/// # Why this test exists
-///
-/// Everything else in this PR proves hash-first BREAKS nothing. Nothing else
-/// proves it HELPS. The whole change is justified by a bandwidth saving, and
-/// until something measures that saving end-to-end it is a hypothesis.
-///
-/// # Why bytes alone would be the wrong assertion
-///
-/// Hash-first trades bytes for messages on the mismatch path: one `Summaries`
-/// becomes `SummaryDigests` -> `SummaryRequest` -> `Summaries`. #4861
-/// established per-peer broadcast MESSAGES/s — not bytes — as the load-bearing
-/// storm signal, so a version that halved bytes while multiplying messages
-/// would regress the exact axis that caused the storm. Both are asserted.
-///
-/// # Why an absolute "zero summary bytes" assertion would be wrong
-///
-/// `RemoteConnection::remote_protoc_version` is `None` on the joiner->gateway
-/// path (the gateway's `AckConnection` carries no version), so a regular node
-/// never learns its gateway's version, fails closed, and keeps sending
-/// full-bytes `Summaries` UP to its gateway while receiving digests DOWN from
-/// it. That makes this topology a genuine mixed-encoding link — which is the
-/// production rollout shape, and convergence across it is worth having.
-#[test_log::test]
-fn test_hash_first_summaries_ships_fewer_bytes_and_still_converges() {
+/// Shared A/B machinery: run one scenario under one encoding and report the
+/// summary-exchange counters plus what converged.
+struct HashFirstRun {
+    digest_msgs: u64,
+    full_msgs: u64,
+    full_bytes: u64,
+    byte_requests: u64,
+    agree_single: u64,
+    agree_multi: u64,
+    mismatch_single: u64,
+    mismatch_multi: u64,
+    hosting: Vec<String>,
+}
+
+impl HashFirstRun {
+    /// Every message the summary exchange put on the wire, both encodings.
+    fn exchange_msgs(&self) -> u64 {
+        self.digest_msgs + self.full_msgs + self.byte_requests
+    }
+    fn agreements(&self) -> u64 {
+        self.agree_single + self.agree_multi
+    }
+    fn mismatches(&self) -> u64 {
+        self.mismatch_single + self.mismatch_multi
+    }
+}
+
+/// `divergent = false`: both peers converge on one state, so digests agree.
+/// `divergent = true`: the two peers are SEEDED with different states for the
+/// same contract, so their summaries genuinely differ and the digest exchange
+/// must take the mismatch path.
+fn run_hash_first_ab(name: &str, seed: u64, hash_first: bool, divergent: bool) -> HashFirstRun {
     use freenet::dev_tool::{NodeLabel, ScheduledOperation, SimOperation};
 
-    const SEED: u64 = 0x4965_5F01_CAFE;
+    // Seeds GlobalRng/GlobalSimulationTime and resets GlobalTestMetrics. The
+    // handler's over-cap rotation draws from GlobalRng, so an unseeded run
+    // would be nondeterministic here.
+    setup_deterministic_state(seed);
+    let rt = create_runtime();
 
-    struct Run {
-        digest_msgs: u64,
-        full_msgs: u64,
-        full_bytes: u64,
-        byte_requests: u64,
-        agree_single: u64,
-        agree_multi: u64,
-        mismatch_single: u64,
-        mismatch_multi: u64,
-        hosting: Vec<String>,
+    let gateway = NodeLabel::gateway(name, 0);
+    let node1 = NodeLabel::node(name, 1);
+
+    let contract = SimOperation::create_test_contract(0x49);
+    let contract_key = contract.key();
+
+    let mut sim = rt.block_on(async { SimNetwork::new(name, 1, 1, 7, 3, 10, 2, seed).await });
+    if hash_first {
+        sim.enable_hash_first_summaries();
+    } else {
+        sim.disable_hash_first_summaries();
     }
 
-    impl Run {
-        /// Every message the summary exchange put on the wire, both encodings.
-        /// The #4861 axis: a byte saving bought with a message multiplication
-        /// is not a saving.
-        fn exchange_msgs(&self) -> u64 {
-            self.digest_msgs + self.full_msgs + self.byte_requests
-        }
-    }
-
-    fn run(name: &str, hash_first: bool) -> Run {
-        setup_deterministic_state(SEED);
-        let rt = create_runtime();
-
-        let gateway = NodeLabel::gateway(name, 0);
-        let node1 = NodeLabel::node(name, 1);
-
-        let contract = SimOperation::create_test_contract(0x49);
-        let contract_key = contract.key();
-        let state = SimOperation::create_test_state(0x49);
-
-        let mut sim = rt.block_on(async { SimNetwork::new(name, 1, 1, 7, 3, 10, 2, SEED).await });
-        if hash_first {
-            sim.enable_hash_first_summaries();
-        } else {
-            sim.disable_hash_first_summaries();
-        }
-
-        // Subscribe makes node1 an interested peer; the UPDATE then drives the
-        // proactive summary notification — the send site that fires on every
-        // state change to every interested peer, and the one hash-first is
-        // most meant to shrink.
-        let operations = vec![
+    let operations = if divergent {
+        // Both peers genuinely HOST the same contract with DIFFERENT states,
+        // seeded locally so no network propagation reconciles them. Their
+        // summaries therefore differ when the connection-time interest
+        // exchange runs, which is what forces the digest mismatch path.
+        // Seeding alone produces NO summary exchange: with no network
+        // activity the peers never run an interest exchange inside the driven
+        // window (verified — every counter came back zero). So a SECOND
+        // contract is PUT and subscribed to drive connections and the
+        // interest exchange, while the first stays divergent by construction:
+        // it is only ever seeded locally, never PUT, so nothing reconciles it.
+        let driver = SimOperation::create_test_contract(0x5B);
+        let driver_key = driver.key();
+        vec![
+            ScheduledOperation::new(
+                gateway.clone(),
+                SimOperation::SeedHostedContract {
+                    contract: contract.clone(),
+                    state: SimOperation::create_test_state(0x49),
+                },
+            ),
+            ScheduledOperation::new(
+                node1.clone(),
+                SimOperation::SeedHostedContract {
+                    contract: contract.clone(),
+                    state: SimOperation::create_test_state(0xA7),
+                },
+            ),
+            ScheduledOperation::new(
+                gateway.clone(),
+                SimOperation::Put {
+                    contract: driver.clone(),
+                    state: SimOperation::create_test_state(0x5B),
+                    subscribe: true,
+                },
+            ),
+            ScheduledOperation::new(
+                node1.clone(),
+                SimOperation::Subscribe {
+                    contract_id: *driver_key.id(),
+                },
+            ),
+        ]
+    } else {
+        vec![
             ScheduledOperation::new(
                 gateway.clone(),
                 SimOperation::Put {
                     contract: contract.clone(),
-                    state: state.clone(),
+                    state: SimOperation::create_test_state(0x49),
                     subscribe: true,
                 },
             ),
@@ -15368,53 +15396,87 @@ fn test_hash_first_summaries_ships_fewer_bytes_and_still_converges() {
                     data: SimOperation::create_test_state(0x4A),
                 },
             ),
-        ];
+        ]
+    };
 
-        let result = sim.run_controlled_simulation(
-            SEED,
-            operations,
-            Duration::from_secs(120),
-            Duration::from_secs(30),
-        );
-        assert!(
-            result.turmoil_result.is_ok(),
-            "hash-first sim ({name}) failed: {:?}",
-            result.turmoil_result.err()
-        );
+    // 400s > the 300s INTEREST_HEARTBEAT_INTERVAL, so the PERIODIC
+    // Interests -> reply exchange fires inside the window, not just the
+    // connection-time one. Virtual time, so the extra 280s is nearly free.
+    let result = sim.run_controlled_simulation(
+        seed,
+        operations,
+        Duration::from_secs(400),
+        Duration::from_secs(30),
+    );
+    assert!(
+        result.turmoil_result.is_ok(),
+        "hash-first sim ({name}) failed: {:?}",
+        result.turmoil_result.err()
+    );
 
-        // Strip the per-run network-name prefix. `NodeLabel` renders as
-        // `<network>-gateway-0`, and the two runs necessarily use DIFFERENT
-        // network names (turmoil keys its DNS on them), so comparing raw
-        // labels compares the run names and can never match. What is being
-        // compared is which ROLES converged, not what the networks were
-        // called.
-        let prefix = format!("{name}-");
-        let mut hosting: Vec<String> = result
-            .node_storages
-            .iter()
-            .filter(|(_, s)| s.get_stored_state(&contract_key).is_some())
-            .map(|(label, _)| {
-                let full = label.to_string();
-                full.strip_prefix(&prefix).unwrap_or(&full).to_string()
-            })
-            .collect();
-        hosting.sort();
+    // Strip the per-run network-name prefix. `NodeLabel` renders as
+    // `<network>-gateway-0`, and the two runs necessarily use DIFFERENT network
+    // names (turmoil keys its DNS on them), so comparing raw labels compares the
+    // run names and can never match. What is compared is which ROLES converged.
+    let prefix = format!("{name}-");
+    let mut hosting: Vec<String> = result
+        .node_storages
+        .iter()
+        .filter(|(_, s)| s.get_stored_state(&contract_key).is_some())
+        .map(|(label, _)| {
+            let full = label.to_string();
+            full.strip_prefix(&prefix).unwrap_or(&full).to_string()
+        })
+        .collect();
+    hosting.sort();
 
-        Run {
-            digest_msgs: GlobalTestMetrics::summary_digest_msgs(),
-            full_msgs: GlobalTestMetrics::summary_full_msgs(),
-            full_bytes: GlobalTestMetrics::summary_full_bytes(),
-            byte_requests: GlobalTestMetrics::summary_byte_requests(),
-            agree_single: GlobalTestMetrics::summary_digest_agreements_single(),
-            agree_multi: GlobalTestMetrics::summary_digest_agreements_multi(),
-            mismatch_single: GlobalTestMetrics::summary_digest_mismatches_single(),
-            mismatch_multi: GlobalTestMetrics::summary_digest_mismatches_multi(),
-            hosting,
-        }
+    HashFirstRun {
+        digest_msgs: GlobalTestMetrics::summary_digest_msgs(),
+        full_msgs: GlobalTestMetrics::summary_full_msgs(),
+        full_bytes: GlobalTestMetrics::summary_full_bytes(),
+        byte_requests: GlobalTestMetrics::summary_byte_requests(),
+        agree_single: GlobalTestMetrics::summary_digest_agreements_single(),
+        agree_multi: GlobalTestMetrics::summary_digest_agreements_multi(),
+        mismatch_single: GlobalTestMetrics::summary_digest_mismatches_single(),
+        mismatch_multi: GlobalTestMetrics::summary_digest_mismatches_multi(),
+        hosting,
     }
+}
 
-    let on = run("hash-first-on", true);
-    let off = run("hash-first-off", false);
+/// **A/B falsifier, AGREE arm: hash-first must ship strictly fewer summary
+/// bytes without costing more messages, and without changing convergence.**
+///
+/// # Why this test exists
+///
+/// Everything else in this PR proves hash-first BREAKS nothing. Nothing else
+/// proves it HELPS. The change is justified entirely by a bandwidth saving, and
+/// until something measures that saving end to end it is a hypothesis.
+///
+/// # Why bytes alone would be the wrong assertion
+///
+/// Hash-first trades bytes for messages on the mismatch path: one `Summaries`
+/// becomes `SummaryDigests` -> `SummaryRequest` -> `Summaries`. #4861
+/// established per-peer broadcast MESSAGES/s — not bytes — as the load-bearing
+/// storm signal, so a version that halved bytes while multiplying messages
+/// would regress the exact axis that caused the storm.
+///
+/// In THIS arm every comparison agrees, so the mismatch multiplier is zero and
+/// the message count must not rise at all — which is asserted, with
+/// `mismatches() == 0` pinned as an explicit PREMISE so the reader knows the
+/// no-multiplier case is what is being tested.
+///
+/// **Stated limit:** this arm therefore cannot catch a message-multiplication
+/// bug, because its fixture has no mismatches to multiply. The multiplication
+/// itself is covered at handler level by
+/// `node.rs::hash_first_summaries::mismatching_digest_requests_bytes_and_the_heal_still_fires`.
+/// See the note below this test for the three sim fixtures that failed to
+/// produce a mismatch and why no sim-level divergent arm is shipped.
+#[test_log::test]
+fn test_hash_first_summaries_ships_fewer_bytes_and_still_converges() {
+    const SEED: u64 = 0x4965_5F01_CAFE;
+
+    let on = run_hash_first_ab("hash-first-on", SEED, true, false);
+    let off = run_hash_first_ab("hash-first-off", SEED, false, false);
 
     tracing::info!(
         on_digest_msgs = on.digest_msgs,
@@ -15422,21 +15484,19 @@ fn test_hash_first_summaries_ships_fewer_bytes_and_still_converges() {
         on_full_bytes = on.full_bytes,
         on_byte_requests = on.byte_requests,
         on_exchange_msgs = on.exchange_msgs(),
-        on_agree_single = on.agree_single,
-        on_agree_multi = on.agree_multi,
-        on_mismatch_single = on.mismatch_single,
-        on_mismatch_multi = on.mismatch_multi,
+        on_agreements = on.agreements(),
+        on_mismatches = on.mismatches(),
         off_full_msgs = off.full_msgs,
         off_full_bytes = off.full_bytes,
         off_exchange_msgs = off.exchange_msgs(),
-        "hash-first A/B counters"
+        "hash-first A/B (agree arm)"
     );
 
-    // ---- PREMISES, asserted before any conclusion is drawn ----
+    // ---- PREMISES, before any conclusion is drawn ----
     //
     // Without these, two runs that both did the same thing produce an
     // equal-bytes result that reads as "no regression" rather than "the test
-    // never exercised the feature". That is the vacuous-test shape.
+    // never exercised the feature".
     assert_eq!(
         off.digest_msgs, 0,
         "premise: the pinned-fallback run must emit NO SummaryDigests. If it \
@@ -15446,18 +15506,21 @@ fn test_hash_first_summaries_ships_fewer_bytes_and_still_converges() {
     assert!(
         on.digest_msgs > 0,
         "premise: the enabled run must emit SummaryDigests. Zero means the \
-         hash-first path never ran — the exact way this test would go quiet \
-         if the sim default or the version gate changed underneath it"
+         hash-first path never ran — the exact way this test would go quiet if \
+         the sim default, the version gate, or the leg restriction changed \
+         underneath it"
     );
     assert!(
         off.full_bytes > 0,
         "premise: the fallback run must actually ship summary bytes, or there \
          is no baseline to improve on"
     );
-    assert!(
-        !off.hosting.is_empty(),
-        "premise: at least one peer must host the contract, or the convergence \
-         comparison is between two empty sets"
+    assert_eq!(
+        on.mismatches(),
+        0,
+        "premise for THIS arm: every comparison must agree, so the message \
+         assertion below is testing the no-multiplier case. Non-zero means the \
+         fixture drifted and the divergent twin is the test that applies"
     );
 
     // ---- THE CLAIM ----
@@ -15465,7 +15528,7 @@ fn test_hash_first_summaries_ships_fewer_bytes_and_still_converges() {
         on.full_bytes < off.full_bytes,
         "hash-first must ship strictly FEWER summary bytes for identical work \
          ({} enabled vs {} fallback). This is the entire justification for the \
-         wire change; if it does not hold, the change is not paying for itself.",
+         wire change.",
         on.full_bytes,
         off.full_bytes
     );
@@ -15473,35 +15536,32 @@ fn test_hash_first_summaries_ships_fewer_bytes_and_still_converges() {
     // ---- ...WITHOUT PAYING FOR IT IN MESSAGES (#4861) ----
     assert!(
         on.exchange_msgs() <= off.exchange_msgs(),
-        "hash-first must not cost MORE summary-exchange messages than the \
-         fallback ({} enabled vs {} fallback). #4861 established per-peer \
-         messages/s as the load-bearing storm signal, so a byte saving bought \
-         with a message multiplication would regress the axis that caused the \
-         storm.",
+        "with zero mismatches hash-first must not cost MORE summary-exchange \
+         messages than the fallback ({} vs {})",
         on.exchange_msgs(),
         off.exchange_msgs()
     );
 
     // ---- WHERE THE SAVING COMES FROM ----
     assert!(
-        on.agree_single + on.agree_multi > 0,
+        on.agreements() > 0,
         "the enabled run must settle at least one contract by digest agreement \
          — that is the mechanism; a run that saved bytes with zero agreements \
-         saved them for some other reason and this test would be measuring the \
-         wrong thing"
+         saved them for some other reason"
     );
     assert_eq!(
-        off.agree_single + off.agree_multi,
+        off.agreements(),
         0,
         "the fallback run cannot agree by digest — it never sends one"
     );
 
     // ---- CONVERGENCE IS UNAFFECTED ----
-    // Guard the normalisation itself. If `NodeLabel`'s rendering changes so the
-    // prefix no longer strips, both sides stay run-scoped and the equality
-    // below fails loudly — fine. The dangerous direction is the other one: if
-    // both sides normalised to the same constant, the comparison would pass
-    // vacuously. Requiring a recognisable role name rules that out.
+    //
+    // Guard the normalisation itself: if `NodeLabel`'s rendering changes so the
+    // prefix no longer strips, both sides stay run-scoped and the equality below
+    // fails loudly. The dangerous direction is the other one — both sides
+    // normalising to the same constant would pass vacuously. Requiring a
+    // recognisable role name rules that out.
     assert!(
         on.hosting.iter().any(|l| l.contains("gateway")),
         "convergence labels should be role-scoped after stripping the run \
@@ -15515,6 +15575,38 @@ fn test_hash_first_summaries_ships_fewer_bytes_and_still_converges() {
          network converges to"
     );
 }
+
+// NOT PRESENT: a sim-level DIVERGENT arm.
+//
+// The review asked for a second arm that forces digest MISMATCHES, so the
+// message-multiplication bound (`on <= off + 2*mismatches`) would have a
+// non-empty population to apply to. Three fixtures were tried and none
+// produced a single mismatch, so no such test is shipped rather than one whose
+// premise it cannot meet:
+//
+//   1. `SeedHostedContract` with different states on both peers, 120s window —
+//      every counter zero; with no network activity the peers never run an
+//      interest exchange inside the driven window at all.
+//   2. Same, 400s window (past the 300s `INTEREST_HEARTBEAT_INTERVAL`) —
+//      still all zero; the run ends when the scheduled operations drain, so
+//      the longer virtual window never elapses.
+//   3. Same, plus a second contract PUT+subscribed to drive connections — an
+//      exchange DOES occur (1 digest, 1 agreement) but it covers only the
+//      driver contract; the locally-seeded divergent contract never enters
+//      `get_matching_contracts`, because the interest exchange has already run
+//      by the time the seeds land.
+//
+// The mismatch path is NOT untested: `node.rs::hash_first_summaries::
+// mismatching_digest_requests_bytes_and_the_heal_still_fires` drives the full
+// chain at handler level (digest mismatch -> `SummaryRequest` -> full
+// `Summaries` -> targeted `SyncStateToPeer` heal) with real state, and is
+// mutation-verified. What is missing is only the SIM-level confirmation that
+// the message arithmetic holds end to end under real scheduling.
+//
+// Tracked as a follow-up rather than blocking: the arithmetic is analytic
+// (1 message per agreement, 3 per mismatch), the failure mode is fail-safe
+// (fall back to bytes), and the leg restriction bounds the exposure to one
+// exchange per pair per heartbeat.
 
 // =============================================================================
 // NEAREST-NEIGHBOR RING LATTICE — validation + regression (feat(topology)).

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -115,6 +115,26 @@ Current wire-gated floors:
   incident-scale fan-out, and the broadcast-assembly-failure telemetry (#4498)
   was deployed to record a baseline and watch the rollout.
 
+- `SUMMARY_FIRST_PUT_MIN_VERSION` in the same file (summary-first PUT
+  probe/dispatch variants, #4642 step 3-bis).
+
+  Set to **`(0, 2, 95)`** and FROZEN — the release that first shipped the
+  `PutMsg::ProbeRequest` / `ProbeResponse` / `ProbeReconcile` variants together
+  with their handler.
+
+- `HASH_FIRST_SUMMARIES_MIN_VERSION` in the same file (hash-first InterestSync
+  summary exchange, #4965).
+
+  Set to **`(0, 2, 116)`**, the release that first ships the
+  `InterestMessage::SummaryDigests` / `SummaryRequest` variants and their
+  handlers. **RELEASE-TIME CHECK:** if the release that first carries this
+  feature is renumbered, update the constant to match BEFORE cutting the tag,
+  then freeze it. A floor below the shipping version sends an undecodable
+  variant to peers on the prior release and drops their connections during the
+  0-4h staggered rollout; a floor above it silently disables the feature.
+  `connection_manager.rs::hash_first_floor_stays_above_every_release_without_the_variants`
+  guards the lower bound.
+
 When a NEW wire-gated feature first ships (not this one), set its floor to
 **exactly that release version** and freeze it, as described above.
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -125,15 +125,41 @@ Current wire-gated floors:
 - `HASH_FIRST_SUMMARIES_MIN_VERSION` in the same file (hash-first InterestSync
   summary exchange, #4965).
 
-  Set to **`(0, 2, 116)`**, the release that first ships the
+  Set to **`(0, 2, 116)`**, the release intended to first ship the
   `InterestMessage::SummaryDigests` / `SummaryRequest` variants and their
-  handlers. **RELEASE-TIME CHECK:** if the release that first carries this
-  feature is renumbered, update the constant to match BEFORE cutting the tag,
-  then freeze it. A floor below the shipping version sends an undecodable
-  variant to peers on the prior release and drops their connections during the
-  0-4h staggered rollout; a floor above it silently disables the feature.
-  `connection_manager.rs::hash_first_floor_stays_above_every_release_without_the_variants`
-  guards the lower bound.
+  handlers.
+
+  **This one is guarded by a marker, not by a manual check.** Alongside the
+  floor there is `HASH_FIRST_SHIPPED_IN: Option<(u8, u8, u16)>`, currently
+  `None`. The test
+  `connection_manager.rs::hash_first_floor_tracks_the_shipping_release`
+  asserts:
+
+  - while the marker is `None`, the floor must stay **strictly above**
+    `CARGO_PKG_VERSION`;
+  - once it is `Some(v)`, `v` must **equal** the floor and be at or below the
+    crate version.
+
+  So the moment a release bump raises `Cargo.toml` to the floor's value, that
+  test fails and the releaser must consciously choose:
+
+  - **this release carries hash-first** → set
+    `HASH_FIRST_SHIPPED_IN = Some(HASH_FIRST_SUMMARIES_MIN_VERSION)` and freeze
+    both; or
+  - **it does not** → raise `HASH_FIRST_SUMMARIES_MIN_VERSION` to the release
+    that will.
+
+  Why a marker rather than the manual check used above: at this project's
+  cadence (five releases in four days at the time of writing) a floor naming
+  "the next release" goes stale silently. If 0.2.116 ships *without* the
+  feature, peers on the real 0.2.116 satisfy the floor while carrying no
+  `SummaryDigests` variant index — they cannot decode it, and the connection is
+  closed, presenting as fleet-wide transport churn during the 0-4h staggered
+  rollout. The marker makes that state fail a test instead of reaching users.
+
+  `hash_first_floor_stays_above_every_release_without_the_variants` is kept as
+  a companion: it catches the floor being *lowered*, which the marker test does
+  not.
 
 When a NEW wire-gated feature first ships (not this one), set its floor to
 **exactly that release version** and freeze it, as described above.


### PR DESCRIPTION
## Problem

`InterestMessage::Summaries` ships **full `StateSummary` bytes for every shared contract, to every co-host neighbour, on every cycle**. The 0.2.110 outbound census (#4965) measured that one exchange at **49.8–53.7% of all outbound bytes** — 4.8 GB over 180k messages, a **26.5 KB mean per "heartbeat"**.

The falsifier added in the same measurement answers whether that spend buys anything: **98.1% of summary comparisons find both sides already byte-identical.** Nearly all of it is spent saying "nothing changed".

## Approach

Send a **digest** of the summary; send the summary itself only when the digest cannot settle the question. Two variants, **appended** to `InterestMessage`:

```rust
SummaryDigests { entries: Vec<SummaryDigestEntry>, emitter },  // (u32 hash, Option<[u8;16]> digest)
SummaryRequest { hashes: Vec<u32> },
```

A capable peer receives digests where it used to receive `Summaries`. The receiver digests **its own actual summary** and compares. Agreement settles the entry with zero summary bytes on the wire; only a mismatch provokes a `SummaryRequest`, answered with a plain full-bytes `Summaries` — so divergence funnels back into the **unchanged** handler.

### Why not "sender omits bytes it thinks the peer already has"

The sender cannot make that call. The only thing it knows about the peer is the cached `PeerInterest.summary`, which is *belief* — and a wrong belief is precisely the failure anti-entropy exists to repair. Both sides here compare against state they actually hold.

### The heal is preserved, not traded away

1. **The agreement path does not assume its answer.** A digest match proves the peer's bytes equal ours, which is the same input the `Summaries` staleness check receives — so the arm runs `summary_indicates_stale_peer` for real, and any `true` verdict lands in the same heal emission.
2. **One heal implementation.** The bounded, targeted, ban-checked `SyncStateToPeer` emission is extracted into `emit_stale_peer_syncs` and shared verbatim. A second copy is how the #3791/#3796 targeting, the #3798 budget, and the Phase-7 ban gate drift apart.
3. **Mismatch defers, it does not decide.** Bytes arrive as an ordinary `Summaries` and run the untouched handler, `get_state_delta` probe included. Cost: one sub-second round trip against a ~5-minute heartbeat. A lost request leaves the contract diverged until the next heartbeat — the same outcome a lost `Summaries` has today.

`upsert_peer_summary` still runs on agreement (#4952 seeding), which also refreshes the peer's interest TTL as a side effect — preserved deliberately, since losing it would age peers out of the fan-out silently.

## Measured, not assumed

`test_hash_first_summaries_ships_fewer_bytes_and_still_converges` runs the same seed, topology and operations twice — hash-first enabled vs pinned to the pre-0.2.116 fallback:

```
enabled:  digest_msgs=1  full_msgs=1  full_bytes=32  byte_requests=0  agreements=1
fallback: digest_msgs=0  full_msgs=2  full_bytes=64
exchange messages: 2 vs 2
```

**Summary bytes halve; message count does not move.** That second number is load-bearing: hash-first trades bytes for messages on the mismatch path, and #4861 established per-peer broadcast **messages/s** — not bytes — as the storm signal, so a version that halved bytes while multiplying messages would regress the axis that caused the storm. Asserted as `<=`, not merely logged.

Premises are asserted before any conclusion: the fallback must emit zero digests, the enabled run must emit some, and the fallback must actually ship bytes. **Verified discriminating by mutation** — pinning both arms to the fallback fails on the premise assertion naming the cause, rather than silently reporting "no saving".

**Scope limit, stated rather than implied:** bytes halved on the exercised path — a **reply leg**, single shared contract, 2-peer topology. The heartbeat multi-entry path is structurally identical code but **unmeasured in sim**. A 2-peer topology with one small contract is also a weak proxy for a fleet-wide byte distribution: the *ratio* is the readout, the absolute saving is meaningless at this scale, and this does not predict the fleet number.

### The message-axis risk, with the arithmetic

Hash-first trades bytes for messages on mismatch: 1 message becomes 3. Per exchange, with per-contract agreement `p` and `k` shared contracts, expected messages are `1 + 2(1 - p^k)`:

| k | 1 | 10 | 30 |
|---|---|----|----|
| expected messages (p = 0.981) | +4% | +35% | +88% |

#4861 established per-peer broadcast **messages/s** as the load-bearing storm signal, so this is the axis that matters. Two things bound it: the leg restriction (below) confines digests to legs that fire once per pair per ~300 s heartbeat, and a mismatch is fail-safe — it falls back to shipping the bytes the old path always shipped.

**The A/B cannot test the multiplication**, because its fixture has zero mismatches; `on <= off + 2*mismatches` degenerates to `on <= off`. The multiplication is covered at handler level instead (`mismatching_digest_requests_bytes_and_the_heal_still_fires`, mutation-verified). Three sim fixtures were tried to build a divergent arm and none produced a mismatch — post-mortems in #5081, including the reusable finding that `run_controlled_simulation` ends when its operations drain, so widening the `Duration` does not buy simulated time.

## Shipped on the two multi-entry reply legs only

`InterestsReply` and `ChangeInterestsReply` ship digest-first. **`Notification` and `Rejection` stay full-bytes this release.**

The 98.1% agreement evidence comes from a heartbeat-dominated population. The state-change-driven legs fire immediately after *we* change state, so their receivers are precisely those least likely to have applied the update — plausibly a much lower agreement rate, where a mismatch costs 1 message → 3 for the *same* bytes. Nothing in the field can currently tell the legs apart, and there is **no runtime kill-switch** (accepted risk: the only lever is a release). #5003 removes advertised co-hosts from the notification leg's recipients — exactly the likely-agreers — which would make it worse before better. Extend once the counters give a field reading.

## Rider: `remote_version` now clears on an unknown reconnect

Not cosmetic, and not strictly part of hash-first — but hash-first is what made it bite. The mirror was written under `if let Some(version)`, and the joiner→gateway handshake yields `None` (the gateway's `AckConnection` carries no version). So a peer reconnecting on an OLDER build kept its stale "capable" entry, received a variant it could not decode, and had its connection **closed** — flap resembling a transport fault.

Pre-existing (`SUMMARY_FIRST_PUT_MIN_VERSION` has the same exposure), but summary-first PUT consults the mirror only when PUTting to that peer while hash-first consults it on **every** interest-sync exchange, turning rare into persistent. `record_remote_version` now takes the `Option` and writes it through, so `None` removes. Regression test asserts the gate goes back to failing closed.

## Honest bound: the joiner→gateway direction is not covered

`RemoteConnection::remote_protoc_version` is `None` on the **joiner→gateway** path — the gateway's `AckConnection` carries no version. So a peer never learns its gateway's version, the gate fails closed, and **a peer keeps sending full-bytes `Summaries` up to its gateway**.

**Gateway egress IS covered** — the gateway→peer direction gets digests, and peer↔peer links (where co-host interest-sync traffic actually lives, gateways being bootstrap-only) get hash-first in **both** directions. This is one direction of one link class, not half the network.

Pre-existing handshake behaviour, not introduced here; the same carve-out already applies to `SubscribeHint` and summary-first PUT. It is documented because the motivating 49.8% is fleet-wide and the reduction will **not** be uniform across link types — post-release telemetry should be read against that, not against a uniform expectation.

## Wire safety

- **Appended.** bincode encodes a variant by position; inserting above would renumber `Summaries`/`ResyncRequest`/… and make an old peer decode one as another. `interest_message_wire_variant_indices_are_frozen` pins all seven. This is the v0.2.11 incident class.
- **Version-gated** at `HASH_FIRST_SUMMARIES_MIN_VERSION = (0, 2, 116)`, fail-closed on unknown or pre-floor peers.
- **`remote_version` now clears on an unknown reconnect.** Previously the write was guarded by `if let Some(version)`, so a peer reconnecting on an older build kept a stale entry, received a variant it could not decode, and the connection was **closed** — flap resembling a transport fault. Pre-existing, but hash-first consults the mirror on *every* interest-sync exchange rather than only when PUTting, turning rare into persistent.
- **Not a stdlib type.** `InterestMessage` is core-to-core and appears nowhere outside `crates/core/src`; riverctl/fdev speak the stdlib client API, untouched.
- **Deterministic digest**: truncated BLAKE3 (128-bit), pinned to a literal independently reproduced with `b3sum`. Never a `Hasher` — a per-node digest would make every comparison mismatch and re-create the #4857 shape.

## Telemetry

All three legs classify into the existing `interest_sync_summaries` arm, so that field stays a like-for-like before/after total — if it does not shrink, this did not work. The digest form carries the **same #5061 emitter tag** as the `Summaries` it replaces; without that, a path would lose attribution the moment its peer upgraded, showing a named arm shrinking and the residual growing — indistinguishable from the saving being demonstrated. `SummaryRequestReply` and `SummaryRequest` get their own arms since they are what hash-first *adds*.

Agreement rate is split by **message shape** (single-entry ≈ the state-change-driven sites). A true per-emitter split is not implementable: the tag is `#[serde(skip)]`, so an inbound digest always decodes as `Other` and the receiver — the only side that can judge agreement — cannot know the send site. **Stated confound:** a heartbeat reply for a pair sharing one contract is also single-entry, so this is directional evidence, not attribution.

The comparison counter also gains a third **`one_sided`** bucket. The 98.1% headline was computed over `(Some, Some)` comparisons only, structurally excluding the case where we hold nothing and the peer does — which under hash-first classifies as `NeedBytes`, costing +2 messages for bytes the old path delivered immediately *and* used to seed our cache. Its size was never measured; now it will be.

### Field falsifier — load-bearing, not belt-and-braces

The sim proves the mechanism on the agree path only (see the scope limit above), so **these counters are the primary check at fleet scale**, not a confirmation of something already proven:

| what to read | expectation | what a miss means |
|---|---|---|
| `interest_sync_summaries_bytes` (parent arm) | falls between upgraded pairs | the saving is not landing |
| `interest_sync_summaries_request_leg` / `_request_reply` **message** counts | small relative to `_interests_reply` | mismatch tail is multiplying messages — the #4861 axis |
| single-entry agreement rate | ~98%+ | the heartbeat population does not agree as measured |
| **multi-entry** agreement rate | ~98%+ | **low here is the spurious-mismatch signature** — savings evaporate while correctness holds |
| `summary_entries_one_sided` | small | the phantom-interest population is bigger than assumed |

Read the **parent arm** for the before/after, not the per-emitter split: during adoption the split is not like-for-like, because a pair only uses digests once *both* sides are upgraded.

Note `interest_sync_summaries_request_leg` is deliberately not `..._request` — the latter is a strict prefix of `..._request_reply`, so a dashboard glob would double-count.

## Reviewer note: two pre-existing pins were tightened, and one of mine was vacuous

A PR that tightens pins it did not write reads as scope creep unless the reason is explicit. **These pins were weakened *by* this PR in a way that stayed green** — that is the failure mode worth your attention:

- `summaries_arm_uses_semantic_staleness_probe_pin` anchors on "the next arm". Inserting two arms widened its window to span them; since the digest arm calls the same functions, its assertions would have kept passing **with those calls deleted from `Summaries` itself**.
- `summaries_emitter_sites_are_pinned` scoped files by whether they construct the variant. Centralising construction meant `operations/update.rs` no longer did, so it **dropped out of scope entirely and its two emitters stopped being pinned** — the pin went quiet exactly when it became load-bearing.
- My own `digest_arm_shares_the_single_heal_path` was **vacuous on arrival**: the identifiers it asserts are also in the arm's comments, so deleting both calls left it green. Fixed by stripping comments from the scanned window; verified by mutation.

A **fourth** turned up in review, in a pin I had already "fixed" once: `summaries_arm_uses_semantic_staleness_probe_pin`'s window anchor was `InterestMessage::SummaryDigests { entries }` — a form appearing nowhere in `node.rs` except the pin's own line, which `include_str!` includes. It self-matched, widening the window ~8x. Correcting the needle alone was **still** insufficient: the correct window's own comments satisfied two assertions on prose. Both halves were required.

Filed as **#5076** — now four instances of one mechanism, with "a scrape matching zero things must fail" plus "a needle must resolve to a KNOWN LINE, not merely somewhere" (matched-itself defeats matched-zero), and a note that other scrape pins may already be silently green.

## Release-timing guard

`HASH_FIRST_SUMMARIES_MIN_VERSION = (0, 2, 116)` is only correct if this ships in 0.2.116. The old guard compared against a frozen literal, which catches the floor moving *down* but not the *release* moving up past a stationary floor — the real risk at five releases in four days. If 0.2.116 shipped without this feature, peers on the real 0.2.116 would satisfy the floor while carrying no variant index, fail to decode, and lose their connections during the staggered rollout.

`HASH_FIRST_SHIPPED_IN: Option<(u8,u8,u16)> = None` plus a test coupling the floor to `CARGO_PKG_VERSION` makes that state fail CI instead. Verified by simulating the bump: marker `None` with the crate at the floor fails and names both remedies; `Some(floor)` passes; `Some(mismatch)` fails.

## The per-message cap was measured, not guessed

The receive-side cap started at 256 on the assumption that "a healthy pair shares a handful of contracts". Telemetry says otherwise — `hosting_contract_count` over 16,578 deployed samples:

| p50 | p75 | p90 | p95 | p99 | max |
|-----|-----|-----|-----|-----|-----|
| 417 | 698 | 825 | 976 | 2463 | 2814 |

**73% exceed 256**, so the old value would have bound on the common case rather than the abuse case. Byte metrics could not have revealed this: a `None` entry (a contract the responder doesn't host) costs ~5 bytes, so entry count is decoupled from message size and a cheap 400-entry message is invisible in every byte arm. Now 4096, above the observed maximum. `summaries_entries` (#5061, same release) is the ongoing check.

## Simulation coverage

Sim nodes report `CARGO_PKG_VERSION`, so at 0.2.115 every sim exercised the *fallback* and the first integration run of this change would have been the release PR — ambiguous between the feature and the version bump.

Closed by making the floor overridable. **Sims default it ON**, unlike the two existing floor overrides which fail closed: those gate behavioural *cascades* that load unrelated sims, whereas this changes only the *encoding* of an exchange every sim already runs, with identical convergence semantics.

Full suite on this branch: **137/137 passed** (nextest, hash-first ON).

*Note for anyone reading a red `cargo test` on this suite:* it needs process-per-test isolation (`test_strict_determinism_exact_event_equality`: *"Process isolation via nextest eliminates inter-test DashMap state leakage (#3051)"*). Under `cargo test` this suite produced 10 failures that are entirely absent under nextest. The isolation problem is a property of **the suite sharing a process**, not of the individual tests that happen to mention it — tests that never mention nextest can still be corrupted by a neighbour.

## Testing

- `cargo test -p freenet --lib` — **4508 passed, 0 failed**
- `cargo nextest run -p freenet --test simulation_integration` — **137 passed, 0 failed**
- `cargo clippy --locked -- -D warnings` and the `--features trace-ot` pass — clean
- 22 new unit tests; the A/B simulation; 7 mutations on the core logic, all caught

Refs #4965. Related: #4961, #4956, #4952, #4857, #4861, #5061.

[AI-assisted - Claude]
