### PR TITLE
perf: bound the full-bytes summary fallback (#5155)

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -4347,11 +4347,12 @@ impl GlobalTestMetrics {
     // === Hash-first summary exchange falsifiers (#4965) ===
     //
     // The claim under test is "the common case stops shipping summary bytes".
-    // These counters are fed from the TWO constructor functions that can build
-    // these messages — `node::summaries_reply_for_peer` (which chooses the
-    // encoding) and `node::full_summaries_message` (which every full-bytes
-    // path routes through, including the `operations::update` helpers, which
-    // are CALLERS rather than construction sites). So
+    // These counters are fed from the constructor functions that can build
+    // these messages — `node::summaries_reply_in_form` (which applies the
+    // chosen encoding, and which `node::summaries_reply_for_peer` delegates
+    // to) and `node::full_summaries_message` (which every full-bytes path
+    // routes through, including the `operations::update` helpers, which are
+    // CALLERS rather than construction sites). So
     // `summary_full_bytes() == 0` means no summary byte was put on the wire by
     // any path, not merely by the one a test happened to exercise.
     // `no_uninstrumented_full_summaries_construction` pins that no production

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -9455,6 +9455,123 @@ mod tests {
             );
         }
 
+        /// Two `Interests` from the same peer handled concurrently cost at
+        /// most one round of rotation progress, and cannot wedge or corrupt it.
+        ///
+        /// The handler reads the cursor, awaits up to 64 summary fetches, then
+        /// writes the cursor back, so two overlapping invocations for one peer
+        /// can both read the same start and build the same window. Inbound
+        /// messages are dispatched one task per message, so this is reachable
+        /// in production and a peer can provoke it deliberately. The comment at
+        /// the cursor-advance site accepts that cost as "one round"; this test
+        /// is that claim's evidence rather than its restatement.
+        ///
+        /// The load-bearing assertion is the progress floor: after `PAIRS`
+        /// concurrent pairs run back to back with no sequential round between
+        /// them, the union of what was advertised must be at least
+        /// `PAIRS * 64` contracts — i.e. every pair advanced the rotation by at
+        /// least one window even in the worst interleaving. Losing MORE than
+        /// one round per pair, or losing the cursor entirely and re-sending the
+        /// same window forever, both fail here. The bound holds for any
+        /// interleaving, so the test does not depend on the scheduler
+        /// reproducing a particular one: a genuinely concurrent run and a
+        /// serialised run both satisfy it, and only a broken rotation does not.
+        ///
+        /// Multi-threaded flavour with `spawn` on purpose: an earlier version
+        /// of this test used `join!` on a current-thread runtime and the two
+        /// futures did NOT overlap — it passed while exercising nothing.
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn concurrent_interests_from_one_peer_cost_at_most_one_round() {
+            const PAIRS: usize = 3;
+            let h = build_harness("hf-bound-concurrent", 17170, vec![7u8; 64]).await;
+            let keys = host_many(&h, 400);
+            let hashes = distinct_hashes(&keys);
+            let expected: HashSet<u32> = hashes.iter().copied().collect();
+            let ids: HashSet<ContractInstanceId> = keys.iter().map(|k| *k.id()).collect();
+
+            let mut covered: HashSet<u32> = HashSet::new();
+            for pair in 0..PAIRS {
+                let spawn_one = || {
+                    let op_manager = Arc::clone(&h.op_manager);
+                    let hashes = hashes.clone();
+                    let peer = h.old_peer;
+                    tokio::spawn(async move {
+                        handle_interest_sync_message(
+                            &op_manager,
+                            peer,
+                            InterestMessage::Interests { hashes },
+                        )
+                        .await
+                    })
+                };
+                let (first, second) = tokio::join!(spawn_one(), spawn_one());
+
+                for (which, joined) in [("first", first), ("second", second)] {
+                    match joined.expect("handler task panicked") {
+                        Some(InterestMessage::Summaries { entries, .. }) => {
+                            assert!(
+                                entries.len() <= 64,
+                                "pair {pair} {which} reply carried {} entries; the \
+                                 per-reply bound must hold regardless of overlap",
+                                entries.len()
+                            );
+                            assert!(summary_bytes_of(&entries) <= 9 * 1024 + h.our_summary.len());
+                            covered.extend(entries.iter().map(|e| e.hash));
+                        }
+                        other => panic!("pair {pair} {which} reply was {other:?}"),
+                    }
+                }
+
+                // The cursor must still name a contract that exists, not a
+                // value torn between the two writers.
+                let cursor = h
+                    .op_manager
+                    .interest_manager
+                    .peek_fallback_cursor(h.old_peer)
+                    .expect("a fallback reply must leave a cursor");
+                assert!(
+                    ids.contains(&cursor),
+                    "after pair {pair} the cursor is no longer a member of the \
+                     shared set — concurrent writers corrupted the rotation \
+                     rather than merely duplicating a window"
+                );
+            }
+
+            assert!(
+                covered.len() >= PAIRS * 64,
+                "{PAIRS} concurrent pairs advertised only {} distinct contracts; \
+                 each pair must advance the rotation by at least one 64-entry \
+                 window, so the overlap cost more than the one round the \
+                 cursor-advance comment claims",
+                covered.len()
+            );
+
+            // And the rotation still completes from there.
+            for _ in 0..hashes.len().div_ceil(64) {
+                match handle_interest_sync_message(
+                    &h.op_manager,
+                    h.old_peer,
+                    InterestMessage::Interests {
+                        hashes: hashes.clone(),
+                    },
+                )
+                .await
+                {
+                    Some(InterestMessage::Summaries { entries, .. }) => {
+                        covered.extend(entries.iter().map(|e| e.hash));
+                    }
+                    other => panic!("expected full bytes, got {other:?}"),
+                }
+            }
+            assert_eq!(
+                covered.len(),
+                expected.len(),
+                "{} contracts still unadvertised after the concurrent pairs plus \
+                 a full sequential cycle",
+                expected.difference(&covered).count()
+            );
+        }
+
         /// The rotation bounds what we ADVERTISE, never who we consider a
         /// broadcast target.
         ///

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -2861,6 +2861,15 @@ const MAX_FALLBACK_SUMMARIES_PER_REPLY: usize = 64;
 /// same links is a multi-megabyte message every 5 minutes; there is no setting
 /// of this constant that is both cheap and fast, which is the argument for
 /// repairing the version gate (#5156 / #5161) rather than tuning here.
+///
+/// # Before retuning either constant, get the field reading
+///
+/// Everything above is a MODEL, derived from fleet averages. That is how the
+/// entry cap came to be sized off a mean of 143 B/entry when the population it
+/// governs is nothing like the mean — the error survived review of the
+/// arithmetic because no counter contradicted it. **#5169** adds
+/// entries-per-reply and bytes-per-reply on this path. Do not move either
+/// constant on the strength of another average; read the distribution.
 const MAX_FALLBACK_SUMMARY_BYTES_PER_REPLY: usize = 9 * 1024;
 
 /// Which wire form a multi-entry `Summaries` reply to a peer takes.

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -2867,9 +2867,13 @@ const MAX_FALLBACK_SUMMARIES_PER_REPLY: usize = 64;
 /// Everything above is a MODEL, derived from fleet averages. That is how the
 /// entry cap came to be sized off a mean of 143 B/entry when the population it
 /// governs is nothing like the mean — the error survived review of the
-/// arithmetic because no counter contradicted it. **#5169** adds
+/// arithmetic because no counter contradicted it. **#5168** adds
 /// entries-per-reply and bytes-per-reply on this path. Do not move either
 /// constant on the strength of another average; read the distribution.
+///
+/// Those counters are also the cleanest read on #5161: as gateway links learn
+/// peer versions and stop taking this path at all, they should fall toward
+/// zero.
 const MAX_FALLBACK_SUMMARY_BYTES_PER_REPLY: usize = 9 * 1024;
 
 /// Which wire form a multi-entry `Summaries` reply to a peer takes.

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -2752,18 +2752,23 @@ fn classify_summary_digest(
 ///
 /// The digest form is derived from the very `SummaryEntry` values we would
 /// otherwise have sent, so the two forms cannot describe different state: the
-/// digest is a pure function of the exact bytes the fallback carries. Callers
-/// therefore build entries exactly as before and let this decide the encoding.
+/// digest is a pure function of the exact bytes the fallback carries.
 ///
 /// Fail-closed on an unknown peer version (see
 /// [`crate::node::HASH_FIRST_SUMMARIES_MIN_VERSION`]): the fallback is what
 /// every peer does today, so the cost of guessing wrong is bandwidth, never
 /// convergence.
 ///
-/// # Only the two MULTI-ENTRY reply legs use this (#4965 review §2)
+/// # Only the MULTI-ENTRY reply legs use this (#4965 review §2)
 ///
-/// `InterestsReply` and `ChangeInterestsReply` route through here. The two
-/// single-entry legs — `Notification` and `Rejection` — call
+/// `ChangeInterestsReply` routes through here. `InterestsReply` no longer
+/// does: #5155 needs the form BEFORE it builds entries, so that it can bound
+/// what the full-bytes fallback carries, and it calls [`summary_reply_form`]
+/// and [`summaries_reply_in_form`] separately rather than reading the gate
+/// twice. The encoding decision is identical; only the point at which it is
+/// taken moved.
+///
+/// The two single-entry legs — `Notification` and `Rejection` — call
 /// [`full_summaries_message`] directly and ship full bytes this release.
 ///
 /// The reason is evidential, not technical: the 98.1% agreement rate that
@@ -2793,8 +2798,22 @@ pub(crate) fn summaries_reply_for_peer(
 /// 64 comes from tying the fallback's cost to the digest message it stands in
 /// for: a digest reply over the same set is 265.91 x 21 B ~= 5.6 KB, and a
 /// full-bytes entry averages 143 B, so ~39 entries is break-even. 64 spends
-/// about 9.2 KB to halve how long a rotation takes to come back round — 5
-/// rounds rather than 9 over a 266-contract set.
+/// about 9.2 KB for a shorter rotation.
+///
+/// # This is the SECONDARY bound, and on a real fallback link it is inert
+///
+/// 143 B/entry is the interests_reply average across the whole fleet, which is
+/// dominated by 21-byte digest entries and by entries for contracts the sender
+/// does not host (those carry no summary at all). It does not describe the
+/// population that takes this path. A peer whose shared set is mostly hosted
+/// River rooms carries ~16.7 KB per entry, so
+/// [`MAX_FALLBACK_SUMMARY_BYTES_PER_REPLY`] binds after the first hosted
+/// contract and this cap is never reached.
+///
+/// The entry cap is therefore best read as the guard for the OPPOSITE
+/// extreme — a wide set of contracts we do not host, where each entry costs
+/// almost nothing and the byte budget would never bind — not as the number
+/// that governs how fast the rotation turns. Quote the byte budget for that.
 const MAX_FALLBACK_SUMMARIES_PER_REPLY: usize = 64;
 
 /// Byte budget for one full-bytes summary fallback reply (#5155).
@@ -2817,6 +2836,31 @@ const MAX_FALLBACK_SUMMARIES_PER_REPLY: usize = 64;
 /// summary alone exceeds the budget still gets sent rather than stalling the
 /// rotation forever. That trade is deliberate: a single oversized summary is
 /// bounded by the contract, an unbounded reply is not.
+///
+/// # What this actually costs, in rounds
+///
+/// Because the budget usually binds before the entry cap, the cycle length is
+/// governed by BYTES, not by entry count:
+///
+/// ```text
+/// rounds per cycle ~= total summary bytes for the shared set / 9 KiB
+/// ```
+///
+/// For the heaviest links this change targets — the reconstructed ~1.16 MB
+/// reply behind the 1.26 MB largest message observed in the field — that is
+/// ~130 rounds at a 5-minute heartbeat, so **on the order of ten hours** to
+/// come back round, not the ~25 minutes a naive `ceil(266 / 64)` reading
+/// suggests. Worst case, a set where every summary exceeds the whole budget,
+/// it degenerates to one contract per round.
+///
+/// That is the real, stated cost of this bound. It is defensible because this
+/// is the backstop layer and not the delivery path — the event-driven paths
+/// (push-on-update, request-full-state-when-too-far-behind, resend-on-failed-
+/// patch) are untouched and still bound detection for any contract anybody
+/// touches — but it must not be quoted as minutes. The alternative on those
+/// same links is a multi-megabyte message every 5 minutes; there is no setting
+/// of this constant that is both cheap and fast, which is the argument for
+/// repairing the version gate (#5156 / #5161) rather than tuning here.
 const MAX_FALLBACK_SUMMARY_BYTES_PER_REPLY: usize = 9 * 1024;
 
 /// Which wire form a multi-entry `Summaries` reply to a peer takes.
@@ -3087,25 +3131,29 @@ async fn handle_interest_sync_message(
             // Positions in `matching` whose summaries this reply carries, in the
             // order they are charged against the byte budget.
             //
-            // Digests: every contract, in the set's own order — unchanged.
+            // `None` means every contract in the set's own order: the digest
+            // path, unchanged, and deliberately WITHOUT materialising an
+            // identity permutation — that would put an allocation the size of
+            // the shared set on the hot path this change claims not to touch.
             //
-            // FullBytes: a bounded window that rotates from where the last
-            // reply to this peer stopped, so successive rounds cover the whole
-            // set instead of re-sending the same prefix forever. The resume
-            // point is derived from the last contract id SENT rather than a
-            // stored index, which is what makes it survive contracts being
-            // added and removed between rounds — see `first_index_after`.
-            let order: Vec<usize> = match form {
-                SummaryReplyForm::Digests => (0..matching.len()).collect(),
+            // `Some(window)` is the full-bytes fallback: a bounded window that
+            // rotates from where the last reply to this peer stopped, so
+            // successive rounds cover the whole set instead of re-sending the
+            // same prefix forever. The resume point is derived from the last
+            // contract id SENT rather than a stored index, which is what makes
+            // it survive contracts being added and removed between rounds — see
+            // `first_index_after`.
+            let window: Option<Vec<usize>> = match form {
+                SummaryReplyForm::Digests => None,
                 SummaryReplyForm::FullBytes => {
                     let start = op_manager
                         .interest_manager
                         .fallback_window_start(source, &matching);
-                    crate::ring::interest::rotation_window_indices(
+                    Some(crate::ring::interest::rotation_window_indices(
                         matching.len(),
                         start,
                         MAX_FALLBACK_SUMMARIES_PER_REPLY,
-                    )
+                    ))
                 }
             };
 
@@ -3151,15 +3199,21 @@ async fn handle_interest_sync_message(
             }
 
             // Build the summaries this reply carries, in rotation order.
-            let mut entries = Vec::with_capacity(order.len());
+            let reply_len = window.as_ref().map_or(matching.len(), |w| w.len());
+            let mut entries = Vec::with_capacity(reply_len);
             let mut summary_bytes_used = 0usize;
             let mut last_included: Option<ContractInstanceId> = None;
-            for idx in order {
-                let contract = matching[idx];
-                // #5155 byte budget. Checked BEFORE the entry rather than after,
-                // and never against an empty reply, so every round carries at
-                // least one contract and the rotation cannot stall on a summary
-                // larger than the whole budget. See
+            for pos in 0..reply_len {
+                let contract = matching[window.as_ref().map_or(pos, |w| w[pos])];
+                // #5155 byte budget. The check is RETROSPECTIVE — it asks
+                // whether the budget is already spent, not whether this entry
+                // would breach it — which is what guarantees the first entry
+                // always goes out and a summary larger than the whole budget
+                // cannot stall the rotation behind it. `entries.is_empty()` is
+                // belt-and-braces: the accumulator only grows once an entry is
+                // pushed, so it is implied today, and it is here so that a
+                // future edit charging bytes for skipped entries cannot turn
+                // this into a reply that carries nothing. See
                 // `MAX_FALLBACK_SUMMARY_BYTES_PER_REPLY`.
                 if form == SummaryReplyForm::FullBytes
                     && !entries.is_empty()
@@ -3182,6 +3236,21 @@ async fn handle_interest_sync_message(
             // Advance the rotation to what was actually SENT. A budget cut
             // short of the selected window must not advance past the entries it
             // dropped, or they wait a full cycle instead of coming next.
+            //
+            // Two known imprecisions here, both accepted, both costing at most
+            // one cycle of delay for the affected contracts and neither able to
+            // skip one permanently (the window wraps, and a cycle boundary
+            // restarts at a random offset):
+            //
+            // - This advances on send ATTEMPT. The reply is handed to the
+            //   connection afterwards and a send failure is only logged, so a
+            //   dropped reply costs those contracts a cycle. Making it
+            //   delivery-driven would need an ack this exchange does not have.
+            // - Two `Interests` from the same peer handled concurrently both
+            //   read the same start and build the same window, losing one
+            //   round of progress. Reserving the window at read time instead
+            //   would trade that for a worse failure: a budget-cut round would
+            //   then skip everything it did not reach.
             if form == SummaryReplyForm::FullBytes {
                 if let Some(last) = last_included {
                     op_manager
@@ -3873,12 +3942,17 @@ async fn handle_interest_sync_message(
             //
             // No separate rate limit, deliberately: a peer that wanted to
             // force this work could already do so by spamming `Interests`,
-            // which runs the identical `get_matching_contracts` +
+            // which runs the same `get_matching_contracts` +
             // `summary_if_hosted_or_in_use` loop AND additionally rewrites its
-            // interest registrations. This arm is strictly the cheaper of the
-            // two, so it adds no amplification surface that is not already
-            // reachable — and the summaries themselves are memoized on the
-            // state hash, so repeats do not re-enter WASM.
+            // interest registrations. Since #5155 the two loops are no longer
+            // literally identical — the `Interests` arm windows its summary
+            // fetches for full-bytes peers — but the conclusion is unchanged
+            // and now rests on WHO can reach this arm: only a peer that
+            // negotiated digests sends `SummaryRequest`, and a digest-capable
+            // peer still gets the unwindowed loop on `Interests`. So this arm
+            // is still no cheaper to abuse than one that peer already has, and
+            // the summaries themselves are memoized on the state hash, so
+            // repeats do not re-enter WASM.
             let bounded = &hashes[..hashes.len().min(MAX_SUMMARY_HASHES_PER_MESSAGE)];
             let matching = op_manager.interest_manager.get_matching_contracts(bounded);
             let mut entries = Vec::with_capacity(matching.len());
@@ -9077,10 +9151,16 @@ mod tests {
                         "the reply must still carry something — a bound that \
                          sends nothing is not a bound, it is a silent outage"
                     );
+                    // ABSOLUTE literals, deliberately not the constants. An
+                    // assertion written against the constant that produced the
+                    // value moves with any regression to it and can never fail:
+                    // raising the cap to 100k would leave `entries.len() <=
+                    // MAX_FALLBACK_SUMMARIES_PER_REPLY` true and this test
+                    // green while the field message went back to megabytes.
                     assert!(
-                        entries.len() <= MAX_FALLBACK_SUMMARIES_PER_REPLY,
+                        entries.len() <= 64,
                         "fallback reply carried {} entries against {} shared \
-                         contracts; the cap is {MAX_FALLBACK_SUMMARIES_PER_REPLY}",
+                         contracts; the intended cap is 64",
                         entries.len(),
                         hashes.len()
                     );
@@ -9089,9 +9169,19 @@ mod tests {
                     // the first. See `MAX_FALLBACK_SUMMARY_BYTES_PER_REPLY`.
                     let bytes = summary_bytes_of(&entries);
                     assert!(
-                        bytes <= MAX_FALLBACK_SUMMARY_BYTES_PER_REPLY + h.our_summary.len(),
+                        bytes <= 9 * 1024 + h.our_summary.len(),
                         "fallback reply carried {bytes} summary bytes, over the \
-                         {MAX_FALLBACK_SUMMARY_BYTES_PER_REPLY} budget plus one entry"
+                         intended 9 KiB budget plus one entry"
+                    );
+                    // Pin which limit is doing the work in THIS fixture, so a
+                    // regression to either one is caught rather than masked by
+                    // the other. 64-byte summaries: 64 entries is 4 KB, well
+                    // under the byte budget, so the entry cap must bind exactly.
+                    assert_eq!(
+                        entries.len(),
+                        64,
+                        "premise: with 64-byte summaries the ENTRY cap should be \
+                         the binding constraint at 2,448 shared contracts"
                     );
                 }
                 other => panic!("a version-unknown peer must get full bytes, got {other:?}"),
@@ -9161,6 +9251,17 @@ mod tests {
             );
             let keys = host_many(&h, 8);
             let hashes = distinct_hashes(&keys);
+
+            // Seed the cursor so both rounds are mid-cycle and the starting
+            // offset is fixed. Without this the first round would begin at a
+            // random cycle-boundary offset (see `fallback_window_start`) and a
+            // start on the last contract would wrap into a second random draw,
+            // making the "moved on to a different contract" assertion flaky.
+            let mut sorted = keys.clone();
+            sorted.sort_by(|a, b| a.id().as_bytes().cmp(b.id().as_bytes()));
+            h.op_manager
+                .interest_manager
+                .record_fallback_cursor(h.old_peer, *sorted[0].id());
 
             let mut seen: Vec<u32> = Vec::new();
             for round in 0..2 {
@@ -9270,6 +9371,74 @@ mod tests {
                  the rotation still had not advertised {} of the shared contracts",
                 hashes.len(),
                 expected.difference(&covered).count()
+            );
+        }
+
+        /// When summaries are large the byte budget, not the entry cap, sets
+        /// the cycle length — and the cycle is then FAR longer than
+        /// `ceil(n / 64)` rounds.
+        ///
+        /// This test exists to stop the comfortable number being quoted. The
+        /// PR-level claim is naturally read as "a divergence is noticed within
+        /// ceil(266/64) ~= 5 heartbeats, about 25 minutes"; that holds only in
+        /// the regime where entries are cheap. Here every summary is 5 KB, so
+        /// a round carries two entries and covering 40 contracts takes ~20
+        /// rounds, not 1. At a 5-minute heartbeat that is a bit over an hour,
+        /// and for a set of River-sized summaries it is longer still.
+        ///
+        /// If someone later makes the budget adaptive, or reworks the bound so
+        /// the entry cap governs again, this test SHOULD fail — and its failure
+        /// means the cost story in the PR needs rewriting, not that the test
+        /// needs relaxing.
+        #[tokio::test]
+        async fn heavy_summaries_make_the_cycle_far_longer_than_the_entry_cap_suggests() {
+            let h = build_harness("hf-bound-cycle-cost", 17160, vec![4u8; 5000]).await;
+            let keys = host_many(&h, 40);
+            let hashes = distinct_hashes(&keys);
+            let expected: HashSet<u32> = hashes.iter().copied().collect();
+
+            // The optimistic reading: entry cap only.
+            let optimistic_rounds = hashes.len().div_ceil(64);
+            assert_eq!(
+                optimistic_rounds, 1,
+                "premise: 40 contracts is one round under the entry cap alone"
+            );
+
+            let mut covered: HashSet<u32> = HashSet::new();
+            let mut rounds_taken = 0usize;
+            for _ in 0..200 {
+                rounds_taken += 1;
+                let reply = handle_interest_sync_message(
+                    &h.op_manager,
+                    h.old_peer,
+                    InterestMessage::Interests {
+                        hashes: hashes.clone(),
+                    },
+                )
+                .await;
+                match reply {
+                    Some(InterestMessage::Summaries { entries, .. }) => {
+                        covered.extend(entries.iter().map(|e| e.hash));
+                    }
+                    other => panic!("expected full bytes, got {other:?}"),
+                }
+                if covered == expected {
+                    break;
+                }
+            }
+
+            assert_eq!(
+                covered, expected,
+                "the rotation must still reach every contract — slower is the \
+                 accepted cost, never-covered is not"
+            );
+            assert!(
+                rounds_taken > optimistic_rounds * 5,
+                "premise of this test: with 5 KB summaries the byte budget must \
+                 dominate, making the real cycle much longer than the \
+                 {optimistic_rounds}-round entry-cap reading. It took \
+                 {rounds_taken}. If this now passes quickly, the cost model in \
+                 the PR and in MAX_FALLBACK_SUMMARY_BYTES_PER_REPLY is stale."
             );
         }
 
@@ -10181,12 +10350,24 @@ mod tests {
                  full_summaries_message — the instrumented full-bytes \
                  constructor"
             );
-            assert!(
-                !body.contains("summaries_reply_for_peer"),
-                "the SummaryRequest arm must NOT route through \
-                 summaries_reply_for_peer: answering a request for bytes with \
-                 digests loops the exchange (digests → request → digests → …)"
-            );
+            // Every entry point to the encoding CHOICE, not just the original
+            // one. #5155 split `summaries_reply_for_peer` into
+            // `summary_reply_form` + `summaries_reply_in_form`, and neither new
+            // name is a substring of the old one — so a future edit routing
+            // this arm through the split pair would reintroduce the
+            // digests → request → digests loop with this pin still green.
+            for banned in [
+                "summaries_reply_for_peer",
+                "summary_reply_form",
+                "summaries_reply_in_form",
+            ] {
+                assert!(
+                    !body.contains(banned),
+                    "the SummaryRequest arm must NOT route through {banned}: \
+                     answering a request for bytes with digests loops the \
+                     exchange (digests → request → digests → …)"
+                );
+            }
         }
 
         /// Source pin: the `SummaryDigests` arm must reach the heal through the

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -2779,20 +2779,105 @@ pub(crate) fn summaries_reply_for_peer(
     entries: Vec<crate::message::SummaryEntry>,
     emitter: crate::message::SummariesEmitter,
 ) -> crate::message::InterestMessage {
-    use crate::message::{InterestMessage, SummaryDigestEntry};
+    summaries_reply_in_form(summary_reply_form(op_manager, target), entries, emitter)
+}
 
+/// Maximum number of entries in one full-bytes summary fallback reply (#5155).
+///
+/// The fallback carries every shared contract's summary in a single message.
+/// At the measured 265.91 shared contracts and 16,675 B per summary that is a
+/// multi-megabyte message every 5 minutes, and the largest single message
+/// observed in the field was 1.26 MB. Bounding it is what stops one peer we
+/// cannot negotiate digests with from costing more than every peer we can.
+///
+/// 64 comes from tying the fallback's cost to the digest message it stands in
+/// for: a digest reply over the same set is 265.91 x 21 B ~= 5.6 KB, and a
+/// full-bytes entry averages 143 B, so ~39 entries is break-even. 64 spends
+/// about 9.2 KB to halve how long a rotation takes to come back round — 5
+/// rounds rather than 9 over a 266-contract set.
+const MAX_FALLBACK_SUMMARIES_PER_REPLY: usize = 64;
+
+/// Byte budget for one full-bytes summary fallback reply (#5155).
+///
+/// [`MAX_FALLBACK_SUMMARIES_PER_REPLY`] on its own does NOT bound the message.
+/// An entry carries a whole summary and summaries are not uniform: a contract
+/// we do not host contributes no summary bytes at all, while a River room
+/// contributes ~16.7 KB. The 143 B/entry that the entry cap is derived from is
+/// a fleet AVERAGE, so it describes the typical mix rather than the worst case,
+/// and 64 heavy entries is ~1.07 MB — the message class this change exists to
+/// remove, reproduced under a cap that looks like it forbids it.
+///
+/// 9 KiB is the same break-even target expressed in the unit that actually
+/// bounds the wire (64 x 143 B ~= 9.2 KB). On a typical mix it never binds and
+/// the entry cap governs; it binds exactly where the entry cap would have
+/// failed.
+///
+/// The budget is checked BEFORE adding each entry and never blocks the first
+/// one, so a reply is at most `budget + one summary` and a contract whose
+/// summary alone exceeds the budget still gets sent rather than stalling the
+/// rotation forever. That trade is deliberate: a single oversized summary is
+/// bounded by the contract, an unbounded reply is not.
+const MAX_FALLBACK_SUMMARY_BYTES_PER_REPLY: usize = 9 * 1024;
+
+/// Which wire form a multi-entry `Summaries` reply to a peer takes.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum SummaryReplyForm {
+    /// Peer is at or above the hash-first floor: 21-byte digests, whole shared
+    /// set every round. Unchanged by #5155.
+    Digests,
+    /// Peer is pre-floor, or its version is unknown: full summary bytes,
+    /// bounded and rotated (#5155).
+    FullBytes,
+}
+
+/// Resolve the reply's wire form ONCE, so the size decision and the encoding
+/// decision cannot disagree.
+///
+/// The caller needs the answer twice — to decide how many entries to build, and
+/// to encode them — and reading the version gate twice would open a window in
+/// which a reconnect changes it in between. The dangerous direction is known ->
+/// unknown: `record_remote_version` writes `None` THROUGH on the
+/// joiner->gateway path (`ring/connection_manager.rs`), clearing the entry, so
+/// a re-read could build the FULL entry set believing it was headed for digests
+/// and then encode it as full bytes. That is precisely the unbounded message
+/// this change removes, reassembled from two correct-looking halves. One read,
+/// threaded through.
+pub(crate) fn summary_reply_form(
+    op_manager: &OpManager,
+    target: std::net::SocketAddr,
+) -> SummaryReplyForm {
     if op_manager
         .ring
         .connection_manager
         .supports_hash_first_summaries(target)
     {
-        crate::config::GlobalTestMetrics::record_summary_digest_msg();
-        InterestMessage::SummaryDigests {
-            entries: entries.iter().map(SummaryDigestEntry::from_entry).collect(),
-            emitter,
-        }
+        SummaryReplyForm::Digests
     } else {
-        full_summaries_message(entries, emitter)
+        SummaryReplyForm::FullBytes
+    }
+}
+
+/// Encode `entries` in an already-resolved [`SummaryReplyForm`].
+///
+/// Split out of [`summaries_reply_for_peer`] so a caller that must know the
+/// form in advance (to bound what it builds) can reuse the one decision rather
+/// than taking a second, possibly different, reading of the gate.
+pub(crate) fn summaries_reply_in_form(
+    form: SummaryReplyForm,
+    entries: Vec<crate::message::SummaryEntry>,
+    emitter: crate::message::SummariesEmitter,
+) -> crate::message::InterestMessage {
+    use crate::message::{InterestMessage, SummaryDigestEntry};
+
+    match form {
+        SummaryReplyForm::Digests => {
+            crate::config::GlobalTestMetrics::record_summary_digest_msg();
+            InterestMessage::SummaryDigests {
+                entries: entries.iter().map(SummaryDigestEntry::from_entry).collect(),
+                emitter,
+            }
+        }
+        SummaryReplyForm::FullBytes => full_summaries_message(entries, emitter),
     }
 }
 
@@ -2992,19 +3077,46 @@ async fn handle_interest_sync_message(
             // Find contracts we share interest in
             let matching = op_manager.interest_manager.get_matching_contracts(&hashes);
 
-            // Build summaries for shared contracts and register/refresh peer interest
-            let mut entries = Vec::with_capacity(matching.len());
-            for contract in matching {
-                let hash = contract_hash(&contract);
-                // Only summarize contracts we host or actively serve; phantom
-                // peer-interest contracts (no state, no live subscriber) have
-                // nothing to advertise and their pointless GetSummaryQuery
-                // round-trips were the dominant #4473 storm. See
-                // `summary_if_hosted_or_in_use`.
-                let summary = summary_if_hosted_or_in_use(op_manager, &contract).await;
-                entries.push(SummaryEntry::from_summary(hash, summary.as_ref()));
+            // #5155: resolve the wire form BEFORE building anything, and take
+            // exactly one reading of the version gate (see
+            // `summary_reply_form`). A digest-capable peer keeps getting the
+            // whole shared set every round; only the full-bytes fallback is
+            // bounded, because only it pays per-contract summary bytes.
+            let form = summary_reply_form(op_manager, source);
 
-                if let Some(ref pk) = peer_key {
+            // Positions in `matching` whose summaries this reply carries, in the
+            // order they are charged against the byte budget.
+            //
+            // Digests: every contract, in the set's own order — unchanged.
+            //
+            // FullBytes: a bounded window that rotates from where the last
+            // reply to this peer stopped, so successive rounds cover the whole
+            // set instead of re-sending the same prefix forever. The resume
+            // point is derived from the last contract id SENT rather than a
+            // stored index, which is what makes it survive contracts being
+            // added and removed between rounds — see `first_index_after`.
+            let order: Vec<usize> = match form {
+                SummaryReplyForm::Digests => (0..matching.len()).collect(),
+                SummaryReplyForm::FullBytes => {
+                    let start = op_manager
+                        .interest_manager
+                        .fallback_window_start(source, &matching);
+                    crate::ring::interest::rotation_window_indices(
+                        matching.len(),
+                        start,
+                        MAX_FALLBACK_SUMMARIES_PER_REPLY,
+                    )
+                }
+            };
+
+            // Register/refresh peer interest for EVERY shared contract, not just
+            // the ones this round summarises. The rotation bounds what we
+            // ADVERTISE; interest bookkeeping decides who is a viable broadcast
+            // target, and rotating it would drop this peer out of the broadcast
+            // set for whatever fell outside the window — turning a bandwidth
+            // bound into missed updates.
+            if let Some(ref pk) = peer_key {
+                for contract in &matching {
                     // Refresh TTL for existing entries (preserves cached summary).
                     // Only register new interest if this is a genuinely new entry;
                     // otherwise register_peer_interest would overwrite the cached
@@ -3016,10 +3128,10 @@ async fn handle_interest_sync_message(
                     // per shared contract per heartbeat, so the clone was not free.
                     if !op_manager
                         .interest_manager
-                        .refresh_peer_interest(&contract, pk)
+                        .refresh_peer_interest(contract, pk)
                     {
                         let is_new = op_manager.interest_manager.register_peer_interest_from(
-                            &contract,
+                            contract,
                             pk.clone(),
                             None, // New entry; summary arrives in their Summaries response
                             false,
@@ -3031,10 +3143,50 @@ async fn handle_interest_sync_message(
                             // any deferred fresh-contract broadcast so a cold-id
                             // PUT that gave up with no targets reaches it.
                             op_manager
-                                .flush_pending_broadcast_on_interest(&contract)
+                                .flush_pending_broadcast_on_interest(contract)
                                 .await;
                         }
                     }
+                }
+            }
+
+            // Build the summaries this reply carries, in rotation order.
+            let mut entries = Vec::with_capacity(order.len());
+            let mut summary_bytes_used = 0usize;
+            let mut last_included: Option<ContractInstanceId> = None;
+            for idx in order {
+                let contract = matching[idx];
+                // #5155 byte budget. Checked BEFORE the entry rather than after,
+                // and never against an empty reply, so every round carries at
+                // least one contract and the rotation cannot stall on a summary
+                // larger than the whole budget. See
+                // `MAX_FALLBACK_SUMMARY_BYTES_PER_REPLY`.
+                if form == SummaryReplyForm::FullBytes
+                    && !entries.is_empty()
+                    && summary_bytes_used >= MAX_FALLBACK_SUMMARY_BYTES_PER_REPLY
+                {
+                    break;
+                }
+                let hash = contract_hash(&contract);
+                // Only summarize contracts we host or actively serve; phantom
+                // peer-interest contracts (no state, no live subscriber) have
+                // nothing to advertise and their pointless GetSummaryQuery
+                // round-trips were the dominant #4473 storm. See
+                // `summary_if_hosted_or_in_use`.
+                let summary = summary_if_hosted_or_in_use(op_manager, &contract).await;
+                summary_bytes_used += summary.as_ref().map_or(0, |s| s.as_ref().len());
+                entries.push(SummaryEntry::from_summary(hash, summary.as_ref()));
+                last_included = Some(*contract.id());
+            }
+
+            // Advance the rotation to what was actually SENT. A budget cut
+            // short of the selected window must not advance past the entries it
+            // dropped, or they wait a full cycle instead of coming next.
+            if form == SummaryReplyForm::FullBytes {
+                if let Some(last) = last_included {
+                    op_manager
+                        .interest_manager
+                        .record_fallback_cursor(source, last);
                 }
             }
 
@@ -3046,9 +3198,10 @@ async fn handle_interest_sync_message(
                 // is the change #5052 anticipated here: this emitter now sends
                 // DIGESTS to a capable peer, and the tag rides the full-bytes
                 // fallback so the per-emitter rollup keeps attributing it.
-                Some(summaries_reply_for_peer(
-                    op_manager,
-                    source,
+                // #5155 bounds the full-bytes side; `form` is the single gate
+                // reading both that bound and this encoding are taken from.
+                Some(summaries_reply_in_form(
+                    form,
                     entries,
                     SummariesEmitter::InterestsReply,
                 ))
@@ -8847,6 +9000,330 @@ mod tests {
                 Some(their_summary),
                 "their real summary must be cached once received"
             );
+        }
+
+        // ===== #5155: bounded, rotating full-bytes summary fallback =====
+
+        /// Host `n` additional contracts, all summarizable by the harness's
+        /// stand-in handler, and return them in advertisement order.
+        fn host_many(h: &Harness, n: u32) -> Vec<ContractKey> {
+            let mut keys = Vec::with_capacity(n as usize);
+            for i in 0..n {
+                let mut id = [0u8; 32];
+                id[0..4].copy_from_slice(&i.to_le_bytes());
+                id[4] = 0x5A;
+                let mut code = [0u8; 32];
+                code[0..4].copy_from_slice(&i.to_le_bytes());
+                code[4] = 0xC0;
+                let key =
+                    ContractKey::from_id_and_code(ContractInstanceId::new(id), CodeHash::new(code));
+                let _ = h
+                    .op_manager
+                    .ring
+                    .host_contract(key, 128, crate::ring::AccessType::Put);
+                h.op_manager.interest_manager.register_local_hosting(&key);
+                keys.push(key);
+            }
+            keys
+        }
+
+        /// Advertised hashes for `keys`, asserting they are pairwise distinct
+        /// so entry counts can be compared against contract counts.
+        fn distinct_hashes(keys: &[ContractKey]) -> Vec<u32> {
+            let hashes: Vec<u32> = keys.iter().map(contract_hash).collect();
+            assert_eq!(
+                hashes.iter().copied().collect::<HashSet<u32>>().len(),
+                hashes.len(),
+                "premise: the fixture's contract hashes must not collide, or \
+                 entry counts stop being comparable to contract counts"
+            );
+            hashes
+        }
+
+        fn summary_bytes_of(entries: &[SummaryEntry]) -> usize {
+            entries
+                .iter()
+                .filter_map(|e| e.summary_bytes.as_ref())
+                .map(|b| b.len())
+                .sum()
+        }
+
+        /// The fallback reply is bounded at the widest shared set observed in
+        /// the field (2,448 contracts), not merely at the fleet average.
+        ///
+        /// This is the whole point of #5155: `get_matching_contracts` returned
+        /// one full summary per shared contract with no send-side cap, and the
+        /// largest single message seen in production was 1.26 MB. The bound has
+        /// to hold at the tail, because the tail is where the bytes are.
+        #[tokio::test]
+        async fn fallback_reply_is_bounded_at_the_widest_observed_shared_set() {
+            let h = build_harness("hf-bound-wide", 17100, vec![7u8; 64]).await;
+            let keys = host_many(&h, 2448);
+            let hashes = distinct_hashes(&keys);
+
+            let reply = handle_interest_sync_message(
+                &h.op_manager,
+                h.old_peer,
+                InterestMessage::Interests {
+                    hashes: hashes.clone(),
+                },
+            )
+            .await;
+
+            match reply {
+                Some(InterestMessage::Summaries { entries, .. }) => {
+                    assert!(
+                        !entries.is_empty(),
+                        "the reply must still carry something — a bound that \
+                         sends nothing is not a bound, it is a silent outage"
+                    );
+                    assert!(
+                        entries.len() <= MAX_FALLBACK_SUMMARIES_PER_REPLY,
+                        "fallback reply carried {} entries against {} shared \
+                         contracts; the cap is {MAX_FALLBACK_SUMMARIES_PER_REPLY}",
+                        entries.len(),
+                        hashes.len()
+                    );
+                    // The byte bound is `budget + one entry` by construction:
+                    // the budget is checked before each entry and never blocks
+                    // the first. See `MAX_FALLBACK_SUMMARY_BYTES_PER_REPLY`.
+                    let bytes = summary_bytes_of(&entries);
+                    assert!(
+                        bytes <= MAX_FALLBACK_SUMMARY_BYTES_PER_REPLY + h.our_summary.len(),
+                        "fallback reply carried {bytes} summary bytes, over the \
+                         {MAX_FALLBACK_SUMMARY_BYTES_PER_REPLY} budget plus one entry"
+                    );
+                }
+                other => panic!("a version-unknown peer must get full bytes, got {other:?}"),
+            }
+        }
+
+        /// The entry cap alone does not bound the message, so the byte budget
+        /// has to bind first when summaries are large.
+        ///
+        /// Summaries are ~16.7 KB for a River room and near-zero for a contract
+        /// we do not host. The 143 B/entry the entry cap is derived from is a
+        /// fleet AVERAGE; 64 heavy entries is ~1.07 MB, which is the message
+        /// class this change exists to remove. Without this test the cap could
+        /// regress to entries-only and every other assertion here would still
+        /// pass.
+        #[tokio::test]
+        async fn fallback_byte_budget_binds_before_the_entry_cap() {
+            let h = build_harness("hf-bound-bytes", 17110, vec![9u8; 5000]).await;
+            let keys = host_many(&h, 200);
+            let hashes = distinct_hashes(&keys);
+
+            let reply = handle_interest_sync_message(
+                &h.op_manager,
+                h.old_peer,
+                InterestMessage::Interests { hashes },
+            )
+            .await;
+
+            match reply {
+                Some(InterestMessage::Summaries { entries, .. }) => {
+                    let bytes = summary_bytes_of(&entries);
+                    assert!(
+                        bytes > 0,
+                        "premise: the fixture's contracts must actually be \
+                         summarizable, or the byte budget is untested"
+                    );
+                    assert!(
+                        entries.len() < MAX_FALLBACK_SUMMARIES_PER_REPLY,
+                        "with 5 KB summaries the BYTE budget must bind before \
+                         the {MAX_FALLBACK_SUMMARIES_PER_REPLY}-entry cap; got \
+                         {} entries",
+                        entries.len()
+                    );
+                    assert!(
+                        bytes <= MAX_FALLBACK_SUMMARY_BYTES_PER_REPLY + h.our_summary.len(),
+                        "{bytes} summary bytes exceeds the budget plus one entry"
+                    );
+                }
+                other => panic!("expected full bytes, got {other:?}"),
+            }
+        }
+
+        /// A single summary larger than the whole budget still goes out, and
+        /// the rotation still advances past it.
+        ///
+        /// The alternative — refusing any entry that would breach the budget —
+        /// makes an oversized contract a permanent hole: it is never
+        /// advertised, and because the cursor never passes it, nothing behind
+        /// it is either. A stalled rotation is far worse than one oversized
+        /// message, so the budget never blocks the first entry.
+        #[tokio::test]
+        async fn oversized_summary_still_sends_and_the_rotation_advances() {
+            let h = build_harness("hf-bound-oversize", 17120, vec![3u8; 20_000]).await;
+            assert!(
+                h.our_summary.len() > MAX_FALLBACK_SUMMARY_BYTES_PER_REPLY,
+                "premise: this fixture's summary must exceed the whole budget"
+            );
+            let keys = host_many(&h, 8);
+            let hashes = distinct_hashes(&keys);
+
+            let mut seen: Vec<u32> = Vec::new();
+            for round in 0..2 {
+                let reply = handle_interest_sync_message(
+                    &h.op_manager,
+                    h.old_peer,
+                    InterestMessage::Interests {
+                        hashes: hashes.clone(),
+                    },
+                )
+                .await;
+                match reply {
+                    Some(InterestMessage::Summaries { entries, .. }) => {
+                        assert_eq!(
+                            entries.len(),
+                            1,
+                            "round {round}: exactly one oversized entry should \
+                             fit — more would breach the budget, none would stall"
+                        );
+                        seen.push(entries[0].hash);
+                    }
+                    other => panic!("round {round}: expected full bytes, got {other:?}"),
+                }
+            }
+            assert_ne!(
+                seen[0], seen[1],
+                "the rotation must move on to the next contract rather than \
+                 re-sending the same oversized one every heartbeat"
+            );
+        }
+
+        /// Digest-capable peers are completely unaffected: they keep receiving
+        /// every shared contract every round.
+        ///
+        /// #5155 bounds only the fallback. If the bound leaked onto the digest
+        /// path it would slow convergence for the 98% of links that are working
+        /// correctly, to save bytes that path was not spending.
+        #[tokio::test]
+        async fn digest_peer_still_receives_every_shared_contract() {
+            let h = build_harness("hf-bound-digest", 17130, vec![7u8; 64]).await;
+            let keys = host_many(&h, 200);
+            let hashes = distinct_hashes(&keys);
+
+            let reply = handle_interest_sync_message(
+                &h.op_manager,
+                h.new_peer,
+                InterestMessage::Interests {
+                    hashes: hashes.clone(),
+                },
+            )
+            .await;
+
+            match reply {
+                Some(InterestMessage::SummaryDigests { entries, .. }) => {
+                    assert_eq!(
+                        entries.len(),
+                        hashes.len(),
+                        "a hash-first peer must still get the whole shared set \
+                         ({} contracts) in one round, unbounded by \
+                         MAX_FALLBACK_SUMMARIES_PER_REPLY",
+                        hashes.len()
+                    );
+                }
+                other => panic!("a hash-first-capable peer must get digests, got {other:?}"),
+            }
+        }
+
+        /// Successive fallback replies rotate, so the whole shared set is
+        /// covered within `ceil(n / cap)` rounds rather than the same prefix
+        /// being re-sent forever.
+        ///
+        /// A hard cap with no rotation would be simpler and strictly worse:
+        /// everything past the first window would never be advertised to that
+        /// peer at all, turning a bandwidth fix into permanent silent
+        /// divergence.
+        #[tokio::test]
+        async fn fallback_rotation_covers_the_whole_shared_set() {
+            let h = build_harness("hf-bound-rotate", 17140, vec![7u8; 64]).await;
+            let keys = host_many(&h, 200);
+            let hashes = distinct_hashes(&keys);
+            let expected: HashSet<u32> = hashes.iter().copied().collect();
+            let rounds = hashes.len().div_ceil(MAX_FALLBACK_SUMMARIES_PER_REPLY);
+
+            let mut covered: HashSet<u32> = HashSet::new();
+            for round in 0..rounds {
+                let reply = handle_interest_sync_message(
+                    &h.op_manager,
+                    h.old_peer,
+                    InterestMessage::Interests {
+                        hashes: hashes.clone(),
+                    },
+                )
+                .await;
+                match reply {
+                    Some(InterestMessage::Summaries { entries, .. }) => {
+                        assert!(entries.len() <= MAX_FALLBACK_SUMMARIES_PER_REPLY);
+                        covered.extend(entries.iter().map(|e| e.hash));
+                    }
+                    other => panic!("round {round}: expected full bytes, got {other:?}"),
+                }
+            }
+
+            assert_eq!(
+                covered.len(),
+                expected.len(),
+                "after {rounds} rounds (ceil({}/{MAX_FALLBACK_SUMMARIES_PER_REPLY})) \
+                 the rotation still had not advertised {} of the shared contracts",
+                hashes.len(),
+                expected.difference(&covered).count()
+            );
+        }
+
+        /// The rotation bounds what we ADVERTISE, never who we consider a
+        /// broadcast target.
+        ///
+        /// Peer interest is registered for every shared contract, including the
+        /// ones outside this round's window. Rotating that too would drop the
+        /// peer out of the broadcast set for whatever fell outside, converting
+        /// a bandwidth bound into missed updates — a correctness bug wearing a
+        /// performance fix's clothes.
+        #[tokio::test]
+        async fn bounding_the_reply_does_not_bound_interest_registration() {
+            let h = build_harness("hf-bound-interest", 17150, vec![7u8; 64]).await;
+            let keys = host_many(&h, 200);
+            let hashes = distinct_hashes(&keys);
+
+            let reply = handle_interest_sync_message(
+                &h.op_manager,
+                h.old_peer,
+                InterestMessage::Interests {
+                    hashes: hashes.clone(),
+                },
+            )
+            .await;
+            let advertised: HashSet<u32> = match reply {
+                Some(InterestMessage::Summaries { ref entries, .. }) => {
+                    entries.iter().map(|e| e.hash).collect()
+                }
+                other => panic!("expected full bytes, got {other:?}"),
+            };
+            assert!(
+                advertised.len() < hashes.len(),
+                "premise: this round must NOT have advertised everything, or \
+                 the test cannot distinguish registered-for-all from \
+                 registered-for-the-window"
+            );
+
+            let pk = h.peer_key_of(h.old_peer);
+            let unadvertised: Vec<&ContractKey> = keys
+                .iter()
+                .filter(|k| !advertised.contains(&contract_hash(k)))
+                .collect();
+            assert!(!unadvertised.is_empty(), "premise: some contract was cut");
+            for key in unadvertised {
+                assert!(
+                    h.op_manager
+                        .interest_manager
+                        .get_peer_interest(key, &pk)
+                        .is_some(),
+                    "peer interest must be registered for {key} even though \
+                     this round's window did not advertise it"
+                );
+            }
         }
 
         /// Control for the test above: the same `Summaries` message, but

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -965,8 +965,12 @@ pub(crate) fn version_supports_summary_first_put(
 /// Consulted by `ConnectionManager::supports_hash_first_summaries`, which the
 /// digest-capable send sites check before choosing the digest form: the
 /// `Interests` and `ChangeInterests` replies in
-/// `node.rs::handle_interest_sync_message`, both via
-/// `node::summaries_reply_for_peer`.
+/// `node.rs::handle_interest_sync_message`. `ChangeInterests` reads it via
+/// `node::summaries_reply_for_peer`; `Interests` reads it via
+/// `node::summary_reply_form` and threads the answer through
+/// `node::summaries_reply_in_form`, because #5155 must know the form before it
+/// builds entries in order to bound the full-bytes fallback. Both are the same
+/// single reading of this gate.
 ///
 /// Two send sites deliberately do NOT consult it:
 ///

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -2599,7 +2599,8 @@ impl<T: TimeSource + Sync> InterestManager<T> {
 /// First index in `sorted` (ascending by contract id, as
 /// [`InterestManager::get_matching_contracts`] returns it) whose id is strictly
 /// greater than `after`. Returns `sorted.len()` when `after` is at or past the
-/// end, which the caller wraps to 0.
+/// end, which [`InterestManager::fallback_window_start`] reads as the end of a
+/// cycle and answers with a fresh random offset.
 ///
 /// This is the churn-safe half of the rotation. Because it is a binary search
 /// over ids rather than a stored offset, it behaves correctly when the set
@@ -6951,7 +6952,8 @@ mod tests {
              rather than stepping over it"
         );
 
-        // Cursor past the end: caller wraps to 0.
+        // Cursor at the end: signals a completed cycle to the caller, which
+        // restarts at a random offset rather than at 0.
         let beyond = *sorted[7].id();
         assert_eq!(first_index_after(&sorted, &beyond), sorted.len());
     }

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -137,9 +137,17 @@ const RESYNC_THROTTLE_CACHE_SIZE: usize = 4096;
 /// rotation cursor (#5155). Keyed by remote socket address, so it MUST be
 /// bounded — see the per-key-collection rule in `.claude/rules/code-style.md`.
 ///
-/// Eviction fails SAFE: a forgotten cursor restarts that peer's rotation at the
-/// start of the shared set, which re-sends summaries it has already seen. It
-/// can never skip one, which is the failure that would matter.
+/// Eviction costs a peer its place in the cycle, not coverage: a forgotten
+/// cursor restarts that peer's rotation at a random offset, so the contracts
+/// re-sent are ones it may have seen recently rather than ones it is owed.
+///
+/// The random restart is load-bearing here, not decoration. Under a fixed
+/// restart, a single eviction would be harmless, but SUSTAINED eviction — more
+/// concurrently-syncing fallback peers than cache slots — would return every
+/// peer to the head of its set every round and starve the tail permanently. The
+/// cap is well above `max_connections`, so that is not the expected regime; the
+/// randomisation is what makes it a slow cycle rather than a silent hole if it
+/// ever is. See [`InterestManager::fallback_window_start`].
 const SUMMARY_FALLBACK_CURSOR_CACHE_SIZE: usize = 4096;
 
 /// Bounds diagnostic correlation state influenced by remote (contract, peer)
@@ -2526,17 +2534,48 @@ impl<T: TimeSource + Sync> InterestManager<T> {
     /// the shared-contract set in [`Self::get_matching_contracts`] order
     /// (ascending by contract id).
     ///
-    /// Returns 0 when there is no cursor for this peer — the first fallback
-    /// reply of a connection, or after an LRU eviction — which restarts the
-    /// rotation at the beginning rather than skipping.
+    /// Mid-cycle this resumes immediately after the last contract SENT to that
+    /// peer, which is what makes successive windows contiguous in id space
+    /// (see [`first_index_after`]). At a cycle BOUNDARY — no cursor yet, the
+    /// cursor evicted or lost, or the previous window ending on the highest id
+    /// — the next cycle starts at a RANDOM offset rather than at 0.
     ///
-    /// See [`first_index_after`] for why the resume point is derived from the
-    /// stored id instead of a stored index.
+    /// A fixed restart at 0 is the failure this codebase has already rejected
+    /// twice, for the same reason each time: see the rotations in
+    /// `emit_stale_peer_syncs` and in the `SummaryDigests` arm, both of which
+    /// note that a fixed prefix "would starve the tail on every cycle
+    /// forever". The two ways to land back at a boundary repeatedly are both
+    /// reachable here, and neither needs an attacker:
+    ///
+    /// - The cursor is in-memory and keyed by address, so it is lost on our
+    ///   own restart, on LRU eviction, and whenever a peer reconnects from a
+    ///   new source port. A peer that reconnects more often than one cycle
+    ///   completes would, with a fixed restart, only ever be told about the
+    ///   head of the set.
+    /// - `sorted` is the INTERSECTION with the hash list the peer advertised,
+    ///   so the peer influences where the cursor lands. Advertising a single
+    ///   high-id contract parks the cursor at the end, and the following full
+    ///   round would restart at 0 — repeat, and everything past the first
+    ///   window is never advertised.
+    ///
+    /// Randomising the boundary costs nothing in the ordinary case: a cycle
+    /// beginning at any offset still advances contiguously and still covers
+    /// the whole set in `ceil(len / limit)` rounds, because the window wraps.
+    /// It only removes the guarantee that the SAME contracts are the ones
+    /// covered first every time.
+    ///
+    /// `GlobalRng` keeps this deterministic under simulation and test.
     pub(crate) fn fallback_window_start(&self, peer: SocketAddr, sorted: &[ContractKey]) -> usize {
+        if sorted.is_empty() {
+            return 0;
+        }
         let after = { self.summary_fallback_cursor.lock().peek(&peer).copied() };
-        match after {
-            Some(after) => first_index_after(sorted, &after),
-            None => 0,
+        let resumed = after.map(|after| first_index_after(sorted, &after));
+        match resumed {
+            // Mid-cycle: continue exactly where the last reply stopped.
+            Some(start) if start < sorted.len() => start,
+            // Cycle boundary (cursor absent, or exhausted past the end).
+            _ => crate::config::GlobalRng::random_range(0..sorted.len()),
         }
     }
 
@@ -2586,8 +2625,16 @@ pub(crate) fn first_index_after(sorted: &[ContractKey], after: &ContractInstance
 ///
 /// Wrapping is what makes the coverage argument hold. A window that stopped at
 /// the end of the set would give the tail a shorter turn than the head on every
-/// cycle; wrapping makes each round advance by a full `limit` entries, so a
-/// stable set of `len` contracts is covered in `ceil(len / limit)` rounds.
+/// cycle; wrapping makes each round advance by a full `limit` entries.
+///
+/// That gives `ceil(len / limit)` rounds to cover a stable set — but ONLY when
+/// every selected entry is actually sent. The caller may send fewer than the
+/// window it asked for (the byte budget in `node.rs` cuts a reply once it has
+/// spent its allowance) and then records the cursor against what it SENT, so
+/// the real cycle length is set by bytes rather than by entry count whenever
+/// summaries are large. See `MAX_FALLBACK_SUMMARY_BYTES_PER_REPLY` for the
+/// honest bound; do not quote `ceil(len / limit)` as the cycle time without
+/// checking which of the two limits binds.
 pub(crate) fn rotation_window_indices(len: usize, start: usize, limit: usize) -> Vec<usize> {
     if len == 0 || limit == 0 {
         return Vec::new();
@@ -6653,6 +6700,13 @@ mod tests {
 
     /// One round of the rotation over `sorted`, resuming after `cursor`.
     /// Returns the ids covered and the new cursor.
+    ///
+    /// `cursor: None` starts at index 0 here rather than at the random offset
+    /// production uses at a cycle boundary. That is deliberate: these tests
+    /// pin the WITHIN-cycle contiguity and coverage properties, which must hold
+    /// from any starting offset, so the tests below sweep the starts explicitly
+    /// instead of sampling them. `fallback_window_start_randomises_the_cycle_
+    /// boundary` covers the production entry point.
     fn rotation_round(
         sorted: &[ContractKey],
         cursor: Option<ContractInstanceId>,
@@ -6720,30 +6774,47 @@ mod tests {
     /// only trades detection LATENCY, never detection itself. If this fails,
     /// some contract is never advertised to that peer at all, which is
     /// permanent silent divergence rather than a slower safety net.
+    /// Coverage must hold from ANY starting offset, not just from index 0, and
+    /// for set sizes that do not divide evenly by the limit.
+    ///
+    /// Both conditions matter. Production starts each cycle at a random offset,
+    /// so a coverage property that only holds from 0 would not describe it. And
+    /// a set size divisible by the limit never produces a short final round,
+    /// which is exactly the case where a window that truncated at the end of
+    /// the set instead of wrapping would still look correct.
     #[test]
     fn rotation_covers_every_contract_within_ceil_n_over_limit_rounds() {
         const LIMIT: usize = 64;
-        for n in [1usize, 5, 63, 64, 65, 128, 266, 2448] {
+        for n in [1usize, 5, 63, 64, 65, 100, 128, 266, 2448] {
             let sorted = sorted_keys(0..n as u32);
             let expected: HashSet<ContractInstanceId> =
                 sorted.iter().map(|k| *k.id()).collect::<HashSet<_>>();
             let rounds = n.div_ceil(LIMIT);
 
-            let mut covered: HashSet<ContractInstanceId> = HashSet::new();
-            let mut cursor = None;
-            for _ in 0..rounds {
-                let (sent, next) = rotation_round(&sorted, cursor, LIMIT);
-                assert!(
-                    sent.len() <= LIMIT,
-                    "a round exceeded the entry bound at n={n}"
+            // Sweep the starting offsets a random cycle boundary could pick.
+            for first in [0usize, 1, n / 3, n / 2, n - 1] {
+                let mut covered: HashSet<ContractInstanceId> = HashSet::new();
+                // Seed the cursor so round one begins at `first`.
+                let mut cursor = if first == 0 {
+                    None
+                } else {
+                    Some(*sorted[first - 1].id())
+                };
+                for _ in 0..rounds {
+                    let (sent, next) = rotation_round(&sorted, cursor, LIMIT);
+                    assert!(
+                        sent.len() <= LIMIT,
+                        "a round exceeded the entry bound at n={n}"
+                    );
+                    covered.extend(sent);
+                    cursor = next;
+                }
+                assert_eq!(
+                    covered, expected,
+                    "n={n} starting at {first} was not fully covered in \
+                     {rounds} rounds (ceil({n}/{LIMIT}))"
                 );
-                covered.extend(sent);
-                cursor = next;
             }
-            assert_eq!(
-                covered, expected,
-                "n={n} was not fully covered in {rounds} rounds (ceil({n}/{LIMIT}))"
-            );
         }
     }
 
@@ -6885,27 +6956,105 @@ mod tests {
         assert_eq!(first_index_after(&sorted, &beyond), sorted.len());
     }
 
-    /// The stored cursor round-trips through the manager, and an unknown peer
-    /// starts at the beginning rather than at an arbitrary offset.
+    /// Mid-cycle the stored cursor round-trips and resumes deterministically,
+    /// and cursors do not leak between peers.
     #[test]
-    fn fallback_cursor_round_trips_and_defaults_to_the_start() {
+    fn fallback_cursor_round_trips_and_resumes_mid_cycle() {
         let (mgr, _clock) = make_manager();
         let peer: SocketAddr = "127.0.0.1:9100".parse().unwrap();
         let sorted = sorted_keys(0..8);
 
-        assert_eq!(
-            mgr.fallback_window_start(peer, &sorted),
-            0,
-            "a peer with no cursor must restart the rotation, not skip"
-        );
         assert_eq!(mgr.peek_fallback_cursor(peer), None);
 
         mgr.record_fallback_cursor(peer, *sorted[2].id());
         assert_eq!(mgr.peek_fallback_cursor(peer), Some(*sorted[2].id()));
-        assert_eq!(mgr.fallback_window_start(peer, &sorted), 3);
+        assert_eq!(
+            mgr.fallback_window_start(peer, &sorted),
+            3,
+            "mid-cycle the resume point must be exactly after the last id sent"
+        );
 
         // Cursors are per peer: one peer's progress must not advance another's.
         let other: SocketAddr = "127.0.0.1:9101".parse().unwrap();
-        assert_eq!(mgr.fallback_window_start(other, &sorted), 0);
+        mgr.record_fallback_cursor(other, *sorted[6].id());
+        assert_eq!(mgr.fallback_window_start(peer, &sorted), 3);
+        assert_eq!(mgr.fallback_window_start(other, &sorted), 7);
+
+        // An empty shared set has no valid offset; it must not panic or draw.
+        assert_eq!(mgr.fallback_window_start(peer, &[]), 0);
+    }
+
+    /// At a CYCLE BOUNDARY the start is random, not a fixed 0.
+    ///
+    /// A boundary is reached with no cursor (first reply, our own restart, LRU
+    /// eviction, a peer reconnecting on a new port) or with a cursor already at
+    /// the highest id. Restarting at 0 every time would re-send the head of the
+    /// set and starve the tail for any peer that keeps returning to a boundary,
+    /// which is the failure `emit_stale_peer_syncs` and the `SummaryDigests`
+    /// arm both already rotate to avoid.
+    ///
+    /// The peer influences this: `sorted` is the intersection with the hash
+    /// list it advertised, so advertising one high-id contract parks the cursor
+    /// at the end. With a fixed restart that alternation pins the window to the
+    /// head forever; with a random one it cannot.
+    #[test]
+    fn fallback_window_start_randomises_the_cycle_boundary() {
+        let (mgr, _clock) = make_manager();
+        let sorted = sorted_keys(0..64);
+
+        // No cursor: many draws, all in range, and not all the same value.
+        let mut seen = HashSet::new();
+        for i in 0..40u32 {
+            let peer: SocketAddr = format!("127.0.0.1:{}", 9200 + i).parse().unwrap();
+            let start = mgr.fallback_window_start(peer, &sorted);
+            assert!(start < sorted.len(), "start {start} out of range");
+            seen.insert(start);
+        }
+        assert!(
+            seen.len() > 1,
+            "a missing cursor must not always restart at the same offset — 40 \
+             draws over 64 contracts all landed on {seen:?}"
+        );
+
+        // Cursor at the highest id: also a boundary, also randomised.
+        let peer: SocketAddr = "127.0.0.1:9300".parse().unwrap();
+        let mut seen_wrapped = HashSet::new();
+        for _ in 0..40 {
+            mgr.record_fallback_cursor(peer, *sorted[sorted.len() - 1].id());
+            seen_wrapped.insert(mgr.fallback_window_start(peer, &sorted));
+        }
+        assert!(
+            seen_wrapped.iter().all(|s| *s < sorted.len()),
+            "wrapped start out of range"
+        );
+        assert!(
+            seen_wrapped.len() > 1,
+            "a cursor at the end of the set must restart at a random offset, \
+             not deterministically at 0 — got {seen_wrapped:?}"
+        );
+    }
+
+    /// Source pin: the cycle-boundary offset must come from `GlobalRng`.
+    ///
+    /// Two things ride on this and neither is visible in the behavioural test
+    /// above: a non-random restart re-opens the tail-starvation failure, and an
+    /// offset drawn from anything other than `GlobalRng` is not reproducible
+    /// under the deterministic simulation harness, which would make any
+    /// convergence simulation covering this path silently non-deterministic.
+    #[test]
+    fn fallback_window_start_draws_its_offset_from_global_rng() {
+        let src = include_str!("interest.rs");
+        let at = src
+            .find("pub(crate) fn fallback_window_start(")
+            .expect("fallback_window_start not found");
+        let body_end = at + src[at..].find("\n    }\n").expect("body end not found");
+        let body = &src[at..body_end];
+        assert!(
+            body.contains("GlobalRng::random_range"),
+            "the cycle-boundary offset is no longer drawn from GlobalRng — a \
+             fixed restart starves the tail of the set for any peer that keeps \
+             returning to a boundary, and a non-GlobalRng source breaks \
+             simulation determinism"
+        );
     }
 }

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -51,7 +51,7 @@
 //! This self-healing mechanism catches forgotten cleanup and prevents zombie interests.
 
 use dashmap::DashMap;
-use freenet_stdlib::prelude::{ContractKey, StateDelta, StateSummary};
+use freenet_stdlib::prelude::{ContractInstanceId, ContractKey, StateDelta, StateSummary};
 use lru::LruCache;
 use parking_lot::Mutex;
 use std::collections::{HashMap, HashSet};
@@ -132,6 +132,15 @@ pub(crate) const RESYNC_REQUEST_MIN_INTERVAL: Duration = Duration::from_secs(30)
 /// open: forgetting an entry merely permits one extra healing `ResyncRequest`,
 /// which is safe.
 const RESYNC_THROTTLE_CACHE_SIZE: usize = 4096;
+
+/// Bound on the number of peers tracked by the full-bytes summary fallback
+/// rotation cursor (#5155). Keyed by remote socket address, so it MUST be
+/// bounded — see the per-key-collection rule in `.claude/rules/code-style.md`.
+///
+/// Eviction fails SAFE: a forgotten cursor restarts that peer's rotation at the
+/// start of the shared set, which re-sends summaries it has already seen. It
+/// can never skip one, which is the failure that would matter.
+const SUMMARY_FALLBACK_CURSOR_CACHE_SIZE: usize = 4096;
 
 /// Bounds diagnostic correlation state influenced by remote (contract, peer)
 /// pairs. Eviction only loses classification detail; it never changes routing.
@@ -1018,6 +1027,36 @@ pub struct InterestManager<T: TimeSource> {
     /// issue #4857.
     resync_request_throttle: Mutex<LruCache<(ContractKey, SocketAddr), Instant>>,
 
+    /// Rotation cursor for the bounded full-bytes summary fallback (#5155),
+    /// keyed by the peer's socket address.
+    ///
+    /// Holds the contract id of the LAST entry included in that peer's previous
+    /// fallback reply — a KEY, not an index. That distinction is what preserves
+    /// the coverage BOUND when the shared set changes between rounds.
+    ///
+    /// A stored index names a position, and a removal below it shifts every
+    /// later contract down by one, so the resume lands one past where it should
+    /// and that contract goes unadvertised for the rest of the cycle. Wrapping
+    /// means it is eventually revisited, so the failure is not permanent
+    /// starvation — but "eventually" is not the property this change is sold
+    /// on. The whole safety argument is a stated upper bound on how long a
+    /// divergence can go unnoticed, and under ordinary contract churn an index
+    /// cursor degrades that from `ceil(n / limit)` rounds to no bound at all.
+    ///
+    /// A key resumes after what was actually SENT, so consecutive rounds are
+    /// contiguous in id space no matter what happened to the set in between:
+    /// an id inserted above the cursor is in the very next window, an id
+    /// inserted below it is picked up on the wrap, and a removed cursor id
+    /// still orders correctly against the rest because the comparison is
+    /// against the stored bytes rather than a lookup that could now fail.
+    /// `rotation_does_not_lose_the_coverage_bound_when_contracts_are_removed`
+    /// runs both designs over the same removal schedule and shows the index
+    /// one missing contracts the key one covers.
+    ///
+    /// Only the full-bytes fallback consults this. Digest-capable peers keep
+    /// receiving the complete set every round and never touch it.
+    summary_fallback_cursor: Mutex<LruCache<SocketAddr, ContractInstanceId>>,
+
     /// Count of concurrently-outstanding queue-full-resync retry tasks (#4862 P1).
     /// Bounds aggregate retry tasks node-wide, independent of the throttle LRU
     /// (which can evict active reservations under key churn). See
@@ -1086,6 +1125,10 @@ impl<T: TimeSource + Sync> InterestManager<T> {
             resync_request_throttle: Mutex::new(LruCache::new(
                 NonZeroUsize::new(RESYNC_THROTTLE_CACHE_SIZE)
                     .expect("RESYNC_THROTTLE_CACHE_SIZE must be > 0"),
+            )),
+            summary_fallback_cursor: Mutex::new(LruCache::new(
+                NonZeroUsize::new(SUMMARY_FALLBACK_CURSOR_CACHE_SIZE)
+                    .expect("SUMMARY_FALLBACK_CURSOR_CACHE_SIZE must be > 0"),
             )),
             missing_summary_history: Mutex::new(LruCache::new(
                 NonZeroUsize::new(MISSING_SUMMARY_HISTORY_SIZE)
@@ -2479,6 +2522,81 @@ impl<T: TimeSource + Sync> InterestManager<T> {
         contracts
     }
 
+    /// Index at which `peer`'s next full-bytes fallback window starts, given
+    /// the shared-contract set in [`Self::get_matching_contracts`] order
+    /// (ascending by contract id).
+    ///
+    /// Returns 0 when there is no cursor for this peer — the first fallback
+    /// reply of a connection, or after an LRU eviction — which restarts the
+    /// rotation at the beginning rather than skipping.
+    ///
+    /// See [`first_index_after`] for why the resume point is derived from the
+    /// stored id instead of a stored index.
+    pub(crate) fn fallback_window_start(&self, peer: SocketAddr, sorted: &[ContractKey]) -> usize {
+        let after = { self.summary_fallback_cursor.lock().peek(&peer).copied() };
+        match after {
+            Some(after) => first_index_after(sorted, &after),
+            None => 0,
+        }
+    }
+
+    /// Record the contract id of the last entry actually included in `peer`'s
+    /// fallback reply, so the next reply resumes after it.
+    ///
+    /// Takes what was SENT, not what was selected: the byte budget can cut a
+    /// window short, and advancing past entries we dropped would skip them
+    /// until the rotation wrapped all the way round.
+    pub(crate) fn record_fallback_cursor(&self, peer: SocketAddr, last_sent: ContractInstanceId) {
+        self.summary_fallback_cursor.lock().put(peer, last_sent);
+    }
+
+    /// Test accessor for the stored cursor.
+    #[cfg(test)]
+    pub(crate) fn peek_fallback_cursor(&self, peer: SocketAddr) -> Option<ContractInstanceId> {
+        self.summary_fallback_cursor.lock().peek(&peer).copied()
+    }
+}
+
+/// First index in `sorted` (ascending by contract id, as
+/// [`InterestManager::get_matching_contracts`] returns it) whose id is strictly
+/// greater than `after`. Returns `sorted.len()` when `after` is at or past the
+/// end, which the caller wraps to 0.
+///
+/// This is the churn-safe half of the rotation. Because it is a binary search
+/// over ids rather than a stored offset, it behaves correctly when the set
+/// changed since the cursor was recorded:
+///
+/// - The cursor's own contract removed: nothing else moves relative to the
+///   remaining ids, so the search still lands on the same successor.
+/// - A contract inserted BELOW the cursor: it sorts before the resume point and
+///   is picked up when the rotation wraps, not skipped.
+/// - A contract inserted ABOVE the cursor: it is inside the very next window.
+///
+/// An index-based cursor gets the removal case wrong: the position it named
+/// now holds a different contract, so the round steps over one. Wrapping means
+/// that contract is seen again eventually, so this is not permanent
+/// starvation — it is the loss of the `ceil(n / limit)` bound, which is the
+/// only thing that makes bounding the reply defensible in the first place.
+pub(crate) fn first_index_after(sorted: &[ContractKey], after: &ContractInstanceId) -> usize {
+    sorted.partition_point(|c| c.id().as_bytes() <= after.as_bytes())
+}
+
+/// Indices of the next rotation window: up to `limit` entries beginning at
+/// `start`, wrapping past the end of the set.
+///
+/// Wrapping is what makes the coverage argument hold. A window that stopped at
+/// the end of the set would give the tail a shorter turn than the head on every
+/// cycle; wrapping makes each round advance by a full `limit` entries, so a
+/// stable set of `len` contracts is covered in `ceil(len / limit)` rounds.
+pub(crate) fn rotation_window_indices(len: usize, start: usize, limit: usize) -> Vec<usize> {
+    if len == 0 || limit == 0 {
+        return Vec::new();
+    }
+    let start = if start >= len { 0 } else { start };
+    (0..limit.min(len)).map(|i| (start + i) % len).collect()
+}
+
+impl<T: TimeSource + Sync> InterestManager<T> {
     /// Cache a computed delta for reuse.
     pub fn cache_delta(
         &self,
@@ -6529,5 +6647,265 @@ mod tests {
             1,
             "the contract must have been consulted for the verdict"
         );
+    }
+
+    // ===== #5155: bounded, rotating full-bytes summary fallback =====
+
+    /// One round of the rotation over `sorted`, resuming after `cursor`.
+    /// Returns the ids covered and the new cursor.
+    fn rotation_round(
+        sorted: &[ContractKey],
+        cursor: Option<ContractInstanceId>,
+        limit: usize,
+    ) -> (Vec<ContractInstanceId>, Option<ContractInstanceId>) {
+        let start = match cursor {
+            Some(ref after) => first_index_after(sorted, after),
+            None => 0,
+        };
+        let sent: Vec<ContractInstanceId> = rotation_window_indices(sorted.len(), start, limit)
+            .into_iter()
+            .map(|i| *sorted[i].id())
+            .collect();
+        let next = sent.last().copied();
+        (sent, next)
+    }
+
+    /// `sorted` in the order `get_matching_contracts` produces (ascending by
+    /// contract id), which the rotation's binary search depends on.
+    fn sorted_keys(seeds: impl IntoIterator<Item = u32>) -> Vec<ContractKey> {
+        let mut keys: Vec<ContractKey> = seeds.into_iter().map(make_unique_contract_key).collect();
+        keys.sort_by(|a, b| a.id().as_bytes().cmp(b.id().as_bytes()));
+        keys
+    }
+
+    /// The window never exceeds the limit, never exceeds the set, and wraps
+    /// past the end rather than returning a short tail.
+    ///
+    /// The wrap is the part worth pinning: a window that truncated at the end
+    /// of the set would give the tail a smaller share of every cycle than the
+    /// head, so the "covered in ceil(n/k) rounds" claim below would be false
+    /// for exactly the contracts furthest from the cursor's starting point.
+    #[test]
+    fn rotation_window_is_bounded_and_wraps() {
+        assert!(rotation_window_indices(0, 0, 64).is_empty(), "empty set");
+        assert!(rotation_window_indices(10, 0, 0).is_empty(), "zero limit");
+
+        // Limit binds.
+        assert_eq!(rotation_window_indices(10, 0, 4), vec![0, 1, 2, 3]);
+        // Set size binds.
+        assert_eq!(rotation_window_indices(3, 0, 64), vec![0, 1, 2]);
+        // Wraps rather than truncating.
+        assert_eq!(rotation_window_indices(10, 8, 4), vec![8, 9, 0, 1]);
+        // A start past the end (every id below the cursor) restarts at 0
+        // instead of producing nothing, which would stall the rotation.
+        assert_eq!(rotation_window_indices(4, 4, 2), vec![0, 1]);
+        assert_eq!(rotation_window_indices(4, 99, 2), vec![0, 1]);
+
+        for len in [1usize, 2, 7, 64, 65, 266, 2448] {
+            for start in [0usize, 1, len / 2, len - 1] {
+                let w = rotation_window_indices(len, start, 64);
+                assert!(w.len() <= 64, "window exceeded the limit at len={len}");
+                assert!(w.len() <= len, "window exceeded the set at len={len}");
+                assert!(
+                    w.iter().collect::<HashSet<_>>().len() == w.len(),
+                    "window repeated an index at len={len} start={start}"
+                );
+            }
+        }
+    }
+
+    /// A stable shared set is fully covered within `ceil(n / limit)` rounds.
+    ///
+    /// This is the convergence claim the bound rests on: bounding the reply
+    /// only trades detection LATENCY, never detection itself. If this fails,
+    /// some contract is never advertised to that peer at all, which is
+    /// permanent silent divergence rather than a slower safety net.
+    #[test]
+    fn rotation_covers_every_contract_within_ceil_n_over_limit_rounds() {
+        const LIMIT: usize = 64;
+        for n in [1usize, 5, 63, 64, 65, 128, 266, 2448] {
+            let sorted = sorted_keys(0..n as u32);
+            let expected: HashSet<ContractInstanceId> =
+                sorted.iter().map(|k| *k.id()).collect::<HashSet<_>>();
+            let rounds = n.div_ceil(LIMIT);
+
+            let mut covered: HashSet<ContractInstanceId> = HashSet::new();
+            let mut cursor = None;
+            for _ in 0..rounds {
+                let (sent, next) = rotation_round(&sorted, cursor, LIMIT);
+                assert!(
+                    sent.len() <= LIMIT,
+                    "a round exceeded the entry bound at n={n}"
+                );
+                covered.extend(sent);
+                cursor = next;
+            }
+            assert_eq!(
+                covered, expected,
+                "n={n} was not fully covered in {rounds} rounds (ceil({n}/{LIMIT}))"
+            );
+        }
+    }
+
+    /// Contracts removed mid-cycle must not cost the rotation its coverage
+    /// BOUND: every contract still shared after `ceil(n / limit)` rounds must
+    /// have been advertised within those rounds.
+    ///
+    /// This is the property that justifies bounding the reply at all. The
+    /// safety argument is "a divergence goes unnoticed for at most one cycle",
+    /// and a cursor that loses entries under churn downgrades that to "at some
+    /// point", which is not a bound and not what the change was reviewed on.
+    ///
+    /// The second half runs the identical removal schedule with an INDEX
+    /// cursor. It is not permanently starved — wrapping revisits everything
+    /// eventually — but it does miss contracts inside the cycle, which is what
+    /// makes the assertion above discriminating rather than true of any cursor.
+    #[test]
+    fn rotation_does_not_lose_the_coverage_bound_when_contracts_are_removed() {
+        const LIMIT: usize = 4;
+        const N: usize = 12;
+        let rounds = N.div_ceil(LIMIT);
+        let full = sorted_keys(0..N as u32);
+
+        // Key-based cursor.
+        let mut sorted = full.clone();
+        let mut covered: HashSet<ContractInstanceId> = HashSet::new();
+        let mut cursor = None;
+        for _ in 0..rounds {
+            let (sent, next) = rotation_round(&sorted, cursor, LIMIT);
+            covered.extend(sent);
+            cursor = next;
+            // Drop the lowest-sorting contract, i.e. one at or below the
+            // cursor — the direction that shifts positions under a cursor
+            // that stored one.
+            if !sorted.is_empty() {
+                sorted.remove(0);
+            }
+        }
+        let survivors: HashSet<ContractInstanceId> = sorted.iter().map(|k| *k.id()).collect();
+        let missed: Vec<_> = survivors.difference(&covered).collect();
+        assert!(
+            missed.is_empty(),
+            "key cursor left {} still-shared contract(s) unadvertised within \
+             {rounds} rounds — the coverage bound the change is sold on",
+            missed.len()
+        );
+
+        // The same schedule with an INDEX cursor, as the control.
+        let mut sorted = full.clone();
+        let mut idx_covered: HashSet<ContractInstanceId> = HashSet::new();
+        let mut idx_cursor = 0usize;
+        for _ in 0..rounds {
+            let w = rotation_window_indices(sorted.len(), idx_cursor, LIMIT);
+            for i in &w {
+                idx_covered.insert(*sorted[*i].id());
+            }
+            // Resume at the position after the last one sent. Nothing records
+            // WHICH contract that was, which is the whole defect.
+            idx_cursor = w.last().map_or(0, |i| i + 1);
+            if !sorted.is_empty() {
+                sorted.remove(0);
+            }
+        }
+        let idx_survivors: HashSet<ContractInstanceId> = sorted.iter().map(|k| *k.id()).collect();
+        assert!(
+            !idx_survivors.is_subset(&idx_covered),
+            "premise of this test: under this removal schedule an index cursor \
+             is supposed to miss a contract inside the cycle. If it no longer \
+             does, the scenario stopped discriminating between the two designs \
+             and the assertion above proves nothing about the key cursor."
+        );
+    }
+
+    /// A contract added mid-cycle is picked up rather than waiting behind a
+    /// cursor that has already passed its position.
+    ///
+    /// Insertion ABOVE the cursor lands in the very next window; insertion
+    /// BELOW it is covered when the rotation wraps. Both are bounded, which is
+    /// the property that matters — neither is skipped indefinitely.
+    #[test]
+    fn rotation_picks_up_contracts_added_mid_cycle() {
+        const LIMIT: usize = 4;
+        let mut sorted = sorted_keys(0..12);
+        let mut cursor = None;
+        // Two rounds in, so the cursor sits in the middle of the set.
+        for _ in 0..2 {
+            let (_, next) = rotation_round(&sorted, cursor, LIMIT);
+            cursor = next;
+        }
+
+        // Add contracts on both sides of the cursor.
+        sorted = sorted_keys((0..12).chain(100..112));
+        let added: HashSet<ContractInstanceId> = sorted_keys(100..112)
+            .iter()
+            .map(|k| *k.id())
+            .collect::<HashSet<_>>();
+
+        let mut covered: HashSet<ContractInstanceId> = HashSet::new();
+        let rounds = sorted.len().div_ceil(LIMIT);
+        for _ in 0..rounds {
+            let (sent, next) = rotation_round(&sorted, cursor, LIMIT);
+            covered.extend(sent);
+            cursor = next;
+        }
+        let missed: Vec<_> = added.difference(&covered).collect();
+        assert!(
+            missed.is_empty(),
+            "{} newly added contract(s) were not covered within one full cycle",
+            missed.len()
+        );
+    }
+
+    /// `first_index_after` resumes correctly when the cursor's own contract is
+    /// the one that was removed — the cursor is compared as bytes, not looked
+    /// up, so a missing id still orders against the rest.
+    #[test]
+    fn first_index_after_handles_a_removed_cursor() {
+        let sorted = sorted_keys(0..8);
+        let cursor = *sorted[3].id();
+
+        assert_eq!(
+            first_index_after(&sorted, &cursor),
+            4,
+            "with the cursor present, resume at the next contract"
+        );
+
+        let mut without = sorted.clone();
+        without.remove(3);
+        let resumed = first_index_after(&without, &cursor);
+        assert_eq!(
+            *without[resumed].id(),
+            *sorted[4].id(),
+            "with the cursor's own contract gone, resume at the SAME successor \
+             rather than stepping over it"
+        );
+
+        // Cursor past the end: caller wraps to 0.
+        let beyond = *sorted[7].id();
+        assert_eq!(first_index_after(&sorted, &beyond), sorted.len());
+    }
+
+    /// The stored cursor round-trips through the manager, and an unknown peer
+    /// starts at the beginning rather than at an arbitrary offset.
+    #[test]
+    fn fallback_cursor_round_trips_and_defaults_to_the_start() {
+        let (mgr, _clock) = make_manager();
+        let peer: SocketAddr = "127.0.0.1:9100".parse().unwrap();
+        let sorted = sorted_keys(0..8);
+
+        assert_eq!(
+            mgr.fallback_window_start(peer, &sorted),
+            0,
+            "a peer with no cursor must restart the rotation, not skip"
+        );
+        assert_eq!(mgr.peek_fallback_cursor(peer), None);
+
+        mgr.record_fallback_cursor(peer, *sorted[2].id());
+        assert_eq!(mgr.peek_fallback_cursor(peer), Some(*sorted[2].id()));
+        assert_eq!(mgr.fallback_window_start(peer, &sorted), 3);
+
+        // Cursors are per peer: one peer's progress must not advance another's.
+        let other: SocketAddr = "127.0.0.1:9101".parse().unwrap();
+        assert_eq!(mgr.fallback_window_start(other, &sorted), 0);
     }
 }


### PR DESCRIPTION
## Problem

The hash-first summary exchange (#4965) picks a wire form per peer: 21-byte digests for peers at or above 0.2.116, full summary bytes otherwise. The fallback had **no send-side cap** — `get_matching_contracts` (`ring/interest.rs`) returns one complete summary per shared contract, and every one of them goes out in a single message. The 4096 cap at `node.rs` is receive-side only.

At the measured 265.91 shared contracts and 16,675 B per summary that is a multi-megabyte message every 5 minutes per such peer. The largest single message observed in the field is **1.26 MB** — a minority of links that cannot negotiate digests costs more than every link that can, combined. The summary arm is 23.7% of all outbound bytes.

To be precise about the share, since an earlier draft of this description overstated it: 85.3% of the arm's bytes are full summaries, but roughly half of that is the `Notification` leg (39.51 GB), which is single-entry by construction and never consults the version gate at all — `operations/update.rs` calls `full_summaries_message` directly, by the explicit #4965 review decision. This PR touches the unbounded fallback only, which is the **~39.5% of the arm** #5155 attributes to it, or ~9% of all outbound bytes.

Worth noting for reviewers, because it changes how you should weigh this PR: the gate declines on unknown version as well as on old version, and unknown is not rare. The joiner-to-gateway handshake carries no protocol version at all (`transport/connection_handler.rs` hardcodes `remote_protoc_version: None` on the `AckConnection` path), so every connection a node opens through a gateway reports an unknown version no matter how new that gateway is. Which of the two causes dominates is not yet measured — that is #5156 — and repairing the handshake is #5161. **This PR is the guard that makes the gate's failure cheap, not the repair.**

## Solution

Bound the fallback to a rotating window: at most **64 entries** and **9 KiB of summary bytes** per reply, resuming where the previous reply to that peer stopped, so a stable shared set is still covered in `ceil(n / 64)` rounds. `emit_stale_peer_syncs` is the in-tree precedent for the shape.

64 comes from tying the fallback's cost to the digest message it stands in for: a digest reply over the same set is 265.91 × 21 B ≈ 5.6 KB and a full-bytes entry averages 143 B, so ~39 entries is break-even; 64 spends ~9.2 KB to halve the rotation period.

Three decisions worth reviewing on their own terms:

**The byte budget is not redundant with the entry cap.** Summaries are not uniform — a contract we do not host contributes no bytes, a River room contributes ~16.7 KB — so 64 entries can still be ~1.07 MB, which is the message class this PR exists to remove, reproduced under a cap that looks like it forbids it. The 143 B/entry the entry cap derives from is a fleet *average*; it describes the typical mix, and the worst case is where the bytes are. The budget is checked before each entry and never blocks the first, so a reply is at most `budget + one summary` and an oversized summary cannot stall the rotation behind it.

**The cursor stores the last contract id SENT, not an index.** An index names a position, and a removal below it shifts every later contract down by one, so the resume steps over one. Wrapping means that contract is revisited eventually, so this is *not* permanent starvation — it is the loss of the `ceil(n / limit)` bound, which is the entire basis on which bounding the reply is defensible. `rotation_does_not_lose_the_coverage_bound_when_contracts_are_removed` runs both designs over one removal schedule and asserts the index one misses contracts the key one covers.

**Cycle boundaries start at a random offset, not at 0.** Mid-cycle the cursor resumes deterministically; at a boundary — no cursor, cursor evicted, or the previous window ending on the highest id — the next cycle begins at a random offset. A fixed restart at 0 is a tail-starvation failure this codebase has already rejected twice for the same reason, and it is reachable here two ways, neither needing an attacker: the cursor is in-memory and keyed by address, so it is lost on our restart, on eviction, and whenever a peer reconnects from a new port; and `sorted` is the intersection with the hash list the *peer* advertised, so alternating a full `Interests` with a single high-id one parks the cursor at the end and forces a restart every other round. A reviewer demonstrated 7 of 12 contracts never advertised over 50 cycles under that pattern. Randomising the boundary costs nothing — a cycle from any offset still covers the set in `ceil(n / limit)` rounds because the window wraps — and removes the fixed prefix.

**The version gate is read once.** The size decision and the encoding decision both need it, and two reads open a window where a reconnect changes the answer between them. The dangerous direction is known → unknown (`record_remote_version` writes `None` through, clearing the entry), which would build the full entry set believing it was headed for digests and then encode it as full bytes — the unbounded message, reassembled from two correct-looking halves. `summary_reply_form` resolves it once and the form is threaded through.

**Not changed:** digest-capable peers keep receiving the whole shared set every round. The `SummaryRequest` reply leg is untouched — it is demand-gated (it answers an explicit request for bytes, and replying with digests would loop the exchange). Note "demand-gated", not "bounded": its only hard limit is `MAX_SUMMARY_HASHES_PER_MESSAGE`, and only a digest-capable peer can reach it. `ChangeInterestsReply` is untouched: it is event-driven rather than periodic, so there is no guaranteed next round to rotate into, and a bound there could skip a newly-added interest indefinitely. Interest *registration* also stays unbounded — the rotation bounds what we advertise, never who counts as a broadcast target, since rotating that would convert a bandwidth bound into missed updates.

## Cost, stated honestly — and corrected

An earlier draft of this description put the cost at "~25 minutes for a typical 266-contract set", from `ceil(266 / 64)` heartbeats. **That number is wrong for the population this change actually affects, by roughly an order of magnitude**, and the review caught it.

`ceil(n / 64)` holds only when the entry cap is what binds. On a real fallback link it never is. The 143 B/entry the entry cap is derived from is a fleet average dominated by 21-byte digest entries and by entries for contracts the sender does not host, which carry no summary at all. A hosted River room carries ~16.7 KB — larger than the whole 9 KiB budget — so the budget binds after the first hosted contract in a round. The honest cycle length is:

```
rounds per cycle ~= total summary bytes for the shared set / 9 KiB
```

For the heaviest links, the ~1.16 MB reply behind the observed 1.26 MB maximum, that is ~130 rounds at a 5-minute heartbeat: **on the order of ten hours**, not 25 minutes. Worst case, every summary over budget, it degenerates to one contract per round.

So the real trade is: on links we cannot negotiate digests with, noticing a **pre-existing** divergence on a contract **nobody touches** can take hours instead of 5 minutes. The event-driven paths — push-on-update, request-full-state-when-too-far-behind, resend-on-failed-patch — are untouched and still bound detection for any contract anybody actually touches, and the peer's own summaries still reach us unbounded every round so *its* staleness is still detected immediately. Only the "we are behind and they must tell us" direction is delayed, on ~2.8% of links.

I think that is still the right trade, because the alternative on those same links is a multi-megabyte message every 5 minutes and there is no setting of these constants that is both cheap and fast. But it is an argument for repairing the version gate (#5156 / #5161) rather than tuning here, and it should not be sold as minutes. `heavy_summaries_make_the_cycle_far_longer_than_the_entry_cap_suggests` pins the long cycle as a test so the comfortable number cannot quietly return.

One second-order cost the review surfaced, not otherwise obvious: the peer-summary cache the broadcast path diffs against is populated from this exchange on fallback links (`DigestAgreement` never fires there), so it warms more slowly, and a `(contract, peer)` pair with no cached summary is what ships full state instead of a delta. `Delivery` covers actively-updated contracts and #5153 finds 57.5% of cold-start sends fire before any heartbeat could have helped, so the marginal cost is probably small — but it is a bytes-for-bytes trade on the same links, not purely a latency one.

## Testing

Six new behavioural tests at the handler level and six at the rotation core, all mutation-tested (they fail against the un-bounded and un-rotated versions of the code, verified by reverting each mechanism in turn):

- `fallback_reply_is_bounded_at_the_widest_observed_shared_set` — 2,448 shared contracts, the widest case seen in the field.
- `fallback_byte_budget_binds_before_the_entry_cap` — 5 KB summaries; the entry cap alone would not bound this.
- `oversized_summary_still_sends_and_the_rotation_advances` — a summary larger than the whole budget; asserts progress rather than a stall.
- `digest_peer_still_receives_every_shared_contract` — the no-change property for the 98%.
- `fallback_rotation_covers_the_whole_shared_set` — full coverage within `ceil(n / cap)` rounds.
- `bounding_the_reply_does_not_bound_interest_registration` — peer interest registered for contracts this round did not advertise.
- Rotation core: bounds and wrapping, coverage for n ∈ {1, 5, 63, 64, 65, 128, 266, 2448}, insertion mid-cycle, removal mid-cycle (with the index-cursor control), a removed cursor id, and per-peer cursor isolation.

Plus, from review: `heavy_summaries_make_the_cycle_far_longer_than_the_entry_cap_suggests` (pins the honest cycle length), `fallback_window_start_randomises_the_cycle_boundary` and a GlobalRng source pin (pin the boundary randomisation), coverage tests sweeping starting offsets over set sizes that do not divide evenly by the limit, and absolute literals in place of assertions written against the constants that produced them.

`cargo fmt`, `cargo clippy --locked -- -D warnings` (the CI invocation), and `cargo test -p freenet` are all clean.

## Review

Five independent blind reviewers (code-first, testing, adversarial, big-picture, and a convergence-specific lens). Consolidated findings and their dispositions are in a comment below; every finding was fixed or has a stated reason. Two were substantive — the cycle-boundary starvation and the order-of-magnitude cost error — and both are addressed above.

Closes #5155

[AI-assisted - Claude]
