### PR TITLE
fix(ring): retain peer summaries across disconnect-grace interest removal

### DIFF
--- a/crates/core/src/node/network_bridge/broadcast_queue.rs
+++ b/crates/core/src/node/network_bridge/broadcast_queue.rs
@@ -1215,13 +1215,23 @@ pub(super) async fn broadcast_to_single_peer(
             // peer (`interested_peers`), not evidence from it. So a wedged but
             // still-connected peer whose cached summary happens to match ours
             // gets refreshed indefinitely, where the TTL previously reaped it.
-            // Two backstops bound that: disconnect drops the entry outright
-            // (`InterestManager::remove_peer`), and the peer's own ~5-min
-            // `Interests` heartbeat is a full REPLACE (node.rs), so an entry the
-            // peer no longer claims is removed regardless of how recently we
-            // refreshed it. TTL expiry is therefore not the mechanism that
-            // reaps a live-but-wedged peer, and using it as one costs every
+            // Two backstops bound that: the disconnect-grace teardown drops the
+            // entry (`InterestManager::execute_pending_removals`), and the peer's
+            // own ~5-min `Interests` heartbeat is a full REPLACE (node.rs), so an
+            // entry the peer no longer claims is removed regardless of how
+            // recently we refreshed it. TTL expiry is therefore not the mechanism
+            // that reaps a live-but-wedged peer, and using it as one costs every
             // converged peer its updates.
+            //
+            // The first backstop is now PARTIAL, and deliberately so. The
+            // teardown preserves the cached summary across the disconnect when
+            // the PEER asserted it (`retain_summary_for_disconnect`), so a
+            // reconnecting peer can be sent a delta instead of a full state. It
+            // still drops a `SelfAssumed` belief — the one this comment is about,
+            // written by `record_delivery_to_interest` below on sender-side send
+            // completion and therefore wrong exactly when a stream tail is lost.
+            // That is the case where a matching-but-wrong belief makes this skip
+            // silent, so that case keeps its unconditional repair.
             //
             // Refresh ONLY. Do not cache the summary or record delivery
             // telemetry here: nothing was delivered, and `sent_delta` has no

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -2202,6 +2202,7 @@ impl Ring {
                     tel,
                     shadow,
                     eff: telemetry.network_efficiency_delivery,
+                    retain: lifecycle.retained_summaries,
                 });
             }
 

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -169,6 +169,54 @@ const MISSING_SUMMARY_HISTORY_SIZE: usize = 65536;
 /// speculatively.
 const MISSING_SUMMARY_ACTIVE_SIZE: usize = 256;
 
+/// How long a summary preserved across a disconnect-grace removal stays usable.
+///
+/// Deliberately equal to [`INTEREST_TTL`]: a LIVE interest entry can already
+/// carry a summary this old before the sweep expires it (nothing refreshes the
+/// cached summary itself — `refresh_peer_interest` only bumps the TTL), so a
+/// retained summary is never staler than a belief the broadcast path already
+/// acts on today. Bounding it makes the added staleness explicit rather than
+/// open-ended.
+const RETAINED_SUMMARY_TTL: Duration = INTEREST_TTL;
+
+/// Max (contract, peer) pairs whose summary survives a disconnect-grace removal.
+///
+/// The key is peer-controlled (a remote peer picks which contracts it registers
+/// interest in, and disconnecting is free), so this MUST be bounded — see the
+/// per-key-collection rule in `.claude/rules/code-style.md`. LRU eviction fails
+/// SAFE: forgetting a retained summary only restores today's behaviour for that
+/// pair (one full-state send), it never produces a wrong delta.
+///
+/// Sized against the fleet rather than guessed: the 0.2.118 outbound rollup
+/// (`interest_sync_summaries_*`, 1,414 peers, 228M entries) measured a **262-byte
+/// mean per `Summaries` entry**, so this cap costs ~4.3 MB at the typical size
+/// and the byte budget below bounds the atypical one. As with
+/// [`MISSING_SUMMARY_HISTORY_SIZE`], the resize signal is the visible overflow
+/// counter (`NetworkEfficiencyV1::retain`, `Evicted` slot), not a re-derivation
+/// from first principles: a saturated LRU of this shape evicts continuously, so
+/// that counter reports steady-state pressure, never reaching zero at any finite
+/// cap.
+const RETAINED_SUMMARY_CACHE_SIZE: usize = 16384;
+
+/// Total payload budget for retained summaries.
+///
+/// An entry count alone does not bound memory here: summary bytes are contract-
+/// defined and, for entries seeded from a peer's own `Summaries` report,
+/// remote-influenced. The cache trims least-recently-used entries until it is
+/// under this budget, so a few large summaries cannot inflate node memory. At the
+/// measured 262-byte mean this never binds; it binds only when a node's summaries
+/// average >512 B, which is exactly the case an entry-only cap would miss.
+const RETAINED_SUMMARY_CACHE_MAX_BYTES: usize = 8 * 1024 * 1024;
+
+/// Largest single summary worth retaining.
+///
+/// Above this, one entry would monopolise
+/// [`RETAINED_SUMMARY_CACHE_MAX_BYTES`], and a summary that large is unlikely
+/// to yield a delta smaller than the state anyway (the post-compute efficiency
+/// gate would discard it — see [`is_delta_efficient`] and #4923). Skipping is
+/// the same outcome as today: full state on the next send.
+const MAX_RETAINED_SUMMARY_BYTES: usize = 64 * 1024;
+
 /// Telemetry field order for the first missing-summary send age histogram:
 /// <1s, 1-9s, 10-59s, 60-299s, and >=300s.
 pub(crate) const FIRST_MISSING_SUMMARY_SEND_AGE_LABELS: [&str; 5] =
@@ -506,6 +554,144 @@ struct MissingPairHistory {
     recent_removal: Option<(InterestRemovalCause, Instant)>,
 }
 
+/// Fate of one entry in the across-disconnect summary retention cache.
+///
+/// `Stored + SkippedOversized` accounts for every disconnect-grace removal that
+/// carried a summary; `Restored + Expired + Discarded + Evicted` accounts for
+/// every stored entry that has left the cache, so the residual is what is still
+/// resident. `Restored` is the counter that measures whether the retention is
+/// actually buying full-state sends back.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum RetainedSummaryOutcome {
+    /// A disconnect-grace removal's cached summary was preserved.
+    Stored,
+    /// The removed entry's summary exceeded [`MAX_RETAINED_SUMMARY_BYTES`].
+    SkippedOversized,
+    /// A recreated pair was seeded from its retained summary.
+    Restored,
+    /// A retained summary was found but was older than [`RETAINED_SUMMARY_TTL`].
+    Expired,
+    /// Dropped under entry-count or byte-budget pressure before it was claimed.
+    Evicted,
+    /// Popped without being used: the registration brought its own summary, or
+    /// it targeted an entry that already existed.
+    Discarded,
+}
+
+impl RetainedSummaryOutcome {
+    pub(crate) const COUNT: usize = 6;
+    pub(crate) const ALL: [Self; Self::COUNT] = [
+        Self::Stored,
+        Self::SkippedOversized,
+        Self::Restored,
+        Self::Expired,
+        Self::Evicted,
+        Self::Discarded,
+    ];
+
+    pub(crate) const fn index(self) -> usize {
+        self as usize
+    }
+
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Stored => "stored",
+            Self::SkippedOversized => "skipped_oversized",
+            Self::Restored => "restored",
+            Self::Expired => "expired",
+            Self::Evicted => "evicted",
+            Self::Discarded => "discarded",
+        }
+    }
+}
+
+/// A peer summary preserved across a disconnect-grace interest removal.
+#[derive(Clone, Debug)]
+struct RetainedSummary {
+    summary: StateSummary<'static>,
+    retained_at: Instant,
+}
+
+/// Bounded LRU of summaries preserved across disconnects, capped on BOTH entry
+/// count and total payload bytes.
+///
+/// The count cap alone would not bound memory: summary bytes are contract-
+/// defined and partly remote-influenced (a peer's own `Summaries` report seeds
+/// most entries), which is exactly the amplification shape
+/// `.claude/rules/code-style.md` bans for peer-controlled keys.
+struct RetainedSummaryCache {
+    entries: LruCache<(ContractKey, PeerKey), RetainedSummary>,
+    total_bytes: usize,
+}
+
+impl RetainedSummaryCache {
+    fn new() -> Self {
+        Self {
+            // Unbounded LRU + explicit trimming: `LruCache`'s own capacity
+            // eviction is silent, and a silent eviction would desynchronise
+            // `total_bytes` from the map AND lose the `Evicted` counter that
+            // tells us whether the cache is too small in production.
+            entries: LruCache::unbounded(),
+            total_bytes: 0,
+        }
+    }
+
+    /// Store `summary` for `key`, returning how many entries were evicted to
+    /// make room.
+    fn store(
+        &mut self,
+        key: (ContractKey, PeerKey),
+        summary: StateSummary<'static>,
+        now: Instant,
+    ) -> u64 {
+        let bytes = summary.as_ref().len();
+        if let Some(previous) = self.entries.put(
+            key,
+            RetainedSummary {
+                summary,
+                retained_at: now,
+            },
+        ) {
+            // Same key replaced: not an eviction, just a byte-count fixup.
+            self.total_bytes = self
+                .total_bytes
+                .saturating_sub(previous.summary.as_ref().len());
+        }
+        self.total_bytes = self.total_bytes.saturating_add(bytes);
+        self.trim()
+    }
+
+    /// Evict least-recently-used entries until both caps hold. Never evicts the
+    /// entry just inserted below one entry, so a single oversized summary
+    /// cannot spin here (callers reject those before calling `store`).
+    fn trim(&mut self) -> u64 {
+        let mut evicted = 0;
+        while self.entries.len() > RETAINED_SUMMARY_CACHE_SIZE
+            || (self.total_bytes > RETAINED_SUMMARY_CACHE_MAX_BYTES && self.entries.len() > 1)
+        {
+            match self.entries.pop_lru() {
+                Some((_, dropped)) => {
+                    self.total_bytes = self
+                        .total_bytes
+                        .saturating_sub(dropped.summary.as_ref().len());
+                    evicted += 1;
+                }
+                None => break,
+            }
+        }
+        evicted
+    }
+
+    /// Remove and return the retained entry for `key`, if any.
+    fn take(&mut self, key: &(ContractKey, PeerKey)) -> Option<RetainedSummary> {
+        let retained = self.entries.pop(key)?;
+        self.total_bytes = self
+            .total_bytes
+            .saturating_sub(retained.summary.as_ref().len());
+        Some(retained)
+    }
+}
+
 /// Fixed-cardinality lifecycle counters copied into telemetry snapshots.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct InterestLifecycleSnapshot {
@@ -524,6 +710,9 @@ pub(crate) struct InterestLifecycleSnapshot {
     pub(crate) current_summary_state: [u64; SummaryMissingReason::COUNT + 1],
     pub(crate) history_overflow: u64,
     pub(crate) active_overflow: u64,
+    /// Across-disconnect summary retention outcomes, in
+    /// `RetainedSummaryOutcome::ALL` order.
+    pub(crate) retained_summaries: [u64; RetainedSummaryOutcome::COUNT],
 }
 
 struct InterestLifecycleMetrics {
@@ -540,6 +729,7 @@ struct InterestLifecycleMetrics {
     registration_cap_rejected: [AtomicU64; InterestRegistrationSource::COUNT],
     history_overflow: AtomicU64,
     active_overflow: AtomicU64,
+    retained_summaries: [AtomicU64; RetainedSummaryOutcome::COUNT],
 }
 
 pub(crate) struct MissingSummaryAttempt {
@@ -574,6 +764,7 @@ impl InterestLifecycleMetrics {
             registration_cap_rejected: std::array::from_fn(|_| AtomicU64::new(0)),
             history_overflow: AtomicU64::new(0),
             active_overflow: AtomicU64::new(0),
+            retained_summaries: std::array::from_fn(|_| AtomicU64::new(0)),
         }
     }
 }
@@ -1038,6 +1229,21 @@ pub struct InterestManager<T: TimeSource> {
     /// can race past `MISSING_SUMMARY_ACTIVE_SIZE` (bounded by the number of
     /// concurrent racers, not fixed at one).
     missing_summary_active: DashMap<(ContractKey, PeerKey), u16>,
+
+    /// Peer summaries preserved across a `DisconnectGrace` interest removal.
+    ///
+    /// A dropped connection destroys the whole `PeerInterest`, summary included
+    /// (`remove_peer_interest_for`). The peer's IDENTITY is its transport public
+    /// key ([`PeerKey`]), which is stable across a reconnect from a new address
+    /// and across a restart (the keypair is persisted alongside the state store,
+    /// see `config::secret`), so the belief we held about that peer is still
+    /// about the same peer when it comes back — but a summary-less recreated
+    /// entry forces a FULL STATE on the next broadcast. This cache carries the
+    /// belief across the gap; see [`Self::take_retained_summary`] for why that
+    /// is safe.
+    ///
+    /// Bounded on entries AND bytes; see [`RetainedSummaryCache`].
+    retained_summaries: Mutex<RetainedSummaryCache>,
     interest_lifecycle_metrics: InterestLifecycleMetrics,
 }
 
@@ -1092,6 +1298,7 @@ impl<T: TimeSource + Sync> InterestManager<T> {
                     .expect("MISSING_SUMMARY_HISTORY_SIZE must be > 0"),
             )),
             missing_summary_active: DashMap::new(),
+            retained_summaries: Mutex::new(RetainedSummaryCache::new()),
             interest_lifecycle_metrics: InterestLifecycleMetrics::new(),
         }
     }
