### PR TITLE
fix(transport): carry the acceptor's version in the connection ack

### DIFF
--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -406,6 +406,31 @@ pub struct NodeConfig {
     /// `#[serde(skip)]`; never serialized.
     #[serde(skip)]
     pub(crate) hash_first_summaries_floor_override: Option<(u8, u8, u16)>,
+    /// Test-only override for the version-carrying-ack floor
+    /// (`GATEWAY_ACK_VERSION_MIN_VERSION`, #5161). Threaded down into the
+    /// TRANSPORT layer (`create_connection_handler`), unlike the three
+    /// overrides above, which are read at the `ConnectionManager`: the gate it
+    /// controls decides how a handshake ack is ENCODED, and the handshake runs
+    /// below the node layer entirely.
+    ///
+    /// In production this is `None` → the real `(0, 2, 120)` floor (untouched).
+    ///
+    /// **Simulations default this ON**, like `hash_first_summaries_floor_override`
+    /// and unlike the two cascade gates. Same reasoning: it changes only the
+    /// ENCODING of an ack every sim already exchanges, with identical handshake
+    /// semantics, so defaulting it on costs unrelated sims nothing and buys the
+    /// one thing a version-gated wire change otherwise cannot get — the whole
+    /// simulation suite exercising the new path BEFORE the release that lifts
+    /// the crate version over the floor. It also un-breaks the sim topology
+    /// asymmetry that several existing tests document and work around (a
+    /// regular node could not learn its gateway's version, so gateway-directed
+    /// PUTs had to originate from the gateway).
+    ///
+    /// Not cfg-gated for the same reason as `subscribe_hint_floor_override`:
+    /// `node::testing_impl` sets it and is compiled unconditionally.
+    /// `#[serde(skip)]`; never serialized.
+    #[serde(skip)]
+    pub(crate) ack_version_floor_override: Option<(u8, u8, u16)>,
     /// Test-only harness flag: when set, a startup-hosted contract
     /// (`SeedHostedContract`, i.e. `append_contracts` with `subscription =
     /// true`) is registered in the neighbor-hosting advertised set so the
@@ -573,6 +598,7 @@ impl NodeConfig {
             subscribe_hint_floor_override: None,
             summary_first_put_floor_override: None,
             hash_first_summaries_floor_override: None,
+            ack_version_floor_override: None,
             advertise_seeded_hosts: false,
             hosting_time_source_override: None,
         })

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -415,16 +415,16 @@ pub struct NodeConfig {
     ///
     /// In production this is `None` → the real `(0, 2, 120)` floor (untouched).
     ///
-    /// **Simulations default this ON**, like `hash_first_summaries_floor_override`
-    /// and unlike the two cascade gates. Same reasoning: it changes only the
-    /// ENCODING of an ack every sim already exchanges, with identical handshake
-    /// semantics, so defaulting it on costs unrelated sims nothing and buys the
-    /// one thing a version-gated wire change otherwise cannot get — the whole
-    /// simulation suite exercising the new path BEFORE the release that lifts
-    /// the crate version over the floor. It also un-breaks the sim topology
-    /// asymmetry that several existing tests document and work around (a
-    /// regular node could not learn its gateway's version, so gateway-directed
-    /// PUTs had to originate from the gateway).
+    /// **Simulations default this OFF**, like the two cascade gates and unlike
+    /// `hash_first_summaries_floor_override`. The gate is encoding-only where it
+    /// fires, but the version it teaches is the INPUT to every other
+    /// `version_supports_*` gate, so enabling it network-wide makes
+    /// node->gateway links newly eligible for those features — a cascade in
+    /// effect. Measured rather than assumed: defaulting it ON changes the
+    /// outcome of the summary-first PUT sims.
+    ///
+    /// A sim that wants it calls `SimNetwork::enable_gateway_ack_version`; see
+    /// that method for the full argument and for what the OFF default costs.
     ///
     /// Not cfg-gated for the same reason as `subscribe_hint_floor_override`:
     /// `node::testing_impl` sets it and is compiled unconditionally.

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -712,6 +712,10 @@ pub(in crate::node) struct P2pConnManager {
     ledbat_min_ssthresh: Option<usize>,
     /// Congestion control configuration.
     congestion_config: CongestionControlConfig,
+    /// Test-only override for the #5161 version-carrying-ack floor, threaded
+    /// into the transport handler. `None` in production.
+    /// See `NodeConfig::ack_version_floor_override`.
+    ack_version_floor_override: Option<(u8, u8, u16)>,
     blocked_addresses: Option<HashSet<SocketAddr>>,
     /// Per-contract retry count for broadcasts that found no targets yet.
     broadcast_retries: HashMap<freenet_stdlib::prelude::ContractKey, u8>,
@@ -1195,6 +1199,7 @@ impl P2pConnManager {
             is_gateway: config.is_gateway,
             this_location: config.location,
             check_version: !config.config.network_api.ignore_protocol_version,
+            ack_version_floor_override: config.ack_version_floor_override,
             bandwidth_limit: config.config.network_api.bandwidth_limit,
             global_bandwidth: config
                 .config
@@ -1279,6 +1284,7 @@ impl P2pConnManager {
             global_bandwidth,
             ledbat_min_ssthresh,
             congestion_config,
+            ack_version_floor_override,
             blocked_addresses,
             broadcast_retries,
             broadcast_no_target_streak,
@@ -1296,6 +1302,7 @@ impl P2pConnManager {
                 global_bandwidth,
                 ledbat_min_ssthresh,
                 Some(congestion_config.clone()),
+                ack_version_floor_override,
             )
             .await?;
 
@@ -1365,6 +1372,9 @@ impl P2pConnManager {
             global_bandwidth: None, // Already used for connection handler, not needed in ctx
             ledbat_min_ssthresh,
             congestion_config, // Already used for connection handler, kept for struct completeness
+            // Already consumed by create_connection_handler above; kept for
+            // struct completeness, same as the two fields around it.
+            ack_version_floor_override,
             blocked_addresses,
             broadcast_retries,
             broadcast_no_target_streak,

--- a/crates/core/src/node/network_bridge/p2p_protoc/connection_lifecycle.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc/connection_lifecycle.rs
@@ -1053,9 +1053,11 @@ impl P2pConnManager {
         // `supports_summary_first_put` check. Keep this write paired with
         // the `self.connections.insert` above if that call site changes.
         // Write the Option THROUGH — unconditionally, so a reconnection whose
-        // version is unknown (`None`, the joiner->gateway path) CLEARS any
-        // stale entry rather than leaving us believing a downgraded peer is
-        // still current. See `ConnectionManager::record_remote_version`.
+        // version is unknown CLEARS any stale entry rather than leaving us
+        // believing a downgraded peer is still current. Since #5161 a `None`
+        // here means the remote is genuinely below the version-carrying-ack
+        // floor, not that this path cannot observe it.
+        // See `ConnectionManager::record_remote_version`.
         self.bridge
             .op_manager
             .ring

--- a/crates/core/src/node/testing_impl.rs
+++ b/crates/core/src/node/testing_impl.rs
@@ -543,6 +543,35 @@ impl ControlledSimulationResult {
             .is_some_and(|ring| ring.is_hosting_contract(key))
     }
 
+    /// The protocol version `label`'s node had recorded for the peer at `addr`
+    /// at the end of the run, or `None` if it never learned one (#5161).
+    ///
+    /// Reads the same `ConnectionManager` mirror the production emission gates
+    /// read, so it answers the question those gates ask rather than a proxy for
+    /// it. `None` when the node never published its Ring.
+    pub fn node_recorded_remote_version(
+        &self,
+        label: &NodeLabel,
+        addr: SocketAddr,
+    ) -> Option<(u8, u8, u16)> {
+        self.node_rings
+            .get(label)
+            .and_then(|ring| ring.connection_manager.remote_version(addr))
+    }
+
+    /// Whether `label`'s node would emit the hash-first summary encoding to the
+    /// peer at `addr` — i.e. whether that link passes the version gate (#4965).
+    ///
+    /// The end-to-end consequence of #5161 on a node->gateway link: before the
+    /// version-carrying ack this could never be true from the node's side, so
+    /// the node answered every anti-entropy exchange with full summary bytes.
+    /// `false` when the node never published its Ring.
+    pub fn node_supports_hash_first_summaries(&self, label: &NodeLabel, addr: SocketAddr) -> bool {
+        self.node_rings
+            .get(label)
+            .is_some_and(|ring| ring.connection_manager.supports_hash_first_summaries(addr))
+    }
+
     /// Number of contracts `label`'s node held in its hosting cache at the end
     /// of the run (its "cache size"). Returns 0 if the node never published its
     /// Ring. See [`Ring::hosting_contracts_count`](crate::ring::Ring::hosting_contracts_count).
@@ -1407,6 +1436,21 @@ pub struct SimNetwork {
     /// release PR, where a red sim could not be attributed between the
     /// feature and the version bump.
     hash_first_summaries_floor_override: Option<(u8, u8, u16)>,
+    /// Per-node version-carrying-ack version-floor override (#5161, see
+    /// [`SimNetwork::enable_gateway_ack_version`]).
+    ///
+    /// **Defaults to `Some(SIM_MIGRATION_DISABLED_FLOOR)` — OFF**, like the two
+    /// cascade gates and unlike `hash_first_summaries_floor_override`. The gate
+    /// is encoding-only where it fires, but the version it teaches is the INPUT
+    /// to every other `version_supports_*` gate, so enabling it network-wide
+    /// makes node->gateway links newly eligible for those features. Measured,
+    /// not assumed: defaulting it ON changed the outcome of unrelated sims.
+    ///
+    /// The cost of OFF, stated plainly: sims keep the pre-0.2.120 topology
+    /// asymmetry (a regular node never learns its gateway's version) even after
+    /// production stops having it. `enable_gateway_ack_version` is how a test
+    /// that cares opts in.
+    ack_version_floor_override: Option<(u8, u8, u16)>,
     /// Optional controllable hosting clock injected into every node's
     /// `HostingManager` (via `NodeConfig::hosting_time_source_override`). When
     /// set, hosting-cache TTL and subscription-lease eviction advance ONLY when
@@ -1606,6 +1650,12 @@ impl SimNetwork {
             // version-gated wire change simulation coverage BEFORE the release
             // that lifts the crate version past its floor.
             hash_first_summaries_floor_override: Some(Self::SIM_MIGRATION_ENABLED_FLOOR),
+            // Fail-CLOSED by default, like the two cascade gates and unlike
+            // hash-first. This gate is encoding-only where it fires, but what
+            // it teaches — the remote's version — is the INPUT to every other
+            // `version_supports_*` gate, so switching it on network-wide is a
+            // cascade in effect. Opt in per sim via `enable_gateway_ack_version`.
+            ack_version_floor_override: Some(Self::SIM_MIGRATION_DISABLED_FLOOR),
             hosting_clock: None,
             hosting_budget_override: None,
             shared_rings: HashMap::new(),
@@ -1962,6 +2012,45 @@ impl SimNetwork {
         self
     }
 
+    /// Opt this simulation into the version-carrying connection ack (#5161) by
+    /// pinning the per-node floor to the always-passing
+    /// [`Self::SIM_MIGRATION_ENABLED_FLOOR`], so a joiner learns the version of
+    /// the gateway (or ack-racing peer) it connects to.
+    ///
+    /// Genuinely opt-in, unlike
+    /// [`enable_hash_first_summaries`](Self::enable_hash_first_summaries) which
+    /// only restates a default. The reasoning is the fail-closed criterion this
+    /// codebase already applies: hash-first is opt-OUT because it changes only
+    /// the ENCODING of an exchange every sim already runs. This gate looks like
+    /// that from the inside — it changes only how one ack is encoded — but its
+    /// EFFECT is a cascade, because the version it teaches is the input to
+    /// every other `version_supports_*` gate. Turning it on network-wide makes
+    /// node->gateway links newly eligible for summary-first PUT probes and
+    /// hash-first digests in whatever sims have those enabled, which is exactly
+    /// the "piles load onto unrelated simulations" shape that
+    /// `subscribe_hint_floor_override` and `summary_first_put_floor_override`
+    /// default OFF to avoid. Measured, not assumed: defaulting it ON changed
+    /// the outcome of several unrelated sims.
+    ///
+    /// Note this leaves the sim suite pinned OFF even after the production
+    /// floor is reached, so sims and production diverge on this from 0.2.120
+    /// onwards. That is the deliberate trade — the alternative is every sim
+    /// silently changing behaviour at a release — and the coverage it costs is
+    /// bought back by `test_joiner_records_gateway_version_through_sim_handshake`
+    /// plus the transport-level tests in `connection_handler`.
+    #[allow(dead_code)]
+    pub fn enable_gateway_ack_version(&mut self) -> &mut Self {
+        let floor = Some(Self::SIM_MIGRATION_ENABLED_FLOOR);
+        self.ack_version_floor_override = floor;
+        for (builder, _) in self.gateways.iter_mut() {
+            builder.config.ack_version_floor_override = floor;
+        }
+        for (builder, _) in self.nodes.iter_mut() {
+            builder.config.ack_version_floor_override = floor;
+        }
+        self
+    }
+
     /// Force the hash-first summary exchange OFF for this simulation by
     /// pinning the per-node floor to the unreachable
     /// [`Self::SIM_MIGRATION_DISABLED_FLOOR`], so every peer falls back to the
@@ -1974,10 +2063,10 @@ impl SimNetwork {
     /// simulation — one peer at the floor, one below — is constructible by
     /// setting the two builders differently rather than using this helper,
     /// which sets every node uniformly. No such test exists yet; the mixed
-    /// case that IS covered today is incidental rather than constructed: a
-    /// regular node never learns its gateway's version (the gateway's
-    /// `AckConnection` carries none), so every gateway link already runs
-    /// digests one way and full bytes the other.
+    /// case that IS covered today is incidental rather than constructed: unless
+    /// a sim calls [`enable_gateway_ack_version`](Self::enable_gateway_ack_version),
+    /// a regular node never learns its gateway's version, so every gateway link
+    /// already runs digests one way and full bytes the other.
     #[allow(dead_code)]
     pub fn disable_hash_first_summaries(&mut self) -> &mut Self {
         let floor = Some(Self::SIM_MIGRATION_DISABLED_FLOOR);
@@ -2644,6 +2733,7 @@ impl SimNetwork {
             config.subscribe_hint_floor_override = self.subscribe_hint_floor_override;
             config.summary_first_put_floor_override = self.summary_first_put_floor_override;
             config.hash_first_summaries_floor_override = self.hash_first_summaries_floor_override;
+            config.ack_version_floor_override = self.ack_version_floor_override;
             config.hosting_time_source_override = self
                 .hosting_clock
                 .clone()
@@ -2745,6 +2835,7 @@ impl SimNetwork {
             config.subscribe_hint_floor_override = self.subscribe_hint_floor_override;
             config.summary_first_put_floor_override = self.summary_first_put_floor_override;
             config.hash_first_summaries_floor_override = self.hash_first_summaries_floor_override;
+            config.ack_version_floor_override = self.ack_version_floor_override;
             config.hosting_time_source_override = self
                 .hosting_clock
                 .clone()

--- a/crates/core/src/ring/connection_manager.rs
+++ b/crates/core/src/ring/connection_manager.rs
@@ -1378,6 +1378,24 @@ impl ConnectionManager {
     /// undecodable wire variant to a downgraded peer; see the
     /// `remote_version` field rustdoc for the full failure.
     ///
+    /// # Why #5161 did NOT relax this to "keep the old value on `None`"
+    ///
+    /// The issue read the clearing as information loss — a reconnect deleting a
+    /// version we already knew. That was the SYMPTOM of the handshake gap, not
+    /// a second bug, and relaxing it would have re-opened the downgrade failure
+    /// above.
+    ///
+    /// What #5161 changed is what `None` MEANS. Enumerate where a `None` can
+    /// now reach this function: the joiner->gateway ack path and the
+    /// peer-to-peer ack race both yield `Some` for any remote at or above
+    /// `GATEWAY_ACK_VERSION_MIN_VERSION`, and the intro-parsing path always
+    /// did. So a remaining `None` is not "we failed to learn it" — it is the
+    /// positive fact that the remote is BELOW the floor. Clearing a stale
+    /// newer entry is then the accurate write, not a lossy one, and every
+    /// `version_supports_*` predicate fails closed on the absence exactly as it
+    /// would on a below-floor value. Pinned by
+    /// `record_remote_version_none_clears_a_stale_entry`.
+    ///
     /// Called from `p2p_protoc::connection_lifecycle` at the same point
     /// `P2pConnManager` records `remote_version` on its own `connections`
     /// entry — keep the two writes together if that call site changes.
@@ -2728,6 +2746,60 @@ mod tests {
         assert_eq!(cm.remote_version(addr), None);
         cm.record_remote_version(addr, Some((0, 2, 94)));
         assert_eq!(cm.remote_version(addr), Some((0, 2, 94)));
+    }
+
+    /// **The address-reuse-with-downgrade case (#5161).** A `None` MUST clear a
+    /// previously recorded version rather than preserve it.
+    ///
+    /// A recorded version is keyed by socket address, and addresses are reused:
+    /// a peer restarts on an older binary, or a NAT reassigns the port. If the
+    /// new connection reports no version and we kept the old one, we would keep
+    /// believing a downgraded peer is current and send it a wire variant it
+    /// cannot deserialize — which closes the connection
+    /// (`ConnectionError::Serialization`) and reads as a transport fault. That
+    /// is the failure the write-through exists to prevent, and #5161 removed
+    /// its most common trigger (the version-less gateway ack) rather than the
+    /// protection itself.
+    ///
+    /// The trailing assertions are the point: a cleared entry must fail closed
+    /// at the gates, so clearing is conservative in the same direction as a
+    /// genuinely below-floor version would be.
+    #[test]
+    fn record_remote_version_none_clears_a_stale_entry() {
+        let cm = make_connection_manager(Some(make_addr(9000)), 1, 10, false);
+        let addr = make_addr(9002);
+
+        cm.record_remote_version(addr, Some((0, 2, 118)));
+        assert_eq!(cm.remote_version(addr), Some((0, 2, 118)));
+
+        // Reconnect at the same address whose handshake yielded no version.
+        cm.record_remote_version(addr, None);
+        assert_eq!(
+            cm.remote_version(addr),
+            None,
+            "a reconnect that reports no version must not leave the previous \
+             version in place — the peer may have restarted on an older build \
+             at this address, and we would then send it an undecodable variant"
+        );
+        assert!(!cm.supports_summary_first_put(addr));
+        assert!(!cm.supports_hash_first_summaries(addr));
+    }
+
+    /// The other half of the same rule: a `Some` at a reused address overwrites
+    /// unconditionally, INCLUDING downwards. A "keep the highest version seen"
+    /// policy would be the same downgrade bug in a different shape.
+    #[test]
+    fn record_remote_version_overwrites_downwards_at_a_reused_address() {
+        let cm = make_connection_manager(Some(make_addr(9000)), 1, 10, false);
+        let addr = make_addr(9003);
+
+        cm.record_remote_version(addr, Some((0, 2, 120)));
+        cm.record_remote_version(addr, Some((0, 2, 100)));
+        assert_eq!(
+            cm.remote_version(addr),
+            Some((0, 2, 100)),
+            "the most recent connection's version wins, even when it is lower"
+        );
     }
 
     /// Emission gate, fail-closed case: a peer with no recorded version

--- a/crates/core/src/transport/connection_handler.rs
+++ b/crates/core/src/transport/connection_handler.rs
@@ -152,6 +152,7 @@ pub async fn create_connection_handler<S: Socket>(
     global_bandwidth: Option<Arc<GlobalBandwidthManager>>,
     ledbat_min_ssthresh: Option<usize>,
     congestion_config: Option<CongestionControlConfig>,
+    ack_version_floor_override: Option<(u8, u8, u16)>,
 ) -> Result<
     (
         OutboundConnectionHandler<S>,
@@ -186,6 +187,7 @@ pub async fn create_connection_handler<S: Socket>(
         global_bandwidth,
         ledbat_min_ssthresh,
         congestion_config,
+        ack_version_floor_override,
     )?;
     Ok((
         och,
@@ -277,6 +279,7 @@ impl<S: Socket> OutboundConnectionHandler<S> {
         global_bandwidth: Option<Arc<GlobalBandwidthManager>>,
         ledbat_min_ssthresh: Option<usize>,
         congestion_config: Option<CongestionControlConfig>,
+        ack_version_floor_override: Option<(u8, u8, u16)>,
     ) -> Result<ListenerSetup<S>, TransportError> {
         let (conn_handler_sender, conn_handler_receiver) = mpsc::channel(100);
         let (new_connection_sender, new_connection_notifier) = mpsc::channel(10);
@@ -309,6 +312,7 @@ impl<S: Socket> OutboundConnectionHandler<S> {
             ),
             time_source,
             congestion_config: Some(congestion_config.unwrap_or_default()),
+            ack_version_floor_override,
         };
         let connection_handler = OutboundConnectionHandler {
             send_queue: conn_handler_sender,
@@ -338,6 +342,23 @@ impl<S: Socket> OutboundConnectionHandler<S> {
         keypair: TransportKeypair,
         is_gateway: bool,
     ) -> Result<(Self, mpsc::Receiver<PeerConnection<S>>), TransportError> {
+        Self::new_test_with_ack_version_floor(socket_addr, socket, keypair, is_gateway, None)
+    }
+
+    /// [`Self::new_test`] with the #5161 version-carrying-ack floor override.
+    ///
+    /// `Some(floor)` lets a test exercise `AckConnectionV2` before the crate
+    /// version reaches `GATEWAY_ACK_VERSION_MIN_VERSION`; `None` is production
+    /// behaviour (the real floor, so a same-build mock pair stays on the legacy
+    /// ack — which is what makes the byte-identity test meaningful).
+    #[cfg(any(test, feature = "bench"))]
+    pub(crate) fn new_test_with_ack_version_floor(
+        socket_addr: SocketAddr,
+        socket: Arc<S>,
+        keypair: TransportKeypair,
+        is_gateway: bool,
+        ack_version_floor_override: Option<(u8, u8, u16)>,
+    ) -> Result<(Self, mpsc::Receiver<PeerConnection<S>>), TransportError> {
         let (handler, receiver, _listen_handle) = Self::config_listener(
             socket,
             keypair,
@@ -347,6 +368,7 @@ impl<S: Socket> OutboundConnectionHandler<S> {
             None,
             None,
             None,
+            ack_version_floor_override,
         )?;
         Ok((handler, receiver))
     }
@@ -365,6 +387,7 @@ impl<S: Socket> OutboundConnectionHandler<S> {
             is_gateway,
             socket_addr,
             bandwidth_limit,
+            None,
             None,
             None,
             None,
@@ -510,6 +533,9 @@ impl<S: Socket> OutboundConnectionHandler<S, crate::simulation::VirtualTime> {
             gw_rate_limiter: GatewayConnectionRateLimiter::new(time_source.clone(), None),
             time_source,
             congestion_config,
+            // Benchmarks measure throughput, not handshake encoding; the real
+            // floor applies here exactly as in production.
+            ack_version_floor_override: None,
         };
         let connection_handler = OutboundConnectionHandler {
             send_queue: conn_handler_sender,
@@ -666,6 +692,17 @@ struct UdpPacketsListener<S = UdpSocket, T: TimeSource = RealTime> {
     /// Ramps up connection acceptance rate to prevent thundering herd.
     /// Only active when `is_gateway` is true.
     gw_rate_limiter: GatewayConnectionRateLimiter<T>,
+    /// Test-only override for [`version_cmp::GATEWAY_ACK_VERSION_MIN_VERSION`]
+    /// (#5161). `None` in production, where the real floor applies.
+    ///
+    /// Load-bearing rather than decorative, for the same reason
+    /// `NodeConfig::hash_first_summaries_floor_override` is: simulations run
+    /// the real transport handshake with the real crate version, which is
+    /// BELOW the floor until the release that lifts it. Without an override
+    /// the first integration-level run of this path would be the release PR
+    /// itself, where a red sim could not be attributed between the feature and
+    /// the version bump.
+    ack_version_floor_override: Option<(u8, u8, u16)>,
 }
 
 type OngoingConnectionResult<S, T> = Option<
@@ -1769,6 +1806,13 @@ impl<S: Socket, T: TimeSource> UdpPacketsListener<S, T> {
         }
     }
 
+    /// Effective floor for emitting the version-carrying ack (#5161): the
+    /// test-only override when set, otherwise the production constant.
+    fn ack_version_floor(&self) -> (u8, u8, u16) {
+        self.ack_version_floor_override
+            .unwrap_or(version_cmp::GATEWAY_ACK_VERSION_MIN_VERSION)
+    }
+
     #[allow(clippy::type_complexity)]
     fn gateway_connection(
         &mut self,
@@ -1786,6 +1830,7 @@ impl<S: Socket, T: TimeSource> UdpPacketsListener<S, T> {
         let socket = self.socket_listener.clone();
         let time_source = self.time_source.clone();
         let congestion_config = self.congestion_config.clone();
+        let ack_version_floor = self.ack_version_floor();
 
         let (inbound_from_remote, mut next_inbound) =
             mpsc::channel::<PacketData<UnknownEncryption>>(100);
@@ -1857,8 +1902,23 @@ impl<S: Socket, T: TimeSource> UdpPacketsListener<S, T> {
                 };
 
             let inbound_key = Aes128Gcm::new(&inbound_key_bytes.into());
-            let outbound_ack_packet =
-                SymmetricMessage::ack_ok(&outbound_key, inbound_key_bytes, remote_addr)?;
+            // #5161: tell the joiner our version when it is new enough to
+            // decode the field. The intro packet we just parsed IS the evidence
+            // for that, which is why this needs no bootstrapping round-trip.
+            // A pre-floor joiner gets the unmodified `ack_ok` bytes.
+            let outbound_ack_packet = if version_cmp::version_supports_ack_version(
+                remote_protoc_version,
+                ack_version_floor,
+            ) {
+                SymmetricMessage::ack_ok_with_version(
+                    &outbound_key,
+                    inbound_key_bytes,
+                    remote_addr,
+                    PROTOC_VERSION,
+                )?
+            } else {
+                SymmetricMessage::ack_ok(&outbound_key, inbound_key_bytes, remote_addr)?
+            };
 
             tracing::trace!(
                 peer_addr = %remote_addr,
@@ -2103,6 +2163,7 @@ impl<S: Socket, T: TimeSource> UdpPacketsListener<S, T> {
         let (inbound_from_remote, mut next_inbound) =
             mpsc::channel::<PacketData<UnknownEncryption>>(100);
         let this_addr = self.this_addr;
+        let ack_version_floor = self.ack_version_floor();
         let f = async move {
             tracing::info!(
                 peer_addr = %remote_addr,
@@ -2160,11 +2221,31 @@ impl<S: Socket, T: TimeSource> UdpPacketsListener<S, T> {
                                 direction = "outbound",
                                 "Sending back protocol version and inbound key to remote"
                             );
-                            let our_inbound = SymmetricMessage::ack_ok(
-                                outbound_sym_key.as_ref().expect("should be set"),
-                                inbound_sym_key_bytes,
-                                remote_addr,
-                            )?;
+                            // #5161: same gate as the gateway path. This side
+                            // has parsed the remote's intro (that is what moved
+                            // us to `RemoteInbound`), so its version is known.
+                            // Load-bearing for peer-to-peer too: if the remote
+                            // races ahead to its own `AckConnection` arm before
+                            // parsing OUR intro, this ack is the only place it
+                            // can learn our version.
+                            let ack_key = outbound_sym_key.as_ref().expect("should be set");
+                            let our_inbound = if version_cmp::version_supports_ack_version(
+                                remote_protoc_version,
+                                ack_version_floor,
+                            ) {
+                                SymmetricMessage::ack_ok_with_version(
+                                    ack_key,
+                                    inbound_sym_key_bytes,
+                                    remote_addr,
+                                    PROTOC_VERSION,
+                                )?
+                            } else {
+                                SymmetricMessage::ack_ok(
+                                    ack_key,
+                                    inbound_sym_key_bytes,
+                                    remote_addr,
+                                )?
+                            };
                             socket
                                 .send_to(our_inbound.data(), remote_addr)
                                 .await
@@ -2228,20 +2309,40 @@ impl<S: Socket, T: TimeSource> UdpPacketsListener<S, T> {
                                         );
                                     }
 
-                                    match symmetric_message.payload {
-                                        SymmetricMessagePayload::AckConnection {
-                                            result:
-                                                Ok(OutboundConnection {
-                                                    key,
-                                                    remote_addr: my_address,
-                                                }),
-                                        } => {
+                                    // #5161: the acceptor's ack comes in two
+                                    // encodings — the legacy `AckConnection`
+                                    // and the version-carrying
+                                    // `AckConnectionV2` — that differ only in
+                                    // whether the acceptor told us its
+                                    // version. Normalize first so the
+                                    // connection-construction body below stays
+                                    // single-copy; duplicating it per arm is
+                                    // how the two encodings would drift.
+                                    if let Some((key, my_address, acceptor_version_bytes)) =
+                                        ack_ok_parts(&symmetric_message.payload)
+                                    {
+                                        {
                                             let outbound_sym_key = Aes128Gcm::new_from_slice(&key)
                                                 .map_err(|_| {
                                                     TransportError::ConnectionEstablishmentFailure {
                                                         cause: "invalid symmetric key".into(),
                                                     }
                                                 })?;
+                                            // Only V2 carries a version. When
+                                            // it does, this is the ONLY point
+                                            // on this path where the acceptor's
+                                            // version can be learned: we never
+                                            // parse an intro packet from it.
+                                            // Report it so version discovery
+                                            // (`gateway_version_probe`, the
+                                            // auto-update signal) sees gateways
+                                            // at all, not only peers that
+                                            // hole-punched back to us.
+                                            if let Some(bytes) = acceptor_version_bytes {
+                                                let info = version_cmp::parse_version_bytes(&bytes);
+                                                crate::transport::report_peer_version(info.version);
+                                                remote_protoc_version = Some(info.version);
+                                            }
                                             tracing::trace!(
                                                 peer_addr = %remote_addr,
                                                 direction = "outbound",
@@ -2309,9 +2410,13 @@ impl<S: Socket, T: TimeSource> UdpPacketsListener<S, T> {
                                                     inbound_symmetric_key_bytes:
                                                         inbound_sym_key_bytes,
                                                     my_address: Some(my_address),
-                                                    // AckConnection (joiner->gateway) payload
-                                                    // carries no protocol version.
-                                                    remote_protoc_version: None,
+                                                    // Set above iff the ack was
+                                                    // `AckConnectionV2`; `None`
+                                                    // means the acceptor is
+                                                    // pre-`GATEWAY_ACK_VERSION_MIN_VERSION`
+                                                    // and genuinely told us
+                                                    // nothing (#5161).
+                                                    remote_protoc_version,
                                                     transport_secret_key: transport_secret_key
                                                         .clone(),
                                                     congestion_controller,
@@ -2326,12 +2431,26 @@ impl<S: Socket, T: TimeSource> UdpPacketsListener<S, T> {
                                                 },
                                             ));
                                         }
+                                    }
+                                    match symmetric_message.payload {
                                         SymmetricMessagePayload::AckConnection {
                                             result: Err(err),
                                         } => {
                                             return Err(handle_ack_connection_error(err));
                                         }
-                                        SymmetricMessagePayload::ShortMessage { .. }
+                                        // The two success encodings are
+                                        // consumed by `ack_ok_parts` above,
+                                        // whose body always returns; they are
+                                        // listed here only to keep the match
+                                        // exhaustive, so a future payload
+                                        // variant has to be classified rather
+                                        // than silently falling into a
+                                        // catch-all.
+                                        SymmetricMessagePayload::AckConnection {
+                                            result: Ok(_),
+                                        }
+                                        | SymmetricMessagePayload::AckConnectionV2 { .. }
+                                        | SymmetricMessagePayload::ShortMessage { .. }
                                         | SymmetricMessagePayload::StreamFragment { .. }
                                         | SymmetricMessagePayload::NoOp
                                         | SymmetricMessagePayload::Ping { .. }
@@ -2483,6 +2602,45 @@ impl<S: Socket, T: TimeSource> UdpPacketsListener<S, T> {
             })
         };
         (f.boxed(), inbound_from_remote)
+    }
+}
+
+/// Destructure a successful connection ack, whichever encoding it arrived in
+/// (#5161), into `(symmetric key, our observed address, acceptor's version
+/// bytes)`.
+///
+/// `None` for anything that is not a success ack — including the failure ack,
+/// which the caller must still handle separately.
+///
+/// The version is `None` for the legacy [`SymmetricMessagePayload::AckConnection`]
+/// and `Some` for [`SymmetricMessagePayload::AckConnectionV2`]. That difference
+/// is the entire point of the variant, and it is deliberately reported as an
+/// `Option` rather than defaulted: "the acceptor is below the floor" and "the
+/// acceptor is version X" are different facts, and every `version_supports_*`
+/// gate fails closed on the former.
+#[allow(clippy::type_complexity)]
+fn ack_ok_parts(
+    payload: &SymmetricMessagePayload,
+) -> Option<([u8; 16], SocketAddr, Option<[u8; 8]>)> {
+    match payload {
+        SymmetricMessagePayload::AckConnection {
+            result:
+                Ok(OutboundConnection {
+                    key,
+                    remote_addr: my_address,
+                }),
+        } => Some((*key, *my_address, None)),
+        SymmetricMessagePayload::AckConnectionV2 { connection } => Some((
+            connection.key,
+            connection.remote_addr,
+            Some(connection.protoc_version),
+        )),
+        SymmetricMessagePayload::AckConnection { result: Err(_) }
+        | SymmetricMessagePayload::ShortMessage { .. }
+        | SymmetricMessagePayload::StreamFragment { .. }
+        | SymmetricMessagePayload::NoOp
+        | SymmetricMessagePayload::Ping { .. }
+        | SymmetricMessagePayload::Pong { .. } => None,
     }
 }
 
@@ -2897,6 +3055,7 @@ pub mod mock_transport {
             false,
             channels,
             None,
+            None,
         )
         .await
         .map(|(pk, (o, _), s)| (pk, o, s))
@@ -2919,6 +3078,7 @@ pub mod mock_transport {
             packet_delay_policy,
             false,
             channels,
+            None,
             None,
         )
         .await
@@ -2944,6 +3104,7 @@ pub mod mock_transport {
             false,
             channels,
             bandwidth_limit,
+            None,
         )
         .await
         .map(|(pk, (o, _), s)| (pk, o, s))
@@ -3002,16 +3163,47 @@ pub mod mock_transport {
             true,
             channels,
             None,
+            None,
         )
         .await
     }
 
+    /// Create a mock gateway whose version-carrying-ack floor (#5161) is
+    /// overridden, so a test can exercise BOTH sides of the gate without
+    /// depending on the crate's current version.
+    pub async fn create_mock_gateway_with_ack_floor(
+        channels: Channels,
+        ack_version_floor_override: Option<(u8, u8, u16)>,
+    ) -> Result<
+        (
+            TransportPublicKey,
+            (
+                OutboundConnectionHandler<MockSocket>,
+                mpsc::Receiver<PeerConnection<MockSocket>>,
+            ),
+            SocketAddr,
+        ),
+        anyhow::Error,
+    > {
+        create_mock_peer_internal(
+            PacketDropPolicy::ReceiveAll,
+            PacketDelayPolicy::NoDelay,
+            true,
+            channels,
+            None,
+            ack_version_floor_override,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
     async fn create_mock_peer_internal(
         packet_drop_policy: PacketDropPolicy,
         packet_delay_policy: PacketDelayPolicy,
         gateway: bool,
         channels: Channels,
         bandwidth_limit: Option<usize>,
+        ack_version_floor_override: Option<(u8, u8, u16)>,
     ) -> Result<
         (
             TransportPublicKey,
@@ -3037,13 +3229,23 @@ pub mod mock_transport {
             )
             .await,
         );
-        let (peer_conn, inbound_conn) = OutboundConnectionHandler::new_test_with_bandwidth(
-            (Ipv4Addr::LOCALHOST, port).into(),
-            socket,
-            peer_keypair,
-            gateway,
-            bandwidth_limit,
-        )
+        let (peer_conn, inbound_conn) = if let Some(floor) = ack_version_floor_override {
+            OutboundConnectionHandler::new_test_with_ack_version_floor(
+                (Ipv4Addr::LOCALHOST, port).into(),
+                socket,
+                peer_keypair,
+                gateway,
+                Some(floor),
+            )
+        } else {
+            OutboundConnectionHandler::new_test_with_bandwidth(
+                (Ipv4Addr::LOCALHOST, port).into(),
+                socket,
+                peer_keypair,
+                gateway,
+                bandwidth_limit,
+            )
+        }
         .expect("failed to create peer");
         Ok((
             peer_pub,
@@ -3547,7 +3749,10 @@ pub mod mock_transport {
         let peer_a = GlobalExecutor::spawn(async move {
             let peer_b_conn = peer_a.connect(gw_pub, gw_addr).await;
             let conn = tokio::time::timeout(Duration::from_secs(60), peer_b_conn).await??;
-            // Joiner->gateway side: the gateway's AckConnection payload carries no version.
+            // Joiner->gateway side: the gateway now tells us its version in the
+            // ack (#5161), gated on ours. Same build here, and the sim/test
+            // default floor is unreachable-high only when explicitly set — this
+            // constructor leaves the production floor in place.
             Ok::<_, anyhow::Error>(conn.remote_version())
         });
 
@@ -3557,9 +3762,123 @@ pub mod mock_transport {
             Some(expected_version),
             "gateway should capture the joiner's protocol version"
         );
+        // Both mock peers run this build, so whether the joiner learns the
+        // gateway's version here depends purely on whether this build is at or
+        // above the production floor. Asserting either constant would make this
+        // test flip at the 0.2.120 release; the two dedicated tests below pin
+        // BOTH sides of the gate against explicit floors instead.
+        let joiner_view = joiner_view?;
+        let crate_at_or_above_floor = version_cmp::version_supports_ack_version(
+            Some(expected_version),
+            version_cmp::GATEWAY_ACK_VERSION_MIN_VERSION,
+        );
         assert_eq!(
-            joiner_view?, None,
-            "joiner->gateway connection has no remote version (AckConnection carries none)"
+            joiner_view.is_some(),
+            crate_at_or_above_floor,
+            "joiner's view of the gateway version must follow the production floor exactly"
+        );
+        Ok(())
+    }
+
+    /// **#5161, the fix.** A joiner at or above the floor learns the gateway's
+    /// protocol version from the ack — the whole point of the issue, since the
+    /// joiner never parses an intro packet from a gateway and previously had no
+    /// other channel for it.
+    #[tokio::test]
+    async fn joiner_learns_gateway_version_when_at_or_above_the_floor() -> anyhow::Result<()> {
+        // A floor every build clears, so the assertion does not move with the
+        // crate version.
+        const REACHABLE_FLOOR: (u8, u8, u16) = (0, 0, 0);
+
+        let channels = Arc::new(DashMap::new());
+        let (_peer_a_pub, mut peer_a, _peer_a_addr) =
+            create_mock_peer(Default::default(), channels.clone()).await?;
+        let (gw_pub, (_oc, mut gw_conn), gw_addr) =
+            create_mock_gateway_with_ack_floor(channels, Some(REACHABLE_FLOOR)).await?;
+
+        let expected_version = version_cmp::parse_version_bytes(&PROTOC_VERSION).version;
+
+        let gw = GlobalExecutor::spawn(async move {
+            let gw = tokio::time::timeout(Duration::from_secs(10), gw_conn.recv())
+                .await?
+                .ok_or(anyhow::anyhow!("no connection"))?;
+            Ok::<_, anyhow::Error>(gw.remote_version())
+        });
+
+        let peer_a = GlobalExecutor::spawn(async move {
+            let conn = tokio::time::timeout(
+                Duration::from_secs(60),
+                peer_a.connect(gw_pub, gw_addr).await,
+            )
+            .await??;
+            Ok::<_, anyhow::Error>(conn.remote_version())
+        });
+
+        let (joiner_view, gw_view) = tokio::try_join!(peer_a, gw)?;
+        assert_eq!(
+            joiner_view?,
+            Some(expected_version),
+            "the joiner MUST record the gateway's version from AckConnectionV2 — \
+             without it every version-gated wire feature fails closed on gateway links"
+        );
+        assert_eq!(
+            gw_view?,
+            Some(expected_version),
+            "the gateway still learns the joiner's version from its intro packet"
+        );
+        Ok(())
+    }
+
+    /// **#5161, the compatibility guarantee.** A gateway must NOT emit
+    /// `AckConnectionV2` to a joiner below the floor: such a peer does not carry
+    /// the variant index, cannot deserialize the ack, and would fail to complete
+    /// the handshake at all.
+    ///
+    /// Simulated by raising the gateway's floor out of reach, which puts the
+    /// same-build joiner below it. The joiner still connects (proving the legacy
+    /// path is intact end to end) and learns nothing — exactly today's
+    /// behaviour. The byte-level half of this guarantee is
+    /// `symmetric_message::test::ack_ok_produces_identical_bytes_to_pre_5161_encoding`.
+    #[tokio::test]
+    async fn pre_floor_joiner_gets_the_legacy_ack_and_still_connects() -> anyhow::Result<()> {
+        // Unreachable by any real build, so the same-build joiner is "pre-floor".
+        const UNREACHABLE_FLOOR: (u8, u8, u16) = (255, 255, 65535);
+
+        let channels = Arc::new(DashMap::new());
+        let (_peer_a_pub, mut peer_a, _peer_a_addr) =
+            create_mock_peer(Default::default(), channels.clone()).await?;
+        let (gw_pub, (_oc, mut gw_conn), gw_addr) =
+            create_mock_gateway_with_ack_floor(channels, Some(UNREACHABLE_FLOOR)).await?;
+
+        let gw = GlobalExecutor::spawn(async move {
+            let gw = tokio::time::timeout(Duration::from_secs(10), gw_conn.recv())
+                .await?
+                .ok_or(anyhow::anyhow!("no connection"))?;
+            Ok::<_, anyhow::Error>(gw.remote_version())
+        });
+
+        let peer_a = GlobalExecutor::spawn(async move {
+            let conn = tokio::time::timeout(
+                Duration::from_secs(60),
+                peer_a.connect(gw_pub, gw_addr).await,
+            )
+            .await??;
+            Ok::<_, anyhow::Error>((conn.remote_version(), conn.remote_addr()))
+        });
+
+        let (joiner_view, gw_view) = tokio::try_join!(peer_a, gw)?;
+        let (joiner_remote_version, joiner_remote_addr) = joiner_view?;
+        assert_eq!(
+            joiner_remote_addr, gw_addr,
+            "the pre-floor handshake must still COMPLETE — the legacy ack path is intact"
+        );
+        assert_eq!(
+            joiner_remote_version, None,
+            "a pre-floor joiner must be told nothing: it cannot decode AckConnectionV2"
+        );
+        assert!(
+            gw_view?.is_some(),
+            "the gateway's own view is unaffected by the gate"
         );
         Ok(())
     }

--- a/crates/core/src/transport/connection_handler.rs
+++ b/crates/core/src/transport/connection_handler.rs
@@ -342,21 +342,28 @@ impl<S: Socket> OutboundConnectionHandler<S> {
         keypair: TransportKeypair,
         is_gateway: bool,
     ) -> Result<(Self, mpsc::Receiver<PeerConnection<S>>), TransportError> {
-        Self::new_test_with_ack_version_floor(socket_addr, socket, keypair, is_gateway, None)
+        Self::new_test_with_options(socket_addr, socket, keypair, is_gateway, None, None)
     }
 
-    /// [`Self::new_test`] with the #5161 version-carrying-ack floor override.
+    /// [`Self::new_test`] with every knob a mock peer can set, so no two of them
+    /// are mutually exclusive.
     ///
-    /// `Some(floor)` lets a test exercise `AckConnectionV2` before the crate
-    /// version reaches `GATEWAY_ACK_VERSION_MIN_VERSION`; `None` is production
-    /// behaviour (the real floor, so a same-build mock pair stays on the legacy
-    /// ack — which is what makes the byte-identity test meaningful).
+    /// `ack_version_floor_override` is the #5161 gate: `Some(floor)` lets a test
+    /// exercise `AckConnectionV2` before the crate version reaches
+    /// `GATEWAY_ACK_VERSION_MIN_VERSION`, `None` is production behaviour.
+    ///
+    /// It takes `bandwidth_limit` too rather than hardcoding `None`. An earlier
+    /// shape had the caller branch between this and `new_test_with_bandwidth`,
+    /// which meant passing a floor override silently discarded any bandwidth
+    /// limit — a trap that would have surfaced as a throughput test which
+    /// mysteriously failed to throttle.
     #[cfg(any(test, feature = "bench"))]
-    pub(crate) fn new_test_with_ack_version_floor(
+    pub(crate) fn new_test_with_options(
         socket_addr: SocketAddr,
         socket: Arc<S>,
         keypair: TransportKeypair,
         is_gateway: bool,
+        bandwidth_limit: Option<usize>,
         ack_version_floor_override: Option<(u8, u8, u16)>,
     ) -> Result<(Self, mpsc::Receiver<PeerConnection<S>>), TransportError> {
         let (handler, receiver, _listen_handle) = Self::config_listener(
@@ -364,7 +371,7 @@ impl<S: Socket> OutboundConnectionHandler<S> {
             keypair,
             is_gateway,
             socket_addr,
-            None,
+            bandwidth_limit,
             None,
             None,
             None,
@@ -1902,23 +1909,13 @@ impl<S: Socket, T: TimeSource> UdpPacketsListener<S, T> {
                 };
 
             let inbound_key = Aes128Gcm::new(&inbound_key_bytes.into());
-            // #5161: tell the joiner our version when it is new enough to
-            // decode the field. The intro packet we just parsed IS the evidence
-            // for that, which is why this needs no bootstrapping round-trip.
-            // A pre-floor joiner gets the unmodified `ack_ok` bytes.
-            let outbound_ack_packet = if version_cmp::version_supports_ack_version(
+            let outbound_ack_packet = build_success_ack(
+                &outbound_key,
+                inbound_key_bytes,
+                remote_addr,
                 remote_protoc_version,
                 ack_version_floor,
-            ) {
-                SymmetricMessage::ack_ok_with_version(
-                    &outbound_key,
-                    inbound_key_bytes,
-                    remote_addr,
-                    PROTOC_VERSION,
-                )?
-            } else {
-                SymmetricMessage::ack_ok(&outbound_key, inbound_key_bytes, remote_addr)?
-            };
+            )?;
 
             tracing::trace!(
                 peer_addr = %remote_addr,
@@ -2221,31 +2218,19 @@ impl<S: Socket, T: TimeSource> UdpPacketsListener<S, T> {
                                 direction = "outbound",
                                 "Sending back protocol version and inbound key to remote"
                             );
-                            // #5161: same gate as the gateway path. This side
-                            // has parsed the remote's intro (that is what moved
-                            // us to `RemoteInbound`), so its version is known.
-                            // Load-bearing for peer-to-peer too: if the remote
-                            // races ahead to its own `AckConnection` arm before
-                            // parsing OUR intro, this ack is the only place it
-                            // can learn our version.
-                            let ack_key = outbound_sym_key.as_ref().expect("should be set");
-                            let our_inbound = if version_cmp::version_supports_ack_version(
+                            // Load-bearing for peer-to-peer, not just the
+                            // gateway path: if the remote races ahead to its own
+                            // `AckConnection` arm before parsing OUR intro, this
+                            // ack is the only place it can learn our version.
+                            // We reached `RemoteInbound` by parsing the remote's
+                            // intro, so its version is known here (#5161).
+                            let our_inbound = build_success_ack(
+                                outbound_sym_key.as_ref().expect("should be set"),
+                                inbound_sym_key_bytes,
+                                remote_addr,
                                 remote_protoc_version,
                                 ack_version_floor,
-                            ) {
-                                SymmetricMessage::ack_ok_with_version(
-                                    ack_key,
-                                    inbound_sym_key_bytes,
-                                    remote_addr,
-                                    PROTOC_VERSION,
-                                )?
-                            } else {
-                                SymmetricMessage::ack_ok(
-                                    ack_key,
-                                    inbound_sym_key_bytes,
-                                    remote_addr,
-                                )?
-                            };
+                            )?;
                             socket
                                 .send_to(our_inbound.data(), remote_addr)
                                 .await
@@ -2337,7 +2322,23 @@ impl<S: Socket, T: TimeSource> UdpPacketsListener<S, T> {
                                             // (`gateway_version_probe`, the
                                             // auto-update signal) sees gateways
                                             // at all, not only peers that
-                                            // hole-punched back to us.
+                                            // hole-punched back to us (#5166).
+                                            //
+                                            // Deliberately NOT run through
+                                            // `is_compatible` /
+                                            // `remote_requires_newer_than_us`
+                                            // the way the four intro-parsing
+                                            // report sites are, and the
+                                            // asymmetry is not an oversight:
+                                            // the acceptor already ran the
+                                            // BIDIRECTIONAL compatibility check
+                                            // against our intro before choosing
+                                            // to send this, and would have
+                                            // replied `ack_error` instead had
+                                            // it required a newer version than
+                                            // ours. So the "we must update to
+                                            // talk to this peer" branch is
+                                            // unreachable here by construction.
                                             if let Some(bytes) = acceptor_version_bytes {
                                                 let info = version_cmp::parse_version_bytes(&bytes);
                                                 crate::transport::report_peer_version(info.version);
@@ -2438,19 +2439,34 @@ impl<S: Socket, T: TimeSource> UdpPacketsListener<S, T> {
                                         } => {
                                             return Err(handle_ack_connection_error(err));
                                         }
-                                        // The two success encodings are
-                                        // consumed by `ack_ok_parts` above,
-                                        // whose body always returns; they are
-                                        // listed here only to keep the match
-                                        // exhaustive, so a future payload
-                                        // variant has to be classified rather
-                                        // than silently falling into a
-                                        // catch-all.
+                                        // Unreachable: `ack_ok_parts` consumed
+                                        // both success encodings above and its
+                                        // body always returns. Kept as its OWN
+                                        // arm rather than folded into the
+                                        // "unexpected packet" list below, and
+                                        // logged at ERROR, because reaching it
+                                        // means a success encoding exists that
+                                        // `ack_ok_parts` does not destructure —
+                                        // e.g. a future `AckConnectionV3` added
+                                        // to the enum and to the list below but
+                                        // forgotten there. That compiles, keeps
+                                        // the match exhaustive, and would
+                                        // otherwise present as a handshake that
+                                        // silently never completes.
                                         SymmetricMessagePayload::AckConnection {
                                             result: Ok(_),
                                         }
-                                        | SymmetricMessagePayload::AckConnectionV2 { .. }
-                                        | SymmetricMessagePayload::ShortMessage { .. }
+                                        | SymmetricMessagePayload::AckConnectionV2 { .. } => {
+                                            tracing::error!(
+                                                peer_addr = %remote_addr,
+                                                direction = "outbound",
+                                                "Success ack not destructured by ack_ok_parts — a \
+                                                 success encoding was added to the payload enum \
+                                                 without teaching ack_ok_parts about it"
+                                            );
+                                            continue;
+                                        }
+                                        SymmetricMessagePayload::ShortMessage { .. }
                                         | SymmetricMessagePayload::StreamFragment { .. }
                                         | SymmetricMessagePayload::NoOp
                                         | SymmetricMessagePayload::Ping { .. }
@@ -2602,6 +2618,41 @@ impl<S: Socket, T: TimeSource> UdpPacketsListener<S, T> {
             })
         };
         (f.boxed(), inbound_from_remote)
+    }
+}
+
+/// Build the success ack for a peer whose protocol version we have just parsed
+/// from its intro packet, choosing the encoding by version (#5161).
+///
+/// Both acceptors — the gateway path and the peer-to-peer `RemoteInbound` path —
+/// go through here so the gate cannot drift between them, and so the reasoning
+/// below lives in one place.
+///
+/// The decision reads ONLY the version parsed during THIS handshake, never a
+/// cached one, which is what makes it impossible for the gate to go stale
+/// against a peer that restarted on an older build at a reused address.
+///
+/// `None` (or below the floor) yields the unmodified `ack_ok`, so a pre-floor
+/// peer receives byte-identical traffic to today. That matters more here than on
+/// the other version-gated surfaces: a peer that cannot decode this particular
+/// message does not merely drop a connection, it fails to complete the handshake
+/// at all, so it could not connect to an upgraded gateway.
+fn build_success_ack(
+    outbound_sym_key: &Aes128Gcm,
+    our_inbound_key: [u8; 16],
+    remote_addr: SocketAddr,
+    remote_protoc_version: Option<(u8, u8, u16)>,
+    ack_version_floor: (u8, u8, u16),
+) -> Result<PacketData<SymmetricAES>, bincode::Error> {
+    if version_cmp::version_supports_ack_version(remote_protoc_version, ack_version_floor) {
+        SymmetricMessage::ack_ok_with_version(
+            outbound_sym_key,
+            our_inbound_key,
+            remote_addr,
+            PROTOC_VERSION,
+        )
+    } else {
+        SymmetricMessage::ack_ok(outbound_sym_key, our_inbound_key, remote_addr)
     }
 }
 
@@ -3168,6 +3219,34 @@ pub mod mock_transport {
         .await
     }
 
+    /// Create a mock (non-gateway) peer whose version-carrying-ack floor (#5161)
+    /// is overridden, with a caller-chosen packet-drop policy.
+    ///
+    /// Both parameters are needed together for the peer-to-peer arm:
+    /// `create_mock_gateway_with_ack_floor` hardcodes `gateway = true`, so
+    /// without this no NAT-traversal pair could carry a floor override — and the
+    /// drop policy is what forces the intro/ack RACE that arm exists to handle.
+    pub async fn create_mock_peer_with_ack_floor(
+        packet_drop_policy: PacketDropPolicy,
+        channels: Channels,
+        ack_version_floor_override: Option<(u8, u8, u16)>,
+    ) -> anyhow::Result<(
+        TransportPublicKey,
+        OutboundConnectionHandler<MockSocket>,
+        SocketAddr,
+    )> {
+        create_mock_peer_internal(
+            packet_drop_policy,
+            PacketDelayPolicy::NoDelay,
+            false,
+            channels,
+            None,
+            ack_version_floor_override,
+        )
+        .await
+        .map(|(pk, (o, _), s)| (pk, o, s))
+    }
+
     /// Create a mock gateway whose version-carrying-ack floor (#5161) is
     /// overridden, so a test can exercise BOTH sides of the gate without
     /// depending on the crate's current version.
@@ -3229,23 +3308,14 @@ pub mod mock_transport {
             )
             .await,
         );
-        let (peer_conn, inbound_conn) = if let Some(floor) = ack_version_floor_override {
-            OutboundConnectionHandler::new_test_with_ack_version_floor(
-                (Ipv4Addr::LOCALHOST, port).into(),
-                socket,
-                peer_keypair,
-                gateway,
-                Some(floor),
-            )
-        } else {
-            OutboundConnectionHandler::new_test_with_bandwidth(
-                (Ipv4Addr::LOCALHOST, port).into(),
-                socket,
-                peer_keypair,
-                gateway,
-                bandwidth_limit,
-            )
-        }
+        let (peer_conn, inbound_conn) = OutboundConnectionHandler::new_test_with_options(
+            (Ipv4Addr::LOCALHOST, port).into(),
+            socket,
+            peer_keypair,
+            gateway,
+            bandwidth_limit,
+            ack_version_floor_override,
+        )
         .expect("failed to create peer");
         Ok((
             peer_pub,
@@ -3549,8 +3619,12 @@ pub mod mock_transport {
         // This is a symmetric peer-to-peer hole-punch (no gateway), so each side
         // captures the remote version while parsing the other's intro packet on
         // the RemoteInbound path. Whichever side races ahead to the AckConnection
-        // path instead would report None (that payload carries no version), so we
-        // require any captured version to match and at least one side to capture it.
+        // path instead reports None here, because both mock peers run this build
+        // and this build is below `GATEWAY_ACK_VERSION_MIN_VERSION` — so we
+        // require any captured version to match and at least one side to capture
+        // it. `nat_traversal_ack_racer_learns_version_from_the_ack` is the test
+        // that forces that race deliberately, with the floor overridden, and
+        // shows the ack now carries a version for the racing side (#5161).
         for v in [a_version, b_version].into_iter().flatten() {
             assert_eq!(v, expected_version);
         }
@@ -3764,18 +3838,97 @@ pub mod mock_transport {
         );
         // Both mock peers run this build, so whether the joiner learns the
         // gateway's version here depends purely on whether this build is at or
-        // above the production floor. Asserting either constant would make this
-        // test flip at the 0.2.120 release; the two dedicated tests below pin
-        // BOTH sides of the gate against explicit floors instead.
+        // above the production floor. Asserting a bare `None` would make this
+        // test flip at the 0.2.120 release.
+        //
+        // The expectation is derived by comparing the crate version against the
+        // floor DIRECTLY, not via `version_supports_ack_version` — that is the
+        // predicate under test, and computing the expectation with it makes the
+        // assertion tautological. It was written that way first, and a
+        // reviewer's mutation showed that the catastrophic regression (a gateway
+        // emitting V2 to EVERY peer regardless of version, breaking every
+        // pre-0.2.120 joiner's handshake) left the test green.
         let joiner_view = joiner_view?;
-        let crate_at_or_above_floor = version_cmp::version_supports_ack_version(
-            Some(expected_version),
-            version_cmp::GATEWAY_ACK_VERSION_MIN_VERSION,
-        );
+        let crate_at_or_above_floor =
+            expected_version >= version_cmp::GATEWAY_ACK_VERSION_MIN_VERSION;
         assert_eq!(
             joiner_view.is_some(),
             crate_at_or_above_floor,
             "joiner's view of the gateway version must follow the production floor exactly"
+        );
+        Ok(())
+    }
+
+    /// **The peer-to-peer half of #5161.** The version-carrying ack is not only
+    /// a gateway mechanism: `traverse_nat`'s `RemoteInbound` arm sends an ack
+    /// too, and the peer receiving it may have raced ahead to its own
+    /// `AckConnection` arm without ever parsing our intro. On that link the ack
+    /// is the ONLY channel through which a version can travel.
+    ///
+    /// Forcing the race is the whole difficulty, and is why this drops peer B's
+    /// first packet. Without the drop both peers parse each other's intro on the
+    /// `StartOutbound` path and learn versions the old way, so the assertion
+    /// holds with or without the fix — the first version of this test did
+    /// exactly that and a mutation confirmed it was vacuous. With B's intro
+    /// dropped, A never parses one, stays in `StartOutbound`, and receives B's
+    /// ack instead: precisely the arm that used to yield `None`.
+    ///
+    /// The pre-existing `simulate_nat_traversal` cannot cover this either — it
+    /// requires only that AT LEAST ONE side captured a version, precisely
+    /// because the loser of the race captured nothing.
+    #[tokio::test]
+    async fn nat_traversal_ack_racer_learns_version_from_the_ack() -> anyhow::Result<()> {
+        // A floor every build clears, so this does not move with the crate
+        // version.
+        const REACHABLE_FLOOR: (u8, u8, u16) = (0, 0, 0);
+
+        let channels = Arc::new(DashMap::new());
+        let (peer_a_pub, mut peer_a, peer_a_addr) = create_mock_peer_with_ack_floor(
+            PacketDropPolicy::ReceiveAll,
+            channels.clone(),
+            Some(REACHABLE_FLOOR),
+        )
+        .await?;
+        // Drop B's first outbound packet — its intro — so A cannot learn B's
+        // version by parsing one.
+        let (peer_b_pub, mut peer_b, peer_b_addr) = create_mock_peer_with_ack_floor(
+            PacketDropPolicy::Ranges(vec![0..1]),
+            channels,
+            Some(REACHABLE_FLOOR),
+        )
+        .await?;
+
+        let expected_version = version_cmp::parse_version_bytes(&PROTOC_VERSION).version;
+
+        let peer_b = GlobalExecutor::spawn(async move {
+            let conn = tokio::time::timeout(
+                Duration::from_secs(500),
+                peer_b.connect(peer_a_pub, peer_a_addr).await,
+            )
+            .await??;
+            Ok::<_, anyhow::Error>(conn.remote_version())
+        });
+
+        let peer_a = GlobalExecutor::spawn(async move {
+            let conn = tokio::time::timeout(
+                Duration::from_secs(500),
+                peer_a.connect(peer_b_pub, peer_b_addr).await,
+            )
+            .await??;
+            Ok::<_, anyhow::Error>(conn.remote_version())
+        });
+
+        let (a_version, b_version) = tokio::try_join!(peer_a, peer_b)?;
+        assert_eq!(
+            a_version?,
+            Some(expected_version),
+            "peer A never saw peer B's intro, so B's ack is the only place A \
+             could have learned B's version — before #5161 this was None"
+        );
+        assert_eq!(
+            b_version?,
+            Some(expected_version),
+            "peer B parsed A's intro and should be unaffected"
         );
         Ok(())
     }

--- a/crates/core/src/transport/connection_handler/version_cmp.rs
+++ b/crates/core/src/transport/connection_handler/version_cmp.rs
@@ -144,6 +144,67 @@ pub(super) fn is_compatible(local: &[u8; 8], remote: &[u8; 8]) -> Result<Version
     Ok(remote_info)
 }
 
+/// Minimum protocol version a peer must report in its intro packet before we
+/// may answer it with the version-carrying
+/// [`SymmetricMessagePayload::AckConnectionV2`](super::super::symmetric_message::SymmetricMessagePayload)
+/// instead of the legacy `AckConnection` (#5161).
+///
+/// # Why a floor at all
+///
+/// The ack payload is bincode, so a peer that does not carry the `AckConnectionV2`
+/// variant index cannot deserialize it. On this particular path the decode
+/// failure is not a dropped connection but a handshake that never completes:
+/// the joiner would be unable to connect to ANY upgraded gateway. So the new
+/// form may only go to a peer already known to decode it.
+///
+/// # Why the usual bootstrapping problem does not arise
+///
+/// Unlike every other version-gated wire feature here, there is no chicken and
+/// egg. The acceptor has already decrypted and parsed the joiner's intro packet
+/// — which carries the joiner's version — BEFORE it builds the ack. So the gate
+/// reads a version we already hold, and a pre-floor joiner receives byte-identical
+/// traffic to today (`SymmetricMessage::ack_ok`, unmodified).
+///
+/// # Release-time check
+///
+/// Per the wire-gated-floor rule in `docs/RELEASING.md`, this MUST equal the
+/// release that first EMITS `AckConnectionV2`, then be frozen. The crate is at
+/// 0.2.119 and this ships in 0.2.120. A floor BELOW the shipping version sends
+/// an undecodable ack to peers on the release just before, breaking their
+/// handshakes outright during the 0-4h staggered rollout; a floor ABOVE it
+/// silently leaves the bug in place against fully-capable peers.
+/// `ack_version_floor_tracks_the_shipping_release` fails the build if a release
+/// bump lifts `PCK_VERSION` to the floor without this having shipped, so the
+/// release cannot silently outrun it in either direction.
+pub(super) const GATEWAY_ACK_VERSION_MIN_VERSION: (u8, u8, u16) = (0, 2, 120);
+
+/// Has the version-carrying ack actually SHIPPED, and in which release?
+///
+/// `Some(v)` — shipped in `v`, which must EQUAL the floor, frozen thereafter.
+/// `None` — not yet shipped, so the floor is a PREDICTION about the next
+/// release and must stay strictly ABOVE the current crate version.
+///
+/// Read only by `ack_version_floor_tracks_the_shipping_release`; it carries no
+/// runtime behaviour by design, mirroring `HASH_FIRST_SHIPPED_IN`.
+#[cfg_attr(not(test), allow(dead_code))]
+pub(super) const ACK_VERSION_SHIPPED_IN: Option<(u8, u8, u16)> = None;
+
+/// Pure version-gate for [`GATEWAY_ACK_VERSION_MIN_VERSION`], mirroring
+/// `node::version_supports_hash_first_summaries`: `true` iff `remote` is known
+/// (`Some`) AND at least `floor`.
+///
+/// Fail-closed on `None`, which on this path means the intro packet was parsed
+/// but yielded no usable version — send the legacy ack, exactly today's
+/// behaviour. Takes an explicit `floor` so the predicate is unit-testable
+/// independent of the production constant, and so simulations can exercise the
+/// path before the crate version passes the real floor.
+pub(super) fn version_supports_ack_version(
+    remote: Option<(u8, u8, u16)>,
+    floor: (u8, u8, u16),
+) -> bool {
+    remote.is_some_and(|v| v >= floor)
+}
+
 /// Check if a version mismatch from an old peer means WE need to update.
 ///
 /// When an old peer rejects us (they do strict exact-match), parse their
@@ -176,6 +237,55 @@ pub(super) fn old_peer_rejection_means_we_must_update(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The #5161 gate fails closed on an unknown version and is a plain `>=`
+    /// against the floor. Both halves matter: `None` must NOT emit the new
+    /// encoding (we would be guessing that a peer can decode a variant it may
+    /// not carry), and the release exactly AT the floor must (a floor that
+    /// excluded its own release would silently never activate).
+    #[test]
+    fn ack_version_gate_is_fail_closed_and_inclusive_at_the_floor() {
+        const FLOOR: (u8, u8, u16) = (0, 2, 120);
+        assert!(
+            !version_supports_ack_version(None, FLOOR),
+            "unknown version must not receive the version-carrying ack"
+        );
+        assert!(!version_supports_ack_version(Some((0, 2, 119)), FLOOR));
+        assert!(!version_supports_ack_version(Some((0, 1, 65535)), FLOOR));
+        assert!(version_supports_ack_version(Some(FLOOR), FLOOR));
+        assert!(version_supports_ack_version(Some((0, 2, 121)), FLOOR));
+        assert!(version_supports_ack_version(Some((0, 3, 0)), FLOOR));
+        assert!(version_supports_ack_version(Some((1, 0, 0)), FLOOR));
+    }
+
+    /// Guard that the version-carrying ack ships in exactly the release its
+    /// floor names, mirroring `hash_first_floor_tracks_the_shipping_release`.
+    ///
+    /// The failure this prevents is not cosmetic. If the floor goes stale — a
+    /// slipped or renumbered release — every test here stays green while a peer
+    /// running the real release at the floor reads as at-floor, receives an ack
+    /// whose variant index it does not carry, and cannot complete the
+    /// handshake at all. The moment a release bump lifts `PCK_VERSION` to the
+    /// floor, this fails until someone consciously either confirms we are
+    /// shipping it or raises the floor.
+    #[test]
+    fn ack_version_floor_tracks_the_shipping_release() {
+        let crate_version = parse_semver(PCK_VERSION);
+        match ACK_VERSION_SHIPPED_IN {
+            Some(shipped) => {
+                assert_eq!(
+                    shipped, GATEWAY_ACK_VERSION_MIN_VERSION,
+                    "the release that ships the version-carrying ack must EQUAL its floor"
+                );
+            }
+            None => assert!(
+                crate_version < GATEWAY_ACK_VERSION_MIN_VERSION,
+                "floor {GATEWAY_ACK_VERSION_MIN_VERSION:?} is a PREDICTION about the next \
+                 release, but the crate is already at {crate_version:?} — either flip \
+                 ACK_VERSION_SHIPPED_IN to Some(floor) (we are shipping it) or raise the floor"
+            ),
+        }
+    }
 
     #[test]
     fn test_parse_semver() {

--- a/crates/core/src/transport/peer_connection.rs
+++ b/crates/core/src/transport/peer_connection.rs
@@ -106,8 +106,13 @@ pub(crate) struct RemoteConnection<S = super::UdpSocket, T: TimeSource = RealTim
     #[allow(dead_code)]
     pub(super) my_address: Option<SocketAddr>,
     /// Remote peer's negotiated protocol version, captured during the handshake.
-    /// `None` on the joiner->gateway path (the gateway's AckConnection payload
-    /// carries no version) — see connection_handler.rs traverse_nat AckConnection arm.
+    ///
+    /// Learned from the remote's intro packet where we parse one, and otherwise
+    /// from the acceptor's `AckConnectionV2` (#5161). `None` means the remote is
+    /// below `GATEWAY_ACK_VERSION_MIN_VERSION`, which is a fact about the peer —
+    /// not a gap in what this path can observe. Before #5161 the joiner->gateway
+    /// path was ALWAYS `None`, because the gateway's `AckConnection` carried no
+    /// version and the joiner never parses an intro packet from it.
     pub(super) remote_protoc_version: Option<(u8, u8, u16)>,
     pub(super) transport_secret_key: TransportSecretKey,
     /// Congestion controller (BBR by default) - adapts to network conditions
@@ -1032,7 +1037,7 @@ impl<S: super::Socket, T: TimeSource> PeerConnection<S, T> {
                                 }
                             }
                         }
-                        SymmetricMessagePayload::AckConnection { .. } | SymmetricMessagePayload::ShortMessage { .. } | SymmetricMessagePayload::StreamFragment { .. } => {}
+                        SymmetricMessagePayload::AckConnection { .. } | SymmetricMessagePayload::AckConnectionV2 { .. } | SymmetricMessagePayload::ShortMessage { .. } | SymmetricMessagePayload::StreamFragment { .. } => {}
                     }
 
                     {
@@ -1640,7 +1645,13 @@ impl<S: super::Socket, T: TimeSource> PeerConnection<S, T> {
             AckConnection { result: Err(cause) } => {
                 Err(TransportError::ConnectionEstablishmentFailure { cause })
             }
-            AckConnection { result: Ok(_) } => {
+            // A duplicate success ack on an ESTABLISHED connection, in either
+            // encoding (#5161): the remote did not see our completion ack, so
+            // re-send it. The reply is deliberately the legacy `ack_ok` in both
+            // cases — this side is the joiner, the remote already learned our
+            // version from our intro packet, and answering a V2 ack with a V2
+            // ack would tell it nothing it does not have.
+            AckConnection { result: Ok(_) } | AckConnectionV2 { .. } => {
                 let packet = SymmetricMessage::ack_ok(
                     &self.remote_conn.outbound_symmetric_key,
                     self.remote_conn.inbound_symmetric_key_bytes,

--- a/crates/core/src/transport/peer_connection.rs
+++ b/crates/core/src/transport/peer_connection.rs
@@ -3499,6 +3499,136 @@ mod tests {
         );
     }
 
+    /// A duplicate `AckConnectionV2` on an ESTABLISHED connection is answered
+    /// with the LEGACY `ack_ok`, and does not disturb the connection (#5161).
+    ///
+    /// The arm handling it is shared with the legacy duplicate ack, and the
+    /// choice to reply in the old encoding is deliberate rather than an
+    /// oversight: this side is the joiner, so the remote already learned our
+    /// version from our intro packet, and answering V2 with V2 would tell it
+    /// nothing it does not have. That reasoning was load-bearing and unpinned
+    /// until this test — a reviewer flagged that nothing drove `process_inbound`
+    /// with either success ack.
+    ///
+    /// Sends a `ShortMessage` behind the ack so `recv()` has something to
+    /// return: the ack arm yields `Ok(None)` and loops, so a test that sent only
+    /// the ack would hang rather than assert.
+    #[tokio::test]
+    async fn duplicate_v2_ack_on_established_connection_is_answered_with_legacy_ack() {
+        use crate::transport::crypto::TransportKeypair;
+        use crate::transport::packet_data::PacketData;
+        use crate::transport::symmetric_message::SymmetricMessagePayload;
+        use crate::util::time_source::SharedMockTimeSource;
+        use bytes::Bytes;
+
+        let time_source = SharedMockTimeSource::new();
+        let (inbound_tx, inbound_rx) = mpsc::channel(16);
+        let remote_addr = SocketAddr::new(Ipv4Addr::new(10, 99, 99, 2).into(), 50002);
+
+        let mut key = [0u8; 16];
+        crate::config::GlobalRng::fill_bytes(&mut key);
+        let cipher = Aes128Gcm::new(&key.into());
+        let keypair = TransportKeypair::new();
+
+        let sent_tracker = Arc::new(parking_lot::Mutex::new(
+            SentPacketTracker::new_with_time_source(time_source.clone()),
+        ));
+        let congestion_controller =
+            crate::transport::congestion_control::CongestionControlConfig::default()
+                .build_arc_with_time_source(time_source.clone());
+        let token_bucket = Arc::new(TokenBucket::new_with_time_source(
+            10_000,
+            10_000_000,
+            time_source.clone(),
+        ));
+        let (sock_tx, mut sock_rx) = mpsc::channel::<(SocketAddr, Arc<[u8]>)>(16);
+        let socket = Arc::new(TestSocket::new(sock_tx));
+
+        let rolling_rtt_stats = crate::transport::rolling_rtt_stats::RollingRttStatsHandle::new(
+            remote_addr,
+            time_source.clone(),
+        );
+        let remote_conn = RemoteConnection {
+            outbound_symmetric_key: cipher.clone(),
+            remote_addr,
+            sent_tracker,
+            last_packet_id: Arc::new(AtomicU32::new(0)),
+            inbound_packet_recv: inbound_rx,
+            inbound_symmetric_key: cipher.clone(),
+            inbound_symmetric_key_bytes: key,
+            my_address: None,
+            remote_protoc_version: Some((0, 2, 120)),
+            transport_secret_key: keypair.secret,
+            congestion_controller,
+            token_bucket,
+            socket,
+            global_bandwidth: None,
+            rolling_rtt_stats,
+            time_source,
+        };
+
+        // A retransmitted V2 success ack, as an upgraded acceptor would resend
+        // if it never saw our completion ack.
+        let v2 = SymmetricMessage::ack_ok_with_version(
+            &cipher,
+            key,
+            remote_addr,
+            [0xFF, 0, 2, 0, 120, 0, 80, 1],
+        )
+        .expect("encode v2 ack");
+        inbound_tx
+            .send(
+                PacketData::<crate::transport::packet_data::UnknownEncryption>::from_buf(v2.data()),
+            )
+            .await
+            .expect("send v2 ack");
+
+        // Something for `recv()` to actually return.
+        let follow_up = SymmetricMessage::serialize_msg_to_packet_data(
+            7,
+            SymmetricMessagePayload::ShortMessage {
+                payload: Bytes::from_static(b"after-the-ack"),
+            },
+            &cipher,
+            vec![],
+        )
+        .expect("encode short message");
+        inbound_tx
+            .send(
+                PacketData::<crate::transport::packet_data::UnknownEncryption>::from_buf(
+                    follow_up.data(),
+                ),
+            )
+            .await
+            .expect("send short message");
+
+        let mut conn = PeerConnection::new(remote_conn);
+        let msg = conn.recv().await.expect("recv");
+        assert_eq!(
+            msg.as_slice(),
+            b"after-the-ack".as_slice(),
+            "the V2 ack must be consumed and the connection carry on"
+        );
+
+        let (target, sent) = sock_rx.try_recv().expect("a reply must have been sent");
+        assert_eq!(target, remote_addr);
+        let decrypted =
+            PacketData::<crate::transport::packet_data::UnknownEncryption>::from_buf(&sent)
+                .try_decrypt_sym(&cipher)
+                .expect("reply is encrypted under the shared key");
+        let reply = SymmetricMessage::deser(decrypted.data()).expect("reply decodes");
+        assert!(
+            matches!(
+                reply.payload,
+                SymmetricMessagePayload::AckConnection { result: Ok(_) }
+            ),
+            "the reply must be the LEGACY ack — replying V2 here would tell the \
+             acceptor nothing it did not already learn from our intro packet, \
+             and would be an ungated send of the new encoding. Got: {:?}",
+            reply.payload
+        );
+    }
+
     /// Regression test for #3369: `last_received_nanos` is a struct field, not a local.
     ///
     /// Before the fix, `last_received_nanos` was a local variable in `recv()`,

--- a/crates/core/src/transport/peer_connection/outbound_stream.rs
+++ b/crates/core/src/transport/peer_connection/outbound_stream.rs
@@ -1029,6 +1029,7 @@ mod tests {
                         // Expected
                     }
                     SymmetricMessagePayload::AckConnection { .. }
+                    | SymmetricMessagePayload::AckConnectionV2 { .. }
                     | SymmetricMessagePayload::ShortMessage { .. }
                     | SymmetricMessagePayload::NoOp
                     | SymmetricMessagePayload::Ping { .. }

--- a/crates/core/src/transport/shadow_demand.rs
+++ b/crates/core/src/transport/shadow_demand.rs
@@ -138,6 +138,7 @@ pub(crate) fn classify(payload: &SymmetricMessagePayload) -> OutboundClass {
         SymmetricMessagePayload::ShortMessage { .. } => OutboundClass::Short,
         SymmetricMessagePayload::NoOp
         | SymmetricMessagePayload::AckConnection { .. }
+        | SymmetricMessagePayload::AckConnectionV2 { .. }
         | SymmetricMessagePayload::Ping { .. }
         | SymmetricMessagePayload::Pong { .. } => OutboundClass::MustFlow,
     }

--- a/crates/core/src/transport/symmetric_message.rs
+++ b/crates/core/src/transport/symmetric_message.rs
@@ -548,6 +548,15 @@ mod test {
     /// bytes — a field added to `OutboundConnection`, a reordering of
     /// `SymmetricMessage`, a bincode config change, or a variant inserted
     /// before `AckConnection` in `SymmetricMessagePayload`.
+    ///
+    /// **Provenance, because the literal cannot vouch for itself.** It was
+    /// hand-derived from the bincode-fixint layout — 4 (`packet_id`) + 8 (empty
+    /// vec length) + 4 (payload variant) + 4 (`Result::Ok`) + 16 (key) + 4
+    /// (`SocketAddr::V4`) + 4 (octets) + 2 (port) = 46 bytes — and cross-checked
+    /// against the pre-#5161 encoder. If you ever find this failing, do NOT
+    /// re-derive the literal from whatever the current code emits: that turns
+    /// the pin into a no-op. Work out which of the four causes above moved, and
+    /// whether the peers who cannot be upgraded can still decode it.
     #[test]
     fn ack_ok_produces_identical_bytes_to_pre_5161_encoding() {
         // packet_id=0 (u32 LE) | confirm_receipt len=0 (u64 LE)

--- a/crates/core/src/transport/symmetric_message.rs
+++ b/crates/core/src/transport/symmetric_message.rs
@@ -136,10 +136,50 @@ impl SymmetricMessage {
                 }),
             },
         };
+        Self::serialize_ack(&message, outbound_sym_key)
+    }
+
+    /// Version-carrying form of [`Self::ack_ok`] (#5161).
+    ///
+    /// Emits [`SymmetricMessagePayload::AckConnectionV2`], which is
+    /// byte-incompatible with a peer that does not carry that variant index —
+    /// the caller MUST have established that the remote is at or above
+    /// `GATEWAY_ACK_VERSION_MIN_VERSION` first. See
+    /// `connection_handler::version_cmp::version_supports_ack_version`.
+    ///
+    /// `ack_ok` is deliberately left untouched rather than generalised to take
+    /// an `Option<[u8; 8]>`: the pre-floor path must keep producing the exact
+    /// bytes it produces today, and calling the same unmodified function is a
+    /// stronger guarantee of that than any amount of branch review.
+    /// `ack_ok_produces_identical_bytes_to_pre_5161_encoding` pins it anyway.
+    pub fn ack_ok_with_version(
+        outbound_sym_key: &Aes128Gcm,
+        our_inbound_key: [u8; 16],
+        remote_addr: SocketAddr,
+        protoc_version: [u8; 8],
+    ) -> Result<PacketData<SymmetricAES>, bincode::Error> {
+        let message = Self {
+            packet_id: Self::FIRST_PACKET_ID,
+            confirm_receipt: vec![],
+            payload: SymmetricMessagePayload::AckConnectionV2 {
+                connection: OutboundConnectionV2 {
+                    key: our_inbound_key,
+                    remote_addr,
+                    protoc_version,
+                },
+            },
+        };
+        Self::serialize_ack(&message, outbound_sym_key)
+    }
+
+    fn serialize_ack(
+        message: &Self,
+        outbound_sym_key: &Aes128Gcm,
+    ) -> Result<PacketData<SymmetricAES>, bincode::Error> {
         let mut packet = [0u8; MAX_DATA_SIZE];
-        let size = bincode::serialized_size(&message)?;
+        let size = bincode::serialized_size(message)?;
         debug_assert!(size <= MAX_DATA_SIZE as u64);
-        bincode::serialize_into(packet.as_mut_slice(), &message)?;
+        bincode::serialize_into(packet.as_mut_slice(), message)?;
         let bytes = &packet[..size as usize];
 
         let packet = PacketData::from_buf_plain(bytes);
@@ -263,6 +303,28 @@ pub(crate) struct OutboundConnection {
     pub(super) remote_addr: SocketAddr,
 }
 
+/// [`OutboundConnection`] plus the ACCEPTOR's protocol version (#5161).
+///
+/// The version is the same 8-byte `PROTOC_VERSION` wire encoding the intro
+/// packet carries, so the receiver parses it with the identical
+/// `version_cmp::parse_version_bytes` and gets `min_compatible` for free.
+///
+/// Why a parallel struct rather than a field on `OutboundConnection`: the
+/// payload is bincode, whose field layout is not forward-tolerant, so the
+/// version can only be sent to a peer already known to decode it. A plain new
+/// field would have to be omitted conditionally, which bincode cannot express
+/// without a hand-written `Serialize`; an `Option` would still emit its
+/// discriminant byte and change the bytes a pre-floor peer sees. Leaving the
+/// legacy type untouched makes the compatibility guarantee structural.
+#[derive(Serialize, Deserialize)]
+#[cfg_attr(test, derive(PartialEq, Debug, Clone))]
+pub(crate) struct OutboundConnectionV2 {
+    pub(super) key: [u8; 16],
+    pub(super) remote_addr: SocketAddr,
+    /// Acceptor's `PROTOC_VERSION` bytes, in the intro packet's encoding.
+    pub(super) protoc_version: [u8; 8],
+}
+
 #[derive(Serialize, Deserialize)]
 #[cfg_attr(test, derive(PartialEq, Debug, Clone))]
 pub(crate) enum SymmetricMessagePayload {
@@ -298,6 +360,26 @@ pub(crate) enum SymmetricMessagePayload {
         /// Sequence number from the corresponding Ping
         sequence: u64,
     },
+    /// Successful connection ack that ALSO carries the acceptor's protocol
+    /// version (#5161).
+    ///
+    /// The legacy [`Self::AckConnection`] tells the joiner nothing about who it
+    /// just connected to, so a node permanently treated every gateway — and
+    /// every peer whose hole-punch raced ahead to the ack — as unknown-version,
+    /// and every version-gated wire feature failed closed on exactly those
+    /// links. The acceptor already parsed the joiner's intro packet before it
+    /// builds the ack, so it knows whether the joiner can decode this variant;
+    /// a joiner below `GATEWAY_ACK_VERSION_MIN_VERSION` still receives the
+    /// byte-identical legacy `AckConnection`.
+    ///
+    /// MUST stay last: appending keeps every existing variant's bincode index
+    /// unchanged, which is what makes the legacy encoding provably untouched.
+    /// The failure case has no V2 form — an incompatible peer is rejected with
+    /// the legacy `AckConnection { result: Err(..) }` (`ack_error`), which is
+    /// correct precisely because such a peer may not carry this index.
+    AckConnectionV2 {
+        connection: OutboundConnectionV2,
+    },
 }
 
 #[cfg(test)]
@@ -325,6 +407,9 @@ impl std::fmt::Display for SymmetricMessagePayload {
             SymmetricMessagePayload::NoOp => write!(f, "NoOp"),
             SymmetricMessagePayload::Ping { sequence } => write!(f, "Ping({sequence})"),
             SymmetricMessagePayload::Pong { sequence } => write!(f, "Pong({sequence})"),
+            SymmetricMessagePayload::AckConnectionV2 { .. } => {
+                write!(f, "AckConnectionV2")
+            }
         }
     }
 }
@@ -448,6 +533,158 @@ mod test {
             SymmetricMessagePayload::AckConnection { result: Ok(_) }
         ));
         Ok(())
+    }
+
+    /// **The #5161 backward-compatibility guarantee, asserted on bytes.**
+    ///
+    /// A joiner below `GATEWAY_ACK_VERSION_MIN_VERSION` must receive the exact
+    /// ack it receives today. `ack_ok` is what it receives, so this pins
+    /// `ack_ok`'s plaintext for a fixed input against a golden literal captured
+    /// from the pre-#5161 encoding.
+    ///
+    /// A golden literal rather than a re-serialization of the same struct: the
+    /// latter would compare the encoder against itself and pass even if the
+    /// wire layout moved wholesale. This fails if ANYTHING shifts the legacy
+    /// bytes — a field added to `OutboundConnection`, a reordering of
+    /// `SymmetricMessage`, a bincode config change, or a variant inserted
+    /// before `AckConnection` in `SymmetricMessagePayload`.
+    #[test]
+    fn ack_ok_produces_identical_bytes_to_pre_5161_encoding() {
+        // packet_id=0 (u32 LE) | confirm_receipt len=0 (u64 LE)
+        // | payload variant 0 = AckConnection (u32 LE)
+        // | Result variant 0 = Ok (u32 LE)
+        // | key: 16 raw bytes
+        // | remote_addr: SocketAddr variant 0 = V4 (u32 LE), 4 octets, port (u16 LE)
+        const PRE_5161_ACK_OK_PLAINTEXT: &[u8] = &[
+            0, 0, 0, 0, // packet_id
+            0, 0, 0, 0, 0, 0, 0, 0, // confirm_receipt: empty vec
+            0, 0, 0, 0, // SymmetricMessagePayload::AckConnection
+            0, 0, 0, 0, // Result::Ok
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, // key
+            0, 0, 0, 0, // SocketAddr::V4
+            127, 0, 0, 1, // 127.0.0.1
+            210, 4, // port 1234
+        ];
+
+        let key = gen_key();
+        let packet = SymmetricMessage::ack_ok(
+            &key,
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+            (Ipv4Addr::LOCALHOST, 1234).into(),
+        )
+        .unwrap();
+        let plaintext = packet.decrypt(&key).unwrap();
+
+        assert_eq!(
+            plaintext.data(),
+            PRE_5161_ACK_OK_PLAINTEXT,
+            "the legacy ack encoding MOVED. A pre-floor joiner would no longer receive \
+             byte-identical traffic, which is the whole compatibility guarantee of #5161."
+        );
+    }
+
+    /// Appending `AckConnectionV2` must not renumber any existing variant.
+    ///
+    /// If it did, the compatibility guarantee above would hold for `ack_ok`
+    /// alone while every OTHER message silently changed meaning on the wire —
+    /// a peer would read a `ShortMessage` as a `StreamFragment`. Reads the
+    /// variant index straight out of the serialized bytes, at the fixed offset
+    /// after `packet_id` (u32) and the empty `confirm_receipt` length (u64).
+    #[test]
+    fn appending_ack_connection_v2_did_not_renumber_existing_variants() {
+        const VARIANT_INDEX_OFFSET: usize = 4 + 8;
+
+        fn variant_index(payload: SymmetricMessagePayload) -> u32 {
+            let bytes = bincode::serialize(&SymmetricMessage {
+                packet_id: 0,
+                confirm_receipt: vec![],
+                payload,
+            })
+            .unwrap();
+            u32::from_le_bytes(
+                bytes[VARIANT_INDEX_OFFSET..VARIANT_INDEX_OFFSET + 4]
+                    .try_into()
+                    .unwrap(),
+            )
+        }
+
+        let expected: [(u32, SymmetricMessagePayload); 7] = [
+            (
+                0,
+                SymmetricMessagePayload::AckConnection {
+                    result: Err(Cow::Borrowed("e")),
+                },
+            ),
+            (
+                1,
+                SymmetricMessagePayload::ShortMessage {
+                    payload: Bytes::new(),
+                },
+            ),
+            (
+                2,
+                SymmetricMessagePayload::StreamFragment {
+                    stream_id: StreamId::next(),
+                    total_length_bytes: 1,
+                    fragment_number: 0,
+                    payload: Bytes::new(),
+                    metadata_bytes: None,
+                },
+            ),
+            (3, SymmetricMessagePayload::NoOp),
+            (4, SymmetricMessagePayload::Ping { sequence: 0 }),
+            (5, SymmetricMessagePayload::Pong { sequence: 0 }),
+            (
+                6,
+                SymmetricMessagePayload::AckConnectionV2 {
+                    connection: OutboundConnectionV2 {
+                        key: [0; 16],
+                        remote_addr: (Ipv4Addr::LOCALHOST, 1).into(),
+                        protoc_version: [0; 8],
+                    },
+                },
+            ),
+        ];
+
+        for (index, payload) in expected {
+            assert_eq!(
+                variant_index(payload),
+                index,
+                "SymmetricMessagePayload variant indices are wire-visible and MUST NOT move; \
+                 AckConnectionV2 has to stay appended at the end"
+            );
+        }
+    }
+
+    /// The version-carrying ack round-trips, and is a DIFFERENT encoding from
+    /// the legacy one for the same connection parameters — i.e. the gate that
+    /// chooses between them is choosing between genuinely different bytes, not
+    /// decorating an unchanged message.
+    #[test]
+    fn ack_ok_with_version_round_trips_and_differs_from_legacy() {
+        let key = gen_key();
+        let sym_key = [9u8; 16];
+        let addr = (Ipv4Addr::LOCALHOST, 4321).into();
+        let version = [0xFF, 0, 2, 0, 120, 0, 80, 1];
+
+        let legacy = SymmetricMessage::ack_ok(&key, sym_key, addr).unwrap();
+        let versioned =
+            SymmetricMessage::ack_ok_with_version(&key, sym_key, addr, version).unwrap();
+
+        let legacy_plain = legacy.decrypt(&key).unwrap();
+        let versioned_plain = versioned.decrypt(&key).unwrap();
+        assert_ne!(legacy_plain.data(), versioned_plain.data());
+
+        let deser = SymmetricMessage::deser(versioned_plain.data()).unwrap();
+        match deser.payload {
+            SymmetricMessagePayload::AckConnectionV2 { connection } => {
+                assert_eq!(connection.key, sym_key);
+                assert_eq!(connection.remote_addr, addr);
+                assert_eq!(connection.protoc_version, version);
+            }
+            other => panic!("expected AckConnectionV2, got {other}"),
+        }
+        assert_eq!(deser.packet_id, SymmetricMessage::FIRST_PACKET_ID);
     }
 
     #[test]

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -15100,19 +15100,23 @@ fn test_step9_source2_removal_subscriber_heals_via_anti_entropy() {
 /// without CRDT emulation. See `mock_runtime.rs::get_contract_state_delta`.
 ///
 /// **Role choice is load-bearing, not arbitrary:** the second (probing) PUT
-/// MUST originate from the GATEWAY, not the regular node. `RemoteConnection::
-/// remote_protoc_version` is `None` on the joiner->gateway path ("the
-/// gateway's AckConnection payload carries no version" — see
-/// `transport/peer_connection.rs`), so a regular node's `ConnectionManager`
-/// never records its gateway's negotiated version and `supports_summary_first_put`
-/// fails closed for EVERY PUT a regular node routes through its gateway link —
-/// in production as much as in sim, this is not a simulation-harness gap.
-/// Only the gateway's connection TO the node carries the node's version, so
-/// only a gateway-originated PUT can pass the emission gate in a
-/// gateway/regular-node topology. (Confirmed empirically: with the roles
-/// reversed, the regular node's PUT never even logs a
+/// MUST originate from the GATEWAY, not the regular node. A regular node's
+/// `ConnectionManager` does not record its gateway's negotiated version here,
+/// so `supports_summary_first_put` fails closed for EVERY PUT a regular node
+/// routes through its gateway link. Only the gateway's connection TO the node
+/// carries the node's version, so only a gateway-originated PUT can pass the
+/// emission gate in a gateway/regular-node topology. (Confirmed empirically:
+/// with the roles reversed, the regular node's PUT never even logs a
 /// `PUT summary-first: ...` line — the whole block is skipped, not merely
 /// falling through inside it.)
+///
+/// That asymmetry USED to be production behaviour too — the gateway's
+/// `AckConnection` carried no version, so a joiner could never learn it — but
+/// #5161 fixed that, and it now survives here only because
+/// `ack_version_floor_override` defaults the version-carrying ack OFF in
+/// simulations (see `SimNetwork::enable_gateway_ack_version` for why). If this
+/// test is ever switched to `enable_gateway_ack_version`, node1's own PUT
+/// starts passing the gate too and the counter assertions below change.
 #[test_log::test]
 fn test_summary_first_put_holder_found_ships_delta() {
     use freenet::dev_tool::{NodeLabel, ScheduledOperation, SimOperation, register_crdt_contract};
@@ -15279,10 +15283,9 @@ fn test_summary_first_put_holder_found_ships_delta() {
 /// hosting behavior rather than silently doing nothing.
 ///
 /// The PUT originates from the GATEWAY, not a regular node — see the rustdoc
-/// on `test_summary_first_put_holder_found_ships_delta` for why: a regular
-/// node's connection to its gateway never carries the gateway's negotiated
-/// version (`RemoteConnection::remote_protoc_version` is `None` on the
-/// joiner->gateway path in both production and sim), so `supports_summary_first_put`
+/// on `test_summary_first_put_holder_found_ships_delta` for why: with the
+/// version-carrying ack off (the simulation default, #5161) a regular node's
+/// connection to its gateway carries no version, so `supports_summary_first_put`
 /// fails closed and a regular-node-originated PUT here would skip the
 /// summary-first block entirely rather than exercising the no-holder branch.
 #[test_log::test]
@@ -17036,5 +17039,108 @@ fn test_every_hop_summarize_calls_flat_vs_fanout() {
          max_per_peer={max_summarize} <= {per_peer_bound} (≈K={K}); \
          total_summarize={total_summarize} << per_target_broadcasts={update_broadcast_targets} \
          (>= vacuity_floor={vacuity_floor})"
+    );
+}
+
+/// **#5161 end to end, through the real handshake, with its own A/B control.**
+///
+/// A regular node connects to a gateway. Before this fix, its side of that link
+/// carried no version at all: the version rides in the asymmetrically-encrypted
+/// intro packet, only the RECEIVING side of an intro learns it, and a gateway
+/// never sends one back — it replies with an `AckConnection` that has no version
+/// field. So `remote_version` was `None` for every gateway link a node held, and
+/// every `version_supports_*` gate fell back to the legacy wire format on
+/// exactly the highest-degree, highest-traffic links on the network.
+///
+/// Two simulations, identical apart from the gate, are run in one test so the
+/// claim is a measured difference rather than an assertion against a
+/// remembered baseline that a later edit could quietly invalidate:
+///
+/// - **enabled** — the node records the gateway's version, and
+///   `supports_hash_first_summaries` is true for that link, so it answers
+///   anti-entropy with digests instead of full summary bytes.
+/// - **control** — the same topology with the gate pinned off reproduces the
+///   pre-fix behaviour exactly. Without this arm the test could pass on a
+///   simulation harness that populated versions by some other route, and would
+///   never have failed against the bug it describes.
+///
+/// The gate is opt-in per simulation rather than a suite-wide default; see
+/// `SimNetwork::enable_gateway_ack_version` for why.
+#[test_log::test]
+fn test_joiner_records_gateway_version_through_sim_handshake() {
+    use freenet::dev_tool::NodeLabel;
+
+    const SEED: u64 = 0x5161_ACC0_CAFE;
+
+    fn run(network_name: &str, enable_ack_version: bool) -> (Option<(u8, u8, u16)>, bool) {
+        setup_deterministic_state(SEED);
+        let rt = create_runtime();
+
+        let gateway = NodeLabel::gateway(network_name, 0);
+        let node1 = NodeLabel::node(network_name, 1);
+
+        let mut sim =
+            rt.block_on(async { SimNetwork::new(network_name, 1, 1, 7, 3, 10, 2, SEED).await });
+        if enable_ack_version {
+            sim.enable_gateway_ack_version();
+        }
+
+        let gateway_addr = *sim
+            .all_node_addresses()
+            .get(&gateway)
+            .expect("gateway must have an address");
+
+        let result = sim.run_controlled_simulation(
+            SEED,
+            Vec::new(),
+            Duration::from_secs(60),
+            Duration::from_secs(10),
+        );
+        assert!(
+            result.turmoil_result.is_ok(),
+            "gateway-ack-version sim failed: {:?}",
+            result.turmoil_result.err()
+        );
+
+        (
+            result.node_recorded_remote_version(&node1, gateway_addr),
+            result.node_supports_hash_first_summaries(&node1, gateway_addr),
+        )
+    }
+
+    let (control_version, control_hash_first) = run("gateway-ack-version-control", false);
+    let (enabled_version, enabled_hash_first) = run("gateway-ack-version-enabled", true);
+
+    tracing::info!(
+        ?control_version,
+        control_hash_first,
+        ?enabled_version,
+        enabled_hash_first,
+        "gateway ack version: A/B outcome"
+    );
+
+    // Control arm: the bug, reproduced. If this ever starts passing, the
+    // enabled arm below has stopped proving anything.
+    assert_eq!(
+        control_version, None,
+        "control arm must reproduce the pre-#5161 behaviour — a node learns \
+         NOTHING about its gateway's version when the version-carrying ack is off"
+    );
+    assert!(
+        !control_hash_first,
+        "control arm: an unknown gateway version must fail the hash-first gate closed"
+    );
+
+    // Enabled arm: the fix.
+    assert!(
+        enabled_version.is_some(),
+        "the node MUST record its gateway's protocol version once the gateway \
+         answers with AckConnectionV2 — this is the whole of #5161"
+    );
+    assert!(
+        enabled_hash_first,
+        "with the gateway's version known, the node->gateway link must pass the \
+         hash-first gate: that is the user-visible consequence, since the \
+         fallback ships one full summary per shared contract"
     );
 }

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -15159,8 +15159,9 @@ fn test_summary_first_put_holder_found_ships_delta() {
         // node1 PUTs + subscribes: becomes a fresh holder
         // (`Ring::is_receiving_updates` true via its own client subscription).
         // Its own PUT never touches the probe counters (see rustdoc above:
-        // its connection to the gateway can't carry the gateway's version),
-        // so this is a clean, counter-neutral way to seed the holder.
+        // with the version-carrying ack off — the sim default, #5161 — its
+        // connection to the gateway carries no gateway version), so this is a
+        // clean, counter-neutral way to seed the holder.
         ScheduledOperation::new(
             node1.clone(),
             SimOperation::Put {
@@ -15208,11 +15209,11 @@ fn test_summary_first_put_holder_found_ships_delta() {
         "summary-first PUT delta test: probe outcome counters"
     );
 
-    // node1's own PUT never touches these counters: its connection to the
-    // gateway never carries the gateway's negotiated version (see rustdoc
-    // above), so `supports_summary_first_put` fails closed and the whole
-    // summary-first block is skipped for node1's PUT — only the gateway's
-    // PUT can move them.
+    // node1's own PUT never touches these counters: with the version-carrying
+    // ack off (the sim default, #5161 — see rustdoc above) its connection to the
+    // gateway carries no gateway version, so `supports_summary_first_put` fails
+    // closed and the whole summary-first block is skipped for node1's PUT —
+    // only the gateway's PUT can move them.
     assert_eq!(
         new_contract_sends, 0,
         "no-holder path must NOT fire: the gateway's PUT found a fresh \
@@ -15437,7 +15438,8 @@ fn test_summary_first_put_reverse_delta_converges_originator() {
     let operations = vec![
         // node1 PUTs v2 + subscribes: becomes a fresh holder AHEAD of the
         // originator. (Its own PUT never touches the probe counters — its
-        // link to the gateway carries no gateway version, see Test A.)
+        // link to the gateway carries no gateway version with the ack gate off,
+        // see Test A.)
         ScheduledOperation::new(
             node1.clone(),
             SimOperation::Put {
@@ -17042,7 +17044,7 @@ fn test_every_hop_summarize_calls_flat_vs_fanout() {
     );
 }
 
-/// **#5161 end to end, through the real handshake, with its own A/B control.**
+/// **#5161 end to end, through the real handshake, with its own controls.**
 ///
 /// A regular node connects to a gateway. Before this fix, its side of that link
 /// carried no version at all: the version rides in the asymmetrically-encrypted
@@ -17052,27 +17054,39 @@ fn test_every_hop_summarize_calls_flat_vs_fanout() {
 /// every `version_supports_*` gate fell back to the legacy wire format on
 /// exactly the highest-degree, highest-traffic links on the network.
 ///
-/// Two simulations, identical apart from the gate, are run in one test so the
-/// claim is a measured difference rather than an assertion against a
-/// remembered baseline that a later edit could quietly invalidate:
+/// Three simulations, run in one test so the claims are measured differences
+/// rather than assertions against a remembered baseline a later edit could
+/// quietly invalidate. They differ only in their two floor overrides (and in
+/// network name, which the harness requires to be unique):
 ///
-/// - **enabled** — the node records the gateway's version, and
-///   `supports_hash_first_summaries` is true for that link, so it answers
-///   anti-entropy with digests instead of full summary bytes.
-/// - **control** — the same topology with the gate pinned off reproduces the
-///   pre-fix behaviour exactly. Without this arm the test could pass on a
-///   simulation harness that populated versions by some other route, and would
-///   never have failed against the bug it describes.
+/// - **control** — gate off. Reproduces the pre-fix behaviour exactly. Without
+///   this arm the enabled arm could pass on a harness that populated versions
+///   by some other route, and would never have failed against the bug.
+/// - **enabled** — gate on. The node records the gateway's *exact* version, and
+///   `supports_hash_first_summaries` is true for that link.
+/// - **enabled, hash-first floor unreachable** — the arm that stops the
+///   hash-first assertion from being a restatement. With the sim's default
+///   hash-first floor of `(0,0,0)`, `supports_hash_first_summaries` reduces
+///   algebraically to `remote_version.is_some()`, so asserting it alongside
+///   `is_some()` carries no independent information (a reviewer caught this).
+///   Pinning that floor out of reach makes the two disagree: the version is
+///   known and the gate is still false, which is what proves the gate composes
+///   version AND floor rather than merely echoing the version.
 ///
-/// The gate is opt-in per simulation rather than a suite-wide default; see
-/// `SimNetwork::enable_gateway_ack_version` for why.
+/// The ack gate is opt-in per simulation rather than a suite-wide default; see
+/// `SimNetwork::enable_gateway_ack_version` for why, and for what that costs.
 #[test_log::test]
 fn test_joiner_records_gateway_version_through_sim_handshake() {
     use freenet::dev_tool::NodeLabel;
 
     const SEED: u64 = 0x5161_ACC0_CAFE;
 
-    fn run(network_name: &str, enable_ack_version: bool) -> (Option<(u8, u8, u16)>, bool) {
+    struct Arm {
+        version: Option<(u8, u8, u16)>,
+        hash_first: bool,
+    }
+
+    fn run(network_name: &str, enable_ack_version: bool, enable_hash_first: bool) -> Arm {
         setup_deterministic_state(SEED);
         let rt = create_runtime();
 
@@ -17083,6 +17097,11 @@ fn test_joiner_records_gateway_version_through_sim_handshake() {
             rt.block_on(async { SimNetwork::new(network_name, 1, 1, 7, 3, 10, 2, SEED).await });
         if enable_ack_version {
             sim.enable_gateway_ack_version();
+        }
+        if enable_hash_first {
+            sim.enable_hash_first_summaries();
+        } else {
+            sim.disable_hash_first_summaries();
         }
 
         let gateway_addr = *sim
@@ -17102,45 +17121,189 @@ fn test_joiner_records_gateway_version_through_sim_handshake() {
             result.turmoil_result.err()
         );
 
-        (
-            result.node_recorded_remote_version(&node1, gateway_addr),
-            result.node_supports_hash_first_summaries(&node1, gateway_addr),
-        )
+        Arm {
+            version: result.node_recorded_remote_version(&node1, gateway_addr),
+            hash_first: result.node_supports_hash_first_summaries(&node1, gateway_addr),
+        }
     }
 
-    let (control_version, control_hash_first) = run("gateway-ack-version-control", false);
-    let (enabled_version, enabled_hash_first) = run("gateway-ack-version-enabled", true);
+    let control = run("gateway-ack-version-control", false, true);
+    let enabled = run("gateway-ack-version-enabled", true, true);
+    let enabled_no_hash_first = run("gateway-ack-version-floored", true, false);
+
+    // The version every node in these sims runs. Asserted as an exact value,
+    // not merely `is_some`: a regression that recorded the WRONG version — the
+    // joiner echoing its own `PROTOC_VERSION`, or misreading the field — would
+    // satisfy `is_some`.
+    //
+    // Parsed here from `CARGO_PKG_VERSION` rather than read back out of the
+    // transport's own `parse_version_bytes`, so the expectation does not come
+    // from the encoder under test. This test crate is part of the `freenet`
+    // package, so the env var is freenet's version.
+    let expected = {
+        let mut parts = env!("CARGO_PKG_VERSION")
+            .split(['.', '-'])
+            .filter_map(|p| p.parse::<u16>().ok());
+        (
+            parts.next().expect("major") as u8,
+            parts.next().expect("minor") as u8,
+            parts.next().expect("patch"),
+        )
+    };
 
     tracing::info!(
-        ?control_version,
-        control_hash_first,
-        ?enabled_version,
-        enabled_hash_first,
-        "gateway ack version: A/B outcome"
+        control_version = ?control.version,
+        control_hash_first = control.hash_first,
+        enabled_version = ?enabled.version,
+        enabled_hash_first = enabled.hash_first,
+        floored_version = ?enabled_no_hash_first.version,
+        floored_hash_first = enabled_no_hash_first.hash_first,
+        "gateway ack version: arm outcomes"
     );
 
-    // Control arm: the bug, reproduced. If this ever starts passing, the
-    // enabled arm below has stopped proving anything.
+    // Control: the bug, reproduced. If this ever starts passing, the enabled
+    // arm has stopped proving anything.
     assert_eq!(
-        control_version, None,
+        control.version, None,
         "control arm must reproduce the pre-#5161 behaviour — a node learns \
          NOTHING about its gateway's version when the version-carrying ack is off"
     );
     assert!(
-        !control_hash_first,
+        !control.hash_first,
         "control arm: an unknown gateway version must fail the hash-first gate closed"
     );
 
-    // Enabled arm: the fix.
-    assert!(
-        enabled_version.is_some(),
-        "the node MUST record its gateway's protocol version once the gateway \
-         answers with AckConnectionV2 — this is the whole of #5161"
+    // Enabled: the fix.
+    assert_eq!(
+        enabled.version,
+        Some(expected),
+        "the node MUST record its gateway's exact protocol version once the \
+         gateway answers with AckConnectionV2 — this is the whole of #5161"
     );
     assert!(
-        enabled_hash_first,
+        enabled.hash_first,
         "with the gateway's version known, the node->gateway link must pass the \
          hash-first gate: that is the user-visible consequence, since the \
          fallback ships one full summary per shared contract"
     );
+
+    // Enabled but floored out: version known, gate still closed. This is what
+    // makes the two assertions above independent of each other.
+    assert_eq!(
+        enabled_no_hash_first.version,
+        Some(expected),
+        "the ack gate and the hash-first floor are independent — raising the \
+         latter must not stop the node learning the version"
+    );
+    assert!(
+        !enabled_no_hash_first.hash_first,
+        "a KNOWN version below the hash-first floor must still fail closed; \
+         without this arm the hash-first assertions above are algebraically \
+         identical to the version assertions and cannot fail separately"
+    );
+}
+
+/// **The cascade #5161 unlocks, exercised where the suite otherwise cannot see
+/// it.** This is the mirror image of `test_summary_first_put_holder_found_ships_delta`:
+/// there the probing PUT MUST originate from the gateway, because a regular
+/// node could never learn its gateway's version and so failed
+/// `supports_summary_first_put` closed on every PUT it routed through that
+/// link. Here the roles are reversed and the regular node's PUT is the probing
+/// one — which works only because the version-carrying ack is enabled.
+///
+/// It exists because the ack gate is OFF by default in simulations (see
+/// `SimNetwork::enable_gateway_ack_version`). That default is deliberate, but
+/// it means no other sim covers what actually happens in production from
+/// 0.2.120: node->gateway links become eligible for every other
+/// `version_supports_*` feature at once, on the highest-degree nodes on the
+/// network. Without this test that transition would first be exercised by the
+/// fleet.
+///
+/// The discriminating assertion is `delta_sends == 1`. With the ack gate off it
+/// is 0 — the whole summary-first block is skipped, not merely fallen through —
+/// which is precisely what the reversed-roles note on Test A records having
+/// observed.
+#[test_log::test]
+fn test_gateway_ack_version_unlocks_node_originated_summary_first_put() {
+    use freenet::dev_tool::{NodeLabel, ScheduledOperation, SimOperation, register_crdt_contract};
+
+    const SEED: u64 = 0x5161_CA5C_ADE1;
+    const NETWORK_NAME: &str = "ack-version-cascade";
+
+    setup_deterministic_state(SEED);
+    let rt = create_runtime();
+
+    let gateway = NodeLabel::gateway(NETWORK_NAME, 0);
+    let node1 = NodeLabel::node(NETWORK_NAME, 1);
+
+    let contract = SimOperation::create_test_contract(0x5F);
+    let contract_id = *contract.key().id();
+    register_crdt_contract(contract_id);
+
+    let state_v1 = SimOperation::create_crdt_state(1, 0x11);
+    let state_v2 = SimOperation::create_crdt_state(2, 0x22);
+
+    let mut sim =
+        rt.block_on(async { SimNetwork::new(NETWORK_NAME, 1, 1, 7, 3, 10, 2, SEED).await });
+    sim.enable_summary_first_put();
+    // The point of the test: without this the node's PUT cannot pass the
+    // emission gate, and `delta_sends` below is 0.
+    sim.enable_gateway_ack_version();
+
+    let operations = vec![
+        // The GATEWAY seeds the holder this time (Test A has the node do it).
+        ScheduledOperation::new(
+            gateway.clone(),
+            SimOperation::Put {
+                contract: contract.clone(),
+                state: state_v1.clone(),
+                subscribe: true,
+            },
+        ),
+        // The regular NODE probes. Its only known peer is the gateway, so the
+        // probe necessarily travels the node->gateway link — the exact link
+        // that carried no version before #5161.
+        ScheduledOperation::new(
+            node1.clone(),
+            SimOperation::Put {
+                contract: contract.clone(),
+                state: state_v2.clone(),
+                subscribe: false,
+            },
+        ),
+    ];
+
+    let result = sim.run_controlled_simulation(
+        SEED,
+        operations,
+        Duration::from_secs(120),
+        Duration::from_secs(30),
+    );
+    assert!(
+        result.turmoil_result.is_ok(),
+        "ack-version cascade sim failed: {:?}",
+        result.turmoil_result.err()
+    );
+
+    let delta_sends = GlobalTestMetrics::put_probe_existing_mesh_delta_sends();
+    let delta_bytes = GlobalTestMetrics::put_probe_existing_mesh_delta_bytes();
+    tracing::info!(
+        delta_sends,
+        delta_bytes,
+        "ack-version cascade: node-originated summary-first PUT counters"
+    );
+
+    assert_eq!(
+        delta_sends, 1,
+        "the NODE's PUT must reach the holder-found branch through its gateway \
+         link. This is 0 without the version-carrying ack — the emission gate \
+         fails closed on an unknown remote version and the summary-first block \
+         is skipped entirely"
+    );
+    assert!(
+        delta_bytes > 0,
+        "the probe must have shipped a real delta, not an empty one"
+    );
+
+    freenet::dev_tool::clear_crdt_contracts();
 }

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -78,10 +78,13 @@ required for the cascade to fire automatically).
 
 ### Wire-gated feature floors (one-time, per feature)
 
-Some features that add a new `NetMessageV1` wire variant are version-gated:
-a node only sends the new variant to peers whose negotiated protocol version
-is at or above a hardcoded floor, so older peers never receive a variant they
-can't deserialize (they'd drop the connection). When you cut the release that
+Some features that add a new wire variant are version-gated: a node only sends
+the new variant to peers whose negotiated protocol version is at or above a
+hardcoded floor, so older peers never receive a variant they can't deserialize
+(they'd drop the connection). Most such variants are added to `NetMessageV1`,
+but **not all** — `GATEWAY_ACK_VERSION_MIN_VERSION` below gates a
+`SymmetricMessagePayload` variant on the transport handshake instead, so do not
+scan for `NetMessageV1` alone when checking which floors apply. When you cut the release that
 **first** ships such a feature, set its floor to **exactly that release
 version**, then leave it frozen — do NOT bump it on later releases (raising it
 above the first-shipping version would silently stop sending to fully-capable
@@ -130,8 +133,9 @@ Current wire-gated floors:
   handlers.
 
   **This one is guarded by a marker, not by a manual check.** Alongside the
-  floor there is `HASH_FIRST_SHIPPED_IN: Option<(u8, u8, u16)>`, currently
-  `None`. The test
+  floor there is `HASH_FIRST_SHIPPED_IN: Option<(u8, u8, u16)>` (now
+  `Some((0, 2, 116))` — the feature shipped; this paragraph previously said
+  "currently `None`" and had gone stale). The test
   `connection_manager.rs::hash_first_floor_tracks_the_shipping_release`
   asserts:
 
@@ -160,6 +164,34 @@ Current wire-gated floors:
   `hash_first_floor_stays_above_every_release_without_the_variants` is kept as
   a companion: it catches the floor being *lowered*, which the marker test does
   not.
+
+- `GATEWAY_ACK_VERSION_MIN_VERSION` in
+  `crates/core/src/transport/connection_handler/version_cmp.rs` — **a different
+  file and a different layer from the three above** (version-carrying connection
+  ack, #5161).
+
+  Set to **`(0, 2, 120)`**, the release intended to first ship the
+  `SymmetricMessagePayload::AckConnectionV2` variant.
+
+  **Its failure mode is more severe than the others', so bias high if in
+  doubt.** The three floors above gate application messages: a peer that cannot
+  decode one drops the connection. This one gates the connection ACK itself, so
+  a peer that cannot decode it never completes the handshake at all — a floor
+  set too low means every pre-floor node fails to connect to any upgraded
+  gateway, and the release cascade upgrades the gateways FIRST.
+
+  Guarded by a marker exactly like `HASH_FIRST_SHIPPED_IN`:
+  `ACK_VERSION_SHIPPED_IN: Option<(u8, u8, u16)>`, currently `None`, checked by
+  `version_cmp.rs::ack_version_floor_tracks_the_shipping_release`. When a
+  release bump raises `CARGO_PKG_VERSION` to `(0, 2, 120)`, that test fails
+  until the releaser consciously either sets
+  `ACK_VERSION_SHIPPED_IN = Some(GATEWAY_ACK_VERSION_MIN_VERSION)` (this release
+  carries it) or raises the floor (it does not).
+
+  Note the emission gate reads the peer's version from the intro packet it just
+  parsed, never from a cached value, so unlike the floors above there is no
+  bootstrapping round-trip and no way for the decision to go stale against a
+  peer that downgraded at a reused address.
 
 When a NEW wire-gated feature first ships (not this one), set its floor to
 **exactly that release version** and freeze it, as described above.


### PR DESCRIPTION
## Problem

**A node never learned the protocol version of any gateway it connected through, no matter how new that gateway was.** It therefore treated the newest, highest-degree nodes on the network as unknown-version permanently, and fell back to legacy wire formats when talking to them.

The version rides in the asymmetrically-encrypted intro packet, and only the **receiving** side of an intro learns it. Peer to peer, NAT traversal means both sides send one, so both learn. A gateway does not send an intro back — it replies with `AckConnection { result: Ok(OutboundConnection { key, remote_addr }) }`, a struct with no version field. So `connection_handler.rs` hardcoded `remote_protoc_version: None` for every joiner→gateway link, with a comment stating the cause outright.

Every version-gated wire feature failed closed on those links: today `supports_hash_first_summaries` and `supports_summary_first_put`, and every future one by default. For the summary exchange (#5153, #5155) that means the uncapped legacy `Summaries` message — one full summary per shared contract — on exactly the links carrying the most anti-entropy traffic.

**This is not only a gateway bug.** The joiner's `AckConnection` arm is also reachable peer-to-peer whenever one side of the hole-punch races ahead to the ack before parsing the other's intro. The existing `simulate_nat_traversal` test documented this by asserting only that *at least one* of the two sides captured a version.

## Solution

Add `SymmetricMessagePayload::AckConnectionV2 { connection: OutboundConnectionV2 { key, remote_addr, protoc_version: [u8; 8] } }`, appended **last** so no existing variant index moves, and emit it in place of the legacy success ack when the peer is at or above a version floor.

**Why this needs no bootstrapping round-trip.** The usual chicken-and-egg with a new wire field — you cannot send it until you know the peer decodes it, and you cannot know that without asking — does not arise. The acceptor has already decrypted and parsed the joiner's intro packet, which carries the joiner's version, *before* it builds the ack. The gate reads a version already in hand, and a pre-floor joiner receives byte-identical traffic.

Design choices worth calling out:

- **`ack_ok` is left untouched** rather than generalised to take an `Option<[u8; 8]>`. The pre-floor path must keep producing exactly the bytes it produces today, and calling the same unmodified function is a stronger guarantee than any amount of branch review. A golden-bytes test pins it regardless.
- **A parallel struct, not a new field on `OutboundConnection`.** The payload is bincode, whose layout is not forward-tolerant, so the version can only go to a peer known to decode it — which means it must be omitted conditionally, and bincode cannot express that without a hand-written `Serialize`. An `Option` would still emit its discriminant byte and change what a pre-floor peer sees.
- **Gated at both `ack_ok` send sites**, the gateway path and the peer-to-peer `RemoteInbound` path, so the hole-punch race above is fixed too. Both sites have already parsed the remote's intro, so both know its version.
- **The failure ack has no V2 form.** An incompatible peer is still rejected with the legacy `AckConnection { result: Err(..) }`, which is correct precisely because such a peer may not carry the new index.
- The joiner also calls **`report_peer_version`** on what it reads from the ack. That is what makes the fix reach auto-update discovery, not just the local gate — see #5166.

Floor: `GATEWAY_ACK_VERSION_MIN_VERSION = (0, 2, 120)`, the release this ships in, with a `HASH_FIRST_SHIPPED_IN`-style guard so a slipped or renumbered release cannot leave it stale silently. A test-only override is threaded `NodeConfig → P2pConnManager → create_connection_handler → config_listener → UdpPacketsListener`; unlike the three existing floor overrides this has to reach the transport layer, because the gate decides how a handshake ack is encoded and the handshake runs below the node layer.

### The erasure (`record_remote_version`)

The issue also asked to stop a `None` from deleting a previously known version. **Kept as is, deliberately**, and the reasoning is now recorded in the code.

The write-through is not an oversight: it was added specifically because this path yields `None`, and a stale entry can name a version *newer* than the peer actually runs — a peer restarting on a downgraded binary at a reused address. We would then send it a variant it cannot decode, which closes the connection as `ConnectionError::Serialization` and presents as a transport fault. Relaxing it would re-open exactly that.

What this PR changes is what `None` **means**. Enumerating where one can still arise: the joiner→gateway ack and the peer-to-peer ack race now both yield `Some` for any remote at or above the floor, and the intro-parsing path always did. So a remaining `None` is not "we failed to learn it" — it is the positive fact that the remote is below the floor, and clearing a stale newer entry is the accurate write rather than a lossy one. Both readings fail closed identically at every `version_supports_*` gate.

### Rollout watch item

From 0.2.120, node→gateway links become eligible for the other version-gated features at once, on the highest-degree nodes on the network. Concretely that is `supports_hash_first_summaries` (the intended benefit, #5153) and `supports_summary_first_put`. Both floors are below 0.2.120, so a gateway that sends `AckConnectionV2` provably supports them and the transition is safe by construction — but it is a real change in traffic shape on the busiest links and worth watching during the staggered rollout. SubscribeHint is *not* affected: it is held off by the `PLACEMENT_MIGRATION_ENABLED` compile-time kill switch, independent of any version gate.

### Simulation default is OFF, opt in per sim

`SimNetwork::enable_gateway_ack_version()`. This deviates from `hash_first_summaries_floor_override`, which defaults ON so a version-gated wire change gets integration coverage before its release, and matches the two cascade gates instead.

The gate is encoding-only where it fires, but the version it teaches is the **input to every other `version_supports_*` gate**, so enabling it network-wide makes node→gateway links newly eligible for summary-first PUT probes and hash-first digests. That is the cascade shape, not the encoding shape. Measured rather than assumed: with the default ON, `test_summary_first_put_holder_found_ships_delta` and `test_summary_first_put_reverse_delta_converges_originator` fail deterministically, because the regular node's own PUT starts passing the emission gate.

The cost — the sim suite keeps a topology asymmetry production no longer has, from 0.2.120 onward — is stated in the code and bought back with a dedicated A/B sim test rather than a suite-wide flip. The rustdocs on those two summary-first tests, which asserted the asymmetry was permanent and "not a simulation-harness gap", are corrected either way.

## Testing

Every claim above has a test, and the ones that could pass vacuously were mutation-checked.

- `ack_ok_produces_identical_bytes_to_pre_5161_encoding` — **the compatibility guarantee, asserted on bytes.** A golden literal captured from the pre-change encoding, not a re-serialization of the same struct: the latter would compare the encoder against itself and pass even if the layout moved wholesale. Fails on a field added to `OutboundConnection`, a reordering of `SymmetricMessage`, a bincode config change, or a variant inserted before `AckConnection`.
- `appending_ack_connection_v2_did_not_renumber_existing_variants` — reads variant indices out of the serialized bytes. Byte-identity for the ack alone would be worth little if every other message silently changed meaning on the wire.
- `ack_ok_with_version_round_trips_and_differs_from_legacy` — the gate chooses between genuinely different bytes, not a decorated identical message.
- `joiner_learns_gateway_version_when_at_or_above_the_floor` / `pre_floor_joiner_gets_the_legacy_ack_and_still_connects` — both sides of the gate through the real mock transport. Against **explicit** floors rather than the crate version, so neither flips at the 0.2.120 release. The pre-floor case asserts the handshake still *completes*, not merely that no version was learned. Mutation-checked: forcing `version_supports_ack_version` to always-false makes the first fail.
- `ack_version_gate_is_fail_closed_and_inclusive_at_the_floor` — unknown version must not receive the new encoding; the release exactly at the floor must.
- `ack_version_floor_tracks_the_shipping_release` — `ACK_VERSION_SHIPPED_IN` is `None`, so this fails the moment a release bump lifts `PCK_VERSION` to 0.2.120 without someone consciously deciding.
- `test_joiner_records_gateway_version_through_sim_handshake` — end-to-end through the real simulated handshake, **with a control arm**: the same topology with the gate off, asserting `remote_version == None` and `supports_hash_first_summaries == false`. Without that arm the enabled arm could pass on a harness that populated versions by some other route, and would never have failed against the bug it describes.
- `record_remote_version_none_clears_a_stale_entry` and `record_remote_version_overwrites_downwards_at_a_reused_address` — pin the anti-downgrade behaviour, including that "keep the highest version seen" would be the same bug in a different shape.

Added after the Full-tier review (see the review comment for the full list and the mutations that drove it):

- `nat_traversal_ack_racer_learns_version_from_the_ack` — the peer-to-peer emit site, which had **no coverage at all** until a reviewer probed it with a `panic!` and the whole suite still passed. Forcing the race is the difficulty: with no packet loss both peers learn versions from intros the old way, so the first version of this test was itself vacuous. It now drops peer B's intro so A stays in `StartOutbound` and receives B's ack instead.
- `test_gateway_ack_version_unlocks_node_originated_summary_first_put` — the cascade the simulation default otherwise excludes: the reversed-roles mirror of the existing summary-first test, 1 delta send with the ack gate on and 0 without.
- `duplicate_v2_ack_on_established_connection_is_answered_with_legacy_ack` — pins the deliberate choice to answer a retransmitted V2 ack in the old encoding.
- A third arm on the A/B sim test, because two of its four assertions were algebraically implied by the other two.
- `simulate_gateway_connection`'s assertion de-circularized. As first written it computed its expected value with the predicate under test, and a reviewer's mutation — a gateway emitting V2 to every peer regardless of version — left it green.

Verification: `cargo fmt`; `cargo clippy --locked -- -D warnings` (the CI invocation) clean; `cargo test -p freenet --lib` 4648 passed; and the simulation tests under `cargo nextest run -p freenet --features "simulation_tests,testing" --test simulation_integration`, which the lib run does not reach.

Deliberately **not** touched: the summary fallback itself, which is #5155.

### On the issue's third acceptance criterion

#5161 asks that `record_remote_version(addr, None)` stop erasing a previously recorded version. This PR deliberately does the opposite (argued above) and pins the erasure with tests. `Closes #5161` will therefore auto-close an issue one of whose three stated criteria was answered rather than implemented — flagging it explicitly so that is a decision rather than an accident.

Closes #5161

[AI-assisted - Claude]
