### PR TITLE
fix(windows): add wrapper single-instance guard, make config.toml writes atomic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -608,7 +608,15 @@ jobs:
   windows_unit:
     name: Windows Service Unit
     runs-on: windows-latest
-    timeout-minutes: 30
+    # This job is new (introduced alongside the #5132 fix), so unlike
+    # macos_unit/windows_check it has no warm Swatinem cache from prior
+    # main-branch runs yet — a stone-cold Windows compile of the full
+    # freenet bin + test harness (wasmtime, tao, tray-icon, criterion,
+    # proptest, ...) does not finish in 30 minutes. 60 minutes gives this
+    # one-time cold start headroom; revisit downward once main has run
+    # this job at least once (cache only saves on `github.ref ==
+    # refs/heads/main`, see the cache step below).
+    timeout-minutes: 60
     needs: fmt_check
     # Same skip conditions as test_unit (see test_unit comment for details).
     if: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -598,6 +598,52 @@ jobs:
       - name: Test service commands
         run: cargo nextest run -p freenet --bin freenet --profile ci -E 'test(commands::service)'
 
+  # Windows unit tests for the wrapper's Windows-only code paths (named-mutex
+  # single-instance guard, process classification, etc). `windows_check` above
+  # only `cargo check`s — compilation is not verification of a `#[cfg(target_os
+  # = "windows")]` path (see .claude/rules/deployment.md) — so without this job
+  # the Windows-specific tests in commands::service would never actually run.
+  # Added alongside the #5132 fix (Windows wrapper had no single-instance
+  # guard at all), mirroring macos_unit above.
+  windows_unit:
+    name: Windows Service Unit
+    runs-on: windows-latest
+    timeout-minutes: 30
+    needs: fmt_check
+    # Same skip conditions as test_unit (see test_unit comment for details).
+    if: |
+      (github.event_name == 'pull_request' || github.event_name == 'merge_group') &&
+      !startsWith(github.head_ref, 'release/v')
+
+    env:
+      RUST_LOG: error
+      CARGO_TARGET_DIR: ${{ github.workspace }}/target
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.93.0
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Install nextest
+        run: |
+          $tmp = New-TemporaryFile | Rename-Item -NewName { $_ -replace 'tmp$', 'zip' } -PassThru
+          Invoke-WebRequest -OutFile $tmp https://get.nexte.st/latest/windows
+          $outputDir = if ($Env:CARGO_HOME) { Join-Path $Env:CARGO_HOME "bin" } else { "$Env:USERPROFILE\.cargo\bin" }
+          $tmp | Expand-Archive -DestinationPath $outputDir -Force
+          $tmp | Remove-Item
+
+      - name: Build freenet bin
+        run: cargo build --locked -p freenet --bin freenet
+
+      - name: Test service commands
+        run: cargo nextest run -p freenet --bin freenet --profile ci -E 'test(commands::service)'
+
   test_simulation:
     name: Simulation
     # Run on the heavy runner for PRs (validates the change) and for release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -618,6 +618,9 @@ jobs:
     env:
       RUST_LOG: error
       CARGO_TARGET_DIR: ${{ github.workspace }}/target
+      # Increase rustc stack size to prevent SIGSEGV during compilation
+      # 256MB required for LLVM optimization passes on large workspaces (rustc suggests this value)
+      RUST_MIN_STACK: 268435456
 
     steps:
       - uses: actions/checkout@v7

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -150,7 +150,7 @@ tikv-jemallocator = { workspace = true }
 tikv-jemalloc-ctl = { workspace = true, optional = true }
 
 [target.'cfg(windows)'.dependencies]
-winapi = { workspace = true, features = ["shellapi", "sysinfoapi", "wincon", "winuser"] }
+winapi = { workspace = true, features = ["shellapi", "sysinfoapi", "wincon", "winuser", "synchapi", "handleapi", "errhandlingapi", "winerror", "winnt", "minwindef"] }
 serde = { workspace = true }
 zip = { workspace = true }
 tray-icon = { workspace = true }

--- a/crates/core/src/bin/commands/service.rs
+++ b/crates/core/src/bin/commands/service.rs
@@ -853,6 +853,47 @@ mod tests {
         );
     }
 
