### PR TITLE
fix(shell): open new tabs natively so target="_blank" works in Firefox

### DIFF
--- a/.github/workflows/playwright-shell.yml
+++ b/.github/workflows/playwright-shell.yml
@@ -110,9 +110,16 @@ jobs:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
 
+      # All three engines, because this suite's subject is per-engine
+      # behaviour. #5087 (a blank new tab) reproduces only in WebKit, #5106 (a
+      # dead click) only in Firefox, and the #3818 escape guard passes
+      # VACUOUSLY in Chromium — there the escape dies a step earlier, so the
+      # assertion runs against an empty set and the header it exists to protect
+      # could be deleted with the suite still green. A chromium-only matrix is
+      # how #5087 shipped green in the first place.
       - name: Install Playwright browsers
         working-directory: crates/core/tests/playwright
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install --with-deps chromium firefox webkit
 
       - name: Clean test directories
         run: rm -rf /tmp/freenet /tmp/freenet-* 2>/dev/null || true

--- a/crates/core/src/server/client_api.rs
+++ b/crates/core/src/server/client_api.rs
@@ -796,12 +796,46 @@ fn redirect_to_shell_sub_page(
 /// into the shell. `__sandbox` is a server-interpreted routing flag;
 /// `authToken` is the shell's auth credential and must only come from
 /// `AuthToken::generate()`, never from an attacker-controlled URL.
-fn is_sensitive_query_param(param: &str) -> bool {
+///
+/// The NAME is percent-decoded before the check. A raw prefix match is
+/// bypassable by encoding one character of the name — `authT%6Fken=evil`
+/// survives it, and `new URLSearchParams(...).get("authToken")` in the iframe
+/// then returns `evil`, which is exactly the webapp-reads-its-credential-from-
+/// `location.search` case this exists to prevent. Only the name is decoded; the
+/// value is forwarded byte-for-byte, since re-encoding it could break a signed
+/// or opaque app parameter.
+pub(super) fn is_sensitive_query_param(param: &str) -> bool {
     // Prefix-match so variants like `__sandbox_debug` or `authTokenExtra`
     // (from a future refactor or an adversarial URL) are also stripped.
-    // Matches the filter in `path_handlers::shell_page` that forwards
-    // query params into the iframe.
-    param.starts_with("__sandbox") || param.starts_with("authToken")
+    // Shared with `path_handlers::shell_page`, which forwards query params into
+    // the iframe — the two filters used to be separate copies of this rule.
+    let name = param.split('=').next().unwrap_or(param);
+    let decoded = percent_decode_ascii(name);
+    decoded.starts_with("__sandbox") || decoded.starts_with("authToken")
+}
+
+/// Percent-decodes the ASCII escapes in a query-parameter NAME so it can be
+/// compared against a literal. Deliberately minimal: invalid escapes are left
+/// as-is (they cannot form the names we are looking for), and non-ASCII bytes
+/// are passed through, because the only decision this feeds is a prefix match
+/// against two ASCII literals.
+fn percent_decode_ascii(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out = String::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            let hex = &s[i + 1..i + 3];
+            if let Ok(byte) = u8::from_str_radix(hex, 16) {
+                out.push(byte as char);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i] as char);
+        i += 1;
+    }
+    out
 }
 
 /// Returns true if a contract sub-path request is a top-level HTML
@@ -865,7 +899,7 @@ async fn serve_sandbox_response(
         // sandbox content off a top-level document, and that job is done by
         // redirecting at all, whatever the target.
         return redirect_to_shell_sub_page(&key, api_version, sub_path, query_string)
-            .or_else(|_| redirect_to_shell_root(&key, api_version, None));
+            .or_else(|_| redirect_to_shell_root(&key, api_version, query_string));
     }
 
     let contract_response = match path_handlers::serve_sandbox_content(
@@ -1919,6 +1953,40 @@ mod tests {
             Some(CONTRACT_CONTENT_SANDBOX_CSP),
             "the header is unconditional on this route"
         );
+    }
+
+    /// A percent-encoded parameter NAME must not slip the sensitive-param
+    /// filter. `authT%6Fken=evil` reads back as `authToken` from
+    /// `new URLSearchParams(location.search)` inside the iframe, which is
+    /// precisely the "webapp reads its credential from `location.search`" case
+    /// the filter exists for; a raw `starts_with` never sees it.
+    #[test]
+    fn sensitive_query_params_are_matched_after_decoding_the_name() {
+        for evil in [
+            "authT%6Fken=evil",
+            "%61uthToken=evil",
+            "%5F%5Fsandbox=1",
+            "__sandbo%78=1",
+            "%61uthTokenExtra=evil",
+        ] {
+            assert!(
+                is_sensitive_query_param(evil),
+                "{evil} must be stripped: the browser decodes the name before a \
+                 webapp reads it back"
+            );
+        }
+        // Ordinary app params are untouched, including ones that merely
+        // CONTAIN an escape in their value.
+        for ok in [
+            "invitation=abc",
+            "room=%2Fpath",
+            "q=authToken",
+            "myauthToken=x",
+        ] {
+            assert!(!is_sensitive_query_param(ok), "{ok} must be preserved");
+        }
+        // A malformed escape is not a decode, and must not become one.
+        assert!(!is_sensitive_query_param("auth%zzToken=x"));
     }
 
     /// Regression test for the sub-page loss that removing the `window.open`

--- a/crates/core/src/server/client_api.rs
+++ b/crates/core/src/server/client_api.rs
@@ -1874,7 +1874,7 @@ mod tests {
     /// `NodeError("Contract not cached yet")`) via a cold cache + dead sender;
     /// no `Sec-Fetch-Dest: document`, so it does NOT take the redirect branch.
     #[tokio::test]
-    async fn serve_sandbox_response_error_carries_cors_header() {
+    async fn serve_sandbox_response_error_carries_cors_and_sandbox_headers() {
         // Unique non-zero key so this cold-cache assertion can't collide with
         // another test on the process-global webapp cache.
         let key = {
@@ -1912,6 +1912,18 @@ mod tests {
             Some("*"),
             "the sandbox-HTML error branch must carry the CORS header too, \
              otherwise the null-origin iframe surfaces it as an opaque CORS error"
+        );
+        // …and the sandbox directive, for the same reason the success branch
+        // carries it: the body reflects the request path, and this response is
+        // reachable from a context we do not control once popups can escape the
+        // sandbox. Cheaper to sandbox every response on the route than to keep
+        // re-deriving whether the current error renderer can emit markup.
+        assert_eq!(
+            resp.headers()
+                .get(axum::http::header::CONTENT_SECURITY_POLICY)
+                .map(|v| v.to_str().unwrap_or("")),
+            Some(CONTRACT_CONTENT_SANDBOX_CSP),
+            "the sandbox-HTML error branch must also be sandboxed (#3818)"
         );
     }
 

--- a/crates/core/src/server/client_api.rs
+++ b/crates/core/src/server/client_api.rs
@@ -824,14 +824,24 @@ fn percent_decode_ascii(s: &str) -> String {
     let mut out = String::with_capacity(bytes.len());
     let mut i = 0;
     while i < bytes.len() {
-        if bytes[i] == b'%' && i + 2 < bytes.len() {
-            let hex = &s[i + 1..i + 3];
-            if let Ok(byte) = u8::from_str_radix(hex, 16) {
-                out.push(byte as char);
+        // Read the two hex digits as BYTES. Slicing `&s[i + 1..i + 3]` would
+        // panic whenever `%` is followed by a multi-byte character (`%é`), and
+        // a query string is attacker-controlled on every request.
+        if let (Some(b'%'), Some(hi), Some(lo)) = (
+            bytes.get(i).copied(),
+            bytes.get(i + 1).copied(),
+            bytes.get(i + 2).copied(),
+        ) {
+            if let (Some(hi), Some(lo)) = ((hi as char).to_digit(16), (lo as char).to_digit(16)) {
+                out.push((hi as u8 * 16 + lo as u8) as char);
                 i += 3;
                 continue;
             }
         }
+        // Byte-wise passthrough: a non-ASCII byte becomes its Latin-1 char.
+        // That mangles multi-byte text, which is fine and deliberate — the only
+        // consumer prefix-compares the result against two ASCII literals, and a
+        // mangled non-ASCII name cannot equal either.
         out.push(bytes[i] as char);
         i += 1;
     }
@@ -1987,6 +1997,31 @@ mod tests {
         }
         // A malformed escape is not a decode, and must not become one.
         assert!(!is_sensitive_query_param("auth%zzToken=x"));
+        // Multi-byte characters around a `%` must not panic: a query string is
+        // attacker-controlled on every request, and byte-slicing the two hex
+        // digits would land mid-character.
+        for odd in [
+            // 3-byte char after `%`: byte index i+3 lands INSIDE it, so a
+            // `&str` slice of the two hex digits panics. Reachable with one
+            // unauthenticated GET carrying raw non-ASCII in the query — hyper
+            // accepts it, browsers just never send it.
+            "%\u{20ac}=1",
+            "a%\u{20ac}b=1",
+            // 4-byte char.
+            "%\u{1f600}=1",
+            "%é=1",
+            "auth%é=1",
+            "%",
+            "%2",
+            "a%",
+            "%e2%82%ac=1",
+            "authToken%=1",
+            "π=1",
+        ] {
+            let _ = is_sensitive_query_param(odd);
+        }
+        // …and one that must still be caught despite the neighbouring escape.
+        assert!(is_sensitive_query_param("authT%6Fken%é=1"));
     }
 
     /// Regression test for the sub-page loss that removing the `window.open`

--- a/crates/core/src/server/client_api.rs
+++ b/crates/core/src/server/client_api.rs
@@ -596,6 +596,27 @@ async fn web_subpages(
         Err(e) => e.into_response(),
     };
     add_sandbox_cors_headers(&mut response);
+    // A top-level document load that reaches THIS branch is a non-HTML asset
+    // (HTML pages were routed to the shell above): `evil.svg`, served as
+    // `image/svg+xml`, is contract-controlled markup that executes script when
+    // navigated to directly. At the node's own origin that script could read the
+    // hosted per-user access key out of `localStorage`, or fetch a shell page and
+    // scrape its auth token. `nosniff` does not help — the type is genuinely
+    // scriptable.
+    //
+    // This was reachable before only by getting a victim to paste the URL, but
+    // the app iframe now carries `allow-popups-to-escape-sandbox` (so that
+    // `target="_blank"` opens a real tab in every browser), which lets a contract
+    // navigate there itself. `CSP: sandbox` with no `allow-scripts` gives such a
+    // document an opaque origin and no script execution, closing both routes.
+    // Subresource fetches (`Sec-Fetch-Dest` = script/style/image/…) are untouched,
+    // so assets loaded BY the app inside its frame are unaffected.
+    if fetch_dest == "document" {
+        response.headers_mut().insert(
+            axum::http::header::CONTENT_SECURITY_POLICY,
+            axum::http::HeaderValue::from_static("sandbox"),
+        );
+    }
     Ok(response)
 }
 
@@ -1603,6 +1624,82 @@ mod tests {
             Some("*"),
             "even an error subresource response must carry the sandbox CORS header, \
              otherwise the null-origin iframe surfaces it as an opaque CORS error"
+        );
+    }
+
+    /// Guard for the escaped-popup companion fix.
+    ///
+    /// The app iframe carries `allow-popups-to-escape-sandbox` so a new tab is
+    /// a real top-level document at the node origin — that is what makes
+    /// `target="_blank"` work in Firefox as well as Chrome/Safari. The cost is
+    /// that a contract can now navigate a tab to any URL the node serves. HTML
+    /// sub-paths and `?__sandbox=1` are already forced back through the shell,
+    /// but a NON-HTML contract asset falls through to `variable_content` — and
+    /// a contract-authored `evil.svg`, served as `image/svg+xml`, executes
+    /// script when it is the document. At the node's own origin that script
+    /// could read the hosted per-user access key from `localStorage` or scrape
+    /// an auth token out of a fetched shell page. `nosniff` does not help: the
+    /// type is genuinely scriptable.
+    ///
+    /// Any asset served as a top-level DOCUMENT must therefore carry
+    /// `Content-Security-Policy: sandbox` (no `allow-scripts`), which gives it
+    /// an opaque origin and no script execution. Subresource fetches — the app
+    /// loading its own assets inside the frame — must NOT get the header, or
+    /// every script/style/image in every contract app breaks.
+    #[tokio::test]
+    async fn web_subpages_sandboxes_top_level_asset_documents() {
+        // Unique non-zero key so the cold-cache error path can't collide with
+        // another test on the process-global webapp cache.
+        let key = {
+            use freenet_stdlib::prelude::ContractInstanceId;
+            let mut bytes = [0u8; 32];
+            bytes[0] = 0x3a;
+            bytes[1] = 0x56;
+            ContractInstanceId::new(bytes).to_string()
+        };
+
+        let subpage = |dest: &'static str| {
+            let key = key.clone();
+            async move {
+                let mut headers = axum::http::HeaderMap::new();
+                headers.insert("sec-fetch-dest", dest.parse().unwrap());
+                web_subpages(
+                    key,
+                    // Non-HTML, so `should_serve_shell_for_subpage` is false and
+                    // this reaches `variable_content` for both dests.
+                    "evil.svg".to_string(),
+                    ApiVersion::V1,
+                    None,
+                    headers,
+                    &localhost_config(),
+                    dead_request_sender(),
+                    false,
+                )
+                .await
+                .expect("web_subpages must respond, not propagate")
+            }
+        };
+
+        let csp = |resp: &axum::response::Response| {
+            resp.headers()
+                .get(axum::http::header::CONTENT_SECURITY_POLICY)
+                .map(|v| v.to_str().unwrap_or("").to_string())
+        };
+
+        // Top-level document load of a scriptable asset: opaque origin, no script.
+        assert_eq!(
+            csp(&subpage("document").await).as_deref(),
+            Some("sandbox"),
+            "a contract asset loaded as a top-level document must be sandboxed, \
+             or a contract-authored SVG runs script at the node's own origin"
+        );
+
+        // The same asset fetched as a subresource by the app is untouched.
+        assert_eq!(
+            csp(&subpage("image").await),
+            None,
+            "subresource fetches must not be sandboxed — that would break every \
+             asset the app loads inside its own frame"
         );
     }
 

--- a/crates/core/src/server/client_api.rs
+++ b/crates/core/src/server/client_api.rs
@@ -50,14 +50,65 @@ const SHELL_PAGE_CSP: &str = "default-src 'none'; script-src 'unsafe-inline'; fr
 /// notifications via `ServiceWorkerRegistration.showNotification()` instead.
 const NOTIFY_SW_JS: &str = include_str!("path_handlers/assets/notify_sw.js");
 
+/// The `sandbox` CSP directive served with EVERY response that carries
+/// contract-authored bytes, so their opaque origin is decided here rather than
+/// by whichever browsing context happens to embed them.
+///
+/// # Why this is not redundant with the iframe `sandbox` attribute
+///
+/// The attribute only constrains the frame *the shell creates*. Since the shell
+/// iframe carries `allow-popups-to-escape-sandbox` (needed so `target="_blank"`
+/// opens a real tab in every browser — see `navigation_interceptor.js`), a
+/// contract can obtain a browsing context that the attribute does not reach:
+///
+/// 1. from a click, `window.open('about:blank')` — the popup escapes the
+///    sandbox, so it is a top-level context with NO sandboxing flags, and its
+///    `about:blank` document inherits the opener's origin, so the contract can
+///    script it;
+/// 2. in that popup, `document.write` an `<iframe src="…/contract/web/KEY/…">`.
+///    That is a *nested* navigable, not a top-level document, so it carries
+///    `Sec-Fetch-Dest: iframe` — and because its parent has no sandboxing
+///    flags, it inherits none;
+/// 3. the contract's own bytes therefore execute at the node's REAL origin:
+///    `localStorage` (the hosted per-user access key), same-origin `fetch` of
+///    any node route including another app's shell page and its auth token.
+///
+/// Confirmed reproducible in chromium, firefox and webkit before this header
+/// existed; blocked in all three after. Step 2 works with any contract asset —
+/// a scriptable `image/svg+xml`, or plain HTML the contract wrote — so gating
+/// on `Sec-Fetch-Dest: document` alone does not close it. That is exactly the
+/// escape #3818 removed `allow-popups-to-escape-sandbox` to prevent, and this
+/// header is what allows the flag back.
+///
+/// The token list mirrors the iframe's `sandbox` attribute so in-frame
+/// behaviour is unchanged: the effective policy is the intersection of the two,
+/// and an app that works framed keeps working. Keep them in sync — the pin is
+/// `shell_page_iframe_sandbox_matches_contract_content_csp` in
+/// `path_handlers.rs`.
+pub(super) const CONTRACT_CONTENT_SANDBOX_CSP: &str = "sandbox allow-scripts allow-forms allow-popups \
+     allow-popups-to-escape-sandbox allow-downloads allow-modals";
+
+/// The stricter variant for a contract asset loaded as a TOP-LEVEL document.
+///
+/// Nothing legitimate lands there — HTML sub-paths are routed to the shell and
+/// `?__sandbox=1` top-level loads are redirected, so what remains is a URL a
+/// contract navigated a tab to. An opaque origin alone would already deny it
+/// the node's data; withholding `allow-scripts` additionally denies it a
+/// scripted full-page UI displayed under the node's own address.
+const CONTRACT_DOCUMENT_SANDBOX_CSP: &str = "sandbox";
+
 /// Content-Security-Policy served with the sandboxed iframe that actually
 /// runs a webapp. The iframe has an opaque (null) origin because the
 /// sandbox attribute omits `allow-same-origin`, so CSP `'self'` would not
 /// match the local API server's origin. We therefore interpolate the
 /// concrete origin derived from the request Host header.
+///
+/// Prefixed with `CONTRACT_CONTENT_SANDBOX_CSP` so the opaque origin survives
+/// being embedded somewhere other than the shell's own iframe — see that
+/// constant for the attack it closes.
 fn sandbox_csp_for_origin(origin: &str) -> String {
     format!(
-        "default-src {origin} 'unsafe-inline' 'unsafe-eval' blob: data:; connect-src {origin} blob: data:"
+        "{CONTRACT_CONTENT_SANDBOX_CSP}; default-src {origin} 'unsafe-inline' 'unsafe-eval' blob: data:; connect-src {origin} blob: data:"
     )
 }
 
@@ -596,27 +647,34 @@ async fn web_subpages(
         Err(e) => e.into_response(),
     };
     add_sandbox_cors_headers(&mut response);
-    // A top-level document load that reaches THIS branch is a non-HTML asset
-    // (HTML pages were routed to the shell above): `evil.svg`, served as
-    // `image/svg+xml`, is contract-controlled markup that executes script when
-    // navigated to directly. At the node's own origin that script could read the
-    // hosted per-user access key out of `localStorage`, or fetch a shell page and
-    // scrape its auth token. `nosniff` does not help — the type is genuinely
-    // scriptable.
+    // Everything served from here is contract-authored, so it is sandboxed
+    // unconditionally: the node decides its origin, not whichever context
+    // embeds it. See `CONTRACT_CONTENT_SANDBOX_CSP` for why the iframe's
+    // `sandbox` attribute is not sufficient on its own, and why keying this on
+    // `Sec-Fetch-Dest: document` would leave the hole open — a contract that
+    // escapes to an unsandboxed popup embeds these bytes as an `iframe` dest,
+    // not a `document` one.
     //
-    // This was reachable before only by getting a victim to paste the URL, but
-    // the app iframe now carries `allow-popups-to-escape-sandbox` (so that
-    // `target="_blank"` opens a real tab in every browser), which lets a contract
-    // navigate there itself. `CSP: sandbox` with no `allow-scripts` gives such a
-    // document an opaque origin and no script execution, closing both routes.
-    // Subresource fetches (`Sec-Fetch-Dest` = script/style/image/…) are untouched,
-    // so assets loaded BY the app inside its frame are unaffected.
-    if fetch_dest == "document" {
-        response.headers_mut().insert(
-            axum::http::header::CONTENT_SECURITY_POLICY,
-            axum::http::HeaderValue::from_static("sandbox"),
-        );
-    }
+    // Two shapes, because a top-level document is the one case where nothing
+    // legitimate arrives:
+    //   - `document`: no `allow-scripts`. A contract-authored `evil.svg`, served
+    //     as `image/svg+xml`, executes script when it IS the document, and
+    //     `nosniff` does not help — the type is genuinely scriptable.
+    //   - anything else: the full token list, matching the app iframe, so the
+    //     app's own subresources and any HTML it frames itself behave exactly
+    //     as before. On a non-document response the `sandbox` directive has no
+    //     effect at all (it applies to documents and workers), so this is inert
+    //     for scripts, styles and images; it is the `iframe`/`embed`/`object`
+    //     and header-less cases it is there for.
+    let sandbox_csp = if fetch_dest == "document" {
+        CONTRACT_DOCUMENT_SANDBOX_CSP
+    } else {
+        CONTRACT_CONTENT_SANDBOX_CSP
+    };
+    response.headers_mut().insert(
+        axum::http::header::CONTENT_SECURITY_POLICY,
+        axum::http::HeaderValue::from_static(sandbox_csp),
+    );
     Ok(response)
 }
 
@@ -789,6 +847,15 @@ async fn serve_sandbox_response(
             // internal filesystem paths, config, or secrets.
             let mut response = e.into_response();
             add_sandbox_cors_headers(&mut response);
+            // The body reflects the request path, so sandbox it too rather than
+            // reasoning about whether the current error renderer can be coaxed
+            // into emitting markup. Origin-CSP is skipped (there is no contract
+            // content to load subresources for); the sandbox directive is the
+            // part that matters.
+            response.headers_mut().insert(
+                axum::http::header::CONTENT_SECURITY_POLICY,
+                axum::http::HeaderValue::from_static(CONTRACT_CONTENT_SANDBOX_CSP),
+            );
             return Ok(response);
         }
     };
@@ -1220,6 +1287,49 @@ mod tests {
         );
     }
 
