### PR TITLE
fix(ci): stop merge-queue entries cancelling each other's rule review

### DIFF
--- a/.github/scripts/check_merge_group_concurrency.py
+++ b/.github/scripts/check_merge_group_concurrency.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Guard against merge-queue entries cancelling each other's required checks.
+
+A workflow that triggers on ``merge_group`` runs once per merge-queue entry.
+Its ``concurrency.group`` key must therefore contain something that VARIES per
+entry. If it does not, every entry lands in the same group, and with
+``cancel-in-progress: true`` each new entry cancels the previous entry's run.
+When the workflow provides a REQUIRED check, a cancelled run never reports, so
+the older queue entry goes ``UNMERGEABLE`` and stalls the queue behind it.
+
+The trap is that this looks fine on a PR. ``github.event.pull_request`` simply
+does not exist on a ``merge_group`` event, so a key like::
+
+    group: claude-pr-review-${{ github.event.pull_request.number }}
+
+silently collapses to the constant ``claude-pr-review-`` -- GitHub's own
+cancellation message names that empty group verbatim. Nothing fails, nothing is
+logged on the PR, and the only symptom is a queue entry that never advances.
+
+Shipped in ``claude-pr-review.yml`` and found 2026-08-04 when three PRs were
+queued together for the 0.2.120 release. Fixed by #5170.
+
+A key is accepted when it references any token that differs between queue
+entries: ``merge_group`` (``merge_group.head_sha`` is the queue entry's own
+commit), ``github.ref`` (on a merge_group event this is the per-entry
+``gh-readonly-queue/...`` branch), ``github.sha``, or ``github.run_id``.
+
+Usage:
+    check_merge_group_concurrency.py [WORKFLOW_DIR]
+    check_merge_group_concurrency.py --self-test
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# A `group:` key is per-entry-safe if it mentions any of these. `github.ref` and
+# `github.sha` both resolve to per-entry values on a merge_group event, and
+# `run_id` is unique per run, so any of them breaks the collapse.
+PER_ENTRY_TOKENS = ("merge_group", "github.ref", "github.sha", "github.run_id")
+
+# `  merge_group:` at exactly two-space indent is a trigger under `on:`. Deeper
+# indents are payload references (`github.event.merge_group.head_sha`), not
+# triggers, so anchoring the indent avoids matching a workflow that merely reads
+# the payload without being triggered by the event.
+MERGE_GROUP_TRIGGER_RE = re.compile(r"^  merge_group:\s*(?:#.*)?$", re.M)
+
+# Capture each `concurrency:` block's `group:` line. GitHub allows `concurrency`
+# at workflow level and per job, so scan for the key rather than assuming
+# top-level, and keep the indent so the message can point at the right one.
+CONCURRENCY_GROUP_RE = re.compile(
+    r"^(?P<indent>[ ]*)concurrency:\s*(?:#.*)?\n"
+    r"(?:^(?P=indent)[ ]+.*\n)*?"  # any keys before `group:` (e.g. `cancel-in-progress`)
+    r"^(?P=indent)[ ]+group:[ ]*(?P<group>.*)$",
+    re.M,
+)
+
+
+def _line_of(text: str, offset: int) -> int:
+    return text.count("\n", 0, offset) + 1
+
+
+def check_source(text: str, name: str) -> list[str]:
+    """Return a list of human-readable errors for one workflow's source."""
+    if not MERGE_GROUP_TRIGGER_RE.search(text):
+        return []
+
+    errors = []
+    for match in CONCURRENCY_GROUP_RE.finditer(text):
+        group = match.group("group").strip()
+        if any(token in group for token in PER_ENTRY_TOKENS):
+            continue
+        line = _line_of(text, match.start("group"))
+        errors.append(
+            f"{name}:{line}: workflow triggers on `merge_group` but its "
+            f"concurrency group does not vary per queue entry:\n"
+            f"      group: {group}\n"
+            f"    Every queue entry lands in the same group, so with "
+            f"cancel-in-progress each new entry cancels the previous entry's "
+            f"run. If this workflow provides a required check, the older entry "
+            f"goes UNMERGEABLE and stalls the queue (see #5170).\n"
+            f"    Add a fallback that differs per entry, e.g.\n"
+            f"      ${{{{ github.event.pull_request.number || "
+            f"github.event.merge_group.head_sha || github.run_id }}}}"
+        )
+    return errors
+
+
+def check_dir(workflow_dir: Path) -> list[str]:
+    errors = []
+    paths = sorted(
+        p for p in workflow_dir.iterdir() if p.suffix in (".yml", ".yaml")
+    )
+    for path in paths:
+        errors.extend(
+            check_source(path.read_text(encoding="utf-8"), str(path))
+        )
+    return errors
+
+
+# --- self-test ---------------------------------------------------------------
+
+# The real pre-fix key from claude-pr-review.yml. Must be flagged.
+_BAD = """\
+name: Bad
+on:
+  pull_request_target:
+    types: [opened]
+  merge_group:
+
+concurrency:
+  group: claude-pr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+"""
+
+# The fix. Must NOT be flagged.
+_GOOD_FALLBACK = """\
+name: Good
+on:
+  pull_request_target:
+  merge_group:
+
+concurrency:
+  group: claude-pr-review-${{ github.event.pull_request.number || github.event.merge_group.head_sha || github.run_id }}
+  cancel-in-progress: true
+"""
+
+# The repo's other merge_group workflows key on github.ref, which is the
+# per-entry queue branch. Must NOT be flagged, or this linter would demand a
+# pointless change to ci.yml and macos-dmg-swap-e2e.yml.
+_GOOD_REF = """\
+name: CI
+on:
+  pull_request:
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+"""
+
+# No merge_group trigger, so a constant key is the author's business. Must NOT
+# be flagged -- over-reach here would make the linter noise rather than signal.
+_GOOD_NO_MERGE_GROUP = """\
+name: Nightly
+on:
+  schedule:
+    - cron: '0 3 * * *'
+
+concurrency:
+  group: netcheck-nightly
+"""
+
+# `merge_group` appearing ONLY as a payload reference is not a trigger. Must NOT
+# be flagged: the workflow never runs on a merge_group event.
+_GOOD_PAYLOAD_ONLY = """\
+name: Reads payload
+on:
+  pull_request:
+
+concurrency:
+  group: reads-payload-${{ github.event.pull_request.number }}
+jobs:
+  x:
+    steps:
+      - run: echo "${{ github.event.merge_group.head_commit.message }}"
+"""
+
+# `cancel-in-progress` before `group:` -- the regex must not depend on key order.
+_BAD_KEY_ORDER = """\
+name: Bad, reordered
+on:
+  merge_group:
+
+concurrency:
+  cancel-in-progress: true
+  group: fixed-${{ github.event.pull_request.number }}
+"""
+
+# Job-level concurrency, not workflow-level. Must still be flagged.
+_BAD_JOB_LEVEL = """\
+name: Bad, job level
+on:
+  merge_group:
+
+jobs:
+  review:
+    concurrency:
+      group: review-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+"""
+
+_CASES = [
+    ("pre-fix claude-pr-review key", _BAD, 1),
+    ("the fallback chain", _GOOD_FALLBACK, 0),
+    ("github.ref key (ci.yml pattern)", _GOOD_REF, 0),
+    ("no merge_group trigger", _GOOD_NO_MERGE_GROUP, 0),
+    ("merge_group only as payload ref", _GOOD_PAYLOAD_ONLY, 0),
+    ("group after cancel-in-progress", _BAD_KEY_ORDER, 1),
+    ("job-level concurrency", _BAD_JOB_LEVEL, 1),
+]
+
+
+def self_test() -> int:
+    failures = 0
+    for desc, source, expected in _CASES:
+        found = len(check_source(source, "<fixture>"))
+        if found == expected:
+            print(f"ok   - {desc}")
+        else:
+            print(
+                f"FAIL - {desc}: expected {expected} error(s), got {found}",
+                file=sys.stderr,
+            )
+            failures += 1
+    if failures:
+        print(f"\n{failures} self-test failure(s)", file=sys.stderr)
+        return 1
+    print(f"\nAll {len(_CASES)} self-tests passed")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if "--self-test" in argv:
+        return self_test()
+
+    workflow_dir = Path(argv[1]) if len(argv) > 1 else Path(".github/workflows")
+    if not workflow_dir.is_dir():
+        print(f"ERROR: {workflow_dir} is not a directory", file=sys.stderr)
+        return 2
+
+    errors = check_dir(workflow_dir)
+    if errors:
+        print(
+            "ERROR: merge-queue concurrency check failed "
+            "(see #5170 for what this prevents)"
+        )
+        for err in errors:
+            print(f"  - {err}")
+        return 1
+
+    print("merge-queue concurrency check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,16 @@ jobs:
       - name: Self-test release.yml merge-queue auto-merge
         run: bash scripts/release_mergequeue_test.sh
 
+      # Regression gate for #5170: a merge_group-triggered workflow whose
+      # concurrency group does not vary per queue entry makes each new entry
+      # cancel the previous entry's required check, so the older entry goes
+      # UNMERGEABLE and stalls the queue — invisibly, since the PR itself still
+      # reads CLEAN. Pins that the linter still fires on the exact key that
+      # shipped, that this repo satisfies the invariant, and that the linter is
+      # still wired into rule_lint.
+      - name: Self-test merge-queue concurrency guard
+        run: bash scripts/merge_group_concurrency_test.sh
+
       # install.sh now sets up a supervised service by default (issue #4073) so
       # new nodes auto-update. The system-vs-user + lingering decision is the
       # load-bearing new logic; these smoke tests pin it without needing real
@@ -262,6 +272,15 @@ jobs:
       # uses (must NOT flag, including the #4616 moved-test-module case).
       - name: Rules #1/#2/#3 linter self-test
         run: python3 .github/scripts/check_banned_patterns.py --self-test
+
+      # Self-test the merge-queue concurrency linter, then run it. Unlike the
+      # linters above this one is NOT diff-scoped — the invariant is a property
+      # of each workflow file as it stands, and checking all of them is cheap.
+      - name: Merge-queue concurrency linter self-test
+        run: python3 .github/scripts/check_merge_group_concurrency.py --self-test
+
+      - name: Check merge_group workflows vary their concurrency group
+        run: python3 .github/scripts/check_merge_group_concurrency.py .github/workflows
 
       - name: Check for banned patterns in new code
         env:

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -94,8 +94,21 @@ on:
   # The job skips the actual review in merge_group context (PR was already reviewed).
   merge_group:
 
+# The group key MUST include a merge_group fallback. `github.event.pull_request`
+# does not exist on a merge_group event, so a key of just `.pull_request.number`
+# collapses to the constant `claude-pr-review-` for EVERY queued PR — and with
+# cancel-in-progress, each new queue entry then cancels the previous entry's run
+# of this required check. A cancelled required check is not a reported check, so
+# the older entry goes UNMERGEABLE and silently falls out of the queue. Observed
+# 2026-08-04 with three PRs queued: #5160's run was cancelled 2s after starting,
+# by #5163's, and #5160 stalled at queue position 1.
+#
+# `merge_group.head_sha` is unique per queue entry, which is the right isolation
+# unit: entries are independent, so nothing should cancel anything here. run_id
+# is a belt-and-braces fallback for any future trigger with neither field — it is
+# unique per run, so an unrecognised event never shares a group.
 concurrency:
-  group: claude-pr-review-${{ github.event.pull_request.number }}
+  group: claude-pr-review-${{ github.event.pull_request.number || github.event.merge_group.head_sha || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/scripts/merge_group_concurrency_test.sh
+++ b/scripts/merge_group_concurrency_test.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Regression tests for the merge-queue concurrency guard (#5170).
+#
+# The bug: a workflow that triggers on `merge_group` runs once per merge-queue
+# entry, so its `concurrency.group` must vary per entry. `claude-pr-review.yml`
+# keyed on `github.event.pull_request.number`, which does not exist on a
+# merge_group event, so the key collapsed to the constant `claude-pr-review-`.
+# With cancel-in-progress, each new queue entry cancelled the previous entry's
+# run of a REQUIRED check; a cancelled check never reports, so the older entry
+# went UNMERGEABLE and stalled the queue behind it. Nothing showed on the PR.
+#
+# `.github/scripts/check_merge_group_concurrency.py` has its own `--self-test`
+# over synthetic fixtures. This file tests the things that self-test cannot:
+# that the linter fires on the REAL pre-fix file, that the repo satisfies the
+# invariant today, and that the linter is actually wired into CI — a guard
+# nobody runs is not a guard.
+#
+# Run manually with: bash scripts/merge_group_concurrency_test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+LINTER="$REPO_ROOT/.github/scripts/check_merge_group_concurrency.py"
+CI_YML="$REPO_ROOT/.github/workflows/ci.yml"
+TEST_TMP=$(mktemp -d)
+trap 'rm -rf "$TEST_TMP"' EXIT
+
+FAILURES=0
+check() {
+    # check <description> <actual> <expected>
+    local desc="$1" actual="$2" expected="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        echo "ok   - $desc"
+    else
+        echo "FAIL - $desc (got '$actual', expected '$expected')" >&2
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+# The linter's own fixture suite must pass.
+SELF_TEST_RC=0
+python3 "$LINTER" --self-test >/dev/null 2>&1 || SELF_TEST_RC=$?
+check "linter self-test passes" "$SELF_TEST_RC" "0"
+
+# The exact key that shipped and caused the incident. If the linter does not
+# flag this, it would not have caught the bug it exists to catch.
+mkdir -p "$TEST_TMP/prefix"
+cat > "$TEST_TMP/prefix/claude-pr-review.yml" <<'YAML'
+name: Claude PR Rule Review
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+  merge_group:
+
+concurrency:
+  group: claude-pr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+YAML
+PREFIX_RC=0
+PREFIX_OUT=$(python3 "$LINTER" "$TEST_TMP/prefix" 2>&1) || PREFIX_RC=$?
+check "flags the pre-fix claude-pr-review key" "$PREFIX_RC" "1"
+check "names the collapsing group in the message" \
+    "$(echo "$PREFIX_OUT" | grep -c 'claude-pr-review-\${{ github.event.pull_request.number }}')" "1"
+
+# A workflow with no merge_group trigger is none of this linter's business.
+# Over-reach would turn it into noise and get it disabled.
+mkdir -p "$TEST_TMP/unrelated"
+cat > "$TEST_TMP/unrelated/nightly.yml" <<'YAML'
+name: Nightly
+on:
+  schedule:
+    - cron: '0 3 * * *'
+
+concurrency:
+  group: netcheck-nightly
+YAML
+UNRELATED_RC=0
+python3 "$LINTER" "$TEST_TMP/unrelated" >/dev/null 2>&1 || UNRELATED_RC=$?
+check "ignores workflows without a merge_group trigger" "$UNRELATED_RC" "0"
+
+# The repo must satisfy the invariant as it stands.
+REPO_RC=0
+python3 "$LINTER" "$REPO_ROOT/.github/workflows" >/dev/null 2>&1 || REPO_RC=$?
+check "every merge_group workflow in this repo varies its group" "$REPO_RC" "0"
+
+# Pin the CI wiring. Without this, deleting the step from ci.yml silently
+# retires the guard while every test above still passes.
+check "ci.yml runs the linter" \
+    "$(grep -c 'check_merge_group_concurrency\.py .github/workflows' "$CI_YML")" "1"
+check "ci.yml runs the linter's self-test" \
+    "$(grep -c 'check_merge_group_concurrency\.py --self-test' "$CI_YML")" "1"
+
+if (( FAILURES > 0 )); then
+    echo ""
+    echo "$FAILURES test(s) failed" >&2
+    exit 1
+fi
+echo ""
+echo "All tests passed"


### PR DESCRIPTION
## The bug

`claude-pr-review.yml` triggers on `merge_group` because branch protection requires its check to report there. Its concurrency key is:

```yaml
group: claude-pr-review-${{ github.event.pull_request.number }}
cancel-in-progress: true
```

`github.event.pull_request` **does not exist on a `merge_group` event.** The key therefore collapses to the constant `claude-pr-review-` for every queued PR, and with `cancel-in-progress: true` each new queue entry cancels the previous entry's run of a **required** check. A cancelled check is never reported, so the older entry goes `UNMERGEABLE` and stalls in the queue.

It only bites when two or more PRs are queued at once, which is presumably why it has gone unnoticed.

## Observed

2026-08-04, with #5160, #5163 and #5167 queued together for the 0.2.120 release:

```
1 #5160 UNMERGEABLE
2 #5163 AWAITING_CHECKS
3 #5167 QUEUED
```

#5160's rule-review run (`30959723455`, event `merge_group`) was **cancelled 2 seconds after it started** — created 23:21:38Z, cancelled 23:21:40Z — by #5163's entry. Meanwhile #5160 itself reported `CLEAN` / `MERGEABLE`, so nothing on the PR page indicated a problem. The only symptom is a queue entry that never advances.

## The fix

Fall back to `merge_group.head_sha`, which is unique per queue entry. That is the correct isolation unit: queue entries are independent, so none of them should cancel any other. `run_id` is a further fallback so a future trigger carrying neither field can never share a group.

## Similar-bug audit

The other two workflows triggering on `merge_group` — `ci.yml` and `macos-dmg-swap-e2e.yml` — both key on `${{ github.workflow }}-${{ github.ref }}`. On a `merge_group` event `github.ref` is the per-entry `gh-readonly-queue/...` branch, so both are already unique per entry and need no change. This workflow was the only one affected.

## Verification

This cannot be fully verified before merge: the failure mode requires two entries in the real merge queue, and the fixed key only takes effect once the workflow is on `main`. What is verifiable now is that the expression is valid and that the PR-event path is unchanged — `github.event.pull_request.number` is still the first operand, so nothing about per-PR behaviour moves. The proof will be the next multi-PR queue: entries should advance independently rather than the leader stalling.

[AI-assisted - Claude]