### PR TITLE
perf: stop re-broadcasting ReadyState every 30s

### DIFF
--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -1483,15 +1483,6 @@ impl P2pConnManager {
                     );
                 }
 
-                // Periodic ReadyState re-broadcast: if we are ready and have readiness
-                // gating enabled, re-broadcast our ReadyState to all peers every 30s.
-                // This ensures lost ReadyState messages are recovered within one tick.
-                if op_manager.ring.connection_manager.min_ready_connections > 0
-                    && op_manager.ring.connection_manager.is_self_ready()
-                {
-                    ctx.handle_broadcast_ready_state(true).await;
-                }
-
                 #[cfg(all(unix, feature = "jemalloc-prof"))]
                 {
                     use tikv_jemalloc_ctl::{epoch, stats};
@@ -5919,6 +5910,54 @@ pub(crate) mod tests {
             !branch.contains("record_failure"),
             "#4145 SITE 6: the connect-command-drop branch must NOT record peer backoff \
              (local channel contention is not a remote connection failure)."
+        );
+    }
+
+    /// Source-scrape regression guard for #5154: the periodic 30s
+    /// `STATS_LOG_INTERVAL` tick must NEVER re-broadcast `ReadyState`.
+    ///
+    /// `ConnectionManager::is_peer_ready` returns `true` for any connection
+    /// older than `OPTIMISTIC_READY_TIMEOUT` (60s) BEFORE consulting
+    /// `ready_peers` (the only reader of what this broadcast wrote), so a
+    /// `ready: true` re-broadcast to already-ready-by-timeout peers changes
+    /// no receiver's decision. Measured fleet-wide, this tick alone was 3.0%
+    /// of every packet the network transmits (9-byte payload, 90 bytes on
+    /// the wire per message after framing/AEAD/UDP overhead) for zero
+    /// behavioral effect. The on-connect immediate send
+    /// (`op_state_manager.rs`) and the transition-driven sends in
+    /// `connection_lifecycle.rs` fully cover the semantics that remain.
+    ///
+    /// Bound the window to the periodic-stats-logging block specifically
+    /// (not the whole event loop) so an unrelated future addition of
+    /// `handle_broadcast_ready_state` elsewhere in the loop does not
+    /// falsely trip this pin.
+    #[test]
+    fn periodic_stats_tick_does_not_rebroadcast_ready_state() {
+        let src = include_str!("p2p_protoc.rs");
+
+        let anchor = "// Periodic stats logging";
+        let start = src
+            .find(anchor)
+            .expect("periodic stats logging block must exist in the event loop");
+        // Tight window: bound at the point the tick resets its own counters,
+        // the unambiguous tail of this block.
+        let end_needle = "loop_iteration_count = 0;";
+        let end_rel = src[start..]
+            .find(end_needle)
+            .expect("periodic stats logging block must reset loop_iteration_count");
+        let body = &src[start..start + end_rel];
+
+        assert!(
+            !body.contains("handle_broadcast_ready_state"),
+            "#5154: the periodic STATS_LOG_INTERVAL tick must not re-broadcast \
+             ReadyState — it is provably inert past the 60s optimistic-ready \
+             timeout and costs 3% of all network packets. Block:\n{body}"
+        );
+        assert!(
+            !body.contains("min_ready_connections"),
+            "#5154: the periodic tick must not reference readiness gating at \
+             all — the re-broadcast conditional should be fully removed, not \
+             just its call site. Block:\n{body}"
         );
     }
 }


### PR DESCRIPTION
## Problem

The periodic `ReadyState` re-broadcast sends **3.0% of every packet the network transmits** and cannot change any receiver's decision.

Measured fleet-wide (1,886 nodes, `outbound_message_mix`): **64.2M messages at exactly 9.0000 bytes each**, ~96 per node per minute. There is no coalescing — one `NetMessage` is always exactly one UDP datagram (`peer_connection.rs::send` -> `outbound_short_message` -> one `socket.send_to`). Fixed per-datagram overhead is 81 bytes: 24 B `SymmetricMessage` framing + 29 B packet type/nonce/AEAD tag + 28 B UDP/IPv4.

So a 9-byte `ReadyState` costs **90 bytes on the wire — 10x inflation**, 5.78 GB for 0.58 GB of payload.

Confirmed to be `ReadyState` rather than the other two `other`-class variants: the mean is exactly 9.0000 B/msg (what `ReadyState{ready:bool}` serializes to), and `other_max_bytes` — the largest single message per node-minute — is 9 at p50, p90 and max across 1,606 nodes. `Aborted` is 24 B and `SubscribeHint` far larger, so one instance of either anywhere in the sample would have pushed some node's max above 9. (Side finding: `SubscribeHint` is confirmed dead on the wire, consistent with the 0.2.88 disable.)

## Solution

Delete the periodic re-broadcast. It is provably inert past 60 seconds.

`ConnectionManager::is_peer_ready` (`connection_manager.rs:2600`) returns `true` for any connection older than `OPTIMISTIC_READY_TIMEOUT` (60s) **before** consulting `ready_peers` — and `ready_peers` has exactly one reader, that function. The periodic broadcast only ever sends `ready: true`, so it can only ever *insert* into `ready_peers`, and for any connection past 60s that insert changes nothing. The tick fires only on connections that survived at least one 30s interval, so in steady state it fires overwhelmingly on connections far past the timeout.

The sub-60s window it claims to cover is already covered by the immediate on-connect send (`op_state_manager.rs:1688-1695`) and the transition-driven sends in `connection_lifecycle.rs`, both untouched here. `handle_broadcast_ready_state` itself is untouched.

## Testing

The existing `test_is_peer_ready_optimistic_timeout` and its `_not_yet` twin already pin the 60s boundary in both directions — those are the safety argument for this deletion, and they still pass.

Adds `periodic_stats_tick_does_not_rebroadcast_ready_state`, a source-scrape pin bounded to the periodic-stats block so a future re-addition trips CI rather than silently restoring 3% of the network's packet count. Bounded to that block specifically so an unrelated later use of `handle_broadcast_ready_state` elsewhere in the event loop does not falsely fail.

`cargo fmt`, `cargo clippy -- -D warnings` and the test suite are clean.

## Impact

Removes ~64M datagrams and their receive-side ACK accounting for zero behaviour change. Packet-rate and syscall cost rather than bandwidth — 0.24% of IP-level bytes — but a strictly-safe deletion, not an optimisation with a tradeoff.

Part of #5153.

Closes #5154

[AI-assisted - Claude]