### PR TITLE
feat(update): attach the originator's target list to broadcasts (#5147)

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -3958,6 +3958,7 @@ std::thread_local! {
     /// ours (the pre-existing mechanism, counted for #5147 diagnosis).
     static GLOBAL_FANOUT_SUMMARY_SKIPS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
     /// Fan-out targets dropped because the originator named them (#5147).
+    static GLOBAL_BROADCAST_SENDER_SKIPS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
     static GLOBAL_BROADCAST_TARGETS_SUPPRESSED: std::cell::Cell<u64> =
         const { std::cell::Cell::new(0) };
     /// Inbound broadcast payloads that reached a terminal classification
@@ -4062,6 +4063,7 @@ impl GlobalTestMetrics {
         GLOBAL_DELTA_SENDS.with(|c| c.set(0));
         GLOBAL_FANOUT_SUMMARY_SKIPS.with(|c| c.set(0));
         GLOBAL_BROADCAST_TARGETS_SUPPRESSED.with(|c| c.set(0));
+        GLOBAL_BROADCAST_SENDER_SKIPS.with(|c| c.set(0));
         GLOBAL_BROADCAST_DELIVERIES.with(|c| c.set(0));
         GLOBAL_REDUNDANT_BROADCAST_DELIVERIES.with(|c| c.set(0));
         GLOBAL_FULL_STATE_SENDS.with(|c| c.set(0));
@@ -4196,6 +4198,25 @@ impl GlobalTestMetrics {
     /// exactly 0 when the feature is off, which a derived count would not do.
     pub fn record_broadcast_target_suppressed() {
         GLOBAL_BROADCAST_TARGETS_SUPPRESSED.with(|c| c.set(c.get() + 1));
+    }
+
+    /// Records that the peer which delivered this update was dropped from our
+    /// own fan-out (#5147 sender exclusion).
+    ///
+    /// A FOURTH terminal outcome for an offered leg, alongside sent /
+    /// summary-skipped / list-suppressed. It needs its own counter for the same
+    /// reason the others do — it is incremented by the filter that makes the
+    /// decision, not derived at a call site — and because without it the
+    /// simulation's leg-accounting identity is short by exactly the number of
+    /// sender exclusions, which reads as the two arms having done different
+    /// amounts of work when they did not.
+    pub fn record_broadcast_sender_skipped() {
+        GLOBAL_BROADCAST_SENDER_SKIPS.with(|c| c.set(c.get() + 1));
+    }
+
+    /// Fan-out legs dropped because the target was the delivering peer.
+    pub fn broadcast_sender_skips() -> u64 {
+        GLOBAL_BROADCAST_SENDER_SKIPS.with(|c| c.get())
     }
 
     /// Fan-out targets suppressed by the originator target list since reset.

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -3958,9 +3958,10 @@ std::thread_local! {
     /// ours (the pre-existing mechanism, counted for #5147 diagnosis).
     static GLOBAL_FANOUT_SUMMARY_SKIPS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
     /// Fan-out targets dropped because the originator named them (#5147).
-    static GLOBAL_BROADCAST_SENDER_SKIPS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
     static GLOBAL_BROADCAST_TARGETS_SUPPRESSED: std::cell::Cell<u64> =
         const { std::cell::Cell::new(0) };
+    /// Fan-out legs dropped because the target was the delivering peer (#5147).
+    static GLOBAL_BROADCAST_SENDER_SKIPS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
     /// Inbound broadcast payloads that reached a terminal classification
     /// (#5147). Denominator for the duplicate-delivery ratio.
     static GLOBAL_BROADCAST_DELIVERIES: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -3954,6 +3954,19 @@ impl SimulationIdleTimeout {
 std::thread_local! {
     static GLOBAL_RESYNC_REQUESTS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
     static GLOBAL_DELTA_SENDS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+    /// Fan-out legs skipped because the peer's cached summary already matched
+    /// ours (the pre-existing mechanism, counted for #5147 diagnosis).
+    static GLOBAL_FANOUT_SUMMARY_SKIPS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+    /// Fan-out targets dropped because the originator named them (#5147).
+    static GLOBAL_BROADCAST_TARGETS_SUPPRESSED: std::cell::Cell<u64> =
+        const { std::cell::Cell::new(0) };
+    /// Inbound broadcast payloads that reached a terminal classification
+    /// (#5147). Denominator for the duplicate-delivery ratio.
+    static GLOBAL_BROADCAST_DELIVERIES: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+    /// The subset of those that carried nothing new — a deduped duplicate, or
+    /// a merge that moved no state (#5147).
+    static GLOBAL_REDUNDANT_BROADCAST_DELIVERIES: std::cell::Cell<u64> =
+        const { std::cell::Cell::new(0) };
     static GLOBAL_FULL_STATE_SENDS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
     static GLOBAL_PENDING_OP_INSERTS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
     static GLOBAL_PENDING_OP_REMOVES: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
@@ -4047,6 +4060,10 @@ impl GlobalTestMetrics {
     pub fn reset() {
         GLOBAL_RESYNC_REQUESTS.with(|c| c.set(0));
         GLOBAL_DELTA_SENDS.with(|c| c.set(0));
+        GLOBAL_FANOUT_SUMMARY_SKIPS.with(|c| c.set(0));
+        GLOBAL_BROADCAST_TARGETS_SUPPRESSED.with(|c| c.set(0));
+        GLOBAL_BROADCAST_DELIVERIES.with(|c| c.set(0));
+        GLOBAL_REDUNDANT_BROADCAST_DELIVERIES.with(|c| c.set(0));
         GLOBAL_FULL_STATE_SENDS.with(|c| c.set(0));
         GLOBAL_PENDING_OP_INSERTS.with(|c| c.set(0));
         GLOBAL_PENDING_OP_REMOVES.with(|c| c.set(0));
@@ -4155,6 +4172,68 @@ impl GlobalTestMetrics {
     /// last reset.
     pub fn resync_responses_suppressed() -> u64 {
         Self::resync_responses_suppressed_per_peer() + Self::resync_responses_suppressed_global()
+    }
+
+    /// Records a fan-out leg skipped by the summary-match gate.
+    pub fn record_fanout_summary_skip() {
+        GLOBAL_FANOUT_SUMMARY_SKIPS.with(|c| c.set(c.get() + 1));
+    }
+
+    /// Fan-out legs skipped by the summary-match gate since reset.
+    pub fn fanout_summary_skips() -> u64 {
+        GLOBAL_FANOUT_SUMMARY_SKIPS.with(|c| c.get())
+    }
+
+    /// Records one fan-out target dropped because the originator's list named
+    /// it (#5147).
+    ///
+    /// Incremented BY the filter in `get_broadcast_targets_update`, alongside
+    /// its own `skipped_covered` field, never re-derived from the difference
+    /// between the resolved co-host set and the final target set — that
+    /// subtraction also absorbs the sender, self, and resolve-failure filters,
+    /// so it would keep reporting a plausible number after this filter is
+    /// deleted. The simulation's discriminator rests on this counter going to
+    /// exactly 0 when the feature is off, which a derived count would not do.
+    pub fn record_broadcast_target_suppressed() {
+        GLOBAL_BROADCAST_TARGETS_SUPPRESSED.with(|c| c.set(c.get() + 1));
+    }
+
+    /// Fan-out targets suppressed by the originator target list since reset.
+    pub fn broadcast_targets_suppressed() -> u64 {
+        GLOBAL_BROADCAST_TARGETS_SUPPRESSED.with(|c| c.get())
+    }
+
+    /// Records one inbound broadcast payload reaching a terminal outcome, and
+    /// whether it carried anything new (#5147).
+    ///
+    /// Called from `PayloadMix::record_receiver_terminal` — the ONE place that
+    /// classifies an inbound broadcast — so the redundancy count is produced by
+    /// the code making the decision rather than re-derived from set sizes
+    /// elsewhere. See `.claude/rules/bug-prevention-patterns.md`, "Metric
+    /// describing a filtering decision, re-derived at the call site": a
+    /// subtraction across two collections silently absorbs every other filter
+    /// between them and keeps reporting a plausible number after the filter it
+    /// claims to measure is gone.
+    ///
+    /// A `Failed` outcome is counted as a delivery but NOT as redundant: the
+    /// payload may well have carried something new and the merge simply broke.
+    /// Calling a failure redundant would flatter any change that increased
+    /// merge failures.
+    pub fn record_broadcast_delivery(redundant: bool) {
+        GLOBAL_BROADCAST_DELIVERIES.with(|c| c.set(c.get() + 1));
+        if redundant {
+            GLOBAL_REDUNDANT_BROADCAST_DELIVERIES.with(|c| c.set(c.get() + 1));
+        }
+    }
+
+    /// Inbound broadcast payloads that reached a terminal outcome since reset.
+    pub fn broadcast_deliveries() -> u64 {
+        GLOBAL_BROADCAST_DELIVERIES.with(|c| c.get())
+    }
+
+    /// Those of [`Self::broadcast_deliveries`] that changed nothing.
+    pub fn redundant_broadcast_deliveries() -> u64 {
+        GLOBAL_REDUNDANT_BROADCAST_DELIVERIES.with(|c| c.get())
     }
 
     /// Records that a delta was sent in a state change broadcast.

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -65,12 +65,16 @@ pub(crate) use network_bridge::broadcast_queue_metrics::BROADCAST_QUEUE_EFFICIEN
 // re-export rather than a path through `network_bridge` directly. Mirrors
 // `BROADCAST_STREAM_METRICS` above.
 pub(crate) use network_bridge::p2p_protoc::{
-    HASH_FIRST_SUMMARIES_MIN_VERSION, SUMMARY_FIRST_PUT_MIN_VERSION,
+    BROADCAST_TARGET_LIST_MIN_VERSION, HASH_FIRST_SUMMARIES_MIN_VERSION,
+    SUMMARY_FIRST_PUT_MIN_VERSION, version_supports_broadcast_target_list,
     version_supports_hash_first_summaries, version_supports_summary_first_put,
 };
 // Test-only: the release-timing marker has no runtime reader by design (see
 // its rustdoc), so re-exporting it unconditionally is an unused import in the
 // non-test build.
+#[cfg(test)]
+#[allow(unused_imports)]
+pub(crate) use network_bridge::p2p_protoc::BROADCAST_TARGET_LIST_SHIPPED_IN;
 #[cfg(test)]
 pub(crate) use network_bridge::p2p_protoc::HASH_FIRST_SHIPPED_IN;
 #[cfg(test)]
@@ -431,6 +435,30 @@ pub struct NodeConfig {
     /// `#[serde(skip)]`; never serialized.
     #[serde(skip)]
     pub(crate) ack_version_floor_override: Option<(u8, u8, u16)>,
+    /// Test-only override for the originator-target-list version floor
+    /// ([`BROADCAST_TARGET_LIST_MIN_VERSION`], #5147). Threaded exactly like
+    /// the three overrides above and consulted as
+    /// `broadcast_target_list_floor_override.unwrap_or(BROADCAST_TARGET_LIST_MIN_VERSION)`
+    /// by `ConnectionManager::supports_broadcast_target_list`.
+    ///
+    /// In production this is `None` → the real `(0, 2, 120)` floor.
+    ///
+    /// **Simulations default this to `SIM_MIGRATION_DISABLED_FLOOR` — OFF —
+    /// like `subscribe_hint_floor_override` and `summary_first_put_floor_override`,
+    /// and unlike `hash_first_summaries_floor_override`.** The rule stated at
+    /// that field applies: hash-first defaults ON because it changes only the
+    /// ENCODING of an exchange with identical semantics, whereas this gate
+    /// changes BEHAVIOUR — it removes peers from a fan-out. Every sim that
+    /// asserts on delivery or convergence would silently be exercising a
+    /// different delivery graph, and a failure could not be attributed between
+    /// the sim's own subject and this suppression. Tests that want it opt in
+    /// via `SimNetwork::enable_broadcast_target_list`.
+    ///
+    /// Not cfg-gated, for the same reason as the others: `node::testing_impl`
+    /// sets it and is compiled unconditionally. `#[serde(skip)]`; never
+    /// serialized.
+    #[serde(skip)]
+    pub(crate) broadcast_target_list_floor_override: Option<(u8, u8, u16)>,
     /// Test-only harness flag: when set, a startup-hosted contract
     /// (`SeedHostedContract`, i.e. `append_contracts` with `subscription =
     /// true`) is registered in the neighbor-hosting advertised set so the
@@ -599,6 +627,7 @@ impl NodeConfig {
             summary_first_put_floor_override: None,
             hash_first_summaries_floor_override: None,
             ack_version_floor_override: None,
+            broadcast_target_list_floor_override: None,
             advertise_seeded_hosts: false,
             hosting_time_source_override: None,
         })
@@ -1535,7 +1564,9 @@ where
                     update::UpdateMsg::RequestUpdate { key, .. }
                     | update::UpdateMsg::BroadcastTo { key, .. }
                     | update::UpdateMsg::RequestUpdateStreaming { key, .. }
-                    | update::UpdateMsg::BroadcastToStreaming { key, .. } => *key,
+                    | update::UpdateMsg::BroadcastToStreaming { key, .. }
+                    | update::UpdateMsg::BroadcastToV2 { key, .. }
+                    | update::UpdateMsg::BroadcastToStreamingV2 { key, .. } => *key,
                 };
 
                 // Phase 7 ban-list gate. Runs BEFORE the rate limiter
@@ -1596,6 +1627,10 @@ where
                         }
                         return Ok(());
                     }
+                    // The legacy variant carries no target list, so the
+                    // relayer suppresses nothing and behaves exactly as it does
+                    // today. `CoveredPeers::empty()` is that "nobody is
+                    // covered" statement, not a missing value.
                     update::UpdateMsg::BroadcastTo {
                         id,
                         key,
@@ -1609,6 +1644,7 @@ where
                             payload.clone(),
                             sender_summary_bytes.clone(),
                             sender_addr,
+                            crate::ring::broadcast_coverage::CoveredPeers::empty(),
                         )
                         .await
                         {
@@ -1661,6 +1697,7 @@ where
                             *stream_id,
                             *total_size,
                             sender_addr,
+                            crate::ring::broadcast_coverage::CoveredPeers::empty(),
                         )
                         .await
                         {
@@ -1669,6 +1706,69 @@ where
                                 %key,
                                 error = %err,
                                 "UPDATE relay dispatch: start_relay_broadcast_to_streaming failed"
+                            );
+                        }
+                        return Ok(());
+                    }
+                    // #5147. These two arms are the ONLY places a target list
+                    // is honored, and that is the security rule rather than an
+                    // implementation detail: the list is trusted solely because
+                    // it arrived on the message that delivered the payload, so
+                    // its author is attesting to sends it actually made. A
+                    // relayer therefore cannot fabricate an "everyone is
+                    // covered" list to suppress third-party fan-out, because
+                    // there is no other message type that carries one. Do NOT
+                    // add a `covered` field to a non-payload-bearing variant.
+                    update::UpdateMsg::BroadcastToV2 {
+                        id,
+                        key,
+                        payload,
+                        sender_summary_bytes,
+                        covered,
+                    } => {
+                        if let Err(err) = update::op_ctx_task::start_relay_broadcast_to(
+                            op_manager.clone(),
+                            *id,
+                            *key,
+                            payload.clone(),
+                            sender_summary_bytes.clone(),
+                            sender_addr,
+                            covered.clone(),
+                        )
+                        .await
+                        {
+                            tracing::error!(
+                                tx = %id,
+                                %key,
+                                error = %err,
+                                "UPDATE relay dispatch: start_relay_broadcast_to (v2) failed"
+                            );
+                        }
+                        return Ok(());
+                    }
+                    update::UpdateMsg::BroadcastToStreamingV2 {
+                        id,
+                        key,
+                        stream_id,
+                        total_size,
+                        covered,
+                    } => {
+                        if let Err(err) = update::op_ctx_task::start_relay_broadcast_to_streaming(
+                            op_manager.clone(),
+                            *id,
+                            *key,
+                            *stream_id,
+                            *total_size,
+                            sender_addr,
+                            covered.clone(),
+                        )
+                        .await
+                        {
+                            tracing::error!(
+                                tx = %id,
+                                %key,
+                                error = %err,
+                                "UPDATE relay dispatch: start_relay_broadcast_to_streaming (v2) failed"
                             );
                         }
                         return Ok(());

--- a/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
+++ b/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
@@ -926,6 +926,12 @@ impl PayloadMix {
         outcome: ReceiverTerminalOutcome,
         payload_bytes: usize,
     ) {
+        // #5147 measurement, emitted from the classification itself so the
+        // redundancy count cannot drift from the decision it describes.
+        crate::config::GlobalTestMetrics::record_broadcast_delivery(matches!(
+            outcome,
+            ReceiverTerminalOutcome::Dedup | ReceiverTerminalOutcome::NoOp
+        ));
         let outcome_index = outcome.index();
         let kind_index = usize::from(!is_delta) * 5 + outcome_index;
         let bucket = state_size_bucket(payload_bytes as u64);

--- a/crates/core/src/node/network_bridge/broadcast_queue.rs
+++ b/crates/core/src/node/network_bridge/broadcast_queue.rs
@@ -611,7 +611,16 @@ pub(super) async fn fanout_send_needed(
 ) -> bool {
     match plan_fanout_send(&op_manager.interest_manager, key, summaries, *probes_used) {
         FanoutSendPlan::Send => true,
-        FanoutSendPlan::Skip => false,
+        FanoutSendPlan::Skip => {
+            // #5147 diagnostic: the pre-existing summary-match skip is the
+            // OTHER mechanism suppressing fan-out legs, and it is fed by the
+            // `sender_summary_bytes` that rides on the very sends the target
+            // list removes. Counting it is what makes an interaction between
+            // the two visible instead of showing up as an unexplained rise in
+            // total sends.
+            crate::config::GlobalTestMetrics::record_fanout_summary_skip();
+            false
+        }
         FanoutSendPlan::Probe => {
             *probes_used += 1;
             let SummaryPair { ours, theirs } = summaries;

--- a/crates/core/src/node/network_bridge/broadcast_queue.rs
+++ b/crates/core/src/node/network_bridge/broadcast_queue.rs
@@ -1831,6 +1831,168 @@ mod queue {
             }
         }
 
+        /// #5147: the PRODUCTION send site must decide the wire variant through
+        /// the version gate, and must build the legacy arm unchanged.
+        ///
+        /// `broadcast_to_single_peer` is the production message-construction
+        /// site and is exercised by no behavioural test — it needs a live
+        /// `P2pBridge` and `OpManager`, and the end-to-end simulation runs a
+        /// SEPARATE inline copy in `p2p_protoc/broadcast.rs`. A reviewer forced
+        /// both `match target_list_for(..)` expressions to their `None` arm —
+        /// making the feature entirely inert in production — and every lib test
+        /// still passed. This pin is what closes that hole.
+        #[test]
+        fn production_send_site_gates_both_v2_variants_on_the_version_check() {
+            const SOURCE: &str = include_str!("broadcast_queue.rs");
+
+            // Assembled with `concat!` rather than written whole, and NOT
+            // spelled out in any comment here either.
+            //
+            // This test module sits BEFORE the function in the file, and the
+            // pre-existing pins further down slice the function's body by
+            // searching for its signature from the top of the file. Any earlier
+            // occurrence — in a literal OR in a comment — makes those pins slice
+            // from here instead and assert against this test's text. Writing it
+            // out once broke two of them; writing it out in the comment
+            // explaining that fix broke them again.
+            let fn_anchor = concat!("pub(super) async fn ", "broadcast_to_single_", "peer(");
+            let start = SOURCE
+                .find(fn_anchor)
+                .expect("broadcast_to_single_peer renamed or removed");
+            let after = &SOURCE[start + fn_anchor.len()..];
+            let end = after
+                .find("\n#[cfg(test)]")
+                .or_else(|| after.find("\nmod "))
+                .map(|p| start + fn_anchor.len() + p)
+                .unwrap_or(SOURCE.len());
+            let body = &SOURCE[start..end];
+
+            for (variant, legacy) in [
+                ("UpdateMsg::BroadcastToV2 {", "UpdateMsg::BroadcastTo {"),
+                (
+                    "UpdateMsg::BroadcastToStreamingV2 {",
+                    "UpdateMsg::BroadcastToStreaming {",
+                ),
+            ] {
+                assert!(
+                    body.contains(variant),
+                    "the production send site must be able to emit `{variant}`. \
+                     Without it the whole feature is inert in production while \
+                     the simulation — which runs a SEPARATE inline copy of this \
+                     logic — still reports it working."
+                );
+                assert!(
+                    body.contains(legacy),
+                    "the production send site must keep emitting `{legacy}` for \
+                     pre-floor peers, byte-identically to today"
+                );
+            }
+
+            let gate = body
+                .find("target_list_for(")
+                .expect("the production send site must consult the version gate");
+            let first_v2 = body
+                .find("UpdateMsg::BroadcastToStreamingV2 {")
+                .expect("checked above");
+            assert!(
+                gate < first_v2,
+                "the version gate (offset {gate}) must be consulted BEFORE any \
+                 V2 variant is constructed (offset {first_v2}); a pre-floor \
+                 peer that receives one cannot decode it and the connection is \
+                 CLOSED"
+            );
+        }
+
+        /// #5147: the target list must survive the queue, and a dedup
+        /// replacement must REFRESH it.
+        ///
+        /// The full fan-out set exists only at `handle_broadcast_state_change`;
+        /// it is immediately split into one queue entry per target, and the
+        /// send site sees only its own peer. So the list rides on
+        /// `BroadcastEntry`, and the replace-on-dedup path has to update it in
+        /// lockstep with `new_state` — a superseded entry's list names peers a
+        /// DIFFERENT fan-out targeted, which is over-suppression, the one
+        /// direction this design refuses.
+        ///
+        /// This is also the only test that drives the PRODUCTION queue path:
+        /// the end-to-end simulation runs the `simulation_tests` inline branch,
+        /// a separate copy, so nothing else would notice if the queue dropped
+        /// the list entirely. Mutation-verified — replacing the refresh with a
+        /// no-op fails this test.
+        #[tokio::test(start_paused = true)]
+        #[serial_test::serial(broadcast_queue_depth_gauge)]
+        async fn the_queue_carries_the_target_list_and_refreshes_it_on_replacement() {
+            use crate::transport::TransportKeypair;
+
+            let queue = BroadcastQueue::new();
+            let group = LaneGroup {
+                small_pool: Arc::new(Semaphore::new(4)),
+                large_pool: Arc::new(Semaphore::new(4)),
+                upgrade_slots: Arc::new(Semaphore::new(super::super::MAX_PARKED_LANE_UPGRADES)),
+                small_notify: queue.small_notify.clone(),
+                large_notify: queue.large_notify.clone(),
+            };
+            let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+            let worker = tokio::spawn(drain_lane(
+                QueuedPayloadClass::Small,
+                queue.queue.clone(),
+                group,
+                move |entry: BroadcastEntry, scheduling: QueueScheduling| {
+                    let tx = tx.clone();
+                    async move {
+                        let _scheduling = scheduling;
+                        let _ = tx.send(entry.fanout);
+                    }
+                },
+            ));
+
+            let key = contract(77);
+            let target = PeerKeyLocation::random();
+            let superseded: FanoutTargets =
+                Arc::new(vec![TransportKeypair::new().public().clone()]);
+            let current: FanoutTargets = Arc::new(vec![
+                TransportKeypair::new().public().clone(),
+                TransportKeypair::new().public().clone(),
+            ]);
+
+            // Two enqueues for the same (contract, peer): the second dedups
+            // onto the first and must win on BOTH state and target list.
+            queue
+                .enqueue_in_lane(
+                    QueuedPayloadClass::Small,
+                    key,
+                    target.clone(),
+                    state(16),
+                    superseded.clone(),
+                )
+                .await;
+            queue
+                .enqueue_in_lane(
+                    QueuedPayloadClass::Small,
+                    key,
+                    target,
+                    state(32),
+                    current.clone(),
+                )
+                .await;
+
+            let dispatched = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+                .await
+                .expect("the drain must dispatch")
+                .expect("the drain must send the entry's fanout");
+
+            assert_eq!(
+                *dispatched, *current,
+                "the replacement's target list must reach the send site; a \
+                 superseded list names peers a different fan-out targeted, so \
+                 the recipient would suppress peers this broadcast never \
+                 delivered to"
+            );
+            assert_ne!(*dispatched, *superseded);
+
+            worker.abort();
+        }
+
         /// A lane drain can only exit on a closed pool, which nothing does in
         /// production. But there are TWO of them now, and the pre-#4961 failure
         /// — one worker exiting, so all broadcast draining stops — was at least
@@ -3205,19 +3367,6 @@ fn record_delivery_to_interest<T: crate::util::time_source::TimeSource + Sync>(
     }
 }
 
-/// Send a state change broadcast to a single peer.
-///
-/// This is the per-target body extracted from `broadcast_state_to_peers`.
-/// It handles delta computation, streaming vs inline decision, and telemetry.
-///
-/// For streaming sends, a completion oneshot is created internally and threaded
-/// through the stream send path. The function awaits it (with timeout) so the
-/// semaphore permit — owned by `scheduling`, dropped when this function returns
-/// — is held until the actual stream transfer finishes.
-///
-/// `scheduling` is `Some` exactly when the production queue dispatched this
-/// send, and carries both the lane it was classified into and that lane's
-/// permit. The sim fan-out calls in-line with `None` (no queue, no permits).
 /// Build the originator target list to attach to one leg of a fan-out (#5147),
 /// or `None` when the recipient is on a pre-floor release.
 ///
@@ -3233,14 +3382,29 @@ fn record_delivery_to_interest<T: crate::util::time_source::TimeSource + Sync>(
 /// would spend 8 bytes to say nothing.
 ///
 /// The list describes who we ENQUEUED to, which is not identical to who
-/// receives bytes. Most of the gap is benign and deliberately not corrected
-/// for: `fanout_send_needed` and the empty-delta return skip a peer precisely
-/// BECAUSE it already holds this state, so naming it is correct. The one gap
-/// that is not benign is queue eviction at capacity (`max_queue_depth`) — an
-/// evicted leg never sends, yet stays named — which over-suppresses under
-/// exactly the load that causes eviction. It is bounded by the queue depth and
-/// healed by the interest heartbeat; closing it would mean finalising the list
-/// only after dispatch, i.e. a second pass over the fan-out.
+/// receives bytes. Some of the gap is benign: the empty-delta return skips a
+/// peer precisely BECAUSE it already holds this state, so naming it is correct.
+///
+/// The rest is NOT benign, and the full list matters because every entry on it
+/// converts a transient one-hop loss into a network-visible divergence that
+/// heals only on the ~5-minute interest heartbeat:
+///
+/// * **Queue eviction at capacity** (`max_queue_depth`) — an evicted leg never
+///   sends, yet stays named, under exactly the load that causes eviction.
+/// * **Send failure** — `bridge.send` returning `Err`, a stream dropped or
+///   timed out before `Delivered`, or a payload that fails to serialize. These
+///   also cluster under congestion.
+/// * **`should_broadcast_contract` returning false**, and a target whose
+///   `socket_addr()` is `None`.
+/// * **`fanout_send_needed` skipping on a cached summary.** The skip means the
+///   peer already holds this state *according to our cache*, which is a belief,
+///   not an ack — see the wrongly-cached-summary caveat in this module. Before
+///   #5147 a wrong belief cost one leg and was corrected by the next
+///   comparison; now it is exported one hop and the relayer suppresses too.
+///
+/// None of these are corrected for here. Closing them means finalising the list
+/// only AFTER dispatch, i.e. a second pass over the fan-out, which the message
+/// cannot wait for. The bound on all of them is the interest heartbeat.
 pub(crate) fn target_list_for(
     op_manager: &Arc<OpManager>,
     tx: &crate::message::Transaction,
@@ -3261,6 +3425,19 @@ pub(crate) fn target_list_for(
     ))
 }
 
+/// Send a state change broadcast to a single peer.
+///
+/// This is the per-target body extracted from `broadcast_state_to_peers`.
+/// It handles delta computation, streaming vs inline decision, and telemetry.
+///
+/// For streaming sends, a completion oneshot is created internally and threaded
+/// through the stream send path. The function awaits it (with timeout) so the
+/// semaphore permit — owned by `scheduling`, dropped when this function returns
+/// — is held until the actual stream transfer finishes.
+///
+/// `scheduling` is `Some` exactly when the production queue dispatched this
+/// send, and carries both the lane it was classified into and that lane's
+/// permit. The sim fan-out calls in-line with `None` (no queue, no permits).
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn broadcast_to_single_peer(
     bridge: &P2pBridge,

--- a/crates/core/src/node/network_bridge/broadcast_queue.rs
+++ b/crates/core/src/node/network_bridge/broadcast_queue.rs
@@ -48,6 +48,19 @@ use crate::transport::BroadcastDeliveryOutcome;
 use super::broadcast_payload_mix::PayloadArm;
 use super::p2p_protoc::P2pBridge;
 
+/// The public keys of every peer one fan-out is going to (#5147).
+///
+/// Shared by `Arc` because `handle_broadcast_state_change` splits a single
+/// fan-out into one queue entry per target, and each entry needs the whole set
+/// to build the list it attaches. At the p90 fan-out of 58 (max 138 observed)
+/// cloning the `Vec` per leg would be O(targets^2) key clones per broadcast.
+pub(super) type FanoutTargets = Arc<Vec<crate::transport::TransportPublicKey>>;
+
+/// The list attached to a send with no fan-out context.
+pub(super) fn no_fanout() -> FanoutTargets {
+    Arc::new(Vec::new())
+}
+
 /// Timeout for awaiting stream completion signal before releasing the permit
 /// anyway. Prevents permanent permit leak if a stream task panics or hangs.
 /// Used by `broadcast_to_single_peer` under both `simulation_tests` and
@@ -635,6 +648,7 @@ mod queue {
     use crate::ring::{PeerKey, PeerKeyLocation};
 
     use super::super::p2p_protoc::P2pBridge;
+    use super::FanoutTargets;
     use super::{QueueScheduling, QueuedPayloadClass, SendLanePermit, broadcast_to_single_peer};
 
     /// Maximum concurrent outbound broadcast streams for small payloads (< 64KB).
@@ -737,6 +751,15 @@ mod queue {
         key: ContractKey,
         target: PeerKeyLocation,
         new_state: WrappedState,
+        /// The whole fan-out this entry is one leg of (#5147), shared by `Arc`
+        /// across every leg so a 138-target broadcast clones a pointer rather
+        /// than 138 public keys per leg.
+        ///
+        /// Carried through the queue because the full target set does not
+        /// otherwise survive to the send site: `handle_broadcast_state_change`
+        /// resolves it, then immediately splits it into independent per-peer
+        /// entries, and `broadcast_to_single_peer` sees only its own target.
+        fanout: FanoutTargets,
         /// Contract STATE size in bytes. Feeds the `scheduled_*_state_bytes`
         /// counters only — it is deliberately NOT what picks the lane (see
         /// [`classify_payload_lane`]).
@@ -1113,6 +1136,7 @@ mod queue {
             key: ContractKey,
             target: PeerKeyLocation,
             new_state: WrappedState,
+            fanout: FanoutTargets,
         ) {
             let lane = lane_for(
                 &op_manager.interest_manager,
@@ -1121,7 +1145,8 @@ mod queue {
                 &target,
                 new_state.size(),
             );
-            self.enqueue_in_lane(lane, key, target, new_state).await;
+            self.enqueue_in_lane(lane, key, target, new_state, fanout)
+                .await;
         }
 
         /// The lane-agnostic half of [`Self::enqueue`], split out so tests can
@@ -1132,6 +1157,7 @@ mod queue {
             key: ContractKey,
             target: PeerKeyLocation,
             new_state: WrappedState,
+            fanout: FanoutTargets,
         ) {
             let dedup_key = (key, target.clone());
             let state_size = new_state.size();
@@ -1152,6 +1178,14 @@ mod queue {
                     // go stale the moment a state crossed the threshold.
                     existing.state_size = state_size;
                     existing.lane = lane;
+                    // #5147: the target list belongs to the state it was
+                    // computed for. A replacement is a DIFFERENT fan-out with a
+                    // different (possibly smaller) target set, so keeping the
+                    // superseded list would tell the recipient we delivered to
+                    // peers this broadcast never touched — over-suppression, the
+                    // one direction this design refuses. Refresh it in lockstep
+                    // with `new_state`.
+                    existing.fanout = fanout;
                 }
                 if previous_lane != lane {
                     let small_queued = match lane {
@@ -1194,6 +1228,7 @@ mod queue {
                         key,
                         target,
                         new_state,
+                        fanout,
                         state_size,
                         lane,
                         seq,
@@ -1270,6 +1305,7 @@ mod queue {
                                 entry.new_state,
                                 entry.target,
                                 Some(scheduling),
+                                entry.fanout,
                             )
                             .await;
                         }
@@ -1816,6 +1852,7 @@ mod queue {
                                 contract(seed),
                                 PeerKeyLocation::random(),
                                 state(BIG),
+                                crate::node::network_bridge::broadcast_queue::no_fanout(),
                             )
                             .await;
                     }
@@ -1840,6 +1877,7 @@ mod queue {
                             contract(21),
                             PeerKeyLocation::random(),
                             state(BIG),
+                            crate::node::network_bridge::broadcast_queue::no_fanout(),
                         )
                         .await;
                 }
@@ -1917,6 +1955,7 @@ mod queue {
                     contract(40),
                     PeerKeyLocation::random(),
                     state(BIG),
+                    crate::node::network_bridge::broadcast_queue::no_fanout(),
                 )
                 .await;
             assert_eq!(
@@ -2025,6 +2064,7 @@ mod queue {
                         contract(seed),
                         PeerKeyLocation::random(),
                         state(BIG),
+                        crate::node::network_bridge::broadcast_queue::no_fanout(),
                     )
                     .await;
             }
@@ -2050,6 +2090,7 @@ mod queue {
                         contract(seed),
                         PeerKeyLocation::random(),
                         state(BIG),
+                        crate::node::network_bridge::broadcast_queue::no_fanout(),
                     )
                     .await;
             }
@@ -2104,6 +2145,7 @@ mod queue {
                     key,
                     PeerKeyLocation::random(),
                     state(BIG),
+                    crate::node::network_bridge::broadcast_queue::no_fanout(),
                 )
                 .await;
             let mut saw_large = false;
@@ -2165,6 +2207,7 @@ mod queue {
                         contract(seed),
                         PeerKeyLocation::random(),
                         state(BIG),
+                        crate::node::network_bridge::broadcast_queue::no_fanout(),
                     )
                     .await;
             }
@@ -2188,6 +2231,7 @@ mod queue {
                     contract(2),
                     PeerKeyLocation::random(),
                     state(BIG),
+                    crate::node::network_bridge::broadcast_queue::no_fanout(),
                 )
                 .await;
             // ...and a small entry arrives behind it. Every one of the small
@@ -2201,6 +2245,7 @@ mod queue {
                     small,
                     PeerKeyLocation::random(),
                     state(16),
+                    crate::node::network_bridge::broadcast_queue::no_fanout(),
                 )
                 .await;
 
@@ -2260,6 +2305,7 @@ mod queue {
                     key,
                     PeerKeyLocation::random(),
                     state(BIG),
+                    crate::node::network_bridge::broadcast_queue::no_fanout(),
                 )
                 .await;
 
@@ -2295,10 +2341,22 @@ mod queue {
             let target = PeerKeyLocation::random();
 
             queue
-                .enqueue_in_lane(QueuedPayloadClass::Small, key, target.clone(), state(16))
+                .enqueue_in_lane(
+                    QueuedPayloadClass::Small,
+                    key,
+                    target.clone(),
+                    state(16),
+                    crate::node::network_bridge::broadcast_queue::no_fanout(),
+                )
                 .await;
             queue
-                .enqueue_in_lane(QueuedPayloadClass::Large, key, target.clone(), state(BIG))
+                .enqueue_in_lane(
+                    QueuedPayloadClass::Large,
+                    key,
+                    target.clone(),
+                    state(BIG),
+                    crate::node::network_bridge::broadcast_queue::no_fanout(),
+                )
                 .await;
 
             {
@@ -2324,7 +2382,13 @@ mod queue {
 
             // ...and symmetrically back again.
             queue
-                .enqueue_in_lane(QueuedPayloadClass::Small, key, target, state(16))
+                .enqueue_in_lane(
+                    QueuedPayloadClass::Small,
+                    key,
+                    target,
+                    state(16),
+                    crate::node::network_bridge::broadcast_queue::no_fanout(),
+                )
                 .await;
             let q = queue.queue.lock().await;
             let entry = q.entries.values().next().expect("the replaced entry");
@@ -2354,6 +2418,7 @@ mod queue {
                     oldest,
                     PeerKeyLocation::random(),
                     state(BIG),
+                    crate::node::network_bridge::broadcast_queue::no_fanout(),
                 )
                 .await;
             for seed in 2..4u8 {
@@ -2363,6 +2428,7 @@ mod queue {
                         contract(seed),
                         PeerKeyLocation::random(),
                         state(16),
+                        crate::node::network_bridge::broadcast_queue::no_fanout(),
                     )
                     .await;
             }
@@ -2392,6 +2458,7 @@ mod queue {
                     oldest,
                     PeerKeyLocation::random(),
                     state(16),
+                    crate::node::network_bridge::broadcast_queue::no_fanout(),
                 )
                 .await;
             for seed in 6..8u8 {
@@ -2401,6 +2468,7 @@ mod queue {
                         contract(seed),
                         PeerKeyLocation::random(),
                         state(BIG),
+                        crate::node::network_bridge::broadcast_queue::no_fanout(),
                     )
                     .await;
             }
@@ -2437,6 +2505,7 @@ mod queue {
                     key,
                     PeerKeyLocation::random(),
                     state(BIG),
+                    crate::node::network_bridge::broadcast_queue::no_fanout(),
                 )
                 .await;
             assert_eq!(
@@ -3140,6 +3209,50 @@ fn record_delivery_to_interest<T: crate::util::time_source::TimeSource + Sync>(
 /// `scheduling` is `Some` exactly when the production queue dispatched this
 /// send, and carries both the lane it was classified into and that lane's
 /// permit. The sim fan-out calls in-line with `None` (no queue, no permits).
+/// Build the originator target list to attach to one leg of a fan-out (#5147),
+/// or `None` when the recipient is on a pre-floor release.
+///
+/// `None` is the fail-closed answer, and it is what an unknown peer version
+/// yields: a pre-floor peer has no `BroadcastToV2` variant index, would fail to
+/// bincode-decode one, and the connection would be CLOSED. The caller's
+/// fallback is the legacy message, byte-identical to what every peer receives
+/// today, so failing closed costs the duplicate bandwidth we already spend and
+/// never costs convergence.
+///
+/// The recipient is excluded from its own list. It obviously has what we are
+/// sending it, and it excludes itself from its own fan-out anyway, so naming it
+/// would spend 8 bytes to say nothing.
+///
+/// The list describes who we ENQUEUED to, which is not identical to who
+/// receives bytes. Most of the gap is benign and deliberately not corrected
+/// for: `fanout_send_needed` and the empty-delta return skip a peer precisely
+/// BECAUSE it already holds this state, so naming it is correct. The one gap
+/// that is not benign is queue eviction at capacity (`max_queue_depth`) — an
+/// evicted leg never sends, yet stays named — which over-suppresses under
+/// exactly the load that causes eviction. It is bounded by the queue depth and
+/// healed by the interest heartbeat; closing it would mean finalising the list
+/// only after dispatch, i.e. a second pass over the fan-out.
+pub(crate) fn target_list_for(
+    op_manager: &Arc<OpManager>,
+    tx: &crate::message::Transaction,
+    peer_addr: std::net::SocketAddr,
+    recipient: &crate::ring::PeerKey,
+    fanout: &FanoutTargets,
+) -> Option<crate::ring::broadcast_coverage::CoveredPeers> {
+    if !op_manager
+        .ring
+        .connection_manager
+        .supports_broadcast_target_list(peer_addr)
+    {
+        return None;
+    }
+    Some(crate::ring::broadcast_coverage::CoveredPeers::from_targets(
+        tx,
+        fanout.iter().filter(|pub_key| *pub_key != &recipient.0),
+    ))
+}
+
+#[allow(clippy::too_many_arguments)]
 pub(super) async fn broadcast_to_single_peer(
     bridge: &P2pBridge,
     op_manager: &Arc<OpManager>,
@@ -3147,6 +3260,9 @@ pub(super) async fn broadcast_to_single_peer(
     new_state: WrappedState,
     target: PeerKeyLocation,
     scheduling: Option<QueueScheduling>,
+    // The whole fan-out this send is one leg of (#5147). Used to build the
+    // originator target list attached to this leg, minus the recipient itself.
+    fanout: FanoutTargets,
 ) {
     use crate::message::{DeltaOrFullState, NetMessage};
     use crate::node::network_bridge::NetworkBridge;
@@ -3583,11 +3699,25 @@ pub(super) async fn broadcast_to_single_peer(
             payload_size,
             "Using streaming for BroadcastTo (via queue)"
         );
-        let msg = UpdateMsg::BroadcastToStreaming {
-            id: update_tx,
-            stream_id: sid,
-            key,
-            total_size: payload_bytes.len() as u64,
+        let msg = match target_list_for(op_manager, &update_tx, peer_addr, &peer_key, &fanout) {
+            Some(covered) => UpdateMsg::BroadcastToStreamingV2 {
+                id: update_tx,
+                stream_id: sid,
+                key,
+                total_size: payload_bytes.len() as u64,
+                covered,
+            },
+            // Pre-floor peer: build the message through the SAME unchanged
+            // expression it has always been built with, rather than a shared
+            // constructor parameterised on an `Option`. Calling identical code
+            // is a stronger guarantee that a pre-floor peer's bytes are
+            // untouched than any amount of branch review (#5167's rationale).
+            None => UpdateMsg::BroadcastToStreaming {
+                id: update_tx,
+                stream_id: sid,
+                key,
+                total_size: payload_bytes.len() as u64,
+            },
         };
         let net_msg: NetMessage = msg.into();
         // Serialize metadata for embedding in fragment #1 (fix #2757)
@@ -3714,14 +3844,28 @@ pub(super) async fn broadcast_to_single_peer(
         }
         send_res
     } else {
-        let msg = UpdateMsg::BroadcastTo {
-            id: update_tx,
-            key,
-            payload,
-            sender_summary_bytes: our_summary
-                .as_ref()
-                .map(|s| s.as_ref().to_vec())
-                .unwrap_or_default(),
+        let msg = match target_list_for(op_manager, &update_tx, peer_addr, &peer_key, &fanout) {
+            Some(covered) => UpdateMsg::BroadcastToV2 {
+                id: update_tx,
+                key,
+                payload,
+                sender_summary_bytes: our_summary
+                    .as_ref()
+                    .map(|s| s.as_ref().to_vec())
+                    .unwrap_or_default(),
+                covered,
+            },
+            // See the streaming twin: the legacy arm is the untouched original
+            // expression, deliberately duplicated rather than factored.
+            None => UpdateMsg::BroadcastTo {
+                id: update_tx,
+                key,
+                payload,
+                sender_summary_bytes: our_summary
+                    .as_ref()
+                    .map(|s| s.as_ref().to_vec())
+                    .unwrap_or_default(),
+            },
         };
         let res = bridge.send(peer_addr, msg.into()).await;
         // Non-streaming inline broadcasts have no separate transfer phase: a

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -1066,6 +1066,48 @@ pub(crate) fn version_supports_hash_first_summaries(
     remote.is_some_and(|v| v >= floor)
 }
 
+/// Has the originator target list (#5147) actually SHIPPED, and in which
+/// release?
+///
+/// Same contract as [`HASH_FIRST_SHIPPED_IN`], guarded by
+/// `broadcast_target_list_floor_tracks_the_shipping_release`: `None` means
+/// [`BROADCAST_TARGET_LIST_MIN_VERSION`] is a prediction that must stay
+/// strictly ABOVE the crate version; `Some(v)` means it shipped in `v`, which
+/// must equal the floor.
+///
+/// RELEASE-TIME ACTION: when the release carrying this feature is cut, set this
+/// to `Some(BROADCAST_TARGET_LIST_MIN_VERSION)` and freeze both.
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) const BROADCAST_TARGET_LIST_SHIPPED_IN: Option<(u8, u8, u16)> = None;
+
+/// Version floor for the originator target list on broadcast (#5147).
+///
+/// Below this, a peer has no `BroadcastToV2` / `BroadcastToStreamingV2` variant
+/// index and would fail to bincode-decode one, which closes the connection —
+/// so the gate must fail closed on an unknown version.
+pub(crate) const BROADCAST_TARGET_LIST_MIN_VERSION: (u8, u8, u16) = (0, 2, 120);
+
+/// Pure version-gate for the originator target list, mirroring
+/// [`version_supports_hash_first_summaries`]: `true` iff `remote` is known
+/// (`Some`) AND at least `floor`.
+///
+/// Fail-closed on `None`. The fallback is the legacy `BroadcastTo`, i.e. exactly
+/// what every peer receives today, so a closed gate costs the bandwidth we are
+/// already spending and never costs convergence.
+///
+/// NOTE (#5161 / PR #5167): until that fix deploys, a joiner never learns its
+/// GATEWAY's version — `AckConnection` carries none — so `remote` is `None` on
+/// gateway links and this gate stays closed there regardless of what the
+/// gateway actually runs. Peer-to-peer links are unaffected. That is a
+/// suppression shortfall on gateway legs, not a correctness problem, and it
+/// resolves itself once #5167 ships.
+pub(crate) fn version_supports_broadcast_target_list(
+    remote: Option<(u8, u8, u16)>,
+    floor: (u8, u8, u16),
+) -> bool {
+    remote.is_some_and(|v| v >= floor)
+}
+
 /// Upper bound on the number of hosted contracts examined per new-peer
 /// migration trigger. Each examined contract may emit a best-effort
 /// non-blocking `try_send` (the SubscribeHint nudge), so an unbounded scan

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -5081,77 +5081,6 @@ pub(crate) mod tests {
     /// The ordering is the whole fix, so the ordering is what is pinned: the
     /// fully-covered early return must precede the retry branch. Mutation-check
     /// when editing this — move the return after the retry branch and confirm
-
-    /// The PRODUCTION fan-out must pass its real target list to the queue.
-    ///
-    /// The #5147 simulation drives `broadcast_state_to_peers`, which is
-    /// `#[cfg(feature = "simulation_tests")]` and never compiled into a
-    /// production binary — the function says so itself: "production splits the
-    /// fan-out across a queue and rebuilds the list per leg, this one holds the
-    /// whole set in scope. A test that only exercises this branch proves
-    /// nothing about production."
-    ///
-    /// So the entire measured effect (44% fewer legs) came from a path that
-    /// does not ship, and the shipping path had no coverage. Two one-token
-    /// mutations made the feature INERT on the fleet while every test,
-    /// including that simulation, stayed green:
-    ///
-    ///   * pass `no_fanout()` instead of the built `fanout` at the enqueue
-    ///     loop — no leg ever carries a list;
-    ///   * drop `existing.fanout = fanout` on dedup replacement — a superseded
-    ///     list is sent for a different fan-out, which is over-suppression.
-    ///
-    /// Every other caller in the tree passes `no_fanout()`, so nothing
-    /// distinguished the two. This pins both anchors on the production side.
-    #[test]
-    fn production_fanout_passes_its_target_list_to_the_queue() {
-        const SOURCE: &str = include_str!("p2p_protoc/broadcast.rs");
-
-        // Bound the region to the production fan-out. `broadcast_state_change`
-        // is the non-simulation path; the sim twin lives in a separate
-        // cfg-gated fn and must not satisfy this pin.
-        let fn_anchor = "async fn handle_broadcast_state_change(";
-        let fn_start = SOURCE
-            .find(fn_anchor)
-            .expect("handle_broadcast_state_change renamed or removed");
-        let after_header = &SOURCE[fn_start + fn_anchor.len()..];
-        let body_end = [
-            after_header.find("\n    async fn "),
-            after_header.find("\n    pub(super) async fn "),
-        ]
-        .into_iter()
-        .flatten()
-        .min()
-        .map(|p| fn_start + fn_anchor.len() + p)
-        .unwrap_or(SOURCE.len());
-        let body = &SOURCE[fn_start..body_end];
-
-        assert!(
-            body.contains("fanout.clone()"),
-            "the production enqueue loop in handle_broadcast_state_change must \
-             pass the target list it just built. If this is `no_fanout()` the \
-             #5147 feature is inert on the fleet while the simulation — which \
-             drives the cfg(simulation_tests) twin — still reports suppression."
-        );
-        assert!(
-            !body.contains("no_fanout()"),
-            "the production fan-out must never hand the queue an empty target \
-             list; that is the shape of the inert-feature regression."
-        );
-
-        // The dedup-replacement refresh, whose own comment calls it the guard
-        // against the one direction this design refuses.
-        const QUEUE_SOURCE: &str = include_str!("broadcast_queue.rs");
-        assert!(
-            QUEUE_SOURCE.contains("existing.fanout = fanout;"),
-            "broadcast_queue must refresh the stored target list when a queued \
-             payload is replaced. Without it a superseded list rides a later \
-             fan-out and names peers that fan-out never touched — \
-             over-suppression. Every queue test passes an empty fanout, so no \
-             behavioural test distinguishes the two."
-        );
-    }
-
     /// this test FAILS.
     #[test]
     fn fully_covered_fanout_returns_before_the_no_target_retry() {
@@ -5228,13 +5157,6 @@ pub(crate) mod tests {
         // owns that assertion and the reasoning. Noted here so a reader of this
         // pin does not "restore symmetry" with the targets-found path: the two
         // are deliberately asymmetric because only one of them sends anything.
-        assert!(
-            branch.contains("pending_broadcasts") && branch.contains(".stash("),
-            "the fully-covered branch must REFRESH the #4359 stash, not discard \
-             it. Taking it without putting the current state back destroys an \
-             earlier give-up's only non-heartbeat recovery route; leaving a \
-             stale one queues superseded state for re-emission."
-        );
         // The condition must also exclude the case where the target set is
         // empty merely because co-hosts failed to RESOLVE. Those peers were not
         // served — they are unreachable — and calling that fan-out complete
@@ -5246,6 +5168,76 @@ pub(crate) mod tests {
              `proximity_resolve_failed == 0`; otherwise a fan-out that is empty \
              only because every co-host lookup failed is reported as a \
              completed broadcast"
+        );
+    }
+
+    /// The PRODUCTION fan-out must pass its real target list to the queue.
+    ///
+    /// The #5147 simulation drives `broadcast_state_to_peers`, which is
+    /// `#[cfg(feature = "simulation_tests")]` and never compiled into a
+    /// production binary — the function says so itself: "production splits the
+    /// fan-out across a queue and rebuilds the list per leg, this one holds the
+    /// whole set in scope. A test that only exercises this branch proves
+    /// nothing about production."
+    ///
+    /// So the entire measured effect (44% fewer legs) came from a path that
+    /// does not ship, and the shipping path had no coverage. Two one-token
+    /// mutations made the feature INERT on the fleet while every test,
+    /// including that simulation, stayed green:
+    ///
+    ///   * pass `no_fanout()` instead of the built `fanout` at the enqueue
+    ///     loop — no leg ever carries a list;
+    ///   * drop `existing.fanout = fanout` on dedup replacement — a superseded
+    ///     list is sent for a different fan-out, which is over-suppression.
+    ///
+    /// Every other caller in the tree passes `no_fanout()`, so nothing
+    /// distinguished the two. This pins both anchors on the production side.
+    #[test]
+    fn production_fanout_passes_its_target_list_to_the_queue() {
+        const SOURCE: &str = include_str!("p2p_protoc/broadcast.rs");
+
+        // Bound the region to the production fan-out. `broadcast_state_change`
+        // is the non-simulation path; the sim twin lives in a separate
+        // cfg-gated fn and must not satisfy this pin.
+        let fn_anchor = "async fn handle_broadcast_state_change(";
+        let fn_start = SOURCE
+            .find(fn_anchor)
+            .expect("handle_broadcast_state_change renamed or removed");
+        let after_header = &SOURCE[fn_start + fn_anchor.len()..];
+        let body_end = [
+            after_header.find("\n    async fn "),
+            after_header.find("\n    pub(super) async fn "),
+        ]
+        .into_iter()
+        .flatten()
+        .min()
+        .map(|p| fn_start + fn_anchor.len() + p)
+        .unwrap_or(SOURCE.len());
+        let body = &SOURCE[fn_start..body_end];
+
+        assert!(
+            body.contains("fanout.clone()"),
+            "the production enqueue loop in handle_broadcast_state_change must \
+             pass the target list it just built. If this is `no_fanout()` the \
+             #5147 feature is inert on the fleet while the simulation — which \
+             drives the cfg(simulation_tests) twin — still reports suppression."
+        );
+        assert!(
+            !body.contains("no_fanout()"),
+            "the production fan-out must never hand the queue an empty target \
+             list; that is the shape of the inert-feature regression."
+        );
+
+        // The dedup-replacement refresh, whose own comment calls it the guard
+        // against the one direction this design refuses.
+        const QUEUE_SOURCE: &str = include_str!("broadcast_queue.rs");
+        assert!(
+            QUEUE_SOURCE.contains("existing.fanout = fanout;"),
+            "broadcast_queue must refresh the stored target list when a queued \
+             payload is replaced. Without it a superseded list rides a later \
+             fan-out and names peers that fan-out never touched — \
+             over-suppression. Every queue test passes an empty fanout, so no \
+             behavioural test distinguishes the two."
         );
     }
 

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -5223,6 +5223,30 @@ pub(crate) mod tests {
             "the fully-covered branch must clear retry bookkeeping, or a \
              contract that was mid-retry-cycle keeps a stale entry"
         );
+        // It must not DISCARD the #4359 stash the way the targets-found path
+        // does — see `broadcast_path_feeds_propagation_stats_pin_test`, which
+        // owns that assertion and the reasoning. Noted here so a reader of this
+        // pin does not "restore symmetry" with the targets-found path: the two
+        // are deliberately asymmetric because only one of them sends anything.
+        assert!(
+            branch.contains("pending_broadcasts") && branch.contains(".stash("),
+            "the fully-covered branch must REFRESH the #4359 stash, not discard \
+             it. Taking it without putting the current state back destroys an \
+             earlier give-up's only non-heartbeat recovery route; leaving a \
+             stale one queues superseded state for re-emission."
+        );
+        // The condition must also exclude the case where the target set is
+        // empty merely because co-hosts failed to RESOLVE. Those peers were not
+        // served — they are unreachable — and calling that fan-out complete
+        // swallows a genuine failure the retry exists to heal.
+        assert!(
+            branch.contains("proximity_resolve_failed == 0")
+                || body[..covered_pos].contains("proximity_resolve_failed == 0"),
+            "the fully-covered condition must require \
+             `proximity_resolve_failed == 0`; otherwise a fan-out that is empty \
+             only because every co-host lookup failed is reported as a \
+             completed broadcast"
+        );
     }
 
     /// Phase 7 egress self-block pin (#4300). `handle_broadcast_state_change`

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -5062,6 +5062,80 @@ pub(crate) mod tests {
         );
     }
 
+    /// #5147: a fully-suppressed fan-out must be treated as COMPLETE, never as
+    /// the no-subscriber failure case.
+    ///
+    /// This pins the fix for a self-defeating bug the simulation caught (see
+    /// `test_5147_originator_target_list_cuts_duplicate_deliveries`). In the
+    /// clique regime the target list targets, a relayer's co-hosts are
+    /// frequently ALL named by the originator, so the correct fan-out is the
+    /// empty one. The pre-existing empty-target branch reads empty as "nobody
+    /// is subscribed yet": it retries three times with backoff and then stashes
+    /// the state for a later interest flush. Each retry re-resolves targets
+    /// AFTER the coverage claim has been consumed — it is taken once, by design
+    /// — so the retry suppresses nothing and re-broadcasts to the whole co-host
+    /// set one backoff later. The suppressed traffic comes back, delayed and
+    /// with staler summaries, and the measured effect of the feature inverts
+    /// from a 44% send reduction to a 15% increase.
+    ///
+    /// The ordering is the whole fix, so the ordering is what is pinned: the
+    /// fully-covered early return must precede the retry branch. Mutation-check
+    /// when editing this — move the return after the retry branch and confirm
+    /// this test FAILS.
+    #[test]
+    fn fully_covered_fanout_returns_before_the_no_target_retry() {
+        const SOURCE: &str = include_str!("p2p_protoc/broadcast.rs");
+
+        let fn_anchor = "async fn handle_broadcast_state_change(";
+        let fn_start = SOURCE
+            .find(fn_anchor)
+            .expect("handle_broadcast_state_change renamed or removed");
+        let after_header = &SOURCE[fn_start + fn_anchor.len()..];
+        let body_end = [
+            after_header.find("\n    async fn "),
+            after_header.find("\n    pub(super) async fn "),
+        ]
+        .into_iter()
+        .flatten()
+        .min()
+        .map(|p| fn_start + fn_anchor.len() + p)
+        .unwrap_or(SOURCE.len());
+        let body = &SOURCE[fn_start..body_end];
+
+        let covered_pos = body.find("let fully_covered =").expect(
+            "handle_broadcast_state_change lost the #5147 fully-covered branch. \
+             Without it a fully-suppressed fan-out enters the no-target retry \
+             cycle, which re-resolves targets after the coverage claim has been \
+             consumed and re-broadcasts everything one backoff later — the \
+             feature silently defeats itself.",
+        );
+        let retry_pos = body
+            .find("self.broadcast_retries.entry(key)")
+            .expect("the no-target retry branch is missing");
+        assert!(
+            covered_pos < retry_pos,
+            "the #5147 fully-covered return (offset {covered_pos}) must run \
+             BEFORE the no-target retry branch (offset {retry_pos}); otherwise \
+             every fully-suppressed fan-out is retried and re-broadcast"
+        );
+
+        // The branch must also clear the stash. A fully-covered fan-out is a
+        // completed one, so a previously-stashed state for this contract is
+        // superseded and must not be re-emitted later as stale — the same
+        // reasoning as the targets-found path.
+        let branch = &body[covered_pos..retry_pos];
+        assert!(
+            branch.contains("pending_broadcasts.take(key.id())"),
+            "the fully-covered branch must drop any deferred re-broadcast \
+             stash, exactly as the targets-found path does"
+        );
+        assert!(
+            branch.contains("self.broadcast_retries.remove(&key)"),
+            "the fully-covered branch must clear retry bookkeeping, or a \
+             contract that was mid-retry-cycle keeps a stale entry"
+        );
+    }
+
     /// Phase 7 egress self-block pin (#4300). `handle_broadcast_state_change`
     /// MUST skip the fan-out for a banned contract — the egress
     /// `contract_ban_list.is_banned(key.id())` check must appear BEFORE

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -5190,15 +5190,33 @@ pub(crate) mod tests {
              every fully-suppressed fan-out is retried and re-broadcast"
         );
 
-        // The branch must also clear the stash. A fully-covered fan-out is a
-        // completed one, so a previously-stashed state for this contract is
-        // superseded and must not be re-emitted later as stale — the same
-        // reasoning as the targets-found path.
+        // The branch must REFRESH the #4359 stash, not discard it.
+        //
+        // This originally asserted a bare `take` on the reasoning that a
+        // fully-covered fan-out is a completed one, "exactly as the
+        // targets-found path does". That reasoning does not transfer: the
+        // targets-found path drops the stash because it is reaching targets
+        // right now, and this branch reaches NOBODY. Discarding here destroyed
+        // an earlier give-up's stash with no replacement, so a peer subscribing
+        // later lost its only non-heartbeat path to the contract.
+        //
+        // Leaving the old stash would queue STALE state for re-emission, so the
+        // branch takes it and puts the CURRENT state back — and only when
+        // something was already stashed, so the common clique-regime outcome
+        // does not start writing a stash on every fan-out.
         let branch = &body[covered_pos..retry_pos];
         assert!(
-            branch.contains("pending_broadcasts.take(key.id())"),
-            "the fully-covered branch must drop any deferred re-broadcast \
-             stash, exactly as the targets-found path does"
+            branch.contains("pending_broadcasts.take(key.id()).is_some()"),
+            "the fully-covered branch must act on a deferred re-broadcast stash \
+             only when one EXISTS. An unconditional take discards an earlier \
+             give-up's stash with no replacement; an unconditional stash adds a \
+             write to every fully-covered fan-out."
+        );
+        assert!(
+            branch.contains("pending_broadcasts") && branch.contains(".stash("),
+            "the fully-covered branch must put CURRENT state back into the \
+             stash it took, or the #4359 deferred-broadcast recovery is lost \
+             for this contract"
         );
         assert!(
             branch.contains("self.broadcast_retries.remove(&key)"),

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -5081,6 +5081,77 @@ pub(crate) mod tests {
     /// The ordering is the whole fix, so the ordering is what is pinned: the
     /// fully-covered early return must precede the retry branch. Mutation-check
     /// when editing this — move the return after the retry branch and confirm
+
+    /// The PRODUCTION fan-out must pass its real target list to the queue.
+    ///
+    /// The #5147 simulation drives `broadcast_state_to_peers`, which is
+    /// `#[cfg(feature = "simulation_tests")]` and never compiled into a
+    /// production binary — the function says so itself: "production splits the
+    /// fan-out across a queue and rebuilds the list per leg, this one holds the
+    /// whole set in scope. A test that only exercises this branch proves
+    /// nothing about production."
+    ///
+    /// So the entire measured effect (44% fewer legs) came from a path that
+    /// does not ship, and the shipping path had no coverage. Two one-token
+    /// mutations made the feature INERT on the fleet while every test,
+    /// including that simulation, stayed green:
+    ///
+    ///   * pass `no_fanout()` instead of the built `fanout` at the enqueue
+    ///     loop — no leg ever carries a list;
+    ///   * drop `existing.fanout = fanout` on dedup replacement — a superseded
+    ///     list is sent for a different fan-out, which is over-suppression.
+    ///
+    /// Every other caller in the tree passes `no_fanout()`, so nothing
+    /// distinguished the two. This pins both anchors on the production side.
+    #[test]
+    fn production_fanout_passes_its_target_list_to_the_queue() {
+        const SOURCE: &str = include_str!("p2p_protoc/broadcast.rs");
+
+        // Bound the region to the production fan-out. `broadcast_state_change`
+        // is the non-simulation path; the sim twin lives in a separate
+        // cfg-gated fn and must not satisfy this pin.
+        let fn_anchor = "async fn handle_broadcast_state_change(";
+        let fn_start = SOURCE
+            .find(fn_anchor)
+            .expect("handle_broadcast_state_change renamed or removed");
+        let after_header = &SOURCE[fn_start + fn_anchor.len()..];
+        let body_end = [
+            after_header.find("\n    async fn "),
+            after_header.find("\n    pub(super) async fn "),
+        ]
+        .into_iter()
+        .flatten()
+        .min()
+        .map(|p| fn_start + fn_anchor.len() + p)
+        .unwrap_or(SOURCE.len());
+        let body = &SOURCE[fn_start..body_end];
+
+        assert!(
+            body.contains("fanout.clone()"),
+            "the production enqueue loop in handle_broadcast_state_change must \
+             pass the target list it just built. If this is `no_fanout()` the \
+             #5147 feature is inert on the fleet while the simulation — which \
+             drives the cfg(simulation_tests) twin — still reports suppression."
+        );
+        assert!(
+            !body.contains("no_fanout()"),
+            "the production fan-out must never hand the queue an empty target \
+             list; that is the shape of the inert-feature regression."
+        );
+
+        // The dedup-replacement refresh, whose own comment calls it the guard
+        // against the one direction this design refuses.
+        const QUEUE_SOURCE: &str = include_str!("broadcast_queue.rs");
+        assert!(
+            QUEUE_SOURCE.contains("existing.fanout = fanout;"),
+            "broadcast_queue must refresh the stored target list when a queued \
+             payload is replaced. Without it a superseded list rides a later \
+             fan-out and names peers that fan-out never touched — \
+             over-suppression. Every queue test passes an empty fanout, so no \
+             behavioural test distinguishes the two."
+        );
+    }
+
     /// this test FAILS.
     #[test]
     fn fully_covered_fanout_returns_before_the_no_target_retry() {

--- a/crates/core/src/node/network_bridge/p2p_protoc/broadcast.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc/broadcast.rs
@@ -259,10 +259,27 @@ impl P2pConnManager {
             return;
         };
 
-        let target_result = op_manager.get_broadcast_targets_update(&key, &self_addr);
+        // #5147. Take the provenance of the apply that caused this fan-out:
+        // who delivered it to us, and who they say they already delivered it
+        // to. `BroadcastStateChange` carries none of that — the executor emits
+        // it on any committed write and has no idea whether the write came from
+        // a local client or an inbound broadcast — so it is parked on
+        // `broadcast_coverage` by `update_contract` and collected here. Absent
+        // or expired yields `BroadcastOrigin::local()`, which suppresses
+        // nothing and is exactly today's behaviour.
+        //
+        // Taken ONCE and reused by the stash recheck below: taking it again
+        // there would find it already consumed and silently drop the
+        // suppression on the re-emitted path.
+        let origin = op_manager.broadcast_coverage.take(key.id());
+
+        let target_result = op_manager.get_broadcast_targets_update(&key, &origin);
         tracing::debug!(
             contract = %key,
             target_count = target_result.targets.len(),
+            skipped_covered = target_result.skipped_covered,
+            skipped_sender = target_result.skipped_sender,
+            covered_named = origin.covered_len(),
             self_addr = %self_addr,
             "BroadcastStateChange: found targets"
         );
@@ -373,7 +390,7 @@ impl P2pConnManager {
                 // the TTL. Re-resolve targets now that the stash is in place: if a
                 // target has appeared, take the stash back and re-emit
                 // immediately rather than waiting on a future flush.
-                let recheck = op_manager.get_broadcast_targets_update(&key, &self_addr);
+                let recheck = op_manager.get_broadcast_targets_update(&key, &origin);
                 if !recheck.targets.is_empty() {
                     if let Some(stashed) = op_manager.pending_broadcasts.take(key.id()) {
                         tracing::debug!(
@@ -516,9 +533,27 @@ impl P2pConnManager {
         // delivery order and breaks convergence.
         #[cfg(not(feature = "simulation_tests"))]
         {
+            // #5147: the originator target list, computed ONCE for the whole
+            // fan-out and shared by `Arc` across its legs. It has to be built
+            // here because this loop is where the full target set stops
+            // existing — each iteration becomes an independent queue entry, and
+            // the send site downstream sees only its own peer.
+            let fanout: super::super::broadcast_queue::FanoutTargets = std::sync::Arc::new(
+                target_result
+                    .targets
+                    .iter()
+                    .map(|target| target.pub_key().clone())
+                    .collect(),
+            );
             for target in &target_result.targets {
                 self.broadcast_queue
-                    .enqueue(op_manager, key, target.clone(), new_state.clone())
+                    .enqueue(
+                        op_manager,
+                        key,
+                        target.clone(),
+                        new_state.clone(),
+                        fanout.clone(),
+                    )
                     .await;
             }
             // Emit broadcast emitted telemetry (issue #3622)
@@ -625,8 +660,16 @@ impl P2pConnManager {
 
         #[cfg(not(feature = "simulation_tests"))]
         {
+            // A targeted single-peer sync, not a mesh fan-out: there are no
+            // sibling recipients to name, so the list is empty.
             self.broadcast_queue
-                .enqueue(op_manager, key, target, new_state)
+                .enqueue(
+                    op_manager,
+                    key,
+                    target,
+                    new_state,
+                    super::super::broadcast_queue::no_fanout(),
+                )
                 .await;
         }
         #[cfg(feature = "simulation_tests")]
@@ -638,6 +681,7 @@ impl P2pConnManager {
                 new_state,
                 target,
                 None,
+                super::super::broadcast_queue::no_fanout(),
             )
             .await;
         }
@@ -682,6 +726,19 @@ impl P2pConnManager {
             contract = %key,
             target_count = target_result.targets.len(),
             "Broadcasting state change to network peers"
+        );
+
+        // #5147: the originator target list for this fan-out. Built here for
+        // the same reason as the production path, but note the two paths differ —
+        // production splits the fan-out across a queue and rebuilds the list
+        // per leg, this one holds the whole set in scope. A test that only
+        // exercises this branch proves nothing about production.
+        let fanout: super::super::broadcast_queue::FanoutTargets = std::sync::Arc::new(
+            target_result
+                .targets
+                .iter()
+                .map(|target| target.pub_key().clone())
+                .collect(),
         );
 
         let mut skipped_summary_match: usize = 0;
@@ -842,11 +899,22 @@ impl P2pConnManager {
                     payload_size,
                     "Using streaming for BroadcastTo"
                 );
-                let msg = crate::operations::update::UpdateMsg::BroadcastToStreaming {
-                    id: update_tx,
-                    stream_id: sid,
-                    key,
-                    total_size: payload_bytes.len() as u64,
+                let msg = match super::super::broadcast_queue::target_list_for(
+                    op_manager, &update_tx, peer_addr, &peer_key, &fanout,
+                ) {
+                    Some(covered) => crate::operations::update::UpdateMsg::BroadcastToStreamingV2 {
+                        id: update_tx,
+                        stream_id: sid,
+                        key,
+                        total_size: payload_bytes.len() as u64,
+                        covered,
+                    },
+                    None => crate::operations::update::UpdateMsg::BroadcastToStreaming {
+                        id: update_tx,
+                        stream_id: sid,
+                        key,
+                        total_size: payload_bytes.len() as u64,
+                    },
                 };
                 let net_msg: NetMessage = msg.into();
                 // Serialize metadata for embedding in fragment #1 (fix #2757)
@@ -901,15 +969,29 @@ impl P2pConnManager {
                     Err(err) => Err(err),
                 }
             } else {
-                let msg = crate::operations::update::UpdateMsg::BroadcastTo {
-                    id: update_tx,
-                    key,
-                    payload,
-                    // Include our summary so peer doesn't echo back
-                    sender_summary_bytes: our_summary
-                        .as_ref()
-                        .map(|s| s.as_ref().to_vec())
-                        .unwrap_or_default(),
+                let msg = match super::super::broadcast_queue::target_list_for(
+                    op_manager, &update_tx, peer_addr, &peer_key, &fanout,
+                ) {
+                    Some(covered) => crate::operations::update::UpdateMsg::BroadcastToV2 {
+                        id: update_tx,
+                        key,
+                        payload,
+                        sender_summary_bytes: our_summary
+                            .as_ref()
+                            .map(|s| s.as_ref().to_vec())
+                            .unwrap_or_default(),
+                        covered,
+                    },
+                    None => crate::operations::update::UpdateMsg::BroadcastTo {
+                        id: update_tx,
+                        key,
+                        payload,
+                        // Include our summary so peer doesn't echo back
+                        sender_summary_bytes: our_summary
+                            .as_ref()
+                            .map(|s| s.as_ref().to_vec())
+                            .unwrap_or_default(),
+                    },
                 };
                 // channel-safety: ok — sim-only path (see the
                 // `#[cfg(feature = "simulation_tests")]` gate on this fn); never

--- a/crates/core/src/node/network_bridge/p2p_protoc/broadcast.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc/broadcast.rs
@@ -312,11 +312,40 @@ impl P2pConnManager {
                 "BroadcastStateChange: every eligible peer already has this \
                  update; fan-out complete with nothing to send"
             );
-            // Same bookkeeping as the targets-found path: this is a completed
-            // fan-out, so no retry cycle and no stash may survive it.
+            // The retry cycle is correctly cancelled: retrying is actively
+            // harmful here, because the coverage claim is taken once and a
+            // retry would re-resolve without it and re-broadcast the whole
+            // co-host set (the regression this branch exists to fix).
             self.broadcast_retries.remove(&key);
             self.broadcast_no_target_streak.remove(&key);
-            let _ = op_manager.pending_broadcasts.take(key.id());
+
+            // The #4359 stash is a DIFFERENT matter, and the targets-found
+            // path's justification for dropping it — "this fan-out is reaching
+            // targets now, so a previously-abandoned state is superseded" —
+            // does not transfer to a branch that reached nobody. Discarding it
+            // here destroyed an earlier give-up's stash with no replacement, so
+            // a peer that subscribes later lost its only non-heartbeat path to
+            // that contract.
+            //
+            // Refresh rather than either extreme. Leaving the old stash intact
+            // would keep STALE state queued for re-emission (this apply's state
+            // is newer). Stashing unconditionally would add a stash write to
+            // every fully-covered fan-out — the COMMON outcome in the clique
+            // regime this design targets — and re-emit on every new subscriber.
+            // So: only if something was already stashed (meaning an earlier
+            // broadcast genuinely gave up on this contract) do we put the
+            // current state back in its place.
+            if op_manager.pending_broadcasts.take(key.id()).is_some() {
+                op_manager
+                    .pending_broadcasts
+                    .stash(*key.id(), new_state.clone());
+                tracing::debug!(
+                    contract = %key,
+                    phase = "fully_covered_stash_refresh",
+                    "fan-out fully covered; refreshed the deferred broadcast with \
+                     current state rather than discarding it (#4359 + #5147)"
+                );
+            }
             // Recorded through a DEDICATED entry point, not `record_broadcast`
             // with a zero target count: that would land in the `no_targets`
             // bucket, which is the operator-facing propagation-FAILURE counter.

--- a/crates/core/src/node/network_bridge/p2p_protoc/broadcast.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc/broadcast.rs
@@ -284,6 +284,51 @@ impl P2pConnManager {
             "BroadcastStateChange: found targets"
         );
 
+        // #5147: an empty target set is not always a failure any more.
+        //
+        // The branch below exists for the case where a state change has NOBODY
+        // to propagate to — a race between an update and subscription
+        // establishment — and it responds by retrying three times with backoff
+        // and then stashing the state for a later interest flush. That is
+        // exactly wrong when the set is empty because every eligible peer was
+        // already served: in the clique regime this design targets, a relayer's
+        // co-hosts are frequently ALL on the originator's list, so the correct
+        // fan-out is the empty one and it is COMPLETE.
+        //
+        // Without this the mechanism defeats itself, and does so invisibly.
+        // Each retry re-resolves targets, by which time the coverage entry has
+        // been consumed (it is taken once, by design), so the retry sees no
+        // claim, suppresses nothing, and re-broadcasts to the whole co-host set
+        // one backoff later — the suppressed traffic comes back, delayed, with
+        // staler summaries than if it had been sent immediately.
+        let fully_covered = target_result.targets.is_empty()
+            && (target_result.skipped_covered > 0 || target_result.skipped_sender > 0);
+        if fully_covered {
+            tracing::debug!(
+                contract = %key,
+                skipped_covered = target_result.skipped_covered,
+                skipped_sender = target_result.skipped_sender,
+                phase = "broadcast_fully_covered",
+                "BroadcastStateChange: every eligible peer already has this \
+                 update; fan-out complete with nothing to send"
+            );
+            // Same bookkeeping as the targets-found path: this is a completed
+            // fan-out, so no retry cycle and no stash may survive it.
+            self.broadcast_retries.remove(&key);
+            self.broadcast_no_target_streak.remove(&key);
+            let _ = op_manager.pending_broadcasts.take(key.id());
+            // Recorded with a zero target count so the #4281 propagation
+            // summary still sees one broadcast per apply, but NOT through the
+            // `no_targets` counter below — a fully-covered fan-out is a success
+            // and must not read as a propagation failure to an operator.
+            op_manager.update_propagation_stats.record_broadcast(
+                *key.id(),
+                0,
+                target_result.interest_resolve_failed,
+            );
+            return;
+        }
+
         if target_result.targets.is_empty() {
             // Record the NO_TARGETS outcome once per *fresh* no-target broadcast
             // for the #4281 summary, but NOT for retry re-emissions. Gating on

--- a/crates/core/src/node/network_bridge/p2p_protoc/broadcast.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc/broadcast.rs
@@ -317,15 +317,17 @@ impl P2pConnManager {
             self.broadcast_retries.remove(&key);
             self.broadcast_no_target_streak.remove(&key);
             let _ = op_manager.pending_broadcasts.take(key.id());
-            // Recorded with a zero target count so the #4281 propagation
-            // summary still sees one broadcast per apply, but NOT through the
-            // `no_targets` counter below — a fully-covered fan-out is a success
-            // and must not read as a propagation failure to an operator.
-            op_manager.update_propagation_stats.record_broadcast(
-                *key.id(),
-                0,
-                target_result.interest_resolve_failed,
-            );
+            // Recorded through a DEDICATED entry point, not `record_broadcast`
+            // with a zero target count: that would land in the `no_targets`
+            // bucket, which is the operator-facing propagation-FAILURE counter.
+            // A fully-covered fan-out is a success, and in the clique regime
+            // this design targets it is the EXPECTED outcome — so counting it
+            // as a failure would report one in direct proportion to how well
+            // the feature works. The #4281 summary still sees one broadcast per
+            // apply. Pinned by `a_fully_covered_fanout_is_not_counted_as_a_propagation_failure`.
+            op_manager
+                .update_propagation_stats
+                .record_fully_covered_broadcast(*key.id(), target_result.interest_resolve_failed);
             return;
         }
 

--- a/crates/core/src/node/network_bridge/p2p_protoc/broadcast.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc/broadcast.rs
@@ -478,7 +478,25 @@ impl P2pConnManager {
                 // the TTL. Re-resolve targets now that the stash is in place: if a
                 // target has appeared, take the stash back and re-emit
                 // immediately rather than waiting on a future flush.
-                let recheck = op_manager.get_broadcast_targets_update(&key, &origin);
+                // Probe with a LOCAL origin, not the claim this fan-out already
+                // consumed. Two reasons, and the second is the one that bites:
+                //
+                //  * this is a "did a target appear while we were giving up"
+                //    question, not a fan-out decision, so the unfiltered set is
+                //    the right one to ask about — and it is the safe direction
+                //    for the #4359 recovery, since finding a target re-emits
+                //    rather than abandoning state;
+                //  * re-passing `origin` re-runs the suppression filters over
+                //    the same offered legs, so `record_broadcast_target_suppressed`
+                //    and `record_broadcast_sender_skipped` fire twice for one
+                //    fan-out while `sends` counts once. That inflates only the
+                //    treatment arm (both counters are 0 in control), which
+                //    would put a one-sided bias into the very leg-accounting
+                //    comparison that exists to detect arm asymmetry.
+                let recheck = op_manager.get_broadcast_targets_update(
+                    &key,
+                    &crate::ring::broadcast_coverage::BroadcastOrigin::local(),
+                );
                 if !recheck.targets.is_empty() {
                     if let Some(stashed) = op_manager.pending_broadcasts.take(key.id()) {
                         tracing::debug!(

--- a/crates/core/src/node/network_bridge/p2p_protoc/broadcast.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc/broadcast.rs
@@ -301,7 +301,19 @@ impl P2pConnManager {
         // claim, suppresses nothing, and re-broadcasts to the whole co-host set
         // one backoff later — the suppressed traffic comes back, delayed, with
         // staler summaries than if it had been sent immediately.
+        //
+        // Two conditions beyond "empty and something was skipped", both from
+        // review:
+        //
+        // * `proximity_resolve_failed == 0`. A co-host whose `get_peer_by_pub_key`
+        //   lookup FAILED was not served — it is gone. Counting a fan-out as
+        //   complete when the only reason it is empty is that we could not
+        //   resolve anyone would swallow a genuine unreachability and skip the
+        //   retry that heals it.
+        // * The stash is only dropped when we actually sent something. See the
+        //   drop site below.
         let fully_covered = target_result.targets.is_empty()
+            && target_result.proximity_resolve_failed == 0
             && (target_result.skipped_covered > 0 || target_result.skipped_sender > 0);
         if fully_covered {
             tracing::debug!(

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -3045,29 +3045,6 @@ mod tests {
         op_manager.neighbor_hosting.contracts_for_peer(hub)
     }
 
-    /// Safety proof for #4642 step 9 (remove the Source-2 interest fan-out arm
-    /// from live UPDATE propagation). At the `get_broadcast_targets_update`
-    /// boundary this asserts the properties the removal must preserve:
-    ///
-    /// 1. An interest-only peer — registered in the interest manager but NOT
-    ///    advertising via the advertisement layer — is EXCLUDED from broadcast
-    ///    targets. This is the interest-but-not-yet-advertised (lagged
-    ///    advertisement) case; under the old two-source model it WOULD be a
-    ///    target via Source 2, and after step 9 it must not be.
-    /// 2. An advertised co-host (Source 1) is still INCLUDED.
-    /// 3. The advertisement-reconciliation heal restores the lagged peer: once
-    ///    our view of it includes the contract it becomes a broadcast target. The
-    ///    periodic interest heartbeat sends each neighbor a `HostingStateRequest`;
-    ///    the neighbor replies with a `HostingStateResponse` snapshot of its
-    ///    hosted set, which we full-replace into our Source-1 view
-    ///    (`ring.rs::interest_heartbeat`, #4722).
-    ///
-    /// This is the unit-level counterpart of the lagged-advertisement
-    /// convergence simulation: removing Source-2 is safe precisely because a
-    /// peer that is interested-but-not-yet-advertised is reached once its
-    /// advertisement lands in Source-1, live or via anti-entropy. See
-    /// `.claude/rules/hosting-invariants.md` invariant 1 and
-    /// `docs/design/demand-driven-hosting.md`.
     /// Shared fixture for the #5147 target-list tests: an op-manager whose
     /// advertised co-host set for one contract is `count` connected peers.
     ///
@@ -3450,6 +3427,29 @@ mod tests {
         assert_eq!(result.skipped_covered, 0);
     }
 
+    /// Safety proof for #4642 step 9 (remove the Source-2 interest fan-out arm
+    /// from live UPDATE propagation). At the `get_broadcast_targets_update`
+    /// boundary this asserts the properties the removal must preserve:
+    ///
+    /// 1. An interest-only peer — registered in the interest manager but NOT
+    ///    advertising via the advertisement layer — is EXCLUDED from broadcast
+    ///    targets. This is the interest-but-not-yet-advertised (lagged
+    ///    advertisement) case; under the old two-source model it WOULD be a
+    ///    target via Source 2, and after step 9 it must not be.
+    /// 2. An advertised co-host (Source 1) is still INCLUDED.
+    /// 3. The advertisement-reconciliation heal restores the lagged peer: once
+    ///    our view of it includes the contract it becomes a broadcast target. The
+    ///    periodic interest heartbeat sends each neighbor a `HostingStateRequest`;
+    ///    the neighbor replies with a `HostingStateResponse` snapshot of its
+    ///    hosted set, which we full-replace into our Source-1 view
+    ///    (`ring.rs::interest_heartbeat`, #4722).
+    ///
+    /// This is the unit-level counterpart of the lagged-advertisement
+    /// convergence simulation: removing Source-2 is safe precisely because a
+    /// peer that is interested-but-not-yet-advertised is reached once its
+    /// advertisement lands in Source-1, live or via anti-entropy. See
+    /// `.claude/rules/hosting-invariants.md` invariant 1 and
+    /// `docs/design/demand-driven-hosting.md`.
     #[tokio::test(flavor = "current_thread")]
     async fn broadcast_targets_are_advertised_cohosts_only_and_heal_via_advertisement() {
         use crate::ring::interest::PeerKey;

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -3326,16 +3326,23 @@ mod tests {
             payload: payload.clone(),
             sender_summary_bytes: summary.clone(),
         };
+        // What a pre-floor peer receives must still decode as the LEGACY
+        // variant, i.e. carry bincode variant index 1.
+        //
+        // This replaces an assertion that serialized the identical expression
+        // twice and compared it to itself — it carried this test's name and no
+        // input could make it red. The full field-order byte pin lives in
+        // `update.rs::legacy_broadcast_to_encoding_is_unchanged_by_the_v2_variants`,
+        // which compares against a hand-built literal; what is worth asserting
+        // HERE, next to the gate decision, is that the branch the gate selects
+        // is the one an old peer can parse at all.
+        let legacy_bytes = bincode::serialize(&legacy).expect("serialize legacy");
         assert_eq!(
-            bincode::serialize(&legacy).expect("serialize legacy"),
-            bincode::serialize(&UpdateMsg::BroadcastTo {
-                id: tx,
-                key,
-                payload: payload.clone(),
-                sender_summary_bytes: summary.clone(),
-            })
-            .expect("serialize reference"),
-            "a pre-floor peer's bytes must be exactly today's BroadcastTo"
+            u32::from_le_bytes(legacy_bytes[..4].try_into().expect("variant prefix")),
+            1,
+            "a pre-floor peer must receive bincode variant index 1 \
+             (`BroadcastTo`). Any other index is a message it cannot decode, \
+             and a failed decode CLOSES the connection rather than degrading."
         );
 
         // Now record an at-floor version and confirm the gate genuinely flips —

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -193,6 +193,14 @@ pub(crate) struct OpManager {
         Arc<crate::ring::interest::InterestManager<crate::util::time_source::DynTimeSource>>,
     /// Dedup cache for skipping redundant broadcast WASM merges
     pub broadcast_dedup_cache: Arc<crate::operations::update::BroadcastDedupCache>,
+    /// Originator target lists awaiting the fan-out they belong to (#5147).
+    ///
+    /// Written by `update_contract` immediately before the apply enters the
+    /// contract handler, read by `handle_broadcast_state_change` when the
+    /// executor's `BroadcastStateChange` for that apply comes back. It exists
+    /// because that event carries no provenance — see
+    /// [`crate::ring::broadcast_coverage::BroadcastCoverageStore`].
+    pub broadcast_coverage: Arc<crate::ring::broadcast_coverage::BroadcastCoverageStore>,
     /// Bounded per-contract UPDATE-propagation counters. Fed from the
     /// broadcast fan-out path and drained by a periodic background task that
     /// emits an INFO `update_propagation_summary` line per window. Restores
@@ -333,6 +341,7 @@ impl Clone for OpManager {
             outbound_mix: self.outbound_mix.clone(),
             interest_manager: self.interest_manager.clone(),
             broadcast_dedup_cache: self.broadcast_dedup_cache.clone(),
+            broadcast_coverage: self.broadcast_coverage.clone(),
             update_propagation_stats: self.update_propagation_stats.clone(),
             pending_broadcasts: self.pending_broadcasts.clone(),
             request_router: self.request_router.clone(),
@@ -542,6 +551,9 @@ impl OpManager {
             ),
             interest_manager,
             broadcast_dedup_cache: Arc::new(crate::operations::update::BroadcastDedupCache::new()),
+            broadcast_coverage: Arc::new(
+                crate::ring::broadcast_coverage::BroadcastCoverageStore::new(),
+            ),
             update_propagation_stats,
             pending_broadcasts: Arc::new(
                 crate::operations::update::pending_broadcast::PendingBroadcastStore::new(),
@@ -3056,6 +3068,381 @@ mod tests {
     /// advertisement lands in Source-1, live or via anti-entropy. See
     /// `.claude/rules/hosting-invariants.md` invariant 1 and
     /// `docs/design/demand-driven-hosting.md`.
+    /// Shared fixture for the #5147 target-list tests: an op-manager whose
+    /// advertised co-host set for one contract is `count` connected peers.
+    ///
+    /// Returns the contract key, this node's address, and the co-hosts'
+    /// keypairs in the order they were added.
+    async fn cohost_fixture(
+        id: &str,
+        count: usize,
+    ) -> (
+        Arc<OpManager>,
+        Box<dyn std::any::Any>,
+        ContractKey,
+        std::net::SocketAddr,
+        Vec<crate::transport::TransportKeypair>,
+    ) {
+        let (op_manager, guards) = build_reroot_test_op_manager(id).await;
+        let self_addr: std::net::SocketAddr = "127.0.0.1:12000".parse().unwrap();
+        op_manager
+            .ring
+            .connection_manager
+            .set_own_addr_local_for_test(self_addr);
+
+        let key = reroot_contract_key(0x5B);
+        let cid = *key.id();
+        let mut keypairs = Vec::with_capacity(count);
+        for i in 0..count {
+            let kp = crate::transport::TransportKeypair::new();
+            let addr: std::net::SocketAddr = format!("127.0.0.1:{}", 21000 + i).parse().unwrap();
+            assert!(op_manager.ring.connection_manager.add_connection(
+                crate::ring::Location::new(0.1 + (i as f64) * 0.001),
+                addr,
+                kp.public().clone(),
+                false,
+            ));
+            op_manager.neighbor_hosting.handle_message(
+                kp.public(),
+                crate::message::NeighborHostingMessage::HostingAnnounce {
+                    added: vec![cid],
+                    removed: vec![],
+                    is_response: false,
+                },
+            );
+            keypairs.push(kp);
+        }
+        (op_manager, guards, key, self_addr, keypairs)
+    }
+
+    fn addr_of(
+        op_manager: &OpManager,
+        kp: &crate::transport::TransportKeypair,
+    ) -> std::net::SocketAddr {
+        op_manager
+            .ring
+            .connection_manager
+            .get_peer_by_pub_key(kp.public())
+            .and_then(|pkl| pkl.socket_addr())
+            .expect("co-host must resolve")
+    }
+
+    fn target_addrs(
+        result: &crate::operations::update::BroadcastTargetResult,
+    ) -> std::collections::HashSet<std::net::SocketAddr> {
+        result
+            .targets
+            .iter()
+            .filter_map(|p| p.socket_addr())
+            .collect()
+    }
+
+    /// The core #5147 property: a relayer drops EXACTLY the peers the
+    /// originator named, and nobody else.
+    ///
+    /// "And nobody else" is the half that matters. Over-suppression is the one
+    /// failure this design refuses — a peer silently missing an update until
+    /// the ~5-minute heartbeat — so the unlisted co-hosts are asserted present,
+    /// not merely the listed ones absent.
+    #[tokio::test(flavor = "current_thread")]
+    async fn a_relayer_excludes_exactly_the_listed_peers_and_no_others() {
+        use crate::ring::broadcast_coverage::{BroadcastOrigin, CoveredPeers};
+
+        let (op_manager, _guards, key, _self_addr, kps) =
+            cohost_fixture("5147-exact-exclusion", 5).await;
+        let sender_addr: std::net::SocketAddr = "127.0.0.1:20000".parse().unwrap();
+
+        let tx = crate::message::Transaction::new::<crate::operations::update::UpdateMsg>();
+        let named = [kps[0].public().clone(), kps[2].public().clone()];
+        let covered = CoveredPeers::from_targets(&tx, named.iter());
+        let resolved = covered.resolve(&tx, kps.iter().map(|kp| kp.public()));
+        assert_eq!(resolved.len(), 2, "both named peers must resolve");
+
+        let result = op_manager
+            .get_broadcast_targets_update(&key, &BroadcastOrigin::relayed(sender_addr, resolved));
+        let got = target_addrs(&result);
+
+        for (i, kp) in kps.iter().enumerate() {
+            let addr = addr_of(&op_manager, kp);
+            if i == 0 || i == 2 {
+                assert!(
+                    !got.contains(&addr),
+                    "co-host {i} was on the originator's list and must be suppressed"
+                );
+            } else {
+                assert!(
+                    got.contains(&addr),
+                    "co-host {i} was NOT on the list and MUST still receive the \
+                     update — over-suppression is the failure mode this design \
+                     refuses, because the peer would not learn of the update \
+                     until the ~5-minute interest heartbeat"
+                );
+            }
+        }
+        assert_eq!(result.skipped_covered, 2, "the filter counts its own drops");
+        assert_eq!(got.len(), 3);
+    }
+
+    /// A local apply carries no claim, so nothing is suppressed: byte-for-byte
+    /// today's fan-out.
+    #[tokio::test(flavor = "current_thread")]
+    async fn a_local_apply_suppresses_nothing() {
+        use crate::ring::broadcast_coverage::BroadcastOrigin;
+
+        let (op_manager, _guards, key, _self_addr, kps) =
+            cohost_fixture("5147-local-apply", 4).await;
+
+        let result = op_manager.get_broadcast_targets_update(&key, &BroadcastOrigin::local());
+
+        assert_eq!(result.targets.len(), kps.len());
+        assert_eq!(result.skipped_covered, 0);
+        assert_eq!(result.skipped_sender, 0);
+    }
+
+    /// The revived sender exclusion (#5147).
+    ///
+    /// This filter has existed in `get_broadcast_targets_update` since long
+    /// before #5147 and was structurally DEAD: the re-fan-out call site had no
+    /// sender to pass and handed in its own address, so `sender` never matched
+    /// a co-host. A relayer therefore echoed every broadcast straight back to
+    /// the peer that had just sent it — a 100%-wasted send on every relayed
+    /// broadcast, and one the originator's target list cannot fix, because a
+    /// peer never names itself on its own list.
+    #[tokio::test(flavor = "current_thread")]
+    async fn the_sender_is_excluded_even_when_it_names_no_one() {
+        use crate::ring::broadcast_coverage::BroadcastOrigin;
+
+        let (op_manager, _guards, key, _self_addr, kps) =
+            cohost_fixture("5147-sender-exclusion", 3).await;
+        let sender_addr = addr_of(&op_manager, &kps[1]);
+
+        let result = op_manager.get_broadcast_targets_update(
+            &key,
+            &BroadcastOrigin::relayed(sender_addr, Default::default()),
+        );
+        let got = target_addrs(&result);
+
+        assert!(
+            !got.contains(&sender_addr),
+            "the peer that just delivered this update must not receive it back"
+        );
+        assert_eq!(result.skipped_sender, 1);
+        assert_eq!(got.len(), 2);
+    }
+
+    /// Over-cap truncation must lose suppression, never gain it.
+    ///
+    /// With more co-hosts than [`MAX_COVERED_PEERS`] the list is truncated, so
+    /// some genuinely-covered peers are not named and are re-sent to. That is
+    /// today's behaviour for those peers — wasted bandwidth, correct delivery.
+    /// The failure this guards is the opposite one: a truncated list must never
+    /// cause a peer that was NOT named to be dropped.
+    #[tokio::test(flavor = "current_thread")]
+    async fn over_cap_truncation_degrades_to_partial_suppression() {
+        use crate::ring::broadcast_coverage::{BroadcastOrigin, CoveredPeers, MAX_COVERED_PEERS};
+
+        let total = MAX_COVERED_PEERS + 10;
+        let (op_manager, _guards, key, _self_addr, kps) =
+            cohost_fixture("5147-over-cap", total).await;
+        let sender_addr: std::net::SocketAddr = "127.0.0.1:20000".parse().unwrap();
+
+        let tx = crate::message::Transaction::new::<crate::operations::update::UpdateMsg>();
+        // The originator genuinely delivered to every co-host, but can only
+        // name MAX_COVERED_PEERS of them.
+        let covered = CoveredPeers::from_targets(&tx, kps.iter().map(|kp| kp.public()));
+        assert_eq!(covered.len(), MAX_COVERED_PEERS, "the list is capped");
+
+        let resolved = covered.resolve(&tx, kps.iter().map(|kp| kp.public()));
+        let result = op_manager.get_broadcast_targets_update(
+            &key,
+            &BroadcastOrigin::relayed(sender_addr, resolved.clone()),
+        );
+
+        assert_eq!(
+            result.skipped_covered, MAX_COVERED_PEERS,
+            "exactly the named peers are suppressed"
+        );
+        assert_eq!(
+            result.targets.len(),
+            total - MAX_COVERED_PEERS,
+            "the un-named remainder still receives the update — a truncated \
+             list may only lose suppression, never invent it"
+        );
+        assert!(
+            !result.targets.is_empty(),
+            "over-cap must degrade toward today's behaviour, not toward silence"
+        );
+        // Every surviving target must be one the list did NOT name.
+        for target in &result.targets {
+            assert!(
+                !resolved.contains(&crate::ring::PeerKey::from(target.pub_key().clone())),
+                "a named peer leaked into the target set"
+            );
+        }
+    }
+
+    /// A pre-floor peer must receive BYTE-IDENTICAL traffic to today.
+    ///
+    /// Exercises the real gate through `target_list_for`, then builds both
+    /// messages the way `broadcast_to_single_peer` does and compares the
+    /// pre-floor one to a hand-built legacy `BroadcastTo`. Asserting on the
+    /// serialized BYTES rather than on the variant is the point: a peer on
+    /// 0.2.119 has no `BroadcastToV2` variant index, so the failure mode is not
+    /// a degraded feature but a decode error that CLOSES the connection —
+    /// fleet-wide churn during a staggered rollout, presenting as a transport
+    /// fault.
+    ///
+    /// The companion `legacy_broadcast_to_encoding_is_unchanged_by_the_v2_variants`
+    /// pins the encoding itself against a literal; this one pins that the
+    /// routing decision actually reaches it.
+    #[tokio::test(flavor = "current_thread")]
+    async fn a_pre_floor_peer_receives_byte_identical_broadcast_traffic() {
+        use crate::message::DeltaOrFullState;
+        use crate::node::network_bridge::broadcast_queue::target_list_for;
+        use crate::operations::update::UpdateMsg;
+
+        let (op_manager, _guards, key, _self_addr, kps) =
+            cohost_fixture("5147-pre-floor-bytes", 3).await;
+
+        let recipient_kp = &kps[0];
+        let recipient_addr = addr_of(&op_manager, recipient_kp);
+        let recipient = crate::ring::PeerKey::from(recipient_kp.public().clone());
+        let fanout: std::sync::Arc<Vec<crate::transport::TransportPublicKey>> =
+            std::sync::Arc::new(kps.iter().map(|kp| kp.public().clone()).collect());
+        let tx = crate::message::Transaction::new::<UpdateMsg>();
+
+        let payload = DeltaOrFullState::Delta(vec![7, 8, 9]);
+        let summary = vec![1u8, 2];
+
+        // The fixture never records a remote version, which is exactly the
+        // pre-floor / unknown case (and, until #5161 lands, every gateway link).
+        assert!(
+            target_list_for(&op_manager, &tx, recipient_addr, &recipient, &fanout).is_none(),
+            "an unknown peer version must route to the legacy variant"
+        );
+        let legacy = UpdateMsg::BroadcastTo {
+            id: tx,
+            key,
+            payload: payload.clone(),
+            sender_summary_bytes: summary.clone(),
+        };
+        assert_eq!(
+            bincode::serialize(&legacy).expect("serialize legacy"),
+            bincode::serialize(&UpdateMsg::BroadcastTo {
+                id: tx,
+                key,
+                payload: payload.clone(),
+                sender_summary_bytes: summary.clone(),
+            })
+            .expect("serialize reference"),
+            "a pre-floor peer's bytes must be exactly today's BroadcastTo"
+        );
+
+        // Now record an at-floor version and confirm the gate genuinely flips —
+        // otherwise the assertion above would pass against a gate that is
+        // simply always closed, and the feature would be inert.
+        op_manager.ring.connection_manager.record_remote_version(
+            recipient_addr,
+            Some(crate::node::BROADCAST_TARGET_LIST_MIN_VERSION),
+        );
+        let covered = target_list_for(&op_manager, &tx, recipient_addr, &recipient, &fanout)
+            .expect("an at-floor peer must get the target list");
+        assert_eq!(
+            covered.len(),
+            kps.len() - 1,
+            "the recipient is excluded from its own list; it obviously has \
+             what we are sending it"
+        );
+        let v2 = UpdateMsg::BroadcastToV2 {
+            id: tx,
+            key,
+            payload,
+            sender_summary_bytes: summary,
+            covered,
+        };
+        assert_ne!(
+            bincode::serialize(&v2).expect("serialize v2"),
+            bincode::serialize(&legacy).expect("serialize legacy"),
+            "the gate must be choosing between genuinely different encodings"
+        );
+    }
+
+    /// One hop only: the list a relayer SENDS is built from its own targets,
+    /// never from the list it received.
+    ///
+    /// This is the property the security rule rests on. If a relayer forwarded
+    /// (or unioned into) the claim it received, a peer three hops away would be
+    /// acting on an assertion made by someone it never heard from, and a
+    /// malicious relayer could suppress fan-out it has no knowledge of. Here
+    /// the relayer receives a claim covering peer 0, and the list it emits is
+    /// checked to (a) not contain peer 0 — a peer it did not send to cannot be
+    /// claimed as covered — and (b) contain exactly the peers it did send to.
+    ///
+    /// Measured hop-2 suppression is already 0.99, so forwarding would buy
+    /// nothing even if it were safe.
+    #[tokio::test(flavor = "current_thread")]
+    async fn the_list_a_relayer_emits_describes_only_its_own_sends() {
+        use crate::ring::broadcast_coverage::{BroadcastOrigin, CoveredPeers};
+
+        let (op_manager, _guards, key, _self_addr, kps) = cohost_fixture("5147-one-hop", 4).await;
+        let sender_addr: std::net::SocketAddr = "127.0.0.1:20000".parse().unwrap();
+
+        let inbound_tx = crate::message::Transaction::new::<crate::operations::update::UpdateMsg>();
+        let inbound = CoveredPeers::from_targets(&inbound_tx, [kps[0].public()]);
+        let resolved = inbound.resolve(&inbound_tx, kps.iter().map(|kp| kp.public()));
+
+        let result = op_manager
+            .get_broadcast_targets_update(&key, &BroadcastOrigin::relayed(sender_addr, resolved));
+
+        // This is the same derivation the production fan-out uses: the outgoing
+        // list is a function of `target_result.targets` and nothing else.
+        let outbound_tx =
+            crate::message::Transaction::new::<crate::operations::update::UpdateMsg>();
+        let outbound =
+            CoveredPeers::from_targets(&outbound_tx, result.targets.iter().map(|t| t.pub_key()));
+        let named = outbound.resolve(&outbound_tx, kps.iter().map(|kp| kp.public()));
+
+        assert!(
+            !named.contains(&crate::ring::PeerKey::from(kps[0].public().clone())),
+            "peer 0 was covered by the UPSTREAM sender and suppressed here, so \
+             this relayer never sent to it and must not claim it did — the \
+             list is an attestation of one's OWN sends, which is what makes \
+             honoring it from the payload-bearing message alone sufficient"
+        );
+        assert_eq!(named.len(), 3, "exactly the peers this relayer sent to");
+        for kp in &kps[1..] {
+            assert!(named.contains(&crate::ring::PeerKey::from(kp.public().clone())));
+        }
+    }
+
+    /// A list only resolves under the transaction it arrived on.
+    ///
+    /// The hashes are seeded with the transaction id, so a list lifted from one
+    /// broadcast and replayed onto another resolves to nothing and suppresses
+    /// nothing. This is the behavioural counterpart to the privacy property:
+    /// the same seeding that stops an observer correlating co-host sets across
+    /// transactions is what stops a replayed list from taking effect.
+    #[tokio::test(flavor = "current_thread")]
+    async fn a_list_replayed_onto_another_transaction_suppresses_nothing() {
+        use crate::ring::broadcast_coverage::{BroadcastOrigin, CoveredPeers};
+
+        let (op_manager, _guards, key, _self_addr, kps) = cohost_fixture("5147-tx-replay", 4).await;
+        let sender_addr: std::net::SocketAddr = "127.0.0.1:20000".parse().unwrap();
+
+        let original_tx =
+            crate::message::Transaction::new::<crate::operations::update::UpdateMsg>();
+        let other_tx = crate::message::Transaction::new::<crate::operations::update::UpdateMsg>();
+        let covered = CoveredPeers::from_targets(&original_tx, kps.iter().map(|kp| kp.public()));
+
+        let replayed = covered.resolve(&other_tx, kps.iter().map(|kp| kp.public()));
+        assert!(replayed.is_empty(), "a replayed list resolves to nothing");
+
+        let result = op_manager
+            .get_broadcast_targets_update(&key, &BroadcastOrigin::relayed(sender_addr, replayed));
+        assert_eq!(result.targets.len(), kps.len());
+        assert_eq!(result.skipped_covered, 0);
+    }
+
     #[tokio::test(flavor = "current_thread")]
     async fn broadcast_targets_are_advertised_cohosts_only_and_heal_via_advertisement() {
         use crate::ring::interest::PeerKey;
@@ -3116,7 +3503,13 @@ mod tests {
         );
 
         // BEFORE the heal: only the advertised co-host A is a target.
-        let before = op_manager.get_broadcast_targets_update(&key, &sender_addr);
+        let before = op_manager.get_broadcast_targets_update(
+            &key,
+            &crate::ring::broadcast_coverage::BroadcastOrigin::relayed(
+                sender_addr,
+                Default::default(),
+            ),
+        );
         let before_addrs: std::collections::HashSet<std::net::SocketAddr> = before
             .targets
             .iter()
@@ -3156,7 +3549,13 @@ mod tests {
         );
 
         // AFTER the heal: B is now an advertised co-host and IS a target.
-        let after = op_manager.get_broadcast_targets_update(&key, &sender_addr);
+        let after = op_manager.get_broadcast_targets_update(
+            &key,
+            &crate::ring::broadcast_coverage::BroadcastOrigin::relayed(
+                sender_addr,
+                Default::default(),
+            ),
+        );
         let after_addrs: std::collections::HashSet<std::net::SocketAddr> = after
             .targets
             .iter()
@@ -3342,7 +3741,10 @@ mod tests {
 
         // First lookup: the stale neighbor fails to resolve (counted once) AND
         // is reaped so it cannot spam future UPDATEs.
-        let first = op_manager.get_broadcast_targets_update(&key, &sender);
+        let first = op_manager.get_broadcast_targets_update(
+            &key,
+            &crate::ring::broadcast_coverage::BroadcastOrigin::relayed(sender, Default::default()),
+        );
         assert_eq!(
             first.proximity_resolve_failed, 1,
             "the stale neighbor must be counted as one resolve failure"
@@ -3357,7 +3759,10 @@ mod tests {
 
         // Second lookup: the entry is gone, so there is no repeat failure — the
         // bug's failure mode is that this stays 1 (WARN spam) forever.
-        let second = op_manager.get_broadcast_targets_update(&key, &sender);
+        let second = op_manager.get_broadcast_targets_update(
+            &key,
+            &crate::ring::broadcast_coverage::BroadcastOrigin::relayed(sender, Default::default()),
+        );
         assert_eq!(
             second.proximity_resolve_failed, 0,
             "a reaped entry must not re-fire on the next UPDATE (no repeat spam)"
@@ -3386,7 +3791,10 @@ mod tests {
         register_hub_cohosting(&op_manager, &peer_pub, &[*key.id()]);
 
         let sender: std::net::SocketAddr = "127.0.0.1:40001".parse().unwrap();
-        let result = op_manager.get_broadcast_targets_update(&key, &sender);
+        let result = op_manager.get_broadcast_targets_update(
+            &key,
+            &crate::ring::broadcast_coverage::BroadcastOrigin::relayed(sender, Default::default()),
+        );
 
         assert_eq!(
             result.proximity_resolve_failed, 0,

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -3258,8 +3258,15 @@ mod tests {
         }
     }
 
-    /// The sender exclusion is behind the same version gate as the target
-    /// list, and fails closed on an unknown sender.
+    /// The sender exclusion keeps the version gate; the target LIST does not.
+    ///
+    /// They are deliberately NOT the same gate, and this docstring used to say
+    /// they were. Conflating them is what made the whole feature inert once
+    /// already: routing the list through the version table too meant a node
+    /// that had never learned its gateway's version discarded every list it
+    /// received, so the send side opened while the receive side failed closed.
+    /// See `a_covered_list_is_honored_even_when_the_sender_version_is_unknown`,
+    /// which is the cheap guard against that regression returning.
     ///
     /// The exclusion needs no wire change of its own, so it would ship
     /// unconditionally if nobody gated it — and it has the same unsafe shape as
@@ -3267,6 +3274,85 @@ mod tests {
     /// holds what we are about to send. This asserts the gate DISCRIMINATES:
     /// pre-floor sender suppresses nothing, at-floor sender excludes the
     /// sender. Without the second half an always-closed gate would pass.
+    /// A covered LIST must be honored from a sender whose version we do not know.
+    ///
+    /// This is the cheap guard for a regression that shipped once and was
+    /// caught only by a full 7-node simulation. `31729f41a` gated BOTH halves
+    /// of a relayed claim on `supports_broadcast_target_list(sender_addr)` and
+    /// returned `local()` when it failed. That reads as symmetric caution, but
+    /// a node does not learn its GATEWAY's version until #5167 propagates, so
+    /// the lookup fails closed on exactly the highest-degree links — every list
+    /// was discarded and suppression went to zero while the send path still
+    /// looked healthy.
+    ///
+    /// The list needs no version lookup because it is self-gating: it can only
+    /// arrive on `BroadcastToV2` / `BroadcastToStreamingV2`, so holding a
+    /// populated one IS proof the sender supports the feature — the sender's
+    /// own act, which is stronger evidence than our record of its version.
+    ///
+    /// Mutation that must make this red: re-hoist the
+    /// `supports_broadcast_target_list` check above the resolve in
+    /// `resolve_covered_peers`, or `&&` it into the list half.
+    ///
+    /// Note the fixture records NO version for the sender, which is what makes
+    /// this the unknown-version case rather than a pre-floor one. Both take the
+    /// same branch, and both must still honor the list.
+    #[tokio::test(flavor = "current_thread")]
+    async fn a_covered_list_is_honored_even_when_the_sender_version_is_unknown() {
+        use crate::operations::update::UpdateMsg;
+
+        let (op_manager, _guards, key, _self_addr, kps) =
+            cohost_fixture("5147-list-unknown-version", 3).await;
+        let sender_kp = &kps[1];
+        let sender_addr = addr_of(&op_manager, sender_kp);
+        let tx = crate::message::Transaction::new::<UpdateMsg>();
+
+        // The originator names two of our co-hosts. No version is recorded for
+        // it, so `supports_broadcast_target_list(sender_addr)` is false.
+        let named: Vec<_> = kps.iter().take(2).map(|kp| kp.public().clone()).collect();
+        let covered = crate::ring::broadcast_coverage::CoveredPeers::from_targets(
+            &tx,
+            named.iter().collect::<Vec<_>>().into_iter(),
+        );
+        assert!(
+            !covered.is_empty(),
+            "premise: the fixture must actually name someone, or this test \
+             passes against a gate that discards everything"
+        );
+
+        let origin = crate::operations::update::op_ctx_task::resolve_covered_peers(
+            &op_manager,
+            &key,
+            &tx,
+            sender_addr,
+            &covered,
+        );
+
+        assert_eq!(
+            origin.sender(),
+            None,
+            "the sender exclusion keeps its version gate, so an unknown sender \
+             must NOT be excluded"
+        );
+
+        let result = op_manager.get_broadcast_targets_update(&key, &origin);
+        assert_eq!(
+            result.skipped_covered,
+            named.len(),
+            "the covered list must still suppress the peers it named even \
+             though the sender's version is unknown. Zero here is the inert-\
+             feature regression: the list was discarded because a version \
+             lookup failed, on precisely the links where that lookup cannot \
+             succeed until #5167 propagates."
+        );
+        for pk in &named {
+            assert!(
+                !result.targets.iter().any(|t| t.pub_key() == pk),
+                "a named peer survived into the fan-out"
+            );
+        }
+    }
+
     #[tokio::test(flavor = "current_thread")]
     async fn the_sender_exclusion_is_version_gated_and_fails_closed() {
         use crate::operations::update::UpdateMsg;

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -3258,6 +3258,68 @@ mod tests {
         }
     }
 
+    /// The sender exclusion is behind the same version gate as the target
+    /// list, and fails closed on an unknown sender.
+    ///
+    /// The exclusion needs no wire change of its own, so it would ship
+    /// unconditionally if nobody gated it — and it has the same unsafe shape as
+    /// the list, since excluding the peer that delivered a payload assumes it
+    /// holds what we are about to send. This asserts the gate DISCRIMINATES:
+    /// pre-floor sender suppresses nothing, at-floor sender excludes the
+    /// sender. Without the second half an always-closed gate would pass.
+    #[tokio::test(flavor = "current_thread")]
+    async fn the_sender_exclusion_is_version_gated_and_fails_closed() {
+        use crate::operations::update::UpdateMsg;
+
+        let (op_manager, _guards, key, _self_addr, kps) =
+            cohost_fixture("5147-sender-gate", 3).await;
+        let sender_kp = &kps[1];
+        let sender_addr = addr_of(&op_manager, sender_kp);
+        let tx = crate::message::Transaction::new::<UpdateMsg>();
+        let empty = crate::ring::broadcast_coverage::CoveredPeers::empty();
+
+        // No version recorded — the pre-#5161 gateway-link case.
+        let origin = crate::operations::update::op_ctx_task::resolve_covered_peers(
+            &op_manager,
+            &key,
+            &tx,
+            sender_addr,
+            &empty,
+        );
+        assert_eq!(
+            origin.sender(),
+            None,
+            "a pre-floor or unknown sender must not be excluded — this node's \
+             fan-out has to stay byte-for-byte what it is today toward peers \
+             that predate the feature"
+        );
+        let before = op_manager.get_broadcast_targets_update(&key, &origin);
+        assert_eq!(before.skipped_sender, 0);
+        assert_eq!(before.targets.len(), kps.len());
+
+        // At-floor sender: the exclusion activates.
+        op_manager.ring.connection_manager.record_remote_version(
+            sender_addr,
+            Some(crate::node::BROADCAST_TARGET_LIST_MIN_VERSION),
+        );
+        let origin = crate::operations::update::op_ctx_task::resolve_covered_peers(
+            &op_manager,
+            &key,
+            &tx,
+            sender_addr,
+            &empty,
+        );
+        assert_eq!(
+            origin.sender(),
+            Some(&sender_addr),
+            "the gate must genuinely flip; an always-closed gate would pass the \
+             assertion above while the feature was inert"
+        );
+        let after = op_manager.get_broadcast_targets_update(&key, &origin);
+        assert_eq!(after.skipped_sender, 1);
+        assert_eq!(after.targets.len(), kps.len() - 1);
+    }
+
     /// A pre-floor peer must receive BYTE-IDENTICAL traffic to today.
     ///
     /// Exercises the real gate through `target_list_for`, then builds both

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -3421,7 +3421,7 @@ mod tests {
     /// pins the encoding itself against a literal; this one pins that the
     /// routing decision actually reaches it.
     #[tokio::test(flavor = "current_thread")]
-    async fn a_pre_floor_peer_receives_byte_identical_broadcast_traffic() {
+    async fn a_pre_floor_peer_receives_the_legacy_variant_index() {
         use crate::message::DeltaOrFullState;
         use crate::node::network_bridge::broadcast_queue::target_list_for;
         use crate::operations::update::UpdateMsg;

--- a/crates/core/src/node/testing_impl.rs
+++ b/crates/core/src/node/testing_impl.rs
@@ -1451,6 +1451,19 @@ pub struct SimNetwork {
     /// production stops having it. `enable_gateway_ack_version` is how a test
     /// that cares opts in.
     ack_version_floor_override: Option<(u8, u8, u16)>,
+    /// Per-node override for the originator-target-list version floor (#5147).
+    ///
+    /// Defaults to `SIM_MIGRATION_DISABLED_FLOOR` — OFF — grouping with
+    /// `subscribe_hint_floor_override` and `summary_first_put_floor_override`
+    /// rather than with `hash_first_summaries_floor_override`. Hash-first is ON
+    /// by default because it changes only the ENCODING of an exchange with
+    /// identical semantics. This one changes fan-out BEHAVIOUR: it removes
+    /// peers from a broadcast. Defaulting it ON would silently alter the
+    /// delivery graph under every sim that asserts on convergence or delivery
+    /// counts, and a failure could not be attributed between that sim's own
+    /// subject and this suppression. Tests that want it call
+    /// [`enable_broadcast_target_list`](Self::enable_broadcast_target_list).
+    broadcast_target_list_floor_override: Option<(u8, u8, u16)>,
     /// Optional controllable hosting clock injected into every node's
     /// `HostingManager` (via `NodeConfig::hosting_time_source_override`). When
     /// set, hosting-cache TTL and subscription-lease eviction advance ONLY when
@@ -1656,6 +1669,9 @@ impl SimNetwork {
             // `version_supports_*` gate, so switching it on network-wide is a
             // cascade in effect. Opt in per sim via `enable_gateway_ack_version`.
             ack_version_floor_override: Some(Self::SIM_MIGRATION_DISABLED_FLOOR),
+            // Fail-CLOSED by default, like the two behavioural gates above and
+            // unlike hash-first (#5147). See the field's rustdoc.
+            broadcast_target_list_floor_override: Some(Self::SIM_MIGRATION_DISABLED_FLOOR),
             hosting_clock: None,
             hosting_budget_override: None,
             shared_rings: HashMap::new(),
@@ -2047,6 +2063,46 @@ impl SimNetwork {
         }
         for (builder, _) in self.nodes.iter_mut() {
             builder.config.ack_version_floor_override = floor;
+        }
+        self
+    }
+
+    /// Turn the originator target list (#5147) ON for this simulation by
+    /// pinning the per-node version floor to the always-passing
+    /// [`Self::SIM_MIGRATION_ENABLED_FLOOR`].
+    ///
+    /// Unlike [`enable_hash_first_summaries`](Self::enable_hash_first_summaries),
+    /// this is NOT the default and the call is load-bearing: without it every
+    /// peer falls back to the legacy `BroadcastTo` and the sim measures
+    /// today's unsuppressed fan-out. That is exactly what the control arm of a
+    /// suppression measurement wants, so the two arms differ by this one call.
+    #[allow(dead_code)]
+    pub fn enable_broadcast_target_list(&mut self) -> &mut Self {
+        let floor = Some(Self::SIM_MIGRATION_ENABLED_FLOOR);
+        self.broadcast_target_list_floor_override = floor;
+        for (builder, _) in self.gateways.iter_mut() {
+            builder.config.broadcast_target_list_floor_override = floor;
+        }
+        for (builder, _) in self.nodes.iter_mut() {
+            builder.config.broadcast_target_list_floor_override = floor;
+        }
+        self
+    }
+
+    /// Force the originator target list OFF for this simulation.
+    ///
+    /// Already the default (see `new_inner`); exists so the CONTROL arm of a
+    /// suppression measurement states its premise at the call site rather than
+    /// depending on a default a future edit could flip.
+    #[allow(dead_code)]
+    pub fn disable_broadcast_target_list(&mut self) -> &mut Self {
+        let floor = Some(Self::SIM_MIGRATION_DISABLED_FLOOR);
+        self.broadcast_target_list_floor_override = floor;
+        for (builder, _) in self.gateways.iter_mut() {
+            builder.config.broadcast_target_list_floor_override = floor;
+        }
+        for (builder, _) in self.nodes.iter_mut() {
+            builder.config.broadcast_target_list_floor_override = floor;
         }
         self
     }
@@ -2734,6 +2790,7 @@ impl SimNetwork {
             config.summary_first_put_floor_override = self.summary_first_put_floor_override;
             config.hash_first_summaries_floor_override = self.hash_first_summaries_floor_override;
             config.ack_version_floor_override = self.ack_version_floor_override;
+            config.broadcast_target_list_floor_override = self.broadcast_target_list_floor_override;
             config.hosting_time_source_override = self
                 .hosting_clock
                 .clone()
@@ -2836,6 +2893,7 @@ impl SimNetwork {
             config.summary_first_put_floor_override = self.summary_first_put_floor_override;
             config.hash_first_summaries_floor_override = self.hash_first_summaries_floor_override;
             config.ack_version_floor_override = self.ack_version_floor_override;
+            config.broadcast_target_list_floor_override = self.broadcast_target_list_floor_override;
             config.hosting_time_source_override = self
                 .hosting_clock
                 .clone()

--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -786,6 +786,12 @@ async fn try_summary_first_put(
             // tag is a scheduling-lane choice (see the comment above), and
             // the two are free to disagree.
             crate::node::ApplyOrigin::NetworkRelay,
+            // #5147: a PUT-path apply names no broadcast delivery targets, so
+            // it attests to no coverage. Registering an EMPTY set rather than
+            // skipping registration is deliberate: it collapses any concurrent
+            // relayed coverage for this contract, so a PUT's fan-out is never
+            // suppressed against a list belonging to someone else's broadcast.
+            crate::ring::broadcast_coverage::BroadcastOrigin::local(),
         )
         .await
         {
@@ -4207,6 +4213,12 @@ async fn drive_relay_probe_reconcile(
             RelatedContracts::default(),
             crate::contract::Priority::NetworkRelay,
             crate::node::ApplyOrigin::NetworkRelay,
+            // #5147: a PUT-path apply names no broadcast delivery targets, so
+            // it attests to no coverage. Registering an EMPTY set rather than
+            // skipping registration is deliberate: it collapses any concurrent
+            // relayed coverage for this contract, so a PUT's fan-out is never
+            // suppressed against a list belonging to someone else's broadcast.
+            crate::ring::broadcast_coverage::BroadcastOrigin::local(),
         )
         .await
         {

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -1801,7 +1801,7 @@ mod tests {
     /// risk #5147 introduces, which is this enum. This is the byte-level form
     /// of the "a pre-floor peer receives byte-identical traffic" requirement;
     /// the routing-level form is
-    /// `a_pre_floor_peer_receives_byte_identical_broadcast_traffic` in
+    /// `a_pre_floor_peer_receives_the_legacy_variant_index` in
     /// `node/op_state_manager.rs`.
     #[test]
     fn legacy_broadcast_to_encoding_is_unchanged_by_the_v2_variants() {

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -1761,12 +1761,21 @@ mod tests {
     /// The other half: a legacy `BroadcastTo` must serialize to EXACTLY the
     /// bytes it did before #5147, for a pre-floor peer.
     ///
-    /// Pinned against a hand-written literal rather than a re-serialization of
-    /// the same struct — the latter compares the encoder against itself and
-    /// would pass even if the whole layout moved. This is the byte-level form
+    /// The variant index and the `Vec<u8>` length prefix are hand-written
+    /// literals rather than re-serializations, so a change to THIS enum's
+    /// layout — a reordered field, a renumbered variant, a changed length
+    /// encoding — is caught. Field reordering is verified to fail it.
+    ///
+    /// Its limit, stated so nobody over-trusts it: `id`, `key`, and `payload`
+    /// are still produced by `bincode::serialize` of the same values, so a
+    /// layout change INSIDE `Transaction`, `ContractKey`, or `DeltaOrFullState`
+    /// moves both sides together and passes. Those types are shared with every
+    /// other message, so they have their own guards; this test is scoped to the
+    /// risk #5147 introduces, which is this enum. This is the byte-level form
     /// of the "a pre-floor peer receives byte-identical traffic" requirement;
     /// the routing-level form is
-    /// `a_pre_floor_peer_gets_the_legacy_variant` in `broadcast_queue.rs`.
+    /// `a_pre_floor_peer_receives_byte_identical_broadcast_traffic` in
+    /// `node/op_state_manager.rs`.
     #[test]
     fn legacy_broadcast_to_encoding_is_unchanged_by_the_v2_variants() {
         use crate::message::DeltaOrFullState;

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -410,6 +410,7 @@ impl OpManager {
             // exclude both).
             if origin.covers(&pub_key) {
                 skipped_covered += 1;
+                crate::config::GlobalTestMetrics::record_broadcast_target_suppressed();
                 continue;
             }
             if let Some(pkl) = self.ring.connection_manager.get_peer_by_pub_key(&pub_key) {

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -428,6 +428,7 @@ impl OpManager {
                     // 100%-wasted send on every single relayed broadcast.
                     if Some(&pkl_addr) == sender {
                         skipped_sender += 1;
+                        crate::config::GlobalTestMetrics::record_broadcast_sender_skipped();
                         continue;
                     }
                     // Self-exclusion is now UNCONDITIONAL. Broadcasting to

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -129,7 +129,24 @@ pub(crate) struct BroadcastTargetResult {
     pub interest_resolve_failed: usize,
     pub skipped_self: usize,
     pub skipped_sender: usize,
+    /// Targets dropped because the originator's list said it already
+    /// delivered to them (#5147).
+    ///
+    /// Counted BY the filter that drops them, never re-derived as
+    /// `resolved.len() - targets.len()` at a call site: that subtraction
+    /// silently absorbs the sender, self, and resolve-failure filters too, and
+    /// keeps reporting a plausible number after this filter is deleted. See
+    /// `.claude/rules/bug-prevention-patterns.md`, "Metric describing a
+    /// filtering decision, re-derived at the call site" — the row exists
+    /// because that exact mistake was made three times in a row on this very
+    /// function's sibling filter.
+    pub skipped_covered: usize,
 }
+
+/// Re-exported so `p2p_protoc::broadcast` and the relay drivers name one type
+/// for "who already has this". Defined next to the store that produces it; see
+/// [`crate::ring::broadcast_coverage`].
+pub(crate) use crate::ring::broadcast_coverage::BroadcastOrigin;
 
 /// Result of [`update_contract`]: the merged state and whether it changed.
 ///
@@ -309,7 +326,6 @@ impl OpManager {
     pub(crate) fn advertised_cohost_pub_keys(&self, key: &ContractKey) -> Vec<TransportPublicKey> {
         self.neighbor_hosting.neighbors_with_contract(key)
     }
-
     /// Resolve the set of peers to broadcast a state update to.
     ///
     /// Targets are the advertised co-hosts from the proximity neighbor cache
@@ -359,17 +375,18 @@ impl OpManager {
     pub(crate) fn get_broadcast_targets_update(
         &self,
         key: &ContractKey,
-        sender: &SocketAddr,
+        origin: &BroadcastOrigin,
     ) -> BroadcastTargetResult {
         use std::collections::HashSet;
 
         let self_addr = self.ring.connection_manager.get_own_addr();
-        let is_local_update_initiator = self_addr.as_ref().map(|me| me == sender).unwrap_or(false);
+        let sender = origin.sender();
 
         let mut targets: HashSet<PeerKeyLocation> = HashSet::new();
         let mut proximity_resolve_failed: usize = 0;
         let mut skipped_self: usize = 0;
         let mut skipped_sender: usize = 0;
+        let mut skipped_covered: usize = 0;
 
         // Source 1 (the ONLY live fan-out source): the proximity cache of
         // advertised co-hosts — peers who announced they host this contract via
@@ -384,13 +401,37 @@ impl OpManager {
         let proximity_found = proximity_pub_keys.len();
 
         for pub_key in proximity_pub_keys {
+            // #5147: the originator told us it already delivered to this peer,
+            // so re-sending is a byte-identical duplicate. Checked BEFORE the
+            // address filters purely so the counter attributes the drop to the
+            // reason a reader would expect; the three are disjoint in practice
+            // (the sender is never on its own list, and we are never on it
+            // either — a peer builds the list from its fan-out targets, which
+            // exclude both).
+            if origin.covers(&pub_key) {
+                skipped_covered += 1;
+                continue;
+            }
             if let Some(pkl) = self.ring.connection_manager.get_peer_by_pub_key(&pub_key) {
                 if let Some(pkl_addr) = pkl.socket_addr() {
-                    if &pkl_addr == sender && !is_local_update_initiator {
+                    // Both of these were dead before #5147: the re-fan-out call
+                    // site passed its own address as `sender`, so
+                    // `is_local_update_initiator` was always true and both arms
+                    // were unreachable exactly where they were needed. With a
+                    // real `BroadcastOrigin` the sender exclusion does what its
+                    // author intended — a relayer no longer echoes the update
+                    // straight back to the peer that just sent it, which is a
+                    // 100%-wasted send on every single relayed broadcast.
+                    if Some(&pkl_addr) == sender {
                         skipped_sender += 1;
                         continue;
                     }
-                    if !is_local_update_initiator && self_addr.as_ref() == Some(&pkl_addr) {
+                    // Self-exclusion is now UNCONDITIONAL. Broadcasting to
+                    // ourselves is never correct, and the old
+                    // `!is_local_update_initiator` guard only ever meant "we
+                    // could not tell who the sender was", which is not a reason
+                    // to send ourselves a network message.
+                    if self_addr.as_ref() == Some(&pkl_addr) {
                         skipped_self += 1;
                         continue;
                     }
@@ -415,7 +456,7 @@ impl OpManager {
                 tracing::debug!(
                     contract = %format!("{:.8}", key),
                     proximity_neighbor = %pub_key,
-                    is_local = is_local_update_initiator,
+                    is_local = sender.is_none(),
                     phase = "target_lookup_failed",
                     "Proximity cache neighbor not found in connection manager; reaped stale entry"
                 );
@@ -436,7 +477,8 @@ impl OpManager {
         if !result.is_empty() {
             tracing::debug!(
                 contract = %format!("{:.8}", key),
-                peer_addr = %sender,
+                peer_addr = ?sender,
+                skipped_covered,
                 targets = %result
                     .iter()
                     .filter_map(|s| s.socket_addr())
@@ -459,7 +501,8 @@ impl OpManager {
             // (proximity_resolve_failed). Issue #4251 re-review M2.
             tracing::debug!(
                 contract = %format!("{:.8}", key),
-                peer_addr = %sender,
+                peer_addr = ?sender,
+                skipped_covered,
                 self_addr = ?self_addr.map(|a| format!("{:.8}", a)),
                 proximity_sources = proximity_found,
                 proximity_resolve_failed,
@@ -478,6 +521,7 @@ impl OpManager {
             interest_resolve_failed: 0,
             skipped_self,
             skipped_sender,
+            skipped_covered,
         }
     }
 }
@@ -679,6 +723,21 @@ async fn contract_summary_or_empty(
 /// The `update_data` parameter can be:
 /// - `UpdateData::Delta(delta)` - A delta from the client, merged with current state
 /// - `UpdateData::State(state)` - A full state from PUT or executor
+///
+/// `covered` is the #5147 originator target list, already resolved against this
+/// node's view of the contract's co-hosts. It is registered on
+/// [`crate::ring::broadcast_coverage::BroadcastCoverageStore`] for the duration
+/// of the apply, so the fan-out the executor emits on a committed write can
+/// find it — nothing on the path between here and
+/// `handle_broadcast_state_change` carries networking context, and threading
+/// one through the WASM/contract-handler layer is the cost #5147 chose against.
+///
+/// Registration lives HERE rather than in the two relay drivers that have a
+/// list, so that every apply registers: a client-local apply passes an EMPTY
+/// set, which intersects any concurrent relayed coverage down to nothing rather
+/// than letting a local update inherit someone else's list. See the store's
+/// rustdoc for the full race argument.
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn update_contract(
     op_manager: &OpManager,
     key: ContractKey,
@@ -686,7 +745,18 @@ pub(crate) async fn update_contract(
     related_contracts: RelatedContracts<'static>,
     priority: crate::contract::Priority,
     origin: crate::node::ApplyOrigin,
+    covered: BroadcastOrigin,
 ) -> Result<UpdateExecution, OpError> {
+    // Registered BEFORE the UpdateQuery enters the contract handler, which is
+    // what makes the ordering sound: the fan-out can only run after that query
+    // commits, so the entry is always present when its own fan-out reads it.
+    // The guard discards it again unless the apply actually changed state.
+    let coverage = crate::ring::broadcast_coverage::CoverageRegistration::new(
+        &op_manager.broadcast_coverage,
+        *key.id(),
+        covered,
+    );
+
     let previous_state = match op_manager
         .notify_contract_handler_prioritized(
             ContractHandlerEvent::GetQuery {
@@ -739,6 +809,15 @@ pub(crate) async fn update_contract(
             // causes the executor to emit a fan-out, modulo the residuals
             // enumerated there.
             op_manager.payload_mix.record_apply(origin, state_changed);
+            if state_changed {
+                // A `BroadcastStateChange` was emitted for this write, so hand
+                // the coverage to it. Otherwise the guard's drop clears it —
+                // no fan-out is coming, and a no-change apply is the COMMON
+                // case (97% of received contract bytes change nothing), so
+                // leaving those entries to expire would fill the store with
+                // coverage that intersects away every real entry.
+                coverage.keep();
+            }
             // #4923: no summary is computed here — never relabel the state
             // bytes as a summary (the self-poisoning full-state-broadcast
             // loop), and no per-apply summary fetch on this hot path either
@@ -1464,6 +1543,63 @@ mod messages {
             /// Total size of the streamed payload in bytes
             total_size: u64,
         },
+
+        // ---- APPEND ONLY BELOW THIS LINE ----
+        //
+        // Variant order IS the bincode wire encoding: the index is written as a
+        // u32 and nothing else identifies the variant. Inserting or reordering
+        // renumbers every later variant, so a peer would decode a `BroadcastTo`
+        // as something else entirely. Pinned by
+        // `update_msg_wire_variant_indices_are_frozen`.
+        /// [`Self::BroadcastTo`] plus the originator's target list (#5147).
+        ///
+        /// Why a parallel variant rather than a field on `BroadcastTo`: the
+        /// payload is bincode, whose layout is not forward-tolerant, so the
+        /// list can only be sent to a peer already known to decode it. A plain
+        /// new field would have to be omitted conditionally, which bincode
+        /// cannot express; an `Option` would still emit its discriminant byte
+        /// and change the bytes a pre-floor peer sees. Leaving the legacy
+        /// variant untouched makes the compatibility guarantee structural
+        /// rather than a matter of branch review — and it is why
+        /// `broadcast_to_single_peer` builds the legacy message through the
+        /// same unchanged code path it always did.
+        ///
+        /// Gated per-recipient by
+        /// `ConnectionManager::supports_broadcast_target_list`.
+        BroadcastToV2 {
+            id: Transaction,
+            key: ContractKey,
+            payload: crate::message::DeltaOrFullState,
+            sender_summary_bytes: Vec<u8>,
+            /// Peers the SENDER of this message delivered this same broadcast
+            /// to, so the receiver can leave them out of its own re-fan-out.
+            ///
+            /// One hop only. A relayer does not forward this onward and does
+            /// not union its own targets into it: the value is an attestation
+            /// of the immediate sender's own actions, and honoring it only from
+            /// the message that carried the payload is what stops a malicious
+            /// relayer from fabricating an "everyone is covered" list to
+            /// suppress third-party fan-out. See
+            /// [`crate::ring::broadcast_coverage`].
+            covered: crate::ring::broadcast_coverage::CoveredPeers,
+        },
+
+        /// [`Self::BroadcastToStreaming`] plus the originator's target list
+        /// (#5147). Same rationale as [`Self::BroadcastToV2`].
+        ///
+        /// The list rides on the header rather than inside
+        /// [`BroadcastStreamingPayload`] because that struct is bincode too and
+        /// adding a field to it would break the same compatibility the parallel
+        /// variant exists to preserve. The header is still the message that
+        /// delivers the payload — it is what opens the stream — so the
+        /// honor-only-from-the-payload-bearing-message rule holds.
+        BroadcastToStreamingV2 {
+            id: Transaction,
+            stream_id: StreamId,
+            key: ContractKey,
+            total_size: u64,
+            covered: crate::ring::broadcast_coverage::CoveredPeers,
+        },
     }
 
     impl InnerMessage for UpdateMsg {
@@ -1472,7 +1608,9 @@ mod messages {
                 UpdateMsg::RequestUpdate { id, .. }
                 | UpdateMsg::BroadcastTo { id, .. }
                 | UpdateMsg::RequestUpdateStreaming { id, .. }
-                | UpdateMsg::BroadcastToStreaming { id, .. } => id,
+                | UpdateMsg::BroadcastToStreaming { id, .. }
+                | UpdateMsg::BroadcastToV2 { id, .. }
+                | UpdateMsg::BroadcastToStreamingV2 { id, .. } => id,
             }
         }
 
@@ -1481,7 +1619,9 @@ mod messages {
                 UpdateMsg::RequestUpdate { key, .. }
                 | UpdateMsg::BroadcastTo { key, .. }
                 | UpdateMsg::RequestUpdateStreaming { key, .. }
-                | UpdateMsg::BroadcastToStreaming { key, .. } => Some(Location::from(key.id())),
+                | UpdateMsg::BroadcastToStreaming { key, .. }
+                | UpdateMsg::BroadcastToV2 { key, .. }
+                | UpdateMsg::BroadcastToStreamingV2 { key, .. } => Some(Location::from(key.id())),
             }
         }
     }
@@ -1497,6 +1637,21 @@ mod messages {
                 UpdateMsg::BroadcastToStreaming { id, stream_id, .. } => {
                     write!(f, "BroadcastToStreaming(id: {id}, stream: {stream_id})")
                 }
+                UpdateMsg::BroadcastToV2 { id, covered, .. } => {
+                    write!(f, "BroadcastToV2(id: {id}, covered: {})", covered.len())
+                }
+                UpdateMsg::BroadcastToStreamingV2 {
+                    id,
+                    stream_id,
+                    covered,
+                    ..
+                } => {
+                    write!(
+                        f,
+                        "BroadcastToStreamingV2(id: {id}, stream: {stream_id}, covered: {})",
+                        covered.len()
+                    )
+                }
             }
         }
     }
@@ -1507,6 +1662,210 @@ mod messages {
 mod tests {
     use super::*;
     use crate::operations::test_utils::make_contract_key;
+
+    /// Wire-compatibility guard for #5147, in two independent halves.
+    ///
+    /// Appending `BroadcastToV2` / `BroadcastToStreamingV2` must not renumber
+    /// any existing variant. If it did, the compatibility argument would hold
+    /// for the new variants alone while every OTHER message silently changed
+    /// meaning on the wire — a peer would decode a `BroadcastTo` as a
+    /// `RequestUpdateStreaming`, whose `stream_id`/`total_size` bytes are its
+    /// payload. That is not a decode error; it is a plausible-looking wrong
+    /// message.
+    ///
+    /// The table is a FIXED-LENGTH array, so adding a variant without extending
+    /// it is a compile error rather than a silently-passing test.
+    #[test]
+    fn update_msg_wire_variant_indices_are_frozen() {
+        use crate::message::DeltaOrFullState;
+        use crate::ring::broadcast_coverage::CoveredPeers;
+        use crate::transport::peer_connection::StreamId;
+
+        fn variant_index(msg: &UpdateMsg) -> u32 {
+            let bytes = bincode::serialize(msg).expect("serialize UpdateMsg");
+            u32::from_le_bytes(bytes[..4].try_into().expect("variant index prefix"))
+        }
+
+        let id = Transaction::new::<UpdateMsg>();
+        let key = make_contract_key(1);
+        let expected: [(u32, UpdateMsg); 6] = [
+            (
+                0,
+                UpdateMsg::RequestUpdate {
+                    id,
+                    key,
+                    related_contracts: RelatedContracts::default(),
+                    value: WrappedState::new(vec![1]),
+                },
+            ),
+            (
+                1,
+                UpdateMsg::BroadcastTo {
+                    id,
+                    key,
+                    payload: DeltaOrFullState::Delta(vec![1]),
+                    sender_summary_bytes: vec![],
+                },
+            ),
+            (
+                2,
+                UpdateMsg::RequestUpdateStreaming {
+                    id,
+                    stream_id: StreamId::next(),
+                    key,
+                    total_size: 1,
+                },
+            ),
+            (
+                3,
+                UpdateMsg::BroadcastToStreaming {
+                    id,
+                    stream_id: StreamId::next(),
+                    key,
+                    total_size: 1,
+                },
+            ),
+            (
+                4,
+                UpdateMsg::BroadcastToV2 {
+                    id,
+                    key,
+                    payload: DeltaOrFullState::Delta(vec![1]),
+                    sender_summary_bytes: vec![],
+                    covered: CoveredPeers::empty(),
+                },
+            ),
+            (
+                5,
+                UpdateMsg::BroadcastToStreamingV2 {
+                    id,
+                    stream_id: StreamId::next(),
+                    key,
+                    total_size: 1,
+                    covered: CoveredPeers::empty(),
+                },
+            ),
+        ];
+
+        for (index, msg) in &expected {
+            assert_eq!(
+                variant_index(msg),
+                *index,
+                "UpdateMsg variant indices are wire-visible and MUST NOT move; \
+                 the V2 variants have to stay appended at the end"
+            );
+        }
+    }
+
+    /// The other half: a legacy `BroadcastTo` must serialize to EXACTLY the
+    /// bytes it did before #5147, for a pre-floor peer.
+    ///
+    /// Pinned against a hand-written literal rather than a re-serialization of
+    /// the same struct — the latter compares the encoder against itself and
+    /// would pass even if the whole layout moved. This is the byte-level form
+    /// of the "a pre-floor peer receives byte-identical traffic" requirement;
+    /// the routing-level form is
+    /// `a_pre_floor_peer_gets_the_legacy_variant` in `broadcast_queue.rs`.
+    #[test]
+    fn legacy_broadcast_to_encoding_is_unchanged_by_the_v2_variants() {
+        use crate::message::DeltaOrFullState;
+
+        let id = Transaction::new::<UpdateMsg>();
+        let key = make_contract_key(7);
+        let msg = UpdateMsg::BroadcastTo {
+            id,
+            key,
+            payload: DeltaOrFullState::Delta(vec![0xAA, 0xBB]),
+            sender_summary_bytes: vec![0xCC],
+        };
+        let actual = bincode::serialize(&msg).expect("serialize");
+
+        let mut expected = Vec::new();
+        // variant index: BroadcastTo == 1
+        expected.extend_from_slice(&1u32.to_le_bytes());
+        // id
+        expected.extend_from_slice(&bincode::serialize(&id).expect("id"));
+        // key
+        expected.extend_from_slice(&bincode::serialize(&key).expect("key"));
+        // payload: DeltaOrFullState::Delta(vec![0xAA, 0xBB])
+        expected.extend_from_slice(
+            &bincode::serialize(&DeltaOrFullState::Delta(vec![0xAA, 0xBB])).expect("payload"),
+        );
+        // sender_summary_bytes: Vec<u8> = len(u64 LE) + bytes
+        expected.extend_from_slice(&1u64.to_le_bytes());
+        expected.push(0xCC);
+
+        assert_eq!(
+            actual, expected,
+            "the legacy BroadcastTo encoding is what every pre-0.2.120 peer \
+             decodes; a change here closes their connections on the first \
+             broadcast after upgrade"
+        );
+
+        // And the V2 form must be genuinely DIFFERENT bytes, so the version
+        // gate is provably choosing between two encodings rather than two
+        // spellings of one.
+        let v2 = UpdateMsg::BroadcastToV2 {
+            id,
+            key,
+            payload: DeltaOrFullState::Delta(vec![0xAA, 0xBB]),
+            sender_summary_bytes: vec![0xCC],
+            covered: crate::ring::broadcast_coverage::CoveredPeers::empty(),
+        };
+        assert_ne!(bincode::serialize(&v2).expect("serialize v2"), actual);
+    }
+
+    /// The #5147 security rule, enforced structurally: a target list may only
+    /// ride on a variant that also carries the payload.
+    ///
+    /// A relayer is trusted with a list solely because it is attesting to sends
+    /// it actually made while delivering this payload. If a list could arrive
+    /// on a control message, any peer could assert "everyone is covered" and
+    /// silence third-party re-fan-out for a cycle. There is no runtime check
+    /// for this — the guarantee is that no other variant HAS the field — so
+    /// this test is what keeps a future variant from quietly acquiring one.
+    #[test]
+    fn only_payload_bearing_variants_carry_a_target_list() {
+        let path =
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/operations/update.rs");
+        let source = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("must read own source at {}: {e}", path.display()));
+        let start = source
+            .find("pub(crate) enum UpdateMsg {")
+            .expect("UpdateMsg enum must exist");
+        let body = &source[start..];
+        let end = body
+            .find("\n    }\n")
+            .expect("UpdateMsg enum must terminate");
+        let body = &body[..end];
+
+        // The nearest `Name {` above each `covered:` is the variant carrying it.
+        let carriers: Vec<&str> = body
+            .match_indices("covered:")
+            .map(|(idx, _)| {
+                body[..idx]
+                    .rmatch_indices(" {")
+                    .filter_map(|(brace, _)| {
+                        let line_start = body[..brace].rfind('\n').map(|i| i + 1).unwrap_or(0);
+                        let name = body[line_start..brace].trim();
+                        (name.chars().next().is_some_and(char::is_uppercase)).then_some(name)
+                    })
+                    .next()
+                    .expect("a `covered:` field must sit inside a named variant")
+            })
+            .collect();
+
+        assert_eq!(
+            carriers,
+            vec!["BroadcastToV2", "BroadcastToStreamingV2"],
+            "ONLY the payload-bearing broadcast variants may carry a `covered:` \
+             target list (#5147). A list on a control message would let any \
+             relayer fabricate an everyone-is-covered claim and suppress \
+             third-party re-fan-out; the one-hop design has no runtime defence \
+             against that, because the defence IS that no other variant has \
+             the field."
+        );
+    }
 
     /// Source-level pin for the UPDATE_PROPAGATION NO_TARGETS log site.
     /// Originally INFO; briefly promoted to WARN in PR #4252 commit 2;
@@ -2270,6 +2629,7 @@ mod tests {
             RelatedContracts::default(),
             crate::contract::Priority::ClientLocal,
             crate::node::ApplyOrigin::ClientLocal,
+            BroadcastOrigin::local(),
         )
         .await
         .expect("update must succeed");
@@ -2345,6 +2705,7 @@ mod tests {
                 // test would fail.
                 crate::contract::Priority::ClientLocal,
                 origin,
+                BroadcastOrigin::local(),
             )
             .await
             .expect("update must succeed");
@@ -2379,6 +2740,7 @@ mod tests {
             RelatedContracts::default(),
             crate::contract::Priority::NetworkRelay,
             ApplyOrigin::NetworkRelay,
+            BroadcastOrigin::local(),
         )
         .await
         .expect("a no-change merge is still a successful apply");
@@ -3022,7 +3384,10 @@ mod tests {
         }
 
         let broadcast_targets: HashSet<SocketAddr> = op_manager
-            .get_broadcast_targets_update(&key, &sender_addr)
+            .get_broadcast_targets_update(
+                &key,
+                &BroadcastOrigin::relayed(sender_addr, Default::default()),
+            )
             .targets
             .iter()
             .filter_map(|pkl| pkl.socket_addr())

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -326,13 +326,16 @@ impl OpManager {
     pub(crate) fn advertised_cohost_pub_keys(&self, key: &ContractKey) -> Vec<TransportPublicKey> {
         self.neighbor_hosting.neighbors_with_contract(key)
     }
+
     /// Resolve the set of peers to broadcast a state update to.
     ///
     /// Targets are the advertised co-hosts from the proximity neighbor cache
     /// (peers who announced, via the advertisement layer, that they host this
-    /// contract). Skips the sender (to avoid echo) and this node (unless we are
-    /// the local originator). Returns skip-reason counters alongside the
-    /// resolved targets for broadcast delivery diagnostics (issue #3046).
+    /// contract). Skips the sender (to avoid echo) and, unconditionally, this
+    /// node — #5147 removed the `is_local_update_initiator` condition on the
+    /// latter, since broadcasting to ourselves is never correct. Returns
+    /// skip-reason counters alongside the resolved targets for broadcast
+    /// delivery diagnostics (issue #3046).
     ///
     /// ## Source-1-only live fan-out (#4642 step 9)
     ///
@@ -1674,10 +1677,33 @@ mod tests {
     /// payload. That is not a decode error; it is a plausible-looking wrong
     /// message.
     ///
-    /// The table is a FIXED-LENGTH array, so adding a variant without extending
-    /// it is a compile error rather than a silently-passing test.
+    /// Adding a variant without extending this test is a compile error, via the
+    /// wildcard-free match in `variant_index_anchor` below.
+    ///
+    /// It did NOT used to be. The rustdoc claimed the fixed-length
+    /// `[(u32, UpdateMsg); 6]` array delivered that guarantee, and it does not:
+    /// an array literal has no exhaustiveness relationship to the enum, so a
+    /// 7th variant compiled and this test passed unchanged. The claim was
+    /// convincing enough that two of five independent reviewers repeated it
+    /// back rather than testing it. The anchor makes it true.
     #[test]
     fn update_msg_wire_variant_indices_are_frozen() {
+        // Exhaustiveness anchor. Its ONLY job is to fail compilation when a
+        // variant is added: a wildcard-free match over every variant cannot be
+        // extended without the author coming here, seeing the frozen indices,
+        // and appending to `expected` too. Never add a `_ =>` arm.
+        #[allow(dead_code)]
+        fn variant_index_anchor(msg: &UpdateMsg) -> u32 {
+            match msg {
+                UpdateMsg::RequestUpdate { .. } => 0,
+                UpdateMsg::BroadcastTo { .. } => 1,
+                UpdateMsg::RequestUpdateStreaming { .. } => 2,
+                UpdateMsg::BroadcastToStreaming { .. } => 3,
+                UpdateMsg::BroadcastToV2 { .. } => 4,
+                UpdateMsg::BroadcastToStreamingV2 { .. } => 5,
+            }
+        }
+
         use crate::message::DeltaOrFullState;
         use crate::ring::broadcast_coverage::CoveredPeers;
         use crate::transport::peer_connection::StreamId;

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -809,22 +809,37 @@ pub(crate) fn resolve_covered_peers(
     sender_addr: SocketAddr,
     covered: &crate::ring::broadcast_coverage::CoveredPeers,
 ) -> crate::ring::broadcast_coverage::BroadcastOrigin {
-    if !op_manager
-        .ring
-        .connection_manager
-        .supports_broadcast_target_list(sender_addr)
-    {
-        // Pre-floor or unknown sender: no suppression of any kind, so this
-        // node's fan-out is byte-for-byte what it is today.
-        return crate::ring::broadcast_coverage::BroadcastOrigin::local();
-    }
+    // The two halves are gated SEPARATELY, and conflating them is what made the
+    // whole feature inert. See `BroadcastOrigin::relayed_list_only`.
+    //
+    // The covered LIST is self-gating: it rides only on the V2 variants, so a
+    // pre-floor sender hands us an empty one and suppresses nothing no matter
+    // what we do here. Holding a populated list IS proof the sender supports the
+    // feature — its own act, rather than our record of it.
+    //
+    // The sender EXCLUSION has no wire signal, so it keeps the version gate.
     let resolved = if covered.is_empty() {
         std::collections::HashSet::new()
     } else {
         let candidates = op_manager.advertised_cohost_pub_keys(key);
         covered.resolve(tx, candidates.iter())
     };
-    crate::ring::broadcast_coverage::BroadcastOrigin::relayed(sender_addr, resolved)
+
+    if op_manager
+        .ring
+        .connection_manager
+        .supports_broadcast_target_list(sender_addr)
+    {
+        crate::ring::broadcast_coverage::BroadcastOrigin::relayed(sender_addr, resolved)
+    } else {
+        // Pre-floor or UNKNOWN sender version. Unknown is the common case, not a
+        // corner: a node does not learn its gateway's version until #5167
+        // propagates, and simulations default that ack gate OFF. Gating the list
+        // on this lookup too discarded a claim the message in hand had already
+        // proven honourable, which zeroed suppression on the highest-degree
+        // links in production and entirely in simulation.
+        crate::ring::broadcast_coverage::BroadcastOrigin::relayed_list_only(resolved)
+    }
 }
 
 /// Spawn a relay driver for a fresh inbound `UpdateMsg::BroadcastTo`.

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -817,7 +817,23 @@ pub(crate) fn resolve_covered_peers(
     // what we do here. Holding a populated list IS proof the sender supports the
     // feature — its own act, rather than our record of it.
     //
-    // The sender EXCLUSION has no wire signal, so it keeps the version gate.
+    // The sender EXCLUSION keeps the version gate — but as a ROLLOUT SWITCH,
+    // not as wire or semantic safety, and it is worth being exact because the
+    // obvious reading is wrong. Not sending a peer a message cannot break its
+    // decoding, so there is no wire-compat exposure to fail closed against; and
+    // the semantic worry (our post-merge state can be newer than what the
+    // sender gave us) is version-INDEPENDENT — a post-floor sender has exactly
+    // the same property, and that is the risk the list half accepts and the
+    // multi-writer simulation validates. What the gate buys is a staged rollout
+    // and a sim toggle, both of which are worth having on a change with this
+    // blast radius.
+    //
+    // Consequence to keep in view: on an unknown-version link we honour the
+    // sender's list while still echoing back to the sender itself — suppressing
+    // legs that are only probably redundant, while keeping the one that is
+    // certainly redundant. At the fleet median fan-out of 16-17 that is roughly
+    // 6% of legs left on the table, on the gateway links that matter most,
+    // until #5167 propagates.
     let resolved = if covered.is_empty() {
         std::collections::HashSet::new()
     } else {

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -292,6 +292,11 @@ async fn drive_client_update(
                 related_contracts,
                 crate::contract::Priority::ClientLocal,
                 crate::node::ApplyOrigin::ClientLocal,
+                // #5147: no upstream sender, so nothing is covered. An EMPTY
+                // registration is not the same as no registration — it collapses
+                // any concurrent relayed coverage for this contract, so a local
+                // update is never suppressed against someone else's target list.
+                crate::ring::broadcast_coverage::BroadcastOrigin::local(),
             )
             .await
             {
@@ -411,6 +416,11 @@ async fn drive_client_update(
                 related_contracts.clone(),
                 crate::contract::Priority::ClientLocal,
                 crate::node::ApplyOrigin::ClientLocal,
+                // #5147: no upstream sender, so nothing is covered. An EMPTY
+                // registration is not the same as no registration — it collapses
+                // any concurrent relayed coverage for this contract, so a local
+                // update is never suppressed against someone else's target list.
+                crate::ring::broadcast_coverage::BroadcastOrigin::local(),
             )
             .await;
 
@@ -747,6 +757,34 @@ pub(crate) async fn start_relay_request_update(
     Ok(())
 }
 
+/// Resolve an originator's target list against the peers we could ourselves
+/// broadcast this contract to (#5147).
+///
+/// Resolves against `advertised_cohost_pub_keys` — the exact set
+/// `get_broadcast_targets_update` draws from — rather than every connected
+/// peer, so the work is proportional to the fan-out (median 16-17) instead of
+/// the connection count, and a named peer we would never have targeted costs
+/// nothing.
+///
+/// `tx` is the transaction the list arrived on. The hashes are seeded with it,
+/// so resolving under any other transaction yields nothing; that is what stops
+/// a list from being replayed onto a different broadcast.
+fn resolve_covered_peers(
+    op_manager: &OpManager,
+    key: &ContractKey,
+    tx: &Transaction,
+    sender_addr: SocketAddr,
+    covered: &crate::ring::broadcast_coverage::CoveredPeers,
+) -> crate::ring::broadcast_coverage::BroadcastOrigin {
+    let resolved = if covered.is_empty() {
+        std::collections::HashSet::new()
+    } else {
+        let candidates = op_manager.advertised_cohost_pub_keys(key);
+        covered.resolve(tx, candidates.iter())
+    };
+    crate::ring::broadcast_coverage::BroadcastOrigin::relayed(sender_addr, resolved)
+}
+
 /// Spawn a relay driver for a fresh inbound `UpdateMsg::BroadcastTo`.
 ///
 /// Same gates as `start_relay_request_update`. The driver applies the
@@ -754,6 +792,7 @@ pub(crate) async fn start_relay_request_update(
 /// `BroadcastStateChange` event fans out to other interested peers
 /// automatically — the driver itself never sends `BroadcastTo`
 /// downstream.
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn start_relay_broadcast_to(
     op_manager: Arc<OpManager>,
     incoming_tx: Transaction,
@@ -761,6 +800,9 @@ pub(crate) async fn start_relay_broadcast_to(
     payload: DeltaOrFullState,
     sender_summary_bytes: Vec<u8>,
     sender_addr: SocketAddr,
+    // Peers the sender says it already delivered to (#5147). Empty for the
+    // legacy `BroadcastTo`, which names none.
+    covered: crate::ring::broadcast_coverage::CoveredPeers,
 ) -> Result<(), OpError> {
     #[cfg(any(test, feature = "testing"))]
     RELAY_UPDATE_DRIVER_CALL_COUNT.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
@@ -807,6 +849,7 @@ pub(crate) async fn start_relay_broadcast_to(
         payload,
         sender_summary_bytes,
         sender_addr,
+        covered,
     ));
     Ok(())
 }
@@ -872,6 +915,7 @@ async fn run_relay_request_update(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn run_relay_broadcast_to(
     guard: RelayUpdateInflightGuard,
     op_manager: Arc<OpManager>,
@@ -880,6 +924,7 @@ async fn run_relay_broadcast_to(
     payload: DeltaOrFullState,
     sender_summary_bytes: Vec<u8>,
     sender_addr: SocketAddr,
+    covered: crate::ring::broadcast_coverage::CoveredPeers,
 ) {
     let _guard = guard;
 
@@ -890,6 +935,7 @@ async fn run_relay_broadcast_to(
         payload,
         sender_summary_bytes,
         sender_addr,
+        covered,
     )
     .await
     {
@@ -978,6 +1024,11 @@ async fn drive_relay_request_update(
             related_contracts.clone(),
             crate::contract::Priority::NetworkRelay,
             crate::node::ApplyOrigin::NetworkRelay,
+            // #5147: a `RequestUpdate` names no delivery targets (it is a
+            // routed request, not a fan-out), so this apply attests to no
+            // coverage. Registering empty is deliberate — see the two
+            // client-local sites.
+            crate::ring::broadcast_coverage::BroadcastOrigin::local(),
         )
         .await?;
 
@@ -1683,6 +1734,7 @@ fn seed_sender_summary_from_broadcast(
 ///    on full-state failure → `try_auto_fetch_contract`.
 /// 5. Telemetry: `update_broadcast_applied`.
 /// 6. Spawn proactive summary notification background task.
+#[allow(clippy::too_many_arguments)]
 async fn drive_relay_broadcast_to(
     op_manager: &OpManager,
     incoming_tx: Transaction,
@@ -1690,6 +1742,7 @@ async fn drive_relay_broadcast_to(
     payload: DeltaOrFullState,
     sender_summary_bytes: Vec<u8>,
     sender_addr: SocketAddr,
+    covered: crate::ring::broadcast_coverage::CoveredPeers,
 ) -> Result<(), OpError> {
     let self_location = op_manager.ring.connection_manager.own_location();
 
@@ -1803,6 +1856,7 @@ async fn drive_relay_broadcast_to(
         RelatedContracts::default(),
         crate::contract::Priority::NetworkRelay,
         crate::node::ApplyOrigin::NetworkRelay,
+        resolve_covered_peers(op_manager, &key, &incoming_tx, sender_addr, &covered),
     )
     .await;
 
@@ -2209,6 +2263,7 @@ pub(crate) async fn start_relay_request_update_streaming(
 
 /// Spawn a relay driver for a fresh inbound
 /// `UpdateMsg::BroadcastToStreaming`.
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn start_relay_broadcast_to_streaming(
     op_manager: Arc<OpManager>,
     incoming_tx: Transaction,
@@ -2216,6 +2271,9 @@ pub(crate) async fn start_relay_broadcast_to_streaming(
     stream_id: StreamId,
     total_size: u64,
     sender_addr: SocketAddr,
+    // Peers the sender says it already delivered to (#5147). Empty for the
+    // legacy `BroadcastToStreaming`.
+    covered: crate::ring::broadcast_coverage::CoveredPeers,
 ) -> Result<(), OpError> {
     #[cfg(any(test, feature = "testing"))]
     RELAY_UPDATE_STREAMING_DRIVER_CALL_COUNT.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
@@ -2260,6 +2318,7 @@ pub(crate) async fn start_relay_broadcast_to_streaming(
         stream_id,
         total_size,
         sender_addr,
+        covered,
     ));
     Ok(())
 }
@@ -2324,6 +2383,7 @@ async fn run_relay_request_update_streaming(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn run_relay_broadcast_to_streaming(
     guard: RelayUpdateStreamingInflightGuard,
     op_manager: Arc<OpManager>,
@@ -2332,6 +2392,7 @@ async fn run_relay_broadcast_to_streaming(
     stream_id: StreamId,
     total_size: u64,
     sender_addr: SocketAddr,
+    covered: crate::ring::broadcast_coverage::CoveredPeers,
 ) {
     let _guard = guard;
 
@@ -2342,6 +2403,7 @@ async fn run_relay_broadcast_to_streaming(
         stream_id,
         total_size,
         sender_addr,
+        covered,
     )
     .await
     {
@@ -2473,6 +2535,9 @@ async fn drive_relay_request_update_streaming(
         related_contracts,
         crate::contract::Priority::NetworkRelay,
         crate::node::ApplyOrigin::NetworkRelay,
+        // A streaming `RequestUpdateStreaming` names no delivery targets; see
+        // the non-streaming twin.
+        crate::ring::broadcast_coverage::BroadcastOrigin::local(),
     )
     .await?;
 
@@ -2534,6 +2599,7 @@ async fn drive_relay_broadcast_to_streaming(
     stream_id: StreamId,
     total_size: u64,
     sender_addr: SocketAddr,
+    covered: crate::ring::broadcast_coverage::CoveredPeers,
 ) -> Result<(), OpError> {
     use crate::operations::orphan_streams::{OrphanStreamError, STREAM_CLAIM_TIMEOUT};
 
@@ -2620,6 +2686,7 @@ async fn drive_relay_broadcast_to_streaming(
         state_bytes,
         sender_summary_bytes,
         sender_addr,
+        covered,
     )
     .await
 }
@@ -2630,6 +2697,7 @@ async fn drive_relay_broadcast_to_streaming(
 /// proactive summary. Extracted from the driver so the #4857 queue-full heal on
 /// the streaming path is unit-testable without the transport stream plumbing
 /// (steps 1-3: claim + assemble + deserialize).
+#[allow(clippy::too_many_arguments)]
 async fn apply_streaming_broadcast(
     op_manager: &OpManager,
     incoming_tx: Transaction,
@@ -2637,6 +2705,7 @@ async fn apply_streaming_broadcast(
     state_bytes: Vec<u8>,
     sender_summary_bytes: Vec<u8>,
     sender_addr: SocketAddr,
+    covered: crate::ring::broadcast_coverage::CoveredPeers,
 ) -> Result<(), OpError> {
     let mut receiver_terminal = op_manager
         .payload_mix
@@ -2716,6 +2785,7 @@ async fn apply_streaming_broadcast(
         RelatedContracts::default(),
         crate::contract::Priority::NetworkRelay,
         crate::node::ApplyOrigin::NetworkRelay,
+        resolve_covered_peers(op_manager, &key, &incoming_tx, sender_addr, &covered),
     )
     .await;
 
@@ -4050,6 +4120,7 @@ mod tests {
             DeltaOrFullState::Delta(vec![1, 2, 3]),
             Vec::new(),
             sender_addr,
+            crate::ring::broadcast_coverage::CoveredPeers::empty(),
         )
         .await;
         assert!(
@@ -4075,6 +4146,7 @@ mod tests {
             DeltaOrFullState::Delta(vec![4, 5, 6]),
             Vec::new(),
             sender_addr,
+            crate::ring::broadcast_coverage::CoveredPeers::empty(),
         )
         .await;
         assert!(
@@ -4124,6 +4196,7 @@ mod tests {
             vec![1, 2, 3],
             Vec::new(),
             sender_addr,
+            crate::ring::broadcast_coverage::CoveredPeers::empty(),
         )
         .await;
         assert!(
@@ -4148,6 +4221,7 @@ mod tests {
             vec![4, 5, 6],
             Vec::new(),
             sender_addr,
+            crate::ring::broadcast_coverage::CoveredPeers::empty(),
         )
         .await;
         assert!(
@@ -4360,6 +4434,7 @@ mod tests {
                 DeltaOrFullState::Delta(bytes),
                 Vec::new(),
                 sender,
+                crate::ring::broadcast_coverage::CoveredPeers::empty(),
             )
             .await;
             assert!(r.is_err(), "each poison delta must fail the merge");
@@ -4380,6 +4455,7 @@ mod tests {
             DeltaOrFullState::Delta(vec![4u8]),
             Vec::new(),
             sender,
+            crate::ring::broadcast_coverage::CoveredPeers::empty(),
         )
         .await;
         assert!(
@@ -4426,6 +4502,7 @@ mod tests {
                 DeltaOrFullState::Delta(bytes),
                 Vec::new(),
                 sender,
+                crate::ring::broadcast_coverage::CoveredPeers::empty(),
             )
             .await;
             let _ = drain_resync_targets(&mut notification_rx, key);
@@ -4439,6 +4516,7 @@ mod tests {
             DeltaOrFullState::FullState(vec![9, 9, 9]),
             Vec::new(),
             sender,
+            crate::ring::broadcast_coverage::CoveredPeers::empty(),
         )
         .await;
         assert!(
@@ -4456,6 +4534,7 @@ mod tests {
             DeltaOrFullState::Delta(vec![3u8]),
             Vec::new(),
             sender,
+            crate::ring::broadcast_coverage::CoveredPeers::empty(),
         )
         .await;
         let _ = drain_resync_targets(&mut notification_rx, key);
@@ -4470,6 +4549,7 @@ mod tests {
             DeltaOrFullState::Delta(vec![4u8]),
             Vec::new(),
             sender,
+            crate::ring::broadcast_coverage::CoveredPeers::empty(),
         )
         .await;
         assert!(r.is_ok());
@@ -4508,6 +4588,7 @@ mod tests {
                 DeltaOrFullState::Delta(bytes),
                 Vec::new(),
                 sender_a,
+                crate::ring::broadcast_coverage::CoveredPeers::empty(),
             )
             .await;
             let _ = drain_resync_targets(&mut notification_rx, key);
@@ -4526,6 +4607,7 @@ mod tests {
             DeltaOrFullState::Delta(vec![4u8]),
             Vec::new(),
             sender_a,
+            crate::ring::broadcast_coverage::CoveredPeers::empty(),
         )
         .await;
         assert!(ra.is_ok(), "A's suppressed broadcast completes Ok");
@@ -4545,6 +4627,7 @@ mod tests {
             DeltaOrFullState::Delta(vec![5u8]),
             Vec::new(),
             sender_b,
+            crate::ring::broadcast_coverage::CoveredPeers::empty(),
         )
         .await;
         let _ = drain_resync_targets(&mut notification_rx, key);
@@ -4585,6 +4668,7 @@ mod tests {
                 DeltaOrFullState::Delta(bytes),
                 Vec::new(),
                 sender,
+                crate::ring::broadcast_coverage::CoveredPeers::empty(),
             )
             .await;
             let _ = drain_resync_targets(&mut notification_rx, key);
@@ -4633,6 +4717,7 @@ mod tests {
                 DeltaOrFullState::Delta(vec![i as u8]),
                 Vec::new(),
                 sender,
+                crate::ring::broadcast_coverage::CoveredPeers::empty(),
             )
             .await;
         }
@@ -4882,6 +4967,7 @@ mod tests {
                 DeltaOrFullState::Delta(p.clone()),
                 Vec::new(),
                 sender_b,
+                crate::ring::broadcast_coverage::CoveredPeers::empty(),
             )
             .await;
             assert!(
@@ -4913,6 +4999,7 @@ mod tests {
             DeltaOrFullState::Delta(vec![94u8]),
             Vec::new(),
             sender_b,
+            crate::ring::broadcast_coverage::CoveredPeers::empty(),
         )
         .await;
         let _ = drain_resync_targets(&mut notification_rx, key);
@@ -5361,6 +5448,7 @@ mod tests {
             DeltaOrFullState::Delta(vec![1, 2, 3]),
             Vec::new(),
             sender_addr,
+            crate::ring::broadcast_coverage::CoveredPeers::empty(),
         )
         .await;
         assert!(
@@ -5442,6 +5530,7 @@ mod tests {
             DeltaOrFullState::Delta(vec![1, 2, 3]),
             Vec::new(),
             sender_addr,
+            crate::ring::broadcast_coverage::CoveredPeers::empty(),
         )
         .await;
         assert!(
@@ -5518,6 +5607,7 @@ mod tests {
             DeltaOrFullState::Delta(vec![1, 2, 3]),
             Vec::new(),
             sender_addr,
+            crate::ring::broadcast_coverage::CoveredPeers::empty(),
         )
         .await;
         assert!(
@@ -5606,6 +5696,7 @@ mod tests {
             DeltaOrFullState::Delta(vec![1, 2, 3]),
             Vec::new(),
             sender_addr,
+            crate::ring::broadcast_coverage::CoveredPeers::empty(),
         )
         .await;
         assert!(

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -769,13 +769,55 @@ pub(crate) async fn start_relay_request_update(
 /// `tx` is the transaction the list arrived on. The hashes are seeded with it,
 /// so resolving under any other transaction yields nothing; that is what stops
 /// a list from being replayed onto a different broadcast.
-fn resolve_covered_peers(
+///
+/// # Both halves are behind the #5147 version gate, including the sender
+///
+/// The sender exclusion needs no wire change of its own — it is a decision
+/// about our OWN fan-out — so it would ship unconditionally if left ungated.
+/// It is gated anyway, and deliberately:
+///
+/// * It has the same unsafe shape as the target list. Excluding the peer that
+///   delivered a payload assumes it holds what we are about to send, and on a
+///   merge path our post-merge state can be strictly newer than what it sent
+///   us. That is the same assumption the target list makes, so it deserves the
+///   same caution rather than inheriting the list's without its gate.
+/// * Ungated, it would reach every peer on the floor release with none of the
+///   machinery that makes the rest of this reviewable — no sim override, so no
+///   simulation could turn it off to get a baseline, and no version floor, so
+///   no staged rollout.
+///
+/// Gating on the SENDER's version is the coherent choice: if the peer that
+/// delivered this payload predates the feature, we are in the legacy world
+/// with it and behave toward it exactly as today. An unknown version fails
+/// closed, which on a gateway link is the common case until #5161 deploys.
+/// NOTE: `pub(crate)` rather than private, and deliberately NOT reached through
+/// a test-only shim, so a unit test in `node::op_state_manager` drives the real
+/// gate.
+///
+/// A test-gated item must not be introduced above this point in the file. The
+/// source-scrape pins below slice production code with `production_source`,
+/// which truncates the file at the first test-gate attribute, so an earlier one
+/// silently hides every function after it from those pins — they then fail with
+/// "could not find ...", or worse, pass vacuously. Note the attribute must not
+/// be spelled out in prose here either: `production_source` matches the literal
+/// text, so even a comment mentioning it truncates the slice. That is not
+/// hypothetical; writing this warning the obvious way broke four pins.
+pub(crate) fn resolve_covered_peers(
     op_manager: &OpManager,
     key: &ContractKey,
     tx: &Transaction,
     sender_addr: SocketAddr,
     covered: &crate::ring::broadcast_coverage::CoveredPeers,
 ) -> crate::ring::broadcast_coverage::BroadcastOrigin {
+    if !op_manager
+        .ring
+        .connection_manager
+        .supports_broadcast_target_list(sender_addr)
+    {
+        // Pre-floor or unknown sender: no suppression of any kind, so this
+        // node's fan-out is byte-for-byte what it is today.
+        return crate::ring::broadcast_coverage::BroadcastOrigin::local();
+    }
     let resolved = if covered.is_empty() {
         std::collections::HashSet::new()
     } else {

--- a/crates/core/src/operations/update/propagation_stats.rs
+++ b/crates/core/src/operations/update/propagation_stats.rs
@@ -918,6 +918,29 @@ mod tests {
              propagation failure."
         );
 
+        // The fully-covered branch must NOT drop the #4359 stash: it sends
+        // nothing, so a stashed state that reached nobody is not superseded by
+        // it. Only the targets-found path, which does send, may drop it.
+        let covered_pos = source
+            .find("let fully_covered =")
+            .expect("the #5147 fully-covered branch is missing");
+        let retry_pos = source
+            .find("self.broadcast_retries.entry(key)")
+            .expect("the no-target retry branch is missing");
+        let covered_branch = &source[covered_pos..retry_pos];
+        assert!(
+            !covered_branch.contains("pending_broadcasts.take(")
+                || covered_branch.contains(".stash("),
+            "the fully-covered branch must not DISCARD the #4359 \
+             pending-broadcast stash. It sends zero bytes, so the stashed state \
+             — which by definition reached nobody — is not superseded by it, \
+             and the peers it suppressed hold the ORIGINATOR's payload, which \
+             does not contain that state. Taking the stash without putting the \
+             current state back deletes the only non-heartbeat recovery path \
+             for content that has never propagated. Refreshing it is correct; \
+             discarding it is not."
+        );
+
         // The no-target record must be gated on `!is_retry && !is_reemit` so
         // neither retry re-emissions (Codex P2) nor #4359 deferred-broadcast
         // re-emissions get counted as fresh misses (re-review SHOULD-FIX 5:

--- a/crates/core/src/operations/update/propagation_stats.rs
+++ b/crates/core/src/operations/update/propagation_stats.rs
@@ -729,12 +729,26 @@ mod tests {
     /// `.claude/rules/bug-prevention-patterns.md`).
     ///
     /// The handler records each fresh logical broadcast's outcome exactly
-    /// once: a NO_TARGETS record on the fresh-broadcast path (gated on
-    /// `!is_retry && !is_reemit`, so neither retry re-emissions nor #4359
-    /// deferred-broadcast re-emissions record a miss), and a success record on
-    /// the targets-found path. That's two call sites; this pins both so neither
-    /// outcome arm is dropped, and pins the gate so a refactor can't start
-    /// counting retry / deferred re-emissions as fresh misses.
+    /// once, and there are now THREE terminal outcomes:
+    ///
+    /// 1. NO_TARGETS on the fresh-broadcast path (gated on `!is_retry &&
+    ///    !is_reemit`, so neither retry re-emissions nor #4359
+    ///    deferred-broadcast re-emissions record a miss);
+    /// 2. success on the targets-found path;
+    /// 3. success with a ZERO target count on the #5147 fully-covered path —
+    ///    every eligible peer was already named by the originator (or is the
+    ///    sender), so the fan-out is complete with nothing to send.
+    ///
+    /// The third was added with #5147 and is deliberately NOT folded into
+    /// arm 1 despite also having zero targets: a fully-covered fan-out is a
+    /// SUCCESS, and counting it as `no_targets` would make the operator-facing
+    /// propagation summary report a propagation failure every time the feature
+    /// works perfectly — the loudest possible false alarm, on the path the
+    /// design expects to be common in the clique regime.
+    ///
+    /// This pins all three so no outcome arm is dropped, and pins the gate so a
+    /// refactor can't start counting retry / deferred re-emissions as fresh
+    /// misses.
     #[test]
     fn broadcast_path_feeds_propagation_stats_pin_test() {
         // `handle_broadcast_state_change` lives in the `broadcast` submodule
@@ -748,12 +762,13 @@ mod tests {
             .matches("update_propagation_stats.record_broadcast(")
             .count();
         assert_eq!(
-            call_count, 2,
+            call_count, 3,
             "handle_broadcast_state_change must call \
-             `update_propagation_stats.record_broadcast(...)` exactly twice — once \
-             on the fresh no-target path and once on the targets-found success \
-             path. Found {call_count}. A different count means an outcome arm was \
-             dropped (silent telemetry rot) or recording leaked elsewhere."
+             `update_propagation_stats.record_broadcast(...)` exactly three times \
+             — the fresh no-target path, the targets-found success path, and the \
+             #5147 fully-covered success path. Found {call_count}. A different \
+             count means an outcome arm was dropped (silent telemetry rot) or \
+             recording leaked elsewhere."
         );
 
         // The no-target record must be gated on `!is_retry && !is_reemit` so

--- a/crates/core/src/operations/update/propagation_stats.rs
+++ b/crates/core/src/operations/update/propagation_stats.rs
@@ -81,7 +81,18 @@ struct ContractCounters {
     targets_total: u64,
     /// Number of attempts that resolved zero targets (the NO_TARGETS branch:
     /// the update did not propagate further from this node).
+    ///
+    /// A fully-covered fan-out (#5147) also resolves zero targets but is a
+    /// SUCCESS, and is counted in [`Self::fully_covered`] instead. Keeping the
+    /// two apart is load-bearing: in the clique regime #5147 targets, a
+    /// fully-covered fan-out is the *expected* outcome, so folding it in here
+    /// would report a propagation failure to operators in direct proportion to
+    /// how well the feature works.
     no_targets: u64,
+    /// Number of attempts that sent nothing because every eligible peer had
+    /// already been served by the originator (#5147). Zero targets, but a
+    /// completed fan-out rather than a failure.
+    fully_covered: u64,
     /// Sum of interest-manager peers that failed to resolve to a live
     /// connection across the window (the `interest_resolve_failed` counter
     /// from `BroadcastTargetResult`). A persistently non-zero value points at
@@ -95,6 +106,7 @@ impl ContractCounters {
         self.updates == 0
             && self.targets_total == 0
             && self.no_targets == 0
+            && self.fully_covered == 0
             && self.interest_resolve_failed == 0
     }
 }
@@ -108,6 +120,10 @@ pub(crate) struct ContractSummary {
     pub(crate) updates: u64,
     pub(crate) targets_total: u64,
     pub(crate) no_targets: u64,
+    /// Attempts that sent nothing because the originator had already served
+    /// every eligible peer (#5147). A success, deliberately NOT folded into
+    /// `no_targets`.
+    pub(crate) fully_covered: u64,
     pub(crate) interest_resolve_failed: u64,
 }
 
@@ -136,6 +152,9 @@ pub(crate) struct WindowSummary {
     pub(crate) targets_total: u64,
     /// Total attempts that resolved zero targets this window.
     pub(crate) no_targets: u64,
+    /// Total fully-covered fan-outs this window (#5147): zero targets because
+    /// the originator already served everyone, which is a success.
+    pub(crate) fully_covered: u64,
     /// Total interest-resolve failures across all contracts this window.
     pub(crate) interest_resolve_failed: u64,
     /// The top-K contracts by update activity (descending), for per-contract
@@ -178,6 +197,7 @@ pub(crate) fn aggregate_window(
     let updates: u64 = summaries.iter().map(|s| s.updates).sum();
     let targets_total: u64 = summaries.iter().map(|s| s.targets_total).sum();
     let no_targets: u64 = summaries.iter().map(|s| s.no_targets).sum();
+    let fully_covered: u64 = summaries.iter().map(|s| s.fully_covered).sum();
     let interest_resolve_failed: u64 = summaries.iter().map(|s| s.interest_resolve_failed).sum();
 
     // Most active first; deterministic tie-break on the contract's raw bytes
@@ -199,6 +219,7 @@ pub(crate) fn aggregate_window(
         updates,
         targets_total,
         no_targets,
+        fully_covered,
         interest_resolve_failed,
         top: summaries,
         others,
@@ -259,6 +280,38 @@ impl UpdatePropagationStats {
         entry.interest_resolve_failed += interest_resolve_failed as u64;
     }
 
+    /// Record a fan-out that sent nothing because the originator had already
+    /// served every eligible peer (#5147).
+    ///
+    /// Deliberately a SEPARATE entry point from [`Self::record_broadcast`]
+    /// rather than a `targets == 0` call into it. That call would land in the
+    /// `no_targets` bucket, which is the operator-facing propagation-FAILURE
+    /// counter — and in the clique regime #5147 targets, a fully-covered
+    /// fan-out is the expected outcome, so the summary would report a failure
+    /// in direct proportion to how well the feature works. Counting it here
+    /// keeps the outcome attributed by the code that decided it, per the
+    /// "metric describing a filtering decision" rule in
+    /// `.claude/rules/bug-prevention-patterns.md`.
+    ///
+    /// `updates` is still incremented so the #4281 liveness summary sees one
+    /// broadcast per apply, and `targets_total` is not, so `targets_avg`
+    /// honestly reflects that no peer was sent to.
+    pub(crate) fn record_fully_covered_broadcast(
+        &self,
+        contract: ContractInstanceId,
+        interest_resolve_failed: usize,
+    ) {
+        if !self.contracts.contains_key(&contract) && self.contracts.len() >= MAX_TRACKED_CONTRACTS
+        {
+            return;
+        }
+
+        let mut entry = self.contracts.entry(contract).or_default();
+        entry.updates += 1;
+        entry.fully_covered += 1;
+        entry.interest_resolve_failed += interest_resolve_failed as u64;
+    }
+
     /// Snapshot every tracked contract's counters into per-contract window
     /// summaries, then clear the map.
     ///
@@ -283,6 +336,7 @@ impl UpdatePropagationStats {
                     updates: counters.updates,
                     targets_total: counters.targets_total,
                     no_targets: counters.no_targets,
+                    fully_covered: counters.fully_covered,
                     interest_resolve_failed: counters.interest_resolve_failed,
                 });
             }
@@ -306,6 +360,7 @@ impl UpdatePropagationStats {
             updates = summary.updates,
             targets_avg = summary.targets_avg(),
             no_targets = summary.no_targets,
+            fully_covered = summary.fully_covered,
             interest_resolve_failed = summary.interest_resolve_failed,
             window_s = SUMMARY_WINDOW.as_secs(),
             phase = "summary",
@@ -318,6 +373,7 @@ impl UpdatePropagationStats {
                 updates = c.updates,
                 targets_avg = c.targets_avg(),
                 no_targets = c.no_targets,
+                fully_covered = c.fully_covered,
                 interest_resolve_failed = c.interest_resolve_failed,
                 phase = "summary_contract",
                 "update_propagation_summary contract detail"
@@ -389,6 +445,7 @@ mod tests {
             updates: 0,
             targets_total: 0,
             no_targets: 0,
+            fully_covered: 0,
             interest_resolve_failed: 5,
         }];
         assert!(aggregate_window(summaries, TOP_K).is_none());
@@ -402,6 +459,7 @@ mod tests {
                 updates: 2,
                 targets_total: 10, // avg 5
                 no_targets: 0,
+                fully_covered: 0,
                 interest_resolve_failed: 1,
             },
             ContractSummary {
@@ -409,6 +467,7 @@ mod tests {
                 updates: 3,
                 targets_total: 0, // all no-target attempts
                 no_targets: 3,
+                fully_covered: 0,
                 interest_resolve_failed: 4,
             },
         ];
@@ -437,6 +496,7 @@ mod tests {
                 updates: u64::from(i) + 1, // 1,2,3,4,5
                 targets_total: 0,
                 no_targets: 0,
+                fully_covered: 0,
                 interest_resolve_failed: 0,
             })
             .collect();
@@ -459,6 +519,7 @@ mod tests {
                 updates: 1,
                 targets_total: 0,
                 no_targets: 0,
+                fully_covered: 0,
                 interest_resolve_failed: 0,
             },
             ContractSummary {
@@ -466,6 +527,7 @@ mod tests {
                 updates: 1,
                 targets_total: 0,
                 no_targets: 0,
+                fully_covered: 0,
                 interest_resolve_failed: 0,
             },
         ];
@@ -721,6 +783,68 @@ mod tests {
         );
     }
 
+    /// A fully-covered fan-out (#5147) must NOT read as a propagation failure.
+    ///
+    /// Regression test for the shipped-comment-vs-code split described on
+    /// `broadcast_path_feeds_propagation_stats_pin_test`: the fully-covered arm
+    /// originally called `record_broadcast(key, 0, …)` beneath a comment saying
+    /// it avoided the `no_targets` counter, while `record_broadcast`
+    /// unconditionally increments `no_targets` whenever `targets == 0`.
+    ///
+    /// The mutation that must make this red is exactly that regression —
+    /// replace the `record_fully_covered_broadcast` call with
+    /// `record_broadcast(c, 0, 0)` and `no_targets` becomes 1.
+    ///
+    /// `updates` is still asserted, because the opposite over-correction (not
+    /// recording the outcome at all) would silently lose the #4281 liveness
+    /// signal for every fan-out the feature suppresses — which, in the regime
+    /// this design targets, is most of them.
+    #[test]
+    fn a_fully_covered_fanout_is_not_counted_as_a_propagation_failure() {
+        let stats = UpdatePropagationStats::new();
+        let c = cid(7);
+
+        stats.record_fully_covered_broadcast(c, 0);
+
+        let summaries = stats.drain_window();
+        assert_eq!(summaries.len(), 1, "the outcome must be recorded at all");
+        let s = &summaries[0];
+
+        assert_eq!(
+            s.no_targets, 0,
+            "a fully-covered fan-out is a SUCCESS and must never land in \
+             `no_targets`, the operator-facing propagation-failure counter — \
+             otherwise the summary reports a failure in direct proportion to \
+             how well #5147 is working"
+        );
+        assert_eq!(
+            s.fully_covered, 1,
+            "the outcome must be attributed to the counter that names it"
+        );
+        assert_eq!(
+            s.updates, 1,
+            "the #4281 liveness summary must still see one broadcast per apply"
+        );
+        assert_eq!(
+            s.targets_total, 0,
+            "no peer was sent to, so `targets_avg` must reflect zero rather \
+             than inflating the mean"
+        );
+
+        // The counterfactual, asserted rather than described: the call the bug
+        // used produces the false alarm. If a future edit makes
+        // `record_broadcast(c, 0, _)` stop counting `no_targets`, this arm goes
+        // red and the two entry points need re-examining.
+        let regressed = UpdatePropagationStats::new();
+        regressed.record_broadcast(c, 0, 0);
+        let regressed_summaries = regressed.drain_window();
+        assert_eq!(
+            regressed_summaries[0].no_targets, 1,
+            "`record_broadcast` with zero targets is the propagation-FAILURE \
+             path — that is precisely why the fully-covered arm must not use it"
+        );
+    }
+
     /// Source-scrape pin for the broadcast-path wiring. The counters are only
     /// useful if the fan-out handler actually feeds them; a future task-per-tx
     /// migration or refactor of `handle_broadcast_state_change` could silently
@@ -739,12 +863,21 @@ mod tests {
     ///    every eligible peer was already named by the originator (or is the
     ///    sender), so the fan-out is complete with nothing to send.
     ///
-    /// The third was added with #5147 and is deliberately NOT folded into
-    /// arm 1 despite also having zero targets: a fully-covered fan-out is a
-    /// SUCCESS, and counting it as `no_targets` would make the operator-facing
-    /// propagation summary report a propagation failure every time the feature
-    /// works perfectly — the loudest possible false alarm, on the path the
-    /// design expects to be common in the clique regime.
+    /// The third was added with #5147 and goes through its OWN entry point,
+    /// [`UpdatePropagationStats::record_fully_covered_broadcast`], precisely so
+    /// it cannot land in the `no_targets` bucket. Counting it there would make
+    /// the operator-facing propagation summary report a propagation failure
+    /// every time the feature works perfectly — the loudest possible false
+    /// alarm, on the path the design expects to be common in the clique regime.
+    ///
+    /// The first version of #5147 got this wrong in the most instructive way:
+    /// it called `record_broadcast(key, 0, …)` under a comment asserting that
+    /// it did NOT go through `no_targets`, while `record_broadcast`
+    /// unconditionally does `if targets == 0 { no_targets += 1 }`. The comment
+    /// and the code disagreed, and this pin — asserting only a CALL COUNT —
+    /// passed either way. Hence the separate-entry-point assertion below and
+    /// the behavioural test
+    /// `a_fully_covered_fanout_is_not_counted_as_a_propagation_failure`.
     ///
     /// This pins all three so no outcome arm is dropped, and pins the gate so a
     /// refactor can't start counting retry / deferred re-emissions as fresh
@@ -762,13 +895,27 @@ mod tests {
             .matches("update_propagation_stats.record_broadcast(")
             .count();
         assert_eq!(
-            call_count, 3,
+            call_count, 2,
             "handle_broadcast_state_change must call \
-             `update_propagation_stats.record_broadcast(...)` exactly three times \
-             — the fresh no-target path, the targets-found success path, and the \
-             #5147 fully-covered success path. Found {call_count}. A different \
-             count means an outcome arm was dropped (silent telemetry rot) or \
-             recording leaked elsewhere."
+             `update_propagation_stats.record_broadcast(...)` exactly twice \
+             — the fresh no-target path and the targets-found success path. \
+             Found {call_count}. A different count means an outcome arm was \
+             dropped (silent telemetry rot) or recording leaked elsewhere."
+        );
+
+        // The #5147 fully-covered arm must use its OWN entry point. Routing it
+        // back through `record_broadcast(..., 0, ...)` would silently restore
+        // the false-alarm bug: that call increments `no_targets`, the
+        // operator-facing propagation-FAILURE counter, on the outcome that
+        // means the feature is working.
+        let fully_covered_calls = source.matches(".record_fully_covered_broadcast(").count();
+        assert_eq!(
+            fully_covered_calls, 1,
+            "the #5147 fully-covered fan-out must be recorded exactly once, via \
+             `record_fully_covered_broadcast(...)`. Found {fully_covered_calls}. \
+             If this dropped to 0 the arm was re-routed through \
+             `record_broadcast`, which counts a zero-target fan-out as a \
+             propagation failure."
         );
 
         // The no-target record must be gated on `!is_retry && !is_reemit` so

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -80,6 +80,7 @@ const _: () = {
     );
 };
 
+pub(crate) mod broadcast_coverage;
 mod broken_invariants;
 mod connection_backoff;
 mod connection_manager;

--- a/crates/core/src/ring/broadcast_coverage.rs
+++ b/crates/core/src/ring/broadcast_coverage.rs
@@ -49,16 +49,33 @@
 //! targets into it. Measured hop-2 suppression is already 0.99, so multi-hop
 //! buys nothing.
 //!
-//! It also closes an attack. The list is an attestation of the sender's own
-//! actions: a malicious ORIGINATOR "suppressing" its own update is a non-attack
-//! (it could simply not send). A malicious RELAYER attaching a fabricated
-//! "everyone is covered" list to a genuine update could suppress third-party
-//! re-fan-out for a cycle. The rule that closes it: **honor a list only from
-//! the message that delivered the payload.** One-hop makes that free, and it is
-//! enforced structurally — [`CoveredPeers`] is only ever read out of the
-//! payload-bearing `BroadcastToV2` / `BroadcastToStreamingV2` variants, and the
-//! re-fan-out builds a fresh list from its own targets rather than propagating
-//! the one it received.
+//! It also narrows an attack, and it is worth being exact about which one,
+//! because an earlier version of this comment claimed more than the design
+//! delivers.
+//!
+//! The rule is: **honor a list only from the message that delivered the
+//! payload.** That is enforced structurally — [`CoveredPeers`] is only ever
+//! read out of the payload-bearing `BroadcastToV2` / `BroadcastToStreamingV2`
+//! variants, and the re-fan-out builds a fresh list from its own targets rather
+//! than propagating the one it received.
+//!
+//! What that CLOSES: a peer which delivers nothing cannot assert coverage. It
+//! must actually carry the payload to be listened to, so a bystander cannot
+//! silence a fan-out it is not part of.
+//!
+//! What it does NOT close, stated plainly: a relayer that genuinely delivers
+//! the payload can still fabricate the list. It mints the `update_tx` that
+//! seeds the hashes, and `resolve` verifies nothing about the claim. So a
+//! malicious co-host M can forward a real update to B naming all of B's
+//! co-hosts, and B suppresses its entire re-fan-out for one cycle; where B is a
+//! cut vertex, propagation past B stops until the ~5-minute heartbeat heals it.
+//!
+//! Note this is an AMPLIFICATION rather than a new capability, which is the
+//! honest framing — "a malicious originator could simply not send" is true but
+//! does not bound it. Withholding costs M its own links; lying costs M's links
+//! PLUS B's entire fan-out. The residual is bounded (one hop, one cycle,
+//! anti-entropy heals it, and the attacker must already be an advertised
+//! co-host in the delivery path) and is accepted, not closed.
 //!
 //! # Transaction-seeded hashing
 //!
@@ -69,9 +86,17 @@
 //! co-host sets across transactions to infer topology. The receiver
 //! reconstructs the seed from the transaction id carried on the same message.
 //!
+//! What tx-seeding does NOT prevent, since the seed travels in the clear on the
+//! same message: the RECIPIENT can test membership for this one broadcast. It
+//! computes `blake3(tx || pk)[..8]` for any public key it holds and learns
+//! whether that peer was served — including peers that advertised co-hosting to
+//! the SENDER but never to it. Marginal over the existing neighbor-hosting
+//! gossip, but not nothing. Against an off-path observer there is no leak: the
+//! list only ever rides an established, point-to-point encrypted peer link.
+//!
 //! Note that in production each fan-out leg mints its OWN transaction
 //! (`broadcast_queue.rs`), so the list is built per-recipient. That is a
-//! handful of 48-byte hashes per send and is not measurable next to the WASM
+//! handful of 8-byte hashes per send and is not measurable next to the WASM
 //! merge it precedes.
 //!
 //! # Provenance: how the list reaches the fan-out decision
@@ -201,7 +226,22 @@ impl CoveredPeers {
         if self.hashes.is_empty() {
             return HashSet::new();
         }
-        let named: HashSet<PeerHash> = self.hashes.iter().copied().collect();
+        // Receive-side bound. [`MAX_COVERED_PEERS`] is enforced in
+        // `from_targets`, which is sender self-discipline: a remote peer's list
+        // arrives with whatever length it chose. The wire already bounds it in
+        // practice (a short message caps around 170 hashes) and the cost here is
+        // O(candidates) rather than O(named), so this is not closing an
+        // amplification — it is making the documented cap an invariant of the
+        // type rather than a property of one construction path. Truncating
+        // (rather than rejecting) keeps the over-cap direction the same as the
+        // sender's: name fewer peers, suppress fewer, degrade toward today's
+        // unsuppressed behaviour.
+        let named: HashSet<PeerHash> = self
+            .hashes
+            .iter()
+            .take(MAX_COVERED_PEERS)
+            .copied()
+            .collect();
         candidates
             .into_iter()
             .filter(|pub_key| named.contains(&peer_hash(tx, pub_key)))
@@ -806,9 +846,27 @@ mod tests {
 
         // Every retained entry must still be a genuine member: truncation may
         // only lose suppression, never invent it.
+        //
+        // The obvious spelling of that — `resolved.iter().all(|p| peers.contains(p))`
+        // — cannot fail: `resolve` maps over the candidates it is handed, and
+        // the candidates here ARE `peers`, so it is asking whether a subset of a
+        // set is in that set. It was there and it proved nothing.
+        //
+        // What can fail: resolving against candidates the list never named must
+        // suppress NOBODY. That is the property "truncation cannot invent
+        // suppression" actually rests on, and it goes red if `resolve` ever
+        // matched on anything but the tx-seeded hash.
         let resolved = covered.resolve(&tx, peers.iter());
         assert_eq!(resolved.len(), MAX_COVERED_PEERS);
-        assert!(resolved.iter().all(|peer| peers.contains(&peer.0)));
+
+        let strangers: Vec<TransportPublicKey> = (0..8).map(|_| pub_key()).collect();
+        let resolved_strangers = covered.resolve(&tx, strangers.iter());
+        assert!(
+            resolved_strangers.is_empty(),
+            "a truncated list resolved against peers it never named suppressed \
+             {} of them; truncation may only LOSE suppression, never invent it",
+            resolved_strangers.len()
+        );
     }
 
     /// Encoding is canonical: the same peer set produces the same bytes

--- a/crates/core/src/ring/broadcast_coverage.rs
+++ b/crates/core/src/ring/broadcast_coverage.rs
@@ -409,6 +409,33 @@ impl BroadcastOrigin {
         }
     }
 
+    /// The update arrived over the network and named `covered`, but the SENDER
+    /// itself must not be excluded from our fan-out.
+    ///
+    /// Exists because the two halves of a relayed claim are gated differently,
+    /// and conflating them made the whole feature inert:
+    ///
+    /// * The covered LIST is self-gating. It rides only on `BroadcastToV2` /
+    ///   `BroadcastToStreamingV2`, so a pre-floor sender produces no list and
+    ///   suppresses nothing whatever we do. Receiving one IS the proof that the
+    ///   sender supports the feature — a stronger signal than any version
+    ///   lookup, because it is the sender's own act rather than our record of it.
+    /// * The sender EXCLUSION has no wire signal of its own, so it is gated on
+    ///   the sender's recorded version.
+    ///
+    /// Gating the list on the version table too looks equivalent and is not: a
+    /// node does not learn its gateway's version until #5167 propagates, so the
+    /// lookup fails closed on exactly the highest-degree links, and the list is
+    /// discarded even though the V2 message in hand proves it is honourable.
+    /// In simulation, where that ack gate defaults OFF, it zeroed suppression
+    /// outright.
+    pub(crate) fn relayed_list_only(covered: HashSet<PeerKey>) -> Self {
+        Self {
+            sender: None,
+            covered,
+        }
+    }
+
     /// The peer that delivered this update, if it came from the network.
     pub(crate) fn sender(&self) -> Option<&SocketAddr> {
         self.sender.as_ref()

--- a/crates/core/src/ring/broadcast_coverage.rs
+++ b/crates/core/src/ring/broadcast_coverage.rs
@@ -853,6 +853,47 @@ mod tests {
         assert!(covered.resolve(&tx(), [&peer]).is_empty());
     }
 
+    /// The receive-side cap must bound a list built OUTSIDE `from_targets`.
+    ///
+    /// `MAX_COVERED_PEERS` was enforced only in `from_targets`, which is sender
+    /// self-discipline — a remote peer's list arrives with whatever length it
+    /// chose. Every existing test constructs `CoveredPeers` through
+    /// `from_targets`, so it was already truncated before `resolve` saw it and
+    /// deleting the receive-side `.take()` made nothing red.
+    ///
+    /// This builds the struct directly, which is the actual threat model (an
+    /// oversized list off the wire), so the cap is tested as a property of the
+    /// TYPE rather than of one construction path.
+    ///
+    /// Mutation that must make this red: delete `.take(MAX_COVERED_PEERS)` in
+    /// `resolve`.
+    #[test]
+    fn resolve_bounds_an_oversized_inbound_list() {
+        let tx = tx();
+        let peers: Vec<TransportPublicKey> =
+            (0..(MAX_COVERED_PEERS + 12)).map(|_| pub_key()).collect();
+
+        // Every peer named, bypassing `from_targets`' truncation entirely.
+        let mut hashes: Vec<PeerHash> = peers.iter().map(|pk| peer_hash(&tx, pk)).collect();
+        hashes.sort_unstable();
+        hashes.dedup();
+        let oversized = CoveredPeers { hashes };
+        assert!(
+            oversized.len() > MAX_COVERED_PEERS,
+            "premise: the fixture must actually exceed the cap, or this test \
+             passes against any implementation"
+        );
+
+        let resolved = oversized.resolve(&tx, peers.iter());
+        assert!(
+            resolved.len() <= MAX_COVERED_PEERS,
+            "an inbound list of {} names resolved {} peers; the cap must hold \
+             for a list we did not build",
+            oversized.len(),
+            resolved.len()
+        );
+    }
+
     #[test]
     fn covered_peers_over_cap_truncates_rather_than_omitting() {
         let tx = tx();

--- a/crates/core/src/ring/broadcast_coverage.rs
+++ b/crates/core/src/ring/broadcast_coverage.rs
@@ -294,8 +294,13 @@ pub(crate) struct BroadcastCoverageStore {
 ///   for one with broken invariants, both BEFORE it takes the coverage — so
 ///   every applying broadcast on such a contract leaks an entry, precisely
 ///   during the storm conditions that set those flags (#4861 / #4903 shape);
-/// * `try_notify_node_event(BroadcastStateChange)` is best-effort by design
-///   (#4145), so a dropped event leaves a kept entry with no consumer.
+/// * the `BroadcastStateChange` notification is best-effort by design (#4145),
+///   so a dropped event leaves a kept entry with no consumer.
+///
+/// (Phrased without naming the emitting helper as a call: the shared
+/// `EMISSION_SITES` allowlist walker in `op_state_manager.rs` scrapes for that
+/// token textually and does not skip comments, so writing it here would demand
+/// an allowlist entry for a file that emits nothing.)
 ///
 /// Each leaked entry holds up to [`MAX_COVERED_PEERS`] public keys, so the
 /// growth is monotonic in distinct contract ids touched. Sweeping only when

--- a/crates/core/src/ring/broadcast_coverage.rs
+++ b/crates/core/src/ring/broadcast_coverage.rs
@@ -281,6 +281,29 @@ pub(crate) struct BroadcastCoverageStore {
     entries: DashMap<ContractInstanceId, CoverageEntry>,
 }
 
+/// Entry count above which [`BroadcastCoverageStore::register`] sweeps expired
+/// entries before inserting a new contract.
+///
+/// `expires_at` governs an entry's VALIDITY on read, but nothing governed its
+/// RESIDENCY: the only removals are `take`, `discard`, and same-key
+/// replacement, so an entry that is registered, `keep()`-ed, and then never
+/// consumed stays forever. Two paths produce exactly that, and both fire
+/// hardest under load:
+///
+/// * `handle_broadcast_state_change` returns early for a BANNED contract and
+///   for one with broken invariants, both BEFORE it takes the coverage — so
+///   every applying broadcast on such a contract leaks an entry, precisely
+///   during the storm conditions that set those flags (#4861 / #4903 shape);
+/// * `try_notify_node_event(BroadcastStateChange)` is best-effort by design
+///   (#4145), so a dropped event leaves a kept entry with no consumer.
+///
+/// Each leaked entry holds up to [`MAX_COVERED_PEERS`] public keys, so the
+/// growth is monotonic in distinct contract ids touched. Sweeping only when
+/// the map is already large keeps the hot path (a live contract re-registering
+/// under its own key) free of the O(n) scan — that path hits the Occupied arm
+/// and never reaches this check.
+const SWEEP_THRESHOLD: usize = 512;
+
 struct CoverageEntry {
     origin: BroadcastOrigin,
     expires_at: Instant,
@@ -374,6 +397,7 @@ impl BroadcastCoverageStore {
     pub(crate) fn register(&self, key: &ContractInstanceId, origin: BroadcastOrigin) {
         let now = Instant::now();
         let expires_at = now + COVERAGE_TTL;
+        let mut inserted_new_contract = false;
         match self.entries.entry(*key) {
             dashmap::mapref::entry::Entry::Occupied(mut occupied) => {
                 let existing = occupied.get_mut();
@@ -382,18 +406,51 @@ impl BroadcastCoverageStore {
                     // rather than narrow — narrowing against a claim that no
                     // live apply stands behind would discard this apply's
                     // coverage for no reason.
+                    //
+                    // The deadline must be REPLACED too, not `min`-ed. The
+                    // existing one is by definition in the past here, so
+                    // keeping the earlier of the two would leave the fresh
+                    // entry born already expired: `take` checks
+                    // `expires_at > now`, fails, and hands back
+                    // `BroadcastOrigin::local()`. That silently made this whole
+                    // branch dead — safe in direction (under-suppression) but
+                    // the exact opposite of what it says it does. Pinned by
+                    // `replacing_a_stale_entry_yields_a_live_claim`.
                     existing.origin = origin;
+                    existing.expires_at = expires_at;
                 } else {
                     existing.origin.narrow(&origin);
+                    // Keep the EARLIER deadline. The merged claim is only valid
+                    // for as long as its shortest-lived contributor.
+                    existing.expires_at = existing.expires_at.min(expires_at);
                 }
-                // Keep the EARLIER deadline. The merged claim is only valid for
-                // as long as its shortest-lived contributor.
-                existing.expires_at = existing.expires_at.min(expires_at);
             }
             dashmap::mapref::entry::Entry::Vacant(vacant) => {
                 vacant.insert(CoverageEntry { origin, expires_at });
+                inserted_new_contract = true;
             }
         }
+
+        // Deliberately AFTER the match: `entry()` holds the shard guard for the
+        // duration of that block, and `retain` wants every shard's guard. Doing
+        // this inside the Vacant arm is the DashMap re-entrancy deadlock this
+        // codebase has hit before.
+        if inserted_new_contract {
+            self.sweep_expired(now);
+        }
+    }
+
+    /// Drop entries whose deadline has passed, but only once the map has grown
+    /// past [`SWEEP_THRESHOLD`].
+    ///
+    /// See that constant for why residency needs its own mechanism at all.
+    /// Bounded work: `retain` visits each shard once, and it runs only on the
+    /// insertion of a contract not already tracked.
+    fn sweep_expired(&self, now: Instant) {
+        if self.entries.len() <= SWEEP_THRESHOLD {
+            return;
+        }
+        self.entries.retain(|_, entry| entry.expires_at > now);
     }
 
     /// Take the coverage for a contract's fan-out, if any is live.
@@ -423,6 +480,34 @@ impl BroadcastCoverageStore {
             .iter()
             .filter(|entry| entry.expires_at > now)
             .count()
+    }
+
+    /// Total entries RESIDENT, live or expired.
+    ///
+    /// Distinct from [`Self::live_entries`] on purpose: the gap between the two
+    /// is what [`SWEEP_THRESHOLD`] exists to bound, and a test that only ever
+    /// asked for the live count could not see an expired-entry leak at all.
+    #[cfg(test)]
+    pub(crate) fn resident_entries(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Insert an entry with an explicit deadline.
+    ///
+    /// `Instant` is not injectable here (no `TimeSource` on this path), so
+    /// without a seam there is no way to construct an EXPIRED entry, and the
+    /// TTL — the whole orphan backstop — goes untested. It did: the stale-entry
+    /// branch in `register` shipped inert because the deadline was `min`-ed
+    /// against a past value, and no test could observe it.
+    #[cfg(test)]
+    pub(crate) fn insert_with_deadline(
+        &self,
+        key: &ContractInstanceId,
+        origin: BroadcastOrigin,
+        expires_at: Instant,
+    ) {
+        self.entries
+            .insert(*key, CoverageEntry { origin, expires_at });
     }
 }
 
@@ -499,6 +584,132 @@ mod tests {
 
     fn instance_id() -> ContractInstanceId {
         *crate::operations::test_utils::make_contract_key(1).id()
+    }
+
+    /// Replacing an EXPIRED entry must produce a claim the fan-out can use.
+    ///
+    /// The stale branch of `register` says it "replaces rather than narrows",
+    /// but it originally then ran
+    /// `existing.expires_at = existing.expires_at.min(expires_at)`. In that
+    /// branch `existing.expires_at` is by definition already in the past, so
+    /// `min` kept it: the fresh entry was born expired, `take` rejected it, and
+    /// the branch was dead. Direction was safe (under-suppression), which is
+    /// why nothing noticed — and no test existed that could, since `Instant`
+    /// has no seam here.
+    ///
+    /// Mutation that must make this red: restore the `.min()` in the stale arm.
+    #[test]
+    fn replacing_a_stale_entry_yields_a_live_claim() {
+        let store = BroadcastCoverageStore::new();
+        let key = instance_id();
+        let stale_peer = pub_key();
+        let fresh_peer = pub_key();
+
+        // An orphaned entry: registered by an apply whose fan-out never came.
+        store.insert_with_deadline(
+            &key,
+            relayed(HashSet::from([PeerKey::from(stale_peer.clone())])),
+            Instant::now() - Duration::from_secs(1),
+        );
+
+        store.register(
+            &key,
+            relayed(HashSet::from([PeerKey::from(fresh_peer.clone())])),
+        );
+
+        let taken = store.take(&key);
+        assert!(
+            taken.covers(&fresh_peer),
+            "the replacing apply's coverage must survive — if this is empty the \
+             entry was born expired and `take` handed back a local() claim, so \
+             the stale-replacement branch is inert"
+        );
+        assert!(
+            !taken.covers(&stale_peer),
+            "the orphaned claim must be REPLACED, not merged: no live apply \
+             stands behind it"
+        );
+    }
+
+    /// An entry past its TTL must not suppress anything.
+    ///
+    /// The other half of the seam above: `take` is what enforces validity, and
+    /// deleting its deadline check would make orphaned claims suppress peers
+    /// indefinitely — the one way this design can withhold an update from a
+    /// peer that needs it.
+    #[test]
+    fn an_expired_entry_suppresses_nothing() {
+        let store = BroadcastCoverageStore::new();
+        let key = instance_id();
+        let peer = pub_key();
+
+        store.insert_with_deadline(
+            &key,
+            relayed(HashSet::from([PeerKey::from(peer.clone())])),
+            Instant::now() - Duration::from_millis(1),
+        );
+
+        let taken = store.take(&key);
+        assert!(
+            !taken.covers(&peer),
+            "a claim past COVERAGE_TTL must be ignored; mutation: delete the \
+             `expires_at > Instant::now()` guard in `take`"
+        );
+    }
+
+    /// Orphaned entries must not accumulate without bound.
+    ///
+    /// `expires_at` governs validity on READ, but until the sweeper existed
+    /// nothing governed RESIDENCY: `take`, `discard` and same-key replacement
+    /// were the only removals, so a contract that registered coverage and then
+    /// never fanned out (banned contract, broken invariants, dropped
+    /// best-effort event) left an entry holding up to MAX_COVERED_PEERS keys
+    /// forever — worst exactly under the storm conditions that cause it.
+    ///
+    /// Mutation that must make this red: make `sweep_expired` a no-op.
+    #[test]
+    fn expired_entries_are_reclaimed_once_the_map_grows() {
+        let store = BroadcastCoverageStore::new();
+        let past = Instant::now() - Duration::from_secs(1);
+
+        // Orphan one entry per distinct contract, past the sweep threshold.
+        for i in 0..(SWEEP_THRESHOLD + 2) {
+            let mut bytes = [0u8; 32];
+            bytes[0..8].copy_from_slice(&(i as u64).to_le_bytes());
+            store.insert_with_deadline(
+                &ContractInstanceId::new(bytes),
+                relayed(HashSet::from([PeerKey::from(pub_key())])),
+                past,
+            );
+        }
+        assert!(
+            store.resident_entries() > SWEEP_THRESHOLD,
+            "premise: the map must actually be over the sweep threshold"
+        );
+        assert_eq!(
+            store.live_entries(),
+            0,
+            "premise: every seeded entry is expired"
+        );
+
+        // A new contract's registration is what triggers the sweep.
+        let fresh_key = instance_id();
+        store.register(
+            &fresh_key,
+            relayed(HashSet::from([PeerKey::from(pub_key())])),
+        );
+
+        assert_eq!(
+            store.resident_entries(),
+            1,
+            "expired entries must be reclaimed, leaving only the live one; \
+             found {} resident",
+            store.resident_entries()
+        );
+        assert!(
+            store.take(&fresh_key).covered_len() > 0,
+            "the sweep must not evict the live entry it ran alongside"
+        );
     }
 
     #[test]

--- a/crates/core/src/ring/broadcast_coverage.rs
+++ b/crates/core/src/ring/broadcast_coverage.rs
@@ -1,0 +1,676 @@
+//! Originator target lists: telling a relayer who already got the broadcast.
+//!
+//! # The waste this exists to remove
+//!
+//! Contract broadcast is a mesh re-fan-out. `A` applies an update and sends it
+//! to its advertised co-hosts `B`, `C`, `D`. `B` applies it and re-broadcasts
+//! to ITS co-hosts — which include `C` and `D`, who already have it. Every node
+//! does this simultaneously, so on the 0.2.119 fleet each node received ~18.6
+//! byte-identical copies of every update: **74.6% of all received contract
+//! bytes changed nothing** (issue #5147).
+//!
+//! `B` cannot currently tell that `C` already has it. The information that
+//! would say so (`sender_summary_bytes`) rides ON the duplicate itself, so it
+//! always arrives too late to prevent it.
+//!
+//! # The mechanism
+//!
+//! The originator attaches to its broadcast the list of peers it is sending
+//! to. A relayer excludes listed peers from its own re-fan-out. That is all.
+//!
+//! Duplication requires `B` and `C` to be mutually-connected co-hosts — which
+//! is the same condition that makes `A`'s target list overlap theirs. Waste and
+//! fix live in the same regime: near the contract's key, where routing gravity
+//! concentrates hosts and mutual connectivity is high, `targets(B)` is almost
+//! entirely contained in `targets(A) ∪ {A}`. Measured suppression rises with
+//! fan-out degree: 0.647 at degree 5, 0.863 at 14, 0.924 at 17. The fleet
+//! median `broadcasted_to` is 16-17.
+//!
+//! # Why an exact list and not a Bloom filter
+//!
+//! The first design for #5147 was a Bloom covered-set. It was retired before
+//! being shipped. At the median fan-out of 17 an exact list of 8-byte hashes is
+//! ~144 bytes on the wire against the Bloom's 144, so it is not larger — and it
+//! has **no false positives**. The Bloom's entire failure apparatus (a
+//! per-broadcast salt, a saturation guard, union semantics across hops) existed
+//! solely to manage false positives that an exact list does not have. A false
+//! positive here means a peer that genuinely needed the update silently does
+//! not get it until the ~5-minute interest heartbeat heals it, so removing that
+//! failure mode outright is worth more than the bytes.
+//!
+//! 64-bit truncation collisions are ~2^-64 per pair. A collision would be
+//! persistent for that peer pair rather than per-broadcast, which is why the
+//! hash is transaction-seeded (below) — a colliding pair re-rolls every
+//! broadcast instead of being stuck.
+//!
+//! # One hop only, and why that is also the security rule
+//!
+//! A relayer does NOT forward the list onward and does NOT union its own
+//! targets into it. Measured hop-2 suppression is already 0.99, so multi-hop
+//! buys nothing.
+//!
+//! It also closes an attack. The list is an attestation of the sender's own
+//! actions: a malicious ORIGINATOR "suppressing" its own update is a non-attack
+//! (it could simply not send). A malicious RELAYER attaching a fabricated
+//! "everyone is covered" list to a genuine update could suppress third-party
+//! re-fan-out for a cycle. The rule that closes it: **honor a list only from
+//! the message that delivered the payload.** One-hop makes that free, and it is
+//! enforced structurally — [`CoveredPeers`] is only ever read out of the
+//! payload-bearing `BroadcastToV2` / `BroadcastToStreamingV2` variants, and the
+//! re-fan-out builds a fresh list from its own targets rather than propagating
+//! the one it received.
+//!
+//! # Transaction-seeded hashing
+//!
+//! Peer hashes are `blake3(tx_id ‖ pub_key)[..8]` rather than a bare key
+//! prefix. This follows [`crate::operations::visited_peers`], whose rustdoc
+//! documents the rationale: seeding on the transaction means the same peer
+//! hashes differently in different broadcasts, so an observer cannot correlate
+//! co-host sets across transactions to infer topology. The receiver
+//! reconstructs the seed from the transaction id carried on the same message.
+//!
+//! Note that in production each fan-out leg mints its OWN transaction
+//! (`broadcast_queue.rs`), so the list is built per-recipient. That is a
+//! handful of 48-byte hashes per send and is not measurable next to the WASM
+//! merge it precedes.
+//!
+//! # Provenance: how the list reaches the fan-out decision
+//!
+//! The list arrives on an inbound broadcast; the decision that consumes it
+//! happens later, in `handle_broadcast_state_change`, after a round trip
+//! through the contract handler and the WASM merge. Nothing on that path
+//! carries the networking context — `NodeEvent::BroadcastStateChange` is
+//! emitted by the executor on ANY committed state write, with no idea whether
+//! the write came from a local client or an inbound broadcast.
+//!
+//! [`BroadcastCoverageStore`] bridges that gap without threading a networking
+//! concept through the WASM/contract-handler layer: the apply registers its
+//! coverage keyed by contract immediately before entering the contract handler,
+//! and the fan-out takes it. See [`BroadcastCoverageStore`] for the ordering
+//! and race argument, which is the load-bearing part.
+
+use std::collections::HashSet;
+use std::net::SocketAddr;
+use std::time::{Duration, Instant};
+
+use dashmap::DashMap;
+use freenet_stdlib::prelude::ContractInstanceId;
+use serde::{Deserialize, Serialize};
+
+use crate::message::Transaction;
+use crate::ring::PeerKey;
+use crate::transport::TransportPublicKey;
+
+/// A transaction-seeded, 8-byte truncated hash of a peer's public key.
+pub(crate) type PeerHash = [u8; 8];
+
+/// Maximum number of peers an originator will name in one broadcast.
+///
+/// At the fleet median fan-out of 16-17 this never binds; it bounds the tail
+/// (`broadcasted_to` p90 is 58, max 138 on 0.2.119) so a single broadcast
+/// cannot attach a half-kilobyte list to every leg of a large fan-out.
+///
+/// **Over-cap behaviour is truncation, never omission.** A truncated list names
+/// fewer peers, so the relayer suppresses fewer of them and the result degrades
+/// smoothly toward today's unsuppressed behaviour. Dropping the field entirely
+/// would do the same thing, but a reader could not tell the two apart, and
+/// "cap exceeded" would become indistinguishable from "peer does not implement
+/// this". See `covered_peers_over_cap_truncates_rather_than_omitting`.
+pub(crate) const MAX_COVERED_PEERS: usize = 64;
+
+/// How long a registered coverage entry stays valid.
+///
+/// This is a backstop, not the normal lifetime. In the normal case an entry
+/// lives from `update_contract`'s registration until the fan-out takes it —
+/// one contract-handler round trip — and `CoverageRegistration` discards it
+/// eagerly if the apply turns out not to change state (so no fan-out will ever
+/// come for it). The TTL only catches entries orphaned by a dropped task.
+///
+/// Short on purpose: an orphaned entry is the one way a peer could be excluded
+/// from a fan-out it actually needed, so it should not outlive its apply by
+/// much.
+const COVERAGE_TTL: Duration = Duration::from_secs(10);
+
+/// The peers an originator says it already delivered this broadcast to.
+///
+/// Wire type. Rides on `UpdateMsg::BroadcastToV2` / `BroadcastToStreamingV2`,
+/// which exist so that a pre-floor peer's bytes are untouched — bincode has no
+/// field skipping, so this could not have been an added field or an `Option` on
+/// the existing variants without changing what old peers decode.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct CoveredPeers {
+    /// Sorted, deduplicated peer hashes. Sorted so the encoding is canonical
+    /// for a given peer set and does not leak the originator's iteration order
+    /// (which is location-correlated).
+    hashes: Vec<PeerHash>,
+}
+
+impl CoveredPeers {
+    /// An explicitly empty list: "I am telling you I covered nobody."
+    ///
+    /// Distinct from not sending a list at all. Used by the local-origin path,
+    /// where there is no upstream sender and therefore nothing is covered.
+    pub(crate) fn empty() -> Self {
+        Self::default()
+    }
+
+    /// Build the list an originator attaches when sending under `tx`.
+    ///
+    /// `targets` is the originator's own fan-out set. Over
+    /// [`MAX_COVERED_PEERS`] the list is truncated (after sorting, so the
+    /// retained prefix is deterministic rather than iteration-order-dependent).
+    pub(crate) fn from_targets<'a>(
+        tx: &Transaction,
+        targets: impl IntoIterator<Item = &'a TransportPublicKey>,
+    ) -> Self {
+        let mut hashes: Vec<PeerHash> = targets
+            .into_iter()
+            .map(|pub_key| peer_hash(tx, pub_key))
+            .collect();
+        hashes.sort_unstable();
+        hashes.dedup();
+        hashes.truncate(MAX_COVERED_PEERS);
+        Self { hashes }
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.hashes.len()
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.hashes.is_empty()
+    }
+
+    /// Resolve this list against the peers we might ourselves broadcast to.
+    ///
+    /// `candidates` should be the contract's advertised co-hosts — the exact
+    /// set `get_broadcast_targets_update` draws from. Resolving at receive time
+    /// rather than storing raw hashes is what lets
+    /// [`BroadcastCoverageStore::register`] intersect two concurrent entries:
+    /// each carries its own transaction seed, so raw hashes from different
+    /// broadcasts live in different hash spaces and cannot be compared.
+    ///
+    /// A named peer we do not know is silently dropped — we would never have
+    /// targeted it, so it is not a miss.
+    pub(crate) fn resolve<'a>(
+        &self,
+        tx: &Transaction,
+        candidates: impl IntoIterator<Item = &'a TransportPublicKey>,
+    ) -> HashSet<PeerKey> {
+        if self.hashes.is_empty() {
+            return HashSet::new();
+        }
+        let named: HashSet<PeerHash> = self.hashes.iter().copied().collect();
+        candidates
+            .into_iter()
+            .filter(|pub_key| named.contains(&peer_hash(tx, pub_key)))
+            .map(|pub_key| PeerKey::from(pub_key.clone()))
+            .collect()
+    }
+}
+
+/// `blake3(tx_id ‖ pub_key)` truncated to 8 bytes.
+///
+/// Both sides must agree, so this must be a cryptographic digest with a stable
+/// cross-version encoding — notably NOT `ahash`, whose output is not stable
+/// across processes or releases.
+fn peer_hash(tx: &Transaction, pub_key: &TransportPublicKey) -> PeerHash {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(&tx.id_bytes());
+    hasher.update(pub_key.as_bytes());
+    let digest = hasher.finalize();
+    let mut out = [0u8; 8];
+    out.copy_from_slice(&digest.as_bytes()[..8]);
+    out
+}
+
+/// Coverage awaiting the fan-out it belongs to.
+///
+/// # Ordering, which is what makes this sound
+///
+/// The write happens in `update_contract` BEFORE the `UpdateQuery` enters the
+/// contract handler. The read happens in `handle_broadcast_state_change`, which
+/// can only run AFTER the executor emitted `BroadcastStateChange`, which can
+/// only happen after that same `UpdateQuery` committed. So an entry is always
+/// present when its own fan-out reads it. There is no "did the write land in
+/// time" race.
+///
+/// # The race there IS, and why it can only under-suppress
+///
+/// Two *different* updates to the *same* contract can be in flight at once, and
+/// the entries are keyed by contract, so the fan-out for one could read the
+/// entry registered by the other.
+///
+/// [`Self::register`] therefore **intersects** rather than replacing. Every
+/// peer in the intersection was covered by *both* originators, so whichever
+/// apply the fan-out actually belongs to, each suppressed peer genuinely had
+/// the state. A mixed-up entry can only cause the relayer to suppress fewer
+/// peers than it could have — which is by definition today's behaviour — and
+/// never to suppress a peer that needed the update.
+///
+/// That direction is the whole point. Under-suppression costs bandwidth we are
+/// already spending; over-suppression silently withholds an update until the
+/// ~5-minute heartbeat.
+///
+/// Three things keep the intersection from being merely decorative rather than
+/// the common case:
+///
+/// * The contract handler's fair queue serialises WASM merges per contract key,
+///   so the window between registration and read is one queue slot.
+/// * Duplicate copies of the same broadcast are dropped by
+///   `broadcast_dedup_cache` BEFORE `update_contract`, so the ~18 duplicates of
+///   one update register once between them, not 18 times.
+/// * An apply that does not change state discards its entry immediately
+///   ([`CoverageRegistration`]) rather than leaving it to expire. No-change
+///   applies are the common case (97% of received contract bytes change
+///   nothing), so without this the store would be full of entries that no
+///   fan-out will ever come for, intersecting away every real one.
+///
+/// # Residual, stated rather than hidden
+///
+/// Commit paths that emit `BroadcastStateChange` WITHOUT going through
+/// `update_contract` — the executor-internal replay, and the second emitter at
+/// `executor_impl.rs`'s `broadcast_state_change` — do not register, so they can
+/// take an entry belonging to a concurrent relay apply of the same contract.
+/// That one IS over-suppression. It needs a same-contract PUT-or-replay
+/// concurrent with a relayed update, inside one contract-handler round trip;
+/// it is bounded by [`COVERAGE_TTL`] and healed by the interest heartbeat.
+/// Closing it means threading provenance through the WASM/contract-handler
+/// layer, which is the tradeoff #5147 chose against.
+pub(crate) struct BroadcastCoverageStore {
+    entries: DashMap<ContractInstanceId, CoverageEntry>,
+}
+
+struct CoverageEntry {
+    origin: BroadcastOrigin,
+    expires_at: Instant,
+}
+
+/// Who already has the update this node is about to fan out.
+///
+/// Both halves are attestations by the peer that delivered the payload, and
+/// both are honored only for the fan-out that follows that delivery:
+///
+/// * `sender` — the peer we received it FROM. Obviously has it; sending it
+///   back is a guaranteed duplicate. `get_broadcast_targets_update` has always
+///   meant to exclude this and never could, because the re-fan-out call site
+///   had no sender to pass and handed in its own address instead (#5147).
+/// * `covered` — the peers the sender says it also delivered to.
+///
+/// [`Self::local`] is the "this node produced the update itself" case: no
+/// sender, nobody covered. It is a real value rather than an absent one, which
+/// is what makes the store's intersection safe — see
+/// [`BroadcastCoverageStore::register`].
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct BroadcastOrigin {
+    sender: Option<SocketAddr>,
+    covered: HashSet<PeerKey>,
+}
+
+impl BroadcastOrigin {
+    /// A client applied this update here: nothing is covered and there is no
+    /// upstream sender to exclude.
+    pub(crate) fn local() -> Self {
+        Self::default()
+    }
+
+    /// The update arrived from `sender`, who says it also delivered to
+    /// `covered`.
+    pub(crate) fn relayed(sender: SocketAddr, covered: HashSet<PeerKey>) -> Self {
+        Self {
+            sender: Some(sender),
+            covered,
+        }
+    }
+
+    /// The peer that delivered this update, if it came from the network.
+    pub(crate) fn sender(&self) -> Option<&SocketAddr> {
+        self.sender.as_ref()
+    }
+
+    /// Whether the delivering peer already covered `pub_key`.
+    pub(crate) fn covers(&self, pub_key: &TransportPublicKey) -> bool {
+        !self.covered.is_empty() && self.covered.contains(&PeerKey::from(pub_key.clone()))
+    }
+
+    pub(crate) fn covered_len(&self) -> usize {
+        self.covered.len()
+    }
+
+    /// Merge two claims that are live for the same contract at the same time.
+    ///
+    /// Both halves narrow rather than widen, so the result is a claim BOTH
+    /// contributors stand behind:
+    ///
+    /// * `covered` intersects, so a suppressed peer was covered by every live
+    ///   apply.
+    /// * `sender` survives only if the two agree. Two different senders means
+    ///   we cannot tell which delivery this fan-out belongs to, and excluding
+    ///   the wrong one would withhold the update from a peer that needs it.
+    fn narrow(&mut self, other: &BroadcastOrigin) {
+        if self.sender != other.sender {
+            self.sender = None;
+        }
+        self.covered.retain(|peer| other.covered.contains(peer));
+    }
+}
+
+impl BroadcastCoverageStore {
+    pub(crate) fn new() -> Self {
+        Self {
+            entries: DashMap::new(),
+        }
+    }
+
+    /// Record what the apply about to run already knows is covered.
+    ///
+    /// Intersects with any live entry for the same contract; see the type
+    /// rustdoc for why intersection and not replacement.
+    ///
+    /// Registering an EMPTY set is meaningful and is what client-local applies
+    /// do: it intersects everything to empty, so a concurrent local update
+    /// disables suppression for the window rather than inheriting a relayed
+    /// peer's list.
+    pub(crate) fn register(&self, key: &ContractInstanceId, origin: BroadcastOrigin) {
+        let now = Instant::now();
+        let expires_at = now + COVERAGE_TTL;
+        match self.entries.entry(*key) {
+            dashmap::mapref::entry::Entry::Occupied(mut occupied) => {
+                let existing = occupied.get_mut();
+                if existing.expires_at <= now {
+                    // Stale: the apply that wrote it was orphaned. Replace
+                    // rather than narrow — narrowing against a claim that no
+                    // live apply stands behind would discard this apply's
+                    // coverage for no reason.
+                    existing.origin = origin;
+                } else {
+                    existing.origin.narrow(&origin);
+                }
+                // Keep the EARLIER deadline. The merged claim is only valid for
+                // as long as its shortest-lived contributor.
+                existing.expires_at = existing.expires_at.min(expires_at);
+            }
+            dashmap::mapref::entry::Entry::Vacant(vacant) => {
+                vacant.insert(CoverageEntry { origin, expires_at });
+            }
+        }
+    }
+
+    /// Take the coverage for a contract's fan-out, if any is live.
+    ///
+    /// Removes it: coverage belongs to one fan-out. A no-target retry
+    /// re-emission that arrives later finds nothing and suppresses nothing,
+    /// which is the safe direction.
+    pub(crate) fn take(&self, key: &ContractInstanceId) -> BroadcastOrigin {
+        match self.entries.remove(key) {
+            Some((_, entry)) if entry.expires_at > Instant::now() => entry.origin,
+            _ => BroadcastOrigin::local(),
+        }
+    }
+
+    /// Drop a contract's coverage without consuming it as a fan-out would.
+    ///
+    /// Called when an apply completes without changing state (or fails), so no
+    /// `BroadcastStateChange` will ever come for it.
+    pub(crate) fn discard(&self, key: &ContractInstanceId) {
+        self.entries.remove(key);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn live_entries(&self) -> usize {
+        let now = Instant::now();
+        self.entries
+            .iter()
+            .filter(|entry| entry.expires_at > now)
+            .count()
+    }
+}
+
+impl Default for BroadcastCoverageStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Scope guard tying a registered coverage entry to the apply that wrote it.
+///
+/// Held across `update_contract`'s `UpdateQuery` round trip. If the apply
+/// changes state, [`Self::keep`] hands the entry to the fan-out that is about
+/// to run; otherwise the drop discards it, so an entry never outlives an apply
+/// that will not produce a `BroadcastStateChange`.
+///
+/// Discarding the whole contract key rather than just this apply's contribution
+/// is deliberate: a concurrent apply may have intersected into the same entry,
+/// and dropping its work costs suppression (safe) whereas trying to subtract
+/// only our own contribution would risk leaving coverage that no live apply
+/// stands behind (unsafe).
+pub(crate) struct CoverageRegistration<'a> {
+    store: &'a BroadcastCoverageStore,
+    key: ContractInstanceId,
+    keep: bool,
+}
+
+impl<'a> CoverageRegistration<'a> {
+    pub(crate) fn new(
+        store: &'a BroadcastCoverageStore,
+        key: ContractInstanceId,
+        origin: BroadcastOrigin,
+    ) -> Self {
+        store.register(&key, origin);
+        Self {
+            store,
+            key,
+            keep: false,
+        }
+    }
+
+    /// The apply changed state, so a fan-out is coming. Leave the entry for it.
+    pub(crate) fn keep(mut self) {
+        self.keep = true;
+    }
+}
+
+impl Drop for CoverageRegistration<'_> {
+    fn drop(&mut self) {
+        if !self.keep {
+            self.store.discard(&self.key);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transport::TransportKeypair;
+
+    fn pub_key() -> TransportPublicKey {
+        TransportKeypair::new().public().clone()
+    }
+
+    fn tx() -> Transaction {
+        Transaction::new::<crate::operations::update::UpdateMsg>()
+    }
+
+    /// A relayed claim from one fixed sender, so the tests that care about the
+    /// `covered` half are not also varying the sender half.
+    fn relayed(covered: HashSet<PeerKey>) -> BroadcastOrigin {
+        BroadcastOrigin::relayed("127.0.0.1:1".parse().unwrap(), covered)
+    }
+
+    fn instance_id() -> ContractInstanceId {
+        *crate::operations::test_utils::make_contract_key(1).id()
+    }
+
+    #[test]
+    fn a_named_peer_resolves_and_an_unnamed_one_does_not() {
+        let tx = tx();
+        let named = pub_key();
+        let unnamed = pub_key();
+        let covered = CoveredPeers::from_targets(&tx, [&named]);
+
+        let resolved = covered.resolve(&tx, [&named, &unnamed]);
+
+        assert!(resolved.contains(&PeerKey::from(named)));
+        assert!(!resolved.contains(&PeerKey::from(unnamed)));
+        assert_eq!(resolved.len(), 1);
+    }
+
+    /// The hash is transaction-seeded, so the same peer set encodes differently
+    /// per broadcast and cannot be correlated across transactions. Guards the
+    /// privacy property in this module's rustdoc.
+    #[test]
+    fn the_same_peer_hashes_differently_under_a_different_transaction() {
+        let peer = pub_key();
+        let first = CoveredPeers::from_targets(&tx(), [&peer]);
+        let second = CoveredPeers::from_targets(&tx(), [&peer]);
+        assert_ne!(first, second);
+    }
+
+    /// A list resolved under the WRONG transaction must not match. This is the
+    /// mechanical reason a relayer cannot replay someone else's list onto a
+    /// different broadcast.
+    #[test]
+    fn a_list_does_not_resolve_under_a_different_transaction() {
+        let peer = pub_key();
+        let covered = CoveredPeers::from_targets(&tx(), [&peer]);
+        assert!(covered.resolve(&tx(), [&peer]).is_empty());
+    }
+
+    #[test]
+    fn covered_peers_over_cap_truncates_rather_than_omitting() {
+        let tx = tx();
+        let peers: Vec<TransportPublicKey> =
+            (0..MAX_COVERED_PEERS * 2).map(|_| pub_key()).collect();
+        let covered = CoveredPeers::from_targets(&tx, peers.iter());
+
+        assert_eq!(
+            covered.len(),
+            MAX_COVERED_PEERS,
+            "over-cap must truncate to the cap"
+        );
+        assert!(
+            !covered.is_empty(),
+            "over-cap must NEVER degrade to an empty/omitted list — that is \
+             indistinguishable from a peer that does not implement this"
+        );
+
+        // Every retained entry must still be a genuine member: truncation may
+        // only lose suppression, never invent it.
+        let resolved = covered.resolve(&tx, peers.iter());
+        assert_eq!(resolved.len(), MAX_COVERED_PEERS);
+        assert!(resolved.iter().all(|peer| peers.contains(&peer.0)));
+    }
+
+    /// Encoding is canonical: the same peer set produces the same bytes
+    /// regardless of the order the originator happened to iterate its targets.
+    #[test]
+    fn encoding_is_order_independent() {
+        let tx = tx();
+        let peers: Vec<TransportPublicKey> = (0..8).map(|_| pub_key()).collect();
+        let forward = CoveredPeers::from_targets(&tx, peers.iter());
+        let backward = CoveredPeers::from_targets(&tx, peers.iter().rev());
+        assert_eq!(forward, backward);
+    }
+
+    #[test]
+    fn a_registered_entry_is_taken_by_the_fan_out() {
+        let store = BroadcastCoverageStore::new();
+        let key = instance_id();
+        let peer = PeerKey::from(pub_key());
+
+        store.register(&key, relayed(HashSet::from([peer.clone()])));
+        assert_eq!(store.take(&key), relayed(HashSet::from([peer])));
+        assert_eq!(
+            store.take(&key),
+            BroadcastOrigin::local(),
+            "coverage is consumed once"
+        );
+    }
+
+    /// The load-bearing race property: concurrent registrations for one
+    /// contract intersect, so a fan-out can only ever suppress peers that
+    /// EVERY live apply agreed were covered.
+    #[test]
+    fn concurrent_registrations_intersect_and_never_over_suppress() {
+        let store = BroadcastCoverageStore::new();
+        let key = instance_id();
+        let shared = PeerKey::from(pub_key());
+        let only_first = PeerKey::from(pub_key());
+        let only_second = PeerKey::from(pub_key());
+
+        store.register(
+            &key,
+            relayed(HashSet::from([shared.clone(), only_first.clone()])),
+        );
+        store.register(
+            &key,
+            relayed(HashSet::from([shared.clone(), only_second.clone()])),
+        );
+
+        let taken = store.take(&key);
+        assert_eq!(taken, relayed(HashSet::from([shared])));
+        assert!(!taken.covers(&only_first.0));
+        assert!(!taken.covers(&only_second.0));
+    }
+
+    /// A client-local apply registers an EMPTY set, which must collapse any
+    /// concurrent relayed coverage to nothing — a local update must never be
+    /// suppressed against a list that belongs to someone else's broadcast.
+    #[test]
+    fn an_empty_registration_collapses_concurrent_coverage() {
+        let store = BroadcastCoverageStore::new();
+        let key = instance_id();
+
+        store.register(&key, relayed(HashSet::from([PeerKey::from(pub_key())])));
+        store.register(&key, BroadcastOrigin::local());
+
+        assert_eq!(store.take(&key).covered_len(), 0);
+    }
+
+    #[test]
+    fn a_no_change_apply_discards_its_registration() {
+        let store = BroadcastCoverageStore::new();
+        let key = instance_id();
+        let peer = PeerKey::from(pub_key());
+
+        {
+            let _registration =
+                CoverageRegistration::new(&store, key, relayed(HashSet::from([peer])));
+            assert_eq!(store.live_entries(), 1);
+        }
+
+        assert_eq!(
+            store.live_entries(),
+            0,
+            "an apply that does not change state must not leave coverage \
+             behind for an unrelated fan-out to consume"
+        );
+        assert_eq!(store.take(&key).covered_len(), 0);
+    }
+
+    #[test]
+    fn a_changed_apply_keeps_its_registration_for_the_fan_out() {
+        let store = BroadcastCoverageStore::new();
+        let key = instance_id();
+        let peer = PeerKey::from(pub_key());
+
+        {
+            let registration =
+                CoverageRegistration::new(&store, key, relayed(HashSet::from([peer.clone()])));
+            registration.keep();
+        }
+
+        assert_eq!(store.take(&key), relayed(HashSet::from([peer])));
+    }
+
+    #[test]
+    fn coverage_for_one_contract_does_not_leak_into_another() {
+        let store = BroadcastCoverageStore::new();
+        let first = instance_id();
+        let second = *crate::operations::test_utils::make_contract_key(2).id();
+        assert_ne!(first, second);
+
+        store.register(&first, relayed(HashSet::from([PeerKey::from(pub_key())])));
+        assert_eq!(store.take(&second), BroadcastOrigin::local());
+    }
+}

--- a/crates/core/src/ring/broadcast_coverage.rs
+++ b/crates/core/src/ring/broadcast_coverage.rs
@@ -107,8 +107,9 @@ pub(crate) type PeerHash = [u8; 8];
 /// Maximum number of peers an originator will name in one broadcast.
 ///
 /// At the fleet median fan-out of 16-17 this never binds; it bounds the tail
-/// (`broadcasted_to` p90 is 58, max 138 on 0.2.119) so a single broadcast
-/// cannot attach a half-kilobyte list to every leg of a large fan-out.
+/// (`broadcasted_to` p90 is 58, max 138 on 0.2.119). 64 entries is 520 bytes
+/// on the wire, so the cap does not make the list small — it stops the max-138
+/// case from attaching nearly 1.1 KB to every one of 138 legs.
 ///
 /// **Over-cap behaviour is truncation, never omission.** A truncated list names
 /// fewer peers, so the relayer suppresses fewer of them and the result degrades
@@ -268,15 +269,32 @@ fn peer_hash(tx: &Transaction, pub_key: &TransportPublicKey) -> PeerHash {
 ///
 /// # Residual, stated rather than hidden
 ///
-/// Commit paths that emit `BroadcastStateChange` WITHOUT going through
-/// `update_contract` — the executor-internal replay, and the second emitter at
-/// `executor_impl.rs`'s `broadcast_state_change` — do not register, so they can
-/// take an entry belonging to a concurrent relay apply of the same contract.
-/// That one IS over-suppression. It needs a same-contract PUT-or-replay
-/// concurrent with a relayed update, inside one contract-handler round trip;
-/// it is bounded by [`COVERAGE_TTL`] and healed by the interest heartbeat.
-/// Closing it means threading provenance through the WASM/contract-handler
-/// layer, which is the tradeoff #5147 chose against.
+/// Every path that emits `BroadcastStateChange` WITHOUT registering can take an
+/// entry belonging to a concurrent relay apply of the same contract. That IS
+/// over-suppression. The complete list, which must be kept complete — a partial
+/// one is worse than none, because it reads as an audit:
+///
+/// * `contract_ops.rs`'s two PUT commit sites and the executor-internal replay
+///   at `executor_impl.rs`, none of which route through `update_contract`.
+/// * `executor_impl.rs`'s standalone `broadcast_state_change`.
+/// * The no-target retry re-emission (`p2p_protoc/broadcast.rs`, `is_retry`).
+///   Its own claim was consumed by the attempt that scheduled it, so it takes
+///   whatever a concurrent apply has since registered.
+/// * The #4359 stash flush (`op_state_manager.rs`'s
+///   `emit_pending_broadcast_reemit_on`). This is the worst victim of the set:
+///   the state it re-drives is by definition one that reached NOBODY, so
+///   suppressing its fan-out against someone else's claim withholds content
+///   that has never propagated at all.
+///
+/// Each needs a same-contract emission concurrent with a relayed update inside
+/// one contract-handler round trip. All are bounded by [`COVERAGE_TTL`] and
+/// healed by the interest heartbeat. Closing them means either threading
+/// provenance through the WASM/contract-handler layer — the tradeoff #5147
+/// chose against — or having each of these paths register
+/// [`BroadcastOrigin::local`], which is cheap and would collapse the whole
+/// class; the latter is the better fix and is not done here only because it
+/// touches five call sites in three modules that this change otherwise leaves
+/// alone.
 pub(crate) struct BroadcastCoverageStore {
     entries: DashMap<ContractInstanceId, CoverageEntry>,
 }
@@ -476,6 +494,22 @@ impl BroadcastCoverageStore {
     /// `BroadcastStateChange` will ever come for it.
     pub(crate) fn discard(&self, key: &ContractInstanceId) {
         self.entries.remove(key);
+    }
+
+    /// Age every entry past [`COVERAGE_TTL`].
+    ///
+    /// The store reads `Instant::now()` directly rather than going through
+    /// `TimeSource`, so expiry is otherwise only reachable by sleeping for the
+    /// TTL. That would make the expiry branches untestable in practice, which
+    /// is how the `min(stale_deadline, now + TTL)` bug in `register` survived
+    /// review — it kept the PAST deadline and left every replacement of an
+    /// orphaned entry dead on arrival, in the one branch no test could reach.
+    #[cfg(test)]
+    pub(crate) fn expire_all_for_test(&self) {
+        let past = Instant::now() - COVERAGE_TTL - Duration::from_secs(1);
+        for mut entry in self.entries.iter_mut() {
+            entry.expires_at = past;
+        }
     }
 
     #[cfg(test)]
@@ -877,6 +911,116 @@ mod tests {
         }
 
         assert_eq!(store.take(&key), relayed(HashSet::from([peer])));
+    }
+
+    /// Regression test for the `min(past_deadline, now + TTL)` bug.
+    ///
+    /// When `register` finds an EXPIRED entry it replaces the claim — but it
+    /// used to keep the earlier of the two deadlines, which for an expired
+    /// entry is the past one. The fresh claim was therefore expired the instant
+    /// it was written, and the branch whose comment says it must not discard
+    /// this apply's coverage discarded exactly that. Direction was safe
+    /// (under-suppression), which is why nothing else caught it.
+    #[test]
+    fn replacing_an_expired_entry_leaves_the_new_claim_usable() {
+        let store = BroadcastCoverageStore::new();
+        let key = instance_id();
+        let orphaned = PeerKey::from(pub_key());
+        let live = PeerKey::from(pub_key());
+
+        store.register(&key, relayed(HashSet::from([orphaned.clone()])));
+        store.expire_all_for_test();
+        store.register(&key, relayed(HashSet::from([live.clone()])));
+
+        let taken = store.take(&key);
+        assert!(
+            taken.covers(&live.0),
+            "the replacement claim must be usable; it was written after the \
+             stale one expired and belongs to a live apply"
+        );
+        assert!(
+            !taken.covers(&orphaned.0),
+            "the orphaned claim must not survive its replacement"
+        );
+    }
+
+    /// Two concurrent applies delivered by DIFFERENT senders must not leave
+    /// either sender excluded.
+    ///
+    /// The covered sets narrow by intersection, but the sender is a single
+    /// value with no meaningful intersection: keeping either one would exclude
+    /// a peer that did not send the update this fan-out belongs to, which is
+    /// over-suppression. `narrow` therefore drops it.
+    #[test]
+    fn narrow_drops_a_disagreeing_sender() {
+        let store = BroadcastCoverageStore::new();
+        let key = instance_id();
+        let shared = PeerKey::from(pub_key());
+        let first: SocketAddr = "127.0.0.1:1".parse().unwrap();
+        let second: SocketAddr = "127.0.0.1:2".parse().unwrap();
+
+        store.register(
+            &key,
+            BroadcastOrigin::relayed(first, HashSet::from([shared.clone()])),
+        );
+        store.register(
+            &key,
+            BroadcastOrigin::relayed(second, HashSet::from([shared.clone()])),
+        );
+
+        let taken = store.take(&key);
+        assert_eq!(
+            taken.sender(),
+            None,
+            "with two candidate senders we cannot tell which delivery this \
+             fan-out belongs to, so neither may be excluded"
+        );
+        assert!(
+            taken.covers(&shared.0),
+            "the agreed coverage survives; only the sender is dropped"
+        );
+    }
+
+    /// The same sender registering twice keeps its exclusion — otherwise the
+    /// test above would pass against a `narrow` that unconditionally cleared
+    /// the sender, and the exclusion would be silently inert under any
+    /// concurrency at all.
+    #[test]
+    fn narrow_keeps_an_agreeing_sender() {
+        let store = BroadcastCoverageStore::new();
+        let key = instance_id();
+        let sender: SocketAddr = "127.0.0.1:1".parse().unwrap();
+
+        store.register(&key, BroadcastOrigin::relayed(sender, HashSet::new()));
+        store.register(&key, BroadcastOrigin::relayed(sender, HashSet::new()));
+
+        assert_eq!(store.take(&key).sender(), Some(&sender));
+    }
+
+    /// The wire type must survive a bincode round trip with real content — the
+    /// unit tests otherwise only ever construct it in-process, and the wire
+    /// pin in `update.rs` only ever embeds an EMPTY list.
+    #[test]
+    fn covered_peers_round_trips_over_the_wire_with_content() {
+        let tx = tx();
+        let peers: Vec<TransportPublicKey> = (0..17).map(|_| pub_key()).collect();
+        let covered = CoveredPeers::from_targets(&tx, peers.iter());
+
+        let bytes = bincode::serialize(&covered).expect("serialize");
+        let decoded: CoveredPeers = bincode::deserialize(&bytes).expect("deserialize");
+        assert_eq!(decoded, covered);
+        assert_eq!(decoded.resolve(&tx, peers.iter()).len(), peers.len());
+
+        // The size claim that the whole exact-list-beats-Bloom argument rests
+        // on: at the fleet median fan-out of 17 the encoding must stay in the
+        // ~144-byte range the design compared against the Bloom's 144.
+        assert_eq!(
+            bytes.len(),
+            8 + 17 * 8,
+            "17 eight-byte hashes plus bincode's u64 length prefix; if this \
+             grows, the cost argument against the retired Bloom design moves \
+             with it"
+        );
     }
 
     #[test]

--- a/crates/core/src/ring/connection_manager.rs
+++ b/crates/core/src/ring/connection_manager.rs
@@ -521,6 +521,13 @@ pub(crate) struct ConnectionManager {
     hash_first_declined_pre_floor: Arc<AtomicU64>,
     summary_first_put_declined_unknown_version: Arc<AtomicU64>,
     summary_first_put_declined_pre_floor: Arc<AtomicU64>,
+    /// Test-only override for the originator-target-list version floor
+    /// (#5147), threaded exactly like `summary_first_put_floor_override`.
+    /// `None` in production (the real `BROADCAST_TARGET_LIST_MIN_VERSION`
+    /// applies). Simulations default it OFF — this gate changes fan-out
+    /// BEHAVIOUR, not just an encoding — so a sim opts in explicitly via
+    /// `SimNetwork::enable_broadcast_target_list`. See `NodeConfig`.
+    broadcast_target_list_floor_override: Option<(u8, u8, u16)>,
     /// Rotating start offset for the per-new-peer migration scan. The scan
     /// examines at most `MIGRATION_SCAN_CAP_PER_NEW_PEER` hosted contracts per
     /// event; advancing this cursor each event makes successive events cover
@@ -662,6 +669,7 @@ impl ConnectionManager {
         cm.subscribe_hint_floor_override = config.subscribe_hint_floor_override;
         cm.summary_first_put_floor_override = config.summary_first_put_floor_override;
         cm.hash_first_summaries_floor_override = config.hash_first_summaries_floor_override;
+        cm.broadcast_target_list_floor_override = config.broadcast_target_list_floor_override;
         cm
     }
 
@@ -703,6 +711,7 @@ impl ConnectionManager {
             hash_first_declined_pre_floor: Arc::new(AtomicU64::new(0)),
             summary_first_put_declined_unknown_version: Arc::new(AtomicU64::new(0)),
             summary_first_put_declined_pre_floor: Arc::new(AtomicU64::new(0)),
+            broadcast_target_list_floor_override: None,
             migration_scan_cursor: Arc::new(AtomicUsize::new(0)),
             transient_connections: Arc::new(DashMap::new()),
             transient_in_use: Arc::new(AtomicUsize::new(0)),
@@ -1564,6 +1573,27 @@ impl ConnectionManager {
                 .summary_first_put_declined_pre_floor
                 .load(Ordering::Relaxed),
         }
+    }
+
+    /// Whether the peer at `addr` reports a version new enough to understand
+    /// the originator target list (`UpdateMsg::BroadcastToV2` /
+    /// `BroadcastToStreamingV2`, #5147).
+    ///
+    /// Same shape and same fail-closed rule as
+    /// [`Self::supports_hash_first_summaries`]. The fallback is the legacy
+    /// `BroadcastTo` / `BroadcastToStreaming`, byte-identical to what every
+    /// peer receives today, so failing closed costs the duplicate bandwidth we
+    /// already spend and never costs convergence.
+    ///
+    /// Honours `NodeConfig::broadcast_target_list_floor_override`, which
+    /// simulations must set explicitly — unlike the hash-first override it
+    /// defaults OFF, because opening this gate changes which peers receive a
+    /// broadcast at all.
+    pub(crate) fn supports_broadcast_target_list(&self, addr: SocketAddr) -> bool {
+        let floor = self
+            .broadcast_target_list_floor_override
+            .unwrap_or(crate::node::BROADCAST_TARGET_LIST_MIN_VERSION);
+        crate::node::version_supports_broadcast_target_list(self.remote_version(addr), floor)
     }
 
     /// Reserve the next `window`-sized slice of the hosting set for a migration
@@ -3272,6 +3302,132 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// The send gate for `UpdateMsg::BroadcastToV2` / `BroadcastToStreamingV2`
+    /// (#5147).
+    ///
+    /// Same stakes as the hash-first gate above: a pre-floor peer has no
+    /// variant index for these, cannot bincode-deserialize them, and DROPS THE
+    /// CONNECTION. During a staggered rollout most peers are pre-floor.
+    ///
+    /// Asserts the gate DISCRIMINATES rather than always-rejecting — an
+    /// always-false gate would pass a test that only checked the unknown case,
+    /// and the feature would be silently inert.
+    #[test]
+    fn supports_broadcast_target_list_gate_discriminates_by_version() {
+        let cm = make_connection_manager(Some(make_addr(9200)), 1, 10, false);
+
+        let unknown = make_addr(9201);
+        assert!(
+            !cm.supports_broadcast_target_list(unknown),
+            "an unrecorded peer version must fail CLOSED. Note this is not \
+             hypothetical during rollout: until #5161/#5167 deploys, a node \
+             never learns its GATEWAY's version at all, so every gateway link \
+             takes this branch"
+        );
+
+        // 0.2.119 is the highest already-released version at the time this
+        // shipped and carries neither V2 variant.
+        let pre_floor = make_addr(9202);
+        cm.record_remote_version(pre_floor, Some((0, 2, 119)));
+        assert!(
+            !cm.supports_broadcast_target_list(pre_floor),
+            "a peer one release below the floor must keep receiving the legacy \
+             BroadcastTo, byte-identical to today"
+        );
+
+        let at_floor = make_addr(9203);
+        cm.record_remote_version(
+            at_floor,
+            Some(crate::node::BROADCAST_TARGET_LIST_MIN_VERSION),
+        );
+        assert!(
+            cm.supports_broadcast_target_list(at_floor),
+            "the floor release carries the variants, so it must be accepted — \
+             otherwise the feature never activates at all"
+        );
+
+        let newer = make_addr(9204);
+        cm.record_remote_version(newer, Some((0, 3, 0)));
+        assert!(
+            cm.supports_broadcast_target_list(newer),
+            "the floor is a minimum, never an equality test"
+        );
+    }
+
+    /// #5147's copy of the release-timing guard. See
+    /// `hash_first_floor_tracks_the_shipping_release` for the full rationale;
+    /// the failure it prevents is identical — a floor left behind by a release
+    /// bump means peers on the real 0.2.120 read as at-floor, receive a
+    /// `BroadcastToV2` they have no variant index for, fail to decode, and the
+    /// connection is closed.
+    #[test]
+    fn broadcast_target_list_floor_tracks_the_shipping_release() {
+        fn crate_version() -> (u8, u8, u16) {
+            let v = env!("CARGO_PKG_VERSION");
+            let mut it = v.split('.');
+            let major = it.next().unwrap().parse().expect("major");
+            let minor = it.next().unwrap().parse().expect("minor");
+            let patch = it
+                .next()
+                .unwrap()
+                .split(['-', '+'])
+                .next()
+                .unwrap()
+                .parse()
+                .expect("patch");
+            (major, minor, patch)
+        }
+
+        let floor = crate::node::BROADCAST_TARGET_LIST_MIN_VERSION;
+        let current = crate_version();
+
+        match crate::node::BROADCAST_TARGET_LIST_SHIPPED_IN {
+            None => assert!(
+                floor > current,
+                "BROADCAST_TARGET_LIST_MIN_VERSION is {floor:?} but the crate \
+                 is already at {current:?}, and BROADCAST_TARGET_LIST_SHIPPED_IN \
+                 is None.\n\n\
+                 The release has caught up with the floor. Decide which is true \
+                 and encode it:\n\
+                 - This release DOES carry the target list -> set \
+                 BROADCAST_TARGET_LIST_SHIPPED_IN = Some({floor:?}) and freeze \
+                 both.\n\
+                 - It does NOT -> raise BROADCAST_TARGET_LIST_MIN_VERSION to the \
+                 release that will.\n\n\
+                 Leaving it ships a floor that peers on the real {current:?} \
+                 satisfy without carrying the BroadcastToV2 variant: they cannot \
+                 decode it, and the connection is closed."
+            ),
+            Some(shipped) => {
+                assert_eq!(
+                    shipped, floor,
+                    "BROADCAST_TARGET_LIST_SHIPPED_IN ({shipped:?}) must EQUAL \
+                     BROADCAST_TARGET_LIST_MIN_VERSION ({floor:?})"
+                );
+                assert!(
+                    floor <= current,
+                    "shipped in {shipped:?} but the crate is only at {current:?} \
+                     — a release cannot have shipped in the future"
+                );
+            }
+        }
+    }
+
+    /// Catches the floor being LOWERED, which the marker test above cannot see.
+    #[test]
+    fn broadcast_target_list_floor_stays_above_every_release_without_the_variants() {
+        /// Last release that does NOT carry the V2 broadcast variants.
+        const LAST_RELEASE_WITHOUT_VARIANTS: (u8, u8, u16) = (0, 2, 119);
+        assert!(
+            crate::node::BROADCAST_TARGET_LIST_MIN_VERSION > LAST_RELEASE_WITHOUT_VARIANTS,
+            "BROADCAST_TARGET_LIST_MIN_VERSION ({:?}) dropped to or below \
+             {LAST_RELEASE_WITHOUT_VARIANTS:?}, a release with no BroadcastToV2 \
+             variant index. Emitting to those peers fails to decode and drops \
+             the connection.",
+            crate::node::BROADCAST_TARGET_LIST_MIN_VERSION,
+        );
     }
 
     /// Companion to the marker guard: the floor must never drop to or below a

--- a/crates/core/src/ring/contract_ban_list.rs
+++ b/crates/core/src/ring/contract_ban_list.rs
@@ -1113,6 +1113,12 @@ mod tests {
             "UpdateMsg::BroadcastTo {",
             "UpdateMsg::RequestUpdateStreaming {",
             "UpdateMsg::BroadcastToStreaming {",
+            // #5147 appended these two. The list was NOT extended when they
+            // landed, so this guard — whose entire job is to fail when a new
+            // UPDATE wire variant appears ungated — silently passed on the very
+            // change that added two. No live bypass resulted (the key is
+            // extracted from all six variants at node.rs before both gates run),
+            // but the guard had stopped guarding.
             "UpdateMsg::BroadcastToV2 {",
             "UpdateMsg::BroadcastToStreamingV2 {",
         ] {

--- a/crates/core/src/ring/contract_ban_list.rs
+++ b/crates/core/src/ring/contract_ban_list.rs
@@ -1101,14 +1101,20 @@ mod tests {
              the rate limiter (offset {rate_limit_pos}) so banned \
              traffic doesn't consume the rate-limit budget"
         );
-        // All four UPDATE wire variants must remain matched; if a new
-        // one is added it must be gated through both the ban list
-        // and the rate limiter.
+        // EVERY UPDATE wire variant must remain matched; if a new one is
+        // added it must be gated through both the ban list and the rate
+        // limiter, and named here. The list was left at four when #5147
+        // appended the two V2 variants — behaviour stayed correct because the
+        // new arms sit inside the same dispatch block, but the guard silently
+        // stopped covering them, which is precisely what a guard carrying the
+        // instruction "update this list" exists to prevent.
         for variant in [
             "UpdateMsg::RequestUpdate {",
             "UpdateMsg::BroadcastTo {",
             "UpdateMsg::RequestUpdateStreaming {",
             "UpdateMsg::BroadcastToStreaming {",
+            "UpdateMsg::BroadcastToV2 {",
+            "UpdateMsg::BroadcastToStreamingV2 {",
         ] {
             assert!(
                 block.contains(variant),

--- a/crates/core/src/ring/update_rate_limit.rs
+++ b/crates/core/src/ring/update_rate_limit.rs
@@ -715,6 +715,12 @@ mod tests {
             "UpdateMsg::BroadcastTo {",
             "UpdateMsg::RequestUpdateStreaming {",
             "UpdateMsg::BroadcastToStreaming {",
+            // #5147 appended these two. The list was NOT extended when they
+            // landed, so this guard — whose entire job is to fail when a new
+            // UPDATE wire variant appears ungated — silently passed on the very
+            // change that added two. No live bypass resulted (the key is
+            // extracted from all six variants at node.rs before both gates run),
+            // but the guard had stopped guarding.
             "UpdateMsg::BroadcastToV2 {",
             "UpdateMsg::BroadcastToStreamingV2 {",
         ] {

--- a/crates/core/src/ring/update_rate_limit.rs
+++ b/crates/core/src/ring/update_rate_limit.rs
@@ -707,13 +707,16 @@ mod tests {
              messages don't pay the spawn cost"
         );
 
-        // (c) all four wire variants are matched in the dispatch, and
-        //     each spawn site is also present.
+        // (c) EVERY wire variant is matched in the dispatch, and each spawn
+        //     site is also present. Kept in step with the variant list in
+        //     `contract_ban_list.rs`; see the note there about #5147.
         for variant in [
             "UpdateMsg::RequestUpdate {",
             "UpdateMsg::BroadcastTo {",
             "UpdateMsg::RequestUpdateStreaming {",
             "UpdateMsg::BroadcastToStreaming {",
+            "UpdateMsg::BroadcastToV2 {",
+            "UpdateMsg::BroadcastToStreamingV2 {",
         ] {
             assert!(
                 block.contains(variant),

--- a/crates/core/src/tracing/register.rs
+++ b/crates/core/src/tracing/register.rs
@@ -2145,14 +2145,28 @@ mod broadcast_to_telemetry_tests {
     #[test]
     fn from_inbound_msg_v1_has_no_broadcast_to_arm() {
         let body = from_inbound_msg_v1_body();
-        assert!(
-            !body.contains("UpdateMsg::BroadcastTo {"),
-            "from_inbound_msg_v1 must not match UpdateMsg::BroadcastTo directly — \
-             doing so reintroduces the #5149 duplicate/self-attributed \
-             update_broadcast_received event. The driver-side emitters in \
-             operations/update/op_ctx_task.rs (drive_relay_broadcast_to, \
-             apply_streaming_broadcast) already cover this event correctly."
-        );
+        // Every payload-bearing broadcast variant, not just the original.
+        // #5147 added V2 forms of both; an arm for either would reintroduce the
+        // #5149 duplicate exactly as an arm for `BroadcastTo` would, and would
+        // additionally make the two encodings produce DIFFERENT event counts
+        // for the same logical delivery — which would move the very metric the
+        // #5147 rollout is judged on, in the direction that flatters it.
+        for variant in [
+            "UpdateMsg::BroadcastTo {",
+            "UpdateMsg::BroadcastToStreaming {",
+            "UpdateMsg::BroadcastToV2 {",
+            "UpdateMsg::BroadcastToStreamingV2 {",
+        ] {
+            assert!(
+                !body.contains(variant),
+                "from_inbound_msg_v1 must not match `{variant}` directly — \
+                 doing so reintroduces the #5149 duplicate/self-attributed \
+                 update_broadcast_received event. The driver-side emitters in \
+                 operations/update/op_ctx_task.rs (drive_relay_broadcast_to, \
+                 apply_streaming_broadcast) already cover this event correctly \
+                 for every variant."
+            );
+        }
         assert!(
             body.contains("NetMessageV1::Update(_)"),
             "the generic Update wildcard arm must still exist so BroadcastTo \

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -17628,6 +17628,56 @@ fn test_5147_originator_target_list_cuts_duplicate_deliveries() {
         control.sends,
     );
 
+    // DISCRIMINATOR D: the duplicate FRACTION fell, not just the numerator.
+    //
+    // B alone is satisfiable the wrong way: an arm that halves total deliveries
+    // halves redundant deliveries with it and passes, having suppressed real
+    // traffic rather than duplicate traffic. `deliveries` exists as the
+    // denominator for exactly this ratio (see its rustdoc) and was previously
+    // gathered and never used. Cross-multiplied to stay in integers:
+    //   treatment.redundant / treatment.deliveries < control.redundant / control.deliveries
+    // Measured: control 321/440 = 73.0%, treatment 136/236 = 57.6%.
+    assert!(
+        treatment.redundant * control.deliveries < control.redundant * treatment.deliveries,
+        "#5147 reduced redundant deliveries ({} vs control {}) only in step with \
+         total deliveries ({} vs control {}), so the duplicate FRACTION did not \
+         improve. That is what suppressing genuine traffic looks like, and \
+         discriminator B alone cannot tell the two apart.",
+        treatment.redundant,
+        control.redundant,
+        treatment.deliveries,
+        control.deliveries,
+    );
+
+    // DISCRIMINATOR E: the saving is in BYTES, not merely in message count.
+    //
+    // Every assertion above counts legs. This design has a specific, known way
+    // to cut legs while RAISING bytes: suppressing a leg also suppresses the
+    // `sender_summary_bytes` piggyback that keeps peer-summary caches warm, and
+    // a peer whose cached summary we lack receives FULL STATE
+    // (`FullNoTheirSummaryTracked`) instead of a delta — 26.9% of broadcast
+    // bytes at a 357 KB mean in the 0.2.109 fleet profile, against a few KB for
+    // a delta. Roughly a dozen extra full states would erase the entire
+    // measured saving while `sends`, `redundant` and `suppressed` all still
+    // moved the right way.
+    //
+    // `full_state_sends` was captured and logged but never asserted, which left
+    // the one number that reveals the inversion outside the test's reach.
+    // Measured: 16 in BOTH arms — the saving here is entirely in deltas
+    // (444 -> 240), so this holds with margin rather than by a hair.
+    assert!(
+        treatment.full_state_sends <= control.full_state_sends,
+        "#5147 cut broadcast legs ({} vs control {}) but pushed peers onto the \
+         FULL-STATE path ({} vs control {}). A full state is ~357 KB against a \
+         few-KB delta, so this is a bandwidth INCREASE wearing the costume of a \
+         bandwidth saving — the second-order failure this design's summary-seeding \
+         interaction makes possible.",
+        treatment.sends,
+        control.sends,
+        treatment.full_state_sends,
+        control.full_state_sends,
+    );
+
     // SAFETY: no bandwidth saving justifies a peer not converging. This is the
     // assertion that fails on over-suppression.
     assert!(

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -17324,6 +17324,17 @@ struct SuppressionArm {
     summary_skips: u64,
     /// Contracts that converged, and how many there were.
     converged: (usize, usize),
+    /// Peers that actually agreed on the converged state.
+    ///
+    /// `converged` counts CONTRACTS, and this simulation has one, so on its own
+    /// it reduces to `1 >= 1`. `check_convergence_from_logs` also skips any
+    /// contract with fewer than two reporting peers and counts only peers that
+    /// logged a state hash — so a peer that stops RECEIVING stops logging and
+    /// leaves the denominator rather than being counted as diverged. The
+    /// replica count is what notices that.
+    replicas: usize,
+    /// Contracts whose replicas disagreed outright.
+    diverged: usize,
     /// Peers that were suppressed because the originator named them.
     suppressed: u64,
     /// Hosting advertisements exchanged. The premise check: without these no
@@ -17440,6 +17451,12 @@ fn run_5147_suppression_arm(network_name: &str, target_list_enabled: bool) -> Su
         resync_suppressed: GlobalTestMetrics::resync_requests_suppressed(),
         summary_skips: GlobalTestMetrics::fanout_summary_skips(),
         converged: (convergence.converged.len(), convergence.total_contracts()),
+        replicas: convergence
+            .converged
+            .iter()
+            .map(|c| c.replica_count)
+            .sum::<usize>(),
+        diverged: convergence.diverged.len(),
         suppressed: GlobalTestMetrics::broadcast_targets_suppressed(),
         hosting_updates: GlobalTestMetrics::neighbor_hosting_updates(),
     }
@@ -17520,7 +17537,7 @@ fn test_5147_originator_target_list_cuts_duplicate_deliveries() {
 
     tracing::info!(
         "#5147 control:   deliveries={} redundant={} sends={} (delta={} full={}) \
-         suppressed={} summary_skips={} resync_suppressed={} converged={:?}",
+         suppressed={} summary_skips={} resync_suppressed={} converged={:?} replicas={} diverged={}",
         control.deliveries,
         control.redundant,
         control.sends,
@@ -17530,10 +17547,12 @@ fn test_5147_originator_target_list_cuts_duplicate_deliveries() {
         control.summary_skips,
         control.resync_suppressed,
         control.converged,
+        control.replicas,
+        control.diverged,
     );
     tracing::info!(
         "#5147 treatment: deliveries={} redundant={} sends={} (delta={} full={}) \
-         suppressed={} summary_skips={} resync_suppressed={} converged={:?}",
+         suppressed={} summary_skips={} resync_suppressed={} converged={:?} replicas={} diverged={}",
         treatment.deliveries,
         treatment.redundant,
         treatment.sends,
@@ -17543,6 +17562,8 @@ fn test_5147_originator_target_list_cuts_duplicate_deliveries() {
         treatment.summary_skips,
         treatment.resync_suppressed,
         treatment.converged,
+        treatment.replicas,
+        treatment.diverged,
     );
 
     // PREMISE 1: the peers really became each other's advertised co-hosts. If
@@ -17591,13 +17612,32 @@ fn test_5147_originator_target_list_cuts_duplicate_deliveries() {
     // summary gate, or suppressed by the target list — so the sum is the
     // fan-out volume. If it differs, the arms are not comparable and the
     // reduction below could be a topology difference rather than the feature.
+    // Exact equality is deliberate and is NOT a flake risk here, but the reason
+    // is worth stating because it does not generalise: this simulation is
+    // turmoil-scheduled from a fixed seed with peer identity derived from the
+    // label rather than the network name, so each arm is individually
+    // deterministic and re-running either reproduces its counts exactly. The
+    // equality is therefore a real claim about the two arms, not a sample.
+    //
+    // What it is NOT is a conservation law. The three buckets do not partition
+    // every offered leg: `sends` counts only SUCCESSFUL sends, the `compute_delta`
+    // empty-delta return skips without incrementing `summary_skips`, and the
+    // `should_broadcast_contract` early return and queue eviction leave no trace
+    // in any of them. So if this fires, the honest reading is "the arms did
+    // different amounts of work OR a leg took an unbucketed exit" — the failure
+    // message must not send the next reader hunting a topology difference that
+    // did not happen.
     let control_legs = control.sends + control.summary_skips + control.suppressed;
     let treatment_legs = treatment.sends + treatment.summary_skips + treatment.suppressed;
     assert_eq!(
         control_legs, treatment_legs,
-        "the arms offered different numbers of fan-out legs ({control_legs} vs \
-         {treatment_legs}), so they are not comparable and any reduction \
-         measured between them is not attributable to #5147"
+        "the arms accounted for different numbers of fan-out legs \
+         ({control_legs} vs {treatment_legs}). Either they genuinely did \
+         different amounts of work — in which case the reduction below is not \
+         attributable to #5147 — or a leg exited through a path none of the \
+         three counters observe (a failed send, an empty-delta skip, a \
+         should_broadcast_contract early return, or a queue eviction). Check \
+         which before treating this as a topology difference."
     );
 
     // DISCRIMINATOR B: it removed real traffic, not just incremented a counter.
@@ -17680,6 +17720,42 @@ fn test_5147_originator_target_list_cuts_duplicate_deliveries() {
 
     // SAFETY: no bandwidth saving justifies a peer not converging. This is the
     // assertion that fails on over-suppression.
+    // PREMISE 4: the control arm converged at all. Without this the assertion
+    // below is satisfied by `0 >= 0` if a future change breaks BOTH arms.
+    assert!(
+        control.converged.0 > 0 && control.diverged == 0,
+        "premise: the control arm did not converge ({} converged, {} diverged), \
+         so the treatment-vs-control safety comparison below means nothing",
+        control.converged.0,
+        control.diverged,
+    );
+
+    // SAFETY (a): nobody diverged outright.
+    assert_eq!(
+        treatment.diverged, 0,
+        "#5147 left {} contract(s) with replicas holding different state; a \
+         peer wrongly excluded from a fan-out does not learn of the update \
+         until the ~5-minute interest heartbeat",
+        treatment.diverged,
+    );
+
+    // SAFETY (b): no peer silently dropped OUT of the comparison.
+    //
+    // Divergence alone cannot see the failure this design is most likely to
+    // cause. Over-suppression does not give a peer WRONG state, it gives it NO
+    // state — and a peer that never receives never logs a state hash, so it
+    // leaves the denominator instead of being counted as diverged. Comparing
+    // replica counts across arms is what catches that.
+    assert!(
+        treatment.replicas >= control.replicas,
+        "#5147 cut the number of peers holding the converged state ({} vs \
+         control {}). Suppressing a peer that needed the update does not show \
+         up as divergence — the peer simply stops reporting — so this is the \
+         assertion that sees it.",
+        treatment.replicas,
+        control.replicas,
+    );
+
     assert!(
         treatment.converged.0 >= control.converged.0,
         "#5147 cost convergence: control converged {:?}, treatment {:?}. A \

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -17272,6 +17272,42 @@ fn test_gateway_ack_version_unlocks_node_originated_summary_first_put() {
             },
         ),
     ];
+
+    let result = sim.run_controlled_simulation(
+        SEED,
+        operations,
+        Duration::from_secs(120),
+        Duration::from_secs(30),
+    );
+    assert!(
+        result.turmoil_result.is_ok(),
+        "ack-version cascade sim failed: {:?}",
+        result.turmoil_result.err()
+    );
+
+    let delta_sends = GlobalTestMetrics::put_probe_existing_mesh_delta_sends();
+    let delta_bytes = GlobalTestMetrics::put_probe_existing_mesh_delta_bytes();
+    tracing::info!(
+        delta_sends,
+        delta_bytes,
+        "ack-version cascade: node-originated summary-first PUT counters"
+    );
+
+    assert_eq!(
+        delta_sends, 1,
+        "the NODE's PUT must reach the holder-found branch through its gateway \
+         link. This is 0 without the version-carrying ack — the emission gate \
+         fails closed on an unknown remote version and the summary-first block \
+         is skipped entirely"
+    );
+    assert!(
+        delta_bytes > 0,
+        "the probe must have shipped a real delta, not an empty one"
+    );
+
+    freenet::dev_tool::clear_crdt_contracts();
+}
+
 /// One arm of the #5147 suppression measurement: run an update workload over a
 /// co-host mesh and report what the fleet received.
 #[cfg(test)]
@@ -17383,36 +17419,6 @@ fn run_5147_suppression_arm(network_name: &str, target_list_enabled: bool) -> Su
     let result = sim.run_controlled_simulation(
         SEED,
         operations,
-        Duration::from_secs(120),
-        Duration::from_secs(30),
-    );
-    assert!(
-        result.turmoil_result.is_ok(),
-        "ack-version cascade sim failed: {:?}",
-        result.turmoil_result.err()
-    );
-
-    let delta_sends = GlobalTestMetrics::put_probe_existing_mesh_delta_sends();
-    let delta_bytes = GlobalTestMetrics::put_probe_existing_mesh_delta_bytes();
-    tracing::info!(
-        delta_sends,
-        delta_bytes,
-        "ack-version cascade: node-originated summary-first PUT counters"
-    );
-
-    assert_eq!(
-        delta_sends, 1,
-        "the NODE's PUT must reach the holder-found branch through its gateway \
-         link. This is 0 without the version-carrying ack — the emission gate \
-         fails closed on an unknown remote version and the summary-first block \
-         is skipped entirely"
-    );
-    assert!(
-        delta_bytes > 0,
-        "the probe must have shipped a real delta, not an empty one"
-    );
-
-    freenet::dev_tool::clear_crdt_contracts();
         Duration::from_secs(240),
         Duration::from_secs(90),
     );

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -17272,6 +17272,113 @@ fn test_gateway_ack_version_unlocks_node_originated_summary_first_put() {
             },
         ),
     ];
+/// One arm of the #5147 suppression measurement: run an update workload over a
+/// co-host mesh and report what the fleet received.
+#[cfg(test)]
+struct SuppressionArm {
+    /// Inbound broadcast payloads that reached a terminal outcome.
+    deliveries: u64,
+    /// Those that changed nothing — the waste #5147 removes.
+    redundant: u64,
+    /// Outbound broadcast legs actually put on the wire.
+    sends: u64,
+    delta_sends: u64,
+    full_state_sends: u64,
+    resync_suppressed: u64,
+    summary_skips: u64,
+    /// Contracts that converged, and how many there were.
+    converged: (usize, usize),
+    /// Peers that were suppressed because the originator named them.
+    suppressed: u64,
+    /// Hosting advertisements exchanged. The premise check: without these no
+    /// peer has an advertised co-host, so there is no mesh and nothing to
+    /// suppress.
+    hosting_updates: u64,
+}
+
+#[cfg(test)]
+fn run_5147_suppression_arm(network_name: &str, target_list_enabled: bool) -> SuppressionArm {
+    use freenet::dev_tool::{NodeLabel, ScheduledOperation, SimOperation, register_crdt_contract};
+
+    const SEED: u64 = 0x5147_0001_0001;
+    // Enough peers that each has SEVERAL non-sender co-hosts. With two, a
+    // peer's only other co-host is the sender, the originator's list is empty
+    // after excluding the recipient, and the measurement is vacuous.
+    const PEERS: usize = 6;
+    const SUSTAINED_UPDATES: usize = 20;
+
+    GlobalTestMetrics::reset();
+    setup_deterministic_state(SEED);
+    let rt = create_runtime();
+
+    let (sim, logs_handle) = rt.block_on(async {
+        let mut sim = SimNetwork::new(
+            network_name,
+            1, // 1 gateway (the update source)
+            PEERS,
+            7, // max_htl
+            3, // rnd_if_htl_above
+            // Wide enough that the peers connect to EACH OTHER. At a narrower
+            // cap a star forms, every peer's only co-host is the sender, and
+            // the target list has nobody to name — the same blind spot the
+            // #4965 co-host test documents.
+            12, // max_connections
+            4,  // min_connections
+            SEED,
+        )
+        .await;
+        // The ONLY difference between the two arms. Stated explicitly on both
+        // sides rather than relying on the default, so a future edit that flips
+        // the default cannot silently turn the control arm into a second
+        // treatment arm and make the comparison read as "no effect".
+        if target_list_enabled {
+            sim.enable_broadcast_target_list();
+        } else {
+            sim.disable_broadcast_target_list();
+        }
+        // Space the updates across the ~5-minute InterestSync heartbeat
+        // (`INTEREST_HEARTBEAT_INTERVAL`, 300s). At the 3s default the whole
+        // update burst finishes inside one heartbeat window, so the ONLY thing
+        // keeping peer-summary caches fresh is the `sender_summary_bytes`
+        // riding on the broadcasts themselves — precisely what this feature
+        // removes. That regime makes the measurement a study of the sim's
+        // pacing rather than of production, where a River-style update cadence
+        // is minutes apart with heartbeats in between.
+        sim.with_controlled_op_interval(Duration::from_secs(3));
+        let logs_handle = sim.event_logs_handle();
+        (sim, logs_handle)
+    });
+
+    // CRDT contract so post-bootstrap broadcasts compute real version-aware
+    // deltas; a hash contract's "delta" is full state.
+    let contract = SimOperation::create_test_contract(0x51);
+    let contract_id = *contract.key().id();
+    let contract_key = contract.key();
+    register_crdt_contract(contract_id);
+
+    let mut operations = vec![ScheduledOperation::new(
+        NodeLabel::gateway(network_name, 0),
+        SimOperation::Put {
+            contract: contract.clone(),
+            state: SimOperation::create_crdt_state(1, 0x10),
+            subscribe: true,
+        },
+    )];
+    for node_idx in 1..=PEERS {
+        operations.push(ScheduledOperation::new(
+            NodeLabel::node(network_name, node_idx),
+            SimOperation::Subscribe { contract_id },
+        ));
+    }
+    for v in 0..SUSTAINED_UPDATES {
+        operations.push(ScheduledOperation::new(
+            NodeLabel::gateway(network_name, 0),
+            SimOperation::Update {
+                key: contract_key,
+                data: SimOperation::create_crdt_state((v as u64) + 2, 0x20 + v as u8),
+            },
+        ));
+    }
 
     let result = sim.run_controlled_simulation(
         SEED,
@@ -17306,4 +17413,224 @@ fn test_gateway_ack_version_unlocks_node_originated_summary_first_put() {
     );
 
     freenet::dev_tool::clear_crdt_contracts();
+        Duration::from_secs(240),
+        Duration::from_secs(90),
+    );
+    assert!(
+        result.turmoil_result.is_ok(),
+        "{network_name}: simulation should complete: {:?}",
+        result.turmoil_result.err()
+    );
+
+    let convergence =
+        rt.block_on(async { freenet::dev_tool::check_convergence_from_logs(&logs_handle).await });
+
+    SuppressionArm {
+        deliveries: GlobalTestMetrics::broadcast_deliveries(),
+        redundant: GlobalTestMetrics::redundant_broadcast_deliveries(),
+        sends: GlobalTestMetrics::delta_sends() + GlobalTestMetrics::full_state_sends(),
+        delta_sends: GlobalTestMetrics::delta_sends(),
+        full_state_sends: GlobalTestMetrics::full_state_sends(),
+        resync_suppressed: GlobalTestMetrics::resync_requests_suppressed(),
+        summary_skips: GlobalTestMetrics::fanout_summary_skips(),
+        converged: (convergence.converged.len(), convergence.total_contracts()),
+        suppressed: GlobalTestMetrics::broadcast_targets_suppressed(),
+        hosting_updates: GlobalTestMetrics::neighbor_hosting_updates(),
+    }
+}
+
+/// End-to-end measurement of #5147 on a co-host mesh, with a control arm.
+///
+/// ## Measured (7 nodes, 20 CRDT updates, identical seed and topology)
+///
+/// ```text
+/// control:   sends=460 summary_skips=317 suppressed=0   redundant=321 converged=1/1
+/// treatment: sends=256 summary_skips=21  suppressed=500 redundant=136 converged=1/1
+/// ```
+///
+/// 44% fewer broadcast legs on the wire and 58% fewer redundant deliveries,
+/// with convergence unchanged. Note `sends + summary_skips + suppressed` is
+/// **777 in both arms**: the two runs did the identical amount of fan-out work
+/// and the treatment merely reclassified 500 legs, which is what rules out a
+/// topology difference between the arms as the explanation. That identity is
+/// asserted below.
+///
+/// The overlap with the pre-existing summary-match gate is large here — of the
+/// 500 suppressions, roughly 300 were legs that gate would have skipped for
+/// free — which is why the send reduction (44%) is smaller than the suppression
+/// count suggests. On the fleet that overlap is much smaller: the measured
+/// dedup ratio there is 18.6 against this simulation's 3.7, i.e. the
+/// summary-match gate is suppressing far less in production than it does here,
+/// so the target list's marginal value is larger, not smaller.
+///
+/// ## This test earned its keep once already
+///
+/// Written before the code was believed correct, it FAILED on the first run —
+/// treatment sends 528 vs control 460, redundant 400 vs 321 — i.e. the feature
+/// made traffic worse. A control-vs-control run (byte-identical numbers)
+/// cleared the rig, so the regression was real. Cause: a fully-suppressed
+/// fan-out has an empty target set, and `handle_broadcast_state_change` treated
+/// empty as the no-subscriber FAILURE case — three retries with backoff, then a
+/// stash. Each retry re-resolved targets after the coverage claim had already
+/// been consumed, so it suppressed nothing and re-broadcast the whole co-host
+/// set one backoff later. The mechanism defeated itself and would have shipped
+/// looking plausible: every unit test passed, and the only visible symptom was
+/// a bandwidth number nobody had a baseline for. The `fully_covered` branch in
+/// `broadcast.rs` is the fix, and this test is its regression test.
+///
+/// ## Why a control arm and not a threshold
+///
+/// A single-arm test asserting "redundant deliveries are below N" pins the
+/// simulation's own convergence behaviour as much as the feature: change the
+/// topology, the update count, or the CONNECT timing and N moves for reasons
+/// that have nothing to do with the target list. Two arms differing by exactly
+/// one `enable_broadcast_target_list()` call measure the FEATURE, and the
+/// control arm doubles as the "this is what today looks like" baseline.
+///
+/// ## What is asserted, and what deliberately is not
+///
+/// The discriminator is that the treatment arm suppresses fan-out targets AND
+/// receives strictly fewer redundant deliveries than the control. Both halves
+/// are needed: the suppression counter alone would pass if the mechanism fired
+/// but the duplicates arrived by some other route, and the delivery drop alone
+/// could come from a topology difference between the two runs.
+///
+/// A specific suppression FRACTION is NOT asserted. The measured fleet figures
+/// (0.647 at degree 5, rising to 0.924 at 17) are degree-dependent, and this
+/// simulation's achieved degree is far below the fleet's — the topology it
+/// builds is the regime with the LEAST overlap to exploit, so a fleet-derived
+/// threshold here would be measuring the wrong graph. The achieved numbers are
+/// logged so a reader can see the regime rather than infer it.
+///
+/// ## Safety half
+///
+/// Convergence must be no worse in the treatment arm. This is the assertion
+/// that fails if suppression over-reaches: a peer wrongly excluded from a
+/// fan-out does not converge, and no bandwidth saving justifies that.
+#[test_log::test]
+fn test_5147_originator_target_list_cuts_duplicate_deliveries() {
+    let control = run_5147_suppression_arm("i5147-control", false);
+    let treatment = run_5147_suppression_arm("i5147-treatment", true);
+
+    tracing::info!(
+        "#5147 control:   deliveries={} redundant={} sends={} (delta={} full={}) \
+         suppressed={} summary_skips={} resync_suppressed={} converged={:?}",
+        control.deliveries,
+        control.redundant,
+        control.sends,
+        control.delta_sends,
+        control.full_state_sends,
+        control.suppressed,
+        control.summary_skips,
+        control.resync_suppressed,
+        control.converged,
+    );
+    tracing::info!(
+        "#5147 treatment: deliveries={} redundant={} sends={} (delta={} full={}) \
+         suppressed={} summary_skips={} resync_suppressed={} converged={:?}",
+        treatment.deliveries,
+        treatment.redundant,
+        treatment.sends,
+        treatment.delta_sends,
+        treatment.full_state_sends,
+        treatment.suppressed,
+        treatment.summary_skips,
+        treatment.resync_suppressed,
+        treatment.converged,
+    );
+
+    // PREMISE 1: the peers really became each other's advertised co-hosts. If
+    // they did not, no peer has a co-host to name, the list is empty
+    // everywhere, and every assertion below is vacuous.
+    assert!(
+        control.hosting_updates > 0 && treatment.hosting_updates > 0,
+        "premise: no hosting advertisements were exchanged, so there is no \
+         co-host mesh and #5147 has nothing to suppress. control={} \
+         treatment={}",
+        control.hosting_updates,
+        treatment.hosting_updates,
+    );
+
+    // PREMISE 2: the control arm actually exhibits the waste being removed.
+    assert!(
+        control.redundant > 0,
+        "premise: the control arm received ZERO redundant deliveries, so this \
+         topology does not reproduce the duplicate fan-out at all and the \
+         comparison below measures nothing"
+    );
+
+    // PREMISE 3: the control arm is genuinely unsuppressed. Without this a
+    // default flip would make both arms treatment arms and the test would read
+    // "no effect" as success.
+    assert_eq!(
+        control.suppressed, 0,
+        "the control arm must be running today's behaviour; a non-zero \
+         suppression count means the version gate opened when it should have \
+         stayed shut, and the comparison has no baseline"
+    );
+
+    // DISCRIMINATOR A: the mechanism fired.
+    assert!(
+        treatment.suppressed > 0,
+        "#5147 suppressed nothing on a topology built to exercise it: \
+         {} hosting advertisements were exchanged, so peers ARE advertised \
+         co-hosts of each other, yet no fan-out target was ever dropped. \
+         Either the version gate never opened, or the coverage never reached \
+         the fan-out decision.",
+        treatment.hosting_updates,
+    );
+
+    // The two arms must have done the SAME amount of fan-out work. Every
+    // offered leg ends in exactly one of three places — sent, skipped by the
+    // summary gate, or suppressed by the target list — so the sum is the
+    // fan-out volume. If it differs, the arms are not comparable and the
+    // reduction below could be a topology difference rather than the feature.
+    let control_legs = control.sends + control.summary_skips + control.suppressed;
+    let treatment_legs = treatment.sends + treatment.summary_skips + treatment.suppressed;
+    assert_eq!(
+        control_legs, treatment_legs,
+        "the arms offered different numbers of fan-out legs ({control_legs} vs \
+         {treatment_legs}), so they are not comparable and any reduction \
+         measured between them is not attributable to #5147"
+    );
+
+    // DISCRIMINATOR B: it removed real traffic, not just incremented a counter.
+    assert!(
+        treatment.redundant < control.redundant,
+        "#5147 suppressed {} fan-out targets yet the fleet still received as \
+         many redundant deliveries ({} vs control {}). A suppression that does \
+         not show up as fewer received duplicates is suppressing the wrong \
+         thing.",
+        treatment.suppressed,
+        treatment.redundant,
+        control.redundant,
+    );
+
+    // DISCRIMINATOR C: fewer legs actually on the wire. Distinct from B —
+    // B says the fleet RECEIVES fewer duplicates, this says the fleet SENDS
+    // less. The retry bug in this test's history passed neither, but a future
+    // regression that merely delays the suppressed traffic would pass B while
+    // failing here.
+    assert!(
+        treatment.sends < control.sends,
+        "#5147 suppressed {} targets yet the fleet sent as many broadcast legs \
+         ({} vs control {}). Suppressed traffic that reappears later — via the \
+         no-target retry, an anti-entropy heal, or a stash re-emission — is not \
+         suppressed, it is deferred.",
+        treatment.suppressed,
+        treatment.sends,
+        control.sends,
+    );
+
+    // SAFETY: no bandwidth saving justifies a peer not converging. This is the
+    // assertion that fails on over-suppression.
+    assert!(
+        treatment.converged.0 >= control.converged.0,
+        "#5147 cost convergence: control converged {:?}, treatment {:?}. A \
+         peer wrongly excluded from a fan-out does not learn of the update \
+         until the ~5-minute interest heartbeat, which is exactly the failure \
+         this design refuses.",
+        control.converged,
+        treatment.converged,
+    );
 }

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -17508,21 +17508,28 @@ fn run_5147_arm_inner(
 /// ## Measured (7 nodes, 20 CRDT updates, identical seed and topology)
 ///
 /// ```text
-/// control:   sends=460 summary_skips=317 suppressed=0   redundant=321 converged=1/1
-/// treatment: sends=256 summary_skips=21  suppressed=500 redundant=136 converged=1/1
+/// control:   sends=460 summary_skips=417 suppressed=0   redundant=321 replicas=7 diverged=0
+/// treatment: sends=288 summary_skips=146 suppressed=428 redundant=160 replicas=7 diverged=0
 /// ```
 ///
-/// 44% fewer broadcast legs on the wire and 58% fewer redundant deliveries,
-/// with convergence unchanged. Note `sends + summary_skips + suppressed` is
-/// **777 in both arms**: the two runs did the identical amount of fan-out work
-/// and the treatment merely reclassified 500 legs, which is what rules out a
-/// topology difference between the arms as the explanation. That identity is
-/// asserted below.
+/// 37% fewer broadcast legs on the wire and 50% fewer redundant deliveries,
+/// with convergence unchanged and every replica retained.
 ///
-/// The overlap with the pre-existing summary-match gate is large here — of the
-/// 500 suppressions, roughly 300 were legs that gate would have skipped for
-/// free — which is why the send reduction (44%) is smaller than the suppression
-/// count suggests. On the fleet that overlap is much smaller: the measured
+/// These numbers superseded an earlier `460 -> 256` reading, and the reason is
+/// worth keeping: back then the sender exclusion shipped UNGATED, so it was
+/// live in BOTH arms and the control arm was not main's behaviour. Gating it
+/// made the comparison apples-to-apples and moved the measured saving down.
+///
+/// An earlier version of this doc also claimed
+/// `sends + summary_skips + suppressed` was **identical in both arms** and
+/// called that a conservation law. It is not one, and the assertion below is a
+/// 5% bound rather than an equality — see the comment at that assertion for the
+/// buckets an offered leg can exit through uncounted.
+///
+/// The overlap with the pre-existing summary-match gate is large here — many of
+/// the suppressions are legs that gate would have skipped for free — which is
+/// why the send reduction is smaller than the suppression count suggests. On
+/// the fleet that overlap is much smaller: the measured
 /// dedup ratio there is 18.6 against this simulation's 3.7, i.e. the
 /// summary-match gate is suppressing far less in production than it does here,
 /// so the target list's marginal value is larger, not smaller.
@@ -17569,119 +17576,6 @@ fn run_5147_arm_inner(
 /// ## Safety half
 ///
 /// Convergence must be no worse in the treatment arm. This is the assertion
-/// **The multi-writer safety case for #5147.**
-///
-/// The target list attests DELIVERY, not state equality: it says "A sent this
-/// payload to C". But a relayer re-broadcasts its own POST-MERGE state, and
-/// under concurrent writers that state can be strictly newer than the payload
-/// it received. Suppressing C on A's say-so can therefore skip a leg that
-/// carried something C genuinely did not have.
-///
-/// The headline measurement cannot see this. Every one of its updates
-/// originates from the gateway, so all peers merge the same payload into the
-/// same prior state, the relayer's state and the originator's payload agree,
-/// and suppression is correct by construction. That is the regime most
-/// favourable to the feature, and asserting safety only there would be
-/// assuming the answer.
-///
-/// Here the writer rotates across peers, so relayer-ahead-of-recipient is
-/// reachable on every round. What is asserted is SAFETY, not bandwidth:
-///
-/// * nobody diverges, and
-/// * suppression does not cost the converged state any replicas.
-///
-/// The second is the load-bearing one. Over-suppression does not hand a peer
-/// WRONG state — it hands it none — and a peer that stops receiving stops
-/// logging a state hash, so it silently leaves the denominator instead of being
-/// counted as diverged. Comparing replica counts across arms is what sees it.
-///
-/// Deliberately NOT asserted: any bandwidth reduction. The single-writer test
-/// owns that claim; duplicating it here would just be a second sample of the
-/// same mechanism, and a suppression fraction measured on this graph would not
-/// transfer to the fleet's anyway.
-#[test_log::test]
-fn test_5147_multi_writer_suppression_preserves_convergence() {
-    let control = run_5147_multi_writer_arm("5147-mw-control", false);
-    let treatment = run_5147_multi_writer_arm("5147-mw-treatment", true);
-
-    tracing::info!(
-        "#5147 multi-writer control:   deliveries={} redundant={} sends={} \
-         (delta={} full={}) suppressed={} summary_skips={} resync_suppressed={} \
-         converged={:?} replicas={} diverged={}",
-        control.deliveries,
-        control.redundant,
-        control.sends,
-        control.delta_sends,
-        control.full_state_sends,
-        control.suppressed,
-        control.summary_skips,
-        control.resync_suppressed,
-        control.converged,
-        control.replicas,
-        control.diverged,
-    );
-    tracing::info!(
-        "#5147 multi-writer treatment: deliveries={} redundant={} sends={} \
-         (delta={} full={}) suppressed={} summary_skips={} resync_suppressed={} \
-         converged={:?} replicas={} diverged={}",
-        treatment.deliveries,
-        treatment.redundant,
-        treatment.sends,
-        treatment.delta_sends,
-        treatment.full_state_sends,
-        treatment.suppressed,
-        treatment.summary_skips,
-        treatment.resync_suppressed,
-        treatment.converged,
-        treatment.replicas,
-        treatment.diverged,
-    );
-
-    // PREMISE 1: the control arm converged, so the comparison means something.
-    assert!(
-        control.converged.0 > 0 && control.diverged == 0,
-        "premise: the multi-writer control arm did not converge ({} converged, \
-         {} diverged), so nothing below is a statement about #5147",
-        control.converged.0,
-        control.diverged,
-    );
-
-    // PREMISE 2: the feature actually engaged on this workload. Without this the
-    // safety assertions pass trivially against a treatment arm that suppressed
-    // nothing, which is exactly what a broken gate would produce.
-    assert!(
-        treatment.suppressed > 0,
-        "premise: the treatment arm suppressed nothing under the multi-writer \
-         workload, so this test is not exercising the mechanism it exists for"
-    );
-    assert_eq!(
-        control.suppressed, 0,
-        "premise: the control arm suppressed {} targets, so the arms do not \
-         differ by the feature alone",
-        control.suppressed,
-    );
-
-    // SAFETY: concurrent writers must not diverge under suppression.
-    assert_eq!(
-        treatment.diverged, 0,
-        "#5147 left {} contract(s) diverged under concurrent writers. This is \
-         the case the single-writer measurement cannot reach: a relayer whose \
-         post-merge state is newer than the payload it received suppressed a \
-         peer that needed the difference.",
-        treatment.diverged,
-    );
-
-    assert!(
-        treatment.replicas >= control.replicas,
-        "#5147 cut the number of peers holding the converged state under \
-         concurrent writers ({} vs control {}). A peer suppressed while the \
-         relayer held state it lacked stops reporting rather than reporting a \
-         conflict, so this — not divergence — is what that failure looks like.",
-        treatment.replicas,
-        control.replicas,
-    );
-}
-
 /// that fails if suppression over-reaches: a peer wrongly excluded from a
 /// fan-out does not converge, and no bandwidth saving justifies that.
 #[test_log::test]
@@ -17740,6 +17634,28 @@ fn test_5147_originator_target_list_cuts_duplicate_deliveries() {
          comparison below measures nothing"
     );
 
+    // PREMISE 2-bis: the sender exclusion is gated WITH the feature, so it must
+    // be absent from the control arm and present in the treatment arm.
+    //
+    // The field's own doc asserts exactly this, and nothing checked it. That
+    // matters because `sender_skips` was added to explain a gap in the leg
+    // accounting: if it were zero in BOTH arms, adding the bucket changed
+    // nothing, the gap has some other cause, and the stated explanation would
+    // be unverified while looking settled.
+    assert_eq!(
+        control.sender_skips, 0,
+        "premise: the control arm excluded the sender {} times, so the sender \
+         exclusion is not gated with the feature and the arms differ by more \
+         than one flag",
+        control.sender_skips,
+    );
+    assert!(
+        treatment.sender_skips > 0,
+        "premise: the treatment arm never excluded a delivering sender, so \
+         `sender_skips` explains none of the leg-accounting gap it was added \
+         to explain"
+    );
+
     // PREMISE 3: the control arm is genuinely unsuppressed. Without this a
     // default flip would make both arms treatment arms and the test would read
     // "no effect" as success.
@@ -17761,11 +17677,6 @@ fn test_5147_originator_target_list_cuts_duplicate_deliveries() {
         treatment.hosting_updates,
     );
 
-    // The two arms must have done the SAME amount of fan-out work. Every
-    // offered leg ends in exactly one of three places — sent, skipped by the
-    // summary gate, or suppressed by the target list — so the sum is the
-    // fan-out volume. If it differs, the arms are not comparable and the
-    // reduction below could be a topology difference rather than the feature.
     // The two arms must have done comparable amounts of fan-out WORK, so the
     // reduction below cannot be a topology difference between the runs.
     //
@@ -17926,5 +17837,118 @@ fn test_5147_originator_target_list_cuts_duplicate_deliveries() {
          this design refuses.",
         control.converged,
         treatment.converged,
+    );
+}
+
+/// **The multi-writer safety case for #5147.**
+///
+/// The target list attests DELIVERY, not state equality: it says "A sent this
+/// payload to C". But a relayer re-broadcasts its own POST-MERGE state, and
+/// under concurrent writers that state can be strictly newer than the payload
+/// it received. Suppressing C on A's say-so can therefore skip a leg that
+/// carried something C genuinely did not have.
+///
+/// The headline measurement cannot see this. Every one of its updates
+/// originates from the gateway, so all peers merge the same payload into the
+/// same prior state, the relayer's state and the originator's payload agree,
+/// and suppression is correct by construction. That is the regime most
+/// favourable to the feature, and asserting safety only there would be
+/// assuming the answer.
+///
+/// Here the writer rotates across peers, so relayer-ahead-of-recipient is
+/// reachable on every round. What is asserted is SAFETY, not bandwidth:
+///
+/// * nobody diverges, and
+/// * suppression does not cost the converged state any replicas.
+///
+/// The second is the load-bearing one. Over-suppression does not hand a peer
+/// WRONG state — it hands it none — and a peer that stops receiving stops
+/// logging a state hash, so it silently leaves the denominator instead of being
+/// counted as diverged. Comparing replica counts across arms is what sees it.
+///
+/// Deliberately NOT asserted: any bandwidth reduction. The single-writer test
+/// owns that claim; duplicating it here would just be a second sample of the
+/// same mechanism, and a suppression fraction measured on this graph would not
+/// transfer to the fleet's anyway.
+#[test_log::test]
+fn test_5147_multi_writer_suppression_preserves_convergence() {
+    let control = run_5147_multi_writer_arm("5147-mw-control", false);
+    let treatment = run_5147_multi_writer_arm("5147-mw-treatment", true);
+
+    tracing::info!(
+        "#5147 multi-writer control:   deliveries={} redundant={} sends={} \
+         (delta={} full={}) suppressed={} summary_skips={} resync_suppressed={} \
+         converged={:?} replicas={} diverged={}",
+        control.deliveries,
+        control.redundant,
+        control.sends,
+        control.delta_sends,
+        control.full_state_sends,
+        control.suppressed,
+        control.summary_skips,
+        control.resync_suppressed,
+        control.converged,
+        control.replicas,
+        control.diverged,
+    );
+    tracing::info!(
+        "#5147 multi-writer treatment: deliveries={} redundant={} sends={} \
+         (delta={} full={}) suppressed={} summary_skips={} resync_suppressed={} \
+         converged={:?} replicas={} diverged={}",
+        treatment.deliveries,
+        treatment.redundant,
+        treatment.sends,
+        treatment.delta_sends,
+        treatment.full_state_sends,
+        treatment.suppressed,
+        treatment.summary_skips,
+        treatment.resync_suppressed,
+        treatment.converged,
+        treatment.replicas,
+        treatment.diverged,
+    );
+
+    // PREMISE 1: the control arm converged, so the comparison means something.
+    assert!(
+        control.converged.0 > 0 && control.diverged == 0,
+        "premise: the multi-writer control arm did not converge ({} converged, \
+         {} diverged), so nothing below is a statement about #5147",
+        control.converged.0,
+        control.diverged,
+    );
+
+    // PREMISE 2: the feature actually engaged on this workload. Without this the
+    // safety assertions pass trivially against a treatment arm that suppressed
+    // nothing, which is exactly what a broken gate would produce.
+    assert!(
+        treatment.suppressed > 0,
+        "premise: the treatment arm suppressed nothing under the multi-writer \
+         workload, so this test is not exercising the mechanism it exists for"
+    );
+    assert_eq!(
+        control.suppressed, 0,
+        "premise: the control arm suppressed {} targets, so the arms do not \
+         differ by the feature alone",
+        control.suppressed,
+    );
+
+    // SAFETY: concurrent writers must not diverge under suppression.
+    assert_eq!(
+        treatment.diverged, 0,
+        "#5147 left {} contract(s) diverged under concurrent writers. This is \
+         the case the single-writer measurement cannot reach: a relayer whose \
+         post-merge state is newer than the payload it received suppressed a \
+         peer that needed the difference.",
+        treatment.diverged,
+    );
+
+    assert!(
+        treatment.replicas >= control.replicas,
+        "#5147 cut the number of peers holding the converged state under \
+         concurrent writers ({} vs control {}). A peer suppressed while the \
+         relayer held state it lacked stops reporting rather than reporting a \
+         conflict, so this — not divergence — is what that failure looks like.",
+        treatment.replicas,
+        control.replicas,
     );
 }

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -17337,6 +17337,13 @@ struct SuppressionArm {
     diverged: usize,
     /// Peers that were suppressed because the originator named them.
     suppressed: u64,
+    /// Legs dropped because the target was the peer that delivered the update.
+    ///
+    /// The FOURTH terminal outcome. It is gated with the feature, so it is
+    /// zero in the control arm and non-zero in the treatment arm — which means
+    /// leaving it out of the accounting identity below made the arms look
+    /// unequal by exactly this count.
+    sender_skips: u64,
     /// Hosting advertisements exchanged. The premise check: without these no
     /// peer has an advertised co-host, so there is no mesh and nothing to
     /// suppress.
@@ -17345,6 +17352,31 @@ struct SuppressionArm {
 
 #[cfg(test)]
 fn run_5147_suppression_arm(network_name: &str, target_list_enabled: bool) -> SuppressionArm {
+    run_5147_arm_inner(network_name, target_list_enabled, false)
+}
+
+/// Same arm, but every update originates from a DIFFERENT peer in turn.
+///
+/// This is the workload that exercises the design's sharpest open question.
+/// The target list attests DELIVERY of the originator's payload — "A sent this
+/// to C" — but a relayer re-broadcasts its own POST-MERGE state, which under
+/// concurrent writers can be strictly newer than the payload it received. If B
+/// suppresses C on A's say-so while holding state C lacks, C does not learn it
+/// until the ~5-minute anti-entropy heartbeat.
+///
+/// The single-writer arm cannot see this: with one writer every peer merges the
+/// same payload into the same prior state, so the relayer's state and the
+/// originator's payload agree and suppression is exactly right. Rotating the
+/// writer is what makes relayer-ahead-of-recipient reachable.
+fn run_5147_multi_writer_arm(network_name: &str, target_list_enabled: bool) -> SuppressionArm {
+    run_5147_arm_inner(network_name, target_list_enabled, true)
+}
+
+fn run_5147_arm_inner(
+    network_name: &str,
+    target_list_enabled: bool,
+    multi_writer: bool,
+) -> SuppressionArm {
     use freenet::dev_tool::{NodeLabel, ScheduledOperation, SimOperation, register_crdt_contract};
 
     const SEED: u64 = 0x5147_0001_0001;
@@ -17418,8 +17450,16 @@ fn run_5147_suppression_arm(network_name: &str, target_list_enabled: bool) -> Su
         ));
     }
     for v in 0..SUSTAINED_UPDATES {
+        // Single-writer: always the gateway, so every peer merges the same
+        // payload into the same prior state. Multi-writer: rotate across the
+        // subscribing peers, so a relayer can hold state its recipient lacks.
+        let writer = if multi_writer {
+            NodeLabel::node(network_name, (v % PEERS) + 1)
+        } else {
+            NodeLabel::gateway(network_name, 0)
+        };
         operations.push(ScheduledOperation::new(
-            NodeLabel::gateway(network_name, 0),
+            writer,
             SimOperation::Update {
                 key: contract_key,
                 data: SimOperation::create_crdt_state((v as u64) + 2, 0x20 + v as u8),
@@ -17458,6 +17498,7 @@ fn run_5147_suppression_arm(network_name: &str, target_list_enabled: bool) -> Su
             .sum::<usize>(),
         diverged: convergence.diverged.len(),
         suppressed: GlobalTestMetrics::broadcast_targets_suppressed(),
+        sender_skips: GlobalTestMetrics::broadcast_sender_skips(),
         hosting_updates: GlobalTestMetrics::neighbor_hosting_updates(),
     }
 }
@@ -17528,6 +17569,119 @@ fn run_5147_suppression_arm(network_name: &str, target_list_enabled: bool) -> Su
 /// ## Safety half
 ///
 /// Convergence must be no worse in the treatment arm. This is the assertion
+/// **The multi-writer safety case for #5147.**
+///
+/// The target list attests DELIVERY, not state equality: it says "A sent this
+/// payload to C". But a relayer re-broadcasts its own POST-MERGE state, and
+/// under concurrent writers that state can be strictly newer than the payload
+/// it received. Suppressing C on A's say-so can therefore skip a leg that
+/// carried something C genuinely did not have.
+///
+/// The headline measurement cannot see this. Every one of its updates
+/// originates from the gateway, so all peers merge the same payload into the
+/// same prior state, the relayer's state and the originator's payload agree,
+/// and suppression is correct by construction. That is the regime most
+/// favourable to the feature, and asserting safety only there would be
+/// assuming the answer.
+///
+/// Here the writer rotates across peers, so relayer-ahead-of-recipient is
+/// reachable on every round. What is asserted is SAFETY, not bandwidth:
+///
+/// * nobody diverges, and
+/// * suppression does not cost the converged state any replicas.
+///
+/// The second is the load-bearing one. Over-suppression does not hand a peer
+/// WRONG state — it hands it none — and a peer that stops receiving stops
+/// logging a state hash, so it silently leaves the denominator instead of being
+/// counted as diverged. Comparing replica counts across arms is what sees it.
+///
+/// Deliberately NOT asserted: any bandwidth reduction. The single-writer test
+/// owns that claim; duplicating it here would just be a second sample of the
+/// same mechanism, and a suppression fraction measured on this graph would not
+/// transfer to the fleet's anyway.
+#[test_log::test]
+fn test_5147_multi_writer_suppression_preserves_convergence() {
+    let control = run_5147_multi_writer_arm("5147-mw-control", false);
+    let treatment = run_5147_multi_writer_arm("5147-mw-treatment", true);
+
+    tracing::info!(
+        "#5147 multi-writer control:   deliveries={} redundant={} sends={} \
+         (delta={} full={}) suppressed={} summary_skips={} resync_suppressed={} \
+         converged={:?} replicas={} diverged={}",
+        control.deliveries,
+        control.redundant,
+        control.sends,
+        control.delta_sends,
+        control.full_state_sends,
+        control.suppressed,
+        control.summary_skips,
+        control.resync_suppressed,
+        control.converged,
+        control.replicas,
+        control.diverged,
+    );
+    tracing::info!(
+        "#5147 multi-writer treatment: deliveries={} redundant={} sends={} \
+         (delta={} full={}) suppressed={} summary_skips={} resync_suppressed={} \
+         converged={:?} replicas={} diverged={}",
+        treatment.deliveries,
+        treatment.redundant,
+        treatment.sends,
+        treatment.delta_sends,
+        treatment.full_state_sends,
+        treatment.suppressed,
+        treatment.summary_skips,
+        treatment.resync_suppressed,
+        treatment.converged,
+        treatment.replicas,
+        treatment.diverged,
+    );
+
+    // PREMISE 1: the control arm converged, so the comparison means something.
+    assert!(
+        control.converged.0 > 0 && control.diverged == 0,
+        "premise: the multi-writer control arm did not converge ({} converged, \
+         {} diverged), so nothing below is a statement about #5147",
+        control.converged.0,
+        control.diverged,
+    );
+
+    // PREMISE 2: the feature actually engaged on this workload. Without this the
+    // safety assertions pass trivially against a treatment arm that suppressed
+    // nothing, which is exactly what a broken gate would produce.
+    assert!(
+        treatment.suppressed > 0,
+        "premise: the treatment arm suppressed nothing under the multi-writer \
+         workload, so this test is not exercising the mechanism it exists for"
+    );
+    assert_eq!(
+        control.suppressed, 0,
+        "premise: the control arm suppressed {} targets, so the arms do not \
+         differ by the feature alone",
+        control.suppressed,
+    );
+
+    // SAFETY: concurrent writers must not diverge under suppression.
+    assert_eq!(
+        treatment.diverged, 0,
+        "#5147 left {} contract(s) diverged under concurrent writers. This is \
+         the case the single-writer measurement cannot reach: a relayer whose \
+         post-merge state is newer than the payload it received suppressed a \
+         peer that needed the difference.",
+        treatment.diverged,
+    );
+
+    assert!(
+        treatment.replicas >= control.replicas,
+        "#5147 cut the number of peers holding the converged state under \
+         concurrent writers ({} vs control {}). A peer suppressed while the \
+         relayer held state it lacked stops reporting rather than reporting a \
+         conflict, so this — not divergence — is what that failure looks like.",
+        treatment.replicas,
+        control.replicas,
+    );
+}
+
 /// that fails if suppression over-reaches: a peer wrongly excluded from a
 /// fan-out does not converge, and no bandwidth saving justifies that.
 #[test_log::test]
@@ -17612,32 +17766,40 @@ fn test_5147_originator_target_list_cuts_duplicate_deliveries() {
     // summary gate, or suppressed by the target list — so the sum is the
     // fan-out volume. If it differs, the arms are not comparable and the
     // reduction below could be a topology difference rather than the feature.
-    // Exact equality is deliberate and is NOT a flake risk here, but the reason
-    // is worth stating because it does not generalise: this simulation is
-    // turmoil-scheduled from a fixed seed with peer identity derived from the
-    // label rather than the network name, so each arm is individually
-    // deterministic and re-running either reproduces its counts exactly. The
-    // equality is therefore a real claim about the two arms, not a sample.
+    // The two arms must have done comparable amounts of fan-out WORK, so the
+    // reduction below cannot be a topology difference between the runs.
     //
-    // What it is NOT is a conservation law. The three buckets do not partition
-    // every offered leg: `sends` counts only SUCCESSFUL sends, the `compute_delta`
-    // empty-delta return skips without incrementing `summary_skips`, and the
-    // `should_broadcast_contract` early return and queue eviction leave no trace
-    // in any of them. So if this fires, the honest reading is "the arms did
-    // different amounts of work OR a leg took an unbucketed exit" — the failure
-    // message must not send the next reader hunting a topology difference that
-    // did not happen.
-    let control_legs = control.sends + control.summary_skips + control.suppressed;
-    let treatment_legs = treatment.sends + treatment.summary_skips + treatment.suppressed;
-    assert_eq!(
-        control_legs, treatment_legs,
-        "the arms accounted for different numbers of fan-out legs \
-         ({control_legs} vs {treatment_legs}). Either they genuinely did \
-         different amounts of work — in which case the reduction below is not \
-         attributable to #5147 — or a leg exited through a path none of the \
-         three counters observe (a failed send, an empty-delta skip, a \
-         should_broadcast_contract early return, or a queue eviction). Check \
-         which before treating this as a topology difference."
+    // This was originally an exact equality on sends + summary_skips +
+    // suppressed, justified as a conservation law: "every offered leg ends in
+    // exactly one of three places". It is not one, and a reviewer said so
+    // before the numbers did. Two independent leaks showed up:
+    //
+    //  * the sender exclusion is a FOURTH terminal outcome, counted nowhere
+    //    (now `sender_skips`, recorded at the decision site);
+    //  * legs still exit through paths no counter observes — a failed send
+    //    (`sends` counts only successful ones), the `compute_delta` empty-delta
+    //    return, `should_broadcast_contract`, and queue eviction.
+    //
+    // With all four buckets the arms land at 877 vs 869: under 1%. So the
+    // assertion is a bound, not an identity. It is still a real discriminator —
+    // a genuine topology difference between the arms moves this by far more
+    // than a few unbucketed legs — while no longer being a tripwire that fires
+    // on a single extra send failure, which under this repo's
+    // flaky-tests-are-blockers rule would make it a merge blocker of its own.
+    let control_legs =
+        control.sends + control.summary_skips + control.suppressed + control.sender_skips;
+    let treatment_legs =
+        treatment.sends + treatment.summary_skips + treatment.suppressed + treatment.sender_skips;
+    let leg_gap = control_legs.abs_diff(treatment_legs);
+    let leg_tolerance = control_legs / 20; // 5%
+    assert!(
+        leg_gap <= leg_tolerance,
+        "the arms accounted for very different amounts of fan-out work \
+         ({control_legs} vs {treatment_legs}, gap {leg_gap} > tolerance \
+         {leg_tolerance}). A few unbucketed legs are expected — a failed send, \
+         an empty-delta skip, a should_broadcast_contract early return, a queue \
+         eviction — but a gap this size means the two runs did genuinely \
+         different work, so the reduction below is not attributable to #5147."
     );
 
     // DISCRIMINATOR B: it removed real traffic, not just incremented a counter.

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -17701,6 +17701,11 @@ fn test_5147_originator_target_list_cuts_duplicate_deliveries() {
         control.sends + control.summary_skips + control.suppressed + control.sender_skips;
     let treatment_legs =
         treatment.sends + treatment.summary_skips + treatment.suppressed + treatment.sender_skips;
+    assert!(
+        control_legs > 0,
+        "premise: the control arm accounted for ZERO fan-out legs, so the \
+         tolerance below is 0 and the comparison passes vacuously"
+    );
     let leg_gap = control_legs.abs_diff(treatment_legs);
     let leg_tolerance = control_legs / 20; // 5%
     assert!(
@@ -17749,7 +17754,8 @@ fn test_5147_originator_target_list_cuts_duplicate_deliveries() {
     // denominator for exactly this ratio (see its rustdoc) and was previously
     // gathered and never used. Cross-multiplied to stay in integers:
     //   treatment.redundant / treatment.deliveries < control.redundant / control.deliveries
-    // Measured: control 321/440 = 73.0%, treatment 136/236 = 57.6%.
+    // Measured after the gating fix: control 321/440 = 73.0%, treatment
+    // 160/260 = 61.5%.
     assert!(
         treatment.redundant * control.deliveries < control.redundant * treatment.deliveries,
         "#5147 reduced redundant deliveries ({} vs control {}) only in step with \
@@ -17776,8 +17782,15 @@ fn test_5147_originator_target_list_cuts_duplicate_deliveries() {
     //
     // `full_state_sends` was captured and logged but never asserted, which left
     // the one number that reveals the inversion outside the test's reach.
-    // Measured: 16 in BOTH arms — the saving here is entirely in deltas
-    // (444 -> 240), so this holds with margin rather than by a hair.
+    //
+    // Measured after the gating fix: **16 in both arms**, saving entirely in
+    // deltas (444 -> 272). State that honestly: under a `<=` comparison, equal
+    // counts pass by exactly one step, not "with margin" as an earlier version
+    // of this comment claimed. And the direction of risk is real — every extra
+    // suppressed leg also suppresses the `sender_summary_bytes` piggyback named
+    // above, which is what would push the treatment arm's full-state count up.
+    // So if this ever reddens, the first hypothesis is that suppression grew,
+    // not that the test is brittle.
     assert!(
         treatment.full_state_sends <= control.full_state_sends,
         "#5147 cut broadcast legs ({} vs control {}) but pushed peers onto the \
@@ -17840,38 +17853,60 @@ fn test_5147_originator_target_list_cuts_duplicate_deliveries() {
     );
 }
 
-/// **The multi-writer safety case for #5147.**
+/// **What suppression does under CONCURRENT WRITERS.**
 ///
-/// The target list attests DELIVERY, not state equality: it says "A sent this
-/// payload to C". But a relayer re-broadcasts its own POST-MERGE state, and
-/// under concurrent writers that state can be strictly newer than the payload
-/// it received. Suppressing C on A's say-so can therefore skip a leg that
-/// carried something C genuinely did not have.
+/// Renamed and rescoped after a reviewer showed the safety claim it originally
+/// made was one it could not support. Read the limits before quoting it.
 ///
-/// The headline measurement cannot see this. Every one of its updates
-/// originates from the gateway, so all peers merge the same payload into the
-/// same prior state, the relayer's state and the originator's payload agree,
-/// and suppression is correct by construction. That is the regime most
-/// favourable to the feature, and asserting safety only there would be
-/// assuming the answer.
+/// ## What this DOES establish
 ///
-/// Here the writer rotates across peers, so relayer-ahead-of-recipient is
-/// reachable on every round. What is asserted is SAFETY, not bandwidth:
+/// The feature engages under a rotating-writer workload, and its benefit is
+/// strongly regime-dependent:
 ///
-/// * nobody diverges, and
-/// * suppression does not cost the converged state any replicas.
+/// ```text
+/// control:   sends=459 redundant=319 suppressed=0
+/// treatment: sends=420 redundant=288 suppressed=229
+/// ```
 ///
-/// The second is the load-bearing one. Over-suppression does not hand a peer
-/// WRONG state — it hands it none — and a peer that stops receiving stops
-/// logging a state hash, so it silently leaves the denominator instead of being
-/// counted as diverged. Comparing replica counts across arms is what sees it.
+/// About -8.5% sends here against -37% in the single-writer test on the same
+/// topology. That gap is the point: every update in the headline measurement
+/// originates at the GATEWAY, and quoting its number as the expected fleet
+/// saving would overstate it, since real River traffic is multi-writer.
 ///
-/// Deliberately NOT asserted: any bandwidth reduction. The single-writer test
-/// owns that claim; duplicating it here would just be a second sample of the
-/// same mechanism, and a suppression fraction measured on this graph would not
-/// transfer to the fleet's anyway.
+/// ## What this does NOT establish, despite an earlier version claiming it
+///
+/// It does **not** show that suppression is safe against the design's sharpest
+/// hazard — that a relayer's post-merge state can be newer than the payload it
+/// received, so suppressing on DELIVERY can skip a leg carrying state the
+/// recipient lacks.
+///
+/// Demonstrated, not suspected: making suppression UNCONDITIONAL (drop every
+/// advertised co-host on any relayed fan-out — 480 suppressions, sends
+/// 459 -> 317) leaves this test GREEN, `diverged=0` and `replicas=7`. So its
+/// convergence assertions cannot detect over-suppression here, and three
+/// independent properties of the setup explain why:
+///
+/// * **Topology.** 7 peers at `max_connections: 12` is near-clique, so no peer
+///   depends on a relayer for any update; over-suppressing relay legs costs
+///   nobody state.
+/// * **Merge semantics.** The CRDT fixture is an LWW register with strictly
+///   increasing versions, so missing an OLDER update is harmless by
+///   construction — and `apply_crdt_full_state` returning `CurrentWon`
+///   re-broadcasts, which actively heals the case being probed.
+/// * **Settle window.** Convergence is checked after 90 simulated seconds of
+///   quiet, long enough for that healing to finish.
+///
+/// Closing it needs a workload where a recipient's ONLY path to newer state
+/// runs through the suppressing relayer — a sparser graph, equal-version
+/// writes that fork, or a settle window shorter than the heal — plus a counter
+/// asserting the relayer-ahead condition actually occurred rather than merely
+/// being reachable. Tracked rather than bodged in at the end of a long session.
+///
+/// The convergence assertions are kept because they are cheap and would catch a
+/// gross regression, but they are NOT evidence on the hazard above and must not
+/// be cited as such.
 #[test_log::test]
-fn test_5147_multi_writer_suppression_preserves_convergence() {
+fn test_5147_multi_writer_suppression_is_regime_dependent() {
     let control = run_5147_multi_writer_arm("5147-mw-control", false);
     let treatment = run_5147_multi_writer_arm("5147-mw-treatment", true);
 
@@ -17935,10 +17970,9 @@ fn test_5147_multi_writer_suppression_preserves_convergence() {
     // SAFETY: concurrent writers must not diverge under suppression.
     assert_eq!(
         treatment.diverged, 0,
-        "#5147 left {} contract(s) diverged under concurrent writers. This is \
-         the case the single-writer measurement cannot reach: a relayer whose \
-         post-merge state is newer than the payload it received suppressed a \
-         peer that needed the difference.",
+        "#5147 left {} contract(s) diverged under concurrent writers. A gross \
+         regression check only — see this test's rustdoc for why it cannot \
+         detect targeted over-suppression in this topology.",
         treatment.diverged,
     );
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -226,6 +226,19 @@ Current wire-gated floors:
   If the feature slips to a later release, RAISE THE FLOOR; do not set the
   marker to make the test pass.
 
+  **This floor DEPENDS on `GATEWAY_ACK_VERSION_MIN_VERSION` above and shares
+  its target release.** Until the version-carrying ack ships, a node never
+  learns its gateway's version, so this gate fails closed on every gateway link
+  no matter what the gateway actually runs. If the two are ever separated, this
+  one must not ship BEFORE that one, or it is inert on exactly the links that
+  carry the most fan-out.
+
+  Note also that a mis-set floor here is not symmetric with the others. Too low
+  closes connections, as above. Too high does not merely lose an optimisation
+  either — it is the *suppression* side that carries the risk, because a
+  wrongly-suppressed peer waits for the ~5-minute interest heartbeat. Bias
+  high, but understand that neither direction is free.
+
 When a NEW wire-gated feature first ships (not this one), set its floor to
 **exactly that release version** and freeze it, as described above.
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -193,6 +193,39 @@ Current wire-gated floors:
   bootstrapping round-trip and no way for the decision to go stale against a
   peer that downgraded at a reused address.
 
+- `BROADCAST_TARGET_LIST_MIN_VERSION` in
+  `crates/core/src/node/network_bridge/p2p_protoc.rs` — the originator target
+  list on contract broadcasts (#5147).
+
+  Set to **`(0, 2, 120)`**, the release intended to first ship the
+  `UpdateMsg::BroadcastToV2` / `BroadcastToStreamingV2` variants.
+
+  Same failure mode as the three application-message floors above, and it is
+  worth stating concretely because it is easy to read as merely a lost
+  optimisation: a peer at or above the floor that does **not** carry the code
+  receives a variant index it has no arm for, `decode_msg` fails, and the
+  connection is CLOSED rather than degraded. Across the 0-4h staggered rollout
+  that presents as fleet-wide transport churn, not as a feature that quietly
+  did nothing.
+
+  Guarded by a marker exactly like `HASH_FIRST_SHIPPED_IN`:
+  `BROADCAST_TARGET_LIST_SHIPPED_IN: Option<(u8, u8, u16)>`, currently `None`,
+  checked by
+  `connection_manager.rs::broadcast_target_list_floor_tracks_the_shipping_release`.
+  When a release bump raises `CARGO_PKG_VERSION` to `(0, 2, 120)`, that test
+  fails until the releaser consciously either sets
+  `BROADCAST_TARGET_LIST_SHIPPED_IN = Some(BROADCAST_TARGET_LIST_MIN_VERSION)`
+  (this release carries it) or raises the floor (it does not).
+  `broadcast_target_list_floor_stays_above_every_release_without_the_variants`
+  is the companion that catches the floor being *lowered*.
+
+  **Know the one way to resolve that red test wrongly.** The `Some(..)` arm
+  asserts `shipped == floor && floor <= current`. Setting the marker to
+  `Some((0, 2, 120))` when the code did NOT land in 0.2.120 satisfies both
+  clauses and goes green — so the marker records a claim no test can check.
+  If the feature slips to a later release, RAISE THE FLOOR; do not set the
+  marker to make the test pass.
+
 When a NEW wire-gated feature first ships (not this one), set its floor to
 **exactly that release version** and freeze it, as described above.
 


### PR DESCRIPTION
## Problem

Contract broadcast is a mesh re-fan-out. `A` applies an update and sends it to its advertised co-hosts `B`, `C`, `D`. `B` applies it and re-broadcasts to ITS co-hosts — which include `C` and `D`, who already have it. Every node does this simultaneously, so on the 0.2.119 fleet each node received **~18.6 byte-identical copies of every update, 74.6% of all received contract bytes** (#5147).

`B` cannot currently tell that `C` already has it. The information that would say so (`sender_summary_bytes`) rides ON the duplicate itself, so it always arrives too late to prevent it.

## Approach

The originator attaches to its broadcast the list of peers it is sending to; a relayer excludes listed peers from its own re-fan-out.

**Exact list, not a Bloom filter.** This supersedes the covered-set-as-Bloom direction (commits `8afecb599`, `2c8b070de`, retired — not built on). At the median fan-out of 17 an exact list of 8-byte hashes is no larger than the Bloom, and it has no false positives, so the salt / saturation guard / union semantics that existed solely to manage those false positives are all unnecessary. A false positive here means a peer that genuinely needed the update silently does not get it until the ~5-minute heartbeat, so removing that failure mode outright is worth more than the bytes.

**One hop only**, which is also the security rule. A relayer does not forward the list and does not union its own targets into it (measured hop-2 suppression is already 0.99, so multi-hop buys nothing). The list is honored ONLY from the message that delivered the payload, so a malicious relayer cannot attach a fabricated "everyone is covered" claim to suppress third-party fan-out. That is enforced structurally rather than by a runtime check: **no other variant has the field**, and `only_payload_bearing_variants_carry_a_target_list` parses the enum to keep it that way.

**Transaction-seeded hashing.** Hashes are `blake3(tx_id ‖ pub_key)[..8]`, following `VisitedPeers`, whose rustdoc documents the topology-inference rationale for tx-seeding. It buys a second property free: a list lifted from one broadcast and replayed onto another resolves to nothing.

### Provenance plumbing — the choice, and why

`NodeEvent::BroadcastStateChange` is emitted by the executor on ANY committed write and carries no idea whether the write came from a local client or an inbound broadcast; nothing between the receive driver and the fan-out carries networking context.

Threading it explicitly through `ContractHandlerEvent::UpdateQuery` is ~10 signatures and 2 trait methods × 3 impls, **plus three things worth naming because they are easy to miss**: the deferral path re-runs the upsert (so the value must live in `DeferralCtx` and be replayed), there is a second `BroadcastStateChange` emitter at `executor_impl.rs` that bypasses `commit_state_update`, and there is a second `UpdateQuery` producer at `node.rs` (the `ResyncResponse` arm) that bypasses `update_contract` entirely. That is a large diff through the WASM layer with three places where getting it wrong is silent.

Instead the apply parks its claim on a short-TTL store keyed by contract, and the fan-out takes it. Ordering is sound by construction: the write happens before the `UpdateQuery` enters the contract handler, and the read can only happen after that query committed.

**The race, and why it can only under-suppress.** Two different updates to the same contract can be in flight, and the entries are keyed by contract. `register` therefore **narrows** rather than replaces: coverage intersects, and a disagreeing sender is dropped. Every peer in the intersection was covered by *both* live applies, so whichever apply the fan-out belongs to, each suppressed peer genuinely had the state. A mixed-up entry can only suppress fewer peers — today's behaviour — never withhold an update. Three things keep that from being merely decorative: the fair queue serialises WASM merges per contract key; duplicates are dropped by `broadcast_dedup_cache` *before* `update_contract`, so ~18 copies of one update register once between them; and an apply that changes nothing discards its entry rather than leaving it to expire (no-change is the common case — 97% of received contract bytes change nothing).

**Residual, stated rather than hidden:** commit paths that emit `BroadcastStateChange` without going through `update_contract` (the executor-internal replay, the second emitter) can take an entry belonging to a concurrent relay apply of the same contract. That one IS over-suppression. It needs a same-contract PUT-or-replay concurrent with a relayed update inside one contract-handler round trip; it is TTL-bounded and healed by the heartbeat.

### The dead sender-exclusion, revived

`get_broadcast_targets_update` has had sender- and self-exclusion filters for a long time and **both were structurally dead**: the re-fan-out call site had no sender to pass and handed in its own address, so `is_local_update_initiator` was always true there. A relayer echoed every broadcast straight back to the peer that had just sent it — a 100%-wasted send on every relayed broadcast, and one the target list cannot fix, since a peer never names itself on its own list. Replacing the `&SocketAddr` sentinel with a `BroadcastOrigin` makes both filters live. Self-exclusion is now unconditional; broadcasting to ourselves is never correct.

Called out separately so its share of the measured effect can be attributed. Say the word if you would rather it were its own PR.

## Testing

**The simulation earned its keep — it failed first, and the failure was a real bug.**

First run: the feature made traffic *worse* (treatment sends 528 vs control 460, redundant deliveries 400 vs 321). A control-vs-control run gave byte-identical numbers, clearing the rig. Cause: a fully-suppressed fan-out has an empty target set, and `handle_broadcast_state_change` read empty as the no-subscriber FAILURE case — three retries with backoff, then a stash. Each retry re-resolved targets after the coverage claim had been consumed, so it suppressed nothing and re-broadcast the whole co-host set one backoff later. **The mechanism defeated itself and would have shipped looking plausible**: every unit test passed, and the only symptom was a bandwidth number nobody had a baseline for. Second commit fixes it; `fully_covered_fanout_returns_before_the_no_target_retry` pins the ordering.

After the fix, 1 gateway + 6 subscribing peers, 20 CRDT updates, identical seed, arms differing by exactly one `enable_broadcast_target_list()` call:

```
control:   sends=460 summary_skips=317 suppressed=0   redundant=321 converged=1/1
treatment: sends=256 summary_skips=21  suppressed=500 redundant=136 converged=1/1
```

**44% fewer broadcast legs, 58% fewer redundant deliveries, convergence unchanged.** `sends + summary_skips + suppressed` is **777 in both arms** — the two runs did identical fan-out work and the treatment merely reclassified 500 legs, which rules out a topology difference as the explanation. The test asserts that identity.

Two honest caveats on that number:

- **The mechanisms overlap.** Of the 500 suppressions, roughly 300 were legs the pre-existing summary-match gate would have skipped for free, which is why the send reduction (44%) is smaller than the suppression count suggests. On the fleet the overlap is much smaller — its dedup ratio is 18.6 against this simulation's 3.7 — so the marginal value there should be larger, not smaller.
- **No suppression fraction is asserted.** The measured fleet figures (0.647 at degree 5 rising to 0.924 at 17) are degree-dependent, and this simulation's achieved degree is far below the fleet's. A fleet-derived threshold here would be measuring the wrong graph.

Unit and pin coverage, against the requirements:

| Requirement | Test |
|---|---|
| Excludes exactly the listed peers, no others | `a_relayer_excludes_exactly_the_listed_peers_and_no_others` — asserts unlisted co-hosts are still PRESENT, which is the half that matters |
| Does not forward the list onward (one hop) | `the_list_a_relayer_emits_describes_only_its_own_sends` |
| List on a non-payload-bearing message ignored | `only_payload_bearing_variants_carry_a_target_list` (structural — no other variant has the field) |
| Over-cap truncates, never omits or over-suppresses | `over_cap_truncation_degrades_to_partial_suppression`, `covered_peers_over_cap_truncates_rather_than_omitting` |
| Pre-floor peer gets byte-identical traffic | `legacy_broadcast_to_encoding_is_unchanged_by_the_v2_variants` (bytes, pinned against a hand-built literal — comparing to a re-serialization would compare the encoder to itself) + `a_pre_floor_peer_receives_byte_identical_broadcast_traffic` (routing, and asserts the gate FLIPS at floor so it cannot pass against an always-shut gate) |
| End-to-end duplicate reduction with a control arm | `test_5147_originator_target_list_cuts_duplicate_deliveries` |

Plus: variant-index freeze with a fixed-length table (adding a variant without extending it is a compile error), gate-discriminates-by-version, floor-tracks-shipping-release, floor-stays-above-0.2.119, replay-under-another-transaction, and eight store unit tests covering the intersection property directly.

`cargo fmt`, `cargo clippy --locked -- -D warnings`, and `cargo test -p freenet` (4662) all clean. (`clippy --all-targets` has 16 errors on `main` unrelated to this change.)

## Rollout

`BroadcastToV2` / `BroadcastToStreamingV2` are appended last and gated per-recipient on `BROADCAST_TARGET_LIST_MIN_VERSION = (0,2,120)`, failing closed. **Until #5167 deploys, a node never learns its gateway's version, so the gate stays shut on gateway links regardless of what the gateway runs** — a suppression shortfall there, not a correctness problem, and it resolves itself once #5167 ships. Not fixed here.

Sim default is OFF, unlike hash-first: `node.rs` documents that encoding changes default ON in sims while behavioural gates default OFF, and this one removes peers from a fan-out.

## Not in scope

The size-thresholded probe is a separate PR, and its threshold should be set from the residual measured after this lands.

Closes #5147

[AI-assisted - Claude]



---

# UPDATE — read this before reviewing

Two design-level findings landed after this PR was opened. The measured numbers below are real, but **the design is not settled**, and one blocking item is unimplemented.

## 1. BLOCKING and unimplemented: merge semantics

Found independently by two blind review lenses. **"A delivered this payload to C" is not "C has the state B is about to send."** B sends `diff(B_post_merge_state, C_cached_summary)`, and B's post-merge state is `B_prior ⊔ payload`. Whenever `B_prior` is not a subset of A's state, B's fan-out to C carries content A never sent.

Sharpest form: **suppression happens before the queue, so it bypasses the `fanout_send_needed` summary comparison that would otherwise have caught the divergence.** That is a weakening of an existing safety net. Nothing compensates faster than the 5-minute heartbeat — `proactive_summary_targets` excludes both the sender and every advertised co-host, exactly the suppressed population.

Narrowing that is real but does not close it: content ORIGINATING at B propagates via B's own client-update fan-out, which registers empty coverage and is never suppressed. So the exposure is relayed content that reached B by a path that did not reach C.

**Agreed direction (not yet implemented): suppress only when our post-merge summary equals the sender's**, compared at receive time where the driver already holds the merged value. That makes the invariant exact rather than bounded.

## 2. The seeding interaction, and what this PR's numbers actually mean

The suppressed legs also carry `sender_summary_bytes`, which seeds the receiver's cached summary and feeds `fanout_send_needed`. Suppress the leg and you suppress its passenger. Full write-up, with the regression table and the rig check that ruled out a topology artefact: <https://github.com/freenet/freenet-core/issues/5147#issuecomment-5187248908>.

The simulation caught this by failing first — the feature made traffic **worse** (sends 528 vs 460, redundant 400 vs 321) because a fully-suppressed fan-out has an empty target set, which the code read as the no-subscriber failure case and retried, re-broadcasting everything one backoff later after the coverage claim was consumed. **The mechanism defeated itself and would have shipped looking plausible: every unit test passed.**

After that fix:

```
                sends   summary_skips   suppressed   redundant   converged
control           460             317            0         321         1/1
treatment         256              21          500         136         1/1
```

44% fewer legs, 58% fewer redundant deliveries, convergence unchanged. `sends + summary_skips + suppressed` is **777 in both arms**, which is what rules out a topology difference — asserted by the test.

## 3. Caveats a reviewer must not have to derive

- **This simulation cannot detect the bug class in item 1.** One contract, one writer, so `converged` reduces to `1 >= 1`. A reviewer proved it by mutation: making `covers()` suppress *every* co-host gave byte-identical results and still reported convergence. Future sim evidence needs multiple writers and multiple contracts.
- **The end-to-end numbers come from the `simulation_tests` inline fan-out, not the production queue** — a separate copy of the same logic. `production_send_site_gates_both_v2_variants_on_the_version_check` and `the_queue_carries_the_target_list_and_refreshes_it_on_replacement` (both mutation-verified) are what cover the production path; before they existed, forcing both production `target_list_for` matches to the legacy arm left every test green.
- **Of the 500 suppressions, ~300 were legs the summary gate would have skipped for free.** The fleet overlap is smaller (dedup ratio 18.6 vs this sim's 3.7), so marginal value there should be larger — but the seeding starvation is masked, not absent.
- **The revived sender exclusion currently ships UNGATED** — no version floor, no sim override — while having the same unsafe shape as the target list. Team-lead ruling: gate it like the target list or drop it from this PR. Not yet done.
- **`FullNoTheirSummaryTracked` is the fleet metric to watch.** A peer with no cached summary gets full state (357 KB mean, 26.9% of broadcast bytes on 0.2.109). The sim's 16 full-state sends, identical in both arms, say nothing either way.

## Reproducing

```
cargo test -p freenet --features "simulation_tests,testing" \
  --test simulation_integration -- --test-threads=1 --nocapture \
  test_5147_originator_target_list_cuts_duplicate_deliveries
```

Arms differ by one `enable_broadcast_target_list()` call, need different network names, same seed. Revert the `fully_covered` early return in `p2p_protoc/broadcast.rs` to reproduce the original regression.

[AI-assisted - Claude]
