### PR TITLE
fix(security): disable forgeable RegisterDelegateWithPredecessors secret copy-forward

### DIFF
--- a/apps/freenet-ping/app/tests/run_delegate_secret_copy_forward_e2e.rs
+++ b/apps/freenet-ping/app/tests/run_delegate_secret_copy_forward_e2e.rs
@@ -100,37 +100,38 @@ async fn delegate_app_msg(
     }
 }
 
-/// E2E test for the delegate secret copy-forward feature's H1 same-origin gate
-/// (#4117), exercised end-to-end over token-less raw WebSocket connections.
+/// E2E test for `RegisterDelegateWithPredecessors`'s secret copy-forward,
+/// exercised end-to-end over token-less raw WebSocket connections.
 ///
 /// A delegate's on-disk key is BLAKE3(code_hash || params), so any WASM
 /// rebuild (or, as here, a param change simulating one) mints a new key and
 /// a new, empty secret namespace. `DelegateRequest::RegisterDelegateWithPredecessors`
-/// carries Local-scope secrets forward from a list of predecessor keys into
-/// the newly-registered successor's namespace so `get_secret` can resolve
-/// under the new key — but ONLY when the registering request's web-app origin
-/// equals the predecessor's FIRST-registration origin (the H1 same-origin
-/// gate; see `SecretsStore::migrate_secrets`). A raw WS connection like the
-/// one this test harness opens carries no web-app origin attestation, so both
-/// registrations below run with `origin_contract = None`; `None` is NEVER
-/// privileged by the gate (not even against a predecessor with no recorded
-/// origin), so the copy-forward is REFUSED.
+/// was designed to carry Local-scope secrets forward from a list of
+/// predecessor keys into the newly-registered successor's namespace, gated by
+/// an H1 same-origin check in `SecretsStore::migrate_secrets` — but as of
+/// freenet/freenet-core#5198, the copy-forward call is UNCONDITIONALLY
+/// DISABLED at the handler level (`crates/core/src/contract/executor/runtime/delegates.rs`):
+/// `origin_contract` is forgeable by any HTTP client, so the H1 gate cannot
+/// actually authorize anything, and re-enabling the copy needs that fixed
+/// first. This test's raw WS connection carries no origin attestation at all
+/// (`origin_contract = None`), which was already unprivileged even before
+/// #5198 — so this test exercises the same observable outcome (copy refused)
+/// both before and after the fix, but for a different reason now (disabled
+/// entirely, not merely None-unprivileged).
 ///
 /// This test registers a "predecessor" delegate (test-delegate-2), stores a
 /// Local-scope secret in it via `set_secret` (exercised through the
 /// `StoreSecret` app message), then registers a "successor" delegate — same
 /// WASM, different params, so a DIFFERENT `DelegateKey` — via
 /// `RegisterDelegateWithPredecessors` naming the predecessor. It asserts that
-/// registration itself still succeeds (the gate never fails registration,
-/// only the copy), that the successor genuinely has NO migrated secret (the
-/// refusal took effect), and that the predecessor's own copy is untouched
-/// (no-delete invariant, independent of the gate outcome). The
-/// successful-copy path — where the registering origin matches the
-/// predecessor's recorded origin — is covered end-to-end by the store-level
-/// `migrate_secrets` tests and the handler-level
-/// `register_delegate_with_predecessors_copies_secrets_forward` test in
-/// `crates/core/src`, both of which can inject an origin directly; this raw-WS
-/// harness has no way to attach a web-app origin to a connection.
+/// registration itself still succeeds (disabling the copy never fails
+/// registration), that the successor genuinely has NO migrated secret, and
+/// that the predecessor's own copy is untouched (no-delete invariant). The
+/// handler-level `register_delegate_with_predecessors_never_copies_secrets`
+/// test in `crates/core/src` covers the stronger claim directly (copy refused
+/// even when `origin_contract` DOES match the predecessor's recorded origin);
+/// this raw-WS harness has no way to attach any origin to a connection, so it
+/// only ever exercises the `None` case.
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_delegate_secret_copy_forward_e2e_refuses_token_less_origin() -> anyhow::Result<()> {
     // Same WASM, different params => different DelegateKeys
@@ -288,14 +289,13 @@ async fn test_delegate_secret_copy_forward_e2e_refuses_token_less_origin() -> an
             }
         }
 
