### PR TITLE
test(priority-select): size the event-loop poll bound as a hang guard

### DIFF
--- a/crates/core/src/node/network_bridge/priority_select/tests.rs
+++ b/crates/core/src/node/network_bridge/priority_select/tests.rs
@@ -428,13 +428,23 @@ async fn test_priority_select_event_loop_simulation() {
 
     let mut received_events = Vec::new();
 
+    // Hang guard, NOT a latency budget. The property under test is that the
+    // stream keeps its waker registration across `.next().await` calls; a
+    // regression makes iteration 0 hang FOREVER, so any generous bound fails the
+    // same way. The previous 50ms bound read like an assertion but only measured
+    // whether the producer task — which sleeps 10ms of REAL time before its first
+    // send — got scheduled promptly, so it failed on a loaded machine while the
+    // behaviour under test was fine. Wall-clock durations are not a
+    // synchronization primitive (`.claude/rules/flaky-tests.md`).
+    const WAKER_REGISTRATION_HANG_GUARD: Duration = Duration::from_secs(10);
+
     // Simulate event loop: poll stream until we've received all expected messages (3+2+2+1 = 8)
     let expected_count = 8;
     for iteration in 0..expected_count {
         tracing::info!("Event loop iteration {}", iteration);
 
         // Poll the SAME stream on each iteration - waker registration is maintained
-        let result = timeout(Duration::from_millis(50), stream.as_mut().next()).await;
+        let result = timeout(WAKER_REGISTRATION_HANG_GUARD, stream.as_mut().next()).await;
         assert!(result.is_ok(), "Iteration {} should complete", iteration);
 
         let event = result.unwrap().expect("Stream should yield value");


### PR DESCRIPTION
Split out of #5109, where it rode along inside a `fix(ring)` PR and tripped the scope rule-review check.

## Why it is separate

It has no dependency on the retention change. The flake was surfaced by load average ~70 on the build host (four concurrent release builds), not by the ring work, and #5109's 12 CI checks were green without it. So it is not covered by the "tiny follow-up needed to make the PR mergeable" exemption — it is a genuinely independent fix.

## The change

`test_priority_select_event_loop_simulation` bounded each poll at 50 ms of REAL time while its producer task sleeps 10 ms before its first send, leaving iteration 0 a ~40 ms scheduling margin. It failed on a loaded machine and passed 3/3 in isolation.

The bound is a **hang guard, not a latency assertion**: the property under test is that the stream keeps its waker registration across `.next().await` calls, and a regression makes iteration 0 hang forever — so any generous bound fails identically. Widening it therefore costs no coverage. Wall-clock durations are not a synchronization primitive (`.claude/rules/flaky-tests.md`).

## Scope

The same file has ~20 more timeouts of this shape. Several deliberately assert "nothing is ready yet" and want different treatment (`start_paused`) rather than a bigger number, so they are analysed per-site in #5110 rather than swept in here. This changes only the one test that actually failed.

Refs #5110

[AI-assisted - Claude]