### PR TITLE
test(update): count proactive summary notifications sent, not just skipped

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -3977,6 +3977,9 @@ std::thread_local! {
     /// Recipients dropped from a proactive summary notification because they
     /// are advertised co-hosts the broadcast already covered (#4965).
     static GLOBAL_NOTIFICATION_COHOSTS_SKIPPED: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+    /// Recipients a proactive summary notification actually SENT to — the cost
+    /// side of the pair above, which only ever counted the saving.
+    static GLOBAL_NOTIFICATION_TARGETS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
     // Hosting advertisement retractions emitted on stop-hosting (eviction).
     // Advertisement-layer reliability + retraction, #4642 spec step 1.
     static GLOBAL_NEIGHBOR_HOSTING_RETRACTIONS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
@@ -4073,6 +4076,7 @@ impl GlobalTestMetrics {
         GLOBAL_PENDING_OP_HWM.with(|c| c.set(0));
         GLOBAL_NEIGHBOR_HOSTING_UPDATES.with(|c| c.set(0));
         GLOBAL_NOTIFICATION_COHOSTS_SKIPPED.with(|c| c.set(0));
+        GLOBAL_NOTIFICATION_TARGETS.with(|c| c.set(0));
         GLOBAL_NEIGHBOR_HOSTING_RETRACTIONS.with(|c| c.set(0));
         GLOBAL_ANTI_STARVATION_TRIGGERS.with(|c| c.set(0));
         GLOBAL_TERMINAL_CONSULT_ATTEMPTS.with(|c| c.set(0));
@@ -4331,6 +4335,28 @@ impl GlobalTestMetrics {
 
     pub fn notification_cohosts_skipped() -> u64 {
         GLOBAL_NOTIFICATION_COHOSTS_SKIPPED.with(|c| c.get())
+    }
+
+    /// A proactive summary notification SENT to `n` recipients.
+    ///
+    /// The cost half of the pair. `notification_cohosts_skipped` counts only
+    /// what the #4965 exclusion SAVED, so for as long as it stood alone the
+    /// simulation could see this mechanism getting cheaper and could not see it
+    /// getting more expensive.
+    ///
+    /// That asymmetry is not academic: #5190's fix restores notifications to
+    /// every peer the #5147 target list suppresses, and the A/B rig that exists
+    /// specifically to judge #5147 measured the 13 sends it saved while being
+    /// structurally blind to the ~429 messages it added. The trade could only
+    /// be argued, not measured. **A counter for a mechanism's saving needs its
+    /// twin for the mechanism's cost, or the rig can only ever return good
+    /// news.**
+    pub fn record_notification_targets(n: u64) {
+        GLOBAL_NOTIFICATION_TARGETS.with(|c| c.set(c.get() + n));
+    }
+
+    pub fn notification_targets() -> u64 {
+        GLOBAL_NOTIFICATION_TARGETS.with(|c| c.get())
     }
 
     /// A hosting advertisement retraction was emitted because this node stopped

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -4337,7 +4337,13 @@ impl GlobalTestMetrics {
         GLOBAL_NOTIFICATION_COHOSTS_SKIPPED.with(|c| c.get())
     }
 
-    /// A proactive summary notification SENT to `n` recipients.
+    /// A proactive summary notification ATTEMPTED to `n` recipients.
+    ///
+    /// Attempted, not delivered: `n` is the resolved recipient set, counted
+    /// once per notification round, before the per-peer enqueue can fail. That
+    /// matches what the cost question asks (how many messages this mechanism
+    /// puts on the wire) and matches its sibling `notification_cohosts_skipped`,
+    /// which is likewise an intent count. Do not read it as an ack.
     ///
     /// The cost half of the pair. `notification_cohosts_skipped` counts only
     /// what the #4965 exclusion SAVED, so for as long as it stood alone the

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -1238,8 +1238,11 @@ pub(crate) async fn send_proactive_summary_notification(
     crate::config::GlobalTestMetrics::record_notification_cohosts_skipped(cohosts_skipped as u64);
     // The cost twin. Recorded next to the saving so the two cannot drift apart:
     // the #5147 A/B could see this mechanism get cheaper and was blind to it
-    // getting more expensive, which is how #5190's fix reached a green unit
-    // suite while adding ~429 messages to buy 13 fewer sends.
+    // getting more expensive. A CANDIDATE #5190 fix (since withdrawn) restored a
+    // notification to each suppressed peer; the rig showed a green suite while
+    // it added ~429 messages to buy 13 fewer sends, because nothing counted the
+    // messages. Zero on every path today — that is the before-reading, pinned by
+    // `notification_cost_counter_is_wired` and by the A/B's own assertion.
     crate::config::GlobalTestMetrics::record_notification_targets(targets.len() as u64);
 
     tracing::debug!(
@@ -3101,6 +3104,41 @@ mod tests {
             "with the exclusion inactive the co-host skip count MUST be 0 — \
              a non-zero value here means the metric is measuring the sender/\
              self drops and cannot detect the exclusion being removed"
+        );
+    }
+
+    /// The cost counter must stay WIRED to the emitter.
+    ///
+    /// The A/B's before-reading assertion pins the VALUE at zero, but a zero is
+    /// also what you get if the recorder is deleted — so on its own it cannot
+    /// tell "this mechanism is free" from "nobody is counting". This pins the
+    /// call itself, bounded to the emitter body so it cannot match its own
+    /// assertion string.
+    #[test]
+    fn notification_cost_counter_is_wired() {
+        let src = include_str!("update.rs");
+        let prod = &src[..src.find("\nmod tests {").expect("tests module not found")];
+        let start = prod
+            .find("pub(crate) async fn send_proactive_summary_notification(")
+            .expect("emitter not found");
+        let rest = &prod[start..];
+        let end = 1 + rest[1..]
+            .find("\npub(crate) fn ")
+            .expect("expected a following item to bound the emitter body");
+        let body: String = rest[..end].chars().filter(|c| !c.is_whitespace()).collect();
+
+        assert!(
+            body.contains("record_notification_targets(targets.len()"),
+            "send_proactive_summary_notification must record the number of \
+             notifications it sends. Without it the A/B rig reports \
+             `notif_sent=0` forever, which reads as this mechanism being free \
+             — the false-good-news failure the counter exists to prevent"
+        );
+        assert!(
+            body.contains("record_notification_cohosts_skipped("),
+            "the SAVING counter must stay recorded alongside the COST counter; \
+             a rig that keeps only one of the pair can only move in one \
+             direction"
         );
     }
 

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -1236,6 +1236,11 @@ pub(crate) async fn send_proactive_summary_notification(
     // in `delta_sends`/`full_state_sends` — see
     // `GlobalTestMetrics::record_notification_cohosts_skipped`.
     crate::config::GlobalTestMetrics::record_notification_cohosts_skipped(cohosts_skipped as u64);
+    // The cost twin. Recorded next to the saving so the two cannot drift apart:
+    // the #5147 A/B could see this mechanism get cheaper and was blind to it
+    // getting more expensive, which is how #5190's fix reached a green unit
+    // suite while adding ~429 messages to buy 13 fewer sends.
+    crate::config::GlobalTestMetrics::record_notification_targets(targets.len() as u64);
 
     tracing::debug!(
         contract = %key,

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -17348,6 +17348,14 @@ struct SuppressionArm {
     /// peer has an advertised co-host, so there is no mesh and nothing to
     /// suppress.
     hosting_updates: u64,
+    /// Standalone `Summaries` notifications SENT.
+    ///
+    /// The cost axis. Every other counter here measures traffic this feature
+    /// REMOVES; without this one the rig can only ever report good news. #5190's
+    /// fix restores a notification to each suppressed peer, so its cost lands
+    /// entirely here and nowhere else: it is invisible in `sends`,
+    /// `delta_sends`, `full_state_sends` and `summary_skips`.
+    notification_targets: u64,
 }
 
 #[cfg(test)]
@@ -17500,6 +17508,7 @@ fn run_5147_arm_inner(
         suppressed: GlobalTestMetrics::broadcast_targets_suppressed(),
         sender_skips: GlobalTestMetrics::broadcast_sender_skips(),
         hosting_updates: GlobalTestMetrics::neighbor_hosting_updates(),
+        notification_targets: GlobalTestMetrics::notification_targets(),
     }
 }
 
@@ -17585,7 +17594,7 @@ fn test_5147_originator_target_list_cuts_duplicate_deliveries() {
 
     tracing::info!(
         "#5147 control:   deliveries={} redundant={} sends={} (delta={} full={}) \
-         suppressed={} summary_skips={} resync_suppressed={} converged={:?} replicas={} diverged={}",
+         suppressed={} summary_skips={} notif_sent={} resync_suppressed={} converged={:?} replicas={} diverged={}",
         control.deliveries,
         control.redundant,
         control.sends,
@@ -17593,6 +17602,7 @@ fn test_5147_originator_target_list_cuts_duplicate_deliveries() {
         control.full_state_sends,
         control.suppressed,
         control.summary_skips,
+        control.notification_targets,
         control.resync_suppressed,
         control.converged,
         control.replicas,
@@ -17600,7 +17610,7 @@ fn test_5147_originator_target_list_cuts_duplicate_deliveries() {
     );
     tracing::info!(
         "#5147 treatment: deliveries={} redundant={} sends={} (delta={} full={}) \
-         suppressed={} summary_skips={} resync_suppressed={} converged={:?} replicas={} diverged={}",
+         suppressed={} summary_skips={} notif_sent={} resync_suppressed={} converged={:?} replicas={} diverged={}",
         treatment.deliveries,
         treatment.redundant,
         treatment.sends,
@@ -17608,6 +17618,7 @@ fn test_5147_originator_target_list_cuts_duplicate_deliveries() {
         treatment.full_state_sends,
         treatment.suppressed,
         treatment.summary_skips,
+        treatment.notification_targets,
         treatment.resync_suppressed,
         treatment.converged,
         treatment.replicas,
@@ -17912,7 +17923,7 @@ fn test_5147_multi_writer_suppression_is_regime_dependent() {
 
     tracing::info!(
         "#5147 multi-writer control:   deliveries={} redundant={} sends={} \
-         (delta={} full={}) suppressed={} summary_skips={} resync_suppressed={} \
+         (delta={} full={}) suppressed={} summary_skips={} notif_sent={} resync_suppressed={} \
          converged={:?} replicas={} diverged={}",
         control.deliveries,
         control.redundant,
@@ -17921,6 +17932,7 @@ fn test_5147_multi_writer_suppression_is_regime_dependent() {
         control.full_state_sends,
         control.suppressed,
         control.summary_skips,
+        control.notification_targets,
         control.resync_suppressed,
         control.converged,
         control.replicas,
@@ -17928,7 +17940,7 @@ fn test_5147_multi_writer_suppression_is_regime_dependent() {
     );
     tracing::info!(
         "#5147 multi-writer treatment: deliveries={} redundant={} sends={} \
-         (delta={} full={}) suppressed={} summary_skips={} resync_suppressed={} \
+         (delta={} full={}) suppressed={} summary_skips={} notif_sent={} resync_suppressed={} \
          converged={:?} replicas={} diverged={}",
         treatment.deliveries,
         treatment.redundant,
@@ -17937,6 +17949,7 @@ fn test_5147_multi_writer_suppression_is_regime_dependent() {
         treatment.full_state_sends,
         treatment.suppressed,
         treatment.summary_skips,
+        treatment.notification_targets,
         treatment.resync_suppressed,
         treatment.converged,
         treatment.replicas,

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -17352,10 +17352,14 @@ struct SuppressionArm {
     /// counted before the per-peer enqueue can fail).
     ///
     /// The cost axis. Every other counter here measures traffic this feature
-    /// REMOVES; without this one the rig can only ever report good news. #5190's
-    /// fix restores a notification to each suppressed peer, so its cost lands
-    /// entirely here and nowhere else: it is invisible in `sends`,
-    /// `delta_sends`, `full_state_sends` and `summary_skips`.
+    /// REMOVES; without this one the rig can only ever report good news.
+    ///
+    /// A candidate #5190 fix (since withdrawn) restored a notification to each
+    /// suppressed peer. Its cost was invisible in `sends`, `delta_sends`,
+    /// `full_state_sends` and `summary_skips` — it lands here and nowhere else.
+    /// Zero in both arms today; the assertions below pin that, so the day a
+    /// change starts sending notifications the test fails and someone has to
+    /// look at the number rather than inferring it costs nothing.
     notification_targets: u64,
 }
 
@@ -17624,6 +17628,25 @@ fn test_5147_originator_target_list_cuts_duplicate_deliveries() {
         treatment.converged,
         treatment.replicas,
         treatment.diverged,
+    );
+
+    // BEFORE-READING: the standalone-notification path currently sends nothing
+    // in this scenario, in either arm. Pinned rather than merely logged.
+    //
+    // A counter that is only printed is an unfailable check: delete the
+    // recorder and the suite stays green while `notif_sent=0` is printed
+    // forever, which reads as "this mechanism costs nothing" — the exact
+    // false-good-news failure this counter was added to prevent. Asserting the
+    // zero means the day a change starts sending notifications, this fails and
+    // someone has to look at the number. If you are that person: the number is
+    // the cost of your change on the messages/s axis. Update the assertion with
+    // it, and state it in your PR.
+    assert_eq!(
+        (control.notification_targets, treatment.notification_targets),
+        (0, 0),
+        "proactive summary notifications were sent where the before-reading is \
+         zero. That is not necessarily wrong, but it is a message-axis cost \
+         that no other counter in this struct can see — measure it and say so"
     );
 
     // PREMISE 1: the peers really became each other's advertised co-hosts. If

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -17348,7 +17348,8 @@ struct SuppressionArm {
     /// peer has an advertised co-host, so there is no mesh and nothing to
     /// suppress.
     hosting_updates: u64,
-    /// Standalone `Summaries` notifications SENT.
+    /// Standalone `Summaries` notifications ATTEMPTED (resolved recipients,
+    /// counted before the per-peer enqueue can fail).
     ///
     /// The cost axis. Every other counter here measures traffic this feature
     /// REMOVES; without this one the rig can only ever report good news. #5190's


### PR DESCRIPTION
## Problem

`GlobalTestMetrics::notification_cohosts_skipped` counts what the #4965 co-host exclusion **saves**. Nothing counted what the proactive-summary path **costs**. So the #5147 A/B rig could observe this mechanism getting cheaper and was structurally blind to it getting more expensive.

That gap has already cost real time. The #5190 fix (PR #5200) restores a standalone `Summaries` to every peer the #5147 target list suppresses. The rig measured the 13 sends it saved, and could not see the messages it added. The trade could be argued but not measured, and the argument was resolved only by adding this counter.

## Approach

Add `record_notification_targets` next to the existing skipped counter, recorded at the same site so the pair cannot drift, and surface `notif_sent` in all four A/B log lines (single-writer and multi-writer arms).

This is deliberately the twin of an existing counter rather than a new stream. The generalisable rule: **a counter for a mechanism's saving needs its twin for the mechanism's cost, or the rig can only ever return good news.**

## Testing

`test_5147_originator_target_list_cuts_duplicate_deliveries` passes unchanged on this branch, with the new field reading zero in both arms:

```
control:   sends=460 suppressed=0   summary_skips=417 notif_sent=0
treatment: sends=288 suppressed=428 summary_skips=146 notif_sent=0
```

Zero in both arms is the correct "before" reading: on main every advertised co-host is either broadcast to or excluded, so the notification path has no recipients in this scenario. That the number is zero here is exactly why it needed measuring elsewhere.

For contrast, the same test with PR #5200's fix applied reads `notif_sent=429` in the treatment arm — and that 429 is exact, not an upper bound: the 100ms-per-contract throttle collapses none of them.

No production behaviour change: `GlobalTestMetrics` is a thread-local test/simulation instrument, and the only added production statement is one increment alongside the existing one.

Refs #5147, #5190

[AI-assisted - Claude]
