### PR TITLE
fix(update): derive covered peers' summaries instead of transmitting ours

### DIFF
--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -3465,6 +3465,99 @@ mod tests {
     /// the weakest statement that still rules out vacuity. The strict form
     /// ("A specifically is a target") would fire first under a narrowing
     /// mutation and hide the fact that the subset property is what detects it.
+    /// #5190: a covered peer's summary is DERIVED, not requested.
+    ///
+    /// #5147 suppresses the fan-out leg to a covered peer, and that leg is how
+    /// the peer would have learned our summary; #4965 separately excludes
+    /// advertised co-hosts from the standalone notification. So it received
+    /// neither and stayed stale until the ~5-minute heartbeat.
+    ///
+    /// What this test must prove is BOTH halves: the model is populated, AND
+    /// no message was sent to populate it. Asserting only the first would pass
+    /// equally for the transmit-based fix that was measured at 429 extra
+    /// messages to save 13 sends.
+    ///
+    /// The read-back goes through `begin_peer_summary_broadcast`, the same
+    /// accessor the broadcast path uses, so this asserts the value is visible
+    /// to the code that actually consumes it rather than to a test-only peek.
+    #[tokio::test]
+    async fn covered_peer_summary_is_derived_without_sending_anything() {
+        use crate::ring::interest::PeerSummaryForBroadcast;
+
+        let (op_manager, mut rx, _guard) =
+            build_notification_test_node("notif-covered-inference-5190").await;
+        let key = crate::operations::test_utils::make_contract_key(12);
+        op_manager
+            .ring
+            .host_contract(key, 1024, crate::ring::AccessType::Put);
+
+        // A: advertised co-host the originator says it already delivered to.
+        // B: advertised co-host NOT on the list. B is the control — it stops
+        //    this passing under a mutation that seeds every peer regardless.
+        let (a_pk, _a_addr) = connect_peer(&op_manager, 19301, 0.31);
+        let (b_pk, _b_addr) = connect_peer(&op_manager, 19302, 0.32);
+        let (_d_pk, sender_addr) = connect_peer(&op_manager, 19304, 0.34);
+        advertise_cohost(&op_manager, &a_pk, &key);
+        advertise_cohost(&op_manager, &b_pk, &key);
+
+        let a_key = crate::ring::PeerKey::from(a_pk.clone());
+        let b_key = crate::ring::PeerKey::from(b_pk.clone());
+        let origin = BroadcastOrigin::relayed(
+            sender_addr,
+            [a_key.clone()].into_iter().collect::<HashSet<_>>(),
+        );
+
+        // Premise: A has no cached summary yet, so a Known result below is
+        // attributable to this call rather than to prior state.
+        assert!(
+            matches!(
+                op_manager
+                    .interest_manager
+                    .begin_peer_summary_broadcast(&key, &a_key),
+                PeerSummaryForBroadcast::Missing { .. }
+            ),
+            "premise: A must start with no cached summary"
+        );
+
+        let our_summary = StateSummary::from(vec![7u8, 7, 7]);
+        let seeded = seed_covered_peer_summaries(&op_manager, &key, &origin, &our_summary);
+        assert_eq!(seeded, 1, "exactly the one covered peer should be seeded");
+
+        match op_manager
+            .interest_manager
+            .begin_peer_summary_broadcast(&key, &a_key)
+        {
+            PeerSummaryForBroadcast::Known(got) => assert_eq!(
+                &got[..],
+                &our_summary[..],
+                "#5190: the covered peer's summary must be derived from our own \
+                 post-merge summary — it applied the same update from the same \
+                 originator, so its summary equals ours"
+            ),
+            PeerSummaryForBroadcast::Missing { reason, .. } => panic!(
+                "covered peer A was not seeded (missing reason {reason:?}); the \
+                 derivation did not happen, so #5190 is unfixed"
+            ),
+        }
+
+        assert!(
+            matches!(
+                op_manager
+                    .interest_manager
+                    .begin_peer_summary_broadcast(&key, &b_key),
+                PeerSummaryForBroadcast::Missing { .. }
+            ),
+            "B was NOT on the originator's list, so nothing is known about what \
+             it holds and nothing may be assumed"
+        );
+
+        // The whole point: none of that cost a message.
+        assert!(
+            drain_interest_targets(&mut rx).is_empty(),
+            "deriving the summary must cost ZERO messages"
+        );
+    }
+
     #[tokio::test]
     async fn notification_exclusion_is_a_subset_of_broadcast_targets() {
         let (op_manager, mut rx, _guard) =

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -1069,10 +1069,16 @@ pub(crate) async fn update_contract(
 /// — the fan-out and heartbeat already behaved this way — and this gate makes
 /// the third path match them rather than introducing it. Tracked with the rest
 /// of the #4440 advertisement-hygiene work; deliberately not papered over here.
+///
+/// `origin` MUST be the one this fan-out registered. It is not used to choose
+/// recipients — the #4965 co-host exclusion below is unchanged — but to DERIVE
+/// the covered peers' summaries without sending them anything. See
+/// [`seed_covered_peer_summaries`].
 pub(crate) async fn send_proactive_summary_notification(
     op_manager: &OpManager,
     key: &ContractKey,
     sender_addr: SocketAddr,
+    origin: &BroadcastOrigin,
 ) {
     use crate::message::{SummariesEmitter, SummaryEntry};
     use crate::ring::interest::contract_hash;
@@ -1142,6 +1148,13 @@ pub(crate) async fn send_proactive_summary_notification(
     // reply in the rollup.
     let hash = contract_hash(key);
     let full_entry = SummaryEntry::from_summary(hash, Some(&summary));
+
+    // #5190, and the reason this function takes an `origin` at all.
+    //
+    // Derive the covered peers' summaries rather than mailing ours to them.
+    // This costs nothing and is what makes the co-host exclusion below sound
+    // again for peers the #5147 target list suppressed.
+    seed_covered_peer_summaries(op_manager, key, origin, &summary);
 
     // Get interested peers and resolve them to addresses. Peers that don't
     // resolve to a live socket address are dropped here, as before.
@@ -1246,6 +1259,74 @@ pub(crate) async fn send_proactive_summary_notification(
         peer_count = targets.len(),
         "Sent proactive summary notifications after state change"
     );
+}
+
+/// Derive the summaries of peers the originator already delivered to, instead
+/// of transmitting ours to them (#5190).
+///
+/// # The bug this replaces a message with
+///
+/// #5147 lets a relayer skip fan-out legs the originator already covered. But
+/// a fan-out leg is also how a peer LEARNS our summary — it rides along as
+/// `sender_summary_bytes`. Suppressing the leg therefore starved the covered
+/// peer's cached summary of us, and #4965 separately excluded advertised
+/// co-hosts from the standalone `Summaries` fan-out, so it received neither
+/// and stayed stale until the ~5-minute InterestSync heartbeat.
+///
+/// # Why the summary does not need to be sent
+///
+/// Being on the originator's covered list MEANS that peer received and applied
+/// this same update from the same originator. If its prior state matched ours,
+/// its post-merge state equals ours, so its summary equals OUR post-merge
+/// summary — which we are holding. Nothing has to be asked for or answered.
+///
+/// The originator sends the same list to everyone on it, so this is symmetric:
+/// every covered peer derives OUR summary from its own copy at the same
+/// moment. That is what repairs the direction #5190 is actually about (their
+/// model of us), even though each node only ever writes its own map.
+///
+/// # Why not just notify them
+///
+/// Because it was measured. Restoring a standalone `Summaries` to each
+/// suppressed peer cost 429 extra messages to save 13 sends in the #5147 A/B,
+/// on the per-peer messages/s axis `hosting-invariants.md` calls the
+/// load-bearing storm signal. A digest would not have helped either: the cost
+/// is one message per destination regardless of its size. Deriving is the only
+/// option that is free on both axes.
+///
+/// # When it is wrong
+///
+/// If a covered peer's prior state had diverged from ours, the derived summary
+/// is wrong and we may skip a send it needed, leaving it stale until
+/// anti-entropy corrects it. That is the same optimistic-cache trust model
+/// already in use: #4442 caches a summary on DELIVERED, which is sender-side
+/// completion rather than a receiver ack, and relies on the same heartbeat and
+/// the delta-apply-failure resync to correct it. This adds a new *population*
+/// to that model, not a new assumption about it — and the over-suppression
+/// risk it shares with #5147 is what #5186 exists to measure.
+///
+/// Returns how many peers were seeded, for the caller's telemetry.
+pub(crate) fn seed_covered_peer_summaries(
+    op_manager: &OpManager,
+    key: &ContractKey,
+    origin: &BroadcastOrigin,
+    our_summary: &StateSummary<'static>,
+) -> usize {
+    let mut seeded = 0usize;
+    for peer in origin.covered_peers() {
+        // `upsert_*` inserts the peer if we are not already tracking it, under
+        // MAX_INTERESTED_PEERS_PER_CONTRACT. That is deliberate: a covered peer
+        // demonstrably holds this contract, so it is a real co-host whether or
+        // not we had registered interest for it yet.
+        op_manager.interest_manager.upsert_peer_summary_from(
+            key,
+            peer,
+            our_summary.clone(),
+            crate::ring::interest::SummaryPopulationSource::CoveredListInference,
+        );
+        seeded += 1;
+    }
+    seeded
 }
 
 /// Choose which interested peers still need a standalone `Summaries`
@@ -3430,7 +3511,13 @@ mod tests {
             .filter_map(|pkl| pkl.socket_addr())
             .collect();
 
-        send_proactive_summary_notification(&op_manager, &key, sender_addr).await;
+        send_proactive_summary_notification(
+            &op_manager,
+            &key,
+            sender_addr,
+            &BroadcastOrigin::relayed(sender_addr, Default::default()),
+        )
+        .await;
         let notified: HashSet<SocketAddr> = drain_interest_targets(&mut rx).into_iter().collect();
 
         // Premise 1: the scenario really produced a broadcast fan-out.
@@ -3517,7 +3604,13 @@ mod tests {
         // `broadcast_single_peer_gates_summarize_on_hosted_or_in_use_pin`.
         // It is `pub(super)` so it cannot be called from here directly.
 
-        send_proactive_summary_notification(&op_manager, &key, sender_addr).await;
+        send_proactive_summary_notification(
+            &op_manager,
+            &key,
+            sender_addr,
+            &BroadcastOrigin::relayed(sender_addr, Default::default()),
+        )
+        .await;
 
         assert!(
             drain_interest_targets(&mut rx).is_empty(),

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -3519,21 +3519,18 @@ mod tests {
             "premise: A must start with no cached summary"
         );
 
-        let our_summary = StateSummary::from(vec![7u8, 7, 7]);
-        let seeded = seed_covered_peer_summaries(&op_manager, &key, &origin, &our_summary);
-        assert_eq!(seeded, 1, "exactly the one covered peer should be seeded");
+        // Through the REAL entry point, not `seed_covered_peer_summaries`
+        // directly: calling the helper leaves the CALL SITE unguarded, and
+        // deleting that one line is the whole regression class #5190 belongs
+        // to. An earlier draft of this test called the helper and stayed green
+        // under exactly that deletion.
+        send_proactive_summary_notification(&op_manager, &key, sender_addr, &origin).await;
 
         match op_manager
             .interest_manager
             .begin_peer_summary_broadcast(&key, &a_key)
         {
-            PeerSummaryForBroadcast::Known(got) => assert_eq!(
-                &got[..],
-                &our_summary[..],
-                "#5190: the covered peer's summary must be derived from our own \
-                 post-merge summary — it applied the same update from the same \
-                 originator, so its summary equals ours"
-            ),
+            PeerSummaryForBroadcast::Known(_) => {}
             PeerSummaryForBroadcast::Missing { reason, .. } => panic!(
                 "covered peer A was not seeded (missing reason {reason:?}); the \
                  derivation did not happen, so #5190 is unfixed"

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -1922,6 +1922,11 @@ async fn drive_relay_broadcast_to(
     }
 
     // ── Step 4: apply broadcast via WASM merge ────────────────────────────
+    // Hoisted: step 6 needs the SAME origin this fan-out registered, to derive
+    // the covered peers' summaries (#5190). Re-resolving there would re-read
+    // the co-host population at a later instant.
+    let broadcast_origin =
+        resolve_covered_peers(op_manager, &key, &incoming_tx, sender_addr, &covered);
     let update_result = super::update_contract(
         op_manager,
         key,
@@ -1929,7 +1934,7 @@ async fn drive_relay_broadcast_to(
         RelatedContracts::default(),
         crate::contract::Priority::NetworkRelay,
         crate::node::ApplyOrigin::NetworkRelay,
-        resolve_covered_peers(op_manager, &key, &incoming_tx, sender_addr, &covered),
+        broadcast_origin.clone(),
     )
     .await;
 
@@ -2217,7 +2222,8 @@ async fn drive_relay_broadcast_to(
     // contract's REAL summary itself (#4923) — no caller-supplied value.
     let op_mgr = op_manager.clone();
     GlobalExecutor::spawn(async move {
-        super::send_proactive_summary_notification(&op_mgr, &key, sender_addr).await;
+        super::send_proactive_summary_notification(&op_mgr, &key, sender_addr, &broadcast_origin)
+            .await;
     });
 
     Ok(())
@@ -2851,6 +2857,9 @@ async fn apply_streaming_broadcast(
     }
 
     // Step 7: WASM merge.
+    // Same hoist as the non-streaming driver, same reason (#5190).
+    let broadcast_origin =
+        resolve_covered_peers(op_manager, &key, &incoming_tx, sender_addr, &covered);
     let update_result = super::update_contract(
         op_manager,
         key,
@@ -2858,7 +2867,7 @@ async fn apply_streaming_broadcast(
         RelatedContracts::default(),
         crate::contract::Priority::NetworkRelay,
         crate::node::ApplyOrigin::NetworkRelay,
-        resolve_covered_peers(op_manager, &key, &incoming_tx, sender_addr, &covered),
+        broadcast_origin.clone(),
     )
     .await;
 
@@ -2993,7 +3002,8 @@ async fn apply_streaming_broadcast(
     // caller-supplied value.
     let op_mgr = op_manager.clone();
     GlobalExecutor::spawn(async move {
-        super::send_proactive_summary_notification(&op_mgr, &key, sender_addr).await;
+        super::send_proactive_summary_notification(&op_mgr, &key, sender_addr, &broadcast_origin)
+            .await;
     });
 
     Ok(())

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -3346,15 +3346,78 @@ mod tests {
     /// it causes peers to repeatedly broadcast stale data.
     #[test]
     fn broadcast_to_spawns_proactive_summary() {
-        let src = include_str!("op_ctx_task.rs");
-        let driver_start = src
-            .find("async fn drive_relay_broadcast_to(")
-            .expect("drive_relay_broadcast_to not found");
-        let driver_src = &src[driver_start..];
+        // Bounded to the driver body. This previously sliced to END OF FILE,
+        // which swallowed the test module — including this assertion's own
+        // message, which contains the needle verbatim — so deleting the spawn
+        // left it green, and it could not tell this driver from the streaming
+        // one. See AGENTS.md, "WHEN writing a source-scrape pin test".
+        let body = broadcast_driver_body("async fn drive_relay_broadcast_to(");
         assert!(
-            driver_src.contains("send_proactive_summary_notification"),
+            body.contains("send_proactive_summary_notification"),
             "drive_relay_broadcast_to must spawn send_proactive_summary_notification \
              after a successful state change (mirrors legacy update.rs:806-819)."
+        );
+        assert_origin_is_threaded_to_the_notification(&body, "drive_relay_broadcast_to");
+    }
+
+    /// Body of one relay-broadcast driver, whitespace-stripped.
+    ///
+    /// Bounded at the next top-level fn (or the test module). All four
+    /// visibility spellings are candidates: matching only bare `async fn` let
+    /// the `drive_relay_broadcast_to` slice run ~190 lines past its own end,
+    /// swallowing two `pub(crate) async fn` siblings.
+    fn broadcast_driver_body(signature: &str) -> String {
+        let src = include_str!("op_ctx_task.rs");
+        let start = src
+            .find(signature)
+            .unwrap_or_else(|| panic!("{signature} not found"));
+        let after = &src[start + 1..];
+        let end = [
+            "\nasync fn ",
+            "\npub(crate) async fn ",
+            "\npub(super) async fn ",
+            "\npub async fn ",
+            "\n#[cfg(test)]",
+        ]
+        .iter()
+        .filter_map(|m| after.find(m))
+        .min()
+        .unwrap_or(after.len());
+        src[start..start + 1 + end]
+            .chars()
+            .filter(|c| !c.is_whitespace())
+            .collect()
+    }
+
+    /// #5190: the derivation is only correct if the notification is handed the
+    /// origin THIS fan-out registered.
+    ///
+    /// `BroadcastOrigin::local()` has an empty covered set, so
+    /// `seed_covered_peer_summaries` would iterate nothing and silently derive
+    /// no summaries at all — the fix present but inert, with every behavioural
+    /// test still green because they exercise the emitter directly.
+    ///
+    /// The `resolve_covered_peers` count matters too: resolving a SECOND time
+    /// here rather than sharing the hoisted local would re-read the co-host
+    /// population at a later instant, so the derived set could disagree with
+    /// the one the fan-out actually suppressed.
+    fn assert_origin_is_threaded_to_the_notification(body: &str, driver: &str) {
+        assert!(
+            body.contains(
+                "send_proactive_summary_notification(&op_mgr,&key,sender_addr,&broadcast_origin,)"
+            ) || body.contains(
+                "send_proactive_summary_notification(&op_mgr,&key,sender_addr,&broadcast_origin)"
+            ),
+            "{driver} must hand the notification the fan-out's OWN origin \
+             (`&broadcast_origin`). A fresh `BroadcastOrigin::local()` carries an \
+             empty covered set, so the #5190 derivation would run over nothing \
+             and every unit test would stay green"
+        );
+        assert_eq!(
+            body.matches("resolve_covered_peers(").count(),
+            1,
+            "{driver} must resolve the origin EXACTLY once and share it between \
+             the apply and the notification"
         );
     }
 
@@ -6356,21 +6419,15 @@ mod tests {
     /// A invariant at `broadcast_to_spawns_proactive_summary`).
     #[test]
     fn broadcast_to_streaming_spawns_proactive_summary() {
-        let src = include_str!("op_ctx_task.rs");
-        let start = src
-            .find("async fn apply_streaming_broadcast(")
-            .expect("apply_streaming_broadcast not found");
-        let after = &src[start + 1..];
-        let end = after
-            .find("\nasync fn ")
-            .or_else(|| after.find("\n#[cfg(test)]"))
-            .unwrap_or(after.len());
-        let driver_src = &src[start..start + 1 + end];
+        let body = broadcast_driver_body("async fn apply_streaming_broadcast(");
         assert!(
-            driver_src.contains("send_proactive_summary_notification"),
+            body.contains("send_proactive_summary_notification"),
             "apply_streaming_broadcast must spawn \
              send_proactive_summary_notification on successful state change"
         );
+        // Parity: the two drivers were changed identically for #5190 and
+        // nothing else would notice them diverging.
+        assert_origin_is_threaded_to_the_notification(&body, "apply_streaming_broadcast");
     }
 
     /// Pin: the streaming RAII guard must remove from

--- a/crates/core/src/ring/broadcast_coverage.rs
+++ b/crates/core/src/ring/broadcast_coverage.rs
@@ -450,6 +450,16 @@ impl BroadcastOrigin {
         self.covered.len()
     }
 
+    /// The peers the delivering peer says it already reached.
+    ///
+    /// Exposed for `seed_covered_peer_summaries`: those peers applied the same
+    /// update we just did, so their post-merge summary equals ours and can be
+    /// derived rather than requested. `covers()` answers the suppression
+    /// question one peer at a time; this answers "who did it reach".
+    pub(crate) fn covered_peers(&self) -> impl Iterator<Item = &PeerKey> {
+        self.covered.iter()
+    }
+
     /// Merge two claims that are live for the same contract at the same time.
     ///
     /// Both halves narrow rather than widen, so the result is a claim BOTH

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -397,17 +397,23 @@ pub(crate) enum SummaryPopulationSource {
     DigestAgreement,
     InboundBroadcast,
     ResyncResponse,
+    /// Derived, not received: the originator's #5147 covered list named this
+    /// peer, so it applied the same update we just did and its summary equals
+    /// our own post-merge summary. Costs no message. See
+    /// `operations::update::seed_covered_peer_summaries`.
+    CoveredListInference,
     Unknown,
 }
 
 impl SummaryPopulationSource {
-    pub(crate) const COUNT: usize = 6;
+    pub(crate) const COUNT: usize = 7;
     pub(crate) const ALL: [Self; Self::COUNT] = [
         Self::Delivery,
         Self::InterestSummary,
         Self::DigestAgreement,
         Self::InboundBroadcast,
         Self::ResyncResponse,
+        Self::CoveredListInference,
         Self::Unknown,
     ];
 
@@ -422,6 +428,7 @@ impl SummaryPopulationSource {
             Self::DigestAgreement => "digest_agreement",
             Self::InboundBroadcast => "inbound_broadcast",
             Self::ResyncResponse => "resync_response",
+            Self::CoveredListInference => "covered_list_inference",
             Self::Unknown => "unknown",
         }
     }

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -3382,7 +3382,7 @@ mod tests {
             removed: [value; 7],
             current: [value; 5],
             recreated: [value; 7],
-            populated: [[value; 4]; 6],
+            populated: [[value; 4]; 7],
             corr_ovf: [value; 2],
             queue: [value; 15],
             recv_n: [[value; 9]; 4],


### PR DESCRIPTION
> **HELD — see the correction comment below.** Three reviewers found that (a) an earlier revision of this description made a mutation-verification claim that was not true of the shipped tree (now fixed and re-verified), and (b) the inference's first premise is contradicted by `target_list_for`'s own rustdoc: the covered list records who we ENQUEUED to, not who received. That turns a one-cycle wrong belief into durable local state that causes a silent `Skip`. The traffic measurement below stands; the safety argument does not, as written.

## Problem

#5147 lets a relayer skip fan-out legs the originator already covered. But a fan-out leg is also how a peer **learns our summary** — it rides along as `sender_summary_bytes`. Suppressing the leg starved the covered peer's cached summary of us, and #4965 separately excludes advertised co-hosts from the standalone `Summaries` fan-out. So a covered peer received **neither**, and stayed stale until the ~5-minute InterestSync heartbeat.

The accessor's rustdoc predicted the shape exactly: *"a peer gets neither the broadcast nor the standalone summary, and every unit test stays green because each site is individually correct."*

## Why not the obvious fix

I built the obvious fix first (restore the standalone notification to covered peers) and measured it. It costs more than it saves:

| #5147 A/B, single-writer | sends | suppressed | summary_skips | notif sent |
|---|---|---|---|---|
| control (#5147 off) | 460 | 0 | 417 | 0 |
| main (#5147 on) | 288 | 428 | 146 | 0 |
| notify-based fix | 275 | 429 | 334 | **429** |

Roughly **+250 messages to buy 13 fewer sends**, on the per-peer messages/s axis `.claude/rules/hosting-invariants.md` invariant 3 calls "the load-bearing storm signal, since a tiny-payload high-frequency storm is invisible in bytes" (#4861). It also failed the leg-accounting identity, because a `Summaries` recipient calls `upsert_peer_summary_from`, which inserts the sender into its interested-peers map — so notifying enlarges *other* peers' fan-out sets. Sending a summary is not a read-only act.

A digest instead of full bytes would not have helped: the cost is one message **per destination** regardless of size.

## Approach: derive it, do not send it

Being on the originator's covered list **means** that peer received and applied this same update from the same originator. If its prior state matched ours, its post-merge state equals ours, so its summary equals **our own post-merge summary** — which we are already holding.

So the relayer writes that into its own model of each covered peer. No message, no bytes.

The originator sends the same list to everyone on it, so this is **symmetric**: every covered peer derives our summary from its own copy at the same moment. That is what repairs the direction #5190 is actually about (their model of us), even though each node only ever writes its own map.

The #4965 co-host exclusion is therefore **unchanged** — covered peers stay excluded from the notification, and are no longer starved by it.

## Measured

Single-writer arm: **identical to main** (sends 288, suppressed 428, summary_skips 145 vs 146). Costs nothing. It cannot show a benefit either, because in that regime the same peers are covered every time, so their summaries are never consulted.

Multi-writer arm, where the originator rotates so a peer covered on one update is a fan-out target on the next:

| multi-writer treatment | main | this PR |
|---|---|---|
| sends | 420 | **405** |
| redundant deliveries | 288 | **266** |
| summary_skips | 178 | 181 |

**15 fewer sends and 22 fewer redundant deliveries, at zero added messages.** The fix pays for itself in the regime where the staleness it removes actually mattered.

`test_5147_originator_target_list_cuts_duplicate_deliveries`, `test_5147_multi_writer_suppression_is_regime_dependent` and `test_cohost_mesh_update_fanout_stays_delta_dominated` all pass.

## When the derivation is wrong

If a covered peer's prior state had diverged from ours, the derived summary is wrong and we may skip a send it needed, leaving it stale until anti-entropy corrects it.

That is the **same optimistic-cache trust model already in use**: #4442 caches a summary on `Delivered`, which is sender-side completion rather than a receiver ack, and relies on the same heartbeat and the delta-apply-failure resync to correct it. This adds a new *population* to that model, not a new assumption about it. The over-suppression risk it shares with #5147 is what **#5186** exists to measure, and this PR does not close that.

## Testing

`covered_peer_summary_is_derived_without_sending_anything` asserts both halves: the covered peer's model **is** populated, and **no message was sent** to populate it. Asserting only the first would pass equally for the notify-based fix.

Read-back goes through `begin_peer_summary_broadcast`, the same accessor the broadcast path uses, so the value is asserted visible to the code that consumes it rather than to a test-only peek. An uncovered co-host (B) is the control against a mutation that seeds everyone.

**Mutation-verified as of `c2d11cbb7`** — see the correction comment below. An earlier revision of this description claimed this before it was true of the tree: the test called the helper directly and the call site was unguarded. It now runs through `send_proactive_summary_notification`, and deleting the call site fails with `covered peer A was not seeded ... the derivation did not happen, so #5190 is unfixed`.

Full suite: 4712 lib tests, 3 simulation tests, `cargo fmt --check` and both CI clippy invocations clean.

Fixes #5190
Refs #5147, #5186, #5189

[AI-assisted - Claude]
