### PR TITLE
fix(service): reap same-version init-adopted orphans

### DIFF
--- a/crates/core/src/bin/commands/service.rs
+++ b/crates/core/src/bin/commands/service.rs
@@ -1482,16 +1482,15 @@ mod tests {
         // Verify exit code 43 prevents restart (another instance already running)
         assert!(service_content.contains("RestartPreventExitStatus=43"));
 
-        // Regression for #3967: stale-orphan self-heal pre-flight. Because
+        // Regression for #3967: orphan self-heal pre-flight. Because
         // RestartPreventExitStatus=43 blocks restart on exit 43, the
-        // version-compare-and-kill must run as an ExecStartPre before the main
-        // ExecStart so a stale orphan can't hold the port forever.
+        // orphan-reap must run as an ExecStartPre before the main
+        // ExecStart so an init-adopted orphan can't hold the port forever.
         assert!(
             service_content.contains("ExecStartPre=")
-                && service_content.contains("Freenet version:")
                 && service_content.contains("kill -TERM")
                 && service_content.contains("kill -KILL"),
-            "systemd unit must run a stale-orphan version-compare-and-kill pre-flight (#3967)"
+            "systemd unit must run an orphan-reap pre-flight (#3967)"
         );
 
         // Verify graceful shutdown timeout is set. 45s = 30s drain
@@ -1583,13 +1582,12 @@ mod tests {
         // Verify exit code 43 prevents restart (another instance already running)
         assert!(service_content.contains("RestartPreventExitStatus=43"));
 
-        // Regression for #3967: stale-orphan self-heal pre-flight (system unit).
+        // Regression for #3967: orphan self-heal pre-flight (system unit).
         assert!(
             service_content.contains("ExecStartPre=")
-                && service_content.contains("Freenet version:")
                 && service_content.contains("kill -TERM")
                 && service_content.contains("kill -KILL"),
-            "system systemd unit must run a stale-orphan version-compare-and-kill pre-flight (#3967)"
+            "system systemd unit must run an orphan-reap pre-flight (#3967)"
         );
 
         // Logging routes to journal (same reasoning as the user-unit test).
@@ -1902,7 +1900,7 @@ mod tests {
 
             // Post-render the file on disk MUST carry the systemd-level `$$`
             // form for the shell identifiers the pre-flight relies on.
-            for needle in ["$$pid", "$$exe", "$$ondisk", "$$self", "$$(id -u)"] {
+            for needle in ["$$pid", "$$ppid", "$$self", "$$(id -u)"] {
                 assert!(
                     pre.contains(needle),
                     "{which} ExecStartPre must double shell dollars (missing `{needle}`); \
@@ -1917,13 +1915,7 @@ mod tests {
             // NB: we cannot blanket-assert absence of `$(id -u)` because the
             // VALID doubled form `$$(id -u)` contains it as a substring; the
             // `$$(id -u)` presence check above covers that identifier instead.
-            for bad in [
-                "/proc/$pid/",
-                "\"$pid\"",
-                "\"$exe\"",
-                "\"$ondisk\"",
-                "\"$self\"",
-            ] {
+            for bad in ["/proc/$pid/", "\"$pid\"", "\"$ppid\"", "\"$self\""] {
                 assert!(
                     !pre.contains(bad),
                     "{which} ExecStartPre contains bare single-`$` `{bad}` that systemd \
@@ -1967,11 +1959,18 @@ mod tests {
                  (#3967 round-2 RE-REVIEW)"
             );
 
-            // MUST-FIX #3/#4: kill is gated on PPID==1 AND (readable-version
-            // mismatch OR unreadable holder version). Render-level check.
+            // MUST-FIX #3: kill is gated on PPID==1 (init-adopted orphan).
+            // The former version-compare gate is deliberately GONE: sparing a
+            // current-version orphan wedges the unit into success-but-dead
+            // with the node unsupervised. Render-level check.
             assert!(
-                pre.contains("[ \"$$ppid\" = \"1\" ] &&"),
+                pre.contains("if [ \"$$ppid\" = \"1\" ]; then"),
                 "{which} ExecStartPre must require PPID==1 before killing (#3967 MUST-FIX 3)"
+            );
+            assert!(
+                !pre.contains("$$ondisk") && !pre.contains("$$hv"),
+                "{which} ExecStartPre must not version-gate the orphan kill — a \
+                 same-version orphan wedges the unit into unsupervised mode"
             );
 
             // Now emulate systemd's `$$` -> `$` collapse and confirm the body

--- a/crates/core/src/bin/commands/service.rs
+++ b/crates/core/src/bin/commands/service.rs
@@ -2231,30 +2231,31 @@ echo "RC=$?"
         );
     }
 
-    /// Behavioral regression for the SYSTEMD inline self-heal DECISION (#3967,
-    /// round-2 RE-REVIEW). The render + `sh -n` test proves the inline body
-    /// PARSES; this proves it DECIDES correctly. Crucially it locks the round-2
-    /// fix: the round-1 unit anchored the holder loop on
-    /// `[ "$exe" != "$bin" ] && continue`, which skipped every holder whose exe
-    /// differed from the unit's on-disk binary — i.e. exactly the stale orphan
-    /// (running an OLD binary) the self-heal exists to kill. Here the fake
-    /// holder's exe path is DIFFERENT from the on-disk binary, and we assert it
-    /// IS killed.
+    /// Shared harness for the systemd ExecStartPre self-heal DECISION tests
+    /// (#3967). The render + `sh -n` test proves the inline body PARSES; the
+    /// tests built on this harness prove it DECIDES correctly.
     ///
-    /// We extract the `ExecStartPre` `/bin/sh -c '...'` body from the rendered
-    /// unit, collapse systemd's `$$` -> `$`, and run it under `sh` with
-    /// PATH-shimmed `pgrep`/`readlink`/`timeout` and a `kill` shell function
-    /// (functions beat the builtin) that records targets to a marker.
+    /// Extracts the `ExecStartPre` `/bin/sh -c '...'` body from the rendered
+    /// user unit, collapses systemd's `$$` -> `$`, and returns the on-disk
+    /// binary path plus a `run(holder_version, holder_ppid, pgrep_pid)`
+    /// closure that executes the body under `sh` with PATH-shimmed
+    /// `pgrep`/`readlink`/`timeout` and a `kill` shell function (functions
+    /// beat the builtin) recording kills to a marker; it returns whether the
+    /// holder was killed. The version machinery is deliberately kept even
+    /// though the current pre-flight is version-blind: if a version gate is
+    /// ever reintroduced, the same-version regression test below fails.
     ///
     /// Linux-only because it exercises the `/proc`-based systemd inline path
     /// and the unit generators are `#[cfg(target_os = "linux")]`.
-    #[test]
     #[cfg(target_os = "linux")]
-    fn test_systemd_execstartpre_heal_decision_behavior() {
+    fn systemd_heal_harness(
+        dir: &std::path::Path,
+    ) -> (
+        std::path::PathBuf,
+        impl Fn(&str, &str, Option<&str>) -> bool,
+    ) {
         use std::os::unix::fs::PermissionsExt;
 
-        let tmp = tempfile::tempdir().unwrap();
-        let dir = tmp.path();
         let chmod_x = |p: &std::path::Path| {
             std::fs::set_permissions(p, std::fs::Permissions::from_mode(0o755)).unwrap();
         };
@@ -2332,11 +2333,12 @@ echo "RC=$?"
         // shim's */proc/*/exe arm fires.
 
         let killed_marker = dir.join("killed");
+        let harness_path = dir.join("harness.sh");
         let path_env = format!("{}:{}", bin.display(), std::env::var("PATH").unwrap());
 
         // Returns (holder_was_killed). HOLDER_PPID drives the fake stat file's
         // PPID field; HOLDER_VER drives the holder binary's version.
-        let run = |holder_ver: &str, holder_ppid: &str, pgrep_pid: Option<&str>| -> bool {
+        let run = move |holder_ver: &str, holder_ppid: &str, pgrep_pid: Option<&str>| -> bool {
             std::fs::remove_file(&killed_marker).ok();
             std::fs::write(
                 &stat_file,
@@ -2351,7 +2353,6 @@ echo "RC=$?"
                 marker = killed_marker.display(),
                 body = body,
             );
-            let harness_path = dir.join("harness.sh");
             std::fs::write(&harness_path, harness).unwrap();
             let mut cmd = std::process::Command::new("sh");
             cmd.arg(&harness_path)
@@ -2363,6 +2364,19 @@ echo "RC=$?"
             cmd.output().expect("failed to run systemd heal harness");
             killed_marker.exists()
         };
+        (ondisk_bin, run)
+    }
+
+    /// Behavioral regression for the systemd self-heal decision (#3967,
+    /// round-2 RE-REVIEW): an init-adopted orphan (PPID==1) is killed, a
+    /// user-parented holder (PPID!=1) is deferred to.
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_systemd_execstartpre_heal_decision_behavior() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let (ondisk_bin, run) = systemd_heal_harness(tmp.path());
 
         // (a) ROUND-2 CORE: orphan (PPID==1) running an OLD version at a
         // DIFFERENT exe path than the on-disk binary -> MUST be KILLED. The
@@ -2374,11 +2388,8 @@ echo "RC=$?"
              exe==bin anchor wrongly skipped it)"
         );
 
-        // (b) orphan (PPID==1) running the SAME current version -> DEFER.
-        assert!(
-            !run("1.0.0 (current)", "1", None),
-            "systemd self-heal must DEFER to a same-version holder (polite path)"
-        );
+        // (b) same-version PPID==1 orphan -> KILLED; covered by the dedicated
+        // regression test test_systemd_execstartpre_kills_same_version_orphan.
 
         // (c) version-mismatched but USER-parented (PPID!=1) -> DEFER.
         assert!(
@@ -2386,21 +2397,33 @@ echo "RC=$?"
             "systemd self-heal must DEFER to a user-parented (PPID!=1) holder (#3967 MUST-FIX 3)"
         );
 
-        // (d) on-disk binary version UNREADABLE (`$ondisk` empty) -> DEFER even for
-        // a PPID==1 orphan whose own version IS readable. With no trustworthy
-        // baseline we must not version-compare; killing here would reap a healthy
-        // current node during an update window when the binary is momentarily
-        // unreadable. Mirrors the macOS test's chmod-644 case (#3967 MUST-FIX 4),
-        // which the systemd path's `[ -n "$$ondisk" ]` guard implements but had no
-        // behavioral coverage on Linux (rule-review Info on #4408).
+        // (d) on-disk binary UNREADABLE -> still KILLED. The pre-flight no
+        // longer reads any version (the version gate was exactly the #3967
+        // same-version wedge), so an unreadable on-disk binary cannot spare a
+        // PPID==1 orphan.
         std::fs::set_permissions(&ondisk_bin, std::fs::Permissions::from_mode(0o644)).unwrap();
         assert!(
-            !run("0.9.0 (old)", "1", None),
-            "systemd self-heal must DEFER when the on-disk version is unreadable, even \
-             for a readable-version PPID==1 orphan (#3967 MUST-FIX 4: empty $ondisk \
-             must not drive a kill)"
+            run("0.9.0 (old)", "1", None),
+            "systemd self-heal must KILL a PPID==1 orphan even when the on-disk \
+             version is unreadable — the pre-flight is version-blind"
         );
-        chmod_x(&ondisk_bin); // restore for any later use
+    }
+
+    /// Regression for the same-version orphan wedge (#3967 follow-up): a
+    /// SAME-VERSION init-adopted orphan (PPID==1) MUST be killed. The earlier
+    /// pre-flight version-compared and deferred to a same-version holder,
+    /// which wedged the unit into success-but-dead (ExecStart exits 43, no
+    /// restart) with the node running unsupervised forever.
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_systemd_execstartpre_kills_same_version_orphan() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (_ondisk_bin, run) = systemd_heal_harness(tmp.path());
+        assert!(
+            run("1.0.0 (current)", "1", None),
+            "systemd self-heal must KILL a same-version PPID==1 orphan — sparing \
+             it wedges the unit into success-but-dead / unsupervised mode (#3967)"
+        );
     }
 
     #[test]

--- a/crates/core/src/bin/commands/service/linux.rs
+++ b/crates/core/src/bin/commands/service/linux.rs
@@ -450,31 +450,31 @@ Environment=FREENET_SUPERVISED=1
 # (auto-updated but not reinstalled) or the mac/Windows wrapper keeps emitting the
 # self-healing exit 42 instead of a 45 the supervisor would mishandle.
 Environment={fast_crash_marker}=1
-# Stale-orphan self-heal (issue #3967): RestartPreventExitStatus=43 below
-# means an exit 43 ("another instance already running") never restarts the
-# unit. That is correct for a legitimate second instance, but if the port
-# holder is an ORPHANED `freenet network` (PPID=1) still running an OLD
-# binary, the unit would stand down and the orphan would serve stale assets
-# forever. This pre-flight runs before every start: it finds the port
-# holder, and kills it ONLY when it is an init-adopted orphan (PPID==1) whose
-# `Freenet version:` line differs from the binary this unit would launch (or
-# whose version can't be read). A user-run `freenet network` (parented by a
-# shell, PPID!=1) is always left alone, as is a current-version orphan.
+# Orphan self-heal (issue #3967): RestartPreventExitStatus=43 below means an
+# exit 43 ("another instance already running") never restarts the unit. That is
+# correct for a legitimate second instance, but an init-adopted ORPHANED
+# `freenet network` (PPID==1) holding the port wedges the unit permanently:
+# ExecStart exits 43, the unit reports success-but-dead, and the orphan runs
+# UNSUPERVISED forever — no Restart= on crash, no systemctl control, and (if it
+# is an old binary) stale assets served indefinitely. This pre-flight runs
+# before every start and kills ANY init-adopted orphan, regardless of version:
+# an earlier revision compared `Freenet version:` lines and spared a
+# current-version orphan, but that just wedges the unit into the unsupervised
+# state — when the operator starts this unit, a PPID==1 holder is always wrong.
+# A user-run `freenet network` (parented by a live shell, PPID!=1) is left
+# alone; it wins the port and the unit stands down via exit 43 as designed.
 #
 # systemd performs its own $VAR/${{VAR}} expansion on Exec* lines BEFORE handing
 # the string to /bin/sh, so every dollar the SHELL must see is written as $$
 # here (systemd collapses $$ -> a single $ for sh). Self-match guards: the
 # pre-flight sh's OWN argv contains the literal "freenet network" (it is the
 # substring `pgrep -f` matches), so the pre-flight excludes its own PID ($$$$ ->
-# the sh's $$) and PID 1 from the holder loop. We deliberately do NOT anchor on
-# the holder's exe equalling THIS unit's on-disk binary: a #3967 orphan is, by
-# definition, running an OLD/DIFFERENT binary, so an `exe == on-disk binary`
-# guard would skip exactly the orphan we must kill. The PPID==1 + version-line
-# checks below are what distinguish a stale orphan from a legitimate holder.
+# the sh's $$) and PID 1 from the holder loop.
 # PPID is read after the final ')' in /proc/PID/stat (comm is parenthesized) so
-# a comm containing whitespace can't shift the field. The '-' prefix means a
-# failure here never blocks the start.
-ExecStartPre=-/bin/sh -c 'self=$$$$; ondisk=$$(timeout 5 {binary} --version 2>/dev/null | grep "^Freenet version:"); for pid in $$(pgrep -f -u "$$(id -u)" "freenet network" 2>/dev/null); do [ "$$pid" = "$$self" ] && continue; [ "$$pid" = "1" ] && continue; exe=$$(readlink -f /proc/$$pid/exe 2>/dev/null); hv=""; [ -x "$$exe" ] && hv=$$(timeout 5 "$$exe" --version 2>/dev/null | grep "^Freenet version:"); ppid=$$(sed "s/.*) //" /proc/$$pid/stat 2>/dev/null | awk "{{print \$$2}}"); mismatch=1; [ -n "$$ondisk" ] && [ -n "$$hv" ] && [ "$$hv" != "$$ondisk" ] && mismatch=0; if [ "$$ppid" = "1" ] && {{ [ "$$mismatch" = "0" ] || [ -z "$$hv" ]; }}; then kill -TERM "$$pid" 2>/dev/null || true; w=0; while kill -0 "$$pid" 2>/dev/null && [ $$w -lt 12 ]; do sleep 1; w=$$((w+1)); done; kill -0 "$$pid" 2>/dev/null && kill -KILL "$$pid" 2>/dev/null || true; fi; done'
+# a comm containing whitespace can't shift the field; `cut` (not awk) extracts
+# the field so the line carries no backslash escapes for journald to warn
+# about. The '-' prefix means a failure here never blocks the start.
+ExecStartPre=-/bin/sh -c 'self=$$$$; for pid in $$(pgrep -f -u "$$(id -u)" "freenet network" 2>/dev/null); do [ "$$pid" = "$$self" ] && continue; [ "$$pid" = "1" ] && continue; ppid=$$(sed "s/.*) //" /proc/$$pid/stat 2>/dev/null | cut -d" " -f2); if [ "$$ppid" = "1" ]; then kill -TERM "$$pid" 2>/dev/null || true; w=0; while kill -0 "$$pid" 2>/dev/null && [ $$w -lt 12 ]; do sleep 1; w=$$((w+1)); done; kill -0 "$$pid" 2>/dev/null && kill -KILL "$$pid" 2>/dev/null || true; fi; done'
 ExecStart={binary} network
 Restart=always
 # Wait 10 seconds before restart to avoid rapid restart loops. The actual
@@ -620,19 +620,17 @@ Environment=FREENET_SUPERVISED=1
 # node emits exit 45 only when this is present (this unit handles 45); otherwise it
 # keeps the self-healing exit 42.
 Environment={fast_crash_marker}=1
-# Stale-orphan self-heal (issue #3967): see the matching comment in the user
-# unit (including the systemd $$-escaping, the PPID-after-final-')' parse, and
-# why we do NOT anchor on the holder's exe equalling this unit's on-disk binary
-# — a #3967 orphan runs an OLD/DIFFERENT binary, so that anchor would skip the
-# very process we must kill). The self-PID and PID-1 skips exclude the
-# pre-flight's own sh (whose argv contains the literal "freenet network").
-# RestartPreventExitStatus=43 means an exit 43 never restarts the unit, so an
-# init-adopted orphan (PPID==1) running an OLD binary would hold the port
-# forever. This pre-flight kills the holder ONLY when it is such an orphan whose
-# `Freenet version:` differs from (or can't be read against) the binary this
-# unit launches; a user-run instance (PPID!=1) is always left alone. The '-'
-# prefix means a failure here never blocks the start.
-ExecStartPre=-/bin/sh -c 'self=$$$$; ondisk=$$(timeout 5 {binary} --version 2>/dev/null | grep "^Freenet version:"); for pid in $$(pgrep -f -u "$$(id -u)" "freenet network" 2>/dev/null); do [ "$$pid" = "$$self" ] && continue; [ "$$pid" = "1" ] && continue; exe=$$(readlink -f /proc/$$pid/exe 2>/dev/null); hv=""; [ -x "$$exe" ] && hv=$$(timeout 5 "$$exe" --version 2>/dev/null | grep "^Freenet version:"); ppid=$$(sed "s/.*) //" /proc/$$pid/stat 2>/dev/null | awk "{{print \$$2}}"); mismatch=1; [ -n "$$ondisk" ] && [ -n "$$hv" ] && [ "$$hv" != "$$ondisk" ] && mismatch=0; if [ "$$ppid" = "1" ] && {{ [ "$$mismatch" = "0" ] || [ -z "$$hv" ]; }}; then kill -TERM "$$pid" 2>/dev/null || true; w=0; while kill -0 "$$pid" 2>/dev/null && [ $$w -lt 12 ]; do sleep 1; w=$$((w+1)); done; kill -0 "$$pid" 2>/dev/null && kill -KILL "$$pid" 2>/dev/null || true; fi; done'
+# Orphan self-heal (issue #3967): see the matching comment in the user unit
+# (including the systemd $$-escaping and the PPID-after-final-')' parse). The
+# self-PID and PID-1 skips exclude the pre-flight's own sh (whose argv contains
+# the literal "freenet network"). RestartPreventExitStatus=43 means an exit 43
+# never restarts the unit, so an init-adopted orphan (PPID==1) holding the port
+# would wedge the unit into success-but-dead and run unsupervised forever. This
+# pre-flight kills ANY such orphan regardless of version (an earlier revision
+# spared current-version orphans, which is exactly the wedge); a user-run
+# instance (PPID!=1) is always left alone. The '-' prefix means a failure here
+# never blocks the start.
+ExecStartPre=-/bin/sh -c 'self=$$$$; for pid in $$(pgrep -f -u "$$(id -u)" "freenet network" 2>/dev/null); do [ "$$pid" = "$$self" ] && continue; [ "$$pid" = "1" ] && continue; ppid=$$(sed "s/.*) //" /proc/$$pid/stat 2>/dev/null | cut -d" " -f2); if [ "$$ppid" = "1" ]; then kill -TERM "$$pid" 2>/dev/null || true; w=0; while kill -0 "$$pid" 2>/dev/null && [ $$w -lt 12 ]; do sleep 1; w=$$((w+1)); done; kill -0 "$$pid" 2>/dev/null && kill -KILL "$$pid" 2>/dev/null || true; fi; done'
 ExecStart={binary} network
 Restart=always
 # Wait 10 seconds before restart to avoid rapid restart loops. The actual


### PR DESCRIPTION
Fixes #5187.

The #3967 `ExecStartPre` pre-flight only killed an init-adopted (PPID==1) orphan whose `Freenet version:` differed from the on-disk binary, deliberately sparing same-version orphans. But a same-version orphan wedges the unit identically: ExecStart exits 43, `RestartPreventExitStatus=43` stands the unit down (reported as success), and the node runs unsupervised forever — no `Restart=`, no `systemctl` control, no ExecStopPost auto-update path. Hit in production; repro logs in #5187.

Changes (both Linux unit templates, user + system):

- The pre-flight now kills **any** PPID==1 `freenet network` orphan, version notwithstanding — a strict superset of the old behavior, so the #3967 old-binary case is still covered. A user-run instance parented by a live shell (PPID!=1) is still left alone and wins the port via exit 43 as designed.
- The version-compare machinery (`ondisk`/`exe`/`hv`/`mismatch`) is deleted with its gate. Dropping the embedded awk (`\$$2` → `cut -d" " -f2`) also silences journald's "Ignoring unknown escape sequences" warning on every daemon-reload.
- Tests updated: the $$-doubling needles track the surviving identifiers, the PPID==1 gate assertion matches the new form, and a new assertion pins the *absence* of a version gate so the spare-same-version behavior can't come back.

The macOS wrapper's exit-43 self-heal has the same version-gated shape and is deliberately out of scope here.

Verified: `sh -n` on the post-$$-collapse body (existing render test emulates this; also run by hand), and an equivalent unconditional PPID==1 reaper deployed as ExecStartPre on the affected host cleanly reaped a same-version orphan, with the unit running supervised since.