### PR TITLE
fix(telemetry): phase mix rollups off the shadow-stat boundary

### DIFF
--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -93,6 +93,15 @@ mod network_bridge;
 /// `network_bridge` is private outside this module.
 pub(crate) use network_bridge::broadcast_payload_mix::ApplyOrigin;
 
+/// Re-exported for `tracing::telemetry`'s shadow sub-budget guard, which has
+/// to name the minute rollups' cadence and phase to derive the worst-case
+/// number of shadow events in one second. Test-only, and `network_bridge` is
+/// private outside this module.
+#[cfg(test)]
+pub(crate) use network_bridge::broadcast_payload_mix::{
+    ROLLUP_PHASE_OFFSET as MIX_ROLLUP_PHASE_OFFSET, ROLLUP_WINDOW as MIX_ROLLUP_WINDOW,
+};
+
 // Re-export fault injection types for test infrastructure.
 // No cfg gate: underlying items are unconditionally compiled and integration
 // tests compile the lib without cfg(test).

--- a/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
+++ b/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
@@ -323,21 +323,42 @@ pub(crate) const ROLLUP_WINDOW: Duration = Duration::from_secs(60);
 /// each other. The five shadow-stat streams close a
 /// [`crate::transport::shadow_stats::SHADOW_ROLLUP_WINDOW_SECS`] (30 s) window
 /// and the two mix streams a 60 s one, so without an offset all seven emit in
-/// the SAME second every 60 s. The telemetry worker admits at most
-/// `MAX_SHADOW_EVENTS_PER_SECOND` (6) shadow events per second, so on a
-/// gateway — the only place all seven run, since `shadow_reference_ping` and
-/// `shadow_iface_tx` are gateway opt-ins — exactly one rollup was dropped
-/// every minute, and WHICH one depended on task-wakeup order. Gateways are
-/// precisely where these rollups get read.
+/// the SAME second every 60 s, against a `MAX_SHADOW_EVENTS_PER_SECOND` of 6.
 ///
-/// Offsetting is preferred over raising the shadow sub-budget to 7: it adds
-/// no telemetry volume, whereas a cap of 7 would leave only 3 of the 10
-/// aggregate slots per second for operational telemetry.
+/// This is a LATENT defect, not a measured production loss. Do not restate it
+/// as one: an earlier version of this comment claimed gateways lost a rollup
+/// every minute, and production telemetry says otherwise on both counts.
+/// Measured over 1382 nodes, the shadow sub-budget has dropped 54 events
+/// fleet-wide in total, because `admit_event` tests the aggregate 10/s cap
+/// FIRST and returns early — that cap discards ~31 % of shadow and ~77 % of
+/// operational telemetry, and is the real bottleneck (see #5197). And the two
+/// opt-in streams are not in fact co-enabled on the production gateways, which
+/// run six streams against a cap of six and so cannot drop at all; only 2 of
+/// 1382 nodes run all seven.
+///
+/// The offset is kept anyway because the invariant is worth holding
+/// independently of today's numbers: nothing else ties the sub-budget to the
+/// emit schedule. The cap was chosen against a hand-counted five streams, two
+/// were added without revisiting it, and whoever changes the aggregate cap
+/// makes the sub-budget binding for the first time. The guard is the schedule
+/// test named below, not this constant.
+///
+/// Offsetting is preferred over raising the sub-budget to 7: it adds no
+/// telemetry volume, whereas a cap of 7 would leave only 3 of the 10 aggregate
+/// slots per second for operational telemetry that is already losing 77 %.
 ///
 /// 15 s is half the shadow window, which maximises the distance to the
 /// nearest 30 s boundary and so is the most tolerant of spawn-time skew.
 /// Applied to BOTH mix rollups equally, preserving the shared cadence that
 /// lets them be joined per node-minute without interpolation.
+///
+/// Known limit: the separation is probabilistic, not structural. Both cadences
+/// use `MissedTickBehavior::Delay`, so relative phase drifts on a node whose
+/// runtime stalls, and 15 s of margin is eventually consumable. Accumulated
+/// drift, not spawn-time skew, is the mode to watch. Relatedly, production
+/// shows sub-budget drops on nodes running only FIVE streams, which this
+/// schedule model says is impossible — so some source of emission bunching
+/// remains unidentified (see #5195 discussion).
 ///
 /// `telemetry::tests::shadow_rollup_emit_schedule_fits_the_shadow_sub_budget`
 /// derives the collision schedule from these constants and fails if this is
