### PR TITLE
fix(node): exit 0 on a requested graceful shutdown

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -58,6 +58,18 @@ retries = 0
 filter = "test(test_ping_blocked_peers)"
 retries = 0
 
+# #5227 graceful-shutdown exit code. The whole subject of this test is a signal
+# race (SIGTERM must reach an installed handler and the process must exit 0), so
+# a retry would be indistinguishable from the regression it exists to catch —
+# exactly the flake-laundering the repo's flaky-tests rule forbids. It also boots
+# a real `freenet network` subprocess, so its budget (120s readiness + 45s exit)
+# needs more headroom than the 240s default; without this the harness SIGKILLs it
+# instead of letting the test emit its own log-attached diagnostic.
+[[profile.ci.overrides]]
+filter = "test(graceful_shutdown_on_sigterm_exits_zero)"
+retries = 0
+slow-timeout = { period = "300s", terminate-after = 2 }
+
 [profile.nightly]
 # Nightly tests run longer by design; no retries since failures need investigation.
 retries = 0

--- a/crates/core/src/bin/freenet.rs
+++ b/crates/core/src/bin/freenet.rs
@@ -366,9 +366,18 @@ async fn run_network_node_with_signals(
     let mut sigterm = signal::unix::signal(signal::unix::SignalKind::terminate())
         .context("failed to install SIGTERM handler")?;
 
+    // Set when THIS process asks the node to stop because an operator signalled
+    // it (SIGTERM from `systemctl stop`, SIGINT from Ctrl+C). Load-bearing for
+    // the exit code: see `finish_run` — an "operator asked us to stop" exit is a
+    // SUCCESS, but the same `EventLoopExitReason::GracefulShutdown` value is
+    // ALSO produced by a fault (a critical internal channel dying, see
+    // `p2p_protoc::ChannelCloseReason`), which must keep failing loudly.
+    let shutdown_requested = Arc::new(std::sync::atomic::AtomicBool::new(false));
+
     // Spawn a task to listen for shutdown signals and trigger graceful shutdown
     let signal_task = {
         let shutdown_handle = shutdown_handle.clone();
+        let shutdown_requested = Arc::clone(&shutdown_requested);
         GlobalExecutor::spawn(async move {
             #[cfg(unix)]
             let shutdown_reason = tokio::select! {
@@ -383,6 +392,9 @@ async fn run_network_node_with_signals(
             };
 
             tracing::info!(reason = shutdown_reason, "Initiating graceful shutdown");
+            // Record the request BEFORE making it, so the flag is always visible
+            // by the time the event loop can observe the shutdown and return.
+            shutdown_requested.store(true, std::sync::atomic::Ordering::SeqCst);
             shutdown_handle.shutdown().await;
         })
     };
@@ -899,11 +911,62 @@ async fn run_network_node_with_signals(
     // and complete their cleanup without being forcefully killed by SIGKILL.
     tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 
+    let result = finish_run(
+        result,
+        shutdown_requested.load(std::sync::atomic::Ordering::SeqCst),
+    );
+
     if result.is_ok() {
         tracing::info!("Graceful shutdown complete");
     }
 
     result
+}
+
+/// Decide what a finished node run means for the PROCESS EXIT CODE (#5227).
+///
+/// `run_network_node` reports a clean SIGTERM/SIGINT stop as
+/// `Err(EventLoopExitReason::GracefulShutdown)` — a typed sentinel, not a real
+/// error. `main` used to hand that straight to its `eprintln!("Error: …")` +
+/// `std::process::exit(1)` fallback, so a deliberate `systemctl stop` was logged
+/// as `status=1/FAILURE`; and because `rollback::classify_stop` treats any
+/// status outside {0, 2, 42, 43, 44} as a crash, three clean stops of a freshly
+/// updated node inside its post-update probation window were enough to trigger
+/// an auto-rollback of a perfectly healthy release (#4073).
+///
+/// Two conditions are required to map that to a success exit, and the second is
+/// the load-bearing one:
+///
+/// 1. `listener_exit_is_graceful(&err)` — the SAME predicate the #4549
+///    fatal-listener force-exit path uses, so the two cannot disagree about
+///    which errors are candidates.
+/// 2. `shutdown_requested` — THIS process asked the node to stop, because an
+///    operator signalled it.
+///
+/// (1) alone is NOT sufficient, and this is the whole reason the flag exists.
+/// `p2p_protoc` raises the very same `GracefulShutdown` when a critical internal
+/// channel dies (`ChannelCloseReason::{Bridge, Controller, Notification,
+/// OpExecution}`) — a node-fatal fault that logs `CRITICAL: Channel closed …`.
+/// `client_events.rs` likewise sends the identical `NodeEvent::Disconnect` when
+/// every client transport has died, a degraded state its own comments call
+/// "restart recommended". Neither is distinguishable from an operator stop at the
+/// p2p layer, so this flag is the sole discriminator. Both must keep a non-zero
+/// exit: on Linux that is what still fires the unit's `ExecStopPost` self-heal
+/// and counts the crash toward probation, and on the macOS/Windows wrappers an
+/// exit 0 is read as "normal shutdown" and would leave the node DOWN rather than
+/// relaunching it.
+///
+/// The auto-update exit is untouched: it surfaces as `UpdateNeededError`, not an
+/// `EventLoopExitReason`, so it still exits 42 and still fires the supervisor's
+/// `freenet update` hook. In the rare race where an update is detected in the
+/// same instant as a SIGTERM, the unbiased `select!` above may resolve the node
+/// arm and the exit is a clean 0 — the operator asked us to stop, so stopping
+/// wins, and the update is picked up by `startup_update_check` on the next boot.
+fn finish_run(result: anyhow::Result<()>, shutdown_requested: bool) -> anyhow::Result<()> {
+    match result {
+        Err(e) if shutdown_requested && freenet::listener_exit_is_graceful(&e) => Ok(()),
+        other => other,
+    }
 }
 
 /// Exit code when another freenet instance is already running.
@@ -1331,6 +1394,63 @@ fn main() {
 mod tests {
     #[cfg(target_os = "linux")]
     use super::parse_listening_inode;
+
+    /// #5227 truth table for the process exit code. The end-to-end proof is
+    /// `tests/graceful_shutdown_exit_code.rs` (it asserts the real process's
+    /// status); this pins the decision itself, including the case that test
+    /// cannot drive a live node into — an UNREQUESTED `GracefulShutdown`, raised
+    /// when a critical internal channel dies (`p2p_protoc::ChannelCloseReason`)
+    /// or every client transport is lost (`client_events.rs`).
+    ///
+    /// Restoring the bug (`finish_run` returning `result`), broadening the guard
+    /// to `Err(_) => Ok(())`, or dropping either conjunct fails this test.
+    #[test]
+    fn finish_run_maps_only_a_requested_graceful_stop_to_success() {
+        use super::commands::auto_update::UpdateNeededError;
+        use super::finish_run;
+        use freenet::EventLoopExitReason;
+
+        // The bug: an operator-requested stop is a SUCCESS.
+        assert!(
+            finish_run(Err(EventLoopExitReason::GracefulShutdown.into()), true).is_ok(),
+            "a SIGTERM/SIGINT stop must exit 0, or systemd logs status=1/FAILURE for a \
+             clean `systemctl stop` and the post-update probation counts it as a crash"
+        );
+
+        // The trap: the SAME sentinel is raised by a critical-channel death that
+        // nobody asked for. It must keep failing, or the macOS/Windows wrappers
+        // read "normal shutdown" and leave the node DOWN, and systemd skips the
+        // ExecStopPost self-heal and the probation crash count.
+        assert!(
+            finish_run(Err(EventLoopExitReason::GracefulShutdown.into()), false).is_err(),
+            "an UNREQUESTED graceful-shutdown exit is a fault and must stay non-zero"
+        );
+
+        // Ordinary fatal listener exits are untouched, requested or not.
+        assert!(finish_run(Err(EventLoopExitReason::UnexpectedStreamEnd.into()), true).is_err());
+        assert!(finish_run(Err(anyhow::anyhow!("boom")), true).is_err());
+
+        // Auto-update must still exit 42, or `ExecStopPost` (which skips `0|43`)
+        // never runs `freenet update`.
+        let update = finish_run(
+            Err(UpdateNeededError {
+                new_version: "9.9.9".to_string(),
+            }
+            .into()),
+            true,
+        )
+        .expect_err("update exit must not become a success");
+        assert_eq!(
+            update
+                .downcast_ref::<UpdateNeededError>()
+                .map(|u| u.new_version.as_str()),
+            Some("9.9.9"),
+            "the UpdateNeededError must survive so `main` exits 42"
+        );
+
+        // A run that somehow returned Ok stays Ok.
+        assert!(finish_run(Ok(()), false).is_ok());
+    }
 
     #[test]
     fn auto_update_default_stays_enabled_flag_and_dirty_disable() {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -21,7 +21,8 @@ mod message;
 mod node;
 pub use node::{
     EventLoopExitReason, Node, ShutdownHandle, enable_abort_on_fatal_listener_exit,
-    enable_abort_on_redb_poison, enable_fast_crash_exit_code, run_local_node, run_network_node,
+    enable_abort_on_redb_poison, enable_fast_crash_exit_code, listener_exit_is_graceful,
+    run_local_node, run_network_node,
 };
 
 /// Network operation/transaction state machines.

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -109,6 +109,7 @@ pub(crate) mod testing_impl;
 pub(crate) use p2p_impl::abort_process_on_redb_poison;
 pub use p2p_impl::{
     enable_abort_on_fatal_listener_exit, enable_abort_on_redb_poison, enable_fast_crash_exit_code,
+    listener_exit_is_graceful,
 };
 pub use request_router::{DeduplicatedRequest, RequestRouter};
 

--- a/crates/core/src/node/p2p_impl.rs
+++ b/crates/core/src/node/p2p_impl.rs
@@ -245,7 +245,21 @@ pub fn enable_abort_on_fatal_listener_exit() {
 /// Graceful shutdown (`NodeEvent::Disconnect`, e.g. SIGTERM or auto-update) returns
 /// [`EventLoopExitReason::GracefulShutdown`]; every other listener-exit error
 /// (UDP-listener death, unexpected stream end, a handler/transport error) is fatal.
-fn listener_exit_is_graceful(err: &anyhow::Error) -> bool {
+///
+/// Public because the `freenet` binary must classify the SAME error with the SAME
+/// predicate to choose its PROCESS EXIT CODE (#5227): this predicate already
+/// reported "graceful" for a SIGTERM stop while `main` still fell through to
+/// `eprintln!("Error: …")` + `std::process::exit(1)`, so a clean `systemctl stop`
+/// logged `status=1/FAILURE` and the crash-loop rollback counted it as a crash.
+///
+/// **Necessary but NOT sufficient for a success exit.** `p2p_protoc` also raises
+/// [`EventLoopExitReason::GracefulShutdown`] when a critical internal channel dies
+/// (`ChannelCloseReason::{Bridge, Controller, Notification, OpExecution}`) — a
+/// node-fatal fault nobody requested. This predicate is deliberately permissive
+/// there, because its own job is only to suppress the #4549 force-exit; a caller
+/// choosing an EXIT CODE must additionally confirm the stop was REQUESTED. See
+/// `bin/freenet.rs::finish_run`.
+pub fn listener_exit_is_graceful(err: &anyhow::Error) -> bool {
     err.downcast_ref::<EventLoopExitReason>()
         .is_some_and(|reason| matches!(reason, EventLoopExitReason::GracefulShutdown))
 }

--- a/crates/core/tests/graceful_shutdown_exit_code.rs
+++ b/crates/core/tests/graceful_shutdown_exit_code.rs
@@ -1,0 +1,306 @@
+//! A graceful shutdown must make the `freenet` PROCESS exit 0 (#5227).
+//!
+//! Regression test for a production incident on a node running 0.2.121. A
+//! deliberate `systemctl --user stop freenet` produced:
+//!
+//! ```text
+//! CRITICAL: Network event listener exited: Graceful shutdown
+//! Error: Graceful shutdown
+//! systemd: freenet.service: Main process exited, code=exited, status=1/FAILURE
+//! Freenet 0.2.121: crash 1/3 during post-update probation (node stop status 1);
+//!   not updating, will auto-roll-back if it keeps crashing.
+//! ```
+//!
+//! Nothing had crashed. `run_network_node` reports a clean SIGTERM stop as
+//! `Err(EventLoopExitReason::GracefulShutdown)` — a typed sentinel, not a real
+//! error — and `main` handed it to the `eprintln!("Error: …")` +
+//! `std::process::exit(1)` fallback. `rollback::classify_stop` treats any status
+//! outside {0, 2, 42, 43, 44} as a crash, so three clean stops of a freshly
+//! updated node inside its probation window were enough to auto-roll-back a
+//! perfectly healthy release (#4073).
+//!
+//! ## Why this test spawns a real process
+//!
+//! The classification predicate was ALREADY correct: `p2p_impl::
+//! listener_exit_is_graceful` returned `true` for this exit, and
+//! `listener_exit_graceful_classification` pinned that. The bug lived entirely
+//! in the gap between that predicate and the process exit code, which no
+//! in-process test can observe — `std::process::exit` only runs in the real
+//! binary's `main`. So the assertion here is deliberately on
+//! `ExitStatus::code()` of a spawned `freenet network`, not on any predicate.
+//!
+//! The decision itself — including the case a live node cannot easily be driven
+//! into, an UNREQUESTED `GracefulShutdown` from a critical channel death, which
+//! must still exit non-zero — is pinned by
+//! `finish_run_maps_only_a_requested_graceful_stop_to_success` in
+//! `src/bin/freenet.rs`.
+//!
+//! Unix only: the failure is about SIGTERM handling, which has no Windows
+//! analogue (the Windows service stop path goes through `commands::service`).
+
+#![cfg(unix)]
+
+use std::{
+    path::{Path, PathBuf},
+    process::{Child, Command, Stdio},
+    time::{Duration, Instant},
+};
+
+/// Log line emitted by `node::run_network_node`, which the binary only reaches
+/// from INSIDE the `tokio::select!` of `run_network_node_with_signals` — i.e.
+/// strictly after `signal::unix::signal(SignalKind::terminate())` has installed
+/// the SIGTERM handler. Waiting for it is what makes the test deterministic: a
+/// SIGTERM delivered before that point would kill the process with the signal's
+/// default disposition (no exit code at all) rather than exercising the
+/// graceful-shutdown path. The node's WS API is NOT a usable readiness signal —
+/// `run_network` binds it several steps earlier, before the node is built.
+const READY_MARKER: &str = "Starting node";
+
+/// Emitted by the signal task in `run_network_node_with_signals` on SIGTERM /
+/// SIGINT. Asserted after exit so a status of 0 cannot be credited to some other
+/// clean-exit path (`run_disabled_idle`, an early return) — the test must prove
+/// the node exited 0 *because it handled the signal*.
+const SHUTDOWN_MARKER: &str = "Initiating graceful shutdown";
+
+/// Path to the `freenet` binary built for THIS test run. Cargo sets
+/// `CARGO_BIN_EXE_<name>` for integration tests and builds the binary first, so
+/// unlike a hand-rolled `target/debug/…` lookup this can never assert against a
+/// stale binary that predates the change under test.
+fn freenet_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_freenet"))
+}
+
+/// Reserve an ephemeral port by binding then immediately freeing it. The kernel
+/// won't hand the same port straight back on the next `:0` request, so this
+/// races far less than a fixed port.
+fn reserve_port() -> std::io::Result<u16> {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0")?;
+    Ok(listener.local_addr()?.port())
+}
+
+/// A spawned `freenet network` subprocess, SIGKILLed and reaped on drop so a
+/// panicking assertion never leaks a node process.
+struct NodeProcess {
+    child: Child,
+    log_dir: PathBuf,
+}
+
+impl Drop for NodeProcess {
+    fn drop(&mut self) {
+        if self.child.kill().is_ok() {
+            let _reaped = self.child.wait().is_ok();
+        }
+    }
+}
+
+impl NodeProcess {
+    /// Spawn a self-contained, fully offline gateway node rooted at `dir`.
+    fn spawn(dir: &Path) -> anyhow::Result<Self> {
+        let ws_port = reserve_port()?;
+        let network_port = reserve_port()?;
+        let child = Command::new(freenet_bin())
+            .arg("network")
+            // Same #4366 telemetry-contamination guard as persistence_roundtrip.rs:
+            // this runs the real binary from target/<profile>/, so neither of the
+            // in-process "under cargo test" signals fires and telemetry would
+            // otherwise default ON and POST to the production OTLP collector.
+            .env("FREENET_TELEMETRY_ENABLED", "false")
+            // Pin the child's logging rather than inheriting it. CI's test_unit
+            // job exports `RUST_LOG=error` (ci.yml), and the tracing layer builds
+            // its file filter with `from_env_lossy()`, which would drop the INFO
+            // readiness marker entirely and strand this test on its timeout.
+            // Clear the log-destination overrides for the same reason: both
+            // markers must land in a *file* in the log dir, because stdout/stderr
+            // are /dev/null here and the console layer is off under `cargo test`
+            // (it requires a terminal).
+            .env("RUST_LOG", "info")
+            .env_remove("FREENET_LOG_TO_STDERR")
+            .env_remove("FREENET_DISABLE_LOGS")
+            .env_remove("FREENET_LOG_FORMAT")
+            .args(["--ws-api-address", "127.0.0.1"])
+            .args(["--ws-api-port", &ws_port.to_string()])
+            .args(["--network-address", "127.0.0.1"])
+            .args(["--network-port", &network_port.to_string()])
+            .args(["--public-network-address", "127.0.0.1"])
+            .args(["--public-network-port", &network_port.to_string()])
+            .arg("--is-gateway")
+            // No gateway-index fetch, so the node boots with no internet.
+            .arg("--skip-load-from-network")
+            .arg("--ignore-protocol-checking")
+            // Without this the node asks GitHub for a newer release at startup
+            // and, on a clean (non-dirty) CI build, could exit 42 instead of 0 —
+            // a real update path, but not the one under test. The disabled
+            // branch is taken before the 0-60s startup jitter sleep, so this
+            // also keeps the test fast.
+            .arg("--disable-auto-update")
+            .args(["--location", "0.5"])
+            // Nothing is in flight, so there is nothing to drain; keep the stop
+            // prompt rather than waiting out the 30s default.
+            .args(["--shutdown-drain-secs", "1"])
+            .args(["--config-dir", &dir.to_string_lossy()])
+            .args(["--data-dir", &dir.to_string_lossy()])
+            .args(["--log-dir", &dir.to_string_lossy()])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()?;
+        Ok(Self {
+            child,
+            log_dir: dir.to_path_buf(),
+        })
+    }
+
+    fn pid(&self) -> i32 {
+        self.child.id() as i32
+    }
+
+    /// Concatenated contents of the node's rotated log files. The tracing layer
+    /// only mirrors to the console when stdout is a terminal (it is not under
+    /// `cargo test`), so the log dir is the sole place the marker appears.
+    fn logs(&self) -> String {
+        let mut out = String::new();
+        if let Ok(entries) = std::fs::read_dir(&self.log_dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.extension().is_some_and(|e| e == "log") {
+                    out.push_str(&std::fs::read_to_string(&path).unwrap_or_default());
+                }
+            }
+        }
+        out
+    }
+
+    /// Block until the node has installed its SIGTERM handler and entered the
+    /// event loop, or fail with the node's own logs attached.
+    fn wait_until_ready(&mut self, timeout: Duration) -> anyhow::Result<()> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if let Some(status) = self.child.try_wait()? {
+                anyhow::bail!(
+                    "freenet exited ({status:?}) before reaching {READY_MARKER:?}. Logs:\n{}",
+                    self.logs()
+                );
+            }
+            if self.logs().contains(READY_MARKER) {
+                return Ok(());
+            }
+            if Instant::now() >= deadline {
+                anyhow::bail!(
+                    "freenet did not log {READY_MARKER:?} within {timeout:?}. Logs:\n{}",
+                    self.logs()
+                );
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+    }
+
+    fn send_sigterm(&self) -> anyhow::Result<()> {
+        // SAFETY: `kill(2)` with a pid we own and a valid signal number. The
+        // child is still un-reaped (we have not called `wait`), so the pid
+        // cannot have been recycled.
+        if unsafe { libc::kill(self.pid(), libc::SIGTERM) } != 0 {
+            anyhow::bail!("kill(SIGTERM) failed: {}", std::io::Error::last_os_error());
+        }
+        Ok(())
+    }
+
+    /// Wait for the process to exit, returning its raw `ExitStatus`.
+    fn wait_for_exit(&mut self, timeout: Duration) -> anyhow::Result<std::process::ExitStatus> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if let Some(status) = self.child.try_wait()? {
+                return Ok(status);
+            }
+            if Instant::now() >= deadline {
+                anyhow::bail!(
+                    "freenet did not exit within {timeout:?} of SIGTERM. Logs:\n{}",
+                    self.logs()
+                );
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+    }
+}
+
+/// SIGTERM a running node and assert the PROCESS exits 0.
+///
+/// Before the fix this failed with `Some(1)`: `main` returned
+/// `Err(EventLoopExitReason::GracefulShutdown)` and `Termination` turned the
+/// sentinel into a failure status.
+#[test]
+fn graceful_shutdown_on_sigterm_exits_zero() -> anyhow::Result<()> {
+    use std::os::unix::process::ExitStatusExt;
+
+    let dir = tempfile::tempdir()?;
+    let mut node = NodeProcess::spawn(dir.path())?;
+
+    // A debug-profile node on a loaded self-hosted runner needs a moment to open
+    // redb and build; it is seconds, not minutes. Kept well inside nextest's
+    // per-test cap so a slow run still produces this test's own log-attached
+    // diagnostic instead of being SIGKILLed by the harness.
+    node.wait_until_ready(Duration::from_secs(120))?;
+
+    node.send_sigterm()?;
+
+    // The binary sleeps 2s after aborting its background tasks, on top of the
+    // 1s drain window; systemd allows 45s (TimeoutStopSec) for the whole
+    // teardown, so match that bound.
+    let status = node.wait_for_exit(Duration::from_secs(45))?;
+
+    // Distinguish the two failure shapes explicitly. `signal()` is set (and
+    // `code()` is None) only if SIGTERM arrived before the handler was
+    // installed, which would mean the readiness gate above is not doing its job
+    // — a test bug, not the regression.
+    assert!(
+        status.signal().is_none(),
+        "node was killed by signal {:?} instead of handling SIGTERM — the readiness \
+         gate raced. Logs:\n{}",
+        status.signal(),
+        node.logs()
+    );
+    assert_eq!(
+        status.code(),
+        Some(0),
+        "a graceful shutdown must exit 0 (#5227). Any other code is classified as a \
+         CRASH by rollback::classify_stop, so systemd logs status=N/FAILURE for a clean \
+         `systemctl stop` and the post-update probation counts it toward an \
+         auto-rollback. Logs:\n{}",
+        node.logs()
+    );
+    // Guards against crediting the 0 to some other clean-exit path: the node must
+    // have exited 0 BECAUSE it handled the signal.
+    let logs = node.logs();
+    assert!(
+        logs.contains(SHUTDOWN_MARKER),
+        "exit 0 must come from the signal-handling path — {SHUTDOWN_MARKER:?} is absent, \
+         so the node exited cleanly for some other reason and this test proves nothing. \
+         Logs:\n{logs}"
+    );
+
+    Ok(())
+}
+
+/// The exposed predicate must key on the error TYPE, not its text.
+///
+/// `finish_run` only reaches a success exit for errors this returns `true` for,
+/// so a string-shaped match here would let any error whose `Display` happens to
+/// read "Graceful shutdown" (a peer-supplied or formatted message) be laundered
+/// into exit 0.
+#[test]
+fn graceful_classification_is_by_type_not_by_message() {
+    #[derive(Debug, thiserror::Error)]
+    #[error("Graceful shutdown")]
+    struct GracefulLookalike;
+
+    assert!(freenet::listener_exit_is_graceful(
+        &freenet::EventLoopExitReason::GracefulShutdown.into()
+    ));
+    assert!(!freenet::listener_exit_is_graceful(
+        &freenet::EventLoopExitReason::UnexpectedStreamEnd.into()
+    ));
+    assert!(!freenet::listener_exit_is_graceful(&anyhow::Error::new(
+        GracefulLookalike
+    )));
+    assert!(!freenet::listener_exit_is_graceful(&anyhow::anyhow!(
+        "Graceful shutdown"
+    )));
+}


### PR DESCRIPTION
## Problem

A **graceful** shutdown of `freenet network` exited with status **1**. Observed directly on a production node running 0.2.121 — a deliberate `systemctl --user stop`, nothing crashed:

```
18:15:14  CRITICAL: Network event listener exited: Graceful shutdown
18:15:16  Error: Graceful shutdown
18:15:16  systemd: freenet.service: Main process exited, code=exited, status=1/FAILURE
18:15:16  Freenet 0.2.121: crash 1/3 during post-update probation (node stop status 1);
          not updating, will auto-roll-back if it keeps crashing.
```

`run_network_node` reports a clean SIGTERM stop as `Err(EventLoopExitReason::GracefulShutdown)` — a typed sentinel, not a real error — and `run_network_node_with_signals` returned it verbatim, so `main` fell through to its `eprintln!("Error: {e:?}")` + `std::process::exit(1)` fallback.

That matters because `rollback::classify_stop` treats any status outside `{0, 2, 42, 43, 44}` as a crash. Three clean stops of a freshly updated node inside its post-update probation window were enough to auto-roll-back a perfectly healthy release (#4073).

Two independent signals that exit 0 was always the intent:

- the adjacent `if result.is_ok() { tracing::info!("Graceful shutdown complete") }` in the same function could never fire;
- both service wrappers already contain a written-but-unreachable branch for it — `macos.rs` (`elif [ $EXIT_CODE -eq 0 ]` → `log_event "Normal shutdown"`) and `service/wrapper.rs` (`0 => WrapperAction::Exit`).

## Solution

`finish_run(result, shutdown_requested)` in `bin/freenet.rs` maps the sentinel to `Ok(())`, but only when **both** conditions hold:

1. `p2p_impl::listener_exit_is_graceful(&err)` — the same predicate the #4549 fatal-listener force-exit already uses (made `pub` and re-exported, so the two classifications cannot disagree about which errors are candidates);
2. **this process asked the node to stop** — an `AtomicBool` set by the signal task immediately before it calls `shutdown_handle.shutdown()`.

Condition 2 is the load-bearing half, and the reason this is not a one-line change. `EventLoopExitReason::GracefulShutdown` is **not** exclusive to a requested stop:

- `p2p_protoc.rs` raises the same value when a critical internal channel dies (`ChannelCloseReason::{Bridge, Controller, Notification, OpExecution}` — the path that logs `CRITICAL: Channel closed …`);
- `client_events.rs` sends the identical `NodeEvent::Disconnect` when every client transport has been lost, a degraded state its own comments call "restart recommended".

Neither is distinguishable from an operator stop at the p2p layer, and both must keep exiting non-zero: on Linux that is what still fires the unit's `ExecStopPost` self-heal and counts the crash toward probation, and on the macOS/Windows wrappers an exit 0 is read as "normal shutdown" and would leave the node **down** instead of relaunching it. Keying on the sentinel alone would have converted those faults into silent successes.

Nothing else changes. Every other error still exits non-zero, and the auto-update exit still surfaces as `UpdateNeededError` (exit 42).

## ⚠️ Merge ordering: this MUST land after the `v`-prefix update fix

**Do not merge this until the fix for the `v`-prefix parse bug (#5104 regression) is on `main`.** This is not a stylistic preference; merging it first makes the fleet strictly worse.

PR #5104 (shipped in 0.2.120) made the node's in-process update check hand the raw GitHub tag to `semver::Version::parse`. `compare_versions_for_startup` in `auto_update.rs` parses `latest` directly, and semver rejects a leading `v`, so on 0.2.120 and 0.2.121 every node logs

```
WARN Startup update check: failed to parse latest version 'v0.2.121':
     unexpected character 'v' while parsing major version number
```

and fails open — returning `None`, never exiting 42. The node's own update path is dead fleet-wide.

I verified the consequence rather than assuming it. Because a graceful shutdown currently exits **1**, it does not match the unit's `0|43` skip list, so `ExecStopPost` runs `freenet update --quiet` on **every** restart. That path goes through `update.rs::run_async`, which calls `version_from_tag()` (`tag.strip_prefix('v')`) *before* `Version::parse` — so it parses correctly and installs. Reachability confirmed end to end: exit 1 → `*)` arm → `FREENET_POST_STOP_EXIT_CODE=1 freenet update --quiet` → `handle_post_stop("1", …)` → `PostStopOutcome::Proceed` (no probation marker) → normal update flow → install.

So while #5104 is live, that accident is the only working auto-update route, and this PR removes it.

One caveat on the accidental path that the two bugs make worse together: it only installs when the node is **not** in post-update probation. A node freshly updated to 0.2.121 that is restarted three times inside its probation window hits `PostStopOutcome::CrashRecorded` instead and gets **rolled back** — because this very bug reports each clean stop as a crash. The accidental path therefore both delivers updates and, on a recently-updated node, can undo them.

## Behaviour change to be aware of: `ExecStopPost` no longer fires on a graceful stop

The generated systemd unit has:

```
ExecStopPost=-/bin/sh -c 'case "$EXIT_STATUS" in 0|43) ;; *) … freenet update --quiet ;; esac'
SuccessExitStatus=42 43
```

Today's exit 1 is neither 0 nor 43, so **`freenet update` currently runs on every graceful stop**. After this change a graceful stop exits 0 and that hook no longer fires. This is deliberate; it is safe because:

- **The intended trigger is unaffected.** A node that detects an update exits **42**, which still matches the `*)` arm and still runs `freenet update`. Verified against the template text in `service/linux.rs` (both the user and system units) — the skip list is only `0|43`.
- **Nothing depends on the update running at stop time.** Update discovery is the node's own boot-time `startup_update_check` plus the ~6h jittered re-poll, both of which end in exit 42. So `systemctl restart`, a reboot, and `freenet service restart` still pick up a new release — one boot later at worst.
- **`Restart=always` still restarts after an exit 0**, so a graceful stop that was not an explicit stop job still brings the node back on Linux.
- It also removes a race during release rollouts on units generated by `freenet service install`: previously every `systemctl stop` of such a unit spawned a `freenet update --quiet` that could install the GitHub latest underneath a deploy script's own binary swap. Note this never applied to the gateway fleet, which runs `scripts/freenet-gateway.service` — that unit has no `ExecStopPost` at all (only `Restart=always`), so no such race existed there.

Also checked and unaffected: `RestartPreventExitStatus=43`, the `StartLimit*` counters (they count starts, not statuses), `crates/release-agent/` and `gateway-update.yml` (both judge convergence by `/version` + `systemctl is-active`, never by the node's exit code), and the Windows service stop path (a hard `taskkill`, which never produces exit 0).

**Known consequence on the macOS/Windows wrappers**, called out rather than hidden: those wrappers cannot tell "the service is being stopped" from "someone SIGTERMed the node child only" (e.g. a manual `pkill -f "freenet network"`). With exit 0 they now take their `"Normal shutdown"` branch and stand down, where previously exit 1 made them relaunch. In the common case this is a **fix** — on macOS a `launchctl stop` previously had the wrapper fight the stop, relaunch the node, and get SIGKILLed, leaving a PPID-1 orphan holding the port (the #3967 stale-orphan signature). The manual-`pkill` case is a genuine regression on desktop; it needs a `WRAPPER_TERMINATING`-style flag in both wrappers and cannot be verified from CI (no runner exercises those paths), so it is filed as #5228 rather than smuggled in here with an untestable diff.

## Testing

**End-to-end on the process exit status**, which is the whole point — the classification predicate was already correct and already pinned by `listener_exit_graceful_classification`; the bug lived in the gap between that predicate and the exit code, where no in-process test can see it.

- `crates/core/tests/graceful_shutdown_exit_code.rs::graceful_shutdown_on_sigterm_exits_zero` spawns the real `freenet` binary (via `CARGO_BIN_EXE_freenet`, so it can never assert against a stale build), waits for a readiness marker that is only logged *after* the SIGTERM handler is installed, sends SIGTERM, and asserts `ExitStatus::code() == Some(0)` — plus that `signal()` is `None` (proving the handler ran, not the default disposition) and that the signal path actually executed (so a 0 cannot be credited to some other clean-exit path).
- `finish_run_maps_only_a_requested_graceful_stop_to_success` pins the truth table, including the case a live node cannot easily be driven into: an **unrequested** `GracefulShutdown` must stay non-zero.
- `graceful_classification_is_by_type_not_by_message` pins that the predicate keys on the error type, so an error whose `Display` merely reads "Graceful shutdown" cannot be laundered into a success exit.

**Revert-verified**: with `finish_run` restored to the pre-fix `result`, the end-to-end test fails with `Some(1)` (the exact production symptom) and the unit truth table fails on its first assertion. Both pass with the fix.

The node is spawned fully offline (`--skip-load-from-network`, `--disable-auto-update`), with `RUST_LOG` pinned on the child rather than inherited — CI's `test_unit` job exports `RUST_LOG=error`, which would otherwise filter out the readiness marker. A nextest override sets `retries = 0` for it: the subject of the test is a signal race, so a retry would be indistinguishable from the regression it exists to catch.

Reviewed by three independent blind lenses (correctness; supervisor/service-manager interaction; test quality). The correctness lens found the `ChannelCloseReason` conflation described above, which is why the `shutdown_requested` gate exists.

Addresses the main path of #5227, but does **not** fully close it — deliberately not using a closing keyword.

Adversarial review found a second, pre-existing path to the same symptom that this PR does not cover: the SIGTERM handler is installed at `bin/freenet.rs:366`, which `run_network` only reaches after `serve_client_api`, `NodeConfig::new` and `node_config.build()` (the redb open + contract-store load). A stop *during that startup window* kills the process under the default signal disposition; systemd then sets `$EXIT_STATUS` to the signal NAME, `service/linux.rs:539` matches its `*)` arm, and `rollback.rs` has no arm for signal names, so it falls through to `_ => StopClass::Crash`.

That window matters precisely because it coincides with probation: a node inside its post-update probation window has just restarted, so it is also near the front of its boot. The new end-to-end test structurally cannot see this, since it waits for the readiness marker specifically to get past that point.

#5227 stays open for that remainder.

[AI-assisted - Claude]

