### PR TITLE
fix(config): default the client API to loopback in both operation modes

### DIFF
--- a/crates/core/src/bin/freenet.rs
+++ b/crates/core/src/bin/freenet.rs
@@ -1058,6 +1058,12 @@ fn run_node(config_args: ConfigArgs) -> anyhow::Result<()> {
     rt.block_on(async move {
         let config = config_args.build().await?;
         freenet::config::set_logger(None, None, config.paths().log_dir());
+        // Same reason as the info! below: `ConfigArgs::build()` resolves the
+        // client API's bind address, but it runs with no subscriber installed,
+        // so it records the decision instead of logging it. Replay it here —
+        // this is the only place an operator learns that their node stopped
+        // answering clients on other machines, and why.
+        config.log_client_api_exposure();
         // The logger is needed before this info which is why it's here instead of above
         tracing::info!(
             max_blocking_threads,
@@ -1070,6 +1076,34 @@ fn run_node(config_args: ConfigArgs) -> anyhow::Result<()> {
     })?;
 
     Ok(())
+}
+
+/// Carry the client-API exposure flags across the subcommand boundary.
+///
+/// `--ws-api-address` / `--allowed-host` / `--allowed-source-cidrs` placed
+/// BEFORE the subcommand (`freenet --ws-api-address :: network`) land in the
+/// top-level `ConfigArgs`, which the `Network`/`Local` arms otherwise discard —
+/// the same trap `--disable-auto-update` hit in #4690.
+///
+/// This matters more since the client API started defaulting to loopback
+/// (GHSA-824h-7x5x-wfmf): these three flags are exactly how an operator asks
+/// for a wider bind, so silently dropping one leaves the node loopback-only
+/// while the operator believes they opted out. Previously the same typo was
+/// harmless, because network mode bound `::` either way.
+///
+/// The subcommand's own value wins; the top-level one only fills a gap.
+fn merge_pre_subcommand_ws_api_args(config: &mut ConfigArgs, top_level: &ConfigArgs) {
+    config.ws_api.address = config.ws_api.address.or(top_level.ws_api.address);
+    config.ws_api.allowed_host = config
+        .ws_api
+        .allowed_host
+        .take()
+        .or_else(|| top_level.ws_api.allowed_host.clone());
+    config.ws_api.allowed_source_cidrs = config
+        .ws_api
+        .allowed_source_cidrs
+        .take()
+        .or_else(|| top_level.ws_api.allowed_source_cidrs.clone());
 }
 
 fn freenet_main() -> anyhow::Result<()> {
@@ -1111,11 +1145,13 @@ fn freenet_main() -> anyhow::Result<()> {
             // opt-out leaves the from-source node auto-updating (the exact loop
             // we are preventing).
             config.disable_auto_update |= cli.config.disable_auto_update;
+            merge_pre_subcommand_ws_api_args(&mut config, &cli.config);
             run_node(config)
         }
         Some(Command::Local { mut config }) => {
             config.mode = Some(OperationMode::Local);
             config.disable_auto_update |= cli.config.disable_auto_update;
+            merge_pre_subcommand_ws_api_args(&mut config, &cli.config);
             run_node(config)
         }
         None => {
@@ -1340,6 +1376,82 @@ mod tests {
                 "flag must be honored in either position: {argv:?}"
             );
         }
+    }
+
+    /// Same trap, for the flags that now decide the client API's bind: placed
+    /// before the subcommand they land in the top-level `ConfigArgs`, which the
+    /// `Network`/`Local` arms discard. Dropping one leaves the node
+    /// loopback-only while the operator believes they widened it.
+    #[test]
+    fn ws_api_exposure_flags_are_honored_before_the_subcommand() {
+        use super::{Cli, Command, merge_pre_subcommand_ws_api_args};
+        use clap::Parser;
+        for argv in [
+            vec![
+                "freenet",
+                "--ws-api-address",
+                "::",
+                "--allowed-host",
+                "node.example",
+                "--allowed-source-cidrs",
+                "100.64.0.0/10",
+                "network",
+            ],
+            vec![
+                "freenet",
+                "network",
+                "--ws-api-address",
+                "::",
+                "--allowed-host",
+                "node.example",
+                "--allowed-source-cidrs",
+                "100.64.0.0/10",
+            ],
+        ] {
+            let cli = Cli::try_parse_from(&argv).expect("parse");
+            let mut config = match cli.command {
+                Some(Command::Network { config }) => config,
+                _ => panic!("expected network subcommand"),
+            };
+            merge_pre_subcommand_ws_api_args(&mut config, &cli.config);
+            assert_eq!(
+                config.ws_api.address,
+                Some("::".parse().unwrap()),
+                "--ws-api-address must survive in either position: {argv:?}"
+            );
+            assert_eq!(
+                config.ws_api.allowed_host.as_deref(),
+                Some(&["node.example".to_string()][..]),
+                "--allowed-host must survive in either position: {argv:?}"
+            );
+            assert_eq!(
+                config.ws_api.allowed_source_cidrs.as_deref(),
+                Some(&["100.64.0.0/10".to_string()][..]),
+                "--allowed-source-cidrs must survive in either position: {argv:?}"
+            );
+        }
+    }
+
+    /// The subcommand's own value wins; the top-level one only fills a gap.
+    #[test]
+    fn subcommand_ws_api_address_beats_the_pre_subcommand_one() {
+        use super::{Cli, Command, merge_pre_subcommand_ws_api_args};
+        use clap::Parser;
+        let cli = Cli::try_parse_from([
+            "freenet",
+            "--ws-api-address",
+            "::",
+            "network",
+            "--ws-api-address",
+            "127.0.0.1",
+        ])
+        .expect("parse");
+        let mut config = match cli.command {
+            Some(Command::Network { config }) => config,
+            _ => panic!("expected network subcommand"),
+        };
+        merge_pre_subcommand_ws_api_args(&mut config, &cli.config);
+        assert_eq!(config.ws_api.address, Some("127.0.0.1".parse().unwrap()));
     }
 
     #[test]

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -1271,8 +1271,13 @@ impl ConfigArgs {
         // reports it after the subscriber exists. See `WsApiExposure`.
         let ws_api_exposure = WsApiExposure {
             source: ws_api_address_source,
+            // Report the discard ONLY when the bind actually got narrower.
+            // A node whose persisted `::1` is dropped and then auto-widened to
+            // `::` is getting MORE exposed, so "clients on other machines can
+            // no longer reach this node" would be flatly untrue — and would
+            // print directly above the auto-widen line saying the opposite.
             dropped_persisted_address: dropped_persisted_wildcard
-                .filter(|persisted| *persisted != ws_api_address),
+                .filter(|persisted| !persisted.is_loopback() && ws_api_address.is_loopback()),
         };
         let this = Config {
             mode,
@@ -9679,6 +9684,24 @@ shutdown-drain-secs = 42
         assert_eq!(
             migrated.ws_api.exposure.source,
             WsApiAddressSource::DefaultLoopback
+        );
+
+        // Boot 3 in the same dir: the operator adds a CIDR grant, so the
+        // persisted `::1` is dropped and immediately auto-widened back to `::`.
+        // The bind got WIDER, so the "clients on other machines can no longer
+        // reach this node" notice must NOT fire — it would print directly above
+        // the auto-widen line and say the opposite of it.
+        let mut widened_later = ws_api_test_args(OperationMode::Network, upgrade_dir.path());
+        widened_later.ws_api.allowed_source_cidrs = Some(vec!["100.64.0.0/10".to_string()]);
+        let cfg = widened_later
+            .build_with_gateways_index(&index_url)
+            .await
+            .expect("third build should succeed");
+        assert_eq!(cfg.ws_api.address, default_listening_address());
+        assert_eq!(cfg.ws_api.exposure.source, WsApiAddressSource::AutoWidened);
+        assert_eq!(
+            cfg.ws_api.exposure.dropped_persisted_address, None,
+            "a widening re-derivation must not report itself as a loss of access"
         );
     }
 

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -3119,7 +3119,7 @@ const fn default_local_address() -> IpAddr {
 /// See [`WsApiExposure`].
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum WsApiAddressSource {
-    /// The operator named an address (`--ws-api-address`, `WS_API_ADDRESS`, or
+    /// The operator named an address (`--ws-api-address`, `FREENET_WS_API_ADDRESS`, or
     /// a `ws-api-address` key in `config.toml` that this code could not itself
     /// have written). Used verbatim.
     ///
@@ -3151,8 +3151,14 @@ pub struct WsApiExposure {
     /// How the bind address was chosen.
     pub source: WsApiAddressSource,
     /// A `ws-api-address` this code could itself have auto-written, discarded
-    /// from `config.toml` during the merge so it could be re-derived. `Some`
-    /// only when the operator supplied no address by flag or env.
+    /// from `config.toml` during the merge so it could be re-derived.
+    ///
+    /// `Some` only when the operator supplied no address by flag or env AND the
+    /// re-derivation actually MOVED the bind. A value that re-derives to itself
+    /// — the steady state from the second boot onward — is not recorded, because
+    /// re-announcing an unchanged bind every boot is how a log line gets tuned
+    /// out. Which direction it moved selects the message; see
+    /// `Config::log_client_api_exposure`.
     pub dropped_persisted_address: Option<IpAddr>,
 }
 
@@ -3302,7 +3308,8 @@ fn resolve_ws_api_address(
 /// current state rather than a structural guarantee. Making this branch fire
 /// only when the shared namespace actually holds something needs a probe of the
 /// secrets tree, which is a separate change with its own failure modes — it is
-/// tracked separately rather than bolted onto a default-hardening PR, because a
+/// tracked in advisory GHSA-824h-7x5x-wfmf §8, with the measured tree shape and
+/// the requirements, rather than bolted onto a default-hardening PR, because a
 /// probe that is wrong in either direction is worse than no warning: too eager
 /// and it fires on every boot of the flagship and trains operators to ignore the
 /// one signal there is.
@@ -9495,7 +9502,7 @@ shutdown-drain-secs = 42
         }
     }
 
-    /// `ALLOWED_HOST=` declared with no value — routine in a docker-compose
+    /// `FREENET_ALLOWED_HOST=` declared with no value — routine in a docker-compose
     /// `.env`, a k8s ConfigMap, or a systemd `Environment=` line — parses as
     /// `Some(vec![""])`. Reading that as intent would widen the bind on a node
     /// whose operator granted nothing.
@@ -9588,7 +9595,9 @@ shutdown-drain-secs = 42
         }
     }
 
-    /// The exposure warning fires on hosted-mode-off AND (non-loopback bind OR
+    /// The exposure warning fires on a non-loopback bind REGARDLESS of hosted
+    /// mode (an untokened connection reaches the shared namespace either way),
+    /// and additionally on (non-loopback bind OR
     /// an `--allowed-host` reverse-proxy grant). Both triggers matter: a proxy
     /// terminates the connection itself, so every visitor looks local to the
     /// node's own source-IP filters even when the bind is `127.0.0.1`.
@@ -10030,6 +10039,38 @@ shutdown-drain-secs = 42
             report.contains("tracing::warn!"),
             "log_client_api_exposure no longer warns about a shared-namespace exposure"
         );
+
+        // A re-derivation that MOVED the bind is reported in whichever direction
+        // it moved, and both branches must survive. The record-site filter is
+        // pinned above, so re-applying the old "suppress the contradiction" fix
+        // there fails — but deleting the widening `else` here achieves the same
+        // silence and is invisible to every behavioural test, because nothing
+        // asserts on emitted logs. That is the cannot-fail shape this function's
+        // own comment block warns about, so pin the selection by its message
+        // stems.
+        for (stem, direction) in [
+            ("can no longer reach this node's API", "narrowing"),
+            ("widened the bind", "widening"),
+        ] {
+            assert!(
+                report.contains(stem),
+                "log_client_api_exposure no longer reports the {direction} \
+                 re-derivation. Both directions must speak: silencing one is how \
+                 a node that got MORE exposed stopped saying so."
+            );
+        }
+
+        // Each renamed environment variable must keep its deprecation notice.
+        // Dropping a pair from the array is silent: the operator's old-style
+        // variable is then ignored with no explanation, which is exactly the
+        // failure the loop exists to prevent.
+        for legacy in ["WS_API_ADDRESS", "ALLOWED_HOST", "ALLOWED_SOURCE_CIDRS"] {
+            assert!(
+                report.contains(&format!("(\"{legacy}\", \"FREENET_{legacy}\")")),
+                "log_client_api_exposure no longer reports a leftover `{legacy}`; a \
+                 deployment relying on it goes loopback-only with no explanation"
+            );
+        }
 
         // The mode-keyed DEFAULT must not come back. Pin it on the resolver's
         // signature rather than on a text search of `build()`: `mode` is a

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -733,16 +733,14 @@ impl ConfigArgs {
             // wildcard bind forever — the hardening would reach fresh installs
             // only, which is no hardening at all.
             //
-            // The sentinel is "wildcard", not one literal: the auto-default was
-            // `0.0.0.0` before #3648 and `::` after, and both are exactly the
-            // "any interface" bind this change exists to stop defaulting to. So
-            // an unspecified persisted address is treated as auto-written: skip
-            // the merge and let the resolution below re-derive — loopback, or
-            // the wildcard again if --allowed-source-cidrs / --allowed-host
-            // says the operator wants non-local clients. Any OTHER persisted
-            // value (a specific interface IP, `127.0.0.1`, `::1`) was never
-            // auto-written, so it is an explicit choice and is preserved
-            // unchanged.
+            // The sentinel is "a value this code could have written itself"
+            // (`is_auto_derivable_ws_api_address`), which is why it includes
+            // the loopback default and not just the wildcards: persisting the
+            // post-migration `::1` and then reading it back as an operator
+            // choice would permanently disable the auto-widen remedy the
+            // release note points people at. Any OTHER persisted value
+            // (`127.0.0.1`, a specific interface IP) this code never writes on
+            // its own, so it is an explicit choice and is preserved unchanged.
             //
             // CLI/env values are parsed into `self` BEFORE this merge, so
             // `--ws-api-address ::` still wins on every boot. Accepted,
@@ -750,7 +748,7 @@ impl ConfigArgs {
             // into config.toml with no CLI flag and no allow-list is
             // indistinguishable from the old auto-default and gets re-derived
             // to loopback. The remedy is one flag.
-            if !cfg.ws_api.address.is_unspecified() {
+            if !is_auto_derivable_ws_api_address(cfg.ws_api.address) {
                 self.ws_api.address.get_or_insert(cfg.ws_api.address);
             } else if self.ws_api.address.is_none() {
                 // Only note it if the re-derivation actually CHANGES the bind.
@@ -1263,48 +1261,19 @@ impl ConfigArgs {
         let ws_api_allowed_hosts = self.ws_api.allowed_host.clone().unwrap_or_default();
         let ws_api_hosted_mode = self.ws_api.hosted_mode.unwrap_or(false);
         let (ws_api_address, ws_api_address_source) = resolve_ws_api_address(
+            mode,
             self.ws_api.address,
             self.ws_api.allowed_source_cidrs.as_deref(),
             self.ws_api.allowed_host.as_deref(),
         );
-        if let Some(persisted) = dropped_persisted_wildcard {
-            if ws_api_address != persisted {
-                tracing::info!(
-                    %persisted,
-                    resolved = %ws_api_address,
-                    "The client API now defaults to loopback, so the wildcard \
-                     `ws-api-address` previously auto-written to config.toml is being \
-                     re-derived. Clients on OTHER machines will no longer be able to \
-                     reach this node's API. Pass --ws-api-address :: (or set \
-                     --allowed-source-cidrs / --allowed-host) if they should."
-                );
-            }
-        }
-        if ws_api_address_source == WsApiAddressSource::AutoWidened {
-            tracing::info!(
-                address = %ws_api_address,
-                "Client API bound to all interfaces because --allowed-source-cidrs \
-                 and/or --allowed-host was set (those flags are no-ops on a loopback \
-                 listener). The default is loopback only; pass --ws-api-address \
-                 explicitly to override this."
-            );
-        }
-        if let Some(reason) = ws_api_shares_one_namespace_with_remote_clients(
-            ws_api_hosted_mode,
-            ws_api_address,
-            &ws_api_allowed_hosts,
-        ) {
-            tracing::warn!(
-                address = %ws_api_address,
-                allowed_hosts = ?ws_api_allowed_hosts,
-                "Client API is reachable from outside this machine while hosted mode is \
-                 OFF, so every connection shares ONE delegate-secret namespace and can \
-                 read and modify this node's contract state, identities and keys: \
-                 {reason}. Bind loopback (--ws-api-address ::1) unless you intend this, \
-                 or enable --hosted-mode for per-user isolation."
-            );
-        }
-
+        // Recorded, NOT logged: `build()` runs before `set_logger`, so anything
+        // emitted here has no subscriber. `Config::log_client_api_exposure()`
+        // reports it after the subscriber exists. See `WsApiExposure`.
+        let ws_api_exposure = WsApiExposure {
+            source: ws_api_address_source,
+            dropped_persisted_address: dropped_persisted_wildcard
+                .filter(|persisted| *persisted != ws_api_address),
+        };
         let this = Config {
             mode,
             peer_id,
@@ -1416,6 +1385,9 @@ impl ConfigArgs {
                 // Runtime-only: resolve the unpacked-webapp cache so the HTTP
                 // layer knows which directory its LRU sweep may delete from.
                 webapp_cache_dir: default_webapp_cache_dir(),
+                // Runtime-only: this boot's exposure decision, replayed by
+                // `Config::log_client_api_exposure()` once logging exists.
+                exposure: ws_api_exposure,
             },
             secrets,
             log_level: self.log_level.unwrap_or(tracing::log::LevelFilter::Info),
@@ -1844,6 +1816,59 @@ impl Config {
 
     pub fn paths(&self) -> Arc<ConfigPaths> {
         self.config_paths.clone()
+    }
+
+    /// Report how the client (HTTP/WebSocket) API's exposure was decided.
+    ///
+    /// **Call this AFTER [`set_logger`].** These messages cannot live in
+    /// `ConfigArgs::build()`, which runs before the global tracing subscriber
+    /// is installed: emitted there they would be silently dropped, and the
+    /// operator whose LAN clients just stopped connecting would get no
+    /// explanation at all. `build()` records the decision on
+    /// [`WebsocketApiConfig::exposure`] and this replays it.
+    ///
+    /// Three independent things get reported, in the order an operator needs
+    /// them: what changed for this node, why the bind is wide if it is, and
+    /// whether the resulting exposure is dangerous.
+    pub fn log_client_api_exposure(&self) {
+        let address = self.ws_api.address;
+        if let Some(persisted) = self.ws_api.exposure.dropped_persisted_address {
+            tracing::info!(
+                %persisted,
+                resolved = %address,
+                "The client API now defaults to loopback, so the `ws-api-address` \
+                 previously auto-written to config.toml has been re-derived. Clients \
+                 on OTHER machines can no longer reach this node's API. Add \
+                 --ws-api-address :: to this node's invocation (or set \
+                 --allowed-source-cidrs / --allowed-host) if they should — a value \
+                 only persisted in config.toml is not enough, because this code \
+                 cannot tell its own past output from your choice."
+            );
+        }
+        if self.ws_api.exposure.source == WsApiAddressSource::AutoWidened {
+            tracing::info!(
+                %address,
+                "Client API bound to all interfaces because --allowed-source-cidrs \
+                 and/or --allowed-host is set, preserving an invocation that relied on \
+                 the old network-mode default. The default is now loopback; pass \
+                 --ws-api-address explicitly to override this either way."
+            );
+        }
+        if let Some(reason) = ws_api_shares_one_namespace_with_remote_clients(
+            self.ws_api.hosted_mode,
+            address,
+            &self.ws_api.allowed_hosts,
+        ) {
+            tracing::warn!(
+                %address,
+                allowed_hosts = ?self.ws_api.allowed_hosts,
+                hosted_mode = self.ws_api.hosted_mode,
+                "Client API exposure: {reason}. A connection that presents no per-user \
+                 token drives this node's SHARED namespace and can read and modify its \
+                 contract state, identities and keys. Bind loopback \
+                 (--ws-api-address ::1) unless you intend this."
+            );
+        }
     }
 }
 
@@ -2695,7 +2720,12 @@ impl Default for TelemetryConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WebsocketApiConfig {
     /// Address to bind to
-    #[serde(default = "default_listening_address", rename = "ws-api-address")]
+    /// The serde fallback is LOOPBACK, matching `resolve_ws_api_address`: a
+    /// `WebsocketApiConfig` deserialized outside `ConfigArgs::build()` must not
+    /// land on a wildcard listener just because the key was absent
+    /// (GHSA-824h-7x5x-wfmf). Inside `build()` either value is re-derived
+    /// anyway — both are `is_auto_derivable_ws_api_address`.
+    #[serde(default = "default_local_address", rename = "ws-api-address")]
     pub address: IpAddr,
 
     /// Port to expose api on
@@ -2775,6 +2805,16 @@ pub struct WebsocketApiConfig {
     /// has no secrets tree to mark.
     #[serde(skip)]
     pub secrets_dir: std::path::PathBuf,
+
+    /// How this boot decided the client API's exposure. RUNTIME-ONLY
+    /// (`#[serde(skip)]`, same reason as `secrets_dir` above): it describes a
+    /// resolution, not operator-authored TOML.
+    ///
+    /// Populated by `ConfigArgs::build()` and reported by
+    /// [`Config::log_client_api_exposure`]. It is carried rather than logged
+    /// in place because `build()` runs before the tracing subscriber exists.
+    #[serde(skip)]
+    pub exposure: WsApiExposure,
 
     /// Directory holding unpacked web-contract bundles, derived in `build()`
     /// (see [`default_webapp_cache_dir`]). Runtime-only for the same reason as
@@ -2926,6 +2966,7 @@ impl From<SocketAddr> for WebsocketApiConfig {
             per_user_export_min_interval_secs: default_per_user_export_min_interval_secs(),
             secrets_dir: std::path::PathBuf::new(),
             webapp_cache_dir: default_webapp_cache_dir(),
+            exposure: WsApiExposure::default(),
         }
     }
 }
@@ -2950,6 +2991,7 @@ impl Default for WebsocketApiConfig {
             per_user_export_min_interval_secs: default_per_user_export_min_interval_secs(),
             secrets_dir: std::path::PathBuf::new(),
             webapp_cache_dir: default_webapp_cache_dir(),
+            exposure: WsApiExposure::default(),
         }
     }
 }
@@ -2967,21 +3009,79 @@ const fn default_local_address() -> IpAddr {
 
 /// How [`resolve_ws_api_address`] arrived at the client-API bind address.
 ///
-/// Carried out of the pure resolver so `build()` can log the auto-widen at
-/// INFO without the resolver itself needing a tracing dependency (and so the
-/// unit tests can assert on the decision rather than only its byte value).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum WsApiAddressSource {
+/// Carried on the resolved [`WebsocketApiConfig`] rather than logged inline,
+/// because `build()` runs BEFORE the global tracing subscriber is installed.
+/// See [`WsApiExposure`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum WsApiAddressSource {
     /// The operator named an address (`--ws-api-address`, `WS_API_ADDRESS`, or
-    /// a `ws-api-address` key in `config.toml`). Used verbatim.
+    /// a `ws-api-address` key in `config.toml` that this code could not itself
+    /// have written). Used verbatim.
+    ///
+    /// The default for a `WebsocketApiConfig` composed directly (tests, the
+    /// standalone server paths): such a caller always names its own address.
+    #[default]
     Explicit,
-    /// No address given, and no LAN/overlay access was configured either:
-    /// loopback (`::1`, plus its `127.0.0.1` companion bind).
+    /// No address given and nothing configured that only makes sense for a
+    /// non-local listener: loopback (`::1`, plus its `127.0.0.1` companion).
     DefaultLoopback,
-    /// No address given, but `--allowed-source-cidrs` and/or `--allowed-host`
-    /// was — flags that only mean anything for a non-loopback listener. Widened
-    /// to the wildcard `::` so those invocations keep working unchanged.
+    /// No address given, but in NETWORK mode with `--allowed-source-cidrs`
+    /// and/or `--allowed-host` set. Widened to the wildcard `::` so
+    /// invocations that were relying on the old network-mode default keep
+    /// working untouched.
     AutoWidened,
+}
+
+/// How this boot decided the client API's exposure, for reporting once logging
+/// exists. RUNTIME-ONLY (`#[serde(skip)]`, like `WebsocketApiConfig::secrets_dir`):
+/// it describes this boot's resolution, not operator-authored TOML.
+///
+/// This exists because `ConfigArgs::build()` runs BEFORE
+/// [`set_logger`] installs the global subscriber (see `bin/freenet.rs`), so a
+/// `tracing::warn!` inside `build()` is emitted with no subscriber and goes
+/// nowhere. [`Config::log_client_api_exposure`] replays the decision after the
+/// subscriber exists. Do NOT move these messages back into `build()`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct WsApiExposure {
+    /// How the bind address was chosen.
+    pub source: WsApiAddressSource,
+    /// A `ws-api-address` this code could itself have auto-written, discarded
+    /// from `config.toml` during the merge so it could be re-derived. `Some`
+    /// only when the operator supplied no address by flag or env.
+    pub dropped_persisted_address: Option<IpAddr>,
+}
+
+/// True for any address [`resolve_ws_api_address`] could itself have produced,
+/// in this release or an earlier one.
+///
+/// This is the migration sentinel. `build()` persists the RESOLVED config, so a
+/// `ws-api-address` in `config.toml` is just as likely to be this code's own
+/// past output as an operator's choice — and the two are indistinguishable by
+/// value. Treating the auto-derivable values as "not an operator choice" is
+/// what lets the resolution re-run each boot:
+///
+/// - `::` (the network-mode auto-default since #3648) and `0.0.0.0` (before
+///   it) must be re-derived, or the hardening would reach fresh installs only;
+/// - `::1` must be re-derived too, or the FIRST post-upgrade boot would persist
+///   loopback and thereby make it look explicit, permanently disabling the
+///   auto-widen remedy that the release note and the startup log both point
+///   operators at.
+///
+/// Anything else — `127.0.0.1`, a specific interface address — this code never
+/// writes on its own, so it is an operator choice and is preserved.
+fn is_auto_derivable_ws_api_address(addr: IpAddr) -> bool {
+    addr.is_unspecified() || addr == default_local_address()
+}
+
+/// Whether a `--allowed-host` / `--allowed-source-cidrs` list grants anything.
+///
+/// An empty list grants nothing, and neither does a list of blank strings:
+/// `ALLOWED_HOST=` declared with no value in a docker-compose `.env`, a k8s
+/// ConfigMap, or a systemd `Environment=` line parses as `Some(vec![""])`, and
+/// reading that as "the operator wants non-local clients" would widen the bind
+/// on a node whose operator set nothing.
+fn grants_anything(list: Option<&[String]>) -> bool {
+    list.is_some_and(|entries| entries.iter().any(|e| !e.trim().is_empty()))
 }
 
 /// Resolve the address the client (HTTP/WebSocket) API binds to.
@@ -2991,16 +3091,24 @@ enum WsApiAddressSource {
 /// govern who may drive the client API. Running as a network peer is a
 /// statement about the overlay, not consent to expose a fully-privileged
 /// control API (contract state, delegate secrets, key material) to every host
-/// on the LAN. Anyone who wants that exposure asks for it — see the two
-/// non-default branches below.
+/// that can route to this machine.
 ///
-/// Auto-widening exists so the pre-existing, working invocations keep working
-/// with zero operator action: `--allowed-source-cidrs` (the Tailscale/WireGuard
-/// overlay grant) and `--allowed-host` (the reverse-proxy hostname grant) are
-/// both no-ops on a loopback listener, so setting either is an unambiguous
-/// statement of intent to serve non-local clients. Setting `--ws-api-address`
-/// explicitly always wins; auto-widening never overrides an operator's choice.
+/// Auto-widening is a BACKWARD-COMPATIBILITY measure, not a claim that the two
+/// flags are meaningless on loopback — they are not. `--allowed-host` is a
+/// Host-header allowlist that is fully functional, and often required, for a
+/// reverse proxy on the SAME host talking to the node over loopback, and
+/// `--allowed-source-cidrs` still widens which `Host` IPs are accepted. What
+/// the flags have in common is that, before this change, a node in network mode
+/// bound `::` by DEFAULT, so an operator who set either one and nothing else
+/// was silently relying on that wide default. Widening for them preserves those
+/// invocations with zero operator action.
+///
+/// Which is exactly why widening is scoped to `OperationMode::Network`: local
+/// mode has always bound loopback, so there is no wide default to preserve, and
+/// widening there would mean this hardening opened a socket that used to be
+/// closed. An explicit `--ws-api-address` always wins in either mode.
 fn resolve_ws_api_address(
+    mode: OperationMode,
     explicit: Option<IpAddr>,
     allowed_source_cidrs: Option<&[String]>,
     allowed_hosts: Option<&[String]>,
@@ -3008,11 +3116,9 @@ fn resolve_ws_api_address(
     if let Some(addr) = explicit {
         return (addr, WsApiAddressSource::Explicit);
     }
-    // `Some(vec![])` is treated as unset: an empty list grants nothing, and the
-    // config-file merge can hand us an empty vec from a persisted `[]`.
-    let widening_intent = allowed_source_cidrs.is_some_and(|c| !c.is_empty())
-        || allowed_hosts.is_some_and(|h| !h.is_empty());
-    if widening_intent {
+    let compat_widen = matches!(mode, OperationMode::Network)
+        && (grants_anything(allowed_source_cidrs) || grants_anything(allowed_hosts));
+    if compat_widen {
         (default_listening_address(), WsApiAddressSource::AutoWidened)
     } else {
         (default_local_address(), WsApiAddressSource::DefaultLoopback)
@@ -3020,48 +3126,58 @@ fn resolve_ws_api_address(
 }
 
 /// Whether startup should warn that the client API is reachable beyond this
-/// machine while every connection shares ONE secret namespace.
+/// machine while connections can land in ONE shared secret namespace, and if
+/// so, why. `None` means stay quiet.
 ///
-/// Hosted mode (`--hosted-mode`) is what gives each connection its own
-/// delegate-secret namespace keyed by `userToken`. With it OFF, every
-/// connection — local or not — drives the same single-user node: the same
-/// delegate secrets, the same identities, the same contract state. That is
-/// correct and safe for a loopback-only listener, and is the silent-exposure
-/// case the moment the listener is reachable from elsewhere.
+/// The shared namespace is the danger. `decide_user_token` hands a connection
+/// the node's single-user context whenever hosted mode is off **or the
+/// connection simply omits `userToken`** — so hosted mode ADDS a per-user
+/// namespace for well-behaved clients, it does not remove the shared one. A
+/// remote client that presents no token still drives the same delegate secrets,
+/// identities and contract state as the operator's own browser.
 ///
-/// Two independently-sufficient triggers:
-/// - a **non-loopback bind**: any host that can route to the address can drive
-///   the API;
-/// - **`--allowed-host` set**: the reverse-proxy grant. A proxy terminates the
-///   connection itself, so every visitor arrives wearing the proxy's source
-///   address and looks local to the node's own filters — the LAN/CIDR checks
-///   cannot distinguish them. This fires even on a loopback bind, because a
-///   proxy in front of `127.0.0.1:7509` is precisely how a node gets exposed
-///   to the internet without ever binding a non-loopback address.
+/// Hence the two triggers:
+/// - a **non-loopback bind** warns regardless of hosted mode, because any host
+///   that can route to the address can omit a token and land in the shared
+///   namespace;
+/// - **`--allowed-host` on a loopback bind** warns only with hosted mode OFF.
+///   That flag names a reverse proxy, and a proxy terminates the connection
+///   itself, so every visitor arrives wearing the proxy's source address and
+///   the node's own source-IP filters cannot tell them apart. Loopback + hosted
+///   mode is precisely the shape hosted mode was built for (the proxy hop is
+///   local and `userToken` is honored), so it stays quiet.
 ///
-/// Returns the reason to warn about, or `None` to stay quiet. Naming the
-/// reason keeps the log actionable: "bound to 0.0.0.0" and "sits behind a
-/// reverse proxy" call for different fixes, and a warning that guesses wrong
-/// is a warning operators learn to ignore.
+/// Naming the reason keeps the log actionable: a wide bind and a proxy call for
+/// different fixes, and a warning that guesses wrong is one operators learn to
+/// ignore.
 fn ws_api_shares_one_namespace_with_remote_clients(
     hosted_mode: bool,
     address: IpAddr,
     allowed_hosts: &[String],
 ) -> Option<&'static str> {
+    if !address.is_loopback() {
+        return Some(if hosted_mode {
+            "the client API is bound to a non-loopback address, and hosted mode does \
+             not close that: a connection which simply omits `userToken` still lands \
+             in this node's shared single-user namespace"
+        } else {
+            "the client API is bound to a non-loopback address, so any host that can \
+             route to it can drive this node"
+        });
+    }
     if hosted_mode {
+        // Loopback bind + hosted mode: the same-host reverse-proxy deployment
+        // hosted mode exists to serve. Quiet on purpose.
         return None;
     }
-    if !address.is_loopback() {
-        Some(
-            "the client API is bound to a non-loopback address, so any host that can route to it can drive this node",
-        )
-    } else if !allowed_hosts.is_empty() {
-        Some(
-            "--allowed-host names a reverse proxy in front of this node; a proxy terminates the connection itself, so every visitor arrives looking local and the source-IP filters cannot tell them apart",
-        )
-    } else {
-        None
+    if !allowed_hosts.is_empty() {
+        return Some(
+            "--allowed-host names a reverse proxy in front of this node, and a proxy \
+             terminates the connection itself, so every visitor arrives looking local \
+             and the source-IP filters cannot tell them apart",
+        );
     }
+    None
 }
 
 #[inline]
@@ -7243,6 +7359,14 @@ shutdown-drain-secs = 42
                 // serde-skip runtime field; repopulated by build() and not
                 // asserted in the round-trip (bound to `_` in the destructure).
                 secrets_dir: std::path::PathBuf::new(),
+                // Runtime-only (`#[serde(skip)]`): describes THIS boot's
+                // resolution, so it is deliberately not round-tripped. Seeded
+                // non-default anyway so the guard below is not comparing two
+                // defaults.
+                exposure: WsApiExposure {
+                    source: WsApiAddressSource::AutoWidened,
+                    dropped_persisted_address: Some(default_listening_address()),
+                },
                 webapp_cache_dir: default_webapp_cache_dir(),
             },
             secrets: base.secrets.clone(),
@@ -7472,6 +7596,11 @@ shutdown-drain-secs = 42
             // serde-skip runtime field, repopulated by build() from
             // `default_webapp_cache_dir()` (env-overridable).
             webapp_cache_dir: _,
+            // serde-skip runtime field: how THIS boot resolved the client-API
+            // bind. Not config — it is an output of `build()`, re-derived every
+            // boot — so it deliberately does not round-trip. Its own coverage
+            // is `build_records_the_exposure_decision_for_later_reporting`.
+            exposure: _,
         } = ws_api;
         assert_eq!(ws_address, seed.ws_api.address, "ws_api.address");
         assert_eq!(ws_port, seed.ws_api.port, "ws_api.port");
@@ -9184,31 +9313,103 @@ shutdown-drain-secs = 42
     /// every already-booted node has in its `config.toml`.
     #[test]
     fn empty_allow_lists_do_not_widen() {
+        for mode in [OperationMode::Network, OperationMode::Local] {
+            assert_eq!(
+                resolve_ws_api_address(mode, None, Some(&[]), Some(&[])),
+                (default_local_address(), WsApiAddressSource::DefaultLoopback)
+            );
+            assert_eq!(
+                resolve_ws_api_address(mode, None, None, None),
+                (default_local_address(), WsApiAddressSource::DefaultLoopback)
+            );
+        }
+    }
+
+    /// `ALLOWED_HOST=` declared with no value — routine in a docker-compose
+    /// `.env`, a k8s ConfigMap, or a systemd `Environment=` line — parses as
+    /// `Some(vec![""])`. Reading that as intent would widen the bind on a node
+    /// whose operator granted nothing.
+    #[test]
+    fn blank_allow_list_entries_do_not_widen() {
         assert_eq!(
-            resolve_ws_api_address(None, Some(&[]), Some(&[])),
+            resolve_ws_api_address(
+                OperationMode::Network,
+                None,
+                Some(&[String::new()]),
+                Some(&["   ".to_string()]),
+            ),
             (default_local_address(), WsApiAddressSource::DefaultLoopback)
         );
-        assert_eq!(
-            resolve_ws_api_address(None, None, None),
-            (default_local_address(), WsApiAddressSource::DefaultLoopback)
-        );
+    }
+
+    /// Local mode has ALWAYS bound loopback, so there is no wide default to
+    /// preserve there. Widening for it would mean this hardening OPENED a
+    /// socket that used to be closed — the exact thing it exists to prevent.
+    #[test]
+    fn local_mode_never_auto_widens() {
+        for (cidrs, hosts) in [
+            (Some(&["100.64.0.0/10".to_string()][..]), None),
+            (None, Some(&["proxy.example".to_string()][..])),
+            (
+                Some(&["100.64.0.0/10".to_string()][..]),
+                Some(&["proxy.example".to_string()][..]),
+            ),
+        ] {
+            assert_eq!(
+                resolve_ws_api_address(OperationMode::Local, None, cidrs, hosts),
+                (default_local_address(), WsApiAddressSource::DefaultLoopback),
+                "local mode must stay loopback for cidrs={cidrs:?} hosts={hosts:?}"
+            );
+        }
     }
 
     #[test]
     fn resolve_ws_api_address_reports_how_it_decided() {
         let explicit = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 50));
+        for mode in [OperationMode::Network, OperationMode::Local] {
+            assert_eq!(
+                resolve_ws_api_address(mode, Some(explicit), None, None),
+                (explicit, WsApiAddressSource::Explicit)
+            );
+        }
         assert_eq!(
-            resolve_ws_api_address(Some(explicit), None, None),
-            (explicit, WsApiAddressSource::Explicit)
-        );
-        assert_eq!(
-            resolve_ws_api_address(None, Some(&["10.0.0.0/8".to_string()]), None),
+            resolve_ws_api_address(
+                OperationMode::Network,
+                None,
+                Some(&["10.0.0.0/8".to_string()]),
+                None
+            ),
             (default_listening_address(), WsApiAddressSource::AutoWidened)
         );
         assert_eq!(
-            resolve_ws_api_address(None, None, Some(&["h.example".to_string()])),
+            resolve_ws_api_address(
+                OperationMode::Network,
+                None,
+                None,
+                Some(&["h.example".to_string()])
+            ),
             (default_listening_address(), WsApiAddressSource::AutoWidened)
         );
+    }
+
+    /// The migration sentinel is "a value this code could have written", which
+    /// must include the loopback default — see
+    /// `remedy_still_works_after_the_upgrade_persisted_loopback`.
+    #[test]
+    fn auto_derivable_addresses_are_exactly_the_ones_this_code_writes() {
+        for auto in [
+            default_listening_address(),
+            IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+            default_local_address(),
+        ] {
+            assert!(is_auto_derivable_ws_api_address(auto), "{auto}");
+        }
+        for chosen in [
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            IpAddr::V4(Ipv4Addr::new(192, 168, 1, 50)),
+        ] {
+            assert!(!is_auto_derivable_ws_api_address(chosen), "{chosen}");
+        }
     }
 
     /// The exposure warning fires on hosted-mode-off AND (non-loopback bind OR
@@ -9233,10 +9434,13 @@ shutdown-drain-secs = 42
             ws_api_shares_one_namespace_with_remote_clients(true, loopback, &proxy),
             None
         );
-        assert_eq!(
-            ws_api_shares_one_namespace_with_remote_clients(true, wildcard, &proxy),
-            None
-        );
+        // Fires: hosted mode does NOT make a wide bind safe. `decide_user_token`
+        // returns the shared single-user context whenever a connection omits
+        // `userToken`, so a remote client that presents nothing still drives
+        // the same delegate secrets — which is the advisory's own scenario.
+        let hosted_wide = ws_api_shares_one_namespace_with_remote_clients(true, wildcard, &proxy)
+            .expect("a wildcard bind must warn even in hosted mode");
+        assert!(hosted_wide.contains("hosted mode does"), "{hosted_wide}");
 
         // Fires: reachable from other machines, one shared namespace. The
         // reason names the bind, which is the thing to change.
@@ -9367,48 +9571,173 @@ shutdown-drain-secs = 42
         assert_eq!(cfg.ws_api.allowed_source_cidrs.len(), 1);
     }
 
-    /// Source pin: `build()` must actually consult the resolver and the warning
-    /// predicate. A unit-tested pure function that nothing calls is a
-    /// verification that cannot fail.
+    /// Local mode with a widening flag must stay loopback end-to-end, not just
+    /// in the pure resolver. On `origin/main` this invocation bound `::1`; a
+    /// hardening change that made it bind `::` would be a regression caused by
+    /// the fix.
+    #[tokio::test]
+    async fn local_mode_with_allow_lists_still_binds_loopback() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let (_server, index_url) = empty_gateways_index_server();
+
+        let mut args = ws_api_test_args(OperationMode::Local, temp_dir.path());
+        args.ws_api.allowed_source_cidrs = Some(vec!["100.64.0.0/10".to_string()]);
+        args.ws_api.allowed_host = Some(vec!["proxy.example".to_string()]);
+
+        let cfg = args
+            .build_with_gateways_index(&index_url)
+            .await
+            .expect("build should succeed");
+        assert_eq!(cfg.ws_api.address, default_local_address());
+    }
+
+    /// The remedy the release note and the startup log both point at has to
+    /// work on the SECOND boot, not only the first.
+    ///
+    /// `build()` persists the resolved address, so after the upgrade boot the
+    /// file holds `::1`. If that counted as an operator choice, adding
+    /// `--allowed-source-cidrs` afterwards would resolve through the Explicit
+    /// short-circuit and do nothing at all — the node would stay loopback while
+    /// its logs claimed the flag widens the bind.
+    #[tokio::test]
+    async fn remedy_still_works_after_the_upgrade_persisted_loopback() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let (_server, index_url) = empty_gateways_index_server();
+
+        // Boot 1: pre-upgrade node with the old wildcard auto-default.
+        let mut first = ws_api_test_args(OperationMode::Network, temp_dir.path());
+        first.ws_api.address = Some(default_listening_address());
+        first
+            .build_with_gateways_index(&index_url)
+            .await
+            .expect("first build should succeed");
+
+        // Boot 2: upgraded, flag-less. Re-derived to loopback and persisted.
+        let migrated = ws_api_test_args(OperationMode::Network, temp_dir.path())
+            .build_with_gateways_index(&index_url)
+            .await
+            .expect("second build should succeed");
+        assert_eq!(migrated.ws_api.address, default_local_address());
+        let persisted =
+            std::fs::read_to_string(temp_dir.path().join("config.toml")).expect("config persisted");
+        assert!(
+            persisted.contains(r#"ws-api-address = "::1""#),
+            "test premise: the loopback address must be persisted, got:\n{persisted}"
+        );
+
+        // Boot 3: the operator applies the documented remedy.
+        let mut remedied = ws_api_test_args(OperationMode::Network, temp_dir.path());
+        remedied.ws_api.allowed_source_cidrs = Some(vec!["100.64.0.0/10".to_string()]);
+        let cfg = remedied
+            .build_with_gateways_index(&index_url)
+            .await
+            .expect("third build should succeed");
+        assert_eq!(
+            cfg.ws_api.address,
+            default_listening_address(),
+            "the auto-widen remedy must still work once the migration has run"
+        );
+    }
+
+    /// The exposure decision must survive onto the resolved `Config`, because
+    /// that is the only way it reaches a log: `build()` runs before the tracing
+    /// subscriber is installed, so anything it emits is dropped.
+    #[tokio::test]
+    async fn build_records_the_exposure_decision_for_later_reporting() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let (_server, index_url) = empty_gateways_index_server();
+
+        let mut args = ws_api_test_args(OperationMode::Network, temp_dir.path());
+        args.ws_api.allowed_source_cidrs = Some(vec!["100.64.0.0/10".to_string()]);
+        let widened = args
+            .build_with_gateways_index(&index_url)
+            .await
+            .expect("build should succeed");
+        assert_eq!(
+            widened.ws_api.exposure.source,
+            WsApiAddressSource::AutoWidened
+        );
+        assert_eq!(widened.ws_api.exposure.dropped_persisted_address, None);
+
+        // A fresh dir, so the migration branch is the one under test.
+        let upgrade_dir = tempfile::tempdir().unwrap();
+        let mut first = ws_api_test_args(OperationMode::Network, upgrade_dir.path());
+        first.ws_api.address = Some(default_listening_address());
+        first
+            .build_with_gateways_index(&index_url)
+            .await
+            .expect("first build should succeed");
+        let migrated = ws_api_test_args(OperationMode::Network, upgrade_dir.path())
+            .build_with_gateways_index(&index_url)
+            .await
+            .expect("second build should succeed");
+        assert_eq!(
+            migrated.ws_api.exposure.dropped_persisted_address,
+            Some(default_listening_address()),
+            "the operator must be told their LAN clients just lost access"
+        );
+        assert_eq!(
+            migrated.ws_api.exposure.source,
+            WsApiAddressSource::DefaultLoopback
+        );
+    }
+
+    /// Source pin: the resolver and the reporting path must actually be wired
+    /// in. A unit-tested pure function that nothing calls is a verification
+    /// that cannot fail.
+    ///
+    /// Both halves matter and they live in different functions: `build()` must
+    /// RESOLVE through the helper, and `Config::log_client_api_exposure` must
+    /// be the thing that reports it (it cannot be reported from `build()`,
+    /// which has no tracing subscriber yet).
     #[test]
-    fn build_resolves_the_ws_api_address_through_the_shared_helpers() {
-        let body = extract_fn_body(
-            production_source(),
+    fn the_client_api_exposure_path_stays_wired_end_to_end() {
+        let src = production_source();
+
+        let build = extract_fn_body(
+            src,
             "async fn build_with_gateways_index(mut self, gateways_index: &str)",
         );
-        for needle in [
-            "resolve_ws_api_address(",
-            "ws_api_shares_one_namespace_with_remote_clients(",
-        ] {
-            assert!(
-                body.contains(needle),
-                "build_with_gateways_index no longer calls `{needle}` — the client-API \
-                 exposure default/warning has been bypassed"
-            );
-        }
-        // Bound the "no mode-keyed default" check to the `ws_api` literal.
-        // A bare `body.contains(..)` would match `network_api`'s own
-        // `OperationMode::Network => default_listening_address()` a few lines
-        // above and pass vacuously — the network transport SHOULD keep binding
-        // all interfaces; only the client API moves.
-        let ws_api_literal = {
-            let start = body
-                .find("ws_api: WebsocketApiConfig {")
-                .expect("build() must still construct the ws_api config inline");
-            let rest = &body[start..];
-            let end = rest
-                .find("port: self")
-                .expect("the ws_api literal must still set `port` right after `address`");
-            &rest[..end]
-        };
         assert!(
-            ws_api_literal.contains("address: ws_api_address"),
-            "the ws_api bind address no longer comes from resolve_ws_api_address: \n{ws_api_literal}"
+            build.contains("resolve_ws_api_address("),
+            "build_with_gateways_index no longer resolves the client-API bind through \
+             the shared helper"
         );
         assert!(
-            !ws_api_literal.contains("OperationMode::"),
-            "the mode-keyed ws-api default is back: OperationMode must not govern \
-             who may drive the client API (GHSA-824h-7x5x-wfmf)"
+            build.contains("exposure: ws_api_exposure"),
+            "build_with_gateways_index no longer records the exposure decision, so \
+             nothing downstream can report it"
+        );
+        // `build()` legitimately warns about other things (gateway dedup, source
+        // CIDRs), so pin the specific property: it must not CONSULT the exposure
+        // predicate, because anything it decided to say about exposure would be
+        // emitted before `set_logger` and silently dropped.
+        assert!(
+            !build.contains("ws_api_shares_one_namespace_with_remote_clients("),
+            "the exposure warning must NOT be decided in build(): it runs before \
+             set_logger, so the message would be silently dropped"
+        );
+
+        let report = extract_fn_body(src, "pub fn log_client_api_exposure(&self)");
+        assert!(
+            report.contains("ws_api_shares_one_namespace_with_remote_clients("),
+            "log_client_api_exposure no longer consults the exposure predicate"
+        );
+        assert!(
+            report.contains("tracing::warn!"),
+            "log_client_api_exposure no longer warns about a shared-namespace exposure"
+        );
+
+        // The mode-keyed DEFAULT must not come back. Pin it on the resolver's
+        // signature rather than on a text search of `build()`: `mode` is a
+        // legitimate input (it scopes the compat auto-widen), so what must stay
+        // true is that the no-flags branch is mode-independent — which the
+        // behavioural test `empty_allow_lists_do_not_widen` asserts for both
+        // modes. Here we only pin that the resolver is the single decision site.
+        let resolver = extract_fn_body(src, "fn resolve_ws_api_address(");
+        assert!(
+            resolver.contains("WsApiAddressSource::DefaultLoopback"),
+            "resolve_ws_api_address no longer has a loopback default branch"
         );
     }
 }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -1282,13 +1282,14 @@ impl ConfigArgs {
         // reports it after the subscriber exists. See `WsApiExposure`.
         let ws_api_exposure = WsApiExposure {
             source: ws_api_address_source,
-            // Report the discard ONLY when the bind actually got narrower.
-            // A node whose persisted `::1` is dropped and then auto-widened to
-            // `::` is getting MORE exposed, so "clients on other machines can
-            // no longer reach this node" would be flatly untrue — and would
-            // print directly above the auto-widen line saying the opposite.
+            // Recorded when the re-derivation actually MOVED the bind, in
+            // either direction; `log_client_api_exposure` picks the message
+            // from which way it went. A value that re-derives to itself (the
+            // steady state from boot 2 onward) is not reported at all, because
+            // re-announcing an unchanged bind every boot is how a log line gets
+            // tuned out.
             dropped_persisted_address: dropped_persisted_wildcard
-                .filter(|persisted| !persisted.is_loopback() && ws_api_address.is_loopback()),
+                .filter(|persisted| *persisted != ws_api_address),
         };
         let this = Config {
             mode,
@@ -1849,15 +1850,18 @@ impl Config {
     pub fn log_client_api_exposure(&self) {
         let address = self.ws_api.address;
 
-        // The two allow-list env vars were UNNAMESPACED (`ALLOWED_HOST`,
+        // These three were UNNAMESPACED (`WS_API_ADDRESS`, `ALLOWED_HOST`,
         // `ALLOWED_SOURCE_CIDRS`) until GHSA-824h-7x5x-wfmf. That was survivable
-        // while they only added a Host-header entry to a socket that was wide
-        // anyway; now `--allowed-source-cidrs` DECIDES whether the socket is
-        // wide, so a stray value in a shared container, CI runner or systemd
-        // environment could open the API. They are namespaced, and a leftover
-        // old-style variable is reported rather than ignored — otherwise a
-        // working overlay deployment goes loopback-only with no explanation.
+        // while a network-mode node bound `::` anyway and they only shaped which
+        // Host headers it accepted; it is not now that `--ws-api-address`
+        // decides the socket directly, at the highest precedence, and
+        // `--allowed-source-cidrs` decides whether it is wide. A stray value in
+        // a shared container, CI runner or systemd environment could open the
+        // API. They are namespaced, and a leftover old-style variable is
+        // REPORTED rather than ignored — otherwise a working deployment goes
+        // loopback-only with no explanation.
         for (legacy, replacement) in [
+            ("WS_API_ADDRESS", "FREENET_WS_API_ADDRESS"),
             ("ALLOWED_HOST", "FREENET_ALLOWED_HOST"),
             ("ALLOWED_SOURCE_CIDRS", "FREENET_ALLOWED_SOURCE_CIDRS"),
         ] {
@@ -1872,25 +1876,43 @@ impl Config {
             }
         }
         if let Some(persisted) = self.ws_api.exposure.dropped_persisted_address {
-            // warn!, not info!: this fires on ONE boot and never again (the
-            // filter keys on a non-loopback persisted value, and boot 2 onward
-            // sees loopback). For a remote gateway whose operator finds out
-            // days later when a client fails, this line is the whole
-            // explanation, so it must not be ranked below the exposure warning
-            // that fires for the comparatively safe case.
-            tracing::warn!(
-                %persisted,
-                resolved = %address,
-                "The client API now defaults to loopback, so the `ws-api-address` \
-                 previously auto-written to config.toml has been re-derived. Clients \
-                 on OTHER machines can no longer reach this node's API. If they \
-                 should, add --ws-api-address :: to the node's invocation and KEEP it \
-                 there — a value only persisted in config.toml is not enough, because \
-                 this code cannot tell its own past output from your choice. On a \
-                 systemd install add it with `systemctl edit` as a drop-in; do not \
-                 hand-edit the generated unit, which marks it user-modified and opts \
-                 this node out of future unit updates."
-            );
+            if address.is_loopback() {
+                // warn!, not info!: this fires on ONE boot and never again (from
+                // boot 2 the persisted value re-derives to itself and is not
+                // reported). For a remote gateway whose operator finds out days
+                // later when a client fails, this line is the whole
+                // explanation, so it must not rank below the exposure warning
+                // that fires for the comparatively safe case.
+                tracing::warn!(
+                    %persisted,
+                    resolved = %address,
+                    "The client API now defaults to loopback, so the `ws-api-address` \
+                     previously auto-written to config.toml has been re-derived. Clients \
+                     on OTHER machines can no longer reach this node's API. If they \
+                     should, add --ws-api-address :: to the node's invocation and KEEP it \
+                     there — a value only persisted in config.toml is not enough, because \
+                     this code cannot tell its own past output from your choice. On a \
+                     systemd install add it with `systemctl edit` as a drop-in; do not \
+                     hand-edit the generated unit, which marks it user-modified and opts \
+                     this node out of future unit updates."
+                );
+            } else {
+                // The opposite direction, and the one a hardening change owes an
+                // operator loudly: their config named a LOOPBACK address, and we
+                // dropped it (this code writes that value itself, so it cannot be
+                // told from an operator's choice) and then widened on the CIDR
+                // grant. The socket is more exposed than the config it replaced.
+                tracing::warn!(
+                    %persisted,
+                    resolved = %address,
+                    "The loopback `ws-api-address` in config.toml was re-derived — this \
+                     code writes that value itself, so it cannot be distinguished from a \
+                     deliberate pin — and --allowed-source-cidrs then widened the bind. \
+                     The client API is now reachable from OTHER machines, which the \
+                     config file alone said it should not be. Pass --ws-api-address \
+                     explicitly to pin it either way."
+                );
+            }
         }
         if self.ws_api.exposure.source == WsApiAddressSource::AutoWidened {
             tracing::info!(
@@ -1907,7 +1929,6 @@ impl Config {
             self.ws_api.hosted_mode,
             address,
             &self.ws_api.allowed_hosts,
-            shared_delegate_namespace_is_occupied(&self.ws_api.secrets_dir),
         ) {
             tracing::warn!(
                 %address,
@@ -2456,16 +2477,22 @@ pub struct WebsocketApiArgs {
     /// operation modes: running as a network peer says nothing about wanting
     /// this node's fully-privileged control API driveable from other machines.
     /// Pass `::` (or a specific interface address) to serve clients on other
-    /// hosts. Setting `--allowed-source-cidrs` or `--allowed-host` without this
-    /// flag widens the bind to `::` automatically, since neither flag does
-    /// anything on a loopback listener.
+    /// hosts, and keep the flag in the node's invocation — a value left only in
+    /// config.toml is re-derived on the next boot.
+    ///
+    /// One flag widens the bind on its own, in network mode:
+    /// `--allowed-source-cidrs`, which is inert on a loopback socket and so can
+    /// only have been set by someone expecting non-local clients.
+    /// `--allowed-host` does NOT: it is a Host-header allowlist that works
+    /// perfectly on loopback, where a same-host reverse proxy lives. Running
+    /// the proxy on a DIFFERENT host needs this flag as well.
     ///
     /// SECURITY: anything that can reach this address and port can read and
     /// modify your contract state, identities and keys.
     #[arg(
         name = "ws_api_address",
         long = "ws-api-address",
-        env = "WS_API_ADDRESS"
+        env = "FREENET_WS_API_ADDRESS"
     )]
     #[serde(rename = "ws-api-address", skip_serializing_if = "Option::is_none")]
     pub address: Option<IpAddr>,
@@ -3230,68 +3257,6 @@ fn resolve_ws_api_address(
     }
 }
 
-/// Whether the node's SHARED (non-per-user) delegate-secret namespace holds
-/// anything, checked by looking for a single file.
-///
-/// Layout is `<secrets_dir>/<delegate_key>/…`, with hosted mode's per-user
-/// namespaces under a `users/` component. So a file inside a delegate directory
-/// but NOT under `users/` is a secret that EVERY untokened connection shares.
-/// Node key material (`transport_keypair`, `delegate_cipher`, …) sits directly
-/// in `secrets_dir` at depth 1 and is deliberately not counted: it is not
-/// reachable through the delegate API this warning is about.
-///
-/// Returns `true` if it cannot tell (an unreadable secrets tree): "I could not
-/// check" must not read as "nothing to protect".
-///
-/// Stops at the first hit and bounds its own depth, so the common case is a
-/// couple of `read_dir` calls at startup.
-fn shared_delegate_namespace_is_occupied(secrets_dir: &Path) -> bool {
-    fn walk(dir: &Path, depth: u32) -> bool {
-        // Deep enough for `<delegate>/<subdir>/<file>`; a legitimate shared
-        // secret is never buried deeper than this, and the cap keeps a
-        // symlinked or pathological tree from stalling startup.
-        const MAX_DEPTH: u32 = 4;
-        if depth > MAX_DEPTH {
-            return false;
-        }
-        let Ok(entries) = std::fs::read_dir(dir) else {
-            // Unreadable: fail loud rather than silently claiming "empty".
-            return true;
-        };
-        for entry in entries.flatten() {
-            let Ok(file_type) = entry.file_type() else {
-                continue;
-            };
-            if file_type.is_dir() {
-                // Per-user namespaces are exactly what hosted mode isolates,
-                // so they are not the shared namespace.
-                if entry.file_name() == "users" {
-                    continue;
-                }
-                if walk(&entry.path(), depth + 1) {
-                    return true;
-                }
-            } else if file_type.is_file() {
-                return true;
-            }
-        }
-        false
-    }
-
-    if secrets_dir.as_os_str().is_empty() {
-        // The standalone/test composition carries no secrets tree.
-        return false;
-    }
-    let Ok(entries) = std::fs::read_dir(secrets_dir) else {
-        return false; // No secrets tree yet: nothing is shared.
-    };
-    // Depth 1 is node key material, not delegate secrets — descend past it.
-    entries
-        .flatten()
-        .filter(|e| e.file_type().is_ok_and(|t| t.is_dir()))
-        .any(|e| walk(&e.path(), 2))
-}
-
 /// Whether startup should warn that the client API is reachable beyond this
 /// machine while connections can land in ONE shared secret namespace, and if
 /// so, why. `None` means stay quiet.
@@ -3299,32 +3264,33 @@ fn shared_delegate_namespace_is_occupied(secrets_dir: &Path) -> bool {
 /// The shared namespace is the danger. `decide_user_token` hands a connection
 /// the node's single-user context whenever hosted mode is off **or the
 /// connection simply omits `userToken`** — so hosted mode ADDS a per-user
-/// namespace for well-behaved clients, it does not remove the shared one. A
-/// remote client that presents no token still drives the same delegate secrets,
-/// identities and contract state as the operator's own browser.
+/// namespace for well-behaved clients, it does not remove the shared one.
 ///
-/// Three cases:
+/// Two triggers:
 /// - a **non-loopback bind** warns regardless of hosted mode, because any host
 ///   that can route to the address can omit a token and land in the shared
 ///   namespace;
-/// - **`--allowed-host` on a loopback bind with hosted mode OFF** warns
-///   unconditionally. That flag names a reverse proxy, and a proxy terminates
-///   the connection itself, so every visitor arrives wearing the proxy's source
-///   address and the node's own source-IP filters cannot tell them apart. It is
-///   not gated on occupancy because with hosted mode off there is no isolation
-///   at all: the namespace becomes occupied the moment anyone uses it.
-/// - **loopback + hosted mode** — try.freenet.org's shape — warns ONLY if the
-///   shared namespace already holds secrets. Hosted mode routes tokened
-///   connections to per-user namespaces, so the shared one stays empty in the
-///   intended deployment, and containment is real if unglamorous: there is
-///   nothing there to take. Warning on every boot of the flagship deployment
-///   would train operators to ignore the one signal we have, so this warning is
-///   made ACCURATE rather than loud.
+/// - **`--allowed-host` on a loopback bind with hosted mode OFF** warns. That
+///   flag names a reverse proxy, and a proxy terminates the connection itself,
+///   so every visitor arrives wearing the proxy's source address and the node's
+///   own source-IP filters cannot tell them apart.
+///
+/// **Loopback + hosted mode stays quiet, and that is a known gap, not an
+/// assertion of safety.** A connection that omits `userToken` reads the shared
+/// namespace there too, and behind a public proxy that is any visitor;
+/// containment on the flagship deployment today is that the shared namespace is
+/// empty (measured: zero files outside `*/users/*`), which is a fact about
+/// current state rather than a structural guarantee. Making this branch fire
+/// only when the shared namespace actually holds something needs a probe of the
+/// secrets tree, which is a separate change with its own failure modes — it is
+/// tracked separately rather than bolted onto a default-hardening PR, because a
+/// probe that is wrong in either direction is worse than no warning: too eager
+/// and it fires on every boot of the flagship and trains operators to ignore the
+/// one signal there is.
 fn ws_api_shares_one_namespace_with_remote_clients(
     hosted_mode: bool,
     address: IpAddr,
     allowed_hosts: &[String],
-    shared_namespace_occupied: bool,
 ) -> Option<&'static str> {
     if !address.is_loopback() {
         return Some(if hosted_mode {
@@ -3337,11 +3303,7 @@ fn ws_api_shares_one_namespace_with_remote_clients(
         });
     }
     if hosted_mode {
-        return shared_namespace_occupied.then_some(
-            "this node is in hosted mode but its SHARED delegate-secret namespace is \
-             not empty, and a connection that omits `userToken` reads that namespace \
-             rather than a per-user one — behind a proxy, any visitor can",
-        );
+        return None;
     }
     if !allowed_hosts.is_empty() {
         return Some(
@@ -9616,104 +9578,39 @@ shutdown-drain-secs = 42
         let loopback = default_local_address();
         let wildcard = default_listening_address();
         let proxy = vec!["try.freenet.org".to_string()];
-        // (hosted_mode, address, allowed_hosts, shared namespace occupied)
-        let quiet =
-            |h, a, l: &[String], occ| ws_api_shares_one_namespace_with_remote_clients(h, a, l, occ);
 
         // Quiet: the default single-user desktop node.
-        assert_eq!(quiet(false, loopback, &[], false), None);
-        // Quiet: try.freenet.org's shape. Hosted mode routes tokened
-        // connections to per-user namespaces, and the shared one is empty, so
-        // there is nothing behind the proxy to take. Warning on every boot of
-        // the flagship deployment would train operators to ignore this signal.
-        assert_eq!(quiet(true, loopback, &proxy, false), None);
-
-        // Fires: SAME shape, but the shared namespace now holds secrets, which
-        // is the real containment boundary rather than any structural
-        // guarantee — a connection omitting `userToken` reads it.
-        let occupied = quiet(true, loopback, &proxy, true)
-            .expect("a hosted node with a non-empty shared namespace must warn");
-        assert!(occupied.contains("SHARED"), "{occupied}");
+        assert_eq!(
+            ws_api_shares_one_namespace_with_remote_clients(false, loopback, &[]),
+            None
+        );
+        // Quiet: try.freenet.org's shape. A KNOWN GAP rather than a safety
+        // claim — an untokened connection reads the shared namespace here too.
+        // Containment today is that the namespace is empty; making the warning
+        // conditional on that needs a probe of the secrets tree, tracked
+        // separately so a probe that is wrong in either direction cannot ride
+        // in on a default-hardening change.
+        assert_eq!(
+            ws_api_shares_one_namespace_with_remote_clients(true, loopback, &proxy),
+            None
+        );
 
         // Fires: reachable from other machines, one shared namespace. The
         // reason names the bind, which is the thing to change.
-        let bind_reason = quiet(false, wildcard, &[], false)
+        let bind_reason = ws_api_shares_one_namespace_with_remote_clients(false, wildcard, &[])
             .expect("a wildcard bind with hosted mode off must warn");
         assert!(bind_reason.contains("non-loopback"), "{bind_reason}");
 
-        // Fires: hosted mode does NOT make a wide bind safe, occupied or not.
-        // `decide_user_token` returns the shared context whenever a connection
-        // omits `userToken`, so a remote client presenting nothing still drives
-        // the same delegate secrets.
-        for occ in [false, true] {
-            let hosted_wide = quiet(true, wildcard, &proxy, occ)
-                .expect("a wildcard bind must warn even in hosted mode");
-            assert!(hosted_wide.contains("hosted mode does"), "{hosted_wide}");
-        }
+        // Fires: hosted mode does NOT make a wide bind safe. `decide_user_token`
+        // returns the shared context whenever a connection omits `userToken`.
+        let hosted_wide = ws_api_shares_one_namespace_with_remote_clients(true, wildcard, &proxy)
+            .expect("a wildcard bind must warn even in hosted mode");
+        assert!(hosted_wide.contains("hosted mode does"), "{hosted_wide}");
 
-        // Fires: proxied with hosted mode off. NOT gated on occupancy — with no
-        // isolation at all the namespace fills the moment anyone uses it.
-        let proxy_reason = quiet(false, loopback, &proxy, false)
+        // Fires: proxied with hosted mode off, the shape with no isolation.
+        let proxy_reason = ws_api_shares_one_namespace_with_remote_clients(false, loopback, &proxy)
             .expect("a proxied node with hosted mode off must warn");
         assert!(proxy_reason.contains("--allowed-host"), "{proxy_reason}");
-    }
-
-    /// The occupancy probe must distinguish hosted mode's per-user namespaces
-    /// (which are the isolation, not a leak) from a genuinely shared secret,
-    /// and must not count the node's own key material at the tree root.
-    #[test]
-    fn shared_namespace_probe_ignores_per_user_dirs_and_node_keys() {
-        let dir = tempfile::tempdir().unwrap();
-        let root = dir.path();
-
-        // Empty tree.
-        assert!(!shared_delegate_namespace_is_occupied(root));
-
-        // Node key material lives at depth 1 and is not delegate-reachable.
-        std::fs::write(root.join("transport_keypair"), b"k").unwrap();
-        assert!(!shared_delegate_namespace_is_occupied(root));
-
-        // try.freenet.org's measured shape: every secret under `users/`.
-        let delegate = root.join("2hwN7pycUxLzzaEeCLNsi3XQ9zA1EpPTrWdWxcUozb9j");
-        std::fs::create_dir_all(delegate.join("users").join("alice")).unwrap();
-        std::fs::write(delegate.join("users").join("alice").join("s"), b"x").unwrap();
-        assert!(
-            !shared_delegate_namespace_is_occupied(root),
-            "per-user namespaces are the isolation, not the shared namespace"
-        );
-
-        // A secret in the delegate dir itself IS shared.
-        std::fs::write(delegate.join("shared_secret"), b"x").unwrap();
-        assert!(shared_delegate_namespace_is_occupied(root));
-    }
-
-    /// An unreadable secrets tree must read as "cannot tell", not as "empty":
-    /// silence here would be a warning suppressed by a permissions bug.
-    #[test]
-    #[cfg(unix)]
-    fn shared_namespace_probe_fails_loud_when_it_cannot_read() {
-        use std::os::unix::fs::PermissionsExt;
-        let dir = tempfile::tempdir().unwrap();
-        let delegate = dir.path().join("delegate");
-        std::fs::create_dir_all(&delegate).unwrap();
-        std::fs::set_permissions(&delegate, std::fs::Permissions::from_mode(0o000)).unwrap();
-        let unreadable = shared_delegate_namespace_is_occupied(dir.path());
-        // Restore before the assert so the tempdir can always clean up.
-        std::fs::set_permissions(&delegate, std::fs::Permissions::from_mode(0o755)).unwrap();
-        // Running as root defeats the permission bit; skip rather than lie.
-        if !nix_running_as_root() {
-            assert!(
-                unreadable,
-                "an unreadable secrets tree must not read as empty"
-            );
-        }
-    }
-
-    #[cfg(unix)]
-    fn nix_running_as_root() -> bool {
-        // SAFETY: `geteuid` takes no arguments, touches no memory and cannot
-        // fail; it is unsafe only because it is an extern "C" call.
-        unsafe { libc::geteuid() == 0 }
     }
 
     /// `build()` persists the RESOLVED config, so every node that has already
@@ -9823,16 +9720,21 @@ shutdown-drain-secs = 42
         assert_eq!(cfg.ws_api.address, IpAddr::V4(Ipv4Addr::UNSPECIFIED));
     }
 
-    /// The migration keys on "wildcard" and nothing else: a specific interface
-    /// address was never auto-written, so it is an operator choice and must
-    /// survive an upgrade untouched. Same for an explicit loopback literal —
-    /// `127.0.0.1` must not be silently rewritten to `::1`, since a node bound
-    /// to exactly one family is a deliberate posture (see `in_process_restart`).
+    /// The migration keys on "a value this code could have written" and nothing
+    /// else: a specific interface address is never auto-written, so it is an
+    /// operator choice and must survive an upgrade untouched.
+    ///
+    /// Note `127.0.0.1` is deliberately NOT in this test any more. It became
+    /// auto-derivable when re-derivation started preserving the address family
+    /// — it is what an IPv4 node re-derives TO — so it round-trips to itself
+    /// rather than being preserved. Same observable value, different mechanism;
+    /// asserting it here would pass for the wrong reason. Its real coverage is
+    /// `auto_derivable_addresses_are_exactly_the_ones_this_code_writes`.
     #[tokio::test]
     async fn persisted_explicit_address_survives_the_migration() {
         for chosen in [
             IpAddr::V4(Ipv4Addr::new(192, 168, 1, 50)),
-            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 5)),
         ] {
             let temp_dir = tempfile::tempdir().unwrap();
             let (_server, index_url) = empty_gateways_index_server();
@@ -9955,11 +9857,13 @@ shutdown-drain-secs = 42
             WsApiAddressSource::DefaultLoopback
         );
 
-        // Boot 3 in the same dir: the operator adds a CIDR grant, so the
-        // persisted `::1` is dropped and immediately auto-widened back to `::`.
-        // The bind got WIDER, so the "clients on other machines can no longer
-        // reach this node" notice must NOT fire — it would print directly above
-        // the auto-widen line and say the opposite of it.
+        // Boot 3 in the same dir: the operator applies the documented remedy on
+        // an ALREADY-MIGRATED node — config.toml holds the post-migration
+        // loopback, and the CIDR grant arrives now. This is the sequence the
+        // startup message actually points operators at, and it only works
+        // because the sentinel treats loopback as auto-derivable: read back as
+        // an operator choice it would take the Explicit short-circuit and the
+        // remedy would silently do nothing.
         let mut widened_later = ws_api_test_args(OperationMode::Network, upgrade_dir.path());
         widened_later.ws_api.allowed_source_cidrs = Some(vec!["100.64.0.0/10".to_string()]);
         let cfg = widened_later
@@ -9968,9 +9872,58 @@ shutdown-drain-secs = 42
             .expect("third build should succeed");
         assert_eq!(cfg.ws_api.address, default_listening_address());
         assert_eq!(cfg.ws_api.exposure.source, WsApiAddressSource::AutoWidened);
+        // Recorded, because the bind MOVED — and moved toward exposure. A
+        // hardening change that widens a node whose config named loopback owes
+        // the operator a loud line about it, which is why the notice is
+        // directional rather than suppressed here.
         assert_eq!(
-            cfg.ws_api.exposure.dropped_persisted_address, None,
-            "a widening re-derivation must not report itself as a loss of access"
+            cfg.ws_api.exposure.dropped_persisted_address,
+            Some(default_local_address()),
+            "widening past a persisted loopback address must be reported, not silent"
+        );
+    }
+
+    /// D4 regression: the same remedy sequence, asserted on the BIND rather
+    /// than on the exposure record, and starting from a node that is already
+    /// migrated. `auto_widen_preserves_the_address_family` starts from a
+    /// persisted wildcard, which is the migration boot, not the remedy.
+    #[tokio::test]
+    async fn remedy_still_works_after_the_upgrade_persisted_loopback() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let (_server, index_url) = empty_gateways_index_server();
+
+        // Boot 1: pre-upgrade node with the old wildcard auto-default.
+        let mut first = ws_api_test_args(OperationMode::Network, temp_dir.path());
+        first.ws_api.address = Some(default_listening_address());
+        first
+            .build_with_gateways_index(&index_url)
+            .await
+            .expect("first build should succeed");
+
+        // Boot 2: upgraded, flag-less. Re-derived to loopback and persisted.
+        let migrated = ws_api_test_args(OperationMode::Network, temp_dir.path())
+            .build_with_gateways_index(&index_url)
+            .await
+            .expect("second build should succeed");
+        assert_eq!(migrated.ws_api.address, default_local_address());
+        let persisted =
+            std::fs::read_to_string(temp_dir.path().join("config.toml")).expect("config persisted");
+        assert!(
+            persisted.contains(r#"ws-api-address = "::1""#),
+            "test premise: the loopback address must be persisted, got:\n{persisted}"
+        );
+
+        // Boot 3: the operator applies the documented remedy.
+        let mut remedied = ws_api_test_args(OperationMode::Network, temp_dir.path());
+        remedied.ws_api.allowed_source_cidrs = Some(vec!["100.64.0.0/10".to_string()]);
+        let cfg = remedied
+            .build_with_gateways_index(&index_url)
+            .await
+            .expect("third build should succeed");
+        assert_eq!(
+            cfg.ws_api.address,
+            default_listening_address(),
+            "the auto-widen remedy must still work once the migration has run"
         );
     }
 

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -1875,6 +1875,25 @@ impl Config {
                 );
             }
         }
+        // These two branches report the SAME event — a persisted address was
+        // dropped and re-derived — in the two directions it can go. They are
+        // deliberately separate messages rather than one message plus a filter,
+        // and the history is worth keeping.
+        //
+        // An earlier cut emitted only the narrowing text and fired it whenever
+        // anything was dropped, so a node that dropped a loopback value and then
+        // auto-widened printed "clients on other machines can no longer reach
+        // this node" directly above "bound to all interfaces". The fix applied to
+        // that contradiction was to SUPPRESS the first line for the widening
+        // case — which silenced the only notice that a node someone had pinned
+        // to loopback was now listening on every interface, and that widening
+        // then went unnoticed through two further rounds of review.
+        //
+        // The lesson, because the next person to hit a noisy contradiction will
+        // reach for the same fix: a contradictory pair of log lines is evidence
+        // that the code does two DIFFERENT things on one path. Make each message
+        // say which one happened. Never silence one of them — the branch you
+        // suppress is the one nobody will hear about again.
         if let Some(persisted) = self.ws_api.exposure.dropped_persisted_address {
             if address.is_loopback() {
                 // warn!, not info!: this fires on ONE boot and never again (from

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -266,7 +266,15 @@ impl Default for ConfigArgs {
                 bbr_startup_rate: None,    // Uses default from BBR config
             },
             ws_api: WebsocketApiArgs {
-                address: Some(default_listening_address()),
+                // `None`, NOT an explicit address: this is the "operator said
+                // nothing" state, so it must fall through to
+                // `resolve_ws_api_address` and land on loopback. Pinning
+                // `Some(default_listening_address())` here took the Explicit
+                // branch and silently reinstated the wildcard bind for every
+                // programmatic composition (GHSA-824h-7x5x-wfmf). Contrast
+                // `network_api.address` above, which SHOULD stay `::`: that is
+                // the overlay transport, which does have to accept peers.
+                address: None,
                 ws_api_port: Some(default_ws_api_port()),
                 token_ttl_seconds: None,
                 token_cleanup_interval_seconds: None,
@@ -708,11 +716,50 @@ impl ConfigArgs {
             }
         };
 
+        // Set when the config.toml merge below discards a persisted wildcard
+        // `ws-api-address` as the old auto-default; reported after resolution,
+        // and only if the bind actually moved. See the merge site.
+        let mut dropped_persisted_wildcard: Option<IpAddr> = None;
+
         // merge the configuration from the file with the command line arguments
         if let Some(cfg) = cfg {
             self.secrets.merge(cfg.secrets);
             self.mode.get_or_insert(cfg.mode);
-            self.ws_api.address.get_or_insert(cfg.ws_api.address);
+            // GHSA-824h-7x5x-wfmf upgrade migration. `build()` persists the
+            // RESOLVED config, so every node that has ever booted in network
+            // mode already has the old auto-default written into its
+            // config.toml as a literal `ws-api-address`. A plain get_or_insert
+            // would merge that back and pin the whole existing fleet to the
+            // wildcard bind forever — the hardening would reach fresh installs
+            // only, which is no hardening at all.
+            //
+            // The sentinel is "wildcard", not one literal: the auto-default was
+            // `0.0.0.0` before #3648 and `::` after, and both are exactly the
+            // "any interface" bind this change exists to stop defaulting to. So
+            // an unspecified persisted address is treated as auto-written: skip
+            // the merge and let the resolution below re-derive — loopback, or
+            // the wildcard again if --allowed-source-cidrs / --allowed-host
+            // says the operator wants non-local clients. Any OTHER persisted
+            // value (a specific interface IP, `127.0.0.1`, `::1`) was never
+            // auto-written, so it is an explicit choice and is preserved
+            // unchanged.
+            //
+            // CLI/env values are parsed into `self` BEFORE this merge, so
+            // `--ws-api-address ::` still wins on every boot. Accepted,
+            // release-note-worthy edge: an operator who hand-edited a wildcard
+            // into config.toml with no CLI flag and no allow-list is
+            // indistinguishable from the old auto-default and gets re-derived
+            // to loopback. The remedy is one flag.
+            if !cfg.ws_api.address.is_unspecified() {
+                self.ws_api.address.get_or_insert(cfg.ws_api.address);
+            } else if self.ws_api.address.is_none() {
+                // Only note it if the re-derivation actually CHANGES the bind.
+                // A node with an overlay/proxy grant drops the persisted
+                // wildcard here and auto-widens straight back to it, and
+                // announcing "ignoring your address" on every boot of a node
+                // whose bind never moved is how a log line gets tuned out.
+                dropped_persisted_wildcard = Some(cfg.ws_api.address);
+            }
             self.ws_api.ws_api_port.get_or_insert(cfg.ws_api.port);
             self.ws_api
                 .token_ttl_seconds
@@ -1207,6 +1254,57 @@ impl ConfigArgs {
             gateways = cli_gateways;
         }
 
+        // --- client (HTTP/WebSocket) API exposure ---------------------------
+        // Resolved before the `Config` literal so the bind address, the host
+        // allowlist and the hosted-mode flag are all in scope together: the
+        // exposure warning below needs all three, and the auto-widen decision
+        // needs to be logged, which a struct-literal field initializer cannot
+        // do cleanly.
+        let ws_api_allowed_hosts = self.ws_api.allowed_host.clone().unwrap_or_default();
+        let ws_api_hosted_mode = self.ws_api.hosted_mode.unwrap_or(false);
+        let (ws_api_address, ws_api_address_source) = resolve_ws_api_address(
+            self.ws_api.address,
+            self.ws_api.allowed_source_cidrs.as_deref(),
+            self.ws_api.allowed_host.as_deref(),
+        );
+        if let Some(persisted) = dropped_persisted_wildcard {
+            if ws_api_address != persisted {
+                tracing::info!(
+                    %persisted,
+                    resolved = %ws_api_address,
+                    "The client API now defaults to loopback, so the wildcard \
+                     `ws-api-address` previously auto-written to config.toml is being \
+                     re-derived. Clients on OTHER machines will no longer be able to \
+                     reach this node's API. Pass --ws-api-address :: (or set \
+                     --allowed-source-cidrs / --allowed-host) if they should."
+                );
+            }
+        }
+        if ws_api_address_source == WsApiAddressSource::AutoWidened {
+            tracing::info!(
+                address = %ws_api_address,
+                "Client API bound to all interfaces because --allowed-source-cidrs \
+                 and/or --allowed-host was set (those flags are no-ops on a loopback \
+                 listener). The default is loopback only; pass --ws-api-address \
+                 explicitly to override this."
+            );
+        }
+        if let Some(reason) = ws_api_shares_one_namespace_with_remote_clients(
+            ws_api_hosted_mode,
+            ws_api_address,
+            &ws_api_allowed_hosts,
+        ) {
+            tracing::warn!(
+                address = %ws_api_address,
+                allowed_hosts = ?ws_api_allowed_hosts,
+                "Client API is reachable from outside this machine while hosted mode is \
+                 OFF, so every connection shares ONE delegate-secret namespace and can \
+                 read and modify this node's contract state, identities and keys: \
+                 {reason}. Bind loopback (--ws-api-address ::1) unless you intend this, \
+                 or enable --hosted-mode for per-user isolation."
+            );
+        }
+
         let this = Config {
             mode,
             peer_id,
@@ -1266,12 +1364,7 @@ impl ConfigArgs {
                 skip_load_from_network: self.network_api.skip_load_from_network,
             },
             ws_api: WebsocketApiConfig {
-                address: {
-                    self.ws_api.address.unwrap_or_else(|| match mode {
-                        OperationMode::Local => default_local_address(),
-                        OperationMode::Network => default_listening_address(),
-                    })
-                },
+                address: ws_api_address,
                 port: self.ws_api.ws_api_port.unwrap_or(default_ws_api_port()),
                 token_ttl_seconds: self
                     .ws_api
@@ -1281,7 +1374,7 @@ impl ConfigArgs {
                     .ws_api
                     .token_cleanup_interval_seconds
                     .unwrap_or(default_token_cleanup_interval_seconds()),
-                allowed_hosts: self.ws_api.allowed_host.unwrap_or_default(),
+                allowed_hosts: ws_api_allowed_hosts,
                 allowed_source_cidrs: self
                     .ws_api
                     .allowed_source_cidrs
@@ -1304,7 +1397,7 @@ impl ConfigArgs {
                     })
                     .transpose()?
                     .unwrap_or_default(),
-                hosted_mode: self.ws_api.hosted_mode.unwrap_or(false),
+                hosted_mode: ws_api_hosted_mode,
                 per_user_op_rate_limit: self
                     .ws_api
                     .per_user_op_rate_limit
@@ -2282,7 +2375,18 @@ fn default_bbr_startup_rate() -> Option<u64> {
 
 #[derive(clap::Parser, Debug, Default, Clone, Serialize, Deserialize)]
 pub struct WebsocketApiArgs {
-    /// Address to bind to for the websocket API, default is :: (dual-stack)
+    /// Address to bind to for the local HTTP/WebSocket client API.
+    ///
+    /// Defaults to loopback (`::1`, with a `127.0.0.1` companion bind) in BOTH
+    /// operation modes: running as a network peer says nothing about wanting
+    /// this node's fully-privileged control API driveable from other machines.
+    /// Pass `::` (or a specific interface address) to serve clients on other
+    /// hosts. Setting `--allowed-source-cidrs` or `--allowed-host` without this
+    /// flag widens the bind to `::` automatically, since neither flag does
+    /// anything on a loopback listener.
+    ///
+    /// SECURITY: anything that can reach this address and port can read and
+    /// modify your contract state, identities and keys.
     #[arg(
         name = "ws_api_address",
         long = "ws-api-address",
@@ -2830,7 +2934,11 @@ impl Default for WebsocketApiConfig {
     #[inline]
     fn default() -> Self {
         Self {
-            address: default_listening_address(),
+            // Loopback, matching `resolve_ws_api_address`'s default: a caller
+            // that composes this config without going through
+            // `ConfigArgs::build()` gets the safe bind rather than silently
+            // inheriting a wildcard listener (GHSA-824h-7x5x-wfmf).
+            address: default_local_address(),
             port: default_ws_api_port(),
             token_ttl_seconds: default_token_ttl_seconds(),
             token_cleanup_interval_seconds: default_token_cleanup_interval_seconds(),
@@ -2855,6 +2963,105 @@ const fn default_listening_address() -> IpAddr {
 #[inline]
 const fn default_local_address() -> IpAddr {
     IpAddr::V6(Ipv6Addr::LOCALHOST)
+}
+
+/// How [`resolve_ws_api_address`] arrived at the client-API bind address.
+///
+/// Carried out of the pure resolver so `build()` can log the auto-widen at
+/// INFO without the resolver itself needing a tracing dependency (and so the
+/// unit tests can assert on the decision rather than only its byte value).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WsApiAddressSource {
+    /// The operator named an address (`--ws-api-address`, `WS_API_ADDRESS`, or
+    /// a `ws-api-address` key in `config.toml`). Used verbatim.
+    Explicit,
+    /// No address given, and no LAN/overlay access was configured either:
+    /// loopback (`::1`, plus its `127.0.0.1` companion bind).
+    DefaultLoopback,
+    /// No address given, but `--allowed-source-cidrs` and/or `--allowed-host`
+    /// was — flags that only mean anything for a non-loopback listener. Widened
+    /// to the wildcard `::` so those invocations keep working unchanged.
+    AutoWidened,
+}
+
+/// Resolve the address the client (HTTP/WebSocket) API binds to.
+///
+/// The default is **loopback in both operation modes**. `OperationMode` still
+/// governs ring participation and `secrets_dir(mode)`; it deliberately does NOT
+/// govern who may drive the client API. Running as a network peer is a
+/// statement about the overlay, not consent to expose a fully-privileged
+/// control API (contract state, delegate secrets, key material) to every host
+/// on the LAN. Anyone who wants that exposure asks for it — see the two
+/// non-default branches below.
+///
+/// Auto-widening exists so the pre-existing, working invocations keep working
+/// with zero operator action: `--allowed-source-cidrs` (the Tailscale/WireGuard
+/// overlay grant) and `--allowed-host` (the reverse-proxy hostname grant) are
+/// both no-ops on a loopback listener, so setting either is an unambiguous
+/// statement of intent to serve non-local clients. Setting `--ws-api-address`
+/// explicitly always wins; auto-widening never overrides an operator's choice.
+fn resolve_ws_api_address(
+    explicit: Option<IpAddr>,
+    allowed_source_cidrs: Option<&[String]>,
+    allowed_hosts: Option<&[String]>,
+) -> (IpAddr, WsApiAddressSource) {
+    if let Some(addr) = explicit {
+        return (addr, WsApiAddressSource::Explicit);
+    }
+    // `Some(vec![])` is treated as unset: an empty list grants nothing, and the
+    // config-file merge can hand us an empty vec from a persisted `[]`.
+    let widening_intent = allowed_source_cidrs.is_some_and(|c| !c.is_empty())
+        || allowed_hosts.is_some_and(|h| !h.is_empty());
+    if widening_intent {
+        (default_listening_address(), WsApiAddressSource::AutoWidened)
+    } else {
+        (default_local_address(), WsApiAddressSource::DefaultLoopback)
+    }
+}
+
+/// Whether startup should warn that the client API is reachable beyond this
+/// machine while every connection shares ONE secret namespace.
+///
+/// Hosted mode (`--hosted-mode`) is what gives each connection its own
+/// delegate-secret namespace keyed by `userToken`. With it OFF, every
+/// connection — local or not — drives the same single-user node: the same
+/// delegate secrets, the same identities, the same contract state. That is
+/// correct and safe for a loopback-only listener, and is the silent-exposure
+/// case the moment the listener is reachable from elsewhere.
+///
+/// Two independently-sufficient triggers:
+/// - a **non-loopback bind**: any host that can route to the address can drive
+///   the API;
+/// - **`--allowed-host` set**: the reverse-proxy grant. A proxy terminates the
+///   connection itself, so every visitor arrives wearing the proxy's source
+///   address and looks local to the node's own filters — the LAN/CIDR checks
+///   cannot distinguish them. This fires even on a loopback bind, because a
+///   proxy in front of `127.0.0.1:7509` is precisely how a node gets exposed
+///   to the internet without ever binding a non-loopback address.
+///
+/// Returns the reason to warn about, or `None` to stay quiet. Naming the
+/// reason keeps the log actionable: "bound to 0.0.0.0" and "sits behind a
+/// reverse proxy" call for different fixes, and a warning that guesses wrong
+/// is a warning operators learn to ignore.
+fn ws_api_shares_one_namespace_with_remote_clients(
+    hosted_mode: bool,
+    address: IpAddr,
+    allowed_hosts: &[String],
+) -> Option<&'static str> {
+    if hosted_mode {
+        return None;
+    }
+    if !address.is_loopback() {
+        Some(
+            "the client API is bound to a non-loopback address, so any host that can route to it can drive this node",
+        )
+    } else if !allowed_hosts.is_empty() {
+        Some(
+            "--allowed-host names a reverse proxy in front of this node; a proxy terminates the connection itself, so every visitor arrives looking local and the source-IP filters cannot tell them apart",
+        )
+    } else {
+        None
+    }
 }
 
 #[inline]
@@ -4718,6 +4925,7 @@ mod tests {
     use httptest::{Expectation, Server, matchers::*, responders::*};
 
     use std::collections::BTreeSet;
+    use std::net::Ipv4Addr;
 
     use crate::node::NodeConfig;
     use crate::transport::TransportKeypair;
@@ -8843,5 +9051,364 @@ shutdown-drain-secs = 42
             i += 1;
         }
         panic!("unterminated body for {signature_prefix}");
+    }
+
+    // ------------------------------------------------------------------
+    // GHSA-824h-7x5x-wfmf — the client API defaults to loopback in BOTH
+    // operation modes.
+    //
+    // Before this change `OperationMode::Network` defaulted the client API to
+    // the wildcard `::`, so every host on the LAN could drive a fully
+    // privileged control API (contract state, delegate secrets, key material)
+    // on any node whose operator had done nothing but run `freenet network`.
+    // `OperationMode` still governs ring participation and `secrets_dir(mode)`;
+    // it no longer governs who may drive the client API.
+    // ------------------------------------------------------------------
+
+    /// Build a `ConfigArgs` in `mode` with everything unrelated to the client
+    /// API pinned to something inert, so a test can vary only the ws-api knobs.
+    fn ws_api_test_args(mode: OperationMode, config_dir: &std::path::Path) -> ConfigArgs {
+        ConfigArgs {
+            mode: Some(mode),
+            config_paths: ConfigPathsArgs {
+                config_dir: Some(config_dir.to_path_buf()),
+                data_dir: Some(config_dir.to_path_buf()),
+                log_dir: Some(config_dir.to_path_buf()),
+            },
+            network_api: NetworkArgs {
+                // A public identity means the peer may bootstrap disjoint, so
+                // an empty gateway index is not a build error and the test
+                // stays focused on the ws-api resolution.
+                public_address: Some("198.51.100.7".parse().unwrap()),
+                public_port: Some(31337),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn ws_api_defaults_to_loopback_in_network_mode() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let (_server, index_url) = empty_gateways_index_server();
+
+        let cfg = ws_api_test_args(OperationMode::Network, temp_dir.path())
+            .build_with_gateways_index(&index_url)
+            .await
+            .expect("build should succeed");
+
+        assert_eq!(
+            cfg.ws_api.address,
+            default_local_address(),
+            "a plain `freenet network` node must NOT expose its client API to the LAN"
+        );
+        assert!(cfg.ws_api.address.is_loopback());
+    }
+
+    #[tokio::test]
+    async fn ws_api_defaults_to_loopback_in_local_mode() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let (_server, index_url) = empty_gateways_index_server();
+
+        let cfg = ws_api_test_args(OperationMode::Local, temp_dir.path())
+            .build_with_gateways_index(&index_url)
+            .await
+            .expect("build should succeed");
+
+        assert_eq!(cfg.ws_api.address, default_local_address());
+    }
+
+    #[tokio::test]
+    async fn ws_api_auto_widens_when_allowed_source_cidrs_is_set() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let (_server, index_url) = empty_gateways_index_server();
+
+        let mut args = ws_api_test_args(OperationMode::Network, temp_dir.path());
+        // The canonical Tailscale invocation, which worked before this change
+        // only because the default happened to be `::`.
+        args.ws_api.allowed_source_cidrs = Some(vec!["100.64.0.0/10".to_string()]);
+
+        let cfg = args
+            .build_with_gateways_index(&index_url)
+            .await
+            .expect("build should succeed");
+
+        assert_eq!(
+            cfg.ws_api.address,
+            default_listening_address(),
+            "--allowed-source-cidrs is a no-op on a loopback listener, so it must widen the bind"
+        );
+    }
+
+    #[tokio::test]
+    async fn ws_api_auto_widens_when_allowed_host_is_set() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let (_server, index_url) = empty_gateways_index_server();
+
+        let mut args = ws_api_test_args(OperationMode::Network, temp_dir.path());
+        args.ws_api.allowed_host = Some(vec!["node.example.org".to_string()]);
+
+        let cfg = args
+            .build_with_gateways_index(&index_url)
+            .await
+            .expect("build should succeed");
+
+        assert_eq!(cfg.ws_api.address, default_listening_address());
+    }
+
+    #[tokio::test]
+    async fn explicit_ws_api_address_is_never_auto_widened() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let (_server, index_url) = empty_gateways_index_server();
+
+        // This is try.freenet.org's exact shape: an explicit loopback bind
+        // behind a reverse proxy that is named with --allowed-host. The
+        // explicit flag must win, or the hardening would silently un-harden
+        // the one deployment that already did the right thing.
+        let mut args = ws_api_test_args(OperationMode::Network, temp_dir.path());
+        args.ws_api.address = Some(IpAddr::V4(Ipv4Addr::LOCALHOST));
+        args.ws_api.allowed_host = Some(vec!["try.freenet.org".to_string()]);
+        args.ws_api.allowed_source_cidrs = Some(vec!["100.64.0.0/10".to_string()]);
+
+        let cfg = args
+            .build_with_gateways_index(&index_url)
+            .await
+            .expect("build should succeed");
+
+        assert_eq!(cfg.ws_api.address, IpAddr::V4(Ipv4Addr::LOCALHOST));
+    }
+
+    /// An empty allow-list grants nothing, so it must not be read as intent to
+    /// widen. This is not hypothetical: the config-file merge hands `build()`
+    /// the persisted `allowed-host = []` / `allowed-source-cidrs = []` that
+    /// every already-booted node has in its `config.toml`.
+    #[test]
+    fn empty_allow_lists_do_not_widen() {
+        assert_eq!(
+            resolve_ws_api_address(None, Some(&[]), Some(&[])),
+            (default_local_address(), WsApiAddressSource::DefaultLoopback)
+        );
+        assert_eq!(
+            resolve_ws_api_address(None, None, None),
+            (default_local_address(), WsApiAddressSource::DefaultLoopback)
+        );
+    }
+
+    #[test]
+    fn resolve_ws_api_address_reports_how_it_decided() {
+        let explicit = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 50));
+        assert_eq!(
+            resolve_ws_api_address(Some(explicit), None, None),
+            (explicit, WsApiAddressSource::Explicit)
+        );
+        assert_eq!(
+            resolve_ws_api_address(None, Some(&["10.0.0.0/8".to_string()]), None),
+            (default_listening_address(), WsApiAddressSource::AutoWidened)
+        );
+        assert_eq!(
+            resolve_ws_api_address(None, None, Some(&["h.example".to_string()])),
+            (default_listening_address(), WsApiAddressSource::AutoWidened)
+        );
+    }
+
+    /// The exposure warning fires on hosted-mode-off AND (non-loopback bind OR
+    /// an `--allowed-host` reverse-proxy grant). Both triggers matter: a proxy
+    /// terminates the connection itself, so every visitor looks local to the
+    /// node's own source-IP filters even when the bind is `127.0.0.1`.
+    #[test]
+    fn exposure_warning_fires_only_when_one_namespace_is_reachable_remotely() {
+        let loopback = default_local_address();
+        let wildcard = default_listening_address();
+        let proxy = vec!["try.freenet.org".to_string()];
+
+        // Quiet: the default single-user desktop node.
+        assert_eq!(
+            ws_api_shares_one_namespace_with_remote_clients(false, loopback, &[]),
+            None
+        );
+        // Quiet: hosted mode gives each connection its own secret namespace,
+        // which is exactly what makes a proxied deployment safe. try.freenet.org
+        // is this row — it must not emit a scary warning on every restart.
+        assert_eq!(
+            ws_api_shares_one_namespace_with_remote_clients(true, loopback, &proxy),
+            None
+        );
+        assert_eq!(
+            ws_api_shares_one_namespace_with_remote_clients(true, wildcard, &proxy),
+            None
+        );
+
+        // Fires: reachable from other machines, one shared namespace. The
+        // reason names the bind, which is the thing to change.
+        let bind_reason = ws_api_shares_one_namespace_with_remote_clients(false, wildcard, &[])
+            .expect("a wildcard bind with hosted mode off must warn");
+        assert!(bind_reason.contains("non-loopback"), "{bind_reason}");
+
+        // Fires: the genuinely dangerous shape — proxied with hosted mode off.
+        // Different reason, because the remedy is different.
+        let proxy_reason = ws_api_shares_one_namespace_with_remote_clients(false, loopback, &proxy)
+            .expect("a proxied node with hosted mode off must warn");
+        assert!(proxy_reason.contains("--allowed-host"), "{proxy_reason}");
+    }
+
+    /// `build()` persists the RESOLVED config, so every node that has already
+    /// booted in network mode carries the old auto-default
+    /// `ws-api-address = "::"` in its `config.toml`. Merging that back would
+    /// pin the entire existing fleet to the wildcard bind and leave the
+    /// hardening reaching fresh installs only.
+    #[tokio::test]
+    async fn persisted_legacy_wildcard_address_is_re_derived_to_loopback() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let (_server, index_url) = empty_gateways_index_server();
+
+        // First boot on the OLD code: resolve to `::` and persist it.
+        let mut first = ws_api_test_args(OperationMode::Network, temp_dir.path());
+        first.ws_api.address = Some(default_listening_address());
+        let first_cfg = first
+            .build_with_gateways_index(&index_url)
+            .await
+            .expect("first build should succeed");
+        assert_eq!(first_cfg.ws_api.address, default_listening_address());
+        let persisted =
+            std::fs::read_to_string(temp_dir.path().join("config.toml")).expect("config persisted");
+        assert!(
+            persisted.contains(r#"ws-api-address = "::""#),
+            "test premise: the wildcard must actually be written to config.toml, got:\n{persisted}"
+        );
+
+        // Second boot on the NEW code, flag-less: the persisted `::` is
+        // recognised as the old auto-default and re-derived.
+        let cfg = ws_api_test_args(OperationMode::Network, temp_dir.path())
+            .build_with_gateways_index(&index_url)
+            .await
+            .expect("second build should succeed");
+        assert_eq!(
+            cfg.ws_api.address,
+            default_local_address(),
+            "an upgrading node must stop exposing its client API to the LAN"
+        );
+    }
+
+    /// `default_listening_address()` was `0.0.0.0` before #3648 and `::` after,
+    /// so a node old enough to have persisted the IPv4 wildcard must be
+    /// migrated too — keying the sentinel on today's literal only would leave
+    /// the oldest installs (the ones most likely to be forgotten) exposed.
+    #[tokio::test]
+    async fn persisted_legacy_ipv4_wildcard_is_also_re_derived_to_loopback() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let (_server, index_url) = empty_gateways_index_server();
+
+        let mut first = ws_api_test_args(OperationMode::Network, temp_dir.path());
+        first.ws_api.address = Some(IpAddr::V4(Ipv4Addr::UNSPECIFIED));
+        first
+            .build_with_gateways_index(&index_url)
+            .await
+            .expect("first build should succeed");
+
+        let cfg = ws_api_test_args(OperationMode::Network, temp_dir.path())
+            .build_with_gateways_index(&index_url)
+            .await
+            .expect("second build should succeed");
+        assert_eq!(cfg.ws_api.address, default_local_address());
+    }
+
+    /// The migration keys on "wildcard" and nothing else: a specific interface
+    /// address was never auto-written, so it is an operator choice and must
+    /// survive an upgrade untouched. Same for an explicit loopback literal —
+    /// `127.0.0.1` must not be silently rewritten to `::1`, since a node bound
+    /// to exactly one family is a deliberate posture (see `in_process_restart`).
+    #[tokio::test]
+    async fn persisted_explicit_address_survives_the_migration() {
+        for chosen in [
+            IpAddr::V4(Ipv4Addr::new(192, 168, 1, 50)),
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+        ] {
+            let temp_dir = tempfile::tempdir().unwrap();
+            let (_server, index_url) = empty_gateways_index_server();
+
+            let mut first = ws_api_test_args(OperationMode::Network, temp_dir.path());
+            first.ws_api.address = Some(chosen);
+            first
+                .build_with_gateways_index(&index_url)
+                .await
+                .expect("first build should succeed");
+
+            let cfg = ws_api_test_args(OperationMode::Network, temp_dir.path())
+                .build_with_gateways_index(&index_url)
+                .await
+                .expect("second build should succeed");
+            assert_eq!(cfg.ws_api.address, chosen);
+        }
+    }
+
+    /// The upgrade path for a Tailscale-style node: it persisted `::` (the old
+    /// auto-default) alongside its CIDR grant, so the migration drops the
+    /// address and auto-widening must put it straight back. Zero operator
+    /// action, same bind as before the upgrade.
+    #[tokio::test]
+    async fn upgrading_node_with_cidr_grant_keeps_its_wildcard_bind() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let (_server, index_url) = empty_gateways_index_server();
+
+        let mut first = ws_api_test_args(OperationMode::Network, temp_dir.path());
+        first.ws_api.address = Some(default_listening_address());
+        first.ws_api.allowed_source_cidrs = Some(vec!["100.64.0.0/10".to_string()]);
+        first
+            .build_with_gateways_index(&index_url)
+            .await
+            .expect("first build should succeed");
+
+        // Flag-less restart: the CIDR grant comes back from config.toml.
+        let cfg = ws_api_test_args(OperationMode::Network, temp_dir.path())
+            .build_with_gateways_index(&index_url)
+            .await
+            .expect("second build should succeed");
+        assert_eq!(cfg.ws_api.address, default_listening_address());
+        assert_eq!(cfg.ws_api.allowed_source_cidrs.len(), 1);
+    }
+
+    /// Source pin: `build()` must actually consult the resolver and the warning
+    /// predicate. A unit-tested pure function that nothing calls is a
+    /// verification that cannot fail.
+    #[test]
+    fn build_resolves_the_ws_api_address_through_the_shared_helpers() {
+        let body = extract_fn_body(
+            production_source(),
+            "async fn build_with_gateways_index(mut self, gateways_index: &str)",
+        );
+        for needle in [
+            "resolve_ws_api_address(",
+            "ws_api_shares_one_namespace_with_remote_clients(",
+        ] {
+            assert!(
+                body.contains(needle),
+                "build_with_gateways_index no longer calls `{needle}` — the client-API \
+                 exposure default/warning has been bypassed"
+            );
+        }
+        // Bound the "no mode-keyed default" check to the `ws_api` literal.
+        // A bare `body.contains(..)` would match `network_api`'s own
+        // `OperationMode::Network => default_listening_address()` a few lines
+        // above and pass vacuously — the network transport SHOULD keep binding
+        // all interfaces; only the client API moves.
+        let ws_api_literal = {
+            let start = body
+                .find("ws_api: WebsocketApiConfig {")
+                .expect("build() must still construct the ws_api config inline");
+            let rest = &body[start..];
+            let end = rest
+                .find("port: self")
+                .expect("the ws_api literal must still set `port` right after `address`");
+            &rest[..end]
+        };
+        assert!(
+            ws_api_literal.contains("address: ws_api_address"),
+            "the ws_api bind address no longer comes from resolve_ws_api_address: \n{ws_api_literal}"
+        );
+        assert!(
+            !ws_api_literal.contains("OperationMode::"),
+            "the mode-keyed ws-api default is back: OperationMode must not govern \
+             who may drive the client API (GHSA-824h-7x5x-wfmf)"
+        );
     }
 }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -3,7 +3,7 @@ use std::{
     fs::{self, File},
     future::Future,
     io::{Read, Write},
-    net::{IpAddr, Ipv6Addr, SocketAddr},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     path::{Path, PathBuf},
     sync::{Arc, LazyLock, atomic::AtomicBool},
     time::Duration,
@@ -716,10 +716,21 @@ impl ConfigArgs {
             }
         };
 
-        // Set when the config.toml merge below discards a persisted wildcard
-        // `ws-api-address` as the old auto-default; reported after resolution,
-        // and only if the bind actually moved. See the merge site.
+        // Set when the config.toml merge below discards an auto-derivable
+        // `ws-api-address`; reported after resolution, and only if the bind
+        // actually narrowed. Also carries the address FAMILY forward, which the
+        // re-derivation must not change. See the merge site.
         let mut dropped_persisted_wildcard: Option<IpAddr> = None;
+
+        // Captured BEFORE the merge below, because the merge folds a PERSISTED
+        // `allowed-source-cidrs` back into `self` and `build()` then persists
+        // whatever it resolves. Reading the merged value would make the
+        // auto-widen sticky: one boot with the flag would pin the node to the
+        // wildcard bind forever, and REMOVING the flag would never narrow it
+        // again — the hardening would permanently miss every node that ever set
+        // an allow-list. The address itself already gets exactly this
+        // treatment; the grant that widens it has to match.
+        let cidrs_granted_this_boot = self.ws_api.allowed_source_cidrs.clone();
 
         // merge the configuration from the file with the command line arguments
         if let Some(cfg) = cfg {
@@ -1263,8 +1274,8 @@ impl ConfigArgs {
         let (ws_api_address, ws_api_address_source) = resolve_ws_api_address(
             mode,
             self.ws_api.address,
-            self.ws_api.allowed_source_cidrs.as_deref(),
-            self.ws_api.allowed_host.as_deref(),
+            cidrs_granted_this_boot.as_deref(),
+            dropped_persisted_wildcard,
         );
         // Recorded, NOT logged: `build()` runs before `set_logger`, so anything
         // emitted here has no subscriber. `Config::log_client_api_exposure()`
@@ -1837,32 +1848,66 @@ impl Config {
     /// whether the resulting exposure is dangerous.
     pub fn log_client_api_exposure(&self) {
         let address = self.ws_api.address;
+
+        // The two allow-list env vars were UNNAMESPACED (`ALLOWED_HOST`,
+        // `ALLOWED_SOURCE_CIDRS`) until GHSA-824h-7x5x-wfmf. That was survivable
+        // while they only added a Host-header entry to a socket that was wide
+        // anyway; now `--allowed-source-cidrs` DECIDES whether the socket is
+        // wide, so a stray value in a shared container, CI runner or systemd
+        // environment could open the API. They are namespaced, and a leftover
+        // old-style variable is reported rather than ignored — otherwise a
+        // working overlay deployment goes loopback-only with no explanation.
+        for (legacy, replacement) in [
+            ("ALLOWED_HOST", "FREENET_ALLOWED_HOST"),
+            ("ALLOWED_SOURCE_CIDRS", "FREENET_ALLOWED_SOURCE_CIDRS"),
+        ] {
+            if std::env::var_os(legacy).is_some() && std::env::var_os(replacement).is_none() {
+                tracing::warn!(
+                    legacy,
+                    replacement,
+                    "The environment variable `{legacy}` is no longer read (it was \
+                     unnamespaced, and it can now decide whether the client API listens \
+                     beyond this machine). Rename it to `{replacement}`."
+                );
+            }
+        }
         if let Some(persisted) = self.ws_api.exposure.dropped_persisted_address {
-            tracing::info!(
+            // warn!, not info!: this fires on ONE boot and never again (the
+            // filter keys on a non-loopback persisted value, and boot 2 onward
+            // sees loopback). For a remote gateway whose operator finds out
+            // days later when a client fails, this line is the whole
+            // explanation, so it must not be ranked below the exposure warning
+            // that fires for the comparatively safe case.
+            tracing::warn!(
                 %persisted,
                 resolved = %address,
                 "The client API now defaults to loopback, so the `ws-api-address` \
                  previously auto-written to config.toml has been re-derived. Clients \
-                 on OTHER machines can no longer reach this node's API. Add \
-                 --ws-api-address :: to this node's invocation (or set \
-                 --allowed-source-cidrs / --allowed-host) if they should — a value \
-                 only persisted in config.toml is not enough, because this code \
-                 cannot tell its own past output from your choice."
+                 on OTHER machines can no longer reach this node's API. If they \
+                 should, add --ws-api-address :: to the node's invocation and KEEP it \
+                 there — a value only persisted in config.toml is not enough, because \
+                 this code cannot tell its own past output from your choice. On a \
+                 systemd install add it with `systemctl edit` as a drop-in; do not \
+                 hand-edit the generated unit, which marks it user-modified and opts \
+                 this node out of future unit updates."
             );
         }
         if self.ws_api.exposure.source == WsApiAddressSource::AutoWidened {
             tracing::info!(
                 %address,
-                "Client API bound to all interfaces because --allowed-source-cidrs \
-                 and/or --allowed-host is set, preserving an invocation that relied on \
-                 the old network-mode default. The default is now loopback; pass \
-                 --ws-api-address explicitly to override this either way."
+                "Client API bound to all interfaces because --allowed-source-cidrs is \
+                 set, preserving an invocation that relied on the old network-mode \
+                 default (that flag is inert on a loopback socket). The default is now \
+                 loopback; pass --ws-api-address explicitly to override this either \
+                 way, and keep the flag in the invocation — a grant left only in \
+                 config.toml does not widen a later boot."
             );
         }
         if let Some(reason) = ws_api_shares_one_namespace_with_remote_clients(
             self.ws_api.hosted_mode,
             address,
             &self.ws_api.allowed_hosts,
+            shared_delegate_namespace_is_occupied(&self.ws_api.secrets_dir),
         ) {
             tracing::warn!(
                 %address,
@@ -2450,16 +2495,25 @@ pub struct WebsocketApiArgs {
     /// Use when accessing the node via a custom domain (e.g., through a reverse proxy).
     /// Can be specified multiple times. If omitted, only the machine's hostname and
     /// bound IP are accepted.
-    #[arg(long, env = "ALLOWED_HOST")]
+    #[arg(long, env = "FREENET_ALLOWED_HOST")]
     #[serde(rename = "allowed-host", skip_serializing_if = "Option::is_none")]
     pub allowed_host: Option<Vec<String>>,
 
     /// Additional source IP ranges (CIDR notation) permitted to reach the
     /// local HTTP/WebSocket API.
     ///
-    /// By default, only loopback and RFC1918 / IPv6 ULA ranges are accepted.
-    /// Use this to grant access from VPN overlays you control (e.g. Tailscale:
-    /// `--allowed-source-cidrs 100.64.0.0/10`). Can be specified multiple times.
+    /// This flag does TWO things, and the first is easy to miss:
+    ///
+    /// 1. With no `--ws-api-address`, in network mode, it BINDS THE API TO ALL
+    ///    INTERFACES. The source filter it relaxes never runs on a loopback
+    ///    socket, so the flag would otherwise be inert.
+    /// 2. It then admits the ranges named here IN ADDITION to loopback and the
+    ///    whole of RFC1918 / IPv6 ULA, which are always accepted. It does not
+    ///    narrow anything: this is not an "only these sources" allowlist.
+    ///
+    /// Net effect of `--allowed-source-cidrs 100.64.0.0/10` on its own: listen
+    /// on every interface, accept your entire local network, plus that range.
+    /// Pass `--ws-api-address` as well to keep the bind under your control.
     ///
     /// SECURITY: Only add ranges you fully control. CGNAT space like
     /// `100.64.0.0/10` is shared between subscribers of some ISPs (Starlink,
@@ -2468,7 +2522,7 @@ pub struct WebsocketApiArgs {
     /// can access your contract state, keys, and client API.
     #[arg(
         long = "allowed-source-cidrs",
-        env = "ALLOWED_SOURCE_CIDRS",
+        env = "FREENET_ALLOWED_SOURCE_CIDRS",
         value_delimiter = ','
     )]
     #[serde(
@@ -3057,7 +3111,7 @@ pub struct WsApiExposure {
 }
 
 /// True for any address [`resolve_ws_api_address`] could itself have produced,
-/// in this release or an earlier one.
+/// in this release or an earlier one: the two wildcards and the two loopbacks.
 ///
 /// This is the migration sentinel. `build()` persists the RESOLVED config, so a
 /// `ws-api-address` in `config.toml` is just as likely to be this code's own
@@ -3065,26 +3119,55 @@ pub struct WsApiExposure {
 /// value. Treating the auto-derivable values as "not an operator choice" is
 /// what lets the resolution re-run each boot:
 ///
-/// - `::` (the network-mode auto-default since #3648) and `0.0.0.0` (before
-///   it) must be re-derived, or the hardening would reach fresh installs only;
-/// - `::1` must be re-derived too, or the FIRST post-upgrade boot would persist
-///   loopback and thereby make it look explicit, permanently disabling the
-///   auto-widen remedy that the release note and the startup log both point
-///   operators at.
+/// - `::` (the network-mode auto-default since #3648) and `0.0.0.0` (before it)
+///   must be re-derived, or the hardening would reach fresh installs only;
+/// - the loopbacks must be re-derived too, or the FIRST post-upgrade boot would
+///   persist loopback and thereby make it look explicit, permanently disabling
+///   the auto-widen remedy the release note and the startup log point at.
 ///
-/// Anything else — `127.0.0.1`, a specific interface address — this code never
-/// writes on its own, so it is an operator choice and is preserved.
+/// Enumerated exactly rather than tested with `is_loopback()`, so an operator
+/// who deliberately pinned some other loopback address (`127.0.0.5`, a
+/// per-service loopback alias) keeps it: this code never writes that, so it is
+/// a choice.
 fn is_auto_derivable_ws_api_address(addr: IpAddr) -> bool {
-    addr.is_unspecified() || addr == default_local_address()
+    match addr {
+        IpAddr::V4(v4) => v4 == Ipv4Addr::UNSPECIFIED || v4 == Ipv4Addr::LOCALHOST,
+        IpAddr::V6(v6) => v6 == Ipv6Addr::UNSPECIFIED || v6 == Ipv6Addr::LOCALHOST,
+    }
 }
 
-/// Whether a `--allowed-host` / `--allowed-source-cidrs` list grants anything.
+/// The loopback / wildcard address in the same family as `family_hint`.
+///
+/// Re-derivation must never cross address families. The primary bind is FATAL
+/// while only the companion is best-effort (`server::serve_dual_stack`), so
+/// handing `::1` to a host with IPv6 disabled fails with EAFNOSUPPORT and the
+/// node does not start. That is unrecoverable rather than merely broken:
+/// `build()` rewrites `config.toml` BEFORE the bind is attempted, and
+/// `commands::rollback` does not snapshot config, so the crash-loop rollback
+/// restores the previous binary onto a config that now names an unbindable
+/// family and it dies identically — and rollback does not fire twice.
+///
+/// A node that persisted `0.0.0.0` (the pre-#3648 auto-default) has been
+/// binding IPv4 successfully for its whole life; that is the only evidence
+/// available about which families this host actually supports, so honour it.
+/// With no hint (a fresh install) the IPv6 default stands, which is the same
+/// exposure `main` already had — network mode defaulted to `::`.
+fn ws_api_default_for_family(family_hint: Option<IpAddr>, wildcard: bool) -> IpAddr {
+    match (family_hint, wildcard) {
+        (Some(IpAddr::V4(_)), false) => IpAddr::V4(Ipv4Addr::LOCALHOST),
+        (Some(IpAddr::V4(_)), true) => IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+        (_, false) => default_local_address(),
+        (_, true) => default_listening_address(),
+    }
+}
+
+/// Whether a `--allowed-source-cidrs` list grants anything.
 ///
 /// An empty list grants nothing, and neither does a list of blank strings:
-/// `ALLOWED_HOST=` declared with no value in a docker-compose `.env`, a k8s
-/// ConfigMap, or a systemd `Environment=` line parses as `Some(vec![""])`, and
-/// reading that as "the operator wants non-local clients" would widen the bind
-/// on a node whose operator set nothing.
+/// `FREENET_ALLOWED_SOURCE_CIDRS=` declared with no value in a docker-compose
+/// `.env`, a k8s ConfigMap, or a systemd `Environment=` line parses as
+/// `Some(vec![""])`, and reading that as "the operator wants non-local clients"
+/// would widen the bind on a node whose operator granted nothing.
 fn grants_anything(list: Option<&[String]>) -> bool {
     list.is_some_and(|entries| entries.iter().any(|e| !e.trim().is_empty()))
 }
@@ -3098,36 +3181,115 @@ fn grants_anything(list: Option<&[String]>) -> bool {
 /// control API (contract state, delegate secrets, key material) to every host
 /// that can route to this machine.
 ///
-/// Auto-widening is a BACKWARD-COMPATIBILITY measure, not a claim that the two
-/// flags are meaningless on loopback — they are not. `--allowed-host` is a
-/// Host-header allowlist that is fully functional, and often required, for a
-/// reverse proxy on the SAME host talking to the node over loopback, and
-/// `--allowed-source-cidrs` still widens which `Host` IPs are accepted. What
-/// the flags have in common is that, before this change, a node in network mode
-/// bound `::` by DEFAULT, so an operator who set either one and nothing else
-/// was silently relying on that wide default. Widening for them preserves those
-/// invocations with zero operator action.
+/// Auto-widening is a BACKWARD-COMPATIBILITY measure for one flag only.
+/// `--allowed-source-cidrs` is genuinely inert on a loopback socket — a
+/// non-private source can never reach `::1`, so the filter it relaxes never
+/// runs — which means an operator who set it and nothing else was relying on
+/// the old wide network-mode default. Widening preserves that with no action.
 ///
-/// Which is exactly why widening is scoped to `OperationMode::Network`: local
-/// mode has always bound loopback, so there is no wide default to preserve, and
-/// widening there would mean this hardening opened a socket that used to be
-/// closed. An explicit `--ws-api-address` always wins in either mode.
+/// `--allowed-host` is deliberately NOT a trigger, though an earlier cut of
+/// this change made it one. It is a Host-header allowlist that is fully
+/// functional on loopback, and the same-host reverse proxy is its primary
+/// documented use — indeed the ONLY shape in which hosted mode's `userToken` is
+/// honoured at all, since `decide_user_token` requires a loopback source. So
+/// widening for it would bind every interface, for no functional gain, in the
+/// commonest proxy deployment there is. A proxy on a DIFFERENT host is a
+/// deliberate multi-machine choice whose operator passes `--ws-api-address`;
+/// the startup log says so.
+///
+/// `cidrs_granted_this_boot` must come from the CLI/env values captured BEFORE
+/// the `config.toml` merge. Reading the merged value would make the widen
+/// sticky: one boot with the flag would pin the node to the wildcard forever,
+/// and removing the flag would never narrow it back.
+///
+/// Widening is scoped to `OperationMode::Network` because local mode has always
+/// bound loopback, so there is no wide default to preserve and widening there
+/// would mean this hardening OPENED a socket that used to be closed. An
+/// explicit `--ws-api-address` always wins in either mode.
 fn resolve_ws_api_address(
     mode: OperationMode,
     explicit: Option<IpAddr>,
-    allowed_source_cidrs: Option<&[String]>,
-    allowed_hosts: Option<&[String]>,
+    cidrs_granted_this_boot: Option<&[String]>,
+    family_hint: Option<IpAddr>,
 ) -> (IpAddr, WsApiAddressSource) {
     if let Some(addr) = explicit {
         return (addr, WsApiAddressSource::Explicit);
     }
-    let compat_widen = matches!(mode, OperationMode::Network)
-        && (grants_anything(allowed_source_cidrs) || grants_anything(allowed_hosts));
+    let compat_widen =
+        matches!(mode, OperationMode::Network) && grants_anything(cidrs_granted_this_boot);
     if compat_widen {
-        (default_listening_address(), WsApiAddressSource::AutoWidened)
+        (
+            ws_api_default_for_family(family_hint, true),
+            WsApiAddressSource::AutoWidened,
+        )
     } else {
-        (default_local_address(), WsApiAddressSource::DefaultLoopback)
+        (
+            ws_api_default_for_family(family_hint, false),
+            WsApiAddressSource::DefaultLoopback,
+        )
     }
+}
+
+/// Whether the node's SHARED (non-per-user) delegate-secret namespace holds
+/// anything, checked by looking for a single file.
+///
+/// Layout is `<secrets_dir>/<delegate_key>/…`, with hosted mode's per-user
+/// namespaces under a `users/` component. So a file inside a delegate directory
+/// but NOT under `users/` is a secret that EVERY untokened connection shares.
+/// Node key material (`transport_keypair`, `delegate_cipher`, …) sits directly
+/// in `secrets_dir` at depth 1 and is deliberately not counted: it is not
+/// reachable through the delegate API this warning is about.
+///
+/// Returns `true` if it cannot tell (an unreadable secrets tree): "I could not
+/// check" must not read as "nothing to protect".
+///
+/// Stops at the first hit and bounds its own depth, so the common case is a
+/// couple of `read_dir` calls at startup.
+fn shared_delegate_namespace_is_occupied(secrets_dir: &Path) -> bool {
+    fn walk(dir: &Path, depth: u32) -> bool {
+        // Deep enough for `<delegate>/<subdir>/<file>`; a legitimate shared
+        // secret is never buried deeper than this, and the cap keeps a
+        // symlinked or pathological tree from stalling startup.
+        const MAX_DEPTH: u32 = 4;
+        if depth > MAX_DEPTH {
+            return false;
+        }
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            // Unreadable: fail loud rather than silently claiming "empty".
+            return true;
+        };
+        for entry in entries.flatten() {
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if file_type.is_dir() {
+                // Per-user namespaces are exactly what hosted mode isolates,
+                // so they are not the shared namespace.
+                if entry.file_name() == "users" {
+                    continue;
+                }
+                if walk(&entry.path(), depth + 1) {
+                    return true;
+                }
+            } else if file_type.is_file() {
+                return true;
+            }
+        }
+        false
+    }
+
+    if secrets_dir.as_os_str().is_empty() {
+        // The standalone/test composition carries no secrets tree.
+        return false;
+    }
+    let Ok(entries) = std::fs::read_dir(secrets_dir) else {
+        return false; // No secrets tree yet: nothing is shared.
+    };
+    // Depth 1 is node key material, not delegate secrets — descend past it.
+    entries
+        .flatten()
+        .filter(|e| e.file_type().is_ok_and(|t| t.is_dir()))
+        .any(|e| walk(&e.path(), 2))
 }
 
 /// Whether startup should warn that the client API is reachable beyond this
@@ -3141,24 +3303,28 @@ fn resolve_ws_api_address(
 /// remote client that presents no token still drives the same delegate secrets,
 /// identities and contract state as the operator's own browser.
 ///
-/// Hence the two triggers:
+/// Three cases:
 /// - a **non-loopback bind** warns regardless of hosted mode, because any host
 ///   that can route to the address can omit a token and land in the shared
 ///   namespace;
-/// - **`--allowed-host` on a loopback bind** warns only with hosted mode OFF.
-///   That flag names a reverse proxy, and a proxy terminates the connection
-///   itself, so every visitor arrives wearing the proxy's source address and
-///   the node's own source-IP filters cannot tell them apart. Loopback + hosted
-///   mode is precisely the shape hosted mode was built for (the proxy hop is
-///   local and `userToken` is honored), so it stays quiet.
-///
-/// Naming the reason keeps the log actionable: a wide bind and a proxy call for
-/// different fixes, and a warning that guesses wrong is one operators learn to
-/// ignore.
+/// - **`--allowed-host` on a loopback bind with hosted mode OFF** warns
+///   unconditionally. That flag names a reverse proxy, and a proxy terminates
+///   the connection itself, so every visitor arrives wearing the proxy's source
+///   address and the node's own source-IP filters cannot tell them apart. It is
+///   not gated on occupancy because with hosted mode off there is no isolation
+///   at all: the namespace becomes occupied the moment anyone uses it.
+/// - **loopback + hosted mode** — try.freenet.org's shape — warns ONLY if the
+///   shared namespace already holds secrets. Hosted mode routes tokened
+///   connections to per-user namespaces, so the shared one stays empty in the
+///   intended deployment, and containment is real if unglamorous: there is
+///   nothing there to take. Warning on every boot of the flagship deployment
+///   would train operators to ignore the one signal we have, so this warning is
+///   made ACCURATE rather than loud.
 fn ws_api_shares_one_namespace_with_remote_clients(
     hosted_mode: bool,
     address: IpAddr,
     allowed_hosts: &[String],
+    shared_namespace_occupied: bool,
 ) -> Option<&'static str> {
     if !address.is_loopback() {
         return Some(if hosted_mode {
@@ -3171,9 +3337,11 @@ fn ws_api_shares_one_namespace_with_remote_clients(
         });
     }
     if hosted_mode {
-        // Loopback bind + hosted mode: the same-host reverse-proxy deployment
-        // hosted mode exists to serve. Quiet on purpose.
-        return None;
+        return shared_namespace_occupied.then_some(
+            "this node is in hosted mode but its SHARED delegate-secret namespace is \
+             not empty, and a connection that omits `userToken` reads that namespace \
+             rather than a per-user one — behind a proxy, any visitor can",
+        );
     }
     if !allowed_hosts.is_empty() {
         return Some(
@@ -5046,7 +5214,6 @@ mod tests {
     use httptest::{Expectation, Server, matchers::*, responders::*};
 
     use std::collections::BTreeSet;
-    use std::net::Ipv4Addr;
 
     use crate::node::NodeConfig;
     use crate::transport::TransportKeypair;
@@ -7351,6 +7518,12 @@ shutdown-drain-secs = 42
                 skip_load_from_network: true,
             },
             ws_api: WebsocketApiConfig {
+                // Deliberately NOT an auto-derivable address: this guard is
+                // about persisted-field round-tripping, so it must not also
+                // exercise the migration. Its green therefore says nothing
+                // about the sentinel — that is
+                // `auto_derivable_addresses_are_exactly_the_ones_this_code_writes`
+                // and `re_derivation_preserves_the_address_family`.
                 address: "10.1.2.4".parse().unwrap(),
                 port: 8123,
                 token_ttl_seconds: 4321,
@@ -9274,8 +9447,14 @@ shutdown-drain-secs = 42
         );
     }
 
+    /// `--allowed-host` must NOT widen the bind. It is a Host-header allowlist
+    /// that works perfectly on loopback, and the same-host reverse proxy is its
+    /// primary documented use — the only shape in which hosted mode honours
+    /// `userToken` at all, since `decide_user_token` requires a loopback source.
+    /// Widening for it would bind every interface in the commonest proxy
+    /// deployment for no functional gain.
     #[tokio::test]
-    async fn ws_api_auto_widens_when_allowed_host_is_set() {
+    async fn allowed_host_alone_does_not_widen_the_bind() {
         let temp_dir = tempfile::tempdir().unwrap();
         let (_server, index_url) = empty_gateways_index_server();
 
@@ -9287,7 +9466,12 @@ shutdown-drain-secs = 42
             .await
             .expect("build should succeed");
 
-        assert_eq!(cfg.ws_api.address, default_listening_address());
+        assert_eq!(cfg.ws_api.address, default_local_address());
+        assert_eq!(
+            cfg.ws_api.allowed_hosts.len(),
+            1,
+            "the allowlist still applies"
+        );
     }
 
     #[tokio::test]
@@ -9320,7 +9504,7 @@ shutdown-drain-secs = 42
     fn empty_allow_lists_do_not_widen() {
         for mode in [OperationMode::Network, OperationMode::Local] {
             assert_eq!(
-                resolve_ws_api_address(mode, None, Some(&[]), Some(&[])),
+                resolve_ws_api_address(mode, None, Some(&[]), None),
                 (default_local_address(), WsApiAddressSource::DefaultLoopback)
             );
             assert_eq!(
@@ -9340,8 +9524,8 @@ shutdown-drain-secs = 42
             resolve_ws_api_address(
                 OperationMode::Network,
                 None,
-                Some(&[String::new()]),
-                Some(&["   ".to_string()]),
+                Some(&[String::new(), "   ".to_string()]),
+                None,
             ),
             (default_local_address(), WsApiAddressSource::DefaultLoopback)
         );
@@ -9352,18 +9536,17 @@ shutdown-drain-secs = 42
     /// socket that used to be closed — the exact thing it exists to prevent.
     #[test]
     fn local_mode_never_auto_widens() {
-        for (cidrs, hosts) in [
-            (Some(&["100.64.0.0/10".to_string()][..]), None),
-            (None, Some(&["proxy.example".to_string()][..])),
-            (
-                Some(&["100.64.0.0/10".to_string()][..]),
-                Some(&["proxy.example".to_string()][..]),
-            ),
-        ] {
-            assert_eq!(
-                resolve_ws_api_address(OperationMode::Local, None, cidrs, hosts),
-                (default_local_address(), WsApiAddressSource::DefaultLoopback),
-                "local mode must stay loopback for cidrs={cidrs:?} hosts={hosts:?}"
+        for hint in [None, Some(IpAddr::V4(Ipv4Addr::UNSPECIFIED))] {
+            let (addr, source) = resolve_ws_api_address(
+                OperationMode::Local,
+                None,
+                Some(&["100.64.0.0/10".to_string()]),
+                hint,
+            );
+            assert_eq!(source, WsApiAddressSource::DefaultLoopback);
+            assert!(
+                addr.is_loopback(),
+                "local mode must stay loopback, got {addr}"
             );
         }
     }
@@ -9386,14 +9569,12 @@ shutdown-drain-secs = 42
             ),
             (default_listening_address(), WsApiAddressSource::AutoWidened)
         );
+        // `--allowed-host` is deliberately NOT a widening trigger: it is fully
+        // functional on a loopback socket, where the same-host reverse proxy —
+        // the only shape in which hosted mode honours `userToken` — lives.
         assert_eq!(
-            resolve_ws_api_address(
-                OperationMode::Network,
-                None,
-                None,
-                Some(&["h.example".to_string()])
-            ),
-            (default_listening_address(), WsApiAddressSource::AutoWidened)
+            resolve_ws_api_address(OperationMode::Network, None, None, None),
+            (default_local_address(), WsApiAddressSource::DefaultLoopback)
         );
     }
 
@@ -9409,8 +9590,17 @@ shutdown-drain-secs = 42
         ] {
             assert!(is_auto_derivable_ws_api_address(auto), "{auto}");
         }
+        // `127.0.0.1` is auto-derivable too: it is what an IPv4-family node
+        // re-derives to, so treating it as a choice would strand exactly the
+        // hosts B1 exists to protect.
+        assert!(is_auto_derivable_ws_api_address(IpAddr::V4(
+            Ipv4Addr::LOCALHOST
+        )));
+        // A deliberately-pinned loopback ALIAS is a choice — this code never
+        // writes one, which is why the sentinel enumerates instead of calling
+        // `is_loopback()`.
         for chosen in [
-            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 5)),
             IpAddr::V4(Ipv4Addr::new(192, 168, 1, 50)),
         ] {
             assert!(!is_auto_derivable_ws_api_address(chosen), "{chosen}");
@@ -9426,38 +9616,104 @@ shutdown-drain-secs = 42
         let loopback = default_local_address();
         let wildcard = default_listening_address();
         let proxy = vec!["try.freenet.org".to_string()];
+        // (hosted_mode, address, allowed_hosts, shared namespace occupied)
+        let quiet =
+            |h, a, l: &[String], occ| ws_api_shares_one_namespace_with_remote_clients(h, a, l, occ);
 
         // Quiet: the default single-user desktop node.
-        assert_eq!(
-            ws_api_shares_one_namespace_with_remote_clients(false, loopback, &[]),
-            None
-        );
-        // Quiet: hosted mode gives each connection its own secret namespace,
-        // which is exactly what makes a proxied deployment safe. try.freenet.org
-        // is this row — it must not emit a scary warning on every restart.
-        assert_eq!(
-            ws_api_shares_one_namespace_with_remote_clients(true, loopback, &proxy),
-            None
-        );
-        // Fires: hosted mode does NOT make a wide bind safe. `decide_user_token`
-        // returns the shared single-user context whenever a connection omits
-        // `userToken`, so a remote client that presents nothing still drives
-        // the same delegate secrets — which is the advisory's own scenario.
-        let hosted_wide = ws_api_shares_one_namespace_with_remote_clients(true, wildcard, &proxy)
-            .expect("a wildcard bind must warn even in hosted mode");
-        assert!(hosted_wide.contains("hosted mode does"), "{hosted_wide}");
+        assert_eq!(quiet(false, loopback, &[], false), None);
+        // Quiet: try.freenet.org's shape. Hosted mode routes tokened
+        // connections to per-user namespaces, and the shared one is empty, so
+        // there is nothing behind the proxy to take. Warning on every boot of
+        // the flagship deployment would train operators to ignore this signal.
+        assert_eq!(quiet(true, loopback, &proxy, false), None);
+
+        // Fires: SAME shape, but the shared namespace now holds secrets, which
+        // is the real containment boundary rather than any structural
+        // guarantee — a connection omitting `userToken` reads it.
+        let occupied = quiet(true, loopback, &proxy, true)
+            .expect("a hosted node with a non-empty shared namespace must warn");
+        assert!(occupied.contains("SHARED"), "{occupied}");
 
         // Fires: reachable from other machines, one shared namespace. The
         // reason names the bind, which is the thing to change.
-        let bind_reason = ws_api_shares_one_namespace_with_remote_clients(false, wildcard, &[])
+        let bind_reason = quiet(false, wildcard, &[], false)
             .expect("a wildcard bind with hosted mode off must warn");
         assert!(bind_reason.contains("non-loopback"), "{bind_reason}");
 
-        // Fires: the genuinely dangerous shape — proxied with hosted mode off.
-        // Different reason, because the remedy is different.
-        let proxy_reason = ws_api_shares_one_namespace_with_remote_clients(false, loopback, &proxy)
+        // Fires: hosted mode does NOT make a wide bind safe, occupied or not.
+        // `decide_user_token` returns the shared context whenever a connection
+        // omits `userToken`, so a remote client presenting nothing still drives
+        // the same delegate secrets.
+        for occ in [false, true] {
+            let hosted_wide = quiet(true, wildcard, &proxy, occ)
+                .expect("a wildcard bind must warn even in hosted mode");
+            assert!(hosted_wide.contains("hosted mode does"), "{hosted_wide}");
+        }
+
+        // Fires: proxied with hosted mode off. NOT gated on occupancy — with no
+        // isolation at all the namespace fills the moment anyone uses it.
+        let proxy_reason = quiet(false, loopback, &proxy, false)
             .expect("a proxied node with hosted mode off must warn");
         assert!(proxy_reason.contains("--allowed-host"), "{proxy_reason}");
+    }
+
+    /// The occupancy probe must distinguish hosted mode's per-user namespaces
+    /// (which are the isolation, not a leak) from a genuinely shared secret,
+    /// and must not count the node's own key material at the tree root.
+    #[test]
+    fn shared_namespace_probe_ignores_per_user_dirs_and_node_keys() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        // Empty tree.
+        assert!(!shared_delegate_namespace_is_occupied(root));
+
+        // Node key material lives at depth 1 and is not delegate-reachable.
+        std::fs::write(root.join("transport_keypair"), b"k").unwrap();
+        assert!(!shared_delegate_namespace_is_occupied(root));
+
+        // try.freenet.org's measured shape: every secret under `users/`.
+        let delegate = root.join("2hwN7pycUxLzzaEeCLNsi3XQ9zA1EpPTrWdWxcUozb9j");
+        std::fs::create_dir_all(delegate.join("users").join("alice")).unwrap();
+        std::fs::write(delegate.join("users").join("alice").join("s"), b"x").unwrap();
+        assert!(
+            !shared_delegate_namespace_is_occupied(root),
+            "per-user namespaces are the isolation, not the shared namespace"
+        );
+
+        // A secret in the delegate dir itself IS shared.
+        std::fs::write(delegate.join("shared_secret"), b"x").unwrap();
+        assert!(shared_delegate_namespace_is_occupied(root));
+    }
+
+    /// An unreadable secrets tree must read as "cannot tell", not as "empty":
+    /// silence here would be a warning suppressed by a permissions bug.
+    #[test]
+    #[cfg(unix)]
+    fn shared_namespace_probe_fails_loud_when_it_cannot_read() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let delegate = dir.path().join("delegate");
+        std::fs::create_dir_all(&delegate).unwrap();
+        std::fs::set_permissions(&delegate, std::fs::Permissions::from_mode(0o000)).unwrap();
+        let unreadable = shared_delegate_namespace_is_occupied(dir.path());
+        // Restore before the assert so the tempdir can always clean up.
+        std::fs::set_permissions(&delegate, std::fs::Permissions::from_mode(0o755)).unwrap();
+        // Running as root defeats the permission bit; skip rather than lie.
+        if !nix_running_as_root() {
+            assert!(
+                unreadable,
+                "an unreadable secrets tree must not read as empty"
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    fn nix_running_as_root() -> bool {
+        // SAFETY: `geteuid` takes no arguments, touches no memory and cannot
+        // fail; it is unsafe only because it is an extern "C" call.
+        unsafe { libc::geteuid() == 0 }
     }
 
     /// `build()` persists the RESOLVED config, so every node that has already
@@ -9498,12 +9754,56 @@ shutdown-drain-secs = 42
         );
     }
 
-    /// `default_listening_address()` was `0.0.0.0` before #3648 and `::` after,
-    /// so a node old enough to have persisted the IPv4 wildcard must be
-    /// migrated too — keying the sentinel on today's literal only would leave
-    /// the oldest installs (the ones most likely to be forgotten) exposed.
+    /// Re-derivation must PRESERVE THE ADDRESS FAMILY, because the primary bind
+    /// is fatal while only the companion is best-effort (`server.rs`
+    /// `serve_dual_stack`).
+    ///
+    /// A node installed before #3648 persisted `0.0.0.0`. Re-deriving that to
+    /// the IPv6 `::1` on a host with IPv6 disabled makes the primary bind fail
+    /// with EAFNOSUPPORT — and `build()` has already rewritten `config.toml`
+    /// before the bind is attempted, so the crash-loop rollback restores the
+    /// previous binary onto a config that now says `::1` and it dies the same
+    /// way. Rollback does not fire twice: the node is down for good. The
+    /// brick-safety mechanism becomes the brick, reached through a VALUE change
+    /// rather than the key change `code-style.md` already guards.
     #[tokio::test]
-    async fn persisted_legacy_ipv4_wildcard_is_also_re_derived_to_loopback() {
+    async fn re_derivation_preserves_the_address_family() {
+        for (persisted, expected) in [
+            (
+                IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+                IpAddr::V4(Ipv4Addr::LOCALHOST),
+            ),
+            (
+                IpAddr::V6(Ipv6Addr::UNSPECIFIED),
+                IpAddr::V6(Ipv6Addr::LOCALHOST),
+            ),
+        ] {
+            let temp_dir = tempfile::tempdir().unwrap();
+            let (_server, index_url) = empty_gateways_index_server();
+
+            let mut first = ws_api_test_args(OperationMode::Network, temp_dir.path());
+            first.ws_api.address = Some(persisted);
+            first
+                .build_with_gateways_index(&index_url)
+                .await
+                .expect("first build should succeed");
+
+            let cfg = ws_api_test_args(OperationMode::Network, temp_dir.path())
+                .build_with_gateways_index(&index_url)
+                .await
+                .expect("second build should succeed");
+            assert_eq!(
+                cfg.ws_api.address, expected,
+                "persisted {persisted} must re-derive within its own family; \
+                 crossing families is a fatal bind on a single-stack host"
+            );
+        }
+    }
+
+    /// Same requirement for the auto-widen branch: an IPv4-family node that
+    /// applies the documented remedy must widen to `0.0.0.0`, not `::`.
+    #[tokio::test]
+    async fn auto_widen_preserves_the_address_family() {
         let temp_dir = tempfile::tempdir().unwrap();
         let (_server, index_url) = empty_gateways_index_server();
 
@@ -9514,11 +9814,13 @@ shutdown-drain-secs = 42
             .await
             .expect("first build should succeed");
 
-        let cfg = ws_api_test_args(OperationMode::Network, temp_dir.path())
+        let mut remedied = ws_api_test_args(OperationMode::Network, temp_dir.path());
+        remedied.ws_api.allowed_source_cidrs = Some(vec!["100.64.0.0/10".to_string()]);
+        let cfg = remedied
             .build_with_gateways_index(&index_url)
             .await
             .expect("second build should succeed");
-        assert_eq!(cfg.ws_api.address, default_local_address());
+        assert_eq!(cfg.ws_api.address, IpAddr::V4(Ipv4Addr::UNSPECIFIED));
     }
 
     /// The migration keys on "wildcard" and nothing else: a specific interface
@@ -9550,9 +9852,9 @@ shutdown-drain-secs = 42
         }
     }
 
-    /// The upgrade path for a Tailscale-style node: it persisted `::` (the old
-    /// auto-default) alongside its CIDR grant, so the migration drops the
-    /// address and auto-widening must put it straight back. Zero operator
+    /// The upgrade path for a Tailscale-style node whose systemd unit passes
+    /// `--allowed-source-cidrs` on every boot: the migration drops the
+    /// persisted `::` and auto-widening puts it straight back. Zero operator
     /// action, same bind as before the upgrade.
     #[tokio::test]
     async fn upgrading_node_with_cidr_grant_keeps_its_wildcard_bind() {
@@ -9567,8 +9869,10 @@ shutdown-drain-secs = 42
             .await
             .expect("first build should succeed");
 
-        // Flag-less restart: the CIDR grant comes back from config.toml.
-        let cfg = ws_api_test_args(OperationMode::Network, temp_dir.path())
+        // Restart with the flag still in the invocation, as a service does.
+        let mut second = ws_api_test_args(OperationMode::Network, temp_dir.path());
+        second.ws_api.allowed_source_cidrs = Some(vec!["100.64.0.0/10".to_string()]);
+        let cfg = second
             .build_with_gateways_index(&index_url)
             .await
             .expect("second build should succeed");
@@ -9576,72 +9880,37 @@ shutdown-drain-secs = 42
         assert_eq!(cfg.ws_api.allowed_source_cidrs.len(), 1);
     }
 
-    /// Local mode with a widening flag must stay loopback end-to-end, not just
-    /// in the pure resolver. On `origin/main` this invocation bound `::1`; a
-    /// hardening change that made it bind `::` would be a regression caused by
-    /// the fix.
+    /// The auto-widen must NOT be sticky. A grant that only survives in
+    /// `config.toml` cannot widen a later boot, or one run with the flag would
+    /// pin the node to the wildcard forever and REMOVING the flag would never
+    /// narrow it again — the hardening would permanently miss every node that
+    /// ever set an allow-list.
     #[tokio::test]
-    async fn local_mode_with_allow_lists_still_binds_loopback() {
+    async fn a_persisted_cidr_grant_does_not_widen_a_later_flagless_boot() {
         let temp_dir = tempfile::tempdir().unwrap();
         let (_server, index_url) = empty_gateways_index_server();
 
-        let mut args = ws_api_test_args(OperationMode::Local, temp_dir.path());
-        args.ws_api.allowed_source_cidrs = Some(vec!["100.64.0.0/10".to_string()]);
-        args.ws_api.allowed_host = Some(vec!["proxy.example".to_string()]);
-
-        let cfg = args
-            .build_with_gateways_index(&index_url)
-            .await
-            .expect("build should succeed");
-        assert_eq!(cfg.ws_api.address, default_local_address());
-    }
-
-    /// The remedy the release note and the startup log both point at has to
-    /// work on the SECOND boot, not only the first.
-    ///
-    /// `build()` persists the resolved address, so after the upgrade boot the
-    /// file holds `::1`. If that counted as an operator choice, adding
-    /// `--allowed-source-cidrs` afterwards would resolve through the Explicit
-    /// short-circuit and do nothing at all — the node would stay loopback while
-    /// its logs claimed the flag widens the bind.
-    #[tokio::test]
-    async fn remedy_still_works_after_the_upgrade_persisted_loopback() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let (_server, index_url) = empty_gateways_index_server();
-
-        // Boot 1: pre-upgrade node with the old wildcard auto-default.
         let mut first = ws_api_test_args(OperationMode::Network, temp_dir.path());
-        first.ws_api.address = Some(default_listening_address());
-        first
+        first.ws_api.allowed_source_cidrs = Some(vec!["100.64.0.0/10".to_string()]);
+        let widened = first
             .build_with_gateways_index(&index_url)
             .await
             .expect("first build should succeed");
+        assert_eq!(widened.ws_api.address, default_listening_address());
 
-        // Boot 2: upgraded, flag-less. Re-derived to loopback and persisted.
-        let migrated = ws_api_test_args(OperationMode::Network, temp_dir.path())
+        // Flag removed from the invocation; only config.toml still names it.
+        let cfg = ws_api_test_args(OperationMode::Network, temp_dir.path())
             .build_with_gateways_index(&index_url)
             .await
             .expect("second build should succeed");
-        assert_eq!(migrated.ws_api.address, default_local_address());
-        let persisted =
-            std::fs::read_to_string(temp_dir.path().join("config.toml")).expect("config persisted");
-        assert!(
-            persisted.contains(r#"ws-api-address = "::1""#),
-            "test premise: the loopback address must be persisted, got:\n{persisted}"
-        );
-
-        // Boot 3: the operator applies the documented remedy.
-        let mut remedied = ws_api_test_args(OperationMode::Network, temp_dir.path());
-        remedied.ws_api.allowed_source_cidrs = Some(vec!["100.64.0.0/10".to_string()]);
-        let cfg = remedied
-            .build_with_gateways_index(&index_url)
-            .await
-            .expect("third build should succeed");
         assert_eq!(
             cfg.ws_api.address,
-            default_listening_address(),
-            "the auto-widen remedy must still work once the migration has run"
+            default_local_address(),
+            "a grant the operator no longer passes must not keep the socket wide"
         );
+        // The list itself still applies to the source filter; only the BIND
+        // decision is re-taken from this boot's flags.
+        assert_eq!(cfg.ws_api.allowed_source_cidrs.len(), 1);
     }
 
     /// The exposure decision must survive onto the resolved `Config`, because
@@ -9705,6 +9974,45 @@ shutdown-drain-secs = 42
         );
     }
 
+    /// The notice must fire ONCE. Its filter has two clauses, and only one of
+    /// them was covered: dropping `!persisted.is_loopback()` while keeping the
+    /// other passes every other test, yet makes the notice reappear on every
+    /// flagless boot forever — the tuned-out-log failure the migration comment
+    /// exists to avoid. Boot three times and assert the third is silent.
+    #[tokio::test]
+    async fn the_loss_of_access_notice_does_not_repeat_after_the_migration_boot() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let (_server, index_url) = empty_gateways_index_server();
+
+        let mut first = ws_api_test_args(OperationMode::Network, temp_dir.path());
+        first.ws_api.address = Some(default_listening_address());
+        first
+            .build_with_gateways_index(&index_url)
+            .await
+            .expect("first build should succeed");
+
+        let migrated = ws_api_test_args(OperationMode::Network, temp_dir.path())
+            .build_with_gateways_index(&index_url)
+            .await
+            .expect("migration boot should succeed");
+        assert_eq!(
+            migrated.ws_api.exposure.dropped_persisted_address,
+            Some(default_listening_address()),
+            "the migration boot must report the loss of access exactly once"
+        );
+
+        let steady = ws_api_test_args(OperationMode::Network, temp_dir.path())
+            .build_with_gateways_index(&index_url)
+            .await
+            .expect("third build should succeed");
+        assert_eq!(steady.ws_api.address, default_local_address());
+        assert_eq!(
+            steady.ws_api.exposure.dropped_persisted_address, None,
+            "re-announcing an unchanged bind on every boot is how a log line \
+             gets tuned out"
+        );
+    }
+
     /// Source pin: the resolver and the reporting path must actually be wired
     /// in. A unit-tested pure function that nothing calls is a verification
     /// that cannot fail.
@@ -9761,6 +10069,43 @@ shutdown-drain-secs = 42
         assert!(
             resolver.contains("WsApiAddressSource::DefaultLoopback"),
             "resolve_ws_api_address no longer has a loopback default branch"
+        );
+
+        // Cross-file: both helpers are called from exactly ONE place each, in a
+        // different file, so deleting a call site leaves every test in this
+        // module green while silently removing the only operator-facing signal
+        // (and, for the merge, the flags that decide the bind). Scraping the
+        // binary's source from HERE also avoids the self-match trap that an
+        // `include_str!("freenet.rs")` inside that file's own test module would
+        // hit, the same reason `production_source()` exists.
+        let main_src = include_str!("bin/freenet.rs");
+        let main_body = extract_fn_body(main_src, "fn freenet_main() -> anyhow::Result<()>");
+        for (needle, why) in [
+            (
+                "config.log_client_api_exposure()",
+                "nothing would report the client API's exposure — build() cannot, it \
+                 runs before set_logger",
+            ),
+            (
+                "merge_pre_subcommand_ws_api_args(",
+                "flags placed before the subcommand would be silently discarded, \
+                 leaving the node loopback-only against the operator's intent",
+            ),
+        ] {
+            assert!(
+                main_src.contains(needle),
+                "bin/freenet.rs no longer calls `{needle}`: {why}"
+            );
+        }
+        // The merge must run for BOTH subcommands, not just whichever one a
+        // refactor happened to keep.
+        assert_eq!(
+            main_body
+                .matches("merge_pre_subcommand_ws_api_args(")
+                .count(),
+            2,
+            "merge_pre_subcommand_ws_api_args must be called from the Network arm \
+             AND the Local arm"
         );
     }
 }

--- a/crates/core/src/contract/user_input.rs
+++ b/crates/core/src/contract/user_input.rs
@@ -1152,8 +1152,9 @@ mod tests {
     // specific bind is used as-is, with IPv6 literals bracketed.
     #[test]
     fn dashboard_authority_maps_bind_address_to_reachable_url_host() {
-        // IPv6 wildcard (the default ws-api-address): primary is IPv6, so use
-        // the IPv6 loopback rather than the best-effort IPv4 companion.
+        // IPv6 wildcard (`--ws-api-address ::`, or the auto-widened bind):
+        // primary is IPv6, so use the IPv6 loopback rather than the
+        // best-effort IPv4 companion.
         assert_eq!(
             dashboard_authority(SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 7509)),
             "[::1]:7509"

--- a/crates/core/src/server.rs
+++ b/crates/core/src/server.rs
@@ -563,7 +563,17 @@ fn build_allowed_hosts(
     hosts.add_machine_hostname();
 
     if !bind_addr.is_unspecified() {
-        hosts.add(&bind_addr.to_string());
+        // Bracket IPv6 literals. A `Host` header carries `[::1]:7509`, never
+        // `::1:7509`, so the unbracketed forms `add` would otherwise insert are
+        // one dead entry plus one malformed one. Harmless (add_localhost has
+        // already inserted the bracketed `[::1]`), but this branch became the
+        // DEFAULT path when the client API moved to a loopback bind
+        // (GHSA-824h-7x5x-wfmf), so the junk now shows up in the
+        // `allowed_hosts` startup log on every node.
+        match bind_addr {
+            IpAddr::V6(v6) => hosts.add(&format!("[{v6}]")),
+            IpAddr::V4(v4) => hosts.add(&v4.to_string()),
+        }
     }
 
     for host in extra_allowed_hosts {

--- a/crates/core/src/server.rs
+++ b/crates/core/src/server.rs
@@ -1299,8 +1299,11 @@ mod tests {
 
     #[test]
     fn test_build_allowed_hosts_excludes_ipv6_unspecified() {
-        // :: is the new default bind address; verify it's excluded from allowlist
-        // but localhost variants are still included
+        // `::` is a wildcard bind (an explicit --ws-api-address, or the compat
+        // auto-widen; it stopped being the network-mode default in
+        // GHSA-824h-7x5x-wfmf). It must still be excluded from the Host
+        // allowlist — a wildcard names no host — while the localhost variants
+        // stay included.
         let hosts = build_allowed_hosts(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 7509, &[]);
         assert!(!hosts.contains("::"));
         assert!(!hosts.contains("[::]:7509"));

--- a/docker/freenet-gateway/docker-compose.yml
+++ b/docker/freenet-gateway/docker-compose.yml
@@ -5,6 +5,11 @@ services:
       dockerfile: Dockerfile
     image: freenet-gateway:latest
     environment:
+      # The client API binds LOOPBACK by default (GHSA-824h-7x5x-wfmf), so it is
+      # reachable only from inside this container. That is the right posture for
+      # a gateway, whose job is the P2P port below, not the control API. Set
+      # WS_API_ADDRESS=:: only if you deliberately need to drive this gateway's
+      # API from elsewhere, and put an authenticating proxy in front of it.
       TRANSPORT_KEYPAIR: /root/.cache/freenet/keys/transport-keypair.pem
       PUBLIC_NETWORK_ADDRESS: 0.0.0.0
       PUBLIC_NETWORK_PORT: 31337

--- a/docker/freenet-gateway/docker-compose.yml
+++ b/docker/freenet-gateway/docker-compose.yml
@@ -5,11 +5,14 @@ services:
       dockerfile: Dockerfile
     image: freenet-gateway:latest
     environment:
-      # The client API binds LOOPBACK by default (GHSA-824h-7x5x-wfmf), so it is
-      # reachable only from inside this container. That is the right posture for
-      # a gateway, whose job is the P2P port below, not the control API. Set
-      # WS_API_ADDRESS=:: only if you deliberately need to drive this gateway's
-      # API from elsewhere, and put an authenticating proxy in front of it.
+      # The client API binds LOOPBACK by default (GHSA-824h-7x5x-wfmf). This
+      # service uses `network_mode: host`, so that is the HOST's loopback:
+      # reachable from anything on the host (including other containers sharing
+      # its namespace), not from the LAN. That is the right posture for a
+      # gateway, whose job is the P2P port below, not the control API. Set
+      # FREENET_WS_API_ADDRESS=:: only if you deliberately need to drive this
+      # gateway's API from another machine, and put an authenticating proxy in
+      # front of it.
       TRANSPORT_KEYPAIR: /root/.cache/freenet/keys/transport-keypair.pem
       PUBLIC_NETWORK_ADDRESS: 0.0.0.0
       PUBLIC_NETWORK_PORT: 31337

--- a/docker/freenet-node/Dockerfile.yml
+++ b/docker/freenet-node/Dockerfile.yml
@@ -41,6 +41,11 @@ COPY freenet-node-startup.sh /usr/local/bin/freenet-node-startup.sh
 RUN chmod +x /usr/local/bin/freenet-node-startup.sh
 
 # Expose default WebSocket API port
+# NOTE: the client API binds LOOPBACK by default as of GHSA-824h-7x5x-wfmf, so
+# publishing this port (`-p 7509:7509`) forwards into a container whose API is
+# listening only on the container's own loopback and connections are refused.
+# Set WS_API_ADDRESS=:: to make it reachable — and put an authenticating proxy
+# in front of it, because that API can read and modify contract state and keys.
 EXPOSE 7509
 
 # Use the startup script as the entrypoint

--- a/docker/freenet-node/Dockerfile.yml
+++ b/docker/freenet-node/Dockerfile.yml
@@ -44,7 +44,7 @@ RUN chmod +x /usr/local/bin/freenet-node-startup.sh
 # NOTE: the client API binds LOOPBACK by default as of GHSA-824h-7x5x-wfmf, so
 # publishing this port (`-p 7509:7509`) forwards into a container whose API is
 # listening only on the container's own loopback and connections are refused.
-# Set WS_API_ADDRESS=:: to make it reachable — and put an authenticating proxy
+# Set FREENET_WS_API_ADDRESS=:: to make it reachable — and put an authenticating proxy
 # in front of it, because that API can read and modify contract state and keys.
 EXPOSE 7509
 

--- a/docker/freenet-node/docker-compose.yml
+++ b/docker/freenet-node/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       # opt-in. Uncomment to serve clients on other machines, and put an
       # authenticating reverse proxy in front of it if the network is not
       # fully trusted.
-      # - WS_API_ADDRESS=::
+      # - FREENET_WS_API_ADDRESS=::
     network_mode: host
     volumes:
       - freenet-data:/root/.cache/freenet

--- a/docker/freenet-node/docker-compose.yml
+++ b/docker/freenet-node/docker-compose.yml
@@ -6,6 +6,14 @@ services:
     image: freenet-node:latest
     environment:
       - WS_API_PORT=7509
+      # The client API binds loopback by default (of the host's network
+      # namespace, since `network_mode: host`), so it is reachable from this
+      # machine only. That API is fully privileged — it can read and modify
+      # contract state, identities and keys — so exposing it to the LAN is
+      # opt-in. Uncomment to serve clients on other machines, and put an
+      # authenticating reverse proxy in front of it if the network is not
+      # fully trusted.
+      # - WS_API_ADDRESS=::
     network_mode: host
     volumes:
       - freenet-data:/root/.cache/freenet

--- a/docs/client-api-exposure.md
+++ b/docs/client-api-exposure.md
@@ -58,7 +58,7 @@ rather than trusted, and the flag has to stay in whatever launches the node:
   drop-in overriding `ExecStart`. Do **not** hand-edit the generated unit file:
   that trips the installer's checksum, permanently marks the unit as
   user-modified, and opts the node out of every future unit-template change.
-- **Docker** — `WS_API_ADDRESS` in the compose `environment:` block.
+- **Docker** — `FREENET_WS_API_ADDRESS` in the compose `environment:` block.
 - **By hand** — the flag on the command line, every time.
 
 A **specific** address (`192.0.2.10`, `127.0.0.5`) is not a value this code ever
@@ -109,3 +109,9 @@ delegate-secret namespace. It adds isolation for well-behaved clients; it does
 not remove the shared namespace. A connection that simply omits the token still
 lands in the node's single-user context. So hosted mode does not make a
 non-loopback bind safe, and the exposure warning fires for one regardless.
+
+**Known gap:** on a loopback bind with hosted mode on, **no warning fires** —
+including when a reverse proxy is in front of the node. Treat that silence as
+"not yet reported", not as "checked and safe". If you run a hosted node behind a
+public proxy, keep an eye on the shared namespace yourself; making the warning
+conditional on what is actually in it is tracked separately.

--- a/docs/client-api-exposure.md
+++ b/docs/client-api-exposure.md
@@ -1,0 +1,111 @@
+# Who can reach the client API
+
+The node's **client API** is the local HTTP/WebSocket surface that applications
+talk to: contract reads and writes, subscriptions, delegate messages, the
+dashboard. It is fully privileged. Anything that can reach its address and port
+can read and modify this node's contract state, its identities, and its key
+material. There is no per-connection authentication in front of it.
+
+So the only question that matters is **which hosts can open a socket to it**,
+and that is what this page is about.
+
+## The default
+
+**Loopback, in both operation modes.** A node answers the client API on
+`127.0.0.1` and `[::1]` only, so applications running on the same machine work
+and nothing else can connect.
+
+This is deliberately not tied to `--mode`. Running as a network peer is a
+statement about the overlay — that this node routes, stores and forwards for
+others. It says nothing about wanting the machine's control API driveable by
+whoever else is on the wifi. Earlier releases conflated the two and defaulted
+network-mode nodes to every interface.
+
+## Serving clients on other machines
+
+Pick the narrowest option that fits.
+
+| Situation | Flag |
+| --- | --- |
+| A browser or `riverctl` on another machine on your LAN | `--ws-api-address ::` |
+| Only one interface should answer | `--ws-api-address 192.0.2.10` |
+| A VPN overlay you control (Tailscale, WireGuard) | `--allowed-source-cidrs 100.64.0.0/10` |
+| A reverse proxy on **this** machine | nothing — loopback already works; add `--allowed-host your.domain` so the proxy's `Host` header is accepted |
+| A reverse proxy on **another** machine | `--ws-api-address ::` **and** `--allowed-host your.domain` |
+
+`--allowed-source-cidrs` widens the bind on its own, in network mode. It is
+inert on a loopback socket — a non-private source can never reach `::1` — so
+setting it can only have been meant as "serve non-local clients". Note what it
+does *not* do: it never narrows anything. Loopback and the whole of RFC1918 /
+IPv6 ULA are always accepted, and this flag adds to that list. Its net effect on
+its own is "listen everywhere, accept the entire local network, plus this
+range".
+
+`--allowed-host` does **not** widen the bind. It is a `Host` header allowlist,
+and it works perfectly on a loopback socket, which is where a same-host reverse
+proxy talks to the node. That is also the only arrangement in which hosted
+mode's per-user tokens are honoured at all.
+
+## Keep the flag in the invocation
+
+A node persists its resolved configuration to `config.toml` on every boot. That
+means a wildcard or loopback `ws-api-address` sitting in that file is just as
+likely to be the node's own past output as your choice, and the two are
+indistinguishable by value. So those values are **re-derived on every boot**
+rather than trusted, and the flag has to stay in whatever launches the node:
+
+- **systemd** — `sudo systemctl edit freenet` (or the user unit) and add a
+  drop-in overriding `ExecStart`. Do **not** hand-edit the generated unit file:
+  that trips the installer's checksum, permanently marks the unit as
+  user-modified, and opts the node out of every future unit-template change.
+- **Docker** — `WS_API_ADDRESS` in the compose `environment:` block.
+- **By hand** — the flag on the command line, every time.
+
+A **specific** address (`192.0.2.10`, `127.0.0.5`) is not a value this code ever
+writes, so it is recognised as your choice and preserved untouched.
+
+## Environment variables
+
+These are read as an alternative to the flags, and all three are namespaced:
+
+- `FREENET_WS_API_ADDRESS`
+- `FREENET_ALLOWED_HOST`
+- `FREENET_ALLOWED_SOURCE_CIDRS`
+
+They were previously `WS_API_ADDRESS`, `ALLOWED_HOST` and
+`ALLOWED_SOURCE_CIDRS`. Unnamespaced names that decide whether a privileged API
+listens beyond the machine are too easy to set by accident in a shared
+container, a CI runner, or a systemd environment. A leftover old-style variable
+is reported at startup rather than silently ignored.
+
+## What the node tells you at startup
+
+Three messages, all after the logger is up:
+
+- **The bind was re-derived and narrowed.** Fires once, on the first boot after
+  upgrading a node that had been binding every interface. This is the only
+  notice you get that clients on other machines have just lost access.
+- **The bind was re-derived and widened.** Your config named a loopback address,
+  and `--allowed-source-cidrs` widened past it. Said loudly because the socket
+  ended up more exposed than the file it replaced.
+- **Exposure warning.** The API is reachable from beyond this machine while
+  every connection that presents no per-user token shares one namespace. Fires
+  for a non-loopback bind, and for `--allowed-host` on a loopback bind with
+  hosted mode off — a proxy terminates the connection itself, so every visitor
+  arrives looking local and the source-IP filters cannot tell them apart.
+
+## Rolling back
+
+The narrowed `ws-api-address` stays in `config.toml`. An older binary reads it
+as an explicit choice, so a rolled-back node comes back loopback-only and has no
+message explaining why. Nothing fails to parse — no key changed — but the
+previous reachability is not restored automatically. Add `--ws-api-address ::`
+to the invocation if you need it back.
+
+## Hosted mode
+
+`--hosted-mode` gives each connection presenting a `userToken` its own
+delegate-secret namespace. It adds isolation for well-behaved clients; it does
+not remove the shared namespace. A connection that simply omits the token still
+lands in the node's single-user context. So hosted mode does not make a
+non-loopback bind safe, and the exposure warning fires for one regardless.


### PR DESCRIPTION
## Problem

The node's client API — the local HTTP/WebSocket control surface — took its
default bind address from `OperationMode`: loopback in local mode, all
interfaces (`::`) in network mode.

That coupling is wrong. `OperationMode` is a statement about the overlay:
whether this node participates in the ring. It is not a statement about who may
drive the node's control API, which is a separate and much more privileged
surface. A default install of a network peer therefore listened on every
interface without the operator ever asking for it.

The repository documents no intent behind that default. The only prose on the
subject is the rustdoc on `--allowed-source-cidrs`, which is a warning attached
to the opt-in flag for *extending* reach.

Refs: private advisory GHSA-824h-7x5x-wfmf.

Scope note for CONTRIBUTING: this is a user-visible behavior change, which
normally needs an approved public issue first. It is tracked in the private
advisory instead, at Ian's direction — a public issue is the wrong vehicle here.

## Approach

**1. Loopback by default in both modes.** The no-flags branch of
`resolve_ws_api_address` is mode-independent. `OperationMode` keeps governing
ring participation and `secrets_dir(mode)`, and it still scopes the
compatibility auto-widen in point 2; what it no longer does is decide the
*default* bind of the client API. Loopback here is
`::1`, which also binds `127.0.0.1` through the existing companion-bind
mechanism (#4330), so `ws://127.0.0.1:7509` and `ws://[::1]:7509` both keep
working unchanged.

Three places baked the wildcard in, and all three had to move for the default to
actually be loopback: the mode-keyed resolution in `build()`,
`WebsocketApiConfig::default()`, and `ConfigArgs::default()` — which pinned
`Some(default_listening_address())`, i.e. an *explicit* address that takes
precedence over any default, so changing only the first two left every
programmatic composition on the wildcard. That third one is what made the first
run of the new tests fail, which is the argument for having written them.

**2. Auto-widen for backward compatibility — `--allowed-source-cidrs` only,
network mode only, this-boot flags only.** Before this change a network-mode
node bound `::` by default, so an operator who set `--allowed-source-cidrs` and
nothing else was relying on that wide default; the flag is genuinely inert on a
loopback socket, since a non-private source can never reach `::1`, so setting it
is unambiguous intent to serve non-local clients. If it is set, `--ws-api-address`
is not, and the mode is Network, the bind widens and says so at INFO.

Three scoping rules, each of which was wrong in an earlier cut of this PR:

- **`--allowed-host` is NOT a trigger.** It is a Host-header allowlist that is
  fully functional on loopback, the same-host reverse proxy is its primary
  documented use, and that is the *only* shape in which hosted mode's
  `userToken` is honoured at all (`decide_user_token` requires a loopback
  source). Widening for it would bind every interface in the commonest proxy
  deployment for no functional gain. A proxy on a different host is a deliberate
  multi-machine choice whose operator passes `--ws-api-address`.
- **Network mode only.** Local mode has always bound loopback, so there is no
  wide default to preserve and widening there would mean this hardening *opened*
  a socket that used to be closed.
- **This-boot grants only.** The widen decision reads the CLI/env value captured
  *before* the `config.toml` merge. Reading the merged value would make the
  widen sticky: one boot with the flag would pin the node to the wildcard
  forever, and removing the flag would never narrow it again — the hardening
  would permanently miss every node that ever set an allow-list.

**3. Upgrade migration — what makes this reach existing installs.** `build()`
persists the *resolved* config, so every node that has ever booted in network
mode already carries a wildcard `ws-api-address` in its `config.toml`. Merging
that value back would pin the existing fleet to the old bind and leave the
change reaching fresh installs only.

The sentinel is "a value this code could itself have written"
(`is_auto_derivable_ws_api_address`): the two wildcards (`0.0.0.0` before #3648,
`::` after) **and the two loopbacks**. Including loopback is load-bearing, not
tidiness: the migration boot persists a loopback address, and reading that back
as an operator choice on the next boot would take the Explicit short-circuit and
permanently disable the auto-widen remedy this PR's own release note points at.
The sentinel enumerates the four exactly rather than calling `is_loopback()`, so
a deliberately-pinned loopback alias like `127.0.0.5` stays an operator choice.
Any other persisted value — a specific interface IP — is preserved untouched.
CLI/env values are parsed before the merge, so `--ws-api-address ::` still wins.

**Re-derivation preserves the address family, and this is the safety-critical
part.** The primary bind is fatal while only the companion is best-effort
(`serve_dual_stack`). A node installed before #3648 carries `0.0.0.0`; on a host
with IPv6 disabled, re-deriving that to `::1` fails the bind with EAFNOSUPPORT —
and `build()` rewrites `config.toml` *before* the bind is attempted, while
`rollback.rs` does not snapshot config. So the crash-loop rollback restores the
previous binary onto a config that now names an unbindable family, it dies
identically, and rollback does not fire twice: the node is down permanently.
That is `code-style.md`'s "the brick-safety mechanism becomes the brick",
reached through a *value* change rather than the key change the existing rule
guards. Persisted `0.0.0.0` therefore becomes `127.0.0.1`, and an IPv4-family
node widens to `0.0.0.0` rather than `::`.

**4. Startup messages.** A re-derivation that MOVED the bind is reported in
whichever direction it moved, both at `warn!`. Narrowing is the one notice an
operator gets that clients on other machines just lost access. Widening matters
just as much and is easy to overlook: a node whose `config.toml` named a
loopback address, with `--allowed-source-cidrs` in its unit, now binds the
wildcard — because loopback is a value this code writes itself and so cannot be
told from a deliberate pin. On `main` that node stayed loopback. It is symmetric
with the pre-existing `::1` case and unavoidable given family preservation, but a
hardening PR that widens a node someone pinned has to say so loudly rather than
at `info!`.

Then the exposure warning, with two triggers:

- a **non-loopback bind** warns regardless of hosted mode. Hosted mode does not
  make a wide bind safe: `decide_user_token` returns the shared single-user
  context whenever a connection *omits* `userToken`, so hosted mode adds a
  per-user namespace for well-behaved clients without removing the shared one.
- **`--allowed-host` on a loopback bind with hosted mode off** warns
  unconditionally. A reverse proxy terminates the connection itself, so every
  visitor arrives wearing the proxy's source address and the node's own
  source-IP filters cannot tell them apart. Not gated on anything, because with
  hosted mode off there is no isolation at all.
- **loopback + hosted mode** — try.freenet.org's shape — stays quiet, and that
  is a **known gap, not a safety claim**. An untokened connection reads the
  shared namespace there too, and behind a public proxy that is any visitor;
  containment today is that the shared namespace is empty (measured on the live
  hosted node: zero files outside `*/users/*` across 28 delegates), which is a
  fact about current state rather than a structural guarantee. Making this
  branch conditional on that requires probing the secrets tree, which is its own
  change with its own failure modes — a probe that is wrong in either direction
  is worse than no warning, since one that is too eager fires on every boot of
  the flagship and trains operators to ignore the only signal there is. Tracked
  separately rather than bolted onto a default-hardening PR.

The messages are emitted from `Config::log_client_api_exposure()`, called from
`main` **after** `set_logger`. They cannot live in `ConfigArgs::build()`: it runs
before the global tracing subscriber is installed, so anything emitted there is
silently dropped — and this log is the only place an operator learns why their
LAN clients stopped connecting. `build()` records the decision on a runtime-only
`WebsocketApiConfig::exposure` field and `main` replays it.

Note this warning is the one behavior here that is *not* a bug fix in the
strict sense — it is a diagnostic on an existing configuration shape. It is in
this PR rather than a follow-up because the default change is what makes the
remaining exposed shapes worth naming.

## Release note

**Who is affected:** anyone who reaches a self-hosted node's UI or API **from a
different machine** — a phone or laptop browsing the node's dashboard, or
`fdev` / `riverctl` pointed at another host. After this change the node answers
on loopback only unless told otherwise, so those connections are refused. Access
from the machine running the node (`localhost` / `127.0.0.1` / `::1`) is
unchanged.

This applies **on upgrade**, not only to fresh installs: a wildcard
`ws-api-address` that was previously written into `config.toml` automatically is
re-derived to loopback. A persisted `127.0.0.1` or specific interface address is
left alone.

**Remedy — one flag.** Pick the narrowest that fits:

| Want | Add |
| --- | --- |
| Serve clients on other machines | `--ws-api-address ::` (or `WS_API_ADDRESS=::`) |
| One interface only | `--ws-api-address 192.0.2.10` |
| A VPN overlay (Tailscale/WireGuard) | `--allowed-source-cidrs 100.64.0.0/10` — widens the bind on its own, network mode |
| Behind a reverse proxy on another host | `--ws-api-address ::` plus `--allowed-host your.domain` |

**The flag has to live in the node's invocation and stay there** (the systemd
unit, docker-compose `environment:`, whatever launches it) — running it once is
not enough, and neither is leaving it in `config.toml`. Both the address and the
CIDR grant are re-decided from the invocation on every boot, precisely so that
removing a flag narrows the socket again. A specific address (`192.0.2.10`) is
distinguishable from this code's own output and does persist.

**On a systemd install, use `systemctl edit` to add a drop-in** overriding
`ExecStart`. Do not hand-edit the generated unit: that trips the installer's
sidecar hash, permanently marks the unit `UserModified`, and silently opts the
node out of every future unit-template change (including future hardening).

**Three environment variables were renamed.** `WS_API_ADDRESS`, `ALLOWED_HOST`
and `ALLOWED_SOURCE_CIDRS` are now `FREENET_WS_API_ADDRESS`,
`FREENET_ALLOWED_HOST` and `FREENET_ALLOWED_SOURCE_CIDRS`. Unnamespaced names
were survivable while a network-mode node bound `::` anyway and these only
shaped which `Host` headers it accepted. They are not now that
`--ws-api-address` decides the socket directly at the highest precedence and
`--allowed-source-cidrs` decides whether it is wide — a stray value in a shared
container, CI runner or systemd environment could open the API. A leftover
old-style variable is reported at startup rather than silently ignored.

**Also in this PR, and a widening rather than a narrowing:** `--ws-api-address`,
`--allowed-host` and `--allowed-source-cidrs` placed *before* the subcommand
(`freenet --allowed-source-cidrs … network`) were previously discarded. They are
now honoured, so a node whose operator wrote them in that position starts
admitting the CGNAT sources they intended all along. That is the fix for a
silently-ignored flag, but it is a filter widening riding inside a hardening
change and is called out here rather than buried.

Accepted edge, following directly from that: an operator who hand-edited
`ws-api-address = "::"` into `config.toml`, with no flag and no allow-list, is
indistinguishable from the old auto-default and will be re-derived to loopback.

**Rollback note:** after one boot on this version, `config.toml` holds a
concrete loopback address. A crash-loop auto-rollback to the previous binary
reads that as an explicit choice, so the rolled-back node comes back
loopback-only — and the old binary has none of these messages, so nothing
explains why. No key spelling changes and every value the new binary writes
parses and binds on the old one, so there is no parse-brick; but the previous
*reachability* is not restored automatically. Re-add `--ws-api-address ::`.

**Operator documentation:** `docs/client-api-exposure.md`, covering the default,
the narrowest flag for each situation, why the flag has to stay in the
invocation, the systemd drop-in, the renamed environment variables, and what the
three startup messages mean.

## Testing

New config-resolution tests in `crates/core/src/config.rs`:

- loopback default in **both** operation modes;
- auto-widen on `--allowed-source-cidrs`, and on `--allowed-host`;
- **no** auto-widen when `--ws-api-address` is given (try.freenet.org's exact
  shape: explicit loopback + hosted mode + proxy host);
- empty allow-lists (`[]`, which every already-persisted `config.toml` carries)
  do not count as widening intent;
- re-derivation preserves the address family, and the auto-widen does too —
  both written first and confirmed RED against the pre-fix code, since the test
  they replace pinned the unsafe behaviour;
- `--allowed-host` alone does not widen, while its allowlist still applies;
- a persisted CIDR grant does not widen a later flag-less boot (the sticky-widen
  case), while a grant still in the invocation does;
- Local mode with a widening flag still binds loopback, at both the pure
  resolver and the full-`build()` level;
- the documented remedy still works on an ALREADY-MIGRATED node: persisted
  loopback plus a newly-added CIDR grant widens the bind (it silently would not
  if the sentinel treated loopback as an operator choice);
- a re-derivation that widens past a persisted loopback address is REPORTED
  rather than silent;
- the loss-of-access notice fires on the migration boot and is absent on the
  next one (the half of its filter that was previously unverified);
- blank allow-list entries (`ALLOWED_HOST=` with no value, which parses as
  `Some(vec![""])`) do not count as widening intent;
- the remedy still works on the *second* boot: upgrade → persisted `::1` → add
  `--allowed-source-cidrs` → widens (this fails if the sentinel omits loopback);
- `build()` records the exposure decision on the resolved `Config`, since that
  is the only route by which it can reach a log;
- the warning's trigger matrix, asserting the *reason* it reports, including
  that a wildcard bind warns even in hosted mode and that
  proxied-with-hosted-mode-off fires it;
- migration: persisted `::` and persisted `0.0.0.0` are both re-derived to
  loopback; persisted `127.0.0.1` and a specific interface IP survive; an
  upgrading Tailscale-style node gets its wildcard bind straight back from
  auto-widening with no operator action;
- a source pin asserting the path stays wired end to end, now reaching ACROSS
  files: `build()` resolves through the helper and records the decision but does
  not emit the warning itself (that would be dropped);
  `log_client_api_exposure` consults the predicate and warns; and
  `bin/freenet.rs` still calls both `log_client_api_exposure` and
  `merge_pre_subcommand_ws_api_args` (the latter from *both* subcommand arms).
  Each helper has exactly one call site in a different file, so without the
  cross-file scrape deleting one left every test green.

Every pin above was mutation-tested: the mutation was applied, the test confirmed
red, and the mutation reverted.

Also verified empirically against a node built from this branch, reading the
actual listening sockets from the kernel (`ss -ltnp`, filtered to the node's own
PID) rather than from precedence code — results in a comment below.

Docker NAT simulation was checked and is unaffected: `freenet-test-network`'s
Docker path passes `--ws-api-address 0.0.0.0` explicitly, and its local-backend
path connects over `127.0.0.1`, which the companion bind still serves. Every
integration test under `crates/core/tests/` sets `ws_api.address` explicitly.

[AI-assisted - Claude]