@@ -1637,6 +1658,13 @@ pub(crate) fn spawn_payload_mix_aggregator(
         // replaces the previous skip-the-immediate-tick dance, and makes the
         // reported window of that first rollup match the period it actually
         // accumulated over.
+        //
+        // Consequence worth knowing downstream: the FIRST window after every
+        // node start is 75 s, not 60 s. `rollup_window_secs` derives
+        // `window_secs` from real elapsed time, so the emitted record is
+        // self-describing and correct — but an analysis that hardcodes 60
+        // under-reports that one record by 20 %. Gateways restart on every
+        // auto-update, so this is not rare. Normalise by `window_secs`.
         let mut ticker = tokio::time::interval_at(
             last_rollup + ROLLUP_WINDOW + ROLLUP_PHASE_OFFSET,
             ROLLUP_WINDOW,
@@ -2903,6 +2931,44 @@ mod tests {
             "record_apply must index the origin arm fallibly; a bare \
              `w.applies[idx]` panics inside a held mutex on the apply hot path \
              the moment a variant is added to `index()` but not to `ALL`"
+        );
+    }
+
+    /// The phase offset is only real if the SPAWN SITE applies it.
+    ///
+    /// `ROLLUP_PHASE_OFFSET` carries a long rationale, so it is well guarded
+    /// against being deleted or zeroed. The ticker line that consumes it is the
+    /// unguarded half: `spawn_payload_mix_aggregator` has exactly two callers,
+    /// both in `p2p_impl`, and no test drives it, so reverting it to a plain
+    /// `tokio::time::interval(ROLLUP_WINDOW)` restores the pre-fix alignment
+    /// with the whole suite still green. It reads like boilerplate a refactor
+    /// would happily normalise.
+    ///
+    /// Bounded to the function body (AGENTS.md): an unbounded `find` would
+    /// match this test's own assertion strings and pass vacuously.
+    #[test]
+    fn payload_mix_aggregator_applies_the_phase_offset_pin() {
+        let src = include_str!("broadcast_payload_mix.rs");
+        let start = src
+            .find("pub(crate) fn spawn_payload_mix_aggregator(")
+            .expect("spawn_payload_mix_aggregator not found");
+        let body = &src[start..];
+        let end = body
+            .find("\n}")
+            .expect("end of spawn_payload_mix_aggregator not found");
+        let body: String = body[..end].split_whitespace().collect();
+
+        assert!(
+            body.contains("tokio::time::interval_at("),
+            "spawn_payload_mix_aggregator must start its ticker with \
+             interval_at so the first emit is phase-offset; a plain \
+             `interval(ROLLUP_WINDOW)` puts it back on the 30 s shadow-stat \
+             boundary"
+        );
+        assert!(
+            body.contains("ROLLUP_WINDOW+ROLLUP_PHASE_OFFSET"),
+            "spawn_payload_mix_aggregator must offset its first tick by \
+             ROLLUP_PHASE_OFFSET; without it the constant is inert"
         );
     }
 

--- a/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
+++ b/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
@@ -313,7 +313,36 @@ use crate::tracing::event_kind::{STATE_SIZE_BUCKET_COUNT, state_size_bucket};
 /// a minute rather than the 1 Hz sampling the `shadow_demand` aggregators use;
 /// one event per minute per node is a negligible addition to the telemetry
 /// volume this is meant to explain.
-const ROLLUP_WINDOW: Duration = Duration::from_secs(60);
+pub(crate) const ROLLUP_WINDOW: Duration = Duration::from_secs(60);
+
+/// Phase offset applied to the two minute-cadence mix rollups so they never
+/// share an emit second with the 30 s shadow-stat rollups.
+///
+/// Every shadow emitter is spawned from the same block in
+/// [`crate::node::p2p_impl`], so their tickers start within microseconds of
+/// each other. The five shadow-stat streams close a
+/// [`crate::transport::shadow_stats::SHADOW_ROLLUP_WINDOW_SECS`] (30 s) window
+/// and the two mix streams a 60 s one, so without an offset all seven emit in
+/// the SAME second every 60 s. The telemetry worker admits at most
+/// `MAX_SHADOW_EVENTS_PER_SECOND` (6) shadow events per second, so on a
+/// gateway — the only place all seven run, since `shadow_reference_ping` and
+/// `shadow_iface_tx` are gateway opt-ins — exactly one rollup was dropped
+/// every minute, and WHICH one depended on task-wakeup order. Gateways are
+/// precisely where these rollups get read.
+///
+/// Offsetting is preferred over raising the shadow sub-budget to 7: it adds
+/// no telemetry volume, whereas a cap of 7 would leave only 3 of the 10
+/// aggregate slots per second for operational telemetry.
+///
+/// 15 s is half the shadow window, which maximises the distance to the
+/// nearest 30 s boundary and so is the most tolerant of spawn-time skew.
+/// Applied to BOTH mix rollups equally, preserving the shared cadence that
+/// lets them be joined per node-minute without interpolation.
+///
+/// `telemetry::tests::shadow_rollup_emit_schedule_fits_the_shadow_sub_budget`
+/// derives the collision schedule from these constants and fails if this is
+/// set back to zero or an eighth stream lands on an occupied second.
+pub(crate) const ROLLUP_PHASE_OFFSET: Duration = Duration::from_secs(15);
 
 /// Per-contract attribution cap for one window.
 ///
@@ -1598,13 +1627,21 @@ pub(crate) fn spawn_payload_mix_aggregator(
     monitor: &BackgroundTaskMonitor,
 ) {
     let handle = tokio::spawn(async move {
-        let mut ticker = tokio::time::interval(ROLLUP_WINDOW);
-        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-        ticker.tick().await; // skip the immediate first tick
         // `tokio::time::Instant` (not `std::time::Instant`) so this reads the
         // same clock the ticker uses and stays controllable under a paused
         // test runtime.
         let mut last_rollup = tokio::time::Instant::now();
+        // First emit at one window PLUS `ROLLUP_PHASE_OFFSET`, so this rollup
+        // never lands on the same second as the 30 s shadow-stat rollups (see
+        // `ROLLUP_PHASE_OFFSET`). Starting the interval at the first real emit
+        // replaces the previous skip-the-immediate-tick dance, and makes the
+        // reported window of that first rollup match the period it actually
+        // accumulated over.
+        let mut ticker = tokio::time::interval_at(
+            last_rollup + ROLLUP_WINDOW + ROLLUP_PHASE_OFFSET,
+            ROLLUP_WINDOW,
+        );
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
         loop {
             ticker.tick().await;
             let now = tokio::time::Instant::now();

--- a/crates/core/src/node/network_bridge/outbound_message_mix.rs
+++ b/crates/core/src/node/network_bridge/outbound_message_mix.rs
@@ -93,7 +93,16 @@ const TOP_DIFFERING_CONTRACTS_REPORTED: usize = 10;
 
 /// Rollup cadence, matching [`super::broadcast_payload_mix`] so the two
 /// rollups can be joined per node-minute without interpolation.
-const ROLLUP_WINDOW: Duration = Duration::from_secs(60);
+///
+/// Aliased to that module's constant rather than restated, so the cadence the
+/// join depends on cannot drift between the two files.
+const ROLLUP_WINDOW: Duration = super::broadcast_payload_mix::ROLLUP_WINDOW;
+
+/// Shared with [`super::broadcast_payload_mix`] for the same reason the
+/// cadence is: both minute rollups must sit off the 30 s shadow-stat boundary,
+/// and must stay on the same phase as each other. Rationale for the value is
+/// on `broadcast_payload_mix::ROLLUP_PHASE_OFFSET`.
+const ROLLUP_PHASE_OFFSET: Duration = super::broadcast_payload_mix::ROLLUP_PHASE_OFFSET;
 
 /// Which kind of message put these bytes on the wire.
 ///
@@ -816,10 +825,15 @@ pub(crate) fn spawn_outbound_mix_aggregator(
     monitor: &BackgroundTaskMonitor,
 ) {
     let handle = tokio::spawn(async move {
-        let mut ticker = tokio::time::interval(ROLLUP_WINDOW);
-        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-        ticker.tick().await; // skip the immediate first tick
         let mut last_rollup = tokio::time::Instant::now();
+        // Phase-offset off the 30 s shadow-stat boundary; see
+        // `ROLLUP_PHASE_OFFSET`. Same shape as the payload-mix aggregator, and
+        // the same offset, so the two stay joinable per node-minute.
+        let mut ticker = tokio::time::interval_at(
+            last_rollup + ROLLUP_WINDOW + ROLLUP_PHASE_OFFSET,
+            ROLLUP_WINDOW,
+        );
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
         loop {
             ticker.tick().await;
             let now = tokio::time::Instant::now();

--- a/crates/core/src/node/network_bridge/outbound_message_mix.rs
+++ b/crates/core/src/node/network_bridge/outbound_message_mix.rs
@@ -549,9 +549,13 @@ impl OutboundMix {
     /// Lives on the outbound rollup despite being a RECEIVE-side observation,
     /// for two reasons: it belongs in the same node-minute record as the
     /// `interest_sync_summaries_bytes` it explains (joinable without
-    /// interpolation), and the telemetry budget has room for exactly one more
-    /// aligned rollup stream (`telemetry.rs`, `MAX_SHADOW_EVENTS_PER_SECOND`),
-    /// which this measurement does not deserve to consume.
+    /// interpolation), and adding a rollup stream is not free: whether one
+    /// fits is decided by the emit SCHEDULE, not by a spare slot in
+    /// `MAX_SHADOW_EVENTS_PER_SECOND` (see
+    /// `telemetry::tests::shadow_rollup_emit_schedule_fits_the_shadow_sub_budget`),
+    /// and on a busy node a new stream mostly competes for the aggregate cap
+    /// that already discards ~31 % of shadow telemetry (#5197). This
+    /// measurement does not deserve to consume that.
     pub(crate) fn record_summary_comparison(
         &self,
         contract: &ContractInstanceId,
@@ -1711,6 +1715,43 @@ mod tests {
     /// ASSIGNMENT form instead, because `classify` is where `SummaryRequest`
     /// gets its arm — that message carries no emitter field, having exactly
     /// one possible origin.
+    /// Sibling of `payload_mix_aggregator_applies_the_phase_offset_pin`.
+    ///
+    /// This aggregator must carry the SAME offset as the payload-mix one, not
+    /// merely some offset: the two rollups are joined per node-minute without
+    /// interpolation, so a phase difference between them silently breaks the
+    /// join. Both constants are aliased from `broadcast_payload_mix` so they
+    /// cannot drift in value; this pins that the ticker actually applies them.
+    ///
+    /// Bounded to the function body (AGENTS.md): an unbounded `find` would
+    /// match this test's own assertion strings and pass vacuously.
+    #[test]
+    fn outbound_mix_aggregator_applies_the_phase_offset_pin() {
+        let src = include_str!("outbound_message_mix.rs");
+        let start = src
+            .find("pub(crate) fn spawn_outbound_mix_aggregator(")
+            .expect("spawn_outbound_mix_aggregator not found");
+        let body = &src[start..];
+        let end = body
+            .find("\n}")
+            .expect("end of spawn_outbound_mix_aggregator not found");
+        let body: String = body[..end].split_whitespace().collect();
+
+        assert!(
+            body.contains("tokio::time::interval_at("),
+            "spawn_outbound_mix_aggregator must start its ticker with \
+             interval_at so the first emit is phase-offset; a plain \
+             `interval(ROLLUP_WINDOW)` puts it back on the 30 s shadow-stat \
+             boundary"
+        );
+        assert!(
+            body.contains("ROLLUP_WINDOW+ROLLUP_PHASE_OFFSET"),
+            "spawn_outbound_mix_aggregator must offset its first tick by the \
+             SAME ROLLUP_PHASE_OFFSET as the payload-mix aggregator, or the \
+             per-node-minute join between the two rollups breaks"
+        );
+    }
+
     #[test]
     fn summaries_emitter_sites_are_pinned() {
         use crate::node::network_bridge::p2p_protoc::tests::{

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -437,25 +437,40 @@ const MAX_EVENTS_PER_SECOND: usize = 10;
 ///
 /// Shadow telemetry is admitted under this sub-budget, carved out of the
 /// aggregate [`MAX_EVENTS_PER_SECOND`] cap, so that always-on background
-/// emitters cannot starve operational telemetry (#4380). There are five shadow
-/// streams — `shadow_rtt_aggregate`, `shadow_rate_demand`,
-/// `shadow_outbound_class` (always-on) plus `shadow_reference_ping` /
-/// `shadow_iface_tx` (opt-in on gateways). Each samples at 1 Hz but only emits
-/// one rolled-up event per
-/// `transport::shadow_stats::SHADOW_ROLLUP_WINDOW_SECS`, so the steady-state
-/// shadow rate is well below 1 event/sec.
+/// emitters cannot starve operational telemetry (#4380). The streams are
+/// enumerated by [`KnownShadowRollup`]; there are currently seven, in two
+/// cadence groups:
 ///
-/// The catch: all five aggregator tickers start at node startup and share the
-/// same window length, so their emit ticks ALIGN on the same second every
-/// window — five rollups contend for the sub-budget simultaneously. The cap is
-/// therefore set to 6, one slot above the five aligned rollups, so no window's
-/// rollup is ever dropped for lack of a shadow slot (at a cap of 4 the fifth
-/// aligned rollup was deterministically dropped every window). This still
-/// reserves `MAX_EVENTS_PER_SECOND - MAX_SHADOW_EVENTS_PER_SECOND` (= 4)
-/// slots/sec for operational telemetry, and leaves one slot of headroom for a
-/// sixth stream (e.g. Phase 2 adding a shadow controller decision log). Shadow
-/// events still also count against the aggregate cap, so under genuine
-/// operational load they continue to yield.
+/// - Five 30 s shadow-stat rollups (`transport::shadow_stats::
+///   SHADOW_ROLLUP_WINDOW_SECS`): `shadow_rtt_aggregate`,
+///   `shadow_rate_demand`, `shadow_outbound_class` (always-on) plus
+///   `shadow_reference_ping` / `shadow_iface_tx` (opt-in, set on gateways).
+///   Each samples at 1 Hz but emits only one rolled-up event per window.
+/// - Two 60 s mix rollups, `outbound_message_mix` and
+///   `broadcast_payload_mix`.
+///
+/// Steady-state shadow volume is therefore well below 1 event/sec. What the
+/// cap has to survive is not the average but the ALIGNMENT: every aggregator
+/// is spawned from the same block in [`crate::node::p2p_impl`], so tickers
+/// that share a window length emit on the same second, and the sub-budget is
+/// a per-second tumbling window.
+///
+/// The cap is 6 because five 30 s rollups align (at a cap of 4 the fifth was
+/// deterministically dropped every window), and it stays at 6 rather than
+/// growing with the stream count: raising it to 7 would leave only
+/// `10 - 7 = 3` slots/sec for operational telemetry. The two 60 s rollups are
+/// kept off the 30 s boundary by
+/// [`crate::node::network_bridge::broadcast_payload_mix::ROLLUP_PHASE_OFFSET`]
+/// instead, which costs no volume at all. Before that offset existed, all
+/// seven collided every 60 s on gateways and exactly one rollup was dropped
+/// per minute, the victim decided by task-wakeup order.
+///
+/// So the invariant this constant carries is NOT "cap >= number of streams",
+/// it is "cap >= the most streams that can share one second", which
+/// [`tests::shadow_rollup_emit_schedule_fits_the_shadow_sub_budget`] derives
+/// from the cadence constants. Adding a stream means checking that test, not
+/// bumping this number. Shadow events still also count against the aggregate
+/// cap, so under genuine operational load they continue to yield.
 const MAX_SHADOW_EVENTS_PER_SECOND: usize = 6;
 
 /// Initial backoff duration on failure
@@ -5267,6 +5282,108 @@ mod tests {
             snapshot.known_shadow_rollups[KnownShadowRollup::OutboundMessageMix.index()]
                 .retry_truncated_total,
             1
+        );
+    }
+
+    /// Each shadow rollup's emit cadence as `(first emit second, period)`,
+    /// derived from the production constants rather than restated.
+    ///
+    /// The array is sized by `KnownShadowRollup::ALL.len()`, so adding a
+    /// stream fails to COMPILE here until its cadence is declared — which is
+    /// the point, since a new stream is exactly what would re-break the
+    /// budget.
+    fn shadow_rollup_emit_schedule() -> [(KnownShadowRollup, u64, u64); KnownShadowRollup::ALL.len()]
+    {
+        // The five shadow-stat streams run a 1 Hz aggregator that emits when
+        // its window closes, so they first emit one window in and repeat every
+        // window.
+        let stat = u64::from(crate::transport::shadow_stats::SHADOW_ROLLUP_WINDOW_SECS);
+        // The two mix rollups tick one window PLUS the phase offset in.
+        let mix = crate::node::MIX_ROLLUP_WINDOW.as_secs();
+        let mix_offset = crate::node::MIX_ROLLUP_PHASE_OFFSET.as_secs();
+        [
+            (KnownShadowRollup::ShadowRttAggregate, stat, stat),
+            (KnownShadowRollup::ShadowRateDemand, stat, stat),
+            (KnownShadowRollup::ShadowOutboundClass, stat, stat),
+            (KnownShadowRollup::ShadowReferencePing, stat, stat),
+            (KnownShadowRollup::ShadowIfaceTx, stat, stat),
+            (KnownShadowRollup::OutboundMessageMix, mix + mix_offset, mix),
+            (
+                KnownShadowRollup::BroadcastPayloadMix,
+                mix + mix_offset,
+                mix,
+            ),
+        ]
+    }
+
+    /// The sub-budget must survive the WORST second, not the average rate.
+    ///
+    /// Regression test for the gateway rollup drop: seven shadow streams
+    /// against a cap of six, with every ticker started in the same block, so
+    /// all seven emitted in the same second every 60 s and exactly one rollup
+    /// was silently dropped per minute on gateways (which are the only nodes
+    /// running the two opt-in streams, and the nodes whose rollups get read).
+    ///
+    /// This drives the REAL `admit_event` rather than asserting arithmetic, so
+    /// a change to the admission policy is caught too. Deleting
+    /// `ROLLUP_PHASE_OFFSET` (setting it to zero) makes this fail at t=60s.
+    #[test]
+    fn shadow_rollup_emit_schedule_fits_the_shadow_sub_budget() {
+        let schedule = shadow_rollup_emit_schedule();
+        for stream in KnownShadowRollup::ALL {
+            assert_eq!(
+                schedule.iter().filter(|(s, _, _)| *s == stream).count(),
+                1,
+                "{} is missing from (or duplicated in) the modelled schedule",
+                stream.as_str()
+            );
+        }
+
+        let mut worker = rate_limit_test_worker();
+        let t0 = Instant::now();
+        // An hour covers many multiples of the 30 s / 60 s least-common
+        // multiple, so every recurring alignment is visited.
+        const HORIZON_SECS: u64 = 3600;
+        let mut busiest = (0u64, 0usize);
+
+        for t in 0..=HORIZON_SECS {
+            let now = t0 + Duration::from_secs(t);
+            let mut sharing_this_second = 0usize;
+            for (stream, first_emit, period) in schedule {
+                if t < first_emit || (t - first_emit) % period != 0 {
+                    continue;
+                }
+                sharing_this_second += 1;
+                assert!(
+                    worker.admit_event(EventPriority::Shadow, stream.as_str(), now),
+                    "{} was dropped at t={t}s: {sharing_this_second} shadow rollups \
+                     share that second, against a sub-budget of \
+                     {MAX_SHADOW_EVENTS_PER_SECOND}. Either phase the new stream \
+                     off the occupied second (see ROLLUP_PHASE_OFFSET) or accept \
+                     that one rollup per window is lost.",
+                    stream.as_str()
+                );
+            }
+            if sharing_this_second > busiest.1 {
+                busiest = (t, sharing_this_second);
+            }
+        }
+
+        // Guard against a vacuous pass: if the model never puts two streams in
+        // one second, it is not exercising the alignment this test exists for.
+        assert!(
+            busiest.1 > 1,
+            "modelled schedule never aligns two streams (busiest second t={}s had {}), \
+             so the sub-budget is never actually tested",
+            busiest.0,
+            busiest.1
+        );
+        assert!(
+            busiest.1 <= MAX_SHADOW_EVENTS_PER_SECOND,
+            "busiest second t={}s has {} aligned rollups, over the sub-budget of {}",
+            busiest.0,
+            busiest.1,
+            MAX_SHADOW_EVENTS_PER_SECOND
         );
     }
 

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -461,9 +461,17 @@ const MAX_EVENTS_PER_SECOND: usize = 10;
 /// `10 - 7 = 3` slots/sec for operational telemetry. The two 60 s rollups are
 /// kept off the 30 s boundary by
 /// [`crate::node::network_bridge::broadcast_payload_mix::ROLLUP_PHASE_OFFSET`]
-/// instead, which costs no volume at all. Before that offset existed, all
-/// seven collided every 60 s on gateways and exactly one rollup was dropped
-/// per minute, the victim decided by task-wakeup order.
+/// instead, which costs no volume at all.
+///
+/// IMPORTANT, because it is easy to over-claim here and this docstring already
+/// did once: this sub-budget is NOT what limits shadow telemetry in
+/// production. [`Self::admit_event`] tests the aggregate
+/// [`MAX_EVENTS_PER_SECOND`] cap BEFORE this one and returns early, so on any
+/// node already emitting 10 events in that second the shadow branch is never
+/// reached. Measured over 1382 nodes: this sub-budget has dropped 54 events
+/// fleet-wide in total (0.0005 %), while the aggregate cap discards ~31 % of
+/// shadow and ~77 % of operational telemetry (#5197). Treat the sub-budget as
+/// a latent invariant to keep correct, not as an active control.
 ///
 /// So the invariant this constant carries is NOT "cap >= number of streams",
 /// it is "cap >= the most streams that can share one second", which
@@ -4912,38 +4920,43 @@ mod tests {
     }
 
     #[test]
-    fn test_all_aligned_shadow_rollups_are_admitted() {
-        // Regression: the five shadow streams (shadow_rtt_aggregate,
+    fn test_all_aligned_30s_shadow_rollups_are_admitted() {
+        // Regression: the five 30 s shadow-stat streams (shadow_rtt_aggregate,
         // shadow_rate_demand, shadow_outbound_class, shadow_reference_ping,
         // shadow_iface_tx) each emit one rollup per SHADOW_ROLLUP_WINDOW_SECS.
         // Their aggregator tickers all start at node startup and share the same
         // window length, so their emit ticks align on the same second every
         // window. The shadow sub-budget must admit all five in that one second,
         // or a full 30 s rollup is deterministically dropped every window. A
-        // cap of 4 dropped the fifth; the cap must fit all five with headroom.
-        const SHADOW_STREAMS: usize = 5;
-        const {
-            assert!(
-                MAX_SHADOW_EVENTS_PER_SECOND > SHADOW_STREAMS,
-                "shadow sub-budget must fit all five aligned rollups with headroom"
-            );
-        }
+        // cap of 4 dropped the fifth.
+        //
+        // SCOPE: this covers the 30 s GROUP ONLY, which is why the count below
+        // is 5 and not `KnownShadowRollup::ALL.len()`. It is deliberately NOT
+        // the guard on "does the cap fit every stream" — it once carried a
+        // `MAX_SHADOW_EVENTS_PER_SECOND > 5` assertion that read like one, and
+        // that is exactly how two streams were added without anyone revisiting
+        // the cap. The real invariant is "the cap fits the most streams that
+        // can share ONE SECOND", which depends on the emit phases and is
+        // guarded by `shadow_rollup_emit_schedule_fits_the_shadow_sub_budget`.
+        // Add a stream there, not here.
+        const ALIGNED_30S_STREAMS: usize = 5;
 
         let mut worker = rate_limit_test_worker();
         let now = Instant::now();
 
-        // All five rollups arrive in the same aligned second (no operational
-        // load competing for the aggregate cap).
+        // All five arrive in the same aligned second (no operational load
+        // competing for the aggregate cap — see the note on the schedule test
+        // about what that does and does not model).
         let admitted = admit_n(
             &mut worker,
             EventPriority::Shadow,
             "test_shadow",
-            SHADOW_STREAMS,
+            ALIGNED_30S_STREAMS,
             now,
         );
         assert_eq!(
-            admitted, SHADOW_STREAMS,
-            "all five aligned shadow rollups must be admitted; none dropped"
+            admitted, ALIGNED_30S_STREAMS,
+            "all five aligned 30 s shadow rollups must be admitted; none dropped"
         );
     }
 
@@ -5384,6 +5397,67 @@ mod tests {
             busiest.0,
             busiest.1,
             MAX_SHADOW_EVENTS_PER_SECOND
+        );
+    }
+
+    /// The companion to the schedule test, and the more production-relevant
+    /// of the two: on a real node the shadow sub-budget is NOT what binds.
+    ///
+    /// [`TelemetryWorker::admit_event`] tests the aggregate cap first and
+    /// returns early, so once operational telemetry has filled the second,
+    /// every shadow rollup is refused there and the sub-budget branch is never
+    /// reached. That ordering is why the sub-budget has dropped 54 events
+    /// fleet-wide across 1382 nodes while the aggregate cap discards ~31 % of
+    /// shadow and ~77 % of operational telemetry (#5197).
+    ///
+    /// This exists because the schedule test above deliberately models ZERO
+    /// operational load, which is the alignment invariant's own terms but not
+    /// the condition production runs in. Without this test the pair would
+    /// imply a guarantee the code does not provide.
+    ///
+    /// It is also the guard on the ordering itself: #5197 will change how the
+    /// aggregate cap works, and if it reorders these two checks the drops move
+    /// from one counter to the other and every reading built on them shifts.
+    #[test]
+    fn the_aggregate_cap_not_the_shadow_subbudget_is_what_binds_under_load() {
+        let mut worker = rate_limit_test_worker();
+        let now = Instant::now();
+
+        // Operational telemetry fills the whole aggregate budget for this
+        // second, exactly as it does on a busy node.
+        assert_eq!(
+            admit_n(
+                &mut worker,
+                EventPriority::Operational,
+                "op_event",
+                MAX_EVENTS_PER_SECOND,
+                now,
+            ),
+            MAX_EVENTS_PER_SECOND,
+        );
+
+        // Now every shadow rollup is refused, no matter how few of them there
+        // are or how well phased. The offset cannot help here, and is not
+        // meant to.
+        for stream in KnownShadowRollup::ALL {
+            assert!(
+                !worker.admit_event(EventPriority::Shadow, stream.as_str(), now),
+                "{} must be refused once the aggregate cap is full",
+                stream.as_str()
+            );
+        }
+
+        let snapshot = worker.metrics.snapshot();
+        assert_eq!(
+            snapshot.dropped_aggregate_limit_shadow_total,
+            KnownShadowRollup::ALL.len() as u64,
+            "every refused rollup must be charged to the AGGREGATE cap"
+        );
+        assert_eq!(
+            snapshot.dropped_shadow_limit_total, 0,
+            "the shadow sub-budget must NOT be credited with these drops: \
+             admit_event returns at the aggregate check first, which is why \
+             the sub-budget looks idle in production telemetry"
         );
     }
 


### PR DESCRIPTION
> **Corrected after production measurement.** The first version of this description claimed this bug drops one rollup per minute on every gateway. That is wrong, and the correction is in "Measured impact" below. The code change is unchanged; only the justification is.

## Problem

There are seven shadow rollup streams (`KnownShadowRollup::ALL`) but the shadow sub-budget `MAX_SHADOW_EVENTS_PER_SECOND` is 6, and admission uses a per-second tumbling window.

Every shadow aggregator is spawned from the same block in `p2p_impl.rs`, so their tickers start within microseconds of each other. The five shadow-stat streams close a 30 s window; the two mix rollups (`outbound_message_mix`, `broadcast_payload_mix`) tick every 60 s. So every 60 s all seven land in the same second and the seventh exceeds the sub-budget.

`MAX_SHADOW_EVENTS_PER_SECOND`'s docstring still described "five shadow streams" and "one slot of headroom for a sixth". Two streams were added since it was written, and nothing tied the constant to the stream count — that is the actual defect being fixed, and it is the reason an eighth stream would land silently too.

## Measured impact: small, and NOT the reason to care

Before writing this up I measured it against production telemetry (1,382 nodes, per-stream counters from `NetworkEfficiencyV1.shadow[i][5]`, which is `dropped_shadow_limit_total`):

**The sub-budget has dropped 54 events fleet-wide, all-time — 0.0005% of shadow rollups.**

The collision is real but nearly unreachable, because `admit_event` (telemetry.rs) checks the **aggregate** cap *before* the shadow sub-budget and returns early on failure:

```rust
if self.events_this_second >= MAX_EVENTS_PER_SECOND {   // 10
    ...; return false;                                  // <-- shadow dies here
}
if priority == EventPriority::Shadow {
    if self.shadow_events_this_second >= MAX_SHADOW_EVENTS_PER_SECOND { ... }
}
```

On any node already emitting 10 events in that second, all seven rollups are charged to the aggregate cap and the sub-budget branch is never reached. Fleet-wide the aggregate cap drops **77% of operational** and **31% of shadow** telemetry; per node, operational loss is p25 46% / median 64% / p90 82%.

So the shadow sub-budget is close to dead code in production, and **the real telemetry-loss problem is the 10/s aggregate cap.** That is a separate and much larger issue, filed as #5197 — it is not what this PR fixes, and this PR should not be read as addressing it.

## Why land this anyway

Because the two interact, and in an order that matters:

1. It is a genuine latent defect. Seven aligned streams against a cap of six is wrong regardless of what currently masks it, and nothing ties the cap to the stream count, so an eighth stream lands silently.
2. **It is a prerequisite for fixing the aggregate cap.** Whatever relieves the aggregate starvation (a shadow floor, a burst allowance, a higher cap) makes the sub-budget the binding constraint for the first time. Fixing that one without this one would relocate the drops onto the sub-budget rather than eliminate them, and the alignment would start firing exactly when someone is relying on the instrument.
3. It slightly relieves aggregate pressure today: the collision second carries 5 shadow events instead of 7.

If reviewers disagree that (2) justifies landing it ahead of the aggregate fix, closing this and folding the offset into that work is a reasonable alternative. I would rather land the prerequisite first than carry an unexplained alignment into the change that makes it matter.

## Approach

Offset both minute rollups by 15 s rather than raising the cap to 7. Raising the cap would leave only 3 of the 10 aggregate slots per second for operational telemetry, which — given operational telemetry is already losing 77% — is the wrong direction. The offset costs no telemetry volume.

15 s is half the shadow window, maximising distance to the nearest 30 s boundary and so tolerating spawn-time skew best. Both mix rollups get the same offset, preserving the shared cadence that lets them be joined per node-minute without interpolation. `outbound_message_mix` now aliases both constants from `broadcast_payload_mix` rather than restating the cadence, so the value the join depends on cannot drift.

Starting each ticker with `interval_at` at the first real emit also replaces the skip-the-immediate-tick dance, and makes the first rollup's reported window match the period it actually accumulated over.

The docstring is rewritten to state the invariant it actually carries: **not** "cap >= number of streams" but "cap >= the most streams that can share one second".

## Testing

`shadow_rollup_emit_schedule_fits_the_shadow_sub_budget` derives the emit schedule from the production cadence constants and drives the **real `admit_event`**, so a change to the admission policy is caught too, not just the arithmetic.

- Asserts no stream is dropped, naming the stream and the second.
- A vacuity guard asserts the model actually aligns at least two streams in some second — a schedule that never collides would otherwise pass while testing nothing.
- The schedule array is sized by `KnownShadowRollup::ALL.len()`, so an eighth stream **fails to compile** until its cadence is declared.

**Mutation-checked**: zeroing `ROLLUP_PHASE_OFFSET` fails with `broadcast_payload_mix was dropped at t=60s: 7 shadow rollups share that second, against a sub-budget of 6`.

**Known limitation, stated plainly:** that test exercises shadow events in isolation, with no operational traffic in the window. That is precisely why it passes while the production path is dominated by the aggregate cap — the test cannot see the interaction that makes this bug nearly unreachable. It guards the alignment invariant, not the production drop rate.

Also run: 126 tests across the three touched modules; `cargo fmt --check` and both of CI's clippy invocations clean.

## Note for reviewers

`cargo clippy --all-targets` reports 46 pre-existing errors in untouched files. CI runs clippy without `--all-targets`. Unrelated; see #5196.

Refs #5191. Real telemetry-loss problem: #5197.

[AI-assisted - Claude]
