### PR TITLE
chore(release): flip both version markers for 0.2.120

### DIFF
--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -1076,9 +1076,14 @@ pub(crate) fn version_supports_hash_first_summaries(
 /// must equal the floor.
 ///
 /// RELEASE-TIME ACTION: when the release carrying this feature is cut, set this
-/// to `Some(BROADCAST_TARGET_LIST_MIN_VERSION)` and freeze both.
+/// to a LITERAL `Some((major, minor, patch))` of that release and freeze both.
+///
+/// Write the literal, NOT `Some(BROADCAST_TARGET_LIST_MIN_VERSION)`. Naming the
+/// constant compiles, passes, and reads as tidier, but it makes the guard's
+/// `shipped == floor` assertion compare the floor against itself, so that arm
+/// can never fail again, which is the entire point of the guard.
 #[cfg_attr(not(test), allow(dead_code))]
-pub(crate) const BROADCAST_TARGET_LIST_SHIPPED_IN: Option<(u8, u8, u16)> = None;
+pub(crate) const BROADCAST_TARGET_LIST_SHIPPED_IN: Option<(u8, u8, u16)> = Some((0, 2, 120));
 
 /// Version floor for the originator target list on broadcast (#5147).
 ///

--- a/crates/core/src/transport/connection_handler/version_cmp.rs
+++ b/crates/core/src/transport/connection_handler/version_cmp.rs
@@ -187,7 +187,7 @@ pub(super) const GATEWAY_ACK_VERSION_MIN_VERSION: (u8, u8, u16) = (0, 2, 120);
 /// Read only by `ack_version_floor_tracks_the_shipping_release`; it carries no
 /// runtime behaviour by design, mirroring `HASH_FIRST_SHIPPED_IN`.
 #[cfg_attr(not(test), allow(dead_code))]
-pub(super) const ACK_VERSION_SHIPPED_IN: Option<(u8, u8, u16)> = None;
+pub(super) const ACK_VERSION_SHIPPED_IN: Option<(u8, u8, u16)> = Some((0, 2, 120));
 
 /// Pure version-gate for [`GATEWAY_ACK_VERSION_MIN_VERSION`], mirroring
 /// `node::version_supports_hash_first_summaries`: `true` iff `remote` is known


### PR DESCRIPTION
## Problem

0.2.120 carries two wire-gated features whose version floors were written as *predictions* about the next release:

- `GATEWAY_ACK_VERSION_MIN_VERSION = (0, 2, 120)` (#5167, version-carrying connection ack)
- `BROADCAST_TARGET_LIST_MIN_VERSION = (0, 2, 120)` (#5147 / #5179, originator target list on broadcast)

Each has a companion `*_SHIPPED_IN` marker, currently `None`, meaning "not yet shipped, so the floor must stay strictly above the crate version". Cutting 0.2.120 makes both predictions true, so both markers have to move in the same commit that precedes the cut.

These gate **wire variants whose failure mode is a closed connection, not a degraded feature**. A peer at or above the floor without the code receives a `BroadcastToV2` variant index it has no arm for, `decode_msg` fails, and the link drops. The release cascade upgrades gateways first, so getting this wrong is fleet-wide churn.

## Approach

Both markers set to a **literal** `Some((0, 2, 120))`.

Deliberately **not** `Some(<FLOOR_CONSTANT>)`. That form compiles, passes, and reads as tidier, but it makes each guard's `shipped == floor` assertion compare the floor against itself, so that arm can never fail again. The `BROADCAST_TARGET_LIST_SHIPPED_IN` rustdoc previously instructed exactly that wrong resolution, so this PR corrects the doc rather than leaving it to mislead the next release.

## Timing constraint

Both markers **disarm their own tripwire the moment they are flipped** — the `Some(_)` arm only asserts `shipped == floor` and cannot tell whether the code actually shipped.

- Merge and cut in the same sitting.
- **If 0.2.120 slips, revert this commit.** A standing flip means a renumbered release leaves the floors naming 0.2.120, and a peer on the real 0.2.120 then reads as at-floor, receives a variant it cannot decode, and drops the connection.

## Testing

Guard tests `ack_version_floor_tracks_the_shipping_release` and `broadcast_target_list_floor_tracks_the_shipping_release` cover the constants directly.

Pre-flight soak gates, all green on **framework** (NATed residential peer, 2h on merged main `795ab3317`):

| Gate | Result |
|---|---|
| Outbound bandwidth | **−25.3%** vs matched time-of-day 0.2.118 window (2.38 vs 3.19 GB/day), inside #5164's predicted −20–40% |
| Stability | 0 restarts, 0 panics; every error class decayed into 0.2.118's own steady-state hourly range |
| River smoke test | HEALTHY (6/6 checks, 0 console/page errors), with live message delivery after the swap |

Note the soak **cannot** validate #5147 itself: the target list is version-gated at (0,2,120) and framework's peers are all below it, so the gate stays shut. #5147's real-world effect is a post-release telemetry question as the fleet adopts 0.2.120, tracked in #5191.

[AI-assisted - Claude]
