### PR TITLE
fix(shell): stop routing same-origin target="_blank" through open_url

### DIFF
--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -7130,6 +7130,95 @@ mod tests {
         );
     }
 
+    /// The interceptor's `isLoopbackHost` and the shell `open_url` handler's
+    /// loopback refusal must name the SAME hosts. `isLoopbackHost` exists only
+    /// to predict what the shell will refuse, so that `window.open` falls back
+    /// to native instead of forwarding an open that will be dropped — its own
+    /// comment says "Kept in sync with the loopback block in shell_bridge.js's
+    /// open_url handler", but nothing enforced that until now.
+    ///
+    /// Drift in either direction is a silent user-visible bug:
+    ///   - shell refuses a host the interceptor does not list → the forwarded
+    ///     open vanishes and the click does nothing. That is exactly the
+    ///     failure #5106 hit through the anchor path, which had no such list
+    ///     at all.
+    ///   - interceptor lists a host the shell would open → the open needlessly
+    ///     falls back to a sandbox-inheriting native popup (#4645).
+    ///
+    /// #4846 proposes completing this allow-list (it is exact-match today, so
+    /// e.g. `127.0.0.2` is not covered). Whoever does that must change both
+    /// sides; this test is what tells them so.
+    #[test]
+    fn interceptor_loopback_list_matches_shell_open_url_refusal() {
+        // Collect the host literals from each `h === '<host>'` comparison in a
+        // region. Both sides normalize into a local `h` before comparing, so
+        // this picks up the comparison chain and nothing else (scheme checks
+        // use `u.protocol`, not `h`).
+        fn loopback_hosts(region: &str) -> Vec<String> {
+            const NEEDLE: &str = "h === '";
+            let mut out = Vec::new();
+            let mut rest = region;
+            while let Some(i) = rest.find(NEEDLE) {
+                let after = &rest[i + NEEDLE.len()..];
+                match after.find('\'') {
+                    Some(end) => {
+                        out.push(after[..end].to_string());
+                        rest = &after[end..];
+                    }
+                    None => break,
+                }
+            }
+            out.sort();
+            out.dedup();
+            out
+        }
+
+        let interceptor_fn_idx = NAVIGATION_INTERCEPTOR_JS
+            .find("function isLoopbackHost")
+            .expect("interceptor isLoopbackHost helper present");
+        let interceptor_region = &NAVIGATION_INTERCEPTOR_JS[interceptor_fn_idx..];
+        // The helper is short; bound the region at its closing brace so a later
+        // `h === ...` elsewhere in the file can't leak in.
+        let interceptor_end = interceptor_region
+            .find("\n  }")
+            .expect("isLoopbackHost helper is brace-terminated");
+        let interceptor_hosts = loopback_hosts(&interceptor_region[..interceptor_end]);
+
+        // Anchor tightly on the refusal itself — `var h = u.hostname` up to the
+        // `return;` that drops the message. The sibling tests here bound the
+        // open_url branch with the next `} else if`, but open_url is the LAST
+        // arm of that chain, so that bound silently runs to end-of-file; a
+        // stray `h === 'string'` further down would then be read as a loopback
+        // host. Slicing to the `return;` keeps this to the comparison chain.
+        let refusal_idx = SHELL_BRIDGE_JS
+            .find("var h = u.hostname")
+            .expect("shell open_url loopback normalization present");
+        let rest = &SHELL_BRIDGE_JS[refusal_idx..];
+        let refusal_end = rest
+            .find("return;")
+            .expect("shell open_url loopback refusal returns");
+        let shell_hosts = loopback_hosts(&rest[..refusal_end]);
+
+        // Guard against the comparison going vacuous: if a refactor renames the
+        // local or restructures the chain, both sides would extract nothing and
+        // the equality below would pass while guarding nothing (#5076).
+        assert!(
+            shell_hosts.contains(&"localhost".to_string()),
+            "extracted no loopback hosts from the shell open_url handler — the \
+             `h === '...'` chain moved or was renamed, so this test is no longer \
+             comparing anything. Re-anchor it. Got: {shell_hosts:?}"
+        );
+        assert_eq!(
+            interceptor_hosts, shell_hosts,
+            "isLoopbackHost and the shell's open_url loopback refusal have \
+             drifted. A host the shell refuses but the interceptor does not \
+             list makes window.open forward an open the shell then drops \
+             silently (#5106); the reverse forwards to a sandbox-inheriting \
+             native popup (#4645). Update both, or #4846 when completing the \
+             allow-list."
+        );
+    }
+
     /// Direct postMessages from a malicious iframe can synthesize an
     /// `open_url` payload without going through the upstream
     /// `NAVIGATION_INTERCEPTOR_JS` scheme filter, so the shell-side

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -6830,12 +6830,28 @@ mod tests {
     ///     frame; Gecko and Blink loaded it. Firefox and Chrome users were
     ///     therefore traded a working tab for a dead click.
     ///
-    /// So: keep this branch a plain `return` — hand the click back to the
-    /// browser. Re-routing it needs either `allow-popups-to-escape-sandbox`
-    /// on the app iframe (so the popup is not sandboxed in the first place)
-    /// or a loopback fallback mirroring `window.open`'s. Both assertions
-    /// below must stay: the first fails if the `return` is replaced, the
-    /// second if a forward is added alongside it.
+    /// The revert is not free, and this test should not be read as saying the
+    /// current behaviour is good: the tab the browser opens inherits the
+    /// sandbox, so on a HOSTED node it can't read the per-user access key and
+    /// dead-ends on the "Open this app in a normal tab" panel in every engine
+    /// (#4645), and on WebKit it renders blank (#5087). #5089 fixed both for
+    /// this path incidentally. This test pins the lesser failure, not a good
+    /// one, until a fix lands that has neither.
+    ///
+    /// Two constraints on that fix. `allow-popups-to-escape-sandbox` on the
+    /// app iframe was deliberately REMOVED by #1499 — an escaped popup gains
+    /// the node's real origin, letting a malicious app reach other apps' data
+    /// and bypass permission prompts (pinned in `shell_page_*` above) — so
+    /// that route has to answer #1499 first. A bridge re-route needs a
+    /// loopback fallback mirroring `window.open`'s `isLoopbackHost`.
+    ///
+    /// Note that such a fix WILL fail both assertions below, and that is
+    /// correct — they pin today's behaviour, not a permanent invariant.
+    /// Whoever lands it should replace this test, not weaken it. The first
+    /// assertion is the load-bearing one; the second is a cheap belt-and-
+    /// braces check that a forward was not added ahead of the `return`
+    /// (anything added after it would be unreachable, so it catches less
+    /// than the first).
     #[test]
     fn navigation_interceptor_leaves_same_origin_target_blank_to_the_browser() {
         let js = NAVIGATION_INTERCEPTOR_JS;
@@ -6860,8 +6876,11 @@ mod tests {
         );
         assert!(
             !block.contains("type: 'open_url'"),
-            "the same-origin new-window branch must not forward to open_url without a \
-             loopback fallback like the window.open override's isLoopbackHost check (#5106)"
+            "no open_url forward may be added to the same-origin new-window branch ahead \
+             of the `return` (#5106). If you are DELIBERATELY re-routing this branch — \
+             with a loopback fallback like the window.open override's isLoopbackHost \
+             check, or after removing the sandbox inheritance — this test is pinning the \
+             old behaviour and should be replaced, not deleted piecemeal"
         );
     }
 
@@ -7146,27 +7165,38 @@ mod tests {
     ///     falls back to a sandbox-inheriting native popup (#4645).
     ///
     /// #4846 proposes completing this allow-list (it is exact-match today, so
-    /// e.g. `127.0.0.2` is not covered). Whoever does that must change both
-    /// sides; this test is what tells them so.
+    /// e.g. `127.0.0.2` is not covered). Whoever does that one-sidedly will
+    /// trip this test. Note the limit, though: it compares LITERALS, so if
+    /// #4846 is implemented as a rule (`h.startsWith('127.')`) on both sides,
+    /// both literal sets shrink together and this test goes green without
+    /// having checked the new rule. It catches one-sided literal drift — the
+    /// common case — not a symmetric refactor.
     #[test]
     fn interceptor_loopback_list_matches_shell_open_url_refusal() {
         // Collect the host literals from each `h === '<host>'` comparison in a
-        // region. Both sides normalize into a local `h` before comparing, so
-        // this picks up the comparison chain and nothing else (scheme checks
-        // use `u.protocol`, not `h`).
+        // region.
+        //
+        // The needle is NOT self-limiting: it also matches the tail of
+        // `hash === '` and `iframePath === '`, which occur elsewhere in
+        // shell_bridge.js. What makes this sound is purely the REGION BOUNDS
+        // chosen below — do not loosen them on the theory that `h` is unique.
+        // That mistake is live: see the note on the shell anchor.
         fn loopback_hosts(region: &str) -> Vec<String> {
             const NEEDLE: &str = "h === '";
             let mut out = Vec::new();
             let mut rest = region;
             while let Some(i) = rest.find(NEEDLE) {
                 let after = &rest[i + NEEDLE.len()..];
-                match after.find('\'') {
-                    Some(end) => {
-                        out.push(after[..end].to_string());
-                        rest = &after[end..];
-                    }
-                    None => break,
-                }
+                let end = after.find('\'').expect(
+                    "unterminated host literal in a loopback comparison — the region \
+                     bounds or the JS shape changed; failing loudly rather than \
+                     comparing a silently truncated list",
+                );
+                out.push(after[..end].to_string());
+                // Advances by at least NEEDLE.len() each iteration, so this
+                // terminates; all indices are ASCII-needle finds, so every
+                // slice lands on a char boundary.
+                rest = &after[end..];
             }
             out.sort();
             out.dedup();

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -4724,10 +4724,17 @@ mod tests {
         // allow-popups-to-escape-sandbox must NOT be present. It was removed because
         // escaped popups gain localhost:7509 origin, allowing malicious web apps to
         // access other apps' data and bypass permission prompts. External links are
-        // now opened via the open_url shell bridge message instead. See #1499.
+        // now opened via the open_url shell bridge message instead.
+        //
+        // Citation corrected in #5107: this said "#1499", but that is the
+        // delegate-user-interaction feature request. The flag was removed by
+        // PR #3818 (`ec140e09c`, "browser-based permission prompts with iframe
+        // security hardening"), which is also the commit that wrote the
+        // original "#1499" pointer here. #1499 is the motivation; #3818 is the
+        // change and the place to argue with.
         assert!(
             !html.contains("allow-popups-to-escape-sandbox"),
-            "allow-popups-to-escape-sandbox must not be set (security: #1499)"
+            "allow-popups-to-escape-sandbox must not be set (security: #3818)"
         );
         // open_url handler must be present in shell bridge JS for external links
         assert!(
@@ -6812,8 +6819,13 @@ mod tests {
             .expect("same-origin target check present");
         let block = &js[cross_origin_idx..target_attr_idx];
 
+        // Match the payload shape, not a bare `shiftKey`. This region is the
+        // one #5106 grew by ~30 comment lines, and a bare needle is satisfiable
+        // by prose that merely discusses shift-clicking — the same way a bare
+        // `preventDefault` needle in the sibling test above was left matching a
+        // comment, mutation-confirmed, until it was tightened.
         assert!(
-            block.contains("shiftKey"),
+            block.contains("shiftKey: !!e.shiftKey"),
             "cross-origin open_url postMessage must include shiftKey to honour \
              shift-click as a new-window request (#3853); got block: {block}"
         );
@@ -6831,34 +6843,50 @@ mod tests {
     /// that trade net-negative:
     ///
     ///  1. `open_url` REFUSES loopback hosts (`localhost` / `127.0.0.1` /
-    ///     `::1` / `0.0.0.0`) — see the handler in `shell_bridge.js`. A local
-    ///     node is served from loopback, which is how most desktop users
-    ///     browse, so forwarding meant the click was `preventDefault`-ed and
-    ///     then silently dropped by the shell: NOTHING opened, in every
-    ///     engine. The `window.open` override further down never had this
-    ///     hole — it checks `isLoopbackHost` and falls back to native. The
-    ///     anchor branch has no such fallback, so it must not forward.
+    ///     `::1` / `0.0.0.0`) — see the handler in `shell_bridge.js`. That is
+    ///     the documented way a local node is reached (the service prints
+    ///     `Open http://127.0.0.1:7509/` on start), so forwarding meant the
+    ///     click was `preventDefault`-ed and then silently dropped by the
+    ///     shell: NOTHING opened, in every engine. The `window.open` override
+    ///     further down never had this hole — it checks `isLoopbackHost` and
+    ///     falls back to native. The anchor branch has no such fallback, so
+    ///     it must not forward.
     ///  2. The blank tab it fixed is WebKit-only. Driving the real
-    ///     interceptor inside a sandboxed-shell harness in all three engines
-    ///     (popup blockers on), the pre-#5089 native popup was opaque-origin
-    ///     everywhere, but only WebKit's `frame-src 'self'` refused the app
-    ///     frame; Gecko and Blink loaded it. Firefox and Chrome users were
-    ///     therefore traded a working tab for a dead click.
+    ///     interceptor inside a sandboxed-shell harness in all three engines,
+    ///     the pre-#5089 native popup was opaque-origin everywhere, but only
+    ///     WebKit's `frame-src 'self'` refused the app frame; Gecko and Blink
+    ///     loaded it. Firefox and Chrome users were therefore traded a
+    ///     working tab for a dead click.
+    ///
+    /// Two things NOT to repeat from earlier drafts of this reasoning, both
+    /// retracted after review re-ran the measurements: popup blocking has
+    /// nothing to do with any of it (the matrix is identical with blockers on
+    /// and off; the zero-popup cells are the loopback refusal), and "loopback
+    /// is how most desktop users browse" was never established — #5087's own
+    /// reporter was on `10.44.101.1`, i.e. the configuration where #5089
+    /// helped and this revert does not.
     ///
     /// The revert is not free, and this test should not be read as saying the
-    /// current behaviour is good: the tab the browser opens inherits the
-    /// sandbox, so on a HOSTED node it can't read the per-user access key and
-    /// dead-ends on the "Open this app in a normal tab" panel in every engine
-    /// (#4645), and on WebKit it renders blank (#5087). #5089 fixed both for
-    /// this path incidentally. This test pins the lesser failure, not a good
-    /// one, until a fix lands that has neither.
+    /// current behaviour is good. The tab the browser opens inherits the
+    /// sandbox, so it has an opaque origin, which costs three things: WebKit
+    /// renders it blank (#5087); on a HOSTED node it can't read the per-user
+    /// access key and dead-ends on the "Open this app in a normal tab" panel
+    /// in every engine (#4645); and its permission surface is dead in every
+    /// engine, because `Origin: null` is refused and `/permission/pending`
+    /// answers 200 with an empty list rather than an error, so the prompt
+    /// silently never appears. That last one bites hardest on a LOCAL node in
+    /// Firefox/Chrome — the very case this pins — where the app frame loads
+    /// fine and so looks healthy. #5089 fixed all three for this path
+    /// incidentally. This test pins the lesser failure, not a good one, until
+    /// a fix lands that has neither.
     ///
     /// Two constraints on that fix. `allow-popups-to-escape-sandbox` on the
-    /// app iframe was deliberately REMOVED by #1499 — an escaped popup gains
-    /// the node's real origin, letting a malicious app reach other apps' data
-    /// and bypass permission prompts (pinned in `shell_page_*` above) — so
-    /// that route has to answer #1499 first. A bridge re-route needs a
-    /// loopback fallback mirroring `window.open`'s `isLoopbackHost`.
+    /// app iframe was deliberately REMOVED by #3818 (motivated by #1499) — an
+    /// escaped popup gains the node's real origin, letting a malicious app
+    /// reach other apps' data and bypass permission prompts (its absence is
+    /// pinned in `shell_page_*` above) — so that route has to answer #3818
+    /// first. A bridge re-route needs a loopback fallback mirroring
+    /// `window.open`'s `isLoopbackHost`.
     ///
     /// Note that such a fix WILL fail both assertions below, and that is
     /// correct — they pin today's behaviour, not a permanent invariant.
@@ -6909,33 +6937,56 @@ mod tests {
         //     if (target.target === '_blank') { e.preventDefault(); /* open_url */ return; }
         //     if (target.target && target.target !== '_self') return;
         //
-        // So also pin the whole-handler count. `handleAnchorClick` must forward
-        // open_url from exactly ONE place: the cross-origin branch. Anything
-        // that adds a second forward, anywhere in the handler and under any
-        // condition, trips this.
+        // So also pin the whole-handler count. `handleAnchorClick` must post
+        // open_url from exactly ONE place: the cross-origin branch.
         //
-        // This is also what makes the asymmetry with `window.open` DELIBERATE
-        // rather than an accident of two reverts: the override below forwards
-        // same-origin new-window opens (#4645) and this handler does not. The
-        // anchor path pays #4645's dead-end on hosted nodes to avoid the
-        // loopback dead click (#5106); the override avoids both because it has
-        // an isLoopbackHost fallback. Whoever unifies them should make that
-        // choice on purpose, and will land here.
+        // Scope, precisely — this counts DIRECT forwards, i.e. the literal
+        // postMessage. It does NOT catch a re-route written through the
+        // patched `window.open` (`if (target.target === '_blank') { …
+        // window.open(target.href); return; }`), which passes this and the two
+        // branch assertions. That is deliberate: such a re-route inherits the
+        // override's `isLoopbackHost` fallback, so it is the shape the branch
+        // comment invites rather than the bug this guards.
+        //
+        // It is also NOT a standalone guard against extracting the forward
+        // into a helper — `navigation_interceptor_handles_cross_origin_target_blank`
+        // is what fires there, because it requires the literal INSIDE the
+        // cross-origin block. Do not prune that test as redundant with this
+        // one; it is the half that keeps river#208 closed.
+        //
+        // What this does add is the asymmetry with `window.open` being
+        // DELIBERATE rather than an accident of two reverts: the override
+        // below forwards same-origin new-window opens (#4645) and this handler
+        // does not. The anchor path pays #4645's dead-end on hosted nodes to
+        // avoid the loopback dead click (#5106); the override avoids both
+        // because it has that fallback. Whoever unifies them lands here and
+        // chooses on purpose.
         let handler_start = js
             .find("function handleAnchorClick")
             .expect("anchor click handler present");
         let handler_end = js
             .find("document.addEventListener('click'")
             .expect("anchor click listener registration present");
+        // Function declarations hoist, so moving the listener registrations
+        // above the handler is a legal tidy-up that would invert these bounds.
+        // Catch it with a message rather than a raw slice panic.
+        assert!(
+            handler_start < handler_end,
+            "expected `function handleAnchorClick` before the listener \
+             registration; if the registrations were hoisted above the handler, \
+             re-anchor this bound rather than dropping the check"
+        );
         let forwards = js[handler_start..handler_end]
             .matches("type: 'open_url'")
             .count();
         assert_eq!(
             forwards, 1,
             "handleAnchorClick must forward open_url from exactly one place — the \
-             cross-origin branch (freenet/river#208). A second forward means a \
-             same-origin new-window re-route slipped in outside the branch this \
-             test's other assertions scope to (#5106)"
+             cross-origin branch (freenet/river#208). Too many means a same-origin \
+             new-window re-route slipped in outside the branch this test's other \
+             assertions scope to (#5106). Zero most likely means the forward moved \
+             into a helper, which is fine behaviour but leaves this count guarding \
+             nothing — re-anchor it rather than deleting it"
         );
     }
 

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -6809,22 +6809,35 @@ mod tests {
         );
     }
 
-    /// Regression test for #5087.
+    /// Regression test for #5106 — the fallout of #5089, which is reverted here.
     ///
-    /// A SAME-ORIGIN `<a target="_blank">` used to return early and fall
-    /// through to the browser. The shell iframe has no
-    /// `allow-popups-to-escape-sandbox` (deliberately, #1499), so that popup
-    /// inherited the sandbox: the top-level shell it landed on had an opaque
-    /// origin, its own `frame-src 'self'` could not match, and the app frame
-    /// stayed `about:blank` — a blank tab.
+    /// #5089 routed the same-origin new-window branch through the shell's
+    /// `open_url` bridge to fix a blank tab (#5087). Two measured facts make
+    /// that trade net-negative:
     ///
-    /// Every cross-CONTRACT link is same-ORIGIN (one gateway serves them all),
-    /// so that exemption swallowed exactly the breaking case. The same-origin
-    /// new-window branch must route through `open_url` like the cross-origin
-    /// branch above it, matching the `window.open` override further down,
-    /// which already forwards same-origin new-window opens.
+    ///  1. `open_url` REFUSES loopback hosts (`localhost` / `127.0.0.1` /
+    ///     `::1` / `0.0.0.0`) — see the handler in `shell_bridge.js`. A local
+    ///     node is served from loopback, which is how most desktop users
+    ///     browse, so forwarding meant the click was `preventDefault`-ed and
+    ///     then silently dropped by the shell: NOTHING opened, in every
+    ///     engine. The `window.open` override further down never had this
+    ///     hole — it checks `isLoopbackHost` and falls back to native. The
+    ///     anchor branch has no such fallback, so it must not forward.
+    ///  2. The blank tab it fixed is WebKit-only. Driving the real
+    ///     interceptor inside a sandboxed-shell harness in all three engines
+    ///     (popup blockers on), the pre-#5089 native popup was opaque-origin
+    ///     everywhere, but only WebKit's `frame-src 'self'` refused the app
+    ///     frame; Gecko and Blink loaded it. Firefox and Chrome users were
+    ///     therefore traded a working tab for a dead click.
+    ///
+    /// So: keep this branch a plain `return` — hand the click back to the
+    /// browser. Re-routing it needs either `allow-popups-to-escape-sandbox`
+    /// on the app iframe (so the popup is not sandboxed in the first place)
+    /// or a loopback fallback mirroring `window.open`'s. Both assertions
+    /// below must stay: the first fails if the `return` is replaced, the
+    /// second if a forward is added alongside it.
     #[test]
-    fn navigation_interceptor_routes_same_origin_target_blank_through_open_url() {
+    fn navigation_interceptor_leaves_same_origin_target_blank_to_the_browser() {
         let js = NAVIGATION_INTERCEPTOR_JS;
 
         let target_attr_idx = js
@@ -6839,19 +6852,16 @@ mod tests {
         );
         let block = &js[target_attr_idx..navigate_idx];
 
-        // The old bug: `if (...) return;` handed the click to the browser.
         assert!(
-            !block.contains("!== '_self') return"),
-            "same-origin target=\"_blank\" must not fall through to the browser: the \
-             popup inherits the sandbox and the resulting tab is blank (#5087)"
+            block.contains("!== '_self') return"),
+            "same-origin target=\"_blank\" must fall through to the browser. Routing it \
+             through open_url dead-ends on a loopback node, where the shell's open_url \
+             handler refuses the host and the click does nothing at all (#5106)"
         );
         assert!(
-            block.contains("preventDefault"),
-            "same-origin new-window branch must preventDefault before forwarding (#5087)"
-        );
-        assert!(
-            block.contains("type: 'open_url'"),
-            "same-origin new-window branch must forward via open_url, not navigate (#5087)"
+            !block.contains("type: 'open_url'"),
+            "the same-origin new-window branch must not forward to open_url without a \
+             loopback fallback like the window.open override's isLoopbackHost check (#5106)"
         );
     }
 

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -1841,8 +1841,14 @@ const WEBSOCKET_SHIM_JS: &str = include_str!("path_handlers/assets/websocket_shi
 /// shell page, which opens it with a proper origin via `window.open`.
 ///
 /// Same-origin links with an explicit non-`_self` target are left to the
-/// browser so webapps that legitimately want multi-tab navigation within
-/// their own contract still work.
+/// browser, so webapps that want multi-tab navigation within their own
+/// contract get their tab. That tab inherits the sandbox, though, so it has
+/// an opaque origin: on a hosted node it can't read the per-user access key
+/// and dead-ends (#4645), and on WebKit it renders blank (#5087). #5089
+/// routed this branch through `open_url` to fix that and was reverted in
+/// #5106, because the bridge refuses loopback hosts and the click then did
+/// nothing at all on a local node. See the comment on that branch in
+/// `navigation_interceptor.js` for the full trade.
 ///
 /// The interceptor also overrides programmatic `window.open`: an app that opens
 /// a new tab from its own JS bypasses the click/auxclick listeners, and on a
@@ -6751,9 +6757,18 @@ mod tests {
 
         // The cross-origin branch must call preventDefault and send open_url,
         // not navigate.
+        //
+        // Match `e.preventDefault()` with the receiver and parens, not the bare
+        // word: this block also spans the same-origin branch's COMMENT, which
+        // discusses being "preventDefault-ed". A bare `preventDefault` needle is
+        // satisfied by that prose alone, so deleting the real call here would
+        // leave this river#208 / #3852 pin green while cross-origin
+        // `target="_blank"` went back to opening null-origin sandboxed popups.
+        // Verified by mutation: bare needle survives the deletion, this one does
+        // not.
         let cross_origin_block = &js[cross_origin_idx..target_attr_idx];
         assert!(
-            cross_origin_block.contains("preventDefault"),
+            cross_origin_block.contains("e.preventDefault()"),
             "cross-origin branch must preventDefault before opening popup"
         );
         assert!(
@@ -6849,9 +6864,10 @@ mod tests {
     /// correct — they pin today's behaviour, not a permanent invariant.
     /// Whoever lands it should replace this test, not weaken it. The first
     /// assertion is the load-bearing one; the second is a cheap belt-and-
-    /// braces check that a forward was not added ahead of the `return`
-    /// (anything added after it would be unreachable, so it catches less
-    /// than the first).
+    /// braces check. What it uniquely covers is a forward inserted BETWEEN
+    /// the `return` and the `navigate` postMessage — reachable code, just
+    /// for untargeted same-origin links rather than for this branch. A
+    /// forward ahead of the `return` is already caught by the first.
     #[test]
     fn navigation_interceptor_leaves_same_origin_target_blank_to_the_browser() {
         let js = NAVIGATION_INTERCEPTOR_JS;
@@ -6881,6 +6897,45 @@ mod tests {
              with a loopback fallback like the window.open override's isLoopbackHost \
              check, or after removing the sandbox inheritance — this test is pinning the \
              old behaviour and should be replaced, not deleted piecemeal"
+        );
+
+        // Both assertions above scope to the branch, which leaves an evasion:
+        // a re-route added as a SEPARATE EARLIER branch is outside the block
+        // entirely, so `find()` still lands on the untouched `_self` check and
+        // both pass while the bug is fully present. That is not contrived —
+        // "special-case `_blank`, leave named targets alone" is a plausible
+        // next attempt:
+        //
+        //     if (target.target === '_blank') { e.preventDefault(); /* open_url */ return; }
+        //     if (target.target && target.target !== '_self') return;
+        //
+        // So also pin the whole-handler count. `handleAnchorClick` must forward
+        // open_url from exactly ONE place: the cross-origin branch. Anything
+        // that adds a second forward, anywhere in the handler and under any
+        // condition, trips this.
+        //
+        // This is also what makes the asymmetry with `window.open` DELIBERATE
+        // rather than an accident of two reverts: the override below forwards
+        // same-origin new-window opens (#4645) and this handler does not. The
+        // anchor path pays #4645's dead-end on hosted nodes to avoid the
+        // loopback dead click (#5106); the override avoids both because it has
+        // an isLoopbackHost fallback. Whoever unifies them should make that
+        // choice on purpose, and will land here.
+        let handler_start = js
+            .find("function handleAnchorClick")
+            .expect("anchor click handler present");
+        let handler_end = js
+            .find("document.addEventListener('click'")
+            .expect("anchor click listener registration present");
+        let forwards = js[handler_start..handler_end]
+            .matches("type: 'open_url'")
+            .count();
+        assert_eq!(
+            forwards, 1,
+            "handleAnchorClick must forward open_url from exactly one place — the \
+             cross-origin branch (freenet/river#208). A second forward means a \
+             same-origin new-window re-route slipped in outside the branch this \
+             test's other assertions scope to (#5106)"
         );
     }
 
@@ -7170,7 +7225,12 @@ mod tests {
     /// #4846 is implemented as a rule (`h.startsWith('127.')`) on both sides,
     /// both literal sets shrink together and this test goes green without
     /// having checked the new rule. It catches one-sided literal drift — the
-    /// common case — not a symmetric refactor.
+    /// common case — not a symmetric refactor. Two more divergences it cannot
+    /// see, both of which keep identical literals: flipping `||` to `&&` on
+    /// one side (uncovered anywhere), and dropping the bracket-strip
+    /// normalization so `[::1]` stops matching (covered for the shell by
+    /// `shell_open_url_handler_blocks_ipv6_loopback`, and behaviourally for
+    /// the interceptor by window-open.spec.ts). Do not over-trust the parity.
     #[test]
     fn interceptor_loopback_list_matches_shell_open_url_refusal() {
         // Collect the host literals from each `h === '<host>'` comparison in a
@@ -7203,6 +7263,10 @@ mod tests {
             out
         }
 
+        // The `function ` prefix is load-bearing: the name `isLoopbackHost`
+        // also appears in prose in the same-origin branch's comment ABOVE the
+        // declaration, so anchoring on the bare name would slice from the
+        // comment and miss the helper entirely.
         let interceptor_fn_idx = NAVIGATION_INTERCEPTOR_JS
             .find("function isLoopbackHost")
             .expect("interceptor isLoopbackHost helper present");
@@ -7229,23 +7293,46 @@ mod tests {
             .expect("shell open_url loopback refusal returns");
         let shell_hosts = loopback_hosts(&rest[..refusal_end]);
 
-        // Guard against the comparison going vacuous: if a refactor renames the
-        // local or restructures the chain, both sides would extract nothing and
-        // the equality below would pass while guarding nothing (#5076).
-        assert!(
-            shell_hosts.contains(&"localhost".to_string()),
-            "extracted no loopback hosts from the shell open_url handler — the \
-             `h === '...'` chain moved or was renamed, so this test is no longer \
-             comparing anything. Re-anchor it. Got: {shell_hosts:?}"
-        );
+        // The two lists have OPPOSITE polarity, so a bare equality is not
+        // enough. The shell side is a SECURITY control: host in list ->
+        // refuse, which is what stops a contract forging an `open_url` at the
+        // viewer's own loopback services, the local node's API included (see
+        // `shell_open_url_handler_blocks_ipv6_loopback`, and note the handler
+        // deliberately does NOT block RFC1918 — loopback is the one network
+        // class it guards). The interceptor side blocks nothing at all: it is
+        // only a PREDICTION of the shell's refusal so `window.open` can fall
+        // back to native.
+        //
+        // So equality must never be reachable by SHRINKING the shell list.
+        // Drop `127.0.0.1`/`::1`/`0.0.0.0` from both and a bare assert_eq is
+        // green while `open_url` will happily open `http://127.0.0.1:7509/…`
+        // for any contract that asks. Pin a floor on the security side first,
+        // and make the equality message name the correct repair direction —
+        // someone red on #4846 otherwise has an easier wrong fix available
+        // (delete an arm) than the right one.
+        for host in ["localhost", "127.0.0.1", "::1", "0.0.0.0"] {
+            assert!(
+                shell_hosts.iter().any(|h| h == host),
+                "the shell's open_url refusal no longer covers `{host}` — or the \
+                 extraction above truncated, e.g. because the chain was split into \
+                 per-host `if (h === '…') return;` lines, which the `return;` bound \
+                 would cut short (check shell_bridge.js by eye). This list is a \
+                 security boundary. If you are here because the equality below went \
+                 red, the fix is to WIDEN isLoopbackHost in navigation_interceptor.js \
+                 — never to narrow this one. Got: {shell_hosts:?}"
+            );
+        }
         assert_eq!(
             interceptor_hosts, shell_hosts,
-            "isLoopbackHost and the shell's open_url loopback refusal have \
-             drifted. A host the shell refuses but the interceptor does not \
-             list makes window.open forward an open the shell then drops \
-             silently (#5106); the reverse forwards to a sandbox-inheriting \
-             native popup (#4645). Update both, or #4846 when completing the \
-             allow-list."
+            "isLoopbackHost and the shell's open_url loopback refusal have drifted \
+             (or a region bound truncated one of them — compare the two lists above \
+             before assuming drift). Correct repair direction: make \
+             navigation_interceptor.js's isLoopbackHost match shell_bridge.js, not \
+             the reverse. A host the shell refuses but the interceptor omits makes \
+             window.open forward an open the shell then drops silently (#5106); the \
+             reverse merely falls back to a sandbox-inheriting native popup (#4645). \
+             When completing the allow-list per #4846, widen BOTH, starting with the \
+             shell."
         );
     }
 

--- a/crates/core/src/server/path_handlers/assets/navigation_interceptor.js
+++ b/crates/core/src/server/path_handlers/assets/navigation_interceptor.js
@@ -71,17 +71,29 @@
     //
     // What this costs, so the next person prices it honestly: the tab the
     // browser opens inherits this frame's sandbox, so it has an opaque
-    // origin. On a HOSTED node that means it can't read the per-user access
-    // key and dead-ends on the "Open this app in a normal tab" panel, in
-    // every engine (#4645). On WebKit it renders blank (#5087). #5089 fixed
-    // both for this path as a side effect; reverting restores both.
+    // origin. Three consequences, not one:
+    //   1. On WebKit it renders blank (#5087).
+    //   2. On a HOSTED node it can't read the per-user access key and
+    //      dead-ends on the "Open this app in a normal tab" panel, in every
+    //      engine (#4645).
+    //   3. Its permission surface is dead, in every engine. An opaque origin
+    //      sends `Origin: null`, which the shell's endpoints reject; notably
+    //      `/permission/pending` answers 200 with an EMPTY LIST rather than
+    //      an error, so there is no console message and no failed request --
+    //      the prompt simply never appears. This bites hardest on a LOCAL
+    //      node in Firefox/Chrome, i.e. the case this branch is optimised
+    //      for: the app frame loads fine, so it looks like it works.
+    // (3) is not introduced here -- the window.open loopback fallback below
+    // already yields the same opaque-origin tab on a local node. #5089 fixed
+    // all three for this path as a side effect; reverting restores them.
     //
     // Two constraints on any future fix. Do not re-route through the bridge
     // without a loopback fallback. And `allow-popups-to-escape-sandbox` on
     // the app iframe -- the obvious alternative -- was deliberately REMOVED
-    // by #1499: an escaped popup gains the node's real origin, letting a
-    // malicious app reach other apps' data and bypass permission prompts
-    // (pinned by a test in path_handlers.rs). That road has to answer #1499.
+    // by #3818 (motivated by #1499): an escaped popup gains the node's real
+    // origin, letting a malicious app reach other apps' data and bypass
+    // permission prompts. Its absence is pinned by a test in
+    // path_handlers.rs. That road has to answer #3818.
     if (target.target && target.target !== '_self') return;
     // Same-origin in-contract link: request navigation via shell
     e.preventDefault();

--- a/crates/core/src/server/path_handlers/assets/navigation_interceptor.js
+++ b/crates/core/src/server/path_handlers/assets/navigation_interceptor.js
@@ -52,24 +52,36 @@
       );
       return;
     }
-    // Same-origin link. Respect explicit non-_self targets so webapps
-    // that open multiple tabs within their own contract still work.
+    // Same-origin link with an explicit non-_self target: hand it back to the
+    // browser. That is NOT cost-free -- see "what this costs" below -- but it
+    // is the lesser of the two failures currently available.
     //
-    // #5089 routed this branch through `open_url` too, to fix a Safari-only
-    // blank tab (#5087), and is reverted here (#5106) because that trade was
-    // net-negative:
+    // #5089 routed this branch through `open_url` instead, to fix a blank tab
+    // (#5087). Reverted in #5106 because that trade was net-negative:
     //   - The shell's `open_url` handler REFUSES loopback hosts
-    //     (localhost / 127.0.0.1 / ::1 / 0.0.0.0). On a local node -- how
-    //     most desktop users browse -- forwarding meant the click was
-    //     preventDefault-ed and then silently dropped: nothing happened at
-    //     all, in every engine. The `window.open` override below avoids this
-    //     by falling back to native for loopback hosts; this branch had no
-    //     such fallback.
+    //     (localhost / 127.0.0.1 / ::1 / 0.0.0.0), which is exactly where a
+    //     local node is reached. Forwarding meant the click was
+    //     preventDefault-ed and then silently dropped by the shell: nothing
+    //     happened at all, in every engine. The window.open override below
+    //     avoids precisely this by falling back to native for loopback hosts
+    //     (isLoopbackHost); this branch had no such fallback.
     //   - The blank tab it fixed reproduces only in WebKit. Gecko and Blink
     //     load the app frame fine from the opaque-origin shell, so Firefox
     //     and Chrome users were traded a working tab for a dead click.
-    // Do not re-route this branch without a loopback fallback; the real fix
-    // is expected to be `allow-popups-to-escape-sandbox` on the app iframe.
+    //
+    // What this costs, so the next person prices it honestly: the tab the
+    // browser opens inherits this frame's sandbox, so it has an opaque
+    // origin. On a HOSTED node that means it can't read the per-user access
+    // key and dead-ends on the "Open this app in a normal tab" panel, in
+    // every engine (#4645). On WebKit it renders blank (#5087). #5089 fixed
+    // both for this path as a side effect; reverting restores both.
+    //
+    // Two constraints on any future fix. Do not re-route through the bridge
+    // without a loopback fallback. And `allow-popups-to-escape-sandbox` on
+    // the app iframe -- the obvious alternative -- was deliberately REMOVED
+    // by #1499: an escaped popup gains the node's real origin, letting a
+    // malicious app reach other apps' data and bypass permission prompts
+    // (pinned by a test in path_handlers.rs). That road has to answer #1499.
     if (target.target && target.target !== '_self') return;
     // Same-origin in-contract link: request navigation via shell
     e.preventDefault();

--- a/crates/core/src/server/path_handlers/assets/navigation_interceptor.js
+++ b/crates/core/src/server/path_handlers/assets/navigation_interceptor.js
@@ -52,29 +52,25 @@
       );
       return;
     }
-    // Same-origin link with an explicit new-window target. A popup opened
-    // natively from this frame INHERITS the sandbox (the shell iframe has no
-    // `allow-popups-to-escape-sandbox`, deliberately -- see #1499), so the
-    // top-level shell it lands on has an opaque origin and its own
-    // `frame-src 'self'` can never match: the app frame stays about:blank and
-    // the tab renders empty. Every cross-CONTRACT link is same-ORIGIN, so the
-    // old blanket exemption here swallowed exactly the breaking case. Route
-    // through the shell instead, as the cross-origin branch above does; this
-    // mirrors the window.open override below, which already forwards
-    // same-origin new-window opens.
-    if (target.target && target.target !== '_self') {
-      e.preventDefault();
-      window.parent.postMessage(
-        {
-          __freenet_shell__: true,
-          type: 'open_url',
-          url: target.href,
-          shiftKey: !!e.shiftKey,
-        },
-        '*',
-      );
-      return;
-    }
+    // Same-origin link. Respect explicit non-_self targets so webapps
+    // that open multiple tabs within their own contract still work.
+    //
+    // #5089 routed this branch through `open_url` too, to fix a Safari-only
+    // blank tab (#5087), and is reverted here (#5106) because that trade was
+    // net-negative:
+    //   - The shell's `open_url` handler REFUSES loopback hosts
+    //     (localhost / 127.0.0.1 / ::1 / 0.0.0.0). On a local node -- how
+    //     most desktop users browse -- forwarding meant the click was
+    //     preventDefault-ed and then silently dropped: nothing happened at
+    //     all, in every engine. The `window.open` override below avoids this
+    //     by falling back to native for loopback hosts; this branch had no
+    //     such fallback.
+    //   - The blank tab it fixed reproduces only in WebKit. Gecko and Blink
+    //     load the app frame fine from the opaque-origin shell, so Firefox
+    //     and Chrome users were traded a working tab for a dead click.
+    // Do not re-route this branch without a loopback fallback; the real fix
+    // is expected to be `allow-popups-to-escape-sandbox` on the app iframe.
+    if (target.target && target.target !== '_self') return;
     // Same-origin in-contract link: request navigation via shell
     e.preventDefault();
     window.parent.postMessage(

--- a/crates/core/src/server/path_handlers/assets/shell_bridge.js
+++ b/crates/core/src/server/path_handlers/assets/shell_bridge.js
@@ -1197,7 +1197,18 @@ function freenetBridge(authToken, userToken, hostedMode) {
         // window.open override (#4645). Popups the sandboxed iframe opens
         // itself inherit the opaque origin, breaking CORS on target sites and
         // (hosted) losing the per-user key. The shell opens the URL instead,
-        // giving proper origin. See issue #1499.
+        // giving proper origin. See PR #3818, which removed the popup
+        // sandbox-escape flag from the app iframe and introduced this bridge
+        // in its place. (This cited "#1499" until #5107; that is the
+        // delegate-user-interaction feature request which motivated #3818,
+        // not the hardening itself.)
+        //
+        // Deliberately NOT naming that flag in full here: this file is
+        // inlined verbatim into the shell page, and
+        // `shell_page_contains_iframe_and_bridge` asserts the rendered page
+        // does not contain the flag name anywhere — a comment mentioning it
+        // fails that test. Fail-safe (a false alarm, not a silent pass), but
+        // do not "fix" it by loosening the assertion.
         //
         // Security model: this scheme allow-list is the PRIMARY gate, not
         // defence in depth. A malicious contract iframe can postMessage

--- a/crates/core/src/server/path_handlers/assets/shell_bridge.js
+++ b/crates/core/src/server/path_handlers/assets/shell_bridge.js
@@ -1233,6 +1233,14 @@ function freenetBridge(authToken, userToken, hostedMode) {
         // comments included (external-origin / CORS guard). The live URL
         // lives in scripts/check-endpoints.sh.
         //
+        // Same hazard, same test, second string: do not write the popup
+        // sandbox-escape flag's full name in this file either. That test also
+        // asserts the rendered page never contains it, to prove it is not set
+        // on the iframe. Writing it in a comment fails the test — which is
+        // easy to walk into, since naming the flag is the natural instinct
+        // when documenting why it is absent. It happened in #5107. See the
+        // note in the open_url handler above.
+        //
         // Private networks (RFC1918 192.168/16, 10/8, 172.16-31/12 and
         // RFC4193 fc00::/7, link-local fe80::/10) are deliberately NOT
         // blocked. A user who pastes a link to their home router or NAS

--- a/crates/core/tests/playwright/fixture-webapp/index.html
+++ b/crates/core/tests/playwright/fixture-webapp/index.html
@@ -59,6 +59,21 @@
 -->
 <a id="download-link" href="page2.html" download="hello.txt">Download</a>
 
+<!--
+  Same-origin link carrying an explicit new-window target. The interceptor must
+  NOT intercept this: it early-returns on a non-`_self` target and hands the
+  click back to the browser (freenet/freenet-core#5106).
+
+  #5089 routed this branch through the shell's `open_url` bridge instead. That
+  bridge refuses loopback hosts, and a real local node is served from
+  `127.0.0.1`/`localhost`, so the click was preventDefault-ed and then dropped:
+  nothing opened at all. Note the E2E node here binds `127.x.y.1`, which is NOT
+  in that refusal list (#4846), so the popup outcome cannot distinguish the two
+  behaviours in this harness — the test asserts the interception contract (no
+  postMessage) instead, which does.
+-->
+<a id="same-origin-blank-link" href="page2.html" target="_blank">In-contract page 2, new tab</a>
+
 <!-- Result sink the Playwright tests read via page.evaluate. -->
 <pre id="poll-result">pending</pre>
 

--- a/crates/core/tests/playwright/tests/shell.spec.ts
+++ b/crates/core/tests/playwright/tests/shell.spec.ts
@@ -303,7 +303,14 @@ test("same-origin link with target=_blank is NOT intercepted (#5106)", async ({ 
   // both clicks in ONE document is strictly stronger — it proves the listener
   // was live in the very document the negative assertion is made about.
 
-  // (1) The subject: must open a tab natively.
+  // (1) The subject: the interceptor must NOT cancel the click, so the click
+  // reaches the browser and a popup is created.
+  //
+  // Read this as "the interceptor did not preventDefault", not as "a real user
+  // gets a tab" — Playwright leaves Chromium's popup blocker off, so a popup
+  // here does not establish what a blocker-on user sees. Whether the browser
+  // ultimately grants the tab is the browser's business; what this pins is that
+  // the decision was left to it.
   const [popup] = await Promise.all([
     page.waitForEvent("popup"),
     frame.locator("#same-origin-blank-link").click(),
@@ -311,7 +318,7 @@ test("same-origin link with target=_blank is NOT intercepted (#5106)", async ({ 
   await popup.waitForLoadState("domcontentloaded");
   expect(
     popup.url(),
-    `target="_blank" must open the linked page itself; got ${popup.url()}`,
+    `target="_blank" must reach the browser and resolve to the link's own href; got ${popup.url()}`,
   ).toContain("page2.html");
 
   // (2) Control, in the SAME document: the same href WITHOUT a new-window
@@ -321,7 +328,10 @@ test("same-origin link with target=_blank is NOT intercepted (#5106)", async ({ 
   // simply having raced ahead of a late delivery.
   await frame.locator("#same-origin-link").click();
   await expect
-    .poll(async () => (await shellMessages(page)).map((m) => m.type))
+    .poll(async () => (await shellMessages(page)).map((m) => m.type), {
+      message:
+        'exactly one message expected: the control click\'s `navigate`. An extra `open_url` means the target="_blank" click was intercepted (#5089); no messages at all means the interceptor never ran, so the negative half of this test would have been vacuous',
+    })
     .toEqual(["navigate"]);
 });
 

--- a/crates/core/tests/playwright/tests/shell.spec.ts
+++ b/crates/core/tests/playwright/tests/shell.spec.ts
@@ -271,6 +271,51 @@ test("a link carrying a download attribute is NOT intercepted", async ({ page })
   ).toEqual([]);
 });
 
+test("same-origin link with target=_blank is NOT intercepted (#5106)", async ({ page }) => {
+  await page.goto(shellUrl!);
+  await captureShellMessages(page);
+  const frame = await fixtureFrame(page);
+
+  // `#same-origin-blank-link` is the SAME href as `#same-origin-link`
+  // (page2.html) plus `target="_blank"`. The interceptor early-returns on a
+  // non-`_self` target, so the click must produce NO interception postMessage
+  // — neither `navigate` nor `open_url` — and the browser opens the tab itself.
+  //
+  // #5089 made this branch post `open_url` instead. On a real local node
+  // (`127.0.0.1`/`localhost`) the shell's open_url handler refuses the host, so
+  // the click was cancelled and then silently dropped: no tab, no error. This
+  // harness's node binds `127.x.y.1`, which is not in that refusal list
+  // (#4846), so asserting on the popup would pass either way. Asserting on the
+  // postMessage contract is what actually distinguishes the two.
+  //
+  // Same delta-based shape as the download-link test above, and for the same
+  // reason: the click may natively load page2 and tear down the in-iframe
+  // listeners, so the control click has to come first.
+
+  // (1) Control: the same element minus `target` IS intercepted → the listener
+  // is live and the selector is wired correctly, so a later empty capture is
+  // attributable to the target attribute and not to a dead listener.
+  await frame.locator("#same-origin-blank-link").evaluate((el) => el.removeAttribute("target"));
+  await frame.locator("#same-origin-blank-link").click();
+  await expect
+    .poll(async () => (await shellMessages(page)).map((m) => m.type))
+    .toContain("navigate");
+
+  // (2) Reload to restore the original DOM (with `target="_blank"`) and a
+  // fresh capture buffer, then click the unmodified link.
+  await page.goto(shellUrl!);
+  await captureShellMessages(page);
+  const frame2 = await fixtureFrame(page);
+  await frame2.locator("#same-origin-blank-link").click();
+  // Give any (erroneous) interception postMessage a tick to arrive.
+  await page.waitForTimeout(300);
+  const types = (await shellMessages(page)).map((m) => m.type);
+  expect(
+    types,
+    `same-origin target="_blank" must not be intercepted, but got messages: ${types.join(", ")}`,
+  ).toEqual([]);
+});
+
 test("browser Back restores the previous subpage via the popstate handler (#3839)", async ({
   page,
 }) => {

--- a/crates/core/tests/playwright/tests/shell.spec.ts
+++ b/crates/core/tests/playwright/tests/shell.spec.ts
@@ -278,42 +278,51 @@ test("same-origin link with target=_blank is NOT intercepted (#5106)", async ({ 
 
   // `#same-origin-blank-link` is the SAME href as `#same-origin-link`
   // (page2.html) plus `target="_blank"`. The interceptor early-returns on a
-  // non-`_self` target, so the click must produce NO interception postMessage
-  // — neither `navigate` nor `open_url` — and the browser opens the tab itself.
+  // non-`_self` target, so the click must (a) open a real tab, because the
+  // browser handles it, and (b) produce NO interception postMessage.
   //
-  // #5089 made this branch post `open_url` instead. On a real local node
-  // (`127.0.0.1`/`localhost`) the shell's open_url handler refuses the host, so
-  // the click was cancelled and then silently dropped: no tab, no error. This
-  // harness's node binds `127.x.y.1`, which is not in that refusal list
-  // (#4846), so asserting on the popup would pass either way. Asserting on the
-  // postMessage contract is what actually distinguishes the two.
+  // BOTH halves are load-bearing, and asserting only (b) was the first version
+  // of this test's mistake. A regression of the shape
   //
-  // Same delta-based shape as the download-link test above, and for the same
-  // reason: the click may natively load page2 and tear down the in-iframe
-  // listeners, so the control click has to come first.
+  //     if (target.target && target.target !== '_self') { e.preventDefault(); return; }
+  //
+  // — cancel, forward nothing — posts no message either, so (b) alone stays
+  // green on it. That shape IS #5106's user-visible symptom: the dead click.
+  // (a) is what actually catches it.
+  //
+  // Conversely (b) is what catches #5089, which posted `open_url` here. On a
+  // real local node the shell's open_url handler refuses the loopback host and
+  // drops it, so nothing opened; this harness's node binds `127.x.y.1`, which
+  // is NOT in that refusal list (#4846), so under #5089 a tab would still open
+  // here and (a) alone would not distinguish it. Neither assertion subsumes
+  // the other — keep both.
+  //
+  // Unlike the download-link test above, no reload is needed between the
+  // subject click and its control: `target="_blank"` opens a NEW browsing
+  // context, so this document and its injected listener survive intact. Doing
+  // both clicks in ONE document is strictly stronger — it proves the listener
+  // was live in the very document the negative assertion is made about.
 
-  // (1) Control: the same element minus `target` IS intercepted → the listener
-  // is live and the selector is wired correctly, so a later empty capture is
-  // attributable to the target attribute and not to a dead listener.
-  await frame.locator("#same-origin-blank-link").evaluate((el) => el.removeAttribute("target"));
-  await frame.locator("#same-origin-blank-link").click();
+  // (1) The subject: must open a tab natively.
+  const [popup] = await Promise.all([
+    page.waitForEvent("popup"),
+    frame.locator("#same-origin-blank-link").click(),
+  ]);
+  await popup.waitForLoadState("domcontentloaded");
+  expect(
+    popup.url(),
+    `target="_blank" must open the linked page itself; got ${popup.url()}`,
+  ).toContain("page2.html");
+
+  // (2) Control, in the SAME document: the same href WITHOUT a new-window
+  // target is intercepted as `navigate`. This is a happens-after barrier for
+  // the subject click too — any postMessage it wrongly sent is a message the
+  // shell received before this one, so the exact-equality below cannot pass by
+  // simply having raced ahead of a late delivery.
+  await frame.locator("#same-origin-link").click();
   await expect
     .poll(async () => (await shellMessages(page)).map((m) => m.type))
-    .toContain("navigate");
-
-  // (2) Reload to restore the original DOM (with `target="_blank"`) and a
-  // fresh capture buffer, then click the unmodified link.
-  await page.goto(shellUrl!);
-  await captureShellMessages(page);
-  const frame2 = await fixtureFrame(page);
-  await frame2.locator("#same-origin-blank-link").click();
-  // Give any (erroneous) interception postMessage a tick to arrive.
-  await page.waitForTimeout(300);
-  const types = (await shellMessages(page)).map((m) => m.type);
-  expect(
-    types,
-    `same-origin target="_blank" must not be intercepted, but got messages: ${types.join(", ")}`,
-  ).toEqual([]);
+    .toEqual(["navigate"]);
 });
 
 test("browser Back restores the previous subpage via the popstate handler (#3839)", async ({

--- a/crates/core/tests/playwright_shell.rs
+++ b/crates/core/tests/playwright_shell.rs
@@ -295,7 +295,8 @@ fn run_playwright(shell_url: &str) -> anyhow::Result<()> {
 // Budget: the harness times the WHOLE test, including the `fdev website
 // publish` step (which can burn its full ~90s single-shot Put timeout before
 // the insert lands — see `website_publish_observed`), the shell-readiness poll
-// (up to 120s), and the Playwright suite (~70s for 7 specs). An observed local
+// (up to 120s), and the Playwright suite (~70s for the 9 specs in
+// shell.spec.ts, plus the two node-free suites). An observed local
 // run finished in ~282s, so 300s left almost no slack on a contended runner;
 // 600s gives comfortable headroom without masking a genuine hang (the
 // individual sub-steps have their own tighter internal deadlines).


### PR DESCRIPTION
Fixes #5106. Reverts the JS change from #5089; reopens #5087.

Reverting at @sanity's direction (raised offline, not on an issue): more Firefox users than Safari users are likely affected, so undo #5089 for now while a safer fix is worked out.

## Why

#5089 stopped same-origin `<a target="_blank">` from falling through to the browser and routed it through the shell's `open_url` bridge instead, to fix a blank tab (#5087). On a **loopback** node that turns the click into nothing at all. The shell's `open_url` handler refuses loopback hosts:

```js
if (h === 'localhost' || h === '127.0.0.1' || h === '::1' || h === '0.0.0.0') return;
```

`127.0.0.1:7509` is the documented local path — all three platforms print `Open http://127.0.0.1:7509/ in your browser` on service start (`service/linux.rs:809`, `service/macos.rs:753`, `service/windows.rs:170`), and it is what the tray and setup wizard open (`DASHBOARD_URL`, `service.rs:199`). So the interceptor `preventDefault`s the navigation and the shell then drops the message: no tab, no error, no feedback.

The `window.open` override further down **`navigation_interceptor.js`** never had this hole — it checks `isLoopbackHost` and falls back to native precisely so a forwarded open can't be silently swallowed. The anchor branch #5089 added has no such fallback.

## Evidence

I drove the real `navigation_interceptor.js` in a harness reproducing the shell faithfully: real `SHELL_PAGE_CSP` and `sandbox_csp_for_origin` served as headers, interceptor inlined as `path_handlers.rs:1746` does, one origin serving both "contracts", top-level app-document load redirected to the shell.

| engine | interceptor | host | popup? | popup origin | app iframe loaded? |
|---|---|---|---|---|---|
| Firefox  | pre-#5089 | routable | 1 | `null` (opaque) | **YES** |
| Firefox  | #5089     | routable | 1 | real origin     | YES |
| Firefox  | pre-#5089 | loopback | 1 | `null` (opaque) | **YES** |
| Firefox  | #5089     | loopback | **0** | — | — |
| Chromium | pre-#5089 | routable | 1 | `null` (opaque) | **YES** |
| Chromium | #5089     | routable | 1 | real origin     | YES |
| Chromium | pre-#5089 | loopback | 1 | `null` (opaque) | **YES** |
| Chromium | #5089     | loopback | **0** | — | — |
| WebKit   | pre-#5089 | routable | 1 | `null` (opaque) | **NO** |
| WebKit   | #5089     | routable | 1 | real origin     | YES |
| WebKit   | pre-#5089 | loopback | 1 | `null` (opaque) | **NO** |
| WebKit   | #5089     | loopback | **0** | — | — |

The `0` rows are the regression: the bridge logged `REFUSED_LOOPBACK` and no window was ever opened. The WebKit rows record `frame-src <- http://<host>` in the popup and an empty app frame; Gecko and Blink record no violation and load the frame from the same opaque origin. All twelve rows were independently reproduced by a second, higher-fidelity harness during review, including on a non-loopback, non-secure-context address (`172.17.0.1`), so the WebKit result is not a 127/8 secure-context artifact.

**Correction to an earlier version of this description.** I originally attributed #5089's clean harness result to Playwright disabling popup blocking by default. Review re-ran the full matrix with blockers on *and* off: all twelve cells are identical, and the `0` rows are `REFUSED_LOOPBACK`, not blocked popups. Popup blocking is irrelevant to everything measured here, and I have no evidence for why the original harness missed it. (Also: my harness's launcher does not apply the blocker flag to WebKit at all, so "blockers on in all three engines" was wrong as stated — it was on in Firefox and Chromium.)

## What the revert costs

Stating this plainly, because my first draft priced it as "a WebKit-only blank tab" and that was wrong on three counts. Blind review caught all three.

The tab the browser opens inherits the app frame's sandbox, so it has an opaque origin. That has **three** consequences:

1. **WebKit renders it blank** (#5087) — for every Safari user, on every host, not just loopback.
2. **On a hosted node it dead-ends in every engine** (#4645). An opaque origin can't read the per-user access key from localStorage, so the tab lands on the "Open this app in a normal tab" panel. `shell_bridge.js:80` names the trigger explicitly — "window.open, or a `target=_blank` link" — and `localStorage` throws `SecurityError` in an opaque origin in Gecko, Blink and WebKit alike (measured in all three during review). #4645 has been annotated.
3. **The permission surface is dead in that tab, in every engine — and this is the one that bites the users this PR is *for*.** From an opaque origin the tab sends `Origin: null` (and `Sec-Fetch-Site: cross-site`), and all three permission endpoints deny it: `/permission/events` via `is_origin_trusted` (`permission_prompts.rs:586-590`), `/permission/{nonce}/respond` with a 403, and `/permission/pending` — the polling fallback — with **HTTP 200 and an empty list**. That last one is why it is invisible: no console error, no failed request, just an overlay that never appears. #5087's trace shows the endpoints being refused.

   The sharp version: on a *hosted* node the app frame never loads anyway, so there is no app to request a permission. On a **local node in Firefox or Chrome** — precisely the users the revert buys a working tab for — the app frame loads fine, the delegate requests permission, and the prompt silently never appears. That is what "app iframe loaded? YES" in the table above is hiding.

   Two honest qualifiers: this is deliberate and fail-closed (a sandboxed iframe on any site can present `Origin: null`, so the permission surface always requires a real one — `permission_prompts.rs:578-590` says so). And it is not *introduced* by this PR: the `window.open` override's own loopback fallback already produces this same opaque-origin tab on a local node today. The revert restores the cost for anchors too.

Also: `target="_top"` and `target="_parent"` anchors match this branch too. The sandbox denies the in-place top-navigation they ask for (no `allow-top-navigation`) in every engine, and post-revert Gecko and Blink then do nothing at all — a dead click, by this PR's own standard. **WebKit is different**: it converts the denied navigation into a popup, so those clicks still land somewhere there. (Measured across 5 runs; an earlier draft said "blocked outright, both engines", which was true of the two I had tested and false in the third. **If you re-measure, wait >2.5s** — the WebKit popup does not register within ~2s, and a short wait reports zero, which is how the wrong version got written.)

Under #5089 all three opened a new tab. To be precise about what that was and wasn't: no top-level navigation happened in any engine or either version, so **no sandbox restriction was bypassed** — `allow-popups` permits the tab. #5089 simply made `_top`/`_parent` behave like `_blank`, silently changing the semantics. An earlier draft of this section called it converting a sandbox-denied navigation into an action the sandbox had refused; that read as a sandbox escape and was wrong.

#5089 fixed 1, 2 and 3 for the anchor path as a side effect. Reverting restores all three.

## The alternative this PR declines, and why you may want it instead

Two independent reviewers converged on the same point, so it belongs in the description rather than a comment: **mirroring `isLoopbackHost` in the anchor branch is strictly better than either #5089 or this revert.** Return natively on a loopback host, forward otherwise. That keeps every one of #5089's wins, removes the dead click entirely, and is no worse than the revert anywhere (WebKit-on-loopback stays blank either way). `isLoopbackHost` is a hoisted declaration in the same IIFE, already in scope for `handleAnchorClick` — it is a few lines inside the hunk this PR is already editing.

It matters that #5087's actual reporter was **not** on loopback: their trace reads `"origin": "http://10.44.101.1:7509"`, and #5089 records them confirming the fix worked. So #5089's benefit landed in exactly the configuration the revert takes away, and the loopback dead click never affected them. That also means the claim "loopback is how most desktop users browse" — which I asserted in #5106 — is unsupported; `127.0.0.1` is the *documented* path, but the ws-API default bind is `::` (all interfaces, `config.rs:2510`), so LAN access works out of the box and at least one real user was using it.

This PR reverts anyway because @sanity asked for the revert first and is working on the real fix. Recording it here so the choice is visible as **declined for sequencing**, not unavailable. Reverting leaves both #5087 and #5106 open.

## Change

- `navigation_interceptor.js`: the same-origin non-`_self` branch is `return` again — byte-identical to pre-#5089 apart from the comment, which now records the costs above and the two constraints on any future fix.
- `path_handlers.rs`: #5089's regression test is replaced by `navigation_interceptor_leaves_same_origin_target_blank_to_the_browser`. Besides pinning the branch from both sides, it asserts `handleAnchorClick` forwards `open_url` from exactly **one** place — without that, a re-route added as a separate earlier branch (`if (target.target === '_blank') { … }`) evades both branch-scoped assertions while the bug is fully present. Mutation-verified. That whole-handler count is also what makes the anchor-vs-`window.open` asymmetry deliberate rather than an accident of two reverts.
- `shell.spec.ts` + fixture: a behavioral regression test in a real browser. It asserts **both** that the interceptor leaves the click to the browser (a popup is created, at the link's own href) and that no interception postMessage is sent — neither subsumes the other. Note the first half pins "the interceptor did not cancel it", not "a real user gets a tab": Playwright leaves Chromium's popup blocker off, so it cannot speak to what a blocker-on user sees. Asserting only the postMessage (my first version) stays green on `{ e.preventDefault(); return; }`, which *is* #5106's dead click; asserting only the popup stays green under #5089, because this harness's node binds `127.x.y.1` and so is not in the refusal list (#4846). Both clicks now happen in one document, so the control proves the listener was live in the document the negative assertion is about.

## About the second commit

Being explicit, because the framing in its commit message was too generous and review called it: `interceptor_loopback_list_matches_shell_open_url_refusal` is **independent hardening, not a regression test for this bug**. It passes identically on `origin/main` — this PR does not modify either loopback list. The behavioral regression test for #5106 is the Playwright one.

It is here partly because the `fix:`-needs-a-test CI gate counts `#[test]` attributes in added `.rs` lines only, and the first commit's `#[test]` line survived as diff context, so the gate failed with a genuine new test present. The gate also cannot see the `.test.mjs` / `.ts` suites (#5096). That said, it earns its place on merit: `isLoopbackHost`'s own comment claims the two lists are "kept in sync" with nothing enforcing it, #4846 proposes changing one of them, and a one-sided change reproduces the silent-drop failure this PR is about. It lifts out cleanly as its own PR if a maintainer prefers.

Per review it now also pins a **floor** on the shell-side list rather than bare equality: that list is a security control (it is what stops a contract forging an `open_url` at the viewer's own loopback services), while `isLoopbackHost` blocks nothing and is only a prediction of it. A bare `assert_eq!` is satisfiable by shrinking *both*, which would be green while opening a real hole. The failure messages now name the correct repair direction.

Writing it also surfaced a pre-existing defect: the sibling `shell_open_url_handler_*` tests bound their scraped region with the next `} else if`, but `open_url` is the **last** arm of that chain, so the bound falls through to `unwrap_or(rest.len())` and their region is the entire rest of the file — 32499 bytes (my commit message says 32469, which is the *character* count; `str::len()` is bytes, and the region contains 15 non-ASCII chars). A stray `h === 'string'` lives inside it. My first draft of the new test inherited the bug. Reported on #5076 rather than fixed here.

## Tests

`Shell Playwright E2E` was green on `3227b5610` and `3c2903def`, with the new test running in both (`✓ 8 … same-origin link with target=_blank is NOT intercepted (#5106)`, 19 passed). It must be re-confirmed on the current head before merge, per the per-SHA rule — the head has moved since, and the later commits are not comment-only.

Locally: all `navigation_interceptor_*`, `interceptor_loopback_*`, `shell_open_url_*` and `shell_page_*` tests pass. Prettier + ESLint clean on the served assets.

Non-vacuity, verified rather than assumed: under #5089's JS the Rust test's first assertion finds `!== '_self') {` instead of `return` and its second finds `type: 'open_url'` in the branch, so both fail; the Playwright test's `toEqual([])` sees `["open_url"]`.

## What this does not change

- The iframe `sandbox` attribute is untouched; `allow-popups-to-escape-sandbox` stays absent and the pin on its absence stays green. Note for anyone reading the comments: that flag was *deliberately removed* by PR #3818 (`ec140e09c`), because an escaped popup gains the node's real origin and can then reach other apps' data and bypass permission prompts. Any fix down that road has to answer #3818 — the code comments now say so, since comments outlive PR descriptions.
- The cross-origin branch (freenet/river#208) and the `window.open` override are untouched. Review confirmed by measurement that the revert does not weaken #3818's hardening, river#208/#3852, #3853/#3854, or GHSA-824h-7x5x-wfmf, and that no contract-side trick (`<base href>`, `document.domain`, credentialed URLs, exotic schemes) can steer a cross-origin URL into the restored branch — `<base href>` moves links the *safe* way, into the cross-origin path.

## One citation corrected beyond the revert

`allow-popups-to-escape-sandbox` was removed by **PR #3818** (`ec140e09c`, "browser-based permission prompts with iframe security hardening"). The existing comments cite **#1499**, which is the *delegate-user-interaction feature request* that motivated it — it says nothing about sandbox flags, and there is no PR #1499. #3818 is also the commit that wrote the original "#1499" pointer, so the error is as old as the code.

I corrected the two pre-existing sites (`path_handlers.rs` assertion + comment, `shell_bridge.js` open_url header) rather than adding a correct citation next to broken ones, since this PR's whole argument leans on that reasoning and sends readers to it twice. Comment-only, and each notes what it used to say so the change is auditable.

[AI-assisted - Claude]
