### PR TITLE
test(wasm_runtime): offline self-delta / summarize-determinism probe harness

### DIFF
--- a/crates/core/src/wasm_runtime/tests.rs
+++ b/crates/core/src/wasm_runtime/tests.rs
@@ -7,6 +7,7 @@ mod cache;
 mod contract;
 mod contract_metering;
 mod execution_handling;
+mod self_delta_probe;
 mod time;
 
 pub(crate) fn get_test_module(name: &str) -> Result<Vec<u8>, Box<dyn std::error::Error>> {

--- a/crates/core/src/wasm_runtime/tests/self_delta_probe.rs
+++ b/crates/core/src/wasm_runtime/tests/self_delta_probe.rs
@@ -1,0 +1,187 @@
+//! Offline probe: does `get_state_delta(S, summarize_state(S))` return EMPTY?
+//!
+//! Analysis harness (not a CI test). Driven entirely by environment variables;
+//! with none set it is a no-op, so it costs CI nothing.
+//!
+//! Usage:
+//!   PROBE_DUMP=/path/to/dump PROBE_WASM=/path/to/contracts \
+//!   PROBE_OUT=/path/to/results.jsonl \
+//!   cargo test -p freenet --lib self_delta_probe -- --nocapture --test-threads=1
+//!
+//! `PROBE_DUMP` must contain `manifest.json` plus `state/<instance>.bin` and
+//! `params/<instance>.bin`, as produced by the redb dumper.
+
+use std::sync::Arc;
+
+use freenet_stdlib::prelude::{
+    ContractCode, ContractContainer, ContractWasmAPIVersion, Parameters, StateSummary,
+    WrappedContract, WrappedState,
+};
+
+use crate::wasm_runtime::contract::ContractRuntimeInterface;
+
+fn esc(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', " ")
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn self_delta_probe() -> Result<(), Box<dyn std::error::Error>> {
+    let Ok(dump) = std::env::var("PROBE_DUMP") else {
+        eprintln!("PROBE_DUMP unset; skipping analysis harness");
+        return Ok(());
+    };
+    let wasmdir = std::env::var("PROBE_WASM").expect("PROBE_WASM");
+    let outpath = std::env::var("PROBE_OUT").expect("PROBE_OUT");
+    // Optional filter: only instances whose base58 id starts with this prefix.
+    let only = std::env::var("PROBE_ONLY").ok();
+
+    let manifest: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(format!("{dump}/manifest.json"))?)?;
+    let entries = manifest.as_array().unwrap();
+
+    let temp_dir = crate::util::tests::get_temp_dir();
+    let db = crate::contract::storages::Storage::new(temp_dir.path()).await?;
+    let contract_store = crate::wasm_runtime::ContractStore::new(
+        temp_dir.path().join("contract"),
+        1024 * 1024 * 1024,
+        db.clone(),
+    )?;
+    let delegate_store = crate::wasm_runtime::DelegateStore::new(
+        temp_dir.path().join("delegate"),
+        10_000_000,
+        db.clone(),
+    )?;
+    let secrets_store = crate::wasm_runtime::SecretsStore::new(
+        temp_dir.path().join("secrets"),
+        Default::default(),
+        db,
+    )?;
+    let mut runtime =
+        crate::wasm_runtime::Runtime::build(contract_store, delegate_store, secrets_store, false)?;
+
+    let mut out = std::fs::File::create(&outpath)?;
+    use std::io::Write;
+
+    // Cache wasm blobs by code hash so 763 instances of one code read it once.
+    let mut code_cache: std::collections::HashMap<String, Arc<ContractCode<'static>>> =
+        std::collections::HashMap::new();
+
+    let total = entries.len();
+    for (i, e) in entries.iter().enumerate() {
+        let inst = e["instance"].as_str().unwrap().to_string();
+        if let Some(p) = &only {
+            if !inst.starts_with(p.as_str()) {
+                continue;
+            }
+        }
+        let Some(code_hash) = e["code_hash"].as_str() else {
+            writeln!(
+                out,
+                "{{\"instance\":\"{inst}\",\"status\":\"no_code_hash\"}}"
+            )?;
+            continue;
+        };
+        let code = match code_cache.get(code_hash) {
+            Some(c) => c.clone(),
+            None => {
+                let path = format!("{wasmdir}/{code_hash}.wasm");
+                match std::fs::read(&path) {
+                    Ok(b) => {
+                        let c = Arc::new(ContractCode::from(b));
+                        code_cache.insert(code_hash.to_string(), c.clone());
+                        c
+                    }
+                    Err(err) => {
+                        writeln!(
+                            out,
+                            "{{\"instance\":\"{inst}\",\"code_hash\":\"{code_hash}\",\"status\":\"wasm_missing\",\"err\":\"{}\"}}",
+                            esc(&err.to_string())
+                        )?;
+                        continue;
+                    }
+                }
+            }
+        };
+
+        let params_bytes = std::fs::read(format!("{dump}/params/{inst}.bin")).unwrap_or_default();
+        let state_bytes = std::fs::read(format!("{dump}/state/{inst}.bin"))?;
+        let params: Parameters<'static> = Parameters::from(params_bytes.clone());
+        let state = WrappedState::new(state_bytes.clone());
+
+        let wc = WrappedContract::new(code.clone(), params.clone());
+        let container = ContractContainer::Wasm(ContractWasmAPIVersion::V1(wc));
+        let key = container.key();
+        let derived = key.encoded_contract_id();
+        // Store so the module cache miss path can fetch code by key.
+        let _ = runtime.contract_store.store_contract(container.clone());
+
+        let state_len = state_bytes.len();
+
+        // Three summarize calls to test determinism across fresh instances.
+        let mut sums: Vec<Result<Vec<u8>, String>> = Vec::new();
+        for _ in 0..3 {
+            let r = runtime
+                .summarize_state(&key, &params, &state)
+                .map(|s| s.into_bytes())
+                .map_err(|e| e.to_string());
+            sums.push(r);
+        }
+
+        let (sum_bytes, sum_err) = match &sums[0] {
+            Ok(b) => (Some(b.clone()), None),
+            Err(e) => (None, Some(e.clone())),
+        };
+        let deterministic = sums.iter().all(|r| match (r, &sums[0]) {
+            (Ok(a), Ok(b)) => a == b,
+            (Err(a), Err(b)) => a == b,
+            _ => false,
+        });
+
+        let (delta_len, delta_err, delta_head) = match &sum_bytes {
+            None => (None, Some("summarize failed".to_string()), None),
+            Some(sb) => {
+                let summary = StateSummary::from(sb.clone());
+                match runtime.get_state_delta(&key, &params, &state, &summary) {
+                    Ok(d) => {
+                        let db = d.into_bytes();
+                        let head = db
+                            .iter()
+                            .take(32)
+                            .map(|b| format!("{b:02x}"))
+                            .collect::<String>();
+                        (Some(db.len()), None, Some(head))
+                    }
+                    Err(e) => (None, Some(e.to_string()), None),
+                }
+            }
+        };
+
+        writeln!(
+            out,
+            "{{\"instance\":\"{inst}\",\"derived_id\":\"{derived}\",\"code_hash\":\"{code_hash}\",\"state_len\":{state_len},\"params_len\":{},\"summary_len\":{},\"summary_err\":{},\"deterministic\":{},\"delta_len\":{},\"delta_err\":{},\"delta_head\":{}}}",
+            params_bytes.len(),
+            sum_bytes
+                .as_ref()
+                .map(|b| b.len().to_string())
+                .unwrap_or("null".into()),
+            sum_err
+                .map(|e| format!("\"{}\"", esc(&e)))
+                .unwrap_or("null".into()),
+            deterministic,
+            delta_len.map(|l| l.to_string()).unwrap_or("null".into()),
+            delta_err
+                .map(|e| format!("\"{}\"", esc(&e)))
+                .unwrap_or("null".into()),
+            delta_head
+                .map(|h| format!("\"{h}\""))
+                .unwrap_or("null".into()),
+        )?;
+        out.flush()?;
+        if i % 25 == 0 {
+            eprintln!("progress {i}/{total}");
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Problem

We want to enforce a staleness-probe invariant: *if a peer's summary equals my state's summary, they hold what I hold, so `get_state_delta(S, summarize_state(S))` must be empty.* The only thing blocking it is fear of false positives (#4295 froze the ping contract permanently that way).

That fear was never converted into data. There was no way to answer "does this hold for the contracts the network actually hosts?" without a harness.

## Approach

A test-gated analysis harness that runs the **real** runtime (`Runtime` + wasmtime + `ContractStore`, so Cranelift `OptLevel::None` exactly as production) over (contract WASM, real state) pairs and records, per pair:

- `summarize_state` called **three times**, each on a fresh WASM instance, with full byte comparison — so a non-deterministic summarize (the #4857 HashMap-iteration-order class) is reported *separately* from a broken delta. Those two failures need different fixes and must not be conflated.
- `get_state_delta(S, first_summary)` length, plus the **first 32 bytes of the delta**. The head is the load-bearing part: it distinguishes a semantically-empty encoding (CBOR `null` = `f6`, or a map of empty collections) from a byte-identical whole-state dump. `ring/interest.rs:1856` and `:1944` judge peer staleness by raw `!delta.as_ref().is_empty()`, so those two cases look identical to core but are completely different bugs.
- `summarize_state(S).len()` vs `S.len()` — a summary at or above state size is a bug in every case and is nearly free to collect.

It also records the instance id derived from (params, code) alongside the stored one, which is a free check that the harness is running the right code with the right params.

Driven entirely by `PROBE_DUMP` / `PROBE_WASM` / `PROBE_OUT`. With those unset it returns immediately, so it costs CI nothing.

## Testing

Run against the full contract set the nova gateway hosts: **2470 of 2489 stored states, covering all 190 distinct code hashes** (the other 19 rows have no `contract_index` entry, so their code hash is unknown). The derived instance id matched the stored one for all 2470.

Findings are reported separately; the short version is that the invariant does **not** hold universally — 818 of 2470 states return a non-empty self-delta — and that several of the failures are semantically-empty encodings rather than broken delta mechanisms, which is exactly the distinction a naive `is_empty()` enforcing would get wrong.

## Note

This is an analysis harness, not a product change. It is offered because it is the fixture you would want to re-run before enabling any enforcing probe, and because the same shape could become a CI gate for the invariant. If the team would rather not carry it in-tree, closing this is fine — the findings stand on their own.

[AI-assisted - Claude]