-        // Step 5: The successor must NOT resolve the migrated SecretsId. Both
-        // registrations above ran over a token-less connection
-        // (`origin_contract = None`), and the H1 same-origin gate never
-        // privileges `None` — so `migrate_secrets` refused the copy
-        // (`origin_refused`, and `no_provenance` too since this predecessor was
-        // never given a recorded origin). Registration itself still succeeded
-        // (Step 4), demonstrating the gate never fails registration, only the
-        // copy.
+        // Step 5: The successor must NOT resolve the migrated SecretsId.
+        // Copy-forward is unconditionally disabled (#5198), so this holds
+        // regardless of origin — this token-less connection additionally
+        // carries `origin_contract = None`, which was already unprivileged
+        // under the underlying H1 gate even before #5198. Registration
+        // itself still succeeded (Step 4): disabling the copy never fails
+        // registration.
         match delegate_app_msg(
             &mut client,
             &succ_key,
@@ -306,15 +306,13 @@ async fn test_delegate_secret_copy_forward_e2e_refuses_token_less_origin() -> an
         {
             OutboundAppMessage::SecretResult(None) => {
                 tracing::info!(
-                    "Successor correctly has NO migrated secret — the H1 same-origin gate \
-                     refused the token-less (None-origin) copy-forward, as expected"
+                    "Successor correctly has NO migrated secret — copy-forward is disabled (#5198)"
                 );
             }
             OutboundAppMessage::SecretResult(Some(value)) => {
                 return Err(anyhow!(
-                    "successor unexpectedly read a migrated secret ({} bytes) via a \
-                     token-less registration — the H1 same-origin gate should have refused \
-                     this copy (None is never privileged)",
+                    "successor unexpectedly read a migrated secret ({} bytes) — copy-forward \
+                     must be unconditionally disabled (#5198)",
                     value.len()
                 ));
             }
@@ -347,8 +345,8 @@ async fn test_delegate_secret_copy_forward_e2e_refuses_token_less_origin() -> an
         }
 
         tracing::info!(
-            "Delegate secret copy-forward E2E checks passed: token-less registration \
-             succeeded, and the H1 same-origin gate correctly refused the copy!"
+            "Delegate secret copy-forward E2E checks passed: registration succeeded, \
+             and the copy-forward (disabled, #5198) correctly copied nothing"
         );
         Ok::<_, anyhow::Error>(())
     });

