### PR TITLE
fix(update): narrow the proactive summary exclusion with the broadcast target set

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -4190,8 +4190,14 @@ impl GlobalTestMetrics {
     /// Records one fan-out target dropped because the originator's list named
     /// it (#5147).
     ///
-    /// Incremented BY the filter in `get_broadcast_targets_update`, alongside
-    /// its own `skipped_covered` field, never re-derived from the difference
+    /// The count is PRODUCED by the filter — `OpManager::broadcast_cohost_targets`,
+    /// which returns it as `covered_skipped` — and incremented by its
+    /// broadcast-side caller `get_broadcast_targets_update`, alongside that
+    /// function's own `skipped_covered` field. The increment sits at the caller
+    /// rather than in the filter because #5190 gave the filter a SECOND caller
+    /// (the proactive summary notification), and only one of the two represents
+    /// a suppressed send; incrementing inside would double-count. The count is
+    /// still never re-derived from the difference
     /// between the resolved co-host set and the final target set — that
     /// subtraction also absorbs the sender, self, and resolve-failure filters,
     /// so it would keep reporting a plausible number after this filter is

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -3158,6 +3158,19 @@ mod tests {
         }
         assert_eq!(result.skipped_covered, 2, "the filter counts its own drops");
         assert_eq!(got.len(), 3);
+        // `proximity_found` is the population BEFORE any narrowing, and it
+        // feeds a telemetry denominator (`tracing/register.rs`). #5190 moved
+        // the covered-peer filter into `broadcast_cohost_targets`, so the
+        // count is now `targets.len() + covered_skipped` rather than the raw
+        // list length. Asserted here — with a NON-EMPTY covered set, which the
+        // other two `proximity_found` assertions lack — because dropping the
+        // `+ covered_skipped` term silently halves that denominator with the
+        // whole suite green.
+        assert_eq!(
+            result.proximity_found, 5,
+            "proximity_found must still count every advertised co-host, \
+             including the ones the #5147 list suppressed"
+        );
     }
 
     /// A local apply carries no claim, so nothing is suppressed: byte-for-byte

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -323,8 +323,58 @@ impl OpManager {
     /// **If you add a filter, add it HERE, not at a call site.** That coupling
     /// is the point of this function, and it is pinned by
     /// `cohost_source_is_shared_between_broadcast_and_notification`.
+    ///
+    /// That warning was ignored once and produced #5190: #5147 filtered the
+    /// originator's covered set at the BROADCAST call site only, so a covered
+    /// peer was suppressed from the broadcast and still excluded from the
+    /// notification, receiving neither. The narrowing now lives in
+    /// [`Self::broadcast_cohost_targets`] below, which BOTH sites go through.
+    ///
+    /// This raw accessor survives for one caller that legitimately wants the
+    /// UNnarrowed population: `resolve_covered_peers`, which resolves an
+    /// originator's list against everyone we could have targeted. Narrowing
+    /// there would be circular. Any site that participates in the
+    /// broadcast/notification partition must use `broadcast_cohost_targets`.
     pub(crate) fn advertised_cohost_pub_keys(&self, key: &ContractKey) -> Vec<TransportPublicKey> {
         self.neighbor_hosting.neighbors_with_contract(key)
+    }
+
+    /// The advertised co-hosts this fan-out will actually broadcast to, after
+    /// the #5147 target-list narrowing.
+    ///
+    /// This is the population the broadcast/notification partition is defined
+    /// over, and the ONLY thing either side of it may read. The broadcast
+    /// sends to `targets`; the notification excludes `targets` and therefore
+    /// still notifies the peers this narrowing dropped, which is the whole
+    /// point — they did not get the summary in a broadcast, because they did
+    /// not get a broadcast.
+    ///
+    /// `covered_skipped` is returned rather than recorded here because two
+    /// callers make this same call and only one of them is performing a
+    /// broadcast suppression. Recording inside would double-count the metric
+    /// (see the "a filtering metric must come from the filter" rule — the
+    /// count IS produced by the filter, the caller only decides whether this
+    /// invocation is the one that represents a suppressed send).
+    pub(crate) fn broadcast_cohost_targets(
+        &self,
+        key: &ContractKey,
+        origin: &BroadcastOrigin,
+    ) -> CohostBroadcastTargets {
+        let mut targets = Vec::new();
+        let mut covered_skipped = 0usize;
+        for pub_key in self.advertised_cohost_pub_keys(key) {
+            // #5147: the originator told us it already delivered to this peer,
+            // so re-sending is a byte-identical duplicate.
+            if origin.covers(&pub_key) {
+                covered_skipped += 1;
+                continue;
+            }
+            targets.push(pub_key);
+        }
+        CohostBroadcastTargets {
+            targets,
+            covered_skipped,
+        }
     }
 
     /// Resolve the set of peers to broadcast a state update to.
@@ -396,26 +446,31 @@ impl OpManager {
         // the advertisement layer. The former interest-manager arm (Source 2)
         // was removed in #4642 step 9; see this function's rustdoc.
         //
-        // Read through `advertised_cohost_pub_keys` rather than
-        // `neighbor_hosting` directly: `send_proactive_summary_notification`
-        // EXCLUDES this same set, and the shared accessor is what keeps a
-        // future narrowing from over-excluding there. See its rustdoc.
-        let proximity_pub_keys = self.advertised_cohost_pub_keys(key);
-        let proximity_found = proximity_pub_keys.len();
+        // Read through `broadcast_cohost_targets` rather than
+        // `neighbor_hosting` or the raw accessor:
+        // `send_proactive_summary_notification` EXCLUDES exactly what this
+        // returns, so both sides of the partition see the SAME narrowing.
+        // #5190 is what happens when only one of them does.
+        //
+        // The #5147 covered-peer narrowing therefore happens inside the
+        // accessor, BEFORE the address filters below — as it did when it was
+        // inline here, so the counter still attributes the drop to the reason
+        // a reader would expect. The three are disjoint in practice (the
+        // sender is never on its own list, and we are never on it either — a
+        // peer builds the list from its fan-out targets, which exclude both).
+        let CohostBroadcastTargets {
+            targets: proximity_pub_keys,
+            covered_skipped,
+        } = self.broadcast_cohost_targets(key, origin);
+        // Recorded HERE and not in the accessor: the notification path calls
+        // the same accessor, and a suppression is a suppressed BROADCAST.
+        for _ in 0..covered_skipped {
+            crate::config::GlobalTestMetrics::record_broadcast_target_suppressed();
+        }
+        skipped_covered += covered_skipped;
+        let proximity_found = proximity_pub_keys.len() + covered_skipped;
 
         for pub_key in proximity_pub_keys {
-            // #5147: the originator told us it already delivered to this peer,
-            // so re-sending is a byte-identical duplicate. Checked BEFORE the
-            // address filters purely so the counter attributes the drop to the
-            // reason a reader would expect; the three are disjoint in practice
-            // (the sender is never on its own list, and we are never on it
-            // either — a peer builds the list from its fan-out targets, which
-            // exclude both).
-            if origin.covers(&pub_key) {
-                skipped_covered += 1;
-                crate::config::GlobalTestMetrics::record_broadcast_target_suppressed();
-                continue;
-            }
             if let Some(pkl) = self.ring.connection_manager.get_peer_by_pub_key(&pub_key) {
                 if let Some(pkl_addr) = pkl.socket_addr() {
                     // Both of these were dead before #5147: the re-fan-out call
@@ -1069,10 +1124,17 @@ pub(crate) async fn update_contract(
 /// — the fan-out and heartbeat already behaved this way — and this gate makes
 /// the third path match them rather than introducing it. Tracked with the rest
 /// of the #4440 advertisement-hygiene work; deliberately not papered over here.
+///
+/// `origin` MUST be the same [`BroadcastOrigin`] the accompanying fan-out
+/// used. The exclusion below is "peers the broadcast already reached", and a
+/// broadcast reaches only what [`OpManager::broadcast_cohost_targets`] returns
+/// for that origin. Passing a different origin (or the default) silently
+/// widens the exclusion back to every advertised co-host, which is #5190.
 pub(crate) async fn send_proactive_summary_notification(
     op_manager: &OpManager,
     key: &ContractKey,
     sender_addr: SocketAddr,
+    origin: &BroadcastOrigin,
 ) {
     use crate::message::{SummariesEmitter, SummaryEntry};
     use crate::ring::interest::contract_hash;
@@ -1159,12 +1221,19 @@ pub(crate) async fn send_proactive_summary_notification(
         })
         .collect();
 
-    // The advertised co-hosts are the broadcast fan-out targets, which already
-    // received this summary inside the broadcast. Read through the SHARED
-    // accessor `get_broadcast_targets_update` also uses — see its rustdoc for
-    // why the two sites must not read the population independently.
+    // The peers the broadcast actually reached already received this summary
+    // inside it. Read through the SHARED accessor `get_broadcast_targets_update`
+    // also uses, with the SAME origin, so the excluded set is by construction a
+    // subset of the broadcast target set.
+    //
+    // #5190: this used to read the raw `advertised_cohost_pub_keys`, which the
+    // #5147 covered-peer narrowing did not touch. A covered peer was then
+    // suppressed from the broadcast AND excluded here, so it received neither
+    // the state nor the summary and went stale until the ~5-minute heartbeat.
+    // Peers dropped by that narrowing must land in `targets` below.
     let advertised_cohosts: HashSet<TransportPublicKey> = op_manager
-        .advertised_cohost_pub_keys(key)
+        .broadcast_cohost_targets(key, origin)
+        .targets
         .into_iter()
         .collect();
 
@@ -1299,6 +1368,17 @@ pub(crate) fn proactive_summary_targets(
         targets,
         cohosts_skipped,
     }
+}
+
+/// Outcome of [`OpManager::broadcast_cohost_targets`]: the co-hosts this
+/// fan-out will really send to, and how many the #5147 target list removed.
+///
+/// The two travel together so a caller cannot consume the narrowed set while
+/// re-deriving the count some other way — the failure mode the "a filtering
+/// metric must come from the filter" rule exists to prevent.
+pub(crate) struct CohostBroadcastTargets {
+    pub(crate) targets: Vec<TransportPublicKey>,
+    pub(crate) covered_skipped: usize,
 }
 
 /// Outcome of [`proactive_summary_targets`]: who to notify, and how many
@@ -3133,9 +3213,18 @@ mod tests {
             .collect();
 
         assert!(
-            body.contains("advertised_cohost_pub_keys(key)"),
-            "the emitter MUST consult the advertisement layer — without it the \
-             co-host exclusion silently does nothing (#4965)"
+            body.contains("broadcast_cohost_targets(key,origin)"),
+            "the emitter MUST consult the advertisement layer through the \
+             NARROWED accessor, passing the fan-out's own origin. Without the \
+             advertisement layer the #4965 exclusion silently does nothing; \
+             reading the RAW `advertised_cohost_pub_keys` instead re-creates \
+             #5190, where a peer the #5147 target list suppressed from the \
+             broadcast is also excluded here and receives neither"
+        );
+        assert!(
+            !body.contains("advertised_cohost_pub_keys("),
+            "the emitter must NOT read the raw un-narrowed accessor — that is \
+             literally the #5190 regression"
         );
         assert!(
             body.contains("proactive_summary_targets(&resolved,&advertised_cohosts,"),
@@ -3195,16 +3284,32 @@ mod tests {
             stripped.contains("fnadvertised_cohost_pub_keys(&self,key:&ContractKey)"),
             "the shared accessor must still exist"
         );
-        // Both consumers go through it.
+
+        // #5190: sharing the SOURCE was never enough. Both sites read the same
+        // accessor and the bug happened anyway, because #5147 narrowed one of
+        // them at its CALL SITE — which a source-identity check cannot see.
+        // So pin the narrowing itself: within this file the raw accessor is
+        // consumed exactly once, by `broadcast_cohost_targets`, and both sides
+        // of the partition go through THAT.
+        assert_eq!(
+            stripped.matches("self.advertised_cohost_pub_keys(key)").count(),
+            1,
+            "the raw accessor must be consumed exactly once in this file, by \
+             `broadcast_cohost_targets`. A second read is a site that will not \
+             follow the #5147 narrowing — which is exactly how #5190 happened"
+        );
+        // Both consumers go through the NARROWED accessor, with an origin.
         assert!(
-            stripped.contains("letproximity_pub_keys=self.advertised_cohost_pub_keys(key);"),
+            stripped.contains("self.broadcast_cohost_targets(key,origin)"),
             "get_broadcast_targets_update must source its targets from the \
-             shared accessor"
+             narrowed accessor"
         );
         assert!(
-            stripped.contains("op_manager.advertised_cohost_pub_keys(key)"),
+            stripped.contains("op_manager.broadcast_cohost_targets(key,origin)"),
             "send_proactive_summary_notification must source its exclusion set \
-             from the shared accessor"
+             from the narrowed accessor, using the SAME origin the fan-out \
+             used, or the excluded set stops being a subset of what was \
+             actually broadcast (#5190)"
         );
     }
 
@@ -3384,6 +3489,96 @@ mod tests {
     /// the weakest statement that still rules out vacuity. The strict form
     /// ("A specifically is a target") would fire first under a narrowing
     /// mutation and hide the fact that the subset property is what detects it.
+    /// #5190 regression: a peer the #5147 target list suppressed from the
+    /// broadcast MUST still get the standalone summary notification.
+    ///
+    /// The sibling test below establishes the subset property with an EMPTY
+    /// covered set, which is why it stayed green through #5190 — with nothing
+    /// covered, the broadcast set and the raw co-host set are identical and
+    /// the two sites cannot disagree. The bug lives entirely in the case that
+    /// test does not construct. This one constructs it.
+    ///
+    /// A is an advertised co-host, interested, AND named by the originator's
+    /// covered list. So:
+    ///   - the broadcast skips A (the originator already delivered to it), and
+    ///   - the notification must NOT skip A, because no broadcast of ours
+    ///     carried our summary to it.
+    ///
+    /// Before the fix A was in both exclusions and received neither, going
+    /// stale until the ~5-minute InterestSync heartbeat.
+    #[tokio::test]
+    async fn covered_peer_suppressed_from_broadcast_still_gets_the_summary_notification() {
+        let (op_manager, mut rx, _guard) =
+            build_notification_test_node("notif-covered-peer-5190").await;
+        let key = crate::operations::test_utils::make_contract_key(12);
+        op_manager
+            .ring
+            .host_contract(key, 1024, crate::ring::AccessType::Put);
+
+        // A: co-host + interested + COVERED by the originator -> suppressed
+        //    from the broadcast, so it must be notified.
+        // B: co-host + interested, NOT covered -> really is broadcast to, so
+        //    it must still be excluded. Keeping B is what stops this test
+        //    passing under a mutation that simply stops excluding anyone.
+        let (a_pk, a_addr) = connect_peer(&op_manager, 19201, 0.21);
+        let (b_pk, b_addr) = connect_peer(&op_manager, 19202, 0.22);
+        let (_d_pk, sender_addr) = connect_peer(&op_manager, 19204, 0.24);
+
+        advertise_cohost(&op_manager, &a_pk, &key);
+        advertise_cohost(&op_manager, &b_pk, &key);
+        for pk in [&a_pk, &b_pk] {
+            op_manager.interest_manager.register_peer_interest(
+                &key,
+                crate::ring::PeerKey::from(pk.clone()),
+                None,
+                false,
+            );
+        }
+
+        let covered: std::collections::HashSet<crate::ring::PeerKey> =
+            [crate::ring::PeerKey::from(a_pk.clone())]
+                .into_iter()
+                .collect();
+        let origin = BroadcastOrigin::relayed(sender_addr, covered);
+
+        let broadcast_targets: HashSet<SocketAddr> = op_manager
+            .get_broadcast_targets_update(&key, &origin)
+            .targets
+            .iter()
+            .filter_map(|pkl| pkl.socket_addr())
+            .collect();
+
+        // Premise: the covered peer really was suppressed from the broadcast,
+        // and the uncovered one really was targeted. Without both, the
+        // assertion below is not testing what its name says.
+        assert!(
+            !broadcast_targets.contains(&a_addr),
+            "premise: A is covered, so the broadcast must skip it; \
+             targets={broadcast_targets:?}"
+        );
+        assert!(
+            broadcast_targets.contains(&b_addr),
+            "premise: B is not covered, so the broadcast must target it; \
+             targets={broadcast_targets:?}"
+        );
+
+        send_proactive_summary_notification(&op_manager, &key, sender_addr, &origin).await;
+        let notified: HashSet<SocketAddr> = drain_interest_targets(&mut rx).into_iter().collect();
+
+        assert!(
+            notified.contains(&a_addr),
+            "#5190: A was suppressed from the broadcast by the #5147 target \
+             list, so nothing carried our summary to it — the standalone \
+             notification MUST reach it. notified={notified:?}"
+        );
+        assert!(
+            !notified.contains(&b_addr),
+            "B really was broadcast to, so the #4965 exclusion must still \
+             skip it — otherwise this is just 'notify everyone' and the \
+             saving #4965 measured is gone. notified={notified:?}"
+        );
+    }
+
     #[tokio::test]
     async fn notification_exclusion_is_a_subset_of_broadcast_targets() {
         let (op_manager, mut rx, _guard) =
@@ -3420,17 +3615,16 @@ mod tests {
             );
         }
 
+        // ONE origin for both sides of the partition, as production now does.
+        let origin = BroadcastOrigin::relayed(sender_addr, Default::default());
         let broadcast_targets: HashSet<SocketAddr> = op_manager
-            .get_broadcast_targets_update(
-                &key,
-                &BroadcastOrigin::relayed(sender_addr, Default::default()),
-            )
+            .get_broadcast_targets_update(&key, &origin)
             .targets
             .iter()
             .filter_map(|pkl| pkl.socket_addr())
             .collect();
 
-        send_proactive_summary_notification(&op_manager, &key, sender_addr).await;
+        send_proactive_summary_notification(&op_manager, &key, sender_addr, &origin).await;
         let notified: HashSet<SocketAddr> = drain_interest_targets(&mut rx).into_iter().collect();
 
         // Premise 1: the scenario really produced a broadcast fan-out.
@@ -3517,7 +3711,13 @@ mod tests {
         // `broadcast_single_peer_gates_summarize_on_hosted_or_in_use_pin`.
         // It is `pub(super)` so it cannot be called from here directly.
 
-        send_proactive_summary_notification(&op_manager, &key, sender_addr).await;
+        send_proactive_summary_notification(
+            &op_manager,
+            &key,
+            sender_addr,
+            &BroadcastOrigin::relayed(sender_addr, Default::default()),
+        )
+        .await;
 
         assert!(
             drain_interest_targets(&mut rx).is_empty(),

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -1285,13 +1285,23 @@ pub(crate) async fn send_proactive_summary_notification(
             SummariesEmitter::Notification,
         );
 
-        if let Err(e) = op_manager
-            .notify_node_event(NodeEvent::SendInterestMessage {
-                target: *peer_addr,
-                message,
-            })
-            .await
-        {
+        // NON-blocking, deliberately. `notify_node_event` is a 30 s
+        // timeout-bounded blocking send on the bounded event-loop channel; this
+        // loop runs it once per recipient, and #5190 roughly 10x's the
+        // recipient count on a high-degree peer (at the measured 0.924
+        // suppression fraction at degree 17, nearly every co-host is covered
+        // and therefore newly notified). A blocking send per recipient is the
+        // #4145/#4231 back-pressure shape.
+        //
+        // This site meets `try_notify_node_event`'s criterion (2) exactly: a
+        // dropped summary notification is recovered by the ~5-minute
+        // InterestSync heartbeat, which is already this mechanism's stated
+        // backstop. The four best-effort Broadcast emitters were converted in
+        // #4231 for the same reason; this loop was missed.
+        if let Err(e) = op_manager.try_notify_node_event(NodeEvent::SendInterestMessage {
+            target: *peer_addr,
+            message,
+        }) {
             tracing::debug!(
                 contract = %key,
                 peer = %peer_addr,

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -3292,7 +3292,9 @@ mod tests {
         // consumed exactly once, by `broadcast_cohost_targets`, and both sides
         // of the partition go through THAT.
         assert_eq!(
-            stripped.matches("self.advertised_cohost_pub_keys(key)").count(),
+            stripped
+                .matches("self.advertised_cohost_pub_keys(key)")
+                .count(),
             1,
             "the raw accessor must be consumed exactly once in this file, by \
              `broadcast_cohost_targets`. A second read is a site that will not \

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -339,8 +339,8 @@ impl OpManager {
         self.neighbor_hosting.neighbors_with_contract(key)
     }
 
-    /// The advertised co-hosts this fan-out will actually broadcast to, after
-    /// the #5147 target-list narrowing.
+    /// The advertised co-hosts remaining after the #5147 target-list
+    /// narrowing.
     ///
     /// This is the population the broadcast/notification partition is defined
     /// over, and the ONLY thing either side of it may read. The broadcast
@@ -348,6 +348,21 @@ impl OpManager {
     /// still notifies the peers this narrowing dropped, which is the whole
     /// point — they did not get the summary in a broadcast, because they did
     /// not get a broadcast.
+    ///
+    /// Deliberately NOT "the peers the fan-out will really reach". Two
+    /// pre-existing filters sit downstream of this and are not modelled here,
+    /// so `targets` is an over-approximation:
+    ///
+    /// - the broadcast site then drops co-hosts with no resolvable
+    ///   connection, and the notification's own `resolved` step drops the
+    ///   same peers, so the two still agree — but by coincidence rather than
+    ///   by construction;
+    /// - a co-host that is ALSO the sender is dropped by both sites for
+    ///   different reasons.
+    ///
+    /// Neither is widened by #5190 and both predate it. They are the reason
+    /// the subset property is "by construction" only with respect to the
+    /// #5147 narrowing, which is the one that broke it.
     ///
     /// `covered_skipped` is returned rather than recorded here because two
     /// callers make this same call and only one of them is performing a
@@ -3291,13 +3306,18 @@ mod tests {
         // So pin the narrowing itself: within this file the raw accessor is
         // consumed exactly once, by `broadcast_cohost_targets`, and both sides
         // of the partition go through THAT.
+        // Count CALLS, not one spelling of one receiver. Needling
+        // `self.advertised_cohost_pub_keys(key)` would let a re-read written
+        // as `op_manager.advertised_cohost_pub_keys(key)` slip past — and that
+        // is precisely the form `send_proactive_summary_notification` used
+        // before this fix. The definition line strips to
+        // `fnadvertised_cohost_pub_keys(&self,...`, so requiring a leading `.`
+        // excludes it from the count.
         assert_eq!(
-            stripped
-                .matches("self.advertised_cohost_pub_keys(key)")
-                .count(),
+            stripped.matches(".advertised_cohost_pub_keys(").count(),
             1,
-            "the raw accessor must be consumed exactly once in this file, by \
-             `broadcast_cohost_targets`. A second read is a site that will not \
+            "the raw accessor must be CALLED exactly once in this file, by \
+             `broadcast_cohost_targets`. A second call is a site that will not \
              follow the #5147 narrowing — which is exactly how #5190 happened"
         );
         // Both consumers go through the NARROWED accessor, with an origin.

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -1922,6 +1922,14 @@ async fn drive_relay_broadcast_to(
     }
 
     // ── Step 4: apply broadcast via WASM merge ────────────────────────────
+    //
+    // Hoisted into a local because step 6's proactive summary notification
+    // must exclude exactly the peers THIS origin's fan-out reaches. Resolving
+    // it a second time down there would re-read the co-host population at a
+    // later instant and could disagree; re-deriving it as `local()` (the
+    // default) would silently restore #5190.
+    let broadcast_origin =
+        resolve_covered_peers(op_manager, &key, &incoming_tx, sender_addr, &covered);
     let update_result = super::update_contract(
         op_manager,
         key,
@@ -1929,7 +1937,7 @@ async fn drive_relay_broadcast_to(
         RelatedContracts::default(),
         crate::contract::Priority::NetworkRelay,
         crate::node::ApplyOrigin::NetworkRelay,
-        resolve_covered_peers(op_manager, &key, &incoming_tx, sender_addr, &covered),
+        broadcast_origin.clone(),
     )
     .await;
 
@@ -2217,7 +2225,8 @@ async fn drive_relay_broadcast_to(
     // contract's REAL summary itself (#4923) — no caller-supplied value.
     let op_mgr = op_manager.clone();
     GlobalExecutor::spawn(async move {
-        super::send_proactive_summary_notification(&op_mgr, &key, sender_addr).await;
+        super::send_proactive_summary_notification(&op_mgr, &key, sender_addr, &broadcast_origin)
+            .await;
     });
 
     Ok(())
@@ -2851,6 +2860,12 @@ async fn apply_streaming_broadcast(
     }
 
     // Step 7: WASM merge.
+    //
+    // Hoisted for the same reason as the non-streaming driver: the proactive
+    // summary notification below must exclude exactly the peers THIS origin's
+    // fan-out reaches (#5190).
+    let broadcast_origin =
+        resolve_covered_peers(op_manager, &key, &incoming_tx, sender_addr, &covered);
     let update_result = super::update_contract(
         op_manager,
         key,
@@ -2858,7 +2873,7 @@ async fn apply_streaming_broadcast(
         RelatedContracts::default(),
         crate::contract::Priority::NetworkRelay,
         crate::node::ApplyOrigin::NetworkRelay,
-        resolve_covered_peers(op_manager, &key, &incoming_tx, sender_addr, &covered),
+        broadcast_origin.clone(),
     )
     .await;
 
@@ -2993,7 +3008,8 @@ async fn apply_streaming_broadcast(
     // caller-supplied value.
     let op_mgr = op_manager.clone();
     GlobalExecutor::spawn(async move {
-        super::send_proactive_summary_notification(&op_mgr, &key, sender_addr).await;
+        super::send_proactive_summary_notification(&op_mgr, &key, sender_addr, &broadcast_origin)
+            .await;
     });
 
     Ok(())

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -3369,18 +3369,32 @@ mod tests {
 
     /// Body of one relay-broadcast driver, whitespace-stripped.
     ///
-    /// Bounded at the next top-level `async fn` (or the test module) so a pin
-    /// cannot match a sibling driver or its own assertion strings.
+    /// Bounded at the next top-level fn (or the test module) so a pin cannot
+    /// match a sibling driver or its own assertion strings.
+    ///
+    /// All four visibility spellings are candidates, not just bare `async fn`:
+    /// matching only the bare form let the `drive_relay_broadcast_to` slice run
+    /// ~190 lines past its own end, swallowing two `pub(crate) async fn`
+    /// siblings. Harmless today (neither contains the needles) but the helper
+    /// would have been claiming a bound it did not enforce, which is the class
+    /// of defect these pins exist to catch.
     fn broadcast_driver_body(signature: &str) -> String {
         let src = include_str!("op_ctx_task.rs");
         let start = src
             .find(signature)
             .unwrap_or_else(|| panic!("{signature} not found"));
         let after = &src[start + 1..];
-        let end = after
-            .find("\nasync fn ")
-            .or_else(|| after.find("\n#[cfg(test)]"))
-            .unwrap_or(after.len());
+        let end = [
+            "\nasync fn ",
+            "\npub(crate) async fn ",
+            "\npub(super) async fn ",
+            "\npub async fn ",
+            "\n#[cfg(test)]",
+        ]
+        .iter()
+        .filter_map(|marker| after.find(marker))
+        .min()
+        .unwrap_or(after.len());
         src[start..start + 1 + end]
             .chars()
             .filter(|c| !c.is_whitespace())

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -3352,15 +3352,70 @@ mod tests {
     /// it causes peers to repeatedly broadcast stale data.
     #[test]
     fn broadcast_to_spawns_proactive_summary() {
-        let src = include_str!("op_ctx_task.rs");
-        let driver_start = src
-            .find("async fn drive_relay_broadcast_to(")
-            .expect("drive_relay_broadcast_to not found");
-        let driver_src = &src[driver_start..];
+        // Bounded to the driver body. It previously sliced to END OF FILE,
+        // which swallowed this test module — including this assertion's own
+        // message, which contains the needle verbatim. Deleting the spawn
+        // entirely left it green, and it could not tell this driver from
+        // `apply_streaming_broadcast`'s call either. See AGENTS.md, "WHEN
+        // writing a source-scrape pin test".
+        let body = broadcast_driver_body("async fn drive_relay_broadcast_to(");
         assert!(
-            driver_src.contains("send_proactive_summary_notification"),
+            body.contains("send_proactive_summary_notification"),
             "drive_relay_broadcast_to must spawn send_proactive_summary_notification \
              after a successful state change (mirrors legacy update.rs:806-819)."
+        );
+        assert_origin_is_threaded_to_the_notification(&body, "drive_relay_broadcast_to");
+    }
+
+    /// Body of one relay-broadcast driver, whitespace-stripped.
+    ///
+    /// Bounded at the next top-level `async fn` (or the test module) so a pin
+    /// cannot match a sibling driver or its own assertion strings.
+    fn broadcast_driver_body(signature: &str) -> String {
+        let src = include_str!("op_ctx_task.rs");
+        let start = src
+            .find(signature)
+            .unwrap_or_else(|| panic!("{signature} not found"));
+        let after = &src[start + 1..];
+        let end = after
+            .find("\nasync fn ")
+            .or_else(|| after.find("\n#[cfg(test)]"))
+            .unwrap_or(after.len());
+        src[start..start + 1 + end]
+            .chars()
+            .filter(|c| !c.is_whitespace())
+            .collect()
+    }
+
+    /// #5190: the notification's exclusion set is "peers the broadcast really
+    /// reached", which is only true if it is handed the SAME
+    /// `BroadcastOrigin` the fan-out used.
+    ///
+    /// Passing `BroadcastOrigin::local()` — an empty covered set — makes
+    /// `covers()` always false, so `broadcast_cohost_targets` returns the RAW
+    /// co-host set and the exclusion widens back to every advertised co-host.
+    /// That is #5190 restored, in one line, and before this pin existed the
+    /// entire suite stayed green through it: the behavioural test calls the
+    /// emitter directly and never exercises either driver.
+    fn assert_origin_is_threaded_to_the_notification(body: &str, driver: &str) {
+        assert!(
+            body.contains(
+                "send_proactive_summary_notification(&op_mgr,&key,sender_addr,&broadcast_origin,)"
+            ) || body.contains(
+                "send_proactive_summary_notification(&op_mgr,&key,sender_addr,&broadcast_origin)"
+            ),
+            "{driver} must hand the notification the fan-out's OWN origin \
+             (`&broadcast_origin`). A fresh `BroadcastOrigin::local()` or a \
+             re-resolved origin restores #5190: the covered peer is suppressed \
+             from the broadcast AND excluded from the summary, receiving neither"
+        );
+        assert_eq!(
+            body.matches("resolve_covered_peers(").count(),
+            1,
+            "{driver} must resolve the origin EXACTLY once and share it. A \
+             second resolution re-reads the co-host population at a later \
+             instant, so the notification could exclude a peer the fan-out \
+             never targeted"
         );
     }
 
@@ -6362,21 +6417,15 @@ mod tests {
     /// A invariant at `broadcast_to_spawns_proactive_summary`).
     #[test]
     fn broadcast_to_streaming_spawns_proactive_summary() {
-        let src = include_str!("op_ctx_task.rs");
-        let start = src
-            .find("async fn apply_streaming_broadcast(")
-            .expect("apply_streaming_broadcast not found");
-        let after = &src[start + 1..];
-        let end = after
-            .find("\nasync fn ")
-            .or_else(|| after.find("\n#[cfg(test)]"))
-            .unwrap_or(after.len());
-        let driver_src = &src[start..start + 1 + end];
+        let body = broadcast_driver_body("async fn apply_streaming_broadcast(");
         assert!(
-            driver_src.contains("send_proactive_summary_notification"),
+            body.contains("send_proactive_summary_notification"),
             "apply_streaming_broadcast must spawn \
              send_proactive_summary_notification on successful state change"
         );
+        // Parity with the non-streaming driver: the two were changed
+        // identically for #5190 and nothing else would notice them diverging.
+        assert_origin_is_threaded_to_the_notification(&body, "apply_streaming_broadcast");
     }
 
     /// Pin: the streaming RAII guard must remove from


### PR DESCRIPTION
## Problem

#5147 added a filter at a call site that `advertised_cohost_pub_keys`'s rustdoc says in bold must not be added at a call site. The result: a peer suppressed by the originator's target list gets **neither the broadcast nor the standalone summary notification**, so its cached summary of us goes stale until the ~5-minute InterestSync heartbeat.

Two sites are meant to partition the co-host set. `get_broadcast_targets_update` broadcasts to advertised co-hosts, carrying our summary in `sender_summary_bytes`. `send_proactive_summary_notification` **excludes** advertised co-hosts from the standalone `Summaries` fan-out precisely because the broadcast already carried it (#4965).

#5147 narrowed the first set only. The broadcast dropped peers named by the originator's list, while the notification still built its exclusion set from the unfiltered accessor. A covered peer was therefore suppressed from the broadcast *and* skipped by the notification.

The codebase predicted this exactly:

> The exclusion is only sound while the excluded set is a subset of the broadcast target set. If the two sites read different sources, **or one narrows its set and the other does not**, the notification over-excludes: a peer gets neither the broadcast nor the standalone summary, and every unit test stays green because each site is individually correct.
>
> **If you add a filter, add it HERE, not at a call site.**

Direction is staleness, not corruption, and it heals on the heartbeat. But it is a third summary-starvation channel on this feature, and the summary-match gate does most of the real deduplication work — in the #5147 simulation `summary_skips` fell from 417 to 146 when the list engaged — so starving summary refresh partially undercuts the feature that caused the starvation. Pre-#5147 the "gets neither" case needed a failed send; post-#5147 it is every covered co-host on every relayed broadcast. It ramps with adoption, since the target list is gated at (0,2,120).

## Approach

**Fix option 1 from the issue** (restore the stated invariant), implemented so that the narrowing lives where the rustdoc demands.

New `OpManager::broadcast_cohost_targets(key, origin)` returns the co-hosts this fan-out will *actually* send to, applying the #5147 narrowing inside the accessor. The broadcast sends to `targets`; the notification excludes `targets`. The excluded set is a subset of the broadcast set **by construction** rather than by two call sites agreeing to stay in step.

The raw `advertised_cohost_pub_keys` survives for the one caller that legitimately wants the un-narrowed population — `resolve_covered_peers`, which resolves an originator's list against everyone we could have targeted, where narrowing would be circular.

**The origin is threaded, not re-derived.** `drive_relay_broadcast_to` and its streaming sibling now hoist `resolve_covered_peers(...)` into a local and hand the same `BroadcastOrigin` to both the fan-out and the notification. Re-resolving at the notification would re-read the co-host population at a later instant and could disagree; defaulting it to `local()` would silently restore this bug.

`covered_skipped` is returned rather than recorded inside the accessor: two callers now make the same call and only one is performing a broadcast suppression, so recording inside would double-count. The count is still produced by the filter, per the "a filtering metric must come from the filter" rule — the caller only decides whether this invocation represents a suppressed send.

## Testing

**The existing behavioural guard passed with the bug present.** `notification_exclusion_is_a_subset_of_broadcast_targets` only ever used an **empty** covered set, and with nothing covered the broadcast set and the raw co-host set are identical, so the two sites cannot disagree. The bug lives entirely in the case that test does not construct.

New `covered_peer_suppressed_from_broadcast_still_gets_the_summary_notification` constructs it: peer A is an advertised co-host, interested, and named by the originator's covered list; peer B is a co-host that is *not* covered. It asserts both premises (A really is suppressed from the broadcast, B really is targeted), then that **A is notified** and **B is not** — the second half being what stops it passing under a mutation that simply notifies everyone and discards #4965's saving.

**Verified to fail without the fix.** Reverting the notification to the raw accessor:

```
covered_peer_suppressed_from_broadcast_still_gets_the_summary_notification ... FAILED
  #5190: A was suppressed from the broadcast by the #5147 target list, so nothing
  carried our summary to it — the standalone notification MUST reach it. notified={}
```

Empty: A received nothing.

**The structural pin is strengthened, because the old one could not have caught this.** `cohost_source_is_shared_between_broadcast_and_notification` asserted both sites read the same *source* — which remained true, since the narrowing happened after the shared read. A source-identity check cannot see a call-site narrowing, which is the whole failure mode. It now pins that the raw accessor is consumed exactly once in the file, by the narrowing accessor, and that both consumers go through that accessor with an origin. Both pins also fail under the revert.

Full suite: 4710 passed, 0 failed. `cargo fmt --check` and both CI clippy invocations clean.

## Known residual, deliberately not fixed here

The exclusion set is still read at a slightly later instant than the broadcast set (the notification is spawned as a background task). A co-host advertised in between would be excluded without having been broadcast to. That race is **pre-existing** — both sites always read independently — and this change does not widen it. Fixing it means passing the resolved target list across the spawn boundary, which is a larger change than the regression warrants.

Fixes #5190
Refs #5191

[AI-assisted - Claude]
