### PR TITLE
fix(put): never let an op-execution payload displace a live reply waiter

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -4457,6 +4457,7 @@ std::thread_local! {
     static GLOBAL_PENDING_OP_INSERTS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
     static GLOBAL_PENDING_OP_REMOVES: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
     static GLOBAL_PENDING_OP_HWM: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+    static GLOBAL_PENDING_OP_SKIPS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
     static GLOBAL_NEIGHBOR_HOSTING_UPDATES: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
     /// Recipients dropped from a proactive summary notification because they
     /// are advertised co-hosts the broadcast already covered (#4965).
@@ -4556,6 +4557,7 @@ impl GlobalTestMetrics {
         GLOBAL_REDUNDANT_BROADCAST_DELIVERIES.with(|c| c.set(0));
         GLOBAL_FULL_STATE_SENDS.with(|c| c.set(0));
         GLOBAL_PENDING_OP_INSERTS.with(|c| c.set(0));
+        GLOBAL_PENDING_OP_SKIPS.with(|c| c.set(0));
         GLOBAL_PENDING_OP_REMOVES.with(|c| c.set(0));
         GLOBAL_PENDING_OP_HWM.with(|c| c.set(0));
         GLOBAL_NEIGHBOR_HOSTING_UPDATES.with(|c| c.set(0));
@@ -4782,6 +4784,20 @@ impl GlobalTestMetrics {
 
     pub fn pending_op_removes() -> u64 {
         GLOBAL_PENDING_OP_REMOVES.with(|c| c.get())
+    }
+
+    /// A waiter install was refused because a LIVE incumbent already held the tx.
+    ///
+    /// Expected to stay at zero: the invariant is one live waiter per tx per
+    /// node, so a non-zero count means either a genuine collision or that the
+    /// guard is refusing a legitimate waiter — the latter otherwise surfaces
+    /// only as a driver retry with nothing pointing back here.
+    pub fn record_pending_op_skip() {
+        GLOBAL_PENDING_OP_SKIPS.with(|c| c.set(c.get() + 1));
+    }
+
+    pub fn pending_op_skips() -> u64 {
+        GLOBAL_PENDING_OP_SKIPS.with(|c| c.get())
     }
 
     /// Track high-water mark for pending_op_results size.

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -1087,6 +1087,14 @@ fn try_forward_driver_reply(
     op_label: &'static str,
 ) -> bool {
     let Some(callback) = pending_op_result else {
+        // Was silent at every level. Finding the clobber bug required patching
+        // a node to see this branch at all, because "no waiter is registered"
+        // is exactly the symptom a displaced waiter produces.
+        tracing::debug!(
+            tx_id = %reply.id(),
+            %op_label,
+            "try_forward_driver_reply: no waiter registered for this tx; dropping the reply"
+        );
         return false;
     };
     let tx_id = *reply.id();

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -6387,4 +6387,94 @@ pub(crate) mod tests {
              just its call site. Block:\n{body}"
         );
     }
+    /// Deterministic reproduction of the "failed notifying, channel closed"
+    /// leak on originator-loopback PUT (the #4111 forbidden marker,
+    /// v0.2.118 field reports).
+    ///
+    /// Sequence modelled (no timing, no threads):
+    ///   1. The originator's `send_and_await` registers a LIVE waiter under
+    ///      `tx` (`install_pending_op_callback` observes a live callback and
+    ///      inserts it).
+    ///   2. The relay driver — running on the SAME node (originator
+    ///      loopback) — emits a payload for the SAME `tx` through the
+    ///      op-execution channel (`send_fire_and_forget` forward, or
+    ///      `send_local_loopback` Response). Its dummy callback is designed
+    ///      to be observed closed, but the receiver half only drops when the
+    ///      producer's poll finishes; the event loop runs on a different OS
+    ///      thread and can dequeue the payload inside the enqueue→drop
+    ///      window (observed in the field on a starved 1-CPU gateway:
+    ///      `is_closed()` returned false). That state is modelled here by
+    ///      holding the dummy receiver alive across the install call.
+    ///   3. The producer's poll finishes: the dummy receiver drops.
+    ///   4. The terminal Response arrives; the bypass looks up
+    ///      `pending_op_results[tx]` and forwards via
+    ///      `try_forward_driver_reply`.
+    ///
+    /// Pre-fix behaviour: step 2's insert CLOBBERS the live waiter, dropping
+    /// the originator's sender — the driver's `recv()` yields `None`
+    /// (surfaced as `OpError::NotificationError`, i.e. "failed notifying,
+    /// channel closed"), and step 4's `try_send` hits the closed dummy
+    /// (`err=channel closed` with a callback still registered). The PUT
+    /// itself succeeded — an infrastructure leak misreported as a failure.
+    ///
+    /// Contract pinned: an op-execution payload must NEVER displace a LIVE
+    /// `pending_op_results` waiter.
+    #[tokio::test]
+    async fn op_execution_payload_must_not_clobber_live_waiter() {
+        use crate::message::MessageStats; // for `msg.id()`
+        use crate::transport::ExpectedInboundTracker;
+        use tokio::sync::mpsc::error::TryRecvError;
+
+        let mut state = super::EventListenerState::new(ExpectedInboundTracker::empty_for_test());
+        let tx = crate::dev_tool::Transaction::new::<crate::operations::put::PutMsg>();
+
+        // Step 1: the originator's live waiter (send_and_await's callback).
+        let (originator_sender, mut originator_rx) = mpsc::channel::<crate::node::WaiterReply>(1);
+        super::dispatch::install_pending_op_callback(&mut state, tx, originator_sender);
+        assert!(
+            state.pending_op_results.contains_key(&tx),
+            "precondition: the originator's live waiter must be installed"
+        );
+
+        // Step 2: the relay's dummy callback for the SAME tx, observed while
+        // its receiver is still alive.
+        let (dummy_sender, dummy_receiver) = mpsc::channel::<crate::node::WaiterReply>(1);
+        super::dispatch::install_pending_op_callback(&mut state, tx, dummy_sender);
+
+        // Step 3: the producer's poll finishes — the dummy receiver drops.
+        drop(dummy_receiver);
+
+        // The originator's driver must still be wired: its `recv()` must NOT
+        // resolve to `None` (that is `OpError::NotificationError` — the
+        // forbidden "failed notifying, channel closed" leak).
+        match originator_rx.try_recv() {
+            Err(TryRecvError::Empty) => {} // still connected, still waiting — correct
+            Err(TryRecvError::Disconnected) => panic!(
+                "originator's waiter channel was closed by the dummy-callback \
+                 install: the driver's recv() yields None -> NotificationError \
+                 -> the client sees 'failed notifying, channel closed' for a \
+                 PUT that succeeded (the #4111 forbidden marker)"
+            ),
+            Ok(other) => panic!("no reply was sent yet, got {other:?}"),
+        }
+
+        // Step 4: the Response arrives and the bypass forwards it to the
+        // registered callback (mirrors `process_message`'s clone-then-forward).
+        let reply = crate::message::NetMessage::V1(crate::message::NetMessageV1::Aborted(tx));
+        let cb = state.pending_op_results.get(&tx).cloned();
+        let handled = crate::node::try_forward_driver_reply(cb.as_ref(), reply, "put");
+        assert!(handled, "a callback must be registered for the tx");
+
+        // The originator must actually RECEIVE the terminal reply.
+        match originator_rx.try_recv() {
+            Ok(crate::node::WaiterReply::Reply(msg)) => {
+                assert_eq!(msg.id(), &tx, "forwarded reply must carry the tx");
+            }
+            other => panic!(
+                "originator never received the terminal reply (got {other:?}): \
+                 the reply was forwarded into the clobbering dummy callback \
+                 whose receiver is gone (try_send err=channel closed)"
+            ),
+        }
+    }
 }

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -6477,4 +6477,164 @@ pub(crate) mod tests {
             ),
         }
     }