--- a/crates/core/src/client_events.rs
+++ b/crates/core/src/client_events.rs
@@ -1540,10 +1540,12 @@ async fn process_open_request(
                     // conversation, so neither registers a routing path — the
                     // path is established by an ApplicationMessages request that
                     // carries a notification channel (above), never by
-                    // registration. RegisterDelegateWithPredecessors additionally
-                    // triggers the node-side secret copy-forward (#4117), which
-                    // is likewise not an app-routing event. Both are listed
-                    // EXPLICITLY (not swept) per this match's contract that
+                    // registration. RegisterDelegateWithPredecessors's
+                    // node-side secret copy-forward (#4117) is unconditionally
+                    // disabled as of #5198 (its origin_contract gate is
+                    // forgeable) — it was likewise never an app-routing event
+                    // even when active. Both are listed EXPLICITLY (not swept)
+                    // per this match's contract that
                     // app-facing variants must be handled above the wildcard; the
                     // wildcard remains ONLY to satisfy `#[non_exhaustive]` for
                     // genuinely future variants (see git-workflow.md).

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -1506,21 +1506,18 @@ mod remove_contract_tests {
             .with_extension("wasm")
     }
 
-    /// Handler-level (#4117): a `RegisterDelegateWithPredecessors` request
-    /// registers the successor AND copies a predecessor's Local secret into the
-    /// successor's namespace end-to-end — the request→register→migrate→disk
-    /// wiring that the store-level `migrate_secrets` tests do not cover. Verified
-    /// on disk (the successor's secret file materializes), so no successor
-    /// secret-store handle is needed. Also asserts the one-shot marker prevents
-    /// resurrection when the delegate re-registers after the user deletes a copy.
-    ///
-    /// Exercises the H1 same-origin gate (#4117): the predecessor's
-    /// FIRST-registration origin is recorded as `Some(ORIGIN)` before the
-    /// migrating registration, and the registration itself supplies
-    /// `origin_contract = Some(&contract_instance_id)` whose bytes equal
-    /// `ORIGIN` — otherwise the copy would be refused as `no_provenance`.
+    /// Handler-level (freenet/freenet-core#5198): `RegisterDelegateWithPredecessors`
+    /// NEVER copies a predecessor's secrets, even when the registering request's
+    /// `origin_contract` exactly matches the predecessor's recorded
+    /// first-registration origin (the one case the H1 same-origin gate in
+    /// `SecretsStore::migrate_secrets` would otherwise allow). The copy-forward
+    /// call is disabled at the handler level because `origin_contract` itself is
+    /// forgeable by any HTTP client (see #5198) — so even a "matching" origin
+    /// proves nothing. Registration still succeeds, exactly as plain
+    /// `RegisterDelegate` would. This replaces the pre-#5198 test asserting the
+    /// copy DID happen on a matching origin.
     #[tokio::test(flavor = "multi_thread")]
-    async fn register_delegate_with_predecessors_copies_secrets_forward() {
+    async fn register_delegate_with_predecessors_never_copies_secrets() {
         use crate::wasm_runtime::SecretScope;
         use freenet_stdlib::client_api::{DelegateRequest, HostResponse};
         use freenet_stdlib::prelude::{
@@ -1605,29 +1602,24 @@ mod remove_contract_tests {
             other => panic!("expected DelegateResponse, got {other:?}"),
         }
 
-        // The predecessor's Local secret was copied into the successor namespace.
-        assert!(
-            successor_secret_path.exists(),
-            "successor secret file must exist after copy-forward"
-        );
-
-        // One-shot / anti-resurrection at the handler level: delete the copy and
-        // re-register — the marker must make the re-run a no-op (the marker gate
-        // short-circuits before the origin gate, so the same origin is supplied
-        // here purely for realism, not because it's load-bearing for this part).
-        std::fs::remove_file(&successor_secret_path).expect("remove copied secret");
-        let req2 = DelegateRequest::RegisterDelegateWithPredecessors {
-            delegate: DelegateContainer::Wasm(DelegateWasmAPIVersion::V1(succ.clone())),
-            cipher: [7u8; 32],
-            nonce: [9u8; 24],
-            predecessors: vec![pred.key().clone()],
-        };
-        executor
-            .delegate_request(req2, Some(&origin_contract), None, None)
-            .expect("re-registration must succeed");
+        // The predecessor's Local secret must NOT be copied — the copy-forward
+        // is unconditionally disabled (#5198), even though the supplied
+        // `origin_contract` matches the predecessor's recorded origin exactly
+        // (the one case the underlying H1 gate would otherwise have allowed).
         assert!(
             !successor_secret_path.exists(),
-            "one-shot marker must prevent resurrection on re-registration"
+            "successor secret file must NOT exist: copy-forward is disabled (#5198) \
+             regardless of origin_contract"
+        );
+
+        // The predecessor's own secret is untouched (registration never mutates
+        // or deletes a predecessor's data, disabled copy-forward or not).
+        let predecessor_secret_path = secrets_dir
+            .join(pred.key().encode())
+            .join(secret_id.encode());
+        assert!(
+            predecessor_secret_path.exists(),
+            "predecessor secret must remain untouched"
         );
     }
 
@@ -1638,8 +1630,10 @@ mod remove_contract_tests {
     /// registered (no `.reg` file) and no predecessor secret is copied, so a
     /// registered-but-recordless delegate (a claimable first-writer slot an
     /// attacker could later name as its own) can never exist. Once the disk
-    /// recovers, the app's retry registers, records, and copies normally. Uses
-    /// the fault-injecting redb backend to fail the origin-record write on demand.
+    /// recovers, the app's retry registers and records normally (copy-forward
+    /// itself is unconditionally disabled, #5198, so it never copies — see
+    /// the final assertion). Uses the fault-injecting redb backend to fail the
+    /// origin-record write on demand.
     #[cfg(feature = "redb")]
     #[tokio::test(flavor = "multi_thread")]
     async fn register_aborts_when_origin_record_fails_then_recovers() {
@@ -1806,9 +1800,12 @@ mod remove_contract_tests {
             succ_reg_path.exists(),
             "after recovery the successor IS registered (.reg present)"
         );
+        // Copy-forward is unconditionally disabled (#5198): the retry succeeds
+        // (registration itself was only ever blocked by the origin-record
+        // write failure, now healed), but no secret is ever copied.
         assert!(
-            succ_secret_path.exists(),
-            "after recovery the predecessor secret IS copied forward"
+            !succ_secret_path.exists(),
+            "the predecessor secret must NOT be copied forward: copy-forward is disabled (#5198)"
         );
     }
 

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -1623,6 +1623,103 @@ mod remove_contract_tests {
         );
     }
 
+    /// Regression test for freenet/freenet-core#5198, directory-level: a
+    /// predecessor holding MULTIPLE Local secrets, named in a
+    /// `RegisterDelegateWithPredecessors` request with a matching
+    /// `origin_contract`, must leave the successor's on-disk secrets
+    /// directory completely absent (or empty) — not merely missing one
+    /// known secret ID. This is stronger than
+    /// `register_delegate_with_predecessors_never_copies_secrets`, which
+    /// only checks a single secret path; a copy-forward bug that mis-copies
+    /// a DIFFERENT secret ID than the one under test would slip past a
+    /// single-path check but not a whole-directory scan.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn register_delegate_with_predecessors_successor_dir_stays_empty() {
+        use crate::wasm_runtime::SecretScope;
+        use freenet_stdlib::client_api::{DelegateRequest, HostResponse};
+        use freenet_stdlib::prelude::{
+            ContractInstanceId, Delegate, DelegateContainer, DelegateWasmAPIVersion, SecretsId,
+        };
+        use zeroize::Zeroizing;
+
+        const ORIGIN: [u8; 32] = [0x22u8; 32];
+
+        let temp_dir = crate::util::tests::get_temp_dir();
+        let db = Storage::new(temp_dir.path()).await.expect("create db");
+        let contract_store =
+            ContractStore::new(temp_dir.path().join("contracts"), 10_000, db.clone())
+                .expect("create contract store");
+        let delegate_store =
+            DelegateStore::new(temp_dir.path().join("delegate"), 10_000, db.clone())
+                .expect("create delegate store");
+        let secrets_dir = temp_dir.path().join("secrets");
+        let mut secrets_store =
+            SecretsStore::new(secrets_dir.clone(), Default::default(), db.clone())
+                .expect("create secrets store");
+
+        let pred = Delegate::from((&vec![9u8].into(), &vec![1u8].into()));
+        let succ = Delegate::from((&vec![9u8].into(), &vec![2u8].into()));
+
+        // Seed THREE Local secrets under the predecessor.
+        for i in 0u8..3 {
+            secrets_store
+                .store_secret(
+                    pred.key(),
+                    &SecretsId::new(format!("secret-{i}").into_bytes()),
+                    SecretScope::Local,
+                    Zeroizing::new(format!("value-{i}").into_bytes()),
+                )
+                .expect("seed predecessor secret");
+        }
+        secrets_store
+            .record_delegate_registration_origin(pred.key(), Some(ORIGIN))
+            .unwrap();
+
+        let successor_secrets_dir = secrets_dir.join(succ.key().encode());
+        assert!(
+            !successor_secrets_dir.exists(),
+            "successor secrets directory must not exist before registration"
+        );
+
+        let state_store = StateStore::new(db, 10_000_000).expect("create state store");
+        let runtime = Runtime::build(contract_store, delegate_store, secrets_store, false)
+            .expect("build runtime");
+        let mut executor = Executor::new(
+            state_store,
+            || Ok(()),
+            crate::contract::executor::OperationMode::Local,
+            runtime,
+            None,
+        )
+        .await
+        .expect("create executor");
+
+        let origin_contract = ContractInstanceId::new(ORIGIN);
+        let req = DelegateRequest::RegisterDelegateWithPredecessors {
+            delegate: DelegateContainer::Wasm(DelegateWasmAPIVersion::V1(succ.clone())),
+            cipher: [7u8; 32],
+            nonce: [9u8; 24],
+            predecessors: vec![pred.key().clone()],
+        };
+        let resp = executor
+            .delegate_request(req, Some(&origin_contract), None, None)
+            .expect("register-with-predecessors must succeed");
+        assert!(matches!(resp, HostResponse::DelegateResponse { .. }));
+
+        // Whole-directory check: NOTHING was copied into the successor's
+        // namespace, whether the directory was never created or was created
+        // empty.
+        let successor_has_any_secret = successor_secrets_dir
+            .read_dir()
+            .map(|mut entries| entries.next().is_some())
+            .unwrap_or(false);
+        assert!(
+            !successor_has_any_secret,
+            "successor secrets directory must be absent or empty: copy-forward is \
+             disabled (#5198) regardless of origin_contract or predecessor secret count"
+        );
+    }
+
     /// Handler-level (#4117 H1, persistence-succeeds-before-usable): if the
     /// first-writer origin record cannot be DURABLY persisted, the WHOLE
     /// registration is aborted — for BOTH the plain `RegisterDelegate` and the

--- a/crates/core/src/contract/executor/runtime/delegates.rs
+++ b/crates/core/src/contract/executor/runtime/delegates.rs
@@ -313,56 +313,36 @@ impl Executor<Runtime> {
                     )));
                 }
 