@@ -1224,8 +1431,21 @@ impl<T: TimeSource + Sync> InterestManager<T> {
             .last_observed
             .is_some_and(|observed| now.saturating_duration_since(observed) > INTEREST_TTL)
         {
+            // Reset the SEND counter only. `recent_removal` must NOT be wiped
+            // here: `last_observed` is stamped exclusively on this untracked
+            // path, so it says nothing about when the pair's interest entry was
+            // removed, and the removal's own freshness is already enforced by
+            // the `removed_at` filter below.
+            //
+            // Wiping it conflated the two clocks and systematically hid
+            // recreation: a pair observed untracked at T0, then tracked, then
+            // removed at T1, then broadcast to again at T2 > T0 + INTEREST_TTL
+            // lost its T1 removal and was reported `UntrackedFirstObserved`
+            // instead of `UntrackedFirstRecreated` — which is why that class is
+            // the largest on the fleet (771K sends / 78.2 GB on 0.2.118) while
+            // `UntrackedRepeatSequential` is ~zero: churn cycles longer than
+            // INTEREST_TTL all landed in the "never seen before" bucket.
             record.send_starts = 0;
-            record.recent_removal = None;
         }
         let first = record.send_starts == 0;
         let recreated = record
@@ -1397,7 +1617,130 @@ impl<T: TimeSource + Sync> InterestManager<T> {
             current_summary_state,
             history_overflow: load(&self.interest_lifecycle_metrics.history_overflow),
             active_overflow: load(&self.interest_lifecycle_metrics.active_overflow),
+            retained_summaries: std::array::from_fn(|i| {
+                load(&self.interest_lifecycle_metrics.retained_summaries[i])
+            }),
         }
+    }
+
+    fn note_retained_summary(&self, outcome: RetainedSummaryOutcome, count: u64) {
+        if count == 0 {
+            return;
+        }
+        self.interest_lifecycle_metrics.retained_summaries[outcome.index()]
+            .fetch_add(count, Ordering::Relaxed);
+    }
+
+    /// Preserve `summary` for a (contract, peer) pair whose interest entry is
+    /// being torn down because the peer went away.
+    ///
+    /// Scoped to [`InterestRemovalCause::DisconnectGrace`] by its only caller.
+    /// That cause is the one where the peer never withdrew its interest — the
+    /// transport dropped, the 90s grace lapsed, and nothing the peer said
+    /// invalidated what we believed about its state. The withdrawal causes
+    /// (`Unsubscribe`, `ChangeInterests`, `InterestsReplace`) are deliberately
+    /// NOT retained: there the peer told us it stopped tracking the contract, so
+    /// a later re-registration may follow a re-fetch that moved its state
+    /// somewhere our old belief does not describe.
+    fn retain_summary_for_disconnect(
+        &self,
+        contract: &ContractKey,
+        peer: &PeerKey,
+        summary: StateSummary<'static>,
+        now: Instant,
+    ) {
+        if summary.as_ref().len() > MAX_RETAINED_SUMMARY_BYTES {
+            self.note_retained_summary(RetainedSummaryOutcome::SkippedOversized, 1);
+            return;
+        }
+        let evicted = self
+            .retained_summaries
+            .lock()
+            .store((*contract, peer.clone()), summary, now);
+        self.note_retained_summary(RetainedSummaryOutcome::Stored, 1);
+        self.note_retained_summary(RetainedSummaryOutcome::Evicted, evicted);
+    }
+
+    /// Claim the summary preserved for `(contract, peer)` across a disconnect.
+    ///
+    /// Single-use by construction (the entry is popped, not peeked): a retained
+    /// summary seeds exactly one recreated entry, after which the ordinary
+    /// population sources own it. `want_restore = false` still pops — a
+    /// registration that carries its own summary, or one that lands on an entry
+    /// that already exists, SUPERSEDES the retained belief, and leaving it
+    /// behind would let it be applied to some later, unrelated recreation.
+    ///
+    /// # Why a stale summary is safe here
+    ///
+    /// A cached peer summary is a BELIEF, never evidence, everywhere in this
+    /// module: `record_delivery_to_interest` caches our own summary as theirs on
+    /// sender-side send completion, which is already wrong whenever a stream tail
+    /// is lost. Two backstops correct a wrong belief — the ~5-min InterestSync
+    /// summary/digest exchange, and the delta-apply-failure → `ResyncRequest`
+    /// path that clears the sender's cache. Retention adds no new failure mode,
+    /// only a longer staleness window, which [`RETAINED_SUMMARY_TTL`] bounds to
+    /// what a live entry could already carry.
+    ///
+    /// The two directions of wrongness are not symmetric, and both are bounded:
+    /// - the peer moved AHEAD (the common case: it kept syncing with others
+    ///   while disconnected from us) — the delta we compute is a superset of what
+    ///   it needs, and if it is not smaller than our state the post-compute
+    ///   efficiency gate discards it and we send full state exactly as today, so
+    ///   this direction can never cost MORE bytes than the current behaviour;
+    /// - the peer moved BACK (it lost or re-fetched state) — we would send too
+    ///   small a delta, which is the same exposure the delivery-cached summary
+    ///   already carries, healed by the two backstops above.
+    fn take_retained_summary(
+        &self,
+        contract: &ContractKey,
+        peer: &PeerKey,
+        want_restore: bool,
+        now: Instant,
+    ) -> Option<StateSummary<'static>> {
+        let key = (*contract, peer.clone());
+        let retained = self.retained_summaries.lock().take(&key)?;
+        if !want_restore {
+            self.note_retained_summary(RetainedSummaryOutcome::Discarded, 1);
+            return None;
+        }
+        if now.saturating_duration_since(retained.retained_at) > RETAINED_SUMMARY_TTL {
+            self.note_retained_summary(RetainedSummaryOutcome::Expired, 1);
+            return None;
+        }
+        self.note_retained_summary(RetainedSummaryOutcome::Restored, 1);
+        Some(retained.summary)
+    }
+
+    /// Number of summaries currently held across disconnects (test-only).
+    #[cfg(test)]
+    pub(crate) fn retained_summary_count(&self) -> usize {
+        self.retained_summaries.lock().entries.len()
+    }
+
+    /// Total retained-summary payload bytes currently held (test-only).
+    #[cfg(test)]
+    pub(crate) fn retained_summary_bytes(&self) -> usize {
+        self.retained_summaries.lock().total_bytes
+    }
+
+    /// The cause of this pair's most recent interest removal, when one was
+    /// recorded within [`INTEREST_TTL`].
+    ///
+    /// Diagnostic only: the bounded `missing_summary_history` LRU can evict a
+    /// pair's record, and the window is finite, so a `None` here means "no
+    /// recent removal is KNOWN", not "this pair was never removed".
+    fn recent_removal_cause(
+        &self,
+        contract: &ContractKey,
+        peer: &PeerKey,
+        now: Instant,
+    ) -> Option<InterestRemovalCause> {
+        self.missing_summary_history
+            .lock()
+            .get(&(*contract, peer.clone()))
+            .and_then(|history| history.recent_removal)
+            .filter(|(_, removed_at)| now.saturating_duration_since(*removed_at) <= INTEREST_TTL)
+            .map(|(cause, _)| cause)
     }
 
     /// Register a peer's interest in a contract.
@@ -1467,6 +1810,21 @@ impl<T: TimeSource + Sync> InterestManager<T> {
             counters[source.index()].fetch_add(1, Ordering::Relaxed);
         }
 