+
+    /// A REFUSED newcomer's sender must be DROPPED, not parked.
+    ///
+    /// The guard's contract is not only "the incumbent survives" — it is also
+    /// that the refused caller learns it was refused. Dropping the sender makes
+    /// the newcomer's `recv()` yield `None`, which is what drives the ~360ms
+    /// infra-retry in `op_ctx.rs`. A refactor that stashed skipped senders
+    /// anywhere — a retry queue, a side map, even a stray clone held in a local
+    /// — would silently convert every skip into a full-`OPERATION_TTL` hang,
+    /// and every other test in this module would still pass: they all assert
+    /// about the INCUMBENT, and none observes what became of the newcomer.
+    #[tokio::test]
+    async fn install_pending_op_callback_drops_a_refused_newcomer() {
+        use crate::transport::ExpectedInboundTracker;
+
+        let mut state = super::EventListenerState::new(ExpectedInboundTracker::empty_for_test());
+        let tx = crate::dev_tool::Transaction::new::<crate::operations::put::PutMsg>();
+
+        // A live incumbent holds the slot.
+        let (incumbent_tx_, _incumbent_rx) = mpsc::channel::<crate::node::WaiterReply>(1);
+        state.pending_op_results.insert(tx, incumbent_tx_);
+
+        // The newcomer is refused. Keep its RECEIVER so we can observe the
+        // sender's fate; the function must not retain the sender anywhere.
+        use tokio::sync::mpsc::error::TryRecvError;
+
+        let (newcomer_tx, mut newcomer_rx) = mpsc::channel::<crate::node::WaiterReply>(1);
+        super::dispatch::install_pending_op_callback(&mut state, tx, newcomer_tx);
+
+        assert!(
+            !state
+                .pending_op_results
+                .get(&tx)
+                .expect("incumbent must still hold the slot")
+                .is_closed(),
+            "the live incumbent must survive the refusal"
+        );
+
+        // `None`, not `Empty`: every clone of the sender is gone, so the
+        // newcomer's driver fails fast and retries instead of hanging to TTL.
+        assert!(
+            matches!(newcomer_rx.try_recv(), Err(TryRecvError::Disconnected)),
+            "a refused newcomer's sender must be dropped, not parked — otherwise \
+             its recv() blocks until OPERATION_TTL instead of failing fast"
+        );
+    }
+
+    /// Branch 1 of `install_pending_op_callback`: an incoming callback that is
+    /// ALREADY closed is never inserted.
+    ///
+    /// This is the pre-existing #3100 bound — the driver task can be cancelled
+    /// between `op_execution_sender.send()` and the event loop reaching the
+    /// payload (simulation teardown drops driver futures), and inserting a dead
+    /// sender would hold the slot until the 60s sweep. Guarded end-to-end by
+    /// `test_pending_op_results_bounded`, but only through a full simulation;
+    /// this pins the decision itself.
+    #[tokio::test]
+    async fn install_pending_op_callback_skips_a_closed_incoming_callback() {
+        use crate::transport::ExpectedInboundTracker;
+
+        let mut state = super::EventListenerState::new(ExpectedInboundTracker::empty_for_test());
+        let tx = crate::dev_tool::Transaction::new::<crate::operations::put::PutMsg>();
+
+        let (sender, receiver) = mpsc::channel::<crate::node::WaiterReply>(1);
+        drop(receiver); // the driver was cancelled before we got here
+        assert!(
+            sender.is_closed(),
+            "precondition: the callback must be closed"
+        );
+
+        super::dispatch::install_pending_op_callback(&mut state, tx, sender);
+
+        assert!(
+            !state.pending_op_results.contains_key(&tx),
+            "a closed callback must not occupy a pending_op_results slot: it \
+             would be held until the 60s sweep, which is the #3100 unbounded \
+             growth this skip exists to prevent"
+        );
+    }
+
+    /// Branch 3 of `install_pending_op_callback`, the sub-case the live-waiter
+    /// guard puts at risk: a CLOSED incumbent must still be replaced.
+    ///
+    /// The guard refuses to displace a live waiter only. If it were ever
+    /// loosened to `pending_op_results.get(&tx).is_some()` — dropping the
+    /// `!existing.is_closed()` predicate — dead entries would accumulate in the
+    /// map, reintroducing #3100 by the other door. That mutation passes
+    /// `op_execution_payload_must_not_clobber_live_waiter`, whose incumbent is
+    /// live; this test is what fails it.
+    #[tokio::test]
+    async fn install_pending_op_callback_replaces_a_closed_incumbent() {
+        use crate::transport::ExpectedInboundTracker;
+        use tokio::sync::mpsc::error::TryRecvError;
+
+        let mut state = super::EventListenerState::new(ExpectedInboundTracker::empty_for_test());
+        let tx = crate::dev_tool::Transaction::new::<crate::operations::put::PutMsg>();
+
+        // A stale incumbent whose receiver is already gone.
+        let (stale_sender, stale_receiver) = mpsc::channel::<crate::node::WaiterReply>(1);
+        super::dispatch::install_pending_op_callback(&mut state, tx, stale_sender);
+        drop(stale_receiver);
+        assert!(
+            state.pending_op_results[&tx].is_closed(),
+            "precondition: the incumbent must be closed"
+        );
+
+        // A live callback for the same tx must take the slot.
+        let (fresh_sender, mut fresh_rx) = mpsc::channel::<crate::node::WaiterReply>(1);
+        super::dispatch::install_pending_op_callback(&mut state, tx, fresh_sender);
+
+        assert!(
+            !state.pending_op_results[&tx].is_closed(),
+            "a closed incumbent must be replaced, not preserved: keeping it \
+             strands the slot and strands this waiter"
+        );
+
+        // And the slot must be wired to the NEW waiter, not merely non-closed.
+        let reply = crate::message::NetMessage::V1(crate::message::NetMessageV1::Aborted(tx));
+        use crate::message::MessageStats; // for `msg.id()`
+
+        let cb = state.pending_op_results.get(&tx).cloned();
+        crate::node::try_forward_driver_reply(cb.as_ref(), reply, "put");
+        // Assert the reply ARRIVED, not merely that the map had an entry.
+        // `try_forward_driver_reply` returns true for any Some(callback) — a
+        // try_send that fails Closed or Full is swallowed into a debug! — and
+        // `!matches!(.., Err(Empty))` also passes on Err(Disconnected) and on
+        // Ok(PeerDisconnected). A refactor that dropped `fresh_sender` instead
+        // of installing it would satisfy both and still be wrong.
+        match fresh_rx.try_recv() {
+            Ok(crate::node::WaiterReply::Reply(msg)) => {
+                assert_eq!(msg.id(), &tx, "the replacing waiter got the wrong tx");
+            }
+            other => {
+                panic!("the replacing waiter never received the terminal reply (got {other:?})")
+            }
+        }
+    }
+
+    /// Branch 3 of `install_pending_op_callback`, plain case: no existing
+    /// entry and a live callback inserts.
+    ///
+    /// Asserted as a precondition inside
+    /// `op_execution_payload_must_not_clobber_live_waiter`; stated separately
+    /// so the extracted function's branch coverage is legible on its own.
+    #[tokio::test]
+    async fn install_pending_op_callback_inserts_when_the_slot_is_empty() {
+        use crate::transport::ExpectedInboundTracker;
+
+        let mut state = super::EventListenerState::new(ExpectedInboundTracker::empty_for_test());
+        let tx = crate::dev_tool::Transaction::new::<crate::operations::put::PutMsg>();
+
+        let (sender, _rx) = mpsc::channel::<crate::node::WaiterReply>(1);
+        super::dispatch::install_pending_op_callback(&mut state, tx, sender);
+
+        assert!(
+            state.pending_op_results.contains_key(&tx),
+            "a live callback must take an empty slot"
+        );
+        assert!(!state.pending_op_results[&tx].is_closed());
+    }
 }