-                // Register exactly as `RegisterDelegate` does, THEN run the
-                // one-shot, Local-scope copy-forward of the predecessors' secrets.
-                // The copy is best-effort and never fails registration: a
-                // refused/absent/partly-unreadable predecessor is recorded in the
-                // report and logged, but the successor still registers. See
-                // `SecretsStore::migrate_secrets` for the full contract.
-                match self.register_delegate_and_record_origin(
-                    delegate,
-                    cipher,
-                    nonce,
-                    origin_contract,
-                ) {
-                    Ok(key) => {
-                        // Record the originating web-app contract (when present).
-                        // `ContractInstanceId::as_bytes` is the 32-byte id;
-                        // `try_into` never fails but is used to stay panic-free.
-                        let origin_bytes: Option<[u8; 32]> =
-                            origin_contract.and_then(|c| c.as_bytes().try_into().ok());
-                        let report =
-                            self.runtime
-                                .migrate_delegate_secrets(&deduped, &key, origin_bytes);
-                        if report.total_errors() > 0 {
-                            tracing::warn!(
-                                delegate_key = %key,
-                                predecessors = deduped.len(),
-                                copied = report.total_copied(),
-                                skipped_existing = report.total_skipped_existing(),
-                                user_scope_skipped = report.total_user_scope_skipped(),
-                                errors = report.total_errors(),
-                                phase = "secret_copy_forward",
-                                "delegate secret copy-forward completed with errors"
-                            );
-                        } else {
-                            tracing::info!(
-                                delegate_key = %key,
-                                predecessors = deduped.len(),
-                                copied = report.total_copied(),
-                                skipped_existing = report.total_skipped_existing(),
-                                user_scope_skipped = report.total_user_scope_skipped(),
-                                phase = "secret_copy_forward",
-                                "delegate secret copy-forward completed"
-                            );
-                        }
-                        Ok(DelegateResponse {
-                            key,
-                            values: Vec::new(),
-                        })
-                    }
-                    Err(err) => Err(err),
+                // SECURITY (freenet/freenet-core#5198): the predecessor secret
+                // copy-forward below `self.runtime.migrate_delegate_secrets(...)`
+                // is INTENTIONALLY NEVER CALLED. `SecretsStore::migrate_secrets`
+                // gates the copy on `origin_contract` matching the predecessor's
+                // recorded first-registration origin, but `origin_contract` is
+                // forgeable by any HTTP client through the webapp-shell token
+                // issuance path (see #5198 for the full exploit chain) — so the
+                // gate does not actually authorize anything. Do NOT re-enable
+                // this call without first hardening how `origin_contract` is
+                // attested; the gate itself remains sound given a trustworthy
+                // origin. The feature has zero known callers (every app in this
+                // ecosystem has its own client-driven secret-continuity
+                // mechanism instead), so disabling it changes no observed
+                // behavior. Registration proceeds exactly as `RegisterDelegate`.
+                if !deduped.is_empty() {
+                    tracing::warn!(
+                        delegate_key = %delegate.key(),
+                        predecessors = deduped.len(),
+                        "RegisterDelegateWithPredecessors: predecessor secret \
+                         copy-forward is disabled pending a security fix (see \
+                         freenet/freenet-core#5198); registering the delegate \
+                         without migrating any secrets"
+                    );
                 }
+
+                self.register_delegate_and_record_origin(delegate, cipher, nonce, origin_contract)
+                    .map(|key| DelegateResponse {
+                        key,
+                        values: Vec::new(),
+                    })
             }
             DelegateRequest::UnregisterDelegate(key) => {
                 self.delegate_origin_ids.remove(&key);

--- a/crates/core/src/contract/storages/redb.rs
+++ b/crates/core/src/contract/storages/redb.rs
@@ -174,9 +174,18 @@ pub(crate) const MIGRATION_MARKER_TABLE: TableDefinition<&[u8], &[u8]> =
 /// `RegisterDelegateWithPredecessors`). Copy-forward consults it: a predecessor's
 /// Local secrets are copied into a successor ONLY when the registering request's
 /// origin is among the predecessor's recorded origins (or both are the Admin/None
-/// class), so a malicious web-app cannot register a delegate that names an
-/// unrelated victim delegate as a predecessor to exfiltrate its secrets
-/// (predecessor keys are public-derivable). See `SecretsStore::delegate_origins`.
+/// class).
+///
+/// **This gate alone is NOT sufficient protection (freenet/freenet-core#5198).**
+/// The registering request's `origin_contract` is itself forgeable by any HTTP
+/// client (see #5198 for the exploit chain), so a malicious web-app CAN obtain
+/// a value that matches an unrelated victim delegate's recorded origin. The
+/// actual protection today is that the copy-forward's sole caller
+/// (`RegisterDelegateWithPredecessors`'s handler) is unconditionally disabled —
+/// this gate is not currently invoked in production at all. Do not treat this
+/// table as a sufficient authorization control if the copy-forward is ever
+/// re-wired; `origin_contract` attestation needs hardening first. See
+/// `SecretsStore::delegate_origins` and `SecretsStore::migrate_secrets`.
 ///
 /// Key: DelegateKey (64 bytes)
 /// Value: `[has_admin_none: 1][N × ContractInstanceId(32)]` — `has_admin_none`

--- a/crates/core/src/wasm_runtime/runtime.rs
+++ b/crates/core/src/wasm_runtime/runtime.rs
@@ -632,6 +632,16 @@ impl Runtime {
     ///
     /// Runs ON the contract loop (serialized with delegate `store_secret`),
     /// mirroring the on-loop write discipline of `import_secret_bundle`.
+    ///
+    /// UNREACHABLE as of freenet/freenet-core#5198: the sole caller (the
+    /// `RegisterDelegateWithPredecessors` handler in
+    /// `crates/core/src/contract/executor/runtime/delegates.rs`) no longer
+    /// calls this, because the `origin_contract` this method's H1 gate relies
+    /// on is forgeable by any HTTP client — see #5198 for the exploit chain.
+    /// Kept (not deleted) so the underlying `SecretsStore::migrate_secrets`
+    /// mechanism, which is otherwise sound, is easy to re-wire once
+    /// `origin_contract` attestation is hardened.
+    #[allow(dead_code)]
     pub(crate) fn migrate_delegate_secrets(
         &mut self,
         predecessors: &[DelegateKey],

--- a/crates/core/src/wasm_runtime/secrets_store/store.rs
+++ b/crates/core/src/wasm_runtime/secrets_store/store.rs
@@ -2552,6 +2552,15 @@ impl SecretsStore {
     /// `RegisterDelegateWithPredecessors` handler), mirroring the on-loop write
     /// discipline of `store_secret` / the live bundle import. The work is bounded
     /// by the predecessors' own on-disk secret count.
+    ///
+    /// UNREACHABLE FROM PRODUCTION as of freenet/freenet-core#5198: the H1 gate
+    /// above is sound only if `origin_contract` is trustworthy, and it isn't —
+    /// any HTTP client can forge an `origin_contract` value for an arbitrary
+    /// public contract key (see #5198). The one caller
+    /// (`RegisterDelegateWithPredecessors`'s handler) no longer invokes this
+    /// method; it is kept, with its test suite, for potential reactivation once
+    /// `origin_contract` attestation is hardened. Do not re-wire a caller to
+    /// this method without first fixing that.
     pub fn migrate_secrets(
         &mut self,
         predecessors: &[DelegateKey],


### PR DESCRIPTION
## Problem

`DelegateRequest::RegisterDelegateWithPredecessors` (shipped v0.2.105) performs a node-side copy-forward of a predecessor delegate's `Local`-scope secrets into a newly-registered successor. The copy is gated on an authorization check whose input turns out not to be trustworthy, so the gate does not actually constrain who can trigger the copy.

Details are tracked privately in a security advisory rather than here, since the underlying weakness is not yet fully remediated.

## Approach

Disable the network-reachable call to the copy-forward (`SecretsStore::migrate_secrets`) unconditionally. Registration still succeeds, exactly as plain `RegisterDelegate` would.

Confirmed **zero callers** of this request variant anywhere in the ecosystem (River, ghostkeys, Atlas) — each already has its own client-driven secret/state continuity mechanism that doesn't depend on this core mechanism. So this change has no observed behavioral impact beyond removing the exposure.

The underlying `SecretsStore::migrate_secrets` mechanism (idempotence markers, immutable first-writer origin record, fail-closed error handling) is carefully engineered and is left completely intact along with its test suite — only its one network-reachable caller is cut, so it can be re-wired once the input it depends on can be trusted.

## Testing

- Regression test `register_delegate_with_predecessors_never_copies_secrets` constructs the scenario the gate would otherwise have permitted and asserts no copy occurs. Verified it fails without the fix and passes with it.
- `register_delegate_with_predecessors_successor_dir_stays_empty` asserts the successor's on-disk secrets directory stays absent/empty with a multi-secret predecessor.
- Updated `register_aborts_when_origin_record_fails_then_recovers` and the freenet-ping e2e test to match; e2e run against a real node passes.
- `cargo clippy -p freenet --lib -- -D warnings` and `cargo fmt --check`: clean.

[AI-assisted - Claude]
