### PR TITLE
fix(shell): route same-origin target="_blank" through open_url

### DIFF
--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -6809,6 +6809,52 @@ mod tests {
         );
     }
 
+    /// Regression test for #5087.
+    ///
+    /// A SAME-ORIGIN `<a target="_blank">` used to return early and fall
+    /// through to the browser. The shell iframe has no
+    /// `allow-popups-to-escape-sandbox` (deliberately, #1499), so that popup
+    /// inherited the sandbox: the top-level shell it landed on had an opaque
+    /// origin, its own `frame-src 'self'` could not match, and the app frame
+    /// stayed `about:blank` — a blank tab.
+    ///
+    /// Every cross-CONTRACT link is same-ORIGIN (one gateway serves them all),
+    /// so that exemption swallowed exactly the breaking case. The same-origin
+    /// new-window branch must route through `open_url` like the cross-origin
+    /// branch above it, matching the `window.open` override further down,
+    /// which already forwards same-origin new-window opens.
+    #[test]
+    fn navigation_interceptor_routes_same_origin_target_blank_through_open_url() {
+        let js = NAVIGATION_INTERCEPTOR_JS;
+
+        let target_attr_idx = js
+            .find("target.target && target.target !== '_self'")
+            .expect("same-origin target check present");
+        let navigate_idx = js
+            .find("type: 'navigate'")
+            .expect("same-origin in-contract navigate branch present");
+        assert!(
+            target_attr_idx < navigate_idx,
+            "the target-attribute check must precede the in-contract navigate branch"
+        );
+        let block = &js[target_attr_idx..navigate_idx];
+
+        // The old bug: `if (...) return;` handed the click to the browser.
+        assert!(
+            !block.contains("!== '_self') return"),
+            "same-origin target=\"_blank\" must not fall through to the browser: the \
+             popup inherits the sandbox and the resulting tab is blank (#5087)"
+        );
+        assert!(
+            block.contains("preventDefault"),
+            "same-origin new-window branch must preventDefault before forwarding (#5087)"
+        );
+        assert!(
+            block.contains("type: 'open_url'"),
+            "same-origin new-window branch must forward via open_url, not navigate (#5087)"
+        );
+    }
+
     /// Regression test for the middle-click half of #3853. Middle-click is
     /// dispatched as `auxclick` in modern browsers, NOT `click`, so the
     /// interceptor must listen on both events. Without the auxclick

--- a/crates/core/src/server/path_handlers/assets/navigation_interceptor.js
+++ b/crates/core/src/server/path_handlers/assets/navigation_interceptor.js
@@ -52,9 +52,29 @@
       );
       return;
     }
