### PR TITLE
build: declare hash-first shipped in 0.2.116

### DIFF
--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -1035,7 +1035,8 @@ pub(crate) fn version_supports_summary_first_put(
 /// the guard's input, and a runtime reader invented to satisfy the lint would
 /// be the fake dependency this codebase already avoids elsewhere.
 #[cfg_attr(not(test), allow(dead_code))]
-pub(crate) const HASH_FIRST_SHIPPED_IN: Option<(u8, u8, u16)> = None;
+pub(crate) const HASH_FIRST_SHIPPED_IN: Option<(u8, u8, u16)> =
+    Some(HASH_FIRST_SUMMARIES_MIN_VERSION);
 
 pub(crate) const HASH_FIRST_SUMMARIES_MIN_VERSION: (u8, u8, u16) = (0, 2, 116);
 


### PR DESCRIPTION
Unblocks the 0.2.116 release.

`hash_first_floor_tracks_the_shipping_release` fails the version-bump PR because it raises `CARGO_PKG_VERSION` to `HASH_FIRST_SUMMARIES_MIN_VERSION` (0.2.116) while `HASH_FIRST_SHIPPED_IN` is still `None`. That is the guard doing its job — it forces an explicit decision at bump time instead of letting the release silently outrun the gate in either direction. This is what failed merge-queue CI on #5083 and, in turn, timed out the release workflow (see #5084 for the separate diagnostics bug).

0.2.116 carries the hash-first wire variants (#5066), so the marker becomes `Some(HASH_FIRST_SUMMARIES_MIN_VERSION)` and the two are frozen together.

**Why it targets the release branch rather than main:** the guard also asserts `floor <= CARGO_PKG_VERSION`. Setting the marker on main while main is still 0.2.115 fails with *'a release cannot have shipped in the future'*. The marker and the version bump have to land in the same commit-set.

Verified locally: `hash_first_floor_tracks_the_shipping_release` and `hash_first_floor_stays_above_every_release_without_the_variants` both pass with the version at 0.2.116 and the marker set.

[AI-assisted - Claude]