### PR TITLE
fix(update): stop spending GitHub REST quota to check for releases

### DIFF
--- a/crates/core/src/bin/commands/auto_update.rs
+++ b/crates/core/src/bin/commands/auto_update.rs
@@ -570,16 +570,27 @@ pub async fn check_if_update_available(current_version: &str) -> UpdateCheckResu
 ///   asked for, or when this response is itself a `403`/`429`. Callers must
 ///   treat this as "we did not learn anything", never as "no update exists".
 /// * Any transport / parse failure otherwise.
-pub(crate) async fn fetch_latest_release_tag() -> Result<String> {
+pub(crate) async fn fetch_latest_release_tag(bypass_cached_cooldown: bool) -> Result<String> {
     // Honour a cooldown GitHub asked for earlier (possibly in a previous
     // process). Checked BEFORE the request so a limited IP goes quiet instead of
     // continuing to knock — continuing to knock while limited is what escalates a
     // soft per-hour limit into a longer secondary block.
-    if let Some(remaining) = github_cooldown_remaining() {
-        return Err(GithubRateLimitedError {
-            retry_after: Some(remaining),
+    //
+    // `bypass_cached_cooldown` is for `freenet update --force` ONLY. The stored
+    // deadline is our *cached belief* about GitHub, and it can be stale — GitHub
+    // may have reset early, or the limit may have been another client's doing.
+    // `--force` is the documented operator escape hatch (both the token-bucket
+    // message and the crash-loop rollback advice tell users to run it), so it
+    // must not be blocked by our own cache. It does NOT bypass a LIVE 403/429:
+    // the request below still runs, and a real refusal is still honoured and
+    // still re-records the cooldown.
+    if !bypass_cached_cooldown {
+        if let Some(remaining) = github_cooldown_remaining() {
+            return Err(GithubRateLimitedError {
+                retry_after: Some(remaining),
+            }
+            .into());
         }
-        .into());
     }
 
     let client = reqwest::Client::builder()
@@ -593,36 +604,69 @@ pub(crate) async fn fetch_latest_release_tag() -> Result<String> {
 
     let response = client.get(GITHUB_LATEST_REDIRECT_URL).send().await?;
     let status = response.status();
-
-    if is_rate_limited_status(status) {
-        // GitHub told us to stop. Persist the reset instant it handed back so
-        // every poll path on this machine — including the short-lived `freenet
-        // update` processes the supervisor spawns — stays quiet until then.
-        return Err(note_rate_limited_response(|name| {
-            response
-                .headers()
-                .get(name)
-                .and_then(|v| v.to_str().ok())
-                .map(str::to_owned)
-        })
-        .into());
-    }
-
     let location = response
         .headers()
         .get(reqwest::header::LOCATION)
         .and_then(|v| v.to_str().ok())
         .map(str::to_owned);
 
-    match location
-        .as_deref()
-        .and_then(parse_tag_from_release_location)
-    {
-        Some(tag) => Ok(tag),
-        None => anyhow::bail!(
+    match classify_probe_response(status, location.as_deref()) {
+        ProbeOutcome::Tag(tag) => Ok(tag),
+        ProbeOutcome::RateLimited => {
+            // GitHub told us to stop. Persist the reset instant it handed back so
+            // every poll path on this machine — including the short-lived
+            // `freenet update` processes the supervisor spawns — stays quiet
+            // until then.
+            Err(note_rate_limited_response(|name| {
+                response
+                    .headers()
+                    .get(name)
+                    .and_then(|v| v.to_str().ok())
+                    .map(str::to_owned)
+            })
+            .into())
+        }
+        ProbeOutcome::Unusable => anyhow::bail!(
             "GitHub returned {status} with no parseable release tag in Location ({})",
             location.as_deref().unwrap_or("<absent>")
         ),
+    }
+}
+
+/// What a release-probe response means.
+#[derive(Debug, PartialEq)]
+pub(crate) enum ProbeOutcome {
+    /// A usable release tag (leading `v` already stripped).
+    Tag(String),
+    /// GitHub is rate-limiting us; the caller records the cooldown.
+    RateLimited,
+    /// Anything else — no usable tag. Deliberately NOT a version, so a captive
+    /// portal, proxy interstitial, or an unexpected GitHub response can never be
+    /// mistaken for a release and trigger a pointless exit-42 update cycle.
+    Unusable,
+}
+
+/// Classify a `releases/latest` probe response from its status and `Location`.
+///
+/// Pure, so the whole decision is unit-testable without a network round trip —
+/// the status/redirect handling is the part most likely to break silently if
+/// GitHub's response shape ever shifts.
+///
+/// The tag is read from `Location` for ANY non-rate-limited status that supplies
+/// a parseable one, rather than only for `302`. GitHub sends `302` today, but
+/// `301`/`303`/`307`/`308` are all legitimate redirect responses and all carry
+/// the same header; pinning to one code would turn a harmless server-side change
+/// into a fleet-wide update outage.
+pub(crate) fn classify_probe_response(
+    status: reqwest::StatusCode,
+    location: Option<&str>,
+) -> ProbeOutcome {
+    if is_rate_limited_status(status) {
+        return ProbeOutcome::RateLimited;
+    }
+    match location.and_then(parse_tag_from_release_location) {
+        Some(tag) => ProbeOutcome::Tag(tag),
+        None => ProbeOutcome::Unusable,
     }
 }
 
@@ -640,7 +684,9 @@ async fn get_latest_version() -> Result<String> {
         return Err(RateLimitedError.into());
     }
 
-    fetch_latest_release_tag().await
+    // Never bypasses the cooldown: this is the automated path, and the whole
+    // point of the cooldown is to keep it quiet while the IP is limited.
+    fetch_latest_release_tag(false).await
 }
 
 /// Get the state directory for update tracking files.
@@ -2036,7 +2082,7 @@ mod tests {
             .split_once("async fn probe_latest_tag(")
             .expect("probe_latest_tag definition not found");
         let (head, _) = body
-            .split_once("fetch_latest_release_tag()")
+            .split_once("fetch_latest_release_tag(")
             .expect("tag fetch call not found");
         assert!(
             head.contains("try_consume_install_poll()"),
@@ -2377,6 +2423,98 @@ mod tests {
         // bound us, and failing closed here would wedge detection permanently.
         fs::write(tmp.path().join(GITHUB_COOLDOWN_FILE), "not-a-number").unwrap();
         assert_eq!(github_cooldown_remaining_at(tmp.path(), now), None);
+    }
+
+    #[test]
+    fn probe_response_yields_a_tag_for_any_redirect_status() {
+        // GitHub sends 302 today, but every redirect status carries the same
+        // Location. Pinning to one code would turn a harmless server-side change
+        // into a fleet-wide update outage, so the tag is read from the header
+        // regardless of which redirect status arrived.
+        let loc = Some("https://github.com/freenet/freenet-core/releases/tag/v0.2.118");
+        for code in [301u16, 302, 303, 307, 308] {
+            let status = reqwest::StatusCode::from_u16(code).unwrap();
+            assert_eq!(
+                classify_probe_response(status, loc),
+                ProbeOutcome::Tag("0.2.118".to_string()),
+                "status {code} carrying a valid Location must yield the tag"
+            );
+        }
+    }
+
+    #[test]
+    fn probe_response_never_invents_a_version() {
+        // The dangerous failure is a bogus "version": it would compare as newer
+        // and drive a pointless exit-42 update cycle against a release that does
+        // not exist. Every shape that is not a real release redirect must be
+        // Unusable, which the caller surfaces as an error (retry under backoff).
+        let ok = reqwest::StatusCode::OK;
+        // A captive portal / proxy answering 200 with a page instead of a redirect.
+        assert_eq!(classify_probe_response(ok, None), ProbeOutcome::Unusable);
+        // A redirect to somewhere that is not a release tag (e.g. a login wall).
+        assert_eq!(
+            classify_probe_response(
+                reqwest::StatusCode::FOUND,
+                Some("https://github.com/login?return_to=%2Ffreenet")
+            ),
+            ProbeOutcome::Unusable
+        );
+        // Server errors carry no tag either.
+        assert_eq!(
+            classify_probe_response(reqwest::StatusCode::INTERNAL_SERVER_ERROR, None),
+            ProbeOutcome::Unusable
+        );
+        assert_eq!(
+            classify_probe_response(reqwest::StatusCode::NOT_FOUND, None),
+            ProbeOutcome::Unusable
+        );
+    }
+
+    #[test]
+    fn probe_response_reports_rate_limiting_before_reading_location() {
+        // A 403/429 must classify as RateLimited even if a Location is somehow
+        // present, so the cooldown is recorded rather than the response being
+        // silently treated as a successful check.
+        for code in [403u16, 429] {
+            let status = reqwest::StatusCode::from_u16(code).unwrap();
+            assert_eq!(
+                classify_probe_response(
+                    status,
+                    Some("https://github.com/freenet/freenet-core/releases/tag/v9.9.9")
+                ),
+                ProbeOutcome::RateLimited,
+                "status {code} must be treated as rate-limited"
+            );
+        }
+    }
+
+    #[test]
+    fn force_waives_the_cached_cooldown_but_the_automated_path_honours_it() {
+        // Regression guard for the `--force` escape hatch. The stored deadline is
+        // only our CACHED belief about GitHub and can be stale for up to
+        // MAX_GITHUB_COOLDOWN. Two separate operator-facing messages tell users
+        // to run `freenet update --force` to override — if our own marker
+        // silently refused it and reported "already up to date", that advice
+        // would be wrong and an operator could not apply an urgent fix.
+        //
+        // Source pin, because the gate itself lives on the network path: the
+        // bypass flag must be threaded from `force`, and the automated node poll
+        // must pass `false`.
+        let update_src = include_str!("update.rs");
+        assert!(
+            update_src.contains("fetch_latest_release_tag(force)"),
+            "`freenet update --force` must waive the cached cooldown"
+        );
+
+        let this_src = include_str!("auto_update.rs");
+        let (_, after) = this_src
+            .split_once("async fn get_latest_version()")
+            .expect("get_latest_version not found");
+        assert!(
+            after.contains("fetch_latest_release_tag(false)"),
+            "the automated node poll must NOT waive the cooldown — staying quiet \
+             while the IP is limited is the entire point of it"
+        );
     }
 
     #[test]

--- a/crates/core/src/bin/commands/auto_update.rs
+++ b/crates/core/src/bin/commands/auto_update.rs
@@ -120,8 +120,115 @@ const MAX_BACKOFF: Duration = Duration::from_secs(3600);
 /// Maximum consecutive update failures before disabling auto-update.
 const MAX_UPDATE_FAILURES: u32 = 3;
 
-/// GitHub API URL for latest release.
-const GITHUB_API_URL: &str = "https://api.github.com/repos/freenet/freenet-core/releases/latest";
+/// Non-API "latest release" URL (#5102).
+///
+/// This is deliberately **not** `api.github.com`. GitHub's REST API allows only
+/// **60 unauthenticated requests per hour per source IP**, and that budget is
+/// *collective*: every Freenet node behind the same NAT/CGNAT/VPN egress — plus
+/// every unrelated tool on that IP — draws from the same 60. A single node could
+/// previously consume up to ~12 of those 60 per hour (see the token-bucket
+/// section below), so a handful of peers sharing an apparent IP exhausted it and
+/// auto-update started failing with `403`/`429`.
+///
+/// `https://github.com/{repo}/releases/latest` answers with a `302` whose
+/// `Location` header carries the tag (`.../releases/tag/v0.2.118`). It is served
+/// by the web front end, carries **no `x-ratelimit-*` headers at all**, and does
+/// not draw on the REST budget — so version *detection*, which is the part that
+/// runs on a timer, now costs nothing that can be exhausted.
+///
+/// Do NOT "simplify" this back to `api.github.com`: the JSON body is not needed
+/// to learn the tag, and paying REST quota for it is precisely the bug.
+const GITHUB_LATEST_REDIRECT_URL: &str = "https://github.com/freenet/freenet-core/releases/latest";
+
+/// Marker inside the redirect `Location` that precedes the release tag.
+const RELEASE_TAG_PATH_MARKER: &str = "/releases/tag/";
+
+/// User-Agent sent on every GitHub request. GitHub rejects unidentified clients,
+/// and a stable, identifiable agent is what lets them tell us apart from a
+/// runaway crawler if our aggregate load ever does become a problem.
+pub(crate) const GITHUB_USER_AGENT: &str = "freenet-updater";
+
+/// Extract the release tag from a `releases/latest` redirect `Location`.
+///
+/// Accepts absolute (`https://github.com/o/r/releases/tag/v1.2.3`) and relative
+/// (`/o/r/releases/tag/v1.2.3`) forms, tolerates a trailing slash, and strips
+/// any `?`/`#` suffix. Returns the tag with a leading `v` removed, or `None` if
+/// the header does not look like a release-tag redirect at all.
+///
+/// Pure so the parsing contract is unit-testable without touching the network.
+pub(crate) fn parse_tag_from_release_location(location: &str) -> Option<String> {
+    let after = location.split_once(RELEASE_TAG_PATH_MARKER)?.1;
+    let tag = after
+        .split(['?', '#'])
+        .next()
+        .unwrap_or(after)
+        .trim_end_matches('/')
+        .trim();
+    if tag.is_empty() {
+        return None;
+    }
+    Some(tag.trim_start_matches('v').to_string())
+}
+
+/// Whether a status means "GitHub is rate-limiting this IP".
+///
+/// GitHub signals the primary (per-hour) limit with **`403`** and secondary /
+/// abuse limits with **`429`**; both mean "stop asking". We deliberately do not
+/// try to distinguish a rate-limit `403` from an authorization `403` here: we
+/// send no credentials, so an authorization `403` on a public release redirect is
+/// not a case that arises, and treating an ambiguous `403` as "back off" is the
+/// safe direction — the cost is a delayed update, the cost of guessing the other
+/// way is escalating toward an IP block.
+pub(crate) fn is_rate_limited_status(status: reqwest::StatusCode) -> bool {
+    status == reqwest::StatusCode::FORBIDDEN || status == reqwest::StatusCode::TOO_MANY_REQUESTS
+}
+
+/// Longest cooldown we will honour from a server header.
+///
+/// GitHub's core window is one hour, so anything past this is either a secondary
+/// limit with a long fuse or a bad header; clamping keeps a hostile or buggy
+/// value from silently disabling auto-update for days.
+const MAX_GITHUB_COOLDOWN: Duration = Duration::from_secs(6 * 3600);
+
+/// Shortest cooldown worth persisting — below this the normal backoff already
+/// spaces polls out further than the header asks for.
+const MIN_GITHUB_COOLDOWN: Duration = Duration::from_secs(60);
+
+/// Derive how long to stay quiet from a rate-limited response's headers.
+///
+/// Prefers `Retry-After` (whole seconds; GitHub sends the delta form) and falls
+/// back to `x-ratelimit-reset` (absolute Unix seconds). Returns `None` when
+/// neither is present or parseable, so the caller can apply its own default
+/// rather than inventing a number here.
+///
+/// `header` is a lookup closure rather than a `HeaderMap` so this stays pure and
+/// directly unit-testable.
+pub(crate) fn parse_retry_after_at<F>(header: F, now_unix: u64) -> Option<Duration>
+where
+    F: Fn(&str) -> Option<String>,
+{
+    let from_retry_after = header("retry-after")
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .map(Duration::from_secs);
+
+    let from_reset = header("x-ratelimit-reset")
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        // Absolute instant → delta. `saturating_sub` covers a reset already in
+        // the past (clock skew), which yields a zero delta and is then clamped up
+        // to MIN_GITHUB_COOLDOWN below.
+        .map(|reset| Duration::from_secs(reset.saturating_sub(now_unix)));
+
+    let raw = from_retry_after.or(from_reset)?;
+    Some(raw.clamp(MIN_GITHUB_COOLDOWN, MAX_GITHUB_COOLDOWN))
+}
+
+/// [`parse_retry_after_at`] against the live wall clock.
+fn parse_retry_after<F>(header: F) -> Option<Duration>
+where
+    F: Fn(&str) -> Option<String>,
+{
+    parse_retry_after_at(header, now_unix())
+}
 
 /// Error returned when an update is needed.
 /// The main function catches this and exits with EXIT_CODE_UPDATE_NEEDED.
@@ -158,6 +265,58 @@ impl std::fmt::Display for RateLimitedError {
 }
 
 impl std::error::Error for RateLimitedError {}
+
+/// Error returned when **GitHub itself** rate-limited us (`403`/`429`), or when
+/// we are still inside a cooldown GitHub asked for earlier (#5102).
+///
+/// Distinct from [`RateLimitedError`] (our own local token bucket) because the
+/// two say different things to an operator: the local bucket is self-imposed and
+/// clears on a fixed refill schedule, whereas this one means the machine's *IP*
+/// has exhausted a budget shared with every other client on it. Both, however,
+/// mean "we did not learn whether an update exists", so both must map to
+/// [`UpdateCheckResult::RateLimited`] and must never be mistaken for "no update".
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct GithubRateLimitedError {
+    /// How long GitHub asked us to wait, when it said.
+    pub(crate) retry_after: Option<Duration>,
+}
+
+impl GithubRateLimitedError {
+    /// Operator-facing explanation. The bare `429 Too Many Requests` this
+    /// replaces told users nothing about the cause (a *shared* IP budget) or the
+    /// remedy, so they read it as "Freenet is broken" and reinstalled by hand.
+    pub(crate) fn user_message(&self) -> String {
+        let when = match self.retry_after {
+            Some(d) if d.as_secs() >= 120 => format!("in about {} minutes", d.as_secs() / 60),
+            Some(d) => format!("in about {} seconds", d.as_secs().max(1)),
+            None => "within the hour".to_string(),
+        };
+        format!(
+            "GitHub is rate-limiting release checks from this network address, so Freenet could \
+             not confirm the latest version. This is a per-IP limit shared by everything on your \
+             connection (and by every other machine behind the same NAT/CGNAT or VPN exit), not a \
+             limit on your node specifically. Nothing is broken and no action is needed: the node \
+             keeps running on its current version and will retry automatically {when}. To update \
+             immediately anyway, download a release directly from \
+             https://github.com/freenet/freenet-core/releases/latest"
+        )
+    }
+}
+
+impl std::fmt::Display for GithubRateLimitedError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.retry_after {
+            Some(d) => write!(
+                f,
+                "GitHub rate-limited this IP; retrying in {}s",
+                d.as_secs()
+            ),
+            None => write!(f, "GitHub rate-limited this IP"),
+        }
+    }
+}
+
+impl std::error::Error for GithubRateLimitedError {}
 
 /// Result of an update check attempt.
 #[derive(Debug, PartialEq)]
@@ -345,6 +504,25 @@ pub async fn check_if_update_available(current_version: &str) -> UpdateCheckResu
                 UpdateCheckResult::Skipped
             }
         }
+        Err(e) if e.downcast_ref::<GithubRateLimitedError>().is_some() => {
+            // GitHub itself refused (403/429), or we are inside the cooldown it
+            // asked for (#5102). Same handling as our own bucket denial — no
+            // check time recorded, no backoff growth, and crucially NOT a
+            // `Skipped`, so this can never reach the "max backoff + 0
+            // connections -> trust the gateway, exit 42" fallback. Exiting 42
+            // here would hand off to a `freenet update` that shares this very
+            // cooldown and would immediately no-op, i.e. a restart loop driven
+            // by an external rate limit.
+            //
+            // Logged at warn! (not debug!) precisely once per occurrence because
+            // this is the state the user reported as an inscrutable "too many
+            // requests": an operator reading the log should learn that their IP
+            // is limited, that it is shared, and that nothing needs fixing.
+            if let Some(rate_limited) = e.downcast_ref::<GithubRateLimitedError>() {
+                tracing::warn!("Update check deferred: {}", rate_limited.user_message());
+            }
+            UpdateCheckResult::RateLimited
+        }
         Err(e) if e.downcast_ref::<RateLimitedError>().is_some() => {
             // Our OWN rate limiter denied the poll — NOT a GitHub failure, and no
             // network call was made. Deliberately do NOT record a check time or
@@ -373,37 +551,96 @@ pub async fn check_if_update_available(current_version: &str) -> UpdateCheckResu
     }
 }
 
-/// Fetch the latest version string from GitHub releases API.
+/// Fetch the latest release tag from GitHub **without spending REST API quota**
+/// (#5102).
+///
+/// Issues a non-following `GET` to [`GITHUB_LATEST_REDIRECT_URL`] and reads the
+/// tag out of the `302`'s `Location` header. See that constant for why this is
+/// not `api.github.com`.
+///
+/// Shared by the node's detection path ([`get_latest_version`]) and the
+/// supervisor-side installer (`commands::update::get_latest_release`), so both
+/// observe the same server-signalled cooldown.
+///
+/// Returns the version string with any leading `v` stripped.
+///
+/// # Errors
+///
+/// * [`GithubRateLimitedError`] when we are inside a cooldown GitHub previously
+///   asked for, or when this response is itself a `403`/`429`. Callers must
+///   treat this as "we did not learn anything", never as "no update exists".
+/// * Any transport / parse failure otherwise.
+pub(crate) async fn fetch_latest_release_tag() -> Result<String> {
+    // Honour a cooldown GitHub asked for earlier (possibly in a previous
+    // process). Checked BEFORE the request so a limited IP goes quiet instead of
+    // continuing to knock — continuing to knock while limited is what escalates a
+    // soft per-hour limit into a longer secondary block.
+    if let Some(remaining) = github_cooldown_remaining() {
+        return Err(GithubRateLimitedError {
+            retry_after: Some(remaining),
+        }
+        .into());
+    }
+
+    let client = reqwest::Client::builder()
+        .user_agent(GITHUB_USER_AGENT)
+        // We want the `Location` header, not the page it points at: following the
+        // redirect would download the whole HTML release page for a value that is
+        // already in the header.
+        .redirect(reqwest::redirect::Policy::none())
+        .timeout(Duration::from_secs(10))
+        .build()?;
+
+    let response = client.get(GITHUB_LATEST_REDIRECT_URL).send().await?;
+    let status = response.status();
+
+    if is_rate_limited_status(status) {
+        // GitHub told us to stop. Persist the reset instant it handed back so
+        // every poll path on this machine — including the short-lived `freenet
+        // update` processes the supervisor spawns — stays quiet until then.
+        return Err(note_rate_limited_response(|name| {
+            response
+                .headers()
+                .get(name)
+                .and_then(|v| v.to_str().ok())
+                .map(str::to_owned)
+        })
+        .into());
+    }
+
+    let location = response
+        .headers()
+        .get(reqwest::header::LOCATION)
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_owned);
+
+    match location
+        .as_deref()
+        .and_then(parse_tag_from_release_location)
+    {
+        Some(tag) => Ok(tag),
+        None => anyhow::bail!(
+            "GitHub returned {status} with no parseable release tag in Location ({})",
+            location.as_deref().unwrap_or("<absent>")
+        ),
+    }
+}
+
+/// Fetch the latest version string for the node's own detection path.
 async fn get_latest_version() -> Result<String> {
-    // Global persistent rate limit (#4073): refuse to hit GitHub when the shared
-    // token bucket is empty. This is the in-node choke point (the node's startup
-    // check, the #4589 re-poll, and the peer-signal loop all reach GitHub through
-    // here); the supervisor-side `freenet update` is bounded by the same bucket
-    // at `get_latest_release`. A denied poll returns Err so the caller
-    // (`check_if_update_available`) treats it as `Skipped` and retries later —
-    // the node keeps running, it just does not poll GitHub this tick.
+    // Local aggregate-load bound (#4073), kept as defence in depth on top of the
+    // #5102 endpoint switch: refuse to hit GitHub when this node's token bucket
+    // is empty. This is the in-node choke point (the node's startup check, the
+    // #4589 re-poll, and the peer-signal loop all reach GitHub through here); the
+    // supervisor-side `freenet update` is bounded by its own bucket at
+    // `get_latest_release`. A denied poll returns Err so the caller
+    // (`check_if_update_available`) treats it as `RateLimited` and retries later
+    // — the node keeps running, it just does not poll GitHub this tick.
     if !try_consume_node_poll() {
         return Err(RateLimitedError.into());
     }
 
-    let client = reqwest::Client::builder()
-        .user_agent("freenet-updater")
-        .timeout(Duration::from_secs(10))
-        .build()?;
-
-    let response = client.get(GITHUB_API_URL).send().await?;
-
-    if !response.status().is_success() {
-        anyhow::bail!("GitHub API returned {}", response.status());
-    }
-
-    #[derive(serde::Deserialize)]
-    struct Release {
-        tag_name: String,
-    }
-
-    let release: Release = response.json().await?;
-    Ok(release.tag_name.trim_start_matches('v').to_string())
+    fetch_latest_release_tag().await
 }
 
 /// Get the state directory for update tracking files.
@@ -747,6 +984,113 @@ pub(crate) fn try_consume_node_poll() -> bool {
 /// Independent of the node bucket so the node can never starve the installer.
 pub(crate) fn try_consume_install_poll() -> bool {
     try_consume_poll_bucket(INSTALL_POLL_BUCKET_FILE)
+}
+
+// ── Server-signalled GitHub cooldown (#5102) ───────────────────────────────
+//
+// The token buckets above bound what THIS node does. This cooldown records what
+// GITHUB told us to do, and is deliberately **shared** by every poll path on the
+// machine — unlike the two buckets, which are separate on purpose.
+//
+// The asymmetry is the point. The buckets are separate so the node cannot starve
+// the installer of its own self-imposed allowance. But a `403`/`429` is not a
+// property of a code path, it is a property of the IP: if GitHub is refusing the
+// node's detection poll, it will equally refuse the installer's, and letting the
+// installer knock anyway is exactly the behaviour that turns a one-hour primary
+// limit into a longer secondary block. One file, honoured by both.
+
+/// On-disk marker holding the Unix second before which no path may poll GitHub.
+const GITHUB_COOLDOWN_FILE: &str = "github_ratelimit_cooldown";
+
+/// Cooldown applied when GitHub rate-limits us without a usable `Retry-After` /
+/// `x-ratelimit-reset` header. Short enough that a transient limit does not
+/// noticeably delay updates, long enough to stop a restart loop from knocking.
+const DEFAULT_GITHUB_COOLDOWN: Duration = Duration::from_secs(900);
+
+/// Remaining cooldown at `now_unix`, if any. Pure over an explicit directory and
+/// clock so the expiry arithmetic is unit-testable.
+///
+/// A stored instant further out than [`MAX_GITHUB_COOLDOWN`] is clamped rather
+/// than trusted: a backwards clock step or a torn write must not be able to
+/// disable auto-update indefinitely.
+pub(crate) fn github_cooldown_remaining_at(
+    dir: &std::path::Path,
+    now_unix: u64,
+) -> Option<Duration> {
+    let until = fs::read_to_string(dir.join(GITHUB_COOLDOWN_FILE))
+        .ok()?
+        .trim()
+        .parse::<u64>()
+        .ok()?;
+    let remaining = until.checked_sub(now_unix)?;
+    if remaining == 0 {
+        return None;
+    }
+    Some(Duration::from_secs(remaining).min(MAX_GITHUB_COOLDOWN))
+}
+
+/// Live-clock, live-state-dir variant of [`github_cooldown_remaining_at`].
+///
+/// Fails **open** (returns `None`, i.e. "not cooling down") when there is no
+/// resolvable state dir: the cooldown is an optimisation to be polite to GitHub,
+/// and an unresolvable state dir already denies every poll via the token buckets,
+/// which fail closed. Failing closed here too would permanently disable update
+/// detection on such a machine.
+fn github_cooldown_remaining() -> Option<Duration> {
+    github_cooldown_remaining_at(&state_dir()?, now_unix())
+}
+
+/// Persist "do not poll GitHub until `now + retry_after`".
+///
+/// Never shortens an existing cooldown — concurrent processes (the node and a
+/// supervisor-spawned `freenet update`) can both observe a limit, and the later
+/// writer must not walk back the more conservative deadline.
+pub(crate) fn record_github_cooldown_at(
+    dir: &std::path::Path,
+    retry_after: Option<Duration>,
+    now_unix: u64,
+) {
+    let wait = retry_after
+        .unwrap_or(DEFAULT_GITHUB_COOLDOWN)
+        .clamp(MIN_GITHUB_COOLDOWN, MAX_GITHUB_COOLDOWN);
+    let candidate = now_unix.saturating_add(wait.as_secs());
+    let existing = github_cooldown_remaining_at(dir, now_unix)
+        .map(|d| now_unix.saturating_add(d.as_secs()))
+        .unwrap_or(0);
+    let until = candidate.max(existing);
+
+    if fs::create_dir_all(dir)
+        .and_then(|()| fs::write(dir.join(GITHUB_COOLDOWN_FILE), until.to_string()))
+        .is_err()
+    {
+        // Best-effort: the token buckets still bound us if this cannot persist.
+        tracing::debug!("Could not persist GitHub rate-limit cooldown");
+    }
+}
+
+/// Live-clock, live-state-dir variant of [`record_github_cooldown_at`].
+fn record_github_cooldown(retry_after: Option<Duration>) {
+    if let Some(dir) = state_dir() {
+        record_github_cooldown_at(&dir, retry_after, now_unix());
+    }
+}
+
+/// Record the cooldown implied by a rate-limited response's headers and build
+/// the corresponding error.
+///
+/// Exposed so the installer's `api.github.com` asset fetch funnels its `403`/
+/// `429` handling through the same place as the redirect probe — a second,
+/// hand-rolled copy of "parse the header, persist the deadline" is exactly how
+/// one of the two paths ends up quietly not backing off.
+///
+/// `header` is a name → value lookup over the response headers.
+pub(crate) fn note_rate_limited_response<F>(header: F) -> GithubRateLimitedError
+where
+    F: Fn(&str) -> Option<String>,
+{
+    let retry_after = parse_retry_after(header);
+    record_github_cooldown(retry_after);
+    GithubRateLimitedError { retry_after }
 }
 
 /// Check if we should attempt an update based on failure history.
@@ -1676,20 +2020,27 @@ mod tests {
     }
 
     #[test]
-    fn test_get_latest_release_consults_install_bucket() {
+    fn test_installer_probe_consults_install_bucket() {
         // Source pin: the supervisor-side installer fetch must gate on the
         // SEPARATE install bucket (not the node bucket), so the node cannot
         // starve it (#4073 Codex P1).
+        //
+        // Renamed with the #5102 split of `get_latest_release` into
+        // `probe_latest_tag` (quota-free tag probe, runs every invocation) and
+        // `fetch_release_assets` (REST, runs only on a real install). The token
+        // must be spent on the PROBE: that is the call every invocation makes, so
+        // it is the one that bounds a restart loop. Gating only the asset fetch
+        // would leave the crash-loop path unbounded.
         let src = include_str!("update.rs");
         let (_, body) = src
-            .split_once("async fn get_latest_release(")
-            .expect("get_latest_release definition not found");
+            .split_once("async fn probe_latest_tag(")
+            .expect("probe_latest_tag definition not found");
         let (head, _) = body
-            .split_once("reqwest::Client::builder()")
-            .expect("client builder not found");
+            .split_once("fetch_latest_release_tag()")
+            .expect("tag fetch call not found");
         assert!(
             head.contains("try_consume_install_poll()"),
-            "get_latest_release must consume an INSTALL-bucket token before hitting GitHub"
+            "probe_latest_tag must consume an INSTALL-bucket token before hitting GitHub"
         );
     }
 
@@ -1779,17 +2130,280 @@ mod tests {
 
     #[test]
     fn test_repoll_interval_is_under_github_rate_limit() {
-        // GitHub's unauthenticated REST limit is 60 requests/hour/IP. Even at
-        // the jittered minimum, the periodic re-poll alone must stay far under
-        // that (the bursty peer-signal checks share the same IP budget). We
-        // assert the minimum interval is >= 1 hour, i.e. <= 1 periodic request
-        // per hour — a >=60x safety margin.
+        // Keeps the periodic re-poll infrequent in absolute terms.
+        //
+        // NOTE (#5102): the "60x safety margin" this test originally claimed was
+        // measured against the WRONG denominator. GitHub's 60 req/hr limit is
+        // per SOURCE IP and *collective* — every node behind the same NAT/CGNAT
+        // or VPN exit, plus every unrelated tool on that IP, draws from one
+        // shared 60. A per-node margin says nothing about a shared budget, which
+        // is how a "far under the limit" updater still got users 403/429'd. The
+        // real fix was to stop spending REST quota for detection at all (see
+        // `GITHUB_LATEST_REDIRECT_URL`); this bound remains as ordinary
+        // politeness, not as the rate-limit defence it was once mistaken for.
         let min =
             jittered_repoll_interval(UPDATE_REPOLL_INTERVAL, UPDATE_REPOLL_JITTER_FRACTION, 0.0);
         assert!(
             min >= Duration::from_secs(3600),
-            "minimum re-poll interval {min:?} must be >= 1h to stay well under \
-             GitHub's 60 req/hr unauthenticated limit"
+            "minimum re-poll interval {min:?} must be >= 1h"
         );
+    }
+
+    // ── #5102: quota-free version detection ────────────────────────────────
+
+    #[test]
+    fn detection_endpoint_does_not_use_the_rest_api() {
+        // The regression this guards: the detection path polls on a timer, so
+        // pointing it at api.github.com spends a budget shared with every other
+        // client on the IP. The redirect endpoint costs none of it. Verified
+        // empirically against live GitHub when this landed: the api.github.com
+        // form increments `core.used`, this one does not.
+        assert!(
+            !GITHUB_LATEST_REDIRECT_URL.contains("api.github.com"),
+            "version detection must not use the rate-limited REST API, got \
+             {GITHUB_LATEST_REDIRECT_URL}"
+        );
+        assert!(
+            GITHUB_LATEST_REDIRECT_URL.starts_with("https://github.com/"),
+            "detection must use the web redirect endpoint, got {GITHUB_LATEST_REDIRECT_URL}"
+        );
+    }
+
+    #[test]
+    fn parse_tag_from_location_handles_the_shapes_github_sends() {
+        // Absolute form — what GitHub actually returns today.
+        assert_eq!(
+            parse_tag_from_release_location(
+                "https://github.com/freenet/freenet-core/releases/tag/v0.2.118"
+            )
+            .as_deref(),
+            Some("0.2.118"),
+            "the leading 'v' must be stripped, matching the old tag_name handling"
+        );
+        // Relative form — permitted by RFC 7231 even though GitHub sends absolute.
+        assert_eq!(
+            parse_tag_from_release_location("/freenet/freenet-core/releases/tag/v1.2.3").as_deref(),
+            Some("1.2.3")
+        );
+        // A tag without the conventional 'v' must survive intact.
+        assert_eq!(
+            parse_tag_from_release_location("https://github.com/o/r/releases/tag/1.2.3").as_deref(),
+            Some("1.2.3")
+        );
+        // Trailing slash and query/fragment noise must not end up in the version,
+        // or the semver parse downstream fails and the update is silently skipped.
+        assert_eq!(
+            parse_tag_from_release_location("https://github.com/o/r/releases/tag/v1.2.3/")
+                .as_deref(),
+            Some("1.2.3")
+        );
+        assert_eq!(
+            parse_tag_from_release_location("https://github.com/o/r/releases/tag/v1.2.3?x=1")
+                .as_deref(),
+            Some("1.2.3")
+        );
+    }
+
+    #[test]
+    fn parse_tag_from_location_rejects_non_release_redirects() {
+        // Anything that is not a release-tag redirect must be None, NOT a bogus
+        // version string: a bogus version compares as "newer" and would trigger
+        // a pointless exit-42 update cycle.
+        assert_eq!(parse_tag_from_release_location(""), None);
+        assert_eq!(
+            parse_tag_from_release_location("https://github.com/login?return_to=%2Ffreenet"),
+            None
+        );
+        assert_eq!(
+            parse_tag_from_release_location("https://github.com/o/r/releases/tag/"),
+            None,
+            "an empty tag must not parse as a version"
+        );
+        assert_eq!(
+            parse_tag_from_release_location("https://github.com/o/r/releases/latest"),
+            None
+        );
+    }
+
+    #[test]
+    fn rate_limited_statuses_cover_both_github_signals() {
+        // GitHub uses 403 for the primary per-hour limit and 429 for secondary /
+        // abuse limits. Missing either one means we keep knocking while limited,
+        // which is what escalates toward a longer block.
+        assert!(is_rate_limited_status(reqwest::StatusCode::FORBIDDEN));
+        assert!(is_rate_limited_status(
+            reqwest::StatusCode::TOO_MANY_REQUESTS
+        ));
+        // Everything else must stay an ordinary error, not a silent cooldown.
+        assert!(!is_rate_limited_status(reqwest::StatusCode::OK));
+        assert!(!is_rate_limited_status(reqwest::StatusCode::FOUND));
+        assert!(!is_rate_limited_status(reqwest::StatusCode::NOT_FOUND));
+        assert!(!is_rate_limited_status(
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR
+        ));
+    }
+
+    #[test]
+    fn retry_after_header_is_preferred_over_ratelimit_reset() {
+        let headers = |name: &str| match name {
+            "retry-after" => Some("300".to_string()),
+            "x-ratelimit-reset" => Some("9999999999".to_string()),
+            _ => None,
+        };
+        assert_eq!(
+            parse_retry_after_at(headers, 1_000),
+            Some(Duration::from_secs(300)),
+            "Retry-After is the more specific instruction and must win"
+        );
+    }
+
+    #[test]
+    fn ratelimit_reset_is_converted_from_absolute_to_delta() {
+        // x-ratelimit-reset is an ABSOLUTE Unix second. Treating it as a delta
+        // (the easy mistake) would produce a ~56-year cooldown and silently
+        // disable auto-update forever.
+        let now = 1_785_700_000;
+        let headers = |name: &str| match name {
+            "x-ratelimit-reset" => Some((now + 1_800).to_string()),
+            _ => None,
+        };
+        assert_eq!(
+            parse_retry_after_at(headers, now),
+            Some(Duration::from_secs(1_800))
+        );
+    }
+
+    #[test]
+    fn rate_limit_wait_is_clamped_at_both_ends() {
+        let now = 1_785_700_000;
+        // A reset already in the past (clock skew) must not yield a zero wait
+        // that lets us knock again immediately.
+        let past = |name: &str| match name {
+            "x-ratelimit-reset" => Some((now - 500).to_string()),
+            _ => None,
+        };
+        assert_eq!(parse_retry_after_at(past, now), Some(MIN_GITHUB_COOLDOWN));
+
+        // An absurd value must not disable updates for days.
+        let absurd = |name: &str| match name {
+            "retry-after" => Some("99999999".to_string()),
+            _ => None,
+        };
+        assert_eq!(parse_retry_after_at(absurd, now), Some(MAX_GITHUB_COOLDOWN));
+
+        // Nothing parseable → None, so the caller applies its own default rather
+        // than this function inventing one.
+        assert_eq!(parse_retry_after_at(|_| None, now), None);
+        assert_eq!(
+            parse_retry_after_at(
+                |n: &str| (n == "retry-after").then(|| "soon".to_string()),
+                now
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn cooldown_blocks_until_it_expires() {
+        let tmp = tempfile::tempdir().unwrap();
+        let now = 1_785_700_000;
+        assert_eq!(
+            github_cooldown_remaining_at(tmp.path(), now),
+            None,
+            "no marker means no cooldown"
+        );
+
+        record_github_cooldown_at(tmp.path(), Some(Duration::from_secs(600)), now);
+        assert_eq!(
+            github_cooldown_remaining_at(tmp.path(), now),
+            Some(Duration::from_secs(600))
+        );
+        // Still blocking one second before expiry...
+        assert_eq!(
+            github_cooldown_remaining_at(tmp.path(), now + 599),
+            Some(Duration::from_secs(1))
+        );
+        // ...and released exactly at expiry, so a limited node does recover on
+        // its own without operator intervention.
+        assert_eq!(github_cooldown_remaining_at(tmp.path(), now + 600), None);
+        assert_eq!(github_cooldown_remaining_at(tmp.path(), now + 9_999), None);
+    }
+
+    #[test]
+    fn cooldown_is_never_shortened_by_a_later_writer() {
+        // The node and a supervisor-spawned `freenet update` can both hit the
+        // limit. If the second writer overwrote the deadline with its own
+        // shorter wait, the pair would ratchet the cooldown DOWN and keep
+        // knocking — the exact failure the shared marker exists to prevent.
+        let tmp = tempfile::tempdir().unwrap();
+        let now = 1_785_700_000;
+
+        record_github_cooldown_at(tmp.path(), Some(Duration::from_secs(3_000)), now);
+        record_github_cooldown_at(tmp.path(), Some(Duration::from_secs(120)), now);
+
+        assert_eq!(
+            github_cooldown_remaining_at(tmp.path(), now),
+            Some(Duration::from_secs(3_000)),
+            "a shorter later cooldown must not walk back the longer one"
+        );
+    }
+
+    #[test]
+    fn cooldown_without_a_header_uses_the_bounded_default() {
+        let tmp = tempfile::tempdir().unwrap();
+        let now = 1_785_700_000;
+        record_github_cooldown_at(tmp.path(), None, now);
+        assert_eq!(
+            github_cooldown_remaining_at(tmp.path(), now),
+            Some(DEFAULT_GITHUB_COOLDOWN),
+            "a 403/429 with no usable header must still produce a real cooldown"
+        );
+    }
+
+    #[test]
+    fn corrupt_or_skewed_cooldown_cannot_disable_updates_forever() {
+        let tmp = tempfile::tempdir().unwrap();
+        let now = 1_785_700_000;
+
+        // A far-future deadline (backwards clock step, torn write) is clamped
+        // rather than trusted, so the node resumes checking within hours.
+        fs::write(tmp.path().join(GITHUB_COOLDOWN_FILE), u64::MAX.to_string()).unwrap();
+        assert_eq!(
+            github_cooldown_remaining_at(tmp.path(), now),
+            Some(MAX_GITHUB_COOLDOWN)
+        );
+
+        // Unparseable content fails OPEN (no cooldown): the token buckets still
+        // bound us, and failing closed here would wedge detection permanently.
+        fs::write(tmp.path().join(GITHUB_COOLDOWN_FILE), "not-a-number").unwrap();
+        assert_eq!(github_cooldown_remaining_at(tmp.path(), now), None);
+    }
+
+    #[test]
+    fn rate_limit_message_explains_cause_and_remedy() {
+        // The reported symptom was a bare "too many requests", which users read
+        // as "Freenet is broken" and responded to by reinstalling by hand. The
+        // replacement must name the shared-IP cause, say it is not fatal, and
+        // give a manual route.
+        let msg = GithubRateLimitedError {
+            retry_after: Some(Duration::from_secs(1_800)),
+        }
+        .user_message();
+        assert!(
+            msg.contains("30 minutes"),
+            "must say when it retries: {msg}"
+        );
+        assert!(
+            msg.contains("shared") || msg.contains("NAT"),
+            "must explain the per-IP/shared cause: {msg}"
+        );
+        assert!(
+            msg.contains("https://github.com/freenet/freenet-core/releases/latest"),
+            "must offer the manual download route: {msg}"
+        );
+
+        // With no header we still promise a retry rather than leaving it open.
+        let vague = GithubRateLimitedError { retry_after: None }.user_message();
+        assert!(vague.contains("within the hour"), "{vague}");
     }
 }

--- a/crates/core/src/bin/commands/update.rs
+++ b/crates/core/src/bin/commands/update.rs
@@ -4319,6 +4319,41 @@ done
     }
 
     #[test]
+    fn no_supervisor_path_invokes_update_with_force() {
+        // Load-bearing for the whole rate-limit bound (#5102). `--force` waives
+        // BOTH local limiters — the #4073 install token bucket and the cached
+        // GitHub cooldown — because it is an explicit operator action. That is
+        // only safe while it stays operator-only.
+        //
+        // If a supervisor ever gained `--force` (say, to "make auto-update more
+        // reliable"), every crash in a crash-loop would knock at GitHub with no
+        // local bound at all, which is precisely the runaway this PR exists to
+        // stop. Every automated invocation must use `update --quiet`.
+        let sources: [(&str, &str); 4] = [
+            ("service/wrapper.rs", include_str!("service/wrapper.rs")),
+            ("service/linux.rs", include_str!("service/linux.rs")),
+            ("service/macos.rs", include_str!("service/macos.rs")),
+            ("service.rs", include_str!("service.rs")),
+        ];
+        for (name, src) in sources {
+            for (i, line) in src.lines().enumerate() {
+                let code = match line.find("//") {
+                    Some(at) if at == 0 || !line[..at].ends_with(':') => &line[..at],
+                    _ => line,
+                };
+                assert!(
+                    !code.contains("--force"),
+                    "{name}:{} passes --force to an automated `freenet update`; that waives \
+                     both the token bucket and the GitHub cooldown, removing every local \
+                     bound on GitHub polling (#5102). Automated paths must use \
+                     `update --quiet`.\n  {line}",
+                    i + 1
+                );
+            }
+        }
+    }
+
+    #[test]
     fn only_the_install_asset_fetch_uses_api_github_com() {
         // Any NEW api.github.com URL in this file is a regression unless it is
         // similarly gated behind "we are actually installing". Keeping the count

--- a/crates/core/src/bin/commands/update.rs
+++ b/crates/core/src/bin/commands/update.rs
@@ -15,7 +15,15 @@ use super::service::generate_wrapper_script;
 #[cfg(target_os = "linux")]
 use super::service::{generate_system_service_file, generate_user_service_file};
 
-const GITHUB_API_URL: &str = "https://api.github.com/repos/freenet/freenet-core/releases/latest";
+/// Prefix for the by-exact-tag release endpoint; the caller appends `v{version}`.
+///
+/// This is the ONLY `api.github.com` request left in the update path (#5102), and
+/// it is reached only when an install is actually going ahead — we need the asset
+/// list, which the quota-free redirect cannot provide. The former
+/// `/releases/latest` REST call that ran on every invocation is gone: see
+/// `auto_update::GITHUB_LATEST_REDIRECT_URL`.
+const GITHUB_API_TAG_URL_PREFIX: &str =
+    "https://api.github.com/repos/freenet/freenet-core/releases/tags/";
 
 /// Ed25519 public key (raw 32-byte, little-endian compressed point) used to
 /// authenticate the release `SHA256SUMS.txt` manifest before any binary is
@@ -357,9 +365,16 @@ impl UpdateCommand {
             println!("Checking for updates...");
         }
 
-        let latest = get_latest_release(self.force, self.quiet).await?;
-
-        let latest_version = latest.tag_name.trim_start_matches('v');
+        // #5102: resolve the tag over the quota-free `releases/latest` redirect.
+        // The REST asset list is fetched further down, ONLY once we know an
+        // install is actually going to happen — so the two overwhelmingly common
+        // outcomes of this command now cost zero api.github.com quota:
+        //   * "already up to date", which the systemd `ExecStopPost` hook reaches
+        //     on EVERY non-clean node exit (so a crash-looping node used to burn
+        //     REST quota once per crash), and
+        //   * `--check`, which never installs by definition.
+        let latest_tag = probe_latest_tag(self.force, self.quiet).await?;
+        let latest_version = latest_tag.as_str();
         if !self.quiet {
             println!("Latest version: {}", latest_version);
         }
@@ -437,6 +452,12 @@ impl UpdateCommand {
         if !self.quiet {
             println!("Downloading update...");
         }
+        // #5102: only NOW do we spend an api.github.com request, because only now
+        // do we need the asset list (names + download URLs, including the
+        // gnu→musl fallback search and the macOS DMG lookup). Requested by exact
+        // tag rather than `/releases/latest` so we install the release we just
+        // decided about, even if a newer one is published in between.
+        let latest = fetch_release_assets(latest_version).await?;
         // #4073 per-target-version install-failure gate. Count a DETERMINISTIC
         // install failure of this version — a checksum mismatch or invalid
         // release signature (`ReleaseVerificationError`) — toward the gate. After
@@ -1176,20 +1197,31 @@ impl Checksums {
     }
 }
 
-async fn get_latest_release(force: bool, quiet: bool) -> Result<Release> {
-    // Persistent rate limit (#4073): this is the supervisor-side choke point —
-    // the on-crash / on-update `freenet update` one-shot reaches GitHub through
-    // here. It uses its OWN on-disk token bucket (the INSTALL bucket), separate
-    // from the node's `get_latest_version` (NODE bucket), so the node — which
-    // always runs first in a restart cycle — can never spend the installer's
-    // tokens and starve a legitimate update. Because each `freenet update` is a
-    // fresh process, an in-memory limiter would reset on every restart and not
-    // bound a loop; the on-disk bucket holds the limit across restarts.
+/// Resolve the latest release tag for the installer, without spending GitHub
+/// REST API quota (#5102).
+///
+/// Replaces the old `/releases/latest` REST call. See
+/// [`auto_update::GITHUB_LATEST_REDIRECT_URL`] for why the redirect endpoint is
+/// used instead of `api.github.com`.
+///
+/// [`auto_update::GITHUB_LATEST_REDIRECT_URL`]: super::auto_update
+async fn probe_latest_tag(force: bool, quiet: bool) -> Result<String> {
+    // Persistent local rate limit (#4073): this is the supervisor-side choke
+    // point — the on-crash / on-update `freenet update` one-shot reaches GitHub
+    // through here. It uses its OWN on-disk token bucket (the INSTALL bucket),
+    // separate from the node's `get_latest_version` (NODE bucket), so the node —
+    // which always runs first in a restart cycle — can never spend the
+    // installer's tokens and starve a legitimate update. Because each `freenet
+    // update` is a fresh process, an in-memory limiter would reset on every
+    // restart and not bound a loop; the on-disk bucket holds the limit across
+    // restarts.
     //
-    // `--force` (an explicit operator action) bypasses the limiter. An automated,
-    // token-denied poll exits EXIT_CODE_ALREADY_UP_TO_DATE so the supervisor
-    // treats it as "nothing to do" and backs off, rather than as a failure that
-    // would count toward any lockout.
+    // The token is spent HERE (on the probe) rather than on the asset fetch
+    // below, because the probe is the call every invocation makes — it is what
+    // bounds a restart loop. The asset fetch happens only on a real install.
+    //
+    // `--force` (an explicit operator action) bypasses OUR limiter. It does not,
+    // and must not, bypass a cooldown GitHub itself asked for: see below.
     if !force && !super::auto_update::try_consume_install_poll() {
         if !quiet {
             eprintln!(
@@ -1203,26 +1235,79 @@ async fn get_latest_release(force: bool, quiet: bool) -> Result<Release> {
         std::process::exit(EXIT_CODE_ALREADY_UP_TO_DATE);
     }
 
+    match super::auto_update::fetch_latest_release_tag().await {
+        Ok(tag) => Ok(tag),
+        Err(e) => {
+            // #5102: GitHub rate-limiting is NOT an install failure — it is "we
+            // could not find out". Exit as up-to-date so the supervisor backs off
+            // and restarts the current binary, exactly as for a token-denied
+            // poll, instead of counting a failure toward the #3934 lockout or
+            // restart-looping. This is the path the user hit as a bare
+            // "429 Too Many Requests"; it now explains itself.
+            //
+            // Note this is checked even under `--force`: `--force` overrides our
+            // own politeness budget, but knocking harder at a server that is
+            // already refusing us is what escalates toward an IP block, and there
+            // is nothing the operator can do here that waiting would not do
+            // better.
+            if let Some(rate_limited) =
+                e.downcast_ref::<super::auto_update::GithubRateLimitedError>()
+            {
+                if !quiet {
+                    eprintln!("{}", rate_limited.user_message());
+                }
+                tracing::warn!("Update check deferred: {}", rate_limited.user_message());
+                std::process::exit(EXIT_CODE_ALREADY_UP_TO_DATE);
+            }
+            Err(e).context("Failed to determine the latest Freenet release")
+        }
+    }
+}
+
+/// Fetch the full release record (asset names + download URLs) for an exact tag.
+///
+/// This is the one remaining `api.github.com` request in the update path, and it
+/// runs only when an install is actually going ahead (#5102). Keyed by exact tag
+/// rather than `latest` so the assets we install match the version we decided to
+/// install, even if a new release lands between the probe and here.
+async fn fetch_release_assets(tag: &str) -> Result<Release> {
+    let url = format!("{GITHUB_API_TAG_URL_PREFIX}v{tag}");
+
     let client = reqwest::Client::builder()
-        .user_agent("freenet-updater")
-        // Bound the request (parity with auto_update::get_latest_version). The
-        // broadened post-stop ExecStopPost reaches this on every committed
-        // crash's Proceed path, so a hung GitHub connection during a crash must
-        // not stall the post-stop updater (only loosely bounded by
-        // TimeoutStopSec on systemd, and worse under the mac/in-process wrapper).
+        .user_agent(super::auto_update::GITHUB_USER_AGENT)
+        // Bound the request. The broadened post-stop ExecStopPost reaches the
+        // update path on every committed crash's Proceed path, so a hung GitHub
+        // connection during a crash must not stall the post-stop updater (only
+        // loosely bounded by TimeoutStopSec on systemd, and worse under the
+        // mac/in-process wrapper).
         .timeout(std::time::Duration::from_secs(10))
         .build()?;
 
     let response = client
-        .get(GITHUB_API_URL)
+        .get(&url)
+        .header("Accept", "application/vnd.github+json")
         .send()
         .await
         .context("Failed to fetch release info")?;
 
-    if !response.status().is_success() {
+    let status = response.status();
+    if super::auto_update::is_rate_limited_status(status) {
+        // Record the cooldown so subsequent polls (from any path) stay quiet,
+        // then surface the legible message rather than a bare status line.
+        let rate_limited = super::auto_update::note_rate_limited_response(|name| {
+            response
+                .headers()
+                .get(name)
+                .and_then(|v| v.to_str().ok())
+                .map(str::to_owned)
+        });
+        anyhow::bail!("{}", rate_limited.user_message());
+    }
+
+    if !status.is_success() {
         anyhow::bail!(
             "GitHub API returned error: {} {}",
-            response.status(),
+            status,
             response.text().await.unwrap_or_default()
         );
     }
@@ -4153,6 +4238,101 @@ done
             verify_manifest_signature_with(&tampered, Some(&sig_bytes), &pubkey, true, true)
                 .is_err(),
             "a tampered manifest must be refused even with a valid openssl signature"
+        );
+    }
+
+    // ── #5102: the update path must not spend REST quota to say "no change" ──
+
+    /// Strip `//` line comments so source-scrape pins assert on real code, not
+    /// on prose that happens to mention the symbol.
+    ///
+    /// URL-safe, unlike the naive version: a `//` preceded by `:` is a URL
+    /// scheme (`https://`), not a comment. This file is full of GitHub URLs, and
+    /// truncating at the scheme silently emptied every line holding one — which
+    /// made the api.github.com pin below report zero matches and "pass" against
+    /// source it had not actually examined.
+    fn strip_line_comments_for_pin(src: &str) -> String {
+        src.lines()
+            .map(|line| {
+                let bytes = line.as_bytes();
+                let mut i = 0;
+                while let Some(off) = line[i..].find("//") {
+                    let at = i + off;
+                    if at > 0 && bytes[at - 1] == b':' {
+                        i = at + 2;
+                        continue;
+                    }
+                    return &line[..at];
+                }
+                line
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn already_up_to_date_and_check_never_reach_the_rest_api() {
+        // The bug this pins (#5102): `freenet update` used to hit
+        // api.github.com/releases/latest on EVERY invocation, before knowing
+        // whether anything needed installing. systemd's ExecStopPost runs this
+        // command on every non-clean node exit, so a crash-looping node burned
+        // one request from the IP's shared 60/hr budget per crash — and
+        // `--check`, which by definition never installs, paid the same cost.
+        //
+        // The REST call must therefore come strictly AFTER both early exits.
+        let src = strip_line_comments_for_pin(include_str!("update.rs"));
+
+        let probe = src
+            .find("probe_latest_tag(")
+            .expect("run() must resolve the tag via the quota-free probe");
+        let rest_call = src
+            .find("fetch_release_assets(")
+            .expect("the REST asset fetch must still exist for real installs");
+        let up_to_date = src
+            .find("You are already running the latest version.")
+            .expect("already-up-to-date branch not found");
+        let check_branch = src
+            .find("if self.check {")
+            .expect("--check branch not found");
+
+        assert!(
+            probe < up_to_date,
+            "the tag must be probed before the already-up-to-date comparison"
+        );
+        assert!(
+            up_to_date < rest_call,
+            "the already-up-to-date exit must precede the REST asset fetch, or \
+             every ExecStopPost run after a crash spends REST quota (#5102)"
+        );
+        assert!(
+            check_branch < rest_call,
+            "`--check` must return before the REST asset fetch (#5102)"
+        );
+    }
+
+    #[test]
+    fn only_the_install_asset_fetch_uses_api_github_com() {
+        // Any NEW api.github.com URL in this file is a regression unless it is
+        // similarly gated behind "we are actually installing". Keeping the count
+        // at one makes that a deliberate decision rather than a drift.
+        // Counted as a URL prefix rather than as bare prose, so this test's own
+        // assertion messages cannot inflate the count.
+        let src = strip_line_comments_for_pin(include_str!("update.rs"));
+        // Assembled from fragments so this test's own needle is not present in
+        // the source it scans — otherwise the pin counts itself and the expected
+        // total drifts every time the test is edited.
+        let needle = concat!("https://", "api.github.com");
+        let hits = src.matches(needle).count();
+        assert_eq!(
+            hits, 1,
+            "expected exactly one api.github.com URL (the by-tag asset fetch); found {hits}. \
+             Detection must use the quota-free redirect — see \
+             auto_update::GITHUB_LATEST_REDIRECT_URL (#5102)"
+        );
+        assert!(
+            src.contains("releases/tags/"),
+            "the remaining REST call must request an exact tag, so the assets we \
+             install match the version we decided on"
         );
     }
 }

--- a/crates/core/src/bin/commands/update.rs
+++ b/crates/core/src/bin/commands/update.rs
@@ -1220,8 +1220,9 @@ async fn probe_latest_tag(force: bool, quiet: bool) -> Result<String> {
     // below, because the probe is the call every invocation makes — it is what
     // bounds a restart loop. The asset fetch happens only on a real install.
     //
-    // `--force` (an explicit operator action) bypasses OUR limiter. It does not,
-    // and must not, bypass a cooldown GitHub itself asked for: see below.
+    // `--force` (an explicit operator action) bypasses OUR local self-restraint —
+    // both this token bucket and the cached rate-limit cooldown below. It does
+    // NOT bypass a live 403/429 from GitHub, which is still honoured.
     if !force && !super::auto_update::try_consume_install_poll() {
         if !quiet {
             eprintln!(
@@ -1235,7 +1236,14 @@ async fn probe_latest_tag(force: bool, quiet: bool) -> Result<String> {
         std::process::exit(EXIT_CODE_ALREADY_UP_TO_DATE);
     }
 
-    match super::auto_update::fetch_latest_release_tag().await {
+    // `force` also waives the CACHED cooldown. Without this, an operator running
+    // `freenet update --force` after a rate-limit episode would be refused by our
+    // own stale marker for up to MAX_GITHUB_COOLDOWN — even once GitHub had
+    // recovered — and told "already up to date". That would break the escape
+    // hatch two separate messages point users at ("Run `freenet update --force`
+    // to override", and the crash-loop rollback's "run it once a fixed release is
+    // available"). A live 403/429 still refuses and still re-arms the cooldown.
+    match super::auto_update::fetch_latest_release_tag(force).await {
         Ok(tag) => Ok(tag),
         Err(e) => {
             // #5102: GitHub rate-limiting is NOT an install failure — it is "we
@@ -1245,11 +1253,11 @@ async fn probe_latest_tag(force: bool, quiet: bool) -> Result<String> {
             // restart-looping. This is the path the user hit as a bare
             // "429 Too Many Requests"; it now explains itself.
             //
-            // Note this is checked even under `--force`: `--force` overrides our
-            // own politeness budget, but knocking harder at a server that is
-            // already refusing us is what escalates toward an IP block, and there
-            // is nothing the operator can do here that waiting would not do
-            // better.
+            // Reached under `--force` too — but only from a LIVE refusal, since
+            // force waives the cached marker above. Retrying immediately against
+            // a server that is actively refusing us is what escalates toward an
+            // IP block, and there is nothing the operator can do here that
+            // waiting would not do better.
             if let Some(rate_limited) =
                 e.downcast_ref::<super::auto_update::GithubRateLimitedError>()
             {

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -2168,6 +2168,31 @@ mod tests {
         );
     }
 
+    #[test]
+    fn js_update_check_backs_off_after_a_failure() {
+        // #5102: caching only SUCCESS meant a rate-limited browser re-requested
+        // on every single page load — the dashboard knocked hardest exactly
+        // while the IP was already being refused. Failures must be remembered
+        // too, so the client goes quiet and recovers on its own.
+        //
+        // This check cannot move off api.github.com the way the node's poll did:
+        // it runs in a browser, and the quota-free github.com redirect sends no
+        // CORS headers, so fetch() cannot read it. Backing off is the only lever
+        // available here, which is why it is pinned.
+        assert!(
+            JS.contains("failedAt"),
+            "JS must record failed update checks so it can back off (#5102)"
+        );
+        assert!(
+            JS.contains("FAIL_TTL_MS"),
+            "JS must define a failure cooldown window (#5102)"
+        );
+        assert!(
+            JS.contains("rememberFailure"),
+            "the failure path must persist the cooldown, not just log (#5102)"
+        );
+    }
+
     // ─── Governance card (Phase 4.5) ───────────────────────────────
 
     use crate::node::network_status::{

--- a/crates/core/src/server/home_page/assets/dashboard.js
+++ b/crates/core/src/server/home_page/assets/dashboard.js
@@ -190,6 +190,16 @@ function checkForUpdate() {
   var current = badge.getAttribute('data-version') || '';
   if (!current || current === '?') return;
   var TTL_MS = 12 * 60 * 60 * 1000;
+  /* Negative-cache window (#5102). This check must stay on api.github.com —
+     unlike the node's own poll it runs in a browser, and the quota-free
+     github.com redirect sends no CORS headers so fetch() cannot read it. It
+     therefore spends from the same 60/hr per-IP REST budget the node used to,
+     and that budget is shared with every other machine behind the same
+     NAT/CGNAT or VPN exit. Before this, only SUCCESS was cached: once GitHub
+     started refusing, every dashboard reload issued another doomed request,
+     so the one client that should have gone quiet instead knocked hardest
+     exactly while the IP was limited. Remember failures too. */
+  var FAIL_TTL_MS = 60 * 60 * 1000;
   var now = Date.now();
   var cached = null;
   try {
@@ -205,6 +215,18 @@ function checkForUpdate() {
     if (compareSemver(cached.tag, current) > 0) showUpdateBadge(cached.tag);
     return;
   }
+  /* Back off after a failed check. GitHub's core limit resets hourly, so one
+     retry per hour per browser is both polite and enough to recover on its
+     own without the user doing anything. */
+  if (cached && cached.failedAt && now - cached.failedAt < FAIL_TTL_MS) return;
+  var rememberFailure = function () {
+    try {
+      localStorage.setItem(
+        'freenet-update-check',
+        JSON.stringify({ failedAt: now }),
+      );
+    } catch (e) {}
+  };
   fetch('https://api.github.com/repos/freenet/freenet-core/releases/latest', {
     headers: { Accept: 'application/vnd.github+json' },
   })
@@ -214,7 +236,12 @@ function checkForUpdate() {
     })
     .then(function (data) {
       var tag = data && data.tag_name;
-      if (!tag) return;
+      /* A 200 with no usable tag is still a wasted request; treat it as a
+         failure so a malformed response cannot drive a per-reload retry loop. */
+      if (!tag) {
+        rememberFailure();
+        return;
+      }
       try {
         localStorage.setItem(
           'freenet-update-check',
@@ -224,7 +251,9 @@ function checkForUpdate() {
       if (compareSemver(tag, current) > 0) showUpdateBadge(tag);
     })
     .catch(function (e) {
-      /* Network blocked / GitHub rate-limited — silently skip */
+      /* Network blocked / GitHub rate-limited (403/429) — go quiet for
+         FAIL_TTL_MS rather than retrying on every page load. */
+      rememberFailure();
       console.debug('Update check failed:', e);
     });
 }


### PR DESCRIPTION
## Problem

A user reported (Matrix, 2026-08-02) that auto-update failed with "too many requests" and they had to update by hand.

Every node's update path polled **`api.github.com/repos/freenet/freenet-core/releases/latest`**, which allows **60 unauthenticated requests per hour per source IP**. That budget is **collective** — shared by every Freenet node behind the same NAT/CGNAT/VPN egress *and* by everything else on that IP.

Five call sites reach it: the startup check (unconditional, explicitly *"decoupled from the backoff"*), the version-mismatch loop (60s tick, backoff 1 min → 1 h), the 6 h periodic re-poll, `freenet update` (which systemd's `ExecStopPost` runs on **every** non-clean exit — so once per crash), and the dashboard JS.

The bound we had was reasoned **per node**, against a budget that is **per IP**. The source says so in as many words:

> At 6h ± 25% the minimum interval is ~4.5h, far under GitHub's unauthenticated 60 req/hr/IP limit.

and its test:

> a >=60x safety margin

The two on-disk token buckets cap one node at **16 burst + 12/hour sustained** — up to **20 % of an entire IP's hourly allowance from a single peer**. We cut 1–4 releases/day, so the mismatch trigger is armed almost permanently and peers sat at that ceiling continuously. A handful behind one CGNAT exhausts 60/hr.

Nothing read `Retry-After` / `x-ratelimit-reset` either, so on 403/429 we kept knocking through the window — the specific behaviour that escalates a primary limit toward a longer secondary block, which is the IP-block risk. The installer's `anyhow::bail!` is the likely source of the reported string (`reqwest` renders 429 as `429 Too Many Requests`).

## Approach

`https://github.com/<repo>/releases/latest` returns a `302` whose `Location` carries the tag, is served by the web front end, and does **not** touch the REST budget. Measured against live GitHub:

```
OLD (api.github.com/releases/latest): core.used 1 -> 2  (delta=1)
NEW (github.com/releases/latest):     core.used 2 -> 2  (delta=0)
```

1. **Detection** reads the tag from that redirect — zero REST quota on the timer-driven path.
2. **`freenet update`** probes the same way and spends a REST request only when an install is actually going ahead, requested **by exact tag** rather than `latest` (so the assets we install match the version we decided on). "Already up to date" and `--check` are now free. Verified end-to-end: `freenet update --check` consumes 0 REST requests.
3. **Cooldown on 403/429**, persisted in `state_dir()` from `Retry-After` / `x-ratelimit-reset`. Deliberately **shared** by the node and installer paths — unlike the token buckets, which are separate on purpose — because a rate limit is a property of the IP, not of a code path. Never shortened by a later writer; clamped so a skewed clock or torn write cannot disable updates indefinitely.
4. **Legible failure**: names the shared-IP cause, says nothing is broken, gives the manual download route.
5. **Dashboard** negative-caches failures so a limited browser stops re-requesting on every reload. It must stay on `api.github.com` (browser + no CORS headers on the redirect), so backing off is the only lever there.

Deliberately **not** changed: the poll cadence. The endpoint switch removes the quota cost entirely; changing intervals too would be an unevidenced behaviour change on top of a bug fix.

## Testing

13 new tests. The two source pins were **mutation-tested** — each confirmed to fail when the fix is reverted:

- reverting the const to `api.github.com` → `detection_endpoint_does_not_use_the_rest_api` FAILS
- restoring the eager asset fetch → `already_up_to_date_and_check_never_reach_the_rest_api` FAILS

Covered: `Location` parsing (absolute/relative/trailing-slash/query/no-`v`, and rejection of non-release redirects so a bogus tag can't read as "newer" and trigger a pointless exit-42); 403 **and** 429 both recognised; `Retry-After` preferred over `x-ratelimit-reset`; absolute-reset → delta conversion (treating it as a delta would give a ~56-year cooldown); clamping at both ends; cooldown expiry, never-shortened, bounded default, and corrupt/skewed input failing open.

Also updated the stale `test_get_latest_release_consults_install_bucket` pin for the rename, and corrected the "60x safety margin" comment that encoded the wrong denominator.

`cargo fmt`, `cargo clippy -p freenet --bins --lib -- -D warnings`, `cargo test -p freenet --bin freenet` (343 pass), home_page lib tests, and the asset `npm run lint` + `npm test` gates all clean. The 10 pre-existing `--all-targets` clippy errors are #4914 and reproduce identically on `main`.

Closes #5102

[AI-assisted - Claude]


---

## Review round (commits 2–3)

Full-tier review surfaced three findings, all fixed here:

1. **`--force` was refused by our own cached cooldown** (`0f7a9a1`). The check ran unconditionally, so an operator running `freenet update --force` after a rate-limit episode was blocked by our stale marker for up to 6 h — even once GitHub had recovered — and told "already up to date". That silently broke the escape hatch two operator-facing messages point at ("Run `freenet update --force` to override", and the crash-loop rollback's advice). `--force` now waives the *cache*; a **live** 403/429 still refuses and still re-arms the cooldown.
2. **Response handling was inline on the network path, so untestable** (`0f7a9a1`). Extracted as a pure `classify_probe_response`. This also hardened two cases: the tag is now read from `Location` for *any* non-rate-limited status rather than only `302` (every redirect code carries the same header; pinning to one would turn a harmless GitHub-side change into a fleet-wide update outage), and 403/429 classify as rate-limited *before* `Location` is consulted.
3. **Nothing prevented a supervisor gaining `--force`** (`7693440`). Since `--force` now waives both local limiters, that is only safe while it stays operator-only — a supervisor with `--force` would let every crash in a crash-loop knock at GitHub unbounded. Added a mutation-tested pin over the systemd unit, macOS wrapper, and `spawn_update_command`.

Also verified empirically during review: **prerelease semantics are unchanged**. On `electron/electron`, whose newest release *is* a prerelease, both the REST and web `releases/latest` endpoints return the same stable tag.

The full consolidated review is posted as a PR comment, including an honest note on how it was run: six independent reviewers were spawned and none returned, so the lenses were run serially in-session (the documented fallback). That is a weaker signal than blind independent review — an external pass before merge would still add value.
