### PR TITLE
fix(broadcast): bound the lane-correction parking area (follow-up to #5108)

### DIFF
--- a/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
+++ b/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
@@ -155,19 +155,29 @@
 //! do it by different routes:
 //!
 //! `BroadcastQueue`'s small-to-large permit upgrade (`ensure_capacity_for`
-//! phase 2) releases its permit and awaits the large pool with no timeout and
-//! no bound on how many senders may be parked there at once. The small drain
-//! worker reclaims the freed permit and dispatches another entry, which may
-//! also mispredict and park. Nothing limits the parked count: `track_active`
+//! phase 2) used to release its permit and await the large pool with no bound
+//! on how many senders could be parked there at once — the small drain worker
+//! reclaimed the freed permit and dispatched another entry, which could also
+//! mispredict and park, without limit. `track_active` does not stop that: it
 //! reports full at the depth cap but the drain loop dispatches anyway (it sets
 //! `tracked: false` for untrack bookkeeping; it is not an admission gate).
-//! Parked upgraders queue ahead of the large drain worker on the same
-//! FIFO-fair semaphore, the large lane backs up against the shared depth cap,
-//! and `evict_oldest` drops entries. Eviction walks `seq` order, and a
-//! fan-out's per-peer entries are enqueued in a tight loop, so they form a
-//! temporal cluster — concurrent fan-outs interleave their `seq` allocations,
-//! so this is a tendency rather than a guarantee, but what gets dropped is
-//! typically most of a FAN-OUT rather than scattered targets. See #5118.
+//! Parked upgraders queue with the large drain worker on the same FIFO-fair
+//! semaphore, so an unbounded parked set could starve it, the large lane would
+//! back up against the shared depth cap, and `evict_oldest` would drop entries.
+//! Eviction walks `seq` order, and a fan-out's per-peer entries are enqueued in
+//! a tight loop, so they form a temporal cluster — concurrent fan-outs
+//! interleave their `seq` allocations, so this is a tendency rather than a
+//! guarantee, but what would get dropped is typically most of a FAN-OUT rather
+//! than scattered targets.
+//!
+//! That was #5118, and it is FIXED: the parked set is now capped at
+//! `MAX_PARKED_LANE_UPGRADES`, and a send that cannot get a parking slot keeps
+//! its small-lane permit and waits rather than adding to the parked set. So at
+//! most a bounded number of upgraders sit ahead of the large drain, which keeps
+//! getting turns. The paragraphs below still describe what to check before
+//! trusting a LOW R/C, because eviction remains possible under genuine
+//! overload — it is simply no longer unbounded, and no longer a reason to
+//! distrust the number outright.
 //!
 //! A dropped fan-out means the receiving peers never apply, so
 //! `applies_network_relay_changed` never fires: **R/C is biased DOWN, and
@@ -201,9 +211,10 @@
 //!
 //! Before trusting a LOW reading, check the broadcast queue: `capacity_evictions`
 //! (the one that licenses the conclusion — it counts the actual drops),
-//! `large_head_blocking_incidents`, and `active_tracking_overflow` (closest to
-//! the #5118 parking mechanism, though it only fires at the depth cap, so
-//! parking can hurt well before it moves). They live in
+//! `large_head_blocking_incidents`, and `active_tracking_overflow` (which the
+//! #5118 parking bound now keeps structurally unreachable — in-flight sends are
+//! capped well under the depth cap — so a non-zero reading means a leaked
+//! tracking guard, not a scheduling backlog). They live in
 //! `BroadcastQueueEfficiencySnapshot` (`broadcast_queue_metrics.rs`), shipped
 //! as a POSITIONAL array in the 30-minute wide `router_snapshot` diagnostic —
 //! not in this 60 s event, so they cannot be aligned window-for-window, and
@@ -211,9 +222,11 @@
 //! consecutive snapshots is ~zero, not that the raw value is.
 //!
 //! If they are moving, a low R/C may be the queue evicting fan-outs rather
-//! than propagation converging; fix #5118 before reading the number at all.
-//! This applies to a first cold measurement just as much as to a fall — there
-//! is no prior to have fallen from, and the number will still look reasonable.
+//! than propagation converging, so read `capacity_evictions` before drawing a
+//! conclusion. This applies to a first cold measurement just as much as to a
+//! fall — there is no prior to have fallen from, and the number will still look
+//! reasonable. (Before #5118 was fixed this was a reason to discard the number
+//! outright; now it is a check, not a blocker.)
 //!
 //! **What flat counters do NOT buy you.** They exclude the queue-eviction
 //! bias specifically. They say nothing about the other downward effects in
@@ -233,8 +246,7 @@
 //!
 //! The follow-ups that would make R/C tight, rather than merely readable with
 //! the procedure above, are that
-//! `heal_sends` split at `record_delivered`, a PUT-path apply counter, and
-//! #5118.
+//! `heal_sends` split at `record_delivered` and a PUT-path apply counter.
 //!
 //! ### `total_sends / applies_client_local_changed` is looser still
 //!
@@ -442,7 +454,7 @@ impl PayloadArm {
 /// biased in both directions: mostly inflated (heals booked as relayed applies
 /// with no origination behind them; client PUTs originating fan-out without
 /// ever calling `update_contract`), but also deflated by the broadcast queue's
-/// fan-out eviction (#5118), load-correlated, which can make a queue problem
+/// fan-out eviction under overload, load-correlated, which can make a queue problem
 /// look like a clean result.
 ///
 /// The derivation, the full bias list, and the procedure for reading the
@@ -1496,7 +1508,7 @@ fn payload_mix_json(
     //
     // Read the module docs before using either. Both are biased in BOTH
     // directions: mostly upward, but the broadcast queue's fan-out eviction
-    // (#5118) pushes down and is load-correlated, so a FALL in R/C can be a
+    // under overload pushes down and is load-correlated, so a FALL in R/C can be a
     // queue problem wearing the shape of a clean result. The docs give the
     // three queue counters to check first. Do not read either ratio bare, and
     // do not read it to three significant figures.

--- a/crates/core/src/node/network_bridge/broadcast_queue.rs
+++ b/crates/core/src/node/network_bridge/broadcast_queue.rs
@@ -202,9 +202,10 @@ impl SendLanePermit {
     /// its state — mispredicts on every send to every peer permanently. So
     /// treating them as independent events would be wrong.
     ///
-    /// Past the parking area's capacity the small-lane slot IS held for the
-    /// whole wait and the small lane applies backpressure; see the module
-    /// header, that is the deliberate end of the hold-window bound.
+    /// Past the parking area's capacity the small-lane slot is held until a
+    /// parking slot frees and only then given up, so while parking stays full
+    /// the small lane applies backpressure; see the module header, that is the
+    /// deliberate end of the hold-window bound.
     ///
     /// A parked send holds no pool capacity and is putting nothing on the wire,
     /// so the pools alone do not bound how many sends are in flight — that is
@@ -287,7 +288,7 @@ impl SendLanePermit {
     /// stalling forever.
     ///
     /// UNREACHABLE today: nothing closes these semaphores (grep `.close()` in
-    /// this file — the only hit is a test). It exists so that adding a real
+    /// this file — the only hits are tests). It exists so that adding a real
     /// shutdown path later cannot silently strand in-flight sends, and it is
     /// the one documented way a large payload can reach the wire without
     /// large-lane capacity.
@@ -748,8 +749,8 @@ mod queue {
     /// of #4961 (1,887 incidents and a 7,260 s small-entry wait integral per
     /// node-day on the 0.2.118 fleet). (A dispatched send correcting a
     /// mispredicted lane can still hold a small-lane permit — for
-    /// [`UPGRADE_SLOT_HOLD_WINDOW`] while parking has room, and for the whole
-    /// wait once it does not. See `SendLanePermit`.)
+    /// [`UPGRADE_SLOT_HOLD_WINDOW`] while parking has room, and until a parking
+    /// slot frees once it does not. See `SendLanePermit`.)
     ///
     /// Ordering is by a global monotonic sequence number so the two FIFOs stay
     /// comparable: capacity eviction still drops the globally oldest entry, and
@@ -1477,6 +1478,18 @@ mod queue {
                     < task.find("active_guard.finish().await").unwrap(),
                 "normal tracking cleanup must run directly after releasing capacity"
             );
+
+            // The parking area must arrive here already shared, not be built
+            // per dispatch — a per-send pool bounds nothing, and no behavioural
+            // test drives two mispredicting dispatches through this loop.
+            assert!(
+                worker.contains("upgrade_slots.clone(),"),
+                "each dispatched send must get a clone of the SHARED parking area"
+            );
+            assert!(
+                !worker.contains("Semaphore::new("),
+                "the drain loop must not construct a pool of its own"
+            );
         }
 
         /// The structural half of #4961: one drain per lane. A single worker
@@ -1542,10 +1555,15 @@ mod queue {
                 .find("\n        /// The lane-agnostic half")
                 .expect("end of enqueue not found")
                 + enq;
+            let enq_body = &src[enq..enq_end];
             assert!(
-                src[enq..enq_end].contains("let lane = lane_for("),
-                "enqueue must derive the lane it enqueues with from lane_for — not \
-                 merely mention it"
+                enq_body.contains("let lane = lane_for("),
+                "enqueue must derive its lane from lane_for — not merely mention it"
+            );
+            assert!(
+                enq_body.contains("self.enqueue_in_lane(lane,"),
+                "...and must enqueue with THAT lane; deriving it and then passing a \
+                 different one would pass the check above"
             );
         }
 
@@ -2204,25 +2222,46 @@ mod queue {
         }
 
         /// Cancellation safety, which `ensure_capacity_for`'s doc claims: a send
-        /// dropped mid-wait must release whatever it holds, in either phase.
+        /// aborted mid-wait must release whatever it holds, in every state it
+        /// can be waiting in.
+        #[derive(Debug, Clone, Copy)]
+        enum Phase {
+            /// Phase 1: holding the small-lane slot, waiting on the large pool.
+            HoldingSlot,
+            /// Phase 2, parked: holding a parking slot and no lane permit.
+            Parked,
+            /// Phase 2, queued: still holding the small-lane slot while waiting
+            /// for a parking slot.
+            QueuedForParking,
+        }
+
         #[tokio::test(start_paused = true)]
         async fn cancelling_a_waiting_send_releases_its_permit_in_either_phase() {
-            for park_first in [false, true] {
+            for phase in [Phase::HoldingSlot, Phase::Parked, Phase::QueuedForParking] {
+                let park_first = !matches!(phase, Phase::HoldingSlot);
                 let small = Arc::new(Semaphore::new(12));
-                let large = Arc::new(Semaphore::new(1));
-                let parking = Arc::new(Semaphore::new(1));
+                // TWO large permits, one left free, so the "took no large
+                // permit" assertion below can actually fail.
+                let large = Arc::new(Semaphore::new(2));
                 let _occupied = large
                     .clone()
-                    .acquire_owned()
+                    .acquire_many_owned(2)
                     .await
                     .expect("large pool open");
+                let parking = Arc::new(Semaphore::new(1));
+                // For the queued-for-parking case, someone else already holds
+                // the only parking slot, so the send under test blocks on the
+                // parking acquire itself — the wait this round introduced.
+                let _squatter = matches!(phase, Phase::QueuedForParking)
+                    .then(|| parking.clone().try_acquire_owned().expect("parking free"));
                 let mut permit = parked_small_lane_permit(&small, &large, &parking);
                 let mut waiting = tokio::spawn(async move {
                     permit.ensure_capacity_for(BIG).await;
                     permit
                 });
 
-                // Phase 1 holds the small slot; phase 2 has parked without one.
+                // Phase 1 holds the small slot; phase 2 has parked without one,
+                // or is still queued for a slot while holding one.
                 let elapse = if park_first {
                     super::super::UPGRADE_SLOT_HOLD_WINDOW * 2
                 } else {
@@ -2232,10 +2271,16 @@ mod queue {
                     tokio::time::timeout(elapse, &mut waiting).await.is_err(),
                     "[park_first={park_first}] precondition: still waiting"
                 );
+                let parked_now = matches!(phase, Phase::Parked);
                 assert_eq!(
                     parking.available_permits(),
-                    usize::from(!park_first),
-                    "[park_first={park_first}] precondition: parked iff past the window"
+                    usize::from(matches!(phase, Phase::HoldingSlot)),
+                    "[{phase:?}] precondition: holds a parking slot iff parked"
+                );
+                assert_eq!(
+                    small.available_permits(),
+                    if parked_now { 12 } else { 11 },
+                    "[{phase:?}] precondition: still holds its small-lane slot unless parked"
                 );
 
                 // Cancel it the way a shutdown would. `timeout` alone would NOT
@@ -2249,23 +2294,24 @@ mod queue {
                 };
                 assert!(
                     cancelled,
-                    "[park_first={park_first}] the send must have been cancelled mid-wait"
+                    "[{phase:?}] the send must have been cancelled mid-wait"
                 );
 
                 assert_eq!(
                     small.available_permits(),
                     12,
-                    "[park_first={park_first}] the small-lane slot must come back"
+                    "[{phase:?}] the small-lane slot must come back"
                 );
+                drop(_squatter);
                 assert_eq!(
                     parking.available_permits(),
                     1,
-                    "[park_first={park_first}] and so must the parking slot"
+                    "[{phase:?}] and so must the parking slot"
                 );
                 assert_eq!(
                     large.available_permits(),
                     0,
-                    "[park_first={park_first}] the cancelled send took no large permit"
+                    "[{phase:?}] the cancelled send took no large permit"
                 );
             }
         }

--- a/crates/core/src/node/network_bridge/broadcast_queue.rs
+++ b/crates/core/src/node/network_bridge/broadcast_queue.rs
@@ -1230,21 +1230,23 @@ mod queue {
             let small_semaphore = Arc::new(Semaphore::new(self.small_payload_concurrency));
             let large_semaphore = Arc::new(Semaphore::new(self.large_payload_concurrency));
             let upgrade_slots = Arc::new(Semaphore::new(super::MAX_PARKED_LANE_UPGRADES));
+            let group = LaneGroup {
+                small_pool: small_semaphore.clone(),
+                large_pool: large_semaphore.clone(),
+                upgrade_slots,
+                small_notify: self.small_notify.clone(),
+                large_notify: self.large_notify.clone(),
+            };
 
-            let spawn_lane = |lane, semaphore: Arc<Semaphore>| {
+            let spawn_lane = |lane, _semaphore: Arc<Semaphore>| {
                 let queue = self.queue.clone();
-                let notify = self.notify_for(lane).clone();
-                let large_pool = large_semaphore.clone();
-                let upgrade_slots = upgrade_slots.clone();
+                let group = group.clone();
                 let bridge = bridge.clone();
                 let op_manager = op_manager.clone();
                 tokio::spawn(drain_lane(
                     lane,
                     queue,
-                    notify,
-                    semaphore,
-                    large_pool,
-                    upgrade_slots,
+                    group,
                     move |entry: BroadcastEntry, scheduling: QueueScheduling| {
                         let bridge = bridge.clone();
                         let op_manager = op_manager.clone();
@@ -1270,6 +1272,54 @@ mod queue {
         }
     }
 
+    /// The pools and wakeups both lane drains share.
+    ///
+    /// Exists so that either drain exiting can stop the other. Before #4961 a
+    /// single worker drained everything, so its exit stopped ALL broadcast
+    /// draining — bad, but total and therefore noticeable. Splitting the drain
+    /// in two must not convert that into half the broadcast traffic
+    /// disappearing while the node otherwise looks healthy, which is strictly
+    /// harder to notice than the failure it replaced. These handles are
+    /// fire-and-forget (`p2p_protoc` discards them and holds no
+    /// `BackgroundTaskMonitor` to register them with), so the drains have to
+    /// enforce that themselves.
+    #[derive(Clone)]
+    struct LaneGroup {
+        small_pool: Arc<Semaphore>,
+        large_pool: Arc<Semaphore>,
+        upgrade_slots: Arc<Semaphore>,
+        small_notify: Arc<Notify>,
+        large_notify: Arc<Notify>,
+    }
+
+    impl LaneGroup {
+        fn pool(&self, lane: QueuedPayloadClass) -> &Arc<Semaphore> {
+            match lane {
+                QueuedPayloadClass::Small => &self.small_pool,
+                QueuedPayloadClass::Large => &self.large_pool,
+            }
+        }
+
+        fn notify(&self, lane: QueuedPayloadClass) -> &Arc<Notify> {
+            match lane {
+                QueuedPayloadClass::Small => &self.small_notify,
+                QueuedPayloadClass::Large => &self.large_notify,
+            }
+        }
+
+        /// Stop BOTH drains. Closing every pool makes the sibling's next
+        /// `acquire_owned` fail, and the notify wakes it if it is parked idle
+        /// with an empty lane; it also re-checks closure after waking, so an
+        /// idle sibling exits promptly rather than at its next entry.
+        fn shutdown(&self) {
+            self.small_pool.close();
+            self.large_pool.close();
+            self.upgrade_slots.close();
+            self.small_notify.notify_one();
+            self.large_notify.notify_one();
+        }
+    }
+
     /// Drain loop for ONE lane: pop that lane's FIFO, take one of that lane's
     /// permits, and hand the entry to `dispatch` on a spawned task.
     ///
@@ -1286,15 +1336,16 @@ mod queue {
     async fn drain_lane<D, F>(
         lane: QueuedPayloadClass,
         queue: Arc<Mutex<QueueState>>,
-        notify: Arc<Notify>,
-        semaphore: Arc<Semaphore>,
-        large_pool: Arc<Semaphore>,
-        upgrade_slots: Arc<Semaphore>,
+        group: LaneGroup,
         dispatch: D,
     ) where
         D: Fn(BroadcastEntry, QueueScheduling) -> F,
         F: Future<Output = ()> + Send + 'static,
     {
+        let notify = group.notify(lane).clone();
+        let semaphore = group.pool(lane).clone();
+        let large_pool = group.large_pool.clone();
+        let upgrade_slots = group.upgrade_slots.clone();
         let lane_is_large = matches!(lane, QueuedPayloadClass::Large);
         loop {
             // Register the notified future BEFORE checking the queue to avoid
@@ -1355,7 +1406,13 @@ mod queue {
                             .record_large_head_block(blocked_millis, small_entry_millis);
                     }
                     active_guard.finish().await;
-                    tracing::error!(?lane, "Broadcast queue semaphore closed unexpectedly");
+                    tracing::error!(
+                        ?lane,
+                        "Broadcast queue semaphore closed unexpectedly; stopping BOTH \
+                         lane drains so this cannot degrade into half the broadcast \
+                         traffic silently disappearing"
+                    );
+                    group.shutdown();
                     return;
                 };
 
@@ -1391,6 +1448,20 @@ mod queue {
             if !drained_any {
                 // This lane was empty, wait for new entries
                 notified.await;
+                // ...which may have been the sibling drain shutting us down
+                // rather than an enqueue. This exit must ALSO shut down, not
+                // just return: an idle drain can reach it first (its pool
+                // closes while it waits), and returning quietly here would
+                // leave the sibling running — the exact asymmetry this whole
+                // mechanism exists to prevent.
+                if semaphore.is_closed() {
+                    tracing::error!(
+                        ?lane,
+                        "Broadcast lane drain stopping: pool closed; stopping BOTH lanes"
+                    );
+                    group.shutdown();
+                    return;
+                }
             }
             // If we drained entries, loop immediately to check for more
             // (the pre-registered notified future is dropped, which is fine)
@@ -1534,14 +1605,14 @@ mod queue {
                 "the parking area must be constructed exactly once in start_worker"
             );
             let created = body
-                .find("let upgrade_slots = Arc::new(Semaphore::new(")
-                .expect("the parking area must be created here");
+                .find("let group = LaneGroup {")
+                .expect("the shared pools must be bundled into one LaneGroup here");
             let per_lane = body
-                .find("let upgrade_slots = upgrade_slots.clone();")
-                .expect("each drain must CLONE the shared parking area, not build its own");
+                .find("let group = group.clone();")
+                .expect("each drain must CLONE the shared LaneGroup, not build its own");
             assert!(
                 created < per_lane,
-                "the shared parking area must be created before the per-lane clone"
+                "the shared LaneGroup must be created before the per-lane clone"
             );
 
             // And `enqueue` must still route through `lane_for`. Substituting a
@@ -1618,40 +1689,232 @@ mod queue {
             let large_permits = Arc::new(Semaphore::new(large));
             let upgrade_slots = Arc::new(Semaphore::new(super::super::MAX_PARKED_LANE_UPGRADES));
             let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
-            let workers = [
-                (QueuedPayloadClass::Small, small_permits.clone()),
-                (QueuedPayloadClass::Large, large_permits.clone()),
-            ]
-            .into_iter()
-            .map(|(lane, semaphore)| {
-                let tx = tx.clone();
-                tokio::spawn(drain_lane(
-                    lane,
-                    queue.queue.clone(),
-                    queue.notify_for(lane).clone(),
-                    semaphore,
-                    large_permits.clone(),
-                    upgrade_slots.clone(),
-                    move |entry: BroadcastEntry, scheduling: QueueScheduling| {
-                        let tx = tx.clone();
-                        async move {
-                            // Hold the scheduling bundle (and therefore the
-                            // lane permit) for the lifetime of the "send".
-                            let _scheduling = scheduling;
-                            let _ = tx.send((lane, entry.key));
-                            // Never completes: the permit stays held, so the
-                            // test can saturate a lane deterministically.
-                            std::future::pending::<()>().await;
-                        }
-                    },
-                ))
-            })
-            .collect();
+            let group = LaneGroup {
+                small_pool: small_permits.clone(),
+                large_pool: large_permits.clone(),
+                upgrade_slots,
+                small_notify: queue.small_notify.clone(),
+                large_notify: queue.large_notify.clone(),
+            };
+            let workers = [QueuedPayloadClass::Small, QueuedPayloadClass::Large]
+                .into_iter()
+                .map(|lane| {
+                    let tx = tx.clone();
+                    tokio::spawn(drain_lane(
+                        lane,
+                        queue.queue.clone(),
+                        group.clone(),
+                        move |entry: BroadcastEntry, scheduling: QueueScheduling| {
+                            let tx = tx.clone();
+                            async move {
+                                // Hold the scheduling bundle (and therefore the
+                                // lane permit) for the lifetime of the "send".
+                                let _scheduling = scheduling;
+                                let _ = tx.send((lane, entry.key));
+                                // Never completes: the permit stays held, so the
+                                // test can saturate a lane deterministically.
+                                std::future::pending::<()>().await;
+                            }
+                        },
+                    ))
+                })
+                .collect();
             Lanes {
                 small_permits,
                 large_permits,
                 dispatched: rx,
                 workers,
+            }
+        }
+
+        /// A lane drain can only exit on a closed pool, which nothing does in
+        /// production. But there are TWO of them now, and the pre-#4961 failure
+        /// — one worker exiting, so all broadcast draining stops — was at least
+        /// total. Half the traffic vanishing while the node looks healthy is
+        /// harder to notice, so the first drain to exit must take the other with
+        /// it. (`p2p_protoc` discards these handles and holds no
+        /// `BackgroundTaskMonitor` to register them with, so nothing else will.)
+        ///
+        /// A drain has TWO exits and both must shut the sibling down: waking
+        /// idle to find its pool closed, and a pending `acquire` failing under
+        /// it. Covering only one leaves the other free to return quietly, which
+        /// is how this asymmetry comes back.
+        #[tokio::test(start_paused = true)]
+        #[serial_test::serial(broadcast_queue_depth_gauge)]
+        async fn one_lane_drain_exiting_stops_the_other() {
+            for exit_while_idle in [true, false] {
+                let queue = BroadcastQueue::new();
+                let mut lanes = spawn_lanes(&queue, 12, 1);
+                assert_eq!(lanes.next_dispatch().await, None, "both drains are idle");
+
+                if !exit_while_idle {
+                    // Put the large drain INSIDE a pending acquire: one send
+                    // holds the only permit, a second is popped and blocks.
+                    for seed in 30..32u8 {
+                        queue
+                            .enqueue_in_lane(
+                                QueuedPayloadClass::Large,
+                                contract(seed),
+                                PeerKeyLocation::random(),
+                                state(BIG),
+                            )
+                            .await;
+                    }
+                    assert_eq!(
+                        lanes.next_dispatch().await,
+                        Some((QueuedPayloadClass::Large, contract(30))),
+                        "the first large send takes the only permit"
+                    );
+                    assert_eq!(
+                        lanes.large_permits.available_permits(),
+                        0,
+                        "so the second is blocked in acquire_owned"
+                    );
+                }
+
+                // Kill ONLY the large pool, as a lost large-lane drain would.
+                lanes.large_permits.close();
+                if exit_while_idle {
+                    queue
+                        .enqueue_in_lane(
+                            QueuedPayloadClass::Large,
+                            contract(21),
+                            PeerKeyLocation::random(),
+                            state(BIG),
+                        )
+                        .await;
+                }
+
+                // Both drains must stop — including the small one, whose own
+                // pool was never touched. Await the closed lane FIRST so a
+                // failure names which drain hung.
+                let mut workers = std::mem::take(&mut lanes.workers);
+                let large_worker = workers.pop().expect("large drain");
+                tokio::time::timeout(Duration::from_secs(5), large_worker)
+                    .await
+                    .unwrap_or_else(|_| {
+                        panic!("[idle={exit_while_idle}] the drain whose pool closed must exit")
+                    })
+                    .expect("drain must return rather than panic");
+                let small_worker = workers.pop().expect("small drain");
+                tokio::time::timeout(Duration::from_secs(5), small_worker)
+                    .await
+                    .unwrap_or_else(|_| {
+                        panic!("[idle={exit_while_idle}] it must take the OTHER drain down with it")
+                    })
+                    .expect("drain must return rather than panic");
+                assert!(
+                    lanes.small_permits.is_closed(),
+                    "[idle={exit_while_idle}] the surviving lane's pool must be closed \
+                     too, so it cannot keep draining as if healthy"
+                );
+            }
+        }
+
+        /// The escalation from #5112's author: parked upgraders queue on the
+        /// same FIFO pool as the large lane's own drain, so if they could
+        /// accumulate without limit they would starve it, `large_order` would
+        /// back up against the shared depth cap, and `evict_oldest` would start
+        /// dropping the globally oldest entry — whole fan-outs, since
+        /// mispredictions are correlated across every peer of a contract. That
+        /// is an update-propagation failure, not just RSS growth.
+        ///
+        /// The parking bound is what prevents it: at most
+        /// `MAX_PARKED_LANE_UPGRADES` upgraders can be queued ahead of the large
+        /// drain, so it keeps getting turns and the queue keeps draining. This
+        /// drives a sustained burst of mispredicting sends through the REAL
+        /// `ensure_capacity_for` and asserts the large lane still makes
+        /// progress and the queue does not fill.
+        #[tokio::test(start_paused = true)]
+        #[serial_test::serial(broadcast_queue_depth_gauge)]
+        async fn mispredicting_burst_does_not_starve_the_large_lane_into_evicting() {
+            let queue = BroadcastQueue {
+                max_queue_depth: 8,
+                ..BroadcastQueue::new()
+            };
+            let small_permits = Arc::new(Semaphore::new(12));
+            let large_permits = Arc::new(Semaphore::new(2));
+            let upgrade_slots = Arc::new(Semaphore::new(super::super::MAX_PARKED_LANE_UPGRADES));
+            let (tx, mut dispatched) = tokio::sync::mpsc::unbounded_channel();
+            let group = LaneGroup {
+                small_pool: small_permits.clone(),
+                large_pool: large_permits.clone(),
+                upgrade_slots,
+                small_notify: queue.small_notify.clone(),
+                large_notify: queue.large_notify.clone(),
+            };
+            // Every SMALL-lane send mispredicts: it runs the real correction and
+            // ends up needing large-lane capacity. Large-lane sends complete
+            // immediately, so the large pool keeps turning over.
+            let workers: Vec<_> = [QueuedPayloadClass::Small, QueuedPayloadClass::Large]
+                .into_iter()
+                .map(|lane| {
+                    let tx = tx.clone();
+                    tokio::spawn(drain_lane(
+                        lane,
+                        queue.queue.clone(),
+                        group.clone(),
+                        move |entry: BroadcastEntry, mut scheduling: QueueScheduling| {
+                            let tx = tx.clone();
+                            async move {
+                                if matches!(lane, QueuedPayloadClass::Small) {
+                                    scheduling.permit.ensure_capacity_for(BIG).await;
+                                }
+                                let _ = tx.send((lane, entry.key));
+                            }
+                        },
+                    ))
+                })
+                .collect();
+
+            // A sustained correlated burst: far more mispredicting small sends
+            // than the parking area can hold, interleaved with genuine
+            // large-lane entries.
+            for seed in 0..40u8 {
+                let lane = if seed % 4 == 0 {
+                    QueuedPayloadClass::Large
+                } else {
+                    QueuedPayloadClass::Small
+                };
+                queue
+                    .enqueue_in_lane(lane, contract(seed), PeerKeyLocation::random(), state(BIG))
+                    .await;
+                tokio::task::yield_now().await;
+            }
+
+            // Drain what the workers produced.
+            let mut large_dispatched = 0usize;
+            let mut total = 0usize;
+            while let Ok(Some((lane, _))) =
+                tokio::time::timeout(Duration::from_secs(5), dispatched.recv()).await
+            {
+                total += 1;
+                if matches!(lane, QueuedPayloadClass::Large) {
+                    large_dispatched += 1;
+                }
+                if total == 40 {
+                    break;
+                }
+            }
+
+            assert_eq!(
+                total, 40,
+                "every entry must be dispatched — a starved large lane would leave \
+                 entries queued until the depth cap evicted them"
+            );
+            assert_eq!(
+                large_dispatched, 10,
+                "and the large lane specifically must keep making progress while \
+                 mispredicted upgraders contend for its pool"
+            );
+            let q = queue.queue.lock().await;
+            assert!(
+                q.entries.is_empty(),
+                "the queue must have drained rather than backed up to the cap"
+            );
+            drop(q);
+            for worker in workers {
+                worker.abort();
             }
         }
 

--- a/crates/core/src/node/network_bridge/broadcast_queue.rs
+++ b/crates/core/src/node/network_bridge/broadcast_queue.rs
@@ -160,6 +160,9 @@ const UPGRADE_SLOT_HOLD_WINDOW: Duration = Duration::from_millis(250);
 /// Not derived from that constant directly because the pool sizes live in the
 /// `queue` submodule, which is cfg'd out under `simulation_tests` while this
 /// type stays compiled.
+// Only referenced from the production queue, which is cfg'd out under
+// `simulation_tests`; the doc-links from `SendLanePermit` do not count as uses.
+#[cfg_attr(feature = "simulation_tests", allow(dead_code))]
 const MAX_PARKED_LANE_UPGRADES: usize = 12;
 
 #[cfg_attr(feature = "simulation_tests", allow(dead_code))]
@@ -264,8 +267,8 @@ impl SendLanePermit {
                 self.permit = None;
                 Some(slot)
             }
-            // Closed parking (nothing closes it today): keep the small-lane slot
-            // rather than parking unbounded.
+            // Closed parking (only `LaneGroup::shutdown` does that): keep the
+            // small-lane slot rather than parking unbounded.
             Err(_) => None,
         };
         match self.large_pool.clone().acquire_owned().await {
@@ -287,8 +290,10 @@ impl SendLanePermit {
     /// holds — possibly nothing, if it had already parked — rather than
     /// stalling forever.
     ///
-    /// UNREACHABLE today: nothing closes these semaphores (grep `.close()` in
-    /// this file — the only hits are tests). It exists so that adding a real
+    /// Reachable only via [`LaneGroup::shutdown`], which fires when a lane
+    /// drain stops — and a drain only stops on an already-closed pool or a
+    /// panic. So in a healthy node this never runs; after a drain panics it
+    /// can, which is why it releases the send rather than stranding it. It exists so that adding a real
     /// shutdown path later cannot silently strand in-flight sends, and it is
     /// the one documented way a large payload can reach the wire without
     /// large-lane capacity.
@@ -1219,9 +1224,11 @@ mod queue {
         /// handles are not registered with a monitor (pre-existing), and there
         /// are two of them now, so if one ever stopped the other would keep
         /// draining and only that lane would silently go quiet. Two ways it
-        /// could: a closed semaphore (nothing closes them today), or a panic on
-        /// `pop_lane`'s `.expect` if the order maps ever drifted from
-        /// `entries`. Worth revisiting if the pools gain a real close path.
+        /// could: a closed semaphore (only `LaneGroup::shutdown` closes them),
+        /// or a panic on `pop_lane`'s `.expect` if the order maps ever drifted
+        /// from `entries`. Both are covered — `LaneDrainGuard` stops the
+        /// sibling on any exit, panic included — so one lane cannot outlive the
+        /// other and quietly carry half the traffic.
         pub(crate) fn start_worker(
             &self,
             bridge: P2pBridge,
@@ -1238,7 +1245,7 @@ mod queue {
                 large_notify: self.large_notify.clone(),
             };
 
-            let spawn_lane = |lane, _semaphore: Arc<Semaphore>| {
+            let spawn_lane = |lane| {
                 let queue = self.queue.clone();
                 let group = group.clone();
                 let bridge = bridge.clone();
@@ -1266,8 +1273,8 @@ mod queue {
             };
 
             [
-                spawn_lane(QueuedPayloadClass::Small, small_semaphore),
-                spawn_lane(QueuedPayloadClass::Large, large_semaphore.clone()),
+                spawn_lane(QueuedPayloadClass::Small),
+                spawn_lane(QueuedPayloadClass::Large),
             ]
         }
     }
@@ -1320,6 +1327,24 @@ mod queue {
         }
     }
 
+    /// Runs [`LaneGroup::shutdown`] when a drain stops for ANY reason.
+    ///
+    /// The two explicit `shutdown()` calls cover the semaphore-closed returns,
+    /// but those are unreachable in production (nothing closes a pool except
+    /// this mechanism). The exit that CAN happen is a panic — `pop_lane`'s
+    /// `.expect`, or anything else unwinding — and a panic skips both of them,
+    /// leaving the sibling draining and restoring exactly the half-silent
+    /// asymmetry this exists to prevent. `p2p_protoc` discards the handles and
+    /// holds no `BackgroundTaskMonitor`, so nothing else would notice either.
+    /// A `Drop` guard covers panic, abort and normal return alike.
+    struct LaneDrainGuard(LaneGroup);
+
+    impl Drop for LaneDrainGuard {
+        fn drop(&mut self) {
+            self.0.shutdown();
+        }
+    }
+
     /// Drain loop for ONE lane: pop that lane's FIFO, take one of that lane's
     /// permits, and hand the entry to `dispatch` on a spawned task.
     ///
@@ -1342,6 +1367,9 @@ mod queue {
         D: Fn(BroadcastEntry, QueueScheduling) -> F,
         F: Future<Output = ()> + Send + 'static,
     {
+        // Stops the sibling however this drain ends — including a panic, which
+        // skips the explicit `shutdown()` calls below.
+        let _stop_sibling_on_exit = LaneDrainGuard(group.clone());
         let notify = group.notify(lane).clone();
         let semaphore = group.pool(lane).clone();
         let large_pool = group.large_pool.clone();
@@ -1580,20 +1608,26 @@ mod queue {
                 2,
                 "start_worker must spawn exactly one drain per lane"
             );
-            // Pin the lane→pool WIRING, not just the lane count. Handing the
-            // small lane the large semaphore is a one-token slip that caps
-            // small broadcasts at 2 concurrent and puts them back in contention
-            // with full-state sends — i.e. reinstates #4961 at full strength —
-            // while every behavioural test still passes, because they build
-            // their own semaphores instead of going through `start_worker`.
-            assert!(
-                body.contains("spawn_lane(QueuedPayloadClass::Small, small_semaphore)"),
-                "the small lane must be given the SMALL pool"
-            );
-            assert!(
-                body.contains("spawn_lane(QueuedPayloadClass::Large, large_semaphore"),
-                "the large lane must be given the LARGE pool"
-            );
+            // Pin the lane→pool and lane→notify WIRING, which lives in the
+            // `LaneGroup` literal. Transposing either pair here is a one-token
+            // slip: swapping the pools caps small broadcasts at 2 concurrent —
+            // #4961 at full strength — and swapping the notifies makes each
+            // drain wait on the other lane's wakeup, so a lane silently stops
+            // draining. Neither is caught behaviourally, because `start_worker`
+            // has no test caller: every behavioural test builds its own
+            // `LaneGroup`. (`LaneGroup::pool`/`notify` themselves ARE covered —
+            // swapping their match arms fails the scheduling tests.)
+            for wiring in [
+                "small_pool: small_semaphore",
+                "large_pool: large_semaphore",
+                "small_notify: self.small_notify",
+                "large_notify: self.large_notify",
+            ] {
+                assert!(
+                    body.contains(wiring),
+                    "start_worker must wire the shared LaneGroup as `{wiring}`"
+                );
+            }
             // ONE parking pool for the node. Constructing it per dispatch
             // instead would make the parked set unbounded again while every
             // behavioural test stayed green — so pin BOTH halves: created once
@@ -1648,6 +1682,12 @@ mod queue {
             let code = freenet_stdlib::prelude::ContractCode::from(vec![seed]);
             let params = freenet_stdlib::prelude::Parameters::from(vec![seed]);
             ContractKey::from_params_and_code(&params, &code)
+        }
+
+        fn lane_of(
+            dispatched: Option<(QueuedPayloadClass, ContractKey)>,
+        ) -> Option<QueuedPayloadClass> {
+            dispatched.map(|(lane, _)| lane)
         }
 
         fn state(size: usize) -> WrappedState {
@@ -1811,41 +1851,26 @@ mod queue {
             }
         }
 
-        /// The escalation from #5112's author: parked upgraders queue on the
-        /// same FIFO pool as the large lane's own drain, so if they could
-        /// accumulate without limit they would starve it, `large_order` would
-        /// back up against the shared depth cap, and `evict_oldest` would start
-        /// dropping the globally oldest entry — whole fan-outs, since
-        /// mispredictions are correlated across every peer of a contract. That
-        /// is an update-propagation failure, not just RSS growth.
-        ///
-        /// The parking bound is what prevents it: at most
-        /// `MAX_PARKED_LANE_UPGRADES` upgraders can be queued ahead of the large
-        /// drain, so it keeps getting turns and the queue keeps draining. This
-        /// drives a sustained burst of mispredicting sends through the REAL
-        /// `ensure_capacity_for` and asserts the large lane still makes
-        /// progress and the queue does not fill.
+        /// A drain that stops WITHOUT reaching either explicit `shutdown()`
+        /// call must still stop the sibling. That is the exit which can
+        /// actually happen — a panic unwinding out of the drain — since the
+        /// semaphore-closed exits are unreachable in a healthy node. Only
+        /// `LaneDrainGuard`'s `Drop` covers it. Abort is the testable proxy: it
+        /// drops the drain future and runs exactly the same `Drop` path.
         #[tokio::test(start_paused = true)]
         #[serial_test::serial(broadcast_queue_depth_gauge)]
-        async fn mispredicting_burst_does_not_starve_the_large_lane_into_evicting() {
-            let queue = BroadcastQueue {
-                max_queue_depth: 8,
-                ..BroadcastQueue::new()
-            };
+        async fn a_drain_that_stops_without_shutting_down_still_stops_the_other() {
+            let queue = BroadcastQueue::new();
             let small_permits = Arc::new(Semaphore::new(12));
             let large_permits = Arc::new(Semaphore::new(2));
-            let upgrade_slots = Arc::new(Semaphore::new(super::super::MAX_PARKED_LANE_UPGRADES));
-            let (tx, mut dispatched) = tokio::sync::mpsc::unbounded_channel();
             let group = LaneGroup {
                 small_pool: small_permits.clone(),
                 large_pool: large_permits.clone(),
-                upgrade_slots,
+                upgrade_slots: Arc::new(Semaphore::new(2)),
                 small_notify: queue.small_notify.clone(),
                 large_notify: queue.large_notify.clone(),
             };
-            // Every SMALL-lane send mispredicts: it runs the real correction and
-            // ends up needing large-lane capacity. Large-lane sends complete
-            // immediately, so the large pool keeps turning over.
+            let (tx, mut ran) = tokio::sync::mpsc::unbounded_channel();
             let workers: Vec<_> = [QueuedPayloadClass::Small, QueuedPayloadClass::Large]
                 .into_iter()
                 .map(|lane| {
@@ -1854,71 +1879,232 @@ mod queue {
                         lane,
                         queue.queue.clone(),
                         group.clone(),
-                        move |entry: BroadcastEntry, mut scheduling: QueueScheduling| {
+                        move |entry: BroadcastEntry, _s: QueueScheduling| {
                             let tx = tx.clone();
                             async move {
-                                if matches!(lane, QueuedPayloadClass::Small) {
-                                    scheduling.permit.ensure_capacity_for(BIG).await;
-                                }
                                 let _ = tx.send((lane, entry.key));
                             }
                         },
                     ))
                 })
                 .collect();
+            let [small, large]: [_; 2] = workers.try_into().expect("two drains");
 
-            // A sustained correlated burst: far more mispredicting small sends
-            // than the parking area can hold, interleaved with genuine
-            // large-lane entries.
-            for seed in 0..40u8 {
-                let lane = if seed % 4 == 0 {
-                    QueuedPayloadClass::Large
-                } else {
-                    QueuedPayloadClass::Small
-                };
+            // The drain future must actually be POLLED before aborting, or
+            // there is no guard in it yet to drop. Wait until it dispatches.
+            queue
+                .enqueue_in_lane(
+                    QueuedPayloadClass::Large,
+                    contract(40),
+                    PeerKeyLocation::random(),
+                    state(BIG),
+                )
+                .await;
+            assert_eq!(
+                lane_of(
+                    tokio::time::timeout(Duration::from_secs(5), ran.recv())
+                        .await
+                        .expect("the large drain must run before we stop it")
+                ),
+                Some(QueuedPayloadClass::Large),
+            );
+
+            large.abort();
+            let _ = large.await;
+
+            assert!(
+                small_permits.is_closed(),
+                "the surviving drain's pool must be closed by the guard, so it \
+                 cannot keep carrying half the traffic"
+            );
+            tokio::time::timeout(Duration::from_secs(5), small)
+                .await
+                .expect("the sibling drain must stop too")
+                .expect("it must return rather than panic");
+        }
+
+        /// The escalation from #5118 / #5112's author: parked upgraders queue on
+        /// the same FIFO pool as the large lane's own drain, so if they could
+        /// accumulate without limit they would starve it, `large_order` would
+        /// back up against the shared depth cap, and `evict_oldest` would start
+        /// dropping the globally oldest entry — whole fan-outs, since
+        /// mispredictions are correlated across every peer of a contract. That
+        /// is an update-propagation failure, not just RSS growth.
+        ///
+        /// Drives a sustained burst of mispredicting sends through the REAL
+        /// `ensure_capacity_for` and asserts the parking area caps how many park
+        /// at once, that the overflow keeps its small-lane slot rather than
+        /// parking too, and that the large lane keeps draining throughout.
+        ///
+        /// Getting this to actually reach phase 2 is fiddly and the first
+        /// version did not: the large-lane dispatch must HOLD its permit (a
+        /// closure that returns immediately hands every upgrader a large permit
+        /// in phase 1), and the enqueue loop must not `yield_now` per entry (a
+        /// perpetually-ready task keeps the runtime from idling, so the paused
+        /// clock never advances to the hold window and phase 2 is unreachable).
+        /// Three reviewers independently caught that; the `upgrade_slots` handle
+        /// is retained here specifically so the test can prove it got there.
+        #[tokio::test(start_paused = true)]
+        #[serial_test::serial(broadcast_queue_depth_gauge)]
+        async fn mispredicting_burst_parks_boundedly_without_starving_the_large_lane() {
+            let queue = BroadcastQueue {
+                max_queue_depth: 256,
+                ..BroadcastQueue::new()
+            };
+            let small_permits = Arc::new(Semaphore::new(12));
+            let large_permits = Arc::new(Semaphore::new(2));
+            // Two parking slots, so the burst overflows it quickly and the
+            // overflow behaviour is what gets exercised.
+            let upgrade_slots = Arc::new(Semaphore::new(2));
+            let (tx, mut dispatched) = tokio::sync::mpsc::unbounded_channel();
+            let group = LaneGroup {
+                small_pool: small_permits.clone(),
+                large_pool: large_permits.clone(),
+                upgrade_slots: upgrade_slots.clone(),
+                small_notify: queue.small_notify.clone(),
+                large_notify: queue.large_notify.clone(),
+            };
+            // Large-lane sends HOLD their permit until the test releases them,
+            // so the large pool stays saturated and every small send mispredicts
+            // into a real wait.
+            let release = Arc::new(Semaphore::new(0));
+            let workers: Vec<_> = [QueuedPayloadClass::Small, QueuedPayloadClass::Large]
+                .into_iter()
+                .map(|lane| {
+                    let tx = tx.clone();
+                    let release = release.clone();
+                    tokio::spawn(drain_lane(
+                        lane,
+                        queue.queue.clone(),
+                        group.clone(),
+                        move |entry: BroadcastEntry, mut scheduling: QueueScheduling| {
+                            let tx = tx.clone();
+                            let release = release.clone();
+                            async move {
+                                let _ = tx.send((lane, entry.key));
+                                if matches!(lane, QueuedPayloadClass::Large) {
+                                    let _ = release.acquire_owned().await;
+                                } else {
+                                    scheduling.permit.ensure_capacity_for(BIG).await;
+                                }
+                            }
+                        },
+                    ))
+                })
+                .collect();
+
+            // Saturate the large lane first.
+            for seed in 0..2u8 {
                 queue
-                    .enqueue_in_lane(lane, contract(seed), PeerKeyLocation::random(), state(BIG))
+                    .enqueue_in_lane(
+                        QueuedPayloadClass::Large,
+                        contract(seed),
+                        PeerKeyLocation::random(),
+                        state(BIG),
+                    )
                     .await;
-                tokio::task::yield_now().await;
+            }
+            for _ in 0..2 {
+                assert_eq!(
+                    lane_of(dispatched.recv().await),
+                    Some(QueuedPayloadClass::Large),
+                    "both large permits must be taken and held"
+                );
+            }
+            assert_eq!(large_permits.available_permits(), 0);
+
+            // Now a correlated burst of mispredicting small sends — more than
+            // the small pool, so the overflow path is reached too.
+            for seed in 10..26u8 {
+                queue
+                    .enqueue_in_lane(
+                        QueuedPayloadClass::Small,
+                        contract(seed),
+                        PeerKeyLocation::random(),
+                        state(BIG),
+                    )
+                    .await;
+            }
+            for _ in 0..12 {
+                assert_eq!(
+                    lane_of(dispatched.recv().await),
+                    Some(QueuedPayloadClass::Small),
+                    "the small lane dispatches up to its pool width"
+                );
             }
 
-            // Drain what the workers produced.
-            let mut large_dispatched = 0usize;
-            let mut total = 0usize;
+            // Let the hold window elapse so the dispatched sends reach phase 2.
+            tokio::time::sleep(super::super::UPGRADE_SLOT_HOLD_WINDOW * 2).await;
+
+            assert_eq!(
+                upgrade_slots.available_permits(),
+                0,
+                "the burst must actually REACH the parking area — this is the \
+                 assertion the first version of this test could not make"
+            );
+            // The discriminating count. Every dispatched send mispredicts, so
+            // with UNBOUNDED parking each one parks, hands its small-lane slot
+            // straight back, and the drain dispatches a replacement — all 16
+            // would be in flight. With the bound, only as many as parking can
+            // hold ever give their slot back, so dispatch stops at
+            // pool width + parking capacity.
+            let mut dispatched_small = 12usize;
             while let Ok(Some((lane, _))) =
-                tokio::time::timeout(Duration::from_secs(5), dispatched.recv()).await
+                tokio::time::timeout(Duration::from_millis(1), dispatched.recv()).await
             {
-                total += 1;
-                if matches!(lane, QueuedPayloadClass::Large) {
-                    large_dispatched += 1;
-                }
-                if total == 40 {
-                    break;
+                if matches!(lane, QueuedPayloadClass::Small) {
+                    dispatched_small += 1;
                 }
             }
+            assert_eq!(
+                dispatched_small, 14,
+                "dispatch must stop at 12 small permits + 2 parking slots; \
+                 unbounded parking would have put all 16 in flight"
+            );
 
-            assert_eq!(
-                total, 40,
-                "every entry must be dispatched — a starved large lane would leave \
-                 entries queued until the depth cap evicted them"
+            // The large lane must still be able to make progress: release one
+            // large send and a queued entry must take its permit.
+            release.add_permits(1);
+            let key = contract(2);
+            queue
+                .enqueue_in_lane(
+                    QueuedPayloadClass::Large,
+                    key,
+                    PeerKeyLocation::random(),
+                    state(BIG),
+                )
+                .await;
+            let mut saw_large = false;
+            for _ in 0..4 {
+                match tokio::time::timeout(Duration::from_secs(5), dispatched.recv()).await {
+                    Ok(Some((QueuedPayloadClass::Large, k))) if k == key => {
+                        saw_large = true;
+                        break;
+                    }
+                    Ok(Some(_)) => continue,
+                    _ => break,
+                }
+            }
+            assert!(
+                saw_large,
+                "the large lane must keep draining while upgraders contend for \
+                 its pool — starving it is what backs `large_order` up into \
+                 evict_oldest and drops whole fan-outs (#5118)"
             );
-            assert_eq!(
-                large_dispatched, 10,
-                "and the large lane specifically must keep making progress while \
-                 mispredicted upgraders contend for its pool"
-            );
+
             let q = queue.queue.lock().await;
             assert!(
-                q.entries.is_empty(),
-                "the queue must have drained rather than backed up to the cap"
+                q.entries.len() < 256,
+                "and the queue must not have backed up to the depth cap"
             );
             drop(q);
+            release.add_permits(64);
             for worker in workers {
                 worker.abort();
             }
         }
 
-        /// #4961, head-of-line half. A small entry queued behind a large entry
+        /// #4961, head-of-line half.        /// #4961, head-of-line half. A small entry queued behind a large entry
         /// that is waiting for large-lane capacity must still be scheduled.
         ///
         /// Pre-fix, ONE worker drained both lanes and awaited the large

--- a/crates/core/src/node/network_bridge/broadcast_queue.rs
+++ b/crates/core/src/node/network_bridge/broadcast_queue.rs
@@ -101,9 +101,14 @@ pub(super) struct SendLanePermit {
     /// `None` only while parked waiting out a congested large lane — see
     /// [`Self::ensure_capacity_for`]. Nothing is on the wire during that
     /// window, so an absent permit never means unmetered bytes. (The one
-    /// exception is a large pool that CLOSES during that wait, which no code
-    /// path does today; the send then proceeds unmetered rather than hanging
-    /// forever. See [`Self::large_pool_closed`].)
+    /// exception is a large pool that CLOSES during that wait — reachable only
+    /// via [`LaneGroup::shutdown`], i.e. after a drain has already stopped; the
+    /// send then proceeds unmetered rather than hanging forever. Every send
+    /// inside `ensure_capacity_for` takes that exit at once, so a shutdown can
+    /// release a one-off burst of up to `MAX_PARKED_LANE_UPGRADES` +
+    /// small-pool-width sends outside the large-payload limit. That is bounded,
+    /// one-off, and only on an already-broken node. See
+    /// [`Self::large_pool_closed`].)
     permit: Option<tokio::sync::OwnedSemaphorePermit>,
     /// Which pool `permit` came from.
     lane: QueuedPayloadClass,
@@ -1477,11 +1482,9 @@ mod queue {
                 // This lane was empty, wait for new entries
                 notified.await;
                 // ...which may have been the sibling drain shutting us down
-                // rather than an enqueue. This exit must ALSO shut down, not
-                // just return: an idle drain can reach it first (its pool
-                // closes while it waits), and returning quietly here would
-                // leave the sibling running — the exact asymmetry this whole
-                // mechanism exists to prevent.
+                // rather than an enqueue. `LaneDrainGuard` would shut the
+                // sibling down on the way out regardless; the explicit call
+                // below is kept so the log names which lane stopped first.
                 if semaphore.is_closed() {
                     tracing::error!(
                         ?lane,
@@ -1598,8 +1601,11 @@ mod queue {
         fn start_worker_spawns_one_drain_per_lane() {
             let src = include_str!("broadcast_queue.rs");
             let start = src.find("pub(crate) fn start_worker(").unwrap();
+            // Bound at the end of `start_worker` itself, NOT at `drain_lane`:
+            // the wider slice would let the wiring literals below be satisfied
+            // by `LaneGroup`/`LaneDrainGuard`, which sit between the two.
             let end = src[start..]
-                .find("    /// Drain loop for ONE lane")
+                .find("    /// The pools and wakeups both lane drains share.")
                 .unwrap()
                 + start;
             let body = &src[start..end];
@@ -1608,6 +1614,19 @@ mod queue {
                 2,
                 "start_worker must spawn exactly one drain per lane"
             );
+            // Naming both lanes is load-bearing, not decoration: a count of two
+            // is equally satisfied by spawning the SAME lane twice, which leaves
+            // the other lane undrained until `evict_oldest` starts dropping its
+            // entries. `start_worker` has no test caller, so nothing else would
+            // notice. (The previous form of this pin carried the lane names
+            // incidentally, inside the argument literals; removing the dead
+            // argument removed them, which two reviewers caught.)
+            for lane in ["Small", "Large"] {
+                assert!(
+                    body.contains(&format!("spawn_lane(QueuedPayloadClass::{lane})")),
+                    "start_worker must spawn a drain for the {lane} lane"
+                );
+            }
             // Pin the lane→pool and lane→notify WIRING, which lives in the
             // `LaneGroup` literal. Transposing either pair here is a one-token
             // slip: swapping the pools caps small broadcasts at 2 concurrent —
@@ -1957,6 +1976,11 @@ mod queue {
             // overflow behaviour is what gets exercised.
             let upgrade_slots = Arc::new(Semaphore::new(2));
             let (tx, mut dispatched) = tokio::sync::mpsc::unbounded_channel();
+            // Lifetime-cumulative process-global; this test is in the serial
+            // group with the only other test that evicts, so a delta is sound.
+            let evictions_before = crate::node::BROADCAST_QUEUE_EFFICIENCY_METRICS
+                .snapshot()
+                .capacity_evictions;
             let group = LaneGroup {
                 small_pool: small_permits.clone(),
                 large_pool: large_permits.clone(),
@@ -2006,7 +2030,11 @@ mod queue {
             }
             for _ in 0..2 {
                 assert_eq!(
-                    lane_of(dispatched.recv().await),
+                    lane_of(
+                        tokio::time::timeout(Duration::from_secs(5), dispatched.recv())
+                            .await
+                            .expect("both large permits must be taken and held")
+                    ),
                     Some(QueuedPayloadClass::Large),
                     "both large permits must be taken and held"
                 );
@@ -2027,7 +2055,11 @@ mod queue {
             }
             for _ in 0..12 {
                 assert_eq!(
-                    lane_of(dispatched.recv().await),
+                    lane_of(
+                        tokio::time::timeout(Duration::from_secs(5), dispatched.recv())
+                            .await
+                            .expect("the small lane dispatches up to its pool width")
+                    ),
                     Some(QueuedPayloadClass::Small),
                     "the small lane dispatches up to its pool width"
                 );
@@ -2092,19 +2124,23 @@ mod queue {
                  evict_oldest and drops whole fan-outs (#5118)"
             );
 
-            let q = queue.queue.lock().await;
-            assert!(
-                q.entries.len() < 256,
-                "and the queue must not have backed up to the depth cap"
+            assert_eq!(
+                crate::node::BROADCAST_QUEUE_EFFICIENCY_METRICS
+                    .snapshot()
+                    .capacity_evictions,
+                evictions_before,
+                "and nothing was evicted — dropping queued entries under a \
+                 misprediction burst is the user-visible half of #5118, since \
+                 eviction walks seq order and a fan-out's per-peer entries form \
+                 a temporal cluster"
             );
-            drop(q);
             release.add_permits(64);
             for worker in workers {
                 worker.abort();
             }
         }
 
-        /// #4961, head-of-line half.        /// #4961, head-of-line half. A small entry queued behind a large entry
+        /// #4961, head-of-line half. A small entry queued behind a large entry
         /// that is waiting for large-lane capacity must still be scheduled.
         ///
         /// Pre-fix, ONE worker drained both lanes and awaited the large
@@ -2689,8 +2725,6 @@ mod queue {
             for phase in [Phase::HoldingSlot, Phase::Parked, Phase::QueuedForParking] {
                 let park_first = !matches!(phase, Phase::HoldingSlot);
                 let small = Arc::new(Semaphore::new(12));
-                // TWO large permits, one left free, so the "took no large
-                // permit" assertion below can actually fail.
                 let large = Arc::new(Semaphore::new(2));
                 let _occupied = large
                     .clone()
@@ -2757,11 +2791,9 @@ mod queue {
                     1,
                     "[{phase:?}] and so must the parking slot"
                 );
-                assert_eq!(
-                    large.available_permits(),
-                    0,
-                    "[{phase:?}] the cancelled send took no large permit"
-                );
+                // No assertion on `large` here: the test holds both of its
+                // permits for the whole run, so any such check is vacuous. The
+                // small and parking pools above are what discriminate.
             }
         }
 

--- a/crates/core/src/node/network_bridge/broadcast_queue.rs
+++ b/crates/core/src/node/network_bridge/broadcast_queue.rs
@@ -19,13 +19,21 @@
 //! measurements that drove all three of those; before it, one worker drained
 //! one FIFO and picked the pool from the full contract STATE size.
 //!
-//! The correction is the one remaining cross-lane coupling, and it is BOUNDED
-//! rather than absent: a send that was queued small and turns out to be full
-//! state keeps its small-lane slot for at most
+//! The correction is the one remaining cross-lane coupling. A send that was
+//! queued small and turns out to be full state keeps its small-lane slot for
 //! [`UPGRADE_SLOT_HOLD_WINDOW`] while it waits for large-lane capacity, then
-//! gives the slot back and keeps waiting without one. So mispredictions cost
-//! the small lane a bounded stall instead of an unbounded one, and never put
-//! large payloads on the wire outside the large-payload limit.
+//! moves into a bounded parking area ([`MAX_PARKED_LANE_UPGRADES`]) and waits
+//! there holding no slot at all. It never puts large payloads on the wire
+//! outside the large-payload limit.
+//!
+//! Stated plainly, because it is the one guarantee this module gives up: while
+//! parking has room, a misprediction costs unrelated small broadcasts at most
+//! `UPGRADE_SLOT_HOLD_WINDOW`. Once parking is full — sustained misprediction
+//! against a saturated large lane — sends wait for a parking slot while still
+//! holding their small-lane slots, and the small lane applies backpressure at
+//! the large lane's drain rate. That is deliberate: the alternative is an
+//! unbounded set of parked sends each retaining a serialized payload, and
+//! bounded work beats unbounded memory.
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -120,12 +128,13 @@ pub(super) struct SendLanePermit {
 /// dispatched-and-parked senders. That was #5118, fixed by the parking area
 /// below; this window is the other half of the answer.
 ///
-/// This is NOT sized to cover a typical large-lane occupancy: a full-state
-/// stream is >= 64 KiB at the ~1.25 MB/s a rate-limited stream gets, so a
-/// large-lane slot frequently takes longer than this to turn over and phase 2 is
-/// a normal outcome, not an exceptional one. Its job is narrower — absorb
-/// momentary contention without ever handing an unrelated small broadcast a
-/// stall longer than this, however many mispredictions arrive at once.
+/// This is NOT sized to cover a typical large-lane occupancy: the ~1 MB states
+/// this path exists for take the better part of a second at the ~1.25 MB/s a
+/// rate-limited stream gets, so a large-lane slot usually takes longer than this
+/// to turn over and phase 2 is a normal outcome, not an exceptional one. Its job
+/// is narrower — absorb momentary contention, and cap what a misprediction costs
+/// an unrelated small broadcast at this much FOR AS LONG AS the parking area has
+/// room (see [`MAX_PARKED_LANE_UPGRADES`], which is where that cap ends).
 const UPGRADE_SLOT_HOLD_WINDOW: Duration = Duration::from_millis(250);
 
 /// How many mispredicted sends may be parked at once waiting for large-lane
@@ -184,13 +193,18 @@ impl SendLanePermit {
     ///
     /// The wait is in two phases (see [`UPGRADE_SLOT_HOLD_WINDOW`]): first
     /// briefly holding the small-lane slot, then — if the large lane is
-    /// genuinely congested — after handing that slot back, so a burst of
-    /// mispredictions cannot occupy the wide pool and stall small sends behind
-    /// it. Mispredictions ARE bursty: they come from conditions that hit every
-    /// peer of a contract at once (a `get_contract_summary` timeout, an
-    /// `Interests` full-replace wiping cached summaries, the delta-incompat
-    /// memo arming, or a contract whose deltas are never smaller than its
-    /// state), so treating them as independent events would be wrong.
+    /// genuinely congested — in a bounded parking area, after handing that slot
+    /// back. A burst of mispredictions therefore cannot occupy the wide pool.
+    /// Mispredictions ARE bursty, and worse: they come from conditions that hit
+    /// every peer of a contract at once (a `get_contract_summary` timeout, an
+    /// `Interests` full-replace wiping cached summaries, the delta-incompat memo
+    /// arming), and one of them — a contract whose deltas are never smaller than
+    /// its state — mispredicts on every send to every peer permanently. So
+    /// treating them as independent events would be wrong.
+    ///
+    /// Past the parking area's capacity the small-lane slot IS held for the
+    /// whole wait and the small lane applies backpressure; see the module
+    /// header, that is the deliberate end of the hold-window bound.
     ///
     /// A parked send holds no pool capacity and is putting nothing on the wire,
     /// so the pools alone do not bound how many sends are in flight — that is
@@ -234,12 +248,25 @@ impl SendLanePermit {
         // free we keep the small-lane slot and wait under it: the small lane
         // applies backpressure, which is bounded work, rather than the node
         // accumulating unbounded parked payloads.
-        let _parked = self.upgrade_slots.clone().try_acquire_owned().ok();
-        if _parked.is_some() {
-            // Assigning `None` drops the permit; the send is now holding no
-            // pool capacity and sending nothing.
-            self.permit = None;
-        }
+        //
+        // This WAITS for a slot rather than sampling once. A one-shot
+        // `try_acquire` would pin the small-lane slot for the whole remaining
+        // wait of any send that merely happened to arrive while parking was
+        // full, even if a slot freed a millisecond later. Waiting cannot
+        // deadlock: slots are released by sends that already hold a large permit
+        // and are waiting on nothing else, so parking always drains at the large
+        // lane's rate.
+        let _parked = match self.upgrade_slots.clone().acquire_owned().await {
+            Ok(slot) => {
+                // Assigning `None` drops the permit; the send is now holding no
+                // pool capacity and sending nothing.
+                self.permit = None;
+                Some(slot)
+            }
+            // Closed parking (nothing closes it today): keep the small-lane slot
+            // rather than parking unbounded.
+            Err(_) => None,
+        };
         match self.large_pool.clone().acquire_owned().await {
             Ok(large) => self.take_large(large),
             Err(_) => self.large_pool_closed(payload_size),
@@ -720,9 +747,9 @@ mod queue {
     /// it could not `pop` anything at all while waiting — the head-of-line half
     /// of #4961 (1,887 incidents and a 7,260 s small-entry wait integral per
     /// node-day on the 0.2.118 fleet). (A dispatched send correcting a
-    /// mispredicted lane can still hold a small-lane permit briefly; that
-    /// residual is bounded by [`UPGRADE_SLOT_HOLD_WINDOW`], not by the large
-    /// lane's drain rate.)
+    /// mispredicted lane can still hold a small-lane permit — for
+    /// [`UPGRADE_SLOT_HOLD_WINDOW`] while parking has room, and for the whole
+    /// wait once it does not. See `SendLanePermit`.)
     ///
     /// Ordering is by a global monotonic sequence number so the two FIFOs stay
     /// comparable: capacity eviction still drops the globally oldest entry, and
@@ -1025,8 +1052,9 @@ mod queue {
     /// state) get low concurrency (2 slots) to avoid saturating the uplink.
     /// Each pool has its OWN FIFO and its OWN drain worker, so a QUEUED send
     /// waiting for large-lane capacity never delays a small one. (A dispatched
-    /// send correcting a mispredicted lane holds its small-lane permit for at
-    /// most [`UPGRADE_SLOT_HOLD_WINDOW`] — see `SendLanePermit`.)
+    /// send correcting a mispredicted lane does hold a small-lane permit while
+    /// it waits — bounded by [`UPGRADE_SLOT_HOLD_WINDOW`] only while the
+    /// parking area has room; see `SendLanePermit`.)
     #[derive(Clone)]
     pub(crate) struct BroadcastQueue {
         queue: Arc<Mutex<QueueState>>,
@@ -1482,6 +1510,43 @@ mod queue {
                 body.contains("spawn_lane(QueuedPayloadClass::Large, large_semaphore"),
                 "the large lane must be given the LARGE pool"
             );
+            // ONE parking pool for the node. Constructing it per dispatch
+            // instead would make the parked set unbounded again while every
+            // behavioural test stayed green — so pin BOTH halves: created once
+            // at the top, and only CLONED per lane.
+            assert_eq!(
+                body.matches("Arc::new(Semaphore::new(super::MAX_PARKED_LANE_UPGRADES))")
+                    .count(),
+                1,
+                "the parking area must be constructed exactly once in start_worker"
+            );
+            let created = body
+                .find("let upgrade_slots = Arc::new(Semaphore::new(")
+                .expect("the parking area must be created here");
+            let per_lane = body
+                .find("let upgrade_slots = upgrade_slots.clone();")
+                .expect("each drain must CLONE the shared parking area, not build its own");
+            assert!(
+                created < per_lane,
+                "the shared parking area must be created before the per-lane clone"
+            );
+
+            // And `enqueue` must still route through `lane_for`. Substituting a
+            // constant there restores the whole classification defect; only a
+            // dead-code lint on `lane_for` would notice, and only because its
+            // other caller is a test.
+            let enq = src
+                .find("        pub(crate) async fn enqueue(")
+                .expect("enqueue renamed or removed");
+            let enq_end = src[enq..]
+                .find("\n        /// The lane-agnostic half")
+                .expect("end of enqueue not found")
+                + enq;
+            assert!(
+                src[enq..enq_end].contains("let lane = lane_for("),
+                "enqueue must derive the lane it enqueues with from lane_for — not \
+                 merely mention it"
+            );
         }
 
         // ---- scheduling regressions (#4961) ----
@@ -1851,7 +1916,9 @@ mod queue {
         /// `notify_one`, an enqueue can wake the idle lane and leave its own
         /// entry sitting until something else happens to wake the right worker.
         /// Directed: only the LARGE lane has work, so only a large-lane wakeup
-        /// can dispatch it.
+        /// can dispatch it. (Under a reverted shared `Notify` this fails
+        /// because `spawn_lanes` starts the small drain first, so it is first in
+        /// the waiter FIFO and `notify_one` wakes the wrong worker.)
         #[tokio::test(start_paused = true)]
         #[serial_test::serial(broadcast_queue_depth_gauge)]
         async fn each_lane_is_woken_by_its_own_enqueue() {
@@ -1877,15 +1944,20 @@ mod queue {
         }
 
         fn small_lane_permit(small: &Arc<Semaphore>, large: &Arc<Semaphore>) -> SendLanePermit {
-            parked_small_lane_permit(small, large, super::super::MAX_PARKED_LANE_UPGRADES)
+            parked_small_lane_permit(
+                small,
+                large,
+                &Arc::new(Semaphore::new(super::super::MAX_PARKED_LANE_UPGRADES)),
+            )
         }
 
-        /// As above, but with an explicit number of parking slots so a test can
-        /// drive the exhausted-parking path.
+        /// As above, but against a caller-owned parking pool. Tests SHARE one —
+        /// production has exactly one for the whole node, and that sharing is
+        /// the entire reason the parked set is bounded.
         fn parked_small_lane_permit(
             small: &Arc<Semaphore>,
             large: &Arc<Semaphore>,
-            parking: usize,
+            parking: &Arc<Semaphore>,
         ) -> SendLanePermit {
             SendLanePermit::new(
                 QueuedPayloadClass::Small,
@@ -1894,7 +1966,7 @@ mod queue {
                     .try_acquire_owned()
                     .expect("small pool has capacity"),
                 large.clone(),
-                Arc::new(Semaphore::new(parking)),
+                parking.clone(),
             )
         }
 
@@ -2030,49 +2102,105 @@ mod queue {
             assert_eq!(large.available_permits(), 1);
         }
 
-        /// The parking bound. Once `MAX_PARKED_LANE_UPGRADES` sends are parked,
-        /// the next one must KEEP its small-lane slot rather than park too:
-        /// parked sends hold no pool permit, so without this the small drain
-        /// keeps dispatching replacements and the parked set — one serialized
-        /// payload each — grows without limit.
+        /// The parking bound, driven through a SHARED pool the way production
+        /// has it. Parked sends hold no pool permit, so if the pool were
+        /// per-send — or if the slot were released as soon as it was taken —
+        /// the small drain would keep dispatching replacements and the parked
+        /// set would grow without limit, each one retaining a serialized
+        /// payload. Also pins that a slot goes BACK when its send leaves.
         #[tokio::test(start_paused = true)]
-        async fn parking_area_is_bounded_and_falls_back_to_holding_the_slot() {
+        async fn parking_area_is_bounded_and_returns_its_slots() {
             let small = Arc::new(Semaphore::new(12));
             let large = Arc::new(Semaphore::new(1));
+            // One parking slot, shared, so the second upgrader must contend.
+            let parking = Arc::new(Semaphore::new(1));
             let occupied = large
                 .clone()
                 .acquire_owned()
                 .await
                 .expect("large pool open");
 
-            // Parking capacity 0: the only choice left is to hold the slot.
-            let mut permit = parked_small_lane_permit(&small, &large, 0);
+            let mut first = parked_small_lane_permit(&small, &large, &parking);
+            let mut second = parked_small_lane_permit(&small, &large, &parking);
+            assert_eq!(small.available_permits(), 10, "both hold a small slot");
+
+            let mut parked = tokio::spawn(async move {
+                first.ensure_capacity_for(BIG).await;
+                first
+            });
+            // Let the first one get through its hold window and park.
+            assert!(
+                tokio::time::timeout(super::super::UPGRADE_SLOT_HOLD_WINDOW * 2, &mut parked)
+                    .await
+                    .is_err()
+            );
+            assert_eq!(
+                parking.available_permits(),
+                0,
+                "the parked send is holding the only parking slot"
+            );
+            assert_eq!(
+                small.available_permits(),
+                11,
+                "and gave its small-lane slot back"
+            );
+
+            // The second one finds parking full, so it must keep its small slot
+            // rather than parking too.
             let mut waiting = tokio::spawn(async move {
-                permit.ensure_capacity_for(BIG).await;
-                permit
+                second.ensure_capacity_for(BIG).await;
+                second
             });
             assert!(
                 tokio::time::timeout(super::super::UPGRADE_SLOT_HOLD_WINDOW * 4, &mut waiting)
                     .await
                     .is_err(),
-                "still no large-lane capacity, so it must still be waiting"
+                "no large-lane capacity yet, so it is still waiting"
             );
             assert_eq!(
                 small.available_permits(),
                 11,
-                "with no parking slot free the send keeps its small-lane slot, so \
-                 the drain cannot dispatch a replacement — backpressure, not \
-                 unbounded parked payloads"
+                "with parking full the second send keeps its small-lane slot — \
+                 backpressure, not an unbounded parked set"
             );
 
+            // The first send gets large-lane capacity and leaves the parking
+            // area; its slot must go back — and go straight to the send that was
+            // waiting for one, which then gives up ITS small-lane slot. That
+            // hand-off is the difference between waiting for a parking slot and
+            // sampling availability once: with a one-shot check the second send
+            // would keep pinning a small-lane slot for the rest of its wait,
+            // even though the area now has room.
             drop(occupied);
-            let permit = tokio::time::timeout(Duration::from_secs(5), waiting)
+            let first = tokio::time::timeout(Duration::from_secs(5), parked)
                 .await
-                .expect("completes once large-lane capacity frees up")
-                .expect("upgrade task");
+                .expect("first send completes")
+                .expect("task");
+            assert_eq!(
+                parking.available_permits(),
+                0,
+                "the released slot goes straight to the send waiting for one"
+            );
+            assert_eq!(
+                small.available_permits(),
+                12,
+                "so the second send parks too, and the small lane is free again"
+            );
+
+            drop(first);
+            let second = tokio::time::timeout(Duration::from_secs(5), waiting)
+                .await
+                .expect("second send completes once capacity frees up")
+                .expect("task");
             assert_eq!(small.available_permits(), 12);
             assert_eq!(large.available_permits(), 0);
-            drop(permit);
+            assert_eq!(
+                parking.available_permits(),
+                1,
+                "and the parking area is empty once both sends have left it"
+            );
+            drop(second);
+            assert_eq!(large.available_permits(), 1);
         }
 
         /// Cancellation safety, which `ensure_capacity_for`'s doc claims: a send
@@ -2082,13 +2210,14 @@ mod queue {
             for park_first in [false, true] {
                 let small = Arc::new(Semaphore::new(12));
                 let large = Arc::new(Semaphore::new(1));
-                let occupied = large
+                let parking = Arc::new(Semaphore::new(1));
+                let _occupied = large
                     .clone()
                     .acquire_owned()
                     .await
                     .expect("large pool open");
-                let mut permit = small_lane_permit(&small, &large);
-                let waiting = tokio::spawn(async move {
+                let mut permit = parked_small_lane_permit(&small, &large, &parking);
+                let mut waiting = tokio::spawn(async move {
                     permit.ensure_capacity_for(BIG).await;
                     permit
                 });
@@ -2100,18 +2229,43 @@ mod queue {
                     super::super::UPGRADE_SLOT_HOLD_WINDOW / 2
                 };
                 assert!(
-                    tokio::time::timeout(elapse, waiting).await.is_err(),
+                    tokio::time::timeout(elapse, &mut waiting).await.is_err(),
                     "[park_first={park_first}] precondition: still waiting"
                 );
-                // The timeout dropped the JoinHandle's future, but the task
-                // keeps running; abort it the way a shutdown would.
-                tokio::task::yield_now().await;
-                drop(occupied);
-                tokio::time::sleep(Duration::from_millis(1)).await;
+                assert_eq!(
+                    parking.available_permits(),
+                    usize::from(!park_first),
+                    "[park_first={park_first}] precondition: parked iff past the window"
+                );
+
+                // Cancel it the way a shutdown would. `timeout` alone would NOT
+                // do this — dropping a JoinHandle detaches the task, it does not
+                // abort it — and the large permit is deliberately still held, so
+                // nothing but the abort can end this wait.
+                waiting.abort();
+                let cancelled = match waiting.await {
+                    Err(err) => err.is_cancelled(),
+                    Ok(_) => false,
+                };
+                assert!(
+                    cancelled,
+                    "[park_first={park_first}] the send must have been cancelled mid-wait"
+                );
+
                 assert_eq!(
                     small.available_permits(),
                     12,
                     "[park_first={park_first}] the small-lane slot must come back"
+                );
+                assert_eq!(
+                    parking.available_permits(),
+                    1,
+                    "[park_first={park_first}] and so must the parking slot"
+                );
+                assert_eq!(
+                    large.available_permits(),
+                    0,
+                    "[park_first={park_first}] the cancelled send took no large permit"
                 );
             }
         }
@@ -2134,6 +2288,46 @@ mod queue {
                 small.available_permits(),
                 12,
                 "and the small-lane permit is still released exactly once"
+            );
+        }
+
+        /// The same, but closing the pool AFTER the send has already parked —
+        /// the one path where a send proceeds holding no permit at all. Phase 1
+        /// and phase 2 take different exits, and the test above only covers
+        /// phase 1.
+        #[tokio::test(start_paused = true)]
+        async fn large_pool_closing_mid_park_does_not_strand_the_send() {
+            let small = Arc::new(Semaphore::new(12));
+            let large = Arc::new(Semaphore::new(1));
+            let parking = Arc::new(Semaphore::new(1));
+            let _occupied = large
+                .clone()
+                .acquire_owned()
+                .await
+                .expect("large pool open");
+            let mut permit = parked_small_lane_permit(&small, &large, &parking);
+            let mut waiting = tokio::spawn(async move {
+                permit.ensure_capacity_for(BIG).await;
+                permit
+            });
+            assert!(
+                tokio::time::timeout(super::super::UPGRADE_SLOT_HOLD_WINDOW * 2, &mut waiting)
+                    .await
+                    .is_err(),
+                "precondition: parked, waiting on a pool that will never free"
+            );
+            assert_eq!(small.available_permits(), 12, "precondition: parked");
+
+            large.close();
+            let permit = tokio::time::timeout(Duration::from_secs(5), waiting)
+                .await
+                .expect("closing the pool must release the parked send")
+                .expect("task");
+            drop(permit);
+            assert_eq!(
+                parking.available_permits(),
+                1,
+                "and the parking slot goes back"
             );
         }
 
@@ -4129,7 +4323,7 @@ mod tests {
     /// `broadcast_to_single_peer` (it needs a live bridge and OpManager), so
     /// deleting the call, or sliding it past a send, leaves the whole suite
     /// green while up to 12 concurrent full-state streams go out on the
-    /// small lane. Same reason the seven other pins in this file exist.
+    /// small lane. Same reason the other source-scrape pins here exist.
     #[test]
     fn broadcast_to_single_peer_gates_wire_payload_on_lane_capacity_pin() {
         let src = include_str!("broadcast_queue.rs");

--- a/crates/core/src/node/network_bridge/broadcast_queue.rs
+++ b/crates/core/src/node/network_bridge/broadcast_queue.rs
@@ -51,10 +51,16 @@ const STREAM_COMPLETION_TIMEOUT: Duration = Duration::from_secs(120);
 /// narrow large-payload pool instead of the wide small-payload pool.
 ///
 /// Applied to the PREDICTED wire payload at enqueue time (see
-/// `queue::classify_payload_lane`) and again to the ACTUAL wire payload once it
-/// is known (see [`SendLanePermit::ensure_capacity_for`]). It used to be
-/// applied to the full contract STATE size, which is not what goes on the wire
-/// whenever a delta is sent — the classification half of #4961.
+/// `queue::classify_payload_lane`) and again to the selected payload — the
+/// delta or the full state — once it is known (see
+/// [`SendLanePermit::ensure_capacity_for`]). It used to be applied to the full
+/// contract STATE size, which is not what goes on the wire whenever a delta is
+/// sent — the classification half of #4961.
+///
+/// "Selected payload" is not quite the byte count on the wire: the sender's own
+/// summary and the message framing ride along with it, so a small payload with
+/// a large summary is under-counted here. That blind spot is pre-existing (the
+/// old state-size classification had it too) and is not what #4961 was about.
 const BROADCAST_QUEUE_PAYLOAD_SIZE_THRESHOLD: usize = 64 * 1024;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -84,33 +90,68 @@ pub(super) enum QueuedPayloadClass {
 pub(super) struct SendLanePermit {
     /// The permit currently held. Dropping `self` releases it.
     ///
-    /// `None` only while waiting out a congested large lane — see
+    /// `None` only while parked waiting out a congested large lane — see
     /// [`Self::ensure_capacity_for`]. Nothing is on the wire during that
-    /// window, so an absent permit never means unmetered bytes.
+    /// window, so an absent permit never means unmetered bytes. (The one
+    /// exception is a large pool that CLOSES during that wait, which no code
+    /// path does today; the send then proceeds unmetered rather than hanging
+    /// forever. See [`Self::large_pool_closed`].)
     permit: Option<tokio::sync::OwnedSemaphorePermit>,
     /// Which pool `permit` came from.
     lane: QueuedPayloadClass,
     /// The large-payload pool, for the upgrade path.
     large_pool: Arc<tokio::sync::Semaphore>,
+    /// Parking permits for sends waiting out a congested large lane. Bounds
+    /// how many can be in flight holding no pool capacity — see
+    /// [`Self::ensure_capacity_for`] phase 2.
+    upgrade_slots: Arc<tokio::sync::Semaphore>,
 }
 
 /// How long a mispredicted send keeps its small-lane slot while waiting for
-/// large-lane capacity, before handing the slot back and waiting without one.
+/// large-lane capacity, before parking without one.
 ///
-/// The two failure modes this sits between: hold the slot indefinitely and
+/// The two failure modes this sits between: hold the slot for the whole wait and
 /// enough simultaneous mispredictions tie up all 12 small permits, stalling
 /// unrelated small broadcasts — the very head-of-line failure this module was
-/// changed to remove. Hand it back immediately and the drain keeps dispatching,
-/// so the number of in-flight sends (each holding a serialized payload) grows
-/// without bound — NOT, as an earlier version of this comment said, "bounded
-/// only by the queue depth": entries leave `entries` when popped, so the depth
-/// cap bounds QUEUED work, not dispatched-and-parked senders. See #5118 and
-/// the note on `ensure_capacity_for` below.
+/// changed to remove. Give it up immediately and the drain dispatches a
+/// replacement at once, so parked senders pile up holding serialized payloads —
+/// and the queue depth cap does NOT bound them, because an entry leaves
+/// `entries` when it is popped, so that cap bounds QUEUED work rather than
+/// dispatched-and-parked senders. That was #5118, fixed by the parking area
+/// below; this window is the other half of the answer.
 ///
-/// A quarter second covers the common case — the large lane is briefly busy and
-/// a slot frees up — while capping the small lane's exposure to a burst of
-/// mispredictions at 250 ms even if every one of its permits is caught in one.
+/// This is NOT sized to cover a typical large-lane occupancy: a full-state
+/// stream is >= 64 KiB at the ~1.25 MB/s a rate-limited stream gets, so a
+/// large-lane slot frequently takes longer than this to turn over and phase 2 is
+/// a normal outcome, not an exceptional one. Its job is narrower — absorb
+/// momentary contention without ever handing an unrelated small broadcast a
+/// stall longer than this, however many mispredictions arrive at once.
 const UPGRADE_SLOT_HOLD_WINDOW: Duration = Duration::from_millis(250);
+
+/// How many mispredicted sends may be parked at once waiting for large-lane
+/// capacity while holding no pool permit (phase 2 of
+/// [`SendLanePermit::ensure_capacity_for`]).
+///
+/// This is the bound on in-flight sends that the pools otherwise provide.
+/// Parked sends hold no permit, so without a cap the small drain keeps
+/// dispatching replacements and the parked set grows at the enqueue rate while
+/// draining at the large lane's — one serialized payload (>= 64 KiB, and ~1 MB
+/// for the large-state contracts this path exists for) retained per parked
+/// send, unbounded. That is reachable in steady state, not just in a burst: a
+/// contract whose deltas are never smaller than its state mispredicts on every
+/// send to every peer, forever.
+///
+/// Sized at one full turnover of the small pool
+/// (`queue::DEFAULT_SMALL_PAYLOAD_CONCURRENCY`, kept in step by
+/// `parking_matches_one_small_pool_turnover`). Past that, upgraders keep their
+/// small-lane slots and the small lane applies backpressure — which is the
+/// correct response to an uplink genuinely saturated with full-state sends, and
+/// is bounded work rather than unbounded memory.
+///
+/// Not derived from that constant directly because the pool sizes live in the
+/// `queue` submodule, which is cfg'd out under `simulation_tests` while this
+/// type stays compiled.
+const MAX_PARKED_LANE_UPGRADES: usize = 12;
 
 #[cfg_attr(feature = "simulation_tests", allow(dead_code))]
 impl SendLanePermit {
@@ -118,11 +159,13 @@ impl SendLanePermit {
         lane: QueuedPayloadClass,
         permit: tokio::sync::OwnedSemaphorePermit,
         large_pool: Arc<tokio::sync::Semaphore>,
+        upgrade_slots: Arc<tokio::sync::Semaphore>,
     ) -> Self {
         Self {
             permit: Some(permit),
             lane,
             large_pool,
+            upgrade_slots,
         }
     }
 
@@ -149,16 +192,20 @@ impl SendLanePermit {
     /// memo arming, or a contract whose deltas are never smaller than its
     /// state), so treating them as independent events would be wrong.
     ///
-    /// While waiting without a permit the send holds no pool capacity and is
-    /// putting nothing on the wire.
+    /// A parked send holds no pool capacity and is putting nothing on the wire,
+    /// so the pools alone do not bound how many sends are in flight — that is
+    /// what [`MAX_PARKED_LANE_UPGRADES`] is for (#5118). Parking slots are taken
+    /// BEFORE the small-lane slot is given up, so when they run out the send
+    /// simply keeps its small-lane slot and waits, and the small lane applies
+    /// backpressure instead of the node accumulating payloads.
     ///
-    /// The number of senders parked here is NOT bounded by anything.
-    /// `track_active` reporting full does not stop the drain loop dispatching —
-    /// it only sets `tracked: false` for untrack bookkeeping, so it is not an
-    /// admission gate. Parked senders contend with the large drain worker on
-    /// the same FIFO-fair semaphore, and the large lane can back up into
-    /// `evict_oldest`. Tracked as #5118; the consequence for the #5062 fan-out
-    /// multiplier is written up in `broadcast_payload_mix`'s module docs.
+    /// Nothing else bounds it. `track_active` reporting full does NOT stop the
+    /// drain loop dispatching — it only sets `tracked: false` for untrack
+    /// bookkeeping, so it is not an admission gate. Parked senders also contend
+    /// with the large drain worker on the same FIFO-fair semaphore, which is why
+    /// the bound matters for fan-out eviction and not just for memory; the
+    /// consequence for the #5062 fan-out multiplier is written up in
+    /// `broadcast_payload_mix`'s module docs.
     ///
     /// Cancellation: this is awaited inline by the send that OWNS the
     /// `SendLanePermit`, so dropping that send drops the permit too — mid-wait
@@ -180,15 +227,24 @@ impl SendLanePermit {
             Ok(Err(_)) => return self.large_pool_closed(payload_size),
             Err(_elapsed) => {}
         }
-        // Phase 2: the large lane is genuinely congested. Release the
-        // small-lane slot BEFORE parking, so mispredicted sends cannot tie up
-        // the wide pool. Assigning `None` drops the permit; the send is now
-        // holding no capacity and sending nothing.
-        self.permit = None;
+        // Phase 2: the large lane is genuinely congested. Take a parking slot
+        // FIRST — only then is it safe to give up the small-lane slot, because
+        // the drain will immediately dispatch a replacement send and nothing
+        // else bounds how many of those can accumulate. With no parking slot
+        // free we keep the small-lane slot and wait under it: the small lane
+        // applies backpressure, which is bounded work, rather than the node
+        // accumulating unbounded parked payloads.
+        let _parked = self.upgrade_slots.clone().try_acquire_owned().ok();
+        if _parked.is_some() {
+            // Assigning `None` drops the permit; the send is now holding no
+            // pool capacity and sending nothing.
+            self.permit = None;
+        }
         match self.large_pool.clone().acquire_owned().await {
             Ok(large) => self.take_large(large),
             Err(_) => self.large_pool_closed(payload_size),
         }
+        // `_parked` is released here, as the send leaves the parking area.
     }
 
     /// Adopt `large` as the held permit. Assigning drops whatever was held
@@ -199,9 +255,15 @@ impl SendLanePermit {
         self.lane = QueuedPayloadClass::Large;
     }
 
-    /// The large pool is closed, which happens only at shutdown. Let the send
-    /// proceed under whatever it still holds rather than stalling forever; the
-    /// lane worker logs the closure separately and is about to exit.
+    /// The large pool is closed. Let the send proceed under whatever it still
+    /// holds — possibly nothing, if it had already parked — rather than
+    /// stalling forever.
+    ///
+    /// UNREACHABLE today: nothing closes these semaphores (grep `.close()` in
+    /// this file — the only hit is a test). It exists so that adding a real
+    /// shutdown path later cannot silently strand in-flight sends, and it is
+    /// the one documented way a large payload can reach the wire without
+    /// large-lane capacity.
     fn large_pool_closed(&self, payload_size: usize) {
         tracing::debug!(
             payload_size,
@@ -217,9 +279,9 @@ impl SendLanePermit {
 /// bytes on the wire outside the concurrency limit, and a permit without the
 /// class would silently stop feeding the classification-accuracy counters
 /// (`queued_large_actual_small` / `queued_small_actual_large`). Bundling them
-/// is the `.claude/rules/bug-prevention-patterns.md` "paired `Option` fields
-/// that must co-occur" fix shape — the sim fan-out passes `None` for the whole
-/// bundle, so it cannot pass one half.
+/// bundles two fields that must co-occur, so a caller cannot supply one
+/// without the other — the sim fan-out passes `None` for the whole bundle, so
+/// it cannot pass one half.
 #[cfg_attr(feature = "simulation_tests", allow(dead_code))]
 pub(super) struct QueueScheduling {
     /// The lane the entry was CLASSIFIED into at enqueue time. Immutable — the
@@ -390,8 +452,7 @@ pub(super) enum FanoutSendPlan {
 /// call site would compile, pass every unit test and source-scrape pin, and
 /// compute `delta(our_state vs our OWN summary)` — always empty — wrongly
 /// skipping nearly every broadcast (a network-wide update blackout). Bundling
-/// the pair is the `.claude/rules/bug-prevention-patterns.md` "paired fields
-/// that must co-occur — bundle in a sub-struct" fix shape: the only
+/// the pair in a sub-struct makes the two impossible to supply separately: the only
 /// positional-order decisions left live INSIDE [`plan_fanout_send`] /
 /// [`fanout_send_needed`], directly next to the APIs they map onto, and every
 /// call site names the fields (`SummaryPair { ours, theirs }`), so a swap
@@ -561,7 +622,7 @@ mod queue {
     /// predicted WIRE payload, not from the contract state, because a contract
     /// whose state exceeds the threshold still sends ~1 KB deltas to every peer
     /// whose summary we hold. Classifying those as large squeezed two thirds of
-    /// all broadcast traffic through a 2-permit pool (#4961; measured on the
+    /// LARGE-LANE traffic through a 2-permit pool (#4961; measured on the
     /// 0.2.118 fleet as 29,661 of 45,982 large-lane items per node-day having an
     /// actual payload below the threshold, averaging ~950 bytes).
     ///
@@ -610,6 +671,27 @@ mod queue {
         let peer_key = PeerKey::from(target.pub_key().clone());
         interest_manager.has_peer_summary(key, &peer_key)
             && !delta_incompat.deltas_suppressed_peek(key.id())
+    }
+
+    /// The whole enqueue-time lane decision: predict the payload shape, then
+    /// classify. Exists as one function so the COMPOSITION is testable —
+    /// `classify_payload_lane` and `delta_send_expected` are each pinned
+    /// separately, but wiring them together wrongly (a dropped `!`, a hard-coded
+    /// term) is what would silently restore #4961 in production, and that lives
+    /// in neither of them.
+    fn lane_for(
+        interest_manager: &crate::ring::interest::InterestManager<
+            crate::util::time_source::DynTimeSource,
+        >,
+        delta_incompat: &crate::ring::delta_incompat::DeltaIncompat,
+        key: &ContractKey,
+        target: &PeerKeyLocation,
+        state_size: usize,
+    ) -> QueuedPayloadClass {
+        classify_payload_lane(
+            state_size,
+            delta_send_expected(interest_manager, delta_incompat, key, target),
+        )
     }
 
     /// A pending broadcast entry in the queue.
@@ -674,6 +756,11 @@ mod queue {
         /// entries are being scheduled concurrently, so
         /// `small_entry_millis_blocked` becomes an OVERLAP integral rather than
         /// a blockage, and collapsing toward zero is the fix landing.
+        ///
+        /// It does NOT observe the small lane's own stalls — a small entry
+        /// waiting on a small-lane permit, including one held by a
+        /// lane-correction wait, opens no observation here. So a zero reading
+        /// is evidence about cross-lane blocking only. See `router.rs`.
         hol_block: Option<HolBlockHandle>,
     }
 
@@ -988,14 +1075,12 @@ mod queue {
             target: PeerKeyLocation,
             new_state: WrappedState,
         ) {
-            let lane = classify_payload_lane(
+            let lane = lane_for(
+                &op_manager.interest_manager,
+                &op_manager.ring.delta_incompat,
+                &key,
+                &target,
                 new_state.size(),
-                delta_send_expected(
-                    &op_manager.interest_manager,
-                    &op_manager.ring.delta_incompat,
-                    &key,
-                    &target,
-                ),
             );
             self.enqueue_in_lane(lane, key, target, new_state).await;
         }
@@ -1103,10 +1188,11 @@ mod queue {
         ///
         /// The workers run forever; they are spawned as background tasks. The
         /// handles are not registered with a monitor (pre-existing), and there
-        /// are two of them now, so if one ever returned — only possible on a
-        /// closed semaphore, i.e. shutdown — the other would keep draining and
-        /// that lane would silently stop. Worth revisiting if the pools ever
-        /// gain a real close path.
+        /// are two of them now, so if one ever stopped the other would keep
+        /// draining and only that lane would silently go quiet. Two ways it
+        /// could: a closed semaphore (nothing closes them today), or a panic on
+        /// `pop_lane`'s `.expect` if the order maps ever drifted from
+        /// `entries`. Worth revisiting if the pools gain a real close path.
         pub(crate) fn start_worker(
             &self,
             bridge: P2pBridge,
@@ -1114,11 +1200,13 @@ mod queue {
         ) -> [tokio::task::JoinHandle<()>; 2] {
             let small_semaphore = Arc::new(Semaphore::new(self.small_payload_concurrency));
             let large_semaphore = Arc::new(Semaphore::new(self.large_payload_concurrency));
+            let upgrade_slots = Arc::new(Semaphore::new(super::MAX_PARKED_LANE_UPGRADES));
 
             let spawn_lane = |lane, semaphore: Arc<Semaphore>| {
                 let queue = self.queue.clone();
                 let notify = self.notify_for(lane).clone();
                 let large_pool = large_semaphore.clone();
+                let upgrade_slots = upgrade_slots.clone();
                 let bridge = bridge.clone();
                 let op_manager = op_manager.clone();
                 tokio::spawn(drain_lane(
@@ -1127,6 +1215,7 @@ mod queue {
                     notify,
                     semaphore,
                     large_pool,
+                    upgrade_slots,
                     move |entry: BroadcastEntry, scheduling: QueueScheduling| {
                         let bridge = bridge.clone();
                         let op_manager = op_manager.clone();
@@ -1171,6 +1260,7 @@ mod queue {
         notify: Arc<Notify>,
         semaphore: Arc<Semaphore>,
         large_pool: Arc<Semaphore>,
+        upgrade_slots: Arc<Semaphore>,
         dispatch: D,
     ) where
         D: Fn(BroadcastEntry, QueueScheduling) -> F,
@@ -1242,7 +1332,12 @@ mod queue {
 
                 let scheduling = QueueScheduling {
                     queued_class: lane,
-                    permit: SendLanePermit::new(lane, permit, large_pool.clone()),
+                    permit: SendLanePermit::new(
+                        lane,
+                        permit,
+                        large_pool.clone(),
+                        upgrade_slots.clone(),
+                    ),
                 };
                 let send = dispatch(entry, scheduling);
 
@@ -1438,6 +1533,7 @@ mod queue {
         fn spawn_lanes(queue: &BroadcastQueue, small: usize, large: usize) -> Lanes {
             let small_permits = Arc::new(Semaphore::new(small));
             let large_permits = Arc::new(Semaphore::new(large));
+            let upgrade_slots = Arc::new(Semaphore::new(super::super::MAX_PARKED_LANE_UPGRADES));
             let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
             let workers = [
                 (QueuedPayloadClass::Small, small_permits.clone()),
@@ -1452,6 +1548,7 @@ mod queue {
                     queue.notify_for(lane).clone(),
                     semaphore,
                     large_permits.clone(),
+                    upgrade_slots.clone(),
                     move |entry: BroadcastEntry, scheduling: QueueScheduling| {
                         let tx = tx.clone();
                         async move {
@@ -1711,9 +1808,85 @@ mod queue {
             assert!(q.large_order.is_empty());
             assert_eq!(q.small_order.len(), 2);
             assert_eq!(q.small_queued, 2);
+            drop(q);
+
+            // ...and symmetrically, with the SMALL head the older one. Without
+            // this direction, an `evict_oldest` that always picked one lane
+            // would still pass the case above.
+            let queue = BroadcastQueue {
+                max_queue_depth: 2,
+                ..BroadcastQueue::new()
+            };
+            let oldest = contract(5);
+            queue
+                .enqueue_in_lane(
+                    QueuedPayloadClass::Small,
+                    oldest,
+                    PeerKeyLocation::random(),
+                    state(16),
+                )
+                .await;
+            for seed in 6..8u8 {
+                queue
+                    .enqueue_in_lane(
+                        QueuedPayloadClass::Large,
+                        contract(seed),
+                        PeerKeyLocation::random(),
+                        state(BIG),
+                    )
+                    .await;
+            }
+            let q = queue.queue.lock().await;
+            assert_eq!(q.entries.len(), 2);
+            assert!(
+                !q.entries.keys().any(|(key, _)| *key == oldest),
+                "the small entry was the globally oldest, so it is the one evicted"
+            );
+            assert!(q.small_order.is_empty());
+            assert_eq!(q.large_order.len(), 2);
+            assert_eq!(q.small_queued, 0, "and the small-lane count follows it");
+        }
+
+        /// Each lane has its OWN `Notify`. With one shared `Notify` and
+        /// `notify_one`, an enqueue can wake the idle lane and leave its own
+        /// entry sitting until something else happens to wake the right worker.
+        /// Directed: only the LARGE lane has work, so only a large-lane wakeup
+        /// can dispatch it.
+        #[tokio::test(start_paused = true)]
+        #[serial_test::serial(broadcast_queue_depth_gauge)]
+        async fn each_lane_is_woken_by_its_own_enqueue() {
+            let queue = BroadcastQueue::new();
+            let mut lanes = spawn_lanes(&queue, 12, 2);
+            // Let both workers reach their idle wait before anything is queued.
+            assert_eq!(lanes.next_dispatch().await, None, "nothing queued yet");
+
+            let key = contract(11);
+            queue
+                .enqueue_in_lane(
+                    QueuedPayloadClass::Large,
+                    key,
+                    PeerKeyLocation::random(),
+                    state(BIG),
+                )
+                .await;
+            assert_eq!(
+                lanes.next_dispatch().await,
+                Some((QueuedPayloadClass::Large, key)),
+                "a large enqueue must wake the LARGE worker"
+            );
         }
 
         fn small_lane_permit(small: &Arc<Semaphore>, large: &Arc<Semaphore>) -> SendLanePermit {
+            parked_small_lane_permit(small, large, super::super::MAX_PARKED_LANE_UPGRADES)
+        }
+
+        /// As above, but with an explicit number of parking slots so a test can
+        /// drive the exhausted-parking path.
+        fn parked_small_lane_permit(
+            small: &Arc<Semaphore>,
+            large: &Arc<Semaphore>,
+            parking: usize,
+        ) -> SendLanePermit {
             SendLanePermit::new(
                 QueuedPayloadClass::Small,
                 small
@@ -1721,6 +1894,7 @@ mod queue {
                     .try_acquire_owned()
                     .expect("small pool has capacity"),
                 large.clone(),
+                Arc::new(Semaphore::new(parking)),
             )
         }
 
@@ -1805,6 +1979,19 @@ mod queue {
             assert_eq!(large.available_permits(), 1, "and releases it when done");
         }
 
+        /// The parking bound is meant to be one turnover of the small pool.
+        /// The constant cannot reference the pool size (that lives in this
+        /// cfg-gated module while `SendLanePermit` is compiled in both builds),
+        /// so pin the tie here rather than letting the two drift.
+        #[test]
+        fn parking_matches_one_small_pool_turnover() {
+            assert_eq!(
+                super::super::MAX_PARKED_LANE_UPGRADES,
+                DEFAULT_SMALL_PAYLOAD_CONCURRENCY,
+                "at most one full turnover of the small pool may be parked at once"
+            );
+        }
+
         /// A send ALREADY in the large lane must not try to upgrade: it would
         /// wait for a SECOND large permit while holding one, and two such sends
         /// — the whole pool — would wedge full-state broadcasting permanently.
@@ -1818,14 +2005,115 @@ mod queue {
                     .try_acquire_owned()
                     .expect("large pool has capacity"),
                 large.clone(),
+                Arc::new(Semaphore::new(super::super::MAX_PARKED_LANE_UPGRADES)),
             );
             assert_eq!(large.available_permits(), 0, "the pool is now empty");
 
-            tokio::time::timeout(Duration::from_secs(5), permit.ensure_capacity_for(BIG))
-                .await
-                .expect("a large-lane send must not wait on its own pool");
+            // Must return WITHOUT WAITING. A 5-second bound would not catch the
+            // guard being deleted: phase 2 drops this send's own permit back
+            // into the pool and immediately re-acquires it, so the reverted code
+            // still finishes — just `UPGRADE_SLOT_HOLD_WINDOW` later, having
+            // churned the pool. Assert the virtual clock did not move at all.
+            let started = tokio::time::Instant::now();
+            permit.ensure_capacity_for(BIG).await;
+            assert_eq!(
+                tokio::time::Instant::now(),
+                started,
+                "a large-lane send must not wait on its own pool"
+            );
+            assert_eq!(
+                large.available_permits(),
+                0,
+                "and must still hold the permit it started with"
+            );
             drop(permit);
             assert_eq!(large.available_permits(), 1);
+        }
+
+        /// The parking bound. Once `MAX_PARKED_LANE_UPGRADES` sends are parked,
+        /// the next one must KEEP its small-lane slot rather than park too:
+        /// parked sends hold no pool permit, so without this the small drain
+        /// keeps dispatching replacements and the parked set — one serialized
+        /// payload each — grows without limit.
+        #[tokio::test(start_paused = true)]
+        async fn parking_area_is_bounded_and_falls_back_to_holding_the_slot() {
+            let small = Arc::new(Semaphore::new(12));
+            let large = Arc::new(Semaphore::new(1));
+            let occupied = large
+                .clone()
+                .acquire_owned()
+                .await
+                .expect("large pool open");
+
+            // Parking capacity 0: the only choice left is to hold the slot.
+            let mut permit = parked_small_lane_permit(&small, &large, 0);
+            let mut waiting = tokio::spawn(async move {
+                permit.ensure_capacity_for(BIG).await;
+                permit
+            });
+            assert!(
+                tokio::time::timeout(super::super::UPGRADE_SLOT_HOLD_WINDOW * 4, &mut waiting)
+                    .await
+                    .is_err(),
+                "still no large-lane capacity, so it must still be waiting"
+            );
+            assert_eq!(
+                small.available_permits(),
+                11,
+                "with no parking slot free the send keeps its small-lane slot, so \
+                 the drain cannot dispatch a replacement — backpressure, not \
+                 unbounded parked payloads"
+            );
+
+            drop(occupied);
+            let permit = tokio::time::timeout(Duration::from_secs(5), waiting)
+                .await
+                .expect("completes once large-lane capacity frees up")
+                .expect("upgrade task");
+            assert_eq!(small.available_permits(), 12);
+            assert_eq!(large.available_permits(), 0);
+            drop(permit);
+        }
+
+        /// Cancellation safety, which `ensure_capacity_for`'s doc claims: a send
+        /// dropped mid-wait must release whatever it holds, in either phase.
+        #[tokio::test(start_paused = true)]
+        async fn cancelling_a_waiting_send_releases_its_permit_in_either_phase() {
+            for park_first in [false, true] {
+                let small = Arc::new(Semaphore::new(12));
+                let large = Arc::new(Semaphore::new(1));
+                let occupied = large
+                    .clone()
+                    .acquire_owned()
+                    .await
+                    .expect("large pool open");
+                let mut permit = small_lane_permit(&small, &large);
+                let waiting = tokio::spawn(async move {
+                    permit.ensure_capacity_for(BIG).await;
+                    permit
+                });
+
+                // Phase 1 holds the small slot; phase 2 has parked without one.
+                let elapse = if park_first {
+                    super::super::UPGRADE_SLOT_HOLD_WINDOW * 2
+                } else {
+                    super::super::UPGRADE_SLOT_HOLD_WINDOW / 2
+                };
+                assert!(
+                    tokio::time::timeout(elapse, waiting).await.is_err(),
+                    "[park_first={park_first}] precondition: still waiting"
+                );
+                // The timeout dropped the JoinHandle's future, but the task
+                // keeps running; abort it the way a shutdown would.
+                tokio::task::yield_now().await;
+                drop(occupied);
+                tokio::time::sleep(Duration::from_millis(1)).await;
+                assert_eq!(
+                    small.available_permits(),
+                    12,
+                    "[park_first={park_first}] the small-lane slot must come back"
+                );
+            }
         }
 
         /// Shutdown: a closed large pool must not strand the send forever. It
@@ -1903,6 +2191,60 @@ mod queue {
             assert!(
                 !delta_send_expected(&interest, &memo, &key, &target),
                 "an armed memo means full state, cached summary or not"
+            );
+        }
+
+        /// The composition `enqueue` actually calls. The classifier and the
+        /// predicate are each pinned above; this pins that they are wired
+        /// together the right way round, which is where a silent restoration of
+        /// #4961 would live.
+        #[test]
+        fn lane_for_routes_a_large_state_delta_send_to_the_small_lane() {
+            use crate::ring::delta_incompat::{DeltaIncompat, INCOMPAT_TRIP_THRESHOLD};
+            use crate::ring::interest::InterestManager;
+            use crate::util::time_source::{DynTimeSource, SharedMockTimeSource};
+            use freenet_stdlib::prelude::StateSummary;
+
+            let time: DynTimeSource = Arc::new(SharedMockTimeSource::new());
+            let interest = InterestManager::new(time.clone());
+            let memo = DeltaIncompat::new(time);
+            let key = contract(4);
+            let target = PeerKeyLocation::random();
+            let peer = PeerKey::from(target.pub_key().clone());
+            let lane = |state_size| lane_for(&interest, &memo, &key, &target, state_size);
+
+            assert_eq!(
+                lane(BIG),
+                QueuedPayloadClass::Large,
+                "no cached summary: the whole state goes on the wire"
+            );
+            assert_eq!(
+                lane(16),
+                QueuedPayloadClass::Small,
+                "a small state is small however the payload is shaped"
+            );
+
+            interest.register_peer_interest(&key, peer.clone(), None, false);
+            interest.update_peer_summary(&key, &peer, StateSummary::from(vec![1, 2, 3]));
+            assert_eq!(
+                lane(BIG),
+                QueuedPayloadClass::Small,
+                "THE #4961 CASE: a >64 KiB contract sending a delta to a peer whose \
+                 summary we hold must not spend one of the 2 large-lane permits"
+            );
+
+            let addr = |port: u16| -> std::net::SocketAddr {
+                format!("127.0.0.1:{port}").parse().unwrap()
+            };
+            for i in 0..INCOMPAT_TRIP_THRESHOLD {
+                memo.record_delta_sent(*key.id(), addr(7000 + i as u16));
+                memo.note_resync_request(*key.id(), addr(7000 + i as u16));
+            }
+            assert_eq!(
+                lane(BIG),
+                QueuedPayloadClass::Large,
+                "...but once the contract is known to reject deltas, it is a \
+                 full-state send again"
             );
         }
     }
@@ -3921,8 +4263,8 @@ mod tests {
 
     /// Source-scrape pin for the payload-mix arm tagging (#3335).
     ///
-    /// Same precedent as the cost-report pin above (the "Manually-mirrored
-    /// telemetry counters" row in `.claude/rules/bug-prevention-patterns.md`):
+    /// Same precedent as the cost-report pin above — a manually-mirrored
+    /// telemetry counter, where the mirror and its source can silently diverge:
     /// a refactor that drops an arm tag, or re-tags a full-state fallback as
     /// `Delta`, silently corrupts the measurement that decides which fan-out
     /// fix to build — and every behavioral test stays green, because the

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -221,10 +221,12 @@ pub(crate) struct NetworkEfficiencyV1 {
     ///     small-lane entry being queued, and that population widened with the
     ///     lane definition (large-state delta sends are now small-lane
     ///     entries), so all three move for a second reason as well.
-    ///   * active-key overflow was structurally unreachable pre-fix (in-flight
-    ///     sends were capped by the 12+2 permits, far under the 256-key cap);
-    ///     it is now reachable only by the lane-correction parking area, so a
-    ///     non-zero value means mispredicted sends piled up.
+    ///   * active-key overflow STAYS structurally unreachable, but for a new
+    ///     reason: in-flight sends were capped by the 12+2 permits, and are now
+    ///     capped by those plus the lane-correction parking area (12), still an
+    ///     order of magnitude under the 256-key cap. It remains a pure invariant
+    ///     check — a non-zero value means a leaked tracking guard, NOT a
+    ///     scheduling backlog.
     ///   * enqueue-while-pair-active keeps its definition, but the window it
     ///     samples — how long a pair stays in `active` — now includes any
     ///     lane-correction wait, so it inflates for a reason unrelated to

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -202,7 +202,7 @@ pub(crate) struct NetworkEfficiencyV1 {
     ///   * queued-small/actual-large read 0 fleet-wide pre-fix and was close to
     ///     structurally so (the lane came from the state size, which bounds the
     ///     payload from above to within `MIN_FULL_STATE_SAVING_BYTES`); the one
-    ///     ways it could fire were a delta exceeding the state by up to
+    ///     two ways it could fire were a delta exceeding the state by up to
     ///     `MIN_FULL_STATE_SAVING_BYTES`, and the stale-dedup-lane defect fixed
     ///     alongside this in #5108. It is now the payload-misprediction count and is EXPECTED to
     ///     be non-zero. Those sends still take a large-lane permit before

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -199,22 +199,36 @@ pub(crate) struct NetworkEfficiencyV1 {
     ///     volume (they never were on the large side).
     ///   * queued-large/actual-small was the pre-fix misclassification signal
     ///     (64.5% of large-lane items); it should collapse toward zero.
-    ///   * queued-small/actual-large was structurally zero (the lane came from
-    ///     the state size, which bounds the payload from above); it is now the
-    ///     payload-prediction miss rate and is EXPECTED to be non-zero. Those
-    ///     sends still take a large-lane permit before hitting the wire.
+    ///   * queued-small/actual-large read 0 fleet-wide pre-fix and was close to
+    ///     structurally so (the lane came from the state size, which bounds the
+    ///     payload from above to within `MIN_FULL_STATE_SAVING_BYTES`); the one
+    ///     way it could fire was the stale-dedup-lane defect this PR also
+    ///     fixes. It is now the payload-misprediction count and is EXPECTED to
+    ///     be non-zero. Those sends still take a large-lane permit before
+    ///     hitting the wire. It is a COUNT, not a rate: nothing counts correct
+    ///     predictions, and `scheduled_small` is not a usable denominator
+    ///     because it includes sends that return before payload selection.
     ///   * small-entry-ms was small entries BLOCKED behind a large-lane permit
     ///     wait; it is now merely small entries queued DURING one, since the
-    ///     small lane drains them concurrently. Its population also widened
-    ///     with the lane definition (large-state delta sends are now small-lane
-    ///     entries), so it moves for two reasons at once. Collapsing toward zero
-    ///     is the fix landing.
+    ///     small lane drains them concurrently. Collapsing toward zero is the
+    ///     fix landing.
     ///   * large-head incidents/ms keep their trigger (the large drain waiting
     ///     on an empty pool with small entries queued), but the pool has a
     ///     second consumer now — a mispredicted small-lane send correcting its
     ///     lane — so an incident no longer implies a large-lane ENTRY caused the
     ///     exhaustion, and the sampled trigger can miss a wait that an upgrader
-    ///     won the race for.
+    ///     won the race for. BOTH these and small-entry-ms are gated on a
+    ///     small-lane entry being queued, and that population widened with the
+    ///     lane definition (large-state delta sends are now small-lane
+    ///     entries), so all three move for a second reason as well.
+    ///   * active-key overflow was structurally unreachable pre-fix (in-flight
+    ///     sends were capped by the 12+2 permits, far under the 256-key cap);
+    ///     it is now reachable only by the lane-correction parking area, so a
+    ///     non-zero value means mispredicted sends piled up.
+    ///   * enqueue-while-pair-active keeps its definition, but the window it
+    ///     samples — how long a pair stays in `active` — now includes any
+    ///     lane-correction wait, so it inflates for a reason unrelated to
+    ///     enqueue behaviour.
     pub queue: [u64; 15],
     /// Successful apply counts by delta/full x changed/no-op x resulting-state
     /// size bucket.

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -202,8 +202,9 @@ pub(crate) struct NetworkEfficiencyV1 {
     ///   * queued-small/actual-large read 0 fleet-wide pre-fix and was close to
     ///     structurally so (the lane came from the state size, which bounds the
     ///     payload from above to within `MIN_FULL_STATE_SAVING_BYTES`); the one
-    ///     way it could fire was the stale-dedup-lane defect this PR also
-    ///     fixes. It is now the payload-misprediction count and is EXPECTED to
+    ///     ways it could fire were a delta exceeding the state by up to
+    ///     `MIN_FULL_STATE_SAVING_BYTES`, and the stale-dedup-lane defect fixed
+    ///     alongside this in #5108. It is now the payload-misprediction count and is EXPECTED to
     ///     be non-zero. Those sends still take a large-lane permit before
     ///     hitting the wire. It is a COUNT, not a rate: nothing counts correct
     ///     predictions, and `scheduled_small` is not a usable denominator
@@ -211,7 +212,11 @@ pub(crate) struct NetworkEfficiencyV1 {
     ///   * small-entry-ms was small entries BLOCKED behind a large-lane permit
     ///     wait; it is now merely small entries queued DURING one, since the
     ///     small lane drains them concurrently. Collapsing toward zero is the
-    ///     fix landing.
+    ///     fix landing — but read it narrowly: the observation is armed ONLY by
+    ///     the large lane's drain, so a small entry waiting on a small-lane
+    ///     permit (including one held by a send correcting its lane) opens no
+    ///     observation at all. A zero here is evidence about CROSS-lane
+    ///     blocking, not about small-lane latency in general.
     ///   * large-head incidents/ms keep their trigger (the large drain waiting
     ///     on an empty pool with small entries queued), but the pool has a
     ///     second consumer now — a mispredicted small-lane send correcting its


### PR DESCRIPTION
## Problem

#5108 landed at its round-2 commit while review rounds 3 and 4 were still
running. Those two rounds found — and fixed — three P1s and a batch of P2s that
are therefore **not in main**. This PR is exactly those commits, rebased onto
current main with no conflicts and no content change (verified: the tree for the
touched files is byte-identical to the reviewed head).

The load-bearing one: as merged, `SendLanePermit::ensure_capacity_for` phase 2
releases its small-lane permit and parks with **nothing bounding how many sends
can be parked at once**. The doc comment claims the `active` tracking cap bounds
it; it does not — `track_active` is observation-only and `drain_lane` dispatches
whatever it returns. So the small drain keeps dispatching replacements while
parked sends accumulate, each retaining a serialized payload that is >= 64 KiB by
construction and ~1 MB for the large-state contracts this path exists for. The
parked set grows at the enqueue rate and drains at the large lane's.

This is reachable in steady state, not just in a burst: a contract whose deltas
are never smaller than its state mispredicts on **every** send to **every** peer,
permanently. Three of the four round-3 reviewers found it independently.

## What this PR adds

**A bounded parking area** (`MAX_PARKED_LANE_UPGRADES`, one small-pool
turnover). A send takes a parking slot *before* giving up its small-lane slot,
and waits for one rather than sampling availability once. When parking is full it
keeps its small-lane slot and waits under it, so the small lane applies
backpressure — bounded work — instead of the node accumulating unbounded
payloads. That is the right response to an uplink genuinely saturated with
full-state sends. In-flight sends are bounded at 12 + 12 + 2.

Waiting (rather than a one-shot `try_acquire`) matters: it means a send that
merely arrived while parking was full does not pin a small-lane slot for its
whole remaining wait. When a parked send leaves, its slot goes straight to the
send waiting for one, which then releases its own small-lane slot. Round 4
verified this cannot deadlock and cannot leave a large permit idle — a parking
holder registers on the large pool in the same poll in which it takes the slot,
so parking being full implies the large pool has no free permits.

**Test fixes**, including two of my own tests that rounds 3 and 4 caught being
vacuous:
- `large_lane_send_does_not_upgrade_against_itself` passed with its target guard
  deleted (the two-phase wait made the missing guard self-resolve in 250 ms,
  inside the test's 5 s bound). It now asserts the virtual clock did not move.
- `cancelling_a_waiting_send_releases_its_permit_in_either_phase` never
  cancelled anything — it dropped a `JoinHandle`, which detaches rather than
  aborts. It now aborts, asserts the abort took effect, and covers all three
  states a send can be waiting in.
- The parking pool is shared across test permits (a per-send pool would make the
  bound a no-op with everything green), with contention, hand-off and slot return
  asserted.
- Two source-scrape pins that matched their own mutations were tightened:
  `enqueue` must both derive its lane from `lane_for` *and* enqueue with it, and
  `drain_lane` must hand each send the SHARED parking area.
- New coverage: the symmetric `evict_oldest` direction, the per-lane `Notify`
  split, the composition `lane_for`, closing the large pool mid-park.

**Doc corrections** — seven claims that were false or overstated as merged,
including four that promised a stall bounded by `UPGRADE_SLOT_HOLD_WINDOW`
"however many mispredictions arrive at once" (that bound ends where the parking
area does), the `router.rs` note on `active_tracking_overflow` (the parking bound
keeps it structurally unreachable, so a non-zero value means a leaked guard, not
a backlog), and the `UPGRADE_SLOT_HOLD_WINDOW` rationale, whose cited arithmetic
argued the opposite of its own conclusion.

## Review

Rounds 3 and 4 of #5108 reviewed exactly this content — see
[round 3](https://github.com/freenet/freenet-core/pull/5108#issuecomment-5162051485)
and [round 4](https://github.com/freenet/freenet-core/pull/5108#issuecomment-5162201128).
Round 4 found no P0/P1; its seven P2s are all fixed here.

Cumulative mutation matrix: **23 mutations, 23 detections, no collateral
failures**. Every regression test was verified to fail against a deliberate
reversion of the defect it covers — including the pins, which are verified by
running the mutation rather than by reading the assertion, because two of them
initially matched their own.

## Testing

`cargo fmt --all --check`, `cargo clippy -p freenet --lib -- -D warnings`,
`cargo check -p freenet --all-targets`,
`cargo check -p freenet --features simulation_tests --lib` — clean on the
rebased branch. `cargo test -p freenet --lib` — 4,595 passed, 0 failed.

**Fixes #5118.** Follows up #5108. Relates to #4961.

Rebased onto current main (post-#5116); the conflict was in the two doc blocks
#5116 rewrote to describe #5118 as an open bug, resolved in favour of the fix
while keeping its framing and breadcrumb. `broadcast_payload_mix.rs` is updated
in the same PR — it currently tells readers to "fix #5118 before reading the
number at all", which would otherwise have them discard a valid measurement.

[AI-assisted - Claude]