+    /// Windows analogue of `wrapper_lock_is_exclusive` (#5132). Unlike the
+    /// flock primitive above, `CreateMutexW`'s "already exists" signal
+    /// fires even for a second handle opened by the SAME process, so the
+    /// real production function can be exercised directly in-process
+    /// rather than needing a simplified stand-in.
+    ///
+    /// This only compiles and runs on Windows, where the mutex API
+    /// exists. `windows_check` in CI only `cargo check`s the crate, which
+    /// does not execute tests — see `.claude/rules/deployment.md`
+    /// ("compilation is not verification"). CI also runs a dedicated
+    /// `windows_unit` job on `windows-latest` (mirroring `macos_unit`)
+    /// that runs this test for real.
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn wrapper_single_instance_lock_is_exclusive() {
+        let first = match acquire_wrapper_single_instance_lock() {
+            AcquireWrapperLockOutcome::Acquired(guard) => guard,
+            other => panic!("first acquire must succeed on an unheld mutex, got {other:?}"),
+        };
+        assert!(
+            matches!(
+                acquire_wrapper_single_instance_lock(),
+                AcquireWrapperLockOutcome::AnotherWrapperRunning
+            ),
+            "second acquire must report AnotherWrapperRunning while the first holder is alive"
+        );
+
+        // Dropping the holder closes its handle, releasing the mutex; a
+        // new acquirer should now succeed. Exercises the kernel-released-
+        // on-close semantics relied on for crash recovery (a crashed
+        // wrapper's handle is closed by the OS on process exit).
+        drop(first);
+        assert!(
+            matches!(
+                acquire_wrapper_single_instance_lock(),
+                AcquireWrapperLockOutcome::Acquired(_)
+            ),
+            "acquire must succeed once the previous holder has dropped its handle"
+        );
+    }
+
     #[test]
     fn wrapper_lock_path_is_under_cache_dir() {
         // If the platform can resolve a cache dir, the lock lives

--- a/crates/core/src/bin/commands/service.rs
+++ b/crates/core/src/bin/commands/service.rs
@@ -607,6 +607,34 @@ mod tests {
         );
     }
 
+    /// Regression guard for the ordering invariant the single-instance
+    /// guard depends on: `acquire_wrapper_single_instance_lock` MUST run
+    /// before `kill_stale_freenet_processes` in `run_wrapper` (#5132) — a
+    /// second wrapper has to detect the first one is still alive BEFORE
+    /// force-killing what it (wrongly) assumes are only stale orphans. This
+    /// is a call-order invariant inside one function, not something a
+    /// behavioral unit test can exercise, so pin it textually — mirrors the
+    /// `windows_first_run_wiring_is_present` source-scrape pattern above and
+    /// runs on every platform even though the guarded code is
+    /// macOS/Windows-only.
+    #[test]
+    fn wrapper_lock_is_acquired_before_killing_stale_processes() {
+        let wrapper = include_str!("service/wrapper.rs");
+        let acquire_pos = wrapper
+            .find("acquire_wrapper_single_instance_lock()")
+            .expect("run_wrapper must call acquire_wrapper_single_instance_lock");
+        let kill_pos = wrapper
+            .find("kill_stale_freenet_processes(&log_dir)")
+            .expect("run_wrapper must call kill_stale_freenet_processes");
+        assert!(
+            acquire_pos < kill_pos,
+            "acquire_wrapper_single_instance_lock must run BEFORE \
+             kill_stale_freenet_processes in run_wrapper, or a second wrapper \
+             can kill the first wrapper's live backend before the guard has a \
+             chance to detect it and exit"
+        );
+    }
+
     // Pull test-helper functions from submodules that are not re-exported at the
     // service.rs level (they are pub(super) in their submodule, making them
     // visible here via explicit `use`).

