### PR TITLE
build: update and fix the nix flake

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -81,6 +81,16 @@ updates:
           - "minor"
           - "patch"
 
+  - package-ecosystem: "nix"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    # Put all updates in one PR
+    groups:
+      nix:
+        patterns:
+          - "*"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,13 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every weekday
       interval: "daily"
+
+  - package-ecosystem: "nix"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Put all updates in one PR
+    groups:
+      nix:
+        patterns:
+          - "*"

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,81 @@
+name: Nix
+
+# Nothing else in CI evaluates flake.nix, package.nix or the devShell, so the
+# weekly nixpkgs-unstable bump from dependabot would otherwise land with no
+# build signal behind it.
+#
+# NOT a required check: path-filtered workflows do not reliably produce a check
+# context for branch protection (see the note in playwright-shell.yml).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'package.nix'
+      - 'rust-toolchain.toml'
+      - 'Cargo.lock'
+      - 'crates/core/build.rs'
+      - '.github/workflows/nix.yml'
+  pull_request:
+    paths:
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'package.nix'
+      - 'rust-toolchain.toml'
+      - 'Cargo.lock'
+      - 'crates/core/build.rs'
+      - '.github/workflows/nix.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  nix-build:
+    name: Nix flake build
+    runs-on: ubicloud-standard-8
+    # A cold build compiles the whole dependency graph; no binary cache exists.
+    timeout-minutes: 90
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Check flake outputs evaluate
+        run: nix flake check --no-build
+
+      - name: Build the freenet package
+        run: nix build .#freenet -L
+
+      # The devShell breaks independently of the package. `cargo metadata` runs
+      # cargo against the real workspace; a bare `cargo --version` would not.
+      - name: Check the devShell opens and cargo works inside it
+        run: |
+          nix develop --command rustc --version
+          nix develop --command cargo metadata --format-version 1 > /dev/null
+          # Asserted directly because `cargo metadata` runs no build script, so
+          # it passes in a shell where `cargo clippy --workspace` cannot compile.
+          nix develop --command pkg-config --exists openssl
+
+      # A shell whose rustc differs from the pin gives clippy and rustfmt results
+      # that disagree with CI.
+      - name: Verify the devShell matches rust-toolchain.toml
+        run: |
+          pinned="$(grep -oP 'channel\s*=\s*"\K[^"]+' rust-toolchain.toml)"
+          actual="$(nix develop --command rustc --version | awk '{print $2}')"
+          if [ "$pinned" != "$actual" ]; then
+              echo "devShell rustc is $actual but rust-toolchain.toml pins $pinned" >&2
+              exit 1
+          fi
+          echo "devShell rustc matches the pin: $actual"
+
+      # writeShellApplication runs shellcheck at build time, so building the
+      # generated wrapper is the check.
+      - name: Build the auto-update wrapper
+        run: nix build .#freenet-autoupdate -L

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,7 @@ logs/
 
 # Local-only: release-agent binary staged for install.sh (built per-machine)
 scripts/release-agent/freenet-release-agent
+
+# Nix
+/result
+/result-*

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,7 @@ logs/
 
 # Local-only: release-agent binary staged for install.sh (built per-machine)
 scripts/release-agent/freenet-release-agent
+
+# Nix
+result
+result-*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,27 @@ When in doubt about which bucket you're in, file an issue first. It costs you a 
 - **Read the codebase conventions.** See [AGENTS.md](AGENTS.md) for project structure, coding standards, and testing requirements.
 - **Ask questions.** If something is unclear, ask on the issue or in our [Matrix channel](https://matrix.to/#/#freenet:matrix.org) before writing code.
 
+## Building with Nix (optional)
+
+An alternative to a local rustup install, not a requirement.
+
+```bash
+nix develop                  # dev shell: pinned toolchain, nextest, shellcheck, …
+nix build .#freenet          # build the node binary (result/bin/freenet)
+nix run .                    # run the auto-updating wrapper
+```
+
+The shell's toolchain is pinned to [`rust-toolchain.toml`](rust-toolchain.toml),
+so `cargo fmt` and `cargo clippy -- -D warnings` inside it agree with CI. Builds
+are reproducible: the same source gives a bit-identical binary, since
+`BUILD_TIMESTAMP` comes from `SOURCE_DATE_EPOCH` and the git provenance from the
+flake rather than a `.git` directory.
+
+Packagers building outside Nix can supply that provenance with
+`FREENET_GIT_COMMIT_HASH` (≤40 hex characters) and `FREENET_GIT_IS_DIRTY`
+(`1`/`true`, `0`/`false`, or empty to detect it with `git`). The latter gates
+auto-update — a build marked dirty will never update itself.
+
 ## Quality Standards
 
 - PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/) format (`feat:`, `fix:`, `docs:`, etc.) — CI enforces this.

--- a/crates/core/build.rs
+++ b/crates/core/build.rs
@@ -1,5 +1,5 @@
-use std::process::Command;
 use chrono::TimeZone;
+use std::process::Command;
 
 fn main() {
     // Emit build metadata for startup logging
@@ -110,23 +110,47 @@ fn read_min_compatible_from_cargo_toml() -> Option<String> {
 }
 
 fn emit_build_metadata() {
-    // Git commit hash
-    let git_hash = Command::new("git")
-        .args(["rev-parse", "--short=12", "HEAD"])
-        .output()
-        .ok()
-        .and_then(|o| String::from_utf8(o.stdout).ok())
-        .map(|s| s.trim().to_string())
-        .unwrap_or_else(|| "unknown".to_string());
+    // Git commit hash. FREENET_GIT_COMMIT_HASH supplies it for source drops with
+    // no `.git`; empty means "no override", as for FREENET_GIT_IS_DIRTY below.
+    let git_hash = match std::env::var("FREENET_GIT_COMMIT_HASH") {
+        Ok(v) if !v.trim().is_empty() => {
+            let v = v.trim().to_string();
+            // Validated because an embedded newline in a `cargo:` directive would
+            // emit further directives of the caller's choosing.
+            if v.len() > 40 || !v.chars().all(|c| c.is_ascii_hexdigit()) {
+                panic!("FREENET_GIT_COMMIT_HASH ({v}) must be <= 40 hex characters");
+            }
+            v
+        }
+        _ => Command::new("git")
+            .args(["rev-parse", "--short=12", "HEAD"])
+            .output()
+            .ok()
+            .and_then(|o| String::from_utf8(o.stdout).ok())
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| "unknown".to_string()),
+    };
     println!("cargo:rustc-env=GIT_COMMIT_HASH={git_hash}");
 
-    // Git dirty flag
-    let git_dirty = Command::new("git")
-        .args(["status", "--porcelain"])
-        .output()
-        .ok()
-        .map(|o| !o.stdout.is_empty())
-        .unwrap_or(false);
+    // Git dirty flag. Parsed strictly: GIT_DIRTY is the auto-update kill switch
+    // (`auto_update_is_disabled` in src/bin/freenet.rs), so a lenient
+    // "any non-empty value is dirty" rule would let FREENET_GIT_IS_DIRTY=false
+    // ship a release binary that never updates itself.
+    let git_dirty = match std::env::var("FREENET_GIT_IS_DIRTY")
+        .as_deref()
+        .map(str::trim)
+    {
+        Ok("1") | Ok("true") => true,
+        Ok("0") | Ok("false") => false,
+        Ok("") | Err(_) => Command::new("git")
+            .args(["status", "--porcelain"])
+            .output()
+            .ok()
+            .map(|o| !o.stdout.is_empty())
+            .unwrap_or(false),
+        Ok(other) => panic!("FREENET_GIT_IS_DIRTY ({other}) must be 1, true, 0, false, or empty"),
+    };
     let dirty_suffix = if git_dirty { "-dirty" } else { "" };
     println!("cargo:rustc-env=GIT_DIRTY={dirty_suffix}");
 
@@ -146,6 +170,11 @@ fn emit_build_metadata() {
     let timestamp = now.format("%Y-%m-%dT%H:%M:%SZ").to_string();
     println!("cargo:rustc-env=BUILD_TIMESTAMP={timestamp}");
     println!("cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH");
+    // Required: emitting any rerun-if-* directive makes Cargo honor only the
+    // declared set, so without these an unset var leaves stale provenance —
+    // and a stale GIT_DIRTY disables auto-update.
+    println!("cargo:rerun-if-env-changed=FREENET_GIT_COMMIT_HASH");
+    println!("cargo:rerun-if-env-changed=FREENET_GIT_IS_DIRTY");
 
     // Rebuild if git HEAD changes
     println!("cargo:rerun-if-changed=.git/HEAD");

--- a/crates/core/build.rs
+++ b/crates/core/build.rs
@@ -1,5 +1,5 @@
-use std::process::Command;
 use chrono::TimeZone;
+use std::process::Command;
 
 fn main() {
     // Emit build metadata for startup logging
@@ -111,22 +111,27 @@ fn read_min_compatible_from_cargo_toml() -> Option<String> {
 
 fn emit_build_metadata() {
     // Git commit hash
-    let git_hash = Command::new("git")
-        .args(["rev-parse", "--short=12", "HEAD"])
-        .output()
-        .ok()
-        .and_then(|o| String::from_utf8(o.stdout).ok())
-        .map(|s| s.trim().to_string())
-        .unwrap_or_else(|| "unknown".to_string());
+    let git_hash = std::env::var("FREENET_GIT_COMMIT_HASH").unwrap_or_else(|_| {
+        Command::new("git")
+            .args(["rev-parse", "--short=12", "HEAD"])
+            .output()
+            .ok()
+            .and_then(|o| String::from_utf8(o.stdout).ok())
+            .map(|s| s.trim().to_string())
+            .unwrap_or_else(|| "unknown".to_string())
+    });
     println!("cargo:rustc-env=GIT_COMMIT_HASH={git_hash}");
 
     // Git dirty flag
-    let git_dirty = Command::new("git")
-        .args(["status", "--porcelain"])
-        .output()
-        .ok()
-        .map(|o| !o.stdout.is_empty())
-        .unwrap_or(false);
+    let git_dirty = match std::env::var("FREENET_GIT_IS_DIRTY") {
+        Ok(v) if !v.is_empty() => true,
+        _ => Command::new("git")
+            .args(["status", "--porcelain"])
+            .output()
+            .ok()
+            .map(|o| !o.stdout.is_empty())
+            .unwrap_or(false),
+    };
     let dirty_suffix = if git_dirty { "-dirty" } else { "" };
     println!("cargo:rustc-env=GIT_DIRTY={dirty_suffix}");
 

--- a/crates/core/build.rs
+++ b/crates/core/build.rs
@@ -1,4 +1,5 @@
 use std::process::Command;
+use chrono::TimeZone;
 
 fn main() {
     // Emit build metadata for startup logging
@@ -130,8 +131,21 @@ fn emit_build_metadata() {
     println!("cargo:rustc-env=GIT_DIRTY={dirty_suffix}");
 
     // Build timestamp (ISO 8601)
-    let timestamp = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
+    let now = match std::env::var("SOURCE_DATE_EPOCH") {
+        Ok(val) => {
+            let epoch: i64 = val
+                .parse()
+                .unwrap_or_else(|_| panic!("SOURCE_DATE_EPOCH ({val}) is not a valid integer"));
+            chrono::Utc
+                .timestamp_opt(epoch, 0)
+                .single()
+                .unwrap_or_else(|| panic!("SOURCE_DATE_EPOCH ({val}) is not a valid timestamp"))
+        }
+        Err(_) => chrono::Utc::now(),
+    };
+    let timestamp = now.format("%Y-%m-%dT%H:%M:%SZ").to_string();
     println!("cargo:rustc-env=BUILD_TIMESTAMP={timestamp}");
+    println!("cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH");
 
     // Rebuild if git HEAD changes
     println!("cargo:rerun-if-changed=.git/HEAD");

--- a/crates/core/src/bin/commands/auto_update.rs
+++ b/crates/core/src/bin/commands/auto_update.rs
@@ -3609,4 +3609,60 @@ mod tests {
         let vague = GithubRateLimitedError { retry_after: None }.user_message();
         assert!(vague.contains("within the hour"), "{vague}");
     }
+
+    /// [`fn_body`] for a file with no test module. It requires one, to prove the
+    /// anchor did not fall through into the pin's own literals (#5102/#5103);
+    /// `build.rs` is a different file from this one, which gives that by
+    /// construction. The `\n}\n` bound still matters — without it a moved anchor
+    /// matches later in `build.rs` and the assertions pass vacuously.
+    fn build_rs_fn_body<'a>(src: &'a str, signature: &str) -> &'a str {
+        let at = src
+            .find(signature)
+            .unwrap_or_else(|| panic!("definition not found in build.rs: {signature}"));
+        assert!(
+            at == 0 || src.as_bytes()[at - 1] == b'\n',
+            "`{signature}` is indented; the `\\n}}\\n` end-anchor would overshoot"
+        );
+        let after = &src[at + signature.len()..];
+        let (body, _) = after
+            .split_once("\n}\n")
+            .unwrap_or_else(|| panic!("could not locate end of: {signature}"));
+        body
+    }
+
+    /// `GIT_DIRTY` is the auto-update kill switch (`auto_update_is_disabled` in
+    /// `freenet.rs`), and `FREENET_GIT_IS_DIRTY` is an env binding onto it —
+    /// the one `config.rs` refuses to give `--disable-auto-update`. Both
+    /// regressions pinned here ship a binary that never updates itself: lenient
+    /// truthiness reads `=false` as dirty, and a missing `rerun-if-env-changed`
+    /// leaves a stale `GIT_DIRTY` baked in after the var is unset.
+    #[test]
+    fn build_script_git_dirty_override_cannot_silently_disable_auto_update() {
+        let body = build_rs_fn_body(
+            include_str!("../../../build.rs"),
+            "fn emit_build_metadata() {",
+        );
+
+        assert!(
+            body.contains(r#"Ok("0") | Ok("false") => false"#),
+            "FREENET_GIT_IS_DIRTY=0/false must map to CLEAN; without this arm it \
+             falls through to a truthiness test that reads it as DIRTY"
+        );
+        assert!(
+            body.contains(r#"Ok("1") | Ok("true") => true"#),
+            "FREENET_GIT_IS_DIRTY=1/true must map to DIRTY"
+        );
+        assert!(
+            body.contains("Ok(other) => panic!"),
+            "an unrecognised FREENET_GIT_IS_DIRTY must fail the build, not be guessed"
+        );
+
+        for var in ["FREENET_GIT_IS_DIRTY", "FREENET_GIT_COMMIT_HASH"] {
+            assert!(
+                body.contains(&format!("cargo:rerun-if-env-changed={var}")),
+                "{var} must be a declared rerun trigger, or an unset value leaves \
+                 stale provenance baked in"
+            );
+        }
+    }
 }

--- a/flake.lock
+++ b/flake.lock
@@ -37,7 +37,28 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786935912,
+        "narHash": "sha256-26qGGBO364d5JbTMrFchrxp7xY8CJp3D5cjkND99t7E=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "b479967b8ed7aca40ba52cf12f460484c53928a9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     },
     "systems": {

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1770537093,
-        "narHash": "sha256-pF1quXG5wsgtyuPOHcLfYg/ft/QMr8NnX0i6tW2187s=",
+        "lastModified": 1785301185,
+        "narHash": "sha256-eoS3KQTO0aPWXZvIaRbRAzSSHW3l5wdMFXtT1ISfoKA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fef9403a3e4d31b0a23f0bacebbec52c248fbb51",
+        "rev": "9bc02893134c733dd85de46ee4fb2fac696b5529",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,6 +2,10 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =
@@ -9,6 +13,7 @@
       self,
       nixpkgs,
       flake-utils,
+      rust-overlay,
       ...
     }:
     let
@@ -114,13 +119,46 @@
       let
         pkgs = import nixpkgs {
           inherit system;
-          overlays = [ self.overlays.default ];
+          overlays = [
+            rust-overlay.overlays.default
+            self.overlays.default
+          ];
         };
+
+        # The repo's pinned toolchain, not whatever nixpkgs-unstable ships:
+        # clippy and rustfmt only match CI when the compiler version does.
+        toolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+        rustPlatform = pkgs.makeRustPlatform {
+          cargo = toolchain;
+          rustc = toolchain;
+        };
+
+        # Applied here rather than in the overlay, so downstream consumers of
+        # the overlay still get a plain-nixpkgs package.
+        freenet = pkgs.freenet.override { inherit rustPlatform; };
       in
       {
         packages = rec {
-          inherit (pkgs) freenet freenet-autoupdate;
+          inherit freenet;
+          inherit (pkgs) freenet-autoupdate;
           default = freenet-autoupdate;
+        };
+        devShells.default = pkgs.mkShell {
+          inputsFrom = [ freenet ];
+          # Not needed by the freenet binary, but release-agent's openssl-sys
+          # fails to build without them, so `cargo clippy --workspace` in this
+          # shell would not compile.
+          nativeBuildInputs = [ pkgs.pkg-config ];
+          buildInputs = [ pkgs.openssl ];
+          packages = [
+            toolchain
+            pkgs.cargo-nextest
+            pkgs.jq
+            pkgs.nixfmt
+            pkgs.pre-commit
+            pkgs.python3
+            pkgs.shellcheck
+          ];
         };
       }
     );

--- a/flake.nix
+++ b/flake.nix
@@ -14,21 +14,27 @@
     {
       overlays.default = _: pkgs: {
         freenet = pkgs.callPackage (import ./package.nix) { };
-        freenet-autoupdate = pkgs.writeShellScriptBin "freenet-autoupdate" ''
-          trap "" INT
+        freenet-autoupdate = pkgs.writeShellApplication {
+          name = "freenet-autoupdate";
+          runtimeInputs = [ pkgs.gh pkgs.nix ];
+          text = ''
+            while true; do
+                vsn="$(gh release view --repo freenet/freenet-core \
+                  --json tagName --jq .tagName)"
+                echo "Running freenet $vsn"
+                exit_code=0
+                nix --option experimental-features 'nix-command flakes' \
+                  run "github:freenet/freenet-core/$vsn#freenet" || exit_code=$?
 
-          while true; do
-              nix run github:freenet/freenet-core#freenet
-              exit_code=$?
-
-              if [ $exit_code -eq 42 ]; then
-                  echo "Autoupdate triggered. Restarting..."
-              else
-                  echo "Non-autoupdate exit code: $exit_code. Stopping."
-                  break
-              fi
-          done
-        '';
+                if [ $exit_code -eq 42 ]; then
+                    echo "Autoupdate triggered. Restarting..."
+                else
+                    echo "Non-autoupdate exit code: $exit_code. Stopping."
+                    exit $exit_code
+                fi
+            done
+          '';
+        };
       };
     }
     // flake-utils.lib.eachDefaultSystem (

--- a/flake.nix
+++ b/flake.nix
@@ -14,21 +14,78 @@
     {
       overlays.default = _: pkgs: {
         freenet = pkgs.callPackage (import ./package.nix) { };
-        freenet-autoupdate = pkgs.writeShellScriptBin "freenet-autoupdate" ''
-          trap "" INT
+        freenet-autoupdate = pkgs.writeShellApplication {
+          name = "freenet-autoupdate";
+          runtimeInputs = [
+            pkgs.curl
+            pkgs.nix
+          ];
+          text = ''
+            # So the node exits 42 for us instead of logging that it will not update.
+            export FREENET_SUPERVISED=1
 
-          while true; do
-              nix run github:freenet/freenet-core#freenet
-              exit_code=$?
+            # Mirrors MAX_UPDATE_FAILURES (crates/core/src/bin/commands/update.rs):
+            # stop if the node keeps asking to update but the tag never moves.
+            max_failures=3
+            failures=0
+            last_vsn=""
 
-              if [ $exit_code -eq 42 ]; then
-                  echo "Autoupdate triggered. Restarting..."
-              else
-                  echo "Non-autoupdate exit code: $exit_code. Stopping."
-                  break
-              fi
-          done
-        '';
+            # ±20% jitter, mirroring UPDATE_REPOLL_JITTER_FRACTION
+            # (crates/core/src/bin/commands/auto_update.rs). Every instance
+            # polls the same releases/latest redirect and is handed exit 42 at
+            # roughly the same wall-clock moment when a release lands, so a
+            # fixed sleep makes them all retry in lockstep.
+            jittered() {
+                printf '%s' "$(( $1 * 8 / 10 + RANDOM % ($1 * 4 / 10 + 1) ))"
+            }
+
+            while true; do
+                # The auth-free redirect the node itself uses
+                # (GITHUB_LATEST_REDIRECT_URL in .../commands/auto_update.rs).
+                # Not api.github.com: that spends REST quota shared per source
+                # IP (#5102), and needs a token this wrapper should not require.
+                vsn="$(curl -fsSL -o /dev/null -w '%{url_effective}' \
+                  -A freenet-updater \
+                  https://github.com/freenet/freenet-core/releases/latest \
+                  | sed -n 's|.*/releases/tag/||p')" || vsn=""
+
+                if [ -z "$vsn" ]; then
+                    # A network blip must not kill the supervisor.
+                    delay="$(jittered 60)"
+                    echo "Could not resolve the latest freenet release; retrying in $delay seconds." >&2
+                    sleep "$delay"
+                    continue
+                fi
+
+                echo "Running freenet $vsn"
+                exit_code=0
+                nix --extra-experimental-features 'nix-command flakes' \
+                  run "github:freenet/freenet-core/$vsn#freenet" || exit_code=$?
+
+                if [ "$exit_code" -eq 42 ]; then
+                    if [ "$vsn" = "$last_vsn" ]; then
+                        failures=$((failures + 1))
+                    else
+                        failures=0
+                    fi
+                    last_vsn="$vsn"
+
+                    if [ "$failures" -ge "$max_failures" ]; then
+                        echo "freenet $vsn requested an update $max_failures times without the" >&2
+                        echo "released version changing. Giving up." >&2
+                        exit 1
+                    fi
+
+                    delay="$(jittered $((60 * (failures + 1))))"
+                    echo "Autoupdate triggered. Restarting in $delay seconds..."
+                    sleep "$delay"
+                else
+                    echo "Non-autoupdate exit code: $exit_code. Stopping."
+                    exit "$exit_code"
+                fi
+            done
+          '';
+        };
       };
     }
     // flake-utils.lib.eachDefaultSystem (

--- a/flake.nix
+++ b/flake.nix
@@ -11,14 +11,35 @@
       flake-utils,
       ...
     }:
+    let
+      inherit (nixpkgs) lib;
+
+      # `rev` exists only for a clean git source, `dirtyRev` only for a dirty one,
+      # and neither for a tarball, `path:` or non-git source drop — where an
+      # unguarded dereference is a hard eval failure, not a fallback.
+      gitCommitHash =
+        if self ? rev then
+          lib.substring 0 12 self.rev
+        else if self ? dirtyRev then
+          lib.substring 0 12 (lib.removeSuffix "-dirty" self.dirtyRev)
+        else
+          "unknown";
+
+      # Dirty only when nix says so: treating "no VCS metadata" as dirty would
+      # disable auto-update for every source-drop build (see crates/core/build.rs).
+      gitDirty = self ? dirtyRev;
+    in
     {
-      overlays.default = _: pkgs: {
-        freenet = pkgs.callPackage (import ./package.nix) { };
-        freenet-autoupdate = pkgs.writeShellApplication {
+      overlays.default = final: prev: {
+        freenet = final.callPackage (import ./package.nix) {
+          inherit gitCommitHash gitDirty;
+          sourceDateEpoch = toString self.lastModified;
+        };
+        freenet-autoupdate = final.writeShellApplication {
           name = "freenet-autoupdate";
           runtimeInputs = [
-            pkgs.curl
-            pkgs.nix
+            final.curl
+            final.nix
           ];
           text = ''
             # So the node exits 42 for us instead of logging that it will not update.

--- a/flake.nix
+++ b/flake.nix
@@ -63,6 +63,19 @@
           inherit (pkgs) freenet freenet-autoupdate;
           default = freenet-autoupdate;
         };
+        devShells.default = pkgs.mkShell {
+          inputsFrom = [ self.packages.${system}.freenet ];
+          packages = [
+            pkgs.cargo-nextest
+            pkgs.clippy
+            pkgs.jq
+            pkgs.nixfmt
+            pkgs.pre-commit
+            pkgs.python3
+            pkgs.rustfmt
+            pkgs.shellcheck
+          ];
+        };
       }
     );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -11,12 +11,25 @@
       flake-utils,
       ...
     }:
+    let
+      inherit (nixpkgs) lib;
+    in
     {
       overlays.default = _: pkgs: {
-        freenet = pkgs.callPackage (import ./package.nix) { };
+        freenet = pkgs.callPackage (import ./package.nix) {
+          gitDirty = !(self ? rev);
+          gitCommitHash =
+            if self ? rev then
+              lib.substring 0 12 self.rev
+            else
+              lib.substring 0 12 (lib.removeSuffix "-dirty" self.dirtyRev);
+        };
         freenet-autoupdate = pkgs.writeShellApplication {
           name = "freenet-autoupdate";
-          runtimeInputs = [ pkgs.gh pkgs.nix ];
+          runtimeInputs = [
+            pkgs.gh
+            pkgs.nix
+          ];
           text = ''
             while true; do
                 vsn="$(gh release view --repo freenet/freenet-core \

--- a/package.nix
+++ b/package.nix
@@ -1,28 +1,47 @@
 {
-  rustPlatform,
   lib,
+  rustPlatform,
+  gitCommitHash ? "unknown",
+  gitDirty ? false,
+  # stdenv's default is 1980-01-01: reproducible, but useless in a bug report.
+  # The flake passes `self.lastModified`, which is both.
+  sourceDateEpoch ? null,
 }:
+assert lib.assertMsg (
+  gitCommitHash == "unknown"
+  || (
+    builtins.stringLength gitCommitHash <= 40 && builtins.match "[0-9a-fA-F]+" gitCommitHash != null
+  )
+) "gitCommitHash (${gitCommitHash}) must be <= 40 hex characters";
 rustPlatform.buildRustPackage {
   pname = "freenet";
-  version = (fromTOML (builtins.readFile ./crates/core/Cargo.toml)).package.version;
+  version = (builtins.fromTOML (builtins.readFile ./crates/core/Cargo.toml)).package.version;
 
   src = ./.;
 
-  cargoLock = {
-    lockFile = ./Cargo.lock;
+  cargoLock.lockFile = ./Cargo.lock;
+
+  env = {
+    FREENET_GIT_COMMIT_HASH = gitCommitHash;
+    # Not a Nix bool: `false` coerces to "", which build.rs reads as "no override".
+    FREENET_GIT_IS_DIRTY = if gitDirty then "1" else "0";
+  }
+  // lib.optionalAttrs (sourceDateEpoch != null) {
+    SOURCE_DATE_EPOCH = sourceDateEpoch;
   };
 
   cargoBuildFlags = [
-    "--package"
-    "freenet"
-    "--bin"
-    "freenet"
+    "--package=freenet"
+    "--bin=freenet"
   ];
 
   doCheck = false;
 
-  meta = with lib; {
+  meta = {
+    description = "Peer-to-peer platform for decentralized applications";
     homepage = "https://github.com/freenet/freenet-core";
-    license = licenses.agpl3Only;
+    donationPage = "https://freenet.org/donate/";
+    license = lib.licenses.agpl3Only;
+    mainProgram = "freenet";
   };
 }

--- a/package.nix
+++ b/package.nix
@@ -1,28 +1,34 @@
 {
-  rustPlatform,
   lib,
+  rustPlatform,
+  gitCommitHash ? "unknown",
+  gitDirty ? false,
 }:
 rustPlatform.buildRustPackage {
   pname = "freenet";
-  version = (fromTOML (builtins.readFile ./crates/core/Cargo.toml)).package.version;
+  version = (builtins.fromTOML (builtins.readFile ./crates/core/Cargo.toml)).package.version;
 
   src = ./.;
 
-  cargoLock = {
-    lockFile = ./Cargo.lock;
+  cargoLock.lockFile = ./Cargo.lock;
+
+  env = {
+    FREENET_GIT_COMMIT_HASH = gitCommitHash;
+    FREENET_GIT_IS_DIRTY = gitDirty;
   };
 
   cargoBuildFlags = [
-    "--package"
-    "freenet"
-    "--bin"
-    "freenet"
+    "--package=freenet"
+    "--bin=freenet"
   ];
 
   doCheck = false;
 
-  meta = with lib; {
+  meta = {
+    description = "Peer-to-peer platform for decentralized applications";
     homepage = "https://github.com/freenet/freenet-core";
-    license = licenses.agpl3Only;
+    donationPage = "https://freenet.org/donate/";
+    license = lib.licenses.agpl3Only;
+    mainProgram = "freenet";
   };
 }


### PR DESCRIPTION
This implements a bunch of changes to the nix `flake.nix`. The commit messages likely need to be reworded as I'm not sure what some of the prefixes should be.

## Summary of the changes

1. The nix build now works. The flake.lock will now be automatically updated via dependabot so hopefully there won't be any issues with the Rust compiler lagging behind. There are options for converting the toolchain.toml file into Nix, but doing so would require a third-party dependency.

2. The freenet-autoupdate script now uses git tags. Previously every invocation would use the latest commit on `main`

3. The freenet build is now reproducible! Doing so requires the definition of `SOURCE_DATE_EPOCH` (nix does this for you), but its easy to do this for the other CI workflows too. This helps with security as anyone could verify that the binaries on the GitHub releases page were not tampered with.

4. A basic Nix `devShell` was added, to make it easier for nix-users to contribute

5. Allow specifying git revision information via environment variables (`FREENET_GIT_COMMIT_HASH` and `FREENET_GIT_IS_DIRTY`). This was necessary for nix, but can also be useful for building packages for other systems: you can now download a GitHub archive tarball and still embed the proper git commit information instead of needing to depend on the full git commit history in `.git`.