### PR TITLE
fix(shell): forward the contract's own <title> to the browser tab

### DIFF
--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -1765,13 +1765,16 @@ async fn sandbox_content_body(
     body = body.replace("\"/./", &format!("\"{prefix}"));
     body = body.replace("'/./", &format!("'{prefix}"));
 
-    // Inject the WebSocket shim and navigation interceptor before any other scripts.
-    // The shim overrides window.WebSocket so that wasm-bindgen routes connections
-    // through the shell page's bridge. The interceptor catches <a> clicks AND
-    // overrides programmatic window.open, routing both through postMessage for
-    // multi-page navigation without a sandbox-inheriting popup (#4645).
-    let injected_scripts =
-        format!("<script>{WEBSOCKET_SHIM_JS}</script><script>{NAVIGATION_INTERCEPTOR_JS}</script>");
+    // Inject the WebSocket shim, navigation interceptor, and title sync before
+    // any other scripts. The shim overrides window.WebSocket so that
+    // wasm-bindgen routes connections through the shell page's bridge. The
+    // interceptor catches <a> clicks AND overrides programmatic window.open,
+    // routing both through postMessage for multi-page navigation without a
+    // sandbox-inheriting popup (#4645). The title sync forwards this page's
+    // <title> to the shell so the browser tab reflects it.
+    let injected_scripts = format!(
+        "<script>{WEBSOCKET_SHIM_JS}</script><script>{NAVIGATION_INTERCEPTOR_JS}</script><script>{TITLE_SYNC_JS}</script>"
+    );
     if let Some(pos) = body.find("</head>") {
         body.insert_str(pos, &injected_scripts);
     } else if let Some(pos) = body.find("<body") {
@@ -1883,6 +1886,20 @@ const WEBSOCKET_SHIM_JS: &str = include_str!("path_handlers/assets/websocket_shi
 /// inside the click handler, where the gesture is live.
 const NAVIGATION_INTERCEPTOR_JS: &str =
     include_str!("path_handlers/assets/navigation_interceptor.js");
+
+/// JavaScript that forwards the sandboxed iframe's `document.title` to the
+/// shell via the `__freenet_shell__` / `type: 'title'` postMessage
+/// `SHELL_BRIDGE_JS` already handles.
+///
+/// The shell page's own `<title>` is hardcoded (`shell.html`) because this
+/// iframe has no `allow-same-origin` and cannot touch the parent's
+/// `document.title` directly. Before this script existed, the shell's title
+/// only ever changed for the handful of apps that hand-rolled this exact
+/// postMessage themselves (River, Atlas, Delta); every other app — including
+/// a static, JS-free contract website — left the browser tab reading
+/// "Freenet" forever. Injected into every sandboxed page unconditionally so
+/// the tab title is correct with zero per-app opt-in.
+const TITLE_SYNC_JS: &str = include_str!("path_handlers/assets/title_sync.js");
 
 /// Strips the version + contract + key prefix from a request path and returns
 /// the remaining relative asset path (e.g. `assets/app.js`, or `my image.png`).
@@ -5304,6 +5321,45 @@ mod tests {
         assert!(
             !result.contains("__FREENET_AUTH_TOKEN__"),
             "auth token leaked into sandbox content"
+        );
+    }
+
+    /// Regression test: the shell page's `<title>` is hardcoded (`shell.html`)
+    /// and the sandboxed iframe cannot touch `document.title` on the parent
+    /// directly (no `allow-same-origin`), so before `TITLE_SYNC_JS` existed
+    /// the browser tab showed "Freenet" forever for any contract that did not
+    /// hand-roll its own postMessage sender — which was every contract except
+    /// River, Atlas, and Delta. This asserts the sync script is injected
+    /// alongside the WS shim and interceptor for EVERY sandboxed page,
+    /// including one with no app JS at all.
+    #[tokio::test]
+    async fn sandbox_content_injects_title_sync() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = "testkey123";
+        let html =
+            r#"<!DOCTYPE html><html><head><title>My App</title></head><body>Hello</body></html>"#;
+        std::fs::write(dir.path().join("index.html"), html).unwrap();
+
+        let result = response_body(
+            sandbox_content_body(dir.path(), key, ApiVersion::V1, "index.html")
+                .await
+                .unwrap(),
+        )
+        .await;
+
+        assert!(
+            result.contains("type: 'title'"),
+            "title sync script not injected"
+        );
+        assert!(
+            result.contains("__freenet_shell__: true"),
+            "title sync script must use the shell postMessage bridge protocol"
+        );
+        // Must forward document.title, not a hardcoded string — this is what
+        // makes it work for every app rather than needing per-app wiring.
+        assert!(
+            TITLE_SYNC_JS.contains("document.title"),
+            "title sync script must read document.title, not a fixed string"
         );
     }
 

--- a/crates/core/src/server/path_handlers/assets/title_sync.js
+++ b/crates/core/src/server/path_handlers/assets/title_sync.js
@@ -1,0 +1,42 @@
+(function () {
+  'use strict';
+  // Forwards this document's <title> to the shell via the same
+  // `__freenet_shell__` / `type: 'title'` postMessage SHELL_BRIDGE_JS already
+  // handles. The shell page's own <title> is hardcoded (shell.html) because
+  // this iframe has no `allow-same-origin` and cannot touch the parent's
+  // `document.title` directly — this postMessage is the ONLY way a contract's
+  // title ever reaches the tab.
+  //
+  // Injected into every sandboxed page unconditionally, so a contract gets a
+  // correct tab title with zero opt-in — including a static, JS-free website.
+  // A few apps (River, Atlas, Delta) also send this themselves for finer
+  // control (e.g. an unread-count suffix); sending it again here is harmless,
+  // since the shell just re-assigns document.title to the same string.
+  var lastSent = null;
+  function sendTitle() {
+    var title = document.title;
+    if (!title || title === lastSent) return;
+    lastSent = title;
+    window.parent.postMessage(
+      { __freenet_shell__: true, type: 'title', title: title },
+      '*',
+    );
+  }
+  sendTitle();
+  // Catches a <title> set by an inline/deferred script after this runs, and
+  // any later change (SPA route change, async data load). Observing `head`
+  // rather than the <title> element itself also catches the element not
+  // existing yet at injection time — `document.title = 'x'` on a page with no
+  // <title> tag creates one, which this still sees via the head subtree.
+  var head = document.head || document.getElementsByTagName('head')[0];
+  if (head && window.MutationObserver) {
+    new MutationObserver(sendTitle).observe(head, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+    });
+  }
+  // Belt-and-suspenders in case a browser yields to this script before head
+  // parsing (and its <title>) has finished.
+  document.addEventListener('DOMContentLoaded', sendTitle);
+})();

--- a/crates/core/src/server/path_handlers/assets/title_sync.js
+++ b/crates/core/src/server/path_handlers/assets/title_sync.js
@@ -15,6 +15,15 @@
   var lastSent = null;
   function sendTitle() {
     var title = document.title;
+    // A page with no <title> at all (document.title === '') is left alone
+    // rather than resetting the tab: on a multi-page contract site reached
+    // via an in-place navigate hop, this means the tab keeps showing the
+    // PREVIOUS page's real title rather than reverting to "Freenet". That's
+    // a deliberate choice, not an oversight — a stale-but-real title is a
+    // narrower, already-strictly-better-than-baseline edge case (before this
+    // script existed the tab showed "Freenet" unconditionally, always), and
+    // "what should an untitled page show instead" is a separate product
+    // decision this fix doesn't make unilaterally.
     if (!title || title === lastSent) return;
     lastSent = title;
     window.parent.postMessage(

--- a/crates/core/tests/playwright/fixture-webapp/index.html
+++ b/crates/core/tests/playwright/fixture-webapp/index.html
@@ -79,6 +79,15 @@
 <a id="same-origin-link" href="page2.html">In-contract page 2</a>
 
 <!--
+  Same-origin link to a page with NO <title> element at all
+  (fixture-webapp/no-title.html). Locks in title_sync.js's documented choice
+  to leave the tab on the PREVIOUS page's title rather than resetting it —
+  see the comment on that fixture and on the `if (!title || ...)` guard in
+  path_handlers/assets/title_sync.js.
+-->
+<a id="no-title-link" href="no-title.html">In-contract page with no title</a>
+
+<!--
   Download link. The interceptor must NOT intercept links carrying a
   `download` attribute; `handleAnchorClick` early-returns on `download`
   (path_handlers.rs:2013), so no open_url / navigate postMessage is sent and

--- a/crates/core/tests/playwright/fixture-webapp/no-title.html
+++ b/crates/core/tests/playwright/fixture-webapp/no-title.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+</head>
+<body>
+<!--
+  Deliberately has NO <title> element at all. document.title on a page like
+  this is the empty string, and title_sync.js's sendTitle() treats an empty
+  title as "nothing to report" rather than resetting the shell — the shell
+  keeps showing whatever title the PREVIOUS page set. This fixture exists to
+  lock that specific, documented tradeoff in place (see the comment on the
+  `if (!title || ...)` guard in path_handlers/assets/title_sync.js) — the
+  Playwright test that navigates here asserts the tab title does NOT change.
+-->
+<h1 id="no-title-page">No-title fixture page</h1>
+<a id="back-link" href="index.html">Back to index</a>
+</body>
+</html>

--- a/crates/core/tests/playwright/tests/shell.spec.ts
+++ b/crates/core/tests/playwright/tests/shell.spec.ts
@@ -830,3 +830,25 @@ test("browser tab title re-syncs on a later change and dedupes a repeated identi
       `got: ${JSON.stringify(values)}`,
   ).toEqual(["Retitled After Load"]);
 });
+
+test("navigating to a page with no <title> at all leaves the tab on the previous title (documented tradeoff)", async ({
+  page,
+}) => {
+  // title_sync.js's `if (!title || ...) return;` guard deliberately does NOT
+  // reset the shell's tab when the new page has no <title> element — see the
+  // comment on that guard in path_handlers/assets/title_sync.js. This test
+  // locks that specific, chosen behavior in place: the tab must keep showing
+  // the fixture's real title, not blank out or silently do something else.
+  await page.goto(shellUrl!);
+  const frame = await fixtureFrame(page);
+  await expect(page).toHaveTitle("Freenet shell smoke-test fixture");
+
+  await frame.locator("#no-title-link").click();
+  await expect(
+    page.frameLocator("iframe#app").locator("#no-title-page"),
+  ).toBeVisible();
+
+  // The iframe has genuinely navigated to the titleless page (confirmed
+  // above), but the tab title must be UNCHANGED from before the hop.
+  await expect(page).toHaveTitle("Freenet shell smoke-test fixture");
+});

--- a/crates/core/tests/playwright/tests/shell.spec.ts
+++ b/crates/core/tests/playwright/tests/shell.spec.ts
@@ -87,6 +87,7 @@ type ShellMessage = {
   url?: string;
   href?: string;
   shiftKey?: boolean;
+  title?: string;
 };
 
 async function shellMessages(page: Page): Promise<ShellMessage[]> {
@@ -759,4 +760,64 @@ test("browser tab title reflects the contract's own <title>, with no bespoke sen
   await page.goto(shellUrl!);
   await fixtureFrame(page);
   await expect(page).toHaveTitle("Freenet shell smoke-test fixture");
+});
+
+test("browser tab title re-syncs on a later change and dedupes a repeated identical title (MutationObserver + lastSent guard)", async ({
+  page,
+}) => {
+  // The one-shot "reflects the contract's own <title>" test above only
+  // exercises the initial postMessage sent when title_sync.js first runs.
+  // The reason that script installs a MutationObserver on <head> at all —
+  // rather than just posting once — is to also catch a title the app sets
+  // LATER (an SPA route change, an async-loaded page title). This test
+  // exercises that path for real, plus the `lastSent` dedup guard that stops
+  // an unchanged title from posting again.
+  await page.goto(shellUrl!);
+  const frame = await fixtureFrame(page);
+  // Let the INITIAL title postMessage land and settle before we start
+  // capturing: `toHaveTitle` only becomes true once the shell has received
+  // and applied that first message, so installing the message listener AFTER
+  // this point deterministically excludes it — no race against how fast the
+  // sandboxed iframe's own synchronous first post beats our listener attach.
+  await expect(page).toHaveTitle("Freenet shell smoke-test fixture");
+  await captureShellMessages(page);
+
+  // Read the RAW sink directly (not the navigation-tests' shellMessages()
+  // helper, which filters 'title' out) so we can inspect title messages
+  // specifically.
+  const titleMessages = async (): Promise<ShellMessage[]> => {
+    const all = await page.evaluate(
+      () =>
+        (window as unknown as { __freenetMessages: ShellMessage[] })
+          .__freenetMessages,
+    );
+    return all.filter((m) => m.type === "title");
+  };
+
+  // Change the title from inside the sandboxed iframe, simulating an SPA
+  // route change or an async-loaded page title set well after initial load.
+  await frame.locator("html").evaluate(() => {
+    document.title = "Retitled After Load";
+  });
+  await expect(page).toHaveTitle("Retitled After Load");
+
+  // Setting the SAME title again must NOT produce a second postMessage — the
+  // `lastSent` guard in title_sync.js exists specifically to suppress a
+  // redundant identical assignment (e.g. a re-render that re-sets the same
+  // string every tick).
+  await frame.locator("html").evaluate(() => {
+    document.title = "Retitled After Load";
+  });
+  // Give any (incorrect) redundant postMessage a moment to arrive before
+  // asserting its absence.
+  await page.waitForTimeout(300);
+
+  const messages = await titleMessages();
+  const values = messages.map((m) => m.title);
+  expect(
+    values,
+    `expected exactly one post for the change to "Retitled After Load", ` +
+      `with the repeated identical re-assignment deduped away by lastSent; ` +
+      `got: ${JSON.stringify(values)}`,
+  ).toEqual(["Retitled After Load"]);
 });

--- a/crates/core/tests/playwright/tests/shell.spec.ts
+++ b/crates/core/tests/playwright/tests/shell.spec.ts
@@ -90,11 +90,19 @@ type ShellMessage = {
 };
 
 async function shellMessages(page: Page): Promise<ShellMessage[]> {
-  return page.evaluate(
+  const all = await page.evaluate(
     () =>
       (window as unknown as { __freenetMessages: ShellMessage[] })
         .__freenetMessages,
   );
+  // The injected title-sync script posts a `title` message on every
+  // sandboxed-page load (and re-fires on each in-place navigate hop), fully
+  // independent of user interaction. Every call site of this helper asserts
+  // the exact sequence of CLICK-classification messages (navigate/open_url),
+  // so a `title` landing anywhere in that sequence is page-lifecycle noise,
+  // not a signal any of them are testing for — filter it out here rather
+  // than at each call site.
+  return all.filter((m) => m.type !== "title");
 }
 
 // Serve the RFC 2606 documentation domain from the test itself, so the tabs
@@ -737,4 +745,18 @@ test("browser Back restores the previous subpage via the popstate handler (#3839
   await expect(
     page.frameLocator("iframe#app").locator("#page2-title"),
   ).toHaveCount(0);
+});
+
+test("browser tab title reflects the contract's own <title>, with no bespoke sender required", async ({
+  page,
+}) => {
+  // The shell page's <title> is hardcoded ("Freenet") because the sandboxed
+  // iframe has no allow-same-origin and cannot touch document.title on the
+  // parent directly. fixture-webapp/index.html sets its own <title> and
+  // deliberately implements NO shell postMessage sender (see the comment at
+  // the top of that file) — the injected title-sync script
+  // (path_handlers.rs TITLE_SYNC_JS) must be what carries it to the tab.
+  await page.goto(shellUrl!);
+  await fixtureFrame(page);
+  await expect(page).toHaveTitle("Freenet shell smoke-test fixture");
 });

--- a/crates/core/tests/playwright/tests/shell.spec.ts
+++ b/crates/core/tests/playwright/tests/shell.spec.ts
@@ -601,6 +601,15 @@ test("same-origin in-contract link performs an in-place navigate hop", async ({
   ).toBeVisible();
   await expect(page).toHaveURL(/page2\.html/);
   await expect(page).not.toHaveURL(/__sandbox/);
+
+  // A real navigate hop reloads the iframe with a fresh document — including
+  // a fresh title_sync.js instance — so the tab must pick up page 2's own
+  // <title> ("Freenet shell fixture - page 2", set in fixture-webapp/page2.html),
+  // not keep index.html's. Unlike the "re-syncs on a later change" test
+  // (which mutates document.title within the SAME document via JS), this
+  // exercises a genuine iframe reload — the path a real multi-page contract
+  // site actually takes.
+  await expect(page).toHaveTitle("Freenet shell fixture - page 2");
 });
 
 test("a link carrying a download attribute is NOT intercepted", async ({


### PR DESCRIPTION
## Problem

Every Freenet app's browser tab reads "Freenet" instead of the app's own title. The shell page's `<title>` is hardcoded (`shell.html`), and the sandboxed iframe that hosts contract apps has no `allow-same-origin`, so it cannot touch the parent's `document.title` directly. The only escape hatch is a `postMessage` the shell already listens for (`__freenet_shell__` / `type: 'title'`), but nothing in core ever sent it.

Only apps that hand-rolled the exact same ~30 lines of wasm-bindgen glue themselves ever corrected the tab title (River, Atlas, Delta, Ghostkeys). Every other contract — including a static, JS-free website published with `fdev` — left the tab reading "Freenet" forever.

## Approach

Inject a small script (`title_sync.js`) into every sandboxed page, alongside the existing WebSocket shim and navigation interceptor. It forwards `document.title` to the shell on load and on subsequent changes (via a `MutationObserver` on `<head>`, so it also catches a `<title>` set later by app JS), using the exact protocol `SHELL_BRIDGE_JS` already handles. No per-app opt-in required — this makes the four existing bespoke senders redundant (left in place; sending the same value twice is harmless).

A page with no `<title>` at all is left alone rather than resetting the shell — the tab keeps showing whatever the previous page set. That's a deliberate, documented tradeoff (see the comment on the guard in `title_sync.js`), not a regression: before this script existed the tab showed "Freenet" unconditionally, always.

## Testing

- Rust unit test (`sandbox_content_injects_title_sync`) pins that the script is injected for every sandboxed page.
- Four Playwright tests against a **real headless Chromium/Firefox/WebKit** node (`crates/core/tests/playwright/tests/shell.spec.ts`):
  1. Initial-load case — the tab title updates from `fixture-webapp/index.html`'s static `<title>`. That fixture deliberately implements **no** bespoke sender, so this is the exact "static JS-free site" regression case.
  2. `MutationObserver` re-sync + `lastSent` dedup — a later in-place title change, and a repeated identical assignment producing no duplicate post.
  3. A real navigate hop (clicking an in-contract link) — the iframe reloads with a fresh document/script instance and the tab picks up the new page's own `<title>`.
  4. The documented titleless-page tradeoff — navigating to `fixture-webapp/no-title.html` (no `<title>` element) leaves the tab on the previous page's title rather than resetting.
  
  All four were verified non-vacuous by mutation testing: with the relevant guard removed from `title_sync.js`, the corresponding test fails deterministically across all three engines.
- Discovered along the way: the new `title` postMessage was landing in several existing tests' generic message-capture assertions (they install a listener before the iframe finishes loading). Fixed the shared `shellMessages()` test helper to filter it out — it's page-lifecycle noise unrelated to what those tests check (click-classification messages: `navigate`/`open_url`).
- Full local run: `FREENET_PLAYWRIGHT=1 cargo nextest run -p freenet --features testing --test playwright_shell --no-capture` — 57/57 passed across all three browser engines.
- `cargo fmt` clean, `cargo clippy -p freenet --lib -- -D warnings` clean, full `server::path_handlers::tests` module (131 tests) green.

## Review

Ran a manual multi-lens review (Fable 5 skeptical bug-hunt + two independent Claude lenses: code-first intent-vs-implementation, and sandbox-security):

- **Security lens: no new attack surface.** Everything `title_sync.js` does (read `document.title`, post to the shell via the existing `__freenet_shell__`/`type:'title'` protocol) was already reachable by any script running in the sandboxed iframe before this PR — the receiver (`shell_bridge.js`) is unmodified. No DoS vector materially worse than what already existed via other message types.
- **Code-first lens: implementation matches description**, injection is genuinely unconditional across all three fallback branches, and each test does what it claims.
- **Converging finding (Fable + code-first, independently): a titleless page leaves the tab stale.** Not a regression, and a genuine product-design call rather than a bug — documented explicitly and locked in with a regression test (see Testing #4).
- Fable also questioned whether the dedup test could be vacuous. Verified false by mutation testing.

The repo's automated `Claude Rule Review` bot flagged two real gaps along the way (the MutationObserver/dedup path untested, then the titleless-tradeoff untested) — both fixed in follow-up commits, each verified non-vacuous.

[AI-assisted - Claude]