### PR TITLE
fix(update): bound the release downloads, and stop overstating the budget

### DIFF
--- a/crates/core/src/bin/commands/auto_update.rs
+++ b/crates/core/src/bin/commands/auto_update.rs
@@ -628,6 +628,7 @@ pub(crate) async fn fetch_latest_release_tag(bypass_cached_cooldown: bool) -> Re
         // not have to guess whether the Location was malformed, refused for
         // leaving the origin, or never arrived. Previously all three read as
         // "no parseable release tag", which points at the wrong thing.
+        ProbeResult::Aborted { reason } => anyhow::bail!("release probe aborted: {reason}"),
         ProbeResult::Unusable { status, location } => match location.as_deref() {
             None => anyhow::bail!("GitHub returned {status} with no Location header"),
             Some(loc) if parse_tag_from_release_location(loc).is_some() => anyhow::bail!(
@@ -655,6 +656,19 @@ pub(crate) enum ProbeResult {
     Unusable {
         status: u16,
         location: Option<String>,
+    },
+    /// The probe never reached a conclusion — it hit its own limit rather than
+    /// receiving an unusable answer.
+    ///
+    /// Separate from [`ProbeResult::Unusable`] because these causes are not
+    /// HTTP-shaped. Reporting them with a synthetic `status: 0` and the reason
+    /// stuffed into `location` produced operator-facing text like "GitHub
+    /// returned 0 with no parseable release tag in Location (probe exceeded its
+    /// chain deadline)" — a status GitHub never returned, and a cause that is not
+    /// why it failed. That is the conflation the caller's three-way match was
+    /// written to end, reintroduced one function away.
+    Aborted {
+        reason: String,
     },
 }
 
@@ -698,18 +712,14 @@ pub(crate) async fn probe_release_tag_at(url: &str) -> Result<ProbeResult> {
 /// The deadline is a parameter purely so a test can drive it at millisecond
 /// scale: verifying it with the production 10s value would need a test that
 /// actually takes 10s, and a bound nobody has watched fire is not known to work.
-pub(crate) async fn probe_release_tag_within(
-    url: &str,
-    chain_timeout: Duration,
-) -> Result<ProbeResult> {
+async fn probe_release_tag_within(url: &str, chain_timeout: Duration) -> Result<ProbeResult> {
     match tokio::time::timeout(chain_timeout, probe_release_tag_chain(url)).await {
         Ok(result) => result,
-        Err(_elapsed) => Ok(ProbeResult::Unusable {
-            status: 0,
-            location: Some(format!(
+        Err(_elapsed) => Ok(ProbeResult::Aborted {
+            reason: format!(
                 "probe exceeded its {}ms chain deadline",
                 chain_timeout.as_millis()
-            )),
+            ),
         }),
     }
 }
@@ -721,6 +731,12 @@ pub(crate) async fn probe_release_tag_within(
 /// sized against. See [`probe_release_tag_at`].
 const PROBE_CHAIN_TIMEOUT: Duration = Duration::from_secs(10);
 
+/// Per-request timeout inside a probe. A named constant so the test asserting
+/// "the chain costs no more than one request" actually READS it — comparing
+/// against a duplicated literal, as an earlier version did, means the invariant
+/// can be falsified without failing the test that names it.
+const PROBE_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
 async fn probe_release_tag_chain(url: &str) -> Result<ProbeResult> {
     let client = reqwest::Client::builder()
         .user_agent(GITHUB_USER_AGENT)
@@ -729,7 +745,7 @@ async fn probe_release_tag_chain(url: &str) -> Result<ProbeResult> {
         // in the header. Hops are instead followed SELECTIVELY below, only when
         // a redirect does not carry a tag.
         .redirect(reqwest::redirect::Policy::none())
-        .timeout(Duration::from_secs(10))
+        .timeout(PROBE_REQUEST_TIMEOUT)
         .build()?;
 
     let mut current = url.to_string();
@@ -795,9 +811,8 @@ async fn probe_release_tag_chain(url: &str) -> Result<ProbeResult> {
         }
     }
 
-    Ok(ProbeResult::Unusable {
-        status: 0,
-        location: Some(format!("redirect limit ({MAX_PROBE_REDIRECTS}) exceeded")),
+    Ok(ProbeResult::Aborted {
+        reason: format!("redirect limit ({MAX_PROBE_REDIRECTS}) exceeded"),
     })
 }
 
@@ -2349,13 +2364,20 @@ mod tests {
         // mistake this whole helper exists to catch, committed inside the check
         // itself; it stayed hidden until a later PR happened to write that phrase
         // into a doc comment.
-        if let Some(tests_at) = src.find("\n#[cfg(test)]\nmod ").map(|i| i + 1) {
-            assert!(
-                at < tests_at,
-                "`{signature}` matched inside the test module — this pin is \
-                 scraping its own source and would pass vacuously"
-            );
-        }
+        // `.expect`, not `if let`: a pattern that stops matching (a one-line
+        // `#[cfg(test)] mod tests {`, an intervening attribute, `pub mod tests`,
+        // CRLF) would otherwise skip the check entirely and leave every pin
+        // silently unguarded — a fail-OPEN inside the guard whose whole purpose
+        // is to stop things failing open. Refuse rather than verify nothing.
+        let tests_at = src
+            .find("\n#[cfg(test)]\nmod ")
+            .map(|i| i + 1)
+            .expect("test module not located — this guard cannot verify anything");
+        assert!(
+            at < tests_at,
+            "`{signature}` matched inside the test module — this pin is \
+             scraping its own source and would pass vacuously"
+        );
         assert!(
             at == 0 || src.as_bytes()[at - 1] == b'\n',
             "fn_body only supports column-0 free functions; `{signature}` is \
@@ -2370,7 +2392,11 @@ mod tests {
         // the test-module attribute. If it does, the `\n}\n` search ran past the
         // function and this pin is measuring the whole file.
         assert!(
-            !body.contains("#[cfg(test)]"),
+            // Anchored like the check above. A bare `contains` would false-panic
+            // on a doc comment inside the scraped body that merely mentions
+            // `#[cfg(test)]` — the same naive-substring mistake, from the other
+            // direction, and the one that actually bit this file.
+            !body.contains("\n#[cfg(test)]\nmod "),
             "scoped region for `{signature}` escaped into the test module — this \
              pin would pass vacuously"
         );
@@ -3198,8 +3224,8 @@ mod tests {
         let elapsed = started.elapsed();
 
         match got {
-            ProbeResult::Unusable { location, .. } => assert!(
-                location.unwrap_or_default().contains("chain deadline"),
+            ProbeResult::Aborted { reason } => assert!(
+                reason.contains("chain deadline"),
                 "hitting the deadline must say so, so an operator can tell it from \
                  a malformed redirect"
             ),
@@ -3222,17 +3248,37 @@ mod tests {
         // inside TimeoutStopSec=45, which the unit already spends on the 30s
         // drain plus teardown headroom; a probe that grew to 4x would push the
         // SIGKILL from mid-probe into mid-install.
-        let per_request = Duration::from_secs(10);
         assert_eq!(
-            PROBE_CHAIN_TIMEOUT, per_request,
+            PROBE_CHAIN_TIMEOUT, PROBE_REQUEST_TIMEOUT,
             "the chain deadline must equal the per-request timeout, so following \
              redirects costs no additional wall clock"
         );
-        // And it must stay far enough inside the stop budget to leave room for
-        // the install that follows it.
-        assert!(
-            PROBE_CHAIN_TIMEOUT.as_secs() * 2 < 45,
-            "probe + asset fetch must both fit well inside TimeoutStopSec=45"
+
+        // The previous version of this test asserted
+        // `PROBE_CHAIN_TIMEOUT * 2 < 45` under the message "probe + asset fetch
+        // must both fit well inside TimeoutStopSec=45". True, but it OVERSTATED
+        // what was guaranteed: the legs AFTER the asset fetch — the manifest, the
+        // signature and the release archive — had no timeout at all, so the
+        // stop-phase footprint was in fact unbounded. A green assertion naming
+        // the whole budget is worse than no assertion, because it terminates the
+        // investigation (the "overstated saving" row in
+        // `.claude/rules/bug-prevention-patterns.md`).
+        //
+        // A large download legitimately cannot carry a total deadline, so no test
+        // can honestly claim a whole-update wall-clock bound. What IS checkable,
+        // and what actually matters, is that every HTTP client on this path is
+        // bounded by SOMETHING — so a stalled connection can never hang until
+        // systemd SIGKILLs the updater mid-install.
+        let update_src = include_str!("update.rs");
+        let clients = update_src.matches("reqwest::Client::builder()").count();
+        let bounded =
+            update_src.matches(".timeout(").count() + update_src.matches(".read_timeout(").count();
+        assert_eq!(
+            clients, bounded,
+            "every reqwest client in the update path must set a timeout or a \
+             read_timeout: found {clients} client(s) and {bounded} bound(s). An \
+             unbounded client on the ExecStopPost path hangs until SIGKILL, and \
+             that SIGKILL lands mid-install."
         );
     }
 
@@ -3252,9 +3298,9 @@ mod tests {
             .await
             .expect("a redirect loop must terminate, not error out")
         {
-            ProbeResult::Unusable { location, .. } => {
+            ProbeResult::Aborted { reason } => {
                 assert!(
-                    location.unwrap_or_default().contains("redirect limit"),
+                    reason.contains("redirect limit"),
                     "giving up on a loop should say so"
                 );
             }

--- a/crates/core/src/bin/commands/auto_update.rs
+++ b/crates/core/src/bin/commands/auto_update.rs
@@ -3191,6 +3191,61 @@ mod tests {
         }
     }
 
+    #[test]
+    fn an_aborted_probe_is_not_reported_as_an_http_failure() {
+        // The review finding this closes was operator-facing text, so the test is
+        // about text. Both non-HTTP aborts used to travel as
+        // `Unusable { status: 0, location: Some(<prose>) }` and rendered as
+        //   "GitHub returned 0 with no parseable release tag in Location
+        //    (probe exceeded its 10000ms chain deadline)"
+        // — a status GitHub never returned, and a cause that is not why it
+        // failed. Someone debugging a detection outage chases the redirect.
+        //
+        // Scoped with fn_body so a future edit that folds these back into
+        // `Unusable` fails here rather than silently restoring the conflation.
+        let this_src = include_str!("auto_update.rs");
+
+        for (func, what) in [
+            (
+                "async fn probe_release_tag_within(",
+                "the chain-deadline exit",
+            ),
+            (
+                "async fn probe_release_tag_chain(",
+                "the redirect-limit exit",
+            ),
+        ] {
+            let body = fn_body(this_src, func);
+            assert!(
+                body.contains("ProbeResult::Aborted"),
+                "{what} must report Aborted, not an HTTP-shaped Unusable"
+            );
+            assert!(
+                !body.contains("status: 0"),
+                "{what} must not invent a status GitHub never returned"
+            );
+        }
+
+        // And the caller must render it as its own thing.
+        let caller = fn_body(this_src, "pub(crate) async fn fetch_latest_release_tag(");
+        assert!(
+            caller.contains("ProbeResult::Aborted { reason }"),
+            "the caller must handle Aborted explicitly"
+        );
+        let (aborted_arm, _) = caller
+            .split_once("ProbeResult::Unusable")
+            .expect("the Unusable arm should follow the Aborted arm");
+        let (_, aborted_arm) = aborted_arm
+            .split_once("ProbeResult::Aborted { reason }")
+            .expect("Aborted arm not found");
+        assert!(
+            !aborted_arm.contains("GitHub returned")
+                && !aborted_arm.contains("no parseable release tag"),
+            "an aborted probe must not borrow the HTTP failure's wording — that \
+             is the conflation this exists to prevent, got: {aborted_arm}"
+        );
+    }
+
     #[tokio::test]
     async fn probe_chain_is_bounded_in_wall_clock_not_just_hops() {
         use httptest::{Expectation, Server, matchers::*, responders::*};

--- a/crates/core/src/bin/commands/update.rs
+++ b/crates/core/src/bin/commands/update.rs
@@ -22,6 +22,13 @@ use super::service::{generate_system_service_file, generate_user_service_file};
 /// list, which the quota-free redirect cannot provide. The former
 /// `/releases/latest` REST call that ran on every invocation is gone: see
 /// `auto_update::GITHUB_LATEST_REDIRECT_URL`.
+/// Total deadline for the small release assets (`SHA256SUMS.txt`, `.sig`).
+const MANIFEST_DOWNLOAD_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Idle (between-bytes) timeout for the release archive. Bounds a stalled
+/// connection without capping a slow-but-progressing download.
+const STALLED_TRANSFER_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
 const GITHUB_API_TAG_URL_PREFIX: &str =
     "https://api.github.com/repos/freenet/freenet-core/releases/tags/";
 
@@ -1389,7 +1396,13 @@ async fn download_bytes(url: &str) -> Result<Vec<u8>> {
     use futures::StreamExt;
 
     let client = reqwest::Client::builder()
-        .user_agent("freenet-updater")
+        .user_agent(super::auto_update::GITHUB_USER_AGENT)
+        // A TOTAL deadline is right here: these assets are a manifest of a few
+        // hundred bytes and a 64-byte signature, so there is no legitimate slow
+        // transfer to protect. Unbounded, a half-open connection would hang until
+        // systemd SIGKILLs the post-stop updater — the exact hazard the sibling
+        // timeout on the asset-list fetch was added to prevent.
+        .timeout(MANIFEST_DOWNLOAD_TIMEOUT)
         .build()?;
 
     let response = client
@@ -1634,7 +1647,14 @@ fn get_archive_extension() -> &'static str {
 
 async fn download_file(url: &str, dest: &Path, quiet: bool) -> Result<()> {
     let client = reqwest::Client::builder()
-        .user_agent("freenet-updater")
+        .user_agent(super::auto_update::GITHUB_USER_AGENT)
+        // A READ timeout, deliberately NOT a total one: this is the release
+        // archive (tens of MB), so a total deadline would abort a legitimately
+        // slow connection. `read_timeout` bounds time between bytes, which is
+        // what actually distinguishes "slow link" from "stalled connection" —
+        // and it is the stall that would otherwise hang until SIGKILL on the
+        // ExecStopPost path.
+        .read_timeout(STALLED_TRANSFER_TIMEOUT)
         .build()?;
 
     let response = client


### PR DESCRIPTION
## Problem

Follow-up to #5151, from its post-merge review. The finding that matters is not in that diff — it is in what that diff's **test claimed**.

`probe_chain_deadline_does_not_widen_the_stop_phase_budget` asserted:

```rust
assert!(PROBE_CHAIN_TIMEOUT.as_secs() * 2 < 45,
        "probe + asset fetch must both fit well inside TimeoutStopSec=45");
```

True as arithmetic. Misleading as a guarantee — `update.rs` contained exactly **one** `.timeout(` in the entire file. The legs *after* the asset fetch built bare clients with no bound at all:

- `download_bytes` — `SHA256SUMS.txt` and its `.sig`
- `download_file` — the release archive, and the macOS DMG

Those are the long ones, the large ones, and the ones most likely to stall. So the stop-phase footprint on the `ExecStopPost` path was in fact **unbounded**, while a green test named the whole budget.

That is the **"overstated saving"** row in `.claude/rules/bug-prevention-patterns.md`: it terminates further investigation. I wrote that assertion, and it would have told the next reader this was handled.

## Approach

**Bounded at both ends, with the right kind of bound for each:**

- `download_bytes` → a **total** deadline. A few hundred bytes plus a 64-byte signature; there is no legitimate slow transfer to protect.
- `download_file` → a **read (idle)** timeout, deliberately *not* a total one. The archive is tens of MB, so a total deadline would abort a legitimately slow connection; time-between-bytes is what actually separates "slow link" from "stalled connection", and the stall is what would hang until SIGKILL.

**The assertion now checks what it can honestly check.** A large download cannot carry a total deadline, so *no* test can claim a whole-update wall-clock bound. What it pins instead is that every reqwest client on this path is bounded by something — which is the property that actually prevents a hang-until-SIGKILL-mid-install.

## Also fixed

- **Non-HTTP aborts get `ProbeResult::Aborted { reason }`.** They were reporting a synthetic `status: 0` with the reason stuffed into the `Location` field, rendering to operators as *"GitHub returned 0 with no parseable release tag in Location (probe exceeded its chain deadline)"* — a status GitHub never returned, and a cause that is not why it failed. Precisely the conflation #5151's three-way match was written to end, reintroduced one function away.
- **The `#[cfg(test)]` guard failed OPEN.** `if let Some(tests_at) = ...` skipped the check entirely if the pattern stopped matching (a one-line `#[cfg(test)] mod tests {`, an intervening attribute, `pub mod tests`, CRLF) — a fail-open inside the guard whose purpose is to stop things failing open. Now `.expect`.
- **The guard's *other* `#[cfg(test)]` search was still a bare substring** — the same mistake fixed 20 lines above it, which would false-panic on a doc comment inside a scraped body. Both anchored.
- **`PROBE_REQUEST_TIMEOUT` is now a named constant**, so the test asserting "the chain costs no more than one request" actually reads it rather than comparing against a duplicated literal. Previously changing the inline `10` would falsify the invariant without failing the test that names it.
- **`probe_release_tag_within` is private** — only the production wrapper and the same-file test call it.

## Testing

362 binary + 125 lib tests pass; clippy clean. Both new guards **mutation-verified**:

| Mutation | Result |
|---|---|
| drop the archive's `read_timeout` | fails with *"found 3 client(s) and 2 bound(s)"* |
| insert an attribute between `#[cfg(test)]` and `mod` | fails with *"test module not located — this guard cannot verify anything"* (previously: silently skipped) |

Follows up #5151. Relates to #5102.

[AI-assisted - Claude]