-    // Same-origin link. Respect explicit non-_self targets so webapps
-    // that open multiple tabs within their own contract still work.
-    if (target.target && target.target !== '_self') return;
+    // Same-origin link with an explicit new-window target. A popup opened
+    // natively from this frame INHERITS the sandbox (the shell iframe has no
+    // `allow-popups-to-escape-sandbox`, deliberately -- see #1499), so the
+    // top-level shell it lands on has an opaque origin and its own
+    // `frame-src 'self'` can never match: the app frame stays about:blank and
+    // the tab renders empty. Every cross-CONTRACT link is same-ORIGIN, so the
+    // old blanket exemption here swallowed exactly the breaking case. Route
+    // through the shell instead, as the cross-origin branch above does; this
+    // mirrors the window.open override below, which already forwards
+    // same-origin new-window opens.
+    if (target.target && target.target !== '_self') {
+      e.preventDefault();
+      window.parent.postMessage(
+        {
+          __freenet_shell__: true,
+          type: 'open_url',
+          url: target.href,
+          shiftKey: !!e.shiftKey,
+        },
+        '*',
+      );
+      return;
+    }
     // Same-origin in-contract link: request navigation via shell
     e.preventDefault();
     window.parent.postMessage(


### PR DESCRIPTION
Fixes #5087.

## Problem

A same-origin `<a target="_blank">` inside a contract app opened a **sandboxed** top-level shell. That shell's own `frame-src 'self'` cannot match from an opaque origin, so its app iframe was refused, no request was ever dispatched, and the new tab rendered blank.

`navigation_interceptor.js` already prevents this for cross-origin links (freenet/river#208), but exempted same-origin links carrying an explicit non-`_self` target:

```js
// Same-origin link. Respect explicit non-_self targets so webapps
// that open multiple tabs within their own contract still work.
if (target.target && target.target !== '_self') return;
```

Every cross-**contract** link is same-**origin** — one gateway serves them all — so that exemption swallowed exactly the case that breaks. Clicking a link to another contract handed the URL to the browser, the popup inherited the sandbox flags (no `allow-popups-to-escape-sandbox`, deliberately, #1499), and the user got a blank tab.

From the reporting browser, with the app frame stuck at `about:blank`:

```
Refused to load http://<node>:7509/v1/contract/web/<KEY>/?__sandbox=1#/b/freenet
  because it does not appear in the frame-src directive of the Content Security Policy.

Sandbox access violation: Blocked a frame at "http://<node>:7509" from accessing a
  frame at "null".  Both frames are sandboxed and lack the "allow-same-origin" flag.
```

The second line is the tell — the *top-level* shell is sandboxed. Issue #5087 has the full trace, including the Network tab showing no request for `?__sandbox=1` at all.

The comment's justification does not hold even for same-contract links: a `target="_blank"` to the app's own contract also lands on `contract_home` (subpage document loads are redirected to the shell route), so it is a sandboxed shell too. The exemption did not preserve multi-tab — it broke it.

## Change

Route same-origin new-window activations through the shell, exactly as the cross-origin branch above already does. This mirrors the `window.open` override further down the same file, which already forwards **all** http(s) new-window opens and exempts only `_self`/`_parent`/`_top`. Two code paths, one hazard, now one answer.

## Why this does not weaken security

- **The sandbox attribute is untouched.** `allow-popups-to-escape-sandbox` stays absent; the #1499 pin at `path_handlers.rs:4718` stays green. No `allow-top-navigation` either.
- **It removes an escape rather than adding one.** Today this path hands the URL to the browser so the app frame opens a tab directly. After the change the shell opens it, subject to `open_url`'s existing scheme allow-list and loopback refusal. Strictly fewer app-initiated navigations bypass the bridge.
- **No new privilege.** `open_url` is already reachable from this frame for every cross-origin link; this routes one more case through the same gate. The shell remains the sole holder of top-level navigation authority.
- **Same-origin by construction** — the branch is reached only after the cross-origin check, so it cannot reach an origin the cross-origin path did not already permit.

## Why this does not break existing apps

- **Multi-tab still works, and works better.** Apps opening several tabs within their own contract keep doing so; those tabs now have a real origin instead of being blank.
- **`target="_self"` and untargeted links are unaffected** — they continue to the existing same-origin `navigate` path.
- **Same trade-off already shipped for `window.open`:** window name/features are dropped and the tab opens `noopener`. Apps already use `rel="noopener"` on these links; shift-click intent is forwarded as on the cross-origin path.

## Tests

Adds `navigation_interceptor_routes_same_origin_target_blank_through_open_url`, which pins the same-origin new-window branch to `preventDefault` + `open_url` and asserts the old `return` fall-through is gone.

```
running 6 tests
test ...::navigation_interceptor_routes_same_origin_target_blank_through_open_url ... ok
test ...::navigation_interceptor_listens_on_click_and_auxclick ... ok
test ...::navigation_interceptor_forwards_shift_key_for_open_url ... ok
test ...::navigation_interceptor_handles_cross_origin_target_blank ... ok
test ...::navigation_interceptor_js_intercepts_clicks ... ok
test ...::navigation_interceptor_overrides_window_open ... ok
test result: ok. 6 passed; 0 failed
```

Confirmed non-vacuous: reverting only the JS and re-running the new test fails. The existing interceptor pins (`#3853`, river`#208`) and all 14 `shell_page_*` tests still pass, and the JS is Prettier-clean.

## Manual verification

Built at `1b3bf6ca` + this patch, installed on a real node (`0.2.116 (1b3bf6cab018-dirty)`), and confirmed by the reporter in Safari: clicking a cross-contract link in an app now lands on a loaded app instead of a blank tab.

Note for reviewers: the failure does **not** reproduce in headless WebKit or Chromium — popups there did not inherit the sandbox flags in my harness, and the unpatched binary passed a synthetic anchor-click test that should have failed. Verification is from real Safari; the `open_url` bridge behavior itself was separately confirmed against a live node.

## Related, not fixed here

`isLoopbackHost` makes the `window.open` override fall back to native for `localhost`/`127.0.0.1`/`::1`/`0.0.0.0`, reasoning that "local nodes have no per-user dead-end to fix". True of #4645's per-user key, but sandbox inheritance is not per-user — a native popup from a loopback node is opaque-origin and blanks identically. Left alone to keep this diff to one hunk; happy to fold it in if wanted.