--- a/crates/core/src/node/network_bridge/p2p_protoc/dispatch.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc/dispatch.rs
@@ -1,7 +1,8 @@
 //! Event-loop dispatch for [`P2pConnManager`]: priority-select result
 //! routing and the per-message / per-event handlers it fans out to.
 //!
-//! Behavior-preserving extraction from `p2p_protoc.rs`.
+//! Extracted from `p2p_protoc.rs`. The extraction was behavior-preserving;
+//! `install_pending_op_callback` has since gained a live-incumbent guard.
 
 use super::*;
 
@@ -235,30 +236,7 @@ impl P2pConnManager {
     ) -> EventResult {
         match msg {
             Some((callback, msg, target_addr)) => {
-                // The driver task may have been cancelled between
-                // `op_execution_sender.send()` and our processing of the
-                // event — e.g. simulation teardown drops driver futures.
-                // When the response receiver is dropped before we reach
-                // here, the callback sender is closed; inserting it
-                // would leak `pending_op_results` until the 60s sweep,
-                // detectable as imbalance in #3100's regression guard
-                // `test_pending_op_results_bounded`. Skipping the
-                // insert keeps the HashMap bounded; the outbound
-                // request below still dispatches because the receiving
-                // peer's view of the operation is independent of the
-                // local driver's lifecycle.
-                if callback.is_closed() {
-                    tracing::debug!(
-                        tx = %msg.id(),
-                        "handle_op_execution: callback already closed (driver cancelled before insert); skipping"
-                    );
-                } else {
-                    state.pending_op_results.insert(*msg.id(), callback);
-                    crate::config::GlobalTestMetrics::record_pending_op_insert();
-                    crate::config::GlobalTestMetrics::record_pending_op_size(
-                        state.pending_op_results.len() as u64,
-                    );
-                }
+                install_pending_op_callback(state, *msg.id(), callback);
                 // When the driver supplied an explicit target, dispatch the
                 // message to that peer over the network instead of looping it
                 // back as a local InboundMessage. The reply still flows back
@@ -448,5 +426,87 @@ impl P2pConnManager {
         };
         state.pending_from_executor.insert(id);
         EventResult::Continue
+    }
+}
+
+/// Decide whether an `OpExecutionPayload`'s reply callback gets installed
+/// into `pending_op_results[tx]`.
+///
+/// Extracted from `handle_op_execution` so the install decision is unit
+/// testable without a full `P2pConnManager` (same pattern as
+/// `fail_awaiting_connection`).
+///
+/// The driver task may have been cancelled between
+/// `op_execution_sender.send()` and our processing of the
+/// event — e.g. simulation teardown drops driver futures.
+/// When the response receiver is dropped before we reach
+/// here, the callback sender is closed; inserting it
+/// would leak `pending_op_results` until the 60s sweep,
+/// detectable as imbalance in #3100's regression guard
+/// `test_pending_op_results_bounded`. Skipping the
+/// insert keeps the HashMap bounded; the outbound
+/// request still dispatches because the receiving
+/// peer's view of the operation is independent of the
+/// local driver's lifecycle.
+pub(super) fn install_pending_op_callback(
+    state: &mut EventListenerState,
+    tx: Transaction,
+    callback: Sender<WaiterReply>,
+) {
+    // INVARIANT: at most one LIVE waiter exists per tx per node.
+    //
+    // The live-incumbent branch below is only correct while that holds — it
+    // refuses the newcomer, so a second *legitimate* waiter for the same tx
+    // would be dropped rather than served. It holds today because
+    // `RetryDriver` allocates a fresh channel per attempt
+    // (`operations/op_ctx.rs:448`), and because sequential same-tx reuse drops
+    // the previous receiver in the producer task before the next payload is
+    // enqueued, so the incumbent is observed closed and replaced.
+    //
+    // `Transaction::NULL` is the one key that could collide by construction:
+    // it is returned as `msg.id()` for NeighborHosting / InterestSync /
+    // ReadyState / SubscribeHint. Those route via `network_bridge.send()`
+    // rather than `op_execution_sender`, so this is latent rather than live —
+    // but the consequence changed shape with this guard. Before, a NULL-keyed
+    // collision was last-writer-wins; now the first live waiter sticks and
+    // blocks every later one until the 60s sweep.
+    debug_assert!(
+        tx != *Transaction::NULL,
+        "install_pending_op_callback called with Transaction::NULL: every NULL-keyed \
+         op would share one slot, and the live-incumbent guard would block all but the first"
+    );
+    if callback.is_closed() {
+        tracing::debug!(
+            %tx,
+            "handle_op_execution: callback already closed (driver cancelled before insert); skipping"
+        );
+    } else if state
+        .pending_op_results
+        .get(&tx)
+        .is_some_and(|existing| !existing.is_closed())
+    {
+        // A LIVE waiter is already registered for this tx — never displace it.
+        //
+        // The `callback.is_closed()` guard above is NOT sufficient on its own.
+        // Producers such as `send_local_loopback` / `send_fire_and_forget` build a
+        // throwaway channel and drop its receiver, but the receiver is a NAMED binding
+        // that only drops when the producer's poll finishes — while the event loop can
+        // dequeue the payload inside that enqueue->drop window and observe
+        // `is_closed() == false`. Inserting then drops the ORIGINATOR's sender, its
+        // `recv()` yields `None` -> `OpError::NotificationError`, and the client is told
+        // "failed notifying, channel closed" for an operation that actually succeeded
+        // (the #4111 forbidden marker). Widens with event-loop starvation.
+        tracing::debug!(
+            %tx,
+            "handle_op_execution: a live waiter is already registered for this tx; \
+             not displacing it"
+        );
+        crate::config::GlobalTestMetrics::record_pending_op_skip();
+    } else {
+        state.pending_op_results.insert(tx, callback);
+        crate::config::GlobalTestMetrics::record_pending_op_insert();
+        crate::config::GlobalTestMetrics::record_pending_op_size(
+            state.pending_op_results.len() as u64
+        );
     }
 }


### PR DESCRIPTION
Fixes #5182.

## What breaks today

`handle_op_execution` installs a payload's reply callback into `pending_op_results[tx]`
guarded only on the **incoming** callback — it never checks whether a **live waiter is
already registered** for that tx:

```rust
if callback.is_closed() { /* skip */ }
else { state.pending_op_results.insert(*msg.id(), callback); }
```

`send_local_loopback` / `send_fire_and_forget` build a throwaway channel and drop its
receiver, but `_response_receiver` is a **named binding**: it drops when the producer's poll
finishes, *after* the `.await` that hands the sender over. The event loop, on another thread,
can dequeue the payload inside that window and see `is_closed() == false`. The insert then
displaces the originator's live waiter — its sender drops, `recv_waiter_reply` gets `None`
→ `OpError::NotificationError`, the three infra-retries re-lose the same race, and the client
receives `FORBIDDEN_MARKER` for a PUT that **stored and replicated correctly**.

## The change

1. **`test(put)`** — a deterministic reproduction, no timing and no threads. It models the
   window by holding the dummy receiver alive across the install, then dropping it, and
   asserts the originator is still connected *and* actually receives the terminal reply.
2. **`fix(put)`** — check the incumbent: if `pending_op_results[tx]` holds a waiter that is
   still live, do not replace it. A payload whose own callback is closed is still skipped, so
   the #3100 bound on the map is unaffected.

The fix commit also extracts `install_pending_op_callback` out of `handle_op_execution` so
the decision is unit-testable without a full `P2pConnManager`, following the shape of the
existing `fail_awaiting_connection` helper.

## Verifying RED → GREEN

```bash
gh pr checkout 5183
cargo test -p freenet --lib op_execution_payload_must_not_clobber_live_waiter   # GREEN
git revert --no-commit HEAD                                                    # undo the fix only
cargo test -p freenet --lib op_execution_payload_must_not_clobber_live_waiter   # RED
```

## Checks

```
cargo test -p freenet --lib            4671 passed; 0 failed; 28 ignored
cargo fmt --all -- --check             clean
cargo clippy -p freenet --lib -D warnings   clean
```

Verified against `main` @ 998b730, not only against the 0.2.118 tag where it was first
observed.

## Notes for review

- **This is not #4111.** That fix is present and is about a *real* `PutMsg::Error` being lost
  at dispatch; here the operation succeeds and there is no error to forward. Two routes to
  the same string.
- **Why not fix the producers?** Dropping `_response_receiver` before the send was tried
  first. It is whack-a-mole — there is more than one producer — and it could not be shown to
  help: 9 and 19 failures per 50 against a control of 10, with identical code varying 9→19
  between consecutive runs. The consumer-side guard closes every producer at once and is
  testable without timing.
- **Why the existing guards miss it:** every `FORBIDDEN_MARKER` test binds `127.0.0.1:0`, and
  a co-located client keeps the window shut. Field observation needed a client on a separate
  machine from the node.
- The `try_forward_driver_reply` no-waiter branch returns `false` with **no log at any
  level**, so this is invisible to log-level tuning; the node had to be patched to see it.
  Happy to add a `debug!` there in a follow-up if wanted.



[AI-assisted - Claude]