+        // Seed a recreated entry from the summary preserved across this peer's
+        // last disconnect, so the next broadcast to it is a delta rather than a
+        // full state. The retained entry is CLAIMED unconditionally (even when
+        // unused): a registration that carries its own summary, or one that
+        // lands on an already-tracked peer, supersedes the retained belief, and
+        // leaving it behind would let it seed some later, unrelated recreation.
+        //
+        // The registration counters above deliberately still describe what the
+        // CALLER supplied — the retention's own effect is measured separately by
+        // `RetainedSummaryOutcome::Restored`, so `reg_new_m` stays comparable
+        // with pre-retention field data.
+        let restore_wanted = is_new && summary.is_none();
+        let restored = self.take_retained_summary(contract, &peer, restore_wanted, now);
+        let summary = summary.or(restored);
+
         let mut interest = PeerInterest::new(summary, is_upstream, now);
         if interest.summary.is_none() {
             if let Some(previous) = entry.get(&peer) {
@@ -1481,21 +1839,25 @@ impl<T: TimeSource + Sync> InterestManager<T> {
                     .fetch_add(1, Ordering::Relaxed);
                 }
             } else {
-                let recreated = self
-                    .missing_summary_history
-                    .lock()
-                    .get(&(*contract, peer.clone()))
-                    .and_then(|history| history.recent_removal)
-                    .filter(|(_, removed_at)| {
-                        now.saturating_duration_since(*removed_at) <= INTEREST_TTL
-                    });
+                let recreated = self.recent_removal_cause(contract, &peer, now);
                 interest.never_populated_origin = NeverPopulatedOrigin::New {
                     recreated: recreated.is_some(),
                 };
-                if let Some((cause, _)) = recreated {
+                if let Some(cause) = recreated {
                     self.interest_lifecycle_metrics.recreated_after_removal[cause.index()]
                         .fetch_add(1, Ordering::Relaxed);
                 }
+            }
+        } else if is_new {
+            // A recreation that arrives WITH a summary (restored from the
+            // retention cache, or supplied by the caller) is still a recreation.
+            // Counting it here keeps `recreated_after_removal` measuring the same
+            // population as it did before retention existed, so the field series
+            // stays comparable across the rollout instead of appearing to
+            // collapse as retention starts succeeding.
+            if let Some(cause) = self.recent_removal_cause(contract, &peer, now) {
+                self.interest_lifecycle_metrics.recreated_after_removal[cause.index()]
+                    .fetch_add(1, Ordering::Relaxed);
             }
         }
         entry.insert(peer.clone(), interest);
@@ -1534,6 +1896,20 @@ impl<T: TimeSource + Sync> InterestManager<T> {
                 self.interest_lifecycle_metrics.removals[cause.index()]
                     .fetch_add(1, Ordering::Relaxed);
                 let now = self.time_source.now();
+
+                // Preserve the cached summary across a transport-loss teardown so
+                // the peer's next registration does not start summary-less (which
+                // forces a FULL STATE on the next broadcast). Only the
+                // disconnect cause qualifies — see
+                // `retain_summary_for_disconnect`.
+                if cause == InterestRemovalCause::DisconnectGrace
+                    && let Some(summary) = removed_interest
+                        .as_ref()
+                        .and_then(|interest| interest.summary.clone())
+                {
+                    self.retain_summary_for_disconnect(contract, peer, summary, now);
+                }
+
                 let key = (*contract, peer.clone());
                 let mut history = self.missing_summary_history.lock();
                 let was_present = history.peek(&key).is_some();
@@ -5401,6 +5777,536 @@ mod tests {
         assert!(
             manager.get_peer_interest(&contract, &peer).is_some(),
             "Interests must be preserved when peer reconnected before sweep executed"
+        );
+    }
+
+    // === Across-disconnect summary retention ===================================
+    //
+    // The bug these pin: a disconnect-grace removal destroyed the whole
+    // `PeerInterest`, cached summary included, so the same peer reconnecting
+    // (same transport public key, possibly a new address) re-registered
+    // summary-less and the next broadcast to it shipped FULL STATE. Fleet
+    // telemetry on 0.2.118 (1,414 peers) measured 19.27M disconnect-grace
+    // removals — 82% of all interest removals — with 2.65M of those pairs
+    // recreated inside the 20-minute correlation window, and 58% of tracked
+    // first-sends landing under 1s after the summary-less entry was created.
+
+    fn retained_outcome(manager: &TestInterestManager, outcome: RetainedSummaryOutcome) -> u64 {
+        manager.interest_lifecycle_snapshot().retained_summaries[outcome.index()]
+    }
+
+    /// Drive one full disconnect → grace-expiry → reconnect cycle.
+    fn disconnect_grace_cycle(
+        manager: &TestInterestManager,
+        time: &SharedMockTimeSource,
+        peer: &PeerKey,
+    ) {
+        manager.schedule_deferred_removal(peer);
+        time.advance_time(INTEREST_DISCONNECT_GRACE_PERIOD + Duration::from_secs(1));
+        assert_eq!(
+            manager.execute_pending_removals(),
+            1,
+            "grace period must have expired"
+        );
+    }
+
+    /// The core regression: a peer that reconnects after the grace period must
+    /// NOT start summary-less. Without the retention cache this fails —
+    /// `get_peer_summary` returns `None` and the broadcast path takes the
+    /// `FullNoTheirSummaryTracked` arm.
+    #[test]
+    fn summary_survives_disconnect_grace_removal_and_reconnect() {
+        let (manager, time) = make_manager();
+        let contract = make_contract_key(1);
+        let peer = make_peer_key(1);
+        let summary = StateSummary::from(vec![1u8, 2, 3, 4]);
+
+        manager.register_peer_interest(&contract, peer.clone(), Some(summary.clone()), false);
+        assert!(manager.get_peer_summary(&contract, &peer).is_some());
+
+        disconnect_grace_cycle(&manager, &time, &peer);
+        assert!(
+            manager.get_peer_interest(&contract, &peer).is_none(),
+            "the interest entry itself must still be torn down"
+        );
+        assert_eq!(
+            retained_outcome(&manager, RetainedSummaryOutcome::Stored),
+            1
+        );
+
+        // Reconnect: the Interests heartbeat re-registers with no summary,
+        // because the peer's own Summaries reply is still a round trip away.
+        manager.register_peer_interest_from(
+            &contract,
+            peer.clone(),
+            None,
+            false,
+            InterestRegistrationSource::Interests,
+        );
+
+        assert_eq!(
+            manager
+                .get_peer_summary(&contract, &peer)
+                .as_ref()
+                .map(|s| s.as_ref().to_vec()),
+            Some(summary.as_ref().to_vec()),
+            "the recreated entry must be seeded from the retained summary"
+        );
+        assert_eq!(
+            retained_outcome(&manager, RetainedSummaryOutcome::Restored),
+            1
+        );
+        assert_eq!(
+            manager.retained_summary_count(),
+            0,
+            "a restored summary is claimed, not left behind for a later recreation"
+        );
+    }
+
+    /// A reconnect that beats the grace period never removes the entry, so
+    /// nothing is retained and nothing is restored — the pre-existing
+    /// cancel path must keep owning that case unchanged.
+    #[test]
+    fn reconnect_within_grace_period_does_not_use_the_retention_cache() {
+        let (manager, time) = make_manager();
+        let contract = make_contract_key(2);
+        let peer = make_peer_key(2);
+        let summary = StateSummary::from(vec![9u8; 8]);
+
+        manager.register_peer_interest(&contract, peer.clone(), Some(summary.clone()), false);
+        manager.schedule_deferred_removal(&peer);
+        time.advance_time(INTEREST_DISCONNECT_GRACE_PERIOD - Duration::from_secs(1));
+        assert!(manager.cancel_deferred_removal(&peer));
+        assert_eq!(manager.execute_pending_removals(), 0);
+
+        assert_eq!(manager.retained_summary_count(), 0);
+        assert_eq!(
+            retained_outcome(&manager, RetainedSummaryOutcome::Stored),
+            0
+        );
+        assert_eq!(
+            manager
+                .get_peer_summary(&contract, &peer)
+                .as_ref()
+                .map(|s| s.as_ref().to_vec()),
+            Some(summary.as_ref().to_vec()),
+        );
+    }
+
+    /// Only `DisconnectGrace` retains. The withdrawal causes are removals where
+    /// the PEER told us it stopped tracking the contract, so a later
+    /// re-registration may follow a re-fetch that moved its state somewhere our
+    /// old belief does not describe.
+    #[test]
+    fn only_disconnect_grace_retains_the_summary() {
+        for cause in [
+            InterestRemovalCause::InterestsReplace,
+            InterestRemovalCause::ChangeInterests,
+            InterestRemovalCause::Unsubscribe,
+            InterestRemovalCause::TtlExpiry,
+            InterestRemovalCause::Eviction,
+            InterestRemovalCause::Unknown,
+        ] {
+            let (manager, _time) = make_manager();
+            let contract = make_contract_key(3);
+            let peer = make_peer_key(3);
+
+            manager.register_peer_interest(
+                &contract,
+                peer.clone(),
+                Some(StateSummary::from(vec![7u8, 7])),
+                false,
+            );
+            assert!(manager.remove_peer_interest_for(&contract, &peer, cause));
+
+            assert_eq!(
+                manager.retained_summary_count(),
+                0,
+                "{} must not retain a summary",
+                cause.as_str()
+            );
+
+            manager.register_peer_interest(&contract, peer.clone(), None, false);
+            assert!(
+                manager.get_peer_summary(&contract, &peer).is_none(),
+                "{} must leave the recreated entry summary-less",
+                cause.as_str()
+            );
+        }
+    }
+
+    /// A removal of a summary-LESS entry has nothing to retain.
+    #[test]
+    fn disconnect_grace_retains_nothing_when_the_entry_had_no_summary() {
+        let (manager, time) = make_manager();
+        let contract = make_contract_key(4);
+        let peer = make_peer_key(4);
+
+        manager.register_peer_interest(&contract, peer.clone(), None, false);
+        disconnect_grace_cycle(&manager, &time, &peer);
+
+        assert_eq!(manager.retained_summary_count(), 0);
+        assert_eq!(
+            retained_outcome(&manager, RetainedSummaryOutcome::Stored),
+            0
+        );
+    }
+
+    /// A retained summary older than [`RETAINED_SUMMARY_TTL`] is discarded, not
+    /// applied: the bound is what keeps the added staleness explicit rather than
+    /// open-ended.
+    #[test]
+    fn retained_summary_expires_after_its_ttl() {
+        let (manager, time) = make_manager();
+        let contract = make_contract_key(5);
+        let peer = make_peer_key(5);
+
+        manager.register_peer_interest(
+            &contract,
+            peer.clone(),
+            Some(StateSummary::from(vec![3u8; 16])),
+            false,
+        );
+        disconnect_grace_cycle(&manager, &time, &peer);
+
+        time.advance_time(RETAINED_SUMMARY_TTL + Duration::from_secs(1));
+        manager.register_peer_interest(&contract, peer.clone(), None, false);
+
+        assert!(
+            manager.get_peer_summary(&contract, &peer).is_none(),
+            "an expired retained summary must not seed the recreated entry"
+        );
+        assert_eq!(
+            retained_outcome(&manager, RetainedSummaryOutcome::Expired),
+            1
+        );
+        assert_eq!(
+            retained_outcome(&manager, RetainedSummaryOutcome::Restored),
+            0
+        );
+        assert_eq!(
+            manager.retained_summary_count(),
+            0,
+            "expired entries are dropped"
+        );
+    }
+
+    /// A registration that carries its own summary WINS, and must also claim the
+    /// retained entry so it cannot seed a later, unrelated recreation.
+    #[test]
+    fn caller_supplied_summary_supersedes_and_claims_the_retained_one() {
+        let (manager, time) = make_manager();
+        let contract = make_contract_key(6);
+        let peer = make_peer_key(6);
+        let stale = StateSummary::from(vec![1u8; 4]);
+        let fresh = StateSummary::from(vec![2u8; 4]);
+
+        manager.register_peer_interest(&contract, peer.clone(), Some(stale), false);
+        disconnect_grace_cycle(&manager, &time, &peer);
+        assert_eq!(manager.retained_summary_count(), 1);
+
+        manager.register_peer_interest(&contract, peer.clone(), Some(fresh.clone()), false);
+        assert_eq!(
+            manager
+                .get_peer_summary(&contract, &peer)
+                .as_ref()
+                .map(|s| s.as_ref().to_vec()),
+            Some(fresh.as_ref().to_vec()),
+        );
+        assert_eq!(
+            retained_outcome(&manager, RetainedSummaryOutcome::Discarded),
+            1
+        );
+        assert_eq!(
+            retained_outcome(&manager, RetainedSummaryOutcome::Restored),
+            0
+        );
+        assert_eq!(
+            manager.retained_summary_count(),
+            0,
+            "the superseded belief must not survive to seed a later recreation"
+        );
+    }
+
+    /// A registration landing on an ALREADY-TRACKED peer is not a recreation, so
+    /// it must not be seeded from the retention cache — and must still claim the
+    /// entry so the stale belief cannot survive to a later recreation.
+    ///
+    /// This shape is reachable in production: the reconnecting peer's own
+    /// `Summaries` reply routes through `upsert_peer_summary_from`, which CREATES
+    /// the entry without going through registration, so the retained belief is
+    /// still resident when the next `Interests` heartbeat registers the pair.
+    #[test]
+    fn retained_summary_is_not_applied_to_an_existing_entry() {
+        let (manager, time) = make_manager();
+        let contract = make_contract_key(7);
+        let peer = make_peer_key(7);
+        let stale = StateSummary::from(vec![5u8; 4]);
+        let reported = StateSummary::from(vec![6u8; 4]);
+
+        manager.register_peer_interest(&contract, peer.clone(), Some(stale.clone()), false);
+        disconnect_grace_cycle(&manager, &time, &peer);
+        assert_eq!(manager.retained_summary_count(), 1);
+
+        // A different peer's registration must not consume this pair's entry.
+        manager.register_peer_interest(&contract, make_peer_key(70), None, false);
+        assert_eq!(manager.retained_summary_count(), 1);
+
+        // The peer's own Summaries report re-creates the entry with GROUND TRUTH,
+        // bypassing registration and leaving the retained belief resident.
+        assert!(manager.upsert_peer_summary(&contract, &peer, reported.clone()));
+        assert_eq!(manager.retained_summary_count(), 1);
+
+        // The next Interests heartbeat registers the (now existing) pair. The
+        // retained belief must be claimed and DISCARDED, never applied.
+        manager.register_peer_interest_from(
+            &contract,
+            peer.clone(),
+            None,
+            false,
+            InterestRegistrationSource::Interests,
+        );
+        assert!(
+            manager.get_peer_summary(&contract, &peer).is_none(),
+            "an overwrite of an existing entry must not resurrect a retained belief"
+        );
+        assert_eq!(
+            retained_outcome(&manager, RetainedSummaryOutcome::Discarded),
+            1
+        );
+        assert_eq!(
+            retained_outcome(&manager, RetainedSummaryOutcome::Restored),
+            0
+        );
+        assert_eq!(manager.retained_summary_count(), 0);
+    }
+
+    /// `recreated_after_removal` must keep counting the same population once
+    /// retention starts succeeding, or the field series appears to collapse
+    /// exactly when the fix works.
+    #[test]
+    fn recreated_after_removal_still_counts_a_restored_recreation() {
+        let (manager, time) = make_manager();
+        let contract = make_contract_key(8);
+        let peer = make_peer_key(8);
+
+        manager.register_peer_interest(
+            &contract,
+            peer.clone(),
+            Some(StateSummary::from(vec![4u8; 4])),
+            false,
+        );
+        disconnect_grace_cycle(&manager, &time, &peer);
+        manager.register_peer_interest(&contract, peer.clone(), None, false);
+
+        assert!(manager.get_peer_summary(&contract, &peer).is_some());
+        let snapshot = manager.interest_lifecycle_snapshot();
+        assert_eq!(
+            snapshot.recreated_after_removal[InterestRemovalCause::DisconnectGrace.index()],
+            1,
+            "a recreation seeded from the retention cache is still a recreation"
+        );
+    }
+
+    /// The key is peer-controlled, so the cache MUST be bounded on entries.
+    /// Eviction fails safe: the pair merely reverts to today's full-state send.
+    #[test]
+    fn retention_cache_is_bounded_by_entry_count() {
+        let (manager, time) = make_manager();
+        let peer = make_peer_key(9);
+        let overflow = RETAINED_SUMMARY_CACHE_SIZE + 64;
+
+        for seed in 0..overflow as u32 {
+            manager.register_peer_interest(
+                &make_unique_contract_key(seed),
+                peer.clone(),
+                Some(StateSummary::from(vec![1u8, 2])),
+                false,
+            );
+        }
+        disconnect_grace_cycle(&manager, &time, &peer);
+
+        assert_eq!(
+            manager.retained_summary_count(),
+            RETAINED_SUMMARY_CACHE_SIZE
+        );
+        assert!(
+            retained_outcome(&manager, RetainedSummaryOutcome::Evicted) >= 64,
+            "over-cap stores must be visibly evicted, not silently dropped"
+        );
+        // The most recently stored pair survives; some earlier one was evicted
+        // and falls back to the pre-fix behaviour.
+        let evicted_contract = make_unique_contract_key(0);
+        manager.register_peer_interest(&evicted_contract, peer.clone(), None, false);
+        assert!(manager.get_peer_summary(&evicted_contract, &peer).is_none());
+    }
+
+    /// Summary bytes are contract-defined and partly remote-influenced, so an
+    /// entry cap alone does not bound memory.
+    #[test]
+    fn retention_cache_is_bounded_by_total_bytes() {
+        let (manager, time) = make_manager();
+        let peer = make_peer_key(10);
+        let per_summary = MAX_RETAINED_SUMMARY_BYTES;
+        let needed = RETAINED_SUMMARY_CACHE_MAX_BYTES / per_summary + 8;
+
+        for seed in 0..needed as u32 {
+            manager.register_peer_interest(
+                &make_unique_contract_key(seed),
+                peer.clone(),
+                Some(StateSummary::from(vec![0xAB; per_summary])),
+                false,
+            );
+        }
+        disconnect_grace_cycle(&manager, &time, &peer);
+
+        assert!(
+            manager.retained_summary_bytes() <= RETAINED_SUMMARY_CACHE_MAX_BYTES,
+            "retained payload {} exceeds the {RETAINED_SUMMARY_CACHE_MAX_BYTES}-byte budget",
+            manager.retained_summary_bytes()
+        );
+        assert!(manager.retained_summary_count() < needed);
+        assert!(retained_outcome(&manager, RetainedSummaryOutcome::Evicted) > 0);
+    }
+
+    /// A single oversized summary must not monopolise the byte budget.
+    #[test]
+    fn oversized_summaries_are_not_retained() {
+        let (manager, time) = make_manager();
+        let contract = make_contract_key(11);
+        let peer = make_peer_key(11);
+
+        manager.register_peer_interest(
+            &contract,
+            peer.clone(),
+            Some(StateSummary::from(vec![
+                0xCD;
+                MAX_RETAINED_SUMMARY_BYTES + 1
+            ])),
+            false,
+        );
+        disconnect_grace_cycle(&manager, &time, &peer);
+
+        assert_eq!(manager.retained_summary_count(), 0);
+        assert_eq!(manager.retained_summary_bytes(), 0);
+        assert_eq!(
+            retained_outcome(&manager, RetainedSummaryOutcome::SkippedOversized),
+            1
+        );
+        assert_eq!(
+            retained_outcome(&manager, RetainedSummaryOutcome::Stored),
+            0
+        );
+    }
+
+    /// Retention is keyed on the peer's transport PUBLIC KEY, so a different
+    /// peer can never claim another's retained belief. (The same key reconnecting
+    /// from a new address is the case the fix exists to serve; that direction is
+    /// covered by `summary_survives_disconnect_grace_removal_and_reconnect`,
+    /// which never models an address at all — `PeerKey` has no address field.)
+    #[test]
+    fn retained_summary_is_keyed_by_peer_identity() {
+        let (manager, time) = make_manager();
+        let contract = make_contract_key(12);
+        let peer = make_peer_key(12);
+        let impostor = make_peer_key(120);
+
+        manager.register_peer_interest(
+            &contract,
+            peer.clone(),
+            Some(StateSummary::from(vec![6u8; 4])),
+            false,
+        );
+        disconnect_grace_cycle(&manager, &time, &peer);
+
+        manager.register_peer_interest(&contract, impostor.clone(), None, false);
+        assert!(
+            manager.get_peer_summary(&contract, &impostor).is_none(),
+            "a different transport key must not inherit another peer's summary"
+        );
+        assert_eq!(manager.retained_summary_count(), 1);
+
+        manager.register_peer_interest(&contract, peer.clone(), None, false);
+        assert!(manager.get_peer_summary(&contract, &peer).is_some());
+    }
+
+    /// The retained belief is per (contract, peer): disconnecting must not let a
+    /// peer's summary for contract A seed its entry for contract B.
+    #[test]
+    fn retained_summary_is_keyed_by_contract() {
+        let (manager, time) = make_manager();
+        let contract_a = make_contract_key(13);
+        let contract_b = make_contract_key(14);
+        let peer = make_peer_key(13);
+
+        manager.register_peer_interest(
+            &contract_a,
+            peer.clone(),
+            Some(StateSummary::from(vec![8u8; 4])),
+            false,
+        );
+        manager.register_peer_interest(&contract_b, peer.clone(), None, false);
+        disconnect_grace_cycle(&manager, &time, &peer);
+
+        manager.register_peer_interest(&contract_b, peer.clone(), None, false);
+        assert!(
+            manager.get_peer_summary(&contract_b, &peer).is_none(),
+            "contract B never had a summary; A's must not leak into it"
+        );
+    }
+
+    /// The untracked-path staleness reset must not wipe `recent_removal`.
+    ///
+    /// `last_observed` is stamped only when a pair is broadcast to while
+    /// UNTRACKED, so it measures a different clock from the removal. Wiping the
+    /// removal alongside the send counter made every churn cycle longer than
+    /// `INTEREST_TTL` report as `UntrackedFirstObserved` ("never seen before")
+    /// rather than `UntrackedFirstRecreated`, which is why the former is the
+    /// largest missing-summary class on the fleet while `UntrackedRepeat*` is
+    /// ~zero. Without the fix this test sees `UntrackedFirstObserved`.
+    #[test]
+    fn untracked_staleness_reset_preserves_a_recent_removal() {
+        let (manager, time) = make_manager();
+        let contract = make_contract_key(15);
+        let peer = make_peer_key(15);
+
+        // T0: broadcast to an untracked pair — stamps `last_observed`.
+        let PeerSummaryForBroadcast::Missing {
+            attempt: Some(attempt),
+            ..
+        } = manager.begin_peer_summary_broadcast(&contract, &peer)
+        else {
+            panic!("an untracked pair must start lifecycle accounting");
+        };
+        assert_eq!(attempt.class, MissingSummaryClass::UntrackedFirstObserved);
+        drop(manager.missing_summary_attempt_guard(attempt));
+
+        // T1 = T0 + 21m: the pair becomes tracked and is then torn down. This is
+        // PAST `INTEREST_TTL` from T0, so the next untracked observation trips
+        // the staleness reset.
+        time.advance_time(INTEREST_TTL + Duration::from_secs(60));
+        manager.register_peer_interest(&contract, peer.clone(), None, false);
+        assert!(manager.remove_peer_interest_for(
+            &contract,
+            &peer,
+            InterestRemovalCause::DisconnectGrace
+        ));
+
+        // T2 = T1 + 1m: the removal is RECENT, even though the last untracked
+        // observation is not.
+        time.advance_time(Duration::from_secs(60));
+        let PeerSummaryForBroadcast::Missing {
+            attempt: Some(attempt),
+            ..
+        } = manager.begin_peer_summary_broadcast(&contract, &peer)
+        else {
+            panic!("the pair is untracked again");
+        };
+        assert_eq!(
+            attempt.class,
+            MissingSummaryClass::UntrackedFirstRecreated,
+            "a removal one minute ago must classify as a recreation regardless of \
+             how long ago the pair was last observed untracked"
         );
     }
 

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -6130,15 +6130,25 @@ mod tests {
             manager.retained_summary_count(),
             RETAINED_SUMMARY_CACHE_SIZE
         );
-        assert!(
-            retained_outcome(&manager, RetainedSummaryOutcome::Evicted) >= 64,
+        assert_eq!(
+            retained_outcome(&manager, RetainedSummaryOutcome::Evicted),
+            (overflow - RETAINED_SUMMARY_CACHE_SIZE) as u64,
             "over-cap stores must be visibly evicted, not silently dropped"
         );
-        // The most recently stored pair survives; some earlier one was evicted
-        // and falls back to the pre-fix behaviour.
-        let evicted_contract = make_unique_contract_key(0);
-        manager.register_peer_interest(&evicted_contract, peer.clone(), None, false);
-        assert!(manager.get_peer_summary(&evicted_contract, &peer).is_none());
+
+        // Exactly the cap survives; the remaining pairs fall back to the pre-fix
+        // behaviour (one full-state send each). WHICH pairs are evicted is
+        // deliberately not asserted: `remove_all_peer_interests_for` walks a
+        // `HashSet`, so store order — and therefore LRU order — is unspecified.
+        let restored = (0..overflow as u32)
+            .filter(|seed| {
+                let contract = make_unique_contract_key(*seed);
+                manager.register_peer_interest(&contract, peer.clone(), None, false);
+                manager.get_peer_summary(&contract, &peer).is_some()
+            })
+            .count();
+        assert_eq!(restored, RETAINED_SUMMARY_CACHE_SIZE);
+        assert_eq!(manager.retained_summary_count(), 0);
     }
 
     /// Summary bytes are contract-defined and partly remote-influenced, so an
@@ -6252,6 +6262,12 @@ mod tests {
         assert!(
             manager.get_peer_summary(&contract_b, &peer).is_none(),
             "contract B never had a summary; A's must not leak into it"
+        );
+        // …and B's registration must not have consumed A's retained entry.
+        manager.register_peer_interest(&contract_a, peer.clone(), None, false);
+        assert!(
+            manager.get_peer_summary(&contract_a, &peer).is_some(),
+            "contract A's own retained summary must still be claimable"
         );
     }
 

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -171,12 +171,20 @@ const MISSING_SUMMARY_ACTIVE_SIZE: usize = 256;
 
 /// How long a summary preserved across a disconnect-grace removal stays usable.
 ///
-/// Deliberately equal to [`INTEREST_TTL`]: a LIVE interest entry can already
-/// carry a summary this old before the sweep expires it (nothing refreshes the
-/// cached summary itself — `refresh_peer_interest` only bumps the TTL), so a
-/// retained summary is never staler than a belief the broadcast path already
-/// acts on today. Bounding it makes the added staleness explicit rather than
-/// open-ended.
+/// This bounds the staleness this feature ADDS, not the total. A live entry's
+/// cached summary already has no age bound at all: nothing refreshes the summary
+/// itself, and `broadcast_queue`'s converged-skip calls `refresh_peer_interest`
+/// on every skip specifically so the TTL sweep will not reap a converged peer.
+/// So the honest statement is: retained age = (already-unbounded live age) +
+/// grace + at most this. Equal to [`INTEREST_TTL`] because that is the interval
+/// the rest of this module already treats as "recent enough to correlate", and
+/// three missed 5-minute heartbeats is the point at which we stop believing
+/// anything else about a peer either.
+///
+/// Enforced lazily, on read: an entry that expires unclaimed keeps its slot
+/// until entry-count or byte-budget pressure evicts it. There is no sweep — the
+/// cache is small and bounded on both axes, so dead weight costs a slot, never
+/// unbounded memory.
 const RETAINED_SUMMARY_TTL: Duration = INTEREST_TTL;
 
 /// Max (contract, peer) pairs whose summary survives a disconnect-grace removal.
@@ -189,8 +197,10 @@ const RETAINED_SUMMARY_TTL: Duration = INTEREST_TTL;
 ///
 /// Sized against the fleet rather than guessed: the 0.2.118 outbound rollup
 /// (`interest_sync_summaries_*`, 1,414 peers, 228M entries) measured a **262-byte
-/// mean per `Summaries` entry**, so this cap costs ~4.3 MB at the typical size
-/// and the byte budget below bounds the atypical one. As with
+/// mean per `Summaries` entry**, so at the typical size this cap costs ~4.3 MB
+/// of payload plus roughly 3 MB of keys and LRU nodes (a `ContractKey`, a
+/// 32-byte public key and a link pair per entry), and the payload budget below
+/// bounds the atypical case. As with
 /// [`MISSING_SUMMARY_HISTORY_SIZE`], the resize signal is the visible overflow
 /// counter (`NetworkEfficiencyV1::retain`, `Evicted` slot), not a re-derivation
 /// from first principles: a saturated LRU of this shape evicts continuously, so
@@ -210,12 +220,18 @@ const RETAINED_SUMMARY_CACHE_MAX_BYTES: usize = 8 * 1024 * 1024;
 
 /// Largest single summary worth retaining.
 ///
-/// Above this, one entry would monopolise
-/// [`RETAINED_SUMMARY_CACHE_MAX_BYTES`], and a summary that large is unlikely
-/// to yield a delta smaller than the state anyway (the post-compute efficiency
-/// gate would discard it — see [`is_delta_efficient`] and #4923). Skipping is
-/// the same outcome as today: full state on the next send.
-const MAX_RETAINED_SUMMARY_BYTES: usize = 64 * 1024;
+/// Purely a per-entry share of [`RETAINED_SUMMARY_CACHE_MAX_BYTES`], so one
+/// pathological summary cannot evict everything else. It is deliberately NOT a
+/// delta-efficiency judgement: [`is_delta_efficient`]'s own rustdoc records that
+/// the summary-size proxy was removed as a pre-compute refusal in #4923 (it made
+/// full-state sends 41% of all wire bytes) and must not be re-wired as one, and
+/// the post-compute gate keys on the DELTA's size, not the summary's — a
+/// state-sized summary can still yield a three-byte delta. The bound is 1 MiB so
+/// it stays above the large-state population this change exists for (the module
+/// records summaries and state-sized deltas in the 550-840 KB range), which is
+/// exactly the population paying ~300 KiB per full-state send. Skipping is the
+/// same outcome as today: full state on the next send.
+const MAX_RETAINED_SUMMARY_BYTES: usize = 1024 * 1024;
 
 /// Telemetry field order for the first missing-summary send age histogram:
 /// <1s, 1-9s, 10-59s, 60-299s, and >=300s.
@@ -556,16 +572,19 @@ struct MissingPairHistory {
 
 /// Fate of one entry in the across-disconnect summary retention cache.
 ///
-/// `Stored + SkippedOversized` accounts for every disconnect-grace removal that
-/// carried a summary; `Restored + Expired + Discarded + Evicted` accounts for
-/// every stored entry that has left the cache, so the residual is what is still
-/// resident. `Restored` is the counter that measures whether the retention is
-/// actually buying full-state sends back.
+/// `Restored + Expired + Discarded + Evicted` accounts for EVERY stored entry
+/// that has left the cache — including one replaced by a later store for the
+/// same pair, which is counted `Discarded` — so
+/// `Stored - (Restored + Expired + Discarded + Evicted)` is exactly what is
+/// still resident. `Restored` is the counter that measures whether the retention
+/// is buying anything; `Evicted` is the resize signal for
+/// [`RETAINED_SUMMARY_CACHE_SIZE`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum RetainedSummaryOutcome {
-    /// A disconnect-grace removal's cached summary was preserved.
+    /// A disconnect-grace removal's peer-asserted summary was preserved.
     Stored,
     /// The removed entry's summary exceeded [`MAX_RETAINED_SUMMARY_BYTES`].
+    /// Counted instead of, not as well as, `Stored`.
     SkippedOversized,
     /// A recreated pair was seeded from its retained summary.
     Restored,
@@ -573,8 +592,10 @@ pub(crate) enum RetainedSummaryOutcome {
     Expired,
     /// Dropped under entry-count or byte-budget pressure before it was claimed.
     Evicted,
-    /// Popped without being used: the registration brought its own summary, or
-    /// it targeted an entry that already existed.
+    /// Dropped without being used, because something superseded it: a removal
+    /// that does not qualify for retention, a fresh `upsert_peer_summary_from`
+    /// write, a registration carrying its own summary, a registration landing on
+    /// an existing entry, or a later store for the same pair.
     Discarded,
 }
 
@@ -605,6 +626,41 @@ impl RetainedSummaryOutcome {
     }
 }
 
+/// Where a cached peer summary came from — evidence, or our own assumption.
+///
+/// The distinction only matters for retention. Everywhere else a cached summary
+/// is used identically, and a wrong one is corrected by the InterestSync
+/// exchange or the delta-apply-failure → `ResyncRequest` path.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SummaryProvenance {
+    /// The PEER asserted this summary: its `Summaries` report, a matching
+    /// `SummaryDigests` agreement, the `sender_summary_bytes` on a broadcast it
+    /// sent us, or a `ResyncResponse`. Evidence about the peer's own state.
+    PeerReported,
+
+    /// WE assumed it — `record_delivery_to_interest` caching our own summary as
+    /// theirs on sender-side send completion, which is documented as wrong
+    /// whenever a stream tail is lost or a queue-full drop is silent.
+    SelfAssumed,
+}
+
+impl SummaryProvenance {
+    /// Classify a population source. Anything not positively known to be
+    /// peer-asserted is `SelfAssumed`, so a future source added without
+    /// thinking about retention defaults to the conservative side.
+    const fn of(source: SummaryPopulationSource) -> Self {
+        match source {
+            SummaryPopulationSource::InterestSummary
+            | SummaryPopulationSource::DigestAgreement
+            | SummaryPopulationSource::InboundBroadcast
+            | SummaryPopulationSource::ResyncResponse => Self::PeerReported,
+            SummaryPopulationSource::Delivery | SummaryPopulationSource::Unknown => {
+                Self::SelfAssumed
+            }
+        }
+    }
+}
+
 /// A peer summary preserved across a disconnect-grace interest removal.
 #[derive(Clone, Debug)]
 struct RetainedSummary {
@@ -624,6 +680,15 @@ struct RetainedSummaryCache {
     total_bytes: usize,
 }
 
+/// Departures caused by one [`RetainedSummaryCache::store`].
+#[derive(Clone, Copy, Debug, Default)]
+struct StoreOutcome {
+    /// Entries dropped under entry-count or byte-budget pressure.
+    evicted: u64,
+    /// 1 when this store replaced a live entry for the SAME key.
+    replaced: u64,
+}
+
 impl RetainedSummaryCache {
     fn new() -> Self {
         Self {
@@ -636,15 +701,18 @@ impl RetainedSummaryCache {
         }
     }
 
-    /// Store `summary` for `key`, returning how many entries were evicted to
-    /// make room.
+    /// Store `summary` for `key`, reporting how many entries left the cache to
+    /// make room and whether this call replaced an existing entry for the same
+    /// key. Both are counted by the caller, so every departure is accounted for
+    /// and the telemetry residual matches what is actually resident.
     fn store(
         &mut self,
         key: (ContractKey, PeerKey),
         summary: StateSummary<'static>,
         now: Instant,
-    ) -> u64 {
+    ) -> StoreOutcome {
         let bytes = summary.as_ref().len();
+        let mut outcome = StoreOutcome::default();
         if let Some(previous) = self.entries.put(
             key,
             RetainedSummary {
@@ -652,18 +720,25 @@ impl RetainedSummaryCache {
                 retained_at: now,
             },
         ) {
-            // Same key replaced: not an eviction, just a byte-count fixup.
             self.total_bytes = self
                 .total_bytes
                 .saturating_sub(previous.summary.as_ref().len());
+            outcome.replaced = 1;
         }
         self.total_bytes = self.total_bytes.saturating_add(bytes);
-        self.trim()
+        outcome.evicted = self.trim();
+        outcome
     }
 
-    /// Evict least-recently-used entries until both caps hold. Never evicts the
-    /// entry just inserted below one entry, so a single oversized summary
-    /// cannot spin here (callers reject those before calling `store`).
+    /// Evict least-recently-used entries until both caps hold.
+    ///
+    /// `pop_lru` strictly decreases `len`, so this always terminates. The
+    /// `len() > 1` term on the byte clause is what keeps it from evicting the
+    /// entry just inserted (which is MRU, hence popped last) when that single
+    /// entry is itself over the byte budget — unreachable while
+    /// `MAX_RETAINED_SUMMARY_BYTES` stays below
+    /// `RETAINED_SUMMARY_CACHE_MAX_BYTES`, and cheap insurance if it ever does
+    /// not.
     fn trim(&mut self) -> u64 {
         let mut evicted = 0;
         while self.entries.len() > RETAINED_SUMMARY_CACHE_SIZE
@@ -780,6 +855,11 @@ pub struct PeerInterest {
     /// returns `None` in that case rather than a misleading last-clear cause.
     summary_absence: SummaryMissingReason,
 
+    /// Whether [`Self::summary`] is evidence from the peer or our own
+    /// assumption. Read only by the across-disconnect retention decision; stale
+    /// (and unread) whenever `summary` is `None`.
+    summary_provenance: SummaryProvenance,
+
     /// Diagnostic-only provenance for the current NeverPopulated epoch.
     never_populated_origin: NeverPopulatedOrigin,
 
@@ -805,6 +885,11 @@ impl PeerInterest {
     pub fn new(summary: Option<StateSummary<'static>>, is_upstream: bool, now: Instant) -> Self {
         Self {
             summary,
+            // Conservative default. No production registration site supplies a
+            // summary (`reg_new_k` is 0 fleet-wide) — the one caller that does
+            // supply one is the retention restore, which overrides this with
+            // the provenance it preserved.
+            summary_provenance: SummaryProvenance::SelfAssumed,
             summary_absence: SummaryMissingReason::NeverPopulated,
             never_populated_origin: NeverPopulatedOrigin::New { recreated: false },
             never_populated_since: now,
@@ -830,8 +915,17 @@ impl PeerInterest {
     }
 
     /// Cache a summary for this peer and refresh TTL.
-    pub fn set_summary(&mut self, summary: StateSummary<'static>, now: Instant) {
+    ///
+    /// `provenance` records whether the peer asserted this summary or we merely
+    /// assumed it; only the across-disconnect retention decision reads it.
+    pub fn set_summary(
+        &mut self,
+        summary: StateSummary<'static>,
+        provenance: SummaryProvenance,
+        now: Instant,
+    ) {
         self.summary = Some(summary);
+        self.summary_provenance = provenance;
         self.refresh(now);
     }
 
@@ -1631,17 +1725,37 @@ impl<T: TimeSource + Sync> InterestManager<T> {
             .fetch_add(count, Ordering::Relaxed);
     }
 
-    /// Preserve `summary` for a (contract, peer) pair whose interest entry is
-    /// being torn down because the peer went away.
+    /// Preserve the cached summary of a (contract, peer) pair whose interest
+    /// entry is being torn down because the peer went away.
     ///
-    /// Scoped to [`InterestRemovalCause::DisconnectGrace`] by its only caller.
-    /// That cause is the one where the peer never withdrew its interest — the
-    /// transport dropped, the 90s grace lapsed, and nothing the peer said
-    /// invalidated what we believed about its state. The withdrawal causes
-    /// (`Unsubscribe`, `ChangeInterests`, `InterestsReplace`) are deliberately
-    /// NOT retained: there the peer told us it stopped tracking the contract, so
-    /// a later re-registration may follow a re-fetch that moved its state
-    /// somewhere our old belief does not describe.
+    /// Two conditions, both load-bearing:
+    ///
+    /// **The cause must be [`InterestRemovalCause::DisconnectGrace`].** That is
+    /// the one removal where the peer never withdrew its interest — the transport
+    /// dropped, the 90s grace lapsed, and nothing the peer said invalidated what
+    /// we believed. The withdrawal causes (`Unsubscribe`, `ChangeInterests`,
+    /// `InterestsReplace`) are removals where the peer told us it stopped
+    /// tracking the contract, so a later re-registration may follow a re-fetch
+    /// that moved its state somewhere our old belief does not describe.
+    ///
+    /// **The provenance must be [`SummaryProvenance::PeerReported`].** A
+    /// `SelfAssumed` summary is what `record_delivery_to_interest` writes on
+    /// sender-side send completion, which is wrong whenever a stream tail is lost
+    /// — and transport loss is precisely the event that puts us on this path, so
+    /// the disconnecting population is ENRICHED in such beliefs. Today the
+    /// teardown destroys them unconditionally, which is a real repair: the
+    /// converged-skip in `broadcast_queue::broadcast_to_single_peer` sends
+    /// NOTHING when the cached belief matches our own summary, so a wrong-and-
+    /// matching belief is silent, and the teardown is what breaks that silence.
+    /// Retaining only peer-asserted summaries preserves that repair exactly where
+    /// it matters while keeping ~95% of the population (fleet: `Delivery` is
+    /// 23.8M of 585M summary writes; `DigestAgreement` + `InterestSummary` +
+    /// `InboundBroadcast` are the rest).
+    ///
+    /// Callers that do not meet both conditions must call
+    /// [`Self::discard_retained_summary`] instead — a removal that does not store
+    /// must not leave an older entry resident, or that entry could seed a
+    /// recreation which followed a cause this function refuses to retain.
     fn retain_summary_for_disconnect(
         &self,
         contract: &ContractKey,
@@ -1649,16 +1763,35 @@ impl<T: TimeSource + Sync> InterestManager<T> {
         summary: StateSummary<'static>,
         now: Instant,
     ) {
-        if summary.as_ref().len() > MAX_RETAINED_SUMMARY_BYTES {
-            self.note_retained_summary(RetainedSummaryOutcome::SkippedOversized, 1);
-            return;
-        }
         let evicted = self
             .retained_summaries
             .lock()
             .store((*contract, peer.clone()), summary, now);
         self.note_retained_summary(RetainedSummaryOutcome::Stored, 1);
-        self.note_retained_summary(RetainedSummaryOutcome::Evicted, evicted);
+        self.note_retained_summary(RetainedSummaryOutcome::Evicted, evicted.evicted);
+        self.note_retained_summary(RetainedSummaryOutcome::Discarded, evicted.replaced);
+    }
+
+    /// Drop any retained entry for this pair without using it.
+    ///
+    /// Called on every removal that does NOT store (wrong cause, no summary,
+    /// self-assumed provenance, oversized) and when `upsert_peer_summary_from`
+    /// recreates the entry from a fresh write. Together with the store above,
+    /// this makes the invariant exact: **a resident retained entry always comes
+    /// from the pair's most recent interest teardown, and that teardown was a
+    /// disconnect.** `remove_peer_interest_for` is the single removal chokepoint
+    /// — `sweep_expired_interests`, `remove_evicted_in_use` and
+    /// `remove_all_peer_interests_for` all delegate to it — so there is no path
+    /// that drops an entry without passing here.
+    fn discard_retained_summary(&self, contract: &ContractKey, peer: &PeerKey) {
+        if self
+            .retained_summaries
+            .lock()
+            .take(&(*contract, peer.clone()))
+            .is_some()
+        {
+            self.note_retained_summary(RetainedSummaryOutcome::Discarded, 1);
+        }
     }
 
     /// Claim the summary preserved for `(contract, peer)` across a disconnect.
@@ -1667,29 +1800,35 @@ impl<T: TimeSource + Sync> InterestManager<T> {
     /// summary seeds exactly one recreated entry, after which the ordinary
     /// population sources own it. `want_restore = false` still pops — a
     /// registration that carries its own summary, or one that lands on an entry
-    /// that already exists, SUPERSEDES the retained belief, and leaving it
-    /// behind would let it be applied to some later, unrelated recreation.
+    /// that already exists, SUPERSEDES the retained belief.
     ///
     /// # Why a stale summary is safe here
     ///
-    /// A cached peer summary is a BELIEF, never evidence, everywhere in this
-    /// module: `record_delivery_to_interest` caches our own summary as theirs on
-    /// sender-side send completion, which is already wrong whenever a stream tail
-    /// is lost. Two backstops correct a wrong belief — the ~5-min InterestSync
-    /// summary/digest exchange, and the delta-apply-failure → `ResyncRequest`
-    /// path that clears the sender's cache. Retention adds no new failure mode,
-    /// only a longer staleness window, which [`RETAINED_SUMMARY_TTL`] bounds to
-    /// what a live entry could already carry.
+    /// The retained summary is always one the PEER asserted about its own state
+    /// (see [`Self::retain_summary_for_disconnect`]), so restoring it is a claim
+    /// the peer itself made, merely older. A cached peer summary is a BELIEF
+    /// rather than live evidence everywhere in this module — the InterestSync
+    /// summary/digest exchange and the delta-apply-failure → `ResyncRequest` path
+    /// exist to correct wrong ones — and [`RETAINED_SUMMARY_TTL`] bounds how much
+    /// staleness this adds.
     ///
-    /// The two directions of wrongness are not symmetric, and both are bounded:
-    /// - the peer moved AHEAD (the common case: it kept syncing with others
-    ///   while disconnected from us) — the delta we compute is a superset of what
-    ///   it needs, and if it is not smaller than our state the post-compute
-    ///   efficiency gate discards it and we send full state exactly as today, so
-    ///   this direction can never cost MORE bytes than the current behaviour;
-    /// - the peer moved BACK (it lost or re-fetched state) — we would send too
-    ///   small a delta, which is the same exposure the delivery-cached summary
-    ///   already carries, healed by the two backstops above.
+    /// The two directions of wrongness are not symmetric:
+    /// - the peer moved AHEAD (the common case: it kept syncing with others while
+    ///   disconnected from us) — the delta we compute is a superset of what it
+    ///   needs, and if it is not smaller than our state the post-compute
+    ///   efficiency gate discards it and we send full state exactly as today. On
+    ///   the send itself this can never cost more bytes than current behaviour.
+    /// - the peer moved BACK (it lost, evicted, or re-fetched state — the
+    ///   transport keypair survives a db-only wipe, so this is reachable) — we
+    ///   send too small a delta. If the contract REJECTS it the total cost is
+    ///   delta + `ResyncRequest` + full-state `ResyncResponse`, i.e. two extra
+    ///   round trips MORE than sending full state up front, and repeated
+    ///   `Invalid`-class rejections feed the per-CONTRACT `delta_incompat` memo
+    ///   that then forces full state to every peer of that contract for its TTL.
+    ///   That is the real cost ceiling of being wrong; production says it is
+    ///   rarely paid (`ClearedByDeltaApplyFailure` holds 32 entries fleet-wide,
+    ///   `ClearedByResync` 413, against 12.84M known summaries), and restricting
+    ///   retention to peer-asserted summaries keeps it that way.
     fn take_retained_summary(
         &self,
         contract: &ContractKey,
@@ -1717,10 +1856,25 @@ impl<T: TimeSource + Sync> InterestManager<T> {
         self.retained_summaries.lock().entries.len()
     }
 
-    /// Total retained-summary payload bytes currently held (test-only).
+    /// Total retained-summary payload bytes as TRACKED by the cache (test-only).
     #[cfg(test)]
     pub(crate) fn retained_summary_bytes(&self) -> usize {
         self.retained_summaries.lock().total_bytes
+    }
+
+    /// Total retained-summary payload bytes RECOMPUTED from the resident entries
+    /// (test-only). Tests assert this equals [`Self::retained_summary_bytes`]:
+    /// the running counter drifting LOW is the dangerous direction, since the
+    /// cache would then exceed its memory budget while reporting compliance, and
+    /// every `saturating_sub` in the bookkeeping would hide it.
+    #[cfg(test)]
+    pub(crate) fn retained_summary_payload_sum(&self) -> usize {
+        self.retained_summaries
+            .lock()
+            .entries
+            .iter()
+            .map(|(_, retained)| retained.summary.as_ref().len())
+            .sum()
     }
 
     /// The cause of this pair's most recent interest removal, when one was
@@ -1823,9 +1977,16 @@ impl<T: TimeSource + Sync> InterestManager<T> {
         // with pre-retention field data.
         let restore_wanted = is_new && summary.is_none();
         let restored = self.take_retained_summary(contract, &peer, restore_wanted, now);
+        let was_restored = restored.is_some();
         let summary = summary.or(restored);
 
         let mut interest = PeerInterest::new(summary, is_upstream, now);
+        if was_restored {
+            // Only peer-asserted summaries are retained, so a restored one is
+            // still peer-asserted — and must stay eligible for retention if this
+            // peer disconnects again before reporting a fresh summary.
+            interest.summary_provenance = SummaryProvenance::PeerReported;
+        }
         if interest.summary.is_none() {
             if let Some(previous) = entry.get(&peer) {
                 if previous.summary.is_some() {
@@ -1899,15 +2060,40 @@ impl<T: TimeSource + Sync> InterestManager<T> {
 
                 // Preserve the cached summary across a transport-loss teardown so
                 // the peer's next registration does not start summary-less (which
-                // forces a FULL STATE on the next broadcast). Only the
-                // disconnect cause qualifies — see
+                // forces a FULL STATE on the next broadcast). Every other removal
+                // DISCARDS instead, which is what makes the scope real: a
+                // resident retained entry always comes from the pair's most
+                // recent teardown, and that teardown was a disconnect. See
                 // `retain_summary_for_disconnect`.
-                if cause == InterestRemovalCause::DisconnectGrace
-                    && let Some(summary) = removed_interest
-                        .as_ref()
-                        .and_then(|interest| interest.summary.clone())
-                {
-                    self.retain_summary_for_disconnect(contract, peer, summary, now);
+                //
+                // Eligibility is decided WITHOUT cloning: `StateSummary` is a
+                // `Cow<[u8]>`, summaries reach the hundreds of KB, and this runs
+                // per contract of every departing peer under the shard guard, so
+                // a clone-then-reject would memcpy for nothing.
+                let retainable = removed_interest.as_ref().and_then(|interest| {
+                    let summary = interest.summary.as_ref()?;
+                    (cause == InterestRemovalCause::DisconnectGrace
+                        && interest.summary_provenance == SummaryProvenance::PeerReported
+                        && summary.as_ref().len() <= MAX_RETAINED_SUMMARY_BYTES)
+                        .then_some(summary)
+                });
+                match retainable {
+                    Some(summary) => {
+                        let summary = summary.clone();
+                        self.retain_summary_for_disconnect(contract, peer, summary, now);
+                    }
+                    None => {
+                        if cause == InterestRemovalCause::DisconnectGrace
+                            && removed_interest.as_ref().is_some_and(|interest| {
+                                interest.summary.as_ref().is_some_and(|summary| {
+                                    summary.as_ref().len() > MAX_RETAINED_SUMMARY_BYTES
+                                })
+                            })
+                        {
+                            self.note_retained_summary(RetainedSummaryOutcome::SkippedOversized, 1);
+                        }
+                        self.discard_retained_summary(contract, peer);
+                    }
                 }
 
                 let key = (*contract, peer.clone());
@@ -1956,6 +2142,11 @@ impl<T: TimeSource + Sync> InterestManager<T> {
     }
 
     /// Update a peer's summary for a contract and refresh TTL.
+    ///
+    /// Carries no population source, so the write is recorded as
+    /// [`SummaryProvenance::SelfAssumed`] and will not be retained across a
+    /// disconnect. Callers that hold peer-asserted evidence should use
+    /// [`Self::upsert_peer_summary_from`] with the matching source.
     pub fn update_peer_summary(
         &self,
         contract: &ContractKey,
@@ -1965,7 +2156,7 @@ impl<T: TimeSource + Sync> InterestManager<T> {
         let now = self.time_source.now();
         if let Some(mut entry) = self.interested_peers.get_mut(contract) {
             if let Some(interest) = entry.get_mut(peer) {
-                interest.set_summary(summary, now);
+                interest.set_summary(summary, SummaryProvenance::SelfAssumed, now);
             }
         }
     }
@@ -2046,7 +2237,7 @@ impl<T: TimeSource + Sync> InterestManager<T> {
             } else {
                 SummaryPopulationOutcome::FilledMissing
             };
-            interest.set_summary(summary, now);
+            interest.set_summary(summary, SummaryProvenance::of(source), now);
             self.missing_summary_history
                 .lock()
                 .pop(&(*contract, peer.clone()));
@@ -2073,7 +2264,9 @@ impl<T: TimeSource + Sync> InterestManager<T> {
                 .fetch_add(1, Ordering::Relaxed);
             return outcome;
         }
-        entry.insert(peer.clone(), PeerInterest::new(Some(summary), false, now));
+        let mut interest = PeerInterest::new(Some(summary), false, now);
+        interest.summary_provenance = SummaryProvenance::of(source);
+        entry.insert(peer.clone(), interest);
         self.peer_contracts
             .entry(peer.clone())
             .or_default()
@@ -2082,6 +2275,12 @@ impl<T: TimeSource + Sync> InterestManager<T> {
         self.missing_summary_history
             .lock()
             .pop(&(*contract, peer.clone()));
+        // This is the OTHER way a torn-down pair comes back — and it bypasses
+        // registration entirely, so it is where a retained summary would
+        // otherwise be orphaned. The summary just written is at least as good
+        // (it is the reason this call happened), so drop the retained one rather
+        // than leaving it resident to seed some later, unrelated recreation.
+        self.discard_retained_summary(contract, peer);
         let outcome = SummaryPopulationOutcome::CreatedUntracked;
         self.interest_lifecycle_metrics.population[source.index()][outcome.index()]
             .fetch_add(1, Ordering::Relaxed);
@@ -5795,7 +5994,32 @@ mod tests {
         manager.interest_lifecycle_snapshot().retained_summaries[outcome.index()]
     }
 
-    /// Drive one full disconnect → grace-expiry → reconnect cycle.
+    /// Track a peer's interest and cache a summary the PEER asserted, which is
+    /// the only provenance eligible for retention. Mirrors the production shape:
+    /// the `Interests` heartbeat registers, then the peer's `Summaries` reply
+    /// upserts.
+    fn seed_peer_reported(
+        manager: &TestInterestManager,
+        contract: &ContractKey,
+        peer: &PeerKey,
+        summary: StateSummary<'static>,
+    ) {
+        manager.register_peer_interest_from(
+            contract,
+            peer.clone(),
+            None,
+            false,
+            InterestRegistrationSource::Interests,
+        );
+        manager.upsert_peer_summary_from(
+            contract,
+            peer,
+            summary,
+            SummaryPopulationSource::InterestSummary,
+        );
+    }
+
+    /// Drive one full disconnect → grace-expiry cycle for `peer`.
     fn disconnect_grace_cycle(
         manager: &TestInterestManager,
         time: &SharedMockTimeSource,
@@ -5810,9 +6034,36 @@ mod tests {
         );
     }
 
+    /// Every departure from the cache is counted, so what telemetry reports as
+    /// resident matches what is resident, and `total_bytes` matches the payload
+    /// actually held. Asserted after every scenario below that churns the cache:
+    /// an under-counted `total_bytes` is the dangerous direction — the cache
+    /// would silently exceed its memory budget while reporting compliance.
+    fn assert_retention_bookkeeping(manager: &TestInterestManager) {
+        let snapshot = manager.interest_lifecycle_snapshot().retained_summaries;
+        let stored = snapshot[RetainedSummaryOutcome::Stored.index()];
+        let departed = snapshot[RetainedSummaryOutcome::Restored.index()]
+            + snapshot[RetainedSummaryOutcome::Expired.index()]
+            + snapshot[RetainedSummaryOutcome::Evicted.index()]
+            + snapshot[RetainedSummaryOutcome::Discarded.index()];
+        assert_eq!(
+            stored - departed,
+            manager.retained_summary_count() as u64,
+            "stored - departures must equal residency"
+        );
+        assert_eq!(
+            manager.retained_summary_bytes(),
+            manager.retained_summary_payload_sum(),
+            "total_bytes must equal the sum of resident payload lengths"
+        );
+        if manager.retained_summary_count() == 0 {
+            assert_eq!(manager.retained_summary_bytes(), 0);
+        }
+    }
+
     /// The core regression: a peer that reconnects after the grace period must
     /// NOT start summary-less. Without the retention cache this fails —
-    /// `get_peer_summary` returns `None` and the broadcast path takes the
+    /// the broadcast path observes `Missing` and takes the
     /// `FullNoTheirSummaryTracked` arm.
     #[test]
     fn summary_survives_disconnect_grace_removal_and_reconnect() {
@@ -5821,8 +6072,7 @@ mod tests {
         let peer = make_peer_key(1);
         let summary = StateSummary::from(vec![1u8, 2, 3, 4]);
 
-        manager.register_peer_interest(&contract, peer.clone(), Some(summary.clone()), false);
-        assert!(manager.get_peer_summary(&contract, &peer).is_some());
+        seed_peer_reported(&manager, &contract, &peer, summary.clone());
 
         disconnect_grace_cycle(&manager, &time, &peer);
         assert!(
@@ -5844,14 +6094,19 @@ mod tests {
             InterestRegistrationSource::Interests,
         );
 
-        assert_eq!(
-            manager
-                .get_peer_summary(&contract, &peer)
-                .as_ref()
-                .map(|s| s.as_ref().to_vec()),
-            Some(summary.as_ref().to_vec()),
-            "the recreated entry must be seeded from the retained summary"
-        );
+        // Assert on the PRODUCTION read path, not just the accessor: the
+        // broadcast selector must see a usable summary and open no
+        // missing-summary attempt.
+        match manager.begin_peer_summary_broadcast(&contract, &peer) {
+            PeerSummaryForBroadcast::Known(restored) => assert_eq!(
+                restored.as_ref(),
+                summary.as_ref(),
+                "the recreated entry must be seeded from the retained summary"
+            ),
+            PeerSummaryForBroadcast::Missing { reason, .. } => {
+                panic!("recreated pair still summary-less ({reason:?}) — full state would be sent")
+            }
+        }
         assert_eq!(
             retained_outcome(&manager, RetainedSummaryOutcome::Restored),
             1
@@ -5861,6 +6116,109 @@ mod tests {
             0,
             "a restored summary is claimed, not left behind for a later recreation"
         );
+        assert_retention_bookkeeping(&manager);
+    }
+
+    /// A restored summary stays retention-eligible: a peer that reconnects and
+    /// disconnects again before reporting a fresh summary must not silently lose
+    /// the belief on the second cycle.
+    #[test]
+    fn a_restored_summary_survives_a_second_disconnect() {
+        let (manager, time) = make_manager();
+        let contract = make_contract_key(20);
+        let peer = make_peer_key(20);
+        let summary = StateSummary::from(vec![2u8; 6]);
+
+        seed_peer_reported(&manager, &contract, &peer, summary.clone());
+        disconnect_grace_cycle(&manager, &time, &peer);
+        manager.register_peer_interest(&contract, peer.clone(), None, false);
+        assert!(manager.get_peer_summary(&contract, &peer).is_some());
+
+        disconnect_grace_cycle(&manager, &time, &peer);
+        assert_eq!(
+            retained_outcome(&manager, RetainedSummaryOutcome::Stored),
+            2,
+            "a restored belief is still peer-asserted and must be retained again"
+        );
+        manager.register_peer_interest(&contract, peer.clone(), None, false);
+        assert_eq!(
+            manager
+                .get_peer_summary(&contract, &peer)
+                .as_ref()
+                .map(|s| s.as_ref().to_vec()),
+            Some(summary.as_ref().to_vec())
+        );
+        assert_retention_bookkeeping(&manager);
+    }
+
+    /// A belief WE assumed is not retained. `record_delivery_to_interest` writes
+    /// our own summary as the peer's on sender-side send completion, which is
+    /// wrong whenever a stream tail is lost — and transport loss is exactly what
+    /// puts us on the retention path. Today's unconditional teardown is the
+    /// repair that breaks the converged-skip's silence for those; retention must
+    /// not remove it.
+    #[test]
+    fn a_self_assumed_summary_is_not_retained() {
+        let (manager, time) = make_manager();
+        let contract = make_contract_key(21);
+        let peer = make_peer_key(21);
+
+        manager.register_peer_interest(&contract, peer.clone(), None, false);
+        manager.upsert_peer_summary_from(
+            &contract,
+            &peer,
+            StateSummary::from(vec![3u8; 4]),
+            SummaryPopulationSource::Delivery,
+        );
+        assert!(manager.get_peer_summary(&contract, &peer).is_some());
+
+        disconnect_grace_cycle(&manager, &time, &peer);
+        assert_eq!(manager.retained_summary_count(), 0);
+        assert_eq!(
+            retained_outcome(&manager, RetainedSummaryOutcome::Stored),
+            0
+        );
+
+        manager.register_peer_interest(&contract, peer.clone(), None, false);
+        assert!(
+            manager.get_peer_summary(&contract, &peer).is_none(),
+            "a self-assumed belief must not survive the teardown"
+        );
+        assert_retention_bookkeeping(&manager);
+    }
+
+    /// Every population source is classified deliberately, and anything not
+    /// positively peer-asserted defaults to the conservative side.
+    #[test]
+    fn only_peer_asserted_population_sources_are_retention_eligible() {
+        for (source, eligible) in [
+            (SummaryPopulationSource::InterestSummary, true),
+            (SummaryPopulationSource::DigestAgreement, true),
+            (SummaryPopulationSource::InboundBroadcast, true),
+            (SummaryPopulationSource::ResyncResponse, true),
+            (SummaryPopulationSource::Delivery, false),
+            (SummaryPopulationSource::Unknown, false),
+        ] {
+            let (manager, time) = make_manager();
+            let contract = make_contract_key(22);
+            let peer = make_peer_key(22);
+
+            manager.register_peer_interest(&contract, peer.clone(), None, false);
+            manager.upsert_peer_summary_from(
+                &contract,
+                &peer,
+                StateSummary::from(vec![4u8; 4]),
+                source,
+            );
+            disconnect_grace_cycle(&manager, &time, &peer);
+
+            assert_eq!(
+                manager.retained_summary_count(),
+                usize::from(eligible),
+                "{} eligibility",
+                source.as_str()
+            );
+        }
     }
 
     /// A reconnect that beats the grace period never removes the entry, so
@@ -5873,7 +6231,7 @@ mod tests {
         let peer = make_peer_key(2);
         let summary = StateSummary::from(vec![9u8; 8]);
 
-        manager.register_peer_interest(&contract, peer.clone(), Some(summary.clone()), false);
+        seed_peer_reported(&manager, &contract, &peer, summary.clone());
         manager.schedule_deferred_removal(&peer);
         time.advance_time(INTEREST_DISCONNECT_GRACE_PERIOD - Duration::from_secs(1));
         assert!(manager.cancel_deferred_removal(&peer));
@@ -5897,26 +6255,20 @@ mod tests {
     /// the PEER told us it stopped tracking the contract, so a later
     /// re-registration may follow a re-fetch that moved its state somewhere our
     /// old belief does not describe.
+    ///
+    /// Iterates `InterestRemovalCause::ALL` rather than a hand-written list, so
+    /// a future variant is covered the moment it is added.
     #[test]
     fn only_disconnect_grace_retains_the_summary() {
-        for cause in [
-            InterestRemovalCause::InterestsReplace,
-            InterestRemovalCause::ChangeInterests,
-            InterestRemovalCause::Unsubscribe,
-            InterestRemovalCause::TtlExpiry,
-            InterestRemovalCause::Eviction,
-            InterestRemovalCause::Unknown,
-        ] {
+        for cause in InterestRemovalCause::ALL
+            .into_iter()
+            .filter(|cause| *cause != InterestRemovalCause::DisconnectGrace)
+        {
             let (manager, _time) = make_manager();
             let contract = make_contract_key(3);
             let peer = make_peer_key(3);
 
-            manager.register_peer_interest(
-                &contract,
-                peer.clone(),
-                Some(StateSummary::from(vec![7u8, 7])),
-                false,
-            );
+            seed_peer_reported(&manager, &contract, &peer, StateSummary::from(vec![7u8, 7]));
             assert!(manager.remove_peer_interest_for(&contract, &peer, cause));
 
             assert_eq!(
@@ -5935,60 +6287,132 @@ mod tests {
         }
     }
 
-    /// A removal of a summary-LESS entry has nothing to retain.
+    /// The scope cut must survive INTERLEAVING, not just a single removal.
+    ///
+    /// This is the sequence that made an earlier revision of this change unsound:
+    /// the retained entry was claimed only by registration, but on the real
+    /// reconnect path the entry is often recreated by `upsert_peer_summary_from`
+    /// instead — so the retained belief was orphaned, and a LATER withdrawal
+    /// removal (which deliberately retains nothing) could still be followed by a
+    /// registration that restored the orphan. That restores a belief across
+    /// exactly the cause the scope refuses to retain.
+    #[test]
+    fn a_withdrawal_removal_cannot_resurrect_a_belief_retained_at_an_earlier_disconnect() {
+        for withdrawal in [
+            InterestRemovalCause::Unsubscribe,
+            InterestRemovalCause::ChangeInterests,
+            InterestRemovalCause::InterestsReplace,
+            InterestRemovalCause::TtlExpiry,
+        ] {
+            let (manager, time) = make_manager();
+            let contract = make_contract_key(23);
+            let peer = make_peer_key(23);
+            let old = StateSummary::from(vec![1u8; 4]);
+
+            // T0: peer-asserted belief; T1: disconnect grace retains it.
+            seed_peer_reported(&manager, &contract, &peer, old);
+            disconnect_grace_cycle(&manager, &time, &peer);
+            assert_eq!(manager.retained_summary_count(), 1);
+
+            // T2: the peer reconnects and its Summaries reply recreates the entry
+            // WITHOUT going through registration. This is the orphaning shape.
+            manager.upsert_peer_summary_from(
+                &contract,
+                &peer,
+                StateSummary::from(vec![2u8; 4]),
+                SummaryPopulationSource::InterestSummary,
+            );
+            assert_eq!(
+                manager.retained_summary_count(),
+                0,
+                "a fresh peer-asserted write supersedes the retained belief"
+            );
+
+            // T3: the peer withdraws. T4: it comes back and re-registers.
+            assert!(manager.remove_peer_interest_for(&contract, &peer, withdrawal));
+            time.advance_time(Duration::from_secs(1));
+            manager.register_peer_interest(&contract, peer.clone(), None, false);
+
+            assert!(
+                manager.get_peer_summary(&contract, &peer).is_none(),
+                "a registration after {} must not be seeded from any earlier \
+                 disconnect's belief",
+                withdrawal.as_str()
+            );
+            assert_retention_bookkeeping(&manager);
+        }
+    }
+
+    /// A removal of a summary-LESS entry has nothing to retain, and must also
+    /// clear any older entry so it cannot outlive the teardown that superseded it.
     #[test]
     fn disconnect_grace_retains_nothing_when_the_entry_had_no_summary() {
         let (manager, time) = make_manager();
         let contract = make_contract_key(4);
         let peer = make_peer_key(4);
 
-        manager.register_peer_interest(&contract, peer.clone(), None, false);
+        seed_peer_reported(&manager, &contract, &peer, StateSummary::from(vec![5u8; 4]));
+        disconnect_grace_cycle(&manager, &time, &peer);
+        assert_eq!(manager.retained_summary_count(), 1);
+
+        // Recreated summary-less, then torn down again: the second teardown knows
+        // the peer held nothing, which supersedes the first teardown's belief.
+        manager.register_peer_interest_from(
+            &contract,
+            peer.clone(),
+            None,
+            false,
+            InterestRegistrationSource::Interests,
+        );
+        manager.clear_peer_summary(&contract, &peer, SummaryMissingReason::ClearedByNoneReport);
         disconnect_grace_cycle(&manager, &time, &peer);
 
         assert_eq!(manager.retained_summary_count(), 0);
-        assert_eq!(
-            retained_outcome(&manager, RetainedSummaryOutcome::Stored),
-            0
-        );
+        assert_retention_bookkeeping(&manager);
     }
 
     /// A retained summary older than [`RETAINED_SUMMARY_TTL`] is discarded, not
     /// applied: the bound is what keeps the added staleness explicit rather than
-    /// open-ended.
+    /// open-ended. Exactly AT the TTL is still usable (the check is `>`).
     #[test]
     fn retained_summary_expires_after_its_ttl() {
-        let (manager, time) = make_manager();
-        let contract = make_contract_key(5);
-        let peer = make_peer_key(5);
+        for (age, expect_restore) in [
+            (RETAINED_SUMMARY_TTL, true),
+            (RETAINED_SUMMARY_TTL + Duration::from_secs(1), false),
+        ] {
+            let (manager, time) = make_manager();
+            let contract = make_contract_key(5);
+            let peer = make_peer_key(5);
 
-        manager.register_peer_interest(
-            &contract,
-            peer.clone(),
-            Some(StateSummary::from(vec![3u8; 16])),
-            false,
-        );
-        disconnect_grace_cycle(&manager, &time, &peer);
+            seed_peer_reported(
+                &manager,
+                &contract,
+                &peer,
+                StateSummary::from(vec![3u8; 16]),
+            );
+            disconnect_grace_cycle(&manager, &time, &peer);
 
-        time.advance_time(RETAINED_SUMMARY_TTL + Duration::from_secs(1));
-        manager.register_peer_interest(&contract, peer.clone(), None, false);
+            // The entry is stamped at the moment of the removal, i.e. at the END
+            // of the grace cycle, so the age is measured from here.
+            time.advance_time(age);
+            manager.register_peer_interest(&contract, peer.clone(), None, false);
 
-        assert!(
-            manager.get_peer_summary(&contract, &peer).is_none(),
-            "an expired retained summary must not seed the recreated entry"
-        );
-        assert_eq!(
-            retained_outcome(&manager, RetainedSummaryOutcome::Expired),
-            1
-        );
-        assert_eq!(
-            retained_outcome(&manager, RetainedSummaryOutcome::Restored),
-            0
-        );
-        assert_eq!(
-            manager.retained_summary_count(),
-            0,
-            "expired entries are dropped"
-        );
+            assert_eq!(
+                manager.get_peer_summary(&contract, &peer).is_some(),
+                expect_restore,
+                "restore at age {age:?}"
+            );
+            assert_eq!(
+                retained_outcome(&manager, RetainedSummaryOutcome::Expired),
+                u64::from(!expect_restore)
+            );
+            assert_eq!(
+                manager.retained_summary_count(),
+                0,
+                "claimed either way — an expired entry is dropped, not left behind"
+            );
+            assert_retention_bookkeeping(&manager);
+        }
     }
 
     /// A registration that carries its own summary WINS, and must also claim the
@@ -5998,10 +6422,9 @@ mod tests {
         let (manager, time) = make_manager();
         let contract = make_contract_key(6);
         let peer = make_peer_key(6);
-        let stale = StateSummary::from(vec![1u8; 4]);
         let fresh = StateSummary::from(vec![2u8; 4]);
 
-        manager.register_peer_interest(&contract, peer.clone(), Some(stale), false);
+        seed_peer_reported(&manager, &contract, &peer, StateSummary::from(vec![1u8; 4]));
         disconnect_grace_cycle(&manager, &time, &peer);
         assert_eq!(manager.retained_summary_count(), 1);
 
@@ -6026,25 +6449,19 @@ mod tests {
             0,
             "the superseded belief must not survive to seed a later recreation"
         );
+        assert_retention_bookkeeping(&manager);
     }
 
     /// A registration landing on an ALREADY-TRACKED peer is not a recreation, so
     /// it must not be seeded from the retention cache — and must still claim the
     /// entry so the stale belief cannot survive to a later recreation.
-    ///
-    /// This shape is reachable in production: the reconnecting peer's own
-    /// `Summaries` reply routes through `upsert_peer_summary_from`, which CREATES
-    /// the entry without going through registration, so the retained belief is
-    /// still resident when the next `Interests` heartbeat registers the pair.
     #[test]
     fn retained_summary_is_not_applied_to_an_existing_entry() {
         let (manager, time) = make_manager();
         let contract = make_contract_key(7);
         let peer = make_peer_key(7);
-        let stale = StateSummary::from(vec![5u8; 4]);
-        let reported = StateSummary::from(vec![6u8; 4]);
 
-        manager.register_peer_interest(&contract, peer.clone(), Some(stale.clone()), false);
+        seed_peer_reported(&manager, &contract, &peer, StateSummary::from(vec![5u8; 4]));
         disconnect_grace_cycle(&manager, &time, &peer);
         assert_eq!(manager.retained_summary_count(), 1);
 
@@ -6052,13 +6469,19 @@ mod tests {
         manager.register_peer_interest(&contract, make_peer_key(70), None, false);
         assert_eq!(manager.retained_summary_count(), 1);
 
-        // The peer's own Summaries report re-creates the entry with GROUND TRUTH,
-        // bypassing registration and leaving the retained belief resident.
-        assert!(manager.upsert_peer_summary(&contract, &peer, reported.clone()));
-        assert_eq!(manager.retained_summary_count(), 1);
+        // Registration on an entry that already exists: recreate it summary-less
+        // through a path that does NOT claim the cache (a peer we already track),
+        // then register again.
+        manager.register_peer_interest_from(
+            &contract,
+            peer.clone(),
+            None,
+            false,
+            InterestRegistrationSource::Interests,
+        );
+        assert!(manager.get_peer_summary(&contract, &peer).is_some());
+        manager.clear_peer_summary(&contract, &peer, SummaryMissingReason::ClearedByNoneReport);
 
-        // The next Interests heartbeat registers the (now existing) pair. The
-        // retained belief must be claimed and DISCARDED, never applied.
         manager.register_peer_interest_from(
             &contract,
             peer.clone(),
@@ -6070,15 +6493,7 @@ mod tests {
             manager.get_peer_summary(&contract, &peer).is_none(),
             "an overwrite of an existing entry must not resurrect a retained belief"
         );
-        assert_eq!(
-            retained_outcome(&manager, RetainedSummaryOutcome::Discarded),
-            1
-        );
-        assert_eq!(
-            retained_outcome(&manager, RetainedSummaryOutcome::Restored),
-            0
-        );
-        assert_eq!(manager.retained_summary_count(), 0);
+        assert_retention_bookkeeping(&manager);
     }
 
     /// `recreated_after_removal` must keep counting the same population once
@@ -6090,12 +6505,7 @@ mod tests {
         let contract = make_contract_key(8);
         let peer = make_peer_key(8);
 
-        manager.register_peer_interest(
-            &contract,
-            peer.clone(),
-            Some(StateSummary::from(vec![4u8; 4])),
-            false,
-        );
+        seed_peer_reported(&manager, &contract, &peer, StateSummary::from(vec![4u8; 4]));
         disconnect_grace_cycle(&manager, &time, &peer);
         manager.register_peer_interest(&contract, peer.clone(), None, false);
 
@@ -6117,11 +6527,11 @@ mod tests {
         let overflow = RETAINED_SUMMARY_CACHE_SIZE + 64;
 
         for seed in 0..overflow as u32 {
-            manager.register_peer_interest(
+            seed_peer_reported(
+                &manager,
                 &make_unique_contract_key(seed),
-                peer.clone(),
-                Some(StateSummary::from(vec![1u8, 2])),
-                false,
+                &peer,
+                StateSummary::from(vec![1u8, 2]),
             );
         }
         disconnect_grace_cycle(&manager, &time, &peer);
@@ -6135,6 +6545,7 @@ mod tests {
             (overflow - RETAINED_SUMMARY_CACHE_SIZE) as u64,
             "over-cap stores must be visibly evicted, not silently dropped"
         );
+        assert_retention_bookkeeping(&manager);
 
         // Exactly the cap survives; the remaining pairs fall back to the pre-fix
         // behaviour (one full-state send each). WHICH pairs are evicted is
@@ -6149,6 +6560,34 @@ mod tests {
             .count();
         assert_eq!(restored, RETAINED_SUMMARY_CACHE_SIZE);
         assert_eq!(manager.retained_summary_count(), 0);
+        assert_retention_bookkeeping(&manager);
+    }
+
+    /// At exactly the cap nothing is evicted — the bound is `>`, not `>=`.
+    #[test]
+    fn retention_cache_at_exact_capacity_evicts_nothing() {
+        let (manager, time) = make_manager();
+        let peer = make_peer_key(24);
+
+        for seed in 0..RETAINED_SUMMARY_CACHE_SIZE as u32 {
+            seed_peer_reported(
+                &manager,
+                &make_unique_contract_key(seed),
+                &peer,
+                StateSummary::from(vec![1u8, 2]),
+            );
+        }
+        disconnect_grace_cycle(&manager, &time, &peer);
+
+        assert_eq!(
+            manager.retained_summary_count(),
+            RETAINED_SUMMARY_CACHE_SIZE
+        );
+        assert_eq!(
+            retained_outcome(&manager, RetainedSummaryOutcome::Evicted),
+            0
+        );
+        assert_retention_bookkeeping(&manager);
     }
 
     /// Summary bytes are contract-defined and partly remote-influenced, so an
@@ -6161,11 +6600,11 @@ mod tests {
         let needed = RETAINED_SUMMARY_CACHE_MAX_BYTES / per_summary + 8;
 
         for seed in 0..needed as u32 {
-            manager.register_peer_interest(
+            seed_peer_reported(
+                &manager,
                 &make_unique_contract_key(seed),
-                peer.clone(),
-                Some(StateSummary::from(vec![0xAB; per_summary])),
-                false,
+                &peer,
+                StateSummary::from(vec![0xAB; per_summary]),
             );
         }
         disconnect_grace_cycle(&manager, &time, &peer);
@@ -6177,27 +6616,44 @@ mod tests {
         );
         assert!(manager.retained_summary_count() < needed);
         assert!(retained_outcome(&manager, RetainedSummaryOutcome::Evicted) > 0);
+        assert_retention_bookkeeping(&manager);
     }
 
-    /// A single oversized summary must not monopolise the byte budget.
+    /// A single oversized summary must not monopolise the byte budget, and must
+    /// not leave an older belief behind either.
     #[test]
     fn oversized_summaries_are_not_retained() {
         let (manager, time) = make_manager();
         let contract = make_contract_key(11);
         let peer = make_peer_key(11);
 
-        manager.register_peer_interest(
+        // Exactly at the bound is retained; one byte over is not.
+        seed_peer_reported(
+            &manager,
             &contract,
-            peer.clone(),
-            Some(StateSummary::from(vec![
-                0xCD;
-                MAX_RETAINED_SUMMARY_BYTES + 1
-            ])),
-            false,
+            &peer,
+            StateSummary::from(vec![0xCD; MAX_RETAINED_SUMMARY_BYTES]),
+        );
+        disconnect_grace_cycle(&manager, &time, &peer);
+        assert_eq!(manager.retained_summary_count(), 1);
+        assert_eq!(
+            retained_outcome(&manager, RetainedSummaryOutcome::SkippedOversized),
+            0
+        );
+
+        seed_peer_reported(
+            &manager,
+            &contract,
+            &peer,
+            StateSummary::from(vec![0xCD; MAX_RETAINED_SUMMARY_BYTES + 1]),
         );
         disconnect_grace_cycle(&manager, &time, &peer);
 
-        assert_eq!(manager.retained_summary_count(), 0);
+        assert_eq!(
+            manager.retained_summary_count(),
+            0,
+            "an oversized teardown must also discard the older belief it supersedes"
+        );
         assert_eq!(manager.retained_summary_bytes(), 0);
         assert_eq!(
             retained_outcome(&manager, RetainedSummaryOutcome::SkippedOversized),
@@ -6205,8 +6661,34 @@ mod tests {
         );
         assert_eq!(
             retained_outcome(&manager, RetainedSummaryOutcome::Stored),
-            0
+            1
         );
+        assert_retention_bookkeeping(&manager);
+    }
+
+    /// An empty summary is a legitimate value (a contract may summarize empty
+    /// state as no bytes) and must round-trip, not be confused with absence.
+    #[test]
+    fn empty_summary_is_retained_and_restored() {
+        let (manager, time) = make_manager();
+        let contract = make_contract_key(25);
+        let peer = make_peer_key(25);
+
+        seed_peer_reported(&manager, &contract, &peer, StateSummary::from(Vec::new()));
+        disconnect_grace_cycle(&manager, &time, &peer);
+        assert_eq!(manager.retained_summary_count(), 1);
+        assert_eq!(manager.retained_summary_bytes(), 0);
+
+        manager.register_peer_interest(&contract, peer.clone(), None, false);
+        assert_eq!(
+            manager
+                .get_peer_summary(&contract, &peer)
+                .as_ref()
+                .map(|s| s.as_ref().to_vec()),
+            Some(Vec::new()),
+            "an empty summary must restore as Some(empty), not None"
+        );
+        assert_retention_bookkeeping(&manager);
     }
 
     /// Retention is keyed on the peer's transport PUBLIC KEY, so a different
@@ -6221,12 +6703,7 @@ mod tests {
         let peer = make_peer_key(12);
         let impostor = make_peer_key(120);
 
-        manager.register_peer_interest(
-            &contract,
-            peer.clone(),
-            Some(StateSummary::from(vec![6u8; 4])),
-            false,
-        );
+        seed_peer_reported(&manager, &contract, &peer, StateSummary::from(vec![6u8; 4]));
         disconnect_grace_cycle(&manager, &time, &peer);
 
         manager.register_peer_interest(&contract, impostor.clone(), None, false);
@@ -6238,6 +6715,7 @@ mod tests {
 
         manager.register_peer_interest(&contract, peer.clone(), None, false);
         assert!(manager.get_peer_summary(&contract, &peer).is_some());
+        assert_retention_bookkeeping(&manager);
     }
 
     /// The retained belief is per (contract, peer): disconnecting must not let a
@@ -6249,11 +6727,11 @@ mod tests {
         let contract_b = make_contract_key(14);
         let peer = make_peer_key(13);
 
-        manager.register_peer_interest(
+        seed_peer_reported(
+            &manager,
             &contract_a,
-            peer.clone(),
-            Some(StateSummary::from(vec![8u8; 4])),
-            false,
+            &peer,
+            StateSummary::from(vec![8u8; 4]),
         );
         manager.register_peer_interest(&contract_b, peer.clone(), None, false);
         disconnect_grace_cycle(&manager, &time, &peer);
@@ -6269,6 +6747,91 @@ mod tests {
             manager.get_peer_summary(&contract_a, &peer).is_some(),
             "contract A's own retained summary must still be claimable"
         );
+        assert_retention_bookkeeping(&manager);
+    }
+
+    /// The cache is shared mutable state on the interest hot path: stores come
+    /// from the disconnect sweep, takes from registration, discards from both
+    /// plus `upsert_peer_summary_from`. Hammer all three concurrently and assert
+    /// the byte counter and the counter-vs-residency identity still hold —
+    /// `total_bytes` drifting LOW would let the cache exceed its memory budget
+    /// while reporting compliance, and every `saturating_sub` would hide it.
+    #[test]
+    fn concurrent_store_take_and_discard_keep_the_bookkeeping_consistent() {
+        use std::sync::Arc;
+        use std::thread;
+
+        let (manager, _time) = make_manager();
+        let manager = Arc::new(manager);
+        let contract = make_contract_key(26);
+        let rounds = 2_000u32;
+
+        let workers: Vec<_> = (0..4u32)
+            .map(|worker| {
+                let manager = Arc::clone(&manager);
+                thread::spawn(move || {
+                    for round in 0..rounds {
+                        // Deliberately overlapping key spaces: adjacent workers
+                        // contend on the same pairs.
+                        let peer = make_unique_peer_key((round % 8) + worker);
+                        manager.register_peer_interest_from(
+                            &contract,
+                            peer.clone(),
+                            None,
+                            false,
+                            InterestRegistrationSource::Interests,
+                        );
+                        manager.upsert_peer_summary_from(
+                            &contract,
+                            &peer,
+                            StateSummary::from(vec![worker as u8; (round % 32) as usize + 1]),
+                            SummaryPopulationSource::InterestSummary,
+                        );
+                        manager.remove_peer_interest_for(
+                            &contract,
+                            &peer,
+                            if round % 3 == 0 {
+                                InterestRemovalCause::Unsubscribe
+                            } else {
+                                InterestRemovalCause::DisconnectGrace
+                            },
+                        );
+                    }
+                })
+            })
+            .collect();
+        for worker in workers {
+            worker.join().expect("worker panicked");
+        }
+
+        assert_retention_bookkeeping(&manager);
+        assert!(manager.retained_summary_bytes() <= RETAINED_SUMMARY_CACHE_MAX_BYTES);
+        assert!(manager.retained_summary_count() <= RETAINED_SUMMARY_CACHE_SIZE);
+    }
+
+    /// The `retain` telemetry array is decoded positionally by the dashboard
+    /// against `RetainedSummaryOutcome::ALL` (see `router.rs`), but the wire
+    /// order actually comes from `index()`. Pin that the two agree, and that the
+    /// labels are distinct — same guard shape as
+    /// `summary_missing_reason_indices_and_labels_are_distinct`.
+    #[test]
+    fn retained_summary_outcome_indices_and_labels_are_distinct() {
+        let mut seen_labels = std::collections::HashSet::new();
+        for (position, outcome) in RetainedSummaryOutcome::ALL.into_iter().enumerate() {
+            assert_eq!(
+                outcome.index(),
+                position,
+                "{} must sit at its ALL position — the telemetry array is decoded \
+                 positionally against ALL",
+                outcome.as_str()
+            );
+            assert!(
+                seen_labels.insert(outcome.as_str()),
+                "duplicate label {}",
+                outcome.as_str()
+            );
+        }
+        assert_eq!(seen_labels.len(), RetainedSummaryOutcome::COUNT);
     }
 
     /// The untracked-path staleness reset must not wipe `recent_removal`.

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use crate::config::GlobalRng;
 use crate::node::network_status::OpType;
 use crate::ring::interest::{
-    InterestRegistrationSource, InterestRemovalCause, MissingSummaryClass,
+    InterestRegistrationSource, InterestRemovalCause, MissingSummaryClass, RetainedSummaryOutcome,
     SummaryPopulationOutcome, SummaryPopulationSource,
 };
 use crate::ring::{Distance, Location, PeerKeyLocation};
@@ -210,6 +210,10 @@ pub(crate) struct NetworkEfficiencyV1 {
     /// Delivery path for this diagnostic block itself; order is documented in
     /// `TelemetryLocalMetricsSnapshot::network_efficiency_delivery`.
     pub eff: [u64; 8],
+    /// Across-disconnect peer-summary retention, in `RetainedSummaryOutcome::ALL`
+    /// order: stored, skipped_oversized, restored, expired, evicted, discarded.
+    /// `restored` is the count of recreated pairs that skipped a full-state send.
+    pub retain: [u64; RetainedSummaryOutcome::COUNT],
 }
 
 /// Periodic snapshot of the router model state for telemetry.

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -212,7 +212,9 @@ pub(crate) struct NetworkEfficiencyV1 {
     pub eff: [u64; 8],
     /// Across-disconnect peer-summary retention, in `RetainedSummaryOutcome::ALL`
     /// order: stored, skipped_oversized, restored, expired, evicted, discarded.
-    /// `restored` is the count of recreated pairs that skipped a full-state send.
+    /// `restored` counts recreated pairs SEEDED from the cache — whether the
+    /// resulting broadcast was a delta or fell back to full state is decided
+    /// later, by the post-compute efficiency gate, and is reported by `ms_s`.
     pub retain: [u64; RetainedSummaryOutcome::COUNT],
 }
 

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -3377,6 +3377,7 @@ mod tests {
             tel: [value; 15],
             shadow: [[value; 9]; 7],
             eff: [value; 8],
+            retain: [value; 6],
         };
 
         let mut u = arbitrary::Unstructured::new(&[0_u8; 32_768]);
@@ -3390,7 +3391,7 @@ mod tests {
         let object = block
             .as_object()
             .expect("network_efficiency_v1 must remain a JSON object");
-        assert_eq!(object.len(), 31, "schema must remain fixed-cardinality");
+        assert_eq!(object.len(), 32, "schema must remain fixed-cardinality");
         let encoded = serde_json::to_vec(block).expect("serialize diagnostic block");
         assert!(
             encoded.len() <= MAX_BUSY_JSON_BYTES,


### PR DESCRIPTION
## Problem

A dropped connection schedules a deferred interest removal
(`INTEREST_DISCONNECT_GRACE_PERIOD`, 90s). When the grace lapses,
`remove_peer_interest_for` deletes the whole `PeerInterest` — **cached summary
included**. The peer's identity is its transport public key
(`PeerKey(TransportPublicKey)`), which is stable across a reconnect from a new
address and across a restart, so the belief we held is still about the same peer
when it comes back. But the recreated entry starts summary-less, and a
summary-less entry is a **missing input** to `get_state_delta`, so the next
broadcast to that peer ships FULL STATE.

## Evidence (0.2.118 fleet, 1,414 reporting peers, `network_efficiency_v1`)

Removal causes — `DisconnectGrace` is not a contributor, it is the mechanism:

| cause | removals | later recreated (≤20 min) |
|---|---|---|
| **DisconnectGrace** | **19,271,751 (82%)** | **2,645,774** |
| InterestsReplace | 2,896,191 | 1,316,229 |
| ChangeInterests | 684,897 | 665,794 |
| TtlExpiry | 498,714 | 58,229 |
| Unsubscribe | 216,855 | 107,509 |

Missing-summary full-state sends (cumulative, latest snapshot per peer):

| class | sends | bytes | mean |
|---|---|---|---|
| UntrackedFirstObserved | 771,400 | 78.20 GB | 101 KiB |
| TrackedFirstNew | 258,021 | 77.35 GB | 300 KiB |
| TrackedFirstRecreated | 25,704 | 7.72 GB | 300 KiB |
| UntrackedFirstRecreated | 21,150 | 6.53 GB | 309 KiB |
| every `*Repeat*` class | 186 | 31 MB | — |

**Timing** — `ms_age`, the age of the summary-less entry at its first send:
164,867 under 1s (58%), 54,655 at 1–9s (19%), 13,770 at 10–59s, 13,707 at
1–5 min, 35,728 at ≥5 min. Nearly four in five first-sends beat the peer's
`Summaries` reply, which is the window a retained summary short-circuits.

The recreation counters are a **floor**: `recent_removal` is only honoured inside
a 20-minute window, and the bounded history LRU overflowed 1,597,674 times
fleet-wide. Total removals (23.6M) and total new-summary-less registrations
(28.6M) are in the same range, so most creations must be recreations — only 4.79M
of which are detected as such.

## The fix

A bounded LRU preserves the cached summary when an interest entry is torn down,
and seeds the recreated entry from it. Retention requires **two** conditions.

**The cause must be `DisconnectGrace`.** That is the one removal where the peer
never withdrew its interest — the transport dropped and nothing the peer said
invalidated our belief. The withdrawal causes are removals where the peer told us
it stopped tracking the contract, so a re-registration may follow a re-fetch that
moved its state somewhere our belief does not describe.

**The provenance must be peer-asserted.** A summary written by
`record_delivery_to_interest` — our own summary cached as theirs on *sender-side*
send completion — is wrong whenever a stream tail is lost, and transport loss is
exactly what puts us on the retention path, so the disconnecting population is
enriched in such beliefs. Today's unconditional teardown is a real repair for
them: `broadcast_to_single_peer`'s converged-skip sends **nothing** when the
cached belief matches our own summary, so a wrong-and-matching belief is silent,
and the teardown is what breaks that silence. Retention keeps that repair intact
and costs almost nothing: `Delivery` is 23.8M of 585M summary writes fleet-wide;
`DigestAgreement`, `InterestSummary` and `InboundBroadcast` — all peer-asserted —
are the rest.

Every removal that does *not* store **discards** instead, and
`upsert_peer_summary_from` discards when it recreates an entry. That makes the
scope exact: a resident retained entry always comes from the pair's most recent
teardown, and that teardown was a disconnect.
`remove_peer_interest_for` is the single removal chokepoint —
`sweep_expired_interests`, `remove_evicted_in_use` and
`remove_all_peer_interests_for` all delegate to it — so no path drops an entry
without passing through this decision.

**Bounded on entries and bytes.** The key is peer-controlled, so an unbounded map
here would be an amplification vector (`.claude/rules/code-style.md`).
`RETAINED_SUMMARY_CACHE_SIZE = 16384` is sized from the fleet — the
`interest_sync_summaries_*` rollup measures a **262-byte mean per `Summaries`
entry** over 228M entries, so the cap costs ~4.3 MB of payload plus ~3 MB of keys
and LRU nodes — and `RETAINED_SUMMARY_CACHE_MAX_BYTES = 8 MiB` bounds the case
where a node's summaries run large. Eviction fails **safe**: forgetting a retained
summary only restores today's behaviour for that pair.

## Why a stale summary is safe here

The retained summary is always one the **peer itself asserted** about its own
state, merely older. A cached peer summary is a belief rather than live evidence
everywhere in this module, and two backstops correct wrong ones: the InterestSync
summary/digest exchange, and the delta-apply-failure → `ResyncRequest` path.
`RETAINED_SUMMARY_TTL` (= `INTEREST_TTL`) bounds how much staleness this *adds* —
a live entry's summary already has no age bound at all, because the converged-skip
refreshes the interest TTL without refreshing the summary.

The two directions of wrongness are not symmetric:

- **Peer moved ahead** (the common case — it kept syncing with others while
  disconnected from us): the delta is a superset of what it needs, and if it is
  not smaller than our state the post-compute efficiency gate (#4923) discards it
  and we send full state exactly as today. On the send itself this can never cost
  more bytes than current behaviour.
- **Peer moved back** (lost, evicted, or re-fetched state — the transport keypair
  survives a db-only wipe, so this *is* reachable): we send too small a delta. If
  the contract rejects it, the total cost is delta + `ResyncRequest` +
  full-state `ResyncResponse` — two round trips **more** than sending full state
  up front — and repeated `Invalid`-class rejections feed the per-*contract*
  `delta_incompat` memo, which then forces full state to every peer of that
  contract for its TTL. That is the honest cost ceiling of being wrong.
  Production says it is rarely paid: `ClearedByDeltaApplyFailure` currently holds
  **32** entries fleet-wide and `ClearedByResync` **413**, against 12.84M known
  summaries — and restricting retention to peer-asserted summaries keeps it that
  way.

## The first broadcast after a restore, when the retained summary is stale

This is the question the whole change turns on, because a retained-but-wrong
summary is worse than no summary if recovery is not guaranteed — no summary at
least produces a correct full-state send. **It costs at most one wasted delta and
then self-heals; it cannot wedge the pair.** Three properties make that true, and
each is a specific code path rather than an argument:

1. **The restore is single-use.** `take_retained_summary` *pops* the entry
   (`interest.rs`), so one retained summary seeds exactly one recreated entry.
   There is no path that re-applies the same belief on a later broadcast.

2. **A rejected delta clears the belief and forces full state.** The receiver's
   `Invalid`-class rejection drives
   `operations/update/op_ctx_task.rs` → `clear_peer_summary(ClearedByDeltaApplyFailure)`
   + `ResyncRequest` → full-state `ResyncResponse`. Cost: one delta + two round
   trips more than sending full state up front.

3. **The recovery cannot re-arm the bad belief.** The full-state resend that
   follows is cached by `record_delivery_to_interest` with
   `SummaryPopulationSource::Delivery` → `SummaryProvenance::SelfAssumed`, which
   this change refuses to retain. So a stale belief that failed once cannot be
   preserved across the next disconnect and replayed. That closes the only shape
   that could have looped.

The silent-divergence variant — the contract *accepts* a too-small delta and ends
up missing state, with no rejection to trigger (2) — is bounded by the
InterestSync exchange, and load-bearingly so: the `Summaries` arm in `node.rs`
overwrites our cached belief with the peer's own report **unconditionally**,
outside the staleness branch (pinned by
`summaries_arm_writes_summary_outside_staleness_branch_pin`), and only then emits
the targeted `SyncStateToPeer` heals. So the correction does not depend on the
stale detection agreeing; ground truth replaces the belief on the next exchange
either way, and the reconnect itself triggers one.

Net versus the full-state send it replaces: strictly better when the peer moved
ahead (the common case), and bounded by one wasted delta plus two round trips
when it moved back — which is why retention is restricted to summaries the peer
itself asserted, since that is what keeps the "moved back" population small.

## Secondary fix: the untracked staleness reset hid recreation

`begin_peer_summary_broadcast`'s untracked arm reset `recent_removal` whenever
`last_observed` was older than `INTEREST_TTL`. Those are different clocks —
`last_observed` is stamped *only* on that untracked path, so it says nothing about
when the interest entry was removed, and the removal's own freshness is already
enforced by the `removed_at` filter one line below. A pair observed untracked at
T0, tracked, removed at T1, and broadcast to again at T2 > T0+20min lost its T1
removal and reported `UntrackedFirstObserved`.

That is why `UntrackedFirstObserved` is the largest class on the fleet (771K
sends / 78.2 GB) while `UntrackedRepeatSequential` is ~zero: churn cycles longer
than `INTEREST_TTL` all landed in the "never seen before" bucket. The counter
could not answer "genuinely never tracked, or tracked-then-dropped?"; now it can.
No routing changes.

## Telemetry — read this before interpreting the rollup

`NetworkEfficiencyV1.retain: [u64; 6]` —
`[stored, skipped_oversized, restored, expired, evicted, discarded]`.
`Restored + Expired + Discarded + Evicted` accounts for **every** stored entry
that has left the cache, including one replaced by a later store for the same
pair, so `stored − departures` is exactly what is resident. `restored` counts
pairs *seeded* from the cache (whether the resulting broadcast was a delta is
decided later and reported by `ms_s`); `evicted` is the resize signal for
`RETAINED_SUMMARY_CACHE_SIZE`.

`recreated_after_removal` shifts for **two** independent reasons in this PR, and
both are intentional: (1) it now also counts recreations that arrive *with* a
summary, so the series keeps measuring the same population instead of appearing
to collapse exactly as retention starts succeeding; and (2) the staleness-reset
fix above means a pair whose removal is recent but whose last untracked
observation is stale now counts as recreated where it previously did not. Expect a
level shift, not a trend. `reg_new_m` deliberately still describes what the caller
supplied, so it stays comparable with pre-retention field data.

## Tests

19 new unit tests in `ring::interest::tests`, covering: the reconnect round trip
asserted on the production read path (`begin_peer_summary_broadcast`, not just the
accessor); a restored belief surviving a second disconnect; self-assumed summaries
*not* retained; every population source's retention eligibility; within-grace
reconnect still owned by the cancel path; the scope cut iterated over
`InterestRemovalCause::ALL`; the interleaving case (disconnect-store → upsert
recreate → withdrawal removal → re-register must **not** restore); TTL at the
boundary and one tick past; caller-supplied supersession; existing-entry
supersession; `recreated_after_removal` continuity; entry bound at, over, and
under capacity; byte bound; oversized rejection at exactly the bound and one byte
over; empty summaries; peer-identity and per-contract keying; a 4-thread
store/take/discard race; the telemetry array-order pin; and the untracked
staleness-reset regression. A shared `assert_retention_bookkeeping` helper pins
the counter-vs-residency identity and `total_bytes` against a recomputed sum
after every scenario that churns the cache — an under-counted `total_bytes` is
the dangerous direction, since the cache would then exceed its memory budget
while reporting compliance.

### Why a `test(priority-select)` commit is riding in a `fix(ring)` PR

Scope creep is a fair thing to flag here, so: it was blocking the full
`cargo test -p freenet --lib` run on this branch, which is one of the gates for
this change, and it is unrelated to the change itself.
`priority_select::tests::test_priority_select_event_loop_simulation` bounds each
poll at 50ms of REAL time while its producer task sleeps 10ms before its first
send, leaving iteration 0 a ~40ms scheduling margin. It failed on the dev box at
load average ~70 (four parallel release builds, not this branch) and passes 3/3
in isolation, so it is latently broken rather than newly broken, and is unlikely
to be failing on GitHub's runners.

The bound is a **hang guard**, not a latency assertion: a waker-registration
regression makes the poll hang forever, so a generous bound fails identically to
a tight one. Widening it therefore costs no real coverage. It is now a 10s guard
with the reasoning recorded inline, in its own commit so it can be reverted
independently. The same file has ~20 more wall-clock timeouts of this shape —
filed as **#5110** with the per-site analysis rather than swept in here, because
several of them deliberately assert "nothing is ready yet" and want a different
fix (`tokio::time::pause`), not a wider bound.

## What this does NOT fix

- `UntrackedFirstObserved` / `UntrackedFirstRecreated` (84.7 GB): those sends
  happen *before* any registration, so the restore hook is not on that path.
  Whether the same cache should also be consulted on the untracked broadcast arm
  is a separate change with its own safety question.
- The non-disconnect removal causes (4.3M removals, 2.15M recreations).
- The transfer-failure loop in #5049, which is about summaries that were never
  populated rather than ones that were destroyed.
- Benefit is bounded by a race: on reconnect the entry is recreated either by the
  `Interests` registration (restore fires) or by the peer's `Summaries` reply via
  `upsert_peer_summary_from` (ground truth, strictly better, restore discarded).
  Retention only pays when registration wins, which is the ~1 RTT window the
  `ms_age` data says four in five first-sends fall inside.

## Note on #5049

The "self-inflicted clobber" half of #5049 is **not supported by production data**.
`reg_ow_k` — registrations that overwrote an already-KNOWN summary — totals **613**
fleet-wide against 28.6M new-summary-less registrations, and every production
`register_peer_interest` site goes through `register_peer_interest_from` behind a
refresh-if-present guard (the bare-call sites are all `#[cfg(test)]`, pinned by
`p2p_protoc.rs`). The `never_populated` population is churn, not clobbering.

[AI-assisted - Claude]
