### PR TITLE
chore: bump freenet-test-network to 0.1.24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2300,9 +2300,9 @@ dependencies = [
 
 [[package]]
 name = "freenet-test-network"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19879a189ec66a3f559882e200077e101d90861ae6151c9fb63dbd5eda65bdfe"
+checksum = "738747137ffe70134077a0737e09ad90673d5fc3f64c2733dcf80feee7091e16"
 dependencies = [
  "anyhow",
  "bollard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,7 +126,7 @@ wasmparser = "0.255"
 # Testing/simulation
 arbitrary = { version = "1", features = ["derive"] }
 criterion = { version = "0.8", features = ["async_tokio"] }
-freenet-test-network = "0.1.22"
+freenet-test-network = "0.1.24"
 httptest = "0.16"
 proptest = "1"
 regex = "1"

--- a/apps/freenet-ping/app/Cargo.toml
+++ b/apps/freenet-ping/app/Cargo.toml
@@ -25,7 +25,7 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 [dev-dependencies]
 bincode = { workspace = true }
 freenet = { path = "../../../crates/core" }
-freenet-test-network = "0.1.23"
+freenet-test-network = "0.1.24"
 test-log = { workspace = true }
 testresult = { workspace = true }
 


### PR DESCRIPTION
Picks up freenet/freenet-test-network#5: Docker NAT test peers were silently reporting telemetry to the production collector (nova.locut.us:4318) instead of staying silent like the Local backend already does. Version bump only, no code changes here.

[AI-assisted - Claude]