### PR TITLE
docs: drop stale git submodule step from build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,6 @@ Source: [github.com/freenet/paper-1](https://github.com/freenet/paper-1).
 
 ## Build Instructions
 
-Before installing anything you need to run the following in the repository,
-or the commands will fail:
-
-```bash
-$ git submodule update --init --recursive
-```
-
 To install the Freenet core:
 
 ```bash


### PR DESCRIPTION
## Problem

`README.md` opens Build Instructions with:

> Before installing anything you need to run the following in the repository, or the commands will fail:
> ```
> $ git submodule update --init --recursive
> ```

There are no submodules in the repo. `.gitmodules` was deleted in 598a0032 (Release v0.1.5, Jun 2025) when `freenet-stdlib` became a crates.io dependency (`Cargo.toml`: `freenet-stdlib = "0.8.5"`). The command is a no-op, and the claim that builds fail without it is false — new contributors are told a required setup step exists when it does not.

## Solution

Delete the paragraph. Verified on a fresh checkout of `main`: no `.gitmodules`, no submodules, `cargo build` needs no submodule init.

The alternative reading of #5088 — add a missing `.gitmodules` — is wrong; nothing is missing, the docs are just stale.

## Testing

Docs-only, no code paths touched.

## Fixes

Fixes #5088