### PR TITLE
feat(telemetry): diagnose large-state network harm

### DIFF
--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -17,6 +17,7 @@ pub(crate) use fair_queue::Priority;
 pub(crate) use fair_queue::{FairQueueStats, global_stats as fair_queue_stats};
 pub(crate) mod governance;
 mod handler;
+mod state_size_metrics;
 pub mod storages;
 pub(crate) mod user_input;
 
@@ -42,6 +43,9 @@ pub(crate) use handler::{
 
 pub use executor::{ContractQueueFull, Executor, ExecutorError, OperationMode};
 pub use handler::reset_event_id_counter;
+pub(crate) use state_size_metrics::{
+    StateSizeRejectionStage, record_state_size_rejection, state_size_rejection_snapshot,
+};
 
 use freenet_stdlib::client_api::DelegateRequest;
 use tracing::Instrument;

--- a/crates/core/src/contract/executor/runtime/executor_impl.rs
+++ b/crates/core/src/contract/executor/runtime/executor_impl.rs
@@ -375,6 +375,10 @@ where
                 // happen at the node level before any WASM execution.
                 let incoming_size = incoming_state.as_ref().len();
                 if incoming_size > MAX_STATE_SIZE {
+                    crate::contract::record_state_size_rejection(
+                        crate::contract::StateSizeRejectionStage::PreWasmFullState,
+                        incoming_size,
+                    );
                     tracing::warn!(
                         contract = %key,
                         size_bytes = incoming_size,
@@ -1891,6 +1895,10 @@ where
 
         let state_size = new_state.as_ref().len();
         if state_size > MAX_STATE_SIZE {
+            crate::contract::record_state_size_rejection(
+                crate::contract::StateSizeRejectionStage::PostMergeCommit,
+                state_size,
+            );
             tracing::warn!(
                 contract = %key,
                 size_bytes = state_size,

--- a/crates/core/src/contract/state_size_metrics.rs
+++ b/crates/core/src/contract/state_size_metrics.rs
@@ -1,0 +1,90 @@
+//! Fixed-cardinality counters for executor hard-limit rejections.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum StateSizeRejectionStage {
+    /// An incoming full state was rejected before contract WASM ran.
+    PreWasmFullState,
+    /// A merged state was rejected at the canonical commit chokepoint.
+    PostMergeCommit,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct StateSizeRejectionSnapshot {
+    pub pre_wasm_count: u64,
+    pub pre_wasm_max_bytes: u64,
+    pub post_merge_count: u64,
+    pub post_merge_max_bytes: u64,
+}
+
+#[derive(Debug, Default)]
+struct StateSizeRejectionMetrics {
+    pre_wasm_count: AtomicU64,
+    pre_wasm_max_bytes: AtomicU64,
+    post_merge_count: AtomicU64,
+    post_merge_max_bytes: AtomicU64,
+}
+
+impl StateSizeRejectionMetrics {
+    fn record(&self, stage: StateSizeRejectionStage, size_bytes: usize) {
+        let size_bytes = u64::try_from(size_bytes).unwrap_or(u64::MAX);
+        let (count, max) = match stage {
+            StateSizeRejectionStage::PreWasmFullState => {
+                (&self.pre_wasm_count, &self.pre_wasm_max_bytes)
+            }
+            StateSizeRejectionStage::PostMergeCommit => {
+                (&self.post_merge_count, &self.post_merge_max_bytes)
+            }
+        };
+        count.fetch_add(1, Ordering::Relaxed);
+        max.fetch_max(size_bytes, Ordering::Relaxed);
+    }
+
+    fn snapshot(&self) -> StateSizeRejectionSnapshot {
+        StateSizeRejectionSnapshot {
+            pre_wasm_count: self.pre_wasm_count.load(Ordering::Relaxed),
+            pre_wasm_max_bytes: self.pre_wasm_max_bytes.load(Ordering::Relaxed),
+            post_merge_count: self.post_merge_count.load(Ordering::Relaxed),
+            post_merge_max_bytes: self.post_merge_max_bytes.load(Ordering::Relaxed),
+        }
+    }
+}
+
+static STATE_SIZE_REJECTION_METRICS: StateSizeRejectionMetrics = StateSizeRejectionMetrics {
+    pre_wasm_count: AtomicU64::new(0),
+    pre_wasm_max_bytes: AtomicU64::new(0),
+    post_merge_count: AtomicU64::new(0),
+    post_merge_max_bytes: AtomicU64::new(0),
+};
+
+pub(crate) fn record_state_size_rejection(stage: StateSizeRejectionStage, size_bytes: usize) {
+    STATE_SIZE_REJECTION_METRICS.record(stage, size_bytes);
+}
+
+pub(crate) fn state_size_rejection_snapshot() -> StateSizeRejectionSnapshot {
+    STATE_SIZE_REJECTION_METRICS.snapshot()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn counts_and_maxima_are_separate_by_stage() {
+        let metrics = StateSizeRejectionMetrics::default();
+        metrics.record(StateSizeRejectionStage::PreWasmFullState, 12);
+        metrics.record(StateSizeRejectionStage::PreWasmFullState, 8);
+        metrics.record(StateSizeRejectionStage::PostMergeCommit, 20);
+
+        assert_eq!(
+            metrics.snapshot(),
+            StateSizeRejectionSnapshot {
+                pre_wasm_count: 2,
+                pre_wasm_max_bytes: 12,
+                post_merge_count: 1,
+                post_merge_max_bytes: 20,
+            }
+        );
+    }
+}

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -57,6 +57,7 @@ pub(crate) use network_bridge::{
 // (The module-cache metrics were a sibling process-global until #4488 made them
 // a per-node `Arc`.)
 pub(crate) use network_bridge::broadcast_queue::BROADCAST_STREAM_METRICS;
+pub(crate) use network_bridge::broadcast_queue_metrics::BROADCAST_QUEUE_EFFICIENCY_METRICS;
 // Re-export the summary-first PUT version gate (#4642 step 3-bis) so
 // `ring::connection_manager::ConnectionManager::supports_summary_first_put`
 // can consult it — the gate lives behind the private `network_bridge`
@@ -2966,9 +2967,11 @@ async fn handle_interest_sync_message(
                 for contract in &current_contracts {
                     let h = contract_hash(contract);
                     if !incoming_hashes.contains(&h) {
-                        op_manager
-                            .interest_manager
-                            .remove_peer_interest(contract, pk);
+                        op_manager.interest_manager.remove_peer_interest_for(
+                            contract,
+                            pk,
+                            crate::ring::interest::InterestRemovalCause::InterestsReplace,
+                        );
                         removed += 1;
                     }
                 }
@@ -3010,11 +3013,12 @@ async fn handle_interest_sync_message(
                         .interest_manager
                         .refresh_peer_interest(&contract, pk)
                     {
-                        let is_new = op_manager.interest_manager.register_peer_interest(
+                        let is_new = op_manager.interest_manager.register_peer_interest_from(
                             &contract,
                             pk.clone(),
                             None, // New entry; summary arrives in their Summaries response
                             false,
+                            crate::ring::interest::InterestRegistrationSource::Interests,
                         );
                         if is_new {
                             // #4359 (MUST-FIX 1): an Interests-sync registration
@@ -3250,9 +3254,12 @@ async fn handle_interest_sync_message(
                         // `summaries_arm_writes_summary_outside_staleness_branch_pin`.
                         match their_summary {
                             Some(theirs) => {
-                                op_manager
-                                    .interest_manager
-                                    .upsert_peer_summary(&contract, &pk, theirs);
+                                op_manager.interest_manager.upsert_peer_summary_from(
+                                    &contract,
+                                    &pk,
+                                    theirs,
+                                    crate::ring::interest::SummaryPopulationSource::InterestSummary,
+                                );
                             }
                             None => op_manager.interest_manager.clear_peer_summary(
                                 &contract,
@@ -3570,9 +3577,12 @@ async fn handle_interest_sync_message(
                                 // full-state broadcast target. Fact, not
                                 // belief: the digest established that these
                                 // bytes are what the peer holds.
-                                op_manager
-                                    .interest_manager
-                                    .upsert_peer_summary(&contract, &pk, ours);
+                                op_manager.interest_manager.upsert_peer_summary_from(
+                                    &contract,
+                                    &pk,
+                                    ours,
+                                    crate::ring::interest::SummaryPopulationSource::DigestAgreement,
+                                );
                                 if is_stale && !stale_contracts.contains(&contract) {
                                     stale_contracts.push(contract);
                                 }
@@ -3749,9 +3759,11 @@ async fn handle_interest_sync_message(
                 for hash in removed {
                     // Handle hash collisions - remove interest from all matching contracts
                     for contract in op_manager.interest_manager.lookup_by_hash(hash) {
-                        op_manager
-                            .interest_manager
-                            .remove_peer_interest(&contract, pk);
+                        op_manager.interest_manager.remove_peer_interest_for(
+                            &contract,
+                            pk,
+                            crate::ring::interest::InterestRemovalCause::ChangeInterests,
+                        );
                     }
                 }
             }
@@ -3804,11 +3816,12 @@ async fn handle_interest_sync_message(
                         {
                             false
                         } else {
-                            op_manager.interest_manager.register_peer_interest(
+                            op_manager.interest_manager.register_peer_interest_from(
                                 &contract,
                                 pk.clone(),
                                 None,
                                 false,
+                                crate::ring::interest::InterestRegistrationSource::ChangeInterests,
                             )
                         };
                         if is_new {
@@ -4211,9 +4224,12 @@ async fn handle_interest_sync_message(
                 // #4952: upsert — a ResyncResponse sender self-reported the
                 // summary of the full state it just shipped us; seed it even
                 // when we don't interest-track that co-host.
-                op_manager
-                    .interest_manager
-                    .upsert_peer_summary(&key, &pk, summary);
+                op_manager.interest_manager.upsert_peer_summary_from(
+                    &key,
+                    &pk,
+                    summary,
+                    crate::ring::interest::SummaryPopulationSource::ResyncResponse,
+                );
             }
 
             // No response needed
@@ -4797,7 +4813,7 @@ mod tests {
                 .expect("end of handler region not found");
         let body: String = src[handler_start..handler_end].split_whitespace().collect();
         assert!(
-            body.contains("upsert_peer_summary(&contract,&pk,theirs)"),
+            body.contains("upsert_peer_summary_from(&contract,&pk,theirs,"),
             "Summaries arm must upsert a Some(summary) report (seeds untracked \
              co-hosts, #4952)"
         );
@@ -5024,7 +5040,7 @@ mod tests {
 
         // Both writes must be present — they are the only thing refreshing the
         // TTL on this path.
-        let upsert_at = summaries_arm.find("upsert_peer_summary(").expect(
+        let upsert_at = summaries_arm.find("upsert_peer_summary_from(").expect(
             "the Summaries arm must cache the peer's reported summary via \
              upsert_peer_summary — that write is also what refreshes the peer's \
              interest TTL here (#4952, #3046)",
@@ -5060,7 +5076,7 @@ mod tests {
             .filter(|c| !c.is_whitespace())
             .collect();
         assert!(
-            !stripped.contains("ifis_stale{op_manager.interest_manager.upsert_peer_summary("),
+            !stripped.contains("ifis_stale{op_manager.interest_manager.upsert_peer_summary_from("),
             "the summary write must not be gated on is_stale — see above"
         );
     }
@@ -5258,7 +5274,7 @@ mod tests {
              cached summary) and registering ONLY in the else branch. Arm:\n{arm}"
         );
         assert!(
-            stripped.contains("else{op_manager.interest_manager.register_peer_interest("),
+            stripped.contains("else{op_manager.interest_manager.register_peer_interest_from("),
             "the register MUST be the else-branch fallback of that guard, not a \
              separate statement that runs regardless (D2). Arm:\n{arm}"
         );
@@ -5268,7 +5284,7 @@ mod tests {
         // refresh would mean the guard needle above matched a different call
         // than the one gating the register.
         assert_eq!(
-            arm.matches("register_peer_interest(").count(),
+            arm.matches("register_peer_interest_from(").count(),
             1,
             "ChangeInterests arm must contain exactly one (guarded, else-branch) \
              register_peer_interest call; a second would be an unguarded clobber (D2)"
@@ -9478,7 +9494,7 @@ mod tests {
         /// sampling must seed.
         #[tokio::test]
         async fn over_cap_digest_message_stays_bounded() {
-            crate::config::GlobalRng::set_seed(0x4965_CA9);
+            crate::config::GlobalRng::set_seed(0x0496_5CA9);
             let h = build_harness("hf-cap", 17065, vec![5u8; 128]).await;
             let hash = contract_hash(&h.key);
 

--- a/crates/core/src/node/network_bridge.rs
+++ b/crates/core/src/node/network_bridge.rs
@@ -18,6 +18,7 @@ use crate::message::{NetMessage, NodeEvent};
 
 pub(crate) mod broadcast_payload_mix;
 pub(crate) mod broadcast_queue;
+pub(crate) mod broadcast_queue_metrics;
 mod handshake;
 pub(crate) mod in_memory;
 pub(crate) mod outbound_message_mix;

--- a/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
+++ b/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
@@ -85,6 +85,7 @@ use parking_lot::Mutex;
 
 use crate::node::background_task_monitor::BackgroundTaskMonitor;
 use crate::ring::interest::SummaryMissingReason;
+use crate::tracing::event_kind::{STATE_SIZE_BUCKET_COUNT, state_size_bucket};
 
 /// Rollup cadence. Broadcasts are far less frequent than packets, so this is
 /// a minute rather than the 1 Hz sampling the `shadow_demand` aggregators use;
@@ -387,13 +388,160 @@ impl Default for Window {
 /// required.
 pub(crate) struct PayloadMix {
     window: Mutex<Window>,
+    /// Cumulative receiver-side outcomes. Unlike `window`, this is never
+    /// drained: the existing router snapshot can recover the full monotonic
+    /// value after a locally dropped telemetry sample (#5090).
+    receiver_applies: Mutex<ReceiverApplyStats>,
+}
+
+/// Fixed receiver outcome axes. There are deliberately no peer or contract
+/// identifiers here: each successful merge selects exactly one of four arms.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ReceiverApplyClass {
+    DeltaChanged,
+    DeltaNoOp,
+    FullChanged,
+    FullNoOp,
+}
+
+impl ReceiverApplyClass {
+    pub(crate) const ALL: [Self; 4] = [
+        Self::DeltaChanged,
+        Self::DeltaNoOp,
+        Self::FullChanged,
+        Self::FullNoOp,
+    ];
+    pub(crate) const COUNT: usize = Self::ALL.len();
+
+    pub(crate) const fn index(self) -> usize {
+        match self {
+            Self::DeltaChanged => 0,
+            Self::DeltaNoOp => 1,
+            Self::FullChanged => 2,
+            Self::FullNoOp => 3,
+        }
+    }
+
+    pub(crate) const fn from_apply(is_delta: bool, changed: bool) -> Self {
+        match (is_delta, changed) {
+            (true, true) => Self::DeltaChanged,
+            (true, false) => Self::DeltaNoOp,
+            (false, true) => Self::FullChanged,
+            (false, false) => Self::FullNoOp,
+        }
+    }
+}
+
+/// Monotonic, fixed-cardinality receiver-side apply totals. The second array
+/// dimension uses the shared state-size histogram taxonomy from `event_kind`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) struct ReceiverApplyStats {
+    pub(crate) counts: [[u64; STATE_SIZE_BUCKET_COUNT]; ReceiverApplyClass::COUNT],
+    /// Delta/full × terminal outcome × incoming-payload size, flattened with
+    /// delta outcomes first. Within each kind: changed, no-op, dedup, backoff,
+    /// failed. Keeping the dimensions joint is what lets telemetry answer
+    /// whether a 49 MiB no-op was a full state or an oversized delta.
+    pub(crate) terminal_counts: [[u64; STATE_SIZE_BUCKET_COUNT]; 10],
+    pub(crate) terminal_bytes: [[u64; STATE_SIZE_BUCKET_COUNT]; 10],
+}
+
+#[derive(Clone, Copy)]
+enum ReceiverTerminalOutcome {
+    Changed,
+    NoOp,
+    Dedup,
+    Backoff,
+    Failed,
+}
+
+impl ReceiverTerminalOutcome {
+    const fn index(self) -> usize {
+        self as usize
+    }
+}
+
+pub(crate) struct ReceiverTerminalGuard<'a> {
+    mix: &'a PayloadMix,
+    is_delta: bool,
+    payload_bytes: usize,
+    outcome: ReceiverTerminalOutcome,
+}
+
+impl ReceiverTerminalGuard<'_> {
+    pub(crate) fn mark_dedup(&mut self) {
+        self.outcome = ReceiverTerminalOutcome::Dedup;
+    }
+
+    pub(crate) fn mark_backoff(&mut self) {
+        self.outcome = ReceiverTerminalOutcome::Backoff;
+    }
+
+    pub(crate) fn mark_applied(&mut self, changed: bool, state_size: usize) {
+        self.mix
+            .record_receiver_apply(self.is_delta, changed, state_size);
+        self.outcome = if changed {
+            ReceiverTerminalOutcome::Changed
+        } else {
+            ReceiverTerminalOutcome::NoOp
+        };
+    }
+}
+
+impl Drop for ReceiverTerminalGuard<'_> {
+    fn drop(&mut self) {
+        self.mix
+            .record_receiver_terminal(self.is_delta, self.outcome, self.payload_bytes);
+    }
 }
 
 impl PayloadMix {
     pub(crate) fn new() -> Self {
         Self {
             window: Mutex::new(Window::default()),
+            receiver_applies: Mutex::new(ReceiverApplyStats::default()),
         }
+    }
+
+    fn record_receiver_apply(&self, is_delta: bool, changed: bool, state_size: usize) {
+        let class = ReceiverApplyClass::from_apply(is_delta, changed).index();
+        let bucket = state_size_bucket(state_size as u64);
+        let mut stats = self.receiver_applies.lock();
+        stats.counts[class][bucket] = stats.counts[class][bucket].saturating_add(1);
+    }
+
+    pub(crate) fn receiver_terminal_guard(
+        &self,
+        is_delta: bool,
+        payload_bytes: usize,
+    ) -> ReceiverTerminalGuard<'_> {
+        ReceiverTerminalGuard {
+            mix: self,
+            is_delta,
+            payload_bytes,
+            outcome: ReceiverTerminalOutcome::Failed,
+        }
+    }
+
+    fn record_receiver_terminal(
+        &self,
+        is_delta: bool,
+        outcome: ReceiverTerminalOutcome,
+        payload_bytes: usize,
+    ) {
+        let outcome_index = outcome.index();
+        let kind_index = usize::from(!is_delta) * 5 + outcome_index;
+        let bucket = state_size_bucket(payload_bytes as u64);
+        let bytes = u64::try_from(payload_bytes).unwrap_or(u64::MAX);
+        let mut stats = self.receiver_applies.lock();
+        stats.terminal_counts[kind_index][bucket] =
+            stats.terminal_counts[kind_index][bucket].saturating_add(1);
+        stats.terminal_bytes[kind_index][bucket] =
+            stats.terminal_bytes[kind_index][bucket].saturating_add(bytes);
+    }
+
+    /// Read cumulative receiver totals without resetting them.
+    pub(crate) fn receiver_apply_stats(&self) -> ReceiverApplyStats {
+        *self.receiver_applies.lock()
     }
 
     /// Record one **delivered** broadcast.
@@ -975,6 +1123,93 @@ mod tests {
 
     fn contract(byte: u8) -> ContractInstanceId {
         ContractInstanceId::new([byte; 32])
+    }
+
+    #[test]
+    fn receiver_applies_classify_all_outcomes_and_state_size_boundaries() {
+        let mix = PayloadMix::new();
+        let last_bounded = *crate::tracing::event_kind::STATE_SIZE_BUCKET_UPPER_BOUNDS
+            .last()
+            .unwrap() as usize;
+
+        for (is_delta, changed, state_size, payload_bytes) in [
+            (true, true, 64 * 1024, 11),
+            (true, false, 64 * 1024 + 1, 22),
+            (false, true, last_bounded, 33),
+            (false, false, last_bounded + 1, 44),
+        ] {
+            let mut terminal = mix.receiver_terminal_guard(is_delta, payload_bytes);
+            terminal.mark_applied(changed, state_size);
+        }
+
+        let stats = mix.receiver_apply_stats();
+        let delta_changed = ReceiverApplyClass::DeltaChanged.index();
+        let delta_no_op = ReceiverApplyClass::DeltaNoOp.index();
+        let full_changed = ReceiverApplyClass::FullChanged.index();
+        let full_no_op = ReceiverApplyClass::FullNoOp.index();
+
+        assert_eq!(stats.counts[delta_changed][0], 1);
+        assert_eq!(stats.counts[delta_no_op][1], 1);
+        assert_eq!(stats.counts[full_changed][STATE_SIZE_BUCKET_COUNT - 2], 1);
+        assert_eq!(stats.counts[full_no_op][STATE_SIZE_BUCKET_COUNT - 1], 1);
+
+        let total_count: u64 = stats.counts.iter().flatten().sum();
+        let total_payload_bytes: u64 = stats.terminal_bytes.iter().flatten().sum();
+        assert_eq!(total_count, 4);
+        assert_eq!(total_payload_bytes, 110);
+    }
+
+    #[test]
+    fn receiver_apply_totals_are_cumulative_across_sender_window_drains() {
+        let mix = PayloadMix::new();
+        mix.receiver_terminal_guard(false, 100)
+            .mark_applied(false, 3 * 1024 * 1024);
+        let first = mix.receiver_apply_stats();
+
+        // The legacy sender payload mix remains a drained one-minute window.
+        // Draining it must not erase the cumulative router-snapshot source.
+        let _ = mix.take_window();
+        assert_eq!(mix.receiver_apply_stats(), first);
+
+        mix.receiver_terminal_guard(false, 250)
+            .mark_applied(false, 3 * 1024 * 1024);
+        let second = mix.receiver_apply_stats();
+        let class = ReceiverApplyClass::FullNoOp.index();
+        let terminal_class = 5 + ReceiverTerminalOutcome::NoOp.index();
+        let result_state_bucket = state_size_bucket(3 * 1024 * 1024);
+        let incoming_payload_bucket = state_size_bucket(100);
+        assert_eq!(second.counts[class][result_state_bucket], 2);
+        assert_eq!(
+            second.terminal_bytes[terminal_class][incoming_payload_bucket],
+            350
+        );
+    }
+
+    #[test]
+    fn receiver_terminal_guard_accounts_for_dedup_backoff_and_failure_bytes() {
+        let mix = PayloadMix::new();
+        let large = 4 * 1024 * 1024;
+
+        let mut dedup = mix.receiver_terminal_guard(true, large);
+        dedup.mark_dedup();
+        drop(dedup);
+
+        let mut backoff = mix.receiver_terminal_guard(false, large + 1);
+        backoff.mark_backoff();
+        drop(backoff);
+
+        // The default terminal outcome is failure, including early returns and
+        // unwinds that occur before an explicit outcome is selected.
+        drop(mix.receiver_terminal_guard(false, large + 2));
+
+        let stats = mix.receiver_apply_stats();
+        let bucket = state_size_bucket(large as u64);
+        assert_eq!(stats.terminal_counts[2][bucket], 1);
+        assert_eq!(stats.terminal_bytes[2][bucket], large as u64);
+        assert_eq!(stats.terminal_counts[8][bucket], 1);
+        assert_eq!(stats.terminal_bytes[8][bucket], (large + 1) as u64);
+        assert_eq!(stats.terminal_counts[9][bucket], 1);
+        assert_eq!(stats.terminal_bytes[9][bucket], (large + 2) as u64);
     }
 
     /// #4979 / #5056: a contract whose entire cost sits in the `delta` arm must

--- a/crates/core/src/node/network_bridge/broadcast_queue.rs
+++ b/crates/core/src/node/network_bridge/broadcast_queue.rs
@@ -30,6 +30,20 @@ use super::p2p_protoc::P2pBridge;
 /// `queue` submodule.
 const STREAM_COMPLETION_TIMEOUT: Duration = Duration::from_secs(120);
 
+/// The queued state size used to choose the small or large concurrency pool.
+/// The actual delta/full payload may be much smaller; telemetry records that
+/// mismatch at the point where the wire payload is known.
+const BROADCAST_QUEUE_PAYLOAD_SIZE_THRESHOLD: usize = 64 * 1024;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+// The simulation feature replaces the production queue, but keeps the shared
+// payload-selection path and its public signature compiled.
+#[cfg_attr(feature = "simulation_tests", allow(dead_code))]
+pub(super) enum QueuedPayloadClass {
+    Small,
+    Large,
+}
+
 /// Process-global UPDATE-broadcast stream-assembly telemetry (#4440).
 ///
 /// The streaming broadcast path (`broadcast_to_single_peer`'s `use_streaming`
@@ -325,6 +339,8 @@ pub(super) async fn fanout_send_needed(
 mod queue {
     use std::collections::{HashMap, VecDeque};
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::Instant;
 
     use freenet_stdlib::prelude::{ContractKey, WrappedState};
     use tokio::sync::{Mutex, Notify, Semaphore};
@@ -333,7 +349,7 @@ mod queue {
     use crate::ring::PeerKeyLocation;
 
     use super::super::p2p_protoc::P2pBridge;
-    use super::broadcast_to_single_peer;
+    use super::{QueuedPayloadClass, broadcast_to_single_peer};
 
     /// Maximum concurrent outbound broadcast streams for small payloads (< 64KB).
     /// Small payloads (deltas, chat messages) can fan out aggressively without
@@ -343,10 +359,6 @@ mod queue {
     /// Maximum concurrent outbound broadcast streams for large payloads (>= 64KB).
     /// Large payloads (full state) are rate-limited to avoid uplink saturation.
     const DEFAULT_LARGE_PAYLOAD_CONCURRENCY: usize = 2;
-
-    /// Payload size threshold for choosing the small vs large concurrency pool.
-    /// Matches the streaming threshold used elsewhere in the broadcast path.
-    const PAYLOAD_SIZE_THRESHOLD: usize = 64 * 1024;
 
     /// Maximum entries in the queue before oldest are dropped.
     const DEFAULT_MAX_QUEUE_DEPTH: usize = 256;
@@ -369,6 +381,107 @@ mod queue {
         order: VecDeque<DedupeKey>,
         /// Actual entries, keyed by (contract, peer). Dedup replaces the state in-place.
         entries: HashMap<DedupeKey, BroadcastEntry>,
+        /// Pairs already removed from the queue but waiting for a permit or
+        /// actively sending. Observation-only: enqueue still behaves exactly
+        /// as before, while telemetry can identify duplicates that queued
+        /// deduplication cannot see.
+        active: HashMap<DedupeKey, u64>,
+        /// Number of nominal-small entries still queued. Maintained under the
+        /// queue lock so head-of-line observation is O(1).
+        small_queued: usize,
+        /// Time integral for the one FIFO worker waiting at a large-payload
+        /// permit. Updated on every small-queue population change, so arrivals
+        /// during the wait are included rather than sampled away.
+        hol_block: Option<HolBlockHandle>,
+    }
+
+    #[derive(Clone)]
+    struct HolBlockHandle(Arc<HolBlockState>);
+
+    struct HolBlockState {
+        finished: AtomicBool,
+        observation: std::sync::Mutex<HolBlockObservation>,
+    }
+
+    struct HolBlockObservation {
+        started: Instant,
+        last_updated: Instant,
+        small_queued: usize,
+        small_entry_millis: u128,
+        observed_small: bool,
+    }
+
+    impl HolBlockHandle {
+        fn is_finished(&self) -> bool {
+            self.0.finished.load(Ordering::Acquire)
+        }
+
+        fn set_small_queued(&self, next: usize, now: Instant) {
+            if self.is_finished() {
+                return;
+            }
+            let mut block = self.0.observation.lock().unwrap();
+            // `finish_now` may have won the mutex after the fast-path load.
+            if self.is_finished() {
+                return;
+            }
+            block.advance(now);
+            block.small_queued = next;
+            block.observed_small |= next > 0;
+        }
+
+        /// Freeze the integral and its end timestamp as one linearized action.
+        /// Capturing `now` only after taking the same mutex used by queue-size
+        /// updates prevents a later-timestamp update from being incorporated
+        /// before an older semaphore-acquisition cutoff can be applied.
+        fn finish_now(&self) -> Option<(u64, u64)> {
+            let mut block = self.0.observation.lock().unwrap();
+            if self.is_finished() {
+                return None;
+            }
+            let now = Instant::now();
+            self.finish_locked(&mut block, now)
+        }
+
+        #[cfg(test)]
+        fn finish_at(&self, now: Instant) -> Option<(u64, u64)> {
+            let mut block = self.0.observation.lock().unwrap();
+            if self.is_finished() {
+                return None;
+            }
+            self.finish_locked(&mut block, now)
+        }
+
+        fn finish_locked(
+            &self,
+            block: &mut HolBlockObservation,
+            now: Instant,
+        ) -> Option<(u64, u64)> {
+            block.advance(now);
+            let result = block.observed_small.then(|| {
+                let blocked_millis = now
+                    .saturating_duration_since(block.started)
+                    .as_millis()
+                    .min(u128::from(u64::MAX)) as u64;
+                let small_entry_millis = block.small_entry_millis.min(u128::from(u64::MAX)) as u64;
+                (blocked_millis, small_entry_millis)
+            });
+            self.0.finished.store(true, Ordering::Release);
+            result
+        }
+    }
+
+    impl HolBlockObservation {
+        fn advance(&mut self, now: Instant) {
+            if now <= self.last_updated {
+                return;
+            }
+            let millis = now.saturating_duration_since(self.last_updated).as_millis();
+            self.small_entry_millis = self
+                .small_entry_millis
+                .saturating_add(millis.saturating_mul(self.small_queued as u128));
+            self.last_updated = now;
+        }
     }
 
     impl QueueState {
@@ -376,6 +489,9 @@ mod queue {
             Self {
                 order: VecDeque::new(),
                 entries: HashMap::new(),
+                active: HashMap::new(),
+                small_queued: 0,
+                hol_block: None,
             }
         }
 
@@ -384,14 +500,105 @@ mod queue {
         }
 
         /// Pop the oldest entry. Skips stale keys (removed by eviction or dedup).
-        fn pop_front(&mut self) -> Option<BroadcastEntry> {
+        fn pop_front(&mut self, now: Instant) -> Option<BroadcastEntry> {
             while let Some(key) = self.order.pop_front() {
                 if let Some(entry) = self.entries.remove(&key) {
+                    if entry.payload_size < super::BROADCAST_QUEUE_PAYLOAD_SIZE_THRESHOLD {
+                        self.set_small_queued(self.small_queued.saturating_sub(1), now);
+                    }
                     return Some(entry);
                 }
                 // Stale key (was evicted or already popped), skip
             }
             None
+        }
+
+        fn set_small_queued(&mut self, next: usize, now: Instant) {
+            self.small_queued = next;
+            if self
+                .hol_block
+                .as_ref()
+                .is_some_and(HolBlockHandle::is_finished)
+            {
+                self.hol_block = None;
+            }
+            if let Some(block) = &self.hol_block {
+                block.set_small_queued(next, now);
+            }
+        }
+
+        fn start_hol(&mut self, now: Instant) -> HolBlockHandle {
+            let block = HolBlockHandle(Arc::new(HolBlockState {
+                finished: AtomicBool::new(false),
+                observation: std::sync::Mutex::new(HolBlockObservation {
+                    started: now,
+                    last_updated: now,
+                    small_queued: self.small_queued,
+                    small_entry_millis: 0,
+                    observed_small: self.small_queued > 0,
+                }),
+            }));
+            self.hol_block = Some(block.clone());
+            block
+        }
+
+        fn track_active(&mut self, key: DedupeKey) -> bool {
+            if let Some(count) = self.active.get_mut(&key) {
+                *count = count.saturating_add(1);
+                return true;
+            }
+            if self.active.len() >= DEFAULT_MAX_QUEUE_DEPTH {
+                return false;
+            }
+            self.active.insert(key, 1);
+            true
+        }
+
+        fn untrack_active(&mut self, key: &DedupeKey) {
+            if let Some(count) = self.active.get_mut(key) {
+                if *count > 1 {
+                    *count -= 1;
+                } else {
+                    self.active.remove(key);
+                }
+            }
+        }
+    }
+
+    struct ActiveSendGuard {
+        queue: Arc<Mutex<QueueState>>,
+        key: DedupeKey,
+        tracked: bool,
+    }
+
+    impl ActiveSendGuard {
+        /// Normal completion path: update the refcount directly and disarm the
+        /// cancellation fallback. The caller releases its semaphore permit
+        /// first, so diagnostic cleanup never holds scheduler capacity idle.
+        async fn finish(mut self) {
+            if self.tracked {
+                self.queue.lock().await.untrack_active(&self.key);
+                self.tracked = false;
+            }
+        }
+    }
+
+    impl Drop for ActiveSendGuard {
+        fn drop(&mut self) {
+            if !self.tracked {
+                return;
+            }
+            if let Ok(mut queue) = self.queue.try_lock() {
+                queue.untrack_active(&self.key);
+                return;
+            }
+            let queue = self.queue.clone();
+            let key = self.key.clone();
+            if let Ok(runtime) = tokio::runtime::Handle::try_current() {
+                runtime.spawn(async move {
+                    queue.lock().await.untrack_active(&key);
+                });
+            }
         }
     }
 
@@ -435,9 +642,14 @@ mod queue {
             let dedup_key = (key, target.clone());
             let mut queue = self.queue.lock().await;
 
+            if queue.active.contains_key(&dedup_key) {
+                crate::node::BROADCAST_QUEUE_EFFICIENCY_METRICS.record_enqueue_while_active();
+            }
+
             // Replace-on-dedup: if same contract+peer exists, update state in-place
             if let Some(existing) = queue.entries.get_mut(&dedup_key) {
                 existing.new_state = new_state;
+                crate::node::BROADCAST_QUEUE_EFFICIENCY_METRICS.record_dedup_replacement();
                 tracing::trace!(
                     contract = %dedup_key.0,
                     peer = ?target.socket_addr(),
@@ -446,7 +658,8 @@ mod queue {
             } else {
                 // Evict oldest if at capacity
                 while queue.len() >= self.max_queue_depth {
-                    if let Some(entry) = queue.pop_front() {
+                    if let Some(entry) = queue.pop_front(Instant::now()) {
+                        crate::node::BROADCAST_QUEUE_EFFICIENCY_METRICS.record_capacity_eviction();
                         tracing::warn!(
                             contract = %entry.key,
                             peer = ?entry.target.socket_addr(),
@@ -458,6 +671,10 @@ mod queue {
                     }
                 }
                 let payload_size = new_state.size();
+                if payload_size < super::BROADCAST_QUEUE_PAYLOAD_SIZE_THRESHOLD {
+                    let next = queue.small_queued.saturating_add(1);
+                    queue.set_small_queued(next, Instant::now());
+                }
                 queue.entries.insert(
                     dedup_key.clone(),
                     BroadcastEntry {
@@ -503,13 +720,21 @@ mod queue {
                     // Drain all available entries
                     let mut drained_any = false;
                     loop {
-                        let entry = {
+                        let (entry, active_tracked) = {
                             let mut q = queue.lock().await;
-                            let entry = q.pop_front();
+                            let entry = q.pop_front(Instant::now());
+                            let active_tracked = entry.as_ref().is_none_or(|entry| {
+                                let tracked = q.track_active((entry.key, entry.target.clone()));
+                                if !tracked {
+                                    crate::node::BROADCAST_QUEUE_EFFICIENCY_METRICS
+                                        .record_active_tracking_overflow();
+                                }
+                                tracked
+                            });
                             // Phase 1.6 (#4074): publish post-drain depth
                             // under the lock for the shadow demand gauge.
                             crate::transport::shadow_demand::record_broadcast_queue_depth(q.len());
-                            entry
+                            (entry, active_tracked)
                         };
 
                         let Some(entry) = entry else {
@@ -520,7 +745,16 @@ mod queue {
                         // Select concurrency pool based on payload size.
                         // Small payloads (deltas, chat messages) get high concurrency for
                         // fast fan-out. Large payloads get low concurrency to avoid saturation.
-                        let sem = if entry.payload_size < PAYLOAD_SIZE_THRESHOLD {
+                        let nominally_large =
+                            entry.payload_size >= super::BROADCAST_QUEUE_PAYLOAD_SIZE_THRESHOLD;
+                        let queued_class = if nominally_large {
+                            QueuedPayloadClass::Large
+                        } else {
+                            QueuedPayloadClass::Small
+                        };
+                        crate::node::BROADCAST_QUEUE_EFFICIENCY_METRICS
+                            .record_scheduled(nominally_large, entry.payload_size);
+                        let sem = if !nominally_large {
                             small_semaphore.clone()
                         } else {
                             large_semaphore.clone()
@@ -528,8 +762,25 @@ mod queue {
 
                         // Acquire semaphore permit to limit concurrent streams.
                         // This blocks until a slot is available.
+                        let blocked = nominally_large && sem.available_permits() == 0;
+                        let hol_block = if blocked {
+                            Some(queue.lock().await.start_hol(Instant::now()))
+                        } else {
+                            None
+                        };
+                        let active_guard = ActiveSendGuard {
+                            queue: queue.clone(),
+                            key: (entry.key, entry.target.clone()),
+                            tracked: active_tracked,
+                        };
                         let permit = sem.acquire_owned().await;
+                        let hol_metrics = hol_block.as_ref().and_then(HolBlockHandle::finish_now);
                         let Ok(permit) = permit else {
+                            if let Some((blocked_millis, small_entry_millis)) = hol_metrics {
+                                crate::node::BROADCAST_QUEUE_EFFICIENCY_METRICS
+                                    .record_large_head_block(blocked_millis, small_entry_millis);
+                            }
+                            active_guard.finish().await;
                             tracing::error!("Broadcast queue semaphore closed unexpectedly");
                             return;
                         };
@@ -538,17 +789,28 @@ mod queue {
                         let op_manager = op_manager.clone();
 
                         tokio::spawn(async move {
-                            let _permit = permit; // Held until this task completes
-
                             broadcast_to_single_peer(
                                 &bridge,
                                 &op_manager,
                                 entry.key,
                                 entry.new_state,
                                 entry.target,
+                                Some(queued_class),
                             )
                             .await;
+                            // Release scheduler capacity before diagnostic
+                            // cleanup can wait on the queue lock.
+                            drop(permit);
+                            active_guard.finish().await;
                         });
+
+                        // The transfer is runnable before diagnostic counter
+                        // publication. `finish_now` already froze the exact
+                        // semaphore/HOL interval at permit acquisition.
+                        if let Some((blocked_millis, small_entry_millis)) = hol_metrics {
+                            crate::node::BROADCAST_QUEUE_EFFICIENCY_METRICS
+                                .record_large_head_block(blocked_millis, small_entry_millis);
+                        }
                     }
 
                     if !drained_any {
@@ -559,6 +821,84 @@ mod queue {
                     // (the pre-registered notified future is dropped, which is fine)
                 }
             })
+        }
+    }
+
+    #[cfg(test)]
+    mod observation_tests {
+        use super::*;
+        use std::time::Duration;
+
+        #[test]
+        fn hol_integral_includes_small_entries_arriving_during_wait() {
+            let start = Instant::now();
+            let mut queue = QueueState::new();
+            let hol = queue.start_hol(start);
+            queue.set_small_queued(1, start + Duration::from_millis(10));
+            queue.set_small_queued(2, start + Duration::from_millis(20));
+
+            assert_eq!(
+                hol.finish_at(start + Duration::from_millis(30)),
+                Some((30, 30)),
+                "integral is 0×10ms + 1×10ms + 2×10ms"
+            );
+            queue.set_small_queued(9, start + Duration::from_millis(40));
+            assert!(hol.is_finished());
+            assert!(
+                queue.hol_block.is_none(),
+                "first later mutation clears the handle"
+            );
+            assert_eq!(hol.finish_at(start + Duration::from_millis(40)), None);
+        }
+
+        #[test]
+        fn active_refcount_survives_one_of_two_overlapping_completions() {
+            let mut queue = QueueState::new();
+            let code = freenet_stdlib::prelude::ContractCode::from(vec![7]);
+            let params = freenet_stdlib::prelude::Parameters::from(vec![9]);
+            let key = (
+                ContractKey::from_params_and_code(&params, &code),
+                PeerKeyLocation::random(),
+            );
+            assert!(queue.track_active(key.clone()));
+            assert!(queue.track_active(key.clone()));
+            queue.untrack_active(&key);
+            assert_eq!(queue.active.get(&key), Some(&1));
+            queue.untrack_active(&key);
+            assert!(!queue.active.contains_key(&key));
+        }
+
+        #[test]
+        fn worker_wires_hol_boundaries_and_direct_normal_cleanup() {
+            let src = include_str!("broadcast_queue.rs");
+            let start = src.find("pub(crate) fn start_worker(").unwrap();
+            let end = src[start..].find("} // end `mod queue`").unwrap() + start;
+            let worker = &src[start..end];
+            let hol_start = worker.find("start_hol(Instant::now())").unwrap();
+            let acquire = worker.find("sem.acquire_owned().await").unwrap();
+            assert!(
+                hol_start < acquire,
+                "HOL observation must start before waiting"
+            );
+
+            let freeze = worker.find("and_then(HolBlockHandle::finish_now)").unwrap();
+            let permit_match = worker.find("let Ok(permit) = permit").unwrap();
+            assert!(
+                acquire < freeze && freeze < permit_match,
+                "linearize the integral immediately after permit acquisition"
+            );
+            assert!(
+                !worker[acquire + "sem.acquire_owned().await".len()..freeze].contains(".await"),
+                "no further await may separate permit acquisition from HOL linearization"
+            );
+            let success = &worker[worker.find("let Ok(permit) = permit").unwrap()..];
+            let spawn = success.find("tokio::spawn(async move").unwrap();
+            let task = &success[spawn..];
+            assert!(
+                task.find("drop(permit);").unwrap()
+                    < task.find("active_guard.finish().await").unwrap(),
+                "normal tracking cleanup must run directly after releasing capacity"
+            );
         }
     }
 } // end `mod queue` (cfg-gated)
@@ -710,7 +1050,12 @@ fn record_delivery_to_interest<T: crate::util::time_source::TimeSource + Sync>(
     // fixed point: full state on every update, forever. The upsert creates the
     // entry (capped, no demand-counter writes) so the next send is a delta.
     if let Some(summary) = our_summary {
-        interest_manager.upsert_peer_summary(key, peer_key, summary.clone());
+        interest_manager.upsert_peer_summary_from(
+            key,
+            peer_key,
+            summary.clone(),
+            crate::ring::interest::SummaryPopulationSource::Delivery,
+        );
     }
 }
 
@@ -728,6 +1073,7 @@ pub(super) async fn broadcast_to_single_peer(
     key: ContractKey,
     new_state: WrappedState,
     target: PeerKeyLocation,
+    queued_class: Option<QueuedPayloadClass>,
 ) {
     use crate::message::{DeltaOrFullState, NetMessage};
     use crate::node::network_bridge::NetworkBridge;
@@ -800,10 +1146,29 @@ pub(super) async fn broadcast_to_single_peer(
         .get_contract_summary(op_manager, &key)
         .await;
 
-    // Get peer's cached summary
-    let their_summary = op_manager
-        .interest_manager
-        .get_peer_summary(&key, &peer_key);
+    // Read and classify the peer-summary state in one interest-manager
+    // critical section. The optional RAII guard below only records impact if
+    // the send reaches its real delivery gate.
+    let (their_summary, tracked_missing_reason, missing_attempt) = if our_summary.is_some() {
+        match op_manager
+            .interest_manager
+            .begin_peer_summary_broadcast(&key, &peer_key)
+        {
+            crate::ring::interest::PeerSummaryForBroadcast::Known(summary) => {
+                (Some(summary), None, None)
+            }
+            crate::ring::interest::PeerSummaryForBroadcast::Missing { reason, attempt } => {
+                (None, reason, attempt)
+            }
+        }
+    } else {
+        (None, None, None)
+    };
+    let mut missing_attempt_guard = missing_attempt.map(|attempt| {
+        op_manager
+            .interest_manager
+            .missing_summary_attempt_guard(attempt)
+    });
 
     // Semantic skip (#4894's fan-out counterpart). Byte-identical summaries
     // skip as before; byte-DIFFERING summaries are no longer trusted as proof
@@ -904,7 +1269,6 @@ pub(super) async fn broadcast_to_single_peer(
     let mut not_efficient_gate_inputs: Option<(usize, usize)> = None;
     // #4961: WHY a tracked peer has no cached summary. Set only on the
     // `FullNoTheirSummaryTracked` arm below, where the entry exists to be read.
-    let mut tracked_missing_reason: Option<crate::ring::interest::SummaryMissingReason> = None;
     let (payload, sent_delta, payload_arm) = match (&our_summary, &their_summary) {
         // Scoped to the both-summaries-present case ON PURPOSE. When a summary
         // is missing a delta was impossible regardless of the memo, so letting
@@ -1029,21 +1393,7 @@ pub(super) async fn broadcast_to_single_peer(
             PayloadArm::FullNoOurSummary,
         ),
         (Some(_), None) => {
-            let arm = if let Some(interest) = op_manager
-                .interest_manager
-                .get_peer_interest(&key, &peer_key)
-            {
-                // #4961 needs this to tell the three clear paths apart, since
-                // they have three different fixes and this is the largest
-                // broadcast-byte arm.
-                //
-                // Usually `Some`: this match arm means `their_summary` was
-                // `None`. But that was read further up, before an `.await`, so
-                // a concurrent upsert in between leaves the entry holding a
-                // summary and this reads `None`. That send is then counted in
-                // `tracked_missing_unattributed_*` rather than being charged to
-                // a cause that did not produce it.
-                tracked_missing_reason = interest.summary_missing_reason();
+            let arm = if tracked_missing_reason.is_some() {
                 PayloadArm::FullNoTheirSummaryTracked
             } else {
                 PayloadArm::FullNoTheirSummaryUntracked
@@ -1056,6 +1406,20 @@ pub(super) async fn broadcast_to_single_peer(
         }
     };
     let payload_size = payload.size();
+    match (
+        queued_class,
+        payload_size < BROADCAST_QUEUE_PAYLOAD_SIZE_THRESHOLD,
+    ) {
+        (Some(QueuedPayloadClass::Large), true) => {
+            crate::node::BROADCAST_QUEUE_EFFICIENCY_METRICS
+                .record_queued_large_actual_small(payload_size);
+        }
+        (Some(QueuedPayloadClass::Small), false) => {
+            crate::node::BROADCAST_QUEUE_EFFICIENCY_METRICS
+                .record_queued_small_actual_large(payload_size);
+        }
+        _ => {}
+    }
     // Attribute the summarize + delta WASM (CPU) burned to produce this send.
     // Reported for EVERY attempt (the WASM work ran regardless of whether the
     // send lands). The payload BYTES are charged separately, ONLY on a real
@@ -1207,6 +1571,9 @@ pub(super) async fn broadcast_to_single_peer(
                 // v0.2.73 incident.
                 BROADCAST_STREAM_METRICS.record_attempt(delivered);
                 if delivered {
+                    if let Some(guard) = missing_attempt_guard.as_mut() {
+                        guard.mark_delivered(payload_size);
+                    }
                     // #4903 review round-3 Fix 4: charge the fan-out payload
                     // bytes ONLY on a real delivery. A dropped/timed-out stream
                     // put no bytes on the wire; the send CPU was already charged
@@ -1257,6 +1624,9 @@ pub(super) async fn broadcast_to_single_peer(
         // successful enqueue is the terminal state we can observe, so delivery
         // tracks the send result (unchanged pre-#4235 behavior for this path).
         if res.is_ok() {
+            if let Some(guard) = missing_attempt_guard.as_mut() {
+                guard.mark_delivered(payload_size);
+            }
             // #4903 review round-3 Fix 4: charge the fan-out payload bytes on a
             // successful send only. For the inline path a successful enqueue is
             // the terminal delivery signal (see the branch comment above); the
@@ -1854,7 +2224,9 @@ mod tests {
             .expect("end of record_delivery_to_interest not found");
         let body: String = after[..fn_end].split_whitespace().collect();
         assert!(
-            body.contains("interest_manager.upsert_peer_summary(key,peer_key,summary.clone())"),
+            body.contains(
+                "interest_manager.upsert_peer_summary_from(key,peer_key,summary.clone(),"
+            ),
             "post-delivery cache must upsert (create-if-absent) the peer summary"
         );
         assert!(
@@ -2490,18 +2862,16 @@ mod tests {
             );
         }
 
-        // #4961: the tracked arm must READ the reason where it is decided, not
-        // merely pass the variable along. Dropping the assignment leaves it at
-        // `None` forever, so every tracked send lands in
-        // `tracked_missing_unattributed_*` — the split still emits, still
-        // reconciles, and answers nothing. That mutation passes every other
-        // test here, so it needs its own pin.
-        assert!(
-            body.contains("tracked_missing_reason = interest.summary_missing_reason()"),
-            "the FullNoTheirSummaryTracked arm must read the peer's \
-             summary_missing_reason where the arm is decided — without it the \
-             per-reason split is uniformly unattributed and #4961 stays \
-             unanswered"
+        // #5090: summary presence, missing-reason classification, and attempt
+        // correlation must come from one atomic interest-manager operation.
+        // Reintroducing separate reads would let population/removal race the
+        // observation and make the lifecycle evidence internally inconsistent.
+        assert_eq!(
+            body.matches("begin_peer_summary_broadcast(&key, &peer_key)")
+                .count(),
+            1,
+            "broadcast payload selection must use the atomic missing-summary \
+             observation/classification operation exactly once"
         );
 
         // The mix is recorded at exactly the two real-delivery sites, the same
@@ -2552,8 +2922,9 @@ mod tests {
         );
 
         // The no-summary split must stay decided by WHICH side is missing, and
-        // the untracked/tracked sub-split must keep consulting the interest
-        // map. Collapsing either one re-creates the single `full_no_summary`
+        // the atomic peer-summary observation must preserve tracked (reason is
+        // Some) versus untracked (reason is None). Collapsing either one
+        // re-creates the single `full_no_summary`
         // bucket that the 2026-07-25 measurement could not act on: it was the
         // largest consumer of wire bytes on the network with no way to tell a
         // contract-handler failure from a permanent peer-tracking gap.
@@ -2563,12 +2934,11 @@ mod tests {
              missing — a catch-all `_` arm re-blinds the split"
         );
         assert!(
-            collapsed.contains("get_peer_interest(&key,&peer_key)"),
-            "the missing-their-summary arm must consult get_peer_interest to \
-             separate an UNTRACKED peer (whose update_peer_summary write is a \
-             silent no-op — permanent full state until the #4952 upsert; now \
-             transient, first send per pair) from a \
-             TRACKED cold-start peer (which repairs itself on next delivery)"
+            collapsed.contains(
+                "PeerSummaryForBroadcast::Missing{reason,attempt}=>{(None,reason,attempt)}"
+            ),
+            "the atomic peer-summary result must carry the reason through so \
+             tracked and untracked missing-summary sends remain distinct"
         );
     }
 }

--- a/crates/core/src/node/network_bridge/broadcast_queue_metrics.rs
+++ b/crates/core/src/node/network_bridge/broadcast_queue_metrics.rs
@@ -1,0 +1,199 @@
+//! Fixed-cardinality diagnostics for the production broadcast scheduler.
+//!
+//! These are lifetime counters sampled by the existing five-minute
+//! `router_snapshot` task and exported in the wide diagnostic every 30 minutes.
+//! They deliberately contain no peer or contract identifiers, and recording
+//! them never changes queue behavior.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use serde::{Deserialize, Serialize};
+
+/// Cumulative production-queue measurements used to decide the scheduler fix.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(test, derive(arbitrary::Arbitrary))]
+pub(crate) struct BroadcastQueueEfficiencySnapshot {
+    pub capacity_evictions: u64,
+    pub dedup_replacements: u64,
+    pub enqueues_while_pair_active: u64,
+    pub large_head_blocking_incidents: u64,
+    pub large_head_blocked_millis: u64,
+    pub small_entry_millis_blocked: u64,
+    pub queued_large_actual_small: u64,
+    pub queued_small_actual_large: u64,
+    pub queued_large_actual_small_bytes: u64,
+    pub queued_small_actual_large_bytes: u64,
+    pub scheduled_small: u64,
+    pub scheduled_large: u64,
+    pub scheduled_small_state_bytes: u64,
+    pub scheduled_large_state_bytes: u64,
+    pub active_tracking_overflow: u64,
+}
+
+/// Lock-free sink shared by the queue's enqueue, scheduling, and delivery paths.
+#[derive(Debug, Default)]
+pub(crate) struct BroadcastQueueEfficiencyMetrics {
+    capacity_evictions: AtomicU64,
+    dedup_replacements: AtomicU64,
+    enqueues_while_pair_active: AtomicU64,
+    large_head_blocking_incidents: AtomicU64,
+    large_head_blocked_millis: AtomicU64,
+    small_entry_millis_blocked: AtomicU64,
+    queued_large_actual_small: AtomicU64,
+    queued_small_actual_large: AtomicU64,
+    queued_large_actual_small_bytes: AtomicU64,
+    queued_small_actual_large_bytes: AtomicU64,
+    scheduled_small: AtomicU64,
+    scheduled_large: AtomicU64,
+    scheduled_small_state_bytes: AtomicU64,
+    scheduled_large_state_bytes: AtomicU64,
+    active_tracking_overflow: AtomicU64,
+}
+
+// The simulation feature replaces the production scheduler, so its mutation
+// sites are intentionally absent while snapshots remain part of the node API.
+#[cfg_attr(feature = "simulation_tests", allow(dead_code))]
+impl BroadcastQueueEfficiencyMetrics {
+    pub(crate) fn record_capacity_eviction(&self) {
+        self.capacity_evictions.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn record_dedup_replacement(&self) {
+        self.dedup_replacements.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn record_enqueue_while_active(&self) {
+        self.enqueues_while_pair_active
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn record_large_head_block(
+        &self,
+        blocked_millis: u64,
+        small_entry_millis_blocked: u64,
+    ) {
+        self.large_head_blocking_incidents
+            .fetch_add(1, Ordering::Relaxed);
+        self.large_head_blocked_millis
+            .fetch_add(blocked_millis, Ordering::Relaxed);
+        self.small_entry_millis_blocked
+            .fetch_add(small_entry_millis_blocked, Ordering::Relaxed);
+    }
+
+    pub(crate) fn record_scheduled(&self, large: bool, state_bytes: usize) {
+        let state_bytes = u64::try_from(state_bytes).unwrap_or(u64::MAX);
+        let (count, bytes) = if large {
+            (&self.scheduled_large, &self.scheduled_large_state_bytes)
+        } else {
+            (&self.scheduled_small, &self.scheduled_small_state_bytes)
+        };
+        count.fetch_add(1, Ordering::Relaxed);
+        bytes.fetch_add(state_bytes, Ordering::Relaxed);
+    }
+
+    pub(crate) fn record_queued_large_actual_small(&self, payload_bytes: usize) {
+        self.queued_large_actual_small
+            .fetch_add(1, Ordering::Relaxed);
+        self.queued_large_actual_small_bytes.fetch_add(
+            u64::try_from(payload_bytes).unwrap_or(u64::MAX),
+            Ordering::Relaxed,
+        );
+    }
+
+    pub(crate) fn record_queued_small_actual_large(&self, payload_bytes: usize) {
+        self.queued_small_actual_large
+            .fetch_add(1, Ordering::Relaxed);
+        self.queued_small_actual_large_bytes.fetch_add(
+            u64::try_from(payload_bytes).unwrap_or(u64::MAX),
+            Ordering::Relaxed,
+        );
+    }
+
+    pub(crate) fn record_active_tracking_overflow(&self) {
+        self.active_tracking_overflow
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn snapshot(&self) -> BroadcastQueueEfficiencySnapshot {
+        BroadcastQueueEfficiencySnapshot {
+            capacity_evictions: self.capacity_evictions.load(Ordering::Relaxed),
+            dedup_replacements: self.dedup_replacements.load(Ordering::Relaxed),
+            enqueues_while_pair_active: self.enqueues_while_pair_active.load(Ordering::Relaxed),
+            large_head_blocking_incidents: self
+                .large_head_blocking_incidents
+                .load(Ordering::Relaxed),
+            large_head_blocked_millis: self.large_head_blocked_millis.load(Ordering::Relaxed),
+            small_entry_millis_blocked: self.small_entry_millis_blocked.load(Ordering::Relaxed),
+            queued_large_actual_small: self.queued_large_actual_small.load(Ordering::Relaxed),
+            queued_small_actual_large: self.queued_small_actual_large.load(Ordering::Relaxed),
+            queued_large_actual_small_bytes: self
+                .queued_large_actual_small_bytes
+                .load(Ordering::Relaxed),
+            queued_small_actual_large_bytes: self
+                .queued_small_actual_large_bytes
+                .load(Ordering::Relaxed),
+            scheduled_small: self.scheduled_small.load(Ordering::Relaxed),
+            scheduled_large: self.scheduled_large.load(Ordering::Relaxed),
+            scheduled_small_state_bytes: self.scheduled_small_state_bytes.load(Ordering::Relaxed),
+            scheduled_large_state_bytes: self.scheduled_large_state_bytes.load(Ordering::Relaxed),
+            active_tracking_overflow: self.active_tracking_overflow.load(Ordering::Relaxed),
+        }
+    }
+}
+
+/// Production has one queue per process. Simulation uses a separate fan-out
+/// path, matching the existing `BROADCAST_STREAM_METRICS` scope.
+pub(crate) static BROADCAST_QUEUE_EFFICIENCY_METRICS: BroadcastQueueEfficiencyMetrics =
+    BroadcastQueueEfficiencyMetrics {
+        capacity_evictions: AtomicU64::new(0),
+        dedup_replacements: AtomicU64::new(0),
+        enqueues_while_pair_active: AtomicU64::new(0),
+        large_head_blocking_incidents: AtomicU64::new(0),
+        large_head_blocked_millis: AtomicU64::new(0),
+        small_entry_millis_blocked: AtomicU64::new(0),
+        queued_large_actual_small: AtomicU64::new(0),
+        queued_small_actual_large: AtomicU64::new(0),
+        queued_large_actual_small_bytes: AtomicU64::new(0),
+        queued_small_actual_large_bytes: AtomicU64::new(0),
+        scheduled_small: AtomicU64::new(0),
+        scheduled_large: AtomicU64::new(0),
+        scheduled_small_state_bytes: AtomicU64::new(0),
+        scheduled_large_state_bytes: AtomicU64::new(0),
+        active_tracking_overflow: AtomicU64::new(0),
+    };
+
+#[cfg(test)]
+mod tests {
+    use super::BroadcastQueueEfficiencyMetrics;
+
+    #[test]
+    fn snapshot_reconciles_all_queue_harm_counters() {
+        let metrics = BroadcastQueueEfficiencyMetrics::default();
+        metrics.record_capacity_eviction();
+        metrics.record_dedup_replacement();
+        metrics.record_enqueue_while_active();
+        metrics.record_large_head_block(250, 750);
+        metrics.record_scheduled(false, 10);
+        metrics.record_scheduled(true, 20);
+        metrics.record_queued_large_actual_small(30);
+        metrics.record_queued_small_actual_large(40);
+        metrics.record_active_tracking_overflow();
+
+        let snapshot = metrics.snapshot();
+        assert_eq!(snapshot.capacity_evictions, 1);
+        assert_eq!(snapshot.dedup_replacements, 1);
+        assert_eq!(snapshot.enqueues_while_pair_active, 1);
+        assert_eq!(snapshot.large_head_blocking_incidents, 1);
+        assert_eq!(snapshot.large_head_blocked_millis, 250);
+        assert_eq!(snapshot.small_entry_millis_blocked, 750);
+        assert_eq!(snapshot.queued_large_actual_small, 1);
+        assert_eq!(snapshot.queued_small_actual_large, 1);
+        assert_eq!(snapshot.queued_large_actual_small_bytes, 30);
+        assert_eq!(snapshot.queued_small_actual_large_bytes, 40);
+        assert_eq!(snapshot.scheduled_small, 1);
+        assert_eq!(snapshot.scheduled_large, 1);
+        assert_eq!(snapshot.scheduled_small_state_bytes, 10);
+        assert_eq!(snapshot.scheduled_large_state_bytes, 20);
+        assert_eq!(snapshot.active_tracking_overflow, 1);
+    }
+}

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -5439,14 +5439,21 @@ pub(crate) mod tests {
                 Err(_) => continue,
             };
             let prod = strip_cfg_test_regions(&src);
-            let reg_count = prod.matches("register_peer_interest(").count();
+            let unsourced_reg_count = prod.matches(".register_peer_interest(").count();
+            assert_eq!(
+                unsourced_reg_count, 0,
+                "production file {rel} calls the compatibility registration wrapper, which \
+                 records telemetry source as Unknown and evades this source-aware inventory; \
+                 use register_peer_interest_from with an explicit source"
+            );
+            let reg_count = prod.matches("register_peer_interest_from(").count();
             if reg_count == 0 {
                 continue;
             }
             // The interest-manager method *definition* itself lives in
             // ring/interest.rs and is not a call site; ignore it. Detect by the
             // presence of the `pub fn register_peer_interest` definition.
-            if prod.contains("fn register_peer_interest(") {
+            if prod.contains("fn register_peer_interest_from(") {
                 continue;
             }
             found_with_register.insert(rel.clone());

--- a/crates/core/src/node/network_bridge/p2p_protoc/broadcast.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc/broadcast.rs
@@ -635,6 +635,7 @@ impl P2pConnManager {
                 key,
                 new_state,
                 target,
+                None,
             )
             .await;
         }
@@ -977,10 +978,11 @@ impl P2pConnManager {
                 // (`record_delivery_to_interest`) — an untracked co-host must
                 // escape full state after one delivered broadcast in sims too.
                 if let Some(summary) = &our_summary {
-                    op_manager.interest_manager.upsert_peer_summary(
+                    op_manager.interest_manager.upsert_peer_summary_from(
                         &key,
                         &peer_key,
                         summary.clone(),
+                        crate::ring::interest::SummaryPopulationSource::Delivery,
                     );
                 }
             }

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -1344,8 +1344,11 @@ impl OpManager {
                 "Upstream peer address not found, cleaning up locally"
             );
             self.ring.unsubscribe(contract);
-            self.interest_manager
-                .remove_peer_interest(contract, &peer_key);
+            self.interest_manager.remove_peer_interest_for(
+                contract,
+                &peer_key,
+                crate::ring::interest::InterestRemovalCause::Unsubscribe,
+            );
             return;
         };
 
@@ -1355,8 +1358,11 @@ impl OpManager {
                 "Upstream peer has no known address, cleaning up locally"
             );
             self.ring.unsubscribe(contract);
-            self.interest_manager
-                .remove_peer_interest(contract, &peer_key);
+            self.interest_manager.remove_peer_interest_for(
+                contract,
+                &peer_key,
+                crate::ring::interest::InterestRemovalCause::Unsubscribe,
+            );
             return;
         };
 
@@ -1391,8 +1397,11 @@ impl OpManager {
 
         // Clean up local state regardless of send result.
         self.ring.unsubscribe(contract);
-        self.interest_manager
-            .remove_peer_interest(contract, &peer_key);
+        self.interest_manager.remove_peer_interest_for(
+            contract,
+            &peer_key,
+            crate::ring::interest::InterestRemovalCause::Unsubscribe,
+        );
     }
 
     /// Build a per-transaction [`OpCtx`] bound to `tx`.
@@ -3178,8 +3187,7 @@ mod tests {
         // M >> cap in-use contracts, ALL co-hosted by ONE hub peer. Kept within the
         // per-drop SAMPLE cap so the scan returns them all and it is the per-drop
         // re-root cap (not the scan cap) that does the bounding this test measures.
-        const _: () =
-            assert!(MAX_PROMPT_REROOTS_PER_DROP * 3 + 1 <= CONNECTION_DROP_SHADOW_SAMPLE_CAP);
+        const _: () = assert!(MAX_PROMPT_REROOTS_PER_DROP * 3 < CONNECTION_DROP_SHADOW_SAMPLE_CAP);
         let m = MAX_PROMPT_REROOTS_PER_DROP * 3 + 1;
         let mut instance_ids = Vec::new();
         for i in 0..m {

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -3216,9 +3216,13 @@ where
             {
                 false
             } else {
-                op_manager
-                    .interest_manager
-                    .register_peer_interest(&key, peer_key, None, false)
+                op_manager.interest_manager.register_peer_interest_from(
+                    &key,
+                    peer_key,
+                    None,
+                    false,
+                    crate::ring::interest::InterestRegistrationSource::Get,
+                )
             };
             if is_new {
                 // #4359 (MUST-FIX 1): a remote GET with subscribe=false still

--- a/crates/core/src/operations/subscribe.rs
+++ b/crates/core/src/operations/subscribe.rs
@@ -537,9 +537,13 @@ pub(super) async fn finalize_originator_subscribe(
         {
             false
         } else {
-            op_manager
-                .interest_manager
-                .register_peer_interest(&key, peer_key, None, true)
+            op_manager.interest_manager.register_peer_interest_from(
+                &key,
+                peer_key,
+                None,
+                true,
+                crate::ring::interest::InterestRegistrationSource::SubscribeOriginator,
+            )
         };
         if is_new {
             // #4359 (MUST-FIX 1): this upstream peer is now a viable broadcast
@@ -686,9 +690,13 @@ pub(crate) async fn register_downstream_subscriber(
                 .interest_manager
                 .refresh_peer_interest(key, &peer_key)
             {
-                op_manager
-                    .interest_manager
-                    .register_peer_interest(key, peer_key, None, false);
+                op_manager.interest_manager.register_peer_interest_from(
+                    key,
+                    peer_key,
+                    None,
+                    false,
+                    crate::ring::interest::InterestRegistrationSource::SubscribeDownstream,
+                );
             }
             // Key the demand-counter increment on HOSTING-map newness
             // (NewAdd vs Renewal), NOT on interest-map newness: a #4952
@@ -847,9 +855,13 @@ pub(super) async fn finalize_host_subscribe(
         {
             false
         } else {
-            op_manager
-                .interest_manager
-                .register_peer_interest(&key, peer_key, None, true)
+            op_manager.interest_manager.register_peer_interest_from(
+                &key,
+                peer_key,
+                None,
+                true,
+                crate::ring::interest::InterestRegistrationSource::SubscribeRelay,
+            )
         };
         if is_new {
             op_manager.flush_pending_broadcast_on_interest(&key).await;
@@ -931,7 +943,11 @@ pub(crate) async fn handle_unsubscribe_inbound(
         // from one of those (or from a peer the lease sweep already
         // decremented) would otherwise steal a decrement from a real
         // subscriber's count and under-report demand to eviction ranking.
-        let _was_interested = op_manager.interest_manager.remove_peer_interest(&key, peer);
+        let _was_interested = op_manager.interest_manager.remove_peer_interest_for(
+            &key,
+            peer,
+            crate::ring::interest::InterestRemovalCause::Unsubscribe,
+        );
         if was_downstream {
             let lost_interest = op_manager
                 .interest_manager

--- a/crates/core/src/operations/subscribe/tests.rs
+++ b/crates/core/src/operations/subscribe/tests.rs
@@ -91,7 +91,8 @@ fn handle_unsubscribe_inbound_preserves_legacy_branches() {
          to remove the sender from the per-contract downstream list"
     );
     assert!(
-        body.contains("remove_peer_interest(&key, peer)"),
+        body.contains("remove_peer_interest_for(")
+            && body.contains("InterestRemovalCause::Unsubscribe"),
         "handle_unsubscribe_inbound must call `interest_manager.remove_peer_interest` \
          to drop the sender from the per-peer interest registry"
     );
@@ -647,7 +648,7 @@ fn finalize_host_subscribe_fetches_before_register() {
     // from the captured directed holder (`upstream_peer`), NOT the downstream
     // requester, and a newly-viable upstream flushes deferred broadcasts (#4359).
     let upstream_reg = body
-        .find("register_peer_interest(")
+        .find("register_peer_interest_from(")
         .expect("finalize_host_subscribe must register the responder as upstream interest (Fix D)");
     let upstream_call_end = body[upstream_reg..]
         .find(')')

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -1663,11 +1663,12 @@ fn seed_sender_summary_from_broadcast(
     // sender population is by definition co-hosts we often don't
     // interest-track. Seeding here lets OUR next broadcast to them be a delta
     // without waiting for a delivered send.
-    op_manager.interest_manager.upsert_peer_summary(
+    op_manager.interest_manager.upsert_peer_summary_from(
         key,
         &sender_key,
         StateSummary::from(sender_summary_bytes.to_vec()),
-    )
+        crate::ring::interest::SummaryPopulationSource::InboundBroadcast,
+    ) != crate::ring::interest::SummaryPopulationOutcome::RejectedAtCap
 }
 
 /// Inner driver for `BroadcastTo`. Mirrors `update.rs:595-825`.
@@ -1716,6 +1717,9 @@ async fn drive_relay_broadcast_to(
         }
     };
     let is_delta = matches!(payload, DeltaOrFullState::Delta(_));
+    let mut receiver_terminal = op_manager
+        .payload_mix
+        .receiver_terminal_guard(is_delta, payload_bytes.len());
     let state_for_telemetry = WrappedState::from(payload_bytes.clone());
 
     // ── Step 2: telemetry — broadcast received ─────────────────────────────
@@ -1745,6 +1749,7 @@ async fn drive_relay_broadcast_to(
         is_delta,
         op_manager.interest_manager.now(),
     ) {
+        receiver_terminal.mark_dedup();
         tracing::debug!(
             tx = %incoming_tx,
             %key,
@@ -1775,6 +1780,7 @@ async fn drive_relay_broadcast_to(
         crate::ring::merge_backoff::MergeDecision::Allow => {}
         decision @ (crate::ring::merge_backoff::MergeDecision::InBackoff
         | crate::ring::merge_backoff::MergeDecision::KnownFailedPayload) => {
+            receiver_terminal.mark_backoff();
             crate::config::GlobalTestMetrics::record_merge_suppressed_by_backoff();
             tracing::debug!(
                 tx = %incoming_tx,
@@ -2029,6 +2035,7 @@ async fn drive_relay_broadcast_to(
     );
 
     // ── Step 5: telemetry — broadcast applied ─────────────────────────────
+    receiver_terminal.mark_applied(changed, updated_value.len());
     if let Some(event) = NetEventLog::update_broadcast_applied(
         &incoming_tx,
         &op_manager.ring,
@@ -2626,6 +2633,9 @@ async fn apply_streaming_broadcast(
     sender_summary_bytes: Vec<u8>,
     sender_addr: SocketAddr,
 ) -> Result<(), OpError> {
+    let mut receiver_terminal = op_manager
+        .payload_mix
+        .receiver_terminal_guard(false, state_bytes.len());
     // Step 4: update sender's cached summary. Same self-reported provenance
     // and the same empty-means-could-not-summarize guard as the non-streaming
     // BroadcastTo arm above.
@@ -2641,6 +2651,7 @@ async fn apply_streaming_broadcast(
         false,
         op_manager.interest_manager.now(),
     ) {
+        receiver_terminal.mark_dedup();
         tracing::debug!(
             tx = %incoming_tx,
             %key,
@@ -2661,6 +2672,7 @@ async fn apply_streaming_broadcast(
         crate::ring::merge_backoff::MergeDecision::Allow => {}
         decision @ (crate::ring::merge_backoff::MergeDecision::InBackoff
         | crate::ring::merge_backoff::MergeDecision::KnownFailedPayload) => {
+            receiver_terminal.mark_backoff();
             crate::config::GlobalTestMetrics::record_merge_suppressed_by_backoff();
             tracing::debug!(
                 tx = %incoming_tx,
@@ -2800,6 +2812,7 @@ async fn apply_streaming_broadcast(
     };
 
     // Step 8: telemetry — broadcast applied + proactive summary.
+    receiver_terminal.mark_applied(changed, updated_value.len());
     if let Some(event) = NetEventLog::update_broadcast_applied(
         &incoming_tx,
         &op_manager.ring,
@@ -6543,6 +6556,53 @@ mod tests {
              apply_streaming_broadcast (#4857). A direct call here would \
              double-count the streaming path. Issue #4828."
         );
+    }
+
+    /// #5090: every received payload is terminally classified by an RAII guard,
+    /// and successful no-ops are marked before returning.
+    #[test]
+    fn both_broadcast_apply_paths_record_receiver_outcome_before_noop_return() {
+        let full = include_str!("op_ctx_task.rs");
+        let src = production_source(full);
+        for sig in [
+            "async fn drive_relay_broadcast_to(",
+            "async fn apply_streaming_broadcast(",
+        ] {
+            let body = extract_fn_body(src, sig);
+            assert_eq!(
+                body.matches("receiver_terminal_guard(").count(),
+                1,
+                "{sig} must create exactly one terminal receiver guard"
+            );
+            let record = body
+                .find("receiver_terminal.mark_applied(changed, updated_value.len())")
+                .unwrap_or_else(|| panic!("{sig} must classify successful apply outcome"));
+            let no_op_return = body
+                .find("if !changed {")
+                .unwrap_or_else(|| panic!("{sig} must retain its no-op early return"));
+            assert!(
+                record < no_op_return,
+                "{sig} must count a successfully executed no-op before returning"
+            );
+            for marker in [
+                "receiver_terminal.mark_dedup();",
+                "receiver_terminal.mark_backoff();",
+            ] {
+                let marker_offset = body.find(marker).unwrap_or_else(|| {
+                    panic!("{sig} must classify {marker} before its early return")
+                });
+                let return_offset =
+                    body[marker_offset..]
+                        .find("return Ok(());")
+                        .unwrap_or_else(|| {
+                            panic!("{sig} must retain the early return following {marker}")
+                        });
+                assert!(
+                    return_offset > 0,
+                    "{sig} must classify {marker} before its early return"
+                );
+            }
+        }
     }
 
     /// Pin (telemetry accuracy / scope): `relayed_updates_total` counts

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -1643,6 +1643,12 @@ impl Ring {
         let mut prev_broadcast_stream_failures_total: u64 = crate::node::BROADCAST_STREAM_METRICS
             .snapshot()
             .streaming_failures_total;
+        // The diagnostic block is substantially wider than the ordinary
+        // snapshot gauges. Its counters are lifetime-monotonic, so collecting
+        // locally on every event but exporting one in six snapshots preserves
+        // counter evidence while bounding collector/storage load. Start at five
+        // so a newly started node reports after its first five-minute snapshot.
+        let mut network_efficiency_tick = 5u8;
 
         loop {
             if sleep_or_shutdown(&shutdown, async {
@@ -1789,7 +1795,8 @@ impl Ring {
             // WASM blobs + wasmtime compile cache (both du-measured) + their sum.
             // `None` until the tracker is configured and seeded (early startup),
             // in which case the fields stay unset. Observational only in this PR.
-            if let Some(disk) = ring.hosting_manager.disk_usage_stats() {
+            let disk_usage = ring.hosting_manager.disk_usage_stats();
+            if let Some(disk) = disk_usage {
                 snapshot.hosting_disk_state_bytes = Some(disk.state_bytes);
                 snapshot.hosting_disk_wasm_bytes = Some(disk.wasm_bytes);
                 snapshot.hosting_disk_compile_cache_bytes = Some(disk.compile_cache_bytes);
@@ -2049,6 +2056,154 @@ impl Ring {
             snapshot.subscribe_hint_refused_cache = Some(pm.received_refused_cache_admission);
             snapshot.subscribe_hint_acted_succeeded = Some(pm.acted_succeeded);
             snapshot.subscribe_hint_acted_failed = Some(pm.acted_failed);
+
+            // Large-state decision evidence (#5090). The fixed-cardinality
+            // block rides the existing snapshot event once every six ticks
+            // (30 minutes), with no new event stream, peer identifiers, or
+            // contract-key map. Lifetime-monotonic counters recover both local
+            // snapshot drops and the deliberately skipped five-minute ticks.
+            network_efficiency_tick = (network_efficiency_tick + 1) % 6;
+            if network_efficiency_tick == 0
+                && let (Some(op_manager), Some(disk), Some(telemetry)) = (
+                    ring.upgrade_op_manager(),
+                    disk_usage,
+                    crate::tracing::telemetry::telemetry_local_metrics_snapshot(),
+                )
+            {
+                let lifecycle = op_manager.interest_manager.interest_lifecycle_snapshot();
+                let receiver = op_manager.payload_mix.receiver_apply_stats();
+                let queue = crate::node::BROADCAST_QUEUE_EFFICIENCY_METRICS.snapshot();
+                let state_rejections = crate::contract::state_size_rejection_snapshot();
+                let rate_to_u64 = |rate: f64| {
+                    if !rate.is_finite() || rate <= 0.0 {
+                        0
+                    } else if rate >= u64::MAX as f64 {
+                        u64::MAX
+                    } else {
+                        rate.round() as u64
+                    }
+                };
+                let cost_axes = ring.hosting_cost_pressure_axes();
+                let eligibility = ring.hosting_manager.cost_eligibility_stats(&cost_axes);
+                let cost = std::array::from_fn(|index| {
+                    cost_axes.get(index).map_or([0; 5], |axis| {
+                        let max_any = axis.rates.values().copied().fold(0.0, f64::max);
+                        let max_eligible = eligibility.max_eligible_rate[index]
+                            .iter()
+                            .copied()
+                            .fold(0.0, f64::max);
+                        [
+                            rate_to_u64(axis.total_rate),
+                            rate_to_u64(axis.floor),
+                            rate_to_u64(max_any),
+                            rate_to_u64(max_eligible),
+                            axis.rates.len() as u64,
+                        ]
+                    })
+                });
+                let cost_bucket_any = std::array::from_fn(|axis| {
+                    std::array::from_fn(|bucket| {
+                        rate_to_u64(eligibility.max_attributed_rate[axis][bucket])
+                    })
+                });
+                let cost_bucket_eligible = std::array::from_fn(|axis| {
+                    std::array::from_fn(|bucket| {
+                        rate_to_u64(eligibility.max_eligible_rate[axis][bucket])
+                    })
+                });
+
+                let tel = [
+                    telemetry.enqueue_attempts_total,
+                    telemetry.enqueue_succeeded_total,
+                    telemetry.enqueue_dropped_full_total,
+                    telemetry.enqueue_dropped_closed_total,
+                    telemetry.rate_limit_admitted_operational_total,
+                    telemetry.rate_limit_admitted_shadow_total,
+                    telemetry.dropped_aggregate_limit_operational_total,
+                    telemetry.dropped_aggregate_limit_shadow_total,
+                    telemetry.dropped_shadow_limit_total,
+                    telemetry.dropped_backoff_buffer_full_total,
+                    telemetry.batch_send_attempts_total,
+                    telemetry.batch_send_successes_total,
+                    telemetry.batch_send_failures_total,
+                    telemetry.batch_events_sent_total,
+                    telemetry.batch_retry_truncated_events_total,
+                ];
+                let shadow = std::array::from_fn(|index| {
+                    let stream = telemetry.known_shadow_rollups[index];
+                    [
+                        stream.enqueue_attempts_total,
+                        stream.enqueue_dropped_full_total,
+                        stream.enqueue_dropped_closed_total,
+                        stream.rate_limit_admitted_total,
+                        stream.dropped_aggregate_limit_total,
+                        stream.dropped_shadow_limit_total,
+                        stream.dropped_backoff_buffer_full_total,
+                        stream.retry_truncated_total,
+                        stream.sent_total,
+                    ]
+                });
+
+                snapshot.network_efficiency_v1 = Some(crate::router::NetworkEfficiencyV1 {
+                    v: 1,
+                    ms_s: lifecycle.delivered_sends,
+                    ms_b: lifecycle.delivered_bytes,
+                    ms_age: lifecycle.first_send_age,
+                    reg_ow_k: lifecycle.registration_overwrite_known,
+                    reg_ow_m: lifecycle.registration_overwrite_missing,
+                    reg_new_k: lifecycle.registration_new_known,
+                    reg_new_m: lifecycle.registration_new_missing,
+                    reg_cap: lifecycle.registration_cap_rejected,
+                    removed: lifecycle.removals,
+                    current: lifecycle.current_summary_state,
+                    recreated: lifecycle.recreated_after_removal,
+                    populated: lifecycle.population,
+                    corr_ovf: [lifecycle.history_overflow, lifecycle.active_overflow],
+                    queue: [
+                        queue.capacity_evictions,
+                        queue.dedup_replacements,
+                        queue.enqueues_while_pair_active,
+                        queue.large_head_blocking_incidents,
+                        queue.large_head_blocked_millis,
+                        queue.small_entry_millis_blocked,
+                        queue.queued_large_actual_small,
+                        queue.queued_small_actual_large,
+                        queue.queued_large_actual_small_bytes,
+                        queue.queued_small_actual_large_bytes,
+                        queue.scheduled_small,
+                        queue.scheduled_large,
+                        queue.scheduled_small_state_bytes,
+                        queue.scheduled_large_state_bytes,
+                        queue.active_tracking_overflow,
+                    ],
+                    recv_n: receiver.counts,
+                    recv_tn: receiver.terminal_counts,
+                    recv_tb: receiver.terminal_bytes,
+                    state_n: disk.state_size_bucket_counts,
+                    state_b: disk.state_size_bucket_bytes,
+                    state: [
+                        disk.state_count,
+                        disk.state_max_bytes,
+                        disk.state_over_limit_count,
+                        disk.state_over_limit_bytes,
+                        disk.state_limit_bytes,
+                        state_rejections.pre_wasm_count,
+                        state_rejections.pre_wasm_max_bytes,
+                        state_rejections.post_merge_count,
+                        state_rejections.post_merge_max_bytes,
+                    ],
+                    evict_n: eligibility.counts,
+                    evict_b: eligibility.bytes,
+                    vict_n: hosting.eviction_victim_counts,
+                    vict_b: hosting.eviction_victim_bytes,
+                    cost,
+                    cost_ba: cost_bucket_any,
+                    cost_be: cost_bucket_eligible,
+                    tel,
+                    shadow,
+                    eff: telemetry.network_efficiency_delivery,
+                });
+            }
 
             tracing::info!(
                 failure_events = snapshot.failure_events,

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -83,6 +83,19 @@ use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 use tokio::time::Instant;
+
+use crate::tracing::event_kind::{STATE_SIZE_BUCKET_COUNT, state_size_bucket};
+
+/// Current cost-eviction eligibility by state-size bucket. Class order is
+/// `[eligible_zero_demand, subscribed, recent_unsubscribed]`.
+pub(crate) struct CostEligibilityStats {
+    pub counts: [[u64; STATE_SIZE_BUCKET_COUNT]; 3],
+    pub bytes: [[u64; STATE_SIZE_BUCKET_COUNT]; 3],
+    /// Per cost axis × state-size bucket maxima for every attributed contract.
+    pub max_attributed_rate: [[f64; STATE_SIZE_BUCKET_COUNT]; 3],
+    /// Same maxima restricted to cost-eviction-eligible zero-demand contracts.
+    pub max_eligible_rate: [[f64; STATE_SIZE_BUCKET_COUNT]; 3],
+}
 use tracing::{debug, info};
 
 use super::Location;
@@ -882,6 +895,48 @@ impl HostingManager {
             return None;
         }
         Some(tracker.stats())
+    }
+
+    pub(crate) fn cost_eligibility_stats(
+        &self,
+        cost_axes: &[CostAxisPressure],
+    ) -> CostEligibilityStats {
+        let mut counts = [[0u64; STATE_SIZE_BUCKET_COUNT]; 3];
+        let mut bytes = [[0u64; STATE_SIZE_BUCKET_COUNT]; 3];
+        let mut max_attributed_rate = [[0.0f64; STATE_SIZE_BUCKET_COUNT]; 3];
+        let mut max_eligible_rate = [[0.0f64; STATE_SIZE_BUCKET_COUNT]; 3];
+        self.hosting_cache
+            .read()
+            .for_each_cost_eligibility_row(|key, size, recently_accessed| {
+                let (local, downstream) = self.local_and_downstream_counts(key);
+                let class = if local + downstream > 0 {
+                    1
+                } else if recently_accessed {
+                    2
+                } else {
+                    0
+                };
+                let bucket = state_size_bucket(size);
+                counts[class][bucket] = counts[class][bucket].saturating_add(1);
+                bytes[class][bucket] = bytes[class][bucket].saturating_add(size);
+                for (axis_index, axis) in cost_axes.iter().take(3).enumerate() {
+                    let rate = axis.rates.get(key.id()).copied().unwrap_or(0.0);
+                    if rate.is_finite() && rate > 0.0 {
+                        max_attributed_rate[axis_index][bucket] =
+                            max_attributed_rate[axis_index][bucket].max(rate);
+                        if class == 0 {
+                            max_eligible_rate[axis_index][bucket] =
+                                max_eligible_rate[axis_index][bucket].max(rate);
+                        }
+                    }
+                }
+            });
+        CostEligibilityStats {
+            counts,
+            bytes,
+            max_attributed_rate,
+            max_eligible_rate,
+        }
     }
 
     /// Test-only: install a disk tracker on nonexistent paths (so the du-walks
@@ -6439,6 +6494,65 @@ mod tests {
         assert!(
             !needs_renewal.contains(&relay_contract),
             "Relay-cached contract should NOT be in renewal list"
+        );
+    }
+
+    #[test]
+    fn cost_eligibility_stats_separate_zero_demand_subscribed_and_recent_by_size() {
+        use crate::util::time_source::SharedMockTimeSource;
+
+        let clock = SharedMockTimeSource::new();
+        let manager = HostingManager::with_time_source(
+            DEFAULT_HOSTING_BUDGET_BYTES,
+            std::sync::Arc::new(clock.clone()),
+        );
+        let eligible = make_contract_key(11);
+        let subscribed = make_contract_key(12);
+        let recent = make_contract_key(13);
+        let eligible_size = 100;
+        let subscribed_size = 3 * 1024 * 1024;
+        let recent_size = 4 * 1024 * 1024;
+
+        manager.record_contract_access(eligible, eligible_size, AccessType::Get);
+        manager.record_contract_access(subscribed, subscribed_size, AccessType::Get);
+        manager.record_contract_access(recent, recent_size, AccessType::Get);
+        manager.add_downstream_subscriber(&subscribed, make_peer_key(12));
+
+        clock.advance_time(COST_RATE_MIN_WINDOW + Duration::from_secs(1));
+        manager.mark_local_client_access(&recent);
+
+        let axes = [CostAxisPressure {
+            axis: "test",
+            total_rate: 60.0,
+            floor: 1.0,
+            rates: [(*eligible.id(), 10.0), (*subscribed.id(), 50.0)]
+                .into_iter()
+                .collect(),
+        }];
+        let stats = manager.cost_eligibility_stats(&axes);
+        assert_eq!(stats.counts[0][state_size_bucket(eligible_size)], 1);
+        assert_eq!(
+            stats.bytes[0][state_size_bucket(eligible_size)],
+            eligible_size
+        );
+        assert_eq!(stats.counts[1][state_size_bucket(subscribed_size)], 1);
+        assert_eq!(
+            stats.bytes[1][state_size_bucket(subscribed_size)],
+            subscribed_size
+        );
+        assert_eq!(stats.counts[2][state_size_bucket(recent_size)], 1);
+        assert_eq!(stats.bytes[2][state_size_bucket(recent_size)], recent_size);
+        assert_eq!(
+            stats.max_eligible_rate[0][state_size_bucket(eligible_size)],
+            10.0
+        );
+        assert_eq!(
+            stats.max_eligible_rate[0][state_size_bucket(subscribed_size)],
+            0.0
+        );
+        assert_eq!(
+            stats.max_attributed_rate[0][state_size_bucket(subscribed_size)],
+            50.0
         );
     }
 

--- a/crates/core/src/ring/hosting/cache.rs
+++ b/crates/core/src/ring/hosting/cache.rs
@@ -72,6 +72,7 @@ use tokio::time::Instant;
 
 use super::demand::NEUTRAL_DEMAND;
 use crate::ring::interest::PeerKey;
+use crate::tracing::event_kind::{STATE_SIZE_BUCKET_COUNT, state_size_bucket};
 use crate::util::time_source::TimeSource;
 use crate::wasm_runtime::read_total_ram_bytes;
 
@@ -331,6 +332,10 @@ pub(crate) struct HostingCacheStats {
     /// means the floors / share threshold are miscalibrated and churning cheap
     /// contracts.
     pub cost_evictions_total: u64,
+    /// Monotonic eviction victims by reason × state-size bucket. Reason order:
+    /// byte-budget zero-demand, byte-budget in-use, cost pressure.
+    pub eviction_victim_counts: [[u64; STATE_SIZE_BUCKET_COUNT]; 3],
+    pub eviction_victim_bytes: [[u64; STATE_SIZE_BUCKET_COUNT]; 3],
 }
 
 /// Per-contract Greedy-Dual priority row for the local-peer dashboard.
@@ -766,6 +771,8 @@ pub struct HostingCache<T: TimeSource> {
     /// #4861). Only [`Self::evict_cost_pressure`] increments it. See
     /// [`HostingCacheStats::cost_evictions_total`].
     cost_evictions_total: u64,
+    eviction_victim_counts: [[u64; STATE_SIZE_BUCKET_COUNT]; 3],
+    eviction_victim_bytes: [[u64; STATE_SIZE_BUCKET_COUNT]; 3],
     /// Time source for testability
     time_source: T,
 }
@@ -1008,6 +1015,8 @@ impl<T: TimeSource> HostingCache<T> {
             oom_valve_evictions_total: 0,
             subscribed_evictions_total: 0,
             cost_evictions_total: 0,
+            eviction_victim_counts: [[0; STATE_SIZE_BUCKET_COUNT]; 3],
+            eviction_victim_bytes: [[0; STATE_SIZE_BUCKET_COUNT]; 3],
             time_source,
         }
     }
@@ -1017,6 +1026,14 @@ impl<T: TimeSource> HostingCache<T> {
     fn next_seq(&mut self) -> u64 {
         self.access_seq = self.access_seq.saturating_add(1);
         self.access_seq
+    }
+
+    fn record_eviction_victim(&mut self, reason: usize, size_bytes: u64) {
+        let bucket = state_size_bucket(size_bytes);
+        self.eviction_victim_counts[reason][bucket] =
+            self.eviction_victim_counts[reason][bucket].saturating_add(1);
+        self.eviction_victim_bytes[reason][bucket] =
+            self.eviction_victim_bytes[reason][bucket].saturating_add(size_bytes);
     }
 
     /// Evict contracts while the cache is over budget, choosing victims
@@ -1152,6 +1169,7 @@ impl<T: TimeSource> HostingCache<T> {
                 let was_in_use = local + downstream > 0;
                 self.current_bytes = self.current_bytes.saturating_sub(entry.size_bytes);
                 self.budget_evictions_total = self.budget_evictions_total.saturating_add(1);
+                self.record_eviction_victim(usize::from(was_in_use), entry.size_bytes);
                 // Field falsifier for the single riskiest new behavior: shedding a
                 // subscribed contract. Counted by the captured subscriber split
                 // (not by pressure), so it covers the normal AtCapacity last-resort
@@ -1741,10 +1759,31 @@ impl<T: TimeSource> HostingCache<T> {
             budget_evictions_total: self.budget_evictions_total,
             subscribed_evictions_total: self.subscribed_evictions_total,
             cost_evictions_total: self.cost_evictions_total,
+            eviction_victim_counts: self.eviction_victim_counts,
+            eviction_victim_bytes: self.eviction_victim_bytes,
             evictions_of_recently_read_total: self.evictions_of_recently_read_total,
             evicted_unread_total: self.evicted_unread_total,
             evicted_unread_age_secs_sum: self.evicted_unread_age_secs_sum,
             oom_valve_evictions_total: self.oom_valve_evictions_total,
+        }
+    }
+
+    /// Current hosted rows for fixed-cardinality cost-eviction eligibility
+    /// telemetry. Contract identities stay local and are aggregated by the
+    /// hosting manager before export.
+    pub(crate) fn for_each_cost_eligibility_row(
+        &self,
+        mut visit: impl FnMut(&ContractKey, u64, bool),
+    ) {
+        let now = self.time_source.now();
+        for (key, entry) in &self.contracts {
+            let recently_accessed = entry
+                .last_genuine_access
+                .is_some_and(|at| now.saturating_duration_since(at) < COST_RATE_MIN_WINDOW)
+                || entry.local_client_last_access.is_some_and(|at| {
+                    now.saturating_duration_since(at) < super::SUBSCRIPTION_LEASE_DURATION
+                });
+            visit(key, entry.size_bytes, recently_accessed);
         }
     }
 
@@ -1964,6 +2003,7 @@ impl<T: TimeSource> HostingCache<T> {
                 if let Some(entry) = self.contracts.remove(&key) {
                     self.current_bytes = self.current_bytes.saturating_sub(entry.size_bytes);
                     self.cost_evictions_total = self.cost_evictions_total.saturating_add(1);
+                    self.record_eviction_victim(2, entry.size_bytes);
                     // Operator-facing: this is the storm diagnosis surfacing in
                     // the field. read_count is logged (not gated on) so the
                     // field can tell whether cost eviction is hitting contracts
@@ -2345,6 +2385,8 @@ mod tests {
         assert!(cache.get(&junk).is_none());
         let stats = cache.stats();
         assert_eq!(stats.cost_evictions_total, 1);
+        assert_eq!(stats.eviction_victim_counts[2][state_size_bucket(121)], 1);
+        assert_eq!(stats.eviction_victim_bytes[2][state_size_bucket(121)], 121);
         assert_eq!(
             stats.budget_evictions_total, 0,
             "cost evictions must not masquerade as byte-budget evictions"
@@ -3675,6 +3717,8 @@ mod tests {
         assert_eq!(result.evicted, vec![(key2, 0)]);
         let stats = cache.stats();
         assert_eq!(stats.budget_evictions_total, 2);
+        assert_eq!(stats.eviction_victim_counts[0][state_size_bucket(100)], 2);
+        assert_eq!(stats.eviction_victim_bytes[0][state_size_bucket(100)], 200);
         assert_eq!(stats.current_bytes, 200);
         assert_eq!(stats.contract_count, 2);
         assert_eq!(stats.budget_bytes, 200);

--- a/crates/core/src/ring/hosting/disk_usage.rs
+++ b/crates/core/src/ring/hosting/disk_usage.rs
@@ -45,12 +45,15 @@
 //! would admit writes that actually overflow disk), so a seed that cannot read
 //! the truth must surface the error rather than start from an under-count.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use freenet_stdlib::prelude::ContractKey;
 use parking_lot::Mutex;
+
+use crate::tracing::event_kind::{STATE_SIZE_BUCKET_COUNT, state_size_bucket};
+use crate::wasm_runtime::MAX_STATE_SIZE;
 
 /// A pre-write admission check rejected a state/code write because it would
 /// push aggregate on-disk usage past the disk budget (#4683, admission gate live
@@ -89,12 +92,91 @@ impl std::fmt::Display for DiskBudgetExceeded {
 pub(crate) struct DiskUsageStats {
     /// Persisted contract-state bytes (delta-tracked, seeded from redb rows).
     pub state_bytes: u64,
+    /// Number of persisted contract states in the authoritative size index.
+    pub state_count: u64,
+    /// Exact state counts by fixed state-size bucket.
+    pub state_size_bucket_counts: [u64; STATE_SIZE_BUCKET_COUNT],
+    /// Exact state bytes by the same fixed state-size bucket.
+    pub state_size_bucket_bytes: [u64; STATE_SIZE_BUCKET_COUNT],
+    /// Largest persisted contract state, or zero when none are stored.
+    pub state_max_bytes: u64,
+    /// Persisted states above the runtime's hard state-size limit. This should
+    /// always be zero; a nonzero value exposes an enforcement invariant break.
+    pub state_over_limit_count: u64,
+    /// Bytes held by persisted states above the hard state-size limit.
+    pub state_over_limit_bytes: u64,
+    /// Runtime hard state-size limit used for the invariant above.
+    pub state_limit_bytes: u64,
     /// On-disk WASM code blob bytes (`du` of `contracts_dir/*.wasm`).
     pub wasm_bytes: u64,
     /// Wasmtime compile-cache bytes (`du` of the relocated cache dir).
     pub compile_cache_bytes: u64,
     /// Sum of the three above — the aggregate the disk budget bounds.
     pub total_bytes: u64,
+}
+
+/// Exact state-size index with incrementally maintained fixed-cardinality
+/// aggregates. Snapshotting this structure is O(number of buckets), not
+/// O(number of hosted contracts), so telemetry never pauses state commits for
+/// a full-map clone.
+#[derive(Default)]
+struct StateSizeIndex {
+    by_contract: HashMap<ContractKey, u64>,
+    by_size: BTreeMap<u64, u64>,
+    bucket_counts: [u64; STATE_SIZE_BUCKET_COUNT],
+    bucket_bytes: [u64; STATE_SIZE_BUCKET_COUNT],
+    over_limit_count: u64,
+    over_limit_bytes: u64,
+}
+
+impl StateSizeIndex {
+    fn get(&self, key: &ContractKey) -> Option<u64> {
+        self.by_contract.get(key).copied()
+    }
+
+    fn insert(&mut self, key: ContractKey, size: u64) -> Option<u64> {
+        let old = self.by_contract.insert(key, size);
+        if let Some(old) = old {
+            self.remove_size(old);
+        }
+        self.add_size(size);
+        old
+    }
+
+    fn remove(&mut self, key: &ContractKey) -> Option<u64> {
+        let size = self.by_contract.remove(key)?;
+        self.remove_size(size);
+        Some(size)
+    }
+
+    fn add_size(&mut self, size: u64) {
+        let count = self.by_size.entry(size).or_default();
+        *count = count.saturating_add(1);
+        let bucket = state_size_bucket(size);
+        self.bucket_counts[bucket] = self.bucket_counts[bucket].saturating_add(1);
+        self.bucket_bytes[bucket] = self.bucket_bytes[bucket].saturating_add(size);
+        if size > MAX_STATE_SIZE as u64 {
+            self.over_limit_count = self.over_limit_count.saturating_add(1);
+            self.over_limit_bytes = self.over_limit_bytes.saturating_add(size);
+        }
+    }
+
+    fn remove_size(&mut self, size: u64) {
+        if let std::collections::btree_map::Entry::Occupied(mut entry) = self.by_size.entry(size) {
+            if *entry.get() <= 1 {
+                entry.remove();
+            } else {
+                *entry.get_mut() -= 1;
+            }
+        }
+        let bucket = state_size_bucket(size);
+        self.bucket_counts[bucket] = self.bucket_counts[bucket].saturating_sub(1);
+        self.bucket_bytes[bucket] = self.bucket_bytes[bucket].saturating_sub(size);
+        if size > MAX_STATE_SIZE as u64 {
+            self.over_limit_count = self.over_limit_count.saturating_sub(1);
+            self.over_limit_bytes = self.over_limit_bytes.saturating_sub(size);
+        }
+    }
 }
 
 /// Signed-delta + seed-once tracker for aggregate hosting disk usage.
@@ -124,7 +206,7 @@ pub(crate) struct DiskUsageTracker {
     /// [`Self::seed`] and [`Self::record_state_write`]. Per-shard locking would
     /// reopen that race and turn the counter into a load-bearing under-count
     /// now that the admission gate reads it (#4702).
-    state_sizes: Mutex<HashMap<ContractKey, u64>>,
+    state_sizes: Mutex<StateSizeIndex>,
     /// Directory holding `*.wasm` code blobs (mode-resolved `contracts_dir`).
     contracts_dir: PathBuf,
     /// Relocated wasmtime compile-cache directory (on the data-dir mount).
@@ -140,7 +222,7 @@ impl DiskUsageTracker {
             wasm_bytes: AtomicU64::new(0),
             compile_cache_bytes: AtomicU64::new(0),
             seeded: AtomicBool::new(false),
-            state_sizes: Mutex::new(HashMap::new()),
+            state_sizes: Mutex::new(StateSizeIndex::default()),
             contracts_dir,
             compile_cache_dir,
         }
@@ -167,11 +249,33 @@ impl DiskUsageTracker {
 
     /// Snapshot all gauges for telemetry.
     pub(crate) fn stats(&self) -> DiskUsageStats {
-        let state_bytes = self.state_bytes.load(Ordering::Relaxed);
+        // The histogram and ordered size multiset are maintained at each
+        // write/removal, so this lock is held only for a fixed-size copy.
+        let sizes = self.state_sizes.lock();
+        let state_count = sizes.by_contract.len() as u64;
+        let state_size_bucket_counts = sizes.bucket_counts;
+        let state_size_bucket_bytes = sizes.bucket_bytes;
+        let state_bytes = state_size_bucket_bytes
+            .iter()
+            .copied()
+            .fold(0u64, u64::saturating_add);
+        let state_max_bytes = sizes.by_size.last_key_value().map_or(0, |(size, _)| *size);
+        let state_over_limit_count = sizes.over_limit_count;
+        let state_over_limit_bytes = sizes.over_limit_bytes;
+        let state_limit_bytes = MAX_STATE_SIZE as u64;
+        drop(sizes);
+
         let wasm_bytes = self.wasm_bytes.load(Ordering::Relaxed);
         let compile_cache_bytes = self.compile_cache_bytes.load(Ordering::Relaxed);
         DiskUsageStats {
             state_bytes,
+            state_count,
+            state_size_bucket_counts,
+            state_size_bucket_bytes,
+            state_max_bytes,
+            state_over_limit_count,
+            state_over_limit_bytes,
+            state_limit_bytes,
             wasm_bytes,
             compile_cache_bytes,
             total_bytes: state_bytes
@@ -234,16 +338,14 @@ impl DiskUsageTracker {
             // true post-write size while we were unseeded. That value is newer
             // and authoritative — do NOT overwrite it with the stale snapshot.
             // Only rows not already buffered by such a write are inserted.
-            match sizes.entry(key) {
-                std::collections::hash_map::Entry::Occupied(_) => {}
-                std::collections::hash_map::Entry::Vacant(v) => {
-                    v.insert(size);
-                }
+            if !sizes.by_contract.contains_key(&key) {
+                sizes.insert(key, size);
             }
         }
         // Recompute the aggregate from the merged map so buffered concurrent
         // writes are reflected exactly.
         let total = sizes
+            .by_contract
             .values()
             .copied()
             .fold(0u64, |acc, v| acc.saturating_add(v));
@@ -432,7 +534,7 @@ impl DiskUsageTracker {
         // `record_state_write` cannot land its delta between our `old` read and
         // our `total` read and make the projection inconsistent.
         let sizes = self.state_sizes.lock();
-        let old = sizes.get(key).copied().unwrap_or(0);
+        let old = sizes.get(key).unwrap_or(0);
         let total = self.total_bytes();
         drop(sizes);
         // projected = total − old + new (saturating so it can never wrap).
@@ -473,7 +575,7 @@ impl DiskUsageTracker {
         // Hold the delta-path lock so the `old` read and the `total` read are a
         // consistent snapshot (same rationale as `admit_state_write`).
         let sizes = self.state_sizes.lock();
-        let old = sizes.get(key).copied().unwrap_or(0);
+        let old = sizes.get(key).unwrap_or(0);
         // Non-positive delta (shrink or hold) never blocks convergence.
         if new_size <= old {
             return Ok(());
@@ -700,6 +802,68 @@ mod tests {
         // A second seed must be a no-op (no double-count).
         t.seed([(test_key(3), 999)]);
         assert_eq!(t.stats().state_bytes, 150);
+    }
+
+    #[test]
+    fn persisted_state_inventory_is_exact_at_every_bucket_boundary() {
+        let t = tracker();
+        let bounds = crate::tracing::event_kind::STATE_SIZE_BUCKET_UPPER_BOUNDS;
+        let mut rows = Vec::new();
+        let mut expected_counts = [0u64; STATE_SIZE_BUCKET_COUNT];
+        let mut expected_bytes = [0u64; STATE_SIZE_BUCKET_COUNT];
+
+        // Put one state exactly at each inclusive boundary, then one byte above
+        // the hard limit to exercise the final bucket and invariant counter.
+        for (index, size) in bounds.into_iter().enumerate() {
+            rows.push((test_key(index as u8), size));
+            expected_counts[index] += 1;
+            expected_bytes[index] += size;
+        }
+        let over_limit = MAX_STATE_SIZE as u64 + 1;
+        rows.push((test_key(250), over_limit));
+        expected_counts[STATE_SIZE_BUCKET_COUNT - 1] = 1;
+        expected_bytes[STATE_SIZE_BUCKET_COUNT - 1] = over_limit;
+
+        t.seed(rows);
+        let stats = t.stats();
+        assert_eq!(stats.state_count, STATE_SIZE_BUCKET_COUNT as u64);
+        assert_eq!(stats.state_size_bucket_counts, expected_counts);
+        assert_eq!(stats.state_size_bucket_bytes, expected_bytes);
+        assert_eq!(stats.state_max_bytes, over_limit);
+        assert_eq!(stats.state_over_limit_count, 1);
+        assert_eq!(stats.state_over_limit_bytes, over_limit);
+        assert_eq!(stats.state_limit_bytes, MAX_STATE_SIZE as u64);
+        assert_eq!(
+            stats.state_size_bucket_counts.iter().sum::<u64>(),
+            stats.state_count
+        );
+        assert_eq!(
+            stats.state_size_bucket_bytes.iter().sum::<u64>(),
+            stats.state_bytes
+        );
+    }
+
+    #[test]
+    fn persisted_state_inventory_tracks_bucket_crossing_and_removal() {
+        let t = tracker();
+        let key = test_key(1);
+        t.seed([(key, 64 * 1024)]);
+
+        t.record_state_write(&key, 64 * 1024 + 1);
+        let moved = t.stats();
+        assert_eq!(moved.state_size_bucket_counts[0], 0);
+        assert_eq!(moved.state_size_bucket_counts[1], 1);
+        assert_eq!(moved.state_size_bucket_bytes[1], 64 * 1024 + 1);
+        assert_eq!(moved.state_max_bytes, 64 * 1024 + 1);
+
+        t.record_state_removed(&key);
+        let empty = t.stats();
+        assert_eq!(empty.state_count, 0);
+        assert_eq!(empty.state_size_bucket_counts, [0; STATE_SIZE_BUCKET_COUNT]);
+        assert_eq!(empty.state_size_bucket_bytes, [0; STATE_SIZE_BUCKET_COUNT]);
+        assert_eq!(empty.state_max_bytes, 0);
+        assert_eq!(empty.state_over_limit_count, 0);
+        assert_eq!(empty.state_over_limit_bytes, 0);
     }
 
     #[test]

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -1002,7 +1002,12 @@ pub struct InterestManager<T: TimeSource> {
     /// Bounded diagnostic-only state used to distinguish first, recreated,
     /// in-flight duplicate, and sequential missing-summary sends.
     missing_summary_history: Mutex<LruCache<(ContractKey, PeerKey), MissingPairHistory>>,
-    missing_summary_active: Mutex<HashMap<(ContractKey, PeerKey), u16>>,
+    /// Per-key entries are updated through DashMap's shard-local `entry()`
+    /// API, so same-key increment/decrement stays atomic. The total-size
+    /// bound checked in `begin_active_attempt` is a soft diagnostic cap (not
+    /// a security invariant), so a benign cross-key race can occasionally
+    /// admit one entry past `MISSING_SUMMARY_ACTIVE_SIZE`.
+    missing_summary_active: DashMap<(ContractKey, PeerKey), u16>,
     interest_lifecycle_metrics: InterestLifecycleMetrics,
 }
 
@@ -1056,7 +1061,7 @@ impl<T: TimeSource + Sync> InterestManager<T> {
                 NonZeroUsize::new(MISSING_SUMMARY_HISTORY_SIZE)
                     .expect("MISSING_SUMMARY_HISTORY_SIZE must be > 0"),
             )),
-            missing_summary_active: Mutex::new(HashMap::new()),
+            missing_summary_active: DashMap::new(),
             interest_lifecycle_metrics: InterestLifecycleMetrics::new(),
         }
     }
@@ -1227,19 +1232,26 @@ impl<T: TimeSource + Sync> InterestManager<T> {
     }
 
     fn begin_active_attempt(&self, key: &(ContractKey, PeerKey)) -> (bool, bool) {
-        let mut active = self.missing_summary_active.lock();
-        if let Some(count) = active.get_mut(key) {
+        // NOTE: the occupied/vacant checks below are deliberately two
+        // separate DashMap calls (not a single `entry()` match) because
+        // `entry()` holds a write lock on the key's shard for the whole
+        // match arm, and calling `.len()` (or `.insert()`, which also locks
+        // a shard) from inside that arm risks a self-deadlock if it hashes
+        // to the same shard. Dropping the guard before checking `.len()` is
+        // deadlock-free at the cost of the benign cross-key race described
+        // on `missing_summary_active` above.
+        if let Some(mut count) = self.missing_summary_active.get_mut(key) {
             let inflight = *count > 0;
             *count = count.saturating_add(1);
             return (inflight, true);
         }
-        if active.len() >= MISSING_SUMMARY_ACTIVE_SIZE {
+        if self.missing_summary_active.len() >= MISSING_SUMMARY_ACTIVE_SIZE {
             self.interest_lifecycle_metrics
                 .active_overflow
                 .fetch_add(1, Ordering::Relaxed);
             return (false, false);
         }
-        active.insert(key.clone(), 1);
+        self.missing_summary_active.insert(key.clone(), 1);
         (false, true)
     }
 
@@ -1270,13 +1282,21 @@ impl<T: TimeSource + Sync> InterestManager<T> {
         delivered_bytes: Option<u64>,
     ) {
         if attempt.active_tracked {
-            let mut active = self.missing_summary_active.lock();
-            if let Some(count) = active.get_mut(&attempt.key) {
-                if *count <= 1 {
-                    active.remove(&attempt.key);
+            // Drop the shard guard before `.remove()` — see the deadlock
+            // note in `begin_active_attempt`.
+            let should_remove =
+                if let Some(mut count) = self.missing_summary_active.get_mut(&attempt.key) {
+                    if *count <= 1 {
+                        true
+                    } else {
+                        *count -= 1;
+                        false
+                    }
                 } else {
-                    *count -= 1;
-                }
+                    false
+                };
+            if should_remove {
+                self.missing_summary_active.remove(&attempt.key);
             }
         }
         if let Some(bytes) = delivered_bytes {

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -1005,8 +1005,10 @@ pub struct InterestManager<T: TimeSource> {
     /// Per-key entries are updated through DashMap's shard-local `entry()`
     /// API, so same-key increment/decrement stays atomic. The total-size
     /// bound checked in `begin_active_attempt` is a soft diagnostic cap (not
-    /// a security invariant), so a benign cross-key race can occasionally
-    /// admit one entry past `MISSING_SUMMARY_ACTIVE_SIZE`.
+    /// a security invariant): `.len()` is read before the per-key `entry()`
+    /// lock is taken, so concurrent first-time inserts for distinct new keys
+    /// can race past `MISSING_SUMMARY_ACTIVE_SIZE` (bounded by the number of
+    /// concurrent racers, not fixed at one).
     missing_summary_active: DashMap<(ContractKey, PeerKey), u16>,
     interest_lifecycle_metrics: InterestLifecycleMetrics,
 }
@@ -1232,27 +1234,34 @@ impl<T: TimeSource + Sync> InterestManager<T> {
     }
 
     fn begin_active_attempt(&self, key: &(ContractKey, PeerKey)) -> (bool, bool) {
-        // NOTE: the occupied/vacant checks below are deliberately two
-        // separate DashMap calls (not a single `entry()` match) because
-        // `entry()` holds a write lock on the key's shard for the whole
-        // match arm, and calling `.len()` (or `.insert()`, which also locks
-        // a shard) from inside that arm risks a self-deadlock if it hashes
-        // to the same shard. Dropping the guard before checking `.len()` is
-        // deadlock-free at the cost of the benign cross-key race described
-        // on `missing_summary_active` above.
-        if let Some(mut count) = self.missing_summary_active.get_mut(key) {
-            let inflight = *count > 0;
-            *count = count.saturating_add(1);
-            return (inflight, true);
+        // `.len()` is read BEFORE `.entry()` so no shard guard is held while
+        // it runs (it read-locks every shard; doing that while holding a
+        // write lock on one of them, from `entry()` below, would
+        // self-deadlock — DashMap's shard RwLock is not reentrant). The one
+        // `entry()` match that follows then holds a single shard's guard for
+        // its whole arm, so the occupied-increment and vacant-insert are each
+        // atomic per key: two callers racing on the same never-before-seen
+        // key can no longer clobber each other (only the cross-key cap
+        // check above stays a benign soft race, documented on the field).
+        let over_cap = self.missing_summary_active.len() >= MISSING_SUMMARY_ACTIVE_SIZE;
+        match self.missing_summary_active.entry(key.clone()) {
+            dashmap::mapref::entry::Entry::Occupied(mut entry) => {
+                let count = entry.get_mut();
+                let inflight = *count > 0;
+                *count = count.saturating_add(1);
+                (inflight, true)
+            }
+            dashmap::mapref::entry::Entry::Vacant(entry) => {
+                if over_cap {
+                    self.interest_lifecycle_metrics
+                        .active_overflow
+                        .fetch_add(1, Ordering::Relaxed);
+                    return (false, false);
+                }
+                entry.insert(1);
+                (false, true)
+            }
         }
-        if self.missing_summary_active.len() >= MISSING_SUMMARY_ACTIVE_SIZE {
-            self.interest_lifecycle_metrics
-                .active_overflow
-                .fetch_add(1, Ordering::Relaxed);
-            return (false, false);
-        }
-        self.missing_summary_active.insert(key.clone(), 1);
-        (false, true)
     }
 
     fn first_send_age_bucket(age: Duration) -> usize {
@@ -1282,21 +1291,18 @@ impl<T: TimeSource + Sync> InterestManager<T> {
         delivered_bytes: Option<u64>,
     ) {
         if attempt.active_tracked {
-            // Drop the shard guard before `.remove()` — see the deadlock
-            // note in `begin_active_attempt`.
-            let should_remove =
-                if let Some(mut count) = self.missing_summary_active.get_mut(&attempt.key) {
-                    if *count <= 1 {
-                        true
-                    } else {
-                        *count -= 1;
-                        false
-                    }
+            // Single `entry()` match: decrement-or-remove stays atomic per
+            // key, so a concurrent `begin_active_attempt` increment on this
+            // exact key can never be silently dropped by this decrement.
+            if let dashmap::mapref::entry::Entry::Occupied(mut entry) =
+                self.missing_summary_active.entry(attempt.key.clone())
+            {
+                let count = entry.get_mut();
+                if *count <= 1 {
+                    entry.remove();
                 } else {
-                    false
-                };
-            if should_remove {
-                self.missing_summary_active.remove(&attempt.key);
+                    *count -= 1;
+                }
             }
         }
         if let Some(bytes) = delivered_bytes {

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -133,6 +133,19 @@ pub(crate) const RESYNC_REQUEST_MIN_INTERVAL: Duration = Duration::from_secs(30)
 /// which is safe.
 const RESYNC_THROTTLE_CACHE_SIZE: usize = 4096;
 
+/// Bounds diagnostic correlation state influenced by remote (contract, peer)
+/// pairs. Eviction only loses classification detail; it never changes routing.
+const MISSING_SUMMARY_HISTORY_SIZE: usize = 4096;
+
+/// Bounds in-flight missing-summary send correlation. At capacity sends still
+/// proceed, and the visible overflow counter records the lost correlation.
+const MISSING_SUMMARY_ACTIVE_SIZE: usize = 256;
+
+/// Telemetry field order for the first missing-summary send age histogram:
+/// <1s, 1-9s, 10-59s, 60-299s, and >=300s.
+pub(crate) const FIRST_MISSING_SUMMARY_SEND_AGE_LABELS: [&str; 5] =
+    ["lt_1s", "1_9s", "10_59s", "60_299s", "gte_300s"];
+
 /// Node-wide cap on concurrently-outstanding queue-full-resync retry tasks
 /// (#4862 P1). The per-(contract, peer) throttle above is a bounded LRU; under
 /// saturation plus key churn (a peer cycling through more than
@@ -218,8 +231,10 @@ pub enum SummaryMissingReason {
 }
 
 impl SummaryMissingReason {
+    pub const COUNT: usize = 4;
+
     /// Every reason, in telemetry field order.
-    pub const ALL: [SummaryMissingReason; 4] = [
+    pub const ALL: [SummaryMissingReason; Self::COUNT] = [
         SummaryMissingReason::NeverPopulated,
         SummaryMissingReason::ClearedByNoneReport,
         SummaryMissingReason::ClearedByResync,
@@ -247,6 +262,294 @@ impl SummaryMissingReason {
     }
 }
 
+/// Stable, fixed-cardinality origin of an interest registration.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum InterestRegistrationSource {
+    Interests,
+    ChangeInterests,
+    SubscribeOriginator,
+    SubscribeDownstream,
+    SubscribeRelay,
+    Get,
+    Unknown,
+}
+
+impl InterestRegistrationSource {
+    pub(crate) const COUNT: usize = 7;
+    pub(crate) const ALL: [Self; Self::COUNT] = [
+        Self::Interests,
+        Self::ChangeInterests,
+        Self::SubscribeOriginator,
+        Self::SubscribeDownstream,
+        Self::SubscribeRelay,
+        Self::Get,
+        Self::Unknown,
+    ];
+
+    pub(crate) const fn index(self) -> usize {
+        self as usize
+    }
+
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Interests => "interests",
+            Self::ChangeInterests => "change_interests",
+            Self::SubscribeOriginator => "subscribe_originator",
+            Self::SubscribeDownstream => "subscribe_downstream",
+            Self::SubscribeRelay => "subscribe_relay",
+            Self::Get => "get",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+/// Stable reason an interest stopped being tracked.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum InterestRemovalCause {
+    InterestsReplace,
+    ChangeInterests,
+    Unsubscribe,
+    DisconnectGrace,
+    TtlExpiry,
+    Eviction,
+    Unknown,
+}
+
+impl InterestRemovalCause {
+    pub(crate) const COUNT: usize = 7;
+    pub(crate) const ALL: [Self; Self::COUNT] = [
+        Self::InterestsReplace,
+        Self::ChangeInterests,
+        Self::Unsubscribe,
+        Self::DisconnectGrace,
+        Self::TtlExpiry,
+        Self::Eviction,
+        Self::Unknown,
+    ];
+
+    pub(crate) const fn index(self) -> usize {
+        self as usize
+    }
+
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::InterestsReplace => "interests_replace",
+            Self::ChangeInterests => "change_interests",
+            Self::Unsubscribe => "unsubscribe",
+            Self::DisconnectGrace => "disconnect_grace",
+            Self::TtlExpiry => "ttl_expiry",
+            Self::Eviction => "eviction",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+/// Stable source of a peer-summary write.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SummaryPopulationSource {
+    Delivery,
+    InterestSummary,
+    DigestAgreement,
+    InboundBroadcast,
+    ResyncResponse,
+    Unknown,
+}
+
+impl SummaryPopulationSource {
+    pub(crate) const COUNT: usize = 6;
+    pub(crate) const ALL: [Self; Self::COUNT] = [
+        Self::Delivery,
+        Self::InterestSummary,
+        Self::DigestAgreement,
+        Self::InboundBroadcast,
+        Self::ResyncResponse,
+        Self::Unknown,
+    ];
+
+    pub(crate) const fn index(self) -> usize {
+        self as usize
+    }
+
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Delivery => "delivery",
+            Self::InterestSummary => "interest_summary",
+            Self::DigestAgreement => "digest_agreement",
+            Self::InboundBroadcast => "inbound_broadcast",
+            Self::ResyncResponse => "resync_response",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+/// Result of a summary population attempt.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SummaryPopulationOutcome {
+    FilledMissing,
+    RefreshedKnown,
+    CreatedUntracked,
+    RejectedAtCap,
+}
+
+impl SummaryPopulationOutcome {
+    pub(crate) const COUNT: usize = 4;
+    pub(crate) const ALL: [Self; Self::COUNT] = [
+        Self::FilledMissing,
+        Self::RefreshedKnown,
+        Self::CreatedUntracked,
+        Self::RejectedAtCap,
+    ];
+
+    pub(crate) const fn index(self) -> usize {
+        self as usize
+    }
+
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::FilledMissing => "filled_missing",
+            Self::RefreshedKnown => "refreshed_known",
+            Self::CreatedUntracked => "created_untracked",
+            Self::RejectedAtCap => "rejected_at_cap",
+        }
+    }
+}
+
+/// Why a delivered broadcast had no usable peer summary.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum MissingSummaryClass {
+    TrackedFirstNew,
+    TrackedFirstRecreated,
+    TrackedFirstOverwriteKnown,
+    TrackedFirstOverwriteMissing,
+    TrackedRepeatInflight,
+    TrackedRepeatSequential,
+    UntrackedFirstObserved,
+    UntrackedFirstRecreated,
+    UntrackedRepeatInflight,
+    UntrackedRepeatSequential,
+}
+
+impl MissingSummaryClass {
+    pub(crate) const COUNT: usize = 10;
+    pub(crate) const ALL: [Self; Self::COUNT] = [
+        Self::TrackedFirstNew,
+        Self::TrackedFirstRecreated,
+        Self::TrackedFirstOverwriteKnown,
+        Self::TrackedFirstOverwriteMissing,
+        Self::TrackedRepeatInflight,
+        Self::TrackedRepeatSequential,
+        Self::UntrackedFirstObserved,
+        Self::UntrackedFirstRecreated,
+        Self::UntrackedRepeatInflight,
+        Self::UntrackedRepeatSequential,
+    ];
+
+    pub(crate) const fn index(self) -> usize {
+        self as usize
+    }
+
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::TrackedFirstNew => "tracked_first_new",
+            Self::TrackedFirstRecreated => "tracked_first_recreated",
+            Self::TrackedFirstOverwriteKnown => "tracked_first_overwrite_known",
+            Self::TrackedFirstOverwriteMissing => "tracked_first_overwrite_missing",
+            Self::TrackedRepeatInflight => "tracked_repeat_inflight",
+            Self::TrackedRepeatSequential => "tracked_repeat_sequential",
+            Self::UntrackedFirstObserved => "untracked_first_observed",
+            Self::UntrackedFirstRecreated => "untracked_first_recreated",
+            Self::UntrackedRepeatInflight => "untracked_repeat_inflight",
+            Self::UntrackedRepeatSequential => "untracked_repeat_sequential",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum NeverPopulatedOrigin {
+    New { recreated: bool },
+    OverwriteKnown,
+    OverwriteMissing,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct MissingPairHistory {
+    send_starts: u32,
+    last_observed: Option<Instant>,
+    recent_removal: Option<(InterestRemovalCause, Instant)>,
+}
+
+/// Fixed-cardinality lifecycle counters copied into telemetry snapshots.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct InterestLifecycleSnapshot {
+    pub(crate) delivered_sends: [u64; MissingSummaryClass::COUNT],
+    pub(crate) delivered_bytes: [u64; MissingSummaryClass::COUNT],
+    pub(crate) first_send_age: [u64; 5],
+    pub(crate) registration_overwrite_known: [u64; InterestRegistrationSource::COUNT],
+    pub(crate) registration_overwrite_missing: [u64; InterestRegistrationSource::COUNT],
+    pub(crate) registration_new_known: [u64; InterestRegistrationSource::COUNT],
+    pub(crate) registration_new_missing: [u64; InterestRegistrationSource::COUNT],
+    pub(crate) removals: [u64; InterestRemovalCause::COUNT],
+    pub(crate) recreated_after_removal: [u64; InterestRemovalCause::COUNT],
+    pub(crate) population: [[u64; SummaryPopulationOutcome::COUNT]; SummaryPopulationSource::COUNT],
+    pub(crate) registration_cap_rejected: [u64; InterestRegistrationSource::COUNT],
+    /// Current entries: known, then missing by `SummaryMissingReason::ALL`.
+    pub(crate) current_summary_state: [u64; SummaryMissingReason::COUNT + 1],
+    pub(crate) history_overflow: u64,
+    pub(crate) active_overflow: u64,
+}
+
+struct InterestLifecycleMetrics {
+    delivered_sends: [AtomicU64; MissingSummaryClass::COUNT],
+    delivered_bytes: [AtomicU64; MissingSummaryClass::COUNT],
+    first_send_age: [AtomicU64; 5],
+    registration_overwrite_known: [AtomicU64; InterestRegistrationSource::COUNT],
+    registration_overwrite_missing: [AtomicU64; InterestRegistrationSource::COUNT],
+    registration_new_known: [AtomicU64; InterestRegistrationSource::COUNT],
+    registration_new_missing: [AtomicU64; InterestRegistrationSource::COUNT],
+    removals: [AtomicU64; InterestRemovalCause::COUNT],
+    recreated_after_removal: [AtomicU64; InterestRemovalCause::COUNT],
+    population: [[AtomicU64; SummaryPopulationOutcome::COUNT]; SummaryPopulationSource::COUNT],
+    registration_cap_rejected: [AtomicU64; InterestRegistrationSource::COUNT],
+    history_overflow: AtomicU64,
+    active_overflow: AtomicU64,
+}
+
+pub(crate) struct MissingSummaryAttempt {
+    key: (ContractKey, PeerKey),
+    class: MissingSummaryClass,
+    first_age_bucket: Option<usize>,
+    active_tracked: bool,
+}
+
+/// One atomic observation of the cached peer summary used by a broadcast.
+pub(crate) enum PeerSummaryForBroadcast {
+    Known(StateSummary<'static>),
+    Missing {
+        reason: Option<SummaryMissingReason>,
+        attempt: Option<MissingSummaryAttempt>,
+    },
+}
+
+impl InterestLifecycleMetrics {
+    fn new() -> Self {
+        Self {
+            delivered_sends: std::array::from_fn(|_| AtomicU64::new(0)),
+            delivered_bytes: std::array::from_fn(|_| AtomicU64::new(0)),
+            first_send_age: std::array::from_fn(|_| AtomicU64::new(0)),
+            registration_overwrite_known: std::array::from_fn(|_| AtomicU64::new(0)),
+            registration_overwrite_missing: std::array::from_fn(|_| AtomicU64::new(0)),
+            registration_new_known: std::array::from_fn(|_| AtomicU64::new(0)),
+            registration_new_missing: std::array::from_fn(|_| AtomicU64::new(0)),
+            removals: std::array::from_fn(|_| AtomicU64::new(0)),
+            recreated_after_removal: std::array::from_fn(|_| AtomicU64::new(0)),
+            population: std::array::from_fn(|_| std::array::from_fn(|_| AtomicU64::new(0))),
+            registration_cap_rejected: std::array::from_fn(|_| AtomicU64::new(0)),
+            history_overflow: AtomicU64::new(0),
+            active_overflow: AtomicU64::new(0),
+        }
+    }
+}
+
 /// Tracking information for a peer's interest in a specific contract.
 #[derive(Clone, Debug)]
 pub struct PeerInterest {
@@ -257,6 +560,13 @@ pub struct PeerInterest {
     /// is `Some` — always read it via [`Self::summary_missing_reason`], which
     /// returns `None` in that case rather than a misleading last-clear cause.
     summary_absence: SummaryMissingReason,
+
+    /// Diagnostic-only provenance for the current NeverPopulated epoch.
+    never_populated_origin: NeverPopulatedOrigin,
+
+    /// Start time and send-attempt count for that epoch.
+    never_populated_since: Instant,
+    never_populated_send_starts: u32,
 
     /// When this interest entry was last refreshed.
     /// Used for TTL-based expiration.
@@ -277,6 +587,9 @@ impl PeerInterest {
         Self {
             summary,
             summary_absence: SummaryMissingReason::NeverPopulated,
+            never_populated_origin: NeverPopulatedOrigin::New { recreated: false },
+            never_populated_since: now,
+            never_populated_send_starts: 0,
             last_refreshed: now,
             is_upstream,
         }
@@ -312,6 +625,11 @@ impl PeerInterest {
     pub fn clear_summary(&mut self, reason: SummaryMissingReason, now: Instant) {
         self.summary = None;
         self.summary_absence = reason;
+        if reason == SummaryMissingReason::NeverPopulated {
+            self.never_populated_origin = NeverPopulatedOrigin::New { recreated: false };
+            self.never_populated_since = now;
+            self.never_populated_send_starts = 0;
+        }
         self.refresh(now);
     }
 }
@@ -680,6 +998,35 @@ pub struct InterestManager<T: TimeSource> {
     /// outlive the borrow (it is moved into the spawned retry task and
     /// decrements the count on drop).
     resync_retry_slots: Arc<AtomicUsize>,
+
+    /// Bounded diagnostic-only state used to distinguish first, recreated,
+    /// in-flight duplicate, and sequential missing-summary sends.
+    missing_summary_history: Mutex<LruCache<(ContractKey, PeerKey), MissingPairHistory>>,
+    missing_summary_active: Mutex<HashMap<(ContractKey, PeerKey), u16>>,
+    interest_lifecycle_metrics: InterestLifecycleMetrics,
+}
+
+/// Delivery-gated lifecycle accounting. Dropping an unmarked guard records no
+/// bytes, so failed or cancelled sends cannot masquerade as network impact.
+pub(crate) struct MissingSummaryAttemptGuard<'a, T: TimeSource + Sync> {
+    manager: &'a InterestManager<T>,
+    attempt: Option<MissingSummaryAttempt>,
+    delivered_bytes: Option<u64>,
+}
+
+impl<T: TimeSource + Sync> MissingSummaryAttemptGuard<'_, T> {
+    pub(crate) fn mark_delivered(&mut self, bytes: usize) {
+        self.delivered_bytes = Some(bytes as u64);
+    }
+}
+
+impl<T: TimeSource + Sync> Drop for MissingSummaryAttemptGuard<'_, T> {
+    fn drop(&mut self) {
+        if let Some(attempt) = self.attempt.take() {
+            self.manager
+                .finish_missing_summary_attempt(attempt, self.delivered_bytes);
+        }
+    }
 }
 
 impl<T: TimeSource + Sync> InterestManager<T> {
@@ -705,6 +1052,12 @@ impl<T: TimeSource + Sync> InterestManager<T> {
                 NonZeroUsize::new(RESYNC_THROTTLE_CACHE_SIZE)
                     .expect("RESYNC_THROTTLE_CACHE_SIZE must be > 0"),
             )),
+            missing_summary_history: Mutex::new(LruCache::new(
+                NonZeroUsize::new(MISSING_SUMMARY_HISTORY_SIZE)
+                    .expect("MISSING_SUMMARY_HISTORY_SIZE must be > 0"),
+            )),
+            missing_summary_active: Mutex::new(HashMap::new()),
+            interest_lifecycle_metrics: InterestLifecycleMetrics::new(),
         }
     }
 
@@ -744,6 +1097,255 @@ impl<T: TimeSource + Sync> InterestManager<T> {
         self.time_source.now()
     }
 
+    /// Atomically reads the peer summary and, when it is NeverPopulated (or
+    /// the peer is untracked), starts bounded lifecycle correlation for the
+    /// broadcast that will use that observation.
+    pub(crate) fn begin_peer_summary_broadcast(
+        &self,
+        contract: &ContractKey,
+        peer: &PeerKey,
+    ) -> PeerSummaryForBroadcast {
+        let now = self.time_source.now();
+        // The overwhelmingly common known-summary path is read-only. Keep it
+        // on a shared shard guard; only NeverPopulated needs mutation for the
+        // bounded attempt correlation below.
+        if let Some(peers) = self.interested_peers.get(contract)
+            && let Some(interest) = peers.get(peer)
+        {
+            if let Some(summary) = interest.summary.clone() {
+                return PeerSummaryForBroadcast::Known(summary);
+            }
+            let reason = interest.summary_missing_reason();
+            if reason != Some(SummaryMissingReason::NeverPopulated) {
+                return PeerSummaryForBroadcast::Missing {
+                    reason,
+                    attempt: None,
+                };
+            }
+        }
+
+        // Re-check after upgrading to an exclusive guard: a population or
+        // removal may have raced the shared observation above.
+        if let Some(mut peers) = self.interested_peers.get_mut(contract)
+            && let Some(interest) = peers.get_mut(peer)
+        {
+            if let Some(summary) = interest.summary.clone() {
+                return PeerSummaryForBroadcast::Known(summary);
+            }
+            let reason = interest.summary_missing_reason();
+            if reason != Some(SummaryMissingReason::NeverPopulated) {
+                return PeerSummaryForBroadcast::Missing {
+                    reason,
+                    attempt: None,
+                };
+            }
+
+            let key = (*contract, peer.clone());
+            let (inflight, active_tracked) = self.begin_active_attempt(&key);
+            let first = interest.never_populated_send_starts == 0;
+            let class = if inflight {
+                MissingSummaryClass::TrackedRepeatInflight
+            } else if !first {
+                MissingSummaryClass::TrackedRepeatSequential
+            } else {
+                match interest.never_populated_origin {
+                    NeverPopulatedOrigin::New { recreated: false } => {
+                        MissingSummaryClass::TrackedFirstNew
+                    }
+                    NeverPopulatedOrigin::New { recreated: true } => {
+                        MissingSummaryClass::TrackedFirstRecreated
+                    }
+                    NeverPopulatedOrigin::OverwriteKnown => {
+                        MissingSummaryClass::TrackedFirstOverwriteKnown
+                    }
+                    NeverPopulatedOrigin::OverwriteMissing => {
+                        MissingSummaryClass::TrackedFirstOverwriteMissing
+                    }
+                }
+            };
+            interest.never_populated_send_starts =
+                interest.never_populated_send_starts.saturating_add(1);
+            let first_age_bucket = first.then(|| {
+                Self::first_send_age_bucket(
+                    now.saturating_duration_since(interest.never_populated_since),
+                )
+            });
+            return PeerSummaryForBroadcast::Missing {
+                reason,
+                attempt: Some(MissingSummaryAttempt {
+                    key,
+                    class,
+                    first_age_bucket,
+                    active_tracked,
+                }),
+            };
+        }
+
+        let key = (*contract, peer.clone());
+        let mut history = self.missing_summary_history.lock();
+        let was_present = history.peek(&key).is_some();
+        let mut record = history.get(&key).copied().unwrap_or_default();
+        if record
+            .last_observed
+            .is_some_and(|observed| now.saturating_duration_since(observed) > INTEREST_TTL)
+        {
+            record.send_starts = 0;
+            record.recent_removal = None;
+        }
+        let first = record.send_starts == 0;
+        let recreated = record
+            .recent_removal
+            .filter(|(_, removed_at)| now.saturating_duration_since(*removed_at) <= INTEREST_TTL)
+            .is_some();
+        let (inflight, active_tracked) = self.begin_active_attempt(&key);
+        let class = if inflight {
+            MissingSummaryClass::UntrackedRepeatInflight
+        } else if !first {
+            MissingSummaryClass::UntrackedRepeatSequential
+        } else if recreated {
+            MissingSummaryClass::UntrackedFirstRecreated
+        } else {
+            MissingSummaryClass::UntrackedFirstObserved
+        };
+        record.send_starts = record.send_starts.saturating_add(1);
+        record.last_observed = Some(now);
+        if !was_present && history.len() == MISSING_SUMMARY_HISTORY_SIZE {
+            self.interest_lifecycle_metrics
+                .history_overflow
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        history.put(key.clone(), record);
+        PeerSummaryForBroadcast::Missing {
+            reason: None,
+            attempt: Some(MissingSummaryAttempt {
+                key,
+                class,
+                first_age_bucket: None,
+                active_tracked,
+            }),
+        }
+    }
+
+    fn begin_active_attempt(&self, key: &(ContractKey, PeerKey)) -> (bool, bool) {
+        let mut active = self.missing_summary_active.lock();
+        if let Some(count) = active.get_mut(key) {
+            let inflight = *count > 0;
+            *count = count.saturating_add(1);
+            return (inflight, true);
+        }
+        if active.len() >= MISSING_SUMMARY_ACTIVE_SIZE {
+            self.interest_lifecycle_metrics
+                .active_overflow
+                .fetch_add(1, Ordering::Relaxed);
+            return (false, false);
+        }
+        active.insert(key.clone(), 1);
+        (false, true)
+    }
+
+    fn first_send_age_bucket(age: Duration) -> usize {
+        match age.as_secs() {
+            0 => 0,
+            1..=9 => 1,
+            10..=59 => 2,
+            60..=299 => 3,
+            _ => 4,
+        }
+    }
+
+    pub(crate) fn missing_summary_attempt_guard(
+        &self,
+        attempt: MissingSummaryAttempt,
+    ) -> MissingSummaryAttemptGuard<'_, T> {
+        MissingSummaryAttemptGuard {
+            manager: self,
+            attempt: Some(attempt),
+            delivered_bytes: None,
+        }
+    }
+
+    fn finish_missing_summary_attempt(
+        &self,
+        attempt: MissingSummaryAttempt,
+        delivered_bytes: Option<u64>,
+    ) {
+        if attempt.active_tracked {
+            let mut active = self.missing_summary_active.lock();
+            if let Some(count) = active.get_mut(&attempt.key) {
+                if *count <= 1 {
+                    active.remove(&attempt.key);
+                } else {
+                    *count -= 1;
+                }
+            }
+        }
+        if let Some(bytes) = delivered_bytes {
+            let index = attempt.class.index();
+            self.interest_lifecycle_metrics.delivered_sends[index].fetch_add(1, Ordering::Relaxed);
+            self.interest_lifecycle_metrics.delivered_bytes[index]
+                .fetch_add(bytes, Ordering::Relaxed);
+            if let Some(bucket) = attempt.first_age_bucket {
+                self.interest_lifecycle_metrics.first_send_age[bucket]
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
+
+    pub(crate) fn interest_lifecycle_snapshot(&self) -> InterestLifecycleSnapshot {
+        let load = |value: &AtomicU64| value.load(Ordering::Relaxed);
+        let mut current_summary_state = [0u64; SummaryMissingReason::COUNT + 1];
+        for contract_entry in &self.interested_peers {
+            for interest in contract_entry.value().values() {
+                let index = interest
+                    .summary_missing_reason()
+                    .map_or(0, |reason| reason.index() + 1);
+                current_summary_state[index] = current_summary_state[index].saturating_add(1);
+            }
+        }
+        InterestLifecycleSnapshot {
+            delivered_sends: std::array::from_fn(|i| {
+                load(&self.interest_lifecycle_metrics.delivered_sends[i])
+            }),
+            delivered_bytes: std::array::from_fn(|i| {
+                load(&self.interest_lifecycle_metrics.delivered_bytes[i])
+            }),
+            first_send_age: std::array::from_fn(|i| {
+                load(&self.interest_lifecycle_metrics.first_send_age[i])
+            }),
+            registration_overwrite_known: std::array::from_fn(|i| {
+                load(&self.interest_lifecycle_metrics.registration_overwrite_known[i])
+            }),
+            registration_overwrite_missing: std::array::from_fn(|i| {
+                load(
+                    &self
+                        .interest_lifecycle_metrics
+                        .registration_overwrite_missing[i],
+                )
+            }),
+            registration_new_known: std::array::from_fn(|i| {
+                load(&self.interest_lifecycle_metrics.registration_new_known[i])
+            }),
+            registration_new_missing: std::array::from_fn(|i| {
+                load(&self.interest_lifecycle_metrics.registration_new_missing[i])
+            }),
+            removals: std::array::from_fn(|i| load(&self.interest_lifecycle_metrics.removals[i])),
+            recreated_after_removal: std::array::from_fn(|i| {
+                load(&self.interest_lifecycle_metrics.recreated_after_removal[i])
+            }),
+            population: std::array::from_fn(|source| {
+                std::array::from_fn(|outcome| {
+                    load(&self.interest_lifecycle_metrics.population[source][outcome])
+                })
+            }),
+            registration_cap_rejected: std::array::from_fn(|i| {
+                load(&self.interest_lifecycle_metrics.registration_cap_rejected[i])
+            }),
+            current_summary_state,
+            history_overflow: load(&self.interest_lifecycle_metrics.history_overflow),
+            active_overflow: load(&self.interest_lifecycle_metrics.active_overflow),
+        }
+    }
+
     /// Register a peer's interest in a contract.
     ///
     /// Returns true if this is a new interest (peer wasn't previously tracked).
@@ -753,6 +1355,23 @@ impl<T: TimeSource + Sync> InterestManager<T> {
         peer: PeerKey,
         summary: Option<StateSummary<'static>>,
         is_upstream: bool,
+    ) -> bool {
+        self.register_peer_interest_from(
+            contract,
+            peer,
+            summary,
+            is_upstream,
+            InterestRegistrationSource::Unknown,
+        )
+    }
+
+    pub(crate) fn register_peer_interest_from(
+        &self,
+        contract: &ContractKey,
+        peer: PeerKey,
+        summary: Option<StateSummary<'static>>,
+        is_upstream: bool,
+        source: InterestRegistrationSource,
     ) -> bool {
         let now = self.time_source.now();
         // Hold the `interested_peers` shard guard across `peer_contracts`
@@ -774,6 +1393,8 @@ impl<T: TimeSource + Sync> InterestManager<T> {
         // Returns `is_new = false` so a rejected adversary is not treated as a
         // new viable target and cannot trigger the #4359 pending-broadcast flush.
         if is_new && entry.len() >= MAX_INTERESTED_PEERS_PER_CONTRACT {
+            self.interest_lifecycle_metrics.registration_cap_rejected[source.index()]
+                .fetch_add(1, Ordering::Relaxed);
             drop(entry);
             tracing::warn!(
                 contract = %contract,
@@ -783,7 +1404,47 @@ impl<T: TimeSource + Sync> InterestManager<T> {
             return false;
         }
 
-        entry.insert(peer.clone(), PeerInterest::new(summary, is_upstream, now));
+        if is_new {
+            let counters = if summary.is_some() {
+                &self.interest_lifecycle_metrics.registration_new_known
+            } else {
+                &self.interest_lifecycle_metrics.registration_new_missing
+            };
+            counters[source.index()].fetch_add(1, Ordering::Relaxed);
+        }
+
+        let mut interest = PeerInterest::new(summary, is_upstream, now);
+        if interest.summary.is_none() {
+            if let Some(previous) = entry.get(&peer) {
+                if previous.summary.is_some() {
+                    interest.never_populated_origin = NeverPopulatedOrigin::OverwriteKnown;
+                    self.interest_lifecycle_metrics.registration_overwrite_known[source.index()]
+                        .fetch_add(1, Ordering::Relaxed);
+                } else {
+                    interest.never_populated_origin = NeverPopulatedOrigin::OverwriteMissing;
+                    self.interest_lifecycle_metrics
+                        .registration_overwrite_missing[source.index()]
+                    .fetch_add(1, Ordering::Relaxed);
+                }
+            } else {
+                let recreated = self
+                    .missing_summary_history
+                    .lock()
+                    .get(&(*contract, peer.clone()))
+                    .and_then(|history| history.recent_removal)
+                    .filter(|(_, removed_at)| {
+                        now.saturating_duration_since(*removed_at) <= INTEREST_TTL
+                    });
+                interest.never_populated_origin = NeverPopulatedOrigin::New {
+                    recreated: recreated.is_some(),
+                };
+                if let Some((cause, _)) = recreated {
+                    self.interest_lifecycle_metrics.recreated_after_removal[cause.index()]
+                        .fetch_add(1, Ordering::Relaxed);
+                }
+            }
+        }
+        entry.insert(peer.clone(), interest);
 
         // Maintain reverse index for O(1) peer disconnect cleanup
         self.peer_contracts
@@ -802,10 +1463,42 @@ impl<T: TimeSource + Sync> InterestManager<T> {
     ///
     /// Returns true if the peer was actually removed.
     pub fn remove_peer_interest(&self, contract: &ContractKey, peer: &PeerKey) -> bool {
+        self.remove_peer_interest_for(contract, peer, InterestRemovalCause::Unknown)
+    }
+
+    pub(crate) fn remove_peer_interest_for(
+        &self,
+        contract: &ContractKey,
+        peer: &PeerKey,
+        cause: InterestRemovalCause,
+    ) -> bool {
         if let Some(mut entry) = self.interested_peers.get_mut(contract) {
-            let removed = entry.remove(peer).is_some();
+            let removed_interest = entry.remove(peer);
+            let removed = removed_interest.is_some();
 
             if removed {
+                self.interest_lifecycle_metrics.removals[cause.index()]
+                    .fetch_add(1, Ordering::Relaxed);
+                let now = self.time_source.now();
+                let key = (*contract, peer.clone());
+                let mut history = self.missing_summary_history.lock();
+                let was_present = history.peek(&key).is_some();
+                let mut record = history.get(&key).copied().unwrap_or_default();
+                if let Some(interest) = removed_interest.as_ref()
+                    && interest.summary_missing_reason()
+                        == Some(SummaryMissingReason::NeverPopulated)
+                {
+                    record.send_starts =
+                        record.send_starts.max(interest.never_populated_send_starts);
+                }
+                record.recent_removal = Some((cause, now));
+                if !was_present && history.len() == MISSING_SUMMARY_HISTORY_SIZE {
+                    self.interest_lifecycle_metrics
+                        .history_overflow
+                        .fetch_add(1, Ordering::Relaxed);
+                }
+                history.put(key, record);
+
                 // Maintain reverse index
                 if let Some(mut peer_entry) = self.peer_contracts.get_mut(peer) {
                     peer_entry.remove(contract);
@@ -900,6 +1593,17 @@ impl<T: TimeSource + Sync> InterestManager<T> {
         peer: &PeerKey,
         summary: StateSummary<'static>,
     ) -> bool {
+        self.upsert_peer_summary_from(contract, peer, summary, SummaryPopulationSource::Unknown)
+            != SummaryPopulationOutcome::RejectedAtCap
+    }
+
+    pub(crate) fn upsert_peer_summary_from(
+        &self,
+        contract: &ContractKey,
+        peer: &PeerKey,
+        summary: StateSummary<'static>,
+        source: SummaryPopulationSource,
+    ) -> SummaryPopulationOutcome {
         let now = self.time_source.now();
         // Hold the `interested_peers` shard guard across the `peer_contracts`
         // and hash-index writes — same #4129/#4171 discipline as
@@ -907,8 +1611,18 @@ impl<T: TimeSource + Sync> InterestManager<T> {
         // leaving a zombie reverse-index entry.
         let mut entry = self.interested_peers.entry(*contract).or_default();
         if let Some(interest) = entry.get_mut(peer) {
+            let outcome = if interest.summary.is_some() {
+                SummaryPopulationOutcome::RefreshedKnown
+            } else {
+                SummaryPopulationOutcome::FilledMissing
+            };
             interest.set_summary(summary, now);
-            return true;
+            self.missing_summary_history
+                .lock()
+                .pop(&(*contract, peer.clone()));
+            self.interest_lifecycle_metrics.population[source.index()][outcome.index()]
+                .fetch_add(1, Ordering::Relaxed);
+            return outcome;
         }
         if entry.len() >= MAX_INTERESTED_PEERS_PER_CONTRACT {
             // At cap the entry is non-empty, so no cleanup is needed; the
@@ -924,7 +1638,10 @@ impl<T: TimeSource + Sync> InterestManager<T> {
                 limit = MAX_INTERESTED_PEERS_PER_CONTRACT,
                 "upsert_peer_summary: at interested-peer cap, peer stays untracked (full-state sends continue)"
             );
-            return false;
+            let outcome = SummaryPopulationOutcome::RejectedAtCap;
+            self.interest_lifecycle_metrics.population[source.index()][outcome.index()]
+                .fetch_add(1, Ordering::Relaxed);
+            return outcome;
         }
         entry.insert(peer.clone(), PeerInterest::new(Some(summary), false, now));
         self.peer_contracts
@@ -932,8 +1649,14 @@ impl<T: TimeSource + Sync> InterestManager<T> {
             .or_default()
             .insert(*contract);
         self.index_contract_hash(contract);
+        self.missing_summary_history
+            .lock()
+            .pop(&(*contract, peer.clone()));
+        let outcome = SummaryPopulationOutcome::CreatedUntracked;
+        self.interest_lifecycle_metrics.population[source.index()][outcome.index()]
+            .fetch_add(1, Ordering::Relaxed);
         drop(entry);
-        true
+        outcome
     }
 
     /// Refresh the TTL for a peer's interest, leaving `is_upstream` and any
@@ -1194,6 +1917,10 @@ impl<T: TimeSource + Sync> InterestManager<T> {
     /// `peer ∈ peer_contracts[peer] ⇔ peer ∈ interested_peers[contract]`
     /// is preserved even under a concurrent re-registration.
     pub fn remove_all_peer_interests(&self, peer: &PeerKey) -> usize {
+        self.remove_all_peer_interests_for(peer, InterestRemovalCause::Unknown)
+    }
+
+    fn remove_all_peer_interests_for(&self, peer: &PeerKey, cause: InterestRemovalCause) -> usize {
         // Snapshot the contracts this peer is interested in WITHOUT
         // removing the reverse-index entry — `remove_peer_interest`
         // owns the `peer_contracts` update for each contract so the
@@ -1213,7 +1940,7 @@ impl<T: TimeSource + Sync> InterestManager<T> {
         // already cleared an entry between the snapshot and here).
         let removed_count = contracts
             .iter()
-            .filter(|contract| self.remove_peer_interest(contract, peer))
+            .filter(|contract| self.remove_peer_interest_for(contract, peer, cause))
             .count();
 
         if removed_count > 0 {
@@ -1272,7 +1999,8 @@ impl<T: TimeSource + Sync> InterestManager<T> {
             // already removed it (peer reconnected between collect and here), skip
             // the interest removal to avoid a TOCTOU race.
             if self.pending_removals.remove(peer).is_some() {
-                let removed = self.remove_all_peer_interests(peer);
+                let removed =
+                    self.remove_all_peer_interests_for(peer, InterestRemovalCause::DisconnectGrace);
                 tracing::info!(
                     peer = %peer.0,
                     removed_interests = removed,
@@ -1418,7 +2146,7 @@ impl<T: TimeSource + Sync> InterestManager<T> {
         local_client_count: usize,
     ) {
         for peer in downstream_peers {
-            self.remove_peer_interest(contract, peer);
+            self.remove_peer_interest_for(contract, peer, InterestRemovalCause::Eviction);
             self.remove_downstream_subscriber(contract);
         }
         for _ in 0..local_client_count {
@@ -1507,7 +2235,7 @@ impl<T: TimeSource + Sync> InterestManager<T> {
 
         // Remove expired entries
         for (contract, peer) in &expired {
-            self.remove_peer_interest(contract, peer);
+            self.remove_peer_interest_for(contract, peer, InterestRemovalCause::TtlExpiry);
         }
 
         if !expired.is_empty() {
@@ -2335,6 +3063,249 @@ mod tests {
 
         // Remove again returns false
         assert!(!manager.remove_peer_interest(&contract, &peer));
+    }
+
+    #[test]
+    fn missing_summary_lifecycle_is_delivery_gated_and_classifies_repeats() {
+        let (manager, _time) = make_manager();
+        let contract = make_contract_key(71);
+        let peer = make_peer_key(71);
+        manager.register_peer_interest_from(
+            &contract,
+            peer.clone(),
+            None,
+            false,
+            InterestRegistrationSource::Interests,
+        );
+
+        let PeerSummaryForBroadcast::Missing {
+            attempt: Some(attempt),
+            ..
+        } = manager.begin_peer_summary_broadcast(&contract, &peer)
+        else {
+            panic!("new summaryless interest must start lifecycle accounting");
+        };
+        assert_eq!(attempt.class, MissingSummaryClass::TrackedFirstNew);
+        // A failed/cancelled send must release the in-flight slot but record no
+        // delivered bytes.
+        drop(manager.missing_summary_attempt_guard(attempt));
+        assert_eq!(
+            manager.interest_lifecycle_snapshot().delivered_sends,
+            [0; MissingSummaryClass::COUNT]
+        );
+
+        let PeerSummaryForBroadcast::Missing {
+            attempt: Some(attempt),
+            ..
+        } = manager.begin_peer_summary_broadcast(&contract, &peer)
+        else {
+            panic!("summary is still missing");
+        };
+        assert_eq!(attempt.class, MissingSummaryClass::TrackedRepeatSequential);
+        let mut guard = manager.missing_summary_attempt_guard(attempt);
+        guard.mark_delivered(3 * 1024 * 1024);
+        drop(guard);
+        let snapshot = manager.interest_lifecycle_snapshot();
+        assert_eq!(
+            snapshot.delivered_sends[MissingSummaryClass::TrackedRepeatSequential.index()],
+            1
+        );
+        assert_eq!(
+            snapshot.delivered_bytes[MissingSummaryClass::TrackedRepeatSequential.index()],
+            3 * 1024 * 1024
+        );
+    }
+
+    #[test]
+    fn lifecycle_records_overwrite_recreation_and_population_sources() {
+        let (manager, _time) = make_manager();
+        let contract = make_contract_key(72);
+        let peer = make_peer_key(72);
+        let summary = StateSummary::from(vec![1, 2, 3]);
+        manager.register_peer_interest_from(
+            &contract,
+            peer.clone(),
+            Some(summary.clone()),
+            false,
+            InterestRegistrationSource::Interests,
+        );
+        assert!(!manager.register_peer_interest_from(
+            &contract,
+            peer.clone(),
+            None,
+            false,
+            InterestRegistrationSource::ChangeInterests,
+        ));
+        let snapshot = manager.interest_lifecycle_snapshot();
+        assert_eq!(
+            snapshot.registration_overwrite_known
+                [InterestRegistrationSource::ChangeInterests.index()],
+            1
+        );
+
+        assert!(manager.remove_peer_interest_for(
+            &contract,
+            &peer,
+            InterestRemovalCause::InterestsReplace,
+        ));
+        assert!(manager.register_peer_interest_from(
+            &contract,
+            peer.clone(),
+            None,
+            false,
+            InterestRegistrationSource::Interests,
+        ));
+        let PeerSummaryForBroadcast::Missing {
+            attempt: Some(attempt),
+            ..
+        } = manager.begin_peer_summary_broadcast(&contract, &peer)
+        else {
+            panic!("recreated entry must be summaryless");
+        };
+        assert_eq!(attempt.class, MissingSummaryClass::TrackedFirstRecreated);
+        drop(manager.missing_summary_attempt_guard(attempt));
+
+        assert_eq!(
+            manager.upsert_peer_summary_from(
+                &contract,
+                &peer,
+                summary,
+                SummaryPopulationSource::InterestSummary,
+            ),
+            SummaryPopulationOutcome::FilledMissing
+        );
+        let snapshot = manager.interest_lifecycle_snapshot();
+        assert_eq!(
+            snapshot.recreated_after_removal[InterestRemovalCause::InterestsReplace.index()],
+            1
+        );
+        assert_eq!(
+            snapshot.population[SummaryPopulationSource::InterestSummary.index()]
+                [SummaryPopulationOutcome::FilledMissing.index()],
+            1
+        );
+    }
+
+    #[test]
+    fn lifecycle_snapshot_has_registration_removal_current_and_inflight_denominators() {
+        let (manager, _time) = make_manager();
+        let contract = make_contract_key(73);
+        let known_peer = make_peer_key(73);
+        let missing_peer = make_peer_key(74);
+        assert!(manager.register_peer_interest_from(
+            &contract,
+            known_peer.clone(),
+            Some(StateSummary::from(vec![1])),
+            false,
+            InterestRegistrationSource::Get,
+        ));
+        assert!(manager.register_peer_interest_from(
+            &contract,
+            missing_peer.clone(),
+            None,
+            false,
+            InterestRegistrationSource::SubscribeRelay,
+        ));
+
+        let first = match manager.begin_peer_summary_broadcast(&contract, &missing_peer) {
+            PeerSummaryForBroadcast::Missing {
+                attempt: Some(attempt),
+                ..
+            } => attempt,
+            _ => panic!("missing peer must produce a tracked attempt"),
+        };
+        let second = match manager.begin_peer_summary_broadcast(&contract, &missing_peer) {
+            PeerSummaryForBroadcast::Missing {
+                attempt: Some(attempt),
+                ..
+            } => attempt,
+            _ => panic!("overlapping missing send must produce another attempt"),
+        };
+        assert_eq!(second.class, MissingSummaryClass::TrackedRepeatInflight);
+        drop(manager.missing_summary_attempt_guard(first));
+        drop(manager.missing_summary_attempt_guard(second));
+        assert!(manager.remove_peer_interest_for(
+            &contract,
+            &known_peer,
+            InterestRemovalCause::Unsubscribe,
+        ));
+
+        let snapshot = manager.interest_lifecycle_snapshot();
+        assert_eq!(
+            snapshot.registration_new_known[InterestRegistrationSource::Get.index()],
+            1
+        );
+        assert_eq!(
+            snapshot.registration_new_missing[InterestRegistrationSource::SubscribeRelay.index()],
+            1
+        );
+        assert_eq!(
+            snapshot.removals[InterestRemovalCause::Unsubscribe.index()],
+            1
+        );
+        assert_eq!(snapshot.current_summary_state[0], 0);
+        assert_eq!(
+            snapshot.current_summary_state[SummaryMissingReason::NeverPopulated.index() + 1],
+            1
+        );
+    }
+
+    #[test]
+    fn lifecycle_first_send_age_bucket_boundaries_are_exact() {
+        for (seconds, expected) in [
+            (0, 0),
+            (1, 1),
+            (9, 1),
+            (10, 2),
+            (59, 2),
+            (60, 3),
+            (299, 3),
+            (300, 4),
+        ] {
+            assert_eq!(
+                TestInterestManager::first_send_age_bucket(Duration::from_secs(seconds)),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn lifecycle_correlation_overflow_is_bounded_and_observable() {
+        let (manager, _time) = make_manager();
+
+        for seed in 0..=MISSING_SUMMARY_HISTORY_SIZE as u32 {
+            let attempt = match manager.begin_peer_summary_broadcast(
+                &make_unique_contract_key(seed),
+                &make_unique_peer_key(seed),
+            ) {
+                PeerSummaryForBroadcast::Missing {
+                    attempt: Some(attempt),
+                    ..
+                } => attempt,
+                _ => panic!("untracked pair must produce an attempt"),
+            };
+            drop(manager.missing_summary_attempt_guard(attempt));
+        }
+
+        let mut guards = Vec::new();
+        for seed in 10_000..10_000 + MISSING_SUMMARY_ACTIVE_SIZE as u32 + 1 {
+            let attempt = match manager.begin_peer_summary_broadcast(
+                &make_unique_contract_key(seed),
+                &make_unique_peer_key(seed),
+            ) {
+                PeerSummaryForBroadcast::Missing {
+                    attempt: Some(attempt),
+                    ..
+                } => attempt,
+                _ => panic!("untracked pair must produce an attempt"),
+            };
+            guards.push(manager.missing_summary_attempt_guard(attempt));
+        }
+
+        let snapshot = manager.interest_lifecycle_snapshot();
+        assert!(snapshot.history_overflow >= 1);
+        assert_eq!(snapshot.active_overflow, 1);
+        drop(guards);
     }
 
     /// Regression for the InterestManager desync on subscribed eviction
@@ -3414,7 +4385,7 @@ mod tests {
         let stripped = prod_source(include_str!("../operations/subscribe.rs"));
 
         let bare = stripped
-            .matches("register_peer_interest(&key,peer_key,None,true)")
+            .matches("register_peer_interest_from(&key,peer_key,None,true,")
             .count();
         let guarded = stripped
             .matches("refresh_peer_interest_with_upstream(&key,&peer_key,true)")
@@ -3436,7 +4407,7 @@ mod tests {
         assert_eq!(
             stripped
                 .matches(
-                    "refresh_peer_interest_with_upstream(&key,&peer_key,true){false}else{op_manager.interest_manager.register_peer_interest(&key,peer_key,None,true)"
+                    "refresh_peer_interest_with_upstream(&key,&peer_key,true){false}else{op_manager.interest_manager.register_peer_interest_from(&key,peer_key,None,true,"
                 )
                 .count(),
             2,
@@ -3449,7 +4420,7 @@ mod tests {
         // asserting that on an existing entry would downgrade a real upstream.
         assert!(
             stripped.contains(
-                "refresh_peer_interest(key,&peer_key){op_manager.interest_manager.register_peer_interest(key,peer_key,None,false)"
+                "refresh_peer_interest(key,&peer_key){op_manager.interest_manager.register_peer_interest_from(key,peer_key,None,false,"
             ),
             "register_downstream_subscriber must register only when the refresh \
              reports no existing entry (a bare register wipes the cached summary \
@@ -3473,7 +4444,7 @@ mod tests {
         // so a register that runs regardless of the refresh fails here.
         assert!(
             stripped.contains(
-                "refresh_peer_interest(&key,&peer_key){false}else{op_manager.interest_manager.register_peer_interest(&key,peer_key,None,false)"
+                "refresh_peer_interest(&key,&peer_key){false}else{op_manager.interest_manager.register_peer_interest_from(&key,peer_key,None,false,"
             ),
             "the remote-GET registration must register ONLY when the refresh \
              reports no existing entry — otherwise it inserts a fresh \
@@ -3485,7 +4456,7 @@ mod tests {
         // register elsewhere would leave the assertion above green while
         // reintroducing the clobber.
         assert_eq!(
-            stripped.matches("register_peer_interest(").count(),
+            stripped.matches("register_peer_interest_from(").count(),
             1,
             "get/op_ctx_task.rs must contain exactly ONE register_peer_interest \
              call — the guarded one; a second is an unguarded clobber"

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -9,7 +9,12 @@ use serde::{Deserialize, Serialize};
 
 use crate::config::GlobalRng;
 use crate::node::network_status::OpType;
+use crate::ring::interest::{
+    InterestRegistrationSource, InterestRemovalCause, MissingSummaryClass,
+    SummaryPopulationOutcome, SummaryPopulationSource,
+};
 use crate::ring::{Distance, Location, PeerKeyLocation};
+use crate::tracing::event_kind::STATE_SIZE_BUCKET_COUNT;
 pub(crate) use isotonic_estimator::{
     AdjustmentMode, EstimatorType, IsotonicEstimator, IsotonicEvent,
 };
@@ -125,10 +130,101 @@ pub(crate) struct PerOpCurves {
     pub transfer_rate_points: Vec<(f64, f64)>,
 }
 
+/// Compact, fixed-cardinality evidence for the large-state architecture
+/// decision (#5090).
+///
+/// Field names are intentionally short because every reporting peer sends this
+/// block every 30 minutes. Array orders are the corresponding enum `ALL`
+/// constants in `ring::interest`, receiver order is
+/// `[delta_changed, delta_noop, full_changed, full_noop]`, state-size order is
+/// `tracing::event_kind::STATE_SIZE_BUCKET_UPPER_BOUNDS` plus the overflow bin,
+/// queue order is documented at the population site, and shadow-rollup order is
+/// `tracing::telemetry::KnownShadowRollup::ALL`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(test, derive(arbitrary::Arbitrary))]
+pub(crate) struct NetworkEfficiencyV1 {
+    /// Schema version.
+    pub v: u8,
+    /// Delivered missing-summary sends and bytes by `MissingSummaryClass`.
+    pub ms_s: [u64; MissingSummaryClass::COUNT],
+    pub ms_b: [u64; MissingSummaryClass::COUNT],
+    /// First-send entry-age buckets: <1s, 1-9s, 10-59s, 1-4m59s, >=5m.
+    pub ms_age: [u64; 5],
+    /// Registration overwrites of populated/empty entries, and cap rejects.
+    pub reg_ow_k: [u64; InterestRegistrationSource::COUNT],
+    pub reg_ow_m: [u64; InterestRegistrationSource::COUNT],
+    pub reg_new_k: [u64; InterestRegistrationSource::COUNT],
+    pub reg_new_m: [u64; InterestRegistrationSource::COUNT],
+    pub reg_cap: [u64; InterestRegistrationSource::COUNT],
+    /// Successful removals by cause and current known/missing population.
+    pub removed: [u64; InterestRemovalCause::COUNT],
+    pub current: [u64; crate::ring::interest::SummaryMissingReason::COUNT + 1],
+    /// Recreated pairs by their preceding removal cause.
+    pub recreated: [u64; InterestRemovalCause::COUNT],
+    /// Summary-population outcomes by source then outcome.
+    pub populated: [[u64; SummaryPopulationOutcome::COUNT]; SummaryPopulationSource::COUNT],
+    /// Missing-pair history and active-attempt correlation overflows.
+    pub corr_ovf: [u64; 2],
+    /// Queue counters: capacity eviction, queued dedup, enqueue while active,
+    /// large-head incidents, large-head blocked ms, small-entry-ms blocked,
+    /// queued-large/actual-small count, queued-small/actual-large count, their
+    /// respective actual payload bytes, scheduled small/large counts, their
+    /// respective state bytes, then active-key tracking overflow.
+    pub queue: [u64; 15],
+    /// Successful apply counts by delta/full x changed/no-op x resulting-state
+    /// size bucket.
+    pub recv_n: [[u64; STATE_SIZE_BUCKET_COUNT]; 4],
+    /// Every received payload by delta/full x terminal outcome (changed,
+    /// no-op, dedup, backoff, failed) x incoming-payload size bucket. Delta's
+    /// five outcome rows come first, then full state's five rows.
+    pub recv_tn: [[u64; STATE_SIZE_BUCKET_COUNT]; 10],
+    pub recv_tb: [[u64; STATE_SIZE_BUCKET_COUNT]; 10],
+    /// Persisted state counts and bytes by fixed size bucket.
+    pub state_n: [u64; STATE_SIZE_BUCKET_COUNT],
+    pub state_b: [u64; STATE_SIZE_BUCKET_COUNT],
+    /// State inventory summary: count, max bytes, over-limit count,
+    /// over-limit bytes, hard limit, then pre-WASM and post-merge hard-limit
+    /// rejection count/max pairs.
+    pub state: [u64; 9],
+    /// Cost-eviction eligibility by state size: eligible zero-demand,
+    /// subscribed, recent-but-unsubscribed.
+    pub evict_n: [[u64; STATE_SIZE_BUCKET_COUNT]; 3],
+    pub evict_b: [[u64; STATE_SIZE_BUCKET_COUNT]; 3],
+    /// Monotonic actual eviction victims by byte-budget zero-demand,
+    /// byte-budget in-use, and cost-pressure reason × state-size bucket.
+    pub vict_n: [[u64; STATE_SIZE_BUCKET_COUNT]; 3],
+    pub vict_b: [[u64; STATE_SIZE_BUCKET_COUNT]; 3],
+    /// Per cost axis: total rate, floor, max attributed rate, max eligible
+    /// rate, and number of sustained attributed contracts.
+    pub cost: [[u64; 5]; 3],
+    /// Per cost axis × state-size bucket maximum attributed rate, first for
+    /// every hosted contract and then restricted to eviction-eligible ones.
+    pub cost_ba: [[u64; STATE_SIZE_BUCKET_COUNT]; 3],
+    pub cost_be: [[u64; STATE_SIZE_BUCKET_COUNT]; 3],
+    /// Local telemetry pipeline totals in the order documented where populated.
+    pub tel: [u64; 15],
+    /// Per known shadow rollup: generated/enqueue attempts, enqueue full,
+    /// enqueue closed, rate-limit admitted, aggregate-limit drop,
+    /// shadow-subbudget drop, backoff-buffer drop, retry truncation, final sent.
+    pub shadow: [[u64; 9]; 7],
+    /// Delivery path for this diagnostic block itself; order is documented in
+    /// `TelemetryLocalMetricsSnapshot::network_efficiency_delivery`.
+    pub eff: [u64; 8],
+}
+
 /// Periodic snapshot of the router model state for telemetry.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(test, derive(arbitrary::Arbitrary))]
 pub(crate) struct RouterSnapshotInfo {
+    /// Versioned fixed-cardinality network-efficiency evidence. `None` on five
+    /// of every six router snapshots (the wide block exports every 30 minutes)
+    /// and before the production sources are initialized. As with the
+    /// snapshot's earlier added fields, this changes positional bincode AOF decoding:
+    /// buffered pre-upgrade RouterSnapshot records can be skipped once during
+    /// upgrade, while live/self-describing OTLP JSON is unaffected. The AOF
+    /// reader already treats an undecodable telemetry record as skippable.
+    #[serde(default)]
+    pub network_efficiency_v1: Option<NetworkEfficiencyV1>,
     pub failure_events: usize,
     pub success_events: usize,
     pub transfer_rate_events: usize,
@@ -1277,6 +1373,7 @@ impl Router {
     /// Produce a snapshot of the router model state for telemetry.
     pub fn snapshot(&self) -> RouterSnapshotInfo {
         RouterSnapshotInfo {
+            network_efficiency_v1: None,
             failure_events: self.failure_estimator.len(),
             success_events: self.response_start_time_estimator.len(),
             transfer_rate_events: self.transfer_rate_estimator.len(),

--- a/crates/core/src/tracing/event_kind.rs
+++ b/crates/core/src/tracing/event_kind.rs
@@ -8,6 +8,33 @@ use crate::{
     router::RouteEvent,
 };
 
+/// Inclusive upper bounds for the fixed contract-state size histogram used by
+/// the large-state diagnostics (#5090). The final bucket contains values above
+/// the current 50 MiB hard limit, making a persisted over-limit state visible
+/// without introducing a contract-key dimension.
+pub(crate) const STATE_SIZE_BUCKET_UPPER_BOUNDS: [u64; 8] = [
+    64 * 1024,
+    500 * 1024,
+    1024 * 1024,
+    3 * 1024 * 1024,
+    10 * 1024 * 1024,
+    25 * 1024 * 1024,
+    40 * 1024 * 1024,
+    50 * 1024 * 1024,
+];
+
+/// Number of fixed contract-state size buckets, including the unbounded final
+/// bucket above the largest inclusive upper bound.
+pub(crate) const STATE_SIZE_BUCKET_COUNT: usize = STATE_SIZE_BUCKET_UPPER_BOUNDS.len() + 1;
+
+/// Return the fixed histogram bucket for `size_bytes`.
+pub(crate) fn state_size_bucket(size_bytes: u64) -> usize {
+    STATE_SIZE_BUCKET_UPPER_BOUNDS
+        .iter()
+        .position(|upper| size_bytes <= *upper)
+        .unwrap_or(STATE_SIZE_BUCKET_UPPER_BOUNDS.len())
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[cfg_attr(test, derive(arbitrary::Arbitrary))]
 #[non_exhaustive]

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -7,9 +7,10 @@
 //! Features:
 //! - Exponential backoff on connection failures (1s → 2s → 4s → ... → 5min max)
 //! - Event batching (send every 10 seconds or when buffer reaches 100 events)
-//! - Rate limiting (max 10 events/second aggregate), with a separate shadow
-//!   sub-budget (max 6/second) so always-on low-priority shadow telemetry
-//!   cannot starve operational telemetry (#4380)
+//! - Rate limiting (max 10 ordinary events/second aggregate), with a separate
+//!   shadow sub-budget (max 6/second) so always-on low-priority shadow
+//!   telemetry cannot starve operational telemetry (#4380), plus one bounded
+//!   reserved path for the fixed 30-minute #5090 diagnostic
 //! - Priority-based dropping when buffer is full
 //!
 //! ## Design Notes
@@ -22,7 +23,8 @@
 //! TODO(#2456): Enable HTTPS once TLS is configured on the collector server.
 //! Currently the server only accepts HTTP connections.
 
-use std::sync::OnceLock;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 use tokio::time::Instant;
 
@@ -47,7 +49,254 @@ use super::{EventKind, NetEventLog, NetEventRegister, NetLogMessage};
 /// Initialized when `TelemetryReporter::new()` creates the reporter.
 /// If telemetry is disabled, this remains unset and `send_standalone_event`
 /// silently drops events.
-static TELEMETRY_SENDER: OnceLock<mpsc::Sender<TelemetryCommand>> = OnceLock::new();
+static TELEMETRY_SENDER: OnceLock<TelemetryChannel> = OnceLock::new();
+
+/// The fixed set of background rollups admitted at [`EventPriority::Shadow`].
+///
+/// This is deliberately an enum rather than an event-name map: #5090 needs to
+/// identify which aligned rollup was lost without creating attacker-controlled
+/// telemetry cardinality. Keep [`Self::ALL`] exhaustive when adding a stream.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum KnownShadowRollup {
+    ShadowRttAggregate,
+    ShadowRateDemand,
+    ShadowOutboundClass,
+    ShadowReferencePing,
+    ShadowIfaceTx,
+    OutboundMessageMix,
+    BroadcastPayloadMix,
+}
+
+impl KnownShadowRollup {
+    pub(crate) const ALL: [Self; 7] = [
+        Self::ShadowRttAggregate,
+        Self::ShadowRateDemand,
+        Self::ShadowOutboundClass,
+        Self::ShadowReferencePing,
+        Self::ShadowIfaceTx,
+        Self::OutboundMessageMix,
+        Self::BroadcastPayloadMix,
+    ];
+
+    const fn index(self) -> usize {
+        match self {
+            Self::ShadowRttAggregate => 0,
+            Self::ShadowRateDemand => 1,
+            Self::ShadowOutboundClass => 2,
+            Self::ShadowReferencePing => 3,
+            Self::ShadowIfaceTx => 4,
+            Self::OutboundMessageMix => 5,
+            Self::BroadcastPayloadMix => 6,
+        }
+    }
+
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::ShadowRttAggregate => "shadow_rtt_aggregate",
+            Self::ShadowRateDemand => "shadow_rate_demand",
+            Self::ShadowOutboundClass => "shadow_outbound_class",
+            Self::ShadowReferencePing => "shadow_reference_ping",
+            Self::ShadowIfaceTx => "shadow_iface_tx",
+            Self::OutboundMessageMix => "outbound_message_mix",
+            Self::BroadcastPayloadMix => "broadcast_payload_mix",
+        }
+    }
+
+    fn from_event_type(event_type: &str) -> Option<Self> {
+        match event_type {
+            "shadow_rtt_aggregate" => Some(Self::ShadowRttAggregate),
+            "shadow_rate_demand" => Some(Self::ShadowRateDemand),
+            "shadow_outbound_class" => Some(Self::ShadowOutboundClass),
+            "shadow_reference_ping" => Some(Self::ShadowReferencePing),
+            "shadow_iface_tx" => Some(Self::ShadowIfaceTx),
+            "outbound_message_mix" => Some(Self::OutboundMessageMix),
+            "broadcast_payload_mix" => Some(Self::BroadcastPayloadMix),
+            _ => None,
+        }
+    }
+}
+
+/// Loss counters for one fixed shadow-rollup stream.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
+pub(crate) struct KnownShadowRollupMetricsSnapshot {
+    pub event_type: &'static str,
+    pub enqueue_attempts_total: u64,
+    pub enqueue_dropped_full_total: u64,
+    pub enqueue_dropped_closed_total: u64,
+    pub rate_limit_admitted_total: u64,
+    pub dropped_aggregate_limit_total: u64,
+    pub dropped_shadow_limit_total: u64,
+    pub dropped_backoff_buffer_full_total: u64,
+    pub retry_truncated_total: u64,
+    pub sent_total: u64,
+}
+
+/// Process-local telemetry delivery counters for the five-minute node snapshot.
+///
+/// Every field is a monotonic lifetime total. A later successful snapshot can
+/// therefore report a snapshot that was itself dropped; that loss appears one
+/// snapshot late rather than disappearing with the failed event.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
+pub(crate) struct TelemetryLocalMetricsSnapshot {
+    pub enqueue_attempts_total: u64,
+    pub enqueue_succeeded_total: u64,
+    pub enqueue_dropped_full_total: u64,
+    pub enqueue_dropped_closed_total: u64,
+    pub rate_limit_admitted_operational_total: u64,
+    pub rate_limit_admitted_shadow_total: u64,
+    pub dropped_aggregate_limit_operational_total: u64,
+    pub dropped_aggregate_limit_shadow_total: u64,
+    pub dropped_shadow_limit_total: u64,
+    pub dropped_backoff_buffer_full_total: u64,
+    pub batch_send_attempts_total: u64,
+    pub batch_send_successes_total: u64,
+    pub batch_send_failures_total: u64,
+    pub batch_events_sent_total: u64,
+    pub batch_retry_truncated_events_total: u64,
+    pub known_shadow_rollups: [KnownShadowRollupMetricsSnapshot; KnownShadowRollup::ALL.len()],
+    /// Delivery path for router snapshots carrying `network_efficiency_v1`:
+    /// attempts, enqueue full/closed, admitted, rate-limit drop, coalesced
+    /// pending sample, retry truncation, final sent.
+    pub network_efficiency_delivery: [u64; 8],
+}
+
+#[derive(Default)]
+struct NetworkEfficiencyDeliveryMetrics {
+    attempts: AtomicU64,
+    enqueue_full: AtomicU64,
+    enqueue_closed: AtomicU64,
+    admitted: AtomicU64,
+    rate_limit_drop: AtomicU64,
+    coalesced: AtomicU64,
+    retry_truncated: AtomicU64,
+    sent: AtomicU64,
+}
+
+impl NetworkEfficiencyDeliveryMetrics {
+    fn snapshot(&self) -> [u64; 8] {
+        [
+            self.attempts.load(Ordering::Relaxed),
+            self.enqueue_full.load(Ordering::Relaxed),
+            self.enqueue_closed.load(Ordering::Relaxed),
+            self.admitted.load(Ordering::Relaxed),
+            self.rate_limit_drop.load(Ordering::Relaxed),
+            self.coalesced.load(Ordering::Relaxed),
+            self.retry_truncated.load(Ordering::Relaxed),
+            self.sent.load(Ordering::Relaxed),
+        ]
+    }
+}
+
+#[derive(Default)]
+struct KnownShadowRollupMetrics {
+    enqueue_attempts_total: AtomicU64,
+    enqueue_dropped_full_total: AtomicU64,
+    enqueue_dropped_closed_total: AtomicU64,
+    rate_limit_admitted_total: AtomicU64,
+    dropped_aggregate_limit_total: AtomicU64,
+    dropped_shadow_limit_total: AtomicU64,
+    dropped_backoff_buffer_full_total: AtomicU64,
+    retry_truncated_total: AtomicU64,
+    sent_total: AtomicU64,
+}
+
+impl KnownShadowRollupMetrics {
+    fn snapshot(&self, stream: KnownShadowRollup) -> KnownShadowRollupMetricsSnapshot {
+        KnownShadowRollupMetricsSnapshot {
+            event_type: stream.as_str(),
+            enqueue_attempts_total: self.enqueue_attempts_total.load(Ordering::Relaxed),
+            enqueue_dropped_full_total: self.enqueue_dropped_full_total.load(Ordering::Relaxed),
+            enqueue_dropped_closed_total: self.enqueue_dropped_closed_total.load(Ordering::Relaxed),
+            rate_limit_admitted_total: self.rate_limit_admitted_total.load(Ordering::Relaxed),
+            dropped_aggregate_limit_total: self
+                .dropped_aggregate_limit_total
+                .load(Ordering::Relaxed),
+            dropped_shadow_limit_total: self.dropped_shadow_limit_total.load(Ordering::Relaxed),
+            dropped_backoff_buffer_full_total: self
+                .dropped_backoff_buffer_full_total
+                .load(Ordering::Relaxed),
+            retry_truncated_total: self.retry_truncated_total.load(Ordering::Relaxed),
+            sent_total: self.sent_total.load(Ordering::Relaxed),
+        }
+    }
+}
+
+#[derive(Default)]
+struct TelemetryLocalMetrics {
+    enqueue_attempts_total: AtomicU64,
+    enqueue_succeeded_total: AtomicU64,
+    enqueue_dropped_full_total: AtomicU64,
+    enqueue_dropped_closed_total: AtomicU64,
+    rate_limit_admitted_operational_total: AtomicU64,
+    rate_limit_admitted_shadow_total: AtomicU64,
+    dropped_aggregate_limit_operational_total: AtomicU64,
+    dropped_aggregate_limit_shadow_total: AtomicU64,
+    dropped_shadow_limit_total: AtomicU64,
+    dropped_backoff_buffer_full_total: AtomicU64,
+    batch_send_attempts_total: AtomicU64,
+    batch_send_successes_total: AtomicU64,
+    batch_send_failures_total: AtomicU64,
+    batch_events_sent_total: AtomicU64,
+    batch_retry_truncated_events_total: AtomicU64,
+    known_shadow_rollups: [KnownShadowRollupMetrics; KnownShadowRollup::ALL.len()],
+    network_efficiency_delivery: NetworkEfficiencyDeliveryMetrics,
+}
+
+impl TelemetryLocalMetrics {
+    fn shadow(&self, event_type: &str) -> Option<&KnownShadowRollupMetrics> {
+        KnownShadowRollup::from_event_type(event_type)
+            .map(|stream| &self.known_shadow_rollups[stream.index()])
+    }
+
+    fn snapshot(&self) -> TelemetryLocalMetricsSnapshot {
+        TelemetryLocalMetricsSnapshot {
+            enqueue_attempts_total: self.enqueue_attempts_total.load(Ordering::Relaxed),
+            enqueue_succeeded_total: self.enqueue_succeeded_total.load(Ordering::Relaxed),
+            enqueue_dropped_full_total: self.enqueue_dropped_full_total.load(Ordering::Relaxed),
+            enqueue_dropped_closed_total: self.enqueue_dropped_closed_total.load(Ordering::Relaxed),
+            rate_limit_admitted_operational_total: self
+                .rate_limit_admitted_operational_total
+                .load(Ordering::Relaxed),
+            rate_limit_admitted_shadow_total: self
+                .rate_limit_admitted_shadow_total
+                .load(Ordering::Relaxed),
+            dropped_aggregate_limit_operational_total: self
+                .dropped_aggregate_limit_operational_total
+                .load(Ordering::Relaxed),
+            dropped_aggregate_limit_shadow_total: self
+                .dropped_aggregate_limit_shadow_total
+                .load(Ordering::Relaxed),
+            dropped_shadow_limit_total: self.dropped_shadow_limit_total.load(Ordering::Relaxed),
+            dropped_backoff_buffer_full_total: self
+                .dropped_backoff_buffer_full_total
+                .load(Ordering::Relaxed),
+            batch_send_attempts_total: self.batch_send_attempts_total.load(Ordering::Relaxed),
+            batch_send_successes_total: self.batch_send_successes_total.load(Ordering::Relaxed),
+            batch_send_failures_total: self.batch_send_failures_total.load(Ordering::Relaxed),
+            batch_events_sent_total: self.batch_events_sent_total.load(Ordering::Relaxed),
+            batch_retry_truncated_events_total: self
+                .batch_retry_truncated_events_total
+                .load(Ordering::Relaxed),
+            known_shadow_rollups: std::array::from_fn(|index| {
+                self.known_shadow_rollups[index].snapshot(KnownShadowRollup::ALL[index])
+            }),
+            network_efficiency_delivery: self.network_efficiency_delivery.snapshot(),
+        }
+    }
+}
+
+struct TelemetryChannel {
+    sender: mpsc::Sender<TelemetryCommand>,
+    metrics: Arc<TelemetryLocalMetrics>,
+}
+
+/// Read this process's telemetry admission/drop totals for periodic export.
+#[allow(dead_code)] // Read by the router-snapshot integration added alongside #5090.
+pub(crate) fn telemetry_local_metrics_snapshot() -> Option<TelemetryLocalMetricsSnapshot> {
+    TELEMETRY_SENDER
+        .get()
+        .map(|channel| channel.metrics.snapshot())
+}
 
 /// Admission priority for a telemetry event.
 ///
@@ -65,6 +314,12 @@ static TELEMETRY_SENDER: OnceLock<mpsc::Sender<TelemetryCommand>> = OnceLock::ne
 /// can never starve `Operational` telemetry. The sub-budget is best-effort:
 /// excess shadow events are dropped silently, same as any other rate-limited
 /// event.
+///
+/// `NetworkEfficiency` is the one fixed, 30-minute diagnostic used to decide
+/// #5090. It has a dedicated one-slot producer channel and one reserved buffer
+/// slot, and is exempt from the per-second cap. Those structural bounds make
+/// eventual observation independent of ordinary telemetry saturation without
+/// creating an unbounded or attacker-controlled priority path.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum EventPriority {
     /// Operational net-events and node telemetry. Admitted up to the full
@@ -76,6 +331,10 @@ pub enum EventPriority {
     /// analysis). Admitted only under the shadow sub-budget so it yields to
     /// `Operational` events under load.
     Shadow,
+    /// The fixed `router_snapshot.network_efficiency_v1` diagnostic. Routed
+    /// only by [`TelemetryReporter::send_event`], never exposed to standalone
+    /// event producers.
+    NetworkEfficiency,
 }
 
 /// Send a standalone telemetry event from any context.
@@ -133,7 +392,7 @@ fn send_standalone_event_inner(
     event_data: serde_json::Value,
     priority: EventPriority,
 ) {
-    if let Some(sender) = TELEMETRY_SENDER.get() {
+    if let Some(channel) = TELEMETRY_SENDER.get() {
         let event = TelemetryEvent {
             timestamp: current_timestamp_ms(),
             peer_id: peer_id.to_string(),
@@ -142,14 +401,16 @@ fn send_standalone_event_inner(
             event_data,
             priority,
         };
-        // Fire-and-forget: channel full means telemetry event is dropped
-        #[allow(clippy::let_underscore_must_use)]
-        let _ = sender.try_send(TelemetryCommand::Event(event));
+        try_enqueue_event(&channel.sender, &channel.metrics, event);
     }
 }
 
 /// Maximum number of events to buffer before sending
 const MAX_BUFFER_SIZE: usize = 100;
+
+/// One structurally reserved buffer slot for the 30-minute #5090 diagnostic.
+/// Ordinary telemetry remains capped at [`MAX_BUFFER_SIZE`].
+const NETWORK_EFFICIENCY_BUFFER_RESERVE: usize = 1;
 
 /// How often to send batched events (in seconds)
 const BATCH_INTERVAL_SECS: u64 = 10;
@@ -225,6 +486,10 @@ pub fn current_timestamp_ms() -> u64 {
 #[derive(Clone)]
 pub struct TelemetryReporter {
     sender: mpsc::Sender<TelemetryCommand>,
+    /// Dedicated one-slot path for the fixed 30-minute diagnostic. Ordinary
+    /// event bursts cannot consume this channel's capacity.
+    network_efficiency_sender: mpsc::Sender<TelemetryCommand>,
+    metrics: Arc<TelemetryLocalMetrics>,
     /// This node's own peer id, stamped on events that are emitted
     /// without a `NetLogMessage` carrying one (timeouts, transfer
     /// events, transport snapshots). Without it those events carry an
@@ -255,6 +520,78 @@ struct TelemetryEvent {
     /// unchanged.
     #[serde(skip)]
     priority: EventPriority,
+}
+
+fn is_network_efficiency_event(event: &TelemetryEvent) -> bool {
+    event.event_type == "router_snapshot"
+        && event
+            .event_data
+            .get("network_efficiency_v1")
+            .is_some_and(|value| !value.is_null())
+}
+
+/// Enqueue without blocking, preserving the reporter's original best-effort
+/// behavior while making both local loss outcomes observable.
+fn try_enqueue_event(
+    sender: &mpsc::Sender<TelemetryCommand>,
+    metrics: &TelemetryLocalMetrics,
+    event: TelemetryEvent,
+) {
+    metrics
+        .enqueue_attempts_total
+        .fetch_add(1, Ordering::Relaxed);
+    let is_efficiency = is_network_efficiency_event(&event);
+    if is_efficiency {
+        metrics
+            .network_efficiency_delivery
+            .attempts
+            .fetch_add(1, Ordering::Relaxed);
+    }
+    let event_type = event.event_type.clone();
+    if let Some(shadow) = metrics.shadow(&event_type) {
+        shadow
+            .enqueue_attempts_total
+            .fetch_add(1, Ordering::Relaxed);
+    }
+    match sender.try_send(TelemetryCommand::Event(event)) {
+        Ok(()) => {
+            metrics
+                .enqueue_succeeded_total
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        Err(mpsc::error::TrySendError::Full(_)) => {
+            metrics
+                .enqueue_dropped_full_total
+                .fetch_add(1, Ordering::Relaxed);
+            if let Some(shadow) = metrics.shadow(&event_type) {
+                shadow
+                    .enqueue_dropped_full_total
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+            if is_efficiency {
+                metrics
+                    .network_efficiency_delivery
+                    .enqueue_full
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+        }
+        Err(mpsc::error::TrySendError::Closed(_)) => {
+            metrics
+                .enqueue_dropped_closed_total
+                .fetch_add(1, Ordering::Relaxed);
+            if let Some(shadow) = metrics.shadow(&event_type) {
+                shadow
+                    .enqueue_dropped_closed_total
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+            if is_efficiency {
+                metrics
+                    .network_efficiency_delivery
+                    .enqueue_closed
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
 }
 
 /// Best-effort runtime detection of a cargo test/bench harness.
@@ -404,35 +741,50 @@ impl TelemetryReporter {
         // Channel capacity: 1000 events provides ~100 seconds of buffer at max rate (10 events/sec)
         // plus headroom for bursts. Events are dropped via try_send if channel is full.
         let (sender, receiver) = mpsc::channel(1000);
+        let (network_efficiency_sender, network_efficiency_receiver) = mpsc::channel(1);
 
-        // Store a clone in the global sender for standalone event emission
-        // OnceLock::set returns Err if already initialized; expected on repeated calls
-        #[allow(clippy::let_underscore_must_use)]
-        let _ = TELEMETRY_SENDER.set(sender.clone());
+        // Standalone emitters, the reporter, and the worker must update the same
+        // counters. Repeated initialization keeps the first global sender (the
+        // pre-existing OnceLock behavior) and also reuses its metrics so the
+        // crate-visible snapshot never silently switches accumulator instances.
+        let proposed_metrics = Arc::new(TelemetryLocalMetrics::default());
+        let global = TELEMETRY_SENDER.get_or_init(|| TelemetryChannel {
+            sender: sender.clone(),
+            metrics: proposed_metrics.clone(),
+        });
+        let metrics = global.metrics.clone();
 
         // Initialize the transfer event channel for per-transfer telemetry
         let transfer_event_receiver = crate::transport::metrics::init_transfer_event_channel();
 
         // Spawn the background worker
-        let worker = TelemetryWorker::new(
+        let worker = TelemetryWorker::new_with_network_efficiency_receiver(
             endpoint,
             receiver,
+            network_efficiency_receiver,
             transport_snapshot_interval_secs,
             transfer_event_receiver,
             local_peer_id.clone(),
+            metrics.clone(),
         );
         GlobalExecutor::spawn(worker.run());
 
         Some(Self {
             sender,
+            network_efficiency_sender,
+            metrics,
             local_peer_id,
         })
     }
 
-    async fn send_event(&self, event: TelemetryEvent) {
-        // Fire-and-forget: non-blocking send, drop if channel is full
-        #[allow(clippy::let_underscore_must_use)]
-        let _ = self.sender.try_send(TelemetryCommand::Event(event));
+    async fn send_event(&self, mut event: TelemetryEvent) {
+        let sender = if is_network_efficiency_event(&event) {
+            event.priority = EventPriority::NetworkEfficiency;
+            &self.network_efficiency_sender
+        } else {
+            &self.sender
+        };
+        try_enqueue_event(sender, &self.metrics, event);
     }
 }
 
@@ -490,6 +842,7 @@ impl NetEventRegister for TelemetryReporter {
         target_peer: Option<String>,
     ) -> BoxFuture<'_, ()> {
         let sender = self.sender.clone();
+        let metrics = self.metrics.clone();
         let op_type = op_type.to_string();
         let local_peer_id = self.local_peer_id.clone();
         async move {
@@ -505,9 +858,7 @@ impl NetEventRegister for TelemetryReporter {
                 }),
                 priority: EventPriority::Operational,
             };
-            // Fire-and-forget: channel full means telemetry event is dropped
-            #[allow(clippy::let_underscore_must_use)]
-            let _ = sender.try_send(TelemetryCommand::Event(event));
+            try_enqueue_event(&sender, &metrics, event);
         }
         .boxed()
     }
@@ -517,6 +868,8 @@ impl NetEventRegister for TelemetryReporter {
 struct TelemetryWorker {
     endpoint: String,
     receiver: mpsc::Receiver<TelemetryCommand>,
+    network_efficiency_receiver: mpsc::Receiver<TelemetryCommand>,
+    network_efficiency_channel_open: bool,
     buffer: Vec<TelemetryEvent>,
     http_client: reqwest::Client,
     backoff_ms: u64,
@@ -539,20 +892,72 @@ struct TelemetryWorker {
     /// [`RESOURCE_TELEMETRY_BATCH_INTERVAL`] ticks (~60s). Advanced by
     /// [`Self::should_emit_resource_utilization`] on every batch tick.
     resource_emit_batch_counter: u64,
+    /// Shared with every producer feeding this worker so enqueue and worker-side
+    /// losses reconcile into one process-local snapshot.
+    metrics: Arc<TelemetryLocalMetrics>,
 }
 
 impl TelemetryWorker {
+    #[cfg(test)]
     fn new(
         endpoint: String,
         receiver: mpsc::Receiver<TelemetryCommand>,
         transport_snapshot_interval_secs: u64,
         transfer_event_receiver: mpsc::Receiver<super::TransferEvent>,
         local_peer_id: String,
+        metrics: Arc<TelemetryLocalMetrics>,
+    ) -> Self {
+        let (_network_efficiency_sender, network_efficiency_receiver) = mpsc::channel(1);
+        Self::new_inner(
+            endpoint,
+            receiver,
+            network_efficiency_receiver,
+            false,
+            transport_snapshot_interval_secs,
+            transfer_event_receiver,
+            local_peer_id,
+            metrics,
+        )
+    }
+
+    fn new_with_network_efficiency_receiver(
+        endpoint: String,
+        receiver: mpsc::Receiver<TelemetryCommand>,
+        network_efficiency_receiver: mpsc::Receiver<TelemetryCommand>,
+        transport_snapshot_interval_secs: u64,
+        transfer_event_receiver: mpsc::Receiver<super::TransferEvent>,
+        local_peer_id: String,
+        metrics: Arc<TelemetryLocalMetrics>,
+    ) -> Self {
+        Self::new_inner(
+            endpoint,
+            receiver,
+            network_efficiency_receiver,
+            true,
+            transport_snapshot_interval_secs,
+            transfer_event_receiver,
+            local_peer_id,
+            metrics,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn new_inner(
+        endpoint: String,
+        receiver: mpsc::Receiver<TelemetryCommand>,
+        network_efficiency_receiver: mpsc::Receiver<TelemetryCommand>,
+        network_efficiency_channel_open: bool,
+        transport_snapshot_interval_secs: u64,
+        transfer_event_receiver: mpsc::Receiver<super::TransferEvent>,
+        local_peer_id: String,
+        metrics: Arc<TelemetryLocalMetrics>,
     ) -> Self {
         Self {
             endpoint,
             receiver,
-            buffer: Vec::with_capacity(MAX_BUFFER_SIZE),
+            network_efficiency_receiver,
+            network_efficiency_channel_open,
+            buffer: Vec::with_capacity(MAX_BUFFER_SIZE + NETWORK_EFFICIENCY_BUFFER_RESERVE),
             http_client: reqwest::Client::builder()
                 .timeout(Duration::from_secs(30))
                 .build()
@@ -566,6 +971,7 @@ impl TelemetryWorker {
             transfer_event_receiver,
             local_peer_id,
             resource_emit_batch_counter: 0,
+            metrics,
         }
     }
 
@@ -669,6 +1075,30 @@ impl TelemetryWorker {
 
         loop {
             crate::deterministic_select! {
+                cmd = async {
+                    if self.network_efficiency_channel_open {
+                        self.network_efficiency_receiver.recv().await
+                    } else {
+                        std::future::pending::<Option<TelemetryCommand>>().await
+                    }
+                } => {
+                    match cmd {
+                        Some(TelemetryCommand::Event(event)) => {
+                            self.handle_event(event).await;
+                        }
+                        Some(TelemetryCommand::Shutdown) => {
+                            self.flush().await;
+                            break;
+                        }
+                        None => {
+                            // Reporter clones own both senders, but the global
+                            // standalone channel can keep the ordinary sender
+                            // alive after reporter shutdown. Disable only this
+                            // branch so a closed reserved channel cannot spin.
+                            self.network_efficiency_channel_open = false;
+                        }
+                    }
+                },
                 cmd = self.receiver.recv() => {
                     match cmd {
                         Some(TelemetryCommand::Event(event)) => {
@@ -739,15 +1169,41 @@ impl TelemetryWorker {
     ///   the slots, always leaving
     ///   `MAX_EVENTS_PER_SECOND - MAX_SHADOW_EVENTS_PER_SECOND` for
     ///   operational telemetry.
-    fn admit_event(&mut self, priority: EventPriority, now: Instant) -> bool {
+    /// - `NetworkEfficiency` bypasses both counters. Its dedicated one-slot
+    ///   channel, reserved buffer slot, and fixed 30-minute producer cadence
+    ///   provide the bound that the ordinary per-second limiter otherwise
+    ///   supplies.
+    fn admit_event(&mut self, priority: EventPriority, event_type: &str, now: Instant) -> bool {
         if now.duration_since(self.rate_limit_window_start) >= Duration::from_secs(1) {
             self.rate_limit_window_start = now;
             self.events_this_second = 0;
             self.shadow_events_this_second = 0;
         }
 
+        if priority == EventPriority::NetworkEfficiency {
+            return true;
+        }
+
         // Aggregate cap applies to every event regardless of priority.
         if self.events_this_second >= MAX_EVENTS_PER_SECOND {
+            match priority {
+                EventPriority::Operational => self
+                    .metrics
+                    .dropped_aggregate_limit_operational_total
+                    .fetch_add(1, Ordering::Relaxed),
+                EventPriority::Shadow => self
+                    .metrics
+                    .dropped_aggregate_limit_shadow_total
+                    .fetch_add(1, Ordering::Relaxed),
+                EventPriority::NetworkEfficiency => {
+                    unreachable!("network-efficiency telemetry bypasses the aggregate rate limit")
+                }
+            };
+            if let Some(shadow) = self.metrics.shadow(event_type) {
+                shadow
+                    .dropped_aggregate_limit_total
+                    .fetch_add(1, Ordering::Relaxed);
+            }
             return false;
         }
 
@@ -755,32 +1211,103 @@ impl TelemetryWorker {
         // crowd out operational telemetry (#4380).
         if priority == EventPriority::Shadow {
             if self.shadow_events_this_second >= MAX_SHADOW_EVENTS_PER_SECOND {
+                self.metrics
+                    .dropped_shadow_limit_total
+                    .fetch_add(1, Ordering::Relaxed);
+                if let Some(shadow) = self.metrics.shadow(event_type) {
+                    shadow
+                        .dropped_shadow_limit_total
+                        .fetch_add(1, Ordering::Relaxed);
+                }
                 return false;
             }
             self.shadow_events_this_second += 1;
         }
 
         self.events_this_second += 1;
+        match priority {
+            EventPriority::Operational => self
+                .metrics
+                .rate_limit_admitted_operational_total
+                .fetch_add(1, Ordering::Relaxed),
+            EventPriority::Shadow => self
+                .metrics
+                .rate_limit_admitted_shadow_total
+                .fetch_add(1, Ordering::Relaxed),
+            EventPriority::NetworkEfficiency => unreachable!(
+                "network-efficiency telemetry returns before ordinary admission accounting"
+            ),
+        };
+        if let Some(shadow) = self.metrics.shadow(event_type) {
+            shadow
+                .rate_limit_admitted_total
+                .fetch_add(1, Ordering::Relaxed);
+        }
         true
     }
 
     async fn handle_event(&mut self, event: TelemetryEvent) {
+        let is_efficiency = is_network_efficiency_event(&event);
         // Rate limiting (#4380: shadow events admitted under a sub-budget)
-        if !self.admit_event(event.priority, Instant::now()) {
+        if !self.admit_event(event.priority, &event.event_type, Instant::now()) {
+            if is_efficiency {
+                self.metrics
+                    .network_efficiency_delivery
+                    .rate_limit_drop
+                    .fetch_add(1, Ordering::Relaxed);
+            }
             // Drop event due to rate limiting
             return;
         }
+        if is_efficiency {
+            self.metrics
+                .network_efficiency_delivery
+                .admitted
+                .fetch_add(1, Ordering::Relaxed);
+
+            // A collector outage can span multiple 30-minute ticks. Keep the
+            // newest diagnostic rather than consuming more reserved memory.
+            // Its lifetime counters subsume the older counters and its gauges
+            // are the freshest point sample, but this intentionally discards
+            // one historical gauge sample, so record that terminal outcome.
+            if let Some(existing) = self.buffer.iter_mut().find(|queued| {
+                queued.priority == EventPriority::NetworkEfficiency
+                    || is_network_efficiency_event(queued)
+            }) {
+                self.metrics
+                    .network_efficiency_delivery
+                    .coalesced
+                    .fetch_add(1, Ordering::Relaxed);
+                *existing = event;
+                return;
+            }
+        }
 
         // Drop events if buffer is full and we're in backoff (prevents unbounded memory growth)
-        if self.buffer.len() >= MAX_BUFFER_SIZE && self.backoff_ms > 0 {
+        let buffer_capacity = MAX_BUFFER_SIZE
+            + usize::from(self.buffer.iter().any(is_network_efficiency_event))
+                * NETWORK_EFFICIENCY_BUFFER_RESERVE;
+        if !is_efficiency && self.buffer.len() >= buffer_capacity && self.backoff_ms > 0 {
             let elapsed = self.last_send.elapsed();
             if elapsed < Duration::from_millis(self.backoff_ms) {
                 // Still in backoff and buffer full - drop event
+                self.metrics
+                    .dropped_backoff_buffer_full_total
+                    .fetch_add(1, Ordering::Relaxed);
+                if let Some(shadow) = self.metrics.shadow(&event.event_type) {
+                    shadow
+                        .dropped_backoff_buffer_full_total
+                        .fetch_add(1, Ordering::Relaxed);
+                }
                 return;
             }
         }
 
         self.buffer.push(event);
+        debug_assert!(
+            self.buffer.len() <= MAX_BUFFER_SIZE + NETWORK_EFFICIENCY_BUFFER_RESERVE,
+            "only the fixed network-efficiency event may occupy the reserved slot"
+        );
 
         // Send if buffer is full
         if self.buffer.len() >= MAX_BUFFER_SIZE {
@@ -803,10 +1330,31 @@ impl TelemetryWorker {
         }
 
         let events = std::mem::take(&mut self.buffer);
-        self.buffer = Vec::with_capacity(MAX_BUFFER_SIZE);
+        self.buffer = Vec::with_capacity(MAX_BUFFER_SIZE + NETWORK_EFFICIENCY_BUFFER_RESERVE);
+
+        self.metrics
+            .batch_send_attempts_total
+            .fetch_add(1, Ordering::Relaxed);
 
         match self.send_batch(&events).await {
             Ok(()) => {
+                self.metrics
+                    .batch_send_successes_total
+                    .fetch_add(1, Ordering::Relaxed);
+                self.metrics
+                    .batch_events_sent_total
+                    .fetch_add(events.len() as u64, Ordering::Relaxed);
+                for event in &events {
+                    if let Some(shadow) = self.metrics.shadow(&event.event_type) {
+                        shadow.sent_total.fetch_add(1, Ordering::Relaxed);
+                    }
+                    if is_network_efficiency_event(event) {
+                        self.metrics
+                            .network_efficiency_delivery
+                            .sent
+                            .fetch_add(1, Ordering::Relaxed);
+                    }
+                }
                 // Reset backoff on success
                 self.backoff_ms = 0;
                 self.last_send = Instant::now();
@@ -824,12 +1372,44 @@ impl TelemetryWorker {
                 self.backoff_ms = base_backoff + jitter;
                 self.last_send = Instant::now();
 
-                // Put events back in buffer (up to limit)
-                let remaining_capacity = MAX_BUFFER_SIZE.saturating_sub(self.buffer.len());
-                self.buffer
-                    .extend(events.into_iter().take(remaining_capacity));
+                self.requeue_failed_batch(events);
             }
         }
+    }
+
+    /// Restore a failed HTTP batch without changing the existing retry policy,
+    /// accounting for the otherwise-silent tail if capacity ever becomes
+    /// smaller than the failed batch. Under today's serial worker this tail is
+    /// normally zero; keeping the counter at the actual truncation point makes
+    /// that invariant observable and regression-testable.
+    fn requeue_failed_batch(&mut self, events: Vec<TelemetryEvent>) {
+        self.metrics
+            .batch_send_failures_total
+            .fetch_add(1, Ordering::Relaxed);
+        let has_network_efficiency = self.buffer.iter().any(is_network_efficiency_event)
+            || events.iter().any(is_network_efficiency_event);
+        let capacity = MAX_BUFFER_SIZE
+            + usize::from(has_network_efficiency) * NETWORK_EFFICIENCY_BUFFER_RESERVE;
+        let remaining_capacity = capacity.saturating_sub(self.buffer.len());
+        let retained = events.len().min(remaining_capacity);
+        let truncated = events.len().saturating_sub(retained);
+        if truncated > 0 {
+            self.metrics
+                .batch_retry_truncated_events_total
+                .fetch_add(truncated as u64, Ordering::Relaxed);
+            for event in &events[retained..] {
+                if let Some(shadow) = self.metrics.shadow(&event.event_type) {
+                    shadow.retry_truncated_total.fetch_add(1, Ordering::Relaxed);
+                }
+                if is_network_efficiency_event(event) {
+                    self.metrics
+                        .network_efficiency_delivery
+                        .retry_truncated
+                        .fetch_add(1, Ordering::Relaxed);
+                }
+            }
+        }
+        self.buffer.extend(events.into_iter().take(retained));
     }
 
     async fn send_batch(&self, events: &[TelemetryEvent]) -> Result<(), reqwest::Error> {
@@ -2129,6 +2709,13 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
             // the collector unless added here. Pinned by
             // `router_snapshot_json_includes_placement_gauges`.
             if let Some(obj) = body.as_object_mut() {
+                // #5090: one compact, versioned, fixed-cardinality diagnostic
+                // object. Kept nested so its marginal serialized size and
+                // schema can be pinned independently of the legacy snapshot.
+                obj.insert(
+                    "network_efficiency_v1".to_string(),
+                    serde_json::json!(snapshot.network_efficiency_v1),
+                );
                 obj.insert(
                     "hosted_contracts_count".to_string(),
                     serde_json::json!(snapshot.hosted_contracts_count),
@@ -2743,6 +3330,130 @@ mod tests {
             json["fd_soft_limit"], 4096,
             "fd_soft_limit must reach the OTLP body"
         );
+    }
+
+    #[test]
+    fn router_snapshot_network_efficiency_v1_has_explicit_realistic_and_worst_case_budgets() {
+        use arbitrary::Arbitrary;
+
+        const BUSY_FLEET_COUNTER: u64 = 999_999;
+        const MAX_EMPTY_JSON_BYTES: usize = 2_048;
+        const MAX_BUSY_JSON_BYTES: usize = 5_120;
+        const MAX_WORST_CASE_JSON_BYTES: usize = 14_336;
+        const MAX_EMPTY_OTLP_MARGINAL_BYTES: usize = 2_048;
+        const MAX_BUSY_OTLP_MARGINAL_BYTES: usize = 5_120;
+        const MAX_WORST_OTLP_MARGINAL_BYTES: usize = 14_336;
+        const MAX_NULL_OTLP_MARGINAL_BYTES: usize = 64;
+
+        let diagnostic = |value| crate::router::NetworkEfficiencyV1 {
+            v: 1,
+            ms_s: [value; 10],
+            ms_b: [value; 10],
+            ms_age: [value; 5],
+            reg_ow_k: [value; 7],
+            reg_ow_m: [value; 7],
+            reg_new_k: [value; 7],
+            reg_new_m: [value; 7],
+            reg_cap: [value; 7],
+            removed: [value; 7],
+            current: [value; 5],
+            recreated: [value; 7],
+            populated: [[value; 4]; 6],
+            corr_ovf: [value; 2],
+            queue: [value; 15],
+            recv_n: [[value; 9]; 4],
+            recv_tn: [[value; 9]; 10],
+            recv_tb: [[value; 9]; 10],
+            state_n: [value; 9],
+            state_b: [value; 9],
+            state: [value; 9],
+            evict_n: [[value; 9]; 3],
+            evict_b: [[value; 9]; 3],
+            vict_n: [[value; 9]; 3],
+            vict_b: [[value; 9]; 3],
+            cost: [[value; 5]; 3],
+            cost_ba: [[value; 9]; 3],
+            cost_be: [[value; 9]; 3],
+            tel: [value; 15],
+            shadow: [[value; 9]; 7],
+            eff: [value; 8],
+        };
+
+        let mut u = arbitrary::Unstructured::new(&[0_u8; 32_768]);
+        let mut info = crate::router::RouterSnapshotInfo::arbitrary(&mut u)
+            .expect("construct RouterSnapshotInfo for test");
+        let base_info = info.clone();
+        info.network_efficiency_v1 = Some(diagnostic(BUSY_FLEET_COUNTER));
+
+        let json = event_kind_to_json(&EventKind::RouterSnapshot(Box::new(info.clone())));
+        let block = &json["network_efficiency_v1"];
+        let object = block
+            .as_object()
+            .expect("network_efficiency_v1 must remain a JSON object");
+        assert_eq!(object.len(), 31, "schema must remain fixed-cardinality");
+        let encoded = serde_json::to_vec(block).expect("serialize diagnostic block");
+        assert!(
+            encoded.len() <= MAX_BUSY_JSON_BYTES,
+            "busy-fleet diagnostic grew to {} bytes (limit {MAX_BUSY_JSON_BYTES})",
+            encoded.len()
+        );
+
+        let empty = serde_json::to_vec(&diagnostic(0)).expect("serialize empty diagnostic block");
+        assert!(
+            empty.len() <= MAX_EMPTY_JSON_BYTES,
+            "empty diagnostic grew to {} bytes (limit {MAX_EMPTY_JSON_BYTES})",
+            empty.len()
+        );
+
+        let worst_case = serde_json::to_vec(&diagnostic(u64::MAX))
+            .expect("serialize worst-case diagnostic block");
+        assert!(
+            worst_case.len() <= MAX_WORST_CASE_JSON_BYTES,
+            "mathematical worst-case diagnostic grew to {} bytes (limit \
+             {MAX_WORST_CASE_JSON_BYTES})",
+            worst_case.len()
+        );
+
+        let otlp_data_len = |event_data| {
+            let event = TelemetryEvent {
+                timestamp: 1,
+                peer_id: "peer".to_string(),
+                transaction_id: String::new(),
+                event_type: "router_snapshot".to_string(),
+                event_data,
+                priority: EventPriority::Operational,
+            };
+            serde_json::to_vec(&to_otlp_logs(&[event])).unwrap().len()
+        };
+        let base_data = event_kind_to_json(&EventKind::RouterSnapshot(Box::new(base_info.clone())));
+        let base_otlp = otlp_data_len(base_data.clone());
+        let mut without_field = base_data;
+        without_field
+            .as_object_mut()
+            .unwrap()
+            .remove("network_efficiency_v1");
+        let null_otlp = base_otlp.saturating_sub(otlp_data_len(without_field));
+        let busy_otlp = otlp_data_len(event_kind_to_json(&EventKind::RouterSnapshot(Box::new(
+            info,
+        ))))
+        .saturating_sub(base_otlp);
+        let mut empty_info = base_info.clone();
+        empty_info.network_efficiency_v1 = Some(diagnostic(0));
+        let empty_otlp = otlp_data_len(event_kind_to_json(&EventKind::RouterSnapshot(Box::new(
+            empty_info,
+        ))))
+        .saturating_sub(base_otlp);
+        let mut worst_info = base_info;
+        worst_info.network_efficiency_v1 = Some(diagnostic(u64::MAX));
+        let worst_otlp = otlp_data_len(event_kind_to_json(&EventKind::RouterSnapshot(Box::new(
+            worst_info,
+        ))))
+        .saturating_sub(base_otlp);
+        assert_eq!(null_otlp, 31, "null snapshots are part of the fleet budget");
+        assert!(null_otlp <= MAX_NULL_OTLP_MARGINAL_BYTES);
+        assert!(empty_otlp <= MAX_EMPTY_OTLP_MARGINAL_BYTES);
+        assert!(busy_otlp <= MAX_BUSY_OTLP_MARGINAL_BYTES);
+        assert!(worst_otlp <= MAX_WORST_OTLP_MARGINAL_BYTES);
     }
 
     /// Pin: the module-cache gauges (#4440) must also reach the hand-mirrored
@@ -3561,6 +4272,7 @@ mod tests {
             0,
             transfer_rx,
             "snapshot-peer-id".to_string(),
+            Arc::new(TelemetryLocalMetrics::default()),
         );
         let snapshot = crate::transport::metrics::TransportSnapshot::default();
         let event = worker.snapshot_to_telemetry(&snapshot);
@@ -3588,6 +4300,7 @@ mod tests {
             0,
             transfer_rx,
             "resource-peer-id".to_string(),
+            Arc::new(TelemetryLocalMetrics::default()),
         );
         let event = worker.resource_utilization_telemetry();
         assert_eq!(event.event_type, "resource_utilization");
@@ -3633,6 +4346,7 @@ mod tests {
             0,
             transfer_rx,
             "cadence-peer-id".to_string(),
+            Arc::new(TelemetryLocalMetrics::default()),
         );
 
         // The constant yields the intended ~60s cadence.
@@ -3673,8 +4387,12 @@ mod tests {
         use crate::operations::get::GetMsg;
 
         let (sender, mut receiver) = mpsc::channel(1);
+        let (network_efficiency_sender, _network_efficiency_receiver) = mpsc::channel(1);
+        let metrics = Arc::new(TelemetryLocalMetrics::default());
         let mut reporter = TelemetryReporter {
             sender,
+            network_efficiency_sender,
+            metrics,
             local_peer_id: "timeout-peer-id".to_string(),
         };
         let tx = Transaction::new::<GetMsg>();
@@ -3737,6 +4455,7 @@ mod tests {
             0,
             transfer_rx,
             "test-local-peer-id".to_string(),
+            Arc::new(TelemetryLocalMetrics::default()),
         );
         let event = worker.transfer_event_to_telemetry(crate::tracing::TransferEvent::Failed {
             stream_id: 42,
@@ -4041,7 +4760,32 @@ mod tests {
             0,
             transfer_rx,
             "rate-limit-test-peer".to_string(),
+            Arc::new(TelemetryLocalMetrics::default()),
         )
+    }
+
+    fn test_telemetry_event(event_type: &str, priority: EventPriority) -> TelemetryEvent {
+        TelemetryEvent {
+            timestamp: 1,
+            peer_id: "test-peer".to_string(),
+            transaction_id: String::new(),
+            event_type: event_type.to_string(),
+            event_data: serde_json::json!({}),
+            priority,
+        }
+    }
+
+    fn test_network_efficiency_event(sequence: u64) -> TelemetryEvent {
+        TelemetryEvent {
+            timestamp: sequence,
+            peer_id: "test-peer".to_string(),
+            transaction_id: String::new(),
+            event_type: "router_snapshot".to_string(),
+            event_data: serde_json::json!({
+                "network_efficiency_v1": {"v": 1, "sequence": sequence}
+            }),
+            priority: EventPriority::NetworkEfficiency,
+        }
     }
 
     /// Admit `count` events of `priority` at instant `now`, returning how many
@@ -4049,11 +4793,12 @@ mod tests {
     fn admit_n(
         worker: &mut TelemetryWorker,
         priority: EventPriority,
+        event_type: &str,
         count: usize,
         now: Instant,
     ) -> usize {
         (0..count)
-            .filter(|_| worker.admit_event(priority, now))
+            .filter(|_| worker.admit_event(priority, event_type, now))
             .count()
     }
 
@@ -4074,11 +4819,29 @@ mod tests {
 
         // A flood of shadow-only events is capped at the sub-budget, never the
         // full aggregate cap.
-        let admitted = admit_n(&mut worker, EventPriority::Shadow, 100, now);
+        let admitted = admit_n(
+            &mut worker,
+            EventPriority::Shadow,
+            "broadcast_payload_mix",
+            100,
+            now,
+        );
         assert_eq!(
             admitted, MAX_SHADOW_EVENTS_PER_SECOND,
             "shadow events must be capped at the sub-budget within a window"
         );
+        let snapshot = worker.metrics.snapshot();
+        assert_eq!(
+            snapshot.rate_limit_admitted_shadow_total,
+            MAX_SHADOW_EVENTS_PER_SECOND as u64
+        );
+        assert_eq!(
+            snapshot.dropped_shadow_limit_total,
+            (100 - MAX_SHADOW_EVENTS_PER_SECOND) as u64
+        );
+        let stream = snapshot.known_shadow_rollups[KnownShadowRollup::BroadcastPayloadMix.index()];
+        assert_eq!(stream.rate_limit_admitted_total, admitted as u64);
+        assert_eq!(stream.dropped_shadow_limit_total, (100 - admitted) as u64);
     }
 
     #[test]
@@ -4104,7 +4867,13 @@ mod tests {
 
         // All five rollups arrive in the same aligned second (no operational
         // load competing for the aggregate cap).
-        let admitted = admit_n(&mut worker, EventPriority::Shadow, SHADOW_STREAMS, now);
+        let admitted = admit_n(
+            &mut worker,
+            EventPriority::Shadow,
+            "test_shadow",
+            SHADOW_STREAMS,
+            now,
+        );
         assert_eq!(
             admitted, SHADOW_STREAMS,
             "all five aligned shadow rollups must be admitted; none dropped"
@@ -4121,13 +4890,19 @@ mod tests {
         let now = Instant::now();
 
         // Shadow events arrive first and try to grab everything.
-        let shadow_admitted = admit_n(&mut worker, EventPriority::Shadow, 50, now);
+        let shadow_admitted = admit_n(&mut worker, EventPriority::Shadow, "test_shadow", 50, now);
         assert_eq!(shadow_admitted, MAX_SHADOW_EVENTS_PER_SECOND);
 
         // Operational events arriving afterwards still get the slots the
         // shadow sub-budget reserved for them.
         let expected_operational = MAX_EVENTS_PER_SECOND - MAX_SHADOW_EVENTS_PER_SECOND;
-        let op_admitted = admit_n(&mut worker, EventPriority::Operational, 50, now);
+        let op_admitted = admit_n(
+            &mut worker,
+            EventPriority::Operational,
+            "test_operational",
+            50,
+            now,
+        );
         assert_eq!(
             op_admitted, expected_operational,
             "operational events must keep (aggregate cap - shadow sub-budget) \
@@ -4142,11 +4917,168 @@ mod tests {
         let mut worker = rate_limit_test_worker();
         let now = Instant::now();
 
-        let admitted = admit_n(&mut worker, EventPriority::Operational, 100, now);
+        let admitted = admit_n(
+            &mut worker,
+            EventPriority::Operational,
+            "test_operational",
+            100,
+            now,
+        );
         assert_eq!(
             admitted, MAX_EVENTS_PER_SECOND,
             "operational events alone must be able to fill the aggregate cap"
         );
+    }
+
+    #[test]
+    fn test_network_efficiency_has_one_structurally_bounded_reserved_rate_slot() {
+        let mut worker = rate_limit_test_worker();
+        let now = Instant::now();
+
+        assert_eq!(
+            admit_n(
+                &mut worker,
+                EventPriority::Operational,
+                "test_operational",
+                MAX_EVENTS_PER_SECOND,
+                now,
+            ),
+            MAX_EVENTS_PER_SECOND
+        );
+        assert!(
+            worker.admit_event(EventPriority::NetworkEfficiency, "router_snapshot", now,),
+            "ordinary saturation must not starve the fixed 30-minute diagnostic"
+        );
+        assert_eq!(
+            worker.events_this_second, MAX_EVENTS_PER_SECOND,
+            "the reserved diagnostic must not expand the ordinary event budget"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_network_efficiency_uses_dedicated_channel_when_ordinary_channel_is_full() {
+        let (sender, mut receiver) = mpsc::channel(1);
+        sender
+            .try_send(TelemetryCommand::Event(test_telemetry_event(
+                "ordinary-filler",
+                EventPriority::Operational,
+            )))
+            .expect("fill ordinary channel");
+        let (network_efficiency_sender, mut network_efficiency_receiver) = mpsc::channel(1);
+        let metrics = Arc::new(TelemetryLocalMetrics::default());
+        let reporter = TelemetryReporter {
+            sender,
+            network_efficiency_sender,
+            metrics: metrics.clone(),
+            local_peer_id: "test-peer".to_string(),
+        };
+
+        let mut event = test_network_efficiency_event(1);
+        // Production callers initially create every NetEvent as Operational;
+        // send_event owns both classification and reserved routing.
+        event.priority = EventPriority::Operational;
+        reporter.send_event(event).await;
+
+        assert!(
+            receiver.try_recv().is_ok(),
+            "ordinary filler remains queued"
+        );
+        let TelemetryCommand::Event(reserved) = network_efficiency_receiver
+            .try_recv()
+            .expect("diagnostic must enter its dedicated channel")
+        else {
+            panic!("expected reserved Event command");
+        };
+        assert_eq!(reserved.priority, EventPriority::NetworkEfficiency);
+        let snapshot = metrics.snapshot();
+        assert_eq!(snapshot.network_efficiency_delivery[0], 1);
+        assert_eq!(snapshot.network_efficiency_delivery[1], 0);
+        assert_eq!(snapshot.enqueue_succeeded_total, 1);
+    }
+
+    #[tokio::test]
+    async fn test_network_efficiency_keeps_reserved_buffer_slot_during_backoff() {
+        let mut worker = rate_limit_test_worker();
+        worker.buffer = (0..MAX_BUFFER_SIZE)
+            .map(|_| test_telemetry_event("filler", EventPriority::Operational))
+            .collect();
+        worker.backoff_ms = MAX_BACKOFF_MS;
+        worker.last_send = Instant::now();
+
+        worker.handle_event(test_network_efficiency_event(1)).await;
+        assert_eq!(
+            worker.buffer.len(),
+            MAX_BUFFER_SIZE + NETWORK_EFFICIENCY_BUFFER_RESERVE
+        );
+        assert!(worker.buffer.iter().any(is_network_efficiency_event));
+        let snapshot = worker.metrics.snapshot();
+        assert_eq!(snapshot.network_efficiency_delivery[3], 1);
+        assert_eq!(snapshot.network_efficiency_delivery[4], 0);
+        assert_eq!(snapshot.network_efficiency_delivery[5], 0);
+
+        // A later cumulative sample supersedes the old one rather than using
+        // a second reserved slot during a prolonged collector outage.
+        worker.handle_event(test_network_efficiency_event(2)).await;
+        assert_eq!(
+            worker.buffer.len(),
+            MAX_BUFFER_SIZE + NETWORK_EFFICIENCY_BUFFER_RESERVE
+        );
+        let retained: Vec<_> = worker
+            .buffer
+            .iter()
+            .filter(|event| is_network_efficiency_event(event))
+            .collect();
+        assert_eq!(retained.len(), 1);
+        assert_eq!(retained[0].timestamp, 2);
+        assert_eq!(
+            worker.metrics.snapshot().network_efficiency_delivery[5],
+            1,
+            "the replaced historical point sample must be a visible terminal outcome"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_reserved_slot_does_not_reduce_ordinary_buffer_capacity() {
+        let mut worker = rate_limit_test_worker();
+        worker.buffer = (0..MAX_BUFFER_SIZE - 1)
+            .map(|_| test_telemetry_event("filler", EventPriority::Operational))
+            .collect();
+        worker.buffer.push(test_network_efficiency_event(1));
+        worker.backoff_ms = MAX_BACKOFF_MS;
+        worker.last_send = Instant::now();
+
+        worker
+            .handle_event(test_telemetry_event(
+                "last-ordinary-slot",
+                EventPriority::Operational,
+            ))
+            .await;
+
+        assert_eq!(
+            worker.buffer.len(),
+            MAX_BUFFER_SIZE + NETWORK_EFFICIENCY_BUFFER_RESERVE,
+            "the diagnostic reserve must not take one of the 100 ordinary slots"
+        );
+    }
+
+    #[test]
+    fn test_failed_full_batch_retains_network_efficiency_reserved_slot() {
+        let mut worker = rate_limit_test_worker();
+        let mut failed = (0..MAX_BUFFER_SIZE)
+            .map(|_| test_telemetry_event("ordinary", EventPriority::Operational))
+            .collect::<Vec<_>>();
+        failed.push(test_network_efficiency_event(1));
+
+        worker.requeue_failed_batch(failed);
+
+        assert_eq!(
+            worker.buffer.len(),
+            MAX_BUFFER_SIZE + NETWORK_EFFICIENCY_BUFFER_RESERVE
+        );
+        assert!(worker.buffer.iter().any(is_network_efficiency_event));
+        let snapshot = worker.metrics.snapshot();
+        assert_eq!(snapshot.batch_retry_truncated_events_total, 0);
+        assert_eq!(snapshot.network_efficiency_delivery[6], 0);
     }
 
     #[test]
@@ -4160,17 +5092,129 @@ mod tests {
         let op_admitted = admit_n(
             &mut worker,
             EventPriority::Operational,
+            "test_operational",
             MAX_EVENTS_PER_SECOND,
             now,
         );
         assert_eq!(op_admitted, MAX_EVENTS_PER_SECOND);
 
         // Sub-budget untouched, but the aggregate cap is exhausted.
-        let shadow_admitted = admit_n(&mut worker, EventPriority::Shadow, 10, now);
+        let shadow_admitted = admit_n(
+            &mut worker,
+            EventPriority::Shadow,
+            "outbound_message_mix",
+            10,
+            now,
+        );
         assert_eq!(
             shadow_admitted, 0,
             "shadow events must still respect the aggregate cap, not just the \
              sub-budget"
+        );
+        let snapshot = worker.metrics.snapshot();
+        assert_eq!(snapshot.dropped_aggregate_limit_shadow_total, 10);
+        assert_eq!(
+            snapshot.known_shadow_rollups[KnownShadowRollup::OutboundMessageMix.index()]
+                .dropped_aggregate_limit_total,
+            10
+        );
+    }
+
+    #[test]
+    fn test_enqueue_full_and_closed_are_accounted_by_fixed_stream() {
+        let metrics = TelemetryLocalMetrics::default();
+
+        let (full_sender, _full_receiver) = mpsc::channel(1);
+        full_sender
+            .try_send(TelemetryCommand::Event(test_telemetry_event(
+                "filler",
+                EventPriority::Operational,
+            )))
+            .expect("fill the one-slot channel");
+        try_enqueue_event(
+            &full_sender,
+            &metrics,
+            test_telemetry_event("broadcast_payload_mix", EventPriority::Shadow),
+        );
+
+        let (closed_sender, closed_receiver) = mpsc::channel(1);
+        drop(closed_receiver);
+        try_enqueue_event(
+            &closed_sender,
+            &metrics,
+            test_telemetry_event("outbound_message_mix", EventPriority::Shadow),
+        );
+
+        let snapshot = metrics.snapshot();
+        assert_eq!(snapshot.enqueue_attempts_total, 2);
+        assert_eq!(snapshot.enqueue_succeeded_total, 0);
+        assert_eq!(snapshot.enqueue_dropped_full_total, 1);
+        assert_eq!(snapshot.enqueue_dropped_closed_total, 1);
+        assert_eq!(
+            snapshot.known_shadow_rollups[KnownShadowRollup::BroadcastPayloadMix.index()]
+                .enqueue_dropped_full_total,
+            1
+        );
+        assert_eq!(
+            snapshot.known_shadow_rollups[KnownShadowRollup::OutboundMessageMix.index()]
+                .enqueue_dropped_closed_total,
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn test_backoff_full_buffer_drop_is_accounted_by_fixed_stream() {
+        let mut worker = rate_limit_test_worker();
+        worker.buffer = (0..MAX_BUFFER_SIZE)
+            .map(|_| test_telemetry_event("filler", EventPriority::Operational))
+            .collect();
+        worker.backoff_ms = INITIAL_BACKOFF_MS;
+        worker.last_send = Instant::now();
+
+        worker
+            .handle_event(test_telemetry_event(
+                "broadcast_payload_mix",
+                EventPriority::Shadow,
+            ))
+            .await;
+
+        assert_eq!(worker.buffer.len(), MAX_BUFFER_SIZE);
+        let snapshot = worker.metrics.snapshot();
+        assert_eq!(snapshot.rate_limit_admitted_shadow_total, 1);
+        assert_eq!(snapshot.dropped_backoff_buffer_full_total, 1);
+        assert_eq!(
+            snapshot.known_shadow_rollups[KnownShadowRollup::BroadcastPayloadMix.index()]
+                .dropped_backoff_buffer_full_total,
+            1
+        );
+    }
+
+    #[test]
+    fn test_failed_batch_retry_truncation_is_accounted_by_fixed_stream() {
+        let mut worker = rate_limit_test_worker();
+        worker.buffer = (0..MAX_BUFFER_SIZE - 1)
+            .map(|_| test_telemetry_event("buffered", EventPriority::Operational))
+            .collect();
+
+        worker.requeue_failed_batch(vec![
+            test_telemetry_event("retained", EventPriority::Operational),
+            test_telemetry_event("broadcast_payload_mix", EventPriority::Shadow),
+            test_telemetry_event("outbound_message_mix", EventPriority::Shadow),
+        ]);
+
+        assert_eq!(worker.buffer.len(), MAX_BUFFER_SIZE);
+        let snapshot = worker.metrics.snapshot();
+        assert_eq!(snapshot.batch_send_failures_total, 1);
+        assert_eq!(snapshot.batch_retry_truncated_events_total, 2);
+        assert_eq!(
+            snapshot.known_shadow_rollups[KnownShadowRollup::BroadcastPayloadMix.index()]
+                .retry_truncated_total,
+            1
+        );
+        assert_eq!(
+            snapshot.known_shadow_rollups[KnownShadowRollup::OutboundMessageMix.index()]
+                .retry_truncated_total,
+            1
         );
     }
 
@@ -4183,25 +5227,37 @@ mod tests {
 
         // Fill the aggregate cap (some shadow, some operational) in window 0.
         assert_eq!(
-            admit_n(&mut worker, EventPriority::Shadow, 10, t0),
+            admit_n(&mut worker, EventPriority::Shadow, "test_shadow", 10, t0),
             MAX_SHADOW_EVENTS_PER_SECOND
         );
         assert_eq!(
-            admit_n(&mut worker, EventPriority::Operational, 10, t0),
+            admit_n(
+                &mut worker,
+                EventPriority::Operational,
+                "test_operational",
+                10,
+                t0,
+            ),
             MAX_EVENTS_PER_SECOND - MAX_SHADOW_EVENTS_PER_SECOND
         );
         // Window 0 is now full.
-        assert!(!worker.admit_event(EventPriority::Operational, t0));
+        assert!(!worker.admit_event(EventPriority::Operational, "test_operational", t0));
 
         // Roll the window over (exactly 1s is the boundary: >= 1s resets).
         let t1 = t0 + Duration::from_secs(1);
         assert_eq!(
-            admit_n(&mut worker, EventPriority::Shadow, 10, t1),
+            admit_n(&mut worker, EventPriority::Shadow, "test_shadow", 10, t1),
             MAX_SHADOW_EVENTS_PER_SECOND,
             "shadow sub-budget must refresh on window rollover"
         );
         assert_eq!(
-            admit_n(&mut worker, EventPriority::Operational, 10, t1),
+            admit_n(
+                &mut worker,
+                EventPriority::Operational,
+                "test_operational",
+                10,
+                t1,
+            ),
             MAX_EVENTS_PER_SECOND - MAX_SHADOW_EVENTS_PER_SECOND,
             "aggregate cap must refresh on window rollover"
         );
@@ -4217,6 +5273,7 @@ mod tests {
             admit_n(
                 &mut worker,
                 EventPriority::Operational,
+                "test_operational",
                 MAX_EVENTS_PER_SECOND,
                 t0
             ),
@@ -4225,7 +5282,7 @@ mod tests {
 
         let almost = t0 + Duration::from_millis(999);
         assert!(
-            !worker.admit_event(EventPriority::Operational, almost),
+            !worker.admit_event(EventPriority::Operational, "test_operational", almost),
             "window must not reset before a full second elapses"
         );
     }


### PR DESCRIPTION
## Why

Recent production telemetry shows very large contract-state broadcasts, including roughly 49 MiB full-state deliveries that produce no state change. Existing telemetry establishes the network harm but cannot distinguish the mechanisms that cause it: absent or ineffective summary knowledge, queue head-of-line blocking, receiver outcomes, state-size distribution, eviction eligibility/decisions, or telemetry loss itself.

This is an evidence-gathering change for #5090. It does **not** lower `MAX_STATE_SIZE`, change eviction policy, add a second state hash, or change network protocol behavior. Freenet summaries already serve the “peer has this state; do not resend it” role; this telemetry measures why that knowledge is missing or ineffective before we select an architectural fix.

## What

Adds a bounded, fixed-cardinality optional `network_efficiency_v1` block to the existing router snapshot. Its sources are cumulative and cheap; the wide block is exported every sixth five-minute snapshot (30-minute cadence), with `null` on intervening snapshots.

The block covers:

- summary registration, population, removal, missing-state age/current gauges, and delivery-gated missing-summary impact;
- sender payload causes and receiver `delta/full × terminal outcome × payload-size` results, plus resulting-state size for successful applies;
- broadcast queue capacity/dedup pressure, active duplication, queued-versus-actual payload classification, and exact head-of-line blocked time;
- persisted state-size inventory and pre-WASM/post-merge hard-limit rejections;
- current eviction eligibility by state size and actual eviction victims by reason/state bucket;
- telemetry enqueue/admission/drop/retry/sent counters, including the diagnostic block's own attempted-to-sent path.

The fixed diagnostic cannot be starved by ordinary telemetry saturation: it uses a dedicated capacity-one producer channel, bypasses the ordinary 10/s cap, and has one retry-buffer slot beyond the 100 ordinary slots. During a prolonged collector outage, the latest cumulative/current snapshot replaces the older pending one; that discarded historical point sample is counted explicitly as a coalesced terminal outcome.

All correlation and attribution are bounded. No peer IDs or unbounded contract-key collections are exported.

## Telemetry volume

Measured inner JSON / marginal full-OTLP collector ingress (including JSON-string escaping):

| Counter values | Inner block | Full-OTLP marginal |
| --- | ---: | ---: |
| all zero | 1,720 B | 1,778 B |
| all `999,999` | 4,850 B | 4,908 B |
| all `u64::MAX` | 13,614 B | 13,672 B |

An intervening `null` snapshot adds exactly 31 bytes. At the 30-minute cadence, including five null snapshots between blocks, this is about 90.6 / 237.3 / 648.1 KiB per peer-day for the three cases, or about 89 / 232 / 633 MiB/day at 1,000 reporting peers before transport compression.

Tests enforce 2,048 / 5,120 / 14,336-byte ceilings for both the inner block and full-OTLP marginal cases, and a 64-byte ceiling for the null marginal.

## Compatibility

Live OTLP JSON is self-describing. `NetworkEfficiencyV1` is an optional positional field on `RouterSnapshotInfo`; buffered pre-upgrade `RouterSnapshot` records in the append-only telemetry buffer can therefore fail bincode decoding and be skipped once during upgrade. The AOF reader already treats undecodable ephemeral telemetry records as skippable. This one-time buffered-telemetry effect is accepted and disclosed here explicitly.

No per-event `BroadcastApplied` fields were added, avoiding a higher-volume and broader positional-bincode change.

## Validation

- `cargo fmt --all --check`
- `git diff --check`
- `cargo check -p freenet --all-targets`
- `cargo clippy -p freenet --lib -- -D warnings`
- `cargo check -p freenet --features simulation_tests --lib`
- `cargo test -p freenet --lib` — 4,563 passed, 0 failed, 25 ignored
- independent concurrency/runtime, telemetry-schema/volume, and goal/test review passes

Closes #5090.

[AI-assisted - Codex]