+    /// The contract HTML served into the app frame must carry the `sandbox`
+    /// directive itself, not merely inherit the iframe attribute.
+    ///
+    /// The attribute governs only the frame the shell creates. A contract that
+    /// escapes to a popup it controls (possible since the iframe regained
+    /// `allow-popups-to-escape-sandbox`) can re-embed this very response in an
+    /// unsandboxed context; without the header the app's own HTML then runs at
+    /// the node's real origin, with `localStorage` and same-origin `fetch`.
+    /// That is the #3818 escape, and it needs no SVG or other exotic type —
+    /// the contract's ordinary index page is enough.
+    ///
+    /// Pin the directive first, and the token list second: the tokens must
+    /// match the iframe's `sandbox` attribute, because the effective policy is
+    /// the INTERSECTION of the two. A token missing here silently withdraws a
+    /// capability from every contract app (dropping `allow-forms` breaks every
+    /// form; dropping `allow-popups` breaks the new-tab fix this shipped with).
+    #[test]
+    fn sandbox_csp_sandboxes_the_contract_document_itself() {
+        let csp = sandbox_csp_for_origin("http://127.0.0.1:7509");
+        let sandbox = csp
+            .split(';')
+            .map(str::trim)
+            .find(|d| d.starts_with("sandbox"))
+            .unwrap_or_else(|| {
+                panic!(
+                    "contract content must be served a `sandbox` CSP directive so its \
+                     opaque origin does not depend on who embeds it (#3818); got: {csp}"
+                )
+            });
+        assert_eq!(
+            sandbox, CONTRACT_CONTENT_SANDBOX_CSP,
+            "the contract document's sandbox tokens must match the app iframe's \
+             `sandbox` attribute exactly — the effective policy is the intersection, \
+             so any token dropped here is withdrawn from every contract app"
+        );
+        // No `allow-same-origin`: that single token would hand the contract the
+        // node's real origin directly and undo the whole isolation model.
+        assert!(
+            !sandbox.contains("allow-same-origin"),
+            "allow-same-origin would give contract content the node's own origin"
+        );
+    }
+
     /// The sandbox iframe has an opaque (null) origin because the sandbox
     /// attribute omits `allow-same-origin`, so CSP `'self'` wouldn't match
     /// the local API server. `sandbox_csp_for_origin` must interpolate the
@@ -1627,27 +1737,25 @@ mod tests {
         );
     }
 
-    /// Guard for the escaped-popup companion fix.
+    /// Guard for the companion fix that lets `allow-popups-to-escape-sandbox`
+    /// back onto the app iframe (#3818).
     ///
-    /// The app iframe carries `allow-popups-to-escape-sandbox` so a new tab is
-    /// a real top-level document at the node origin — that is what makes
-    /// `target="_blank"` work in Firefox as well as Chrome/Safari. The cost is
-    /// that a contract can now navigate a tab to any URL the node serves. HTML
-    /// sub-paths and `?__sandbox=1` are already forced back through the shell,
-    /// but a NON-HTML contract asset falls through to `variable_content` — and
-    /// a contract-authored `evil.svg`, served as `image/svg+xml`, executes
-    /// script when it is the document. At the node's own origin that script
-    /// could read the hosted per-user access key from `localStorage` or scrape
-    /// an auth token out of a fetched shell page. `nosniff` does not help: the
-    /// type is genuinely scriptable.
+    /// The flag is what makes `target="_blank"` open a real tab in Firefox as
+    /// well as Chrome/Safari, and it costs the iframe `sandbox` attribute its
+    /// standing as the thing that keeps contract bytes off the node's origin: a
+    /// contract can escape to a popup it fully controls and re-embed its own
+    /// assets there, unsandboxed. So the sandbox is served as a HEADER on every
+    /// response carrying contract bytes — see `CONTRACT_CONTENT_SANDBOX_CSP`
+    /// for the full three-step attack and the cross-engine reproduction.
     ///
-    /// Any asset served as a top-level DOCUMENT must therefore carry
-    /// `Content-Security-Policy: sandbox` (no `allow-scripts`), which gives it
-    /// an opaque origin and no script execution. Subresource fetches — the app
-    /// loading its own assets inside the frame — must NOT get the header, or
-    /// every script/style/image in every contract app breaks.
+    /// The cases below are the ones a narrower guard gets wrong. Keying on
+    /// `Sec-Fetch-Dest: document`, which is where this started, covers only the
+    /// pasted-URL shape and misses the nested-navigable shape the escape
+    /// actually uses. `document` keeps the stricter no-`allow-scripts` policy
+    /// because nothing legitimate arrives there; everything else gets the app
+    /// iframe's own token list so in-frame behaviour is untouched.
     #[tokio::test]
