### PR TITLE
feat(telemetry): measure the fan-out multiplier via originated-vs-relayed applies (#5062)

### DIFF
--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -84,6 +84,11 @@ pub(crate) use op_state_manager::OpManager;
 
 mod network_bridge;
 
+/// Where an applied contract update came from (#5062). Re-exported because
+/// `operations::update` has to name it to declare its provenance, and
+/// `network_bridge` is private outside this module.
+pub(crate) use network_bridge::broadcast_payload_mix::ApplyOrigin;
+
 // Re-export fault injection types for test infrastructure.
 // No cfg gate: underlying items are unconditionally compiled and integration
 // tests compile the lib without cfg(test).

--- a/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
+++ b/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
@@ -83,13 +83,55 @@
 //! that separates them is
 //!
 //! ```text
-//! sum(total_sends) / sum(applies_client_local_changed)
+//! sum(applies_network_relay_changed) / sum(applies_client_local_changed)
 //! ```
 //!
-//! summed over the fleet as a RATIO OF SUMS, never a mean of per-window
-//! ratios — most nodes serve no local clients, so a per-node ratio is `0/0`
-//! most windows. `applies_network_relay_changed / applies_client_local_changed`
-//! reads the re-broadcast amplification directly.
+//! — how many distinct peer-side state transitions one originated update
+//! causes. Against the measured ~17.1 co-host degree, ≈17 says the update
+//! reaches its co-host set once and stops; ≫17 says state keeps genuinely
+//! moving hop after hop. See [`ApplyOrigin`] for why "did a re-broadcast
+//! happen" is NOT the discriminant (one happens either way) and whether its
+//! recipients then change state is.
+//!
+//! Always a RATIO OF SUMS over the fleet, never a mean of per-window ratios:
+//! most nodes serve no local clients, so a per-node per-window ratio is `0/0`
+//! far more often than not. Note also that the sum is unbiased only if
+//! telemetry coverage is uniform across relay-heavy and client-serving nodes;
+//! gateways relay much and serve few local clients, so a reporting population
+//! skewed toward them under-samples the denominator.
+//!
+//! ### `total_sends / applies_client_local_changed` is an UPPER BOUND only
+//!
+//! Tempting, and the more direct statement of "sends per originated update",
+//! but the two are not drawn from the same population. `total_sends` counts
+//! every delivery `record_delivered` sees, and the broadcast queue carries
+//! traffic that no `applies_*` counter can ever match:
+//!
+//!   * targeted anti-entropy heals (`NodeEvent::SyncStateToPeer`) enqueue into
+//!     the SAME queue, with no apply behind them at all — and heal volume
+//!     rises with churn, i.e. loudest under the conditions being measured;
+//!   * PUT-, GET-cache-, ResyncResponse-, first-install- and delegate-driven
+//!     applies broadcast without passing through `update_contract`, so they
+//!     add sends with no denominator entry;
+//!   * no-target retries and `PendingBroadcastStore` re-emits re-send an apply
+//!     that was counted once, or never.
+//!
+//! All of those inflate it. Pulling the other way, `record_delivered` is
+//! delivery-gated while `record_apply` is not, and the executor's broadcast
+//! emit is best-effort under channel pressure. So the net direction is not
+//! known, which is why the relay/client ratio above — same function, same drop
+//! semantics on both halves — is the one to read for a spend/don't-spend
+//! decision. Separating heal sends from fan-out sends would make this bound
+//! tight and is the natural follow-up.
+//!
+//! ### Not the same thing as the receiver-apply counters
+//!
+//! [`ReceiverApplyStats`] above also counts changed-vs-no-op applies, and the
+//! two will never reconcile — by construction, not by bug. Those are
+//! cumulative rather than windowed, and are fed only by the two broadcast-
+//! receive drivers that build a [`ReceiverTerminalGuard`], whereas
+//! `applies_network_relay_*` covers every relayed `update_contract` call. The
+//! relay arm is therefore a strict superset. Do not diff them.
 //!
 //! ### What is deliberately NOT here
 //!
@@ -106,11 +148,20 @@
 //!
 //! One short uncontended mutex acquire per **delivered broadcast** (not per
 //! packet), covering a handful of integer adds and at most one bounded
-//! `HashMap` touch, plus one more per completed update APPLY (strictly rarer
-//! than sends, since one apply is what fans out to N peers). Everything else
-//! happens in the aggregator task, and the hot path only ever WRITES. The lock
-//! is what makes a rollup a consistent snapshot; see [`PayloadMix`] for why
-//! per-field atomics were not enough.
+//! `HashMap` touch, plus one more per completed update APPLY.
+//!
+//! That second acquisition is NOT rare: every RECEIVED broadcast runs
+//! `update_contract` too, and by the #5091 figure above only ~1 in 17.5 of
+//! those changes state and fans out. So on a relay-heavy node the apply and
+//! send rates are comparable and this roughly DOUBLES the acquisition rate on
+//! `window` — worth stating plainly, since "one more, strictly rarer" would
+//! license the next apply-path counter on reasoning that is off by ~17x. It is
+//! still cheap in absolute terms: the apply critical section is two array
+//! writes, against up to three bounded `HashMap` touches for a send.
+//!
+//! Everything else happens in the aggregator task, and the hot path only ever
+//! WRITES. The lock is what makes a rollup a consistent snapshot; see
+//! [`PayloadMix`] for why per-field atomics were not enough.
 //!
 //! [`broadcast_to_single_peer`]: super::broadcast_queue::broadcast_to_single_peer
 
@@ -264,49 +315,98 @@ impl PayloadArm {
 ///   * one node fans out to its ~17 co-hosts, and
 ///   * ~17 nodes EACH re-fan-out to their own ~17 co-hosts.
 ///
-/// They differ by a further ~17x in cost. Splitting applies by origin is what
-/// tells them apart: under the first, essentially every broadcast a node emits
-/// follows a locally-originated apply; under the second, all but a ~1/18th
-/// slice follow a RELAYED apply that this node then re-broadcast.
+/// They differ by a further ~17x in cost.
+///
+/// What separates them is NOT "did a re-broadcast happen" — one does happen in
+/// both cases, since the executor emits on every changed apply. It is whether
+/// the re-broadcast's RECIPIENTS then change state too. Under the first
+/// topology the second-hop payloads land on peers that already hold the state,
+/// so their applies are no-ops and are counted in `_total` but not `_changed`.
+/// Under the second they keep changing state hop after hop. So
+///
+/// ```text
+/// sum(applies_network_relay_changed) / sum(applies_client_local_changed)
+/// ```
+///
+/// reads the number of distinct peer-side state transitions one originated
+/// update causes. Against the measured ~17.1 co-host degree: ≈17 means the
+/// update reaches its co-host set once and stops (a payload problem, fix the
+/// bytes); ≫17 means state keeps genuinely moving across hops (a propagation-
+/// topology problem, a different remedy entirely).
+///
+/// That ratio is the SOUND one: both halves come from the same instrumented
+/// function, with the same drop and failure semantics. See the module docs for
+/// why `total_sends / applies_client_local_changed` is only an upper bound.
 ///
 /// ## Why the counter can be taken here at all
 ///
 /// `Executor::bridged_upsert_contract_state_inner` calls `commit_state_update`
-/// — the only production emitter of `NodeEvent::BroadcastStateChange` on the
-/// UPDATE path — inside the `updated_state != current_state` branch, and
-/// returns `UpsertResult::NoChange` otherwise. So a `changed == true` apply is
-/// a 1:1 correlate of a broadcast fan-out being emitted, and no provenance
-/// plumbing through the `ContractExecutor` trait is needed to attribute it:
-/// `update_contract` already receives the origin as a
-/// [`Priority`](crate::contract::Priority) and already learns `changed` from
-/// the handler's reply.
+/// inside the `updated_state != current_state` branch and returns
+/// `UpsertResult::NoChange` otherwise. So on the UPDATE path a `changed`
+/// apply is what causes a broadcast fan-out, and it can be attributed without
+/// any provenance plumbing through the `ContractExecutor` trait: the caller
+/// knows the origin and the handler's reply carries `changed`.
 ///
-/// The one gap in that correspondence is the broken-invariant suppression
-/// (`ring::broken_invariants`), which can swallow a commit that this counter
-/// still counts as changed. It is rare, deliberate, and already separately
-/// observable, so it is left as a documented residual rather than a second
-/// counter.
+/// ## Why origin is an explicit parameter, not read off `Priority`
+///
+/// [`Priority`](crate::contract::Priority) is defined on very nearly this axis
+/// (`ClientLocal` / `NetworkRelay`) and deriving from it would have been free.
+/// It is wrong to do so, and there is already a live counter-example:
+/// `put::op_ctx_task`'s summary-first reverse-delta merge tags
+/// `Priority::ClientLocal` while applying content the REMOTE HOLDER sent back
+/// — its own comment says the tag is chosen to match the originator-loopback
+/// store's scheduling lane. Deriving provenance there would have booked a
+/// relayed apply into the originated bucket and deflated both published
+/// ratios, in the flattering direction.
+///
+/// The general point outlasts that one site: scheduling class and data
+/// provenance are free to diverge, and a future re-tag for queue-fairness
+/// reasons must not silently move a measurement's denominator. Hence an
+/// explicit argument the compiler demands at every call site.
+///
+/// ## Residuals, i.e. where `changed` and "a broadcast happened" come apart
+///
+/// Stated because a multiplier read off a correspondence nobody wrote down is
+/// how a measurement quietly stops meaning what its dashboard says:
+///
+///   * `try_notify_node_event` (`executor_impl.rs`) is best-effort by design
+///     (#4145) and silently drops the emit when the node-event channel is
+///     full. That is a `changed` apply with no sends, and it is
+///     LOAD-CORRELATED — it happens hardest under exactly the fan-out
+///     pressure being measured, so it biases the multiplier DOWN when the
+///     signal is strongest.
+///   * the broken-invariant suppression (`ring::broken_invariants`) can
+///     swallow a commit on a flag flip that races the merge's own check.
+///   * the first-install branch broadcasts via `Executor::broadcast_state_change`
+///     and the queued-op replay loop commits once per replayed op, so one
+///     `changed` apply can correspond to more than one broadcast.
+///   * an UPDATE arriving mid-initialization returns `NoChange` without
+///     merging, and is replayed at init completion where it does merge and
+///     does broadcast — so it lands in `_total` once and its real apply is
+///     never counted.
+///
+/// None of these are worth a counter each; all of them are worth knowing
+/// about before reading a ratio to three significant figures.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ApplyOrigin {
-    /// Originated by a WS/HTTP client connected to THIS node — the true
-    /// denominator of "sends per originated update".
+    /// The update's CONTENT originated with a WS/HTTP client connected to this
+    /// node — the denominator of "sends per originated update".
     ClientLocal,
-    /// Applied on behalf of a remote peer's relayed operation. A `changed`
-    /// apply here is a RE-broadcast: the amplification #5062 exists to size.
+    /// The update's CONTENT arrived from a remote peer. A `changed` apply here
+    /// is a state transition this node then re-broadcasts.
     NetworkRelay,
-    /// Node-internal background work. No `update_contract` call site produces
-    /// this today; it is carried so that one appearing later shows up as its
-    /// own number instead of silently inflating the relay arm.
-    Background,
 }
 
 impl ApplyOrigin {
     /// Every origin, in reporting order.
-    pub(crate) const ALL: [ApplyOrigin; 3] = [
-        ApplyOrigin::ClientLocal,
-        ApplyOrigin::NetworkRelay,
-        ApplyOrigin::Background,
-    ];
+    ///
+    /// Kept in lockstep with [`Self::index`] by
+    /// `apply_origin_variants_are_all_listed_and_densely_indexed`, because
+    /// `COUNT` (hence the counter array's width) is derived from THIS array
+    /// while `index()` is an independent match — the same "add a variant, fix
+    /// the compile errors, forget `ALL`" trap that
+    /// [`PayloadMix::record_delivered`] guards against with fallible indexing.
+    pub(crate) const ALL: [ApplyOrigin; 2] = [ApplyOrigin::ClientLocal, ApplyOrigin::NetworkRelay];
 
     pub(crate) const COUNT: usize = Self::ALL.len();
 
@@ -314,7 +414,6 @@ impl ApplyOrigin {
         match self {
             ApplyOrigin::ClientLocal => 0,
             ApplyOrigin::NetworkRelay => 1,
-            ApplyOrigin::Background => 2,
         }
     }
 
@@ -324,33 +423,6 @@ impl ApplyOrigin {
         match self {
             ApplyOrigin::ClientLocal => "client_local",
             ApplyOrigin::NetworkRelay => "network_relay",
-            ApplyOrigin::Background => "background",
-        }
-    }
-
-    /// Read the origin off the scheduling class the apply was queued under.
-    ///
-    /// [`Priority`](crate::contract::Priority) is a scheduling class that
-    /// happens to be defined on exactly this axis, and all eight production
-    /// `update_contract` call sites tag it explicitly and correctly today
-    /// (three `ClientLocal`, five `NetworkRelay`). Reusing it is what makes
-    /// this measurement a one-site change instead of a new parameter threaded
-    /// through the `ContractExecutor` trait and ~160 call sites.
-    ///
-    /// The risk it carries, stated so a future reader does not have to
-    /// rediscover it: `Priority::DEFAULT` is `NetworkRelay`, so a NEW call
-    /// site that forgets to tag itself reads as "relayed" rather than as
-    /// something unclassified. That biases the multiplier's denominator DOWN
-    /// and the amplification numerator UP — i.e. it can only ever make the
-    /// fan-out problem look worse than it is, never better, which is the safe
-    /// direction for a measurement whose purpose is to decide whether to spend
-    /// engineering effort on propagation topology. A new client-originated
-    /// path that lands untagged is the case to watch for.
-    pub(crate) const fn from_priority(priority: crate::contract::Priority) -> Self {
-        match priority {
-            crate::contract::Priority::ClientLocal => ApplyOrigin::ClientLocal,
-            crate::contract::Priority::NetworkRelay => ApplyOrigin::NetworkRelay,
-            crate::contract::Priority::Background => ApplyOrigin::Background,
         }
     }
 }
@@ -813,36 +885,48 @@ impl PayloadMix {
     /// which the executor emits a broadcast fan-out — see [`ApplyOrigin`].
     ///
     /// Call this only on a terminal apply outcome (merged, or merged-to-no-
-    /// change). Applies that ERRORED are deliberately excluded: nothing was
-    /// committed and nothing was broadcast, so counting them would pad the
-    /// denominator of a ratio whose whole purpose is to be compared against
-    /// sends. Failures are already published receiver-side by #5091's
-    /// `*_failed` terminal counters.
-    /// [`Self::record_apply`], reading the origin off the scheduling class the
-    /// apply was queued under.
+    /// change). Applies that ERRORED are excluded, because a merge that
+    /// returned an error committed nothing and broadcast nothing, so counting
+    /// it would pad a denominator whose whole purpose is to be divided into
+    /// sends.
     ///
-    /// This is the form production calls. It exists so `operations::update`
-    /// never has to name [`ApplyOrigin`] — `node::network_bridge` is private
-    /// outside `node`, and more importantly the apply path has no business
-    /// knowing the telemetry taxonomy. The `Priority` -> origin
-    /// reinterpretation stays in one documented place; see
-    /// [`ApplyOrigin::from_priority`] for the aliasing risk it carries.
-    pub(crate) fn record_apply_with_priority(
-        &self,
-        priority: crate::contract::Priority,
-        changed: bool,
-    ) {
-        self.record_apply(ApplyOrigin::from_priority(priority), changed);
-    }
-
+    /// Two honest caveats on that exclusion. A contract-handler TIMEOUT
+    /// (`CH_EV_RESPONSE_TIME_OUT`) surfaces as an error here without cancelling
+    /// the queued event, so a commit that lands late is a send with no apply.
+    /// And fair-queue shedding drops sub-`ClientLocal` work first, so under
+    /// saturation the relay arm is undercounted relative to the client arm.
+    /// Both bias the relay/client ratio the same way — toward "no problem" —
+    /// which is the direction to be suspicious of.
     pub(crate) fn record_apply(&self, origin: ApplyOrigin, changed: bool) {
         let idx = origin.index();
         let changed_idx = usize::from(changed);
         let mut w = self.window.lock();
-        // Saturating for the same reason as the send counters: a wrapped
-        // denominator would report an absurd multiplier rather than an
-        // obviously-clamped one.
-        w.applies[idx][changed_idx] = w.applies[idx][changed_idx].saturating_add(1);
+        // Fallible indexing, NOT `[idx]`, for exactly the reason spelled out in
+        // `record_delivered`: `COUNT` is derived from `ApplyOrigin::ALL` while
+        // `index()` is an independent exhaustive match, so "add a variant, fix
+        // the two compile errors, forget `ALL`" yields an out-of-range index.
+        // As `[idx]` that would PANIC inside a held mutex on the contract-apply
+        // hot path. Dropping the record instead keeps the miss visible (the
+        // per-origin counts stop covering the real apply rate) without killing
+        // an operation for a telemetry bookkeeping slip.
+        if let Some(counts) = w.applies.get_mut(idx) {
+            // Saturating for the same reason as the send counters: a wrapped
+            // denominator would report an absurd multiplier rather than an
+            // obviously-clamped one.
+            counts[changed_idx] = counts[changed_idx].saturating_add(1);
+        }
+    }
+
+    /// Test-only view of the apply counters, indexed `[origin][changed]`.
+    ///
+    /// Reads without draining and without emitting a telemetry event, so a
+    /// test in another module can assert that driving the REAL
+    /// `update_contract` moved the right counter. That assertion is the one
+    /// thing a source-scrape pin fundamentally cannot make: a pin counts text,
+    /// so it stays green against a call that has been commented out.
+    #[cfg(test)]
+    pub(crate) fn applies_snapshot(&self) -> [[u64; 2]; ApplyOrigin::COUNT] {
+        self.window.lock().applies
     }
 
     /// Atomically take the current window, leaving a fresh empty one.
@@ -1886,7 +1970,13 @@ mod tests {
     }
 
     /// Concurrent recorders racing a rollup must not lose or double-count
-    /// bytes: every recorded byte lands in exactly one window.
+    /// bytes OR applies: every record lands in exactly one window.
+    ///
+    /// Applies are included because `record_apply` is called from async
+    /// operation tasks racing the same 60 s rollup, and because conservation
+    /// across a rollover is precisely what makes the #5062 ratio well-defined
+    /// — a lost apply shrinks a denominator, which reads as amplification that
+    /// is not there.
     #[test]
     fn concurrent_records_racing_a_rollup_conserve_bytes() {
         use std::sync::Arc;
@@ -1900,15 +1990,21 @@ mod tests {
         // A rollup loop running concurrently with the writers, accumulating
         // what it drains.
         let drained_total = Arc::new(Mutex::new(0u64));
+        let drained_applies = Arc::new(Mutex::new(0u64));
         let drainer = {
             let mix = Arc::clone(&mix);
             let stop = Arc::clone(&stop);
             let drained_total = Arc::clone(&drained_total);
+            let drained_applies = Arc::clone(&drained_applies);
             std::thread::spawn(move || {
                 while !stop.load(std::sync::atomic::Ordering::Relaxed) {
                     let w = mix.take_window();
                     let sum: u64 = w.arms().iter().map(|(_, _, b)| b).sum();
                     *drained_total.lock() += sum;
+                    // Same atomic take must carry the applies, or the two
+                    // halves of the ratio drift apart across a rollover.
+                    *drained_applies.lock() +=
+                        w.applies().iter().map(|(_, _, total)| total).sum::<u64>();
                     // Sleep rather than spin. A hot loop here would burn a
                     // whole core for the duration of the test, and the suite
                     // runs tests in parallel — starving a timing-sensitive
@@ -1925,13 +2021,23 @@ mod tests {
             .map(|t| {
                 let mix = Arc::clone(&mix);
                 std::thread::spawn(move || {
-                    for _ in 0..PER_THREAD {
+                    for i in 0..PER_THREAD {
                         mix.record_delivered(
                             PayloadArm::FullNotEfficient,
                             &contract(t as u8),
                             7,
                             None,
                             None,
+                        );
+                        // Alternate origin and outcome so the drainer races
+                        // writes to every slot of the applies array.
+                        mix.record_apply(
+                            if i % 2 == 0 {
+                                ApplyOrigin::ClientLocal
+                            } else {
+                                ApplyOrigin::NetworkRelay
+                            },
+                            i % 3 == 0,
                         );
                     }
                 })
@@ -1944,12 +2050,23 @@ mod tests {
         drainer.join().unwrap();
 
         // Whatever the final drainer pass missed is still in the accumulator.
-        let leftover: u64 = mix.take_window().arms().iter().map(|(_, _, b)| b).sum();
+        let final_window = mix.take_window();
+        let leftover: u64 = final_window.arms().iter().map(|(_, _, b)| b).sum();
+        let leftover_applies: u64 = final_window
+            .applies()
+            .iter()
+            .map(|(_, _, total)| total)
+            .sum();
         let total = *drained_total.lock() + leftover;
         assert_eq!(
             total,
             (THREADS * PER_THREAD * 7) as u64,
             "bytes were lost or double-counted across a concurrent rollover"
+        );
+        assert_eq!(
+            *drained_applies.lock() + leftover_applies,
+            (THREADS * PER_THREAD) as u64,
+            "applies were lost or double-counted across a concurrent rollover"
         );
     }
 
@@ -2464,34 +2581,31 @@ mod tests {
 
     // ---- #5062: the fan-out multiplier's denominator ----
 
-    /// Every `Priority` class maps to a distinct origin, and the mapping is
-    /// the one the schema claims.
+    /// `ALL` must list every variant, and `index()` must be dense over it.
     ///
-    /// This is the single point where a scheduling class is reinterpreted as
-    /// provenance, so it is the single point where that reinterpretation can
-    /// silently rot — e.g. a new `Priority` variant folded into an existing
-    /// arm. An exhaustive check here is what makes the reuse safe.
+    /// `COUNT` — hence the width of `Window::applies` — is derived from `ALL`,
+    /// while `index()` is an independent exhaustive match. Adding a variant
+    /// forces an `index()` arm (the match is exhaustive) but does NOT force
+    /// extending `ALL`, so the counter array stays too narrow and the new
+    /// origin's records are silently dropped by the bounds check in
+    /// `record_apply`. This test is what catches that.
     #[test]
-    fn apply_origin_maps_each_priority_class_to_its_own_arm() {
-        use crate::contract::Priority;
-
-        assert_eq!(
-            ApplyOrigin::from_priority(Priority::ClientLocal),
-            ApplyOrigin::ClientLocal
-        );
-        assert_eq!(
-            ApplyOrigin::from_priority(Priority::NetworkRelay),
-            ApplyOrigin::NetworkRelay
-        );
-        assert_eq!(
-            ApplyOrigin::from_priority(Priority::Background),
-            ApplyOrigin::Background
-        );
-
-        // Distinct indices and distinct labels: two origins sharing either
-        // would silently merge two arms of the measurement.
+    fn apply_origin_variants_are_all_listed_and_densely_indexed() {
         let indices: Vec<usize> = ApplyOrigin::ALL.iter().map(|o| o.index()).collect();
-        assert_eq!(indices, vec![0, 1, 2], "indices must be dense and ordered");
+        assert_eq!(
+            indices,
+            (0..ApplyOrigin::COUNT).collect::<Vec<_>>(),
+            "indices must be dense, ordered, and cover exactly `ALL`"
+        );
+        // Every index reachable from `index()` must be in range for the
+        // counter array — the invariant `record_apply`'s bounds check exists
+        // to survive, and that this test exists to keep unnecessary.
+        for origin in ApplyOrigin::ALL {
+            assert!(
+                origin.index() < ApplyOrigin::COUNT,
+                "{origin:?} indexes outside the counter array"
+            );
+        }
         let mut labels: Vec<&str> = ApplyOrigin::ALL.iter().map(|o| o.label()).collect();
         labels.sort_unstable();
         labels.dedup();
@@ -2500,6 +2614,32 @@ mod tests {
             ApplyOrigin::COUNT,
             "every origin needs a unique wire label"
         );
+    }
+
+    /// An out-of-range origin index degrades to a dropped record rather than
+    /// panicking inside the held mutex on the apply hot path.
+    #[test]
+    fn out_of_range_origin_index_drops_the_record_instead_of_panicking() {
+        let mix = PayloadMix::new();
+        {
+            // Simulate the "added a variant, forgot `ALL`" state directly: an
+            // index past the array's width. `record_apply` must survive it.
+            let mut w = mix.window.lock();
+            assert!(
+                w.applies.get_mut(ApplyOrigin::COUNT).is_none(),
+                "test premise: COUNT indexes past the end"
+            );
+        }
+        // The real call cannot produce an out-of-range index today, so assert
+        // the guard's shape rather than reaching through it: every listed
+        // origin records, and the window stays consistent.
+        for origin in ApplyOrigin::ALL {
+            mix.record_apply(origin, true);
+        }
+        let json = emit(&mix);
+        for origin in ApplyOrigin::ALL {
+            assert_eq!(json[format!("applies_{}_changed", origin.label())], 1);
+        }
     }
 
     /// The published schema splits applies by origin AND by whether the merge
@@ -2522,11 +2662,6 @@ mod tests {
         assert_eq!(json["applies_client_local_total"], 2);
         assert_eq!(json["applies_network_relay_changed"], 1);
         assert_eq!(json["applies_network_relay_total"], 3);
-        // Untouched origins are published as explicit zeros, not omitted: a
-        // missing field and a zero field read identically to a careless query
-        // but differently to a careful one.
-        assert_eq!(json["applies_background_changed"], 0);
-        assert_eq!(json["applies_background_total"], 0);
     }
 
     /// `total` is never less than `changed` for any origin — the invariant a
@@ -2655,22 +2790,47 @@ mod tests {
             .expect("end of update_contract not found");
         let body = &body[..end];
 
+        // Whitespace-collapsed before matching, following the convention of
+        // the sibling pin in this same file
+        // (`update_contract_never_builds_a_summary_from_state_bytes`): needles
+        // that embed rustfmt's line breaks turn a green test red on a pure
+        // reformat, which teaches the next person to delete the pin.
+        let collapsed: String = body.split_whitespace().collect::<Vec<_>>().join(" ");
+
         assert_eq!(
-            body.matches("record_apply_with_priority(priority,").count(),
+            collapsed.matches("record_apply(origin,").count(),
             2,
             "update_contract must record exactly two apply outcomes — the \
              state-changed merge and the merged-to-no-change arm — and both \
-             must pass this call's OWN `priority` rather than a hardcoded \
-             origin, because `priority` IS the provenance (#5062). Dropping \
-             either arm silently biases the fan-out denominator."
+             must pass this call's OWN `origin`. Dropping either arm silently \
+             biases the #5062 fan-out denominator."
         );
-        // The changed arm must forward the handler's verdict, not a literal:
-        // hardcoding `true` there would count every no-op merge as a
-        // broadcast-emitting apply.
+        // The changed arm must forward the handler's verdict; the no-change arm
+        // must pass a literal `false`. Hardcoding `true` in either would count
+        // no-op merges as broadcast-emitting applies and inflate the ratio.
         assert!(
-            body.contains("record_apply_with_priority(priority, state_changed)"),
+            collapsed.contains("record_apply(origin, state_changed)"),
             "the state-changed arm must record the handler's own \
              `state_changed` verdict"
+        );
+        assert!(
+            collapsed.contains("record_apply(origin, false)"),
+            "the merged-to-no-change arm must record `changed = false`"
+        );
+        // Ordering: the no-change record must precede the state-recovery
+        // fallback's error exit, or an early failure there silently drops that
+        // arm from the denominator. Same idiom as the offset-comparison pins in
+        // `update/op_ctx_task.rs`.
+        let no_change_pos = collapsed
+            .find("record_apply(origin, false)")
+            .expect("no-change record not found");
+        let fallback_err_pos = collapsed
+            .find("Cannot extract state from delta-only UpdateData")
+            .expect("state-recovery fallback not found");
+        assert!(
+            no_change_pos < fallback_err_pos,
+            "the no-change apply must be recorded BEFORE the state-recovery \
+             fallback can bail out ({no_change_pos} < {fallback_err_pos})"
         );
     }
 }

--- a/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
+++ b/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
@@ -95,38 +95,70 @@
 //!
 //! Always a RATIO OF SUMS over the fleet, never a mean of per-window ratios:
 //! most nodes serve no local clients, so a per-node per-window ratio is `0/0`
-//! far more often than not. Note also that the sum is unbiased only if
-//! telemetry coverage is uniform across relay-heavy and client-serving nodes;
-//! gateways relay much and serve few local clients, so a reporting population
-//! skewed toward them under-samples the denominator.
+//! far more often than not.
 //!
-//! ### `total_sends / applies_client_local_changed` is an UPPER BOUND only
+//! ### R/C IS BIASED UPWARD. Read it as an upper bound.
 //!
-//! Tempting, and the more direct statement of "sends per originated update",
-//! but the two are not drawn from the same population. `total_sends` counts
-//! every delivery `record_delivered` sees, and the broadcast queue carries
-//! traffic that no `applies_*` counter can ever match:
+//! Both halves come out of the same function, but NOT out of the same
+//! population, and the residuals do not cancel — they push the same way. An
+//! earlier revision of this doc called the ratio "sound" on the same-function
+//! argument; that was wrong, and wrong in the direction that costs money,
+//! because every effect below inflates R/C toward the ≫17 reading whose remedy
+//! is the expensive one.
+//!
+//! Numerator gets relayed `changed` applies with no origination behind them:
 //!
 //!   * targeted anti-entropy heals (`NodeEvent::SyncStateToPeer`) enqueue into
-//!     the SAME queue, with no apply behind them at all — and heal volume
-//!     rises with churn, i.e. loudest under the conditions being measured;
-//!   * PUT-, GET-cache-, ResyncResponse-, first-install- and delegate-driven
-//!     applies broadcast without passing through `update_contract`, so they
-//!     add sends with no denominator entry;
-//!   * no-target retries and `PendingBroadcastStore` re-emits re-send an apply
-//!     that was counted once, or never.
+//!     the SAME broadcast queue and arrive as the same `UpdateMsg::BroadcastTo`
+//!     wire shape, so the receiver applies them as `NetworkRelay` and cannot
+//!     tell them from a fan-out leg. Heal volume rises with churn, i.e. it is
+//!     loudest under the conditions being measured;
+//!   * the summary-first PUT reverse-delta merge books a relay entry at the
+//!     ORIGINATOR of a local PUT whose origination is not in the denominator.
 //!
-//! All of those inflate it. Pulling the other way, `record_delivered` is
-//! delivery-gated while `record_apply` is not, and the executor's broadcast
-//! emit is best-effort under channel pressure. So the net direction is not
-//! known, which is why the relay/client ratio above — same function, same drop
-//! semantics on both halves — is the one to read for a spend/don't-spend
-//! decision. Separating heal sends from fan-out sends would make this bound
-//! tight and is the natural follow-up.
+//! Denominator misses originations entirely:
+//!
+//!   * a client PUT never calls `update_contract` — it broadcasts from
+//!     `broadcast_state_change` on the `PutQuery` path — yet its fan-out
+//!     produces relayed `changed` applies fleet-wide. Same for delegate-driven
+//!     PUT/UPDATE, and for ResyncResponse heals, which apply relayed state via
+//!     a raw `UpdateQuery`;
+//!   * a client UPDATE on a node that is not hosting fails its local apply
+//!     while propagation proceeds regardless.
+//!
+//! Pulling the other way, and smaller: the broadcast dedup cache and the
+//! merge-failure backoff gate both short-circuit BEFORE `update_contract`, so
+//! some relayed applies never reach the numerator (the backoff one concentrated
+//! on poison contracts — again the churn being measured); and fair-queue
+//! shedding drops sub-`ClientLocal` work first.
+//!
+//! Practical reading: **R/C ≈ 17 is strong evidence of one-hop reach**, because
+//! the biases can only push it up. **R/C ≫ 17 is suggestive, not conclusive** —
+//! before spending on propagation topology, bound the heal and PUT-origination
+//! contribution. The follow-ups that would make this tight are a `heal_sends`
+//! split at `record_delivered` and a PUT-path apply counter.
+//!
+//! ### `total_sends / applies_client_local_changed` is looser still
+//!
+//! The more direct statement of "sends per originated update", and the one
+//! #5062 asks for, but its numerator additionally carries every heal delivery,
+//! every PUT/GET-cache/Resync/first-install/delegate-driven send, and no-target
+//! retries plus `PendingBroadcastStore` re-emits of already-counted applies.
+//! Against that, `record_delivered` is delivery-gated while `record_apply` is
+//! not, and the executor's emit is best-effort under channel pressure. Prefer
+//! R/C; use this only as a coarse cross-check.
+//!
+//! ### Coverage
+//!
+//! Either ratio is unbiased across the fleet only if telemetry coverage is
+//! uniform across relay-heavy and client-serving nodes. Gateways relay much and
+//! serve few local clients, so a reporting population skewed toward them
+//! under-samples the denominator — pushing both ratios up, same direction as
+//! everything above.
 //!
 //! ### Not the same thing as the receiver-apply counters
 //!
-//! [`ReceiverApplyStats`] above also counts changed-vs-no-op applies, and the
+//! [`ReceiverApplyStats`] below also counts changed-vs-no-op applies, and the
 //! two will never reconcile — by construction, not by bug. Those are
 //! cumulative rather than windowed, and are fed only by the two broadcast-
 //! receive drivers that build a [`ReceiverTerminalGuard`], whereas
@@ -147,8 +179,8 @@
 //! ## Cost
 //!
 //! One short uncontended mutex acquire per **delivered broadcast** (not per
-//! packet), covering a handful of integer adds and at most one bounded
-//! `HashMap` touch, plus one more per completed update APPLY.
+//! packet), covering a handful of integer adds and up to three bounded
+//! `HashMap` touches, plus one more per completed update APPLY.
 //!
 //! That second acquisition is NOT rare: every RECEIVED broadcast runs
 //! `update_contract` too, and by the #5091 figure above only ~1 in 17.5 of
@@ -156,8 +188,8 @@
 //! send rates are comparable and this roughly DOUBLES the acquisition rate on
 //! `window` — worth stating plainly, since "one more, strictly rarer" would
 //! license the next apply-path counter on reasoning that is off by ~17x. It is
-//! still cheap in absolute terms: the apply critical section is two array
-//! writes, against up to three bounded `HashMap` touches for a send.
+//! still cheap in absolute terms: the apply critical section is a single array
+//! write, against up to three bounded `HashMap` touches for a send.
 //!
 //! Everything else happens in the aggregator task, and the hot path only ever
 //! WRITES. The lock is what makes a rollup a consistent snapshot; see
@@ -546,7 +578,7 @@ struct Window {
     /// applies describe the same 60 s of work and the ratio between them is
     /// meaningful rather than smeared across window boundaries.
     ///
-    /// Fixed cardinality (3 x 2 `u64`s), no per-contract map: see the module
+    /// Fixed cardinality (2 x 2 `u64`s), no per-contract map: see the module
     /// docs for why the per-contract refinement is deliberately not here.
     applies: [[u64; 2]; ApplyOrigin::COUNT],
 }
@@ -1332,18 +1364,21 @@ fn payload_mix_json(
         "attribution_dropped_bytes".into(),
         attribution_dropped_bytes.into(),
     );
-    // #5062: the fan-out multiplier's denominator. `total_sends` above is the
-    // numerator, recorded into the same window and drained by the same atomic
-    // take, so the two describe the same 60 s of work.
+    // #5062: update applies split by origin, recorded into the same window as
+    // the send counters above and drained by the same atomic take.
     //
-    // NO ratio is published here, deliberately. The quantity that matters is a
-    // ratio of SUMS over the fleet —
-    //   sum(total_sends) / sum(applies_client_local_changed)
-    // — and most nodes host no local clients, so a per-window per-node ratio is
-    // `0/0` far more often than not. Publishing one would invite exactly the
-    // mean-of-ratios aggregation that `not_efficient_summary_to_state_bytes_ratio`
-    // above is named to steer consumers away from, on data where it is far more
-    // degenerate. Raw counters only; the division belongs in the query.
+    // The quantity to build a dashboard on is the ratio of SUMS over the fleet
+    //   sum(applies_network_relay_changed) / sum(applies_client_local_changed)
+    // — NOT `total_sends / applies_client_local_changed`, which is looser. Read
+    // the module docs before using either: both are biased UPWARD, and by how
+    // much is not published. Do not read them to three significant figures.
+    //
+    // NO ratio is published here, deliberately. Most nodes host no local
+    // clients, so a per-window per-node ratio is `0/0` far more often than not,
+    // and publishing one would invite exactly the mean-of-ratios aggregation
+    // that `not_efficient_summary_to_state_bytes_ratio` above is named to steer
+    // consumers away from, on data where it is far more degenerate. Raw
+    // counters only; the division belongs in the query.
     for (origin, changed, total) in applies {
         obj.insert(
             format!("applies_{}_changed", origin.label()),
@@ -1991,11 +2026,13 @@ mod tests {
         // what it drains.
         let drained_total = Arc::new(Mutex::new(0u64));
         let drained_applies = Arc::new(Mutex::new(0u64));
+        let drained_changed = Arc::new(Mutex::new(0u64));
         let drainer = {
             let mix = Arc::clone(&mix);
             let stop = Arc::clone(&stop);
             let drained_total = Arc::clone(&drained_total);
             let drained_applies = Arc::clone(&drained_applies);
+            let drained_changed = Arc::clone(&drained_changed);
             std::thread::spawn(move || {
                 while !stop.load(std::sync::atomic::Ordering::Relaxed) {
                     let w = mix.take_window();
@@ -2003,8 +2040,17 @@ mod tests {
                     *drained_total.lock() += sum;
                     // Same atomic take must carry the applies, or the two
                     // halves of the ratio drift apart across a rollover.
+                    // `changed` is conserved SEPARATELY from the total: it is
+                    // the slot the ratio actually divides by, and a mutation
+                    // that always wrote the unchanged slot would conserve the
+                    // total perfectly while zeroing the measurement.
                     *drained_applies.lock() +=
                         w.applies().iter().map(|(_, _, total)| total).sum::<u64>();
+                    *drained_changed.lock() += w
+                        .applies()
+                        .iter()
+                        .map(|(_, changed, _)| changed)
+                        .sum::<u64>();
                     // Sleep rather than spin. A hot loop here would burn a
                     // whole core for the duration of the test, and the suite
                     // runs tests in parallel — starving a timing-sensitive
@@ -2057,6 +2103,11 @@ mod tests {
             .iter()
             .map(|(_, _, total)| total)
             .sum();
+        let leftover_changed: u64 = final_window
+            .applies()
+            .iter()
+            .map(|(_, changed, _)| changed)
+            .sum();
         let total = *drained_total.lock() + leftover;
         assert_eq!(
             total,
@@ -2067,6 +2118,15 @@ mod tests {
             *drained_applies.lock() + leftover_applies,
             (THREADS * PER_THREAD) as u64,
             "applies were lost or double-counted across a concurrent rollover"
+        );
+        // Writers pass `changed = i % 3 == 0`, so each thread contributes
+        // ceil(PER_THREAD / 3).
+        assert_eq!(
+            *drained_changed.lock() + leftover_changed,
+            (THREADS * PER_THREAD.div_ceil(3)) as u64,
+            "CHANGED applies were lost, double-counted, or routed to the wrong \
+             slot across a concurrent rollover — that slot is the ratio's \
+             denominator, so conserving only the total would miss it"
         );
     }
 
@@ -2591,21 +2651,36 @@ mod tests {
     /// `record_apply`. This test is what catches that.
     #[test]
     fn apply_origin_variants_are_all_listed_and_densely_indexed() {
+        // The exhaustive match is the load-bearing part, and it must live HERE
+        // rather than iterate `ALL`. Deriving the variant list from `ALL` is
+        // what makes the obvious version of this test vacuous: it would check
+        // `ALL` against itself and stay green in exactly the case that matters
+        // — a variant added to `index()` but missing from `ALL`, whose records
+        // `record_apply`'s bounds check then silently drops. Adding a variant
+        // fails to compile here until it is listed below AND in `ALL`.
+        let every_variant = [ApplyOrigin::ClientLocal, ApplyOrigin::NetworkRelay];
+        for v in every_variant {
+            match v {
+                ApplyOrigin::ClientLocal | ApplyOrigin::NetworkRelay => {}
+            }
+            assert!(
+                ApplyOrigin::ALL.contains(&v),
+                "{v:?} exists but is missing from `ALL`, so `COUNT` under-sizes \
+                 the counter array and every record for it is dropped"
+            );
+        }
+        assert_eq!(
+            ApplyOrigin::COUNT,
+            every_variant.len(),
+            "`ALL` must list every variant"
+        );
+
         let indices: Vec<usize> = ApplyOrigin::ALL.iter().map(|o| o.index()).collect();
         assert_eq!(
             indices,
             (0..ApplyOrigin::COUNT).collect::<Vec<_>>(),
             "indices must be dense, ordered, and cover exactly `ALL`"
         );
-        // Every index reachable from `index()` must be in range for the
-        // counter array — the invariant `record_apply`'s bounds check exists
-        // to survive, and that this test exists to keep unnecessary.
-        for origin in ApplyOrigin::ALL {
-            assert!(
-                origin.index() < ApplyOrigin::COUNT,
-                "{origin:?} indexes outside the counter array"
-            );
-        }
         let mut labels: Vec<&str> = ApplyOrigin::ALL.iter().map(|o| o.label()).collect();
         labels.sort_unstable();
         labels.dedup();
@@ -2616,30 +2691,36 @@ mod tests {
         );
     }
 
-    /// An out-of-range origin index degrades to a dropped record rather than
-    /// panicking inside the held mutex on the apply hot path.
+    /// `record_apply` must index the origin arm FALLIBLY.
+    ///
+    /// No in-range call can demonstrate this, since `index()` cannot currently
+    /// return an out-of-range value — which is exactly why it needs a pin
+    /// rather than a behavioural test. If a variant is ever added to `index()`
+    /// without being added to `ALL`, `COUNT` under-sizes the array and the
+    /// index goes out of range; as `[idx]` that would PANIC inside a held mutex
+    /// on the contract-apply hot path, which the sibling `tracked_missing`
+    /// counters in `record_delivered` already refuse to do for the same reason.
+    ///
+    /// A source scrape is the honest instrument here. The previous version of
+    /// this test asserted `applies.get_mut(COUNT).is_none()`, which is a
+    /// compile-time truth about any fixed-size array and stayed green when the
+    /// guard was replaced with `[idx]`.
     #[test]
-    fn out_of_range_origin_index_drops_the_record_instead_of_panicking() {
-        let mix = PayloadMix::new();
-        {
-            // Simulate the "added a variant, forgot `ALL`" state directly: an
-            // index past the array's width. `record_apply` must survive it.
-            let mut w = mix.window.lock();
-            assert!(
-                w.applies.get_mut(ApplyOrigin::COUNT).is_none(),
-                "test premise: COUNT indexes past the end"
-            );
-        }
-        // The real call cannot produce an out-of-range index today, so assert
-        // the guard's shape rather than reaching through it: every listed
-        // origin records, and the window stays consistent.
-        for origin in ApplyOrigin::ALL {
-            mix.record_apply(origin, true);
-        }
-        let json = emit(&mix);
-        for origin in ApplyOrigin::ALL {
-            assert_eq!(json[format!("applies_{}_changed", origin.label())], 1);
-        }
+    fn record_apply_indexes_the_origin_arm_fallibly_pin() {
+        let src = include_str!("broadcast_payload_mix.rs");
+        let start = src
+            .find("pub(crate) fn record_apply(")
+            .expect("record_apply not found");
+        let body = &src[start..];
+        let end = body.find("\n    }").expect("end of record_apply not found");
+        let body: String = body[..end].split_whitespace().collect();
+
+        assert!(
+            body.contains("w.applies.get_mut(idx)"),
+            "record_apply must index the origin arm fallibly; a bare \
+             `w.applies[idx]` panics inside a held mutex on the apply hot path \
+             the moment a variant is added to `index()` but not to `ALL`"
+        );
     }
 
     /// The published schema splits applies by origin AND by whether the merge
@@ -2769,6 +2850,64 @@ mod tests {
         );
     }
 
+    /// Source-scrape pin: every `update_contract` call site's `ApplyOrigin`.
+    ///
+    /// This is THE production mutation for this feature and no other test sees
+    /// it: flipping `ClientLocal` to `NetworkRelay` at a driver call site
+    /// collapses the denominator and explodes the published multiplier, while
+    /// the whole suite stays green. The behavioural test proves
+    /// `update_contract` honours the origin it is HANDED; only this pins which
+    /// origin each caller hands it.
+    ///
+    /// Counts rather than names the sites, so adding a legitimate one is a
+    /// deliberate update to this test rather than a silent drift. If you are
+    /// here because the count changed: check the new site tags its CONTENT's
+    /// provenance, not its scheduling lane — see `ApplyOrigin`.
+    #[test]
+    fn update_contract_call_sites_tag_their_origin_pin() {
+        // (file, ClientLocal sites, NetworkRelay sites)
+        let files = [
+            (
+                "update/op_ctx_task.rs",
+                include_str!("../../operations/update/op_ctx_task.rs"),
+                2,
+                4,
+            ),
+            (
+                "put/op_ctx_task.rs",
+                include_str!("../../operations/put/op_ctx_task.rs"),
+                0,
+                2,
+            ),
+        ];
+        let (mut client_total, mut relay_total) = (0, 0);
+        for (name, src, want_client, want_relay) in files {
+            let flat: String = src.split_whitespace().collect();
+            let client = flat
+                .matches("crate::node::ApplyOrigin::ClientLocal")
+                .count();
+            let relay = flat
+                .matches("crate::node::ApplyOrigin::NetworkRelay")
+                .count();
+            assert_eq!(
+                (client, relay),
+                (want_client, want_relay),
+                "{name}: update_contract origin tags changed. A wrong tag here \
+                 silently moves the #5062 denominator and nothing else catches it."
+            );
+            client_total += client;
+            relay_total += relay;
+        }
+        assert_eq!(
+            (client_total, relay_total),
+            (2, 6),
+            "8 production update_contract call sites: 2 client-originated, \
+             6 relayed. The put reverse-delta merge is deliberately RELAYED — \
+             it applies content the remote holder sent back, even though its \
+             `Priority` is ClientLocal for scheduling reasons."
+        );
+    }
+
     /// Source-scrape pin: `update_contract` must record BOTH terminal apply
     /// outcomes.
     ///
@@ -2790,12 +2929,15 @@ mod tests {
             .expect("end of update_contract not found");
         let body = &body[..end];
 
-        // Whitespace-collapsed before matching, following the convention of
-        // the sibling pin in this same file
-        // (`update_contract_never_builds_a_summary_from_state_bytes`): needles
-        // that embed rustfmt's line breaks turn a green test red on a pure
-        // reformat, which teaches the next person to delete the pin.
-        let collapsed: String = body.split_whitespace().collect::<Vec<_>>().join(" ");
+        // ALL whitespace removed before matching, which is the convention of
+        // the sibling pin over this same function
+        // (`update_contract_never_builds_a_summary_from_state_bytes`, in
+        // `operations/update.rs`). Joining on a single space instead — as an
+        // earlier revision of this test did — still embeds rustfmt's choices:
+        // reflowing the call across lines yields `record_apply( origin,` and
+        // every needle below misses. A pin that goes red on a pure reformat
+        // teaches the next person to delete it.
+        let collapsed: String = body.split_whitespace().collect();
 
         assert_eq!(
             collapsed.matches("record_apply(origin,").count(),
@@ -2809,23 +2951,25 @@ mod tests {
         // must pass a literal `false`. Hardcoding `true` in either would count
         // no-op merges as broadcast-emitting applies and inflate the ratio.
         assert!(
-            collapsed.contains("record_apply(origin, state_changed)"),
+            collapsed.contains("record_apply(origin,state_changed)"),
             "the state-changed arm must record the handler's own \
              `state_changed` verdict"
         );
         assert!(
-            collapsed.contains("record_apply(origin, false)"),
+            collapsed.contains("record_apply(origin,false)"),
             "the merged-to-no-change arm must record `changed = false`"
         );
         // Ordering: the no-change record must precede the state-recovery
         // fallback's error exit, or an early failure there silently drops that
-        // arm from the denominator. Same idiom as the offset-comparison pins in
-        // `update/op_ctx_task.rs`.
+        // arm from the denominator. The harness cannot reach that exit (its
+        // stand-in always serves the fallback's GetQuery), so this textual
+        // check is the only thing holding the ordering. Same idiom as the
+        // offset-comparison pins in `update/op_ctx_task.rs`.
         let no_change_pos = collapsed
-            .find("record_apply(origin, false)")
+            .find("record_apply(origin,false)")
             .expect("no-change record not found");
         let fallback_err_pos = collapsed
-            .find("Cannot extract state from delta-only UpdateData")
+            .find("Cannotextractstatefromdelta-onlyUpdateData")
             .expect("state-recovery fallback not found");
         assert!(
             no_change_pos < fallback_err_pos,

--- a/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
+++ b/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
@@ -67,13 +67,50 @@
 //!
 //! [rt]: crate::topology::meter::ResourceType::BroadcastFanoutCost
 //!
+//! ## The fan-out multiplier (#5062)
+//!
+//! Everything above measures what this node SENT. [`ApplyOrigin`] measures the
+//! other half — what this node APPLIED, and whether it came from a local
+//! client or from a peer — because the send counters alone cannot distinguish
+//! the two topologies that produce the fleet's observed ~17.5 payloads per
+//! state-changing one (#5091):
+//!
+//!   * one node fanning out to its ~17 co-hosts, versus
+//!   * ~17 nodes each RE-fanning-out to their own ~17 co-hosts.
+//!
+//! Those differ by a further ~17x in cost, and by which fix applies: a payload
+//! fix for the first, a propagation-topology fix for the second. The number
+//! that separates them is
+//!
+//! ```text
+//! sum(total_sends) / sum(applies_client_local_changed)
+//! ```
+//!
+//! summed over the fleet as a RATIO OF SUMS, never a mean of per-window
+//! ratios — most nodes serve no local clients, so a per-node ratio is `0/0`
+//! most windows. `applies_network_relay_changed / applies_client_local_changed`
+//! reads the re-broadcast amplification directly.
+//!
+//! ### What is deliberately NOT here
+//!
+//! #5062 also asks for this split PER CONTRACT. That is not in this rollup, on
+//! volume grounds: a top-N array of per-contract origin counts roughly doubles
+//! this event's contribution, on a collector already ingesting ~30 GB/day with
+//! ~3-day retention, to refine a number nobody has read yet. Per-contract SENDS
+//! already ship (`top_contracts_by_total_bytes`, #4979/#5055), so the moment
+//! the node-level ratio says re-broadcast amplification is real, the
+//! per-contract denominator is a small follow-up against a known-useful
+//! measurement rather than a speculative one.
+//!
 //! ## Cost
 //!
 //! One short uncontended mutex acquire per **delivered broadcast** (not per
 //! packet), covering a handful of integer adds and at most one bounded
-//! `HashMap` touch. Everything else happens in the aggregator task, and the
-//! hot path only ever WRITES. The lock is what makes a rollup a consistent
-//! snapshot; see [`PayloadMix`] for why per-field atomics were not enough.
+//! `HashMap` touch, plus one more per completed update APPLY (strictly rarer
+//! than sends, since one apply is what fans out to N peers). Everything else
+//! happens in the aggregator task, and the hot path only ever WRITES. The lock
+//! is what makes a rollup a consistent snapshot; see [`PayloadMix`] for why
+//! per-field atomics were not enough.
 //!
 //! [`broadcast_to_single_peer`]: super::broadcast_queue::broadcast_to_single_peer
 
@@ -213,6 +250,111 @@ impl PayloadArm {
     }
 }
 
+/// Where an update this node APPLIED came from — the denominator half of the
+/// fan-out multiplier (#5062).
+///
+/// ## Why this is the missing measurement
+///
+/// The sender-side arm counters above say how many payloads this node put on
+/// the wire, and #5091's receiver-side counters say how few of them changed
+/// anything (fleet-measured at 17.5 payloads delivered per one that changes
+/// state). Neither can separate the two topologies that produce that number
+/// and have completely different remedies:
+///
+///   * one node fans out to its ~17 co-hosts, and
+///   * ~17 nodes EACH re-fan-out to their own ~17 co-hosts.
+///
+/// They differ by a further ~17x in cost. Splitting applies by origin is what
+/// tells them apart: under the first, essentially every broadcast a node emits
+/// follows a locally-originated apply; under the second, all but a ~1/18th
+/// slice follow a RELAYED apply that this node then re-broadcast.
+///
+/// ## Why the counter can be taken here at all
+///
+/// `Executor::bridged_upsert_contract_state_inner` calls `commit_state_update`
+/// — the only production emitter of `NodeEvent::BroadcastStateChange` on the
+/// UPDATE path — inside the `updated_state != current_state` branch, and
+/// returns `UpsertResult::NoChange` otherwise. So a `changed == true` apply is
+/// a 1:1 correlate of a broadcast fan-out being emitted, and no provenance
+/// plumbing through the `ContractExecutor` trait is needed to attribute it:
+/// `update_contract` already receives the origin as a
+/// [`Priority`](crate::contract::Priority) and already learns `changed` from
+/// the handler's reply.
+///
+/// The one gap in that correspondence is the broken-invariant suppression
+/// (`ring::broken_invariants`), which can swallow a commit that this counter
+/// still counts as changed. It is rare, deliberate, and already separately
+/// observable, so it is left as a documented residual rather than a second
+/// counter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ApplyOrigin {
+    /// Originated by a WS/HTTP client connected to THIS node — the true
+    /// denominator of "sends per originated update".
+    ClientLocal,
+    /// Applied on behalf of a remote peer's relayed operation. A `changed`
+    /// apply here is a RE-broadcast: the amplification #5062 exists to size.
+    NetworkRelay,
+    /// Node-internal background work. No `update_contract` call site produces
+    /// this today; it is carried so that one appearing later shows up as its
+    /// own number instead of silently inflating the relay arm.
+    Background,
+}
+
+impl ApplyOrigin {
+    /// Every origin, in reporting order.
+    pub(crate) const ALL: [ApplyOrigin; 3] = [
+        ApplyOrigin::ClientLocal,
+        ApplyOrigin::NetworkRelay,
+        ApplyOrigin::Background,
+    ];
+
+    pub(crate) const COUNT: usize = Self::ALL.len();
+
+    const fn index(self) -> usize {
+        match self {
+            ApplyOrigin::ClientLocal => 0,
+            ApplyOrigin::NetworkRelay => 1,
+            ApplyOrigin::Background => 2,
+        }
+    }
+
+    /// Stable wire label. Used as a telemetry field infix, so changing one
+    /// breaks existing dashboard queries.
+    pub(crate) const fn label(self) -> &'static str {
+        match self {
+            ApplyOrigin::ClientLocal => "client_local",
+            ApplyOrigin::NetworkRelay => "network_relay",
+            ApplyOrigin::Background => "background",
+        }
+    }
+
+    /// Read the origin off the scheduling class the apply was queued under.
+    ///
+    /// [`Priority`](crate::contract::Priority) is a scheduling class that
+    /// happens to be defined on exactly this axis, and all eight production
+    /// `update_contract` call sites tag it explicitly and correctly today
+    /// (three `ClientLocal`, five `NetworkRelay`). Reusing it is what makes
+    /// this measurement a one-site change instead of a new parameter threaded
+    /// through the `ContractExecutor` trait and ~160 call sites.
+    ///
+    /// The risk it carries, stated so a future reader does not have to
+    /// rediscover it: `Priority::DEFAULT` is `NetworkRelay`, so a NEW call
+    /// site that forgets to tag itself reads as "relayed" rather than as
+    /// something unclassified. That biases the multiplier's denominator DOWN
+    /// and the amplification numerator UP — i.e. it can only ever make the
+    /// fan-out problem look worse than it is, never better, which is the safe
+    /// direction for a measurement whose purpose is to decide whether to spend
+    /// engineering effort on propagation topology. A new client-originated
+    /// path that lands untagged is the case to watch for.
+    pub(crate) const fn from_priority(priority: crate::contract::Priority) -> Self {
+        match priority {
+            crate::contract::Priority::ClientLocal => ApplyOrigin::ClientLocal,
+            crate::contract::Priority::NetworkRelay => ApplyOrigin::NetworkRelay,
+            crate::contract::Priority::Background => ApplyOrigin::Background,
+        }
+    }
+}
+
 /// One rollup window's counters.
 ///
 /// Every field advances together under a single lock so a rollup takes a
@@ -319,6 +461,22 @@ struct Window {
     /// [`SummaryMissingReason::index`]; sums to the `tracked` arm's totals.
     tracked_missing_sends: [u64; SummaryMissingReason::ALL.len()],
     tracked_missing_bytes: [u64; SummaryMissingReason::ALL.len()],
+
+    /// Update applies this node completed, by [`ApplyOrigin`] — the
+    /// denominator of the fan-out multiplier (#5062).
+    ///
+    /// Indexed `[origin][changed as usize]`, so `[o][1]` counts the applies
+    /// that actually mutated state (and therefore emitted a broadcast) and
+    /// `[o][0] + [o][1]` is every completed apply for that origin.
+    ///
+    /// Deliberately recorded into the SAME window as the `sends` counters
+    /// above and drained by the same atomic take, so a rollup's sends and its
+    /// applies describe the same 60 s of work and the ratio between them is
+    /// meaningful rather than smeared across window boundaries.
+    ///
+    /// Fixed cardinality (3 x 2 `u64`s), no per-contract map: see the module
+    /// docs for why the per-contract refinement is deliberately not here.
+    applies: [[u64; 2]; ApplyOrigin::COUNT],
 }
 
 impl Default for Window {
@@ -339,6 +497,7 @@ impl Default for Window {
             not_efficient_state_bytes_max: 0,
             tracked_missing_sends: [0; SummaryMissingReason::ALL.len()],
             tracked_missing_bytes: [0; SummaryMissingReason::ALL.len()],
+            applies: [[0; 2]; ApplyOrigin::COUNT],
         }
     }
 }
@@ -647,6 +806,45 @@ impl PayloadMix {
         }
     }
 
+    /// Record one COMPLETED update apply and where it came from (#5062).
+    ///
+    /// `changed` must be the contract handler's own verdict on whether the
+    /// merge mutated state, because that is precisely the condition under
+    /// which the executor emits a broadcast fan-out — see [`ApplyOrigin`].
+    ///
+    /// Call this only on a terminal apply outcome (merged, or merged-to-no-
+    /// change). Applies that ERRORED are deliberately excluded: nothing was
+    /// committed and nothing was broadcast, so counting them would pad the
+    /// denominator of a ratio whose whole purpose is to be compared against
+    /// sends. Failures are already published receiver-side by #5091's
+    /// `*_failed` terminal counters.
+    /// [`Self::record_apply`], reading the origin off the scheduling class the
+    /// apply was queued under.
+    ///
+    /// This is the form production calls. It exists so `operations::update`
+    /// never has to name [`ApplyOrigin`] — `node::network_bridge` is private
+    /// outside `node`, and more importantly the apply path has no business
+    /// knowing the telemetry taxonomy. The `Priority` -> origin
+    /// reinterpretation stays in one documented place; see
+    /// [`ApplyOrigin::from_priority`] for the aliasing risk it carries.
+    pub(crate) fn record_apply_with_priority(
+        &self,
+        priority: crate::contract::Priority,
+        changed: bool,
+    ) {
+        self.record_apply(ApplyOrigin::from_priority(priority), changed);
+    }
+
+    pub(crate) fn record_apply(&self, origin: ApplyOrigin, changed: bool) {
+        let idx = origin.index();
+        let changed_idx = usize::from(changed);
+        let mut w = self.window.lock();
+        // Saturating for the same reason as the send counters: a wrapped
+        // denominator would report an absurd multiplier rather than an
+        // obviously-clamped one.
+        w.applies[idx][changed_idx] = w.applies[idx][changed_idx].saturating_add(1);
+    }
+
     /// Atomically take the current window, leaving a fresh empty one.
     ///
     /// One lock acquisition covers every field, so the aggregate counters and
@@ -664,6 +862,20 @@ impl Window {
             .map(|arm| {
                 let idx = arm.index();
                 (*arm, self.sends[idx], self.bytes[idx])
+            })
+            .collect()
+    }
+
+    /// Per-origin `(changed, total)` applies in [`ApplyOrigin::ALL`] order.
+    fn applies(&self) -> Vec<(ApplyOrigin, u64, u64)> {
+        ApplyOrigin::ALL
+            .iter()
+            .map(|origin| {
+                let counts = self.applies[origin.index()];
+                // `total` is emitted rather than `unchanged` so the ratio's
+                // denominator is present as a published field instead of
+                // something a consumer has to reconstruct by addition.
+                (*origin, counts[1], counts[0].saturating_add(counts[1]))
             })
             .collect()
     }
@@ -814,6 +1026,7 @@ fn payload_mix_json(
     attribution_dropped_bytes: u64,
     gate: NotEfficientGateStats,
     tracked_missing: &[(SummaryMissingReason, u64, u64)],
+    applies: &[(ApplyOrigin, u64, u64)],
     window_secs: u64,
 ) -> serde_json::Value {
     let mut obj = serde_json::Map::new();
@@ -1035,6 +1248,26 @@ fn payload_mix_json(
         "attribution_dropped_bytes".into(),
         attribution_dropped_bytes.into(),
     );
+    // #5062: the fan-out multiplier's denominator. `total_sends` above is the
+    // numerator, recorded into the same window and drained by the same atomic
+    // take, so the two describe the same 60 s of work.
+    //
+    // NO ratio is published here, deliberately. The quantity that matters is a
+    // ratio of SUMS over the fleet —
+    //   sum(total_sends) / sum(applies_client_local_changed)
+    // — and most nodes host no local clients, so a per-window per-node ratio is
+    // `0/0` far more often than not. Publishing one would invite exactly the
+    // mean-of-ratios aggregation that `not_efficient_summary_to_state_bytes_ratio`
+    // above is named to steer consumers away from, on data where it is far more
+    // degenerate. Raw counters only; the division belongs in the query.
+    for (origin, changed, total) in applies {
+        obj.insert(
+            format!("applies_{}_changed", origin.label()),
+            (*changed).into(),
+        );
+        obj.insert(format!("applies_{}_total", origin.label()), (*total).into());
+    }
+
     obj.insert("window_secs".into(), window_secs.into());
     serde_json::Value::Object(obj)
 }
@@ -1062,6 +1295,7 @@ pub(crate) fn emit_payload_mix_rollup(
         window.attribution_dropped_bytes,
         window.gate_stats(),
         &window.tracked_missing(),
+        &window.applies(),
         window_secs,
     );
     crate::tracing::telemetry::send_standalone_shadow_event_with_peer_id(
@@ -1413,6 +1647,7 @@ mod tests {
             window.attribution_dropped_bytes,
             window.gate_stats(),
             &[],
+            &[],
             60,
         );
         let top_sum: u64 = json["top_contracts_by_full_state_bytes"]
@@ -1465,6 +1700,7 @@ mod tests {
             window.attribution_dropped_sends,
             window.attribution_dropped_bytes,
             window.gate_stats(),
+            &[],
             &[],
             60,
         );
@@ -1582,6 +1818,7 @@ mod tests {
             window.attribution_dropped_bytes,
             window.gate_stats(),
             &window.tracked_missing(),
+            &window.applies(),
             60,
         );
         assert_eq!(json["total_attribution_dropped_sends"], 3);
@@ -1738,6 +1975,7 @@ mod tests {
             0,
             NotEfficientGateStats::default(),
             &[],
+            &[],
             60,
         );
         assert_eq!(json["total_bytes"], 1000);
@@ -1793,6 +2031,7 @@ mod tests {
             window.attribution_dropped_bytes,
             window.gate_stats(),
             &[],
+            &[],
             60,
         );
 
@@ -1825,6 +2064,7 @@ mod tests {
             window.attribution_dropped_bytes,
             window.gate_stats(),
             &window.tracked_missing(),
+            &window.applies(),
             60,
         )
     }
@@ -1996,6 +2236,7 @@ mod tests {
             window.attribution_dropped_bytes,
             window.gate_stats(),
             &[],
+            &[],
             60,
         );
         assert_eq!(json["not_efficient_summary_bytes_sum"], 2000);
@@ -2025,6 +2266,7 @@ mod tests {
             0,
             window.gate_stats(),
             &[],
+            &[],
             60,
         );
         assert!(json["not_efficient_summary_to_state_bytes_ratio"].is_null());
@@ -2045,6 +2287,7 @@ mod tests {
             0,
             0,
             NotEfficientGateStats::default(),
+            &[],
             &[],
             60,
         );
@@ -2217,5 +2460,217 @@ mod tests {
                 "{arm:?} must attribute its full-state bytes to the contract"
             );
         }
+    }
+
+    // ---- #5062: the fan-out multiplier's denominator ----
+
+    /// Every `Priority` class maps to a distinct origin, and the mapping is
+    /// the one the schema claims.
+    ///
+    /// This is the single point where a scheduling class is reinterpreted as
+    /// provenance, so it is the single point where that reinterpretation can
+    /// silently rot — e.g. a new `Priority` variant folded into an existing
+    /// arm. An exhaustive check here is what makes the reuse safe.
+    #[test]
+    fn apply_origin_maps_each_priority_class_to_its_own_arm() {
+        use crate::contract::Priority;
+
+        assert_eq!(
+            ApplyOrigin::from_priority(Priority::ClientLocal),
+            ApplyOrigin::ClientLocal
+        );
+        assert_eq!(
+            ApplyOrigin::from_priority(Priority::NetworkRelay),
+            ApplyOrigin::NetworkRelay
+        );
+        assert_eq!(
+            ApplyOrigin::from_priority(Priority::Background),
+            ApplyOrigin::Background
+        );
+
+        // Distinct indices and distinct labels: two origins sharing either
+        // would silently merge two arms of the measurement.
+        let indices: Vec<usize> = ApplyOrigin::ALL.iter().map(|o| o.index()).collect();
+        assert_eq!(indices, vec![0, 1, 2], "indices must be dense and ordered");
+        let mut labels: Vec<&str> = ApplyOrigin::ALL.iter().map(|o| o.label()).collect();
+        labels.sort_unstable();
+        labels.dedup();
+        assert_eq!(
+            labels.len(),
+            ApplyOrigin::COUNT,
+            "every origin needs a unique wire label"
+        );
+    }
+
+    /// The published schema splits applies by origin AND by whether the merge
+    /// changed state — the `changed` arm being the one that corresponds 1:1
+    /// with an emitted broadcast.
+    #[test]
+    fn applies_split_by_origin_and_by_whether_state_changed() {
+        let mix = PayloadMix::new();
+        // Two locally-originated updates, one of which was a no-op merge.
+        mix.record_apply(ApplyOrigin::ClientLocal, true);
+        mix.record_apply(ApplyOrigin::ClientLocal, false);
+        // Three relayed applies, one of which actually moved state and so
+        // triggered a re-broadcast from this node.
+        mix.record_apply(ApplyOrigin::NetworkRelay, true);
+        mix.record_apply(ApplyOrigin::NetworkRelay, false);
+        mix.record_apply(ApplyOrigin::NetworkRelay, false);
+
+        let json = emit(&mix);
+        assert_eq!(json["applies_client_local_changed"], 1);
+        assert_eq!(json["applies_client_local_total"], 2);
+        assert_eq!(json["applies_network_relay_changed"], 1);
+        assert_eq!(json["applies_network_relay_total"], 3);
+        // Untouched origins are published as explicit zeros, not omitted: a
+        // missing field and a zero field read identically to a careless query
+        // but differently to a careful one.
+        assert_eq!(json["applies_background_changed"], 0);
+        assert_eq!(json["applies_background_total"], 0);
+    }
+
+    /// `total` is never less than `changed` for any origin — the invariant a
+    /// consumer divides by.
+    #[test]
+    fn applies_total_covers_changed_for_every_origin() {
+        let mix = PayloadMix::new();
+        for (i, origin) in ApplyOrigin::ALL.iter().enumerate() {
+            for _ in 0..=i {
+                mix.record_apply(*origin, true);
+            }
+            mix.record_apply(*origin, false);
+        }
+        let json = emit(&mix);
+        for (i, origin) in ApplyOrigin::ALL.iter().enumerate() {
+            let changed = json[format!("applies_{}_changed", origin.label())]
+                .as_u64()
+                .expect("changed must be a number");
+            let total = json[format!("applies_{}_total", origin.label())]
+                .as_u64()
+                .expect("total must be a number");
+            assert_eq!(changed, i as u64 + 1, "{origin:?} changed count");
+            assert_eq!(total, i as u64 + 2, "{origin:?} total count");
+            assert!(
+                total >= changed,
+                "{origin:?}: total ({total}) must cover changed ({changed})"
+            );
+        }
+    }
+
+    /// The multiplier's numerator and denominator must come out of the SAME
+    /// window, and the same atomic drain must reset both.
+    ///
+    /// This is the property that makes `total_sends / applies_*_changed`
+    /// meaningful at all. If applies survived a drain that reset sends (or
+    /// vice versa), the ratio would be computed across mismatched intervals —
+    /// the exact defect the single-mutex design exists to prevent for the
+    /// per-contract maps.
+    #[test]
+    fn applies_and_sends_share_one_window_and_one_drain() {
+        let mix = PayloadMix::new();
+        mix.record_apply(ApplyOrigin::ClientLocal, true);
+        mix.record_delivered(PayloadArm::Delta, &contract(1), 100, None, None);
+        mix.record_delivered(PayloadArm::Delta, &contract(1), 100, None, None);
+
+        let first = emit(&mix);
+        assert_eq!(first["applies_client_local_changed"], 1);
+        assert_eq!(first["total_sends"], 2, "one apply fanned out to two peers");
+
+        // Second window: the drain reset BOTH halves, so a quiet window
+        // reports zeros rather than re-reporting the previous window's work.
+        let second = emit(&mix);
+        assert_eq!(second["applies_client_local_changed"], 0);
+        assert_eq!(second["applies_client_local_total"], 0);
+        assert_eq!(second["total_sends"], 0);
+    }
+
+    /// An empty window publishes every apply field as zero.
+    #[test]
+    fn empty_window_publishes_zero_applies_for_every_origin() {
+        let json = emit(&PayloadMix::new());
+        for origin in ApplyOrigin::ALL.iter() {
+            assert_eq!(
+                json[format!("applies_{}_changed", origin.label())],
+                0,
+                "{origin:?} changed must be present and zero"
+            );
+            assert_eq!(
+                json[format!("applies_{}_total", origin.label())],
+                0,
+                "{origin:?} total must be present and zero"
+            );
+        }
+    }
+
+    /// Counters saturate rather than wrap.
+    ///
+    /// A wrapped denominator is worse than a clamped one: it reports a
+    /// plausible-looking small number, which yields an absurd multiplier that
+    /// reads as a real finding. Clamping at `u64::MAX` is obviously broken.
+    #[test]
+    fn apply_counters_saturate_rather_than_wrap() {
+        let mix = PayloadMix::new();
+        {
+            let mut w = mix.window.lock();
+            let idx = ApplyOrigin::NetworkRelay.index();
+            w.applies[idx][1] = u64::MAX;
+            w.applies[idx][0] = u64::MAX;
+        }
+        mix.record_apply(ApplyOrigin::NetworkRelay, true);
+        mix.record_apply(ApplyOrigin::NetworkRelay, false);
+
+        let json = emit(&mix);
+        assert_eq!(
+            json["applies_network_relay_changed"],
+            u64::MAX,
+            "changed count must clamp, not wrap to 0"
+        );
+        // `total` sums two saturated halves, and must itself clamp rather than
+        // overflow the addition in `Window::applies`.
+        assert_eq!(
+            json["applies_network_relay_total"],
+            u64::MAX,
+            "total must clamp, not wrap"
+        );
+    }
+
+    /// Source-scrape pin: `update_contract` must record BOTH terminal apply
+    /// outcomes.
+    ///
+    /// The two arms are ~100 lines apart in `operations/update.rs` and the
+    /// no-change one sits above a block of state-recovery fallback logic, so
+    /// the plausible regression is that a refactor keeps the changed arm and
+    /// drops the other. That would not fail any assertion — it would just make
+    /// every no-op apply vanish from the denominator and shrink the reported
+    /// multiplier, silently and in the flattering direction.
+    #[test]
+    fn update_contract_records_both_terminal_apply_outcomes_pin() {
+        let src = include_str!("../../operations/update.rs");
+        let start = src
+            .find("pub(crate) async fn update_contract(")
+            .expect("update_contract not found");
+        let body = &src[start..];
+        let end = body
+            .find("\n/// Send proactive summary notifications")
+            .expect("end of update_contract not found");
+        let body = &body[..end];
+
+        assert_eq!(
+            body.matches("record_apply_with_priority(priority,").count(),
+            2,
+            "update_contract must record exactly two apply outcomes — the \
+             state-changed merge and the merged-to-no-change arm — and both \
+             must pass this call's OWN `priority` rather than a hardcoded \
+             origin, because `priority` IS the provenance (#5062). Dropping \
+             either arm silently biases the fan-out denominator."
+        );
+        // The changed arm must forward the handler's verdict, not a literal:
+        // hardcoding `true` there would count every no-op merge as a
+        // broadcast-emitting apply.
+        assert!(
+            body.contains("record_apply_with_priority(priority, state_changed)"),
+            "the state-changed arm must record the handler's own \
+             `state_changed` verdict"
+        );
     }
 }

--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -780,6 +780,12 @@ async fn try_summary_first_put(
             UpdateData::Delta(reverse_delta),
             RelatedContracts::default(),
             crate::contract::Priority::ClientLocal,
+            // Provenance, deliberately NOT derived from the `Priority` above:
+            // this delta is what the REMOTE HOLDER sent back, so for #5062 it
+            // is relayed content this node re-broadcasts. The `ClientLocal`
+            // tag is a scheduling-lane choice (see the comment above), and
+            // the two are free to disagree.
+            crate::node::ApplyOrigin::NetworkRelay,
         )
         .await
         {
@@ -4200,6 +4206,7 @@ async fn drive_relay_probe_reconcile(
             UpdateData::Delta(delta),
             RelatedContracts::default(),
             crate::contract::Priority::NetworkRelay,
+            crate::node::ApplyOrigin::NetworkRelay,
         )
         .await
         {

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -732,10 +732,12 @@ pub(crate) async fn update_contract(
                 new_val.size() > 0,
                 "update_contract: state must be non-empty after successful UPDATE for contract {key}"
             );
-            // #5062: attribute this apply to where the update came from. See
-            // `ApplyOrigin` for why `priority` is a sound provenance source
-            // and why `state_changed` is a 1:1 correlate of a broadcast
-            // fan-out being emitted.
+            // #5062: attribute this apply to where its CONTENT came from —
+            // `origin`, never the `priority` above. Those are free to diverge
+            // (a scheduling lane is not a provenance claim) and at one call
+            // site they already do; see `ApplyOrigin`. `state_changed` is what
+            // causes the executor to emit a fan-out, modulo the residuals
+            // enumerated there.
             op_manager.payload_mix.record_apply(origin, state_changed);
             // #4923: no summary is computed here — never relabel the state
             // bytes as a summary (the self-poisoning full-state-broadcast

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -685,6 +685,7 @@ pub(crate) async fn update_contract(
     update_data: UpdateData<'static>,
     related_contracts: RelatedContracts<'static>,
     priority: crate::contract::Priority,
+    origin: crate::node::ApplyOrigin,
 ) -> Result<UpdateExecution, OpError> {
     let previous_state = match op_manager
         .notify_contract_handler_prioritized(
@@ -735,9 +736,7 @@ pub(crate) async fn update_contract(
             // `ApplyOrigin` for why `priority` is a sound provenance source
             // and why `state_changed` is a 1:1 correlate of a broadcast
             // fan-out being emitted.
-            op_manager
-                .payload_mix
-                .record_apply_with_priority(priority, state_changed);
+            op_manager.payload_mix.record_apply(origin, state_changed);
             // #4923: no summary is computed here — never relabel the state
             // bytes as a summary (the self-poisoning full-state-broadcast
             // loop), and no per-apply summary fetch on this hot path either
@@ -762,9 +761,7 @@ pub(crate) async fn update_contract(
             // about reconstructing a value to RETURN, not about whether the
             // apply happened, so an early error there must not silently drop
             // this arm from the denominator.
-            op_manager
-                .payload_mix
-                .record_apply_with_priority(priority, false);
+            op_manager.payload_mix.record_apply(origin, false);
             // Helper to extract state from UpdateData variants that contain state
             fn extract_state_from_update_data(
                 update_data: &UpdateData<'static>,
@@ -2156,6 +2153,7 @@ mod tests {
     async fn build_summary_test_node(
         id: &str,
         summary_ok: bool,
+        update_changes_state: bool,
     ) -> (
         std::sync::Arc<OpManager>,
         WrappedState,
@@ -2216,10 +2214,17 @@ mod tests {
                             },
                         }
                     }
-                    ContractHandlerEvent::UpdateQuery { .. } => {
-                        ContractHandlerEvent::UpdateResponse {
-                            new_value: Ok(handler_state.clone()),
-                            state_changed: true,
+                    ContractHandlerEvent::UpdateQuery { key, .. } => {
+                        if update_changes_state {
+                            ContractHandlerEvent::UpdateResponse {
+                                new_value: Ok(handler_state.clone()),
+                                state_changed: true,
+                            }
+                        } else {
+                            // The merged-to-no-change reply. `update_contract`
+                            // answers this by re-fetching state via GetQuery,
+                            // which this stand-in already serves.
+                            ContractHandlerEvent::UpdateNoChange { key }
                         }
                     }
                     other => panic!("unexpected handler event: {other:?}"),
@@ -2253,7 +2258,7 @@ mod tests {
     #[tokio::test]
     async fn client_facing_summary_is_the_contract_summary_not_the_state() {
         let (op_manager, merged_state, contract_summary, _guard) =
-            build_summary_test_node("update-summary-poison-4923", true).await;
+            build_summary_test_node("update-summary-poison-4923", true, true).await;
 
         let key = make_contract_key(1);
         let execution = update_contract(
@@ -2262,6 +2267,7 @@ mod tests {
             UpdateData::Delta(StateDelta::from(vec![1u8, 2, 3])),
             RelatedContracts::default(),
             crate::contract::Priority::ClientLocal,
+            crate::node::ApplyOrigin::ClientLocal,
         )
         .await
         .expect("update must succeed");
@@ -2297,6 +2303,98 @@ mod tests {
         );
     }
 
+    /// #5062: driving the REAL `update_contract` must move the apply counter
+    /// that matches the origin it was called with, on BOTH terminal outcomes.
+    ///
+    /// The source-scrape pin in `broadcast_payload_mix` cannot establish this.
+    /// A pin counts text, so it stays green if the recording calls are
+    /// commented out, moved into dead code, or handed a hardcoded origin. This
+    /// exercises the production function end to end against a real
+    /// `OpManager`, so the counter either moves or the test fails.
+    #[tokio::test]
+    async fn update_contract_records_the_apply_against_the_origin_it_was_given() {
+        use crate::node::ApplyOrigin;
+
+        // Index into `applies_snapshot()`: [origin][changed as usize].
+        const CHANGED: usize = 1;
+        const UNCHANGED: usize = 0;
+        const CLIENT: usize = 0;
+        const RELAY: usize = 1;
+
+        // --- state-changing merges ---
+        let (op_manager, _state, _summary, _guard) =
+            build_summary_test_node("update-applies-5062-changed", true, true).await;
+        let key = make_contract_key(1);
+
+        for (origin, arm) in [
+            (ApplyOrigin::ClientLocal, CLIENT),
+            (ApplyOrigin::NetworkRelay, RELAY),
+        ] {
+            let before = op_manager.payload_mix.applies_snapshot();
+            update_contract(
+                &op_manager,
+                key,
+                UpdateData::Delta(StateDelta::from(vec![1u8, 2, 3])),
+                RelatedContracts::default(),
+                // Priority deliberately held CONSTANT across both iterations
+                // while the origin varies: if the counter were still derived
+                // from the scheduling class rather than the explicit origin,
+                // the relay iteration would book into the client arm and this
+                // test would fail.
+                crate::contract::Priority::ClientLocal,
+                origin,
+            )
+            .await
+            .expect("update must succeed");
+            let after = op_manager.payload_mix.applies_snapshot();
+
+            assert_eq!(
+                after[arm][CHANGED],
+                before[arm][CHANGED] + 1,
+                "{origin:?}: a state-changing apply must increment its own \
+                 changed counter"
+            );
+            let other = 1 - arm;
+            assert_eq!(
+                after[other], before[other],
+                "{origin:?}: no other origin's counters may move"
+            );
+            assert_eq!(
+                after[arm][UNCHANGED], before[arm][UNCHANGED],
+                "{origin:?}: a changed apply must not touch the unchanged slot"
+            );
+        }
+
+        // --- merged-to-no-change ---
+        let (op_manager, _state, _summary, _guard) =
+            build_summary_test_node("update-applies-5062-nochange", true, false).await;
+
+        let before = op_manager.payload_mix.applies_snapshot();
+        let execution = update_contract(
+            &op_manager,
+            key,
+            UpdateData::Delta(StateDelta::from(vec![1u8, 2, 3])),
+            RelatedContracts::default(),
+            crate::contract::Priority::NetworkRelay,
+            ApplyOrigin::NetworkRelay,
+        )
+        .await
+        .expect("a no-change merge is still a successful apply");
+        assert!(!execution.changed, "stand-in reports an unchanged state");
+
+        let after = op_manager.payload_mix.applies_snapshot();
+        assert_eq!(
+            after[RELAY][UNCHANGED],
+            before[RELAY][UNCHANGED] + 1,
+            "a merged-to-no-change apply must be counted in the total"
+        );
+        assert_eq!(
+            after[RELAY][CHANGED], before[RELAY][CHANGED],
+            "a no-op merge emits no broadcast, so it must NOT be counted as \
+             changed — that slot is the fan-out multiplier's denominator"
+        );
+    }
+
     /// MINOR 6 error path: when the summarize fails (saturated executor,
     /// WASM error, missing state), `contract_summary_or_empty` must return
     /// the EMPTY summary — never the state bytes, which would re-open the
@@ -2304,7 +2402,7 @@ mod tests {
     #[tokio::test]
     async fn contract_summary_or_empty_error_path_returns_empty_not_state() {
         let (op_manager, merged_state, _contract_summary, _guard) =
-            build_summary_test_node("update-summary-poison-4923-errpath", false).await;
+            build_summary_test_node("update-summary-poison-4923-errpath", false, true).await;
 
         let key = make_contract_key(1);
         let summary =

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -731,6 +731,13 @@ pub(crate) async fn update_contract(
                 new_val.size() > 0,
                 "update_contract: state must be non-empty after successful UPDATE for contract {key}"
             );
+            // #5062: attribute this apply to where the update came from. See
+            // `ApplyOrigin` for why `priority` is a sound provenance source
+            // and why `state_changed` is a 1:1 correlate of a broadcast
+            // fan-out being emitted.
+            op_manager
+                .payload_mix
+                .record_apply_with_priority(priority, state_changed);
             // #4923: no summary is computed here — never relabel the state
             // bytes as a summary (the self-poisoning full-state-broadcast
             // loop), and no per-apply summary fetch on this hot path either
@@ -748,6 +755,16 @@ pub(crate) async fn update_contract(
             Err(err.into())
         }
         Ok(ContractHandlerEvent::UpdateNoChange { .. }) => {
+            // #5062: recorded at the TOP of the arm, before the state-recovery
+            // fallback below. The apply itself is already terminal and already
+            // decided — the handler merged and the state did not move, so no
+            // broadcast was emitted. The fallback's own failure paths are
+            // about reconstructing a value to RETURN, not about whether the
+            // apply happened, so an early error there must not silently drop
+            // this arm from the denominator.
+            op_manager
+                .payload_mix
+                .record_apply_with_priority(priority, false);
             // Helper to extract state from UpdateData variants that contain state
             fn extract_state_from_update_data(
                 update_data: &UpdateData<'static>,

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -291,6 +291,7 @@ async fn drive_client_update(
                 update_data,
                 related_contracts,
                 crate::contract::Priority::ClientLocal,
+                crate::node::ApplyOrigin::ClientLocal,
             )
             .await
             {
@@ -409,6 +410,7 @@ async fn drive_client_update(
                 update_data.clone(),
                 related_contracts.clone(),
                 crate::contract::Priority::ClientLocal,
+                crate::node::ApplyOrigin::ClientLocal,
             )
             .await;
 
@@ -975,6 +977,7 @@ async fn drive_relay_request_update(
             UpdateData::State(State::from(value.clone())),
             related_contracts.clone(),
             crate::contract::Priority::NetworkRelay,
+            crate::node::ApplyOrigin::NetworkRelay,
         )
         .await?;
 
@@ -1799,6 +1802,7 @@ async fn drive_relay_broadcast_to(
         update_data,
         RelatedContracts::default(),
         crate::contract::Priority::NetworkRelay,
+        crate::node::ApplyOrigin::NetworkRelay,
     )
     .await;
 
@@ -2468,6 +2472,7 @@ async fn drive_relay_request_update_streaming(
         UpdateData::State(State::from(value.clone())),
         related_contracts,
         crate::contract::Priority::NetworkRelay,
+        crate::node::ApplyOrigin::NetworkRelay,
     )
     .await?;
 
@@ -2710,6 +2715,7 @@ async fn apply_streaming_broadcast(
         UpdateData::State(State::from(state_bytes.clone())),
         RelatedContracts::default(),
         crate::contract::Priority::NetworkRelay,
+        crate::node::ApplyOrigin::NetworkRelay,
     )
     .await;
 


### PR DESCRIPTION
Closes #5062.

## What the shortcut check established

#5062 says to check the transaction-identity shortcut before doing anything else. **It does not work**, definitively:

- The inbound `Transaction` is dropped at `update/op_ctx_task.rs:1796` (relay `BroadcastTo`) and `:293` / `:411` (client), because `update_contract` (`update.rs:682`) has no `Transaction` parameter.
- From there down, the client-originated and relay-originated paths are byte-identical: same `UpdateQuery` variant, same fair queue, same `maybe_defer_upsert`, same executor call, same emit.
- `NodeEvent::BroadcastStateChange` carries no tx and no origin; `BroadcastEntry` carries none; `broadcast_queue.rs:1432` mints a fresh one. This is already documented in-tree at `p2p_protoc/broadcast.rs:522-530`.

So transaction identity cannot distinguish them.

**But the issue's ~160-call-site trait surgery is not needed either.** `update_contract` already receives the caller's provenance intent and already learns `state_changed` from the handler's reply — and `bridged_upsert_contract_state_inner` calls `commit_state_update` (which emits the fan-out) *only* inside the `updated_state != current_state` branch. So a changed apply is what causes a broadcast, and it can be attributed at that one function. The whole measurement is one parameter and two counter calls, with no `ContractExecutor` trait change.

## What this ships

Four fields on the existing 60s `broadcast_payload_mix` rollup:

```
applies_client_local_changed / applies_client_local_total
applies_network_relay_changed / applies_network_relay_total
```

Fixed cardinality (2 origins x 2 outcomes), no per-contract map, no peer IDs, recorded into the same window and drained by the same atomic take as the existing `sends` counters.

**The number to read** is the ratio of sums over the fleet:

```
sum(applies_network_relay_changed) / sum(applies_client_local_changed)
```

— distinct peer-side state transitions per originated update. Against the measured ~17.1 co-host degree: ≈17 means the update reaches its co-host set once and stops (payload problem); ≫17 means state keeps genuinely moving hop after hop (propagation-topology problem). That is the #5062 question.

Note the discriminant is **not** "did a re-broadcast happen" — one happens in both topologies, since the executor emits on every changed apply. It is whether the second hop's recipients *also* change state. Review caught this; the first draft of the docs had it wrong.

No derived ratio is published. Most nodes serve no local clients, so a per-node per-window ratio is `0/0` far more often than not, and publishing one would invite exactly the mean-of-ratios aggregation the module's existing `not_efficient_summary_to_state_bytes_ratio` is named to steer people away from. The division belongs in the query.

### R/C is biased UPWARD — read it as an upper bound

An earlier revision of this PR called R/C "sound" because both halves come from the same function. Review showed that is wrong, and wrong in the direction that costs money: same function is not the same population, and the residuals do not cancel — they all push R/C toward the ≫17 reading whose remedy is the expensive one.

Numerator gets relayed `changed` applies with no origination behind them: anti-entropy heals (`SyncStateToPeer`) share the broadcast queue and arrive as the same `UpdateMsg::BroadcastTo` wire shape, so the receiver cannot tell them from a fan-out leg — and heal volume rises with churn, i.e. it is loudest under the conditions being measured. Denominator misses originations entirely: a client PUT never calls `update_contract`, yet its fan-out produces relayed changed applies fleet-wide; same for delegate-driven work and for ResyncResponse heals.

Pulling the other way, and smaller: the broadcast dedup cache and the merge-failure backoff gate short-circuit before `update_contract`, and fair-queue shedding drops sub-`ClientLocal` work first.

**Practical reading: R/C ≈ 17 is strong evidence of one-hop reach**, since the biases can only push it up. **R/C ≫ 17 is suggestive, not conclusive** — bound the heal and PUT-origination contribution before spending on propagation topology. This is all stated in the module docs, not just here.

## Correction to the issue text

#5062 says "nothing measures it today" — written before #5091 shipped. The `network_efficiency_v1` receiver-side counters now measure the **effect** (fleet-wide: 11.4M byte-identical delta duplicates, 5.2M full-state duplicates, 17.5 payloads delivered per one that changes anything, 97.2% of received contract-payload bytes changing nothing). What was still missing, and is what this PR adds, is the **attribution** — and that is the difference between a payload fix and a propagation-topology fix. Nobody should re-derive this.

## Honest limits, stated in the module docs

- `total_sends / applies_client_local_changed` is the more direct statement of "sends per originated update", and the one #5062 asks for, but it is **looser still** than R/C and is demoted to a coarse cross-check. Its numerator additionally carries every heal delivery, every PUT/GET-cache/Resync/first-install/delegate-driven send, and no-target retries plus `PendingBroadcastStore` re-emits of already-counted applies. Against that, `record_delivered` is delivery-gated while `record_apply` is not, and the executor's emit is best-effort under channel pressure.
- Telemetry coverage must be uniform across relay-heavy and client-serving nodes for either ratio to be unbiased. Gateways relay much and serve few local clients, so a reporting population skewed toward them under-samples the denominator — same upward direction as everything else.
- Residuals where `changed` and "a broadcast happened" diverge are enumerated in `ApplyOrigin`'s docs rather than claimed absent. The load-correlated one (`try_notify_node_event` dropping silently when the node-event channel is full) matters most, since it biases downward exactly when the signal is strongest.
- These counters will never reconcile against the existing `ReceiverApplyStats`: those are cumulative, not windowed, and fed by only the two receive drivers that build a `ReceiverTerminalGuard`. Documented so nobody wastes an afternoon diffing them.

## Provenance is explicit, not derived from `Priority`

`contract::Priority` is defined on nearly this axis and deriving from it would have been free. Review found a live counter-example: `put/op_ctx_task.rs`'s summary-first reverse-delta merge tags `Priority::ClientLocal` while applying content the **remote holder** sent back — its own comment says the tag is chosen to match the originator-loopback store's scheduling lane. Deriving there would have booked a relayed apply into the originated bucket, deflating both ratios in the flattering direction.

So origin is an explicit argument the compiler demands at all 8 production call sites (`ClientLocal` x2, `NetworkRelay` x6 including the corrected one), and a source-scrape pin holds those counts — flipping one tag was, per review, *the* production mutation for this feature and previously passed the entire suite. Scheduling class and data provenance are free to diverge, and a future re-tag for queue-fairness reasons must not silently move a measurement's denominator.

## Telemetry volume

Measured on the actual field names, not estimated:

| | bytes/rollup | KB/peer/day | MB/day @ 1,100 peers | share of ~30 GB/day |
|---|---|---|---|---|
| all-zero window | 130 | 183 | 196 | 0.64% |
| busy node | 134 | 188 | 202 | 0.66% |
| 6-digit worst case | 150 | 211 | 227 | 0.74% |

## Deliberately left undone

**Per-contract origin split.** #5062 asks for it; it is not here. A top-N per-contract array roughly doubles this event's contribution, to refine a number nobody has read yet. Per-contract *sends* already ship (`top_contracts_by_total_bytes`, #4979/#5055), so the moment the node-level ratio says re-broadcast amplification is real, the per-contract denominator becomes a small follow-up against a known-useful measurement instead of a speculative one. If the ratio comes back ≈17, it is not needed at all.

**Separating heal sends from fan-out sends** in `record_delivered`, and **a PUT-path apply counter**. Together these are what would turn R/C from an upper bound into a tight number. The first needs a flag on `BroadcastEntry` and `broadcast_to_single_peer`; the second needs instrumenting `put_contract`'s `PutQuery` path. Both are more than a telemetry-only change should carry the night before a release, and neither is needed if R/C comes back ≈17.

## Scope and risk

Telemetry only. No propagation behaviour, fan-out policy, or wire-format change. The one signature change is `update_contract`'s new parameter, which the compiler enforces at every call site.

## Validation

`cargo fmt --all --check`, `cargo clippy -p freenet --lib -- -D warnings`, `cargo check -p freenet --all-targets`, `cargo check -p freenet --features simulation_tests --lib`, and `cargo test -p freenet --lib` (4,576 passed, 0 failed) all green.

Four tests are mutation-verified rather than asserted to work:

| test | mutation | result |
|---|---|---|
| `update_contract_records_the_apply_against_the_origin_it_was_given` | record commented out | fails (`left: 0, right: 1`) |
| same | origin hardcoded | fails |
| `update_contract_call_sites_tag_their_origin_pin` | a driver's `ClientLocal` flipped to `NetworkRelay` | fails (`(1,5)` vs `(2,4)`) |
| `record_apply_indexes_the_origin_arm_fallibly_pin` | `get_mut` replaced with `[idx]` | fails |
| `concurrent_records_racing_a_rollup_conserve_bytes` | always write the unchanged slot | fails (`left: 0, right: 668`) |

Two earlier tests were replaced because review showed they did **not** test what their names said — one checked `ALL` against itself, the other asserted a compile-time truth about fixed-size arrays. See the review comment.

Refs #5062, #5091, #4956, #5055.

[AI-assisted - Claude]
