### PR TITLE
fix(update): normalise the release tag on the node's detection path

### DIFF
--- a/crates/core/src/bin/commands/auto_update.rs
+++ b/crates/core/src/bin/commands/auto_update.rs
@@ -953,7 +953,25 @@ async fn get_latest_version() -> Result<String> {
     // Never bypasses the cooldown: this is the automated path, and the whole
     // point of the cooldown is to keep it quiet while the IP is limited. (The
     // check above already returned; the flag covers the re-check inside.)
-    fetch_latest_release_tag(false).await
+    //
+    // Normalise HERE, at the producer, not at the call sites. This function is
+    // the node's DETECTION path (see the rustdoc above): every consumer of it
+    // wants a comparable version, never a string that addresses the release.
+    // `fetch_latest_release_tag` returns the tag VERBATIM (`v0.2.121`) since
+    // #5104, which is correct for the INSTALLER — `update.rs` builds asset URLs
+    // from it — but every consumer on this path either parses it as semver or
+    // compares it against a stored version, and both reject the leading `v`.
+    //
+    // #5104 stripped at one consumer (`update.rs:389`) and left this path raw,
+    // which silently broke auto-update fleet-wide for v0.2.120 and v0.2.121:
+    // `semver::Version::parse("v0.2.121")` fails, the update is dropped with a
+    // `warn!`, and nothing else notices. Stripping per-call-site would fix the
+    // parses and leave the #4073 gates below (`is_version_pinned_bad`,
+    // `is_version_install_gated`) comparing a `v`-prefixed string against the
+    // stripped values their writers store — silently disabling the
+    // crash-loop-rollback pin. One normalisation at the boundary fixes both.
+    let tag = fetch_latest_release_tag(false).await?;
+    Ok(version_from_tag(&tag).to_string())
 }
 
 /// Get the state directory for update tracking files.
@@ -1694,6 +1712,62 @@ mod tests {
             Some("0.1.75".to_string())
         );
         assert_eq!(compare_versions_for_startup("0.1.75", "0.1.75-alpha"), None);
