### PR TITLE
docs(5155): record how the vacuous concurrency test was caught

### DIFF
--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -9506,6 +9506,21 @@ mod tests {
         /// Multi-threaded flavour with `spawn` on purpose: an earlier version
         /// of this test used `join!` on a current-thread runtime and the two
         /// futures did NOT overlap — it passed while exercising nothing.
+        ///
+        /// # How that was caught, since the same trap is easy to re-enter
+        ///
+        /// A concurrency test that passes first time deserves suspicion,
+        /// because the cheapest way to pass one is not to be concurrent. The
+        /// check that separated "passes" from "is evidence" was to probe for
+        /// the race's own signature rather than for the assertions: both
+        /// handlers reading the same cursor must produce the SAME window, so
+        /// **identical windows prove the overlap happened and different ones
+        /// prove it did not**. The `join!` version produced different windows,
+        /// which is what exposed it as vacuous.
+        ///
+        /// If you rewrite this test, re-run that probe rather than trusting a
+        /// green result — and do not "simplify" it back to `join!` on the
+        /// default runtime, which is where it started.
         #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
         async fn concurrent_interests_from_one_peer_cost_at_most_one_round() {
             const PAIRS: usize = 3;


### PR DESCRIPTION
## Problem

`concurrent_interests_from_one_peer_cost_at_most_one_round` (added in #5164) already documents *why* it spawns onto a multi-threaded runtime: an earlier version used `tokio::join!` on the default current-thread runtime, the two handlers never overlapped, and it passed while exercising nothing.

What it does not record is the transferable half — *how* that was detected. That only existed in a review thread, and the next person to touch this test is likely to reach for exactly the simplification it started as. A green result will not warn them.

## Solution

Comment-only. Records the tell: probe for the race's own signature rather than for the assertions. Two handlers reading the same cursor must build the **same** window, so identical windows prove the overlap happened and different ones prove it did not. The `join!` version produced different windows, which is what exposed it — every assertion in it was green at the time.

The general form, which is the reason this is worth a file rather than a thread: **a concurrency test that passes first time deserves suspicion, because the cheapest way to pass one is not to be concurrent.**

## Testing

No behaviour change; the diff is entirely `///` lines. `cargo fmt` clean and the test still passes. Verified comment-only before committing (no non-comment lines in the diff).

Follow-up to #5164. Part of #5153.

[AI-assisted - Claude]
