### PR TITLE
fix(telemetry): stop the untracked staleness reset from hiding recreation

### DIFF
--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -1227,18 +1227,30 @@ impl<T: TimeSource + Sync> InterestManager<T> {
             // Reset the SEND counter only. `recent_removal` must NOT be wiped
             // here: `last_observed` is stamped exclusively on this untracked
             // path, so it says nothing about when the pair's interest entry was
-            // removed, and the removal's own freshness is already enforced by
-            // the `removed_at` filter immediately below.
+            // removed. Its freshness is enforced independently, by the
+            // `removed_at` filter in BOTH readers — the one immediately below,
+            // and `register_peer_interest_from`'s, which drives
+            // `NeverPopulatedOrigin::New { recreated }` and
+            // `recreated_after_removal`. So the wipe was redundant with those
+            // filters and could only ever suppress true positives.
             //
-            // Wiping it conflated the two clocks and systematically hid
-            // recreation: a pair observed untracked at T0, then tracked, then
-            // removed at T1, then broadcast to again at T2 > T0 + INTEREST_TTL
-            // lost its T1 removal and reported `UntrackedFirstObserved` instead
-            // of `UntrackedFirstRecreated`. That is why the former is the
-            // largest missing-summary class on the fleet (771K sends / 78.2 GB
-            // on 0.2.118) while `UntrackedRepeatSequential` is ~zero: every
-            // churn cycle longer than INTEREST_TTL landed in the "never seen
-            // before" bucket.
+            // Wiping it conflated the two clocks and hid recreation: a pair
+            // observed untracked at T0, tracked, removed at T1, then broadcast
+            // to again at T2 > T0 + INTEREST_TTL lost its T1 removal and
+            // reported `UntrackedFirstObserved` however recent T1 was.
+            //
+            // Scope of the correction, stated precisely because it is easy to
+            // overclaim: this moves sends between `UntrackedFirstObserved` and
+            // `UntrackedFirstRecreated` (and, via the second reader, between
+            // `TrackedFirstNew` and `TrackedFirstRecreated`). It does NOT
+            // change the First-vs-Repeat split, which is decided by
+            // `send_starts` — still reset on the line below — and it does not
+            // change the total number of missing-summary sends or bytes. The
+            // affected population is only pairs that were broadcast to while
+            // untracked more than INTEREST_TTL ago AND removed within the last
+            // INTEREST_TTL AND whose history entry survived the LRU across
+            // both; a pair with `last_observed == None` never tripped the wipe
+            // and already classified correctly.
             record.send_starts = 0;
         }
         let first = record.send_starts == 0;
