### PR TITLE
fix(client-api): withhold attested identity and delegate notifications from non-local connections

### DIFF
--- a/crates/core/src/client_events.rs
+++ b/crates/core/src/client_events.rs
@@ -1510,9 +1510,16 @@ async fn process_open_request(
 
                 // The attested app identity of THIS connection, after the
                 // loopback gate: `None` for any caller the node will not attest
-                // (GHSA-824h-7x5x-wfmf). Computed once here and used for both the
-                // routing registration below and the executor dispatch further
-                // down, so the two can never disagree about who the caller is.
+                // (GHSA-824h-7x5x-wfmf). Used for the routing registration below.
+                //
+                // The executor dispatch further down is NOT handed this value —
+                // it receives the raw `origin_contract` alongside
+                // `connection_scope` and applies the gate itself, because it must
+                // also gate the two origin sources this layer cannot see
+                // (`caller_delegate` and the node's inherited-origins map). Both
+                // gates read the SAME `request.connection_scope`, so they agree
+                // on whether the caller is attestable; `resolve_message_origin`
+                // is the single place that decides what that attestation is.
                 let attested_origin = if request.connection_scope.is_local() {
                     request.origin_contract
                 } else {

--- a/crates/core/src/client_events.rs
+++ b/crates/core/src/client_events.rs
@@ -1508,22 +1508,26 @@ async fn process_open_request(
                 );
                 let delegate_key = req.key().clone();
 
-                // The attested app identity of THIS connection, after the
-                // loopback gate: `None` for any caller the node will not attest
-                // (GHSA-824h-7x5x-wfmf). Used for the routing registration below.
+                // Who this connection is, from the perspective of delegate
+                // notification routing (GHSA-824h-7x5x-wfmf). Only a connection
+                // the node proved is local may receive a delegate's output; the
+                // attested contract id rides along for diagnostics but does NOT
+                // decide delivery (see `route_to_apps` for why matching on it is
+                // unsafe).
                 //
                 // The executor dispatch further down is NOT handed this value —
                 // it receives the raw `origin_contract` alongside
                 // `connection_scope` and applies the gate itself, because it must
                 // also gate the two origin sources this layer cannot see
                 // (`caller_delegate` and the node's inherited-origins map). Both
-                // gates read the SAME `request.connection_scope`, so they agree
-                // on whether the caller is attestable; `resolve_message_origin`
-                // is the single place that decides what that attestation is.
-                let attested_origin = if request.connection_scope.is_local() {
-                    request.origin_contract
+                // read the SAME `request.connection_scope`, so they agree on
+                // whether the caller is attestable.
+                let app_identity = if request.connection_scope.is_local() {
+                    crate::contract::delegate_app_registry::AppIdentity::Local {
+                        attested: request.origin_contract,
+                    }
                 } else {
-                    None
+                    crate::contract::delegate_app_registry::AppIdentity::Remote
                 };
 
                 // Register (or refresh) this app's routing path so the delegate
@@ -1535,10 +1539,9 @@ async fn process_open_request(
                 // (installing the delegate binary) does NOT register an app —
                 // it's an admin op, not an app conversation.
                 //
-                // The registration is BOUND to `attested_origin`: registering is
-                // still open to anyone (it is how a client asks to be pushed to),
-                // but the delegate's output is only routed to a registration
-                // whose identity matches the delegate's own — see
+                // The registration records `app_identity`: registering stays open
+                // to anyone (it is how a client asks to be pushed to), but only a
+                // LOCAL registration is ever a delivery target — see
                 // `delegate_app_registry::route_to_apps`.
                 match &req {
                     freenet_stdlib::client_api::DelegateRequest::ApplicationMessages { .. } => {
@@ -1546,7 +1549,7 @@ async fn process_open_request(
                             if !crate::contract::delegate_app_registry::register_app(
                                 &delegate_key,
                                 client_id,
-                                attested_origin,
+                                app_identity,
                                 sender.clone(),
                             ) {
                                 tracing::warn!(
@@ -1567,7 +1570,7 @@ async fn process_open_request(
                     // carries a notification channel (above), never by
                     // registration. RegisterDelegateWithPredecessors's
                     // node-side secret copy-forward (#4117) is unconditionally
-                    // disabled as of #5198 (its origin_contract gate is
+                    // disabled as of GHSA-824h-7x5x-wfmf (its origin_contract gate is
                     // forgeable) — it was likewise never an app-routing event
                     // even when active. Both are listed EXPLICITLY (not swept)
                     // per this match's contract that
@@ -2020,18 +2023,17 @@ mod serve_during_gate_tests {
         );
     }
 
-    /// GHSA-824h-7x5x-wfmf: the app-routing registration must be bound to the
-    /// ATTESTED origin, and "attested" must be gated on the connection scope.
+    /// GHSA-824h-7x5x-wfmf: the app-routing registration must record WHO
+    /// registered, derived from the connection scope.
     ///
-    /// A compile-time signature change already forces SOMETHING to be passed as
-    /// the origin, so the type system alone does not protect this: passing
-    /// `request.origin_contract` directly would compile and would re-open the
-    /// hole for every off-host caller holding a token. This pins that the value
-    /// handed to `register_app` is derived through `connection_scope.is_local()`
-    /// and that the SAME derived value is what reaches the executor, so the two
-    /// cannot disagree about who the caller is.
+    /// The type system alone does not protect this: `AppIdentity::Local { .. }`
+    /// is constructible unconditionally, so a version that classified every
+    /// registration as `Local` would compile and would re-open the hole for
+    /// every off-host caller. This pins that the identity handed to
+    /// `register_app` is derived through `connection_scope.is_local()`, and that
+    /// the connection scope also reaches the executor.
     #[test]
-    fn delegate_registration_binds_to_the_gated_attested_origin() {
+    fn delegate_registration_binds_to_the_connection_scope() {
         let src = include_str!("client_events.rs");
         // Bound the scrape to the DelegateOp arm. An unbounded `split_once`
         // would happily match this test's own assertion strings further down
@@ -2046,9 +2048,9 @@ mod serve_during_gate_tests {
             .expect("the arm is bounded by the next ClientRequest arm");
 
         let derivation = arm
-            .find("let attested_origin = if request.connection_scope.is_local()")
+            .find("let app_identity = if request.connection_scope.is_local()")
             .expect(
-                "the attested origin must be derived by gating `origin_contract` on \
+                "the registration identity must be derived from \
                  `connection_scope.is_local()`",
             );
         let registration = arm
@@ -2065,9 +2067,9 @@ mod serve_during_gate_tests {
             .next()
             .expect("register_app call must be bounded");
         assert!(
-            register_call.contains("attested_origin"),
-            "register_app must receive the GATED origin, not `request.origin_contract`; \
-             got: {register_call}"
+            register_call.contains("app_identity"),
+            "register_app must receive the scope-derived identity, not a value \
+             built from `request.origin_contract` alone; got: {register_call}"
         );
 
         assert!(

--- a/crates/core/src/client_events.rs
+++ b/crates/core/src/client_events.rs
@@ -25,7 +25,7 @@ pub(crate) use error::{Error, ensure_peer_ready};
 pub(crate) use proxy::BoxedClient;
 pub use proxy::ClientEventsProxy;
 pub(crate) use types::HostIncomingMsg;
-pub use types::{AuthToken, ClientId, HostResult, OpenRequest, RequestId};
+pub use types::{AuthToken, ClientId, ConnectionScope, HostResult, OpenRequest, RequestId};
 
 use either::Either;
 use freenet_stdlib::{
@@ -1508,6 +1508,17 @@ async fn process_open_request(
                 );
                 let delegate_key = req.key().clone();
 
+                // The attested app identity of THIS connection, after the
+                // loopback gate: `None` for any caller the node will not attest
+                // (GHSA-824h-7x5x-wfmf). Computed once here and used for both the
+                // routing registration below and the executor dispatch further
+                // down, so the two can never disagree about who the caller is.
+                let attested_origin = if request.connection_scope.is_local() {
+                    request.origin_contract
+                } else {
+                    None
+                };
+
                 // Register (or refresh) this app's routing path so the delegate
                 // can push notification-driven ApplicationMessages back to it
                 // (#3275). An app "registers with a delegate" by talking to it
@@ -1516,12 +1527,19 @@ async fn process_open_request(
                 // the path. UnregisterDelegate tears it down. RegisterDelegate
                 // (installing the delegate binary) does NOT register an app —
                 // it's an admin op, not an app conversation.
+                //
+                // The registration is BOUND to `attested_origin`: registering is
+                // still open to anyone (it is how a client asks to be pushed to),
+                // but the delegate's output is only routed to a registration
+                // whose identity matches the delegate's own — see
+                // `delegate_app_registry::route_to_apps`.
                 match &req {
                     freenet_stdlib::client_api::DelegateRequest::ApplicationMessages { .. } => {
                         if let Some(sender) = &subscription_listener {
                             if !crate::contract::delegate_app_registry::register_app(
                                 &delegate_key,
                                 client_id,
+                                attested_origin,
                                 sender.clone(),
                             ) {
                                 tracing::warn!(
@@ -1627,6 +1645,7 @@ async fn process_open_request(
                     );
                 }
                 let origin_contract = request.origin_contract;
+                let connection_scope = request.connection_scope;
                 // Per-connection user secret namespace (hosted mode). Taken from
                 // the OpenRequest, which received it from the connection layer —
                 // NOT from anything inside `req`. Moving it into the event keeps
@@ -1638,6 +1657,7 @@ async fn process_open_request(
                         ContractHandlerEvent::DelegateRequest {
                             req,
                             origin_contract,
+                            connection_scope,
                             user_context,
                         },
                         crate::contract::Priority::ClientLocal,
@@ -1990,6 +2010,64 @@ mod serve_during_gate_tests {
              blocking_subscribe — that silently downgrades an explicit \
              blocking_subscribe=true GET to fire-and-forget (#4524 regression). \
              Call args: {args_only:?}"
+        );
+    }
+
+    /// GHSA-824h-7x5x-wfmf: the app-routing registration must be bound to the
+    /// ATTESTED origin, and "attested" must be gated on the connection scope.
+    ///
+    /// A compile-time signature change already forces SOMETHING to be passed as
+    /// the origin, so the type system alone does not protect this: passing
+    /// `request.origin_contract` directly would compile and would re-open the
+    /// hole for every off-host caller holding a token. This pins that the value
+    /// handed to `register_app` is derived through `connection_scope.is_local()`
+    /// and that the SAME derived value is what reaches the executor, so the two
+    /// cannot disagree about who the caller is.
+    #[test]
+    fn delegate_registration_binds_to_the_gated_attested_origin() {
+        let src = include_str!("client_events.rs");
+        // Bound the scrape to the DelegateOp arm. An unbounded `split_once`
+        // would happily match this test's own assertion strings further down
+        // the file and pass vacuously.
+        let arm = src
+            .split("ClientRequest::DelegateOp(req) => {")
+            .nth(1)
+            .expect("the DelegateOp arm must exist");
+        let arm = arm
+            .split("\n            ClientRequest::")
+            .next()
+            .expect("the arm is bounded by the next ClientRequest arm");
+
+        let derivation = arm
+            .find("let attested_origin = if request.connection_scope.is_local()")
+            .expect(
+                "the attested origin must be derived by gating `origin_contract` on \
+                 `connection_scope.is_local()`",
+            );
+        let registration = arm
+            .find("register_app(")
+            .expect("the DelegateOp arm must register the app routing path");
+        assert!(
+            derivation < registration,
+            "the scope gate must be applied BEFORE the value reaches register_app"
+        );
+
+        let register_call = &arm[registration..];
+        let register_call = register_call
+            .split(") {")
+            .next()
+            .expect("register_app call must be bounded");
+        assert!(
+            register_call.contains("attested_origin"),
+            "register_app must receive the GATED origin, not `request.origin_contract`; \
+             got: {register_call}"
+        );
+
+        assert!(
+            arm.contains("let connection_scope = request.connection_scope;")
+                && arm.contains("connection_scope,\n                            user_context,"),
+            "the same connection scope must also reach the executor via \
+             ContractHandlerEvent::DelegateRequest"
         );
     }
 }

--- a/crates/core/src/client_events.rs
+++ b/crates/core/src/client_events.rs
@@ -1510,10 +1510,10 @@ async fn process_open_request(
 
                 // Who this connection is, from the perspective of delegate
                 // notification routing (GHSA-824h-7x5x-wfmf). Only a connection
-                // the node proved is local may receive a delegate's output; the
-                // attested contract id rides along for diagnostics but does NOT
-                // decide delivery (see `route_to_apps` for why matching on it is
-                // unsafe).
+                // the node proved is local may receive a delegate's output.
+                // Locality is the WHOLE of the identity here — no contract id is
+                // carried, because keying delivery on one is unsafe (see
+                // `route_to_apps`).
                 //
                 // The executor dispatch further down is NOT handed this value —
                 // it receives the raw `origin_contract` alongside

--- a/crates/core/src/client_events.rs
+++ b/crates/core/src/client_events.rs
@@ -1523,9 +1523,7 @@ async fn process_open_request(
                 // read the SAME `request.connection_scope`, so they agree on
                 // whether the caller is attestable.
                 let app_identity = if request.connection_scope.is_local() {
-                    crate::contract::delegate_app_registry::AppIdentity::Local {
-                        attested: request.origin_contract,
-                    }
+                    crate::contract::delegate_app_registry::AppIdentity::Local
                 } else {
                     crate::contract::delegate_app_registry::AppIdentity::Remote
                 };
@@ -2026,7 +2024,7 @@ mod serve_during_gate_tests {
     /// GHSA-824h-7x5x-wfmf: the app-routing registration must record WHO
     /// registered, derived from the connection scope.
     ///
-    /// The type system alone does not protect this: `AppIdentity::Local { .. }`
+    /// The type system alone does not protect this: `AppIdentity::Local`
     /// is constructible unconditionally, so a version that classified every
     /// registration as `Local` would compile and would re-open the hole for
     /// every off-host caller. This pins that the identity handed to

--- a/crates/core/src/client_events/combinator.rs
+++ b/crates/core/src/client_events/combinator.rs
@@ -135,6 +135,7 @@ impl<const N: usize> super::ClientEventsProxy for ClientEventsCombinator<N> {
                                 notification_channel,
                                 token,
                                 origin_contract,
+                                connection_scope,
                                 user_context,
                             }) => {
                                 let id = *self.external_clients[idx]
@@ -152,8 +153,10 @@ impl<const N: usize> super::ClientEventsProxy for ClientEventsCombinator<N> {
                                     notification_channel,
                                     token,
                                     origin_contract,
-                                    // Preserve the connection's user context through
-                                    // the ID-remapping proxy combinator unchanged.
+                                    // Preserve the connection's scope and user
+                                    // context through the ID-remapping proxy
+                                    // combinator unchanged.
+                                    connection_scope,
                                     user_context,
                                 })
                             }
@@ -295,6 +298,7 @@ async fn client_fn(
                         notification_channel,
                         token,
                         origin_contract,
+                        connection_scope,
                         user_context,
                     }) => {
                         tracing::debug!(
@@ -308,7 +312,9 @@ async fn client_fn(
                                 notification_channel,
                                 token,
                                 origin_contract,
-                                // Forward the connection's user context unchanged.
+                                // Forward the connection's scope and user context
+                                // unchanged.
+                                connection_scope,
                                 user_context,
                             }))
                             .await

--- a/crates/core/src/client_events/test.rs
+++ b/crates/core/src/client_events/test.rs
@@ -144,6 +144,7 @@ impl<R> MemoryEventsGen<R> {
             notification_channel,
             token: None,
             origin_contract: None,
+            connection_scope: ConnectionScope::Local,
             user_context: None,
         }
         .into_owned()

--- a/crates/core/src/client_events/test_correlation.rs
+++ b/crates/core/src/client_events/test_correlation.rs
@@ -34,6 +34,7 @@ mod tests {
             notification_channel: None,
             token: None,
             origin_contract: None,
+            connection_scope: crate::client_events::ConnectionScope::Local,
             user_context: None,
         };
 

--- a/crates/core/src/client_events/types.rs
+++ b/crates/core/src/client_events/types.rs
@@ -147,6 +147,89 @@ impl From<String> for AuthToken {
     }
 }
 
+/// Where the client connection that issued a request reached the node from.
+///
+/// This is the trust boundary for **attested application identity**: the node
+/// hands a delegate a [`freenet_stdlib::prelude::MessageOrigin`] naming the web
+/// app on whose behalf a request runs, and delegates authorize on that name. The
+/// client API has no authentication, so the only non-forgeable signal available
+/// at the connection boundary is the peer address the kernel recorded for the
+/// accepted socket (`ConnectInfo<SocketAddr>`) — the same anchor
+/// `decide_user_token` (`client_events::websocket`) already uses to gate the durable
+/// per-user token.
+///
+/// `Local` therefore means "this HOST", not "this user" — see the security
+/// notes on [`Self::from_source_ip`].
+///
+/// **Fail closed:** anything that cannot be *proven* loopback is [`Self::Remote`],
+/// including a missing `ConnectInfo`. [`Default`] is `Remote` for the same
+/// reason: a construction site that forgets to set the scope loses attestation
+/// (a visible functional failure) rather than granting it (a silent
+/// vulnerability).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ConnectionScope {
+    /// The kernel observed the peer address of this connection as loopback.
+    Local,
+    /// Off-host, or not provably loopback.
+    #[default]
+    Remote,
+}
+
+impl ConnectionScope {
+    pub fn is_local(self) -> bool {
+        matches!(self, Self::Local)
+    }
+
+    /// Classify a connection from the peer address the kernel recorded.
+    ///
+    /// # Security scope — read before relying on this
+    ///
+    /// A loopback peer address proves the connection was accepted over the
+    /// loopback interface of THIS HOST. It does **not** prove:
+    ///
+    /// - **the same user.** A different local user account, or an app confined
+    ///   from `$HOME` (Flatpak/Snap/container) but able to open a localhost
+    ///   socket, is loopback and passes this check. (A same-user *unconfined*
+    ///   process is out of scope entirely: it can read `secrets_dir/node_kek`
+    ///   and decrypt directly, so no client-API gate could help it.)
+    /// - **the same machine as the human.** Behind a colocated reverse proxy
+    ///   every client presents the proxy's loopback address, so this classifies
+    ///   every request as `Local` and the gate is a no-op for that deployment.
+    ///
+    /// `None` (no `ConnectInfo` on the request — only reachable from unit tests
+    /// that omit it) is `Remote`: we cannot prove loopback, so we must not
+    /// attest.
+    pub fn from_source_ip(source_ip: Option<std::net::IpAddr>) -> Self {
+        match source_ip {
+            Some(ip) if is_loopback_source(ip) => Self::Local,
+            _ => Self::Remote,
+        }
+    }
+}
+
+/// Whether a source IP is loopback (`127.0.0.0/8`, `::1`), after normalizing an
+/// IPv4-mapped IPv6 source (`::ffff:127.0.0.1`) from a dual-stack socket.
+///
+/// Loopback is the trust anchor for two distinct per-connection decisions —
+/// honoring a durable per-user token (`decide_user_token` (`client_events::websocket`))
+/// and attesting an application identity ([`ConnectionScope::from_source_ip`]).
+/// Both live on this ONE definition on purpose: two copies of "is this local"
+/// would be free to drift, and a normalization fixed in one (the IPv4-mapped
+/// case) would silently not reach the other.
+///
+/// Anything off-host cannot forge a loopback source — the kernel sets it from
+/// the accepted socket (`ConnectInfo<SocketAddr>`) — so it is a sound,
+/// non-spoofable signal that the connection did not cross the network.
+pub(crate) fn is_loopback_source(ip: std::net::IpAddr) -> bool {
+    match ip {
+        std::net::IpAddr::V4(v4) => v4.is_loopback(),
+        std::net::IpAddr::V6(v6) => match v6.to_ipv4_mapped() {
+            Some(v4) => v4.is_loopback(),
+            None => v6.is_loopback(),
+        },
+    }
+}
+
 #[non_exhaustive]
 pub struct OpenRequest<'a> {
     pub client_id: ClientId,
@@ -155,6 +238,11 @@ pub struct OpenRequest<'a> {
     pub notification_channel: Option<mpsc::Sender<HostResult>>,
     pub token: Option<AuthToken>,
     pub origin_contract: Option<ContractInstanceId>,
+    /// Whether the issuing connection is entitled to an *attested* application
+    /// identity (see [`ConnectionScope`]). Like `user_context` this rides
+    /// alongside the request and is never read from the request body, so a
+    /// client cannot forge it.
+    pub connection_scope: ConnectionScope,
     /// Per-connection per-user secret namespace (hosted mode, P2 of #4381),
     /// derived once at the WS connection boundary from the connection's user
     /// token. `None` outside hosted mode or when no token was presented. This
@@ -189,6 +277,7 @@ impl<'a> OpenRequest<'a> {
             notification_channel: None,
             token: None,
             origin_contract: None,
+            connection_scope: ConnectionScope::default(),
             user_context: None,
         }
     }
@@ -208,8 +297,91 @@ impl<'a> OpenRequest<'a> {
         self
     }
 
+    pub fn with_connection_scope(mut self, scope: ConnectionScope) -> Self {
+        self.connection_scope = scope;
+        self
+    }
+
     pub fn with_user_context(mut self, user_context: Option<UserSecretContext>) -> Self {
         self.user_context = user_context;
         self
+    }
+}
+
+#[cfg(test)]
+mod connection_scope_tests {
+    use super::*;
+    use std::net::IpAddr;
+
+    /// GHSA-824h-7x5x-wfmf: the whole gate rests on this classification, so it
+    /// must fail CLOSED. A missing `ConnectInfo` cannot prove loopback and must
+    /// not be read as local — the same fail-closed rule `decide_user_token`
+    /// applies to the durable per-user token.
+    #[test]
+    fn missing_source_ip_is_remote() {
+        assert_eq!(
+            ConnectionScope::from_source_ip(None),
+            ConnectionScope::Remote
+        );
+        assert!(!ConnectionScope::from_source_ip(None).is_local());
+    }
+
+    #[test]
+    fn loopback_sources_are_local_including_ipv4_mapped() {
+        for ip in [
+            "127.0.0.1",
+            // Anywhere in 127.0.0.0/8, not just .1.
+            "127.4.5.6",
+            "::1",
+            // A dual-stack socket reports an IPv4 loopback peer in this form;
+            // failing to normalize it would misclassify every local browser on
+            // a dual-stack bind as Remote and break the shell outright.
+            "::ffff:127.0.0.1",
+        ] {
+            let parsed: IpAddr = ip.parse().expect("test address must parse");
+            assert_eq!(
+                ConnectionScope::from_source_ip(Some(parsed)),
+                ConnectionScope::Local,
+                "{ip} must classify as Local"
+            );
+        }
+    }
+
+    #[test]
+    fn off_host_sources_are_remote() {
+        for ip in [
+            // LAN — the case this fix deliberately breaks (see the PR's
+            // limitations): a browser on another machine no longer gets an
+            // attested identity.
+            "192.168.1.50",
+            "10.0.0.7",
+            "5.9.111.215",
+            "2001:db8::1",
+            // An IPv4-mapped NON-loopback address must not be waved through by
+            // the normalization above.
+            "::ffff:192.168.1.50",
+        ] {
+            let parsed: IpAddr = ip.parse().expect("test address must parse");
+            assert_eq!(
+                ConnectionScope::from_source_ip(Some(parsed)),
+                ConnectionScope::Remote,
+                "{ip} must classify as Remote"
+            );
+        }
+    }
+
+    /// A construction site that forgets to set the scope must lose attestation
+    /// (a visible functional failure), never grant it (a silent hole).
+    #[test]
+    fn default_scope_is_remote() {
+        assert_eq!(ConnectionScope::default(), ConnectionScope::Remote);
+        assert!(
+            !OpenRequest::new(
+                ClientId::FIRST,
+                Box::new(freenet_stdlib::client_api::ClientRequest::Close),
+            )
+            .connection_scope
+            .is_local()
+        );
     }
 }

--- a/crates/core/src/client_events/websocket.rs
+++ b/crates/core/src/client_events/websocket.rs
@@ -140,7 +140,7 @@ use crate::{
     },
 };
 
-use super::{ClientError, ClientEventsProxy, ClientId, HostResult, OpenRequest};
+use super::{ClientError, ClientEventsProxy, ClientId, ConnectionScope, HostResult, OpenRequest};
 use crate::client_events::user_op_rate_limit::UserOpRateLimiter;
 use crate::server::client_api::OriginContractMap;
 use crate::wasm_runtime::UserSecretContext;
@@ -550,6 +550,7 @@ impl WebSocketProxy {
         req: Box<ClientRequest<'static>>,
         auth_token: Option<AuthToken>,
         origin_contract: Option<ContractInstanceId>,
+        connection_scope: ConnectionScope,
         user_context: Option<UserSecretContext>,
     ) -> Option<OpenRequest<'static>> {
         let (tx, rx) =
@@ -571,6 +572,7 @@ impl WebSocketProxy {
                 .with_notification(tx)
                 .with_token(auth_token)
                 .with_origin_contract(origin_contract)
+                .with_connection_scope(connection_scope)
                 .with_user_context(user_context),
         )
     }
@@ -597,6 +599,7 @@ impl WebSocketProxy {
                 Ok(None)
             }
             ClientConnection::Request {
+                connection_scope,
                 client_id,
                 req,
                 auth_token,
@@ -651,6 +654,7 @@ impl WebSocketProxy {
                         req,
                         auth_token,
                         origin_contract,
+                        connection_scope,
                         user_context,
                     ) {
                         Some(r) => r,
@@ -660,6 +664,7 @@ impl WebSocketProxy {
                     OpenRequest::new(client_id, req)
                         .with_token(auth_token)
                         .with_origin_contract(origin_contract)
+                        .with_connection_scope(connection_scope)
                         .with_user_context(user_context)
                 };
                 Ok(Some(open_req))
@@ -783,24 +788,13 @@ pub(crate) enum UserTokenDecision {
     Local,
 }
 
-/// Whether a source IP is loopback (`127.0.0.0/8`, `::1`), after normalizing an
-/// IPv4-mapped IPv6 source (`::ffff:127.0.0.1`) from a dual-stack socket.
+/// Whether a source IP is loopback. A direct local browser, or a
+/// TLS-terminating reverse proxy colocated on the same host, both connect from
+/// loopback; anything off-host cannot forge it.
 ///
-/// Loopback is the trust anchor for honoring a durable per-user token: a direct
-/// local browser, or a TLS-terminating reverse proxy colocated on the same host,
-/// both connect from loopback. Anything off-host cannot forge a loopback source
-/// (the kernel sets it from the accepted socket — see `ConnectInfo<SocketAddr>`
-/// in `private_network_filter`), so it is a sound, non-spoofable signal that the
-/// plaintext HTTP port was NOT exposed to the network for this connection.
-pub(crate) fn is_loopback_source(ip: std::net::IpAddr) -> bool {
-    match ip {
-        std::net::IpAddr::V4(v4) => v4.is_loopback(),
-        std::net::IpAddr::V6(v6) => match v6.to_ipv4_mapped() {
-            Some(v4) => v4.is_loopback(),
-            None => v6.is_loopback(),
-        },
-    }
-}
+/// Re-exported from [`crate::client_events::types`] so this file and
+/// [`ConnectionScope`] share ONE definition — see its rustdoc for why.
+pub(crate) use super::types::is_loopback_source;
 
 /// The security-critical gate: decide whether to honor a per-user `userToken`.
 ///
@@ -1107,9 +1101,20 @@ async fn connection_info(
         request_path = req.uri().path(),
         "connection_info middleware: resolved auth token, hosted-mode context, and encoding protocol",
     );
+    // ATTESTED-ORIGIN scope (GHSA-824h-7x5x-wfmf). Classified HERE, from the
+    // same kernel-observed `source_ip` the token gate above already reads, and
+    // NOT inside `websocket_commands`'s `on_upgrade` closure — that closure has
+    // no extractor and therefore no access to `ConnectInfo`, which is exactly
+    // why the connection's scope has to be captured at this layer and carried
+    // down as an extension (mirroring `user_context`).
+    //
+    // Fail closed: a missing `ConnectInfo` yields `Remote`, so a connection we
+    // cannot prove local never receives an attested application identity.
+    let connection_scope = ConnectionScope::from_source_ip(source_ip);
     req.extensions_mut().insert(encoding_protoc);
     req.extensions_mut().insert(auth_token);
     req.extensions_mut().insert(user_context);
+    req.extensions_mut().insert(connection_scope);
     // `streaming` query parameter is accepted but ignored — streaming is now
     // always enabled for payloads exceeding CHUNK_THRESHOLD (512 KiB).
 
@@ -1128,6 +1133,11 @@ async fn websocket_commands(
     // (hosted mode). `None` outside hosted mode or when no user token was
     // presented. Owned and moved into the connection task below.
     Extension(user_context): Extension<Option<UserSecretContext>>,
+    // Whether this connection is entitled to an attested application identity
+    // (GHSA-824h-7x5x-wfmf), classified in `connection_info` from the
+    // kernel-observed peer address. Moved into the connection task below and
+    // fixed for the connection's lifetime, exactly like `user_context`.
+    Extension(connection_scope): Extension<ConnectionScope>,
     // Per-node per-user operation rate limiter (#4561, P5 of #4381). Installed
     // as an `Extension` by `serve_client_api_in_impl` (the only path that has
     // the operator config). OPTIONAL: the standalone `create_router` test path
@@ -1200,6 +1210,7 @@ async fn websocket_commands(
             rs.clone(),
             auth_and_instance,
             user_context,
+            connection_scope,
             op_rate_limiter,
             activity_secrets_dir,
             token_is_invalid,
@@ -1232,6 +1243,7 @@ async fn notify_disconnect(
     request_sender: &WebSocketRequest,
     client_id: ClientId,
     auth_token: &Option<(AuthToken, ContractInstanceId)>,
+    connection_scope: ConnectionScope,
     api_version: ApiVersion,
 ) {
     tracing::debug!(%client_id, "Notifying node of disconnect for subscription cleanup");
@@ -1241,6 +1253,7 @@ async fn notify_disconnect(
             req: Box::new(ClientRequest::Disconnect { cause: None }),
             auth_token: auth_token.as_ref().map(|t| t.0.clone()),
             origin_contract: auth_token.as_ref().map(|t| t.1),
+            connection_scope,
             // Synthetic disconnect: no secret operations, so no user context.
             user_context: None,
             api_version,
@@ -1260,6 +1273,11 @@ async fn websocket_interface(
     // `ClientConnection::Request` so every request from this connection (and
     // only this connection) binds to the same user namespace.
     user_context: Option<UserSecretContext>,
+    // Whether this connection may receive an attested application identity
+    // (GHSA-824h-7x5x-wfmf). Classified once in `connection_info` from the
+    // kernel-observed peer address and immutable for the connection's life,
+    // like `user_context`; copied into every `ClientConnection::Request`.
+    connection_scope: ConnectionScope,
     // Per-node per-user op rate limiter (hosted mode, #4561). `None` on the
     // standalone/local paths that install no limiter. Shared across all of a
     // user's connections; consulted in `process_client_request` only when this
@@ -1329,7 +1347,14 @@ async fn websocket_interface(
         // (since auth_token=None), so the delegate receives origin=None and fails with
         // "missing message origin". The client handles AUTH_TOKEN_INVALID by reloading
         // the page to get a fresh token, so closing is the correct behavior.
-        notify_disconnect(&request_sender, client_id, &auth_token, api_version).await;
+        notify_disconnect(
+            &request_sender,
+            client_id,
+            &auth_token,
+            connection_scope,
+            api_version,
+        )
+        .await;
         // Close with the trusted application code (not a bare close) so the shell
         // can distinguish a stale-token rejection from any other disconnect and
         // recover autonomously — see AUTH_TOKEN_INVALID_CLOSE_CODE. The serialized
@@ -1396,7 +1421,7 @@ async fn websocket_interface(
                 {
                     Err(err) => {
                         tracing::debug!(err = %err, "client channel closed");
-                        notify_disconnect(&request_sender, client_id, &auth_token, api_version).await;
+                        notify_disconnect(&request_sender, client_id, &auth_token, connection_scope, api_version).await;
                         if let Err(e) = server_sink.send(Message::Close(None)).await {
                             tracing::debug!(error = %e, "Failed to send WebSocket close frame");
                         }
@@ -1411,6 +1436,7 @@ async fn websocket_interface(
                     &request_sender,
                     &mut auth_token.as_mut().map(|t| t.0.clone()),
                     auth_token.as_mut().map(|t| t.1),
+                    connection_scope,
                     user_context.as_ref(),
                     op_rate_limiter.as_ref(),
                     activity_secrets_dir.as_ref(),
@@ -1423,14 +1449,14 @@ async fn websocket_interface(
                     Ok(Some(error)) => {
                         if let Err(err) = server_sink.send(error).await {
                             tracing::debug!(err = %err, "error sending error response to client");
-                            notify_disconnect(&request_sender, client_id, &auth_token, api_version).await;
+                            notify_disconnect(&request_sender, client_id, &auth_token, connection_scope, api_version).await;
                             return Err(err.into());
                         }
                     }
                     Ok(None) => continue,
                     Err(None) => {
                         tracing::debug!(%client_id, "client channel closed during request processing");
-                        notify_disconnect(&request_sender, client_id, &auth_token, api_version).await;
+                        notify_disconnect(&request_sender, client_id, &auth_token, connection_scope, api_version).await;
                         if let Err(e) = server_sink.send(Message::Close(None)).await {
                             tracing::debug!(error = %e, "Failed to send WebSocket close frame");
                         }
@@ -1438,7 +1464,7 @@ async fn websocket_interface(
                     },
                     Err(Some(err)) => {
                         tracing::debug!(%client_id, err = %err, "client request error");
-                        notify_disconnect(&request_sender, client_id, &auth_token, api_version).await;
+                        notify_disconnect(&request_sender, client_id, &auth_token, connection_scope, api_version).await;
                         return Err(err)
                     },
                 }
@@ -1449,7 +1475,7 @@ async fn websocket_interface(
                 let msg = match process_host_response(msg, client_id, &mut server_sink, &mut delegate_rate_limiter, &mut conn_state).await {
                     Ok(msg) => msg,
                     Err(err) => {
-                        notify_disconnect(&request_sender, client_id, &auth_token, api_version).await;
+                        notify_disconnect(&request_sender, client_id, &auth_token, connection_scope, api_version).await;
                         return Err(err);
                     }
                 };
@@ -1463,7 +1489,7 @@ async fn websocket_interface(
                 let response = match response {
                     Ok(r) => r,
                     Err(err) => {
-                        notify_disconnect(&request_sender, client_id, &auth_token, api_version).await;
+                        notify_disconnect(&request_sender, client_id, &auth_token, connection_scope, api_version).await;
                         return Err(err);
                     }
                 };
@@ -1477,14 +1503,14 @@ async fn websocket_interface(
                         Ok(res) => match res.into_fbs_bytes() {
                             Ok(b) => b,
                             Err(err) => {
-                                notify_disconnect(&request_sender, client_id, &auth_token, api_version).await;
+                                notify_disconnect(&request_sender, client_id, &auth_token, connection_scope, api_version).await;
                                 return Err(err.into());
                             }
                         },
                         Err(err) => match err.into_fbs_bytes() {
                             Ok(b) => b,
                             Err(err) => {
-                                notify_disconnect(&request_sender, client_id, &auth_token, api_version).await;
+                                notify_disconnect(&request_sender, client_id, &auth_token, connection_scope, api_version).await;
                                 return Err(err.into());
                             }
                         },
@@ -1492,14 +1518,14 @@ async fn websocket_interface(
                     EncodingProtocol::Native => match bincode::serialize(&response) {
                         Ok(b) => b,
                         Err(err) => {
-                            notify_disconnect(&request_sender, client_id, &auth_token, api_version).await;
+                            notify_disconnect(&request_sender, client_id, &auth_token, connection_scope, api_version).await;
                             return Err(err.into());
                         }
                     },
                 };
                 if let Err(err) = send_response_message(&mut server_sink, serialized_res, &mut conn_state, stream_content).await {
                     tracing::debug!(err = %err, "error sending notification to client");
-                    notify_disconnect(&request_sender, client_id, &auth_token, api_version).await;
+                    notify_disconnect(&request_sender, client_id, &auth_token, connection_scope, api_version).await;
                     return Err(err.into());
                 }
             }
@@ -1508,7 +1534,7 @@ async fn websocket_interface(
                 tracing::trace!(%client_id, "sending WebSocket ping to keep connection alive");
                 if let Err(err) = server_sink.send(Message::Ping(vec![].into())).await {
                     tracing::debug!(%client_id, %err, "ping failed, connection dead");
-                    notify_disconnect(&request_sender, client_id, &auth_token, api_version).await;
+                    notify_disconnect(&request_sender, client_id, &auth_token, connection_scope, api_version).await;
                     return Err(err.into());
                 }
             }
@@ -1730,6 +1756,7 @@ async fn process_client_request(
     request_sender: &mpsc::Sender<ClientConnection>,
     auth_token: &mut Option<AuthToken>,
     origin_contract: Option<ContractInstanceId>,
+    connection_scope: ConnectionScope,
     user_context: Option<&UserSecretContext>,
     op_rate_limiter: Option<&UserOpRateLimiter>,
     activity_secrets_dir: Option<&crate::server::ActivitySecretsDir>,
@@ -1997,6 +2024,7 @@ async fn process_client_request(
             req: Box::new(req),
             auth_token: auth_token.clone(),
             origin_contract,
+            connection_scope,
             // Clone the connection's user context into this request. Every
             // request from this connection carries the SAME context, derived
             // once at upgrade; a client cannot vary it per-request.
@@ -2745,6 +2773,7 @@ mod tests {
                     rs,
                     None,
                     None,
+                    ConnectionScope::Local,
                     None,
                     None,
                     true,
@@ -4153,6 +4182,7 @@ mod tests {
             &tx,
             &mut auth_token,
             None,
+            ConnectionScope::Local,
             user_context,
             op_rate_limiter,
             None, // no activity stamping in rate-limit unit tests
@@ -4394,6 +4424,7 @@ mod tests {
                 req,
                 auth_token: None,
                 origin_contract: None,
+                connection_scope: ConnectionScope::Local,
                 user_context: None,
                 api_version: ApiVersion::V1,
             })
@@ -4420,5 +4451,43 @@ mod tests {
                 "expected a SubscriptionChannel callback for the delegate request, got {other:?}"
             ),
         }
+    }
+
+    /// GHSA-824h-7x5x-wfmf: the connection's scope must be captured in
+    /// `connection_info`, from the kernel-observed peer address.
+    ///
+    /// It cannot be captured in `websocket_commands`'s `on_upgrade` closure —
+    /// that closure takes no extractor, so `ConnectInfo` is not reachable from
+    /// it. A refactor that "simplifies" this by moving the classification down
+    /// into the upgrade path would have nothing to classify FROM and would have
+    /// to invent a default, which is exactly how a fail-open default gets
+    /// introduced. Pin the placement and the input.
+    #[test]
+    fn connection_scope_is_classified_in_connection_info_from_the_peer_address() {
+        let src = include_str!("websocket.rs");
+        let body = src
+            .split("async fn connection_info(")
+            .nth(1)
+            .expect("connection_info must exist");
+        let body = body
+            .split("\nasync fn websocket_commands(")
+            .next()
+            .unwrap_or(body);
+        // Bound defensively in case the neighbouring fn is renamed.
+        let body = body
+            .split("\n#[allow(clippy::too_many_arguments)]")
+            .next()
+            .unwrap_or(body);
+
+        assert!(
+            body.contains("ConnectionScope::from_source_ip(source_ip)"),
+            "connection_info must classify the scope from the kernel-observed \
+             ConnectInfo peer address, not from a header or a default"
+        );
+        assert!(
+            body.contains("req.extensions_mut().insert(connection_scope);"),
+            "the classified scope must be injected as a request extension so the \
+             upgrade path can move it into the connection task"
+        );
     }
 }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -2700,8 +2700,11 @@ pub struct WebsocketApiConfig {
     /// themselves, because both are real user-facing modes rather than test
     /// scaffolding:
     ///
-    /// - `HttpClientApi::as_router`, which `server::local_node::run_local_node`
-    ///   serves through. Its signature is public API and takes no cache root.
+    /// - `HttpClientApi::as_router`, the direct router-composition entry point.
+    ///   Its signature is public API and takes no cache root. (It used to be
+    ///   described as what `server::local_node::run_local_node` serves through;
+    ///   that serve loop was unreachable and has been deleted — see the note
+    ///   where it stood in `server.rs`.)
     /// - `WebsocketApiConfig::default()` / `From<SocketAddr>`, the fallback for
     ///   any serving config not produced by `build()`.
     ///
@@ -8778,9 +8781,8 @@ shutdown-drain-secs = 42
     ///    precedent, not its safety.
     /// 2. It would not close the door it is aimed at. `HttpClientApi::as_router`
     ///    is the direct router-composition entry a test would reach for, and it
-    ///    resolves `default_webapp_cache_dir()` itself because
-    ///    `local_node::run_local_node` (a real user-facing mode) serves through
-    ///    it. Its signature is public API and carries no cache root.
+    ///    resolves `default_webapp_cache_dir()` itself. Its signature is public
+    ///    API and carries no cache root.
     /// 3. These constructors are the fallback for any future serving path that
     ///    is not `ConfigArgs::build()`, where an unbounded cache under an
     ///    arbitrary working directory would be strictly worse than a shared but

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -2701,10 +2701,7 @@ pub struct WebsocketApiConfig {
     /// scaffolding:
     ///
     /// - `HttpClientApi::as_router`, the direct router-composition entry point.
-    ///   Its signature is public API and takes no cache root. (It used to be
-    ///   described as what `server::local_node::run_local_node` serves through;
-    ///   that serve loop was unreachable and has been deleted — see the note
-    ///   where it stood in `server.rs`.)
+    ///   Its signature is public API and takes no cache root.
     /// - `WebsocketApiConfig::default()` / `From<SocketAddr>`, the fallback for
     ///   any serving config not produced by `build()`.
     ///

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -504,18 +504,6 @@ async fn fetch_related_off_loop(
     }
 }
 
-/// Handle a delegate request, including any contract request messages in the response.
-///
-/// When a delegate emits contract request messages, this function:
-/// 1. For GET: Fetches the contract state and sends GetContractResponse back
-/// 2. For PUT: Upserts the contract state via `upsert_contract_state` (which automatically
-///    propagates to the network via `BroadcastStateChange`), sends PutContractResponse back
-/// 3. For UPDATE: Applies a state update via `upsert_contract_state` (same propagation),
-///    sends UpdateContractResponse back
-/// 4. For SUBSCRIBE: Registers in subscription registry, sends SubscribeContractResponse back
-/// 5. Repeats until no more contract request messages
-///
-/// Returns the final response with contract request messages filtered out.
 /// Whether a delegate run may deliver delegate-to-delegate messages.
 ///
 /// This exists because the two callers of
@@ -532,6 +520,18 @@ enum InterDelegateDispatch {
     Suppressed,
 }
 
+/// Handle a delegate request, including any contract request messages in the response.
+///
+/// When a delegate emits contract request messages, this function:
+/// 1. For GET: Fetches the contract state and sends GetContractResponse back
+/// 2. For PUT: Upserts the contract state via `upsert_contract_state` (which automatically
+///    propagates to the network via `BroadcastStateChange`), sends PutContractResponse back
+/// 3. For UPDATE: Applies a state update via `upsert_contract_state` (same propagation),
+///    sends UpdateContractResponse back
+/// 4. For SUBSCRIBE: Registers in subscription registry, sends SubscribeContractResponse back
+/// 5. Repeats until no more contract request messages
+///
+/// Returns the final response with contract request messages filtered out.
 #[allow(clippy::too_many_arguments)]
 async fn handle_delegate_with_contract_requests<CH, P>(
     contract_handler: &mut CH,
@@ -1065,7 +1065,31 @@ where
             //
             // Suppressing the hop on this path removes the laundering route
             // outright, which is stronger than propagating a scope and is what
-            // the function's own design notes always claimed happened. If
+            // the function's own design notes always claimed happened.
+            //
+            // TEST COVERAGE, precisely: this suppression has NO behavioural
+            // test. It is covered only by the source scrape
+            // `inter_delegate_hop_forwards_the_originating_scope`, which asserts
+            // that this call site passes `InterDelegateDispatch::Suppressed` and
+            // that the hop forwards a scope variable rather than a literal.
+            // Both halves were checked non-vacuous by mutation. What that does
+            // NOT cover is the runtime behaviour — that a delegate emitting
+            // `SendDelegateMessage` from a notification run really is not
+            // delivered to. Exercising that needs a delegate that subscribes,
+            // then messages, under a notification-driven run; if you add one,
+            // this comment should shrink.
+            //
+            // Safe to suppress because nothing first-party emits here, verified
+            // by reading the delegates rather than by observing tests: River's
+            // chat delegate returns only empty or `UpdateContractRequest` from
+            // `ContractNotification` and never constructs a `DelegateMessage`,
+            // ghostkeys rejects notifications in its catch-all, and the only
+            // in-tree emitter of `SendDelegateMessage` sits in the
+            // `ApplicationMessage` arm and errors on notifications. "No test
+            // relied on it" is deliberately NOT the grounds here — that is the
+            // same reasoning that let the tokenless-CLI break through.
+            //
+            // If
             // notification-driven inter-delegate messaging is ever wanted, it
             // must come back with the originating scope RECORDED ON THE
             // SUBSCRIPTION (both `DELEGATE_SUBSCRIPTIONS` registration paths) and

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -2953,6 +2953,50 @@ mod tests {
         ContractKey::from_params_and_code(&params, &code)
     }
 
+    /// GHSA-824h-7x5x-wfmf: the identity rendered to the HUMAN in a consent
+    /// prompt must come from the GATED origin.
+    ///
+    /// `caller_identity_from_origin` feeds `CallerIdentity` to
+    /// `DashboardPrompter`, which names the requesting app to the user deciding
+    /// whether to approve. Fed the raw `origin_contract`, a caller the node
+    /// cannot prove is local could mint a token for a well-known contract id,
+    /// drive a delegate that emits `RequestUserInput` with attacker-chosen text,
+    /// and have the prompt attribute the request to that app.
+    ///
+    /// This is a source pin rather than a behavioural test because reaching the
+    /// prompt needs a full delegate + prompter harness; what it must catch is
+    /// the gate being deleted or moved below its consumer, which it does. The
+    /// region is bounded to the function so the pin cannot match its own
+    /// assertion strings further down the file.
+    #[test]
+    fn consent_prompt_identity_comes_from_the_gated_origin() {
+        let src = include_str!("contract.rs");
+        let body = src
+            .split("async fn handle_delegate_with_contract_requests")
+            .nth(1)
+            .expect("handle_delegate_with_contract_requests must exist");
+        let body = body
+            .split("\nasync fn ")
+            .next()
+            .expect("bounded by the next free function");
+
+        let gate = body
+            .find("let origin_contract = if connection_scope.is_local()")
+            .expect(
+                "handle_delegate_with_contract_requests must gate `origin_contract` on \
+                 the connection scope before using it",
+            );
+        let prompt_use = body
+            .find("caller_identity_from_origin(origin_contract)")
+            .expect("the prompter's caller identity must be built from origin_contract");
+        assert!(
+            gate < prompt_use,
+            "the connection-scope gate must run BEFORE the origin reaches the \
+             consent prompt, or a non-local caller's forged app identity is \
+             rendered to the user"
+        );
+    }
+
     // Regression test for issue #3857: the executor's origin context must be
     // mapped onto the prompter's CallerIdentity correctly. Without this test,
     // accidentally swapping the Some/None arms — or wiring the wrong

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -532,6 +532,7 @@ enum InterDelegateDispatch {
     Suppressed,
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn handle_delegate_with_contract_requests<CH, P>(
     contract_handler: &mut CH,
     initial_req: DelegateRequest<'static>,

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -516,11 +516,28 @@ async fn fetch_related_off_loop(
 /// 5. Repeats until no more contract request messages
 ///
 /// Returns the final response with contract request messages filtered out.
+/// Whether a delegate run may deliver delegate-to-delegate messages.
+///
+/// This exists because the two callers of
+/// [`handle_delegate_with_contract_requests`] differ in a security-relevant way:
+/// one descends from a client connection whose scope is known, the other does
+/// not descend from a connection at all (GHSA-824h-7x5x-wfmf).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InterDelegateDispatch {
+    /// Client-driven run. The hop carries the ORIGINATING connection scope, so a
+    /// non-local caller cannot obtain an attested `MessageOrigin::Delegate`.
+    Allowed,
+    /// Contract-notification-driven run. Suppressed — see the rationale at the
+    /// dispatch site.
+    Suppressed,
+}
+
 async fn handle_delegate_with_contract_requests<CH, P>(
     contract_handler: &mut CH,
     initial_req: DelegateRequest<'static>,
     origin_contract: Option<&ContractInstanceId>,
     connection_scope: crate::client_events::ConnectionScope,
+    inter_delegate: InterDelegateDispatch,
     user_context: Option<&UserSecretContext>,
     delegate_key: &DelegateKey,
     prompter: &P,
@@ -951,10 +968,14 @@ where
         //   sees `MessageOrigin::Delegate(caller_key)` and can authorize on it
         //   (issue #3860). The runtime attests this identity — the calling delegate
         //   cannot forge it.
-        // - Inter-delegate messaging only works via ApplicationMessages path; messages
-        //   from handle_delegate_notification (contract state change callbacks) do not
-        //   trigger delegate-to-delegate delivery.
-        if !delegate_messages.is_empty() {
+        // - Inter-delegate delivery runs ONLY for a client-driven run
+        //   (`InterDelegateDispatch::Allowed`). It is SUPPRESSED for a
+        //   contract-notification-driven run — see the guard below. An earlier
+        //   version of this comment asserted that notification-driven runs did
+        //   not reach this code; that was false, because
+        //   `handle_delegate_notification` calls THIS function, and the guard is
+        //   what finally makes the statement true.
+        if !delegate_messages.is_empty() && inter_delegate == InterDelegateDispatch::Allowed {
             tracing::debug!(
                 delegate_key = %delegate_key,
                 count = delegate_messages.len(),
@@ -979,12 +1000,22 @@ where
                     // keeps the per-user namespace bound to the connection
                     // boundary, not propagated transitively through delegate
                     // messages (part of the #4381 unforgeability invariant).
-                    // The originating connection's scope rides along: a hop
-                    // driven by an off-host caller must not manufacture an
-                    // attested `MessageOrigin::Delegate` that the caller could
-                    // not have obtained directly (GHSA-824h-7x5x-wfmf). Paired
-                    // with the executor's refusal to dispatch from a delegate
-                    // that has no registration origin at all.
+                    // The ORIGINATING connection's scope rides along, never a
+                    // literal `Local`: a hop driven by an off-host caller must
+                    // not manufacture an attested `MessageOrigin::Delegate` that
+                    // the caller could not have obtained directly
+                    // (GHSA-824h-7x5x-wfmf). This forwarding is the control that
+                    // REPLACED the deleted registration-record refusal, so it is
+                    // source-pinned by
+                    // `inter_delegate_hop_forwards_the_originating_scope`.
+                    //
+                    // Scope nulls the `origin` ARGUMENT only. `msg.sender` still
+                    // rides through unchanged on every path, so the target can
+                    // always see which delegate sent it — that field is
+                    // runtime-attested (`execution.rs` overwrites it with the key
+                    // of the delegate that actually ran) and is a hash of that
+                    // delegate's own code, so it is self-authenticating rather
+                    // than borrowed authority.
                     .execute_delegate_request(
                         target_req,
                         None,
@@ -1016,6 +1047,40 @@ where
                     }
                 }
             }
+        } else if !delegate_messages.is_empty() {
+            // SCOPE-LAUNDERING GUARD (GHSA-824h-7x5x-wfmf).
+            //
+            // `handle_delegate_notification` invokes this function for a run that
+            // descends from a contract state change rather than from any client
+            // connection, so it has no connection scope to pass and hardcodes
+            // `Local`. That made the notification path a laundry: a non-local
+            // caller drives its own delegate (correctly resolving to NO attested
+            // origin), the delegate emits `SubscribeContractRequest`, and on the
+            // next state change of that contract the SAME delegate re-executes
+            // under `Local` — at which point its `SendDelegateMessage` would
+            // reach a victim carrying a fully attested
+            // `MessageOrigin::Delegate(caller)`. The scope the caller was
+            // refused would have been handed back to it one hop later.
+            //
+            // Suppressing the hop on this path removes the laundering route
+            // outright, which is stronger than propagating a scope and is what
+            // the function's own design notes always claimed happened. If
+            // notification-driven inter-delegate messaging is ever wanted, it
+            // must come back with the originating scope RECORDED ON THE
+            // SUBSCRIPTION (both `DELEGATE_SUBSCRIPTIONS` registration paths) and
+            // propagated here — never with a hardcoded `Local`.
+            //
+            // `info!`, not `debug!`: the crate sets `release_max_level_info`, so
+            // a `debug!` would compile out of shipped binaries and a delegate
+            // author would have no way to see why their message vanished.
+            tracing::info!(
+                delegate_key = %delegate_key,
+                count = delegate_messages.len(),
+                "Suppressed delegate-to-delegate messages from a \
+                 notification-driven run (GHSA-824h-7x5x-wfmf): this path carries \
+                 no client connection scope, so it must not confer an attested \
+                 caller identity"
+            );
         }
 
         // Process UserInput requests: prompt the user and send responses back
@@ -2025,10 +2090,17 @@ async fn handle_delegate_notification<CH, P>(
         req,
         None,
         // Node-internal invocation: this descends from a contract state change,
-        // not from any client connection, so there is no connection to classify
-        // and nothing an off-host caller could have steered. `Local` keeps the
-        // delegate's own inherited attestation intact exactly as before.
+        // not from any client connection, so there is NO scope to classify and
+        // this hardcodes `Local` to keep the delegate's own inherited
+        // attestation intact exactly as before.
+        //
+        // That hardcoded `Local` is precisely why the inter-delegate hop must be
+        // SUPPRESSED below: a non-local caller can steer WHICH delegate runs here
+        // (drive it once, have it subscribe, then trigger a state change), so a
+        // hop under this scope would hand back the attestation the caller was
+        // refused. See the guard in `handle_delegate_with_contract_requests`.
         crate::client_events::ConnectionScope::Local,
+        InterDelegateDispatch::Suppressed,
         // Contract-state-change notification: not driven by a client
         // connection, so there is no user token and no per-user secret
         // namespace. Secrets stay `SecretScope::Local`.
@@ -2088,11 +2160,18 @@ async fn handle_delegate_notification<CH, P>(
             });
         let delivered = delegate_app_registry::route_to_apps(&delegate_key, response);
         if delivered == 0 {
-            // `info!`, not `debug!`: the crate sets `release_max_level_info`, so
-            // a `debug!` would compile out of shipped binaries and an operator
-            // whose app stopped receiving notifications would see nothing. This
-            // is the line that says "the delegate spoke and nobody heard it".
-            tracing::info!(
+            // `debug!` on purpose. This fires once per notification, so at
+            // `release_max_level_info` it would ship one line per contract-state
+            // change on any node where nobody happens to be registered — a
+            // headless node, or simply a closed browser tab. That is the same
+            // per-room-update amplification removed from the executor's audit
+            // line, and "nobody is listening" is a normal state rather than a
+            // security event.
+            //
+            // The case that IS a security event — a registration that exists but
+            // is withheld from delivery — is reported at INFO by
+            // `route_to_apps`, once per registration.
+            tracing::debug!(
                 delegate = %delegate_key,
                 "Delegate notification produced an ApplicationMessage but no \
                  local app is registered with this delegate — nothing to route to"
@@ -2451,6 +2530,10 @@ where
                 req,
                 origin_contract.as_ref(),
                 connection_scope,
+                // Client-driven: the hop forwards THIS connection's scope, so a
+                // non-local caller cannot obtain an attested caller identity
+                // through it.
+                InterDelegateDispatch::Allowed,
                 user_context.as_ref(),
                 &delegate_key,
                 prompter,
@@ -2951,6 +3034,69 @@ mod tests {
         let code = ContractCode::from(vec![42u8; 32]);
         let params = Parameters::from(vec![7u8; 8]);
         ContractKey::from_params_and_code(&params, &code)
+    }
+
+    /// H2 — the control that REPLACED the deleted registration-record gate.
+    ///
+    /// Removing a control is only safe if the thing standing in for it is
+    /// itself pinned. The inter-delegate hop is safe because it forwards the
+    /// ORIGINATING connection scope, so a non-local caller cannot launder its
+    /// lack of attestation through a delegate. Nothing enforced that: passing a
+    /// literal `ConnectionScope::Local` at the hop compiled and broke nothing.
+    ///
+    /// Two properties, because the hop has two callers with different scope
+    /// provenance:
+    ///  1. the hop forwards the `connection_scope` VARIABLE, never a literal; and
+    ///  2. the notification path — which has no connection and therefore
+    ///     hardcodes `Local` — is `InterDelegateDispatch::Suppressed`, so that
+    ///     hardcoded value can never reach the hop.
+    #[test]
+    fn inter_delegate_hop_forwards_the_originating_scope() {
+        let src = include_str!("contract.rs");
+        let body = src
+            .split("async fn handle_delegate_with_contract_requests")
+            .nth(1)
+            .expect("handle_delegate_with_contract_requests must exist");
+        let body = body
+            .split("\nasync fn ")
+            .next()
+            .expect("bounded by the next free function");
+
+        // Isolate the hop's own executor call.
+        let hop = body
+            .split(".execute_delegate_request(")
+            .nth(2)
+            .expect("the inter-delegate hop is the SECOND execute_delegate_request call");
+        // Bound on `.await`, not on the first `)` — the argument list itself
+        // contains parentheses (`Some(delegate_key)`).
+        let hop_args = hop
+            .split(".await")
+            .next()
+            .expect("the call is bounded by its .await");
+        assert!(
+            hop_args.contains("connection_scope"),
+            "the hop must forward the originating connection scope; got args: {hop_args}"
+        );
+        assert!(
+            !hop_args.contains("ConnectionScope::Local"),
+            "the hop must NOT hardcode a scope — that is the laundering bug this \
+             replaced the removed registration-record gate to avoid; got args: {hop_args}"
+        );
+
+        // And the scopeless caller must not be able to reach it at all.
+        let notification = src
+            .split("async fn handle_delegate_notification")
+            .nth(1)
+            .expect("handle_delegate_notification must exist");
+        let notification = notification
+            .split("\nasync fn ")
+            .next()
+            .expect("bounded by the next free function");
+        assert!(
+            notification.contains("InterDelegateDispatch::Suppressed"),
+            "the notification path hardcodes ConnectionScope::Local, so it MUST \
+             suppress inter-delegate dispatch or that literal reaches the hop"
+        );
     }
 
     /// GHSA-824h-7x5x-wfmf: the identity rendered to the HUMAN in a consent

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -1988,26 +1988,6 @@ async fn handle_delegate_notification<CH, P>(
         inbound,
     };
 
-    // The delegate's own attested app identity, read from its durable
-    // first-registration origin record. This is what decides who may receive the
-    // output below (GHSA-824h-7x5x-wfmf), and it is read BEFORE the delegate
-    // runs so a delegate cannot influence its own routing.
-    //
-    // Skipped when nobody is registered for this delegate: on the pooled
-    // executor the lookup checks an executor out of the pool, and this path runs
-    // on the contract loop for every contract notification. Nothing to route to
-    // means nothing to decide. The check is on the registry (which the delegate
-    // cannot write) and still happens before the delegate runs, so it does not
-    // weaken the "read before it runs" property.
-    let attested_origin = if delegate_app_registry::has_registrations(&delegate_key) {
-        contract_handler
-            .executor()
-            .delegate_attested_origin(&delegate_key)
-            .await
-    } else {
-        None
-    };
-
     let outbound = handle_delegate_with_contract_requests(
         contract_handler,
         req,
@@ -2064,6 +2044,29 @@ async fn handle_delegate_notification<CH, P>(
     if app_messages.is_empty() {
         return;
     }
+
+    // The delegate's own attested app identity, read from its durable
+    // first-registration origin record. This is what decides who may receive the
+    // output (GHSA-824h-7x5x-wfmf).
+    //
+    // Read HERE rather than before the run, and only when there is both output
+    // and somebody registered to receive it: on the pooled executor the lookup
+    // checks an executor out of the pool, and this path runs on the contract loop
+    // for every contract notification, so doing it unconditionally would add a
+    // checkout per notification. Reading it after the run is safe because the
+    // record is first-writer-wins and immutable for the delegate's lifetime
+    // (`register_delegate_and_record_origin`), and a delegate cannot register
+    // delegates — so nothing the run just did can have changed the answer.
+    let attested_origin = if delegate_app_registry::has_registrations(&delegate_key) {
+        contract_handler
+            .executor()
+            .delegate_attested_origin(&delegate_key)
+            .await
+    } else {
+        // Nobody registered: `route_to_apps` will deliver to nobody regardless,
+        // so skip the lookup entirely.
+        None
+    };
 
     // One HostResponse per ApplicationMessage so an app sees each reply as a
     // distinct DelegateResponse, exactly as it would for a client-initiated

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -1992,10 +1992,21 @@ async fn handle_delegate_notification<CH, P>(
     // first-registration origin record. This is what decides who may receive the
     // output below (GHSA-824h-7x5x-wfmf), and it is read BEFORE the delegate
     // runs so a delegate cannot influence its own routing.
-    let attested_origin = contract_handler
-        .executor()
-        .delegate_attested_origin(&delegate_key)
-        .await;
+    //
+    // Skipped when nobody is registered for this delegate: on the pooled
+    // executor the lookup checks an executor out of the pool, and this path runs
+    // on the contract loop for every contract notification. Nothing to route to
+    // means nothing to decide. The check is on the registry (which the delegate
+    // cannot write) and still happens before the delegate runs, so it does not
+    // weaken the "read before it runs" property.
+    let attested_origin = if delegate_app_registry::has_registrations(&delegate_key) {
+        contract_handler
+            .executor()
+            .delegate_attested_origin(&delegate_key)
+            .await
+    } else {
+        None
+    };
 
     let outbound = handle_delegate_with_contract_requests(
         contract_handler,

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -535,6 +535,26 @@ where
     // the loop before params are read — but the new variant is listed EXPLICITLY
     // for local consistency with this match's style; the wildcard remains only to
     // satisfy `#[non_exhaustive]`.
+    // GATE THE ORIGIN BEFORE ANY CONSUMER IN THIS FUNCTION
+    // (GHSA-824h-7x5x-wfmf).
+    //
+    // Two consumers below read `origin_contract`: the executor call (which
+    // gates again internally, so it is safe either way) and
+    // `caller_identity_from_origin`, which names the calling app to the HUMAN in
+    // the consent prompt. The prompt was the one that mattered: a remote caller
+    // could mint a token for a well-known contract id, drive a delegate that
+    // emits `RequestUserInput` with attacker-chosen text, and have the prompt
+    // render that contract's identity as the requester to a local user who then
+    // approves it.
+    //
+    // Gating here rather than at the prompt call site keeps the two consumers on
+    // one value, so a future third consumer cannot be added ungated by accident.
+    let origin_contract = if connection_scope.is_local() {
+        origin_contract
+    } else {
+        None
+    };
+
     let initial_params = match &initial_req {
         DelegateRequest::ApplicationMessages { params, .. } => params.clone(),
         DelegateRequest::RegisterDelegate { .. }
@@ -1008,9 +1028,21 @@ where
 
             // The caller identity passed to the prompter is built from the
             // executor's runtime context, NOT from anything the delegate could
-            // influence — so a malicious delegate cannot spoof another app's
-            // or delegate's identity in the structured fields the prompt UI
-            // renders. Today the only attested non-None caller is a web app
+            // influence — so a malicious DELEGATE cannot spoof another app's
+            // identity in the structured fields the prompt UI renders.
+            //
+            // That was never the whole story, and the missing half was a real
+            // hole (GHSA-824h-7x5x-wfmf): the identity came from
+            // `origin_contract`, which the CLIENT chooses by presenting a token
+            // the node mints on request for any contract id. A caller the node
+            // cannot prove is local now resolves to `None` (gated at the top of
+            // this function), so it is rendered as an unattested caller rather
+            // than as the app whose id it named. This bounds the spoof to
+            // callers that are already on this host — see the PR's limitations:
+            // "local" means this HOST, not this USER, and it is not a defence
+            // behind a colocated reverse proxy.
+            //
+            // Today the only attested non-None caller is a web app
             // (via `MessageOrigin::WebApp`); delegate-to-delegate attestation
             // is tracked by #3860 and will appear here as a new variant.
             //
@@ -2045,29 +2077,6 @@ async fn handle_delegate_notification<CH, P>(
         return;
     }
 
-    // The delegate's own attested app identity, read from its durable
-    // first-registration origin record. This is what decides who may receive the
-    // output (GHSA-824h-7x5x-wfmf).
-    //
-    // Read HERE rather than before the run, and only when there is both output
-    // and somebody registered to receive it: on the pooled executor the lookup
-    // checks an executor out of the pool, and this path runs on the contract loop
-    // for every contract notification, so doing it unconditionally would add a
-    // checkout per notification. Reading it after the run is safe because the
-    // record is first-writer-wins and immutable for the delegate's lifetime
-    // (`register_delegate_and_record_origin`), and a delegate cannot register
-    // delegates — so nothing the run just did can have changed the answer.
-    let attested_origin = if delegate_app_registry::has_registrations(&delegate_key) {
-        contract_handler
-            .executor()
-            .delegate_attested_origin(&delegate_key)
-            .await
-    } else {
-        // Nobody registered: `route_to_apps` will deliver to nobody regardless,
-        // so skip the lookup entirely.
-        None
-    };
-
     // One HostResponse per ApplicationMessage so an app sees each reply as a
     // distinct DelegateResponse, exactly as it would for a client-initiated
     // ApplicationMessages request.
@@ -2077,15 +2086,16 @@ async fn handle_delegate_notification<CH, P>(
                 key: delegate_key.clone(),
                 values: vec![app_msg],
             });
-        let delivered =
-            delegate_app_registry::route_to_apps(&delegate_key, attested_origin, response);
+        let delivered = delegate_app_registry::route_to_apps(&delegate_key, response);
         if delivered == 0 {
-            tracing::debug!(
+            // `info!`, not `debug!`: the crate sets `release_max_level_info`, so
+            // a `debug!` would compile out of shipped binaries and an operator
+            // whose app stopped receiving notifications would see nothing. This
+            // is the line that says "the delegate spoke and nobody heard it".
+            tracing::info!(
                 delegate = %delegate_key,
-                ?attested_origin,
-                "Delegate notification produced an ApplicationMessage but no app \
-                 holding this delegate's attested identity is registered — \
-                 nothing to route to"
+                "Delegate notification produced an ApplicationMessage but no \
+                 local app is registered with this delegate — nothing to route to"
             );
         }
     }

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -520,6 +520,7 @@ async fn handle_delegate_with_contract_requests<CH, P>(
     contract_handler: &mut CH,
     initial_req: DelegateRequest<'static>,
     origin_contract: Option<&ContractInstanceId>,
+    connection_scope: crate::client_events::ConnectionScope,
     user_context: Option<&UserSecretContext>,
     delegate_key: &DelegateKey,
     prompter: &P,
@@ -563,7 +564,13 @@ where
         // Execute the delegate request
         let values = match contract_handler
             .executor()
-            .execute_delegate_request(current_req, origin_contract, None, user_context)
+            .execute_delegate_request(
+                current_req,
+                origin_contract,
+                None,
+                connection_scope,
+                user_context,
+            )
             .await
         {
             Ok(freenet_stdlib::client_api::HostResponse::DelegateResponse { key: _, values }) => {
@@ -952,7 +959,19 @@ where
                     // keeps the per-user namespace bound to the connection
                     // boundary, not propagated transitively through delegate
                     // messages (part of the #4381 unforgeability invariant).
-                    .execute_delegate_request(target_req, None, Some(delegate_key), None)
+                    // The originating connection's scope rides along: a hop
+                    // driven by an off-host caller must not manufacture an
+                    // attested `MessageOrigin::Delegate` that the caller could
+                    // not have obtained directly (GHSA-824h-7x5x-wfmf). Paired
+                    // with the executor's refusal to dispatch from a delegate
+                    // that has no registration origin at all.
+                    .execute_delegate_request(
+                        target_req,
+                        None,
+                        Some(delegate_key),
+                        connection_scope,
+                        None,
+                    )
                     .await
                 {
                     Ok(freenet_stdlib::client_api::HostResponse::DelegateResponse {
@@ -1969,10 +1988,24 @@ async fn handle_delegate_notification<CH, P>(
         inbound,
     };
 
+    // The delegate's own attested app identity, read from its durable
+    // first-registration origin record. This is what decides who may receive the
+    // output below (GHSA-824h-7x5x-wfmf), and it is read BEFORE the delegate
+    // runs so a delegate cannot influence its own routing.
+    let attested_origin = contract_handler
+        .executor()
+        .delegate_attested_origin(&delegate_key)
+        .await;
+
     let outbound = handle_delegate_with_contract_requests(
         contract_handler,
         req,
         None,
+        // Node-internal invocation: this descends from a contract state change,
+        // not from any client connection, so there is no connection to classify
+        // and nothing an off-host caller could have steered. `Local` keeps the
+        // delegate's own inherited attestation intact exactly as before.
+        crate::client_events::ConnectionScope::Local,
         // Contract-state-change notification: not driven by a client
         // connection, so there is no user token and no per-user secret
         // namespace. Secrets stay `SecretScope::Local`.
@@ -2030,12 +2063,15 @@ async fn handle_delegate_notification<CH, P>(
                 key: delegate_key.clone(),
                 values: vec![app_msg],
             });
-        let delivered = delegate_app_registry::route_to_apps(&delegate_key, response);
+        let delivered =
+            delegate_app_registry::route_to_apps(&delegate_key, attested_origin, response);
         if delivered == 0 {
             tracing::debug!(
                 delegate = %delegate_key,
-                "Delegate notification produced an ApplicationMessage but no apps \
-                 are registered with this delegate — nothing to route to"
+                ?attested_origin,
+                "Delegate notification produced an ApplicationMessage but no app \
+                 holding this delegate's attested identity is registered — \
+                 nothing to route to"
             );
         }
     }
@@ -2371,6 +2407,7 @@ where
         ContractHandlerEvent::DelegateRequest {
             req,
             origin_contract,
+            connection_scope,
             user_context,
         } => {
             let delegate_key = req.key().clone();
@@ -2389,6 +2426,7 @@ where
                 contract_handler,
                 req,
                 origin_contract.as_ref(),
+                connection_scope,
                 user_context.as_ref(),
                 &delegate_key,
                 prompter,

--- a/crates/core/src/contract/delegate_app_registry.rs
+++ b/crates/core/src/contract/delegate_app_registry.rs
@@ -45,7 +45,7 @@
 use std::sync::LazyLock;
 
 use dashmap::DashMap;
-use freenet_stdlib::prelude::{ContractInstanceId, DelegateKey};
+use freenet_stdlib::prelude::DelegateKey;
 use tokio::sync::mpsc;
 
 use crate::client_events::{ClientId, HostResult};
@@ -546,10 +546,6 @@ mod tests {
         assert!(rx.try_recv().is_ok());
     }
 
-    fn contract(seed: u8) -> ContractInstanceId {
-        ContractInstanceId::new([seed; 32])
-    }
-
     // -----------------------------------------------------------------------
     // GHSA-824h-7x5x-wfmf, gap 2 (delegate app registry).
     //
@@ -699,13 +695,15 @@ mod tests {
         );
     }
 
-    /// Delivery must NOT depend on the attested contract id. Two local apps with
-    /// different attested identities both receive the output — the deliberate
-    /// scope limit (locality, not per-app separation), and the reason the
-    /// immutable-record matching was reverted.
+    /// Delivery keys ONLY on locality: two distinct local clients both receive
+    /// the output. This is the deliberate scope limit (locality, not per-app
+    /// separation) and the reason the immutable-record matching was reverted —
+    /// see `route_to_apps`. It is also the cross-app harvesting the PR's
+    /// limitations call out, pinned so the retreat is explicit rather than
+    /// accidental.
     #[tokio::test(start_paused = true)]
     #[serial_test::serial]
-    async fn delivery_does_not_key_on_the_attested_contract_id() {
+    async fn delivery_keys_only_on_locality_not_on_app_identity() {
         let ns = Namespace::new();
         let dk = ns.key(0);
         let (a_tx, mut a_rx) = mpsc::channel::<HostResult>(4);

--- a/crates/core/src/contract/delegate_app_registry.rs
+++ b/crates/core/src/contract/delegate_app_registry.rs
@@ -84,13 +84,12 @@ pub(crate) enum AppIdentity {
     /// Registered over a connection the node proved is local. Eligible to
     /// receive the delegate's output.
     ///
-    /// `attested` is the connection's app identity where it had one (`None` for
-    /// the tokenless local CLI shape — riverctl, atlasctl, fdev). It is carried
-    /// for diagnostics ONLY and is deliberately NOT part of the delivery
-    /// decision: see [`route_to_apps`] for why matching on it is unsafe.
-    Local {
-        attested: Option<ContractInstanceId>,
-    },
+    /// Deliberately carries NO contract id. An earlier revision kept the
+    /// connection's attested app identity here "for diagnostics", but nothing
+    /// read it — a field justified as diagnostic that nothing diagnoses is dead
+    /// weight that also invites the next reader to gate on it, which is exactly
+    /// what [`route_to_apps`] explains must not happen.
+    Local,
     /// Not provably local. Recorded so the caps and TTL bookkeeping stay
     /// identical, but never a delivery target.
     Remote,
@@ -107,6 +106,10 @@ impl AppIdentity {
 struct AppRegistration {
     client_id: ClientId,
     identity: AppIdentity,
+    /// Whether this registration has already reported being withheld from
+    /// delivery, so the report is once-per-registration rather than
+    /// once-per-notification. See [`route_to_apps`].
+    withhold_logged: bool,
     sender: mpsc::Sender<HostResult>,
     /// `tokio::time::Instant` (not `std::time::Instant`) so tests using
     /// `tokio::time::pause` / `advance` can drive TTL eviction deterministically,
@@ -151,6 +154,9 @@ pub(crate) fn register_app(
         existing.sender = sender;
         existing.identity = identity;
         existing.last_seen = now;
+        // A refresh is the same connection, so do NOT re-arm the withhold log:
+        // an app that talks to a delegate in a loop would otherwise defeat the
+        // once-per-registration bound.
         return true;
     }
 
@@ -180,6 +186,7 @@ pub(crate) fn register_app(
     apps.push(AppRegistration {
         client_id,
         identity,
+        withhold_logged: false,
         sender,
         last_seen: now,
     });
@@ -231,24 +238,44 @@ pub(crate) fn route_to_apps(delegate_key: &DelegateKey, message: HostResult) -> 
     let mut delivered = 0usize;
     let mut closed_clients: Vec<ClientId> = Vec::new();
 
-    apps.retain(|app| {
-        // Identity mismatch: not a delivery target. Keep the registration (it is
-        // still a live client, just not one entitled to THIS delegate's output);
-        // only closed channels are pruned.
-        // Not provably local: not a delivery target. Keep the registration (it
-        // is still a live client) — only closed channels are pruned.
-        //
-        // `info!`, not `debug!`: the crate sets `release_max_level_info`, so a
-        // `debug!` here would compile out of every shipped binary and an
-        // operator whose app silently stopped receiving notifications would have
-        // nothing to look at.
+    apps.retain_mut(|app| {
         if !app.identity.may_receive() {
-            tracing::info!(
-                delegate = %delegate_key,
-                client_id = %app.client_id,
-                "Withholding delegate notification from a non-local registration \
-                 (GHSA-824h-7x5x-wfmf); the client is connected but off-host"
-            );
+            // PRUNE BEFORE SKIP (GHSA-824h-7x5x-wfmf).
+            //
+            // Returning `true` here unconditionally would re-introduce exactly
+            // the remotely-triggerable denial of service that made the
+            // record-matching design unacceptable. Before this fix the
+            // `try_send` below was what reaped registrations whose client had
+            // vanished without a clean disconnect. Skipping ahead of it means a
+            // non-local registration is never reaped: an off-host caller opens
+            // `MAX_APPS_PER_DELEGATE` connections to a derivable delegate key,
+            // sends one `ApplicationMessages` on each, drops them uncleanly, and
+            // the dead slots survive the full `REGISTRATION_TTL` — during which
+            // the legitimate LOCAL app's `register_app` is refused at the cap and
+            // it receives nothing. Renewable indefinitely.
+            //
+            // `is_closed()` gives the same liveness signal `try_send` gave,
+            // without delivering anything.
+            if app.sender.is_closed() {
+                closed_clients.push(app.client_id);
+                return false;
+            }
+            // Report ONCE per registration, not once per message. This line
+            // ships (`release_max_level_info`) and the fan-out runs per
+            // contract-state change, so a per-message log would let an attacker
+            // turn every room update into one line per parked connection. The
+            // flag lives on the registration, so `MAX_APPS_PER_DELEGATE` bounds
+            // the total.
+            if !app.withhold_logged {
+                app.withhold_logged = true;
+                tracing::info!(
+                    delegate = %delegate_key,
+                    client_id = %app.client_id,
+                    "Withholding delegate notifications from a non-local \
+                     registration (GHSA-824h-7x5x-wfmf); the client is connected \
+                     but off-host. Logged once per registration."
+                );
+            }
             return true;
         }
         match app.sender.try_send(message.clone()) {
@@ -388,7 +415,7 @@ mod tests {
         let ns = Namespace::new();
         let dk = ns.key(0);
         let (tx, mut rx) = mpsc::channel::<HostResult>(4);
-        assert!(register_app(&dk, ns.client(0), local(None), tx));
+        assert!(register_app(&dk, ns.client(0), AppIdentity::Local, tx));
 
         let delivered = route_to_apps(&dk, host_msg());
         assert_eq!(delivered, 1);
@@ -410,11 +437,16 @@ mod tests {
         let dk = ns.key(0);
         for i in 0..MAX_APPS_PER_DELEGATE {
             let (tx, _rx) = mpsc::channel::<HostResult>(1);
-            assert!(register_app(&dk, ns.client(i), local(None), tx));
+            assert!(register_app(&dk, ns.client(i), AppIdentity::Local, tx));
         }
         let (tx, _rx) = mpsc::channel::<HostResult>(1);
         assert!(
-            !register_app(&dk, ns.client(MAX_APPS_PER_DELEGATE), local(None), tx),
+            !register_app(
+                &dk,
+                ns.client(MAX_APPS_PER_DELEGATE),
+                AppIdentity::Local,
+                tx
+            ),
             "registration past per-delegate cap must be rejected"
         );
     }
@@ -426,11 +458,16 @@ mod tests {
         let client = ns.client(0);
         for i in 0..MAX_DELEGATES_PER_CLIENT {
             let (tx, _rx) = mpsc::channel::<HostResult>(1);
-            assert!(register_app(&ns.key(i), client, local(None), tx));
+            assert!(register_app(&ns.key(i), client, AppIdentity::Local, tx));
         }
         let (tx, _rx) = mpsc::channel::<HostResult>(1);
         assert!(
-            !register_app(&ns.key(MAX_DELEGATES_PER_CLIENT), client, local(None), tx),
+            !register_app(
+                &ns.key(MAX_DELEGATES_PER_CLIENT),
+                client,
+                AppIdentity::Local,
+                tx
+            ),
             "registration past per-client cap must be rejected"
         );
     }
@@ -442,13 +479,13 @@ mod tests {
         let dk = ns.key(0);
         let client = ns.client(0);
         let (tx, _rx) = mpsc::channel::<HostResult>(1);
-        assert!(register_app(&dk, client, local(None), tx));
+        assert!(register_app(&dk, client, AppIdentity::Local, tx));
         remove_client(client);
         assert_eq!(route_to_apps(&dk, host_msg()), 0);
         // Count freed, so client can register up to the cap again.
         for i in 0..MAX_DELEGATES_PER_CLIENT {
             let (tx, _rx) = mpsc::channel::<HostResult>(1);
-            assert!(register_app(&ns.key(i + 1), client, local(None), tx));
+            assert!(register_app(&ns.key(i + 1), client, AppIdentity::Local, tx));
         }
     }
 
@@ -459,13 +496,13 @@ mod tests {
         let dk = ns.key(0);
         let client = ns.client(0);
         let (tx, rx) = mpsc::channel::<HostResult>(1);
-        assert!(register_app(&dk, client, local(None), tx));
+        assert!(register_app(&dk, client, AppIdentity::Local, tx));
         drop(rx); // client gone
         assert_eq!(route_to_apps(&dk, host_msg()), 0);
         // Registration pruned and client count freed: can fill cap again.
         for i in 0..MAX_DELEGATES_PER_CLIENT {
             let (t, _r) = mpsc::channel::<HostResult>(1);
-            assert!(register_app(&ns.key(i + 1), client, local(None), t));
+            assert!(register_app(&ns.key(i + 1), client, AppIdentity::Local, t));
         }
     }
 
@@ -475,7 +512,7 @@ mod tests {
         let ns = Namespace::new();
         let dk = ns.key(0);
         let (tx, _rx) = mpsc::channel::<HostResult>(1);
-        assert!(register_app(&dk, ns.client(0), local(None), tx));
+        assert!(register_app(&dk, ns.client(0), AppIdentity::Local, tx));
 
         tokio::time::advance(REGISTRATION_TTL + std::time::Duration::from_secs(1)).await;
         sweep_expired();
@@ -493,11 +530,11 @@ mod tests {
         let dk = ns.key(0);
         let client = ns.client(0);
         let (tx, mut rx) = mpsc::channel::<HostResult>(4);
-        assert!(register_app(&dk, client, local(None), tx.clone()));
+        assert!(register_app(&dk, client, AppIdentity::Local, tx.clone()));
 
         // Advance nearly to TTL, then refresh.
         tokio::time::advance(REGISTRATION_TTL - std::time::Duration::from_secs(10)).await;
-        assert!(register_app(&dk, client, local(None), tx));
+        assert!(register_app(&dk, client, AppIdentity::Local, tx));
         // Advance past the ORIGINAL expiry but within the refreshed window.
         tokio::time::advance(std::time::Duration::from_secs(20)).await;
         sweep_expired();
@@ -507,10 +544,6 @@ mod tests {
             "refreshed registration must survive"
         );
         assert!(rx.try_recv().is_ok());
-    }
-
-    fn local(attested: Option<ContractInstanceId>) -> AppIdentity {
-        AppIdentity::Local { attested }
     }
 
     fn contract(seed: u8) -> ContractInstanceId {
@@ -545,13 +578,8 @@ mod tests {
         let (cli_tx, mut cli_rx) = mpsc::channel::<HostResult>(4);
         let (remote_tx, mut remote_rx) = mpsc::channel::<HostResult>(4);
 
-        assert!(register_app(
-            &dk,
-            ns.client(0),
-            local(Some(contract(0x11))),
-            app_tx
-        ));
-        assert!(register_app(&dk, ns.client(1), local(None), cli_tx));
+        assert!(register_app(&dk, ns.client(0), AppIdentity::Local, app_tx));
+        assert!(register_app(&dk, ns.client(1), AppIdentity::Local, cli_tx));
         assert!(register_app(
             &dk,
             ns.client(2),
@@ -599,6 +627,78 @@ mod tests {
         );
     }
 
+    /// J1 regression: a non-local registration whose client vanished must still
+    /// be PRUNED, not parked.
+    ///
+    /// Skipping ahead of `try_send` removed the only reaper on this path. An
+    /// off-host caller could then fill `MAX_APPS_PER_DELEGATE` with dead
+    /// registrations and starve the legitimate local app for the full
+    /// `REGISTRATION_TTL`, renewably — the same remotely-triggerable denial of
+    /// service that made the record-matching design unacceptable.
+    #[tokio::test(start_paused = true)]
+    #[serial_test::serial]
+    async fn dead_non_local_registration_is_pruned_not_parked() {
+        let ns = Namespace::new();
+        let dk = ns.key(0);
+        let (remote_tx, remote_rx) = mpsc::channel::<HostResult>(4);
+        assert!(register_app(
+            &dk,
+            ns.client(0),
+            AppIdentity::Remote,
+            remote_tx
+        ));
+        // The off-host client goes away WITHOUT a clean disconnect.
+        drop(remote_rx);
+
+        assert_eq!(
+            route_to_apps(&dk, host_msg()),
+            0,
+            "a non-local registration is never a delivery target"
+        );
+        assert!(
+            DELEGATE_APPS.get(&dk).is_none_or(|apps| apps.is_empty()),
+            "a dead non-local registration must be reaped, or an off-host caller \
+             can hold every slot for the whole TTL and starve the local app"
+        );
+        // The per-client slot must be released too, or the cap leaks.
+        assert!(
+            CLIENT_REGISTRATION_COUNTS
+                .get(&ns.client(0))
+                .is_none_or(|c| *c == 0),
+            "pruning must release the client's registration count"
+        );
+    }
+
+    /// The withheld report is once per REGISTRATION, not once per notification:
+    /// this line ships at `release_max_level_info`, and the fan-out runs per
+    /// contract-state change.
+    #[tokio::test(start_paused = true)]
+    #[serial_test::serial]
+    async fn withhold_is_reported_once_per_registration() {
+        let ns = Namespace::new();
+        let dk = ns.key(0);
+        let (remote_tx, _remote_rx) = mpsc::channel::<HostResult>(4);
+        assert!(register_app(
+            &dk,
+            ns.client(0),
+            AppIdentity::Remote,
+            remote_tx
+        ));
+
+        for _ in 0..5 {
+            assert_eq!(route_to_apps(&dk, host_msg()), 0);
+        }
+        let logged_once = DELEGATE_APPS
+            .get(&dk)
+            .map(|apps| apps.iter().all(|a| a.withhold_logged))
+            .unwrap_or(false);
+        assert!(
+            logged_once,
+            "the flag must latch on the first withheld notification so later ones \
+             do not each emit a shipped log line"
+        );
+    }
+
     /// Delivery must NOT depend on the attested contract id. Two local apps with
     /// different attested identities both receive the output — the deliberate
     /// scope limit (locality, not per-app separation), and the reason the
@@ -610,18 +710,8 @@ mod tests {
         let dk = ns.key(0);
         let (a_tx, mut a_rx) = mpsc::channel::<HostResult>(4);
         let (b_tx, mut b_rx) = mpsc::channel::<HostResult>(4);
-        assert!(register_app(
-            &dk,
-            ns.client(0),
-            local(Some(contract(0x22))),
-            a_tx
-        ));
-        assert!(register_app(
-            &dk,
-            ns.client(1),
-            local(Some(contract(0x33))),
-            b_tx
-        ));
+        assert!(register_app(&dk, ns.client(0), AppIdentity::Local, a_tx));
+        assert!(register_app(&dk, ns.client(1), AppIdentity::Local, b_tx));
 
         assert_eq!(route_to_apps(&dk, host_msg()), 2);
         assert!(a_rx.try_recv().is_ok());

--- a/crates/core/src/contract/delegate_app_registry.rs
+++ b/crates/core/src/contract/delegate_app_registry.rs
@@ -54,6 +54,24 @@ use crate::client_events::{ClientId, HostResult};
 /// single delegate. Caps notification fan-out cost per delegate.
 pub(crate) const MAX_APPS_PER_DELEGATE: usize = 128;
 
+/// Slots within [`MAX_APPS_PER_DELEGATE`] that only LOCAL registrations may
+/// occupy.
+///
+/// Without this, a pre-existing denial of service is reachable purely off-host
+/// and needs no unclean disconnect: an off-host caller simply HOLDS
+/// `MAX_APPS_PER_DELEGATE` connections open, sends one `ApplicationMessages` on
+/// each, and every slot is filled by live `Remote` registrations that
+/// [`route_to_apps`] will never deliver to. The legitimate LOCAL app is then
+/// refused at the cap indefinitely. The dead-channel prune does not help,
+/// because nothing here is dead.
+///
+/// Capping `Remote` occupancy below the total leaves this many slots that only a
+/// local client can take, so the local app can always register. 32 is far above
+/// the real local count (usually one app, occasionally a few) while still
+/// leaving 96 for off-host clients, which register successfully and simply
+/// receive no pushed output.
+pub(crate) const LOCAL_RESERVED_SLOTS: usize = 32;
+
 /// Maximum number of distinct delegates a single client may register with.
 /// Prevents a resource-spreading attack where one client registers with many
 /// delegates to hold many channels.
@@ -69,8 +87,6 @@ pub(crate) const MAX_DELEGATES_PER_CLIENT: usize = 256;
 /// process lifetime.
 pub(crate) const REGISTRATION_TTL: std::time::Duration = std::time::Duration::from_secs(30 * 60);
 
-/// One app's registration with a delegate: where to push messages, plus when it
-/// was last confirmed (for TTL eviction).
 /// Who made a registration, from the perspective that decides whether it may
 /// receive a delegate's notification output.
 ///
@@ -97,7 +113,7 @@ pub(crate) enum AppIdentity {
 
 impl AppIdentity {
     fn may_receive(self) -> bool {
-        matches!(self, Self::Local { .. })
+        matches!(self, Self::Local)
     }
 }
 
@@ -107,14 +123,36 @@ struct AppRegistration {
     client_id: ClientId,
     identity: AppIdentity,
     /// Whether this registration has already reported being withheld from
-    /// delivery, so the report is once-per-registration rather than
-    /// once-per-notification. See [`route_to_apps`].
+    /// delivery. Read and set ONLY through
+    /// [`AppRegistration::latch_withhold_report`], so the report stays
+    /// once-per-registration rather than once-per-notification. See
+    /// [`route_to_apps`].
     withhold_logged: bool,
     sender: mpsc::Sender<HostResult>,
     /// `tokio::time::Instant` (not `std::time::Instant`) so tests using
     /// `tokio::time::pause` / `advance` can drive TTL eviction deterministically,
     /// matching the convention used by `DelegateContextEntry` and `RealTime`.
     last_seen: tokio::time::Instant,
+}
+
+impl AppRegistration {
+    /// Claim the right to emit this registration's withheld-from-delivery
+    /// report: `true` exactly once, `false` on every later call.
+    ///
+    /// A method rather than an inline `if` on purpose. The guard and the flag
+    /// write belong together — inlined, deleting the `if` while keeping the
+    /// assignment still sets the flag, so a test that inspects the flag passes
+    /// while the line has silently become once-per-notification. Bundled here,
+    /// that edit instead leaves this method uncalled, which is a `dead_code`
+    /// error under the crate's `-D warnings` build, and the returned sequence is
+    /// directly testable.
+    fn latch_withhold_report(&mut self) -> bool {
+        if self.withhold_logged {
+            return false;
+        }
+        self.withhold_logged = true;
+        true
+    }
 }
 
 /// `delegate -> [app registrations]`.
@@ -147,9 +185,6 @@ pub(crate) fn register_app(
     let mut apps = DELEGATE_APPS.entry(delegate_key.clone()).or_default();
 
     // Refresh path: already registered → update sender + TTL, no cap change.
-    // The origin is refreshed too: a client id is per-connection, so this is the
-    // same connection and therefore the same (immutable) attested identity — but
-    // re-storing it keeps the field from going stale if that ever changes.
     if let Some(existing) = apps.iter_mut().find(|a| a.client_id == client_id) {
         existing.sender = sender;
         existing.identity = identity;
@@ -169,6 +204,26 @@ pub(crate) fn register_app(
             "Rejecting app registration: delegate at max apps"
         );
         return false;
+    }
+
+    // LOCAL SLOT RESERVATION (see `LOCAL_RESERVED_SLOTS`). Off-host
+    // registrations are capped BELOW the total, so holding connections open can
+    // never crowd the local app out of the registry. Counted over `Remote`
+    // entries only, so a delegate legitimately used by many local clients is
+    // unaffected. O(n) over a list bounded by `MAX_APPS_PER_DELEGATE`, on a path
+    // that already scans it for the refresh check above.
+    if !identity.may_receive() {
+        let remote_occupancy = apps.iter().filter(|a| !a.identity.may_receive()).count();
+        if remote_occupancy >= MAX_APPS_PER_DELEGATE - LOCAL_RESERVED_SLOTS {
+            tracing::warn!(
+                delegate = %delegate_key,
+                %client_id,
+                cap = MAX_APPS_PER_DELEGATE - LOCAL_RESERVED_SLOTS,
+                "Rejecting non-local app registration: at the off-host cap, which \
+                 exists so a local app can always register (GHSA-824h-7x5x-wfmf)"
+            );
+            return false;
+        }
     }
 
     // Enforce per-client cap.
@@ -242,20 +297,18 @@ pub(crate) fn route_to_apps(delegate_key: &DelegateKey, message: HostResult) -> 
         if !app.identity.may_receive() {
             // PRUNE BEFORE SKIP (GHSA-824h-7x5x-wfmf).
             //
-            // Returning `true` here unconditionally would re-introduce exactly
-            // the remotely-triggerable denial of service that made the
-            // record-matching design unacceptable. Before this fix the
-            // `try_send` below was what reaped registrations whose client had
-            // vanished without a clean disconnect. Skipping ahead of it means a
-            // non-local registration is never reaped: an off-host caller opens
-            // `MAX_APPS_PER_DELEGATE` connections to a derivable delegate key,
-            // sends one `ApplicationMessages` on each, drops them uncleanly, and
-            // the dead slots survive the full `REGISTRATION_TTL` — during which
-            // the legitimate LOCAL app's `register_app` is refused at the cap and
-            // it receives nothing. Renewable indefinitely.
+            // Before this fix the `try_send` below was what reaped
+            // registrations whose client had vanished without a clean
+            // disconnect. Skipping ahead of it would mean a non-local
+            // registration is never reaped, so dead slots would survive the full
+            // `REGISTRATION_TTL`. `is_closed()` gives the same liveness signal
+            // `try_send` gave, without delivering anything.
             //
-            // `is_closed()` gives the same liveness signal `try_send` gave,
-            // without delivering anything.
+            // SCOPE OF THIS PRUNE, precisely: it reaps CLOSED senders only. It
+            // does NOT close the slot-exhaustion DoS, because the cheaper attack
+            // holds its connections OPEN and nothing here is dead.
+            // `LOCAL_RESERVED_SLOTS` is what makes that attack a non-problem; the
+            // two are complementary and neither substitutes for the other.
             if app.sender.is_closed() {
                 closed_clients.push(app.client_id);
                 return false;
@@ -266,8 +319,7 @@ pub(crate) fn route_to_apps(delegate_key: &DelegateKey, message: HostResult) -> 
             // turn every room update into one line per parked connection. The
             // flag lives on the registration, so `MAX_APPS_PER_DELEGATE` bounds
             // the total.
-            if !app.withhold_logged {
-                app.withhold_logged = true;
+            if app.latch_withhold_report() {
                 tracing::info!(
                     delegate = %delegate_key,
                     client_id = %app.client_id,
@@ -665,6 +717,55 @@ mod tests {
         );
     }
 
+    /// K1 regression: off-host registrations must never crowd a local app out of
+    /// the registry.
+    ///
+    /// The dead-channel prune reaps only CLOSED senders, so it does nothing
+    /// against the cheaper attack: hold the connections OPEN. Without a
+    /// reservation an off-host caller fills all `MAX_APPS_PER_DELEGATE` slots
+    /// with live registrations that are never delivery targets, and the
+    /// legitimate local app is refused at the cap for as long as the attacker
+    /// keeps its sockets open.
+    #[tokio::test(start_paused = true)]
+    #[serial_test::serial]
+    async fn open_remote_connections_cannot_crowd_out_a_local_app() {
+        let ns = Namespace::new();
+        let dk = ns.key(0);
+
+        // Hold the channels alive: nothing here is closed, so the prune cannot
+        // help and only the reservation can.
+        let mut keepalive = Vec::new();
+        let mut accepted = 0usize;
+        for i in 0..MAX_APPS_PER_DELEGATE {
+            let (tx, rx) = mpsc::channel::<HostResult>(1);
+            keepalive.push(rx);
+            if register_app(&dk, ns.client(i), AppIdentity::Remote, tx) {
+                accepted += 1;
+            }
+        }
+        assert_eq!(
+            accepted,
+            MAX_APPS_PER_DELEGATE - LOCAL_RESERVED_SLOTS,
+            "off-host registrations must stop at the reserved boundary"
+        );
+
+        // The local app must still get in, and must actually receive output.
+        let (local_tx, mut local_rx) = mpsc::channel::<HostResult>(4);
+        assert!(
+            register_app(
+                &dk,
+                ns.client(MAX_APPS_PER_DELEGATE + 1),
+                AppIdentity::Local,
+                local_tx
+            ),
+            "a local app must always be able to register, however many off-host \
+             clients are parked on this delegate"
+        );
+        assert_eq!(route_to_apps(&dk, host_msg()), 1);
+        assert!(local_rx.try_recv().is_ok());
+        drop(keepalive);
+    }
+
     /// The withheld report is once per REGISTRATION, not once per notification:
     /// this line ships at `release_max_level_info`, and the fan-out runs per
     /// contract-state change.
@@ -684,14 +785,20 @@ mod tests {
         for _ in 0..5 {
             assert_eq!(route_to_apps(&dk, host_msg()), 0);
         }
-        let logged_once = DELEGATE_APPS
-            .get(&dk)
-            .map(|apps| apps.iter().all(|a| a.withhold_logged))
+
+        // Assert the LATCH, not the flag. After five withheld notifications the
+        // right to report must already be spent, so a further claim returns
+        // false — i.e. exactly one line was emitted, not five. Inspecting
+        // `withhold_logged` instead would pass even if the guard were deleted
+        // and the assignment kept.
+        let spent = DELEGATE_APPS
+            .get_mut(&dk)
+            .map(|mut apps| apps.iter_mut().all(|a| !a.latch_withhold_report()))
             .unwrap_or(false);
         assert!(
-            logged_once,
-            "the flag must latch on the first withheld notification so later ones \
-             do not each emit a shipped log line"
+            spent,
+            "the report must be claimable only once per registration, or every \
+             contract-state change emits a shipped log line per parked connection"
         );
     }
 

--- a/crates/core/src/contract/delegate_app_registry.rs
+++ b/crates/core/src/contract/delegate_app_registry.rs
@@ -164,6 +164,17 @@ pub(crate) fn register_app(
     true
 }
 
+/// Whether any app is currently registered for `delegate_key`.
+///
+/// A cheap pre-check so the notification path can skip the (executor-checkout)
+/// attested-origin lookup entirely when there is nobody to route to — the common
+/// case for a delegate driven only by contract notifications.
+pub(crate) fn has_registrations(delegate_key: &DelegateKey) -> bool {
+    DELEGATE_APPS
+        .get(delegate_key)
+        .is_some_and(|apps| !apps.is_empty())
+}
+
 /// Route a notification-driven `ApplicationMessage` (already wrapped in a
 /// [`HostResult`]) to every registered app that holds `attested_origin` — the
 /// delegate's OWN attested app identity, read from its durable registration

--- a/crates/core/src/contract/delegate_app_registry.rs
+++ b/crates/core/src/contract/delegate_app_registry.rs
@@ -71,19 +71,42 @@ pub(crate) const REGISTRATION_TTL: std::time::Duration = std::time::Duration::fr
 
 /// One app's registration with a delegate: where to push messages, plus when it
 /// was last confirmed (for TTL eviction).
+/// Who made a registration, from the perspective that decides whether it may
+/// receive a delegate's notification output.
+///
+/// Registrations are a push channel for a delegate's output, and that output is
+/// the delegate's app's data. Before GHSA-824h-7x5x-wfmf there was no such
+/// distinction and [`route_to_apps`] fanned every notification to EVERY
+/// registration, so any client that sent one `ApplicationMessages` request to a
+/// delegate received its subsequent output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AppIdentity {
+    /// Registered over a connection the node proved is local. Eligible to
+    /// receive the delegate's output.
+    ///
+    /// `attested` is the connection's app identity where it had one (`None` for
+    /// the tokenless local CLI shape — riverctl, atlasctl, fdev). It is carried
+    /// for diagnostics ONLY and is deliberately NOT part of the delivery
+    /// decision: see [`route_to_apps`] for why matching on it is unsafe.
+    Local {
+        attested: Option<ContractInstanceId>,
+    },
+    /// Not provably local. Recorded so the caps and TTL bookkeeping stay
+    /// identical, but never a delivery target.
+    Remote,
+}
+
+impl AppIdentity {
+    fn may_receive(self) -> bool {
+        matches!(self, Self::Local { .. })
+    }
+}
+
+/// One app's registration with a delegate: where to push messages, who
+/// registered it, plus when it was last confirmed (for TTL eviction).
 struct AppRegistration {
     client_id: ClientId,
-    /// The ATTESTED app identity this registration was made under — the
-    /// `origin_contract` of the registering connection AFTER the loopback gate,
-    /// so it is `None` for any caller the node would not attest.
-    ///
-    /// Registrations are a push channel for a delegate's output, and that output
-    /// is the delegate's app's data. Before GHSA-824h-7x5x-wfmf this field did
-    /// not exist and [`route_to_apps`] fanned every notification to EVERY
-    /// registration, so any client that sent one `ApplicationMessages` request
-    /// to a delegate received its subsequent output. Routing now requires this
-    /// to equal the delegate's own attested origin.
-    origin: Option<ContractInstanceId>,
+    identity: AppIdentity,
     sender: mpsc::Sender<HostResult>,
     /// `tokio::time::Instant` (not `std::time::Instant`) so tests using
     /// `tokio::time::pause` / `advance` can drive TTL eviction deterministically,
@@ -114,7 +137,7 @@ static CLIENT_REGISTRATION_COUNTS: LazyLock<DashMap<ClientId, usize>> =
 pub(crate) fn register_app(
     delegate_key: &DelegateKey,
     client_id: ClientId,
-    origin: Option<ContractInstanceId>,
+    identity: AppIdentity,
     sender: mpsc::Sender<HostResult>,
 ) -> bool {
     let now = tokio::time::Instant::now();
@@ -126,7 +149,7 @@ pub(crate) fn register_app(
     // re-storing it keeps the field from going stale if that ever changes.
     if let Some(existing) = apps.iter_mut().find(|a| a.client_id == client_id) {
         existing.sender = sender;
-        existing.origin = origin;
+        existing.identity = identity;
         existing.last_seen = now;
         return true;
     }
@@ -156,7 +179,7 @@ pub(crate) fn register_app(
 
     apps.push(AppRegistration {
         client_id,
-        origin,
+        identity,
         sender,
         last_seen: now,
     });
@@ -164,39 +187,43 @@ pub(crate) fn register_app(
     true
 }
 
-/// Whether any app is currently registered for `delegate_key`.
-///
-/// A cheap pre-check so the notification path can skip the (executor-checkout)
-/// attested-origin lookup entirely when there is nobody to route to — the common
-/// case for a delegate driven only by contract notifications.
-pub(crate) fn has_registrations(delegate_key: &DelegateKey) -> bool {
-    DELEGATE_APPS
-        .get(delegate_key)
-        .is_some_and(|apps| !apps.is_empty())
-}
-
 /// Route a notification-driven `ApplicationMessage` (already wrapped in a
-/// [`HostResult`]) to every registered app that holds `attested_origin` — the
-/// delegate's OWN attested app identity, read from its durable registration
-/// record by the caller.
+/// [`HostResult`]) to every LOCAL registration for `delegate_key`.
 ///
-/// A registration whose origin differs is skipped: a delegate's output belongs
-/// to the app that installed it, and merely having talked to a delegate is not
-/// a claim on its data (GHSA-824h-7x5x-wfmf). `attested_origin == None` (a
-/// delegate registered by an unattested caller) matches only registrations that
-/// are likewise unattested, which preserves today's behavior for tokenless
-/// local CLI clients.
+/// A registration from a connection the node could not prove is local is
+/// skipped: before GHSA-824h-7x5x-wfmf, sending a delegate one
+/// `ApplicationMessages` request subscribed you to its output, so any off-host
+/// caller could harvest a local app's delegate traffic.
+///
+/// # Why this does NOT match on the app's attested identity
+///
+/// The obvious-looking rule — deliver only to the app whose identity equals the
+/// delegate's own — was implemented and REVERTED, because the only durable
+/// notion of "the delegate's own identity" is its first-registration origin
+/// record, which is first-writer-wins and IMMUTABLE (`redb.rs`). Matching on it
+/// would have created two failures strictly worse than the bug being fixed:
+///
+///  * **Permanent, remotely-triggerable denial of service.** Anyone who can
+///    register a delegate first fixes that record forever. Delegate WASM and
+///    params are public, so the key is derivable; a poisoned record would make
+///    every later notification to the legitimate app be dropped, with no way to
+///    correct it short of wiping the node's database.
+///  * **Breakage on re-key.** An app that re-keys (River does so routinely) gets
+///    a new contract id, which can never match the frozen record.
+///
+/// Locality is the boundary this fix can actually enforce, so it is the only one
+/// used here. The consequence is stated plainly rather than papered over:
+/// **unattested local clients are not separated from each other.** A local
+/// process that talks to a delegate still receives that delegate's output, as it
+/// always has. "Local" means this HOST, not this USER — closing that needs a
+/// real per-client authorization model, not a routing filter.
 ///
 /// Uses `try_send` (never `.await`) so it is safe to call from the
 /// single-threaded contract-handling loop — a full or closed client channel is
 /// dropped/logged, never blocks the loop (see `.claude/rules/channel-safety.md`).
 /// Returns the number of apps the message was delivered to. Closed channels are
 /// pruned as a side effect (the client is gone).
-pub(crate) fn route_to_apps(
-    delegate_key: &DelegateKey,
-    attested_origin: Option<ContractInstanceId>,
-    message: HostResult,
-) -> usize {
+pub(crate) fn route_to_apps(delegate_key: &DelegateKey, message: HostResult) -> usize {
     let Some(mut apps) = DELEGATE_APPS.get_mut(delegate_key) else {
         return 0;
     };
@@ -208,12 +235,19 @@ pub(crate) fn route_to_apps(
         // Identity mismatch: not a delivery target. Keep the registration (it is
         // still a live client, just not one entitled to THIS delegate's output);
         // only closed channels are pruned.
-        if app.origin != attested_origin {
-            tracing::debug!(
+        // Not provably local: not a delivery target. Keep the registration (it
+        // is still a live client) — only closed channels are pruned.
+        //
+        // `info!`, not `debug!`: the crate sets `release_max_level_info`, so a
+        // `debug!` here would compile out of every shipped binary and an
+        // operator whose app silently stopped receiving notifications would have
+        // nothing to look at.
+        if !app.identity.may_receive() {
+            tracing::info!(
                 delegate = %delegate_key,
                 client_id = %app.client_id,
-                "Skipping delegate notification for an app that does not hold \
-                 the delegate's attested identity"
+                "Withholding delegate notification from a non-local registration \
+                 (GHSA-824h-7x5x-wfmf); the client is connected but off-host"
             );
             return true;
         }
@@ -354,9 +388,9 @@ mod tests {
         let ns = Namespace::new();
         let dk = ns.key(0);
         let (tx, mut rx) = mpsc::channel::<HostResult>(4);
-        assert!(register_app(&dk, ns.client(0), None, tx));
+        assert!(register_app(&dk, ns.client(0), local(None), tx));
 
-        let delivered = route_to_apps(&dk, None, host_msg());
+        let delivered = route_to_apps(&dk, host_msg());
         assert_eq!(delivered, 1);
         assert!(rx.try_recv().is_ok(), "app must receive the message");
     }
@@ -365,7 +399,7 @@ mod tests {
     #[serial_test::serial]
     async fn route_to_unknown_delegate_delivers_nothing() {
         let ns = Namespace::new();
-        let delivered = route_to_apps(&ns.key(0), None, host_msg());
+        let delivered = route_to_apps(&ns.key(0), host_msg());
         assert_eq!(delivered, 0);
     }
 
@@ -376,11 +410,11 @@ mod tests {
         let dk = ns.key(0);
         for i in 0..MAX_APPS_PER_DELEGATE {
             let (tx, _rx) = mpsc::channel::<HostResult>(1);
-            assert!(register_app(&dk, ns.client(i), None, tx));
+            assert!(register_app(&dk, ns.client(i), local(None), tx));
         }
         let (tx, _rx) = mpsc::channel::<HostResult>(1);
         assert!(
-            !register_app(&dk, ns.client(MAX_APPS_PER_DELEGATE), None, tx),
+            !register_app(&dk, ns.client(MAX_APPS_PER_DELEGATE), local(None), tx),
             "registration past per-delegate cap must be rejected"
         );
     }
@@ -392,11 +426,11 @@ mod tests {
         let client = ns.client(0);
         for i in 0..MAX_DELEGATES_PER_CLIENT {
             let (tx, _rx) = mpsc::channel::<HostResult>(1);
-            assert!(register_app(&ns.key(i), client, None, tx));
+            assert!(register_app(&ns.key(i), client, local(None), tx));
         }
         let (tx, _rx) = mpsc::channel::<HostResult>(1);
         assert!(
-            !register_app(&ns.key(MAX_DELEGATES_PER_CLIENT), client, None, tx),
+            !register_app(&ns.key(MAX_DELEGATES_PER_CLIENT), client, local(None), tx),
             "registration past per-client cap must be rejected"
         );
     }
@@ -408,13 +442,13 @@ mod tests {
         let dk = ns.key(0);
         let client = ns.client(0);
         let (tx, _rx) = mpsc::channel::<HostResult>(1);
-        assert!(register_app(&dk, client, None, tx));
+        assert!(register_app(&dk, client, local(None), tx));
         remove_client(client);
-        assert_eq!(route_to_apps(&dk, None, host_msg()), 0);
+        assert_eq!(route_to_apps(&dk, host_msg()), 0);
         // Count freed, so client can register up to the cap again.
         for i in 0..MAX_DELEGATES_PER_CLIENT {
             let (tx, _rx) = mpsc::channel::<HostResult>(1);
-            assert!(register_app(&ns.key(i + 1), client, None, tx));
+            assert!(register_app(&ns.key(i + 1), client, local(None), tx));
         }
     }
 
@@ -425,13 +459,13 @@ mod tests {
         let dk = ns.key(0);
         let client = ns.client(0);
         let (tx, rx) = mpsc::channel::<HostResult>(1);
-        assert!(register_app(&dk, client, None, tx));
+        assert!(register_app(&dk, client, local(None), tx));
         drop(rx); // client gone
-        assert_eq!(route_to_apps(&dk, None, host_msg()), 0);
+        assert_eq!(route_to_apps(&dk, host_msg()), 0);
         // Registration pruned and client count freed: can fill cap again.
         for i in 0..MAX_DELEGATES_PER_CLIENT {
             let (t, _r) = mpsc::channel::<HostResult>(1);
-            assert!(register_app(&ns.key(i + 1), client, None, t));
+            assert!(register_app(&ns.key(i + 1), client, local(None), t));
         }
     }
 
@@ -441,12 +475,12 @@ mod tests {
         let ns = Namespace::new();
         let dk = ns.key(0);
         let (tx, _rx) = mpsc::channel::<HostResult>(1);
-        assert!(register_app(&dk, ns.client(0), None, tx));
+        assert!(register_app(&dk, ns.client(0), local(None), tx));
 
         tokio::time::advance(REGISTRATION_TTL + std::time::Duration::from_secs(1)).await;
         sweep_expired();
         assert_eq!(
-            route_to_apps(&dk, None, host_msg()),
+            route_to_apps(&dk, host_msg()),
             0,
             "stale registration must be swept after TTL"
         );
@@ -459,20 +493,24 @@ mod tests {
         let dk = ns.key(0);
         let client = ns.client(0);
         let (tx, mut rx) = mpsc::channel::<HostResult>(4);
-        assert!(register_app(&dk, client, None, tx.clone()));
+        assert!(register_app(&dk, client, local(None), tx.clone()));
 
         // Advance nearly to TTL, then refresh.
         tokio::time::advance(REGISTRATION_TTL - std::time::Duration::from_secs(10)).await;
-        assert!(register_app(&dk, client, None, tx));
+        assert!(register_app(&dk, client, local(None), tx));
         // Advance past the ORIGINAL expiry but within the refreshed window.
         tokio::time::advance(std::time::Duration::from_secs(20)).await;
         sweep_expired();
         assert_eq!(
-            route_to_apps(&dk, None, host_msg()),
+            route_to_apps(&dk, host_msg()),
             1,
             "refreshed registration must survive"
         );
         assert!(rx.try_recv().is_ok());
+    }
+
+    fn local(attested: Option<ContractInstanceId>) -> AppIdentity {
+        AppIdentity::Local { attested }
     }
 
     fn contract(seed: u8) -> ContractInstanceId {
@@ -484,84 +522,109 @@ mod tests {
     //
     // Registration is open to anyone — it is how a client asks to be pushed to
     // — and it happens BEFORE the request is dispatched, so it cannot be gated
-    // on the delegate accepting the caller. The gate has to be on DELIVERY:
-    // a delegate's notification output goes only to a client that proved the
-    // delegate's own attested app identity.
+    // on the delegate accepting the caller. The gate has to be on DELIVERY.
+    //
+    // Delivery keys on LOCALITY, not on the app's attested identity. An earlier
+    // revision matched the registration's origin against the delegate's durable
+    // first-registration record and was reverted: that record is
+    // first-writer-wins and immutable, so matching on it created a permanent,
+    // remotely-triggerable denial of service and broke apps that re-key. See
+    // `route_to_apps`'s rustdoc.
     // -----------------------------------------------------------------------
 
-    /// The core regression: a client that talked to the delegate but holds a
-    /// DIFFERENT (or no) attested identity receives nothing, while the app that
-    /// owns the delegate still does. Before the fix both were delivered to.
+    /// The core regression: an off-host client that talked to the delegate
+    /// receives nothing, while local clients still do. Before the fix both were
+    /// delivered to.
     #[tokio::test(start_paused = true)]
     #[serial_test::serial]
-    async fn route_skips_apps_that_do_not_hold_the_delegates_identity() {
+    async fn route_skips_non_local_registrations() {
         let ns = Namespace::new();
         let dk = ns.key(0);
-        let owner = contract(0x11);
 
-        let (owner_tx, mut owner_rx) = mpsc::channel::<HostResult>(4);
-        let (other_app_tx, mut other_app_rx) = mpsc::channel::<HostResult>(4);
-        let (tokenless_tx, mut tokenless_rx) = mpsc::channel::<HostResult>(4);
+        let (app_tx, mut app_rx) = mpsc::channel::<HostResult>(4);
+        let (cli_tx, mut cli_rx) = mpsc::channel::<HostResult>(4);
+        let (remote_tx, mut remote_rx) = mpsc::channel::<HostResult>(4);
 
-        assert!(register_app(&dk, ns.client(0), Some(owner), owner_tx));
+        assert!(register_app(
+            &dk,
+            ns.client(0),
+            local(Some(contract(0x11))),
+            app_tx
+        ));
+        assert!(register_app(&dk, ns.client(1), local(None), cli_tx));
+        assert!(register_app(
+            &dk,
+            ns.client(2),
+            AppIdentity::Remote,
+            remote_tx
+        ));
+
+        let delivered = route_to_apps(&dk, host_msg());
+
+        assert_eq!(delivered, 2, "both local registrations must receive it");
+        assert!(
+            app_rx.try_recv().is_ok(),
+            "the local web app must receive it"
+        );
+        assert!(
+            cli_rx.try_recv().is_ok(),
+            "the local tokenless CLI must keep receiving it — riverctl, atlasctl \
+             and fdev all register in this shape"
+        );
+        assert!(
+            remote_rx.try_recv().is_err(),
+            "an off-host registration must never receive a delegate's output"
+        );
+    }
+
+    /// A skipped registration is retained, not evicted: the client is still live
+    /// and may hold registrations with other delegates.
+    #[tokio::test(start_paused = true)]
+    #[serial_test::serial]
+    async fn skipped_remote_registration_is_retained_not_evicted() {
+        let ns = Namespace::new();
+        let dk = ns.key(0);
+        let (remote_tx, _remote_rx) = mpsc::channel::<HostResult>(4);
+        assert!(register_app(
+            &dk,
+            ns.client(0),
+            AppIdentity::Remote,
+            remote_tx
+        ));
+
+        assert_eq!(route_to_apps(&dk, host_msg()), 0);
+        assert!(
+            DELEGATE_APPS.get(&dk).is_some_and(|apps| apps.len() == 1),
+            "the registration must survive a skipped delivery"
+        );
+    }
+
+    /// Delivery must NOT depend on the attested contract id. Two local apps with
+    /// different attested identities both receive the output — the deliberate
+    /// scope limit (locality, not per-app separation), and the reason the
+    /// immutable-record matching was reverted.
+    #[tokio::test(start_paused = true)]
+    #[serial_test::serial]
+    async fn delivery_does_not_key_on_the_attested_contract_id() {
+        let ns = Namespace::new();
+        let dk = ns.key(0);
+        let (a_tx, mut a_rx) = mpsc::channel::<HostResult>(4);
+        let (b_tx, mut b_rx) = mpsc::channel::<HostResult>(4);
+        assert!(register_app(
+            &dk,
+            ns.client(0),
+            local(Some(contract(0x22))),
+            a_tx
+        ));
         assert!(register_app(
             &dk,
             ns.client(1),
-            Some(contract(0x22)),
-            other_app_tx
+            local(Some(contract(0x33))),
+            b_tx
         ));
-        assert!(register_app(&dk, ns.client(2), None, tokenless_tx));
 
-        let delivered = route_to_apps(&dk, Some(owner), host_msg());
-
-        assert_eq!(delivered, 1, "only the owning app may receive the output");
-        assert!(
-            owner_rx.try_recv().is_ok(),
-            "the owning app must receive it"
-        );
-        assert!(
-            other_app_rx.try_recv().is_err(),
-            "an app attested as a DIFFERENT contract must not receive it"
-        );
-        assert!(
-            tokenless_rx.try_recv().is_err(),
-            "an unattested client must not receive an attested delegate's output"
-        );
-    }
-
-    /// A non-matching registration is SKIPPED, not evicted: the client is still
-    /// live and may legitimately hold registrations with other delegates. If
-    /// skipping silently dropped it, a later matching delivery would fail.
-    #[tokio::test(start_paused = true)]
-    #[serial_test::serial]
-    async fn skipped_registration_is_retained_not_evicted() {
-        let ns = Namespace::new();
-        let dk = ns.key(0);
-        let owner = contract(0x33);
-        let (tx, mut rx) = mpsc::channel::<HostResult>(4);
-        assert!(register_app(&dk, ns.client(0), Some(owner), tx));
-
-        assert_eq!(route_to_apps(&dk, Some(contract(0x44)), host_msg()), 0);
-        assert_eq!(
-            route_to_apps(&dk, Some(owner), host_msg()),
-            1,
-            "the registration must survive a skipped delivery"
-        );
-        assert!(rx.try_recv().is_ok());
-    }
-
-    /// The tokenless local CLI shape (riverctl, atlasctl, fdev): a delegate with
-    /// NO recorded origin routes to registrations that likewise hold none. This
-    /// is today's behavior for those clients and must not regress.
-    #[tokio::test(start_paused = true)]
-    #[serial_test::serial]
-    async fn unattested_delegate_routes_to_unattested_apps() {
-        let ns = Namespace::new();
-        let dk = ns.key(0);
-        let (tx, mut rx) = mpsc::channel::<HostResult>(4);
-        assert!(register_app(&dk, ns.client(0), None, tx));
-
-        assert_eq!(route_to_apps(&dk, None, host_msg()), 1);
-        assert!(rx.try_recv().is_ok());
+        assert_eq!(route_to_apps(&dk, host_msg()), 2);
+        assert!(a_rx.try_recv().is_ok());
+        assert!(b_rx.try_recv().is_ok());
     }
 }

--- a/crates/core/src/contract/delegate_app_registry.rs
+++ b/crates/core/src/contract/delegate_app_registry.rs
@@ -45,7 +45,7 @@
 use std::sync::LazyLock;
 
 use dashmap::DashMap;
-use freenet_stdlib::prelude::DelegateKey;
+use freenet_stdlib::prelude::{ContractInstanceId, DelegateKey};
 use tokio::sync::mpsc;
 
 use crate::client_events::{ClientId, HostResult};
@@ -73,6 +73,17 @@ pub(crate) const REGISTRATION_TTL: std::time::Duration = std::time::Duration::fr
 /// was last confirmed (for TTL eviction).
 struct AppRegistration {
     client_id: ClientId,
+    /// The ATTESTED app identity this registration was made under — the
+    /// `origin_contract` of the registering connection AFTER the loopback gate,
+    /// so it is `None` for any caller the node would not attest.
+    ///
+    /// Registrations are a push channel for a delegate's output, and that output
+    /// is the delegate's app's data. Before GHSA-824h-7x5x-wfmf this field did
+    /// not exist and [`route_to_apps`] fanned every notification to EVERY
+    /// registration, so any client that sent one `ApplicationMessages` request
+    /// to a delegate received its subsequent output. Routing now requires this
+    /// to equal the delegate's own attested origin.
+    origin: Option<ContractInstanceId>,
     sender: mpsc::Sender<HostResult>,
     /// `tokio::time::Instant` (not `std::time::Instant`) so tests using
     /// `tokio::time::pause` / `advance` can drive TTL eviction deterministically,
@@ -103,14 +114,19 @@ static CLIENT_REGISTRATION_COUNTS: LazyLock<DashMap<ClientId, usize>> =
 pub(crate) fn register_app(
     delegate_key: &DelegateKey,
     client_id: ClientId,
+    origin: Option<ContractInstanceId>,
     sender: mpsc::Sender<HostResult>,
 ) -> bool {
     let now = tokio::time::Instant::now();
     let mut apps = DELEGATE_APPS.entry(delegate_key.clone()).or_default();
 
     // Refresh path: already registered → update sender + TTL, no cap change.
+    // The origin is refreshed too: a client id is per-connection, so this is the
+    // same connection and therefore the same (immutable) attested identity — but
+    // re-storing it keeps the field from going stale if that ever changes.
     if let Some(existing) = apps.iter_mut().find(|a| a.client_id == client_id) {
         existing.sender = sender;
+        existing.origin = origin;
         existing.last_seen = now;
         return true;
     }
@@ -140,6 +156,7 @@ pub(crate) fn register_app(
 
     apps.push(AppRegistration {
         client_id,
+        origin,
         sender,
         last_seen: now,
     });
@@ -148,14 +165,27 @@ pub(crate) fn register_app(
 }
 
 /// Route a notification-driven `ApplicationMessage` (already wrapped in a
-/// [`HostResult`]) to every app registered with `delegate_key`.
+/// [`HostResult`]) to every registered app that holds `attested_origin` — the
+/// delegate's OWN attested app identity, read from its durable registration
+/// record by the caller.
+///
+/// A registration whose origin differs is skipped: a delegate's output belongs
+/// to the app that installed it, and merely having talked to a delegate is not
+/// a claim on its data (GHSA-824h-7x5x-wfmf). `attested_origin == None` (a
+/// delegate registered by an unattested caller) matches only registrations that
+/// are likewise unattested, which preserves today's behavior for tokenless
+/// local CLI clients.
 ///
 /// Uses `try_send` (never `.await`) so it is safe to call from the
 /// single-threaded contract-handling loop — a full or closed client channel is
 /// dropped/logged, never blocks the loop (see `.claude/rules/channel-safety.md`).
 /// Returns the number of apps the message was delivered to. Closed channels are
 /// pruned as a side effect (the client is gone).
-pub(crate) fn route_to_apps(delegate_key: &DelegateKey, message: HostResult) -> usize {
+pub(crate) fn route_to_apps(
+    delegate_key: &DelegateKey,
+    attested_origin: Option<ContractInstanceId>,
+    message: HostResult,
+) -> usize {
     let Some(mut apps) = DELEGATE_APPS.get_mut(delegate_key) else {
         return 0;
     };
@@ -163,23 +193,37 @@ pub(crate) fn route_to_apps(delegate_key: &DelegateKey, message: HostResult) -> 
     let mut delivered = 0usize;
     let mut closed_clients: Vec<ClientId> = Vec::new();
 
-    apps.retain(|app| match app.sender.try_send(message.clone()) {
-        Ok(()) => {
-            delivered += 1;
-            true
-        }
-        Err(mpsc::error::TrySendError::Full(_)) => {
-            tracing::warn!(
+    apps.retain(|app| {
+        // Identity mismatch: not a delivery target. Keep the registration (it is
+        // still a live client, just not one entitled to THIS delegate's output);
+        // only closed channels are pruned.
+        if app.origin != attested_origin {
+            tracing::debug!(
                 delegate = %delegate_key,
                 client_id = %app.client_id,
-                "App notification channel full — delegate ApplicationMessage dropped"
+                "Skipping delegate notification for an app that does not hold \
+                 the delegate's attested identity"
             );
-            true
+            return true;
         }
-        Err(mpsc::error::TrySendError::Closed(_)) => {
-            // Client disconnected without a clean event; drop the registration.
-            closed_clients.push(app.client_id);
-            false
+        match app.sender.try_send(message.clone()) {
+            Ok(()) => {
+                delivered += 1;
+                true
+            }
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                tracing::warn!(
+                    delegate = %delegate_key,
+                    client_id = %app.client_id,
+                    "App notification channel full — delegate ApplicationMessage dropped"
+                );
+                true
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                // Client disconnected without a clean event; drop the registration.
+                closed_clients.push(app.client_id);
+                false
+            }
         }
     });
 
@@ -299,9 +343,9 @@ mod tests {
         let ns = Namespace::new();
         let dk = ns.key(0);
         let (tx, mut rx) = mpsc::channel::<HostResult>(4);
-        assert!(register_app(&dk, ns.client(0), tx));
+        assert!(register_app(&dk, ns.client(0), None, tx));
 
-        let delivered = route_to_apps(&dk, host_msg());
+        let delivered = route_to_apps(&dk, None, host_msg());
         assert_eq!(delivered, 1);
         assert!(rx.try_recv().is_ok(), "app must receive the message");
     }
@@ -310,7 +354,7 @@ mod tests {
     #[serial_test::serial]
     async fn route_to_unknown_delegate_delivers_nothing() {
         let ns = Namespace::new();
-        let delivered = route_to_apps(&ns.key(0), host_msg());
+        let delivered = route_to_apps(&ns.key(0), None, host_msg());
         assert_eq!(delivered, 0);
     }
 
@@ -321,11 +365,11 @@ mod tests {
         let dk = ns.key(0);
         for i in 0..MAX_APPS_PER_DELEGATE {
             let (tx, _rx) = mpsc::channel::<HostResult>(1);
-            assert!(register_app(&dk, ns.client(i), tx));
+            assert!(register_app(&dk, ns.client(i), None, tx));
         }
         let (tx, _rx) = mpsc::channel::<HostResult>(1);
         assert!(
-            !register_app(&dk, ns.client(MAX_APPS_PER_DELEGATE), tx),
+            !register_app(&dk, ns.client(MAX_APPS_PER_DELEGATE), None, tx),
             "registration past per-delegate cap must be rejected"
         );
     }
@@ -337,11 +381,11 @@ mod tests {
         let client = ns.client(0);
         for i in 0..MAX_DELEGATES_PER_CLIENT {
             let (tx, _rx) = mpsc::channel::<HostResult>(1);
-            assert!(register_app(&ns.key(i), client, tx));
+            assert!(register_app(&ns.key(i), client, None, tx));
         }
         let (tx, _rx) = mpsc::channel::<HostResult>(1);
         assert!(
-            !register_app(&ns.key(MAX_DELEGATES_PER_CLIENT), client, tx),
+            !register_app(&ns.key(MAX_DELEGATES_PER_CLIENT), client, None, tx),
             "registration past per-client cap must be rejected"
         );
     }
@@ -353,13 +397,13 @@ mod tests {
         let dk = ns.key(0);
         let client = ns.client(0);
         let (tx, _rx) = mpsc::channel::<HostResult>(1);
-        assert!(register_app(&dk, client, tx));
+        assert!(register_app(&dk, client, None, tx));
         remove_client(client);
-        assert_eq!(route_to_apps(&dk, host_msg()), 0);
+        assert_eq!(route_to_apps(&dk, None, host_msg()), 0);
         // Count freed, so client can register up to the cap again.
         for i in 0..MAX_DELEGATES_PER_CLIENT {
             let (tx, _rx) = mpsc::channel::<HostResult>(1);
-            assert!(register_app(&ns.key(i + 1), client, tx));
+            assert!(register_app(&ns.key(i + 1), client, None, tx));
         }
     }
 
@@ -370,13 +414,13 @@ mod tests {
         let dk = ns.key(0);
         let client = ns.client(0);
         let (tx, rx) = mpsc::channel::<HostResult>(1);
-        assert!(register_app(&dk, client, tx));
+        assert!(register_app(&dk, client, None, tx));
         drop(rx); // client gone
-        assert_eq!(route_to_apps(&dk, host_msg()), 0);
+        assert_eq!(route_to_apps(&dk, None, host_msg()), 0);
         // Registration pruned and client count freed: can fill cap again.
         for i in 0..MAX_DELEGATES_PER_CLIENT {
             let (t, _r) = mpsc::channel::<HostResult>(1);
-            assert!(register_app(&ns.key(i + 1), client, t));
+            assert!(register_app(&ns.key(i + 1), client, None, t));
         }
     }
 
@@ -386,12 +430,12 @@ mod tests {
         let ns = Namespace::new();
         let dk = ns.key(0);
         let (tx, _rx) = mpsc::channel::<HostResult>(1);
-        assert!(register_app(&dk, ns.client(0), tx));
+        assert!(register_app(&dk, ns.client(0), None, tx));
 
         tokio::time::advance(REGISTRATION_TTL + std::time::Duration::from_secs(1)).await;
         sweep_expired();
         assert_eq!(
-            route_to_apps(&dk, host_msg()),
+            route_to_apps(&dk, None, host_msg()),
             0,
             "stale registration must be swept after TTL"
         );
@@ -404,19 +448,109 @@ mod tests {
         let dk = ns.key(0);
         let client = ns.client(0);
         let (tx, mut rx) = mpsc::channel::<HostResult>(4);
-        assert!(register_app(&dk, client, tx.clone()));
+        assert!(register_app(&dk, client, None, tx.clone()));
 
         // Advance nearly to TTL, then refresh.
         tokio::time::advance(REGISTRATION_TTL - std::time::Duration::from_secs(10)).await;
-        assert!(register_app(&dk, client, tx));
+        assert!(register_app(&dk, client, None, tx));
         // Advance past the ORIGINAL expiry but within the refreshed window.
         tokio::time::advance(std::time::Duration::from_secs(20)).await;
         sweep_expired();
         assert_eq!(
-            route_to_apps(&dk, host_msg()),
+            route_to_apps(&dk, None, host_msg()),
             1,
             "refreshed registration must survive"
         );
+        assert!(rx.try_recv().is_ok());
+    }
+
+    fn contract(seed: u8) -> ContractInstanceId {
+        ContractInstanceId::new([seed; 32])
+    }
+
+    // -----------------------------------------------------------------------
+    // GHSA-824h-7x5x-wfmf, gap 2 (delegate app registry).
+    //
+    // Registration is open to anyone — it is how a client asks to be pushed to
+    // — and it happens BEFORE the request is dispatched, so it cannot be gated
+    // on the delegate accepting the caller. The gate has to be on DELIVERY:
+    // a delegate's notification output goes only to a client that proved the
+    // delegate's own attested app identity.
+    // -----------------------------------------------------------------------
+
+    /// The core regression: a client that talked to the delegate but holds a
+    /// DIFFERENT (or no) attested identity receives nothing, while the app that
+    /// owns the delegate still does. Before the fix both were delivered to.
+    #[tokio::test(start_paused = true)]
+    #[serial_test::serial]
+    async fn route_skips_apps_that_do_not_hold_the_delegates_identity() {
+        let ns = Namespace::new();
+        let dk = ns.key(0);
+        let owner = contract(0x11);
+
+        let (owner_tx, mut owner_rx) = mpsc::channel::<HostResult>(4);
+        let (other_app_tx, mut other_app_rx) = mpsc::channel::<HostResult>(4);
+        let (tokenless_tx, mut tokenless_rx) = mpsc::channel::<HostResult>(4);
+
+        assert!(register_app(&dk, ns.client(0), Some(owner), owner_tx));
+        assert!(register_app(
+            &dk,
+            ns.client(1),
+            Some(contract(0x22)),
+            other_app_tx
+        ));
+        assert!(register_app(&dk, ns.client(2), None, tokenless_tx));
+
+        let delivered = route_to_apps(&dk, Some(owner), host_msg());
+
+        assert_eq!(delivered, 1, "only the owning app may receive the output");
+        assert!(
+            owner_rx.try_recv().is_ok(),
+            "the owning app must receive it"
+        );
+        assert!(
+            other_app_rx.try_recv().is_err(),
+            "an app attested as a DIFFERENT contract must not receive it"
+        );
+        assert!(
+            tokenless_rx.try_recv().is_err(),
+            "an unattested client must not receive an attested delegate's output"
+        );
+    }
+
+    /// A non-matching registration is SKIPPED, not evicted: the client is still
+    /// live and may legitimately hold registrations with other delegates. If
+    /// skipping silently dropped it, a later matching delivery would fail.
+    #[tokio::test(start_paused = true)]
+    #[serial_test::serial]
+    async fn skipped_registration_is_retained_not_evicted() {
+        let ns = Namespace::new();
+        let dk = ns.key(0);
+        let owner = contract(0x33);
+        let (tx, mut rx) = mpsc::channel::<HostResult>(4);
+        assert!(register_app(&dk, ns.client(0), Some(owner), tx));
+
+        assert_eq!(route_to_apps(&dk, Some(contract(0x44)), host_msg()), 0);
+        assert_eq!(
+            route_to_apps(&dk, Some(owner), host_msg()),
+            1,
+            "the registration must survive a skipped delivery"
+        );
+        assert!(rx.try_recv().is_ok());
+    }
+
+    /// The tokenless local CLI shape (riverctl, atlasctl, fdev): a delegate with
+    /// NO recorded origin routes to registrations that likewise hold none. This
+    /// is today's behavior for those clients and must not regress.
+    #[tokio::test(start_paused = true)]
+    #[serial_test::serial]
+    async fn unattested_delegate_routes_to_unattested_apps() {
+        let ns = Namespace::new();
+        let dk = ns.key(0);
+        let (tx, mut rx) = mpsc::channel::<HostResult>(4);
+        assert!(register_app(&dk, ns.client(0), None, tx));
+
+        assert_eq!(route_to_apps(&dk, None, host_msg()), 1);
         assert!(rx.try_recv().is_ok());
     }
 }

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -923,13 +923,46 @@ pub(crate) trait ContractExecutor: Send + 'static {
     /// the delegate or client can put in a message can set or forge it. The
     /// inter-delegate dispatch path passes `None` (a delegate-to-delegate hop
     /// does not inherit the originating connection's user namespace).
+    /// `connection_scope` says whether the client connection this request
+    /// descends from is entitled to an ATTESTED application identity
+    /// (GHSA-824h-7x5x-wfmf). When it is
+    /// [`crate::client_events::ConnectionScope::Remote`] the executor resolves
+    /// NO `MessageOrigin` at all — not from `origin_contract`, not from
+    /// `caller_delegate`, not from the node's inherited-origins map — so an
+    /// off-host caller sees exactly what a tokenless local caller has always
+    /// seen. Like `user_context` it travels beside the request, never inside
+    /// it. Node-internal invocations (contract-notification callbacks) pass
+    /// `Local`: they descend from no client connection at all.
     fn execute_delegate_request(
         &mut self,
         req: DelegateRequest<'_>,
         origin_contract: Option<&ContractInstanceId>,
         caller_delegate: Option<&DelegateKey>,
+        connection_scope: crate::client_events::ConnectionScope,
         user_context: Option<&UserSecretContext>,
     ) -> impl Future<Output = Response> + Send;
+
+    /// The contract id `delegate` was FIRST registered under, as durably
+    /// recorded at registration time (`delegates.rs`'s first-writer origin
+    /// record). `None` when the delegate was registered by a caller holding no
+    /// attested identity, when it is unknown to this node, or when the record
+    /// cannot be read.
+    ///
+    /// This is the delegate's own app identity, and it is what notification
+    /// output is routed by: only a client that proved the SAME identity may
+    /// receive it (GHSA-824h-7x5x-wfmf). Fail closed — anything other than a
+    /// positively-read contract id is `None`, which routes only to
+    /// registrations that likewise hold no attested identity.
+    ///
+    /// The default returns `None`, which is the fail-closed answer for
+    /// executors with no delegate store (the mocks).
+    fn delegate_attested_origin(
+        &mut self,
+        delegate: &DelegateKey,
+    ) -> impl Future<Output = Option<ContractInstanceId>> + Send {
+        let _ = delegate;
+        async { None }
+    }
 
     /// Export the per-user delegate secrets named by `user_context` into an
     /// encrypted bundle, sealed under the user's `token` (hosted-mode export,

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -942,28 +942,6 @@ pub(crate) trait ContractExecutor: Send + 'static {
         user_context: Option<&UserSecretContext>,
     ) -> impl Future<Output = Response> + Send;
 
-    /// The contract id `delegate` was FIRST registered under, as durably
-    /// recorded at registration time (`delegates.rs`'s first-writer origin
-    /// record). `None` when the delegate was registered by a caller holding no
-    /// attested identity, when it is unknown to this node, or when the record
-    /// cannot be read.
-    ///
-    /// This is the delegate's own app identity, and it is what notification
-    /// output is routed by: only a client that proved the SAME identity may
-    /// receive it (GHSA-824h-7x5x-wfmf). Fail closed — anything other than a
-    /// positively-read contract id is `None`, which routes only to
-    /// registrations that likewise hold no attested identity.
-    ///
-    /// The default returns `None`, which is the fail-closed answer for
-    /// executors with no delegate store (the mocks).
-    fn delegate_attested_origin(
-        &mut self,
-        delegate: &DelegateKey,
-    ) -> impl Future<Output = Option<ContractInstanceId>> + Send {
-        let _ = delegate;
-        async { None }
-    }
-
     /// Export the per-user delegate secrets named by `user_context` into an
     /// encrypted bundle, sealed under the user's `token` (hosted-mode export,
     /// P3-live of #4381). The bundle round-trips through

--- a/crates/core/src/contract/executor/mock_runtime.rs
+++ b/crates/core/src/contract/executor/mock_runtime.rs
@@ -745,6 +745,7 @@ where
         _req: DelegateRequest<'_>,
         _origin_contract: Option<&ContractInstanceId>,
         _caller_delegate: Option<&DelegateKey>,
+        _connection_scope: crate::client_events::ConnectionScope,
         _user_context: Option<&UserSecretContext>,
     ) -> Response {
         Err(ExecutorError::other(anyhow::anyhow!(

--- a/crates/core/src/contract/executor/mock_wasm_runtime.rs
+++ b/crates/core/src/contract/executor/mock_wasm_runtime.rs
@@ -400,6 +400,7 @@ impl ContractExecutor for Executor<MockWasmRuntime, MockStateStorage> {
         _req: DelegateRequest<'_>,
         _origin_contract: Option<&ContractInstanceId>,
         _caller_delegate: Option<&DelegateKey>,
+        _connection_scope: crate::client_events::ConnectionScope,
         _user_context: Option<&UserSecretContext>,
     ) -> Response {
         Err(ExecutorError::other(anyhow::anyhow!(

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -292,9 +292,23 @@ impl ContractExecutor for Executor<Runtime> {
         req: DelegateRequest<'_>,
         origin_contract: Option<&ContractInstanceId>,
         caller_delegate: Option<&DelegateKey>,
+        connection_scope: crate::client_events::ConnectionScope,
         user_context: Option<&UserSecretContext>,
     ) -> Response {
-        self.delegate_request(req, origin_contract, caller_delegate, user_context)
+        self.delegate_request(
+            req,
+            origin_contract,
+            caller_delegate,
+            connection_scope,
+            user_context,
+        )
+    }
+
+    async fn delegate_attested_origin(
+        &mut self,
+        delegate: &DelegateKey,
+    ) -> Option<ContractInstanceId> {
+        self.registered_delegate_origin(delegate)
     }
 
     // NOTE: `ContractExecutor::try_begin_export` / `finish_export` are NOT
@@ -573,7 +587,16 @@ impl Executor<Runtime> {
             ClientRequest::ContractOp(op) => self.contract_requests(op, id, updates).await,
             // Local-node path (no hosted-mode connection): always single-user
             // (`user_context = None`), so secrets stay `SecretScope::Local`.
-            ClientRequest::DelegateOp(op) => self.delegate_request(op, None, None, None),
+            // `origin_contract` is `None` here, so the connection scope changes
+            // nothing about what this path can attest — pass `Local` so the
+            // behavior is byte-for-byte what it was.
+            ClientRequest::DelegateOp(op) => self.delegate_request(
+                op,
+                None,
+                None,
+                crate::client_events::ConnectionScope::Local,
+                None,
+            ),
             ClientRequest::Disconnect { cause } => {
                 if let Some(cause) = cause {
                     tracing::info!("disconnecting cause: {cause}");
@@ -1506,15 +1529,111 @@ mod remove_contract_tests {
             .with_extension("wasm")
     }
 
-    /// Handler-level (freenet/freenet-core#5198): `RegisterDelegateWithPredecessors`
+    /// Handler-level (GHSA-824h-7x5x-wfmf): `RegisterDelegateWithPredecessors`
+    /// GHSA-824h-7x5x-wfmf, gap 1 (inter-delegate dispatch).
+    ///
+    /// `caller_delegate` is an identity the RUNTIME attests, and it wins over
+    /// every other origin. Before this gate, a delegate could be registered by
+    /// anyone with `origin_contract: None` (no attested identity of its own);
+    /// messaging that delegate makes its own WASM emit `SendDelegateMessage`,
+    /// and the victim then authorizes on `MessageOrigin::Delegate(attacker)`.
+    /// That routes around the connection-scope gate entirely, because the
+    /// attacker never has to hold an attested identity itself.
+    ///
+    /// A delegate with no recorded registration origin therefore cannot lend
+    /// its identity to anyone. The control half matters as much as the refusal:
+    /// it proves the gate keys on the ORIGIN RECORD and not on "any
+    /// `caller_delegate` is refused", which would break legitimate
+    /// inter-delegate messaging outright.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn inter_delegate_dispatch_requires_an_attested_caller_origin() {
+        use freenet_stdlib::client_api::DelegateRequest;
+        use freenet_stdlib::prelude::{
+            ContractInstanceId, Delegate, DelegateContainer, DelegateWasmAPIVersion, Parameters,
+        };
+
+        let (mut executor, _contracts_dir, _temp) =
+            build_disk_executor("inter-delegate-origin").await;
+
+        // Registered by a caller holding NO attested identity — the "anyone can
+        // install this" case.
+        let unattested = Delegate::from((&vec![0u8].into(), &vec![0xA1u8].into()));
+        // Registered by a real web app, so it HAS a recorded origin.
+        let attested = Delegate::from((&vec![0u8].into(), &vec![0xB2u8].into()));
+        let victim = Delegate::from((&vec![0u8].into(), &vec![0xC3u8].into()));
+        let app = ContractInstanceId::new([0x5Au8; 32]);
+
+        for (delegate, origin) in [
+            (&unattested, None),
+            (&attested, Some(&app)),
+            (&victim, Some(&app)),
+        ] {
+            executor
+                .delegate_request(
+                    DelegateRequest::RegisterDelegate {
+                        delegate: DelegateContainer::Wasm(DelegateWasmAPIVersion::V1(
+                            delegate.clone(),
+                        )),
+                        cipher: [7u8; 32],
+                        nonce: [9u8; 24],
+                    },
+                    origin,
+                    None,
+                    crate::client_events::ConnectionScope::Local,
+                    None,
+                )
+                .expect("registration must succeed");
+        }
+
+        let dispatch_to_victim = |executor: &mut Executor<Runtime>, caller: &Delegate| {
+            executor.delegate_request(
+                DelegateRequest::ApplicationMessages {
+                    key: victim.key().clone(),
+                    params: Parameters::from(Vec::new()),
+                    inbound: vec![],
+                },
+                None,
+                Some(caller.key()),
+                crate::client_events::ConnectionScope::Local,
+                None,
+            )
+        };
+
+        // REFUSED: the caller has an origin RECORD (registration writes one
+        // unconditionally) but no contract id in it, so it holds no attested
+        // identity to lend.
+        let err = dispatch_to_victim(&mut executor, &unattested)
+            .expect_err("dispatch from an unattested delegate must be refused");
+        assert!(
+            err.to_string().contains("no attested registration origin"),
+            "refusal must name the cause, got: {err}"
+        );
+
+        // CONTROL: an attested caller is NOT refused by this gate. The call
+        // still fails — the fixture delegates are not real WASM — but it must
+        // fail for a DIFFERENT reason, or the gate is refusing everything and
+        // the assertion above proves nothing.
+        let control = dispatch_to_victim(&mut executor, &attested);
+        let control_err = match control {
+            Ok(_) => None,
+            Err(e) => Some(e.to_string()),
+        };
+        assert!(
+            !control_err
+                .as_deref()
+                .is_some_and(|e| e.contains("no attested registration origin")),
+            "an attested caller must pass the dispatch gate, got: {control_err:?}"
+        );
+    }
+
     /// NEVER copies a predecessor's secrets, even when the registering request's
     /// `origin_contract` exactly matches the predecessor's recorded
     /// first-registration origin (the one case the H1 same-origin gate in
     /// `SecretsStore::migrate_secrets` would otherwise allow). The copy-forward
     /// call is disabled at the handler level because `origin_contract` itself is
-    /// forgeable by any HTTP client (see #5198) — so even a "matching" origin
+    /// forgeable by any HTTP client (see GHSA-824h-7x5x-wfmf) — so even a "matching" origin
     /// proves nothing. Registration still succeeds, exactly as plain
-    /// `RegisterDelegate` would. This replaces the pre-#5198 test asserting the
+    /// `RegisterDelegate` would. This replaces the pre-advisory test asserting the
     /// copy DID happen on a matching origin.
     #[tokio::test(flavor = "multi_thread")]
     async fn register_delegate_with_predecessors_never_copies_secrets() {
@@ -1593,7 +1712,13 @@ mod remove_contract_tests {
             predecessors: vec![pred.key().clone()],
         };
         let resp = executor
-            .delegate_request(req, Some(&origin_contract), None, None)
+            .delegate_request(
+                req,
+                Some(&origin_contract),
+                None,
+                crate::client_events::ConnectionScope::Local,
+                None,
+            )
             .expect("register-with-predecessors must succeed");
         match resp {
             HostResponse::DelegateResponse { key, .. } => {
@@ -1603,12 +1728,12 @@ mod remove_contract_tests {
         }
 
         // The predecessor's Local secret must NOT be copied — the copy-forward
-        // is unconditionally disabled (#5198), even though the supplied
+        // is unconditionally disabled (GHSA-824h-7x5x-wfmf), even though the supplied
         // `origin_contract` matches the predecessor's recorded origin exactly
         // (the one case the underlying H1 gate would otherwise have allowed).
         assert!(
             !successor_secret_path.exists(),
-            "successor secret file must NOT exist: copy-forward is disabled (#5198) \
+            "successor secret file must NOT exist: copy-forward is disabled (GHSA-824h-7x5x-wfmf) \
              regardless of origin_contract"
         );
 
@@ -1623,7 +1748,7 @@ mod remove_contract_tests {
         );
     }
 
-    /// Regression test for freenet/freenet-core#5198, directory-level: a
+    /// Regression test for GHSA-824h-7x5x-wfmf, directory-level: a
     /// predecessor holding MULTIPLE Local secrets, named in a
     /// `RegisterDelegateWithPredecessors` request with a matching
     /// `origin_contract`, must leave the successor's on-disk secrets
@@ -1702,7 +1827,13 @@ mod remove_contract_tests {
             predecessors: vec![pred.key().clone()],
         };
         let resp = executor
-            .delegate_request(req, Some(&origin_contract), None, None)
+            .delegate_request(
+                req,
+                Some(&origin_contract),
+                None,
+                crate::client_events::ConnectionScope::Local,
+                None,
+            )
             .expect("register-with-predecessors must succeed");
         assert!(matches!(resp, HostResponse::DelegateResponse { .. }));
 
@@ -1716,7 +1847,7 @@ mod remove_contract_tests {
         assert!(
             !successor_has_any_secret,
             "successor secrets directory must be absent or empty: copy-forward is \
-             disabled (#5198) regardless of origin_contract or predecessor secret count"
+             disabled (GHSA-824h-7x5x-wfmf) regardless of origin_contract or predecessor secret count"
         );
     }
 
@@ -1728,7 +1859,7 @@ mod remove_contract_tests {
     /// registered-but-recordless delegate (a claimable first-writer slot an
     /// attacker could later name as its own) can never exist. Once the disk
     /// recovers, the app's retry registers and records normally (copy-forward
-    /// itself is unconditionally disabled, #5198, so it never copies — see
+    /// itself is unconditionally disabled, GHSA-824h-7x5x-wfmf, so it never copies — see
     /// the final assertion). Uses the fault-injecting redb backend to fail the
     /// origin-record write on demand.
     #[cfg(feature = "redb")]
@@ -1813,7 +1944,13 @@ mod remove_contract_tests {
         };
         assert!(
             executor
-                .delegate_request(req, Some(&origin_contract), None, None)
+                .delegate_request(
+                    req,
+                    Some(&origin_contract),
+                    None,
+                    crate::client_events::ConnectionScope::Local,
+                    None
+                )
                 .is_err(),
             "registration must FAIL when the first-writer origin record cannot persist"
         );
@@ -1838,7 +1975,13 @@ mod remove_contract_tests {
         };
         assert!(
             executor
-                .delegate_request(req_plain, Some(&origin_contract), None, None)
+                .delegate_request(
+                    req_plain,
+                    Some(&origin_contract),
+                    None,
+                    crate::client_events::ConnectionScope::Local,
+                    None
+                )
                 .is_err(),
             "plain RegisterDelegate must ALSO fail when the origin record cannot persist"
         );
@@ -1891,18 +2034,24 @@ mod remove_contract_tests {
             predecessors: vec![pred.key().clone()],
         };
         executor2
-            .delegate_request(req2, Some(&origin_contract), None, None)
+            .delegate_request(
+                req2,
+                Some(&origin_contract),
+                None,
+                crate::client_events::ConnectionScope::Local,
+                None,
+            )
             .expect("retry after recovery must succeed");
         assert!(
             succ_reg_path.exists(),
             "after recovery the successor IS registered (.reg present)"
         );
-        // Copy-forward is unconditionally disabled (#5198): the retry succeeds
+        // Copy-forward is unconditionally disabled (GHSA-824h-7x5x-wfmf): the retry succeeds
         // (registration itself was only ever blocked by the origin-record
         // write failure, now healed), but no secret is ever copied.
         assert!(
             !succ_secret_path.exists(),
-            "the predecessor secret must NOT be copied forward: copy-forward is disabled (#5198)"
+            "the predecessor secret must NOT be copied forward: copy-forward is disabled (GHSA-824h-7x5x-wfmf)"
         );
     }
 
@@ -1944,7 +2093,13 @@ mod remove_contract_tests {
         };
         assert!(
             executor
-                .delegate_request(req_over, None, None, None)
+                .delegate_request(
+                    req_over,
+                    None,
+                    None,
+                    crate::client_events::ConnectionScope::Local,
+                    None
+                )
                 .is_err(),
             "an over-cap UNIQUE predecessor list must be rejected"
         );
@@ -1975,7 +2130,13 @@ mod remove_contract_tests {
             predecessors: dupes,
         };
         executor
-            .delegate_request(req_ok, None, None, None)
+            .delegate_request(
+                req_ok,
+                None,
+                None,
+                crate::client_events::ConnectionScope::Local,
+                None,
+            )
             .expect("a duplicate-heavy but under-cap-UNIQUE list must be accepted");
         assert!(
             reg_path(&succ_ok).exists(),
@@ -1994,7 +2155,13 @@ mod remove_contract_tests {
         };
         assert!(
             executor
-                .delegate_request(req_raw, None, None, None)
+                .delegate_request(
+                    req_raw,
+                    None,
+                    None,
+                    crate::client_events::ConnectionScope::Local,
+                    None
+                )
                 .is_err(),
             "a raw list past the DoS sanity bound must be rejected even when unique count is small"
         );
@@ -2014,7 +2181,13 @@ mod remove_contract_tests {
             predecessors: at_cap,
         };
         executor
-            .delegate_request(req_at_cap, None, None, None)
+            .delegate_request(
+                req_at_cap,
+                None,
+                None,
+                crate::client_events::ConnectionScope::Local,
+                None,
+            )
             .expect("an exactly-at-cap UNIQUE count (64) must be accepted");
         assert!(
             reg_path(&succ_at_cap).exists(),
@@ -2032,7 +2205,13 @@ mod remove_contract_tests {
             predecessors: Vec::new(),
         };
         executor
-            .delegate_request(req_empty, None, None, None)
+            .delegate_request(
+                req_empty,
+                None,
+                None,
+                crate::client_events::ConnectionScope::Local,
+                None,
+            )
             .expect("an empty predecessor list must be accepted (plain-register equivalent)");
         assert!(
             reg_path(&succ_empty).exists(),
@@ -2059,7 +2238,13 @@ mod remove_contract_tests {
             predecessors: raw_at_bound,
         };
         executor
-            .delegate_request(req_raw_boundary, None, None, None)
+            .delegate_request(
+                req_raw_boundary,
+                None,
+                None,
+                crate::client_events::ConnectionScope::Local,
+                None,
+            )
             .expect("a raw list at exactly the sanity bound (unique within cap) must be accepted");
         assert!(
             reg_path(&succ_raw_boundary).exists(),

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -304,13 +304,6 @@ impl ContractExecutor for Executor<Runtime> {
         )
     }
 
-    async fn delegate_attested_origin(
-        &mut self,
-        delegate: &DelegateKey,
-    ) -> Option<ContractInstanceId> {
-        self.registered_delegate_origin(delegate)
-    }
-
     // NOTE: `ContractExecutor::try_begin_export` / `finish_export` are NOT
     // overridden for a bare `Executor<Runtime>` — only the pooled `RuntimePool`
     // can admit a deferred export (it owns the executor pool + the export
@@ -1529,45 +1522,144 @@ mod remove_contract_tests {
             .with_extension("wasm")
     }
 
-    /// Handler-level (GHSA-824h-7x5x-wfmf): `RegisterDelegateWithPredecessors`
-    /// GHSA-824h-7x5x-wfmf, gap 1 (inter-delegate dispatch).
+    /// GHSA-824h-7x5x-wfmf regression: a NON-LOCAL registration must not be able
+    /// to write the durable first-registration origin record.
     ///
-    /// `caller_delegate` is an identity the RUNTIME attests, and it wins over
-    /// every other origin. Before this gate, a delegate could be registered by
-    /// anyone with `origin_contract: None` (no attested identity of its own);
-    /// messaging that delegate makes its own WASM emit `SendDelegateMessage`,
-    /// and the victim then authorizes on `MessageOrigin::Delegate(attacker)`.
-    /// That routes around the connection-scope gate entirely, because the
-    /// attacker never has to hold an attested identity itself.
+    /// The gate on `resolve_message_origin` only controls what a delegate is
+    /// TOLD about its caller. `origin_contract` has a second, far more damaging
+    /// consumer: `register_delegate_and_record_origin` writes it into a record
+    /// that is FIRST-WRITER-WINS and IMMUTABLE. An off-host caller could mint a
+    /// token for any contract id (the node issues one on request, for any id,
+    /// existing or not) and permanently freeze a delegate's recorded provenance
+    /// to a value of their choosing — unrepairable short of wiping the database.
     ///
-    /// A delegate with no recorded registration origin therefore cannot lend
-    /// its identity to anyone. The control half matters as much as the refusal:
-    /// it proves the gate keys on the ORIGIN RECORD and not on "any
-    /// `caller_delegate` is refused", which would break legitimate
-    /// inter-delegate messaging outright.
+    /// Delegate WASM and params are public, so the key is derivable and the
+    /// record can be poisoned BEFORE the legitimate app ever registers.
     #[tokio::test(flavor = "multi_thread")]
-    async fn inter_delegate_dispatch_requires_an_attested_caller_origin() {
+    async fn remote_registration_cannot_write_the_durable_origin_record() {
+        use crate::contract::storages::Storage;
         use freenet_stdlib::client_api::DelegateRequest;
         use freenet_stdlib::prelude::{
-            ContractInstanceId, Delegate, DelegateContainer, DelegateWasmAPIVersion, Parameters,
+            ContractInstanceId, Delegate, DelegateContainer, DelegateWasmAPIVersion,
+        };
+
+        let temp_dir = crate::util::tests::get_temp_dir();
+        let db = Storage::new(temp_dir.path()).await.expect("create db");
+        let contract_store =
+            ContractStore::new(temp_dir.path().join("contracts"), 10_000, db.clone())
+                .expect("contract store");
+        let delegate_store =
+            DelegateStore::new(temp_dir.path().join("delegate"), 10_000, db.clone())
+                .expect("delegate store");
+        let secrets_store = SecretsStore::new(
+            temp_dir.path().join("secrets"),
+            Default::default(),
+            db.clone(),
+        )
+        .expect("secrets store");
+        let state_store = StateStore::new(db.clone(), 10_000_000).expect("state store");
+        let runtime = Runtime::build(contract_store, delegate_store, secrets_store, false)
+            .expect("build runtime");
+        let mut executor = Executor::new(
+            state_store,
+            || Ok(()),
+            crate::contract::executor::OperationMode::Local,
+            runtime,
+            None,
+        )
+        .await
+        .expect("create executor");
+
+        let victim = Delegate::from((&vec![0u8].into(), &vec![0xD4u8].into()));
+        let attacker_claim = ContractInstanceId::new([0x99u8; 32]);
+
+        // An off-host caller registers the delegate, presenting a token bound to
+        // a contract id it does not own.
+        executor
+            .delegate_request(
+                DelegateRequest::RegisterDelegate {
+                    delegate: DelegateContainer::Wasm(DelegateWasmAPIVersion::V1(victim.clone())),
+                    cipher: [7u8; 32],
+                    nonce: [9u8; 24],
+                },
+                Some(&attacker_claim),
+                None,
+                crate::client_events::ConnectionScope::Remote,
+                None,
+            )
+            .expect("registration itself still succeeds; only the attestation is withheld");
+
+        let (_has_admin_none, origins) = db
+            .get_delegate_origins(victim.key())
+            .expect("record must be readable")
+            .expect("registration must have written a record");
+        assert!(
+            origins.is_empty(),
+            "a non-local registration must record NO contract id (the record is \
+             immutable, so a poisoned value can never be corrected); got {origins:?}"
+        );
+
+        // Control: the SAME request from a local connection DOES record the id,
+        // so the assertion above is about the scope gate and not about the
+        // record being write-only.
+        let legit = Delegate::from((&vec![0u8].into(), &vec![0xD5u8].into()));
+        let app = ContractInstanceId::new([0x11u8; 32]);
+        executor
+            .delegate_request(
+                DelegateRequest::RegisterDelegate {
+                    delegate: DelegateContainer::Wasm(DelegateWasmAPIVersion::V1(legit.clone())),
+                    cipher: [7u8; 32],
+                    nonce: [9u8; 24],
+                },
+                Some(&app),
+                None,
+                crate::client_events::ConnectionScope::Local,
+                None,
+            )
+            .expect("local registration must succeed");
+
+        let (_, origins) = db
+            .get_delegate_origins(legit.key())
+            .expect("record must be readable")
+            .expect("registration must have written a record");
+        assert_eq!(
+            origins.len(),
+            1,
+            "a local registration must still record its attested contract id"
+        );
+        assert_eq!(origins[0], *app.as_bytes(), "wrong contract id recorded");
+    }
+
+    /// GHSA-824h-7x5x-wfmf regression: an UNATTESTED delegate must still be
+    /// able to send delegate-to-delegate messages.
+    ///
+    /// A revision of that fix refused to dispatch from any delegate whose
+    /// first-registration record held no contract id. That record is `None` both
+    /// for "never registered here" AND for the tokenless local CLI shape, so it
+    /// silently broke every delegate installed by riverctl / atlasctl / fdev —
+    /// silently because the caller swallows the error into a warning and the
+    /// client still receives `Ok` with the second delegate's reply simply
+    /// missing. Re-adding any such gate must fail here.
+    ///
+    /// The escalation that gate was aimed at is closed by connection scope
+    /// instead (`resolve_message_origin` returns `None` for a non-local
+    /// connection, and the scope is propagated into the hop), which the
+    /// `remote_connection_gets_no_caller_delegate_origin` unit test pins.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn unattested_delegate_can_still_dispatch_to_another_delegate() {
+        use freenet_stdlib::client_api::DelegateRequest;
+        use freenet_stdlib::prelude::{
+            Delegate, DelegateContainer, DelegateWasmAPIVersion, Parameters,
         };
 
         let (mut executor, _contracts_dir, _temp) =
-            build_disk_executor("inter-delegate-origin").await;
+            build_disk_executor("unattested-inter-delegate").await;
 
-        // Registered by a caller holding NO attested identity — the "anyone can
-        // install this" case.
-        let unattested = Delegate::from((&vec![0u8].into(), &vec![0xA1u8].into()));
-        // Registered by a real web app, so it HAS a recorded origin.
-        let attested = Delegate::from((&vec![0u8].into(), &vec![0xB2u8].into()));
+        // Registered with NO attested origin — the tokenless CLI shape.
+        let cli_delegate = Delegate::from((&vec![0u8].into(), &vec![0xA1u8].into()));
         let victim = Delegate::from((&vec![0u8].into(), &vec![0xC3u8].into()));
-        let app = ContractInstanceId::new([0x5Au8; 32]);
 
-        for (delegate, origin) in [
-            (&unattested, None),
-            (&attested, Some(&app)),
-            (&victim, Some(&app)),
-        ] {
+        for delegate in [&cli_delegate, &victim] {
             executor
                 .delegate_request(
                     DelegateRequest::RegisterDelegate {
@@ -1577,7 +1669,7 @@ mod remove_contract_tests {
                         cipher: [7u8; 32],
                         nonce: [9u8; 24],
                     },
-                    origin,
+                    None,
                     None,
                     crate::client_events::ConnectionScope::Local,
                     None,
@@ -1585,47 +1677,32 @@ mod remove_contract_tests {
                 .expect("registration must succeed");
         }
 
-        let dispatch_to_victim = |executor: &mut Executor<Runtime>, caller: &Delegate| {
-            executor.delegate_request(
-                DelegateRequest::ApplicationMessages {
-                    key: victim.key().clone(),
-                    params: Parameters::from(Vec::new()),
-                    inbound: vec![],
-                },
-                None,
-                Some(caller.key()),
-                crate::client_events::ConnectionScope::Local,
-                None,
-            )
-        };
-
-        // REFUSED: the caller has an origin RECORD (registration writes one
-        // unconditionally) but no contract id in it, so it holds no attested
-        // identity to lend.
-        let err = dispatch_to_victim(&mut executor, &unattested)
-            .expect_err("dispatch from an unattested delegate must be refused");
-        assert!(
-            err.to_string().contains("no attested registration origin"),
-            "refusal must name the cause, got: {err}"
+        let result = executor.delegate_request(
+            DelegateRequest::ApplicationMessages {
+                key: victim.key().clone(),
+                params: Parameters::from(Vec::new()),
+                inbound: vec![],
+            },
+            None,
+            Some(cli_delegate.key()),
+            crate::client_events::ConnectionScope::Local,
+            None,
         );
 
-        // CONTROL: an attested caller is NOT refused by this gate. The call
-        // still fails — the fixture delegates are not real WASM — but it must
-        // fail for a DIFFERENT reason, or the gate is refusing everything and
-        // the assertion above proves nothing.
-        let control = dispatch_to_victim(&mut executor, &attested);
-        let control_err = match control {
-            Ok(_) => None,
-            Err(e) => Some(e.to_string()),
-        };
-        assert!(
-            !control_err
-                .as_deref()
-                .is_some_and(|e| e.contains("no attested registration origin")),
-            "an attested caller must pass the dispatch gate, got: {control_err:?}"
-        );
+        // The fixture delegates are not real WASM, so the call still fails — but
+        // it must fail on EXECUTION, never on a provenance/attestation refusal.
+        // Asserting on the absence of that refusal is the whole point: a
+        // re-introduced gate would short-circuit before execution.
+        if let Err(e) = result {
+            let msg = e.to_string();
+            assert!(
+                !msg.contains("attested registration origin") && !msg.contains("dispatch refused"),
+                "an unattested delegate must not be refused dispatch; got: {msg}"
+            );
+        }
     }
 
+    /// Handler-level (GHSA-824h-7x5x-wfmf): `RegisterDelegateWithPredecessors`
     /// NEVER copies a predecessor's secrets, even when the registering request's
     /// `origin_contract` exactly matches the predecessor's recorded
     /// first-registration origin (the one case the H1 same-origin gate in

--- a/crates/core/src/contract/executor/runtime/delegates.rs
+++ b/crates/core/src/contract/executor/runtime/delegates.rs
@@ -218,11 +218,25 @@ impl Executor<Runtime> {
         }
     }
 
+    /// The contract id `delegate` was FIRST registered under, read from the
+    /// durable first-writer origin record (`register_delegate_and_record_origin`).
+    /// `None` when it was registered by a caller with no attested identity, is
+    /// unknown here, or the record could not be read (fail closed).
+    pub(crate) fn registered_delegate_origin(
+        &self,
+        delegate: &DelegateKey,
+    ) -> Option<ContractInstanceId> {
+        self.runtime
+            .delegate_registration_origin(delegate)
+            .map(ContractInstanceId::new)
+    }
+
     pub fn delegate_request(
         &mut self,
         req: DelegateRequest<'_>,
         origin_contract: Option<&ContractInstanceId>,
         caller_delegate: Option<&DelegateKey>,
+        connection_scope: crate::client_events::ConnectionScope,
         user_context: Option<&UserSecretContext>,
     ) -> Response {
         // Mutual exclusion invariant: a single inbound delegate request is
@@ -242,8 +256,38 @@ impl Executor<Runtime> {
         tracing::debug!(
             origin_contract = ?origin_contract,
             caller_delegate = ?caller_delegate.map(|k| k.to_string()),
+            connection_scope = ?connection_scope,
             "received delegate request"
         );
+
+        // INTER-DELEGATE DISPATCH GATE (GHSA-824h-7x5x-wfmf).
+        //
+        // `caller_delegate` is a runtime-attested identity that wins over every
+        // other origin (see `resolve_message_origin`), so it is a way to hand a
+        // victim delegate an attested caller. A delegate registered WITHOUT an
+        // origin record is one anybody could install — messaging it makes its
+        // own WASM emit `SendDelegateMessage`, and the victim would then
+        // authorize on `MessageOrigin::Delegate(attacker)`. Refuse to dispatch
+        // from such a delegate at all: an unattested delegate cannot lend its
+        // identity to anyone.
+        //
+        // The record is durable and written BEFORE the delegate is registered
+        // (`register_delegate_and_record_origin`), so "no contract id recorded"
+        // is a definite answer, not a race. A read failure yields `None` and is
+        // likewise refused (fail closed).
+        if let Some(caller) = caller_delegate {
+            if self.registered_delegate_origin(caller).is_none() {
+                tracing::warn!(
+                    caller_delegate = %caller,
+                    target_delegate = %req.key(),
+                    "refusing inter-delegate dispatch: caller has no attested registration origin"
+                );
+                return Err(ExecutorError::other(anyhow::anyhow!(
+                    "inter-delegate dispatch refused: calling delegate has no attested registration origin"
+                )));
+            }
+        }
+
         match req {
             DelegateRequest::RegisterDelegate {
                 delegate,
@@ -313,13 +357,13 @@ impl Executor<Runtime> {
                     )));
                 }
 
-                // SECURITY (freenet/freenet-core#5198): the predecessor secret
+                // SECURITY (GHSA-824h-7x5x-wfmf): the predecessor secret
                 // copy-forward below `self.runtime.migrate_delegate_secrets(...)`
                 // is INTENTIONALLY NEVER CALLED. `SecretsStore::migrate_secrets`
                 // gates the copy on `origin_contract` matching the predecessor's
                 // recorded first-registration origin, but `origin_contract` is
                 // forgeable by any HTTP client through the webapp-shell token
-                // issuance path (see #5198 for the full exploit chain) — so the
+                // issuance path (see GHSA-824h-7x5x-wfmf for the full exploit chain) — so the
                 // gate does not actually authorize anything. Do NOT re-enable
                 // this call without first hardening how `origin_contract` is
                 // attested; the gate itself remains sound given a trustworthy
@@ -333,7 +377,7 @@ impl Executor<Runtime> {
                         predecessors = deduped.len(),
                         "RegisterDelegateWithPredecessors: predecessor secret \
                          copy-forward is disabled pending a security fix (see \
-                         freenet/freenet-core#5198); registering the delegate \
+                         GHSA-824h-7x5x-wfmf); registering the delegate \
                          without migrating any secrets"
                     );
                 }
@@ -386,6 +430,27 @@ impl Executor<Runtime> {
                     caller_delegate,
                     origin_contract,
                     &key,
+                    connection_scope,
+                );
+                // AUDIT (info!, not debug! — the crate builds with
+                // `release_max_level_info`, so a `debug!` here would compile out
+                // of every shipped binary and the audit trail would exist only
+                // in development). Ids only: no token values, no key material.
+                tracing::info!(
+                    delegate_key = %key,
+                    origin_kind = match origin.as_ref() {
+                        None => "none",
+                        Some(MessageOrigin::WebApp(_)) => "web_app",
+                        Some(MessageOrigin::Delegate(_)) => "delegate",
+                        Some(_) => "other",
+                    },
+                    origin_id = ?origin.as_ref().map(|o| match o {
+                        MessageOrigin::WebApp(c) => c.to_string(),
+                        MessageOrigin::Delegate(d) => d.to_string(),
+                        other => format!("{other:?}"),
+                    }),
+                    loopback = connection_scope.is_local(),
+                    "delegate ApplicationMessages: resolved message origin"
                 );
                 match self.runtime.inbound_app_message(
                     &key,
@@ -453,7 +518,26 @@ fn resolve_message_origin(
     caller_delegate: Option<&DelegateKey>,
     origin_contract: Option<&ContractInstanceId>,
     delegate_key: &DelegateKey,
+    connection_scope: crate::client_events::ConnectionScope,
 ) -> Option<MessageOrigin> {
+    // GATE THE RESOLVED ORIGIN, NOT ONE OF ITS INPUTS (GHSA-824h-7x5x-wfmf).
+    //
+    // The obvious-looking fix — refuse to look up `origin_contract` for an
+    // off-host caller — closes only branch 2. Branch 3 is keyed on the TARGET
+    // delegate, not on anything the caller supplied, so it would keep handing a
+    // tokenless off-host caller a fully-attested WebApp origin for any delegate
+    // that happens to carry an inherited attestation. Branch 1 is likewise
+    // caller-independent once a delegate has been induced to emit
+    // `SendDelegateMessage`. Returning early HERE is the only placement that
+    // covers all three by construction, and it stays correct if a fourth branch
+    // is ever added below.
+    //
+    // Withholding attestation is not an error: the caller sees exactly what a
+    // tokenless local caller has always seen (`None`), so nothing on the wire
+    // changes and no new response variant is needed.
+    if !connection_scope.is_local() {
+        return None;
+    }
     if let Some(caller) = caller_delegate {
         Some(MessageOrigin::Delegate(caller.clone()))
     } else if let Some(contract_id) = origin_contract {
@@ -472,6 +556,7 @@ fn resolve_message_origin(
 #[cfg(test)]
 mod resolve_message_origin_tests {
     use super::*;
+    use crate::client_events::ConnectionScope;
     use freenet_stdlib::prelude::CodeHash;
 
     fn dkey(seed: u8) -> DelegateKey {
@@ -518,8 +603,13 @@ mod resolve_message_origin_tests {
         let recipient = dkey(0xB2);
         let app_contract = ContractInstanceId::new([0xC3; 32]);
 
-        let origin =
-            resolve_message_origin(&origins(), Some(&caller), Some(&app_contract), &recipient);
+        let origin = resolve_message_origin(
+            &origins(),
+            Some(&caller),
+            Some(&app_contract),
+            &recipient,
+            ConnectionScope::Local,
+        );
 
         match origin {
             Some(MessageOrigin::Delegate(k)) => assert_eq!(k, caller),
@@ -534,7 +624,13 @@ mod resolve_message_origin_tests {
         let recipient = dkey(0xB2);
         let app_contract = ContractInstanceId::new([0xC3; 32]);
 
-        let origin = resolve_message_origin(&origins(), None, Some(&app_contract), &recipient);
+        let origin = resolve_message_origin(
+            &origins(),
+            None,
+            Some(&app_contract),
+            &recipient,
+            ConnectionScope::Local,
+        );
 
         match origin {
             Some(MessageOrigin::WebApp(id)) => assert_eq!(id, app_contract),
@@ -549,7 +645,8 @@ mod resolve_message_origin_tests {
     fn no_arguments_and_no_inherited_yields_none() {
         let recipient = dkey(0xEE);
 
-        let origin = resolve_message_origin(&origins(), None, None, &recipient);
+        let origin =
+            resolve_message_origin(&origins(), None, None, &recipient, ConnectionScope::Local);
         assert!(origin.is_none(), "Expected None, got {origin:?}");
     }
 
@@ -570,7 +667,13 @@ mod resolve_message_origin_tests {
             crate::wasm_runtime::InheritedOriginsEntry::new(vec![inherited_contract]),
         );
 
-        let origin = resolve_message_origin(&origins, Some(&caller), None, &recipient);
+        let origin = resolve_message_origin(
+            &origins,
+            Some(&caller),
+            None,
+            &recipient,
+            ConnectionScope::Local,
+        );
 
         match origin {
             Some(MessageOrigin::Delegate(k)) => assert_eq!(k, caller),
@@ -594,7 +697,8 @@ mod resolve_message_origin_tests {
             InheritedOriginsEntry::new(vec![contract]),
         );
 
-        let origin = resolve_message_origin(&origins, None, None, &recipient);
+        let origin =
+            resolve_message_origin(&origins, None, None, &recipient, ConnectionScope::Local);
 
         assert!(
             matches!(origin, Some(MessageOrigin::WebApp(c)) if c == contract),
@@ -626,14 +730,139 @@ mod resolve_message_origin_tests {
 
         assert!(
             matches!(
-                resolve_message_origin(&node_a, None, None, &recipient),
+                resolve_message_origin(&node_a, None, None, &recipient, ConnectionScope::Local),
                 Some(MessageOrigin::WebApp(c)) if c == contract
             ),
             "node A resolves its own inherited origin"
         );
         assert!(
-            resolve_message_origin(&node_b, None, None, &recipient).is_none(),
+            resolve_message_origin(&node_b, None, None, &recipient, ConnectionScope::Local)
+                .is_none(),
             "node B must NOT resolve node A's inherited origin for the same key"
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // GHSA-824h-7x5x-wfmf: a connection the node cannot prove is local gets NO
+    // attested origin — through EVERY branch of `resolve_message_origin`.
+    //
+    // These three are the load-bearing ones. The advisory's near-miss is a fix
+    // that gates only branch 2 (`origin_contract`, the input the caller's token
+    // produced) and leaves branches 1 and 3 open: branch 3 is keyed on the
+    // TARGET delegate, so it would keep attesting a WebApp origin for a caller
+    // that supplied nothing at all. Revert the `!connection_scope.is_local()`
+    // early return and `remote_connection_gets_no_inherited_origin` fails while
+    // a branch-2-only fix would leave it passing.
+    // ---------------------------------------------------------------------
+
+    /// Branch 2: a remote caller holding a valid auth token still gets nothing.
+    #[test]
+    fn remote_connection_gets_no_webapp_origin_from_token() {
+        let recipient = dkey(0xB2);
+        let app_contract = ContractInstanceId::new([0xC3; 32]);
+
+        let origin = resolve_message_origin(
+            &origins(),
+            None,
+            Some(&app_contract),
+            &recipient,
+            ConnectionScope::Remote,
+        );
+        assert!(
+            origin.is_none(),
+            "a non-loopback connection must receive NO attested origin, got {origin:?}"
+        );
+    }
+
+    /// Branch 3: the branch a token-input-only gate misses. The caller supplies
+    /// NOTHING — the origin comes from the node's own attestation map, keyed on
+    /// the delegate being messaged — so gating the caller's input cannot help.
+    #[test]
+    fn remote_connection_gets_no_inherited_origin() {
+        use crate::wasm_runtime::InheritedOriginsEntry;
+
+        let recipient = dkey(0xC5);
+        let contract = ContractInstanceId::new([0xC6; 32]);
+        let origins = origins();
+        origins.insert(
+            recipient.clone(),
+            InheritedOriginsEntry::new(vec![contract]),
+        );
+
+        // Sanity: the same call from a local connection DOES attest, so this
+        // test is asserting on the scope gate and not on an empty map.
+        assert!(
+            resolve_message_origin(&origins, None, None, &recipient, ConnectionScope::Local)
+                .is_some(),
+            "fixture must attest for a local connection, or the assertion below is vacuous"
+        );
+
+        let origin =
+            resolve_message_origin(&origins, None, None, &recipient, ConnectionScope::Remote);
+        assert!(
+            origin.is_none(),
+            "a non-loopback connection must not inherit the target delegate's \
+             WebApp attestation, got {origin:?}"
+        );
+    }
+
+    /// Branch 1: the highest-precedence branch, which wins unconditionally over
+    /// the other two, is gated as well.
+    #[test]
+    fn remote_connection_gets_no_caller_delegate_origin() {
+        let caller = dkey(0xA1);
+        let recipient = dkey(0xB3);
+
+        assert!(
+            resolve_message_origin(
+                &origins(),
+                Some(&caller),
+                None,
+                &recipient,
+                ConnectionScope::Local
+            )
+            .is_some(),
+            "fixture must attest for a local connection, or the assertion below is vacuous"
+        );
+
+        let origin = resolve_message_origin(
+            &origins(),
+            Some(&caller),
+            None,
+            &recipient,
+            ConnectionScope::Remote,
+        );
+        assert!(
+            origin.is_none(),
+            "a non-loopback connection must not receive an attested caller \
+             delegate identity, got {origin:?}"
+        );
+    }
+
+    /// The gate must be on the RESOLVED value, not bolted onto one branch. A
+    /// future fourth branch added below the early return is covered for free;
+    /// one added above it is not. Pin the early return's position so a
+    /// refactor that moves the branch dispatch above it fails here.
+    #[test]
+    fn scope_gate_precedes_every_branch_in_source() {
+        let src = include_str!("delegates.rs");
+        let body = src
+            .split("fn resolve_message_origin(")
+            .nth(1)
+            .expect("resolve_message_origin must exist")
+            .split("\n#[cfg(test)]")
+            .next()
+            .expect("function body is bounded by the test module");
+        let gate = body
+            .find("if !connection_scope.is_local() {")
+            .expect("resolve_message_origin must early-return for a non-local connection");
+        let first_branch = body
+            .find("if let Some(caller) = caller_delegate {")
+            .expect("branch 1 must exist");
+        assert!(
+            gate < first_branch,
+            "the connection-scope gate must run BEFORE any origin branch, so a \
+             branch added later is covered by construction"
         );
     }
 }

--- a/crates/core/src/contract/executor/runtime/delegates.rs
+++ b/crates/core/src/contract/executor/runtime/delegates.rs
@@ -218,19 +218,6 @@ impl Executor<Runtime> {
         }
     }
 
-    /// The contract id `delegate` was FIRST registered under, read from the
-    /// durable first-writer origin record (`register_delegate_and_record_origin`).
-    /// `None` when it was registered by a caller with no attested identity, is
-    /// unknown here, or the record could not be read (fail closed).
-    pub(crate) fn registered_delegate_origin(
-        &self,
-        delegate: &DelegateKey,
-    ) -> Option<ContractInstanceId> {
-        self.runtime
-            .delegate_registration_origin(delegate)
-            .map(ContractInstanceId::new)
-    }
-
     pub fn delegate_request(
         &mut self,
         req: DelegateRequest<'_>,
@@ -253,6 +240,36 @@ impl Executor<Runtime> {
             "execute_delegate_request: at most one of origin_contract and \
              caller_delegate may be Some (got both)"
         );
+        // GATE THE ORIGIN FOR *EVERY* CONSUMER, NOT JUST MESSAGE RESOLUTION
+        // (GHSA-824h-7x5x-wfmf).
+        //
+        // `resolve_message_origin` gates what a delegate is TOLD about its
+        // caller, but `origin_contract` has a second, more durable consumer:
+        // `register_delegate_and_record_origin` writes it into the immutable
+        // first-writer origin record. Leaving THAT ungated let a remote caller
+        // mint a token for any contract id and register a delegate whose record
+        // then claims that identity — which:
+        //
+        //   1. defeats the inter-delegate dispatch gate below, since the
+        //      attacker's own delegate now has "an attested registration
+        //      origin" and can lend it to a victim delegate; and
+        //   2. enables durable denial by first-writer-poisoning a delegate key
+        //      that is not yet registered locally (WASM and params are public,
+        //      so the key is derivable), permanently fixing its attested origin
+        //      to an attacker value so `route_to_apps` drops every notification
+        //      to the legitimate app.
+        //
+        // The rustdoc on `register_delegate_and_record_origin` names "stealing
+        // the victim's provenance" as the threat the record exists to resist, so
+        // an ungated write is exactly the hole it was built to close. Shadow the
+        // parameter here so no arm below can reach the raw value.
+
+        let origin_contract = if connection_scope.is_local() {
+            origin_contract
+        } else {
+            None
+        };
+
         tracing::debug!(
             origin_contract = ?origin_contract,
             caller_delegate = ?caller_delegate.map(|k| k.to_string()),
@@ -260,33 +277,33 @@ impl Executor<Runtime> {
             "received delegate request"
         );
 
-        // INTER-DELEGATE DISPATCH GATE (GHSA-824h-7x5x-wfmf).
+        // WHY THERE IS NO REGISTRATION-RECORD GATE ON `caller_delegate`
+        // (GHSA-824h-7x5x-wfmf). An earlier revision of this fix refused to
+        // dispatch from any delegate whose first-registration record held no
+        // contract id. It was removed, for two independent reasons:
         //
-        // `caller_delegate` is a runtime-attested identity that wins over every
-        // other origin (see `resolve_message_origin`), so it is a way to hand a
-        // victim delegate an attested caller. A delegate registered WITHOUT an
-        // origin record is one anybody could install — messaging it makes its
-        // own WASM emit `SendDelegateMessage`, and the victim would then
-        // authorize on `MessageOrigin::Delegate(attacker)`. Refuse to dispatch
-        // from such a delegate at all: an unattested delegate cannot lend its
-        // identity to anyone.
+        //  1. It BROKE legitimate use. That record is `None` both for "never
+        //     registered here" and for the tokenless local CLI shape, so every
+        //     delegate installed by riverctl / atlasctl / fdev lost the ability
+        //     to emit `SendDelegateMessage` — silently, because the caller
+        //     swallows the error into a warning and the client still sees `Ok`
+        //     with the reply simply missing.
+        //  2. It was not protecting anything. `caller_delegate` is set by the
+        //     runtime from the key of the delegate that actually ran, and a
+        //     `DelegateKey` is a hash of that delegate's own code and params. So
+        //     `MessageOrigin::Delegate(K)` is SELF-AUTHENTICATING: a caller can
+        //     only ever speak as code it actually got registered, never as some
+        //     other delegate. There is no identity to forge here.
         //
-        // The record is durable and written BEFORE the delegate is registered
-        // (`register_delegate_and_record_origin`), so "no contract id recorded"
-        // is a definite answer, not a race. A read failure yields `None` and is
-        // likewise refused (fail closed).
-        if let Some(caller) = caller_delegate {
-            if self.registered_delegate_origin(caller).is_none() {
-                tracing::warn!(
-                    caller_delegate = %caller,
-                    target_delegate = %req.key(),
-                    "refusing inter-delegate dispatch: caller has no attested registration origin"
-                );
-                return Err(ExecutorError::other(anyhow::anyhow!(
-                    "inter-delegate dispatch refused: calling delegate has no attested registration origin"
-                )));
-            }
-        }
+        // The escalation this gate was aimed at — an off-host caller laundering
+        // its lack of attestation through a delegate hop — is closed where it
+        // should be, by `resolve_message_origin` returning `None` for a non-local
+        // connection: `contract.rs` propagates the ORIGINATING connection scope
+        // into the hop, so the target sees no attestation either. What remains is
+        // that a delegate may present its own key to another delegate. A delegate
+        // that authorizes arbitrary peer delegate keys is making its own trust
+        // decision; the runtime's job is only to make that key unforgeable, which
+        // it does.
 
         match req {
             DelegateRequest::RegisterDelegate {
@@ -437,28 +454,29 @@ impl Executor<Runtime> {
                 // of every shipped binary and the audit trail would exist only
                 // in development). Ids only: no token values, no key material.
                 //
-                // Two events are worth recording: an operation that RECEIVED an
-                // attested identity, and one that was REFUSED one. The remaining
-                // case — a local caller with no identity to begin with, the
-                // tokenless CLI shape — is neither, and it is also the highest
-                // volume, so it is not logged. Without that exclusion this line
-                // fires once per delegate message on a chatty app.
-                if origin.is_some() || !connection_scope.is_local() {
+                // REFUSALS ONLY. An earlier revision also logged every
+                // successfully-attested operation, on the reasoning that the
+                // unattested local case was the high-volume one. That was exactly
+                // backwards: the high-volume case is a web app WITH a token,
+                // which resolves `Some` on every single `ApplicationMessages` —
+                // and, because branch 3 resolves an inherited origin, on every
+                // contract-notification invocation too. A River node in a busy
+                // room would have emitted one shipped INFO per room update.
+                //
+                // Dropping the success case loses nothing: the GRANT of an
+                // attested identity is already recorded once, with the peer
+                // address, at the issuance point in
+                // `server::client_api::render_shell_response`. Re-logging it per
+                // message adds volume, not information. What is NOT recorded
+                // anywhere else, and is genuinely rare, is a connection being
+                // REFUSED attestation — so that is what this line reports.
+                if !connection_scope.is_local() {
                     tracing::info!(
                         delegate_key = %key,
-                        origin_kind = match origin.as_ref() {
-                            None => "none",
-                            Some(MessageOrigin::WebApp(_)) => "web_app",
-                            Some(MessageOrigin::Delegate(_)) => "delegate",
-                            Some(_) => "other",
-                        },
-                        origin_id = ?origin.as_ref().map(|o| match o {
-                            MessageOrigin::WebApp(c) => c.to_string(),
-                            MessageOrigin::Delegate(d) => d.to_string(),
-                            other => format!("{other:?}"),
-                        }),
-                        loopback = connection_scope.is_local(),
-                        "delegate ApplicationMessages: resolved message origin"
+                        from_delegate = ?caller_delegate.map(|k| k.to_string()),
+                        loopback = false,
+                        "delegate ApplicationMessages: withheld attested origin \
+                         from a non-local connection (GHSA-824h-7x5x-wfmf)"
                     );
                 }
                 match self.runtime.inbound_app_message(

--- a/crates/core/src/contract/executor/runtime/delegates.rs
+++ b/crates/core/src/contract/executor/runtime/delegates.rs
@@ -436,22 +436,31 @@ impl Executor<Runtime> {
                 // `release_max_level_info`, so a `debug!` here would compile out
                 // of every shipped binary and the audit trail would exist only
                 // in development). Ids only: no token values, no key material.
-                tracing::info!(
-                    delegate_key = %key,
-                    origin_kind = match origin.as_ref() {
-                        None => "none",
-                        Some(MessageOrigin::WebApp(_)) => "web_app",
-                        Some(MessageOrigin::Delegate(_)) => "delegate",
-                        Some(_) => "other",
-                    },
-                    origin_id = ?origin.as_ref().map(|o| match o {
-                        MessageOrigin::WebApp(c) => c.to_string(),
-                        MessageOrigin::Delegate(d) => d.to_string(),
-                        other => format!("{other:?}"),
-                    }),
-                    loopback = connection_scope.is_local(),
-                    "delegate ApplicationMessages: resolved message origin"
-                );
+                //
+                // Two events are worth recording: an operation that RECEIVED an
+                // attested identity, and one that was REFUSED one. The remaining
+                // case — a local caller with no identity to begin with, the
+                // tokenless CLI shape — is neither, and it is also the highest
+                // volume, so it is not logged. Without that exclusion this line
+                // fires once per delegate message on a chatty app.
+                if origin.is_some() || !connection_scope.is_local() {
+                    tracing::info!(
+                        delegate_key = %key,
+                        origin_kind = match origin.as_ref() {
+                            None => "none",
+                            Some(MessageOrigin::WebApp(_)) => "web_app",
+                            Some(MessageOrigin::Delegate(_)) => "delegate",
+                            Some(_) => "other",
+                        },
+                        origin_id = ?origin.as_ref().map(|o| match o {
+                            MessageOrigin::WebApp(c) => c.to_string(),
+                            MessageOrigin::Delegate(d) => d.to_string(),
+                            other => format!("{other:?}"),
+                        }),
+                        loopback = connection_scope.is_local(),
+                        "delegate ApplicationMessages: resolved message origin"
+                    );
+                }
                 match self.runtime.inbound_app_message(
                     &key,
                     &params,

--- a/crates/core/src/contract/executor/runtime/pool.rs
+++ b/crates/core/src/contract/executor/runtime/pool.rs
@@ -1170,11 +1170,29 @@ impl ContractExecutor for RuntimePool {
         req: DelegateRequest<'_>,
         origin_contract: Option<&ContractInstanceId>,
         caller_delegate: Option<&DelegateKey>,
+        connection_scope: crate::client_events::ConnectionScope,
         user_context: Option<&UserSecretContext>,
     ) -> Response {
         let mut executor = self.pop_executor().await;
-        let result = executor.delegate_request(req, origin_contract, caller_delegate, user_context);
+        let result = executor.delegate_request(
+            req,
+            origin_contract,
+            caller_delegate,
+            connection_scope,
+            user_context,
+        );
         self.return_checked(executor, "execute_delegate_request")
+            .await;
+        result
+    }
+
+    async fn delegate_attested_origin(
+        &mut self,
+        delegate: &DelegateKey,
+    ) -> Option<ContractInstanceId> {
+        let executor = self.pop_executor().await;
+        let result = executor.registered_delegate_origin(delegate);
+        self.return_checked(executor, "delegate_attested_origin")
             .await;
         result
     }

--- a/crates/core/src/contract/executor/runtime/pool.rs
+++ b/crates/core/src/contract/executor/runtime/pool.rs
@@ -1186,17 +1186,6 @@ impl ContractExecutor for RuntimePool {
         result
     }
 
-    async fn delegate_attested_origin(
-        &mut self,
-        delegate: &DelegateKey,
-    ) -> Option<ContractInstanceId> {
-        let executor = self.pop_executor().await;
-        let result = executor.registered_delegate_origin(delegate);
-        self.return_checked(executor, "delegate_attested_origin")
-            .await;
-        result
-    }
-
     fn try_begin_export(
         &mut self,
         user_context: &UserSecretContext,

--- a/crates/core/src/contract/fair_queue.rs
+++ b/crates/core/src/contract/fair_queue.rs
@@ -1287,6 +1287,7 @@ mod tests {
                         inbound: vec![],
                     },
                     origin_contract: None,
+                    connection_scope: crate::client_events::ConnectionScope::Local,
                     user_context: None,
                 },
             ),

--- a/crates/core/src/contract/handler.rs
+++ b/crates/core/src/contract/handler.rs
@@ -812,6 +812,12 @@ pub(crate) enum ContractHandlerEvent {
     DelegateRequest {
         req: DelegateRequest<'static>,
         origin_contract: Option<ContractInstanceId>,
+        /// Whether the issuing connection may receive an ATTESTED application
+        /// identity (GHSA-824h-7x5x-wfmf). Carried on the same forge-proof
+        /// channel as `user_context`; the executor withholds every attested
+        /// [`freenet_stdlib::prelude::MessageOrigin`] when this is
+        /// [`ConnectionScope::Remote`].
+        connection_scope: crate::client_events::ConnectionScope,
         /// Per-connection per-user secret namespace (hosted mode, P2 of #4381),
         /// derived once at the WS connection boundary from the connection's
         /// user token. `None` outside hosted mode or when no token was

--- a/crates/core/src/contract/storages/redb.rs
+++ b/crates/core/src/contract/storages/redb.rs
@@ -176,9 +176,9 @@ pub(crate) const MIGRATION_MARKER_TABLE: TableDefinition<&[u8], &[u8]> =
 /// origin is among the predecessor's recorded origins (or both are the Admin/None
 /// class).
 ///
-/// **This gate alone is NOT sufficient protection (freenet/freenet-core#5198).**
+/// **This gate alone is NOT sufficient protection (GHSA-824h-7x5x-wfmf).**
 /// The registering request's `origin_contract` is itself forgeable by any HTTP
-/// client (see #5198 for the exploit chain), so a malicious web-app CAN obtain
+/// client (see GHSA-824h-7x5x-wfmf for the exploit chain), so a malicious web-app CAN obtain
 /// a value that matches an unrelated victim delegate's recorded origin. The
 /// actual protection today is that the copy-forward's sole caller
 /// (`RegisterDelegateWithPredecessors`'s handler) is unconditionally disabled —

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -4881,6 +4881,7 @@ pub async fn run_local_node(
             notification_channel,
             token,
             origin_contract,
+            connection_scope,
             user_context,
             ..
         } = req;
@@ -4912,7 +4913,17 @@ pub async fn run_local_node(
                 );
                 // `user_context` is `Some` only in hosted mode with a user token;
                 // `None` keeps secrets on the single-user `SecretScope::Local`.
-                executor.delegate_request(op, origin_contract.as_ref(), None, user_context.as_ref())
+                // `connection_scope` decides whether this request may receive an
+                // ATTESTED application identity (GHSA-824h-7x5x-wfmf). It comes
+                // from the connection layer on the same forge-proof channel as
+                // `origin_contract` and `user_context`.
+                executor.delegate_request(
+                    op,
+                    origin_contract.as_ref(),
+                    None,
+                    connection_scope,
+                    user_context.as_ref(),
+                )
             }
             ClientRequest::Disconnect { cause } => {
                 if let Some(cause) = cause {

--- a/crates/core/src/server.rs
+++ b/crates/core/src/server.rs
@@ -81,6 +81,11 @@ pub(crate) enum ClientConnection {
         req: Box<ClientRequest<'static>>,
         auth_token: Option<AuthToken>,
         origin_contract: Option<ContractInstanceId>,
+        /// Whether the issuing connection may receive an ATTESTED application
+        /// identity (GHSA-824h-7x5x-wfmf). Classified once at the HTTP layer
+        /// from the kernel-observed peer address, carried on the connection
+        /// like `user_context` so nothing in the request body can forge it.
+        connection_scope: crate::client_events::ConnectionScope,
         /// Per-connection per-user secret namespace (hosted mode, P2 of #4381),
         /// derived once at WS upgrade from the connection's user token. `None`
         /// outside hosted mode. Carried on the connection, never from the
@@ -251,158 +256,17 @@ fn is_ipv6_ula(addr: &std::net::Ipv6Addr) -> bool {
     (addr.segments()[0] & 0xfe00) == 0xfc00
 }
 
-pub mod local_node {
-    use freenet_stdlib::client_api::{ClientRequest, ErrorKind};
-    use std::net::SocketAddr;
-    use tower_http::trace::TraceLayer;
-
-    use crate::{
-        client_events::{ClientEventsProxy, OpenRequest, websocket::WebSocketProxy},
-        contract::{Executor, ExecutorError},
-    };
-
-    use super::{client_api::HttpClientApi, serve_dual_stack};
-
-    pub async fn run_local_node(mut executor: Executor, socket: SocketAddr) -> anyhow::Result<()> {
-        if !super::is_private_ip(&socket.ip()) {
-            anyhow::bail!(
-                "invalid ip: {}, only loopback and private network addresses are allowed",
-                socket.ip()
-            )
-        }
-        let (mut gw, gw_router) = HttpClientApi::as_router(&socket);
-        let (mut ws_proxy, ws_router) = WebSocketProxy::create_router(gw_router);
-
-        // Route through serve_dual_stack (not the bare single-socket bind) so
-        // this path also binds an IPv4+IPv6 companion pair for loopback/wildcard
-        // addresses — keeping every client-API serve path reachable over both
-        // families (#4330).
-        //
-        // `run_local_node` owns the server for the lifetime of the process (it
-        // loops forever below), so the abort guard is leaked deliberately: there
-        // is no graceful-shutdown hook on this path to hand it to.
-        let mut aborts = crate::util::AbortOnDrop::new();
-        serve_dual_stack(
-            socket,
-            ws_router.layer(TraceLayer::new_for_http()),
-            None,
-            &mut aborts,
-        )
-        .await?;
-        std::mem::forget(aborts);
-
-        // TODO: use combinator instead
-        // let mut all_clients =
-        //    ClientEventsCombinator::new([Box::new(ws_handle), Box::new(http_handle)]);
-        enum Receiver {
-            Ws,
-            Gw,
-        }
-        let mut receiver;
-        loop {
-            let req = crate::deterministic_select! {
-                req = ws_proxy.recv() => {
-                    receiver = Receiver::Ws;
-                    req?
-                },
-                req = gw.recv() => {
-                    receiver = Receiver::Gw;
-                    req?
-                },
-            };
-            let OpenRequest {
-                client_id: id,
-                request,
-                notification_channel,
-                token,
-                user_context,
-                ..
-            } = req;
-            tracing::trace!(cli_id = %id, "got request -> {request}");
-
-            let res = match *request {
-                ClientRequest::ContractOp(op) => {
-                    executor
-                        .contract_requests(op, id, notification_channel)
-                        .await
-                }
-                ClientRequest::DelegateOp(op) => {
-                    let origin_contract = token.and_then(|token| {
-                        gw.origin_contracts
-                            .get(&token)
-                            .map(|entry| entry.contract_id)
-                    });
-                    // `user_context` is `Some` only in hosted mode with a user
-                    // token; otherwise `None` keeps secrets `SecretScope::Local`.
-                    executor.delegate_request(
-                        op,
-                        origin_contract.as_ref(),
-                        None,
-                        user_context.as_ref(),
-                    )
-                }
-                ClientRequest::Disconnect { cause } => {
-                    if let Some(cause) = cause {
-                        tracing::info!("disconnecting cause: {cause}");
-                    }
-                    // fixme: token must live for a bit to allow reconnections
-                    // Drop the iter() guard before remove() to avoid holding a
-                    // DashMap shard guard across a mutating call on the same map
-                    // (clippy: `significant_drop_in_scrutinee`).
-                    // Safe: the outer caller serialises by `id`, so no concurrent
-                    // iter+remove on this shard is possible.
-                    let rm_token = gw.origin_contracts.iter().find_map(|entry| {
-                        let (k, origin) = entry.pair();
-                        (origin.client_id == id).then(|| k.clone())
-                    });
-                    if let Some(rm_token) = rm_token {
-                        gw.origin_contracts.remove(&rm_token);
-                    }
-                    continue;
-                }
-                ClientRequest::Authenticate { .. }
-                | ClientRequest::NodeQueries(_)
-                | ClientRequest::Close
-                | _ => Err(ExecutorError::other(anyhow::anyhow!("not supported"))),
-            };
-
-            match res {
-                Ok(res) => {
-                    match receiver {
-                        Receiver::Ws => ws_proxy.send(id, Ok(res)).await?,
-                        Receiver::Gw => gw.send(id, Ok(res)).await?,
-                    };
-                }
-                Err(err) if err.is_request() => {
-                    let err = ErrorKind::RequestError(err.unwrap_request());
-                    match receiver {
-                        Receiver::Ws => {
-                            ws_proxy.send(id, Err(err.into())).await?;
-                        }
-                        Receiver::Gw => {
-                            gw.send(id, Err(err.into())).await?;
-                        }
-                    };
-                }
-                Err(err) => {
-                    tracing::error!("{err}");
-                    let err = Err(ErrorKind::Unhandled {
-                        cause: format!("{err}").into(),
-                    }
-                    .into());
-                    match receiver {
-                        Receiver::Ws => {
-                            ws_proxy.send(id, err).await?;
-                        }
-                        Receiver::Gw => {
-                            gw.send(id, err).await?;
-                        }
-                    };
-                }
-            }
-        }
-    }
-}
+// `local_node::run_local_node` (a second, standalone client-API serve loop
+// that predated `node::run_local_node`) was DELETED with the
+// GHSA-824h-7x5x-wfmf fix. It was unreachable — `bin/freenet.rs` runs
+// `node::run_local_node` — and it carried a duplicate origin-resolution path
+// that re-derived a request's `origin_contract` by looking the connection's
+// auth token up in `HttpClientApi::origin_contracts`. That re-derivation read
+// the token and NOTHING about the connection it arrived on, so it could not
+// have honored the connection-scope gate; leaving it in place would have left
+// a second, silently-ungated way to obtain an attested identity for whoever
+// revived the entry point. `node::run_local_node` passes `OpenRequest`'s
+// `origin_contract` (and now its `connection_scope`) straight through instead.
 
 pub async fn serve_client_api(config: WebsocketApiConfig) -> std::io::Result<[BoxedClient; 2]> {
     let (gw, ws_proxy) = serve_client_api_in_impl(config, None).await?;
@@ -1411,7 +1275,7 @@ mod tests {
     /// `tests/playwright_shell.rs`, which boots a real node and fetches a shell
     /// page on a plain `cargo test`. A ready-made template for exactly that
     /// substitution sits in `client_api.rs::as_router`, where the same call is
-    /// legitimate (standalone composition, `local_node::run_local_node`).
+    /// legitimate (standalone router composition).
     ///
     /// The threading is a compile-time guarantee against OMISSION only: the
     /// parameter is required and has no default anywhere in the chain, so a

--- a/crates/core/src/server/client_api.rs
+++ b/crates/core/src/server/client_api.rs
@@ -409,6 +409,7 @@ async fn notify_service_worker() -> impl IntoResponse {
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn web_home(
     Path(key): Path<String>,
     Extension(rs): Extension<HttpClientApiRequest>,
@@ -417,6 +418,7 @@ async fn web_home(
     api_version: ApiVersion,
     query_string: Option<String>,
     hosted_mode: bool,
+    source_addr: Option<std::net::SocketAddr>,
 ) -> Result<axum::response::Response, WebSocketApiError> {
     // Check if this is the sandboxed iframe requesting its content
     let is_sandbox = query_string
@@ -446,6 +448,7 @@ async fn web_home(
         None,
         rs,
         hosted_mode,
+        source_addr,
     )
     .await
 }
@@ -469,11 +472,32 @@ async fn render_shell_response(
     sub_path: Option<&str>,
     rs: HttpClientApiRequest,
     hosted_mode: bool,
+    // Peer address of the requesting connection, for the issuance audit log.
+    // `None` only where no `ConnectInfo` is installed (standalone test routers).
+    source_addr: Option<std::net::SocketAddr>,
 ) -> Result<axum::response::Response, WebSocketApiError> {
     use headers::{Header, HeaderMapExt};
 
     // Shell page: generate auth token, serve iframe wrapper with CSP
     let token = AuthToken::generate();
+
+    // AUDIT (GHSA-824h-7x5x-wfmf): this is THE issuance point for an
+    // app-identity auth token — the node mints one on request for ANY contract
+    // id, and whoever holds it is thereafter attested as that app. Record every
+    // issuance so the trail exists after the fact.
+    //
+    // `info!` deliberately, not `debug!`: the crate builds with
+    // `release_max_level_info`, so a `debug!` here would be compiled out of
+    // every shipped binary and the audit log would exist only in development.
+    //
+    // Ids and addresses ONLY. The token itself is never logged — it IS the
+    // credential — and neither is any key material.
+    tracing::info!(
+        contract_id = %key,
+        peer_addr = ?source_addr,
+        api_version = %api_version.prefix(),
+        "Issued app-identity auth token for a contract shell page"
+    );
 
     let auth_header = headers::Authorization::<headers::authorization::Bearer>::name().to_string();
     let version_prefix = api_version.prefix();
@@ -552,6 +576,7 @@ fn hosted_mode_or_default(ext: Option<Extension<crate::server::HostedMode>>) -> 
 }
 
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments)]
 async fn web_subpages(
     key: String,
     last_path: String,
@@ -561,6 +586,7 @@ async fn web_subpages(
     config: &Config,
     request_sender: HttpClientApiRequest,
     hosted_mode: bool,
+    source_addr: Option<std::net::SocketAddr>,
 ) -> Result<axum::response::Response, WebSocketApiError> {
     let is_sandbox = query_string
         .as_ref()
@@ -616,6 +642,7 @@ async fn web_subpages(
             Some(&last_path),
             request_sender,
             hosted_mode,
+            source_addr,
         )
         .await;
     }
@@ -1722,6 +1749,7 @@ mod tests {
                     &localhost_config(),
                     sender,
                     false,
+                    None,
                 )
                 .await
                 .map(|_| ())
@@ -1756,6 +1784,7 @@ mod tests {
             &localhost_config(),
             dead_request_sender(),
             false,
+            None,
         )
         .await
         .expect("sandbox document load must redirect, not error");
@@ -1776,6 +1805,7 @@ mod tests {
             &localhost_config(),
             dead_request_sender(),
             false,
+            None,
         )
         .await;
         match res {
@@ -1826,6 +1856,7 @@ mod tests {
             &localhost_config(),
             dead_request_sender(),
             false,
+            None,
         )
         .await
         .expect("web_subpages must convert the inner error into a response, not propagate it");
@@ -1905,6 +1936,7 @@ mod tests {
                     &localhost_config(),
                     dead_request_sender(),
                     false,
+                    None,
                 )
                 .await
                 .expect("web_subpages must respond, not propagate")

--- a/crates/core/src/server/client_api.rs
+++ b/crates/core/src/server/client_api.rs
@@ -464,6 +464,7 @@ async fn web_home(
 /// freenet/freenet-core#3841). Both must issue the SAME credentials and
 /// headers; factoring it here keeps the deep-link path from drifting out
 /// of sync with the root path (e.g. forgetting the cookie or the CSP).
+#[allow(clippy::too_many_arguments)]
 async fn render_shell_response(
     key: String,
     config: &Config,
@@ -575,7 +576,6 @@ fn hosted_mode_or_default(ext: Option<Extension<crate::server::HostedMode>>) -> 
     ext.map(|Extension(hm)| hm.0).unwrap_or(false)
 }
 
-#[allow(clippy::too_many_arguments)]
 #[allow(clippy::too_many_arguments)]
 async fn web_subpages(
     key: String,

--- a/crates/core/src/server/client_api.rs
+++ b/crates/core/src/server/client_api.rs
@@ -493,12 +493,23 @@ async fn render_shell_response(
     //
     // Ids and addresses ONLY. The token itself is never logged — it IS the
     // credential — and neither is any key material.
-    tracing::info!(
-        contract_id = %key,
-        peer_addr = ?source_addr,
-        api_version = %api_version.prefix(),
-        "Issued app-identity auth token for a contract shell page"
-    );
+    //
+    // LOG THE PARSED ID, NEVER THE RAW PATH. `key` is an unvalidated
+    // `Path<String>` that axum has already percent-DECODED, and this route is
+    // exposed publicly through the hosted proxy, so logging it raw would let any
+    // internet user inject newlines (`%0A`) and forge entries inside the very
+    // audit trail this line exists to produce. Parsing first bounds the value to
+    // 32 base58-encoded bytes with no control characters. An unparseable key is
+    // not logged here at all — it cannot yield a token, and the request fails
+    // below.
+    if let Ok(instance_id) = ContractInstanceId::from_base58(&key) {
+        tracing::info!(
+            contract_id = %instance_id,
+            peer_addr = ?source_addr,
+            api_version = %api_version.prefix(),
+            "Issued app-identity auth token for a contract shell page"
+        );
+    }
 
     let auth_header = headers::Authorization::<headers::authorization::Bearer>::name().to_string();
     let version_prefix = api_version.prefix();
@@ -1037,12 +1048,20 @@ impl ClientEventsProxy for HttpClientApi {
                         req,
                         auth_token,
                         origin_contract,
+                        // Forwarded explicitly rather than swallowed by `..`.
+                        // Every request on THIS proxy is node-internal today
+                        // (webapp-cache fetches, which carry no origin), so
+                        // dropping it would be inert — but the producers set it
+                        // deliberately, and a future client-facing request here
+                        // would otherwise lose its attestation silently.
+                        connection_scope,
                         user_context,
                         ..
                     } => {
                         return Ok(OpenRequest::new(client_id, req)
                             .with_token(auth_token)
                             .with_origin_contract(origin_contract)
+                            .with_connection_scope(connection_scope)
                             .with_user_context(user_context));
                     }
                 }

--- a/crates/core/src/server/client_api/v1.rs
+++ b/crates/core/src/server/client_api/v1.rs
@@ -59,6 +59,12 @@ async fn web_home_v1(
     config: axum::extract::State<Config>,
     headers: axum::http::HeaderMap,
     axum::extract::RawQuery(query): axum::extract::RawQuery,
+    // Peer address for the token-issuance audit log, read out of the request
+    // extensions rather than as a `ConnectInfo` extractor: a router composed
+    // without `into_make_service_with_connect_info` (standalone tests) has no
+    // `ConnectInfo`, and a required extractor there would 500 the whole route.
+    // Same tolerance as `hosted_mode` above.
+    extensions: axum::http::Extensions,
 ) -> Result<axum::response::Response, WebSocketApiError> {
     web_home(
         key,
@@ -68,6 +74,9 @@ async fn web_home_v1(
         ApiVersion::V1,
         query,
         hosted_mode_or_default(hosted_mode),
+        extensions
+            .get::<axum::extract::ConnectInfo<std::net::SocketAddr>>()
+            .map(|ci| ci.0),
     )
     .await
 }
@@ -80,6 +89,8 @@ async fn web_subpages_v1(
     headers: axum::http::HeaderMap,
     axum::extract::State(config): axum::extract::State<Config>,
     Extension(rs): Extension<HttpClientApiRequest>,
+    // See `web_home_*`: read from extensions so standalone routers do not 500.
+    extensions: axum::http::Extensions,
 ) -> Result<axum::response::Response, WebSocketApiError> {
     web_subpages(
         key,
@@ -90,6 +101,9 @@ async fn web_subpages_v1(
         &config,
         rs,
         hosted_mode_or_default(hosted_mode),
+        extensions
+            .get::<axum::extract::ConnectInfo<std::net::SocketAddr>>()
+            .map(|ci| ci.0),
     )
     .await
 }

--- a/crates/core/src/server/client_api/v2.rs
+++ b/crates/core/src/server/client_api/v2.rs
@@ -30,6 +30,12 @@ async fn web_home_v2(
     config: axum::extract::State<Config>,
     headers: axum::http::HeaderMap,
     axum::extract::RawQuery(query): axum::extract::RawQuery,
+    // Peer address for the token-issuance audit log, read out of the request
+    // extensions rather than as a `ConnectInfo` extractor: a router composed
+    // without `into_make_service_with_connect_info` (standalone tests) has no
+    // `ConnectInfo`, and a required extractor there would 500 the whole route.
+    // Same tolerance as `hosted_mode` above.
+    extensions: axum::http::Extensions,
 ) -> Result<axum::response::Response, WebSocketApiError> {
     web_home(
         key,
@@ -39,6 +45,9 @@ async fn web_home_v2(
         ApiVersion::V2,
         query,
         hosted_mode_or_default(hosted_mode),
+        extensions
+            .get::<axum::extract::ConnectInfo<std::net::SocketAddr>>()
+            .map(|ci| ci.0),
     )
     .await
 }
@@ -51,6 +60,8 @@ async fn web_subpages_v2(
     headers: axum::http::HeaderMap,
     axum::extract::State(config): axum::extract::State<Config>,
     Extension(rs): Extension<HttpClientApiRequest>,
+    // See `web_home_*`: read from extensions so standalone routers do not 500.
+    extensions: axum::http::Extensions,
 ) -> Result<axum::response::Response, WebSocketApiError> {
     web_subpages(
         key,
@@ -61,6 +72,9 @@ async fn web_subpages_v2(
         &config,
         rs,
         hosted_mode_or_default(hosted_mode),
+        extensions
+            .get::<axum::extract::ConnectInfo<std::net::SocketAddr>>()
+            .map(|ci| ci.0),
     )
     .await
 }

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -866,6 +866,10 @@ async fn is_locally_known(
             })),
             auth_token: None,
             origin_contract: None,
+            // Node-internal fetch issued by the HTTP layer itself (webapp cache
+            // reconcile), not a client connection. It carries no
+            // `origin_contract`, so the scope attests nothing either way.
+            connection_scope: crate::client_events::ConnectionScope::Local,
             // Internal node-query request: no delegate secrets, no user context.
             user_context: None,
             api_version: Default::default(),
@@ -897,6 +901,10 @@ async fn is_locally_known(
             req: Box::new(ClientRequest::Disconnect { cause: None }),
             auth_token: None,
             origin_contract: None,
+            // Node-internal fetch issued by the HTTP layer itself (webapp cache
+            // reconcile), not a client connection. It carries no
+            // `origin_contract`, so the scope attests nothing either way.
+            connection_scope: crate::client_events::ConnectionScope::Local,
             // Internal node-query request: no delegate secrets, no user context.
             user_context: None,
             api_version: Default::default(),
@@ -1145,6 +1153,10 @@ async fn ensure_contract_cached(
             ),
             auth_token: None,
             origin_contract: None,
+            // Node-internal fetch issued by the HTTP layer itself (webapp cache
+            // reconcile), not a client connection. It carries no
+            // `origin_contract`, so the scope attests nothing either way.
+            connection_scope: crate::client_events::ConnectionScope::Local,
             // Internal node-query request: no delegate secrets, no user context.
             user_context: None,
             api_version: Default::default(),
@@ -1169,6 +1181,10 @@ async fn ensure_contract_cached(
             req: Box::new(ClientRequest::Disconnect { cause: None }),
             auth_token: None,
             origin_contract: None,
+            // Node-internal fetch issued by the HTTP layer itself (webapp cache
+            // reconcile), not a client connection. It carries no
+            // `origin_contract`, so the scope attests nothing either way.
+            connection_scope: crate::client_events::ConnectionScope::Local,
             // Internal node-query request: no delegate secrets, no user context.
             user_context: None,
             api_version: Default::default(),

--- a/crates/core/src/wasm_runtime/delegate/test.rs
+++ b/crates/core/src/wasm_runtime/delegate/test.rs
@@ -3444,7 +3444,7 @@ async fn test_notification_application_message_routed_to_registered_app()
     let app_client = ClientId::FIRST;
     let (app_tx, mut app_rx) = tokio::sync::mpsc::channel::<HostResult>(8);
     assert!(
-        delegate_app_registry::register_app(&delegate_key, app_client, app_tx),
+        delegate_app_registry::register_app(&delegate_key, app_client, None, app_tx),
         "app registration must succeed"
     );
 
@@ -3475,7 +3475,7 @@ async fn test_notification_application_message_routed_to_registered_app()
         key: delegate_key.clone(),
         values: vec![OutboundDelegateMsg::ApplicationMessage(app_msg)],
     });
-    let delivered = delegate_app_registry::route_to_apps(&delegate_key, response);
+    let delivered = delegate_app_registry::route_to_apps(&delegate_key, None, response);
     assert_eq!(delivered, 1, "message must reach the one registered app");
 
     // The registered app receives the delegate's notification-driven reply.
@@ -3511,6 +3511,7 @@ async fn test_notification_application_message_routed_to_registered_app()
     assert_eq!(
         delegate_app_registry::route_to_apps(
             &delegate_key,
+            None,
             Ok(HostResponse::DelegateResponse {
                 key: delegate_key.clone(),
                 values: vec![],

--- a/crates/core/src/wasm_runtime/delegate/test.rs
+++ b/crates/core/src/wasm_runtime/delegate/test.rs
@@ -3444,7 +3444,12 @@ async fn test_notification_application_message_routed_to_registered_app()
     let app_client = ClientId::FIRST;
     let (app_tx, mut app_rx) = tokio::sync::mpsc::channel::<HostResult>(8);
     assert!(
-        delegate_app_registry::register_app(&delegate_key, app_client, None, app_tx),
+        delegate_app_registry::register_app(
+            &delegate_key,
+            app_client,
+            delegate_app_registry::AppIdentity::Local { attested: None },
+            app_tx,
+        ),
         "app registration must succeed"
     );
 
@@ -3475,7 +3480,7 @@ async fn test_notification_application_message_routed_to_registered_app()
         key: delegate_key.clone(),
         values: vec![OutboundDelegateMsg::ApplicationMessage(app_msg)],
     });
-    let delivered = delegate_app_registry::route_to_apps(&delegate_key, None, response);
+    let delivered = delegate_app_registry::route_to_apps(&delegate_key, response);
     assert_eq!(delivered, 1, "message must reach the one registered app");
 
     // The registered app receives the delegate's notification-driven reply.
@@ -3511,7 +3516,6 @@ async fn test_notification_application_message_routed_to_registered_app()
     assert_eq!(
         delegate_app_registry::route_to_apps(
             &delegate_key,
-            None,
             Ok(HostResponse::DelegateResponse {
                 key: delegate_key.clone(),
                 values: vec![],

--- a/crates/core/src/wasm_runtime/delegate/test.rs
+++ b/crates/core/src/wasm_runtime/delegate/test.rs
@@ -3447,7 +3447,7 @@ async fn test_notification_application_message_routed_to_registered_app()
         delegate_app_registry::register_app(
             &delegate_key,
             app_client,
-            delegate_app_registry::AppIdentity::Local { attested: None },
+            delegate_app_registry::AppIdentity::Local,
             app_tx,
         ),
         "app registration must succeed"

--- a/crates/core/src/wasm_runtime/runtime.rs
+++ b/crates/core/src/wasm_runtime/runtime.rs
@@ -660,6 +660,28 @@ impl Runtime {
     ///
     /// Propagates the store's error: a persistence failure MUST fail the whole
     /// registration (see `SecretsStore::record_delegate_registration_origin`).
+    /// Read back the contract id `delegate` was FIRST registered under, or
+    /// `None` if it was registered without an attested origin, is unknown to
+    /// this node, or the record could not be read (fail closed).
+    ///
+    /// The counterpart of [`Self::record_delegate_registration_origin`]; it is
+    /// the delegate's own attested app identity, used to decide who may drive
+    /// it and who may receive its notification output (GHSA-824h-7x5x-wfmf).
+    pub(crate) fn delegate_registration_origin(&self, delegate: &DelegateKey) -> Option<[u8; 32]> {
+        match self.secret_store.delegate_registration_origins(delegate) {
+            Ok(Some((_has_admin_none, origins))) => origins.first().copied(),
+            Ok(None) => None,
+            Err(err) => {
+                tracing::warn!(
+                    delegate = %delegate.encode(),
+                    error = %err,
+                    "could not read delegate first-registration origin; treating as unattested (fail closed)"
+                );
+                None
+            }
+        }
+    }
+
     pub(crate) fn record_delegate_registration_origin(
         &self,
         delegate: &DelegateKey,

--- a/crates/core/src/wasm_runtime/runtime.rs
+++ b/crates/core/src/wasm_runtime/runtime.rs
@@ -633,11 +633,11 @@ impl Runtime {
     /// Runs ON the contract loop (serialized with delegate `store_secret`),
     /// mirroring the on-loop write discipline of `import_secret_bundle`.
     ///
-    /// UNREACHABLE as of freenet/freenet-core#5198: the sole caller (the
+    /// UNREACHABLE as of GHSA-824h-7x5x-wfmf: the sole caller (the
     /// `RegisterDelegateWithPredecessors` handler in
     /// `crates/core/src/contract/executor/runtime/delegates.rs`) no longer
     /// calls this, because the `origin_contract` this method's H1 gate relies
-    /// on is forgeable by any HTTP client — see #5198 for the exploit chain.
+    /// on is forgeable by any HTTP client — see GHSA-824h-7x5x-wfmf for the exploit chain.
     /// Kept (not deleted) so the underlying `SecretsStore::migrate_secrets`
     /// mechanism, which is otherwise sound, is easy to re-wire once
     /// `origin_contract` attestation is hardened.
@@ -660,28 +660,6 @@ impl Runtime {
     ///
     /// Propagates the store's error: a persistence failure MUST fail the whole
     /// registration (see `SecretsStore::record_delegate_registration_origin`).
-    /// Read back the contract id `delegate` was FIRST registered under, or
-    /// `None` if it was registered without an attested origin, is unknown to
-    /// this node, or the record could not be read (fail closed).
-    ///
-    /// The counterpart of [`Self::record_delegate_registration_origin`]; it is
-    /// the delegate's own attested app identity, used to decide who may drive
-    /// it and who may receive its notification output (GHSA-824h-7x5x-wfmf).
-    pub(crate) fn delegate_registration_origin(&self, delegate: &DelegateKey) -> Option<[u8; 32]> {
-        match self.secret_store.delegate_registration_origins(delegate) {
-            Ok(Some((_has_admin_none, origins))) => origins.first().copied(),
-            Ok(None) => None,
-            Err(err) => {
-                tracing::warn!(
-                    delegate = %delegate.encode(),
-                    error = %err,
-                    "could not read delegate first-registration origin; treating as unattested (fail closed)"
-                );
-                None
-            }
-        }
-    }
-
     pub(crate) fn record_delegate_registration_origin(
         &self,
         delegate: &DelegateKey,

--- a/crates/core/src/wasm_runtime/secrets_store/store.rs
+++ b/crates/core/src/wasm_runtime/secrets_store/store.rs
@@ -3003,6 +3003,27 @@ impl SecretsStore {
     /// this gate exists to prevent. `Ok(())` covers both a freshly-written record
     /// AND an already-present one (an idempotent re-registration); neither is an
     /// error.
+    /// Read back the FIRST-registration origin recorded by
+    /// [`Self::record_delegate_registration_origin`], as
+    /// `(has_admin_none, contract_ids)`. `Ok(None)` means the delegate has
+    /// never been registered on this node.
+    ///
+    /// # Errors
+    /// Returns `Err` if the record could not be read. Callers gating an
+    /// authorization decision MUST treat `Err` as "no attested origin"
+    /// (fail closed), never as "any origin".
+    #[allow(clippy::type_complexity)]
+    pub fn delegate_registration_origins(
+        &self,
+        delegate: &DelegateKey,
+    ) -> Result<Option<(bool, Vec<[u8; 32]>)>, SecretStoreError> {
+        self.db.get_delegate_origins(delegate).map_err(|e| {
+            SecretStoreError::IO(std::io::Error::other(format!(
+                "could not read delegate first-registration origin: {e}"
+            )))
+        })
+    }
+
     pub fn record_delegate_registration_origin(
         &self,
         delegate: &DelegateKey,

--- a/crates/core/src/wasm_runtime/secrets_store/store.rs
+++ b/crates/core/src/wasm_runtime/secrets_store/store.rs
@@ -2553,10 +2553,10 @@ impl SecretsStore {
     /// discipline of `store_secret` / the live bundle import. The work is bounded
     /// by the predecessors' own on-disk secret count.
     ///
-    /// UNREACHABLE FROM PRODUCTION as of freenet/freenet-core#5198: the H1 gate
+    /// UNREACHABLE FROM PRODUCTION as of GHSA-824h-7x5x-wfmf: the H1 gate
     /// above is sound only if `origin_contract` is trustworthy, and it isn't —
     /// any HTTP client can forge an `origin_contract` value for an arbitrary
-    /// public contract key (see #5198). The one caller
+    /// public contract key (see GHSA-824h-7x5x-wfmf). The one caller
     /// (`RegisterDelegateWithPredecessors`'s handler) no longer invokes this
     /// method; it is kept, with its test suite, for potential reactivation once
     /// `origin_contract` attestation is hardened. Do not re-wire a caller to
@@ -2992,6 +2992,16 @@ impl SecretsStore {
     /// the H1 same-origin copy-forward gate (#4117). FIRST-WRITER-WINS: a record
     /// is written only if none exists, and is NEVER modified afterward — an
     /// attacker who re-registers a victim's public WASM later cannot add itself.
+    ///
+    /// FIRST-WRITER-WINS ALSO MEANS UNREPAIRABLE. A value written here can never
+    /// be corrected, so a wrong one is permanent for the life of the node's
+    /// database. Two consequences for anything tempted to read it: `origin`
+    /// MUST already be gated on the connection scope before it reaches here
+    /// (`Executor::delegate_request` does this — an ungated write let a remote
+    /// caller mint a token for any contract id and freeze a delegate's
+    /// provenance to a value of their choosing), and it is NOT a safe key for
+    /// any live authorization decision, because an app that re-keys can never
+    /// match the frozen value. It is provenance, not policy.
     /// Called on EVERY registration, BEFORE the delegate is registered.
     ///
     /// # Errors
@@ -3003,27 +3013,6 @@ impl SecretsStore {
     /// this gate exists to prevent. `Ok(())` covers both a freshly-written record
     /// AND an already-present one (an idempotent re-registration); neither is an
     /// error.
-    /// Read back the FIRST-registration origin recorded by
-    /// [`Self::record_delegate_registration_origin`], as
-    /// `(has_admin_none, contract_ids)`. `Ok(None)` means the delegate has
-    /// never been registered on this node.
-    ///
-    /// # Errors
-    /// Returns `Err` if the record could not be read. Callers gating an
-    /// authorization decision MUST treat `Err` as "no attested origin"
-    /// (fail closed), never as "any origin".
-    #[allow(clippy::type_complexity)]
-    pub fn delegate_registration_origins(
-        &self,
-        delegate: &DelegateKey,
-    ) -> Result<Option<(bool, Vec<[u8; 32]>)>, SecretStoreError> {
-        self.db.get_delegate_origins(delegate).map_err(|e| {
-            SecretStoreError::IO(std::io::Error::other(format!(
-                "could not read delegate first-registration origin: {e}"
-            )))
-        })
-    }
-
     pub fn record_delegate_registration_origin(
         &self,
         delegate: &DelegateKey,

--- a/crates/core/tests/origin_attestation_scope.rs
+++ b/crates/core/tests/origin_attestation_scope.rs
@@ -1,0 +1,394 @@
+//! Live end-to-end verification of the connection-scope gate on attested
+//! application identity (GHSA-824h-7x5x-wfmf).
+//!
+//! This boots a REAL node — full event loop, contract executor, WASM runtime —
+//! with its client API bound to `0.0.0.0`, and drives it through the real
+//! HTTP/WS stack with `tokio-tungstenite`. The delegate is real WASM
+//! (`test-delegate-attested`), and it echoes back the `MessageOrigin` the
+//! runtime handed it. So the assertion is on the identity a delegate ACTUALLY
+//! receives, not on an intermediate value.
+//!
+//! Three deployment shapes, which is the whole point:
+//!
+//! 1. **DIRECT LOOPBACK** — a browser or CLI on the node's own host. Must still
+//!    receive `MessageOrigin::WebApp(..)`. This is the regression risk: the gate
+//!    breaking this would break every local app on the node while a health check
+//!    of "process up, /v1/version answers" stayed perfectly green.
+//! 2. **COLOCATED REVERSE PROXY** — the node sees the proxy's loopback address
+//!    even though the human is remote. This is `try.freenet.org`'s topology
+//!    (nginx on the same host, upstream `127.0.0.1`). The gate must be a NO-OP
+//!    here; isolation there comes from hosted mode's `user_context` instead.
+//!    Exercised with a real TCP forwarder listening off-loopback and dialing
+//!    `127.0.0.1`, so the node genuinely observes a loopback peer for a
+//!    connection that originated off-host.
+//! 3. **DIRECT OFF-HOST** — a LAN browser connecting straight to the node. Must
+//!    receive NO attested identity.
+//!
+//! Shapes 2 and 3 need a non-loopback PRIVATE address on this machine (the
+//! client API refuses non-private sources outright, before the gate, so a public
+//! one proves nothing about it). Discovery probes the default route and honours
+//! `FREENET_TEST_OFFHOST_IPV4` for hosts whose default route is public. Where no
+//! address is found the two legs are SKIPPED with a loud log rather than
+//! silently passing; shape 1 always runs, and the `Remote` classification itself
+//! is pinned deterministically by the `ConnectionScope` unit tests in
+//! `client_events::types`. Read a skip as "this environment could not exercise
+//! it", never as "it passed".
+
+// A `_`/`other` arm treats any unexpected variant as a test failure; listing
+// every variant of every non_exhaustive stdlib enum would be brittle noise.
+#![allow(clippy::wildcard_enum_match_arm)]
+
+use std::{
+    net::{Ipv4Addr, SocketAddr, TcpListener},
+    path::Path,
+    time::{Duration, Instant},
+};
+
+use freenet::{
+    dev_tool::AuthToken, local_node::NodeConfig,
+    server::serve_client_api_with_listener_and_contracts, test_utils::load_delegate,
+};
+use freenet_stdlib::{
+    client_api::{ClientRequest, DelegateRequest, HostResponse, WebApi},
+    prelude::*,
+};
+use serde::{Deserialize, Serialize};
+use testresult::TestResult;
+use tokio::time::timeout;
+use tokio_tungstenite::{connect_async, tungstenite::client::IntoClientRequest};
+use tracing::info;
+
+const TEST_DELEGATE: &str = "test-delegate-attested";
+const CIPHER: [u8; 32] = [7u8; 32];
+const NONCE: [u8; 24] = [9u8; 24];
+
+#[derive(Debug, Serialize, Deserialize)]
+enum InboundAppMessage {
+    CheckAttested,
+}
+
+#[derive(Debug, Deserialize)]
+enum OutboundAppMessage {
+    Attested(Option<Vec<u8>>),
+}
+
+/// A non-loopback **private** IPv4 address of this host, or `None`.
+///
+/// Private on purpose. The client API already refuses any connection from a
+/// non-private source before request handling
+/// (`server::private_network_filter`), so a public source address never reaches
+/// the attestation gate at all and would prove nothing about it. The realistic
+/// off-host attacker is on the LAN, which is exactly an RFC1918 source.
+///
+/// Uses the connect-a-UDP-socket trick against several RFC1918 targets: no
+/// packet is sent, the kernel just resolves which local address each route
+/// would use. Works offline and needs no interface enumeration.
+fn private_non_loopback_ipv4() -> Option<Ipv4Addr> {
+    // Explicit override first. Route probing finds only the address the DEFAULT
+    // route uses, so a host whose default route is public (a colocated server
+    // with private addresses on secondary interfaces — wireguard, docker) has a
+    // usable address that probing cannot reach. Set
+    // `FREENET_TEST_OFFHOST_IPV4` to one of its private addresses to exercise
+    // shapes 2 and 3 there.
+    if let Ok(explicit) = std::env::var("FREENET_TEST_OFFHOST_IPV4") {
+        match explicit.parse::<Ipv4Addr>() {
+            Ok(ip) if !ip.is_loopback() && !ip.is_unspecified() => return Some(ip),
+            other => tracing::warn!(
+                ?other,
+                "FREENET_TEST_OFFHOST_IPV4 is set but unusable; falling back to route probing"
+            ),
+        }
+    }
+    for target in ["10.0.0.1:9", "172.16.0.1:9", "192.168.0.1:9"] {
+        let Ok(sock) = std::net::UdpSocket::bind("0.0.0.0:0") else {
+            continue;
+        };
+        if sock.connect(target).is_err() {
+            continue;
+        }
+        if let Ok(SocketAddr::V4(local)) = sock.local_addr() {
+            let ip = *local.ip();
+            if ip.is_private() && !ip.is_loopback() {
+                return Some(ip);
+            }
+        }
+    }
+    None
+}
+
+fn node_config(
+    dir: &Path,
+    ws_port: u16,
+    network_port: u16,
+    keypair_path: &Path,
+) -> freenet::config::ConfigArgs {
+    freenet::config::ConfigArgs {
+        ws_api: freenet::config::WebsocketApiArgs {
+            // 0.0.0.0 on purpose: the point of this test is to accept both a
+            // loopback and an off-host connection on the SAME listener, so the
+            // only thing that differs between the legs is the peer address the
+            // kernel records.
+            address: Some(Ipv4Addr::UNSPECIFIED.into()),
+            ws_api_port: Some(ws_port),
+            ..Default::default()
+        },
+        network_api: freenet::config::NetworkArgs {
+            public_address: Some(Ipv4Addr::LOCALHOST.into()),
+            public_port: Some(network_port),
+            is_gateway: true,
+            skip_load_from_network: true,
+            gateways: Some(vec![]),
+            location: Some(0.5),
+            ignore_protocol_checking: true,
+            address: Some(Ipv4Addr::LOCALHOST.into()),
+            network_port: Some(network_port),
+            ..Default::default()
+        },
+        config_paths: freenet::config::ConfigPathsArgs {
+            config_dir: Some(dir.to_path_buf()),
+            data_dir: Some(dir.to_path_buf()),
+            log_dir: Some(dir.to_path_buf()),
+        },
+        secrets: freenet::config::SecretArgs {
+            transport_keypair: Some(keypair_path.to_path_buf()),
+            ..Default::default()
+        },
+        mode: Some(freenet::local_node::OperationMode::Local),
+        ..Default::default()
+    }
+}
+
+fn reserve_port() -> anyhow::Result<u16> {
+    Ok(TcpListener::bind("127.0.0.1:0")?.local_addr()?.port())
+}
+
+async fn wait_ws_ready(port: u16, within: Duration) -> anyhow::Result<()> {
+    let url = format!("ws://127.0.0.1:{port}/v1/contract/command?encodingProtocol=native");
+    let deadline = Instant::now() + within;
+    loop {
+        match connect_async(&url).await {
+            Ok((stream, _)) => {
+                drop(stream);
+                return Ok(());
+            }
+            Err(e) => {
+                if Instant::now() >= deadline {
+                    anyhow::bail!("WS API on port {port} did not come up within {within:?}: {e}");
+                }
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+        }
+    }
+}
+
+/// Connect to `authority` carrying `token`, register the delegate if asked, then
+/// ask it to echo the `MessageOrigin` it was handed.
+///
+/// Returns the raw echoed bytes: `None` means the delegate saw no attested
+/// identity at all.
+async fn attested_origin_via(
+    authority: &str,
+    token: &AuthToken,
+    delegate: &DelegateContainer,
+    register: bool,
+) -> anyhow::Result<Option<Vec<u8>>> {
+    let url = format!("ws://{authority}/v1/contract/command?encodingProtocol=native");
+    let mut request = url.as_str().into_client_request()?;
+    request.headers_mut().insert(
+        "Authorization",
+        format!("Bearer {}", token.as_str()).parse()?,
+    );
+    let (stream, _) = connect_async(request).await?;
+    let mut client = WebApi::start(stream);
+    let delegate_key = delegate.key().clone();
+
+    if register {
+        client
+            .send(ClientRequest::DelegateOp(
+                DelegateRequest::RegisterDelegate {
+                    delegate: delegate.clone(),
+                    cipher: CIPHER,
+                    nonce: NONCE,
+                },
+            ))
+            .await?;
+        match timeout(Duration::from_secs(20), client.recv()).await?? {
+            HostResponse::DelegateResponse { key, .. } => {
+                anyhow::ensure!(key == delegate_key, "register returned the wrong key");
+            }
+            other => anyhow::bail!("expected DelegateResponse on register, got {other:?}"),
+        }
+    }
+
+    client
+        .send(ClientRequest::DelegateOp(
+            DelegateRequest::ApplicationMessages {
+                key: delegate_key.clone(),
+                params: Parameters::from(vec![]),
+                inbound: vec![InboundDelegateMsg::ApplicationMessage(
+                    ApplicationMessage::new(bincode::serialize(&InboundAppMessage::CheckAttested)?),
+                )],
+            },
+        ))
+        .await?;
+
+    match timeout(Duration::from_secs(20), client.recv()).await?? {
+        HostResponse::DelegateResponse { values, .. } => {
+            anyhow::ensure!(!values.is_empty(), "delegate produced no output");
+            let app_msg = match &values[0] {
+                OutboundDelegateMsg::ApplicationMessage(m) => m,
+                other => anyhow::bail!("expected ApplicationMessage, got {other:?}"),
+            };
+            match bincode::deserialize::<OutboundAppMessage>(&app_msg.payload)? {
+                OutboundAppMessage::Attested(bytes) => Ok(bytes),
+            }
+        }
+        other => anyhow::bail!("expected DelegateResponse, got {other:?}"),
+    }
+}
+
+fn expect_webapp(bytes: Option<Vec<u8>>, expected: ContractInstanceId, shape: &str) -> TestResult {
+    let bytes = match bytes {
+        Some(b) => b,
+        None => panic!(
+            "{shape}: the delegate received NO attested identity. This shape must keep \
+             working — the gate is only meant to withhold attestation from connections \
+             the node cannot prove are local."
+        ),
+    };
+    match bincode::deserialize::<MessageOrigin>(&bytes)? {
+        MessageOrigin::WebApp(id) => {
+            assert_eq!(id, expected, "{shape}: wrong contract attested");
+            Ok(())
+        }
+        other => panic!("{shape}: expected MessageOrigin::WebApp, got {other:?}"),
+    }
+}
+
+/// A one-shot TCP forwarder listening on `listen` and dialing `upstream`.
+///
+/// Stands in for a colocated reverse proxy: the node's peer address is the
+/// forwarder's loopback address, while the client connected off-host.
+fn spawn_forwarder(listen: SocketAddr, upstream: SocketAddr) -> anyhow::Result<()> {
+    let listener = std::net::TcpListener::bind(listen)?;
+    listener.set_nonblocking(true)?;
+    let listener = tokio::net::TcpListener::from_std(listener)?;
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut inbound, _)) = listener.accept().await else {
+                return;
+            };
+            tokio::spawn(async move {
+                if let Ok(mut outbound) = tokio::net::TcpStream::connect(upstream).await {
+                    if let Err(e) = tokio::io::copy_bidirectional(&mut inbound, &mut outbound).await
+                    {
+                        tracing::debug!(error = %e, "forwarder connection ended");
+                    }
+                }
+            });
+        }
+    });
+    Ok(())
+}
+
+#[test_log::test(tokio::test(flavor = "multi_thread", worker_threads = 4))]
+async fn attested_origin_survives_loopback_and_proxy_but_not_off_host() -> TestResult {
+    let data_dir = tempfile::tempdir()?;
+    let data_path = data_dir.path().to_path_buf();
+    let key = freenet::dev_tool::TransportKeypair::new();
+    let keypair_path = data_path.join("private.pem");
+    key.save(&keypair_path)?;
+    key.public().save(data_path.join("public.pem"))?;
+
+    let ws_port = reserve_port()?;
+    let net_port = reserve_port()?;
+    let cfg = node_config(&data_path, ws_port, net_port, &keypair_path)
+        .build()
+        .await?;
+
+    // Bind the client API on 0.0.0.0 ourselves so the same listener serves both
+    // the loopback and the off-host leg, and so we get the OriginContractMap
+    // back to seed a token→contract mapping (what the HTTP shell page would do).
+    let listener = TcpListener::bind(SocketAddr::from((Ipv4Addr::UNSPECIFIED, ws_port)))?;
+    let (clients, origin_contracts) =
+        serve_client_api_with_listener_and_contracts(cfg.ws_api.clone(), listener).await?;
+
+    let node = NodeConfig::new(cfg.clone()).await?.build(clients).await?;
+    let shutdown = node.shutdown_handle();
+    let run = tokio::spawn(async move { node.run().await });
+    wait_ws_ready(ws_port, Duration::from_secs(60)).await?;
+
+    let token = AuthToken::from("origin-scope-e2e-token".to_string());
+    let contract_id = ContractInstanceId::new([42u8; 32]);
+    origin_contracts.insert(
+        token.clone(),
+        freenet::server::OriginContract::new(contract_id, freenet::dev_tool::ClientId::FIRST),
+    );
+
+    let delegate = load_delegate(TEST_DELEGATE, Parameters::from(vec![]))?;
+
+    // SHAPE 1 — direct loopback. Also registers the delegate.
+    let direct =
+        attested_origin_via(&format!("127.0.0.1:{ws_port}"), &token, &delegate, true).await?;
+    expect_webapp(direct, contract_id, "direct loopback")?;
+    info!("shape 1 (direct loopback): attested, as required");
+
+    // SHAPE 2 — colocated reverse proxy. Only meaningful if we can listen
+    // off-loopback; otherwise the forwarder would be loopback→loopback and would
+    // prove nothing about the proxy topology.
+    let lan_ip = private_non_loopback_ipv4();
+    match lan_ip {
+        Some(ip) => {
+            let fwd_port = reserve_port()?;
+            spawn_forwarder(
+                SocketAddr::from((ip, fwd_port)),
+                SocketAddr::from((Ipv4Addr::LOCALHOST, ws_port)),
+            )?;
+            let proxied =
+                attested_origin_via(&format!("{ip}:{fwd_port}"), &token, &delegate, false).await?;
+            expect_webapp(proxied, contract_id, "colocated reverse proxy")?;
+            info!(%ip, "shape 2 (colocated proxy): attested — the gate is a no-op here, as designed");
+
+            // SHAPE 3 — direct off-host. Distinguish two ways of not being
+            // attested: the connection established and the gate withheld
+            // attestation (what this test is for), versus the connection never
+            // establishing because `private_network_filter` refused it first
+            // (also safe, but no evidence about the gate). Reporting the second
+            // as if it were the first is exactly the "verification that cannot
+            // fail" trap.
+            match attested_origin_via(&format!("{ip}:{ws_port}"), &token, &delegate, false).await {
+                Ok(off_host) => {
+                    assert!(
+                        off_host.is_none(),
+                        "direct off-host connection received an attested identity \
+                         ({off_host:?}); a token presented from off-host must attest nothing"
+                    );
+                    info!(%ip, "shape 3 (direct off-host): connection accepted, NOT attested — the gate held");
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        %ip, error = %e,
+                        "shape 3 INCONCLUSIVE: the off-host connection never established (the \
+                         pre-existing private-network filter or the host firewall refused it), \
+                         so the attestation gate itself was not exercised on this host. Safe, \
+                         but not evidence about the gate."
+                    );
+                }
+            }
+        }
+        None => {
+            // Loud, and never mistakable for a pass.
+            tracing::warn!(
+                "SKIPPED shapes 2 and 3: no non-loopback IPv4 address on this host, so the \
+                 proxy and off-host topologies cannot be exercised here. The Remote \
+                 classification itself is pinned by client_events::types unit tests."
+            );
+        }
+    }
+
+    shutdown.shutdown().await;
+    if timeout(Duration::from_secs(30), run).await.is_err() {
+        info!("node run loop did not exit within 30s of shutdown (cleanup only)");
+    }
+    Ok(())
+}

--- a/crates/core/tests/origin_attestation_scope.rs
+++ b/crates/core/tests/origin_attestation_scope.rs
@@ -58,6 +58,23 @@ use tokio::time::timeout;
 use tokio_tungstenite::{connect_async, tungstenite::client::IntoClientRequest};
 use tracing::info;
 
+/// The WebSocket handshake itself failed, so the node never saw a request.
+///
+/// Distinguished from every other error on purpose: "the connection was refused"
+/// says nothing about the attestation gate, while "the connection was accepted
+/// and then something went wrong" is a real failure the off-host leg must not
+/// swallow. See that leg's `Err` arm.
+#[derive(Debug)]
+struct ConnectFailed(tokio_tungstenite::tungstenite::Error);
+
+impl std::fmt::Display for ConnectFailed {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "websocket connect failed: {}", self.0)
+    }
+}
+
+impl std::error::Error for ConnectFailed {}
+
 const TEST_DELEGATE: &str = "test-delegate-attested";
 const CIPHER: [u8; 32] = [7u8; 32];
 const NONCE: [u8; 24] = [9u8; 24];
@@ -198,7 +215,9 @@ async fn attested_origin_via(
         "Authorization",
         format!("Bearer {}", token.as_str()).parse()?,
     );
-    let (stream, _) = connect_async(request).await?;
+    let (stream, _) = connect_async(request)
+        .await
+        .map_err(|e| anyhow::Error::new(ConnectFailed(e)))?;
     let mut client = WebApi::start(stream);
     let delegate_key = delegate.key().clone();
 
@@ -365,22 +384,49 @@ async fn attested_origin_survives_loopback_and_proxy_but_not_off_host() -> TestR
                     );
                     info!(%ip, "shape 3 (direct off-host): connection accepted, NOT attested — the gate held");
                 }
-                Err(e) => {
+                Err(e) if e.downcast_ref::<ConnectFailed>().is_some() => {
+                    // The handshake was refused (the pre-existing private-network
+                    // filter, or a host firewall), so the node never processed a
+                    // request and the gate was not exercised. Safe, but not
+                    // evidence — and deliberately NOT reported as a pass.
                     tracing::warn!(
                         %ip, error = %e,
-                        "shape 3 INCONCLUSIVE: the off-host connection never established (the \
-                         pre-existing private-network filter or the host firewall refused it), \
-                         so the attestation gate itself was not exercised on this host. Safe, \
-                         but not evidence about the gate."
+                        "shape 3 INCONCLUSIVE: the off-host connection never established, \
+                         so the attestation gate itself was not exercised on this host"
+                    );
+                }
+                Err(e) => {
+                    // The connection WAS established and then something went
+                    // wrong. Never treat this as inconclusive: a regression where
+                    // an off-host request errors instead of resolving to no
+                    // attestation would otherwise log a warning and pass.
+                    panic!(
+                        "shape 3 (direct off-host) connected but then failed: {e}. \
+                         The gate must resolve a non-local caller to NO attested \
+                         origin, not error."
                     );
                 }
             }
         }
         None => {
-            // Loud, and never mistakable for a pass.
+            // In CI this is a HARD FAILURE. These two legs are the most valuable
+            // assertions in the PR, and a silent environment-dependent skip is
+            // exactly the "verification that cannot fail" shape: the suite would
+            // stay green while the thing it exists to check never ran.
+            //
+            // Locally it stays a warning, so a developer on a loopback-only
+            // machine is not blocked. Set `FREENET_TEST_OFFHOST_IPV4` to any
+            // private address of the host to run them.
+            assert!(
+                std::env::var_os("CI").is_none(),
+                "shapes 2 and 3 could not run: no non-loopback PRIVATE IPv4 address was \
+                 found on this CI host. These legs are the point of this test, so a skip \
+                 here is a failure, not a pass. Set FREENET_TEST_OFFHOST_IPV4 in the \
+                 workflow to a private address of the runner."
+            );
             tracing::warn!(
-                "SKIPPED shapes 2 and 3: no non-loopback IPv4 address on this host, so the \
-                 proxy and off-host topologies cannot be exercised here. The Remote \
+                "SKIPPED shapes 2 and 3: no non-loopback private IPv4 address on this host, \
+                 so the proxy and off-host topologies cannot be exercised here. The Remote \
                  classification itself is pinned by client_events::types unit tests."
             );
         }


### PR DESCRIPTION
## Problem

The client API has no authentication, and it *issues* app-identity tokens to
anyone who asks, for any contract id (the contract need not exist). Delegates
authorize solely on the identity the node attests from that token, so a caller
that is not the app could obtain the app's attested identity and drive its
delegate.

Advisory: GHSA-824h-7x5x-wfmf.

**This PR withholds two things from a non-local connection: the attested app
identity, AND delivery of delegate notification output.** The second is not
implied by the title and has a user-visible failure mode of its own — see the
limitations.

Three distinct paths produced attested authority for a caller that should not
have had it, and closing only the first leaves the other two open:

1. **Origin resolution.** `resolve_message_origin` has three branches. The
   obvious fix gates `origin_contract` — the input the caller's token produced.
   But branch 3 (`inherited_origins`) is keyed on the **target delegate**, not on
   anything the caller supplied, so a caller that presents nothing at all still
   receives a fully attested `MessageOrigin::WebApp`.
2. **Inter-delegate dispatch.** A delegate can be registered with
   `origin_contract: None`. Messaging it makes its own WASM emit
   `SendDelegateMessage`, and `caller_delegate` wins unconditionally over every
   other origin — so the victim authorizes on an attested caller identity that
   the attacker never had to hold.
3. **Delegate app registry.** Registration happened for any `ApplicationMessages`
   request, before dispatch, and `handle_delegate_notification` fanned a
   delegate's output to **every** registered client with no filtering. Sending one
   message to a delegate subscribed you to its subsequent output.

## Approach

**Gate the resolved origin, not one of its inputs.** `resolve_message_origin`
returns `None` immediately for a connection that is not provably local, before
any branch runs. That covers all three branches by construction and stays
correct if a fourth is added. A source pin (`scope_gate_precedes_every_branch_in_source`)
holds the early return above the branch dispatch.

**Capture the connection's scope where `ConnectInfo` is actually readable.** The
new `ConnectionScope` is classified in `connection_info`
(`client_events/websocket.rs`), from the kernel-observed peer address — the same
anchor `decide_user_token` already uses for the durable per-user token, and the
same fail-closed rule (no `ConnectInfo` ⇒ `Remote`). It cannot be classified
inside `websocket_commands`'s `on_upgrade` closure, which takes no extractor. It
then rides down beside the request (never inside it) exactly like `user_context`,
so nothing a client sends can forge it. `ConnectionScope::default()` is `Remote`
so a construction site that forgets it loses attestation rather than granting it.

**Refuse inter-delegate dispatch from a delegate with no registration origin.**
Core already persists a first-writer origin record before registering
(`register_delegate_and_record_origin`), so "no contract id recorded" is a
definite answer rather than a race. A delegate with no attested identity cannot
lend one to anyone.

**Gate every consumer of the origin, not just message resolution.**
`origin_contract` has three consumers, and review found two of them ungated.
Besides `resolve_message_origin` it feeds (a) the durable first-registration
origin record, and (b) the `CallerIdentity` a consent prompt renders to the
human. Both are now gated at the top of their function so no arm can reach the
raw value. The record one mattered most: it is **first-writer-wins and
immutable**, so an off-host caller could have frozen a delegate's recorded
provenance to a value of their choosing, unrepairable short of wiping the
database.

**Route notification output by LOCALITY, not by attested identity.** An earlier
revision of this PR matched a registration's origin against the delegate's own
record. That was reverted: because the record is immutable, matching on it
created a *permanent, remotely-triggerable denial of service* (poison the record
before the real app registers and its notifications are dropped forever) and
broke any app that re-keys — both strictly worse than the bug being fixed.
Delivery now requires only that the registration came from a provably-local
connection, which is the boundary this fix can actually enforce. The scope limit
is stated rather than papered over: **unattested local clients are not separated
from each other.**

**No registration-record gate on inter-delegate dispatch.** An earlier revision
refused `SendDelegateMessage` from any delegate whose record held no contract id.
Removed, for two reasons. It broke legitimate use — that record is `None` both
for "never registered here" and for the tokenless CLI shape, so every delegate
installed by riverctl/atlasctl/fdev lost the ability to send, *silently* (the
caller swallows the error and the client still sees `Ok`). And it protected
nothing: a `DelegateKey` is a hash of the delegate's own code, so
`MessageOrigin::Delegate(K)` is self-authenticating and there is no identity to
forge. The escalation it targeted — an off-host caller laundering its lack of
attestation through a delegate hop — is closed where it belongs, by propagating
the originating connection scope into the hop.

**Reserve registry slots for local apps.** Off-host registrations are capped
below `MAX_APPS_PER_DELEGATE` so a local app can always register. This closes a
*pre-existing* denial of service (present on `main`) that the rest of this PR
would otherwise have left standing next to code that looked like it addressed it:
an off-host caller that simply holds connections open fills every slot with live
registrations that are never delivery targets. The dead-channel prune does not
help — nothing in that attack is dead.

**Suppress inter-delegate dispatch on the notification path.**
`handle_delegate_notification` descends from a contract state change rather than
a client connection, so it has no scope to pass and hardcodes `Local` — and it
calls the function that contains the inter-delegate hop. That made it a laundry:
a non-local caller drives its own delegate (correctly refused attestation), the
delegate subscribes, and on the next state change the same delegate re-executes
under `Local` and its `SendDelegateMessage` would reach a victim carrying a fully
attested `MessageOrigin::Delegate(caller)` — the scope it was just refused,
handed back one hop later. The hop is now suppressed on that path, which is
stronger than propagating a scope and is what the function's own design notes
already (falsely) claimed happened.

Suppression is safe because nothing first-party emits there, established by
**reading the delegates**: River's chat delegate returns only empty or
`UpdateContractRequest` from `ContractNotification` and never constructs a
`DelegateMessage`; the ghostkeys delegate rejects notifications in its catch-all;
and the only in-tree emitter of `SendDelegateMessage` sits in the
`ApplicationMessage` arm and errors on notifications. *"No test relied on it" is
deliberately not the grounds* — that is the same reasoning that let the
tokenless-CLI regression through earlier in this PR, and it is not evidence about
behaviour nobody wrote a test for.

**Deleted the dead duplicate resolution path** `server::local_node::run_local_node`.
It was unreachable (`bin/freenet.rs` runs `node::run_local_node`) and re-derived
`origin_contract` from the token alone, reading nothing about the connection, so
it could not have honored this gate. Two rustdocs still described it as a real
user-facing mode; both corrected.

**Audit logging at INFO** (the crate sets `release_max_level_info`, so `debug!`
compiles out of shipped binaries): token issuance logs contract id + peer address;
origin-attested delegate operations log the resolved origin kind, its id, the
target delegate, and whether the connection was loopback. Ids and addresses only
— never token values or key material.

Also repointed ten stale `freenet/freenet-core#5198` references at the advisory;
that issue no longer exists, so the citations resolved to nothing.

### Wire compatibility

**No protocol enum gains, loses, or reorders a variant, and no serde attribute on
a wire type changes.** Withholding attestation is not an error condition: the
caller receives exactly what a tokenless local caller has always received (no
`MessageOrigin`), so there is nothing new to encode. The inter-delegate refusal
surfaces through the existing `ExecutorError` path. A client built against the
currently-published freenet-stdlib interoperates with a node from this branch
unchanged.

## Limitations — please read before deploying

These are properties of the fix, not oversights. Stating them up front:

- **"Loopback" means this HOST, not this USER.** The secrets dir is `0o700`
  (`secrets_store/sweep.rs`), but loopback is not user-scoped: a different local
  user account, or a confined app (Flatpak/Snap/container) sandboxed from `$HOME`
  but able to open a localhost socket, passes this check. A same-user
  *unconfined* process is explicitly **out of scope** — it can read
  `secrets_dir/node_kek` and decrypt directly, so no client-API gate could help
  it; that is not a gap in this fix.
- **Locality is coarser than "the app", and does not separate hosted users.**
  Everything local is one bucket. Two consequences worth stating outright rather
  than leaving in a rustdoc:
  - *Cross-app harvesting among LOCAL clients is not prevented.* A second local
    process that sends one `ApplicationMessages` to (say) River's chat delegate
    thereafter receives all of that delegate's notification output. An earlier
    revision of this PR did block that by matching the delegate's attested
    identity; it was reverted because the only durable form of that identity is
    an immutable record, which turned the check into a permanent,
    remotely-triggerable DoS. This is a deliberate retreat, not an oversight.
  - *Hosted users are not separated from each other by this change.* Through a
    colocated proxy every browser is loopback, so all of a node's users land in
    the same bucket. Closing that needs a real per-client authorization model.

- **No-op behind any colocated reverse proxy — hosted or not.** Every client
  then presents the proxy's loopback address, so every request classifies as
  `Local` and this gate does nothing at all. That is `try.freenet.org`'s
  topology. **Do not read this PR as protecting a proxied deployment.** On such
  a node the isolation that carries weight is hosted mode's per-user
  `user_context`, which is path- and key-disjoint from the shared namespace and
  keyed by a token an attacker cannot obtain for another user — a forged app
  identity there lands in the attacker's own namespace. Application-side
  hardening remains necessary; this gate is not a substitute for it.
- **Breaks LAN browser access outright, not gracefully.** A browser on another
  machine on the LAN loses its attested identity, and delegate-backed apps stop
  working for it. There is no degraded mode and no operator opt-out in this PR.

  **Who is affected:** anyone reaching the node from another machine, including
  the setups `--allowed-source-cidrs` explicitly documents (Tailscale, WireGuard
  overlays). One case that is easy to miss: a user *on the node's own host* who
  browses `http://<lan-ip>:50509` or an mDNS `.local` name also presents a
  non-loopback source and is affected — use `127.0.0.1`.

  **What it looks like:** the app loads but delegate-backed features fail, with
  the delegate reporting a missing message origin. The node side logs one INFO
  line naming the delegate and `loopback=false`.

  **Notification DELIVERY is withheld too, and it fails silently.** A non-local
  client's requests and responses still work, so the app looks healthy — but it
  receives none of the delegate's pushed output. On a non-loopback bind this
  includes a browser on the user's own laptop. The node logs one INFO line per
  registration (not per message) naming the delegate and client.

  **Remedy:** reach the node over loopback. Either forward the port —
  `ssh -L 50509:127.0.0.1:50509 <node>`, then browse `http://127.0.0.1:50509` —
  or put a reverse proxy on the node's own host and point it at `127.0.0.1`
  (which is what makes this a no-op for `try.freenet.org`).

## Source-compatibility note

`freenet::server::local_node::run_local_node` was `pub` in a `pub` module, so
deleting it is a source break for any external library consumer across the
0.2.120 → 0.2.121 bump. Nothing in-tree depends on it, and it was unreachable
from the binary. Flagging it for the release notes rather than keeping dead,
silently-ungated code alive.

## Testing

Every behavioral change has a test that was confirmed to fail without the fix
(mutation-tested, not assumed):

| Mutation applied | Tests that failed |
|---|---|
| Delete the resolved-origin early return | all 3 `remote_connection_*` + the source pin |
| **Gate only `origin_contract`** (the near-miss fix) | `remote_connection_gets_no_inherited_origin`, `..._caller_delegate_origin`, source pin |
| Delete the locality delivery filter | `route_skips_non_local_registrations`, `skipped_remote_registration_is_retained_not_evicted` |
| Classify every registration as local | `delegate_registration_binds_to_the_connection_scope` |
| Ungate the durable origin-record write | `remote_registration_cannot_write_the_durable_origin_record` |
| Ungate the consent-prompt identity | `consent_prompt_identity_comes_from_the_gated_origin` |
| Re-add a gate refusing unattested inter-delegate dispatch | `unattested_delegate_can_still_dispatch_to_another_delegate`, **and the pre-existing tokenless e2e `test_delegate_to_delegate_messaging_e2e`** |
| Hardcode `Local` at the inter-delegate hop | `inter_delegate_hop_forwards_the_originating_scope` |
| Allow inter-delegate dispatch on the notification path | `inter_delegate_hop_forwards_the_originating_scope` |
| Skip a non-local registration without pruning its dead channel | `dead_non_local_registration_is_pruned_not_parked` |
| Remove the local slot reservation | `open_remote_connections_cannot_crowd_out_a_local_app` |
| Delete the once-per-registration log latch | `withhold_is_reported_once_per_registration` |

The second row is the one that matters most: a plausible partial fix compiles,
passes the branch-2 test, and is still exploitable. Two tests catch it. The last
three rows were added after review found the corresponding holes; the final one
guards a *regression* the fix itself introduced, so it fails if that gate comes
back.

The CLI-class claim is **verified, not asserted**: re-adding a registration-origin
gate makes `freenet-ping-app`'s pre-existing tokenless
`test_delegate_to_delegate_messaging_e2e` fail with *"Expected
DelegateMessageReceived from B"* — the reply silently missing, no error surfaced
to the client, exactly the failure shape described. That test connects with no
`authToken` over loopback, which is the same wire path riverctl, atlasctl and
fdev use, and it runs under CI's own invocation.

**Known coverage gap, stated rather than implied:** the notification-path
suppression has no behavioural test. It is covered by a source scrape
(`inter_delegate_hop_forwards_the_originating_scope`), both halves of which were
confirmed non-vacuous by mutation, but nothing exercises a delegate actually
failing to deliver `SendDelegateMessage` from a notification-driven run.

Coverage also includes: `ConnectionScope` classification (IPv4-mapped loopback,
127.0.0.0/8, off-host v4/v6, missing `ConnectInfo` ⇒ `Remote`, `Default` ⇒
`Remote`); a control half on the dispatch gate proving it keys on the origin
record and does not refuse all inter-delegate messaging; and preservation of the
tokenless-CLI shape (an unattested delegate still routes to unattested clients).

### Empirical verification across deployment shapes

`crates/core/tests/origin_attestation_scope.rs` boots a **real node** (event
loop, executor, WASM runtime) bound to `0.0.0.0` and drives **real delegate
WASM** through the real HTTP/WS stack. `test-delegate-attested` echoes back the
`MessageOrigin` the runtime actually handed it, so the assertion is on what a
delegate receives, not on an intermediate value. Observed (run on nova, all three
legs):

| Shape | Result |
|---|---|
| Direct loopback (local browser/CLI) | `MessageOrigin::WebApp(3qbR1e…)` — **still attested** |
| Colocated reverse proxy (off-host client → forwarder on a private address → `127.0.0.1`) | **still attested** — the gate is a no-op, which is `try.freenet.org`'s topology |
| Direct off-host (private/LAN source) | **not attested** (`origin_kind="none"`, `loopback=false`) |

Reverting the gate makes the off-host leg fail, so the test is not vacuous.

Shapes 2 and 3 need a non-loopback **private** address (the client API already
refuses non-private sources before the gate, so a public one proves nothing about
it). Discovery probes the default route and honours `FREENET_TEST_OFFHOST_IPV4`
for hosts whose default route is public — nova needed the override. **Under CI a
skip is a hard failure**, not a warning: these are the most valuable assertions
in the PR and an environment-dependent silent skip is exactly the shape where a
suite stays green while the thing it checks never runs. Locally it stays a
warning so a loopback-only machine is not blocked. The off-host leg also
distinguishes "the connection was refused" (inconclusive, reported as such) from
"the connection was accepted and then errored" (a hard failure), so a regression
that errors instead of withholding attestation cannot pass as inconclusive.

Verified unaffected (checked, not assumed): the Rust stdlib client, riverctl, and
atlasctl all connect with no `authToken` and never receive an attested origin
today; `fdev` never sends `ApplicationMessages`; the TS SDK reads the
authorization cookie and appends `?authToken=`, and the shell bridge strips any
caller-supplied token before injecting its own, so browser UIs on localhost are
unchanged.

[AI-assisted - Claude]