+    }
+
+    /// #5221: the node's detection path MUST normalise the release tag.
+    ///
+    /// `fetch_latest_release_tag` returns the tag VERBATIM (`v0.2.121`) since
+    /// #5104 — correct for the installer, which builds asset URLs from it. But
+    /// every consumer of `get_latest_version` either parses it as semver or
+    /// compares it against a stored version, and both reject the leading `v`.
+    /// #5104 stripped at `update.rs` only and left this path raw, so auto-update
+    /// was silently dead fleet-wide for v0.2.120 and v0.2.121.
+    ///
+    /// A source pin rather than a behavioural test because `get_latest_version`
+    /// does network I/O with no injection seam. Bounded to that function so it
+    /// cannot match a later occurrence (AGENTS.md, "WHEN writing a source-scrape
+    /// pin test").
+    #[test]
+    fn get_latest_version_normalises_the_tag() {
+        let src = include_str!("auto_update.rs");
+        let (_, after) = src
+            .split_once("async fn get_latest_version() -> Result<String> {")
+            .expect("get_latest_version definition not found");
+        let (body, _) = after
+            .split_once("/// Get the state directory")
+            .expect("could not bound get_latest_version");
+        let stripped: String = body.chars().filter(|c| !c.is_whitespace()).collect();
+
+        assert!(
+            stripped.contains("version_from_tag("),
+            "get_latest_version must normalise through version_from_tag before \
+             returning. Without it the raw tag reaches semver::Version::parse \
+             (which rejects a leading 'v') AND the #4073 gates \
+             is_version_pinned_bad / is_version_install_gated, whose writers \
+             store STRIPPED values -- so those gates silently never match and \
+             the crash-loop-rollback pin is disabled."
+        );
+    }
+
+    /// Why the normalisation has to happen upstream: the consumers genuinely
+    /// cannot cope with a raw tag. Documents the exact #5221 production failure.
+    #[test]
+    fn raw_tag_is_rejected_by_the_consumers() {
+        // Production log was:
+        //   WARN failed to parse latest version 'v0.2.121':
+        //        unexpected character 'v' while parsing major version number
+        assert_eq!(
+            compare_versions_for_startup("0.2.120", "v0.2.121"),
+            None,
+            "a v-prefixed tag must NOT be treated as an available update -- it \
+             fails to parse and the update is dropped silently"
+        );
+        // Normalised, the very same tag is correctly seen as newer.
+        assert_eq!(
+            compare_versions_for_startup("0.2.120", version_from_tag("v0.2.121")),
+            Some("0.2.121".to_string()),
+            "once normalised the update must be detected"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

**The fleet cannot auto-update.** Since v0.2.120 the node fetches the GitHub release tag and hands it to `semver::Version::parse` **verbatim**, so `"v0.2.121"` fails to parse and every update is silently dropped.

Confirmed on a production node (not inferred):

```
INFO  Startup update check against GitHub current="0.2.120" jitter_secs=20
WARN  Startup update check: failed to parse latest version 'v0.2.121':
      unexpected character 'v' while parsing major version number
```

#5104 changed `parse_tag_from_release_location` to return the tag verbatim — correct for the installer, which builds asset URLs from it — and added `version_from_tag()` to strip. But the stripper was wired into the **installer** path only (`update.rs`). The node's detection path was never updated.

Measured impact: 0.2.120 reached ~85% fleet adoption in 4.6h; 0.2.121 has been flat at ~9-11% for over seven hours. The bug is present in **both** 0.2.120 and 0.2.121, so a fix cannot deliver itself — every operator has to run `freenet update` by hand once.

Tracking: #5221. Post-mortem: #5222.

## Solution

Normalise at the **producer**, in `get_latest_version`, not at each call site.

That function is the node's *detection* path — its own rustdoc says so. Every consumer of it wants a comparable version, never a string that addresses a release. One line at the boundary fixes:

- `compare_versions_for_startup` (the startup check — the site in the log above)
- `check_if_update_available` (the urgent / discovery / version-mismatch triggers, a **separate** broken site that the startup path's tests do not cover)
- the #4073 gates `is_version_pinned_bad` / `is_version_install_gated`

That last one is why the per-call-site fix is wrong. Those gates compare by **exact string equality** against values their writers store **stripped** (`update.rs` `begin_probation` / `record_install_failure`). Fixing only the parses would leave them comparing `"v0.2.121"` against a stored `"0.2.121"`, never matching — silently disabling the crash-loop-rollback pin and the install-failure gate, restoring the restart loop those gates exist to prevent, with no log line.

The raw tag is untouched where a release is **addressed**: `update.rs` still builds asset URLs from `latest_tag`.

## Testing

`get_latest_version_normalises_the_tag` — a **bounded** source pin (the function does network I/O with no injection seam), asserting the normalisation is present. **Verified to FAIL with the normalisation removed**, then pass once restored:

```
test get_latest_version_normalises_the_tag ... FAILED     # fix removed
test get_latest_version_normalises_the_tag ... ok         # fix restored
```

`raw_tag_is_rejected_by_the_consumers` — documents the real failure: a `v`-prefixed tag is **not** detected as an update, while the normalised form is. This is the behaviour that makes upstream normalisation necessary rather than optional.

Full binary suite: 367 passed, 0 failed.

## Why CI did not catch this

The producer's contract and the consumers' contract were each tested, and they **contradicted each other**:

- the producer test asserts the tag comes back **verbatim** (`"v1.2.3"`, with a comment saying so)
- every consumer test injects an **already-stripped** literal (`Ok("0.1.75".to_string())`)

Both passed. Nothing tested the seam. Because both the tag and the version are `String`, the compiler could not object, and the test double was free to drift from the real producer — and did.

#5222 tracks the structural follow-ups: typing the boundary so a release tag and a version cannot be confused (as `release-agent/src/github.rs` already does by returning `semver::Version`), and a release canary that actually exercises **auto**-update — the designated pre-release peer has been running `--disable-auto-update` since 2026-07-29, so the one machine positioned to catch this was configured not to.

## Scope

Deliberately minimal — this normalisation and its tests, nothing else. Every operator must install this release by hand, so a defect means asking the whole network to repeat that. The graceful-shutdown exit-code fix and the `uptime_seconds` fix are ready but held for the next release.

Note on ordering: the exit-code fix must land **after** this one. While this bug is live, graceful-shutdown-exits-1 accidentally fires the unit's `ExecStopPost` hook on every restart, which runs `freenet update` — whose installer path strips correctly and succeeds. That accident is currently the fleet's only working update route, and is the likeliest explanation for the ~10% that have moved.

Fixes #5221

[AI-assisted - Claude]