@@ -3151,15 +3163,22 @@ mod tests {
     ///
     /// `last_observed` is stamped only when a pair is broadcast to while
     /// UNTRACKED, so it measures a different clock from the removal. Wiping the
-    /// removal alongside the send counter made every churn cycle longer than
-    /// `INTEREST_TTL` report as `UntrackedFirstObserved` ("never seen before")
-    /// rather than `UntrackedFirstRecreated` — which is why the former is the
-    /// largest missing-summary class on the fleet while `UntrackedRepeat*` is
-    /// ~zero. Without the fix this test observes `UntrackedFirstObserved`.
+    /// removal alongside the send counter made a pair whose removal was recent,
+    /// but whose last untracked observation was stale, report
+    /// `UntrackedFirstObserved` ("never seen before") rather than
+    /// `UntrackedFirstRecreated`. Without the fix, step T2 below observes
+    /// `UntrackedFirstObserved`.
     ///
-    /// The removal's own freshness is still enforced, by the `removed_at`
-    /// filter that survives the reset — pinned by the second half of this test,
-    /// so the fix cannot drift into honouring an arbitrarily old removal.
+    /// Three things are pinned, because each guards a different way this can
+    /// regress:
+    /// - T2: a recent removal survives a stale-`last_observed` reset.
+    /// - T3: a removal older than `INTEREST_TTL` is still refused — the
+    ///   `removed_at` filter is the remaining guard, so the fix cannot drift
+    ///   into honouring an arbitrarily old removal.
+    /// - T4: the SECOND reader (`register_peer_interest_from`) sees it too.
+    ///   That reader drives `recreated_after_removal` and the tracked-arm
+    ///   `TrackedFirstNew`/`TrackedFirstRecreated` split, so it steps on this
+    ///   change as well and would otherwise be unpinned.
     #[test]
     fn untracked_staleness_reset_preserves_a_recent_removal() {
         let (manager, time) = make_manager();
@@ -3221,6 +3240,56 @@ mod tests {
             MissingSummaryClass::UntrackedFirstObserved,
             "a removal older than INTEREST_TTL must not be honoured just because \
              the wipe is gone — the removed_at filter is the remaining guard"
+        );
+        drop(manager.missing_summary_attempt_guard(attempt));
+
+        // T4: the SECOND reader. `register_peer_interest_from` reads the same
+        // field to set `NeverPopulatedOrigin::New { recreated }` and to bump
+        // `recreated_after_removal`, so it steps on this change too. Re-run the
+        // T0→T2 shape and assert on the counter rather than the class.
+        let contract = make_contract_key(16);
+        let peer = make_peer_key(16);
+        let PeerSummaryForBroadcast::Missing {
+            attempt: Some(attempt),
+            ..
+        } = manager.begin_peer_summary_broadcast(&contract, &peer)
+        else {
+            panic!("an untracked pair must start lifecycle accounting");
+        };
+        drop(manager.missing_summary_attempt_guard(attempt));
+
+        time.advance_time(INTEREST_TTL + Duration::from_secs(60));
+        manager.register_peer_interest(&contract, peer.clone(), None, false);
+        assert!(manager.remove_peer_interest_for(
+            &contract,
+            &peer,
+            InterestRemovalCause::DisconnectGrace
+        ));
+
+        time.advance_time(Duration::from_secs(60));
+        // Trip the staleness reset on the untracked path first, exactly as
+        // production would before the peer re-registers.
+        let PeerSummaryForBroadcast::Missing {
+            attempt: Some(attempt),
+            ..
+        } = manager.begin_peer_summary_broadcast(&contract, &peer)
+        else {
+            panic!("the pair is untracked again");
+        };
+        drop(manager.missing_summary_attempt_guard(attempt));
+
+        let before = manager
+            .interest_lifecycle_snapshot()
+            .recreated_after_removal[InterestRemovalCause::DisconnectGrace.index()];
+        manager.register_peer_interest(&contract, peer.clone(), None, false);
+        let after = manager
+            .interest_lifecycle_snapshot()
+            .recreated_after_removal[InterestRemovalCause::DisconnectGrace.index()];
+        assert_eq!(
+            after - before,
+            1,
+            "the registration reader must also see the preserved removal — \
+             without the fix this counter does not move"
         );
     }
 

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -1224,8 +1224,22 @@ impl<T: TimeSource + Sync> InterestManager<T> {
             .last_observed
             .is_some_and(|observed| now.saturating_duration_since(observed) > INTEREST_TTL)
         {
+            // Reset the SEND counter only. `recent_removal` must NOT be wiped
+            // here: `last_observed` is stamped exclusively on this untracked
+            // path, so it says nothing about when the pair's interest entry was
+            // removed, and the removal's own freshness is already enforced by
+            // the `removed_at` filter immediately below.
+            //
+            // Wiping it conflated the two clocks and systematically hid
+            // recreation: a pair observed untracked at T0, then tracked, then
+            // removed at T1, then broadcast to again at T2 > T0 + INTEREST_TTL
+            // lost its T1 removal and reported `UntrackedFirstObserved` instead
+            // of `UntrackedFirstRecreated`. That is why the former is the
+            // largest missing-summary class on the fleet (771K sends / 78.2 GB
+            // on 0.2.118) while `UntrackedRepeatSequential` is ~zero: every
+            // churn cycle longer than INTEREST_TTL landed in the "never seen
+            // before" bucket.
             record.send_starts = 0;
-            record.recent_removal = None;
         }
         let first = record.send_starts == 0;
         let recreated = record
@@ -3131,6 +3145,83 @@ mod tests {
 
         // Remove again returns false
         assert!(!manager.remove_peer_interest(&contract, &peer));
+    }
+
+    /// The untracked-path staleness reset must not wipe `recent_removal`.
+    ///
+    /// `last_observed` is stamped only when a pair is broadcast to while
+    /// UNTRACKED, so it measures a different clock from the removal. Wiping the
+    /// removal alongside the send counter made every churn cycle longer than
+    /// `INTEREST_TTL` report as `UntrackedFirstObserved` ("never seen before")
+    /// rather than `UntrackedFirstRecreated` — which is why the former is the
+    /// largest missing-summary class on the fleet while `UntrackedRepeat*` is
+    /// ~zero. Without the fix this test observes `UntrackedFirstObserved`.
+    ///
+    /// The removal's own freshness is still enforced, by the `removed_at`
+    /// filter that survives the reset — pinned by the second half of this test,
+    /// so the fix cannot drift into honouring an arbitrarily old removal.
+    #[test]
+    fn untracked_staleness_reset_preserves_a_recent_removal() {
+        let (manager, time) = make_manager();
+        let contract = make_contract_key(15);
+        let peer = make_peer_key(15);
+
+        // T0: broadcast to an untracked pair — stamps `last_observed`.
+        let PeerSummaryForBroadcast::Missing {
+            attempt: Some(attempt),
+            ..
+        } = manager.begin_peer_summary_broadcast(&contract, &peer)
+        else {
+            panic!("an untracked pair must start lifecycle accounting");
+        };
+        assert_eq!(attempt.class, MissingSummaryClass::UntrackedFirstObserved);
+        drop(manager.missing_summary_attempt_guard(attempt));
+
+        // T1 = T0 + 21m: the pair becomes tracked and is then torn down. This is
+        // PAST `INTEREST_TTL` from T0, so the next untracked observation trips
+        // the staleness reset.
+        time.advance_time(INTEREST_TTL + Duration::from_secs(60));
+        manager.register_peer_interest(&contract, peer.clone(), None, false);
+        assert!(manager.remove_peer_interest_for(
+            &contract,
+            &peer,
+            InterestRemovalCause::DisconnectGrace
+        ));
+
+        // T2 = T1 + 1m: the removal is RECENT, even though the last untracked
+        // observation is not.
+        time.advance_time(Duration::from_secs(60));
+        let PeerSummaryForBroadcast::Missing {
+            attempt: Some(attempt),
+            ..
+        } = manager.begin_peer_summary_broadcast(&contract, &peer)
+        else {
+            panic!("the pair is untracked again");
+        };
+        assert_eq!(
+            attempt.class,
+            MissingSummaryClass::UntrackedFirstRecreated,
+            "a removal one minute ago must classify as a recreation regardless of \
+             how long ago the pair was last observed untracked"
+        );
+        drop(manager.missing_summary_attempt_guard(attempt));
+
+        // T3 = T2 + 21m: the removal is now STALE. The surviving `removed_at`
+        // filter must still refuse to call this a recreation.
+        time.advance_time(INTEREST_TTL + Duration::from_secs(60));
+        let PeerSummaryForBroadcast::Missing {
+            attempt: Some(attempt),
+            ..
+        } = manager.begin_peer_summary_broadcast(&contract, &peer)
+        else {
+            panic!("the pair is still untracked");
+        };
+        assert_eq!(
+            attempt.class,
+            MissingSummaryClass::UntrackedFirstObserved,
+            "a removal older than INTEREST_TTL must not be honoured just because \
+             the wipe is gone — the removed_at filter is the remaining guard"
+        );
     }
 
     #[test]

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -146,6 +146,16 @@ pub(crate) struct NetworkEfficiencyV1 {
     /// Schema version.
     pub v: u8,
     /// Delivered missing-summary sends and bytes by `MissingSummaryClass`.
+    ///
+    /// Four rows changed MEANING (not definition, recording site, or position)
+    /// at #5117: the untracked staleness reset used to wipe a pair's recorded
+    /// removal, so a pair whose removal was recent but whose last untracked
+    /// observation was stale classified as "never seen before". Sends move
+    /// `UntrackedFirstObserved` → `UntrackedFirstRecreated` and, via the same
+    /// field's second reader, `TrackedFirstNew` → `TrackedFirstRecreated`; see
+    /// also [`Self::recreated`]. TOTALS are unaffected — only the splits — and
+    /// the First-vs-Repeat split is untouched. Read pre- and post-#5117 series
+    /// separately; a step at that boundary is the fix, not a regression.
     pub ms_s: [u64; MissingSummaryClass::COUNT],
     pub ms_b: [u64; MissingSummaryClass::COUNT],
     /// First-send entry-age buckets: <1s, 1-9s, 10-59s, 1-4m59s, >=5m.
@@ -160,6 +170,12 @@ pub(crate) struct NetworkEfficiencyV1 {
     pub removed: [u64; InterestRemovalCause::COUNT],
     pub current: [u64; crate::ring::interest::SummaryMissingReason::COUNT + 1],
     /// Recreated pairs by their preceding removal cause.
+    ///
+    /// Steps UP at #5117 for the same reason as [`Self::ms_s`] — the recorded
+    /// removal this counts is no longer wiped by the untracked staleness reset,
+    /// so recreations that were previously invisible are now counted. Read pre-
+    /// and post-#5117 series separately. Still an undercount either way: the
+    /// removal is only honoured within `INTEREST_TTL` and lives in a bounded LRU.
     pub recreated: [u64; InterestRemovalCause::COUNT],
     /// Summary-population outcomes by source then outcome.
     pub populated: [[u64; SummaryPopulationOutcome::COUNT]; SummaryPopulationSource::COUNT],


### PR DESCRIPTION
## Problem

`begin_peer_summary_broadcast`'s untracked arm resets a pair's missing-summary history when it goes stale, and the reset wiped `recent_removal` alongside the send counter:

```rust
if record.last_observed.is_some_and(|observed| now - observed > INTEREST_TTL) {
    record.send_starts = 0;
    record.recent_removal = None;   // <- removed by this PR
}
```

Those are **different clocks**. `last_observed` is stamped *only* on this untracked broadcast path, so it says nothing about when the pair's interest entry was removed. The removal's own freshness is already enforced two lines below, by the `removed_at` filter that survives the reset:

```rust
let recreated = record.recent_removal
    .filter(|(_, removed_at)| now.saturating_duration_since(*removed_at) <= INTEREST_TTL)
    .is_some();
```

So the wipe added nothing and cost the signal. A pair observed untracked at T0, tracked, removed at T1, and broadcast to again at T2 > T0 + `INTEREST_TTL` lost its T1 removal and was reported `UntrackedFirstObserved` — "never seen before" — no matter how recent T1 was.

## Why it matters

This is the field the fleet's missing-summary attribution reads from. On the 0.2.118 fleet (1,414 reporting peers), `UntrackedFirstObserved` is the single largest missing-summary class at 771,400 sends / 78.20 GB against `UntrackedFirstRecreated`'s 21,150 / 6.53 GB — and the wipe means an unknown share of the former is actually the latter. That is the discrepancy previously attributed to the interest seeding / heartbeat chain when the class looked far larger than #4952 should allow.

### What this does and does not claim

Being precise here, because an earlier draft of this PR overstated it and the review caught it:

- It moves sends **between** `UntrackedFirstObserved` and `UntrackedFirstRecreated`, and — via a second reader, below — between `TrackedFirstNew` and `TrackedFirstRecreated`. Totals are unchanged.
- It does **not** explain why `UntrackedRepeat*` is ~zero. First-vs-Repeat is decided by `send_starts`, whose reset this PR deliberately keeps. `UntrackedRepeat*` is structurally near-zero for an unrelated reason: `record_delivery_to_interest` upserts an interest entry on delivery (#4952), so a delivered untracked send makes the pair *tracked* and the next broadcast takes the tracked arm. An earlier draft called the `UntrackedRepeatSequential ≈ 0` reading a "fingerprint" of this bug; it isn't, and it will still read ~zero after this lands.
- It does **not** bound the effect size. The staleness branch only fires when `last_observed.is_some()`, so the affected population is the intersection of: previously broadcast to while untracked >20 min ago, AND removed within the last 20 min, AND the history entry surviving the LRU across both. A pair with `last_observed == None` never tripped the wipe and already classified correctly. I have not measured what fraction of the 771K moves, and this PR does not assert one.
- It does **not** make the counter correct. `recent_removal` is honoured only within `INTEREST_TTL` and lives in a bounded LRU (raised to 65,536 by #5097, still overflowing 1,597,674 times fleet-wide on 0.2.118), so recreation stays undercounted. This removes a systematic mis-attribution; it does not remove the undercount.

## Two readers, not one

`recent_removal` has a second reader in `register_peer_interest_from` (`interest.rs:1498-1512`), which sets `NeverPopulatedOrigin::New { recreated }` — feeding the tracked-arm `TrackedFirstNew`/`TrackedFirstRecreated` split — and increments `recreated_after_removal`. It applies the same `removed_at` filter, so the deletion is equally safe there, but it means **four** series step at this change, not two: the untracked split, the tracked split, and `recreated_after_removal`.

That discontinuity is recorded on the wire-schema field docs (`router.rs`, on `ms_s` and `recreated`), following the precedent set by the `queue` field's #4961 note — so it survives where a PR body would not.

## Safety

Behaviourally this changes telemetry classification only — no routing, no payload selection, no broadcast targeting, no state authorization. Both reviewers traced the full consumer chain independently: `attempt.class` is read at exactly one non-test site to index `delivered_sends`/`delivered_bytes`; `NeverPopulatedOrigin` is read at exactly one site to pick a class; and `broadcast_to_single_peer`'s payload selection keys off `their_summary` and `tracked_missing_reason`, neither derived from `recent_removal`.

It cannot resurrect an arbitrarily old removal — both readers filter on `removed_at <= INTEREST_TTL`, which is what the wipe was redundant with, so it could only ever suppress true positives.

It cannot double-count. On the untracked path, honouring removal T1 at broadcast T2 requires `T2 − last_observed > TTL` and `T2 − T1 <= TTL`; `last_observed` is then unconditionally re-stamped to T2, so a second reset needs `T3 − T2 > TTL`, whence `T3 − T1 > TTL` and the filter rejects the same removal. Between resets `send_starts > 0` forces the Repeat arm, which never consults `recreated`. On the registration path the increment requires the peer to be absent from `interested_peers`, and the only removal site overwrites `recent_removal` with a fresh stamp — so one removal yields at most one recreation count.

No growth or LRU-profile change: `MissingPairHistory` is `Copy` with the removal stored inline, and `history.put` runs on every untracked broadcast regardless, so key set, entry count and recency order are byte-identical pre- and post-fix.

The wiped line arrived in `bf4568c40` (#5091) with no rationale comment and no pin test (`git log -S` confirms), and nothing in the repo asserted the old behaviour — so removing it contradicts no documented invariant and breaks no test.

## Test

One regression test pinning three things, each guarding a different regression route:

- **T2** — a removal one minute old classifies as a recreation even though the last untracked observation is 22 minutes old. Verified to fail without the fix: `left: UntrackedFirstObserved, right: UntrackedFirstRecreated`.
- **T3** — a removal 22 minutes old is still refused, so the fix cannot drift into honouring a stale removal. Independently load-bearing: replacing the surviving `removed_at` filter with `recent_removal.is_some()` fails here.
- **T4** — the second reader sees it too, asserted on `recreated_after_removal[DisconnectGrace]` rather than on a class. This counter reads 0 pre-fix and 1 post-fix, so it is a real pin, and it was the series most at risk of stepping unpinned.

## Provenance

Split out of #5109, which attempted to retain peer summaries across a disconnect teardown. That mechanism was withdrawn after two rounds of full-tier review (see #5115); this classifier fix was reviewed as correct and independently valuable by two of the four reviewers, so it is landing on its own.

[AI-assisted - Claude]