--- a/crates/core/src/bin/commands/service/launch_at_login.rs
+++ b/crates/core/src/bin/commands/service/launch_at_login.rs
@@ -85,9 +85,17 @@ pub(crate) fn macos_app_bundle_path(exe: &Path) -> Option<PathBuf> {
 /// packaging convention. See `scripts/package-macos.sh` for how this
 /// wrapper is produced: it execs the inner `freenet-bin` with the
 /// `service run-wrapper` subcommand.
+///
+/// Builds the path with an explicit `/` join rather than `Path::join`:
+/// this always describes a macOS bundle layout (always `/`-separated,
+/// regardless of what OS actually executes this code — e.g. this pure
+/// function is exercised on Windows too, in `windows_unit` CI). `Path`
+/// inserts the HOST OS's separator for newly-appended components, which
+/// is `\` on Windows and would silently mix separators into a path that
+/// must always be macOS-shaped.
 #[allow(dead_code)]
-fn macos_app_bundle_wrapper(bundle: &Path) -> PathBuf {
-    bundle.join("Contents").join("MacOS").join("Freenet")
+fn macos_app_bundle_wrapper(bundle: &Path) -> String {
+    format!("{}/Contents/MacOS/Freenet", bundle.to_string_lossy())
 }
 
 /// Compute the ProgramArguments array for the user LaunchAgent. If we're
@@ -100,11 +108,7 @@ fn macos_app_bundle_wrapper(bundle: &Path) -> PathBuf {
 #[allow(dead_code)]
 pub(super) fn launch_agent_program_arguments(exe: &Path) -> Vec<String> {
     match macos_app_bundle_path(exe) {
-        Some(bundle) => vec![
-            macos_app_bundle_wrapper(&bundle)
-                .to_string_lossy()
-                .into_owned(),
-        ],
+        Some(bundle) => vec![macos_app_bundle_wrapper(&bundle)],
         None => vec![
             exe.to_string_lossy().into_owned(),
             "service".to_string(),

--- a/crates/core/src/bin/commands/service/single_instance.rs
+++ b/crates/core/src/bin/commands/service/single_instance.rs
@@ -167,6 +167,15 @@ impl Drop for WrapperSingleInstanceLock {
 /// service on Windows — see `install_service`), and an unprefixed name
 /// is scoped to the caller's session, avoiding any cross-user collision
 /// or the extra privilege `Global\` names can require.
+///
+/// Known limitation: this does NOT guard across sessions for the SAME
+/// user (e.g. RDP'd into a machine where that user is also logged in at
+/// the console) — each session gets its own mutex namespace, so two
+/// wrappers in different sessions would each acquire successfully. Given
+/// config.toml persistence is already made atomic (see config.rs), that
+/// scenario can no longer scrub config.toml; it can still race on which
+/// node ends up running. Out of scope for #5132 (a single-session
+/// relaunch), but worth knowing about if this ever needs revisiting.
 #[cfg(target_os = "windows")]
 pub(super) const WRAPPER_MUTEX_NAME: &str = "FreenetWrapperSingleInstance";
 

--- a/crates/core/src/bin/commands/service/single_instance.rs
+++ b/crates/core/src/bin/commands/service/single_instance.rs
@@ -111,17 +111,123 @@ pub(super) fn acquire_wrapper_single_instance_lock() -> AcquireWrapperLockOutcom
     }
 }
 
-/// Non-macOS stub so `run_wrapper` compiles without cfg gates around
-/// every mention. On Linux the backend-level port guard is sufficient
-/// (no tray); on Windows the install-time wrapper detection is the
-/// analogous mechanism.
-#[cfg(not(target_os = "macos"))]
+// ── Windows wrapper single-instance lock ──
+//
+// Problem: unlike macOS (launchd RunAtLoad racing an open-launch) or
+// Linux (no tray, so no wrapper-overlap concern), the Windows wrapper had
+// NO single-instance guard at all — every relaunch (double-clicking the
+// downloaded exe, or launching the installed
+// `%localappdata%\Freenet\bin\freenet.exe`, while Freenet was already
+// running from autostart or a prior launch) fell straight through to
+// `kill_stale_freenet_processes`, which unconditionally `taskkill`s every
+// `freenet network` child for the current user — "stale" in name only,
+// it has no way to distinguish an orphan from the process a live wrapper
+// is actively supervising. The result: every relaunch kills the running
+// node and starts a new one, and when the kill races the new wrapper's
+// own startup closely enough, two `freenet network` processes can end up
+// concurrently reading and (pre-#5132-fix) non-atomically rewriting
+// config.toml, which is how a hand-edit could come back as defaults.
+// See #5132.
+//
+// Solution: a named kernel mutex, acquired in `run_wrapper` BEFORE
+// `kill_stale_freenet_processes` and before any user-visible state
+// change — the direct Windows analogue of the macOS flock guard above.
+// `CreateMutexW` on a name already held by another process (even a
+// different handle held by the SAME process) returns a valid handle but
+// sets the last error to `ERROR_ALREADY_EXISTS`; checking that lets a
+// second wrapper detect the first and exit silently instead of killing
+// it. The mutex is released automatically by the kernel when every
+// handle to it closes, including on ungraceful process exit, so there is
+// no stale-lock cleanup to get wrong.
+#[cfg(target_os = "windows")]
+#[derive(Debug)]
+#[allow(dead_code)]
+pub(super) struct WrapperSingleInstanceLock {
+    // The raw handle keeps the mutex alive; closing it (on Drop) releases
+    // the mutex. Never used for anything else post-acquisition, so the
+    // struct only exists to hold the handle for its lifetime.
+    handle: winapi::um::winnt::HANDLE,
+}
+
+#[cfg(target_os = "windows")]
+impl Drop for WrapperSingleInstanceLock {
+    fn drop(&mut self) {
+        // SAFETY: `self.handle` is a valid mutex handle returned by a
+        // prior successful `CreateMutexW`, not yet closed (this is the
+        // only place that closes it, and it runs at most once per value).
+        unsafe {
+            winapi::um::handleapi::CloseHandle(self.handle);
+        }
+    }
+}
+
+/// Name of the wrapper single-instance mutex. The `Global\` prefix is
+/// deliberately omitted: this only needs to be unique per interactive
+/// user session (Freenet installs and runs per-user, never as a system
+/// service on Windows — see `install_service`), and an unprefixed name
+/// is scoped to the caller's session, avoiding any cross-user collision
+/// or the extra privilege `Global\` names can require.
+#[cfg(target_os = "windows")]
+pub(super) const WRAPPER_MUTEX_NAME: &str = "FreenetWrapperSingleInstance";
+
+/// Acquire the wrapper single-instance mutex via `CreateMutexW`.
+#[cfg(target_os = "windows")]
+#[allow(dead_code)]
+pub(super) fn acquire_wrapper_single_instance_lock() -> AcquireWrapperLockOutcome {
+    use std::os::windows::ffi::OsStrExt;
+    // NUL-terminate explicitly: `CreateMutexW` reads `lpName` as a
+    // NUL-terminated wide string, and `encode_wide()` does not append one.
+    let name: Vec<u16> = std::ffi::OsStr::new(WRAPPER_MUTEX_NAME)
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    // SAFETY: `name` is a valid, NUL-terminated UTF-16 buffer that outlives
+    // the call (it's a local `Vec` still in scope). Passing null security
+    // attributes and `FALSE` for `bInitialOwner` requests default security
+    // and does not implicitly acquire the mutex, matching a plain
+    // "does this name already exist" probe.
+    let handle = unsafe {
+        winapi::um::synchapi::CreateMutexW(
+            std::ptr::null_mut(),
+            winapi::shared::minwindef::FALSE,
+            name.as_ptr(),
+        )
+    };
+    if handle.is_null() {
+        tracing::warn!(
+            "Wrapper lock: CreateMutexW failed (error {}); proceeding without lock",
+            unsafe { winapi::um::errhandlingapi::GetLastError() }
+        );
+        return AcquireWrapperLockOutcome::UnavailableSoProceed;
+    }
+    // SAFETY: `handle` was just returned non-null by `CreateMutexW` above;
+    // `GetLastError` reflects that call's outcome (nothing else has run
+    // on this thread since).
+    let already_exists = unsafe { winapi::um::errhandlingapi::GetLastError() }
+        == winapi::shared::winerror::ERROR_ALREADY_EXISTS;
+    if already_exists {
+        // SAFETY: `handle` is the valid handle just returned; we're done
+        // with it immediately since we're not the owner.
+        unsafe {
+            winapi::um::handleapi::CloseHandle(handle);
+        }
+        AcquireWrapperLockOutcome::AnotherWrapperRunning
+    } else {
+        AcquireWrapperLockOutcome::Acquired(WrapperSingleInstanceLock { handle })
+    }
+}
+
+/// Non-macOS, non-Windows stub so `run_wrapper` compiles without cfg
+/// gates around every mention. Linux has no tray and no wrapper-overlap
+/// concern (no autostart mechanism analogous to launchd RunAtLoad or the
+/// Windows Run key double-launches this guards against).
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
 #[allow(dead_code)]
 pub(super) fn acquire_wrapper_single_instance_lock() -> AcquireWrapperLockOutcome {
     AcquireWrapperLockOutcome::UnavailableSoProceed
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
 #[derive(Debug)]
 #[allow(dead_code)]
 pub(super) struct WrapperSingleInstanceLock;

--- a/crates/core/src/bin/commands/service/wrapper.rs
+++ b/crates/core/src/bin/commands/service/wrapper.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 #[cfg(target_os = "macos")]
 use super::launch_at_login::macos_launch_at_login_startup;
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 use super::single_instance::{AcquireWrapperLockOutcome, acquire_wrapper_single_instance_lock};
 
 #[cfg(any(target_os = "windows", target_os = "macos"))]
@@ -461,40 +461,57 @@ pub(super) fn run_wrapper(version: &str) -> Result<()> {
     std::fs::create_dir_all(&log_dir)
         .with_context(|| format!("Failed to create log directory: {}", log_dir.display()))?;
 
-    // macOS wrapper single-instance guard. MUST run before
+    // Wrapper single-instance guard (macOS + Windows). MUST run before
     // `kill_stale_freenet_processes` and before anything user-visible.
-    // The kill helper uses `pkill -f "freenet network"` which matches
-    // the CURRENTLY-RUNNING backend child of a live wrapper, not just
-    // stale orphans; if we were to kill_stale before the single-
-    // instance check, a second wrapper would happily murder the first
-    // wrapper's backend, then see a free port, then proceed to build a
-    // duplicate tray. The flock-based guard is immune to that race
-    // because it inspects wrapper-level state (the lockfile held by
-    // the first wrapper process) not backend state.
+    // The kill helper matches the CURRENTLY-RUNNING backend child of a
+    // live wrapper, not just stale orphans; if we were to kill_stale
+    // before the single-instance check, a second wrapper would happily
+    // murder the first wrapper's backend, then see a free port/process
+    // slot, then proceed to build a duplicate tray — or, on Windows,
+    // race a freshly spawned `freenet network` against the first
+    // wrapper's own respawn of its just-killed child, both reading and
+    // (pre-#5132-fix) non-atomically rewriting config.toml. The guard is
+    // immune to that race because it inspects wrapper-level state (a
+    // lockfile on macOS, a named kernel mutex on Windows, held by the
+    // first wrapper process) rather than backend state.
     //
-    // Phase-1 smoke test on 2026-04-22 reproduced the duplicate tray
-    // whenever launchd's RunAtLoad fired while the user's open-
-    // launched wrapper was still alive; this guard prevents that
+    // macOS: phase-1 smoke test on 2026-04-22 reproduced a duplicate
+    // tray whenever launchd's RunAtLoad fired while the user's open-
+    // launched wrapper was still alive; the flock guard prevents that
     // overlap without changing the LAL agent's `RunAtLoad=true`
     // semantics (login-time auto-start still works; only the in-
     // session overlap is suppressed).
     //
-    // Linux has no tray and Windows has install-time guards; the
-    // overlap race only manifests on macOS where launchd can spawn a
-    // concurrent wrapper via RunAtLoad.
-    #[cfg(target_os = "macos")]
+    // Windows: #5132 — every relaunch (the downloaded exe, or the
+    // installed `%localappdata%\Freenet\bin\freenet.exe`) fell straight
+    // through to `kill_stale_freenet_processes` with no guard at all,
+    // so relaunching while Freenet was already running (e.g. via
+    // autostart) killed the running node and started a new one on every
+    // single launch. The mutex guard closes that gap the same way the
+    // macOS flock does.
+    //
+    // Linux has no tray and no autostart mechanism that can spawn a
+    // concurrent wrapper, so the overlap race does not apply there.
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
     let _wrapper_lock = match acquire_wrapper_single_instance_lock() {
         AcquireWrapperLockOutcome::Acquired(guard) => Some(guard),
         AcquireWrapperLockOutcome::AnotherWrapperRunning => {
+            #[cfg(target_os = "macos")]
+            let holder_detail = "lockfile at ~/Library/Caches/Freenet/wrapper.lock is held; \
+                 try `lsof ~/Library/Caches/Freenet/wrapper.lock` to find the holder";
+            #[cfg(target_os = "windows")]
+            let holder_detail = format!(
+                "named mutex \"{}\" is held by another process",
+                super::single_instance::WRAPPER_MUTEX_NAME
+            );
             log_wrapper_event(
                 &log_dir,
                 &format!(
                     "Wrapper pid={} exiting: another Freenet wrapper is already \
-                     running (lockfile at ~/Library/Caches/Freenet/wrapper.lock is \
-                     held). Expected if launchd fired RunAtLoad while an existing \
-                     wrapper is alive, or if Freenet.app was double-launched. \
-                     If Freenet's menu bar icon is not visible, another process may \
-                     be holding the lock; try `lsof ~/Library/Caches/Freenet/wrapper.lock`.",
+                     running ({holder_detail}). Expected if Freenet was launched \
+                     while already running (e.g. via autostart), or double-launched. \
+                     If Freenet's tray icon is not visible, another process may be \
+                     holding the lock.",
                     std::process::id()
                 ),
             );
@@ -504,7 +521,7 @@ pub(super) fn run_wrapper(version: &str) -> Result<()> {
             log_wrapper_event(
                 &log_dir,
                 "Wrapper single-instance lock unavailable; proceeding without guard. \
-                 Dup-tray risk if RunAtLoad fires while another wrapper is alive.",
+                 Dup-launch risk if another wrapper is started concurrently.",
             );
             None
         }

--- a/crates/core/src/bin/commands/service/wrapper.rs
+++ b/crates/core/src/bin/commands/service/wrapper.rs
@@ -492,8 +492,37 @@ pub(super) fn run_wrapper(version: &str) -> Result<()> {
     //
     // Linux has no tray and no autostart mechanism that can spawn a
     // concurrent wrapper, so the overlap race does not apply there.
+    //
+    // A deliberate self-relaunch (auto-update, crash-loop rollback — see
+    // spawn_new_wrapper's call sites below) spawns the new wrapper process
+    // BEFORE the old one releases this lock: the old process's shutdown
+    // sequencing runs on the tray's ~100ms status-poll loop and, on the
+    // "UpdatedRestarting" terminal status, sleeps a further hard-coded 1s
+    // before quitting (see tray.rs) so the "Updated! Restarting..." status
+    // is visible — reliably longer than how fast the freshly-spawned new
+    // process reaches this same acquire call. A single-shot acquire would
+    // almost always lose that handoff, so self-relaunch would silently
+    // fail to start a replacement wrapper every time. Retry for a few
+    // seconds to ride out the old process's own bounded shutdown window
+    // before concluding a second, genuinely unrelated wrapper is running
+    // (in which case the extra few seconds before exiting are invisible —
+    // the user is looking at the ALREADY-running instance either way).
     #[cfg(any(target_os = "macos", target_os = "windows"))]
-    let _wrapper_lock = match acquire_wrapper_single_instance_lock() {
+    let lock_outcome = {
+        const RETRY_ATTEMPTS: u32 = 20;
+        const RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_millis(250);
+        let mut outcome = acquire_wrapper_single_instance_lock();
+        for _ in 1..RETRY_ATTEMPTS {
+            if !matches!(outcome, AcquireWrapperLockOutcome::AnotherWrapperRunning) {
+                break;
+            }
+            std::thread::sleep(RETRY_INTERVAL);
+            outcome = acquire_wrapper_single_instance_lock();
+        }
+        outcome
+    };
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    let _wrapper_lock = match lock_outcome {
         AcquireWrapperLockOutcome::Acquired(guard) => Some(guard),
         AcquireWrapperLockOutcome::AnotherWrapperRunning => {
             #[cfg(target_os = "macos")]

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -1128,8 +1128,21 @@ impl ConfigArgs {
         let current = std::fs::read_to_string(&config_path).ok();
         if current.as_deref() != Some(new_config_toml.as_str()) {
             tracing::info!(path = ?config_path, "Persisting configuration");
-            let mut file = File::create(&config_path)?;
+            // Write to a sibling temp file and rename into place rather than
+            // truncating config.toml directly. `File::create` + `write_all`
+            // leaves a window where a concurrent reader (e.g. another
+            // `freenet` process racing this one) can observe a truncated or
+            // partially-written file; `rename` replaces the destination
+            // atomically, so a reader always sees either the old or the new
+            // complete content. The temp filename's extension ("toml.tmp",
+            // not "toml") keeps `read_config`'s directory scan from ever
+            // picking it up as a candidate config file if a rename is
+            // interrupted before cleanup.
+            let tmp_path = config_path.with_extension("toml.tmp");
+            let mut file = File::create(&tmp_path)?;
             file.write_all(new_config_toml.as_bytes())?;
+            drop(file);
+            std::fs::rename(&tmp_path, &config_path)?;
         }
 
         Ok(this)
@@ -5132,6 +5145,44 @@ mod tests {
         assert_eq!(
             before, after,
             "a no-op restart must not rewrite config.toml"
+        );
+    }
+
+    #[tokio::test]
+    async fn persisting_config_never_truncates_existing_file_on_temp_write_failure() {
+        // The config.toml write path must go through a temp file + rename
+        // rather than truncating config.toml in place, so a reader (e.g. a
+        // second `freenet` process racing this one — see #5132) can never
+        // observe an empty or partially-written file. Force a failure in the
+        // temp-file write step (by pre-occupying its path with a directory)
+        // and verify the destination file survives byte-for-byte untouched.
+        let temp_dir = tempfile::tempdir().unwrap();
+
+        // First run creates a real config.toml.
+        clap_bare_args(temp_dir.path()).build().await.unwrap();
+        let config_path = temp_dir.path().join("config.toml");
+        let original = std::fs::read_to_string(&config_path).unwrap();
+        assert!(!original.is_empty());
+
+        // Occupy config.toml.tmp with a directory so the next persist's
+        // `File::create` on the temp path fails instead of succeeding.
+        std::fs::create_dir(config_path.with_extension("toml.tmp")).unwrap();
+
+        // Change a value so the persist path actually attempts a write.
+        let mut args = clap_bare_args(temp_dir.path());
+        args.network_api.total_bandwidth_limit = Some(123_456_789);
+        let result = args.build().await;
+
+        assert!(
+            result.is_err(),
+            "build() must surface the forced temp-file write failure, not silently succeed"
+        );
+
+        let after = std::fs::read_to_string(&config_path).unwrap();
+        assert_eq!(
+            original, after,
+            "a failed persist must leave the existing config.toml completely untouched, \
+             never truncated or partially overwritten"
         );
     }
 

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -1128,19 +1128,33 @@ impl ConfigArgs {
         let current = std::fs::read_to_string(&config_path).ok();
         if current.as_deref() != Some(new_config_toml.as_str()) {
             tracing::info!(path = ?config_path, "Persisting configuration");
-            // Write to a sibling temp file and rename into place rather than
-            // truncating config.toml directly. `File::create` + `write_all`
-            // leaves a window where a concurrent reader (e.g. another
-            // `freenet` process racing this one) can observe a truncated or
-            // partially-written file; `rename` replaces the destination
-            // atomically, so a reader always sees either the old or the new
-            // complete content. The temp filename's extension ("toml.tmp",
-            // not "toml") keeps `read_config`'s directory scan from ever
-            // picking it up as a candidate config file if a rename is
-            // interrupted before cleanup.
-            let tmp_path = config_path.with_extension("toml.tmp");
+            // Write to a per-process temp file and rename into place rather
+            // than truncating config.toml directly. `File::create` +
+            // `write_all` leaves a window where a concurrent reader (e.g.
+            // another `freenet` process racing this one) can observe a
+            // truncated or partially-written file; `rename` replaces the
+            // destination atomically, so a reader always sees either the
+            // old or the new complete content.
+            //
+            // The temp filename embeds this process's PID so two writers
+            // racing `build()` concurrently (the wrapper's single-instance
+            // guard only prevents two *wrapper* processes from launching a
+            // node each — it doesn't stop e.g. a manually-run `freenet
+            // network` from racing an already-supervised one) never share
+            // the same temp file: each writes and fsyncs its own complete
+            // copy before renaming, so the destination only ever receives
+            // one writer's complete content, never an interleaved mix of
+            // two. A shared temp filename would defeat this: both writers'
+            // `File::create` + `write_all` calls could interleave on the
+            // same underlying file before either renames.
+            //
+            // The extension ("toml.tmp", not "toml") keeps `read_config`'s
+            // directory scan from ever picking a leftover up as a candidate
+            // config file if a rename is interrupted before cleanup.
+            let tmp_path = config_path.with_extension(format!("{}.toml.tmp", std::process::id()));
             let mut file = File::create(&tmp_path)?;
             file.write_all(new_config_toml.as_bytes())?;
+            file.sync_all()?;
             drop(file);
             std::fs::rename(&tmp_path, &config_path)?;
         }
@@ -5164,9 +5178,12 @@ mod tests {
         let original = std::fs::read_to_string(&config_path).unwrap();
         assert!(!original.is_empty());
 
-        // Occupy config.toml.tmp with a directory so the next persist's
-        // `File::create` on the temp path fails instead of succeeding.
-        std::fs::create_dir(config_path.with_extension("toml.tmp")).unwrap();
+        // Occupy this process's temp path with a directory so the next
+        // persist's `File::create` on it fails instead of succeeding. The
+        // temp filename embeds the current PID (see the persist code), so
+        // it's reproduced here rather than hardcoded.
+        std::fs::create_dir(config_path.with_extension(format!("{}.toml.tmp", std::process::id())))
+            .unwrap();
 
         // Change a value so the persist path actually attempts a write.
         let mut args = clap_bare_args(temp_dir.path());


### PR DESCRIPTION
## Summary

Fixes #5132 — on Windows, editing `config.toml` and relaunching Freenet reverted the edits to defaults.

**Root cause:** the Windows wrapper had no single-instance guard at all. Every relaunch (double-clicking the downloaded exe, or launching the installed `%localappdata%\Freenet\bin\freenet.exe`, while Freenet was already running via autostart or a prior launch) fell straight through to `kill_stale_freenet_processes`, which unconditionally kills every `freenet network` process for the current user — "stale" in name only, it can't distinguish an orphan from the process a live wrapper is actively supervising — then spawned a fresh node. When that kill raced the first wrapper's own respawn of its just-killed child closely enough, two node processes could concurrently read and (pre-fix) non-atomically rewrite `config.toml`, which is how a hand-edit could come back as defaults.

macOS already has the exact fix for this class of bug — a flock-based single-instance guard, added for a different trigger (launchd RunAtLoad racing an open-launch) — but it was `#[cfg(target_os = "macos")]`-gated and never extended to Windows; a stale comment on the guard's call site even asserted "Windows has install-time guards" as the reason, which isn't accurate (the install-time detection only checks *where* the binary lives, not whether an instance is currently running).

## Changes

1. **`single_instance.rs`** — implements the Windows analogue of the macOS flock guard: a named kernel mutex (`CreateMutexW`), acquired in `run_wrapper` before `kill_stale_freenet_processes`. `CreateMutexW`'s "already exists" signal fires even for a second handle from the same process, so it can be exercised directly in a `#[test]` rather than needing a simplified stand-in.
2. **`wrapper.rs`** — widens the guard's call site (and its already-cfg-gated import) from `macos` to `any(macos, windows)`; corrects the stale "Windows has install-time guards" comment; platform-specific log detail on the "another wrapper is running" exit path.
3. **`config.rs`** — makes the `config.toml` persist path atomic: write to a sibling temp file, then `rename` into place, instead of `File::create` truncating the destination directly. Closes the window where a concurrent reader (e.g. a second `freenet` process racing this one) could observe a truncated/partial file. The temp file's extension (`toml.tmp`) keeps `read_config`'s directory scan from ever picking it up as a candidate config file.
4. **`ci.yml`** — adds a `windows_unit` job (mirrors the existing `macos_unit`) running the service-command test suite on `windows-latest`. `windows_check` only `cargo check`s, which never executes tests — without this, the new Windows-only tests would compile but never actually run, matching `.claude/rules/deployment.md`'s "compilation is not verification" rule for platform-gated code.

## Tests

- `wrapper_single_instance_lock_is_exclusive` (Windows-only, `commands/service.rs`) — first acquire succeeds, second acquire in-process reports `AnotherWrapperRunning`, dropping the first allows a new acquire to succeed. Exercises the real production function directly (not a simplified stand-in), since `CreateMutexW`'s already-exists signal fires for a second handle from the same process.
- `persisting_config_never_truncates_existing_file_on_temp_write_failure` (`config.rs`) — forces the temp-file write step to fail (by pre-occupying its path with a directory) and asserts the destination `config.toml` survives byte-for-byte untouched. Fails against the pre-fix code (which writes directly to `config.toml` with no temp file, so nothing in this scenario fails and the file gets overwritten instead of preserved).

## Verification

- Windows target (`x86_64-pc-windows-gnu`) cross-compiles cleanly (`cargo check`), including the new tests.
- `cargo clippy -p freenet --bin freenet -- -D warnings` clean on the native target.
- All 108 `config::` tests and all 107 `commands::service::` tests pass on Linux.
- The new Windows-only test cannot be exercised on this (Linux) dev machine; the new `windows_unit` CI job is what will actually execute it — will confirm green there before merging.

## Out of scope (filed separately)

While investigating, found that `freenet service` (disable/enable/report) resolves a *different* config directory (Roaming, not Local AppData) than `freenet network`/`local` on Windows — a related but distinct bug (breaks `service disable`, not `config.toml` content). Filed as #5133 rather than folding into this PR.

[AI-assisted - Claude]