### PR TITLE
fix(shell): reply with a notification_status on every notification path

### DIFF
--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -5602,11 +5602,6 @@ mod tests {
                 && show_slice.contains("!contractHasConsent()"),
             "showAppNotification must gate on browser permission AND per-contract consent"
         );
-        // Note: "exactly one status per message" is asserted BEHAVIORALLY in
-        // shell_bridge_notifications.test.mjs (cases 9 and 10), which drives the
-        // extracted functions and counts the posts. A substring count here would
-        // be a weaker restatement of that, so it deliberately isn't duplicated.
-        //
         // "Not now" must be durable so a contract that re-sends the enable prompt
         // can't re-pin the host-owned bar over the app.
         assert!(
@@ -5669,6 +5664,80 @@ mod tests {
         assert!(
             !SHELL_BRIDGE_JS.contains("'serviceWorker' in navigator"),
             "feature-detect by attempting the read (serviceWorkerOrNull), not via `in`"
+        );
+    }
+
+    /// #5043: a framed app can't read `Notification.permission` (opaque origin),
+    /// so the shell reporting a status is its ONLY way to learn a notification
+    /// was dropped. Regression pins for the two paths that were silent and were
+    /// re-broken during review of the first fix — the rate-limiter drop, and the
+    /// async service-worker chain, whose only rejection handler covered
+    /// `showNotification` and left a rejected registration lookup (or a
+    /// synchronous throw) with no reply at all.
+    ///
+    /// The exactly-one-status-per-message behavior is verified by driving the
+    /// real extracted functions in `shell_bridge_notifications.test.mjs` (cases
+    /// 9 and 10, run by the lint-assets CI job). These are source pins for the
+    /// two specific silent-return shapes, in the same discipline as the
+    /// `SHELL_BRIDGE_JS.contains` guards above, so a refactor that reintroduces
+    /// either shape fails here too.
+    #[test]
+    fn bridge_js_notification_drops_are_never_silent() {
+        let start = SHELL_BRIDGE_JS
+            .find("notify-show:BEGIN")
+            .expect("notify-show:BEGIN marker must bracket showAppNotification");
+        let end = SHELL_BRIDGE_JS[start..]
+            .find("notify-show:END")
+            .expect("notify-show:END marker must bracket showAppNotification");
+        let show = &SHELL_BRIDGE_JS[start..start + end];
+
+        // The rate-limiter drop is the most frequent one (a busy room hits the
+        // 3s per-tag throttle constantly). `if (...) return;` on one line is the
+        // exact shape it had while it was silent.
+        assert!(
+            !show.contains("if (!notifyLimiter.ok(opts.tag, Date.now())) return;"),
+            "the rate-limited drop must post a status, not return silently (#5043)"
+        );
+        assert!(
+            show.contains("notifyLimiter.ok(") && show.contains("notifyStatusToIframe('granted')"),
+            "the rate-limited drop must report 'granted' — permission and consent \
+             are intact and the shell merely coalesced the message"
+        );
+
+        // The service-worker chain needs a terminal .catch: without it a rejected
+        // notifyRegistrationReady, a synchronous throw from showNotification, or
+        // a non-thenable return all leave the app with no reply.
+        let sw_start = show
+            .find("notifyRegistrationReady(")
+            .expect("the mobile fallback must go through notifyRegistrationReady");
+        let sw_chain = &show[sw_start..];
+        assert!(
+            sw_chain.contains(".catch("),
+            "the service-worker delivery chain must end in a .catch so a rejected \
+             registration lookup or a throwing showNotification still replies (#5043)"
+        );
+        // ...and that backstop must not turn one reply into two: every post from
+        // the chain goes through the post-at-most-once helper, never through
+        // notifyStatusToIframe directly.
+        assert!(
+            show.contains("var swReplied = false;") && sw_chain.contains("swReply("),
+            "the service-worker chain's .catch backstop must be guarded so a throw \
+             from the success-path status post can't produce a second reply"
+        );
+        assert!(
+            !sw_chain.contains("notifyStatusToIframe("),
+            "the service-worker chain must post via swReply(), which is what bounds \
+             it to one reply — a direct notifyStatusToIframe call bypasses that"
+        );
+
+        // The constructor path's status post must sit OUTSIDE the try: inside, a
+        // throw from it reads as "constructor unsupported" and the worker path
+        // displays the SAME notification a second time.
+        assert!(
+            show.contains("shownByConstructor = true;")
+                && show.contains("if (shownByConstructor) {"),
+            "the constructor path must record delivery in a flag and report \
+             outside the try, so a throwing status post can't double-deliver"
         );
     }
 

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -5575,9 +5575,11 @@ mod tests {
         // Every notification is gated on BOTH the browser permission AND this
         // contract's own consent, so one contract's gateway-wide browser grant
         // can't notify the user on behalf of a different contract.
+        // (Two separate gates since #5043, so each drop can report its own
+        // `notification_status` back to the app instead of returning silently.)
         assert!(
-            SHELL_BRIDGE_JS
-                .contains("Notification.permission !== 'granted' || !contractHasConsent()"),
+            SHELL_BRIDGE_JS.contains("Notification.permission !== 'granted'")
+                && SHELL_BRIDGE_JS.contains("!contractHasConsent()"),
             "showAppNotification must gate on browser permission AND per-contract consent"
         );
         // "Not now" must be durable so a contract that re-sends the enable prompt

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -5572,16 +5572,41 @@ mod tests {
             SHELL_BRIDGE_JS.contains(r"/\/v[12]\/contract\/web\/([^/?#]+)/"),
             "notification consent key must derive from the /v[12]/contract/web/<key> path"
         );
+        // The markers bracket showAppNotification so shell_bridge_notifications
+        // .test.mjs can extract and drive it. Pin them here: without this,
+        // deleting the markers AND the .mjs cases together leaves CI green with
+        // the #5043 status coverage silently gone.
+        let show_start = SHELL_BRIDGE_JS
+            .find("notify-show:BEGIN")
+            .expect("notify-show:BEGIN marker must bracket showAppNotification");
+        let show_end = SHELL_BRIDGE_JS[show_start..]
+            .find("notify-show:END")
+            .expect("notify-show:END marker must bracket showAppNotification");
+        let show_slice = &SHELL_BRIDGE_JS[show_start..show_start + show_end];
+        // Same for the enable-prompt ladder (#5043 item 3).
+        let offer_start = SHELL_BRIDGE_JS
+            .find("notify-offer:BEGIN")
+            .expect("notify-offer:BEGIN marker must bracket maybeOfferNotifications");
+        assert!(
+            SHELL_BRIDGE_JS[offer_start..].contains("notify-offer:END"),
+            "notify-offer:END marker must bracket maybeOfferNotifications"
+        );
         // Every notification is gated on BOTH the browser permission AND this
-        // contract's own consent, so one contract's gateway-wide browser grant
-        // can't notify the user on behalf of a different contract.
+        // contract's own consent. Asserted against the marker-bounded slice, so
+        // the gates must live INSIDE showAppNotification — two file-wide
+        // `contains` calls would stay green if a refactor moved them out.
         // (Two separate gates since #5043, so each drop can report its own
         // `notification_status` back to the app instead of returning silently.)
         assert!(
-            SHELL_BRIDGE_JS.contains("Notification.permission !== 'granted'")
-                && SHELL_BRIDGE_JS.contains("!contractHasConsent()"),
+            show_slice.contains("Notification.permission !== 'granted'")
+                && show_slice.contains("!contractHasConsent()"),
             "showAppNotification must gate on browser permission AND per-contract consent"
         );
+        // Note: "exactly one status per message" is asserted BEHAVIORALLY in
+        // shell_bridge_notifications.test.mjs (cases 9 and 10), which drives the
+        // extracted functions and counts the posts. A substring count here would
+        // be a weaker restatement of that, so it deliberately isn't duplicated.
+        //
         // "Not now" must be durable so a contract that re-sends the enable prompt
         // can't re-pin the host-owned bar over the app.
         assert!(

--- a/crates/core/src/server/path_handlers/assets/shell_bridge.js
+++ b/crates/core/src/server/path_handlers/assets/shell_bridge.js
@@ -575,7 +575,12 @@ function freenetBridge(authToken, userToken, hostedMode) {
       notifyStatusToIframe('dismissed');
       return;
     }
-    if (notifyAffordanceShown) return;
+    if (notifyAffordanceShown) {
+      // The bar is already on screen awaiting a click: the prompt is pending,
+      // not lost. Reply so a client can tell "still deciding" from "dropped".
+      notifyStatusToIframe('default');
+      return;
+    }
     notifyAffordanceShown = true;
 
     var bar = document.createElement('div');
@@ -792,10 +797,31 @@ function freenetBridge(authToken, userToken, hostedMode) {
     });
   }
 
+  // notify-show:BEGIN (extracted verbatim by shell_bridge_notifications.test.mjs)
+  // Every `notification` message gets exactly one status reply: the drop paths
+  // below report WHY nothing was shown, and the display paths re-affirm
+  // 'granted'. That re-affirmation is what retracts an earlier 'undeliverable'
+  // — e.g. the first notification of a session racing the service worker's
+  // activation — which otherwise stuck for the whole session (#5043).
   function showAppNotification(msg) {
-    if (typeof Notification === 'undefined') return;
+    if (typeof Notification === 'undefined') {
+      notifyStatusToIframe('unsupported');
+      return;
+    }
     // Gate on BOTH the browser permission and this contract's own consent.
-    if (Notification.permission !== 'granted' || !contractHasConsent()) return;
+    // A framed app can't read Notification.permission itself (opaque origin),
+    // so a permission revoked in site settings after a 'granted' is only
+    // visible to it if we report it here.
+    if (Notification.permission !== 'granted') {
+      notifyStatusToIframe(
+        Notification.permission === 'denied' ? 'denied' : 'default',
+      );
+      return;
+    }
+    if (!contractHasConsent()) {
+      notifyStatusToIframe('default');
+      return;
+    }
     // Notification renders text only (no markup), so no HTML-injection risk;
     // still cap length to prevent oversized/abusive content.
     var title = String(msg.title).slice(0, 128);
@@ -828,6 +854,7 @@ function freenetBridge(authToken, userToken, hostedMode) {
     // Desktop: use the page-level constructor, UNCHANGED. Mobile: it throws
     // (unsupported), so we fall through to the service-worker path below — the
     // only way to show a notification on mobile.
+    var shownByConstructor = false;
     try {
       var n = new Notification(title, opts);
       n.onclick = function () {
@@ -844,16 +871,25 @@ function freenetBridge(authToken, userToken, hostedMode) {
           n.close();
         } catch (e) {}
       };
-      return;
+      shownByConstructor = true;
     } catch (e) {
       // Mobile Chrome/Firefox: the non-persistent `new Notification()`
       // constructor is unsupported and throws. Deliver via the service worker.
+    }
+    // Report OUTSIDE the try: a throw from the status post must not look like a
+    // constructor failure and fall through to a second, duplicate delivery.
+    if (shownByConstructor) {
+      notifyStatusToIframe('granted');
+      return;
     }
 
     notifyRegistrationReady(1500).then(function (reg) {
       if (reg && typeof reg.showNotification === 'function') {
         reg.showNotification(title, opts).then(
-          function () {},
+          function () {
+            // Delivered: re-affirm, retracting any earlier 'undeliverable'.
+            notifyStatusToIframe('granted');
+          },
           function () {
             // The worker exists but the show failed — nothing else can display
             // it; tell the app so it can rely on the in-app unread badge.
@@ -868,6 +904,7 @@ function freenetBridge(authToken, userToken, hostedMode) {
       }
     });
   }
+  // notify-show:END
 
   // Install the click-forward listener eagerly on every shell load (see
   // installNotifyClickListener) so a click on a persistent notification that

--- a/crates/core/src/server/path_handlers/assets/shell_bridge.js
+++ b/crates/core/src/server/path_handlers/assets/shell_bridge.js
@@ -552,6 +552,10 @@ function freenetBridge(authToken, userToken, hostedMode) {
   // by a gesture in the shell: a click inside the sandboxed iframe does not
   // reliably grant the shell the transient activation the browser requires for
   // Notification.requestPermission().
+  // notify-offer:BEGIN (extracted verbatim by shell_bridge_notifications.test.mjs)
+  // Like showAppNotification, every `notification_enable_prompt` gets exactly
+  // one status reply — including the already-showing case, which would
+  // otherwise answer with silence a client can't tell from a lost message.
   function maybeOfferNotifications() {
     if (typeof Notification === 'undefined') {
       notifyStatusToIframe('unsupported');
@@ -655,6 +659,7 @@ function freenetBridge(authToken, userToken, hostedMode) {
     bar.appendChild(dismiss);
     document.body.appendChild(bar);
   }
+  // notify-offer:END
 
   // --- Service-worker fallback for notifications (mobile) ----------------
   // Desktop browsers show notifications with the page-level `new
@@ -798,11 +803,15 @@ function freenetBridge(authToken, userToken, hostedMode) {
   }
 
   // notify-show:BEGIN (extracted verbatim by shell_bridge_notifications.test.mjs)
-  // Every `notification` message gets exactly one status reply: the drop paths
-  // below report WHY nothing was shown, and the display paths re-affirm
-  // 'granted'. That re-affirmation is what retracts an earlier 'undeliverable'
-  // — e.g. the first notification of a session racing the service worker's
-  // activation — which otherwise stuck for the whole session (#5043).
+  // Every well-formed `notification` message gets exactly one status reply:
+  // EVERY path out of this function posts one, whether it displayed or dropped.
+  // The display paths re-affirm 'granted', and that re-affirmation is what
+  // retracts an earlier 'undeliverable' — e.g. the first notification of a
+  // session racing the service worker's activation — which otherwise stuck for
+  // the whole session (#5043). Two bounds on the guarantee: a `notification`
+  // whose `title` isn't a string never reaches here (the dispatcher's type
+  // check drops it), and delivery of the status itself is best-effort, since
+  // sendToIframe no-ops when the iframe is gone.
   function showAppNotification(msg) {
     if (typeof Notification === 'undefined') {
       notifyStatusToIframe('unsupported');
@@ -818,7 +827,18 @@ function freenetBridge(authToken, userToken, hostedMode) {
       );
       return;
     }
+    if (!contractConsentKey()) {
+      // No contract key to gate consent on: permanent for this page, and
+      // re-prompting can never fix it. maybeOfferNotifications reports the same
+      // condition as 'undeliverable'; keep the two in agreement rather than
+      // sending the app into a prompt loop it cannot win.
+      notifyStatusToIframe('undeliverable');
+      return;
+    }
     if (!contractHasConsent()) {
+      // Browser-granted but this contract isn't opted in. Reported as 'default'
+      // — the same client-visible meaning as a browser 'default': not enabled
+      // yet, and the next notification_enable_prompt can still fix it.
       notifyStatusToIframe('default');
       return;
     }
@@ -835,7 +855,16 @@ function freenetBridge(authToken, userToken, hostedMode) {
       ckey + ':' + (typeof msg.tag === 'string' ? msg.tag.slice(0, 64) : 'msg');
     // Per-tag throttle + rolling global cap: distinct rooms aren't dropped, but
     // a consented contract can't flood with unique tags.
-    if (!notifyLimiter.ok(opts.tag, Date.now())) return;
+    if (!notifyLimiter.ok(opts.tag, Date.now())) {
+      // Coalesced by the shell's own flood policy, NOT a delivery problem:
+      // permission and consent are both intact. Report 'granted' so the app
+      // can't confuse a throttled message with a lost one — and so a throttled
+      // message still retracts a stale 'undeliverable'. Reporting
+      // 'undeliverable' here would be the #5043 bug in reverse: a working,
+      // deliberately-throttled setup made to look broken.
+      notifyStatusToIframe('granted');
+      return;
+    }
     // Cap the routing tag like opts.tag — it's attacker-controlled (the app
     // supplies msg.tag) and is echoed back into the iframe on click.
     var routeTag = typeof msg.tag === 'string' ? msg.tag.slice(0, 64) : null;
@@ -857,6 +886,10 @@ function freenetBridge(authToken, userToken, hostedMode) {
     var shownByConstructor = false;
     try {
       var n = new Notification(title, opts);
+      // Set the instant the constructor returns: it has ALREADY displayed, so a
+      // throw from anything below (an exotic onclick setter) must not fall
+      // through to the worker path and display the same notification twice.
+      shownByConstructor = true;
       n.onclick = function () {
         try {
           window.focus();
@@ -871,38 +904,58 @@ function freenetBridge(authToken, userToken, hostedMode) {
           n.close();
         } catch (e) {}
       };
-      shownByConstructor = true;
     } catch (e) {
-      // Mobile Chrome/Firefox: the non-persistent `new Notification()`
-      // constructor is unsupported and throws. Deliver via the service worker.
+      // EXPECTED on mobile Chrome/Firefox: the non-persistent `new
+      // Notification()` constructor is unsupported and throws, so we deliver via
+      // the service worker below. Logged because on DESKTOP this same throw
+      // means a real bug (malformed opts, permission lost between the check and
+      // the call) and is otherwise indistinguishable from the mobile path.
+      try {
+        console.debug('freenet: Notification constructor threw', e);
+      } catch (e2) {}
     }
-    // Report OUTSIDE the try: a throw from the status post must not look like a
-    // constructor failure and fall through to a second, duplicate delivery.
+    // Report OUTSIDE the try: the try must contain only the display attempt, so
+    // its catch means "constructor unsupported" and nothing else. A throw from
+    // the status post inside it would look like a constructor failure and fall
+    // through to a second, duplicate delivery.
     if (shownByConstructor) {
       notifyStatusToIframe('granted');
       return;
     }
 
-    notifyRegistrationReady(1500).then(function (reg) {
-      if (reg && typeof reg.showNotification === 'function') {
-        reg.showNotification(title, opts).then(
-          function () {
+    // Post at most once from the async chain: the .catch below is a backstop for
+    // the whole chain, INCLUDING a throw from a status post in the success
+    // branch, which would otherwise turn one reply into two.
+    var swReplied = false;
+    function swReply(status) {
+      if (swReplied) return;
+      swReplied = true;
+      notifyStatusToIframe(status);
+    }
+
+    notifyRegistrationReady(1500)
+      .then(function (reg) {
+        if (reg && typeof reg.showNotification === 'function') {
+          // Return the inner promise so a rejection (or a synchronous throw, or
+          // a non-thenable return) lands in the single .catch below.
+          return reg.showNotification(title, opts).then(function () {
             // Delivered: re-affirm, retracting any earlier 'undeliverable'.
-            notifyStatusToIframe('granted');
-          },
-          function () {
-            // The worker exists but the show failed — nothing else can display
-            // it; tell the app so it can rely on the in-app unread badge.
-            notifyStatusToIframe('undeliverable');
-          },
-        );
-      } else {
+            swReply('granted');
+          });
+        }
         // No usable service worker (e.g. an insecure-context http origin) AND
         // the page-level constructor threw: nothing can display it. Tell the app
         // so it need not keep sending; the in-app unread badge is the fallback.
-        notifyStatusToIframe('undeliverable');
-      }
-    });
+        swReply('undeliverable');
+      })
+      .catch(function () {
+        // Anything else the worker path can throw or reject with — a
+        // SecurityError from a sandboxed service-worker property read (the
+        // #4945 getter hazard, see serviceWorkerOrNull), a showNotification
+        // that throws or returns a non-promise. Nothing was
+        // displayed, so the app must hear about it rather than wait forever.
+        swReply('undeliverable');
+      });
   }
   // notify-show:END
 

--- a/crates/core/src/server/shell_bridge_notifications.test.mjs
+++ b/crates/core/src/server/shell_bridge_notifications.test.mjs
@@ -326,13 +326,18 @@ function check(name, cond) {
   );
 }
 
-// 9. showAppNotification status replies (#5043): every `notification` message
-//    must produce exactly one `notification_status`. Before the fix the three
-//    drop paths returned silently (so a permission revoked in site settings
-//    left a framed app displaying "enabled" forever — it cannot read
-//    Notification.permission across the opaque origin), and there was no status
-//    on the success path, so a transient 'undeliverable' from the service
-//    worker activation race stuck for the whole session.
+// 9. showAppNotification status replies (#5043): every well-formed
+//    `notification` message must produce exactly one `notification_status`.
+//    Before the fix, showAppNotification returned silently on three conditions
+//    (no Notification API, permission not granted, contract consent withdrawn),
+//    so a permission revoked in site settings left a framed app displaying
+//    "enabled" forever — it cannot read Notification.permission across the
+//    opaque origin. And there was no status on the success path, so a transient
+//    'undeliverable' from the service-worker activation race stuck for the
+//    whole session.
+//
+//    Every check below asserts `statuses.length === 1`, not just the value: a
+//    deleted post and a duplicated post must both fail.
 {
   const SBEGIN = 'notify-show:BEGIN';
   const SEND = 'notify-show:END';
@@ -373,8 +378,19 @@ function check(name, cond) {
           );
     const swShow = (title, opts) => {
       if (ctl.swShowRejects) return Promise.reject(new Error('show failed'));
+      if (ctl.swShowThrows) throw new Error('illegal invocation');
       shown.push({ via: 'sw', title, opts });
-      return Promise.resolve();
+      // A worker whose showNotification returns a non-thenable would make a
+      // bare `.then()` on the result throw — the chain must still reply.
+      return ctl.swShowNonThenable ? undefined : Promise.resolve();
+    };
+    // `statusThrowsOn` makes the Nth (0-indexed) status post throw, standing in
+    // for a postMessage into a torn-down iframe. The value is still recorded, so
+    // a check can assert what WOULD have been sent.
+    let statusCalls = 0;
+    const postStatus = (s) => {
+      statuses.push(s);
+      if (statusCalls++ === ctl.statusThrowsOn) throw new Error('post failed');
     };
     const fn = new Function(
       'Notification',
@@ -386,18 +402,26 @@ function check(name, cond) {
       'notifyRegistrationReady',
       'location',
       'window',
+      // Stubbed so the (expected) mobile-path constructor throw doesn't spray
+      // the diagnostic log over the test output.
+      'console',
       `${showSource}\nreturn showAppNotification;`,
     )(
       Notification,
-      (s) => statuses.push(s),
-      () => ctl.consent !== false,
-      () => 'freenet_notify:KEY',
+      postStatus,
+      () => ctl.consent !== false && ctl.noContractKey !== true,
+      () => (ctl.noContractKey ? null : 'freenet_notify:KEY'),
       { ok: () => ctl.limited !== true },
       () => {},
       () =>
-        Promise.resolve(ctl.swAvailable ? { showNotification: swShow } : null),
+        ctl.regRejects
+          ? Promise.reject(new Error('SecurityError'))
+          : Promise.resolve(
+              ctl.swAvailable ? { showNotification: swShow } : null,
+            ),
       { href: 'https://gw.example/v2/contract/web/KEY/' },
       { focus() {} },
+      { debug() {} },
     );
     return { fn, statuses, shown };
   }
@@ -493,28 +517,237 @@ function check(name, cond) {
       h.statuses.length === 1 && h.statuses[0] === 'undeliverable',
     );
   }
-  // A delivery after a stale 'undeliverable' retracts it: the LAST status a
-  // client sees is 'granted', not the session-long false warning of #5043.
   {
     const h = makeShowHarness({
       permission: 'granted',
       constructorThrows: true,
-      swAvailable: false,
+      swAvailable: true,
+      swShowThrows: true,
     });
-    h.fn({ title: 'first' }); // races SW activation -> undeliverable
+    h.fn({ title: 't' });
     await new Promise((r) => setTimeout(r, 0));
-    const h2 = makeShowHarness({
+    check(
+      'worker show throws synchronously -> exactly one "undeliverable"',
+      h.statuses.length === 1 && h.statuses[0] === 'undeliverable',
+    );
+  }
+  {
+    const h = makeShowHarness({
       permission: 'granted',
       constructorThrows: true,
       swAvailable: true,
+      swShowNonThenable: true,
     });
-    h2.statuses.push(...h.statuses); // same session, same client
-    h2.fn({ title: 'second' }); // worker now active -> delivered
+    h.fn({ title: 't' });
     await new Promise((r) => setTimeout(r, 0));
     check(
-      'a later delivery retracts an earlier "undeliverable"',
-      h2.statuses[0] === 'undeliverable' &&
-        h2.statuses[h2.statuses.length - 1] === 'granted',
+      'worker show returns a non-promise -> exactly one "undeliverable"',
+      h.statuses.length === 1 && h.statuses[0] === 'undeliverable',
+    );
+  }
+  {
+    // notifyRegistrationReady itself rejecting (a SecurityError from a
+    // sandboxed navigator.serviceWorker read, #4945) must not strand the app.
+    const h = makeShowHarness({
+      permission: 'granted',
+      constructorThrows: true,
+      regRejects: true,
+    });
+    h.fn({ title: 't' });
+    await new Promise((r) => setTimeout(r, 0));
+    check(
+      'registration lookup rejects -> exactly one "undeliverable"',
+      h.statuses.length === 1 && h.statuses[0] === 'undeliverable',
+    );
+  }
+  {
+    // No contract key to gate consent on: permanent, so report it as
+    // 'undeliverable' the way maybeOfferNotifications does — NOT 'default',
+    // which would send the app into a re-prompt loop it can never win.
+    const h = makeShowHarness({ permission: 'granted', noContractKey: true });
+    h.fn({ title: 't' });
+    check(
+      'no contract key -> exactly one "undeliverable"',
+      h.statuses.length === 1 && h.statuses[0] === 'undeliverable',
+    );
+  }
+  {
+    // Rate-limited: the shell coalesced it, but permission and consent are both
+    // intact, so the app must not read it as a delivery problem. This branch
+    // fires constantly in a busy room (3s per-tag throttle), so leaving it
+    // silent would be the biggest hole in the one-status-per-message rule.
+    const h = makeShowHarness({ permission: 'granted', limited: true });
+    h.fn({ title: 't' });
+    check(
+      'rate-limited -> exactly one "granted", nothing shown',
+      h.statuses.length === 1 &&
+        h.statuses[0] === 'granted' &&
+        h.shown.length === 0,
+    );
+  }
+  {
+    // Pins the hoist of the constructor-path status post out of the `try`: if
+    // the post throws from INSIDE it, the catch reads as "constructor
+    // unsupported" and the worker path shows the SAME notification a second
+    // time. With the post outside, the throw escapes and there is exactly one
+    // delivery. Reverting the hoist makes this the only failing check.
+    const h = makeShowHarness({
+      permission: 'granted',
+      swAvailable: true,
+      statusThrowsOn: 0,
+    });
+    let threw = false;
+    try {
+      h.fn({ title: 't' });
+    } catch (e) {
+      threw = true;
+    }
+    await new Promise((r) => setTimeout(r, 0));
+    check(
+      'a throwing status post cannot cause a duplicate delivery',
+      threw === true &&
+        h.shown.length === 1 &&
+        h.shown[0].via === 'constructor',
+    );
+  }
+  {
+    // The #5043 headline scenario end to end, on ONE harness so the sequence is
+    // real: the session's first notification loses the service-worker
+    // activation race, the worker then activates, and the second notification
+    // delivers. The client's status stream must be exactly
+    // ['undeliverable', 'granted'] — the false warning is retracted, and
+    // neither message produced zero or two replies.
+    const ctl = { permission: 'granted', constructorThrows: true };
+    const h = makeShowHarness(ctl);
+    ctl.swAvailable = false; // worker not active yet
+    h.fn({ title: 'first' });
+    await new Promise((r) => setTimeout(r, 0));
+    ctl.swAvailable = true; // worker activated
+    h.fn({ title: 'second' });
+    await new Promise((r) => setTimeout(r, 0));
+    check(
+      'stale "undeliverable" is retracted by the next delivery',
+      h.statuses.length === 2 &&
+        h.statuses[0] === 'undeliverable' &&
+        h.statuses[1] === 'granted' &&
+        h.shown.length === 1 &&
+        h.shown[0].via === 'sw',
+    );
+  }
+}
+
+// 10. maybeOfferNotifications status replies (#5043 item 3): every
+//     `notification_enable_prompt` gets exactly one reply too. The
+//     already-showing branch used to return silently, which a client cannot
+//     distinguish from its message being lost. Driven with a stub `document`
+//     so the DOM-building tail runs without a browser.
+{
+  const OBEGIN = 'notify-offer:BEGIN';
+  const OEND = 'notify-offer:END';
+  const ob = src.indexOf(OBEGIN);
+  const oe = src.indexOf(OEND);
+  if (ob < 0 || oe < 0 || oe < ob) {
+    console.error(
+      `FAIL: could not find ${OBEGIN}/${OEND} markers in ${assetPath}.`,
+    );
+    process.exit(1);
+  }
+  const offerRegion = src.slice(ob, oe);
+  const offerStart = offerRegion.indexOf('function maybeOfferNotifications(');
+  if (offerStart < 0) {
+    console.error(
+      'FAIL: no `function maybeOfferNotifications(` between the markers.',
+    );
+    process.exit(1);
+  }
+  const offerSource = offerRegion.slice(offerStart);
+
+  function makeOfferHarness(ctl) {
+    const statuses = [];
+    const clicks = {};
+    const node = () => ({
+      style: {},
+      setAttribute() {},
+      appendChild() {},
+      removeChild() {},
+      addEventListener(ev, cb) {
+        clicks[this.textContent] = cb;
+      },
+    });
+    const body = node();
+    const document = { createElement: node, body };
+    // `notifyAffordanceShown` lives at module scope in the asset; declare it in
+    // the prelude so the extracted function keeps its across-call state.
+    const fn = new Function(
+      'Notification',
+      'notifyStatusToIframe',
+      'contractHasConsent',
+      'isNotifySnoozed',
+      'setNotifySnoozed',
+      'setContractConsent',
+      'ensureNotifyServiceWorker',
+      'document',
+      `var notifyAffordanceShown = false;\n${offerSource}\nreturn maybeOfferNotifications;`,
+    )(
+      ctl.permission === undefined
+        ? undefined
+        : { permission: ctl.permission, requestPermission: () => {} },
+      (s) => statuses.push(s),
+      () => ctl.consent === true,
+      () => ctl.snoozed === true,
+      () => {},
+      () => true,
+      () => {},
+      document,
+    );
+    return { fn, statuses };
+  }
+
+  {
+    const h = makeOfferHarness({ permission: undefined });
+    h.fn();
+    check(
+      'prompt with no Notification API -> exactly one "unsupported"',
+      h.statuses.length === 1 && h.statuses[0] === 'unsupported',
+    );
+  }
+  {
+    const h = makeOfferHarness({ permission: 'denied' });
+    h.fn();
+    check(
+      'prompt when already denied -> exactly one "denied"',
+      h.statuses.length === 1 && h.statuses[0] === 'denied',
+    );
+  }
+  {
+    const h = makeOfferHarness({ permission: 'granted', consent: true });
+    h.fn();
+    check(
+      'prompt when already opted in -> exactly one "granted"',
+      h.statuses.length === 1 && h.statuses[0] === 'granted',
+    );
+  }
+  {
+    const h = makeOfferHarness({ permission: 'default', snoozed: true });
+    h.fn();
+    check(
+      'prompt while snoozed -> exactly one "dismissed"',
+      h.statuses.length === 1 && h.statuses[0] === 'dismissed',
+    );
+  }
+  {
+    // The bar goes up on the first prompt (no status — the user is being asked,
+    // and the answer arrives on the button handlers). A SECOND prompt while it
+    // is still on screen must reply rather than return silently.
+    const h = makeOfferHarness({ permission: 'default' });
+    h.fn();
+    const afterFirst = h.statuses.length;
+    h.fn();
+    check(
+      'a re-sent prompt while the bar is showing -> exactly one "default"',
+      afterFirst === 0 &&
+        h.statuses.length === 1 &&
+        h.statuses[0] === 'default',
     );
   }
 }

--- a/crates/core/src/server/shell_bridge_notifications.test.mjs
+++ b/crates/core/src/server/shell_bridge_notifications.test.mjs
@@ -38,7 +38,9 @@ if (b < 0 || e < 0 || e < b) {
 const region = src.slice(b, e);
 const fnStart = region.indexOf('function makeNotifyRateLimiter(');
 if (fnStart < 0) {
-  console.error('FAIL: no `function makeNotifyRateLimiter(` between the markers.');
+  console.error(
+    'FAIL: no `function makeNotifyRateLimiter(` between the markers.',
+  );
   process.exit(1);
 }
 const fnSource = region.slice(fnStart);
@@ -66,7 +68,9 @@ if (sb < 0 || se < 0 || se < sb) {
 const storeRegion = src.slice(sb, se);
 const storeFnStart = storeRegion.indexOf('function makeNotifyRateStore(');
 if (storeFnStart < 0) {
-  console.error('FAIL: no `function makeNotifyRateStore(` between the store markers.');
+  console.error(
+    'FAIL: no `function makeNotifyRateStore(` between the store markers.',
+  );
   process.exit(1);
 }
 const storeFnSource = storeRegion.slice(storeFnStart);
@@ -114,7 +118,10 @@ function check(name, cond) {
 {
   const rl = makeNotifyRateLimiter();
   check('same tag t=0 allowed', rl.ok('a', 0) === true);
-  check('same tag t=2999 blocked (throttle window)', rl.ok('a', 2999) === false);
+  check(
+    'same tag t=2999 blocked (throttle window)',
+    rl.ok('a', 2999) === false,
+  );
   check('same tag t=3000 allowed (window elapsed)', rl.ok('a', 3000) === true);
 }
 
@@ -132,16 +139,25 @@ function check(name, cond) {
   let passed = 0;
   for (let i = 0; i < 20; i++) if (rl.ok('tag' + i, 1000 + i)) passed++;
   check('first 20 distinct tags pass', passed === 20);
-  check('21st distinct tag blocked by global cap', rl.ok('tag20', 1500) === false);
+  check(
+    '21st distinct tag blocked by global cap',
+    rl.ok('tag20', 1500) === false,
+  );
 }
 
 // 4. Rolling window: once the oldest entries age past 60s, capacity frees up.
 {
   const rl = makeNotifyRateLimiter();
   for (let i = 0; i < 20; i++) rl.ok('t' + i, 0); // fill the window at t=0
-  check('at capacity blocks a new tag at t=59999', rl.ok('new', 59999) === false);
+  check(
+    'at capacity blocks a new tag at t=59999',
+    rl.ok('new', 59999) === false,
+  );
   // At t=60000 the t=0 entries have aged out (now - t is no longer < 60000).
-  check('window expiry frees capacity at t=60000', rl.ok('new', 60000) === true);
+  check(
+    'window expiry frees capacity at t=60000',
+    rl.ok('new', 60000) === true,
+  );
 }
 
 // 5. Bounded per-tag map: a flood of >128 distinct tags must not throw, the
@@ -157,8 +173,14 @@ function check(name, cond) {
   for (let i = 0; i < 300; i++) {
     if (rl.ok('flood' + i, i * 61000) !== true) allOk = false;
   }
-  check('300 spaced distinct tags all pass (eviction bounded, no throw)', allOk);
-  check('per-tag map stays bounded by MAP_CAP after the flood', rl.tagCount() <= 128);
+  check(
+    '300 spaced distinct tags all pass (eviction bounded, no throw)',
+    allOk,
+  );
+  check(
+    'per-tag map stays bounded by MAP_CAP after the flood',
+    rl.tagCount() <= 128,
+  );
 }
 
 // 6. Reload persistence (#4849): the rolling global window is rehydrated from
@@ -179,7 +201,10 @@ function check(name, cond) {
   let filled = 0;
   for (let i = 0; i < 20; i++) if (before.ok('t' + i, 1000 + i)) filled++;
   check('cap fills on first load', filled === 20);
-  check('window persisted to store', Array.isArray(saved) && saved.length === 20);
+  check(
+    'window persisted to store',
+    Array.isArray(saved) && saved.length === 20,
+  );
   // Simulate the reload: a NEW limiter rehydrates from the same store. The next
   // notification (still inside the 60s window) must be blocked — no reset.
   const afterReload = makeNotifyRateLimiter(store);
@@ -256,7 +281,10 @@ function check(name, cond) {
   );
   // Non-array stored value -> null (the sharp Array.isArray guard).
   h.back[h.key] = JSON.stringify('not-an-array');
-  check('adapter returns null for a non-array stored value', h.store.load() === null);
+  check(
+    'adapter returns null for a non-array stored value',
+    h.store.load() === null,
+  );
   // Corrupt JSON -> null (fail safe).
   h.back[h.key] = '{not valid json';
   check('adapter returns null for corrupt JSON', h.store.load() === null);
@@ -265,7 +293,10 @@ function check(name, cond) {
   const filtered = h.store.load();
   check(
     'adapter filters non-finite / non-number entries',
-    Array.isArray(filtered) && filtered.length === 2 && filtered[0] === 1 && filtered[1] === 2,
+    Array.isArray(filtered) &&
+      filtered.length === 2 &&
+      filtered[0] === 1 &&
+      filtered[1] === 2,
   );
   // Future-dated timestamps (backward clock correction) clamped out.
   h.back[h.key] = JSON.stringify([1000, Date.now() + 10 * 60 * 1000]);
@@ -283,10 +314,209 @@ function check(name, cond) {
     saveThrew = true;
   }
   check('adapter save swallows storage errors', saveThrew === false);
-  check('adapter load returns null when storage throws', h.store.load() === null);
+  check(
+    'adapter load returns null when storage throws',
+    h.store.load() === null,
+  );
   // No contract key -> null store (limiter runs in-memory, no persistence).
   const none = makeStoreHarness('/some/other/path');
-  check('makeNotifyRateStore returns null when there is no contract key', none.store === null);
+  check(
+    'makeNotifyRateStore returns null when there is no contract key',
+    none.store === null,
+  );
+}
+
+// 9. showAppNotification status replies (#5043): every `notification` message
+//    must produce exactly one `notification_status`. Before the fix the three
+//    drop paths returned silently (so a permission revoked in site settings
+//    left a framed app displaying "enabled" forever — it cannot read
+//    Notification.permission across the opaque origin), and there was no status
+//    on the success path, so a transient 'undeliverable' from the service
+//    worker activation race stuck for the whole session.
+{
+  const SBEGIN = 'notify-show:BEGIN';
+  const SEND = 'notify-show:END';
+  const nb = src.indexOf(SBEGIN);
+  const ne = src.indexOf(SEND);
+  if (nb < 0 || ne < 0 || ne < nb) {
+    console.error(
+      `FAIL: could not find ${SBEGIN}/${SEND} markers in ${assetPath}.`,
+    );
+    process.exit(1);
+  }
+  // Slice from the `function` keyword: the BEGIN marker sits inside a `//`
+  // comment, so starting at the marker itself would not parse.
+  const showRegion = src.slice(nb, ne);
+  const showStart = showRegion.indexOf('function showAppNotification(');
+  if (showStart < 0) {
+    console.error(
+      'FAIL: no `function showAppNotification(` between the markers.',
+    );
+    process.exit(1);
+  }
+  const showSource = showRegion.slice(showStart);
+
+  // Build showAppNotification with every collaborator injected. `ctl` drives
+  // the branch under test; `statuses` records what the iframe would receive.
+  function makeShowHarness(ctl) {
+    const statuses = [];
+    const shown = [];
+    const Notification =
+      ctl.permission === undefined
+        ? undefined
+        : Object.assign(
+            function (title, opts) {
+              if (ctl.constructorThrows) throw new Error('unsupported');
+              shown.push({ via: 'constructor', title, opts });
+            },
+            { permission: ctl.permission },
+          );
+    const swShow = (title, opts) => {
+      if (ctl.swShowRejects) return Promise.reject(new Error('show failed'));
+      shown.push({ via: 'sw', title, opts });
+      return Promise.resolve();
+    };
+    const fn = new Function(
+      'Notification',
+      'notifyStatusToIframe',
+      'contractHasConsent',
+      'contractConsentKey',
+      'notifyLimiter',
+      'sendToIframe',
+      'notifyRegistrationReady',
+      'location',
+      'window',
+      `${showSource}\nreturn showAppNotification;`,
+    )(
+      Notification,
+      (s) => statuses.push(s),
+      () => ctl.consent !== false,
+      () => 'freenet_notify:KEY',
+      { ok: () => ctl.limited !== true },
+      () => {},
+      () =>
+        Promise.resolve(ctl.swAvailable ? { showNotification: swShow } : null),
+      { href: 'https://gw.example/v2/contract/web/KEY/' },
+      { focus() {} },
+    );
+    return { fn, statuses, shown };
+  }
+
+  // Drop paths: each reports exactly one status instead of returning silently.
+  {
+    const h = makeShowHarness({ permission: undefined });
+    h.fn({ title: 't' });
+    check(
+      'no Notification API -> exactly one "unsupported"',
+      h.statuses.length === 1 && h.statuses[0] === 'unsupported',
+    );
+  }
+  {
+    const h = makeShowHarness({ permission: 'denied' });
+    h.fn({ title: 't' });
+    check(
+      'permission revoked to denied -> exactly one "denied"',
+      h.statuses.length === 1 && h.statuses[0] === 'denied',
+    );
+  }
+  {
+    const h = makeShowHarness({ permission: 'default' });
+    h.fn({ title: 't' });
+    check(
+      'permission reset to default -> exactly one "default"',
+      h.statuses.length === 1 && h.statuses[0] === 'default',
+    );
+  }
+  {
+    const h = makeShowHarness({ permission: 'granted', consent: false });
+    h.fn({ title: 't' });
+    check(
+      'contract consent withdrawn -> exactly one "default"',
+      h.statuses.length === 1 && h.statuses[0] === 'default',
+    );
+  }
+  // Success paths re-affirm 'granted' — the retraction of a stale
+  // 'undeliverable'. Desktop (page-level constructor):
+  {
+    const h = makeShowHarness({ permission: 'granted' });
+    h.fn({ title: 't' });
+    check(
+      'desktop constructor delivery -> exactly one "granted"',
+      h.statuses.length === 1 &&
+        h.statuses[0] === 'granted' &&
+        h.shown.length === 1 &&
+        h.shown[0].via === 'constructor',
+    );
+  }
+  // Mobile (constructor throws, service worker delivers):
+  {
+    const h = makeShowHarness({
+      permission: 'granted',
+      constructorThrows: true,
+      swAvailable: true,
+    });
+    h.fn({ title: 't' });
+    await new Promise((r) => setTimeout(r, 0));
+    check(
+      'mobile service-worker delivery -> exactly one "granted"',
+      h.statuses.length === 1 &&
+        h.statuses[0] === 'granted' &&
+        h.shown.length === 1 &&
+        h.shown[0].via === 'sw',
+    );
+  }
+  // Genuine failures still report 'undeliverable', and only once.
+  {
+    const h = makeShowHarness({
+      permission: 'granted',
+      constructorThrows: true,
+      swAvailable: false,
+    });
+    h.fn({ title: 't' });
+    await new Promise((r) => setTimeout(r, 0));
+    check(
+      'no worker + constructor throws -> exactly one "undeliverable"',
+      h.statuses.length === 1 && h.statuses[0] === 'undeliverable',
+    );
+  }
+  {
+    const h = makeShowHarness({
+      permission: 'granted',
+      constructorThrows: true,
+      swAvailable: true,
+      swShowRejects: true,
+    });
+    h.fn({ title: 't' });
+    await new Promise((r) => setTimeout(r, 0));
+    check(
+      'worker show rejects -> exactly one "undeliverable"',
+      h.statuses.length === 1 && h.statuses[0] === 'undeliverable',
+    );
+  }
+  // A delivery after a stale 'undeliverable' retracts it: the LAST status a
+  // client sees is 'granted', not the session-long false warning of #5043.
+  {
+    const h = makeShowHarness({
+      permission: 'granted',
+      constructorThrows: true,
+      swAvailable: false,
+    });
+    h.fn({ title: 'first' }); // races SW activation -> undeliverable
+    await new Promise((r) => setTimeout(r, 0));
+    const h2 = makeShowHarness({
+      permission: 'granted',
+      constructorThrows: true,
+      swAvailable: true,
+    });
+    h2.statuses.push(...h.statuses); // same session, same client
+    h2.fn({ title: 'second' }); // worker now active -> delivered
+    await new Promise((r) => setTimeout(r, 0));
+    check(
+      'a later delivery retracts an earlier "undeliverable"',
+      h2.statuses[0] === 'undeliverable' &&
+        h2.statuses[h2.statuses.length - 1] === 'granted',
+    );
+  }
 }
 
 if (failures > 0) {


### PR DESCRIPTION
## Problem

`shell_bridge.js` never sends a `notification_status` on several paths, so a framed app's view of notification health goes stale and can't recover (#5043):

1. **A transient `undeliverable` is never retracted.** `notifyRegistrationReady(1500)` resolves `null` when the notification service worker is registered but not yet active. On mobile Chrome/Firefox the *first* notification of a session can lose that 1.5s race, report `undeliverable`, then work fine — with no success status, nothing ever retracts it. River puts a persistent marker on the notification bell for it, so a 1.5s race becomes a session-long false warning.

2. **Per-message drops are never reported.** `showAppNotification` returned silently for `typeof Notification === 'undefined'`, `permission !== 'granted'`, and `!contractHasConsent()`. Worst case: the user revokes the permission in site settings after a `granted`; every notification is then dropped at the permission check while the app still displays "notifications enabled". The app **cannot** detect this itself — its origin is opaque, so `Notification.permission` is unreadable. Only the shell can close it.

3. **The affordance-already-showing path returned with no status**, so a `notification_enable_prompt` could be answered with silence — indistinguishable from a lost message.

## Solution

The invariant: **every `notification` and every `notification_enable_prompt` gets exactly one status reply.**

- Each of the three silent returns in `showAppNotification` now reports why: `unsupported`, `denied`/`default`, `default`.
- Both delivery paths (desktop page-level constructor, mobile service-worker `showNotification`) re-affirm `granted`. That re-affirmation *is* the retraction of a stale `undeliverable` — no new "recovered" status needed, and no change to the wire shape.
- `maybeOfferNotifications` replies `default` when the bar is already on screen.

The constructor-path `granted` is posted **outside** the `try`, guarded by a flag: a throw from the status post must not read as a constructor failure and fall through to a second, duplicate delivery via the service worker.

Rate-limiter drops still return silently — reporting a status on every throttled notification would be noise, and the throttle is working-as-intended rather than a health signal.

Wire compatibility: these are new values on an existing string field. River ignores unrecognised statuses (logs at `warn!` and keeps the status it has), so no client breaks.

## Testing

`shell_bridge_notifications.test.mjs` gains case 9, which extracts `showAppNotification` verbatim from the asset (between new `notify-show:BEGIN`/`:END` markers — the same technique the existing rate-limiter cases use) and drives it with every collaborator injected. It asserts *exactly one* status per call across all nine branches: the four drop paths, both delivery paths, both genuine-failure paths, and a retraction sequence where an `undeliverable` is followed by a delivery and the last status the client sees is `granted`. Verified failing against the pre-fix asset.

`bridge_js_notification_proxy_invariants` in `path_handlers.rs` pinned the combined `permission !== 'granted' || !contractHasConsent()` expression; the gates are now two statements so each can report its own status, so the pin asserts both substrings. Same invariant, same strength.

`npm test` and `npm run lint` in `crates/core/src/server` pass; `cargo test -p freenet --lib server::` passes (436). Pre-existing clippy lints elsewhere in the crate are untouched.

## Fixes

Closes #5043

[AI-assisted - Claude]