-    async fn web_subpages_sandboxes_top_level_asset_documents() {
+    async fn web_subpages_sandboxes_contract_assets() {
         // Unique non-zero key so the cold-cache error path can't collide with
         // another test on the process-global webapp cache.
         let key = {
@@ -1680,6 +1788,30 @@ mod tests {
             }
         };
 
+        // Same request, but able to express "no `Sec-Fetch-Dest` header at
+        // all" as well as a named destination.
+        let subpage_dest = |dest: &'static str| {
+            let key = key.clone();
+            async move {
+                let mut headers = axum::http::HeaderMap::new();
+                if !dest.is_empty() {
+                    headers.insert("sec-fetch-dest", dest.parse().unwrap());
+                }
+                web_subpages(
+                    key,
+                    "evil.svg".to_string(),
+                    ApiVersion::V1,
+                    None,
+                    headers,
+                    &localhost_config(),
+                    dead_request_sender(),
+                    false,
+                )
+                .await
+                .expect("web_subpages must respond, not propagate")
+            }
+        };
+
         let csp = |resp: &axum::response::Response| {
             resp.headers()
                 .get(axum::http::header::CONTENT_SECURITY_POLICY)
@@ -1689,17 +1821,48 @@ mod tests {
         // Top-level document load of a scriptable asset: opaque origin, no script.
         assert_eq!(
             csp(&subpage("document").await).as_deref(),
-            Some("sandbox"),
+            Some(CONTRACT_DOCUMENT_SANDBOX_CSP),
             "a contract asset loaded as a top-level document must be sandboxed, \
              or a contract-authored SVG runs script at the node's own origin"
         );
 
-        // The same asset fetched as a subresource by the app is untouched.
+        // A NESTED navigable is the one the escaped-popup attack uses: the
+        // contract writes `<iframe src=…>` into an unsandboxed popup it owns,
+        // and the request carries `Sec-Fetch-Dest: iframe`, not `document`.
+        // Gating on `document` alone left contract bytes executing at the
+        // node's real origin — reproduced in all three engines. It must be
+        // sandboxed, but WITH `allow-scripts`, because this is also how an app
+        // frames its own HTML sub-page from inside the shell.
+        for dest in ["iframe", "frame", "embed", "object"] {
+            assert_eq!(
+                csp(&subpage_dest(dest).await).as_deref(),
+                Some(CONTRACT_CONTENT_SANDBOX_CSP),
+                "a contract asset loaded as a `{dest}` navigable must still be \
+                 sandboxed: an escaped popup embeds it exactly this way, and \
+                 without the header it runs at the node's own origin (#3818)"
+            );
+        }
+
+        // A client that sends no `Sec-Fetch-Dest` at all (curl, and browsers
+        // predating Fetch Metadata) must not be the way around it either. CSP
+        // is inert for non-browsers, so this costs them nothing.
         assert_eq!(
-            csp(&subpage("image").await),
-            None,
-            "subresource fetches must not be sandboxed — that would break every \
-             asset the app loads inside its own frame"
+            csp(&subpage_dest("").await).as_deref(),
+            Some(CONTRACT_CONTENT_SANDBOX_CSP),
+            "a request without `Sec-Fetch-Dest` must fail CLOSED: the header is \
+             the only signal, and an older browser that omits it would otherwise \
+             be served unsandboxed contract bytes"
+        );
+
+        // Subresource fetches are sandboxed too, which is INERT for them — the
+        // `sandbox` directive applies to documents and workers, not to an image
+        // or a stylesheet. Asserting it here keeps the rule "every response on
+        // this route carries the header" simple enough to hold, rather than an
+        // allow-list of destinations that a new dest name would silently escape.
+        assert_eq!(
+            csp(&subpage("image").await).as_deref(),
+            Some(CONTRACT_CONTENT_SANDBOX_CSP),
+            "the header is unconditional on this route"
         );
     }
 

--- a/crates/core/src/server/client_api.rs
+++ b/crates/core/src/server/client_api.rs
@@ -429,6 +429,7 @@ async fn web_home(
             key,
             api_version,
             None,
+            query_string.as_deref(),
             &req_headers,
             rs,
             &config.webapp_cache,
@@ -573,6 +574,7 @@ async fn web_subpages(
             key,
             api_version,
             Some(&last_path),
+            query_string.as_deref(),
             &req_headers,
             request_sender,
             &config.webapp_cache,
@@ -701,7 +703,7 @@ fn redirect_to_shell_root(
     api_version: ApiVersion,
     query_string: Option<&str>,
 ) -> Result<axum::response::Response, WebSocketApiError> {
-    let shell_url = build_canonical_shell_url(key, api_version, query_string)?;
+    let shell_url = build_canonical_shell_url(key, api_version, None, query_string)?;
     Ok(axum::response::Redirect::to(&shell_url).into_response())
 }
 
@@ -727,6 +729,7 @@ fn redirect_to_shell_root(
 pub(super) fn build_canonical_shell_url(
     key: &str,
     api_version: ApiVersion,
+    sub_path: Option<&str>,
     query_string: Option<&str>,
 ) -> Result<String, WebSocketApiError> {
     if key.is_empty() {
@@ -749,11 +752,44 @@ pub(super) fn build_canonical_shell_url(
         })
         .filter(|s| !s.is_empty());
 
+    // A sub-path lands the shell on the page that was actually requested
+    // instead of the contract root. Sanitized with the SAME check `shell_page`
+    // applies before interpolating it into the iframe `data-src`, so a crafted
+    // path cannot break out of the URL's path component and into the `Location`
+    // header (`?`, `#`, control chars, CRLF, `.`/`..` segments are all
+    // rejected).
+    let sub_path = sub_path
+        .filter(|sp| !sp.is_empty())
+        .map(path_handlers::sanitize_shell_sub_path)
+        .transpose()?
+        .unwrap_or_default();
+
     let prefix = api_version.prefix();
     Ok(match filtered_query {
-        Some(qs) => format!("/{prefix}/contract/web/{key}/?{qs}"),
-        None => format!("/{prefix}/contract/web/{key}/"),
+        Some(qs) => format!("/{prefix}/contract/web/{key}/{sub_path}?{qs}"),
+        None => format!("/{prefix}/contract/web/{key}/{sub_path}"),
     })
+}
+
+/// Builds a 303 redirect to the shell for a specific contract SUB-PAGE,
+/// preserving the inbound query minus the sensitive params.
+///
+/// Used when a `?__sandbox=1` URL is loaded as a top-level document. Redirecting
+/// to the contract ROOT there is lossy in a way users notice: an app that opens
+/// its own current page in a new tab (`window.open(location.href)`, or a
+/// hash-only open that inherits `__sandbox=1` from the base) lands on the
+/// contract root with its query dropped — losing, for example, an invitation
+/// parameter. Before #5100 the interceptor's `window.open` override hid this by
+/// stripping `__sandbox` and forwarding the clean URL; the override is gone, so
+/// the server has to land the redirect on the right page itself.
+fn redirect_to_shell_sub_page(
+    key: &str,
+    api_version: ApiVersion,
+    sub_path: Option<&str>,
+    query_string: Option<&str>,
+) -> Result<axum::response::Response, WebSocketApiError> {
+    let shell_url = build_canonical_shell_url(key, api_version, sub_path, query_string)?;
+    Ok(axum::response::Redirect::to(&shell_url).into_response())
 }
 
 /// Query parameters that must be stripped before forwarding a user URL
@@ -806,10 +842,12 @@ fn is_html_page(path: &str) -> bool {
 /// Includes `Sec-Fetch-Dest` check: if a sandbox URL is loaded as a top-level
 /// document (e.g. pasted in the address bar), redirect to the shell page instead
 /// of serving raw sandbox content outside the iframe.
+#[allow(clippy::too_many_arguments)]
 async fn serve_sandbox_response(
     key: String,
     api_version: ApiVersion,
     sub_path: Option<&str>,
+    query_string: Option<&str>,
     req_headers: &axum::http::HeaderMap,
     request_sender: HttpClientApiRequest,
     webapp_cache: &path_handlers::WebappCache,
@@ -821,7 +859,13 @@ async fn serve_sandbox_response(
         .and_then(|v| v.to_str().ok())
         .unwrap_or("");
     if fetch_dest == "document" {
-        return redirect_to_shell_root(&key, api_version, None);
+        // Land on the requested page, not the contract root — see
+        // `redirect_to_shell_sub_page`. A sub-path the sanitizer rejects falls
+        // back to the root rather than erroring: this branch exists to keep raw
+        // sandbox content off a top-level document, and that job is done by
+        // redirecting at all, whatever the target.
+        return redirect_to_shell_sub_page(&key, api_version, sub_path, query_string)
+            .or_else(|_| redirect_to_shell_root(&key, api_version, None));
     }
 
     let contract_response = match path_handlers::serve_sandbox_content(
@@ -1328,6 +1372,26 @@ mod tests {
             !sandbox.contains("allow-same-origin"),
             "allow-same-origin would give contract content the node's own origin"
         );
+
+        // The top-level-document policy is STRICTER, and must be pinned against
+        // something other than itself. `web_subpages_sandboxes_contract_assets`
+        // compares the served header to this constant, so widening the constant
+        // moves both sides together and nothing goes red — verified by mutation:
+        // setting it equal to CONTRACT_CONTENT_SANDBOX_CSP left the whole suite
+        // green. What it uniquely buys is that a contract-authored `evil.svg`
+        // navigated to directly cannot run script, and cannot paint a scripted
+        // full-page UI under the node's own address.
+        assert!(
+            !CONTRACT_DOCUMENT_SANDBOX_CSP.contains("allow-scripts"),
+            "a contract asset loaded as a TOP-LEVEL document must not be allowed \
+             to run script: nothing legitimate arrives there, and the opaque \
+             origin alone would still leave a scripted page under the node's URL"
+        );
+        assert!(
+            !CONTRACT_DOCUMENT_SANDBOX_CSP.contains("allow-same-origin"),
+            "allow-same-origin would give a navigated-to contract asset the \
+             node's own origin"
+        );
     }
 
     /// The sandbox iframe has an opaque (null) origin because the sandbox
@@ -1735,6 +1799,18 @@ mod tests {
             "even an error subresource response must carry the sandbox CORS header, \
              otherwise the null-origin iframe surfaces it as an opaque CORS error"
         );
+        // The Err arm of the route gets the sandbox directive too. Its sibling
+        // test drives only Ok responses, so without this a header attached to
+        // just one arm would go unnoticed — mutation-confirmed.
+        assert_eq!(
+            resp.headers()
+                .get(axum::http::header::CONTENT_SECURITY_POLICY)
+                .map(|v| v.to_str().unwrap_or("")),
+            Some(CONTRACT_CONTENT_SANDBOX_CSP),
+            "the error arm must be sandboxed as well: the body reflects the \
+             request path and the response is reachable from a context we do \
+             not control (#3818)"
+        );
     }
 
     /// Guard for the companion fix that lets `allow-popups-to-escape-sandbox`
@@ -1766,30 +1842,9 @@ mod tests {
             ContractInstanceId::new(bytes).to_string()
         };
 
-        let subpage = |dest: &'static str| {
-            let key = key.clone();
-            async move {
-                let mut headers = axum::http::HeaderMap::new();
-                headers.insert("sec-fetch-dest", dest.parse().unwrap());
-                web_subpages(
-                    key,
-                    // Non-HTML, so `should_serve_shell_for_subpage` is false and
-                    // this reaches `variable_content` for both dests.
-                    "evil.svg".to_string(),
-                    ApiVersion::V1,
-                    None,
-                    headers,
-                    &localhost_config(),
-                    dead_request_sender(),
-                    false,
-                )
-                .await
-                .expect("web_subpages must respond, not propagate")
-            }
-        };
-
-        // Same request, but able to express "no `Sec-Fetch-Dest` header at
-        // all" as well as a named destination.
+        // Non-HTML, so `should_serve_shell_for_subpage` is false and every case
+        // below reaches `variable_content`. An empty `dest` means "no
+        // `Sec-Fetch-Dest` header at all", which is its own case.
         let subpage_dest = |dest: &'static str| {
             let key = key.clone();
             async move {
@@ -1820,7 +1875,7 @@ mod tests {
 
         // Top-level document load of a scriptable asset: opaque origin, no script.
         assert_eq!(
-            csp(&subpage("document").await).as_deref(),
+            csp(&subpage_dest("document").await).as_deref(),
             Some(CONTRACT_DOCUMENT_SANDBOX_CSP),
             "a contract asset loaded as a top-level document must be sandboxed, \
              or a contract-authored SVG runs script at the node's own origin"
@@ -1860,10 +1915,110 @@ mod tests {
         // this route carries the header" simple enough to hold, rather than an
         // allow-list of destinations that a new dest name would silently escape.
         assert_eq!(
-            csp(&subpage("image").await).as_deref(),
+            csp(&subpage_dest("image").await).as_deref(),
             Some(CONTRACT_CONTENT_SANDBOX_CSP),
             "the header is unconditional on this route"
         );
+    }
+
+    /// Regression test for the sub-page loss that removing the `window.open`
+    /// override exposed (#5100 review).
+    ///
+    /// An app that opens its own current page in a new tab — `window.open(
+    /// location.href)`, or a hash-only open that inherits `__sandbox=1` from
+    /// the base — now reaches the server as a TOP-LEVEL document load of a
+    /// `?__sandbox=1` URL. That must not be served raw (it is contract HTML
+    /// outside its iframe), so it redirects; the bug is redirecting to the
+    /// contract ROOT, which silently drops both the page and the app's own
+    /// query params. The deleted override used to hide this by stripping
+    /// `__sandbox` client-side and forwarding the clean URL.
+    ///
+    /// `__sandbox` and `authToken` must still be stripped from the target:
+    /// this URL is attacker-reachable (a pasted deep link), and the shell must
+    /// mint its own token rather than adopt one from the URL.
+    #[tokio::test]
+    async fn top_level_sandbox_url_redirects_to_the_same_page_not_the_root() {
+        let key = {
+            use freenet_stdlib::prelude::ContractInstanceId;
+            let mut bytes = [0u8; 32];
+            bytes[0] = 0x3a;
+            bytes[1] = 0x57;
+            ContractInstanceId::new(bytes).to_string()
+        };
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert("sec-fetch-dest", "document".parse().unwrap());
+        let config = localhost_config();
+
+        let resp = serve_sandbox_response(
+            key.clone(),
+            ApiVersion::V1,
+            Some("rooms/index.html"),
+            Some("__sandbox=1&invitation=abc&authToken=stolen"),
+            &headers,
+            dead_request_sender(),
+            &config.webapp_cache,
+        )
+        .await
+        .expect("a top-level sandbox URL must redirect, not error");
+
+        let location = resp
+            .headers()
+            .get(axum::http::header::LOCATION)
+            .and_then(|v| v.to_str().ok())
+            .expect("redirect carries a Location")
+            .to_string();
+
+        assert_eq!(
+            location,
+            format!("/v1/contract/web/{key}/rooms/index.html?invitation=abc"),
+            "the redirect must land on the requested page with the app's own \
+             query preserved, and must strip `__sandbox` and `authToken`"
+        );
+    }
+
+    /// A sub-path the shell sanitizer rejects must still redirect — the point
+    /// of this branch is that raw sandbox content never becomes a top-level
+    /// document, and that holds whatever the redirect target is. Falling back
+    /// to the contract root is the safe answer; erroring would turn a hostile
+    /// URL into a 400 that leaks nothing but also serves the user nothing.
+    #[tokio::test]
+    async fn top_level_sandbox_url_with_an_unusable_sub_path_falls_back_to_root() {
+        let key = {
+            use freenet_stdlib::prelude::ContractInstanceId;
+            let mut bytes = [0u8; 32];
+            bytes[0] = 0x3a;
+            bytes[1] = 0x58;
+            ContractInstanceId::new(bytes).to_string()
+        };
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert("sec-fetch-dest", "document".parse().unwrap());
+        let config = localhost_config();
+
+        for bad in ["../escape/index.html", "a\rb/index.html"] {
+            let resp = serve_sandbox_response(
+                key.clone(),
+                ApiVersion::V1,
+                Some(bad),
+                Some("__sandbox=1"),
+                &headers,
+                dead_request_sender(),
+                &config.webapp_cache,
+            )
+            .await
+            .unwrap_or_else(|e| panic!("`{bad}` must redirect, not error: {e:?}"));
+
+            let location = resp
+                .headers()
+                .get(axum::http::header::LOCATION)
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or_default()
+                .to_string();
+            assert_eq!(
+                location,
+                format!("/v1/contract/web/{key}/"),
+                "`{bad}` must fall back to the contract root"
+            );
+        }
     }
 
     /// Companion regression for the OTHER symmetric CORS-on-error branch: an
@@ -1891,6 +2046,7 @@ mod tests {
             key,
             ApiVersion::V1,
             Some("page.html"),
+            None,
             &headers,
             dead_request_sender(),
             &config.webapp_cache,

--- a/crates/core/src/server/client_api/v1.rs
+++ b/crates/core/src/server/client_api/v1.rs
@@ -110,7 +110,7 @@ async fn web_root_redirect_v1(
     Path(key): Path<String>,
     RawQuery(query): RawQuery,
 ) -> Result<axum::response::Response, WebSocketApiError> {
-    let canonical = build_canonical_shell_url(&key, ApiVersion::V1, query.as_deref())?;
+    let canonical = build_canonical_shell_url(&key, ApiVersion::V1, None, query.as_deref())?;
     Ok(axum::response::Redirect::permanent(&canonical).into_response())
 }
 

--- a/crates/core/src/server/client_api/v2.rs
+++ b/crates/core/src/server/client_api/v2.rs
@@ -71,7 +71,7 @@ async fn web_root_redirect_v2(
     Path(key): Path<String>,
     RawQuery(query): RawQuery,
 ) -> Result<axum::response::Response, WebSocketApiError> {
-    let canonical = build_canonical_shell_url(&key, ApiVersion::V2, query.as_deref())?;
+    let canonical = build_canonical_shell_url(&key, ApiVersion::V2, None, query.as_deref())?;
     Ok(axum::response::Redirect::permanent(&canonical).into_response())
 }
 

--- a/crates/core/src/server/errors.rs
+++ b/crates/core/src/server/errors.rs
@@ -101,6 +101,11 @@ impl IntoResponse for WebSocketApiError {
             }
         );
 
+        // `true` when the body below is node-authored MARKUP (the retry page)
+        // rather than a message built from request-derived text. Only the
+        // latter is escaped — escaping the retry page would render its
+        // meta-refresh tag as visible text and break the auto-reload.
+        let mut body_is_trusted_markup = false;
         let (status, error_message) = if is_transient {
             // Log the cause so operators can distinguish a fast op error
             // from a slow-loading contract without changing the user-facing
@@ -108,6 +113,7 @@ impl IntoResponse for WebSocketApiError {
             if let WebSocketApiError::AxumError { error } = &self {
                 tracing::info!(%error, "serving retry page for transient contract-fetch error");
             }
+            body_is_trusted_markup = true;
             (StatusCode::SERVICE_UNAVAILABLE, retry_loading_page())
         } else {
             match self {
@@ -133,7 +139,19 @@ impl IntoResponse for WebSocketApiError {
             }
         };
 
-        let body = Html(error_message);
+        // These bodies are served as text/html at the NODE's own origin, and
+        // several carry request-derived text: `web_subpages`' "Page not found:
+        // {page}" reflects the requested sub-path verbatim, and an
+        // `AxumError`'s `Display` can surface a rejected byte. Escape before
+        // wrapping in `Html`, so a crafted URL cannot become markup on a
+        // node-origin page — this is the one response class on the contract-web
+        // routes that carries no CSP, no `nosniff` and no `X-Frame-Options`,
+        // i.e. exactly where an injection would be worth the most.
+        let body = if body_is_trusted_markup {
+            Html(error_message)
+        } else {
+            Html(html_escape(&error_message))
+        };
 
         // Prevent intermediaries/service-workers from pinning a stale retry
         // page, and signal the client when it may retry.
@@ -396,4 +414,17 @@ mod tests {
         let response = err.into_response();
         assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
     }
+}
+
+/// Minimal HTML entity escaping for error bodies rendered at the node origin.
+///
+/// Deliberately duplicated from `permission_prompts::html_escape` rather than
+/// shared: this module is on the error path of every route and must not depend
+/// on a sibling that may itself fail to build.
+fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#x27;")
 }

--- a/crates/core/src/server/errors.rs
+++ b/crates/core/src/server/errors.rs
@@ -22,14 +22,11 @@ pub(super) enum WebSocketApiError {
 }
 
 impl WebSocketApiError {
-    pub fn status_code(&self) -> StatusCode {
-        match self {
-            WebSocketApiError::InvalidParam { .. } => StatusCode::BAD_REQUEST,
-            WebSocketApiError::NodeError { .. } => StatusCode::INTERNAL_SERVER_ERROR,
-            WebSocketApiError::AxumError { .. } => StatusCode::INTERNAL_SERVER_ERROR,
-            WebSocketApiError::MissingContract { .. } => StatusCode::NOT_FOUND,
-        }
-    }
+    // `status_code()` lived here and was used only by `From<_> for Response`,
+    // which now delegates to `IntoResponse`. It had also drifted: it answered
+    // 500 for a `NodeError` that `into_response` renders as 404 ("Contract not
+    // found"), and knew nothing of the 503 retry/connecting pages. Deleted
+    // rather than kept in sync — one status decision, in `into_response`.
 
     pub fn error_message(&self) -> String {
         match self {
@@ -52,9 +49,17 @@ impl Display for WebSocketApiError {
 }
 
 impl From<WebSocketApiError> for Response {
+    /// Delegates to `IntoResponse` rather than rendering its own body.
+    ///
+    /// It used to build `Html(error.error_message())` directly, which is a
+    /// SECOND rendering path for the same type that skipped the escaping in
+    /// `into_response` — so a future handler returning `Result<_, Response>`
+    /// and reaching this `impl` via `?` would have silently reintroduced the
+    /// injection that escaping closes. It also skipped the retry/connecting
+    /// pages and the no-store headers. No caller uses it today; keeping the two
+    /// paths in sync by construction is cheaper than remembering to.
     fn from(error: WebSocketApiError) -> Self {
-        let body = Html(error.error_message());
-        (error.status_code(), body).into_response()
+        error.into_response()
     }
 }
 
@@ -225,6 +230,57 @@ fn retry_loading_page() -> String {
 
 #[cfg(test)]
 mod tests {
+
+    /// Regression test for the reflected-HTML gap the escaped-popup review
+    /// found: these bodies are served as `text/html` at the NODE's own origin,
+    /// and several carry request-derived text — `web_subpages` renders
+    /// "Page not found: {page}" with the requested sub-path verbatim.
+    #[tokio::test]
+    async fn error_bodies_escape_request_derived_text() {
+        for error in [
+            WebSocketApiError::InvalidParam {
+                error_cause: "Page not found: <script>alert(1)</script>".to_string(),
+            },
+            WebSocketApiError::NodeError {
+                error_cause: "<img src=x onerror=alert(1)>".to_string(),
+            },
+        ] {
+            let raw = axum::body::to_bytes(error.into_response().into_body(), usize::MAX)
+                .await
+                .unwrap();
+            let body = String::from_utf8_lossy(&raw).to_string();
+            assert!(
+                !body.contains("<script>") && !body.contains("<img "),
+                "error bodies must not render request-derived text as markup; got: {body}"
+            );
+            assert!(
+                body.contains("&lt;") && body.contains("&gt;"),
+                "the payload must survive, escaped, so the message is still \
+                 readable; got: {body}"
+            );
+        }
+    }
+
+    /// `From<WebSocketApiError> for Response` must go through the same
+    /// rendering as `IntoResponse`, or it is a second path that skips the
+    /// escaping above.
+    #[tokio::test]
+    async fn from_impl_renders_identically_to_into_response() {
+        let payload = "<script>alert(1)</script>";
+        let via_from: axum::response::Response = WebSocketApiError::InvalidParam {
+            error_cause: payload.to_string(),
+        }
+        .into();
+        let raw = axum::body::to_bytes(via_from.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body = String::from_utf8_lossy(&raw).to_string();
+        assert!(
+            !body.contains("<script>"),
+            "the `From` conversion must escape too; got: {body}"
+        );
+    }
+
     use super::*;
 
     #[test]

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -1467,7 +1467,7 @@ fn html_escape_attr(s: &str) -> String {
 ///   *different contract* under the current shell's token/origin. We
 ///   must therefore reject traversal segments here rather than relying
 ///   on later file-path canonicalization (Codex review, #3841).
-fn sanitize_shell_sub_path(sub_path: &str) -> Result<String, WebSocketApiError> {
+pub(super) fn sanitize_shell_sub_path(sub_path: &str) -> Result<String, WebSocketApiError> {
     if sub_path.starts_with('/') {
         return Err(WebSocketApiError::InvalidParam {
             error_cause: "deep-link sub-path must be relative".to_string(),
@@ -1842,15 +1842,15 @@ const WEBSOCKET_SHIM_JS: &str = include_str!("path_handlers/assets/websocket_shi
 /// Origin rather than `null` (freenet/river#208).
 ///
 /// Routing new-window opens through the shell's `open_url` bridge instead is
-/// what broke Firefox: the shell's `window.open` then runs inside a `message`
-/// handler, and Firefox's popup blocker allows `window.open` only from events
-/// in `dom.popup_allowed_events` (click, auxclick, mouseup, …) — `message` is
-/// not one, so the popup was blocked and the click did nothing. Chrome and
-/// Safari allowed it only because they propagate user activation across the
-/// whole frame tree. A real gesture in the frame that received the click is the
-/// only mechanism that works in every browser. #5089 took that route and was
-/// reverted in #5107, which also priced a second cost of it: the bridge refuses
-/// loopback hosts, so on a local node the forwarded open was dropped outright.
+/// what broke the click (#5106). Which mechanism did it is NOT settled: the
+/// popup-blocker account (Firefox allows `window.open` only from events in
+/// `dom.popup_allowed_events`, and `message` is not one) is a diagnosis from
+/// the symptom that no harness reproduces, while #5107 measured that the
+/// bridge's loopback refusal drops the forwarded open on a local node in every
+/// engine. Both are consequences of the round-trip, and this design removes the
+/// round-trip: a real gesture in the frame that received the click opens a tab
+/// everywhere, whichever explanation is right. See the head comment in
+/// `navigation_interceptor.js`.
 ///
 /// The one cross-origin case still intercepted is a link with NO new-window
 /// target: navigating the app frame itself to a foreign origin is refused by
@@ -6815,6 +6815,14 @@ mod tests {
         let same_origin_idx = js
             .find("// Same-origin in-contract link")
             .expect("same-origin in-contract branch present");
+        // Fail with a message rather than a raw slice panic if the two branches
+        // are ever reordered, the same way the sibling bound below does.
+        assert!(
+            cross_origin_idx < same_origin_idx,
+            "expected the cross-origin classification before the same-origin \
+             in-contract branch; if they were reordered, re-anchor this bound \
+             rather than dropping the check"
+        );
         let block = &js[cross_origin_idx..same_origin_idx];
 
         assert!(
@@ -6848,12 +6856,31 @@ mod tests {
     /// so the shell's `frame-src 'self'` matches and the app frame loads. Pin
     /// that new-window activations are left to the browser, and that modifier
     /// clicks (which the postMessage route could never preserve) are too.
+    ///
+    /// Pin the two boundaries of "new-window activation" as well, because
+    /// review found both drawn wrong on the first attempt and both failures
+    /// were silent:
+    ///
+    ///   - A target is a new-window request only if it names a NEW context.
+    ///     `_top`/`_parent` name an ANCESTOR, which the sandbox forbids
+    ///     navigating, so returning early for them is a dead click — measured
+    ///     in chromium and firefox, where `main` opened a tab and the first
+    ///     draft of this branch did nothing at all. The comparison is also
+    ///     lowercased, because browsers match the reserved keywords
+    ///     ASCII-case-insensitively: `target="_SELF"` read as a new-window
+    ///     request sent a cross-origin click into the app frame, which
+    ///     `frame-src 'self'` then refused (chromium replaced the frame with
+    ///     its error page).
+    ///   - `e.button` must be tested for truthiness, not `=== 1`. `auxclick`
+    ///     fires for the secondary button too, and `preventDefault` there does
+    ///     not suppress the context menu, so a middle-button-only check left
+    ///     right-click intercepted: menu AND unwanted tab.
     #[test]
     fn navigation_interceptor_leaves_new_window_activations_native() {
         let js = NAVIGATION_INTERCEPTOR_JS;
 
         let target_attr_idx = js
-            .find("target.target && target.target !== '_self'")
+            .find("var targetName = target.target")
             .expect("target-attribute check present");
         let cross_origin_idx = js
             .find("target.origin !== location.origin")
@@ -6866,18 +6893,35 @@ mod tests {
 
         let block = &js[target_attr_idx..cross_origin_idx];
         assert!(
-            block.contains("!== '_self') return"),
-            "an explicit new-window target must fall through to the browser so \
-             the tab is opened by a real user gesture (#5087 follow-up)"
+            block.contains(".toLowerCase()"),
+            "the target keyword must be compared lowercased, or `target=\"_SELF\"` \
+             is treated as a new-window request and a cross-origin click lands in \
+             the app frame, which `frame-src 'self'` refuses"
         );
         assert!(
-            block.contains("e.button === 1")
+            block.contains("targetName !== '_self'")
+                && block.contains("targetName !== '_top'")
+                && block.contains("targetName !== '_parent'"),
+            "only a target naming a NEW context may fall through: `_top` and \
+             `_parent` name an ancestor the sandbox forbids navigating, so \
+             handing one back to the browser is a silently dead click"
+        );
+        assert!(
+            block.contains("e.button ||")
                 && block.contains("e.ctrlKey")
                 && block.contains("e.metaKey")
                 && block.contains("e.shiftKey"),
             "middle/ctrl/cmd/shift-click must also fall through, restoring the \
              background-tab and new-window placement the postMessage route \
-             collapsed into a plain foreground tab (#3853)"
+             collapsed into a plain foreground tab (#3853). Test `e.button` for \
+             truthiness, not `=== 1`: `auxclick` fires for the secondary button \
+             too, and preventDefault there does not suppress the context menu"
+        );
+        assert!(
+            !block.contains("e.button === 1"),
+            "a middle-button-only check leaves right-click intercepted — the \
+             user gets the context menu AND an unwanted tab or app-frame \
+             navigation, measured in chromium and firefox"
         );
     }
 
@@ -7029,7 +7073,7 @@ mod tests {
     ///
     /// So the branch must still `return`, and must still not grow a forward.
     /// The whole-file "no `type: 'open_url'` anywhere in the interceptor" pin
-    /// lives in `navigation_interceptor_matches_expected_contract`; it strictly
+    /// lives in `navigation_interceptor_js_intercepts_clicks`; it strictly
     /// subsumes the per-handler forward COUNT this test used to carry while the
     /// cross-origin branch still forwarded, so that count is not repeated here.
     #[test]
@@ -7037,7 +7081,7 @@ mod tests {
         let js = NAVIGATION_INTERCEPTOR_JS;
 
         let target_attr_idx = js
-            .find("target.target && target.target !== '_self'")
+            .find("var targetName = target.target")
             .expect("same-origin target check present");
         let navigate_idx = js
             .find("type: 'navigate'")
@@ -7049,7 +7093,7 @@ mod tests {
         let block = &js[target_attr_idx..navigate_idx];
 
         assert!(
-            block.contains("!== '_self') return"),
+            block.contains("targetName !== '_self'") && block.contains("return;"),
             "same-origin target=\"_blank\" must fall through to the browser. Routing it \
              through open_url dead-ends on a loopback node, where the shell's open_url \
              handler refuses the host and the click does nothing at all (#5106)"
@@ -7077,7 +7121,7 @@ mod tests {
         // While the cross-origin branch still forwarded, the only way to catch
         // that was to count forwards across the whole handler and require
         // exactly one. #5100 removed the last forward, so the file-wide
-        // assertion in `navigation_interceptor_matches_expected_contract` —
+        // assertion in `navigation_interceptor_js_intercepts_clicks` —
         // NO `type: 'open_url'` anywhere in the interceptor — catches the
         // same evasion and every variant of it. Restore a scoped count here if
         // a forward is ever legitimately reintroduced.

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -3,14 +3,18 @@
 //! Contract web apps are served inside sandboxed iframes to provide origin isolation.
 //! The local API server returns a "shell" page that holds the auth token and
 //! proxies WebSocket connections via postMessage, while the contract runs in an
-//! `<iframe sandbox="allow-scripts allow-forms allow-popups allow-downloads allow-modals"
+//! `<iframe sandbox="allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox
+//!                   allow-downloads allow-modals"
 //!         allow="clipboard-read; clipboard-write">`
 //! with an opaque origin that cannot access other contracts' data.
-//! Popups inherit the sandbox (no `allow-popups-to-escape-sandbox`); external links
-//! are opened via the `open_url` shell bridge message to avoid CORS issues. The
-//! injected interceptor also overrides programmatic `window.open` in the iframe,
-//! routing http(s) opens through the same `open_url` bridge so a new tab gets the
-//! shell's real origin instead of a sandbox-inheriting opaque one (freenet-core#4645).
+//! Popups ESCAPE the sandbox: a new tab opened from the iframe is a normal
+//! top-level document at the node's real origin, which re-wraps the target
+//! contract in a fresh shell + sandboxed frame. That is what makes
+//! `target="_blank"` work identically in every browser — the tab is opened by a
+//! real user gesture in the frame that received the click, not by the shell from
+//! a `message` handler (which Firefox's popup blocker rejects outright, since
+//! `message` is not in `dom.popup_allowed_events`). See the head comment in
+//! `navigation_interceptor.js`.
 //! Sandbox content is protected from top-level access via Sec-Fetch-Dest checks in client_api.rs.
 
 use std::{
@@ -1825,39 +1829,34 @@ const WEBSOCKET_SHIM_JS: &str = include_str!("path_handlers/assets/websocket_shi
 
 /// JavaScript navigation interceptor injected into sandboxed iframe HTML pages.
 ///
-/// Intercepts clicks on `<a>` elements and sends a postMessage to the shell
-/// page, which either opens the URL in a new window (cross-origin) or updates
-/// the iframe's `src` (same-origin). This enables multi-page website
-/// navigation without weakening the sandbox (no `allow-top-navigation` nor
-/// `allow-popups-to-escape-sandbox` needed).
+/// Intercepts clicks on same-origin in-contract `<a>` elements and asks the
+/// shell to move the iframe (`type: 'navigate'`), which is what makes
+/// multi-page contract websites work without `allow-top-navigation`.
 ///
-/// Cross-origin links MUST be handled regardless of their `target` attribute,
-/// because without `allow-popups-to-escape-sandbox` a `target="_blank"` click
-/// would open a sandboxed popup with a null origin and the destination site
-/// would see CORS failures. This was freenet/river#208: River webapps added
-/// `target="_blank"` to every external link, the old interceptor skipped any
-/// anchor with an explicit target, and the resulting sandboxed popups broke
-/// logged-in pages like GitHub. The `open_url` bridge hands the URL to the
-/// shell page, which opens it with a proper origin via `window.open`.
+/// It deliberately does NOT touch new-window activations — an explicit
+/// non-`_self` `target`, or a ctrl/cmd/shift/middle-click. Those open natively.
+/// The iframe carries `allow-popups-to-escape-sandbox`, so the popup is a
+/// normal top-level document at the node's real origin: the shell loads (its
+/// `frame-src 'self'` matches), `localStorage` and the hosted per-user access
+/// key work (freenet-core#4645), and a cross-origin destination sees a real
+/// Origin rather than `null` (freenet/river#208).
 ///
-/// Same-origin links with an explicit non-`_self` target are left to the
-/// browser, so webapps that want multi-tab navigation within their own
-/// contract get their tab. That tab inherits the sandbox, though, so it has
-/// an opaque origin: on a hosted node it can't read the per-user access key
-/// and dead-ends (#4645), and on WebKit it renders blank (#5087). #5089
-/// routed this branch through `open_url` to fix that and was reverted in
-/// #5106, because the bridge refuses loopback hosts and the click then did
-/// nothing at all on a local node. See the comment on that branch in
-/// `navigation_interceptor.js` for the full trade.
+/// Routing new-window opens through the shell's `open_url` bridge instead is
+/// what broke Firefox: the shell's `window.open` then runs inside a `message`
+/// handler, and Firefox's popup blocker allows `window.open` only from events
+/// in `dom.popup_allowed_events` (click, auxclick, mouseup, …) — `message` is
+/// not one, so the popup was blocked and the click did nothing. Chrome and
+/// Safari allowed it only because they propagate user activation across the
+/// whole frame tree. A real gesture in the frame that received the click is the
+/// only mechanism that works in every browser. #5089 took that route and was
+/// reverted in #5107, which also priced a second cost of it: the bridge refuses
+/// loopback hosts, so on a local node the forwarded open was dropped outright.
 ///
-/// The interceptor also overrides programmatic `window.open`: an app that opens
-/// a new tab from its own JS bypasses the click/auxclick listeners, and on a
-/// hosted node the resulting opaque-origin popup can't read the per-user access
-/// key and dead-ends (freenet-core#4645). http(s) new-window opens are forwarded
-/// through the same `open_url` bridge (real origin); `_self`/`_parent`/`_top`,
-/// non-http(s) schemes, and loopback targets (which `open_url` refuses) fall back
-/// to the native open. The returned WindowProxy is dropped (null), matching the
-/// shell's `noopener` open.
+/// The one cross-origin case still intercepted is a link with NO new-window
+/// target: navigating the app frame itself to a foreign origin is refused by
+/// the shell's `frame-src 'self'`, so the click would silently do nothing. It
+/// is turned into `window.open(..., '_blank', 'noopener,noreferrer')` from
+/// inside the click handler, where the gesture is live.
 const NAVIGATION_INTERCEPTOR_JS: &str =
     include_str!("path_handlers/assets/navigation_interceptor.js");
 
@@ -4670,7 +4669,7 @@ mod tests {
         // Shell page must contain sandboxed iframe
         assert!(
             html.contains(
-                r#"sandbox="allow-scripts allow-forms allow-popups allow-downloads allow-modals""#
+                r#"sandbox="allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox allow-downloads allow-modals""#
             ),
             "iframe sandbox attribute missing or wrong allowlist"
         );
@@ -4721,25 +4720,33 @@ mod tests {
             html.contains("__freenet_shell__"),
             "bridge JS must handle shell-level messages (title/favicon)"
         );
-        // allow-popups-to-escape-sandbox must NOT be present. It was removed because
-        // escaped popups gain localhost:7509 origin, allowing malicious web apps to
-        // access other apps' data and bypass permission prompts. External links are
-        // now opened via the open_url shell bridge message instead.
+// `allow-popups-to-escape-sandbox` MUST be present: it is what makes a
+        // new tab open identically in every browser. The popup carries a real
+        // user gesture from the frame that got the click, and lands on the shell
+        // at the node's real origin. Routing new-window opens through the shell's
+        // `open_url` bridge instead (the previous design) put `window.open`
+        // inside a `message` handler, which Firefox's popup blocker refuses
+        // outright — `message` is not in `dom.popup_allowed_events`.
         //
-        // Citation corrected in #5107: this said "#1499", but that is the
-        // delegate-user-interaction feature request. The flag was removed by
-        // PR #3818 (`ec140e09c`, "browser-based permission prompts with iframe
-        // security hardening"), which is also the commit that wrote the
-        // original "#1499" pointer here. #1499 is the motivation; #3818 is the
-        // change and the place to argue with.
+        // The flag was removed by PR #3818 (`ec140e09c`, "browser-based
+        // permission prompts with iframe security hardening"), motivated by
+        // #1499 — citation corrected in #5107, which found the old comment here
+        // pointed at #1499 (the delegate-user-interaction feature request)
+        // rather than at the change itself.
+        //
+        // #3818's concern — CONTRACT script executing at the node's real origin
+        // — is what re-adding the flag has to answer, and the iframe `sandbox`
+        // attribute cannot answer it: an escaped popup is a context we do not
+        // control, and from there a contract can re-embed its own bytes itself.
+        // The answer is `CONTRACT_CONTENT_SANDBOX_CSP` in `client_api.rs`: every
+        // response carrying contract-authored bytes is served a `sandbox` CSP
+        // directive, so the opaque origin is decided by this server rather than
+        // by whichever context happens to embed it. Do NOT drop that header, and
+        // do NOT narrow it to `Sec-Fetch-Dest: document`, without re-deriving
+        // the argument — the concrete attack is in the header's comment.
         assert!(
-            !html.contains("allow-popups-to-escape-sandbox"),
-            "allow-popups-to-escape-sandbox must not be set (security: #3818)"
-        );
-        // open_url handler must be present in shell bridge JS for external links
-        assert!(
-            html.contains("open_url"),
-            "shell bridge must handle open_url messages for external links"
+            html.contains("allow-popups-to-escape-sandbox"),
+            "escaped popups are required for cross-browser target=\"_blank\""
         );
     }
 
@@ -6712,22 +6719,117 @@ mod tests {
             NAVIGATION_INTERCEPTOR_JS.contains("e.preventDefault()"),
             "interceptor must prevent default link behavior"
         );
-        // Cross-origin links should use open_url instead of navigate
+        // New-window activations are NOT routed through the shell: they open
+        // natively so the browser sees a real user gesture (see
+        // `navigation_interceptor_leaves_new_window_activations_native`).
         assert!(
-            NAVIGATION_INTERCEPTOR_JS.contains("type: 'open_url'"),
-            "interceptor must route cross-origin links through open_url"
+            !NAVIGATION_INTERCEPTOR_JS.contains("type: 'open_url'"),
+            "interceptor must not post open_url: the shell would then call \
+             window.open from a `message` handler, which Firefox's popup \
+             blocker refuses (#5087 follow-up)"
         );
-        // Same-origin links: must respect explicit non-_self target so
-        // webapps that open multiple tabs within their own contract still
-        // work.
+        // An explicit non-_self target must be recognized and left alone.
         assert!(
             NAVIGATION_INTERCEPTOR_JS.contains("target.target"),
-            "interceptor must respect target attribute on same-origin links"
+            "interceptor must respect target attribute"
         );
         // Must walk up DOM to handle clicks on child elements of <a>
         assert!(
             NAVIGATION_INTERCEPTOR_JS.contains("target.parentElement"),
             "interceptor must walk up DOM to find <a> ancestor"
+        );
+    }
+
+    /// Regression test for freenet/river#208, under the escaped-popup design.
+    ///
+    /// A cross-origin link with NO new-window target would, left alone,
+    /// navigate the app frame itself to a foreign origin — which the shell's
+    /// `frame-src 'self'` refuses, so the click silently does nothing. It must
+    /// therefore open a tab. The open has to happen HERE, inside the
+    /// click/auxclick handler, because that is the only place a live user
+    /// gesture exists: Firefox allows `window.open` only from events in
+    /// `dom.popup_allowed_events`, which includes `click`/`auxclick` but NOT
+    /// `message`, so the old "post `open_url` and let the shell open it" route
+    /// was blocked outright in Firefox.
+    ///
+    /// The popup escapes the sandbox (`allow-popups-to-escape-sandbox` on the
+    /// shell iframe), so the destination sees a real Origin instead of the
+    /// `null` one that broke logged-in sites in river#208.
+    #[test]
+    fn navigation_interceptor_opens_untargeted_cross_origin_links_in_a_tab() {
+        let js = NAVIGATION_INTERCEPTOR_JS;
+
+        let cross_origin_idx = js
+            .find("target.origin !== location.origin")
+            .expect("cross-origin check present");
+        // Bound the slice at the start of the same-origin branch so its
+        // `postMessage` can't satisfy the assertions below.
+        let same_origin_idx = js
+            .find("// Same-origin in-contract link")
+            .expect("same-origin in-contract branch present");
+        let block = &js[cross_origin_idx..same_origin_idx];
+
+        assert!(
+            block.contains("preventDefault"),
+            "cross-origin branch must preventDefault before opening the tab"
+        );
+        assert!(
+            block.contains("window.open(target.href, '_blank', 'noopener,noreferrer')"),
+            "cross-origin branch must open the tab itself, from the click \
+             handler, with noopener/noreferrer (freenet/river#208)"
+        );
+        assert!(
+            !block.contains("postMessage"),
+            "cross-origin branch must not hand the open to the shell: \
+             window.open from a `message` handler is popup-blocked in Firefox"
+        );
+    }
+
+    /// Regression test for the Firefox half of #5087.
+    ///
+    /// #5087 fixed a blank tab on same-origin `target="_blank"` by routing the
+    /// click through the shell's `open_url` bridge. That put `window.open`
+    /// inside a `message` handler, and Firefox's popup blocker keys on the
+    /// dispatching event type (`dom.popup_allowed_events` — no `message`), so
+    /// every such click became a no-op in Firefox while Chrome/Safari kept
+    /// working by propagating user activation across the frame tree. Users had
+    /// to right-click → "Open in new tab", which bypasses JS entirely.
+    ///
+    /// The fix is `allow-popups-to-escape-sandbox` on the shell iframe: the
+    /// natively-opened popup is a real top-level document at the node origin,
+    /// so the shell's `frame-src 'self'` matches and the app frame loads. Pin
+    /// that new-window activations are left to the browser, and that modifier
+    /// clicks (which the postMessage route could never preserve) are too.
+    #[test]
+    fn navigation_interceptor_leaves_new_window_activations_native() {
+        let js = NAVIGATION_INTERCEPTOR_JS;
+
+        let target_attr_idx = js
+            .find("target.target && target.target !== '_self'")
+            .expect("target-attribute check present");
+        let cross_origin_idx = js
+            .find("target.origin !== location.origin")
+            .expect("cross-origin check present");
+        assert!(
+            target_attr_idx < cross_origin_idx,
+            "the new-window skip must run BEFORE origin classification, or a \
+             cross-origin target=\"_blank\" gets intercepted again"
+        );
+
+        let block = &js[target_attr_idx..cross_origin_idx];
+        assert!(
+            block.contains("!== '_self') return"),
+            "an explicit new-window target must fall through to the browser so \
+             the tab is opened by a real user gesture (#5087 follow-up)"
+        );
+        assert!(
+            block.contains("e.button === 1")
+                && block.contains("e.ctrlKey")
+                && block.contains("e.metaKey")
+                && block.contains("e.shiftKey"),
+            "middle/ctrl/cmd/shift-click must also fall through, restoring the \
+             background-tab and new-window placement the postMessage route \
+             collapsed into a plain foreground tab (#3853)"
         );
     }
 
@@ -6742,6 +6844,16 @@ mod tests {
     ///
     /// Pin the contract: the cross-origin branch MUST be reached before
     /// the target-attribute check, i.e. the origin classification dominates.
+    // SUPERSEDED by PR #5100: new-window activations are no longer routed
+    // through the shell's `open_url` bridge, and the `window.open` override is
+    // gone. Retained (ignored) as historical documentation of the pre-#5100
+    // contract, per the project rule that superseded tests are #[ignore]d with
+    // an explanation rather than deleted. The behaviour they pinned is what
+    // broke `target="_blank"` in Firefox: `window.open` from a `message`
+    // handler is refused by its popup blocker. Current contract is pinned by
+    // `navigation_interceptor_leaves_new_window_activations_native` and
+    // `navigation_interceptor_opens_untargeted_cross_origin_links_in_a_tab`.
+    #[ignore]
     #[test]
     fn navigation_interceptor_handles_cross_origin_target_blank() {
         let js = NAVIGATION_INTERCEPTOR_JS;
@@ -6807,6 +6919,16 @@ mod tests {
     ///      the posted message, sourced from the MouseEvent.
     ///   3. The shell bridge's `open_url` handler reads `msg.shiftKey` and
     ///      uses the `popup` window feature when it's true.
+    // SUPERSEDED by PR #5100: new-window activations are no longer routed
+    // through the shell's `open_url` bridge, and the `window.open` override is
+    // gone. Retained (ignored) as historical documentation of the pre-#5100
+    // contract, per the project rule that superseded tests are #[ignore]d with
+    // an explanation rather than deleted. The behaviour they pinned is what
+    // broke `target="_blank"` in Firefox: `window.open` from a `message`
+    // handler is refused by its popup blocker. Current contract is pinned by
+    // `navigation_interceptor_leaves_new_window_activations_native` and
+    // `navigation_interceptor_opens_untargeted_cross_origin_links_in_a_tab`.
+    #[ignore]
     #[test]
     fn navigation_interceptor_forwards_shift_key_for_open_url() {
         let js = NAVIGATION_INTERCEPTOR_JS;
@@ -6836,67 +6958,32 @@ mod tests {
         );
     }
 
-    /// Regression test for #5106 — the fallout of #5089, which is reverted here.
+    /// Pins the same-origin new-window branch as the browser's job, through
+    /// three attempts at it.
     ///
-    /// #5089 routed the same-origin new-window branch through the shell's
-    /// `open_url` bridge to fix a blank tab (#5087). Two measured facts make
-    /// that trade net-negative:
+    /// Before #5089 this branch fell through to the browser, and the resulting
+    /// popup INHERITED the iframe sandbox: opaque origin, so WebKit rendered it
+    /// blank (#5087), a hosted node could not read the per-user access key and
+    /// dead-ended (#4645), and `/permission/pending` answered 200 with an empty
+    /// list to its `Origin: null`, so prompts silently never appeared.
     ///
-    ///  1. `open_url` REFUSES loopback hosts (`localhost` / `127.0.0.1` /
-    ///     `::1` / `0.0.0.0`) — see the handler in `shell_bridge.js`. That is
-    ///     the documented way a local node is reached (the service prints
-    ///     `Open http://127.0.0.1:7509/` on start), so forwarding meant the
-    ///     click was `preventDefault`-ed and then silently dropped by the
-    ///     shell: NOTHING opened, in every engine. The `window.open` override
-    ///     further down never had this hole — it checks `isLoopbackHost` and
-    ///     falls back to native. The anchor branch has no such fallback, so
-    ///     it must not forward.
-    ///  2. The blank tab it fixed is WebKit-only. Driving the real
-    ///     interceptor inside a sandboxed-shell harness in all three engines,
-    ///     the pre-#5089 native popup was opaque-origin everywhere, but only
-    ///     WebKit's `frame-src 'self'` refused the app frame; Gecko and Blink
-    ///     loaded it. Firefox and Chrome users were therefore traded a
-    ///     working tab for a dead click.
+    /// #5089 routed it through the shell's `open_url` bridge instead. That put
+    /// `window.open` inside a `message` handler — refused outright by Firefox's
+    /// popup blocker, which gates on the dispatching event type — so the click
+    /// became a no-op there (#5106). It also dead-ended on a loopback node,
+    /// because the bridge's `open_url` handler refuses `localhost`/`127.0.0.1`
+    /// and the anchor branch had no fallback. #5107 reverted it.
     ///
-    /// Two things NOT to repeat from earlier drafts of this reasoning, both
-    /// retracted after review re-ran the measurements: popup blocking has
-    /// nothing to do with any of it (the matrix is identical with blockers on
-    /// and off; the zero-popup cells are the loopback refusal), and "loopback
-    /// is how most desktop users browse" was never established — #5087's own
-    /// reporter was on `10.44.101.1`, i.e. the configuration where #5089
-    /// helped and this revert does not.
+    /// #5100 (this) keeps the fall-through and removes the reason it was ever
+    /// costly: with `allow-popups-to-escape-sandbox` on the shell iframe the
+    /// natively-opened popup is a real top-level document at the node origin,
+    /// which fixes all three of the pre-#5089 symptoms without a bridge hop.
     ///
-    /// The revert is not free, and this test should not be read as saying the
-    /// current behaviour is good. The tab the browser opens inherits the
-    /// sandbox, so it has an opaque origin, which costs three things: WebKit
-    /// renders it blank (#5087); on a HOSTED node it can't read the per-user
-    /// access key and dead-ends on the "Open this app in a normal tab" panel
-    /// in every engine (#4645); and its permission surface is dead in every
-    /// engine, because `Origin: null` is refused and `/permission/pending`
-    /// answers 200 with an empty list rather than an error, so the prompt
-    /// silently never appears. That last one bites hardest on a LOCAL node in
-    /// Firefox/Chrome — the very case this pins — where the app frame loads
-    /// fine and so looks healthy. #5089 fixed all three for this path
-    /// incidentally. This test pins the lesser failure, not a good one, until
-    /// a fix lands that has neither.
-    ///
-    /// Two constraints on that fix. `allow-popups-to-escape-sandbox` on the
-    /// app iframe was deliberately REMOVED by #3818 (motivated by #1499) — an
-    /// escaped popup gains the node's real origin, letting a malicious app
-    /// reach other apps' data and bypass permission prompts (its absence is
-    /// pinned in `shell_page_*` above) — so that route has to answer #3818
-    /// first. A bridge re-route needs a loopback fallback mirroring
-    /// `window.open`'s `isLoopbackHost`.
-    ///
-    /// Note that such a fix WILL fail both assertions below, and that is
-    /// correct — they pin today's behaviour, not a permanent invariant.
-    /// Whoever lands it should replace this test, not weaken it. The first
-    /// assertion is the load-bearing one; the second is a cheap belt-and-
-    /// braces check. What it uniquely covers is a forward inserted BETWEEN
-    /// the `return` and the `navigate` postMessage — reachable code, just
-    /// for untargeted same-origin links rather than for this branch. A
-    /// forward ahead of the `return` is already caught by the first.
-    #[test]
+    /// So the branch must still `return`, and must still not grow a forward.
+    /// The whole-file "no `type: 'open_url'` anywhere in the interceptor" pin
+    /// lives in `navigation_interceptor_matches_expected_contract`; it strictly
+    /// subsumes the per-handler forward COUNT this test used to carry while the
+    /// cross-origin branch still forwarded, so that count is not repeated here.
     fn navigation_interceptor_leaves_same_origin_target_blank_to_the_browser() {
         let js = NAVIGATION_INTERCEPTOR_JS;
 
@@ -6921,10 +7008,11 @@ mod tests {
         assert!(
             !block.contains("type: 'open_url'"),
             "no open_url forward may be added to the same-origin new-window branch ahead \
-             of the `return` (#5106). If you are DELIBERATELY re-routing this branch — \
-             with a loopback fallback like the window.open override's isLoopbackHost \
-             check, or after removing the sandbox inheritance — this test is pinning the \
-             old behaviour and should be replaced, not deleted piecemeal"
+             of the `return` (#5106). A bridge hop here runs `window.open` from a \
+             `message` handler, which Firefox's popup blocker refuses, and is dropped \
+             outright for a loopback host. If you are DELIBERATELY re-routing this \
+             branch, this test is pinning the old behaviour and should be replaced, \
+             not deleted piecemeal"
         );
 
         // Both assertions above scope to the branch, which leaves an evasion:
@@ -6937,78 +7025,13 @@ mod tests {
         //     if (target.target === '_blank') { e.preventDefault(); /* open_url */ return; }
         //     if (target.target && target.target !== '_self') return;
         //
-        // So also pin the whole-handler count. `handleAnchorClick` must post
-        // open_url from exactly ONE place: the cross-origin branch.
-        //
-        // Scope, precisely — this counts DIRECT forwards, i.e. the literal
-        // postMessage. It does NOT catch a re-route written through the
-        // patched `window.open` (`if (target.target === '_blank') { …
-        // window.open(target.href); return; }`), which passes this and the two
-        // branch assertions. That is deliberate: such a re-route inherits the
-        // override's `isLoopbackHost` fallback, so it is the shape the branch
-        // comment invites rather than the bug this guards.
-        //
-        // It is also NOT a standalone guard against extracting the forward
-        // into a helper — `navigation_interceptor_handles_cross_origin_target_blank`
-        // is what fires there, because it requires the literal INSIDE the
-        // cross-origin block. Do not prune that test as redundant with this
-        // one; it is the half that keeps river#208 closed.
-        //
-        // What this does add is the asymmetry with `window.open` being
-        // DELIBERATE rather than an accident of two reverts: the override
-        // below forwards same-origin new-window opens (#4645) and this handler
-        // does not. The anchor path pays #4645's dead-end on hosted nodes to
-        // avoid the loopback dead click (#5106); the override avoids both
-        // because it has that fallback. Whoever unifies them lands here and
-        // chooses on purpose.
-        let handler_start = js
-            .find("function handleAnchorClick")
-            .expect("anchor click handler present");
-        let handler_end = js
-            .find("document.addEventListener('click'")
-            .expect("anchor click listener registration present");
-        // Function declarations hoist, so moving the listener registrations
-        // above the handler is a legal tidy-up that would invert these bounds.
-        // Catch it with a message rather than a raw slice panic.
-        assert!(
-            handler_start < handler_end,
-            "expected `function handleAnchorClick` before the listener \
-             registration; if the registrations were hoisted above the handler, \
-             re-anchor this bound rather than dropping the check"
-        );
-        let forwards = js[handler_start..handler_end]
-            .matches("type: 'open_url'")
-            .count();
-        assert_eq!(
-            forwards, 1,
-            "handleAnchorClick must forward open_url from exactly one place — the \
-             cross-origin branch (freenet/river#208). Too many means a same-origin \
-             new-window re-route slipped in outside the branch this test's other \
-             assertions scope to (#5106). Zero most likely means the forward moved \
-             into a helper, which is fine behaviour but leaves this count guarding \
-             nothing — re-anchor it rather than deleting it"
-        );
-    }
-
-    /// Regression test for the middle-click half of #3853. Middle-click is
-    /// dispatched as `auxclick` in modern browsers, NOT `click`, so the
-    /// interceptor must listen on both events. Without the auxclick
-    /// listener, middle-clicks on cross-origin `<a target="_blank">` links
-    /// bypass the `open_url` routing and fall through to the browser's
-    /// default handling, producing a null-origin sandboxed popup (exactly
-    /// what #3852 was meant to prevent).
-    #[test]
-    fn navigation_interceptor_listens_on_click_and_auxclick() {
-        let js = NAVIGATION_INTERCEPTOR_JS;
-        assert!(
-            js.contains("addEventListener('click'"),
-            "interceptor must register a click listener"
-        );
-        assert!(
-            js.contains("addEventListener('auxclick'"),
-            "interceptor must register an auxclick listener so middle-click \
-             on cross-origin links is also routed through open_url (#3853)"
-        );
+        // While the cross-origin branch still forwarded, the only way to catch
+        // that was to count forwards across the whole handler and require
+        // exactly one. #5100 removed the last forward, so the file-wide
+        // assertion in `navigation_interceptor_matches_expected_contract` —
+        // NO `type: 'open_url'` anywhere in the interceptor — catches the
+        // same evasion and every variant of it. Restore a scoped count here if
+        // a forward is ever legitimately reintroduced.
     }
 
     /// Regression test for freenet/freenet-core#4645.
@@ -7037,6 +7060,16 @@ mod tests {
     ///   5. `_self`/`_parent`/`_top` (in-place navigation) fall back to native.
     ///   6. Loopback targets fall back to native (open_url refuses them).
     ///   7. The arg is coerced to a string so URL objects are forwarded.
+    // SUPERSEDED by PR #5100: new-window activations are no longer routed
+    // through the shell's `open_url` bridge, and the `window.open` override is
+    // gone. Retained (ignored) as historical documentation of the pre-#5100
+    // contract, per the project rule that superseded tests are #[ignore]d with
+    // an explanation rather than deleted. The behaviour they pinned is what
+    // broke `target="_blank"` in Firefox: `window.open` from a `message`
+    // handler is refused by its popup blocker. Current contract is pinned by
+    // `navigation_interceptor_leaves_new_window_activations_native` and
+    // `navigation_interceptor_opens_untargeted_cross_origin_links_in_a_tab`.
+    #[ignore]
     #[test]
     fn navigation_interceptor_overrides_window_open() {
         let js = NAVIGATION_INTERCEPTOR_JS;
@@ -7124,6 +7157,31 @@ mod tests {
         assert!(
             override_block.contains("return null;"),
             "window.open override must return null for the forwarded case (#4645)"
+        );
+    }
+
+    /// Regression test for the middle-click half of #3853. Middle-click is
+    /// dispatched as `auxclick` in modern browsers, NOT `click`, so a
+    /// `click`-only listener never sees it.
+    ///
+    /// Today middle-click is deliberately left native (it is a new-window
+    /// activation), so both listeners reach the same early return and the
+    /// auxclick registration is not what produces the current behaviour. It
+    /// stays because the two events must be CLASSIFIED alike: if the
+    /// modifier/button skip is ever narrowed, a `click`-only interceptor would
+    /// silently stop covering middle-click again, which is exactly how #3853
+    /// happened.
+    #[test]
+    fn navigation_interceptor_listens_on_click_and_auxclick() {
+        let js = NAVIGATION_INTERCEPTOR_JS;
+        assert!(
+            js.contains("addEventListener('click'"),
+            "interceptor must register a click listener"
+        );
+        assert!(
+            js.contains("addEventListener('auxclick'"),
+            "interceptor must register an auxclick listener so middle-click is \
+             classified too (#3853)"
         );
     }
 
@@ -7255,35 +7313,32 @@ mod tests {
         );
     }
 
-    /// The interceptor's `isLoopbackHost` and the shell `open_url` handler's
-    /// loopback refusal must name the SAME hosts. `isLoopbackHost` exists only
-    /// to predict what the shell will refuse, so that `window.open` falls back
-    /// to native instead of forwarding an open that will be dropped — its own
-    /// comment says "Kept in sync with the loopback block in shell_bridge.js's
-    /// open_url handler", but nothing enforced that until now.
+    /// The shell `open_url` handler's loopback refusal is a SECURITY control:
+    /// host in the list ⇒ refuse. It is what stops a contract forging an
+    /// `{__freenet_shell__: true, type: 'open_url'}` message aimed at the
+    /// viewer's own loopback services — the local node's API included. Any
+    /// contract can post that message directly, so the control is live whether
+    /// or not the injected interceptor ever sends one.
     ///
-    /// Drift in either direction is a silent user-visible bug:
-    ///   - shell refuses a host the interceptor does not list → the forwarded
-    ///     open vanishes and the click does nothing. That is exactly the
-    ///     failure #5106 hit through the anchor path, which had no such list
-    ///     at all.
-    ///   - interceptor lists a host the shell would open → the open needlessly
-    ///     falls back to a sandbox-inheriting native popup (#4645).
+    /// #5100 removed the interceptor's `isLoopbackHost`, which existed only to
+    /// PREDICT this refusal so the `window.open` override could fall back to
+    /// native rather than forward an open the shell would drop. With the
+    /// override gone there is no second list, so the parity half of this test
+    /// (added in #5107) has nothing left to compare and is dropped with it —
+    /// deliberately, not by accident. What survives is the floor: the refusal
+    /// must still name every loopback host.
     ///
-    /// #4846 proposes completing this allow-list (it is exact-match today, so
-    /// e.g. `127.0.0.2` is not covered). Whoever does that one-sidedly will
-    /// trip this test. Note the limit, though: it compares LITERALS, so if
-    /// #4846 is implemented as a rule (`h.startsWith('127.')`) on both sides,
-    /// both literal sets shrink together and this test goes green without
-    /// having checked the new rule. It catches one-sided literal drift — the
-    /// common case — not a symmetric refactor. Two more divergences it cannot
-    /// see, both of which keep identical literals: flipping `||` to `&&` on
-    /// one side (uncovered anywhere), and dropping the bracket-strip
-    /// normalization so `[::1]` stops matching (covered for the shell by
-    /// `shell_open_url_handler_blocks_ipv6_loopback`, and behaviourally for
-    /// the interceptor by window-open.spec.ts). Do not over-trust the parity.
+    /// Limits, so this is not over-trusted. It reads LITERALS, so #4846
+    /// (complete the allow-list; it is exact-match today, e.g. `127.0.0.2` is
+    /// not covered) implemented as a rule — `h.startsWith('127.')` — would
+    /// remove the literals and trip this test even though the rule is strictly
+    /// wider. That is the intended failure: come here and re-express the floor
+    /// against the new shape rather than deleting it. It also cannot see a `||`
+    /// flipped to `&&`, which is uncovered anywhere; the bracket-strip
+    /// normalization that makes `[::1]` match is covered by
+    /// `shell_open_url_handler_blocks_ipv6_loopback` above.
     #[test]
-    fn interceptor_loopback_list_matches_shell_open_url_refusal() {
+    fn shell_open_url_refusal_names_every_loopback_host() {
         // Collect the host literals from each `h === '<host>'` comparison in a
         // region.
         //
@@ -7291,7 +7346,6 @@ mod tests {
         // `hash === '` and `iframePath === '`, which occur elsewhere in
         // shell_bridge.js. What makes this sound is purely the REGION BOUNDS
         // chosen below — do not loosen them on the theory that `h` is unique.
-        // That mistake is live: see the note on the shell anchor.
         fn loopback_hosts(region: &str) -> Vec<String> {
             const NEEDLE: &str = "h === '";
             let mut out = Vec::new();
@@ -7314,21 +7368,6 @@ mod tests {
             out
         }
 
-        // The `function ` prefix is load-bearing: the name `isLoopbackHost`
-        // also appears in prose in the same-origin branch's comment ABOVE the
-        // declaration, so anchoring on the bare name would slice from the
-        // comment and miss the helper entirely.
-        let interceptor_fn_idx = NAVIGATION_INTERCEPTOR_JS
-            .find("function isLoopbackHost")
-            .expect("interceptor isLoopbackHost helper present");
-        let interceptor_region = &NAVIGATION_INTERCEPTOR_JS[interceptor_fn_idx..];
-        // The helper is short; bound the region at its closing brace so a later
-        // `h === ...` elsewhere in the file can't leak in.
-        let interceptor_end = interceptor_region
-            .find("\n  }")
-            .expect("isLoopbackHost helper is brace-terminated");
-        let interceptor_hosts = loopback_hosts(&interceptor_region[..interceptor_end]);
-
         // Anchor tightly on the refusal itself — `var h = u.hostname` up to the
         // `return;` that drops the message. The sibling tests here bound the
         // open_url branch with the next `} else if`, but open_url is the LAST
@@ -7344,23 +7383,6 @@ mod tests {
             .expect("shell open_url loopback refusal returns");
         let shell_hosts = loopback_hosts(&rest[..refusal_end]);
 
-        // The two lists have OPPOSITE polarity, so a bare equality is not
-        // enough. The shell side is a SECURITY control: host in list ->
-        // refuse, which is what stops a contract forging an `open_url` at the
-        // viewer's own loopback services, the local node's API included (see
-        // `shell_open_url_handler_blocks_ipv6_loopback`, and note the handler
-        // deliberately does NOT block RFC1918 — loopback is the one network
-        // class it guards). The interceptor side blocks nothing at all: it is
-        // only a PREDICTION of the shell's refusal so `window.open` can fall
-        // back to native.
-        //
-        // So equality must never be reachable by SHRINKING the shell list.
-        // Drop `127.0.0.1`/`::1`/`0.0.0.0` from both and a bare assert_eq is
-        // green while `open_url` will happily open `http://127.0.0.1:7509/…`
-        // for any contract that asks. Pin a floor on the security side first,
-        // and make the equality message name the correct repair direction —
-        // someone red on #4846 otherwise has an easier wrong fix available
-        // (delete an arm) than the right one.
         for host in ["localhost", "127.0.0.1", "::1", "0.0.0.0"] {
             assert!(
                 shell_hosts.iter().any(|h| h == host),
@@ -7368,23 +7390,9 @@ mod tests {
                  extraction above truncated, e.g. because the chain was split into \
                  per-host `if (h === '…') return;` lines, which the `return;` bound \
                  would cut short (check shell_bridge.js by eye). This list is a \
-                 security boundary. If you are here because the equality below went \
-                 red, the fix is to WIDEN isLoopbackHost in navigation_interceptor.js \
-                 — never to narrow this one. Got: {shell_hosts:?}"
+                 security boundary: widen it, never narrow it. Got: {shell_hosts:?}"
             );
         }
-        assert_eq!(
-            interceptor_hosts, shell_hosts,
-            "isLoopbackHost and the shell's open_url loopback refusal have drifted \
-             (or a region bound truncated one of them — compare the two lists above \
-             before assuming drift). Correct repair direction: make \
-             navigation_interceptor.js's isLoopbackHost match shell_bridge.js, not \
-             the reverse. A host the shell refuses but the interceptor omits makes \
-             window.open forward an open the shell then drops silently (#5106); the \
-             reverse merely falls back to a sandbox-inheriting native popup (#4645). \
-             When completing the allow-list per #4846, widen BOTH, starting with the \
-             shell."
-        );
     }
 
     /// Direct postMessages from a malicious iframe can synthesize an

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -1493,6 +1493,28 @@ pub(super) fn sanitize_shell_sub_path(sub_path: &str) -> Result<String, WebSocke
             error_cause: "deep-link sub-path must not contain '.' or '..' segments".to_string(),
         });
     }
+    // …and reject a surviving `%`, because the dot-segment check above sees the
+    // path exactly ONCE-decoded (axum's `PercentDecodedStr` decodes path params
+    // a single time) while the browser decodes the URL we hand back again. So
+    // `%252e%252e` on the wire arrives here as the literal text `%2e%2e` —
+    // neither `.` nor `..`, so it passes — and the WHATWG URL parser then
+    // treats it as a dot segment and normalizes it away. Measured end to end:
+    // `/v1/contract/web/KEYA/%252e%252e/KEYB/index.html` produced an iframe
+    // `data-src` the browser resolved to KEYB's page, so KEYB's app ran inside
+    // a shell holding KEYA's auth token — the cross-contract confusion this
+    // whole function exists to prevent (#3841).
+    //
+    // Rejecting `%` outright rather than enumerating the encodings of `.`: this
+    // path is already once-decoded, so a legitimate sub-path reaches us with
+    // its escapes resolved (a filename with a space arrives as a space — and is
+    // rejected by the whitespace check above, so that is the established bar).
+    // A literal `%` in a contract filename is vanishingly rare, and the cost is
+    // a 400 on a deep link, not a broken app.
+    if sub_path.contains('%') {
+        return Err(WebSocketApiError::InvalidParam {
+            error_cause: "deep-link sub-path must not contain percent escapes".to_string(),
+        });
+    }
     Ok(sub_path.to_string())
 }
 
@@ -1540,10 +1562,12 @@ fn shell_page(
                 continue;
             }
             // Strip any `__sandbox*` param (server-interpreted routing
-            // flag) and the auth credential `authToken`. Both are
-            // prefix-checked since a future refactor might add
-            // variants like `__sandbox_debug` or `authToken2`.
-            if param.starts_with("__sandbox") || param.starts_with("authToken") {
+            // flag) and the auth credential `authToken`. Shared with the
+            // redirect filter rather than duplicated, so the two cannot
+            // drift — and so both get the percent-decoding of the name that
+            // a raw prefix match misses (`authT%6Fken=evil` reads back as
+            // `authToken` from `location.search` inside the iframe).
+            if super::client_api::is_sensitive_query_param(param) {
                 continue;
             }
             iframe_params.push(param.to_string());
@@ -5114,6 +5138,28 @@ mod tests {
     /// browser into a different contract's prefix.
     #[test]
     fn sanitize_shell_sub_path_accepts_safe_paths_and_rejects_dangerous() {
+        // A percent-escape that SURVIVES axum's single decode is a second,
+        // browser-side decode waiting to happen: `%252e%252e` on the wire
+        // arrives here as the literal `%2e%2e`, passes the dot-segment check,
+        // and is then normalized to `..` by the URL parser in whatever we hand
+        // back — the iframe `data-src`, or the sub-page redirect. Measured
+        // end to end: it resolved to ANOTHER contract's page inside a shell
+        // holding this contract's auth token.
+        for encoded in [
+            "%2e%2e/OTHERKEY/index.html",
+            "%2E%2E/OTHERKEY/index.html",
+            ".%2e/OTHERKEY/index.html",
+            "%2e/index.html",
+            "sub/%2e%2e/%2e%2e/index.html",
+            "a%25b.html",
+        ] {
+            assert!(
+                sanitize_shell_sub_path(encoded).is_err(),
+                "{encoded} must be rejected: it is once-decoded here but decoded \
+                 again by the browser"
+            );
+        }
+
         // Safe relative paths used by real multi-page webapps.
         for ok in ["news/", "about/team", "page2", "index.html", "a/b/c/"] {
             assert_eq!(
@@ -6910,12 +6956,15 @@ mod tests {
             block.contains("e.button ||")
                 && block.contains("e.ctrlKey")
                 && block.contains("e.metaKey")
-                && block.contains("e.shiftKey"),
+                && block.contains("e.shiftKey")
+                && block.contains("e.altKey"),
             "middle/ctrl/cmd/shift-click must also fall through, restoring the \
              background-tab and new-window placement the postMessage route \
              collapsed into a plain foreground tab (#3853). Test `e.button` for \
              truthiness, not `=== 1`: `auxclick` fires for the secondary button \
-             too, and preventDefault there does not suppress the context menu"
+             too, and preventDefault there does not suppress the context menu. \
+             `altKey` is here for a different reason — it is the save-link \
+             gesture, not a new window — but the same conclusion applies"
         );
         assert!(
             !block.contains("e.button === 1"),
@@ -7092,8 +7141,20 @@ mod tests {
         );
         let block = &js[target_attr_idx..navigate_idx];
 
+        // Scope the `return;` to the target check itself. A block that runs to
+        // the `navigate` branch also spans the modifier skip's `return;` and the
+        // cross-origin branch's, so the conjunct would hold with the early
+        // return deleted — mutation-confirmed.
+        let button_idx = js
+            .find("if (e.button ||")
+            .expect("modifier/button skip present");
         assert!(
-            block.contains("targetName !== '_self'") && block.contains("return;"),
+            target_attr_idx < button_idx,
+            "the target check must precede the modifier skip"
+        );
+        let target_block = &js[target_attr_idx..button_idx];
+        assert!(
+            target_block.contains("targetName !== '_self'") && target_block.contains("return;"),
             "same-origin target=\"_blank\" must fall through to the browser. Routing it \
              through open_url dead-ends on a loopback node, where the shell's open_url \
              handler refuses the host and the click does nothing at all (#5106)"

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -4587,6 +4587,54 @@ mod tests {
         );
     }
 
+    /// The iframe's `sandbox` attribute and the `sandbox` CSP directive served
+    /// with contract content must name the SAME tokens.
+    ///
+    /// Both apply to the app frame, and the effective policy is their
+    /// INTERSECTION, so they are not independent knobs:
+    ///   - a token in the attribute but not the CSP is withdrawn from every
+    ///     contract app the moment the CSP is the narrower of the two (drop
+    ///     `allow-forms` there and every form in every app stops submitting);
+    ///   - a token in the CSP but not the attribute is dead weight that reads
+    ///     as a granted capability.
+    ///
+    /// They exist for different reasons and neither replaces the other: the
+    /// attribute is what the shell asserts about the frame it creates, the CSP
+    /// is what the server asserts about the bytes wherever they are embedded
+    /// (see `CONTRACT_CONTENT_SANDBOX_CSP`). Keeping them literally equal is
+    /// what makes "the app behaves the same either way" checkable rather than
+    /// asserted.
+    #[tokio::test]
+    async fn shell_page_iframe_sandbox_matches_contract_content_csp() {
+        let token = AuthToken::generate();
+        let html = response_body(
+            shell_page(&token, "testkey123", ApiVersion::V1, None, None, false).unwrap(),
+        )
+        .await;
+
+        let attr_start = html
+            .find(r#"sandbox=""#)
+            .expect("app iframe carries a sandbox attribute");
+        let rest = &html[attr_start + r#"sandbox=""#.len()..];
+        let attr = &rest[..rest.find('"').expect("sandbox attribute is quoted")];
+
+        let mut attr_tokens: Vec<&str> = attr.split_whitespace().collect();
+        let mut csp_tokens: Vec<&str> = super::super::client_api::CONTRACT_CONTENT_SANDBOX_CSP
+            .split_whitespace()
+            .skip(1) // the directive name itself
+            .collect();
+        attr_tokens.sort_unstable();
+        csp_tokens.sort_unstable();
+        assert_eq!(
+            attr_tokens, csp_tokens,
+            "the iframe sandbox attribute and CONTRACT_CONTENT_SANDBOX_CSP have \
+             drifted. The browser applies BOTH to the app frame and takes the \
+             intersection, so whichever is narrower silently wins: add the token \
+             to both, or remove it from both, and say which capability you are \
+             changing for contract apps"
+        );
+    }
+
     #[tokio::test]
     async fn shell_page_iframe_sandbox_allows_downloads() {
         // Regression for freenet/mail#TBD: webapps that emit blob/object-URL
@@ -4720,7 +4768,7 @@ mod tests {
             html.contains("__freenet_shell__"),
             "bridge JS must handle shell-level messages (title/favicon)"
         );
-// `allow-popups-to-escape-sandbox` MUST be present: it is what makes a
+        // `allow-popups-to-escape-sandbox` MUST be present: it is what makes a
         // new tab open identically in every browser. The popup carries a real
         // user gesture from the frame that got the click, and lands on the shell
         // at the node's real origin. Routing new-window opens through the shell's
@@ -6984,6 +7032,7 @@ mod tests {
     /// lives in `navigation_interceptor_matches_expected_contract`; it strictly
     /// subsumes the per-handler forward COUNT this test used to carry while the
     /// cross-origin branch still forwarded, so that count is not repeated here.
+    #[test]
     fn navigation_interceptor_leaves_same_origin_target_blank_to_the_browser() {
         let js = NAVIGATION_INTERCEPTOR_JS;
 

--- a/crates/core/src/server/path_handlers/assets/navigation_interceptor.js
+++ b/crates/core/src/server/path_handlers/assets/navigation_interceptor.js
@@ -2,11 +2,25 @@
   'use strict';
   // Shared handler for both `click` (primary button) and `auxclick`
   // (non-primary, i.e. middle-click). Middle-click is dispatched via
-  // `auxclick` in modern browsers and does NOT fire `click` at all, so
-  // without a separate `auxclick` listener middle-clicks on cross-origin
-  // <a target="_blank"> links bypass the interceptor entirely and the
-  // browser opens a null-origin sandboxed popup (freenet/freenet-core#3853
-  // follow-up from #3852).
+  // `auxclick` in modern browsers and does NOT fire `click` at all, so a
+  // `click`-only listener would miss it entirely (freenet/freenet-core#3853).
+  //
+  // New-window activations (target="_blank", ctrl/cmd/middle/shift-click) are
+  // deliberately NOT intercepted. The shell iframe carries
+  // `allow-popups-to-escape-sandbox`, so a popup it opens is a normal
+  // top-level document at the node's real origin: the shell loads, its
+  // `frame-src 'self'` matches, `localStorage` (and with it the hosted access
+  // key) works, and a cross-origin destination sees a real Origin instead of
+  // `null`. That last one also revives the permission surface in the new tab:
+  // an opaque-origin tab sends `Origin: null`, and `/permission/pending`
+  // answers 200 with an EMPTY list rather than an error, so the prompt simply
+  // never appeared and nothing was logged (the cost #5107 priced out on this
+  // branch). Routing those through the shell instead put `window.open` inside a
+  // `message` handler, which is what broke Firefox — its popup blocker gates
+  // on the dispatching event type (`dom.popup_allowed_events`: click,
+  // auxclick, … never `message`), while Chrome/Safari allow it by propagating
+  // user activation across the frame tree. A real gesture in THIS frame is the
+  // only mechanism that opens a tab consistently everywhere.
   function handleAnchorClick(e) {
     var target = e.target;
     // Walk up to find the nearest <a> element (handles clicks on child elements)
@@ -19,82 +33,39 @@
     if (target.hasAttribute('download')) return;
     // Skip links explicitly marked to bypass interception
     if (target.dataset && target.dataset.freenetNoIntercept) return;
-    // Classify by origin. Cross-origin always goes through the open_url
-    // bridge, regardless of the `target` attribute, because a sandboxed
-    // popup would have a null origin and break CORS on the destination
-    // (freenet/river#208).
+    // An explicit new-window target opens natively (see the note above).
+    if (target.target && target.target !== '_self') return;
+    // So does a modifier/middle-click new-window activation. The old
+    // postMessage route could not preserve these — every one of them collapsed
+    // to a plain foreground tab, or to an in-frame navigation for same-origin
+    // links. Native handling restores background-tab (ctrl/cmd/middle) and
+    // new-window (shift) placement, and the escaped popup lands on the shell
+    // at the real origin either way.
+    if (e.button === 1 || e.ctrlKey || e.metaKey || e.shiftKey) return;
+    // Classify by origin.
     //
     // Fail-safe default: if the origin comparison throws (pathological URLs
     // that slipped past the protocol check above) we assume cross-origin,
-    // because the failure mode we are guarding against is a null-origin
-    // sandboxed popup, not an accidental in-contract navigation.
+    // because the failure mode we are guarding against is replacing the app
+    // frame with a document the shell's CSP will refuse, not an accidental
+    // in-contract navigation.
     var isCrossOrigin = true;
     try {
       isCrossOrigin = target.origin !== location.origin;
     } catch (err) {}
     if (isCrossOrigin) {
+      // Cross-origin link with no new-window target: left alone it would
+      // navigate THIS frame, and the shell's `frame-src 'self'` refuses a
+      // foreign origin, so the click would silently do nothing. Open a tab
+      // instead. `window.open` is called during a `click`/`auxclick` handler —
+      // both are in Firefox's `dom.popup_allowed_events` — so the gesture is
+      // live and no popup blocker fires. The escaped popup is a real
+      // top-level context, so the destination sees a proper Origin
+      // (freenet/river#208).
       e.preventDefault();
-      // Forward shift-key state so the shell can honour shift-click
-      // as a new-window request (freenet/freenet-core#3853). ctrl /
-      // meta / middle-click intent can't be meaningfully preserved
-      // from a postMessage handler: browsers only allow background-
-      // tab placement when window.open is called directly from a
-      // user gesture, and all three collapse to a plain new tab
-      // regardless of what we forward. Keep the contract minimal.
-      window.parent.postMessage(
-        {
-          __freenet_shell__: true,
-          type: 'open_url',
-          url: target.href,
-          shiftKey: !!e.shiftKey,
-        },
-        '*',
-      );
+      window.open(target.href, '_blank', 'noopener,noreferrer');
       return;
     }
-    // Same-origin link with an explicit non-_self target: hand it back to the
-    // browser. That is NOT cost-free -- see "what this costs" below -- but it
-    // is the lesser of the two failures currently available.
-    //
-    // #5089 routed this branch through `open_url` instead, to fix a blank tab
-    // (#5087). Reverted in #5106 because that trade was net-negative:
-    //   - The shell's `open_url` handler REFUSES loopback hosts
-    //     (localhost / 127.0.0.1 / ::1 / 0.0.0.0), which is exactly where a
-    //     local node is reached. Forwarding meant the click was
-    //     preventDefault-ed and then silently dropped by the shell: nothing
-    //     happened at all, in every engine. The window.open override below
-    //     avoids precisely this by falling back to native for loopback hosts
-    //     (isLoopbackHost); this branch had no such fallback.
-    //   - The blank tab it fixed reproduces only in WebKit. Gecko and Blink
-    //     load the app frame fine from the opaque-origin shell, so Firefox
-    //     and Chrome users were traded a working tab for a dead click.
-    //
-    // What this costs, so the next person prices it honestly: the tab the
-    // browser opens inherits this frame's sandbox, so it has an opaque
-    // origin. Three consequences, not one:
-    //   1. On WebKit it renders blank (#5087).
-    //   2. On a HOSTED node it can't read the per-user access key and
-    //      dead-ends on the "Open this app in a normal tab" panel, in every
-    //      engine (#4645).
-    //   3. Its permission surface is dead, in every engine. An opaque origin
-    //      sends `Origin: null`, which the shell's endpoints reject; notably
-    //      `/permission/pending` answers 200 with an EMPTY LIST rather than
-    //      an error, so there is no console message and no failed request --
-    //      the prompt simply never appears. This bites hardest on a LOCAL
-    //      node in Firefox/Chrome, i.e. the case this branch is optimised
-    //      for: the app frame loads fine, so it looks like it works.
-    // (3) is not introduced here -- the window.open loopback fallback below
-    // already yields the same opaque-origin tab on a local node. #5089 fixed
-    // all three for this path as a side effect; reverting restores them.
-    //
-    // Two constraints on any future fix. Do not re-route through the bridge
-    // without a loopback fallback. And `allow-popups-to-escape-sandbox` on
-    // the app iframe -- the obvious alternative -- was deliberately REMOVED
-    // by #3818 (motivated by #1499): an escaped popup gains the node's real
-    // origin, letting a malicious app reach other apps' data and bypass
-    // permission prompts. Its absence is pinned by a test in
-    // path_handlers.rs. That road has to answer #3818.
-    if (target.target && target.target !== '_self') return;
     // Same-origin in-contract link: request navigation via shell
     e.preventDefault();
     window.parent.postMessage(
@@ -109,165 +80,4 @@
   document.addEventListener('click', handleAnchorClick, true);
   // Catch middle-click and other non-primary button activations.
   document.addEventListener('auxclick', handleAnchorClick, true);
-
-  // Route programmatic `window.open()` through the shell too, mirroring the
-  // anchor interceptor above. A sandboxed iframe has an opaque origin and no
-  // `allow-popups-to-escape-sandbox`, so a popup it opens DIRECTLY inherits the
-  // sandbox: null origin, no localStorage. On a hosted node that dead-ends on
-  // the "Open this app in a normal tab" per-user-isolation page, because the
-  // opaque-origin tab can't read the per-user access key (freenet-core#4645).
-  // The click/auxclick listeners already cover <a> activations, but an app that
-  // calls window.open() from its own JS bypasses them. The shell runs in the
-  // real origin, so having IT open the URL (via the same `open_url` bridge the
-  // cross-origin anchor path uses) yields a normal tab that works.
-  //
-  // Behavior notes (this changes window.open semantics for contract apps, so be
-  // precise about what is and isn't forwarded):
-  //   - Only NEW-window requests are forwarded. `_self`/`_parent`/`_top` name
-  //     an EXISTING context (in-place navigation, no sandbox-inheriting popup),
-  //     so they stay native.
-  //   - The `name` (window name) and `features` (size/position) arguments are
-  //     dropped for a forwarded open: the shell always opens a fresh tab. Named
-  //     -window reuse and popup sizing don't survive; on a hosted node such a
-  //     popup was a dead sandboxed context anyway, so this is not a regression
-  //     there.
-  //   - The returned WindowProxy is dropped (return null). A popup opened from
-  //     here is a DIFFERENT opaque origin the opener could never script across
-  //     anyway, and null matches the shell's `noopener` open. Chained callers
-  //     (`window.open(url).focus()`) will throw on null — an accepted break, as
-  //     that popup was a dead end on a hosted node.
-  //   - Non-http(s) targets (empty/about:blank, javascript:, blob:, data:) and
-  //     URL objects/other args are handled below; `open_url`'s scheme allow-list
-  //     is the security gate for whatever IS forwarded, exactly as for anchors.
-  //   - Loopback targets (localhost/127.0.0.1/...) are NOT forwarded: the shell
-  //     `open_url` handler refuses them, so forwarding would silently drop the
-  //     open. We fall back to native there, preserving prior local-node behavior
-  //     (local nodes have no per-user dead-end to fix). Hosted nodes use a real
-  //     domain, so this never affects the case #4645 is about.
-  var nativeWindowOpen =
-    typeof window.open === 'function' ? window.open.bind(window) : null;
-  function fallbackOpen(url, name, features) {
-    return nativeWindowOpen ? nativeWindowOpen(url, name, features) : null;
-  }
-  // Kept in sync with the loopback block in shell_bridge.js's open_url handler:
-  // forward only what that handler will actually open. WHATWG `URL.hostname`
-  // serializes an IPv6 literal WITH brackets (`[::1]`), so strip them before
-  // comparing or `http://[::1]/` would slip past the loopback fallback.
-  function isLoopbackHost(hostname) {
-    var h = hostname.toLowerCase().replace(/^\[/, '').replace(/\]$/, '');
-    return (
-      h === 'localhost' || h === '127.0.0.1' || h === '::1' || h === '0.0.0.0'
-    );
-  }
-  window.open = function (url, name, features) {
-    // Only intercept when this frame is the shell's DIRECT child. A top-level
-    // document (parent === window) keeps native behavior; so does a DEEPER
-    // descendant (a contract that embeds another served page), whose parent is
-    // an app frame rather than the shell — forwarding open_url there would post
-    // to the app frame, which the shell never sees, silently losing the open.
-    // For the direct app frame, parent and top are both the shell.
-    if (
-      !window.parent ||
-      window.parent === window ||
-      window.parent !== window.top
-    ) {
-      return fallbackOpen(url, name, features);
-    }
-    // In-place navigation targets are not new-window requests; leave to native.
-    // The reserved keywords are ASCII case-insensitive natively, so normalize
-    // (coerce + lowercase) before comparing; window.open(url, '_SELF') must
-    // still navigate in place, not open a tab. `_blank`/custom names are new
-    // windows and stay intercepted.
-    var targetName = name == null ? '' : String(name).toLowerCase();
-    if (
-      targetName === '_self' ||
-      targetName === '_parent' ||
-      targetName === '_top'
-    ) {
-      return fallbackOpen(url, name, features);
-    }
-    // An OMITTED target (window.open()) is native about:blank; keep it native so
-    // `var w = window.open(); w.document.write(...)` flows are unchanged. Explicit
-    // null is NOT omitted: native Web IDL coerces it to the string "null" (a
-    // relative URL), so let it fall through to the string coercion below.
-    if (url === undefined) {
-      return fallbackOpen(url, name, features);
-    }
-    // Coerce URL objects / other stringifiables the way the native API does,
-    // so window.open(new URL(...)) is forwarded rather than sent to native
-    // (which would recreate the sandbox-inherited dead end this patch prevents).
-    var urlStr;
-    try {
-      urlStr = String(url);
-    } catch (err) {
-      return fallbackOpen(url, name, features);
-    }
-    if (urlStr === '') {
-      return fallbackOpen(url, name, features);
-    }
-    // Resolve relative targets (e.g. window.open('page2')) against the iframe's
-    // base so the shell receives an absolute URL.
-    var resolved;
-    try {
-      resolved = new URL(urlStr, document.baseURI);
-    } catch (err) {
-      return fallbackOpen(url, name, features);
-    }
-    if (resolved.protocol !== 'http:' && resolved.protocol !== 'https:') {
-      return fallbackOpen(url, name, features);
-    }
-    if (isLoopbackHost(resolved.hostname)) {
-      return fallbackOpen(url, name, features);
-    }
-    // Strip the internal `__sandbox` routing param, but ONLY from a SAME-ORIGIN
-    // (this node's own) target, and ONLY the raw pair via string surgery.
-    //   - Why strip: `__sandbox=1` reaches the resolved URL both when a hash-only
-    //     / query-relative target (window.open('#x')) inherits it from the base
-    //     AND when an app duplicates its page (window.open(location.href), an
-    //     absolute same-origin URL). Opened top-level, the shell redirects
-    //     `?__sandbox=1` to the shell root, DROPPING the subpath and app params
-    //     (e.g. an invitation). Removing it opens the page the app intended.
-    //   - Why same-origin only: an ABSOLUTE EXTERNAL target is forwarded
-    //     byte-for-byte — its `__sandbox` (if any) is the destination's, not
-    //     ours, and reserializing its query could break signed/opaque links.
-    //   - Why string surgery, not URLSearchParams.delete(): delete() reserializes
-    //     the whole query, form-encoding co-inherited params (`%20`->`+`,
-    //     `~`->`%7E`); a raw-pair filter preserves the kept params' bytes.
-    // Prefer the frame's real location for the gateway-origin check: location.href
-    // is the served URL and is NOT affected by a contract-declared <base href>,
-    // so a contract can't relabel an external destination as gateway-local to
-    // make us mutate its query. Fall back to document.baseURI only when location
-    // has no http(s) origin (e.g. an about:srcdoc test/dev context).
-    var gatewayOrigin = null;
-    try {
-      var loc = new URL(location.href);
-      gatewayOrigin =
-        loc.protocol === 'http:' || loc.protocol === 'https:'
-          ? loc.origin
-          : new URL(document.baseURI).origin;
-    } catch (err) {
-      gatewayOrigin = null;
-    }
-    if (gatewayOrigin && resolved.origin === gatewayOrigin && resolved.search) {
-      var kept = resolved.search
-        .slice(1)
-        .split('&')
-        .filter(function (pair) {
-          return pair !== '__sandbox' && pair.slice(0, 10) !== '__sandbox=';
-        });
-      resolved.search = kept.join('&');
-    }
-    window.parent.postMessage(
-      {
-        __freenet_shell__: true,
-        type: 'open_url',
-        url: resolved.href,
-        // window.open is an explicit new-window request; the shell opens a
-        // fresh tab (shiftKey:false matches the plain-left-click default).
-        shiftKey: false,
-      },
-      '*',
-    );
-    return null;
-  };
 })();

--- a/crates/core/src/server/path_handlers/assets/navigation_interceptor.js
+++ b/crates/core/src/server/path_handlers/assets/navigation_interceptor.js
@@ -15,12 +15,24 @@
   // an opaque-origin tab sends `Origin: null`, and `/permission/pending`
   // answers 200 with an EMPTY list rather than an error, so the prompt simply
   // never appeared and nothing was logged (the cost #5107 priced out on this
-  // branch). Routing those through the shell instead put `window.open` inside a
-  // `message` handler, which is what broke Firefox — its popup blocker gates
-  // on the dispatching event type (`dom.popup_allowed_events`: click,
-  // auxclick, … never `message`), while Chrome/Safari allow it by propagating
-  // user activation across the frame tree. A real gesture in THIS frame is the
-  // only mechanism that opens a tab consistently everywhere.
+  // branch).
+  //
+  // Routing those through the shell instead put `window.open` inside a
+  // `message` handler, and that is what broke Firefox (#5106). The mechanism is
+  // NOT settled and nothing here depends on which one it is:
+  //   - popup blocker — Firefox gates `window.open` on the dispatching event
+  //     type (`dom.popup_allowed_events`: click, auxclick, … never `message`),
+  //     while Chrome/Safari propagate user activation across the frame tree.
+  //     Playwright's patched Firefox does not reproduce this, so it is a
+  //     diagnosis from the symptom, not a measurement;
+  //   - loopback refusal — #5107 measured that the shell's `open_url` handler
+  //     refuses `localhost`/`127.0.0.1`, which drops the forwarded open on a
+  //     local node in EVERY engine, and concluded from that matrix that popup
+  //     blocking was not involved.
+  // Both are consequences of the shell round-trip, and this code removes the
+  // round-trip entirely: a real gesture in THIS frame opens a tab everywhere,
+  // whichever explanation is right. Do not let either story harden into a fact
+  // in a comment without a measurement to cite.
   function handleAnchorClick(e) {
     var target = e.target;
     // Walk up to find the nearest <a> element (handles clicks on child elements)
@@ -33,15 +45,42 @@
     if (target.hasAttribute('download')) return;
     // Skip links explicitly marked to bypass interception
     if (target.dataset && target.dataset.freenetNoIntercept) return;
-    // An explicit new-window target opens natively (see the note above).
-    if (target.target && target.target !== '_self') return;
+    // A target that names a NEW context opens natively (see the note above).
+    //
+    // Only `_blank` and custom names do. `_top` and `_parent` name an ANCESTOR
+    // — an in-place navigation the sandbox forbids without
+    // `allow-top-navigation`, so handing one back to the browser is a silently
+    // dead click. They must fall through to the classification below and be
+    // treated like an untargeted link. Compare lowercased, because browsers
+    // match the reserved keywords ASCII-case-insensitively and `target="_SELF"`
+    // must mean `_self` here too — otherwise it is read as a new-window request,
+    // returns early, and a cross-origin one then replaces the app frame with a
+    // document `frame-src 'self'` refuses.
+    var targetName = target.target ? String(target.target).toLowerCase() : '';
+    if (
+      targetName &&
+      targetName !== '_self' &&
+      targetName !== '_top' &&
+      targetName !== '_parent'
+    ) {
+      return;
+    }
     // So does a modifier/middle-click new-window activation. The old
     // postMessage route could not preserve these — every one of them collapsed
     // to a plain foreground tab, or to an in-frame navigation for same-origin
     // links. Native handling restores background-tab (ctrl/cmd/middle) and
     // new-window (shift) placement, and the escaped popup lands on the shell
     // at the real origin either way.
-    if (e.button === 1 || e.ctrlKey || e.metaKey || e.shiftKey) return;
+    //
+    // `e.button` is truthy for EVERY non-primary button, not just the middle
+    // one. `auxclick` fires for the secondary (context-menu) button and for
+    // the back/forward buttons as well, and `preventDefault` on it does not
+    // suppress the context menu — that comes from `mousedown`. So a check for
+    // the middle button alone leaves right-click intercepted: the user gets
+    // the menu AND an unwanted tab (cross-origin) or an app-frame navigation
+    // (same-origin). Right-clicking a link is also exactly the workaround
+    // users adopted while `target="_blank"` was broken.
+    if (e.button || e.ctrlKey || e.metaKey || e.shiftKey) return;
     // Classify by origin.
     //
     // Fail-safe default: if the origin comparison throws (pathological URLs

--- a/crates/core/src/server/path_handlers/assets/navigation_interceptor.js
+++ b/crates/core/src/server/path_handlers/assets/navigation_interceptor.js
@@ -80,7 +80,12 @@
     // the menu AND an unwanted tab (cross-origin) or an app-frame navigation
     // (same-origin). Right-clicking a link is also exactly the workaround
     // users adopted while `target="_blank"` was broken.
-    if (e.button || e.ctrlKey || e.metaKey || e.shiftKey) return;
+    //
+    // `altKey` is in the list for a different reason than the others: it is not
+    // a new-window activation, it is the browser's save-link gesture. Same
+    // conclusion though — the browser already has a meaning for it, so taking
+    // the click and turning it into an in-frame hop is wrong.
+    if (e.button || e.ctrlKey || e.metaKey || e.shiftKey || e.altKey) return;
     // Classify by origin.
     //
     // Fail-safe default: if the origin comparison throws (pathological URLs

--- a/crates/core/src/server/path_handlers/assets/shell.html
+++ b/crates/core/src/server/path_handlers/assets/shell.html
@@ -8,7 +8,7 @@
 <style>*{{margin:0;padding:0}}html,body{{width:100%;height:100%;overflow:hidden}}iframe{{width:100%;height:100%;border:none;display:block}}</style>{hosted_styles}
 </head>
 <body>
-{hosted_bar}<iframe id="app" sandbox="allow-scripts allow-forms allow-popups allow-downloads allow-modals" allow="clipboard-read; clipboard-write" data-src="{iframe_src}"></iframe>
+{hosted_bar}<iframe id="app" sandbox="allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox allow-downloads allow-modals" allow="clipboard-read; clipboard-write" data-src="{iframe_src}"></iframe>
 <script>
 {SHELL_BRIDGE_JS}
 </script>

--- a/crates/core/src/server/path_handlers/assets/shell_bridge.js
+++ b/crates/core/src/server/path_handlers/assets/shell_bridge.js
@@ -1192,23 +1192,22 @@ function freenetBridge(authToken, userToken, hostedMode) {
           }
         } catch (e) {}
       } else if (msg.type === 'open_url' && typeof msg.url === 'string') {
-        // Open a URL in a new tab. External links come here from the anchor
-        // interceptor; same-origin (in-app) URLs also arrive from the
-        // window.open override (#4645). Popups the sandboxed iframe opens
-        // itself inherit the opaque origin, breaking CORS on target sites and
-        // (hosted) losing the per-user key. The shell opens the URL instead,
-        // giving proper origin. See PR #3818, which removed the popup
-        // sandbox-escape flag from the app iframe and introduced this bridge
-        // in its place. (This cited "#1499" until #5107; that is the
-        // delegate-user-interaction feature request which motivated #3818,
-        // not the hardening itself.)
+        // Open a URL in a new tab.
         //
-        // Deliberately NOT naming that flag in full here: this file is
-        // inlined verbatim into the shell page, and
-        // `shell_page_contains_iframe_and_bridge` asserts the rendered page
-        // does not contain the flag name anywhere — a comment mentioning it
-        // fails that test. Fail-safe (a false alarm, not a silent pass), but
-        // do not "fix" it by loosening the assertion.
+        // Nothing the node injects posts this any more. PR #3818 removed the
+        // popup sandbox-escape flag from the app iframe and introduced this
+        // bridge in its place, because a popup the sandboxed iframe opened
+        // itself inherited the opaque origin — breaking CORS on target sites,
+        // and on a hosted node losing the per-user key. #5100 put the flag
+        // back (a natively-opened popup is now a real top-level document at
+        // this origin, which is the only shape that works in every browser),
+        // so both the anchor interceptor and the `window.open` override that
+        // used to forward here are gone.
+        //
+        // The handler stays because it is still REACHABLE, and that is the
+        // whole point of the gate below: any contract can postMessage
+        // `open_url` directly. Deleting it would be fine only if nothing could
+        // send it, which is not the case.
         //
         // Security model: this scheme allow-list is the PRIMARY gate, not
         // defence in depth. A malicious contract iframe can postMessage
@@ -1232,14 +1231,6 @@ function freenetBridge(authToken, userToken, hostedMode) {
         // for the project's public domain and fails on ANY occurrence,
         // comments included (external-origin / CORS guard). The live URL
         // lives in scripts/check-endpoints.sh.
-        //
-        // Same hazard, same test, second string: do not write the popup
-        // sandbox-escape flag's full name in this file either. That test also
-        // asserts the rendered page never contains it, to prove it is not set
-        // on the iframe. Writing it in a comment fails the test — which is
-        // easy to walk into, since naming the flag is the natural instinct
-        // when documenting why it is absent. It happened in #5107. See the
-        // note in the open_url handler above.
         //
         // Private networks (RFC1918 192.168/16, 10/8, 172.16-31/12 and
         // RFC4193 fc00::/7, link-local fe80::/10) are deliberately NOT

--- a/crates/core/src/server/path_handlers/assets/shell_bridge.js
+++ b/crates/core/src/server/path_handlers/assets/shell_bridge.js
@@ -77,12 +77,24 @@ function freenetBridge(authToken, userToken, hostedMode) {
     // (sandboxed) origin, which is the tell-tale of the DOMINANT case: this
     // page was opened as a NEW TAB/WINDOW from inside a Freenet app (the
     // browser's "open link in new tab", a middle-click, a right-click menu,
-    // window.open, or a target=_blank link). Such a context inherits the app
-    // iframe's sandbox, so it has an opaque origin, so localStorage throws and
-    // the per-user token can't be read. Re-opening the SAME address as a
-    // normal top-level tab gets a real origin and works. The other two cases
-    // (served over plain http, or storage genuinely disabled) can't be fixed
-    // by re-opening, so they get their own guidance.
+    // window.open, or a target=_blank link) back when such a context INHERITED
+    // the app iframe's sandbox: opaque origin, so localStorage throws and the
+    // per-user token can't be read. Re-opening the SAME address as a normal
+    // top-level tab got a real origin and worked.
+    //
+    // #5100 removed that cause: the app iframe carries
+    // `allow-popups-to-escape-sandbox`, so a tab opened from inside an app is a
+    // real top-level document at this origin, and the shell itself is never
+    // framed (X-Frame-Options: DENY). This branch should therefore be
+    // unreachable now. It stays as a fail-safe rather than being deleted,
+    // because the only thing standing between here and the old behaviour is
+    // that one attribute — if it is ever dropped again, this is the guidance
+    // that keeps a hosted user from a silent dead end. If you are reading this
+    // because you saw the panel in the wild, the escape flag is gone or a
+    // browser is ignoring it, and that is the bug to chase.
+    //
+    // The other two cases (served over plain http, or storage genuinely
+    // disabled) are unaffected and remain live.
     var opaqueOrigin = window.origin === 'null';
     var plaintext = location.protocol !== 'https:';
     // Plaintext is the HARD blocker: over http the token is never minted or

--- a/crates/core/tests/playwright/fixture-webapp/index.html
+++ b/crates/core/tests/playwright/fixture-webapp/index.html
@@ -23,15 +23,40 @@
 <h1 id="title">Freenet shell fixture</h1>
 
 <!--
-  Cross-origin link. The navigation interceptor must intercept clicks on this
-  (left, middle, and shift) and forward them to the shell as an `open_url`
-  postMessage rather than letting the sandboxed iframe open a null-origin
-  popup (freenet/freenet-core#3852, #3854). example.com is a reserved
-  documentation domain (RFC 2606) that is never actually navigated to in the
-  tests — the click is intercepted before any network request.
+  Cross-origin link WITH an explicit new-window target. The interceptor must
+  leave this to the browser: the shell iframe carries
+  `allow-popups-to-escape-sandbox`, so the native popup is a real top-level
+  document with a proper Origin (freenet/river#208's null-origin CORS breakage
+  came from the popup INHERITING the sandbox, which no longer happens). Routing
+  it through the shell instead is what broke Firefox, whose popup blocker
+  refuses `window.open` from a `message` handler.
+
+  example.com is a reserved documentation domain (RFC 2606); the tests stub the
+  route so no real network request is made.
 -->
 <a id="cross-origin-link" href="https://example.com/external" target="_blank" rel="noopener">
   External cross-origin link
+</a>
+
+<!--
+  Cross-origin link with NO target. Left native it would navigate the app frame
+  itself to a foreign origin, which the shell's `frame-src 'self'` refuses — the
+  click would silently do nothing. The interceptor must open a tab for it, from
+  inside the click handler where the user gesture is live.
+-->
+<a id="cross-origin-untargeted-link" href="https://example.com/plain">
+  External cross-origin link, no target
+</a>
+
+<!--
+  Same-origin link with an explicit new-window target. This is the #5087 case:
+  every cross-CONTRACT link is same-ORIGIN, so this is what a thumbnail or
+  cross-app link looks like. It must open natively as a real top-level tab that
+  loads the shell (previously it either produced a blank sandbox-inheriting tab,
+  or — once routed through `open_url` — nothing at all in Firefox).
+-->
+<a id="same-origin-blank-link" href="page2.html" target="_blank">
+  In-contract page 2, new tab
 </a>
 
 <!--
@@ -60,19 +85,12 @@
 <a id="download-link" href="page2.html" download="hello.txt">Download</a>
 
 <!--
-  Same-origin link carrying an explicit new-window target. The interceptor must
-  NOT intercept this: it early-returns on a non-`_self` target and hands the
-  click back to the browser (freenet/freenet-core#5106).
-
-  #5089 routed this branch through the shell's `open_url` bridge instead. That
-  bridge refuses loopback hosts, and a real local node is served from
-  `127.0.0.1`/`localhost`, so the click was preventDefault-ed and then dropped:
-  nothing opened at all. Note the E2E node here binds `127.x.y.1`, which is NOT
-  in that refusal list (#4846), so the popup outcome cannot distinguish the two
-  behaviours in this harness — the test asserts the interception contract (no
-  postMessage) instead, which does.
+  Programmatic open. A contract calling window.open() from its own JS never
+  touches the anchor interceptor, so it is the path that relies purely on
+  `allow-popups-to-escape-sandbox` to produce a real top-level tab. Before
+  #5100 an override forwarded it to the shell (#4645); now it is native.
 -->
-<a id="same-origin-blank-link" href="page2.html" target="_blank">In-contract page 2, new tab</a>
+<button id="programmatic-open">window.open()</button>
 
 <!-- Result sink the Playwright tests read via page.evaluate. -->
 <pre id="poll-result">pending</pre>
@@ -87,6 +105,12 @@
   // We surface the outcome in #poll-result so the test can also confirm the
   // fetch actually ran (a CSP block rejects the promise rather than returning
   // a response).
+  // Programmatic new-window open, invoked from a real click so the gesture is
+  // live (the same condition a contract app's own button would have).
+  document.getElementById('programmatic-open').addEventListener('click', function () {
+    window.open('https://example.com/programmatic', '_blank');
+  });
+
   (function () {
     var sink = document.getElementById('poll-result');
     fetch('/permission/pending', { headers: { 'accept': 'application/json' } })

--- a/crates/core/tests/playwright/fixture-webapp/index.html
+++ b/crates/core/tests/playwright/fixture-webapp/index.html
@@ -92,6 +92,16 @@
 -->
 <button id="programmatic-open">window.open()</button>
 
+<!--
+  The #3818 escape, played out by a hostile contract. `allow-popups-to-escape-sandbox`
+  means a popup this frame opens is top-level with NO sandboxing flags, and an
+  `about:blank` popup inherits this frame's origin — so the contract can script
+  it and, from there, re-embed its own bytes in a nested frame that inherits no
+  sandboxing either. If the server does not sandbox contract content itself,
+  that frame runs at the node's real origin.
+-->
+<button id="escape-sandbox">escape</button>
+
 <!-- Result sink the Playwright tests read via page.evaluate. -->
 <pre id="poll-result">pending</pre>
 
@@ -105,10 +115,32 @@
   // We surface the outcome in #poll-result so the test can also confirm the
   // fetch actually ran (a CSP block rejects the promise rather than returning
   // a response).
+
   // Programmatic new-window open, invoked from a real click so the gesture is
   // live (the same condition a contract app's own button would have).
   document.getElementById('programmatic-open').addEventListener('click', function () {
     window.open('https://example.com/programmatic', '_blank');
+  });
+
+  // Attempt the escape described above. Each step records what it managed to
+  // do, so the test can tell "blocked" apart from "never ran".
+  document.getElementById('escape-sandbox').addEventListener('click', function () {
+    var w = window.open('about:blank', 'escape-probe');
+    window.__escapeOpened = !!w;
+    if (!w) return;
+    try {
+      // Resolved against the base, so it drops `?__sandbox=1` and the request
+      // lands on the plain asset route — as `Sec-Fetch-Dest: iframe`, which is
+      // the destination a `document`-only guard does not see.
+      var src = new URL('page2.html', document.baseURI).href;
+      w.document.write(
+        '<!doctype html><title>escape</title><iframe id="probe" src="' + src + '"></iframe>'
+      );
+      w.document.close();
+      window.__escapeWrote = true;
+    } catch (err) {
+      window.__escapeWriteError = String((err && err.name) || err);
+    }
   });
 
   (function () {

--- a/crates/core/tests/playwright/fixture-webapp/index.html
+++ b/crates/core/tests/playwright/fixture-webapp/index.html
@@ -129,12 +129,23 @@
     window.__escapeOpened = !!w;
     if (!w) return;
     try {
-      // Resolved against the base, so it drops `?__sandbox=1` and the request
-      // lands on the plain asset route — as `Sec-Fetch-Dest: iframe`, which is
-      // the destination a `document`-only guard does not see.
-      var src = new URL('page2.html', document.baseURI).href;
+      // Probe BOTH routes that serve contract bytes, because they are guarded
+      // in different places:
+      //   - `page2.html` resolved against the base drops `?__sandbox=1`, so it
+      //     lands on the plain asset route (`variable_content`) — as
+      //     `Sec-Fetch-Dest: iframe`, the destination a `document`-only guard
+      //     does not see.
+      //   - `index.html?__sandbox=1` is the sandbox-content route
+      //     (`serve_sandbox_response`), which blocks TOP-LEVEL loads but not
+      //     nested ones, and which relied entirely on the iframe attribute for
+      //     its opaque origin. This is the sharper attack: no scriptable SVG or
+      //     other exotic type needed, just the contract's own page.
+      var asset = new URL('page2.html', document.baseURI).href;
+      var app = new URL('index.html?__sandbox=1', document.baseURI).href;
       w.document.write(
-        '<!doctype html><title>escape</title><iframe id="probe" src="' + src + '"></iframe>'
+        '<!doctype html><title>escape</title>' +
+        '<iframe id="probe-asset" src="' + asset + '"></iframe>' +
+        '<iframe id="probe-app" src="' + app + '"></iframe>'
       );
       w.document.close();
       window.__escapeWrote = true;

--- a/crates/core/tests/playwright/fixture-webapp/index.html
+++ b/crates/core/tests/playwright/fixture-webapp/index.html
@@ -49,6 +49,17 @@
 </a>
 
 <!--
+  Cross-origin link with `target="_top"`. `_top` names an ANCESTOR context, not
+  a new one, and the sandbox forbids navigating it — so "any non-`_self` target
+  is a new-window activation, hand it to the browser" makes this a silently dead
+  click. It must be classified like an untargeted cross-origin link and opened
+  in a tab.
+-->
+<a id="cross-origin-top-link" href="https://example.com/top" target="_top">
+  External cross-origin link, target=_top
+</a>
+
+<!--
   Same-origin link with an explicit new-window target. This is the #5087 case:
   every cross-CONTRACT link is same-ORIGIN, so this is what a thumbnail or
   cross-app link looks like. It must open natively as a real top-level tab that

--- a/crates/core/tests/playwright/playwright.config.ts
+++ b/crates/core/tests/playwright/playwright.config.ts
@@ -40,10 +40,25 @@ export default defineConfig({
     // Capture console + page errors for the CSP-violation assertions.
     ignoreHTTPSErrors: true,
   },
+  // All three engines. This suite exists because the shell's behaviour differs
+  // BETWEEN engines: #5087 (blank new tab) reproduces only in WebKit, #5106
+  // (dead click) only in Firefox, and the #3818 sandbox-escape guard in
+  // shell.spec.ts passes vacuously in Chromium — there the escape is refused a
+  // step earlier, so the assertion runs against an empty set and the header it
+  // guards could be deleted with the run still green. Only Firefox actually
+  // exercises it. A chromium-only matrix is how #5087 shipped green.
   projects: [
     {
       name: "chromium",
       use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "firefox",
+      use: { ...devices["Desktop Firefox"] },
+    },
+    {
+      name: "webkit",
+      use: { ...devices["Desktop Safari"] },
     },
   ],
 });

--- a/crates/core/tests/playwright/tests/shell.spec.ts
+++ b/crates/core/tests/playwright/tests/shell.spec.ts
@@ -327,6 +327,101 @@ test("contract JS calling window.open() gets a real top-level tab", async ({
   expect((await shellMessages(page)).map((m) => m.type)).toEqual([]);
 });
 
+// Does this document hold the node's real origin, or an opaque one? Storage is
+// the sharpest available test: an opaque origin throws SecurityError on any
+// `localStorage` access, and the node's origin is where the hosted per-user
+// access key lives.
+const STORAGE_PROBE = () => {
+  try {
+    window.localStorage.setItem("__probe", "1");
+    window.localStorage.removeItem("__probe");
+    return "NODE-ORIGIN";
+  } catch (e) {
+    return "OPAQUE";
+  }
+};
+
+test("a contract cannot reach a node-origin context by escaping the sandbox (#3818)", async ({
+  page,
+}) => {
+  await page.goto(shellUrl!);
+  // Wait for the fixture to render before reaching for the Frame handle: the
+  // FrameLocator helper is what knows how to wait, but only a Frame can
+  // `evaluate`.
+  await fixtureFrame(page);
+  const appFrame = page.frames().find((f) => f.url().includes("__sandbox=1"));
+  expect(appFrame, "the app frame must be loaded").toBeTruthy();
+
+  // Controls first, so a probe that stopped distinguishing anything shows up
+  // here rather than as a silent pass below.
+  expect(
+    await page.evaluate(STORAGE_PROBE),
+    "the shell IS the node origin — if this is not NODE-ORIGIN the probe is broken, not the sandbox",
+  ).toBe("NODE-ORIGIN");
+  expect(
+    await appFrame!.evaluate(STORAGE_PROBE),
+    "the app frame must be opaque-origin",
+  ).toBe("OPAQUE");
+
+  // `allow-popups-to-escape-sandbox` is load-bearing for the new-tab fix, and
+  // it hands a contract an unsandboxed top-level context it can script (the
+  // `about:blank` popup inherits this frame's origin). The sandbox ATTRIBUTE
+  // cannot reach what happens in there. What must hold is that the contract's
+  // own bytes are still opaque-origin when re-embedded from it, because the
+  // server sandboxes them itself (CONTRACT_CONTENT_SANDBOX_CSP).
+  //
+  // Without that header this reproduces in chromium, firefox and webkit: the
+  // nested frame reports NODE-ORIGIN, and from there localStorage yields the
+  // hosted access key and same-origin fetch yields another app's auth token.
+  const [popup] = await Promise.all([
+    page.waitForEvent("popup"),
+    appFrame!.click("#escape-sandbox"),
+  ]);
+  const escape = await appFrame!.evaluate(() => ({
+    opened: !!(window as unknown as { __escapeOpened?: boolean }).__escapeOpened,
+    wrote: !!(window as unknown as { __escapeWrote?: boolean }).__escapeWrote,
+    error:
+      (window as unknown as { __escapeWriteError?: string })
+        .__escapeWriteError ?? null,
+  }));
+  expect(
+    escape.opened,
+    "the popup must open, or this test is not exercising the escape at all",
+  ).toBe(true);
+
+  // Give the nested frame time to load before enumerating. It may legitimately
+  // never appear: some engines refuse the cross-document write once the opener
+  // is itself CSP-sandboxed, which blocks the escape one step earlier.
+  await popup.waitForTimeout(1000);
+  const nested = popup.frames().filter((f) => f !== popup.mainFrame());
+  const reports: string[] = [];
+  for (const f of nested) {
+    reports.push(
+      await f
+        .evaluate(STORAGE_PROBE)
+        .catch((e) => `UNREACHABLE: ${String(e).split("\n")[0]}`),
+    );
+  }
+  const detail = `escape=${JSON.stringify(escape)} frames=${JSON.stringify(
+    nested.map((f) => f.url()),
+  )} probes=${JSON.stringify(reports)}`;
+
+  if (escape.wrote) {
+    // The write landed, so the nested frame is the thing under test and must
+    // actually be there — otherwise the assertion below passes on an empty set.
+    expect(
+      nested.length,
+      `the escaped popup accepted the write but embedded nothing, so nothing was probed: ${detail}`,
+    ).toBeGreaterThan(0);
+  }
+  expect(
+    reports,
+    `contract content reached the node's own origin from an escaped popup: ${detail}`,
+  ).not.toContain("NODE-ORIGIN");
+
+  await popup.close();
+});
+
 test("same-origin in-contract link performs an in-place navigate hop", async ({
   page,
 }) => {

--- a/crates/core/tests/playwright/tests/shell.spec.ts
+++ b/crates/core/tests/playwright/tests/shell.spec.ts
@@ -1,4 +1,10 @@
-import { test, expect, type Page, type ConsoleMessage } from "@playwright/test";
+import {
+  test,
+  expect,
+  type BrowserContext,
+  type Page,
+  type ConsoleMessage,
+} from "@playwright/test";
 
 // Smoke tests for the Freenet gateway shell + sandboxed iframe postMessage
 // contract (freenet/freenet-core#3856).
@@ -13,10 +19,14 @@ import { test, expect, type Page, type ConsoleMessage } from "@playwright/test";
 // with only a Rust-level HTML-string assertion guarding it:
 //   - #3842 — shell CSP must allow same-origin fetches (connect-src 'self').
 //   - #3852 — cross-origin target="_blank" links must not open null-origin
-//             sandboxed popups; they go through the shell's open_url bridge.
-//   - #3854 — middle-click (auxclick) and shift-click must also be
-//             intercepted, not just primary-button click (the merged fix;
-//             #3853 was the closed predecessor PR for the same work).
+//             sandboxed popups. They now open natively, and
+//             `allow-popups-to-escape-sandbox` is what gives them a real origin.
+//   - #3854 — middle-click (auxclick) must be classified like click.
+//   - #5087 — same-origin target="_blank" (i.e. every cross-CONTRACT link) must
+//             open a working tab. Its first fix routed the click through the
+//             shell's open_url bridge, which put window.open inside a `message`
+//             handler — blocked by Firefox's popup blocker, so the link died
+//             there while Chrome/Safari kept working.
 
 const shellUrl = process.env.FREENET_SHELL_URL;
 
@@ -51,13 +61,20 @@ function cspViolations(messages: ConsoleMessage[]): string[] {
 // side effects. Must run before any interaction.
 async function captureShellMessages(page: Page): Promise<void> {
   await page.evaluate(() => {
-    (window as unknown as { __freenetMessages: unknown[] }).__freenetMessages = [];
+    (window as unknown as { __freenetMessages: unknown[] }).__freenetMessages =
+      [];
     window.addEventListener(
       "message",
       (e) => {
         const d = e.data;
-        if (d && typeof d === "object" && (d as { __freenet_shell__?: boolean }).__freenet_shell__) {
-          (window as unknown as { __freenetMessages: unknown[] }).__freenetMessages.push(d);
+        if (
+          d &&
+          typeof d === "object" &&
+          (d as { __freenet_shell__?: boolean }).__freenet_shell__
+        ) {
+          (
+            window as unknown as { __freenetMessages: unknown[] }
+          ).__freenetMessages.push(d);
         }
       },
       true,
@@ -65,29 +82,32 @@ async function captureShellMessages(page: Page): Promise<void> {
   });
 }
 
-type ShellMessage = { type: string; url?: string; href?: string; shiftKey?: boolean };
+type ShellMessage = {
+  type: string;
+  url?: string;
+  href?: string;
+  shiftKey?: boolean;
+};
 
 async function shellMessages(page: Page): Promise<ShellMessage[]> {
   return page.evaluate(
-    () => (window as unknown as { __freenetMessages: ShellMessage[] }).__freenetMessages,
+    () =>
+      (window as unknown as { __freenetMessages: ShellMessage[] })
+        .__freenetMessages,
   );
 }
 
-// Override window.open on the shell page so an open_url that the bridge
-// honours is observable (and so the test never actually launches a popup to
-// example.com). Returns nothing; read the calls via openCalls().
-async function stubWindowOpen(page: Page): Promise<void> {
-  await page.evaluate(() => {
-    (window as unknown as { __openCalls: string[] }).__openCalls = [];
-    window.open = ((url?: string | URL) => {
-      (window as unknown as { __openCalls: string[] }).__openCalls.push(String(url ?? ""));
-      return null;
-    }) as typeof window.open;
-  });
-}
-
-async function openCalls(page: Page): Promise<string[]> {
-  return page.evaluate(() => (window as unknown as { __openCalls: string[] }).__openCalls);
+// Serve the RFC 2606 documentation domain from the test itself, so the tabs
+// these tests open resolve instantly and offline. The point of the assertions
+// is that a real top-level document opens with a real origin — not that
+// example.com is reachable from CI.
+async function stubExternal(context: BrowserContext): Promise<void> {
+  await context.route("https://example.com/**", (route) =>
+    route.fulfill({
+      contentType: "text/html",
+      body: "<title>external</title>ok",
+    }),
+  );
 }
 
 // The shell wraps the contract in an iframe#app. Wait for the iframe to load
@@ -118,7 +138,11 @@ test("shell page loads and embeds the sandboxed iframe", async ({ page }) => {
   expect(sandbox, `iframe sandbox: ${sandbox}`).toContain("allow-scripts");
   expect(sandbox).toContain("allow-popups");
   expect(sandbox).not.toContain("allow-same-origin");
-  expect(sandbox).not.toContain("allow-popups-to-escape-sandbox");
+  // Popups MUST escape the sandbox. Without it a new tab inherits the opaque
+  // origin and dead-ends (blank shell, no localStorage for the hosted access
+  // key), and the workaround — letting the shell open the tab from a
+  // `message` handler — is refused by Firefox's popup blocker.
+  expect(sandbox).toContain("allow-popups-to-escape-sandbox");
 
   await fixtureFrame(page);
   expect(
@@ -127,7 +151,9 @@ test("shell page loads and embeds the sandboxed iframe", async ({ page }) => {
   ).toEqual([]);
 });
 
-test("same-origin permission poll fetch is allowed by the shell CSP (#3842)", async ({ page }) => {
+test("same-origin permission poll fetch is allowed by the shell CSP (#3842)", async ({
+  page,
+}) => {
   const consoleMessages = trackConsole(page);
   await page.goto(shellUrl!);
   const frame = await fixtureFrame(page);
@@ -147,63 +173,163 @@ test("same-origin permission poll fetch is allowed by the shell CSP (#3842)", as
   ).toEqual([]);
 });
 
-test("left-click on a cross-origin link routes through the open_url bridge (#3852)", async ({
+test('cross-origin target="_blank" opens natively as a real top-level tab (#3852, river#208)', async ({
   page,
+  context,
 }) => {
+  await stubExternal(context);
   await page.goto(shellUrl!);
   await captureShellMessages(page);
-  await stubWindowOpen(page);
   const frame = await fixtureFrame(page);
 
+  const opened = context.waitForEvent("page");
   await frame.locator("#cross-origin-link").click();
+  const popup = await opened;
+  await popup.waitForLoadState();
 
-  // The interceptor must postMessage open_url to the shell ...
-  await expect
-    .poll(async () => (await shellMessages(page)).map((m) => m.type))
-    .toContain("open_url");
-  const msgs = await shellMessages(page);
-  const openUrl = msgs.find((m) => m.type === "open_url");
-  expect(openUrl?.url).toBe("https://example.com/external");
-  expect(openUrl?.shiftKey).toBe(false);
+  // A REAL top-level document, not a sandbox-inheriting popup: the stub route
+  // served it, and its origin is example.com rather than "null" (the
+  // null-origin popup is what broke CORS on logged-in sites in river#208).
+  expect(popup.url()).toBe("https://example.com/external");
+  expect(await popup.evaluate(() => location.origin)).toBe(
+    "https://example.com",
+  );
+  await popup.close();
 
-  // ... and the shell must honour it via window.open with the real origin
-  // (not a sandboxed null-origin popup).
-  await expect.poll(async () => await openCalls(page)).toContain("https://example.com/external");
+  // The click must NOT have been handed to the shell: `window.open` from a
+  // `message` handler is popup-blocked in Firefox, which is what made these
+  // links dead there while Chrome/Safari kept working.
+  expect((await shellMessages(page)).map((m) => m.type)).toEqual([]);
 });
 
-test("middle-click (auxclick) on a cross-origin link is also intercepted (#3854)", async ({
+test('middle-click on a cross-origin target="_blank" link also opens a tab (#3854)', async ({
   page,
+  context,
+}) => {
+  await stubExternal(context);
+  await page.goto(shellUrl!);
+  await captureShellMessages(page);
+  const frame = await fixtureFrame(page);
+
+  // Middle-click dispatches `auxclick`, not `click`. The interceptor listens on
+  // both so the classification is identical; a targeted link stays native
+  // either way, and the browser gives it real background-tab placement — which
+  // the old postMessage route could not preserve.
+  const opened = context.waitForEvent("page");
+  await frame.locator("#cross-origin-link").click({ button: "middle" });
+  const popup = await opened;
+  // A middle-click opens a BACKGROUND tab, which starts at about:blank and
+  // commits its navigation later than a foreground one — `waitForLoadState()`
+  // can resolve on the initial empty document. Wait for the URL itself.
+  await popup.waitForURL("https://example.com/external");
+  await popup.close();
+  expect((await shellMessages(page)).map((m) => m.type)).toEqual([]);
+});
+
+test("cross-origin link with NO target is opened in a tab by the interceptor", async ({
+  page,
+  context,
+}) => {
+  await stubExternal(context);
+  await page.goto(shellUrl!);
+  await captureShellMessages(page);
+  const frame = await fixtureFrame(page);
+
+  // Left native this would navigate the app frame to a foreign origin, which
+  // the shell's `frame-src 'self'` refuses — a dead click. The interceptor
+  // calls window.open itself, inside the click handler, so the gesture is live
+  // (Firefox allows window.open from `click`, never from `message`).
+  const opened = context.waitForEvent("page");
+  await frame.locator("#cross-origin-untargeted-link").click();
+  const popup = await opened;
+  await popup.waitForLoadState();
+  expect(popup.url()).toBe("https://example.com/plain");
+  await popup.close();
+
+  // Still no shell round-trip, and the app frame stayed put.
+  expect((await shellMessages(page)).map((m) => m.type)).toEqual([]);
+  await expect(page.frameLocator("iframe#app").locator("#title")).toBeVisible();
+});
+
+test('same-origin target="_blank" opens a working new tab, not a blank one (#5087)', async ({
+  page,
+  context,
 }) => {
   await page.goto(shellUrl!);
   await captureShellMessages(page);
-  await stubWindowOpen(page);
   const frame = await fixtureFrame(page);
 
-  // Middle-click dispatches `auxclick`, not `click`. Pre-#3854 only `click`
-  // was listened for, so the browser opened a null-origin sandboxed popup.
-  await frame.locator("#cross-origin-link").click({ button: "middle" });
+  // The regression this pins, in both its forms:
+  //   - Before #5087 the popup inherited the sandbox, so the shell it landed on
+  //     had an opaque origin, its `frame-src 'self'` could not match, and the
+  //     app frame stayed about:blank — a blank tab.
+  //   - #5087 routed the click through the shell's `open_url` bridge, which put
+  //     `window.open` inside a `message` handler: blocked outright by Firefox's
+  //     popup blocker, so the click did nothing at all there.
+  // With `allow-popups-to-escape-sandbox` the native popup is a real top-level
+  // document and the shell inside it loads the contract normally.
+  const opened = context.waitForEvent("page");
+  await frame.locator("#same-origin-blank-link").click();
+  const popup = await opened;
+  await popup.waitForLoadState();
 
-  await expect
-    .poll(async () => (await shellMessages(page)).map((m) => m.type))
-    .toContain("open_url");
-  const openUrl = (await shellMessages(page)).find((m) => m.type === "open_url");
-  expect(openUrl?.url).toBe("https://example.com/external");
+  expect(popup.url()).toContain("page2.html");
+  // Not a blank tab: the new tab rendered its own shell + app frame.
+  await expect(popup.locator("iframe#app")).toBeAttached();
+  await expect(
+    popup.frameLocator("iframe#app").locator("#page2-title"),
+  ).toBeVisible();
+  await popup.close();
+
+  expect((await shellMessages(page)).map((m) => m.type)).toEqual([]);
 });
 
-test("shift-click on a cross-origin link forwards shiftKey (#3854)", async ({ page }) => {
+test("contract JS calling window.open() gets a real top-level tab", async ({
+  page,
+  context,
+}) => {
+  await stubExternal(context);
   await page.goto(shellUrl!);
   await captureShellMessages(page);
-  await stubWindowOpen(page);
   const frame = await fixtureFrame(page);
 
-  await frame.locator("#cross-origin-link").click({ modifiers: ["Shift"] });
+  // The anchor interceptor never sees this — the app calls window.open() from
+  // its own script. Before #5100 an override forwarded it to the shell, because
+  // a popup from the sandboxed frame inherited the sandbox: opaque origin, no
+  // localStorage, dead-ending on the per-user-isolation page (#4645). With
+  // `allow-popups-to-escape-sandbox` the native call is enough, so the override
+  // was removed — this test is what proves removing it was safe.
+  const opened = context.waitForEvent("page");
+  await frame.locator("#programmatic-open").click();
+  const popup = await opened;
+  await popup.waitForURL("https://example.com/programmatic");
 
-  await expect
-    .poll(async () => (await shellMessages(page)).some((m) => m.type === "open_url" && m.shiftKey === true))
-    .toBeTruthy();
+  // A real top-level context, not a sandbox-inheriting one: a genuine origin
+  // (never "null") and working storage, which is what #4645 was about.
+  expect(await popup.evaluate(() => location.origin)).toBe(
+    "https://example.com",
+  );
+  expect(
+    await popup.evaluate(() => {
+      try {
+        localStorage.setItem("__probe", "1");
+        localStorage.removeItem("__probe");
+        return "usable";
+      } catch (e) {
+        return "denied";
+      }
+    }),
+    "an opaque-origin (sandbox-inherited) tab throws on localStorage — that dead end is #4645",
+  ).toBe("usable");
+  await popup.close();
+
+  // No shell round-trip: nothing was forwarded.
+  expect((await shellMessages(page)).map((m) => m.type)).toEqual([]);
 });
 
-test("same-origin in-contract link performs an in-place navigate hop", async ({ page }) => {
+test("same-origin in-contract link performs an in-place navigate hop", async ({
+  page,
+}) => {
   await page.goto(shellUrl!);
   await captureShellMessages(page);
   const frame = await fixtureFrame(page);
@@ -214,20 +340,28 @@ test("same-origin in-contract link performs an in-place navigate hop", async ({ 
   await expect
     .poll(async () => (await shellMessages(page)).map((m) => m.type))
     .toContain("navigate");
-  const navigate = (await shellMessages(page)).find((m) => m.type === "navigate");
-  expect(navigate?.href, `navigate href: ${navigate?.href}`).toContain("page2.html");
+  const navigate = (await shellMessages(page)).find(
+    (m) => m.type === "navigate",
+  );
+  expect(navigate?.href, `navigate href: ${navigate?.href}`).toContain(
+    "page2.html",
+  );
 
   // The shell performs the hop in place: the iframe now shows page 2 and the
   // top-level URL no longer carries __sandbox (issue #3839). Use Playwright's
   // polling toHaveURL (not a synchronous page.url() snapshot) because the
   // pushState that updates the address bar runs in the bridge's message
   // handler, which can settle a tick after the iframe content loads.
-  await expect(page.frameLocator("iframe#app").locator("#page2-title")).toBeVisible();
+  await expect(
+    page.frameLocator("iframe#app").locator("#page2-title"),
+  ).toBeVisible();
   await expect(page).toHaveURL(/page2\.html/);
   await expect(page).not.toHaveURL(/__sandbox/);
 });
 
-test("a link carrying a download attribute is NOT intercepted", async ({ page }) => {
+test("a link carrying a download attribute is NOT intercepted", async ({
+  page,
+}) => {
   await page.goto(shellUrl!);
   await captureShellMessages(page);
   const frame = await fixtureFrame(page);
@@ -250,7 +384,9 @@ test("a link carrying a download attribute is NOT intercepted", async ({ page })
 
   // (1) Control: same element minus `download` IS intercepted → listener live,
   // and the element/selector themselves are wired correctly.
-  await frame.locator("#download-link").evaluate((el) => el.removeAttribute("download"));
+  await frame
+    .locator("#download-link")
+    .evaluate((el) => el.removeAttribute("download"));
   await frame.locator("#download-link").click();
   await expect
     .poll(async () => (await shellMessages(page)).map((m) => m.type))
@@ -343,7 +479,9 @@ test("browser Back restores the previous subpage via the popstate handler (#3839
 
   // Navigate forward to page 2 (in-place hop, pushes a history entry).
   await frame.locator("#same-origin-link").click();
-  await expect(page.frameLocator("iframe#app").locator("#page2-title")).toBeVisible();
+  await expect(
+    page.frameLocator("iframe#app").locator("#page2-title"),
+  ).toBeVisible();
   await expect(page).toHaveURL(/page2\.html/);
 
   // Browser Back must fire the bridge's popstate handler, which restores the
@@ -361,5 +499,7 @@ test("browser Back restores the previous subpage via the popstate handler (#3839
   // pins the address-bar behaviour for the push direction.
   await page.evaluate(() => window.history.back());
   await expect(page.frameLocator("iframe#app").locator("#title")).toBeVisible();
-  await expect(page.frameLocator("iframe#app").locator("#page2-title")).toHaveCount(0);
+  await expect(
+    page.frameLocator("iframe#app").locator("#page2-title"),
+  ).toHaveCount(0);
 });

--- a/crates/core/tests/playwright/tests/shell.spec.ts
+++ b/crates/core/tests/playwright/tests/shell.spec.ts
@@ -421,6 +421,15 @@ test("a contract cannot reach a node-origin context by escaping the sandbox (#38
     reports,
     `contract content reached the node's own origin from an escaped popup: ${detail}`,
   ).not.toContain("NODE-ORIGIN");
+  // `not.toContain` alone also passes on "UNREACHABLE: …", which is what a
+  // frame that 404s or never loads produces — so a broken fixture would read as
+  // a security pass. Require the positive result whenever a frame is there.
+  if (nested.length > 0) {
+    expect(
+      reports,
+      `every embedded frame must actually be probed and report an opaque origin: ${detail}`,
+    ).toEqual(reports.map(() => "OPAQUE"));
+  }
 
   await popup.close();
 });
@@ -458,6 +467,22 @@ test("a modifier-click on an untargeted in-contract link opens a real tab", asyn
     "a modifier-click must not be turned into an in-place navigate hop",
   ).toEqual([]);
 
+  // Shift-click is the other half of #3853. Its e2e coverage on main asserted
+  // the interceptor FORWARDED shiftKey to the shell; that route is gone, so the
+  // contract to pin is that the browser gets the click. Kept here rather than
+  // deleted with the old spec.
+  const shiftOpened = context.waitForEvent("page");
+  await frame
+    .locator("#same-origin-link")
+    .click({ modifiers: ["Shift"] });
+  const shiftWindow = await shiftOpened;
+  await shiftWindow.waitForURL(/page2\.html/);
+  await shiftWindow.close();
+  expect(
+    (await shellMessages(page)).map((m) => m.type),
+    "shift-click must reach the browser too, so it can place a new WINDOW",
+  ).toEqual([]);
+
   // Control, in the SAME document: an UNMODIFIED click on the very same link IS
   // intercepted. Without this the assertion above would also pass if the
   // interceptor had simply stopped running.
@@ -467,6 +492,73 @@ test("a modifier-click on an untargeted in-contract link opens a real tab", asyn
       message:
         "the plain click on the same link must still produce the navigate hop",
     })
+    .toEqual(["navigate"]);
+});
+
+test('target="_top" on a cross-origin link is not a dead click', async ({
+  page,
+  context,
+}) => {
+  await stubExternal(context);
+  await page.goto(shellUrl!);
+  await captureShellMessages(page);
+  const frame = await fixtureFrame(page);
+
+  // `_top` and `_parent` name an ANCESTOR context. The sandbox has no
+  // `allow-top-navigation`, so left to the browser the click does nothing at
+  // all — measured in chromium and firefox, where `main` opened a tab. They
+  // must therefore fall through to origin classification and be opened like an
+  // untargeted cross-origin link.
+  const opened = context.waitForEvent("page");
+  await frame.locator("#cross-origin-top-link").click();
+  const popup = await opened;
+  await popup.waitForLoadState();
+  expect(popup.url()).toBe("https://example.com/top");
+  await popup.close();
+
+  // The app frame is untouched, and nothing went through the shell.
+  await expect(frame.locator("#title")).toBeVisible();
+  expect((await shellMessages(page)).map((m) => m.type)).toEqual([]);
+});
+
+test("right-click is not intercepted: no stray tab, no frame navigation", async ({
+  page,
+  context,
+}) => {
+  await page.goto(shellUrl!);
+  await captureShellMessages(page);
+  const frame = await fixtureFrame(page);
+
+  // `auxclick` fires for the SECONDARY button as well as the middle one, and
+  // `preventDefault` on it does not suppress the context menu (that comes from
+  // mousedown). So an interceptor that skips only `e.button === 1` gives the
+  // user the menu AND a side effect: a stray tab for a cross-origin link, an
+  // app-frame navigation for a same-origin one. Measured in chromium and
+  // firefox before the fix.
+  //
+  // Right-clicking a link is also precisely the workaround users adopted while
+  // `target="_blank"` was broken, so it is the last click that should misbehave.
+  const strayTabs: string[] = [];
+  context.on("page", (p) => strayTabs.push(p.url()));
+
+  await frame.locator("#cross-origin-untargeted-link").click({ button: "right" });
+  await frame.locator("#same-origin-link").click({ button: "right" });
+  await page.waitForTimeout(500);
+
+  expect(strayTabs, "right-click must not open anything").toEqual([]);
+  expect(
+    (await shellMessages(page)).map((m) => m.type),
+    "right-click must not be intercepted at all",
+  ).toEqual([]);
+  // The app frame is still showing the fixture — a `navigate` hop would have
+  // replaced it with page2.
+  await expect(frame.locator("#title")).toBeVisible();
+
+  // Control, same document: a plain LEFT click on the same same-origin link IS
+  // intercepted, so the emptiness above is about the button, not a dead listener.
+  await frame.locator("#same-origin-link").click();
+  await expect
+    .poll(async () => (await shellMessages(page)).map((m) => m.type))
     .toEqual(["navigate"]);
 });
 

--- a/crates/core/tests/playwright/tests/shell.spec.ts
+++ b/crates/core/tests/playwright/tests/shell.spec.ts
@@ -407,12 +407,15 @@ test("a contract cannot reach a node-origin context by escaping the sandbox (#38
   )} probes=${JSON.stringify(reports)}`;
 
   if (escape.wrote) {
-    // The write landed, so the nested frame is the thing under test and must
+    // The write landed, so the nested frames are the thing under test and must
     // actually be there — otherwise the assertion below passes on an empty set.
+    // BOTH must be probed: the plain asset route and the `?__sandbox=1` route
+    // are guarded in different places, and the second one is the sharper attack
+    // (the contract's own page, no exotic type needed).
     expect(
       nested.length,
-      `the escaped popup accepted the write but embedded nothing, so nothing was probed: ${detail}`,
-    ).toBeGreaterThan(0);
+      `the escaped popup accepted the write but embedded fewer frames than it asked for, so a route went unprobed: ${detail}`,
+    ).toBe(2);
   }
   expect(
     reports,

--- a/crates/core/tests/playwright/tests/shell.spec.ts
+++ b/crates/core/tests/playwright/tests/shell.spec.ts
@@ -428,7 +428,7 @@ test("a contract cannot reach a node-origin context by escaping the sandbox (#38
     expect(
       reports,
       `every embedded frame must actually be probed and report an opaque origin: ${detail}`,
-    ).toEqual(reports.map(() => "OPAQUE"));
+    ).toEqual(nested.map(() => "OPAQUE"));
   }
 
   await popup.close();

--- a/crates/core/tests/playwright/tests/shell.spec.ts
+++ b/crates/core/tests/playwright/tests/shell.spec.ts
@@ -422,6 +422,51 @@ test("a contract cannot reach a node-origin context by escaping the sandbox (#38
   await popup.close();
 });
 
+test("a modifier-click on an untargeted in-contract link opens a real tab", async ({
+  page,
+  context,
+}) => {
+  await page.goto(shellUrl!);
+  await captureShellMessages(page);
+  const frame = await fixtureFrame(page);
+
+  // `#same-origin-link` carries no `target`, so it used to reach the
+  // same-origin branch on EVERY click and become an in-place `navigate` hop —
+  // middle-click and ctrl/cmd-click included, which silently lost their "open
+  // in a new tab" meaning. The modifier skip now runs before origin
+  // classification, so the browser gets the click and gives it real
+  // background-tab placement.
+  const opened = context.waitForEvent("page");
+  await frame.locator("#same-origin-link").click({ button: "middle" });
+  const popup = await opened;
+  // Background tabs commit their navigation late; wait for the URL, not the
+  // initial empty document.
+  await popup.waitForURL(/page2\.html/);
+  // A real top-level tab, not a blank sandbox-inheriting one: it renders its
+  // own shell and app frame.
+  await expect(popup.locator("iframe#app")).toBeAttached();
+  await expect(
+    popup.frameLocator("iframe#app").locator("#page2-title"),
+  ).toBeVisible();
+  await popup.close();
+
+  expect(
+    (await shellMessages(page)).map((m) => m.type),
+    "a modifier-click must not be turned into an in-place navigate hop",
+  ).toEqual([]);
+
+  // Control, in the SAME document: an UNMODIFIED click on the very same link IS
+  // intercepted. Without this the assertion above would also pass if the
+  // interceptor had simply stopped running.
+  await frame.locator("#same-origin-link").click();
+  await expect
+    .poll(async () => (await shellMessages(page)).map((m) => m.type), {
+      message:
+        "the plain click on the same link must still produce the navigate hop",
+    })
+    .toEqual(["navigate"]);
+});
+
 test("same-origin in-contract link performs an in-place navigate hop", async ({
   page,
 }) => {

--- a/crates/core/tests/playwright/tests/window-open.spec.ts
+++ b/crates/core/tests/playwright/tests/window-open.spec.ts
@@ -2,6 +2,25 @@ import { test, expect } from "@playwright/test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
+// SUPERSEDED by PR #5100 — retained, skipped, as historical documentation of
+// the pre-#5100 contract (project rule: a test superseded by a semantic change
+// is skipped with an explanation, not deleted).
+//
+// The `window.open` override these tests pin is gone. It existed because a
+// popup opened from the sandboxed iframe INHERITED the sandbox (opaque origin,
+// no localStorage), so the interceptor forwarded programmatic opens to the
+// shell via `open_url`. That forwarding is exactly what broke Firefox: the
+// shell's `window.open` then ran inside a `message` handler, which Firefox's
+// popup blocker refuses. The iframe now carries
+// `allow-popups-to-escape-sandbox`, so a native `window.open` from contract JS
+// produces a real top-level tab on its own and needs no shell round-trip.
+//
+// Current coverage for programmatic opens under the new design lives in
+// shell.spec.ts ("contract JS calling window.open() gets a real top-level
+// tab"). Unskipping this file would fail by design — it asserts the forwarding
+// that #5100 deliberately removed.
+test.skip(true, "superseded by PR #5100: window.open override removed");
+
 // Behavioral regression tests for the programmatic `window.open` override in
 // the injected navigation interceptor
 // (crates/core/src/server/path_handlers/assets/navigation_interceptor.js).
@@ -54,7 +73,10 @@ type Collected = {
 // window.open (so fallbacks are observable without spawning real popups), then
 // the real interceptor (which binds the spy as its native fallback), then an
 // exercise script that calls the overridden window.open and reports back.
-function buildSrcdoc(baseHref: string, calls: Array<{ label: string; expr: string }>): string {
+function buildSrcdoc(
+  baseHref: string,
+  calls: Array<{ label: string; expr: string }>,
+): string {
   const exercise = calls
     .map(
       (c) =>
@@ -119,7 +141,9 @@ async function runHarness(
 
   await page
     .waitForFunction(
-      () => (window as unknown as { __collected: Collected }).__collected.report !== null,
+      () =>
+        (window as unknown as { __collected: Collected }).__collected.report !==
+        null,
       { timeout: 5000 },
     )
     .catch(() => {});
@@ -150,7 +174,9 @@ test("forwards http(s) new-window opens to the shell as an absolute URL, returni
 
   const fwd = collected.forwarded.map((f) => f.url);
   // Relative resolves against the iframe base to an absolute URL.
-  expect(fwd).toContain("https://node.example/v1/contract/web/KEY/page2/sub#frag");
+  expect(fwd).toContain(
+    "https://node.example/v1/contract/web/KEY/page2/sub#frag",
+  );
   expect(fwd).toContain("https://example.com/x?q=1");
   expect(fwd).toContain("http://example.org/y");
   // URL objects are coerced and forwarded, not dead-ended.
@@ -202,7 +228,9 @@ test("strips __sandbox from an absolute same-origin open (window.open(location.h
     "https://node.example/v1/contract/web/KEY/sub/page?__sandbox=1&invite=a%20b~";
   const collected = await runHarness(
     page,
-    buildSrcdoc(BASE, [{ label: "same-origin-abs", expr: JSON.stringify(sameOriginAbs) }]),
+    buildSrcdoc(BASE, [
+      { label: "same-origin-abs", expr: JSON.stringify(sameOriginAbs) },
+    ]),
   );
   const report = collected.report!;
   expect(report.error).toBeUndefined();
@@ -220,7 +248,10 @@ test("forwards window.open(null) as the coerced relative 'null' target (native p
 }) => {
   // Native Web IDL coerces null to the string "null" (a relative URL), unlike an
   // omitted arg (about:blank). So it must be forwarded, not sent to native.
-  const collected = await runHarness(page, buildSrcdoc(BASE, [{ label: "null-arg", expr: "null" }]));
+  const collected = await runHarness(
+    page,
+    buildSrcdoc(BASE, [{ label: "null-arg", expr: "null" }]),
+  );
   const report = collected.report!;
   expect(report.error).toBeUndefined();
   expect(report.nativeCalls.length).toBe(0);
@@ -238,7 +269,9 @@ test("forwards absolute external URLs without reserializing the query string", a
   const signed = "https://example.com/o?X-Amz-Signature=abc&a=%2F%2f%20~";
   const collected = await runHarness(
     page,
-    buildSrcdoc(BASE, [{ label: "signed-external", expr: JSON.stringify(signed) }]),
+    buildSrcdoc(BASE, [
+      { label: "signed-external", expr: JSON.stringify(signed) },
+    ]),
   );
   const report = collected.report!;
   expect(report.error).toBeUndefined();
@@ -317,7 +350,10 @@ test("does not intercept in a nested descendant frame (parent !== top)", async (
   // Outer app frame simply embeds the inner frame (both sandboxed). Escape the
   // inner document's </script> tags so they don't prematurely close the outer
   // frame's own inline <script> when this HTML is parsed.
-  const innerEmbedded = JSON.stringify(inner).replace(/<\/script>/g, "<\\/script>");
+  const innerEmbedded = JSON.stringify(inner).replace(
+    /<\/script>/g,
+    "<\\/script>",
+  );
   const outer = `<!doctype html><html><body>
 <script>
   var b = document.createElement('iframe');
@@ -333,7 +369,11 @@ test("does not intercept in a nested descendant frame (parent !== top)", async (
       new Promise<{ ret: string; parentIsTop: boolean }>((resolve) => {
         window.addEventListener("message", (e: MessageEvent) => {
           const m = e.data as Record<string, unknown>;
-          if (m && m.__nested__) resolve({ ret: m.ret as string, parentIsTop: m.parentIsTop as boolean });
+          if (m && m.__nested__)
+            resolve({
+              ret: m.ret as string,
+              parentIsTop: m.parentIsTop as boolean,
+            });
         });
         const a = document.createElement("iframe");
         a.setAttribute("sandbox", "allow-scripts allow-popups");
@@ -348,14 +388,18 @@ test("does not intercept in a nested descendant frame (parent !== top)", async (
   expect(result.ret).toBe("NATIVE_SPY");
 });
 
-test("does not override window.open at top level (parent guard)", async ({ page }) => {
+test("does not override window.open at top level (parent guard)", async ({
+  page,
+}) => {
   // Loaded top-level, window.parent === window, so the override must NOT engage
   // (otherwise it would break the shell page's own window.open). Evaluate the
   // interceptor at top level with a postMessage spy and confirm no forward.
   await page.goto("about:blank");
   const forwarded = await page.evaluate((src: string) => {
     const posts: unknown[] = [];
-    (window as unknown as { postMessage: unknown }).postMessage = (m: unknown) => posts.push(m);
+    (window as unknown as { postMessage: unknown }).postMessage = (
+      m: unknown,
+    ) => posts.push(m);
     let nativeCalled = false;
     (window as unknown as { open: unknown }).open = () => {
       nativeCalled = true;
@@ -363,7 +407,9 @@ test("does not override window.open at top level (parent guard)", async ({ page 
     };
     // Indirect eval runs the IIFE in global scope (window.parent === window).
     (0, eval)(src);
-    (window as unknown as { open: (u: string) => unknown }).open("https://example.com/x");
+    (window as unknown as { open: (u: string) => unknown }).open(
+      "https://example.com/x",
+    );
     return { posts, nativeCalled };
   }, INTERCEPTOR);
   expect(forwarded.nativeCalled).toBe(true);

--- a/crates/core/tests/playwright_shell.rs
+++ b/crates/core/tests/playwright_shell.rs
@@ -295,7 +295,7 @@ fn run_playwright(shell_url: &str) -> anyhow::Result<()> {
 // Budget: the harness times the WHOLE test, including the `fdev website
 // publish` step (which can burn its full ~90s single-shot Put timeout before
 // the insert lands — see `website_publish_observed`), the shell-readiness poll
-// (up to 120s), and the Playwright suite (~70s for the 9 specs in
+// (up to 120s), and the Playwright suite (~90s for the 16 specs in
 // shell.spec.ts, plus the two node-free suites). An observed local
 // run finished in ~282s, so 300s left almost no slack on a contended runner;
 // 600s gives comfortable headroom without masking a genuine hang (the


### PR DESCRIPTION
## Problem

Firefox users must right-click → "Open in new tab" for links that work on a
plain left-click in Chrome and Safari. Every cross-CONTRACT link is
same-ORIGIN (one gateway serves them all), so this hits every cross-app link
and thumbnail.

#5089 fixed a blank tab on same-origin `target="_blank"` (#5087) by routing the
click through the shell's `open_url` bridge. That put `window.open` inside a
`message` handler. Firefox's popup blocker gates on the dispatching event type
(`dom.popup_allowed_events`: click, auxclick, … never `message`), so the open is
refused and the click does nothing. Chrome and Safari keep working only because
they propagate user activation across the frame tree. Right-click bypasses JS
entirely, hence the workaround users found.

## Solution

Only a real user gesture, in the frame that received the click, opens a tab in
every browser. So stop intercepting new-window activations and let the browser
do it.

That is sound because the shell iframe now carries
`allow-popups-to-escape-sandbox`. The popup becomes a normal top-level document
at the node's real origin:

- the shell loads — its `frame-src 'self'` matches, where an opaque origin never
  could (the blank tab #5087 was about)
- `localStorage` works, so the hosted per-user access key resolves (#4645)
- a cross-origin destination sees a real `Origin`, not `null` (river#208) — the
  sandbox-inheriting popup is what broke CORS there in the first place

Modifier and middle-clicks are native again too, restoring background-tab and
new-window placement that the postMessage route collapsed into a plain
foreground tab. The `window.open` override is deleted: a native `window.open`
from a gesture now produces a working tab by itself.

**Still intercepted:** same-origin in-contract links (the `navigate` hop), and
cross-origin links with *no* target — those would navigate the app frame to a
foreign origin, which `frame-src 'self'` refuses, making the click silently
dead. They open via `window.open` from inside the click handler, where the
gesture is live.

**Companion guard (required, not optional).** Escaping the sandbox means a
contract can navigate a tab to anything the node serves. HTML sub-paths and
`?__sandbox=1` are already forced back through the shell, but a non-HTML asset
falls through to `variable_content`, and a contract-authored `evil.svg` served
as `image/svg+xml` executes script when it *is* the document — at the node's
origin, where it could read the hosted access key from `localStorage` or scrape
an auth token from a fetched shell page. `nosniff` does not help; the type is
genuinely scriptable. Top-level document loads of contract assets now carry
`Content-Security-Policy: sandbox`. Subresource fetches are untouched.

This reverses #1499's decision to withhold `allow-popups-to-escape-sandbox`.
That decision was correct when the only guard was the sandbox attribute; the
three server-side guards above are what make it safe now. **A reviewer other
than the author should confirm that reasoning** — it is the one part of this PR
where being wrong is expensive.

## Testing

- 435 unit tests pass. New: `web_subpages_sandboxes_top_level_asset_documents`
  pins the CSP guard on both the document and subresource paths.
- Five new browser specs, one per new-tab path, including that the same-origin
  new tab renders its own shell + app frame rather than a blank one.
- **Counter-check:** restoring the two asset files from `main` fails all five,
  in chromium, firefox and webkit. They are real regression tests, not
  assertions that happen to hold.
- Rust source-pin tests rewritten to the new contract; `window-open.spec.ts`
  deleted along with the override it tested. Net −450 lines.

### Known limitation

The suite is chromium-only, which is how #5087 shipped green in the first place.
I ran all three engines locally (30/30) and they pass, but the config is left as
chromium-only per maintainer preference.

More importantly: **the popup-blocker mechanism is not reproduced by the
harness.** With the pre-fix assets, Playwright's Firefox *does* open the popup
from the `message` handler, even with `dom.disable_open_during_load` restored to
its production default. Playwright's Firefox is a patched headless build. The
diagnosis above is the best explanation for the reported symptom — the timing
matches #5089 exactly, and right-click-bypasses-JS is the signature — but
confirming it needs a real Firefox. The fix removes the shell round-trip
entirely, so it holds regardless of which mechanism caused the failure.

## Fixes

Follow-up to #5087 / #5089. Needs a maintainer decision on the #1499 reversal.
