### PR TITLE
ci: cut the release from one validated commit, not from moving main

### DIFF
--- a/.github/workflows/binstall-smoke-test.yml
+++ b/.github/workflows/binstall-smoke-test.yml
@@ -92,7 +92,7 @@ jobs:
         id: release_ready
         shell: bash
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # coalesce-exempt: read-only release lookup, emits no event
         run: |
           set -euo pipefail
           TAG="v${{ steps.versions.outputs.freenet }}"

--- a/.github/workflows/check-token-coalesce.yml
+++ b/.github/workflows/check-token-coalesce.yml
@@ -72,7 +72,17 @@ jobs:
 
           # Self-test: a known-bad line MUST be flagged. Runs the same
           # function the real check uses, so the two cannot drift.
-          SELF_TEST_BAD='+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}' # coalesce-exempt: this is the fixture the self-test feeds in, not a real token usage
+          #
+          # The fixture is assembled from a variable holding a bare `$` on
+          # purpose. Writing the two-brace expression literally here does NOT
+          # produce a literal: Actions evaluates expressions inside `run:`
+          # blocks before the shell sees them, so the fixture would become the
+          # real token value and the self-test would fail — it did exactly
+          # that on the first CI run of this change, which is the self-test
+          # doing its job. Splitting the `$` from the braces keeps the raw
+          # text free of the expression marker.
+          D='$'
+          SELF_TEST_BAD="+          GH_TOKEN: ${D}{{ secrets.GITHUB_TOKEN }}"
           SELF_TEST_OUT=$(printf '%s\n+++ b/.github/workflows/x.yml\n' "$SELF_TEST_BAD" | added_lines)
           if ! echo "$SELF_TEST_OUT" | grep -qE 'GH_TOKEN:\s*\$\{\{\s*secrets\.GITHUB_TOKEN'; then
             echo "::error::Self-test failed: this guard cannot detect a bare GITHUB_TOKEN line, so its result is meaningless. Fix added_lines() before trusting this job."

--- a/.github/workflows/check-token-coalesce.yml
+++ b/.github/workflows/check-token-coalesce.yml
@@ -70,29 +70,57 @@ jobs:
             grep -E '^\+' | grep -vE '^\+\+\+' | grep -vE 'coalesce-exempt' || true
           }
 
-          # Self-test: a known-bad line MUST be flagged. Runs the same
-          # function the real check uses, so the two cannot drift.
-          #
-          # The fixture is assembled from a variable holding a bare `$` on
+          # The two detectors, defined ONCE and used by both the self-test and
+          # the real check below. Sharing only `added_lines` was not enough:
+          # while the regexes were duplicated, breaking the real one left the
+          # self-test green — the same "the check cannot fail" bug this guard
+          # exists to catch, one layer up.
+          flags_bare_gh_token() {
+            grep -qE 'GH_TOKEN:\s*\$\{\{\s*secrets\.GITHUB_TOKEN'
+          }
+          flags_bare_checkout_token() {
+            grep -qE 'token:\s*\$\{\{\s*github\.token'
+          }
+
+          # Fixtures are assembled from a variable holding a bare `$` on
           # purpose. Writing the two-brace expression literally here does NOT
           # produce a literal: Actions evaluates expressions inside `run:`
-          # blocks before the shell sees them, so the fixture would become the
+          # blocks before the shell sees them, so a fixture would become the
           # real token value and the self-test would fail — it did exactly
           # that on the first CI run of this change, which is the self-test
           # doing its job. Splitting the `$` from the braces keeps the raw
           # text free of the expression marker.
           D='$'
-          SELF_TEST_BAD="+          GH_TOKEN: ${D}{{ secrets.GITHUB_TOKEN }}"
-          SELF_TEST_OUT=$(printf '%s\n+++ b/.github/workflows/x.yml\n' "$SELF_TEST_BAD" | added_lines)
-          if ! echo "$SELF_TEST_OUT" | grep -qE 'GH_TOKEN:\s*\$\{\{\s*secrets\.GITHUB_TOKEN'; then
-            echo "::error::Self-test failed: this guard cannot detect a bare GITHUB_TOKEN line, so its result is meaningless. Fix added_lines() before trusting this job."
+          BAD_GH="+          GH_TOKEN: ${D}{{ secrets.GITHUB_TOKEN }}"
+          BAD_CHECKOUT="+          token: ${D}{{ github.token }}"
+          GOOD_GH="+          GH_TOKEN: ${D}{{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}"
+          EXEMPT_GH="${BAD_GH} # coalesce-exempt: self-test fixture"
+
+          self_test_diff() { printf '%s\n+++ b/.github/workflows/x.yml\n' "$1"; }
+          fail_self_test() {
+            echo "::error::Self-test failed: $1 This job's result would be meaningless — fix it before trusting a pass."
             exit 1
+          }
+
+          # Must FIRE on the bad forms...
+          if ! self_test_diff "$BAD_GH" | added_lines | flags_bare_gh_token; then
+            fail_self_test "a bare secrets.GITHUB_TOKEN line is not detected."
+          fi
+          if ! self_test_diff "$BAD_CHECKOUT" | added_lines | flags_bare_checkout_token; then
+            fail_self_test "a bare github.token checkout line is not detected."
+          fi
+          # ...and stay QUIET on the good and the exempted ones, or every PR
+          # that touches a workflow fails for no reason.
+          if self_test_diff "$GOOD_GH" | added_lines | flags_bare_gh_token; then
+            fail_self_test "a correctly coalesced RELEASE_PAT line is reported as bad."
+          fi
+          if self_test_diff "$EXEMPT_GH" | added_lines | flags_bare_gh_token; then
+            fail_self_test "the '# coalesce-exempt:' marker is not honoured."
           fi
           if printf '+++ b/.github/workflows/x.yml\n' | added_lines | grep -q .; then
-            echo "::error::Self-test failed: this guard is not stripping the '+++' diff header."
-            exit 1
+            fail_self_test "the '+++' diff header is not being stripped."
           fi
-          echo "Self-test passed: the guard detects a bare GITHUB_TOKEN line."
+          echo "Self-test passed: both detectors fire on bare tokens and stay quiet on coalesced and exempted lines."
 
           ERRORS=()
           for f in $CHANGED; do
@@ -105,10 +133,10 @@ jobs:
             # workflow file is flagged for review. Suppress via inline comment
             # `# coalesce-exempt: <reason>` on the same line.
             ADDED=$(git diff "$BASE_SHA"..."$HEAD_SHA" -- "$f" | added_lines)
-            if echo "$ADDED" | grep -qE 'GH_TOKEN:\s*\$\{\{\s*secrets\.GITHUB_TOKEN'; then
+            if echo "$ADDED" | flags_bare_gh_token; then
               ERRORS+=("$f: new step uses bare \`secrets.GITHUB_TOKEN\` — should coalesce on \`RELEASE_PAT\` (see AGENTS.md → Release Workflow). Add `# coalesce-exempt: <reason>` on the line if intentionally read-only and event-quiet.")
             fi
-            if echo "$ADDED" | grep -qE 'token:\s*\$\{\{\s*github\.token'; then
+            if echo "$ADDED" | flags_bare_checkout_token; then
               ERRORS+=("$f: new actions/checkout uses bare \`github.token\` — same coalesce rule applies for any subsequent \`git push\`.")
             fi
           done

--- a/.github/workflows/check-token-coalesce.yml
+++ b/.github/workflows/check-token-coalesce.yml
@@ -56,6 +56,34 @@ jobs:
           # of a tag, `gh pr create`, `gh pr reopen`, or `gh workflow run` —
           # in jobs/steps that reference `${{ secrets.GITHUB_TOKEN }}` or
           # `${{ github.token }}` without the coalesce.
+          # Added lines of a diff, minus the `+++` file header, minus anything
+          # explicitly exempted.
+          #
+          # The `+++` filter MUST be an ERE (`grep -vE`). As a BRE, `\+` is
+          # GNU's one-or-more operator, so `^\+\+\+` matches EVERY line
+          # starting with `+` and this function returned nothing at all —
+          # which meant this guard silently flagged nothing from the day it
+          # was written until 2026-08-07. Verified against GNU grep 3.11, the
+          # version on ubuntu-latest. The self-test below now fails if that
+          # ever regresses, so the guard can never go quietly blind again.
+          added_lines() {
+            grep -E '^\+' | grep -vE '^\+\+\+' | grep -vE 'coalesce-exempt' || true
+          }
+
+          # Self-test: a known-bad line MUST be flagged. Runs the same
+          # function the real check uses, so the two cannot drift.
+          SELF_TEST_BAD='+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}' # coalesce-exempt: this is the fixture the self-test feeds in, not a real token usage
+          SELF_TEST_OUT=$(printf '%s\n+++ b/.github/workflows/x.yml\n' "$SELF_TEST_BAD" | added_lines)
+          if ! echo "$SELF_TEST_OUT" | grep -qE 'GH_TOKEN:\s*\$\{\{\s*secrets\.GITHUB_TOKEN'; then
+            echo "::error::Self-test failed: this guard cannot detect a bare GITHUB_TOKEN line, so its result is meaningless. Fix added_lines() before trusting this job."
+            exit 1
+          fi
+          if printf '+++ b/.github/workflows/x.yml\n' | added_lines | grep -q .; then
+            echo "::error::Self-test failed: this guard is not stripping the '+++' diff header."
+            exit 1
+          fi
+          echo "Self-test passed: the guard detects a bare GITHUB_TOKEN line."
+
           ERRORS=()
           for f in $CHANGED; do
             # Skip if file was deleted.
@@ -66,7 +94,7 @@ jobs:
             # We're permissive: any new occurrence of bare GITHUB_TOKEN in a
             # workflow file is flagged for review. Suppress via inline comment
             # `# coalesce-exempt: <reason>` on the same line.
-            ADDED=$(git diff "$BASE_SHA"..."$HEAD_SHA" -- "$f" | grep -E '^\+' | grep -v '^\+\+\+' | grep -vE 'coalesce-exempt' || true)
+            ADDED=$(git diff "$BASE_SHA"..."$HEAD_SHA" -- "$f" | added_lines)
             if echo "$ADDED" | grep -qE 'GH_TOKEN:\s*\$\{\{\s*secrets\.GITHUB_TOKEN'; then
               ERRORS+=("$f: new step uses bare \`secrets.GITHUB_TOKEN\` — should coalesce on \`RELEASE_PAT\` (see AGENTS.md → Release Workflow). Add `# coalesce-exempt: <reason>` on the line if intentionally read-only and event-quiet.")
             fi

--- a/.github/workflows/check-token-coalesce.yml
+++ b/.github/workflows/check-token-coalesce.yml
@@ -89,7 +89,7 @@ jobs:
             # Skip if file was deleted.
             [[ -f "$f" ]] || continue
 
-            # Look for the bad pattern: `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}`
+            # Look for the bad pattern: `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` # coalesce-exempt: prose describing the pattern, not a real usage
             # or `token: ${{ github.token }}` near an event-emitting verb.
             # We're permissive: any new occurrence of bare GITHUB_TOKEN in a
             # workflow file is flagged for review. Suppress via inline comment

--- a/.github/workflows/check-token-coalesce.yml
+++ b/.github/workflows/check-token-coalesce.yml
@@ -128,13 +128,17 @@ jobs:
             [[ -f "$f" ]] || continue
 
             # Look for the bad pattern: `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` # coalesce-exempt: prose describing the pattern, not a real usage
-            # or `token: ${{ github.token }}` near an event-emitting verb.
+            # or `token: ${{ github.token }}` near an event-emitting verb. # coalesce-exempt: prose describing the pattern, not a real usage
             # We're permissive: any new occurrence of bare GITHUB_TOKEN in a
             # workflow file is flagged for review. Suppress via inline comment
             # `# coalesce-exempt: <reason>` on the same line.
             ADDED=$(git diff "$BASE_SHA"..."$HEAD_SHA" -- "$f" | added_lines)
             if echo "$ADDED" | flags_bare_gh_token; then
-              ERRORS+=("$f: new step uses bare \`secrets.GITHUB_TOKEN\` — should coalesce on \`RELEASE_PAT\` (see AGENTS.md → Release Workflow). Add `# coalesce-exempt: <reason>` on the line if intentionally read-only and event-quiet.")
+              # The backticks around the remediation MUST be escaped. Unescaped,
+              # bash runs them as command substitution and the instruction is
+              # silently deleted from the message — which nobody noticed because
+              # the BRE bug meant this line had never once executed.
+              ERRORS+=("$f: new step uses bare \`secrets.GITHUB_TOKEN\` — should coalesce on \`RELEASE_PAT\` (see AGENTS.md → Release Workflow). Add \`# coalesce-exempt: <reason>\` on the line if intentionally read-only and event-quiet.")
             fi
             if echo "$ADDED" | flags_bare_checkout_token; then
               ERRORS+=("$f: new actions/checkout uses bare \`github.token\` — same coalesce rule applies for any subsequent \`git push\`.")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,6 +266,9 @@ jobs:
       # Resolved independently of RELEASE_SHA, so the verifier has an oracle
       # that does not just restate the value that drove the checkout.
       EXPECTED_VERSION: ${{ needs.validate.outputs.version }}
+      # Empty exactly when the `|| github.sha` fallback above engaged, so the
+      # verifier can name that cause instead of reporting a version mismatch.
+      RELEASE_SHA_RESOLVED: ${{ needs.wait_for_pr.outputs.release_sha }}
 
     steps:
       - name: Checkout the validated release commit
@@ -331,6 +334,9 @@ jobs:
       # Resolved independently of RELEASE_SHA, so the verifier has an oracle
       # that does not just restate the value that drove the checkout.
       EXPECTED_VERSION: ${{ needs.validate.outputs.version }}
+      # Empty exactly when the `|| github.sha` fallback above engaged, so the
+      # verifier can name that cause instead of reporting a version mismatch.
+      RELEASE_SHA_RESOLVED: ${{ needs.wait_for_pr.outputs.release_sha }}
 
     steps:
       - name: Checkout the validated release commit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -263,6 +263,9 @@ jobs:
       # NEVER `ref: main` here — see #5233. The fallback is only reachable on
       # the dry-run-with-failed-wait path, and `github.sha` is still immutable.
       RELEASE_SHA: ${{ needs.wait_for_pr.outputs.release_sha || github.sha }}
+      # Resolved independently of RELEASE_SHA, so the verifier has an oracle
+      # that does not just restate the value that drove the checkout.
+      EXPECTED_VERSION: ${{ needs.validate.outputs.version }}
 
     steps:
       - name: Checkout the validated release commit
@@ -325,6 +328,9 @@ jobs:
       # `ref: main` here meant the tag could point at a tree nobody validated
       # and that no published artifact was built from (#5233).
       RELEASE_SHA: ${{ needs.wait_for_pr.outputs.release_sha || github.sha }}
+      # Resolved independently of RELEASE_SHA, so the verifier has an oracle
+      # that does not just restate the value that drove the checkout.
+      EXPECTED_VERSION: ${{ needs.validate.outputs.version }}
 
     steps:
       - name: Checkout the validated release commit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -260,8 +260,12 @@ jobs:
     needs: [validate, wait_for_pr]
     if: always() && (needs.wait_for_pr.result == 'success' || inputs.dry_run)
     env:
-      # NEVER `ref: main` here — see #5233. The fallback is only reachable on
-      # the dry-run-with-failed-wait path, and `github.sha` is still immutable.
+      # NEVER `ref: main` here — see #5233. The `|| github.sha` fallback is not
+      # a convenience: an empty `ref:` makes actions/checkout default to the
+      # branch, which would reinstate the bug. It is reachable only on the
+      # dry-run-with-failed-wait path, and it is NOT benign there — the launch
+      # commit predates the version bump, so the verifier below aborts on
+      # purpose rather than dry-running the wrong tree.
       RELEASE_SHA: ${{ needs.wait_for_pr.outputs.release_sha || github.sha }}
       # Resolved independently of RELEASE_SHA, so the verifier has an oracle
       # that does not just restate the value that drove the checkout.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,6 +224,11 @@ jobs:
       actions: read
       contents: read
       pull-requests: read
+    # The single immutable commit the rest of the pipeline builds, publishes
+    # and tags. Everything downstream MUST check this out explicitly instead of
+    # re-resolving `main`, which moves while this job waits (#5233).
+    outputs:
+      release_sha: ${{ steps.release_sha.outputs.sha }}
 
     steps:
       - name: Checkout code
@@ -238,21 +243,35 @@ jobs:
           PR_NUMBER: ${{ needs.update_versions.outputs.pr_number }}
         run: scripts/wait_for_release_pr.sh
 
+      - name: Resolve the release commit
+        id: release_sha
+        env:
+          # Same least-privilege rationale as the waiter above: read-only PR and
+          # compare lookups that emit no workflow-triggering event.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # coalesce-exempt: read-only lookup
+          PR_NUMBER: ${{ needs.update_versions.outputs.pr_number }}
+          LAUNCH_SHA: ${{ github.sha }}
+        run: scripts/resolve_release_sha.sh
+
   publish_crates:
     name: Publish to crates.io
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: [validate, wait_for_pr]
     if: always() && (needs.wait_for_pr.result == 'success' || inputs.dry_run)
+    env:
+      # NEVER `ref: main` here — see #5233. The fallback is only reachable on
+      # the dry-run-with-failed-wait path, and `github.sha` is still immutable.
+      RELEASE_SHA: ${{ needs.wait_for_pr.outputs.release_sha || github.sha }}
 
     steps:
-      - name: Checkout code
+      - name: Checkout the validated release commit
         uses: actions/checkout@v7
         with:
-          ref: main
+          ref: ${{ needs.wait_for_pr.outputs.release_sha || github.sha }}
 
-      - name: Pull latest changes
-        run: git pull origin main
+      - name: Verify the checkout is the validated release commit
+        run: bash scripts/verify_release_checkout.sh
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -297,14 +316,21 @@ jobs:
     name: Create GitHub release
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [validate, publish_crates]
+    # `wait_for_pr` is in `needs` only to carry `release_sha` through; the
+    # ordering it implies is already enforced via `publish_crates`.
+    needs: [validate, wait_for_pr, publish_crates]
     if: always() && (needs.publish_crates.result == 'success' || inputs.dry_run)
+    env:
+      # The tag MUST land on the same commit that was published to crates.io.
+      # `ref: main` here meant the tag could point at a tree nobody validated
+      # and that no published artifact was built from (#5233).
+      RELEASE_SHA: ${{ needs.wait_for_pr.outputs.release_sha || github.sha }}
 
     steps:
-      - name: Checkout code
+      - name: Checkout the validated release commit
         uses: actions/checkout@v7
         with:
-          ref: main
+          ref: ${{ needs.wait_for_pr.outputs.release_sha || github.sha }}
           fetch-depth: 0
           # `token:` is what `git push` uses later in this job to push the
           # `v$VERSION` tag. The tag push MUST use RELEASE_PAT (when set)
@@ -313,8 +339,8 @@ jobs:
           # anti-recursion safeguard (same root cause as #4118).
           token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
 
-      - name: Pull latest changes
-        run: git pull origin main
+      - name: Verify the checkout is the validated release commit
+        run: bash scripts/verify_release_checkout.sh
 
       - name: Generate release notes
         id: release_notes
@@ -333,9 +359,13 @@ jobs:
             NOTES="Release $VERSION"
           else
             # Generate notes using GitHub's API
+            # The tag does not exist yet at this point, so `target_commitish`
+            # decides which commits the notes describe. Pin it to the commit
+            # actually being released, not to `main` — otherwise the notes can
+            # describe commits that are not in the release (#5233).
             NOTES=$(gh api repos/:owner/:repo/releases/generate-notes \
               -f tag_name="v$VERSION" \
-              -f target_commitish=main \
+              -f target_commitish="$RELEASE_SHA" \
               -f previous_tag_name="$PREV_VERSION" \
               --jq '.body')
           fi

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -251,6 +251,9 @@ gh workflow run release.yml
             └─→ creates "build: release X.Y.Z" PR
             └─→ ci.yml runs on PR (using RELEASE_PAT scope)
             └─→ PR auto-merges to main
+    └─→ release.yml: wait_for_pr
+            └─→ resolves the bump PR's merge commit -> RELEASE_SHA
+                (everything below checks out that exact commit; see #5233)
     └─→ release.yml: publish_crates
             └─→ cargo publish freenet
             └─→ cargo publish fdev
@@ -312,8 +315,9 @@ If it failed with "please provide a non-empty token" or similar, the
 then `gh run rerun --failed`.
 
 If a single crate failed mid-publish (e.g. `fdev` failed but `freenet`
-succeeded), `cargo publish -p fdev` from a clean main checkout, then
-manually move forward to tag + draft release as below.
+succeeded), `cargo publish -p fdev` from a checkout of the **release commit**
+(see below — not from whatever `main` is now), then manually move forward to
+tag + draft release as below.
 
 ### `create_release` failed
 
@@ -324,8 +328,21 @@ the runner. Fixed by [PR #4135] — if it recurs, check that the
 
 To unblock manually:
 
+Tag the **release commit**, not `main`. The release is cut from one pinned
+commit — the version-bump PR's merge commit — and `main` may have moved past
+it since (that is #5233; tagging `main` reintroduces exactly the bug the
+pipeline now prevents). Resolve it the same way the workflow does:
+
 ```bash
-git tag -a vX.Y.Z <main-sha> -m "Release vX.Y.Z"
+# The bump PR is the "build: release X.Y.Z" one; the run log also prints
+# "📌 Release pinned to <sha>".
+RELEASE_SHA=$(gh pr view <BUMP_PR> --repo freenet/freenet-core \
+  --json mergeCommit --jq '.mergeCommit.oid')
+
+# Sanity-check it really is the bump commit before tagging it.
+git show "$RELEASE_SHA:crates/core/Cargo.toml" | grep '^version'
+
+git tag -a vX.Y.Z "$RELEASE_SHA" -m "Release vX.Y.Z"
 git push origin vX.Y.Z
 gh release create vX.Y.Z --title "vX.Y.Z" \
     --notes "Release vX.Y.Z (binaries attached by cross-compile workflow)" \

--- a/scripts/RELEASE_RECOVERY.md
+++ b/scripts/RELEASE_RECOVERY.md
@@ -39,10 +39,25 @@ cargo search freenet --limit 1
 - No git tag exists for version
 
 **Recovery:**
+
+Tag the **release commit**, not `main`. The release is cut from one pinned
+commit (the version-bump PR's merge commit), and `main` may have moved past it
+while the workflow was waiting on the merge queue. Tagging `main` by hand
+reintroduces #5233 — the bug the pipeline now prevents.
+
 ```bash
 cd ~/code/freenet/freenet-core/main
-git pull origin main
-git tag v0.1.X
+git fetch origin
+
+# The bump PR is the "build: release X.Y.Z" one. The release.yml run log also
+# prints "📌 Release pinned to <sha>".
+RELEASE_SHA=$(gh pr view <BUMP_PR> --repo freenet/freenet-core \
+  --json mergeCommit --jq '.mergeCommit.oid')
+
+# Confirm it really is the bump commit before tagging it.
+git show "$RELEASE_SHA:crates/core/Cargo.toml" | grep '^version'
+
+git tag -a v0.1.X "$RELEASE_SHA" -m "Release v0.1.X"
 git push origin v0.1.X
 ```
 
@@ -58,7 +73,7 @@ gh release create v0.1.X \
   --repo freenet/freenet-core \
   --title "v0.1.X" \
   --notes "$(gh api repos/freenet/freenet-core/releases/generate-notes \
-    -f tag_name=v0.1.X -f target_commitish=main --jq .body)"
+    -f tag_name=v0.1.X -f target_commitish="$RELEASE_SHA" --jq .body)"
 ```
 
 ### Step 4: Release Created but Crates Not Published
@@ -70,7 +85,9 @@ gh release create v0.1.X \
 **Recovery:**
 ```bash
 cd ~/code/freenet/freenet-core/main
-git pull origin main
+git fetch origin
+# Publish from the release commit, not from whatever main is now (see Step 2).
+git checkout "$RELEASE_SHA"
 
 # Publish freenet crate
 cargo publish -p freenet
@@ -190,11 +207,11 @@ gh pr create --title "chore: release 0.1.X" --body "Release v0.1.X" --base main
 
 # 2. Wait for CI and merge (or use gh pr merge --auto)
 
-# 3. Create tag
-git checkout main
-git pull
-git tag v0.1.X
-git push origin v0.1.X
+# 3. Create tag — on the bump PR's merge commit, NOT on main (see Step 2)
+git fetch origin
+RELEASE_SHA=$(gh pr view <BUMP_PR> --repo freenet/freenet-core \
+  --json mergeCommit --jq '.mergeCommit.oid')
+git tag -a v0.1.X "$RELEASE_SHA" -m "Release v0.1.X"
 
 # 4. Create GitHub release
 gh release create v0.1.X --repo freenet/freenet-core --generate-notes

--- a/scripts/release_mergequeue_test.sh
+++ b/scripts/release_mergequeue_test.sh
@@ -281,8 +281,192 @@ check "pre-run requeue gap reaches the bounded timeout" \
 check "queued timeout reports queue position and enqueue time" \
   "$(grep -qF 'queue=state=AWAITING_CHECKS, position=2, enqueuedAt=2026-07-31T14:05:00Z' "$PRE_RUN_OUTPUT" && echo present || echo missing)" "present"
 
+# ---------------------------------------------------------------------------
+# #5233: the release must be cut from ONE immutable commit.
+#
+# `publish_crates` and `create_release` used to check out `ref: main` and then
+# `git pull origin main`. Both run AFTER `wait_for_pr`, which blocks ~20 minutes
+# on the merge queue, so any commit that landed on main during that window was
+# silently published and tagged. v0.2.122 shipped an unrelated commit this way.
+# ---------------------------------------------------------------------------
+
+RESOLVE_SCRIPT="$SCRIPT_DIR/resolve_release_sha.sh"
+VERIFY_SCRIPT="$SCRIPT_DIR/verify_release_checkout.sh"
+
+# Job bodies, bounded to the job. An unbounded grep over the whole file would
+# match a neighbouring job and pass vacuously.
+PUBLISH_JOB=$(sed -n '/^  publish_crates:/,/^  create_release:/p' "$RELEASE_YML")
+CREATE_RELEASE_JOB=$(sed -n '/^  create_release:/,/^  summary:/p' "$RELEASE_YML")
+
+check "publish_crates job body was located" \
+  "$([ -n "$PUBLISH_JOB" ] && echo present || echo missing)" "present"
+check "create_release job body was located" \
+  "$([ -n "$CREATE_RELEASE_JOB" ] && echo present || echo missing)" "present"
+
+# The bug itself: no job may resolve a moving reference.
+check "release.yml never checks out 'ref: main'" \
+  "$(grep -qE '^[[:space:]]*ref:[[:space:]]*main[[:space:]]*$' "$RELEASE_YML" && echo moving-ref || echo pinned)" "pinned"
+check "release.yml never re-widens the window with 'git pull origin main'" \
+  "$(grep -qE '^[^#]*git pull origin main' "$RELEASE_YML" && echo pulls || echo no-pull)" "no-pull"
+
+# The pin has to come from somewhere: wait_for_pr resolves it once and exports it.
+# The GitHub expressions below are intentionally matched literally.
+# shellcheck disable=SC2016
+check "wait_for_pr exports the resolved release SHA" \
+  "$(grep -qF 'release_sha: ${{ steps.release_sha.outputs.sha }}' <<< "$WAIT_JOB" && echo present || echo missing)" "present"
+check "wait_for_pr invokes the tested resolver script" \
+  "$(grep -qF 'run: scripts/resolve_release_sha.sh' <<< "$WAIT_JOB" && echo present || echo missing)" "present"
+
+# Both downstream jobs must consume that SHA and re-check it after checkout.
+for job_name in publish_crates create_release; do
+    case "$job_name" in
+      publish_crates) JOB_BODY="$PUBLISH_JOB" ;;
+      create_release) JOB_BODY="$CREATE_RELEASE_JOB" ;;
+    esac
+    # shellcheck disable=SC2016
+    check "$job_name checks out needs.wait_for_pr.outputs.release_sha" \
+      "$(grep -qF 'ref: ${{ needs.wait_for_pr.outputs.release_sha' <<< "$JOB_BODY" && echo pinned || echo missing)" "pinned"
+    check "$job_name verifies the checkout before acting on it" \
+      "$(grep -qF 'scripts/verify_release_checkout.sh' <<< "$JOB_BODY" && echo present || echo missing)" "present"
+    # shellcheck disable=SC2016
+    check "$job_name exports RELEASE_SHA for the verifier" \
+      "$(grep -qF 'RELEASE_SHA: ${{ needs.wait_for_pr.outputs.release_sha' <<< "$JOB_BODY" && echo present || echo missing)" "present"
+done
+
+# create_release can only read the output if wait_for_pr is in its needs.
+check "create_release depends on wait_for_pr so the SHA is in scope" \
+  "$(grep -qE '^    needs: \[validate, wait_for_pr, publish_crates\]$' <<< "$CREATE_RELEASE_JOB" && echo present || echo missing)" "present"
+
+# The notes must describe the commit being released, not whatever main is now.
+# The shell variable reference is intentionally matched literally.
+# shellcheck disable=SC2016
+check "release notes are generated for the pinned commit, not main" \
+  "$(grep -qF 'target_commitish="$RELEASE_SHA"' <<< "$CREATE_RELEASE_JOB" && echo pinned || echo missing)" "pinned"
+
+# --- behavioural: scripts/verify_release_checkout.sh -------------------------
+
+VERIFY_REPO="$TEST_TMP/verify-repo"
+mkdir -p "$VERIFY_REPO"
+(
+  cd "$VERIFY_REPO"
+  git init -q .
+  git -c user.email=t@example.invalid -c user.name=t commit -q --allow-empty -m "release commit"
+) >/dev/null 2>&1
+VERIFY_HEAD=$(cd "$VERIFY_REPO" && git rev-parse HEAD)
+
+run_verify() {
+    local expected_sha="$1" output_file="$2" status
+    set +e
+    ( cd "$VERIFY_REPO" && RELEASE_SHA="$expected_sha" \
+        bash --noprofile --norc "$VERIFY_SCRIPT" ) > "$output_file" 2>&1
+    status=$?
+    set -e
+    echo "$status"
+}
+
+VERIFY_OK_OUTPUT="$TEST_TMP/verify-ok.txt"
+check "verifier accepts a checkout at the pinned commit" \
+  "$(run_verify "$VERIFY_HEAD" "$VERIFY_OK_OUTPUT")" "0"
+
+VERIFY_DRIFT_OUTPUT="$TEST_TMP/verify-drift.txt"
+DRIFT_SHA="0123456789012345678901234567890123456789"
+check "verifier rejects a checkout that drifted off the pinned commit" \
+  "$([ "$(run_verify "$DRIFT_SHA" "$VERIFY_DRIFT_OUTPUT")" -ne 0 ] && echo failed || echo passed)" "failed"
+check "verifier names both SHAs when it rejects" \
+  "$(grep -qF "$DRIFT_SHA" "$VERIFY_DRIFT_OUTPUT" && grep -qF "$VERIFY_HEAD" "$VERIFY_DRIFT_OUTPUT" && echo present || echo missing)" "present"
+
+VERIFY_UNSET_OUTPUT="$TEST_TMP/verify-unset.txt"
+set +e
+( cd "$VERIFY_REPO" && env -u RELEASE_SHA bash --noprofile --norc "$VERIFY_SCRIPT" ) \
+  > "$VERIFY_UNSET_OUTPUT" 2>&1
+VERIFY_UNSET_STATUS=$?
+set -e
+check "verifier fails closed when no pinned SHA was passed" \
+  "$([ "$VERIFY_UNSET_STATUS" -ne 0 ] && echo failed || echo passed)" "failed"
+
+# --- behavioural: scripts/resolve_release_sha.sh -----------------------------
+
+RESOLVE_BIN="$TEST_TMP/resolve-bin"
+mkdir -p "$RESOLVE_BIN"
+cat > "$RESOLVE_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "$*" in
+  *"pr view"*)
+    [ -n "${MOCK_MERGE_SHA:-}" ] || exit 2
+    printf '%s\n' "$MOCK_MERGE_SHA"
+    ;;
+  *compare*)
+    printf '%s' "${MOCK_COMPARE:-}"
+    ;;
+  *)
+    echo "unexpected gh invocation: $*" >&2
+    exit 2
+    ;;
+esac
+EOF
+chmod +x "$RESOLVE_BIN/gh"
+
+MERGED_SHA="1111111111111111111111111111111111111111"
+LAUNCHED_SHA="2222222222222222222222222222222222222222"
+
+run_resolve() {
+    # run_resolve <merge_sha> <compare_body> <output_file> <github_output_file>
+    local merge_sha="$1" compare="$2" output_file="$3" gh_output="$4" status
+    : > "$gh_output"
+    set +e
+    PATH="$RESOLVE_BIN:$PATH" \
+      GITHUB_REPOSITORY="freenet/freenet-core" \
+      PR_NUMBER="5231" \
+      LAUNCH_SHA="$LAUNCHED_SHA" \
+      GITHUB_OUTPUT="$gh_output" \
+      MOCK_MERGE_SHA="$merge_sha" \
+      MOCK_COMPARE="$compare" \
+      bash --noprofile --norc "$RESOLVE_SCRIPT" > "$output_file" 2>&1
+    status=$?
+    set -e
+    echo "$status"
+}
+
+BUMP_ONLY=$'  aaaaaaaaa build: release 0.2.123\n'
+RACED=$'  aaaaaaaaa build: release 0.2.123\n  bbbbbbbbb fix(diagnostics): unrelated change\n  ccccccccc feat: another unrelated change\n'
+
+RESOLVE_OK_OUTPUT="$TEST_TMP/resolve-ok.txt"
+RESOLVE_OK_GH_OUTPUT="$TEST_TMP/resolve-ok.env"
+check "resolver exits zero when the bump PR has a merge commit" \
+  "$(run_resolve "$MERGED_SHA" "$BUMP_ONLY" "$RESOLVE_OK_OUTPUT" "$RESOLVE_OK_GH_OUTPUT")" "0"
+check "resolver exports the merge commit as the release SHA" \
+  "$(grep -qF "sha=$MERGED_SHA" "$RESOLVE_OK_GH_OUTPUT" && echo present || echo missing)" "present"
+check "resolver stays quiet when only the version bump landed" \
+  "$(grep -qF 'main moved during this release' "$RESOLVE_OK_OUTPUT" && echo warned || echo quiet)" "quiet"
+
+RESOLVE_RACE_OUTPUT="$TEST_TMP/resolve-race.txt"
+RESOLVE_RACE_GH_OUTPUT="$TEST_TMP/resolve-race.env"
+check "resolver still succeeds when main moved" \
+  "$(run_resolve "$MERGED_SHA" "$RACED" "$RESOLVE_RACE_OUTPUT" "$RESOLVE_RACE_GH_OUTPUT")" "0"
+check "resolver warns loudly when main moved during the release" \
+  "$(grep -qF '::warning title=main moved during this release' "$RESOLVE_RACE_OUTPUT" && echo warned || echo silent)" "warned"
+check "resolver lists the commits that raced in" \
+  "$(grep -qF 'fix(diagnostics): unrelated change' "$RESOLVE_RACE_OUTPUT" && echo listed || echo hidden)" "listed"
+check "resolver still pins a single SHA when main moved" \
+  "$(grep -qF "sha=$MERGED_SHA" "$RESOLVE_RACE_GH_OUTPUT" && echo present || echo missing)" "present"
+
+# Failing closed is the whole point: a release must never silently fall back to
+# a moving reference because the merge commit could not be read.
+RESOLVE_FAIL_OUTPUT="$TEST_TMP/resolve-fail.txt"
+RESOLVE_FAIL_GH_OUTPUT="$TEST_TMP/resolve-fail.env"
+check "resolver fails when the merge commit cannot be resolved" \
+  "$([ "$(run_resolve "" "$BUMP_ONLY" "$RESOLVE_FAIL_OUTPUT" "$RESOLVE_FAIL_GH_OUTPUT")" -ne 0 ] && echo failed || echo passed)" "failed"
+check "resolver exports no SHA when it cannot resolve one" \
+  "$(grep -qF 'sha=' "$RESOLVE_FAIL_GH_OUTPUT" && echo leaked || echo empty)" "empty"
+
+RESOLVE_JUNK_OUTPUT="$TEST_TMP/resolve-junk.txt"
+RESOLVE_JUNK_GH_OUTPUT="$TEST_TMP/resolve-junk.env"
+check "resolver rejects a non-SHA merge commit rather than checking it out" \
+  "$([ "$(run_resolve "main" "$BUMP_ONLY" "$RESOLVE_JUNK_OUTPUT" "$RESOLVE_JUNK_GH_OUTPUT")" -ne 0 ] && echo failed || echo passed)" "failed"
+
 if [ "$FAILURES" -eq 0 ]; then
-    echo "PASS: release.yml is merge-queue-compatible and reports failed merge-group CI."
+    echo "PASS: release.yml is merge-queue-compatible, reports failed merge-group CI, and is pinned to one validated commit."
 else
     echo "$FAILURES check(s) failed" >&2
     exit 1

--- a/scripts/release_mergequeue_test.sh
+++ b/scripts/release_mergequeue_test.sh
@@ -322,8 +322,10 @@ check "wait_for_pr range is bounded by the next job" \
 # whole-line anchored form. A bare `grep -qF` substring would be satisfied by
 # `# TODO: re-enable <the thing>`, so commenting a guard out would keep this
 # suite green — which is exactly the regression these pins exist to catch.
+# `github.ref` is included because on `workflow_dispatch` it IS `refs/heads/main`,
+# so `ref: ${{ github.ref }}` is the same bug wearing an expression.
 check "release.yml never checks out a moving 'main' reference" \
-  "$(grep -qE "^[[:space:]]*ref:[[:space:]]*['\"]?(main|refs/heads/main)['\"]?[[:space:]]*(#.*)?$" "$RELEASE_YML" && echo moving-ref || echo pinned)" "pinned"
+  "$(grep -qE "^[[:space:]]*ref:[[:space:]]*(['\"]?(main|refs/heads/main)['\"]?|\\\$\\{\\{[[:space:]]*github\\.ref[[:space:]]*\\}\\})[[:space:]]*(#.*)?$" "$RELEASE_YML" && echo moving-ref || echo pinned)" "pinned"
 
 # `git pull origin main` was the original second half of the bug, but ANY
 # shell-level re-pointing of the checkout reopens the same window — and does so

--- a/scripts/release_mergequeue_test.sh
+++ b/scripts/release_mergequeue_test.sh
@@ -310,40 +310,79 @@ check "publish_crates range is bounded by the next job" \
   "$([ "$(tail -n1 <<< "$PUBLISH_JOB")" = "  create_release:" ] && echo bounded || echo ran-to-eof)" "bounded"
 check "create_release range is bounded by the next job" \
   "$([ "$(tail -n1 <<< "$CREATE_RELEASE_JOB")" = "  summary:" ] && echo bounded || echo ran-to-eof)" "bounded"
+# WAIT_JOB is extracted by the pre-existing merge-queue checks above and needs
+# the same guard: renaming publish_crates silently widens it to EOF, after
+# which every wait_for_pr pin starts matching text from other jobs.
+check "wait_for_pr range is bounded by the next job" \
+  "$([ "$(tail -n1 <<< "$WAIT_JOB")" = "  publish_crates:" ] && echo bounded || echo ran-to-eof)" "bounded"
 
 # The bug itself: no job may resolve a moving reference.
-check "release.yml never checks out 'ref: main'" \
-  "$(grep -qE '^[[:space:]]*ref:[[:space:]]*main[[:space:]]*$' "$RELEASE_YML" && echo moving-ref || echo pinned)" "pinned"
-check "release.yml never re-widens the window with 'git pull origin main'" \
-  "$(grep -qE '^[^#]*git pull origin main' "$RELEASE_YML" && echo pulls || echo no-pull)" "no-pull"
+#
+# Every needle below is matched against EXECUTABLE lines (`^[^#]*`) or in a
+# whole-line anchored form. A bare `grep -qF` substring would be satisfied by
+# `# TODO: re-enable <the thing>`, so commenting a guard out would keep this
+# suite green — which is exactly the regression these pins exist to catch.
+check "release.yml never checks out a moving 'main' reference" \
+  "$(grep -qE "^[[:space:]]*ref:[[:space:]]*['\"]?(main|refs/heads/main)['\"]?[[:space:]]*(#.*)?$" "$RELEASE_YML" && echo moving-ref || echo pinned)" "pinned"
+
+# `git pull origin main` was the original second half of the bug, but ANY
+# shell-level re-pointing of the checkout reopens the same window — and does so
+# where the runtime verifier, which has already run, cannot see it.
+for moving_cmd in \
+    'git pull[[:space:]]' \
+    'git checkout[[:space:]]+(-[^[:space:]]+[[:space:]]+)*main' \
+    'git reset[[:space:]]+--hard' \
+    'git merge[[:space:]]+origin/main'; do
+    check "release.yml never re-points the checkout with '$moving_cmd'" \
+      "$(grep -qE "^[^#]*${moving_cmd}" "$RELEASE_YML" && echo moves || echo pinned)" "pinned"
+done
 
 # The pin has to come from somewhere: wait_for_pr resolves it once and exports it.
 # The GitHub expressions below are intentionally matched literally.
 # shellcheck disable=SC2016
 check "wait_for_pr exports the resolved release SHA" \
-  "$(grep -qF 'release_sha: ${{ steps.release_sha.outputs.sha }}' <<< "$WAIT_JOB" && echo present || echo missing)" "present"
+  "$(grep -qE '^[[:space:]]*release_sha: \$\{\{ steps\.release_sha\.outputs\.sha \}\}[[:space:]]*$' <<< "$WAIT_JOB" && echo present || echo missing)" "present"
 check "wait_for_pr invokes the tested resolver script" \
-  "$(grep -qF 'run: scripts/resolve_release_sha.sh' <<< "$WAIT_JOB" && echo present || echo missing)" "present"
+  "$(grep -qE '^[[:space:]]*run: (bash )?scripts/resolve_release_sha\.sh[[:space:]]*$' <<< "$WAIT_JOB" && echo present || echo missing)" "present"
 
 # Both downstream jobs must consume that SHA and re-check it after checkout.
+# The irreversible act each job must never reach unverified. The regex needles
+# below are intentionally literal shell text, not expansions.
+# shellcheck disable=SC2016
 for job_name in publish_crates create_release; do
     case "$job_name" in
-      publish_crates) JOB_BODY="$PUBLISH_JOB" ;;
-      create_release) JOB_BODY="$CREATE_RELEASE_JOB" ;;
+      publish_crates) JOB_BODY="$PUBLISH_JOB"; IRREVERSIBLE='cargo publish' ;;
+      create_release) JOB_BODY="$CREATE_RELEASE_JOB"; IRREVERSIBLE='git push origin "v\$VERSION"' ;;
     esac
-    # shellcheck disable=SC2016
+
     check "$job_name checks out needs.wait_for_pr.outputs.release_sha" \
-      "$(grep -qF 'ref: ${{ needs.wait_for_pr.outputs.release_sha' <<< "$JOB_BODY" && echo pinned || echo missing)" "pinned"
-    check "$job_name verifies the checkout before acting on it" \
-      "$(grep -qF 'scripts/verify_release_checkout.sh' <<< "$JOB_BODY" && echo present || echo missing)" "present"
-    # shellcheck disable=SC2016
+      "$(grep -qE '^[[:space:]]*ref: \$\{\{ needs\.wait_for_pr\.outputs\.release_sha' <<< "$JOB_BODY" && echo pinned || echo missing)" "pinned"
+    check "$job_name verifies the checkout" \
+      "$(grep -qE '^[[:space:]]*run: (bash )?scripts/verify_release_checkout\.sh[[:space:]]*$' <<< "$JOB_BODY" && echo present || echo missing)" "present"
     check "$job_name exports RELEASE_SHA for the verifier" \
-      "$(grep -qF 'RELEASE_SHA: ${{ needs.wait_for_pr.outputs.release_sha' <<< "$JOB_BODY" && echo present || echo missing)" "present"
+      "$(grep -qE '^[[:space:]]*RELEASE_SHA: \$\{\{ needs\.wait_for_pr\.outputs\.release_sha' <<< "$JOB_BODY" && echo present || echo missing)" "present"
     # Without this the verifier degenerates to comparing the checkout ref
     # against itself, which cannot fail.
-    # shellcheck disable=SC2016
     check "$job_name gives the verifier an independent version oracle" \
-      "$(grep -qF 'EXPECTED_VERSION: ${{ needs.validate.outputs.version }}' <<< "$JOB_BODY" && echo present || echo missing)" "present"
+      "$(grep -qE '^[[:space:]]*EXPECTED_VERSION: \$\{\{ needs\.validate\.outputs\.version \}\}[[:space:]]*$' <<< "$JOB_BODY" && echo present || echo missing)" "present"
+    # Lets the verifier distinguish the `|| github.sha` fallback from a
+    # genuinely wrong tree.
+    check "$job_name tells the verifier whether a SHA was actually resolved" \
+      "$(grep -qE '^[[:space:]]*RELEASE_SHA_RESOLVED: \$\{\{ needs\.wait_for_pr\.outputs\.release_sha \}\}[[:space:]]*$' <<< "$JOB_BODY" && echo present || echo missing)" "present"
+
+    # Presence is not enough. A guard placed AFTER the publish or the tag push
+    # verifies nothing — the irreversible act has already happened — so assert
+    # ORDER. Line numbers are relative to the extracted job body.
+    VERIFY_LINE=$(grep -nE '^[[:space:]]*run: (bash )?scripts/verify_release_checkout\.sh[[:space:]]*$' <<< "$JOB_BODY" | head -1 | cut -d: -f1)
+    CHECKOUT_LINE=$(grep -nE '^[[:space:]]*ref: \$\{\{ needs\.wait_for_pr\.outputs\.release_sha' <<< "$JOB_BODY" | head -1 | cut -d: -f1)
+    IRREVERSIBLE_LINE=$(grep -nE "^[^#]*${IRREVERSIBLE}" <<< "$JOB_BODY" | head -1 | cut -d: -f1)
+
+    check "$job_name's irreversible step was located" \
+      "$([ -n "$IRREVERSIBLE_LINE" ] && echo found || echo missing)" "found"
+    check "$job_name verifies BEFORE its irreversible step, not after" \
+      "$([ -n "$VERIFY_LINE" ] && [ -n "$IRREVERSIBLE_LINE" ] && [ "$VERIFY_LINE" -lt "$IRREVERSIBLE_LINE" ] && echo before || echo after)" "before"
+    check "$job_name verifies AFTER the checkout, not before" \
+      "$([ -n "$VERIFY_LINE" ] && [ -n "$CHECKOUT_LINE" ] && [ "$VERIFY_LINE" -gt "$CHECKOUT_LINE" ] && echo after || echo before)" "after"
 done
 
 # create_release can only read the output if wait_for_pr is in its needs.
@@ -353,8 +392,10 @@ check "create_release depends on wait_for_pr so the SHA is in scope" \
 # The notes must describe the commit being released, not whatever main is now.
 # The shell variable reference is intentionally matched literally.
 # shellcheck disable=SC2016
-check "release notes are generated for the pinned commit, not main" \
-  "$(grep -qF 'target_commitish="$RELEASE_SHA"' <<< "$CREATE_RELEASE_JOB" && echo pinned || echo missing)" "pinned"
+check "release notes are generated for the pinned commit" \
+  "$(grep -qE '^[^#]*-f target_commitish="\$RELEASE_SHA"' <<< "$CREATE_RELEASE_JOB" && echo pinned || echo missing)" "pinned"
+check "release notes never fall back to target_commitish=main" \
+  "$(grep -qE '^[^#]*-f target_commitish=main' <<< "$CREATE_RELEASE_JOB" && echo moving || echo pinned)" "pinned"
 
 # --- behavioural: scripts/verify_release_checkout.sh -------------------------
 
@@ -375,6 +416,7 @@ run_verify() {
     local expected_sha="$1" expected_version="$2" output_file="$3" status
     set +e
     ( cd "$VERIFY_REPO" && RELEASE_SHA="$expected_sha" EXPECTED_VERSION="$expected_version" \
+        RELEASE_SHA_RESOLVED="$expected_sha" \
         bash --noprofile --norc "$VERIFY_SCRIPT" ) > "$output_file" 2>&1
     status=$?
     set -e
@@ -401,9 +443,50 @@ check "verifier rejects the right SHA carrying the wrong version" \
 check "verifier explains which version it found versus expected" \
   "$(grep -qF "declares version '$RELEASE_VERSION'" "$VERIFY_WRONG_TREE_OUTPUT" && grep -qF 'this release is 0.2.122' "$VERIFY_WRONG_TREE_OUTPUT" && echo present || echo missing)" "present"
 
+# The `|| github.sha` fallback path: wait_for_pr resolved nothing, so the job
+# is sitting on the launch commit. The failure must name THAT, not report a
+# version mismatch and send the operator to inspect the tree.
+VERIFY_FALLBACK_OUTPUT="$TEST_TMP/verify-fallback.txt"
+set +e
+( cd "$VERIFY_REPO" && RELEASE_SHA="$VERIFY_HEAD" EXPECTED_VERSION="$RELEASE_VERSION" \
+    RELEASE_SHA_RESOLVED="" bash --noprofile --norc "$VERIFY_SCRIPT" ) \
+  > "$VERIFY_FALLBACK_OUTPUT" 2>&1
+VERIFY_FALLBACK_STATUS=$?
+set -e
+check "verifier refuses to act when no release commit was resolved" \
+  "$([ "$VERIFY_FALLBACK_STATUS" -ne 0 ] && echo failed || echo passed)" "failed"
+check "verifier names wait_for_pr as the cause, not the tree" \
+  "$(grep -qF 'wait_for_pr did not resolve a release commit' "$VERIFY_FALLBACK_OUTPUT" && echo correct || echo misattributed)" "correct"
+
+# A manifest with no `^version = "` line must produce the explanatory error,
+# not die silently inside the pipeline that reads it.
+VERIFY_NOVER_REPO="$TEST_TMP/verify-noversion-repo"
+mkdir -p "$VERIFY_NOVER_REPO/crates/core"
+printf '[package]\nname = "freenet"\nversion.workspace = true\n' \
+  > "$VERIFY_NOVER_REPO/crates/core/Cargo.toml"
+(
+  cd "$VERIFY_NOVER_REPO"
+  git init -q .
+  git add crates/core/Cargo.toml
+  git -c user.email=t@example.invalid -c user.name=t commit -q -m "workspace-inherited version"
+) >/dev/null 2>&1
+VERIFY_NOVER_HEAD=$(cd "$VERIFY_NOVER_REPO" && git rev-parse HEAD)
+VERIFY_NOVER_OUTPUT="$TEST_TMP/verify-noversion.txt"
+set +e
+( cd "$VERIFY_NOVER_REPO" && RELEASE_SHA="$VERIFY_NOVER_HEAD" EXPECTED_VERSION="$RELEASE_VERSION" \
+    RELEASE_SHA_RESOLVED="$VERIFY_NOVER_HEAD" bash --noprofile --norc "$VERIFY_SCRIPT" ) \
+  > "$VERIFY_NOVER_OUTPUT" 2>&1
+VERIFY_NOVER_STATUS=$?
+set -e
+check "verifier fails when the manifest has no readable version" \
+  "$([ "$VERIFY_NOVER_STATUS" -ne 0 ] && echo failed || echo passed)" "failed"
+check "verifier explains itself rather than dying silently in a pipeline" \
+  "$(grep -qF '::error' "$VERIFY_NOVER_OUTPUT" && echo explained || echo silent)" "explained"
+
 VERIFY_NO_MANIFEST_OUTPUT="$TEST_TMP/verify-no-manifest.txt"
 set +e
 ( cd "$VERIFY_REPO" && RELEASE_SHA="$VERIFY_HEAD" EXPECTED_VERSION="$RELEASE_VERSION" \
+    RELEASE_SHA_RESOLVED="$VERIFY_HEAD" \
     MANIFEST="crates/core/Absent.toml" bash --noprofile --norc "$VERIFY_SCRIPT" ) \
   > "$VERIFY_NO_MANIFEST_OUTPUT" 2>&1
 VERIFY_NO_MANIFEST_STATUS=$?
@@ -415,6 +498,7 @@ for missing_var in RELEASE_SHA EXPECTED_VERSION; do
     VERIFY_UNSET_OUTPUT="$TEST_TMP/verify-unset-$missing_var.txt"
     set +e
     ( cd "$VERIFY_REPO" && RELEASE_SHA="$VERIFY_HEAD" EXPECTED_VERSION="$RELEASE_VERSION" \
+        RELEASE_SHA_RESOLVED="$VERIFY_HEAD" \
         env -u "$missing_var" bash --noprofile --norc "$VERIFY_SCRIPT" ) \
       > "$VERIFY_UNSET_OUTPUT" 2>&1
     VERIFY_UNSET_STATUS=$?
@@ -453,10 +537,21 @@ case "$*" in
       echo "simulated transient API failure" >&2
       exit 1
     fi
+    # Real `gh pr view --json mergeCommit --jq '.mergeCommit.oid // empty'` on
+    # an UNMERGED PR exits 0 and prints nothing. Modelling that as a non-zero
+    # exit would route the test down the API-failure branch and leave the
+    # PR-has-no-merge-commit branch with no coverage at all.
+    if [ "${MOCK_EMPTY_OID:-0}" = "1" ]; then
+      exit 0
+    fi
     [ -n "${MOCK_MERGE_SHA:-}" ] || exit 2
     printf '%s\n' "$MOCK_MERGE_SHA"
     ;;
   *compare*)
+    if [ "${MOCK_COMPARE_FAILS:-0}" = "1" ]; then
+      echo "simulated compare API failure" >&2
+      exit 1
+    fi
     printf '%s' "${MOCK_COMPARE:-}"
     ;;
   *)
@@ -472,9 +567,10 @@ LAUNCHED_SHA="2222222222222222222222222222222222222222"
 
 run_resolve() {
     # run_resolve <merge_sha> <compare_body> <output_file> <github_output_file>
-    #             [fail_first] [attempts]
+    #             [fail_first] [attempts] [empty_oid] [compare_fails]
     local merge_sha="$1" compare="$2" output_file="$3" gh_output="$4"
-    local fail_first="${5:-0}" attempts="${6:-1}" status
+    local fail_first="${5:-0}" attempts="${6:-1}"
+    local empty_oid="${7:-0}" compare_fails="${8:-0}" status
     : > "$gh_output"
     : > "${gh_output}.calls"
     set +e
@@ -486,6 +582,8 @@ run_resolve() {
       MOCK_MERGE_SHA="$merge_sha" \
       MOCK_COMPARE="$compare" \
       MOCK_FAIL_FIRST="$fail_first" \
+      MOCK_EMPTY_OID="$empty_oid" \
+      MOCK_COMPARE_FAILS="$compare_fails" \
       MOCK_RESOLVE_CALLS="${gh_output}.calls" \
       RESOLVE_ATTEMPTS="$attempts" \
       RESOLVE_RETRY_INTERVAL="0" \
@@ -554,6 +652,58 @@ check "resolver blames the API, not the PR, when the API was unreachable" \
   "$(grep -qF 'GitHub API could not be queried after 3 attempts' "$RESOLVE_EXHAUST_OUTPUT" && echo correct || echo misattributed)" "correct"
 check "resolver tells the operator the bump already merged and to re-run" \
   "$(grep -qF 'gh run rerun --failed' "$RESOLVE_EXHAUST_OUTPUT" && echo present || echo missing)" "present"
+
+# The branch the retry loop exists FOR: gh works fine, the PR simply has no
+# merge commit yet. Real gh exits 0 printing nothing, so this must not be
+# reported as an API failure.
+RESOLVE_EMPTY_OUTPUT="$TEST_TMP/resolve-empty-oid.txt"
+RESOLVE_EMPTY_GH_OUTPUT="$TEST_TMP/resolve-empty-oid.env"
+check "resolver fails when the PR reports no merge commit at all" \
+  "$([ "$(run_resolve "$MERGED_SHA" "$BUMP_ONLY" "$RESOLVE_EMPTY_OUTPUT" "$RESOLVE_EMPTY_GH_OUTPUT" 0 2 1)" -ne 0 ] && echo failed || echo passed)" "failed"
+check "resolver blames the PR, not the API, when the API answered cleanly" \
+  "$(grep -qF "reported merge commit ''" "$RESOLVE_EMPTY_OUTPUT" && echo correct || echo misattributed)" "correct"
+check "resolver does not claim the API was unreachable when it was not" \
+  "$(grep -qF 'GitHub API could not be queried' "$RESOLVE_EMPTY_OUTPUT" && echo misattributed || echo correct)" "correct"
+check "resolver exports no SHA when the PR has no merge commit" \
+  "$(grep -qF 'sha=' "$RESOLVE_EMPTY_GH_OUTPUT" && echo leaked || echo empty)" "empty"
+
+# A failed compare must not be reported as "main did not move". #5233's
+# complaint was a silent divergence; a FALSE all-clear is worse, because it
+# ends the investigation.
+RESOLVE_CMPFAIL_OUTPUT="$TEST_TMP/resolve-compare-fail.txt"
+RESOLVE_CMPFAIL_GH_OUTPUT="$TEST_TMP/resolve-compare-fail.env"
+check "resolver still pins the SHA when the compare call fails" \
+  "$(run_resolve "$MERGED_SHA" "$RACED" "$RESOLVE_CMPFAIL_OUTPUT" "$RESOLVE_CMPFAIL_GH_OUTPUT" 0 1 0 1)" "0"
+check "resolver never claims 'main did not move' on a failed compare" \
+  "$(grep -qF 'main did not move' "$RESOLVE_CMPFAIL_OUTPUT" && echo false-allclear || echo honest)" "honest"
+check "resolver says the divergence check was inconclusive" \
+  "$(grep -qF 'Could not check whether main moved' "$RESOLVE_CMPFAIL_OUTPUT" && echo present || echo missing)" "present"
+
+# The number an operator reads must be the count of SURPRISES, not the total:
+# the version bump is expected and is not an extra.
+check "resolver counts extra commits, excluding the version bump" \
+  "$(grep -oE 'this release::[0-9]+ commit' "$RESOLVE_RACE_OUTPUT" | grep -oE '[0-9]+')" "2"
+
+# A misconfigured budget must not be reported as a PR problem.
+RESOLVE_BADCFG_OUTPUT="$TEST_TMP/resolve-badcfg.txt"
+RESOLVE_BADCFG_GH_OUTPUT="$TEST_TMP/resolve-badcfg.env"
+check "resolver rejects a non-positive retry budget" \
+  "$([ "$(run_resolve "$MERGED_SHA" "$BUMP_ONLY" "$RESOLVE_BADCFG_OUTPUT" "$RESOLVE_BADCFG_GH_OUTPUT" 0 0)" -ne 0 ] && echo failed || echo passed)" "failed"
+check "resolver blames its own configuration, not the PR" \
+  "$(grep -qF 'RESOLVE_ATTEMPTS must be a positive integer' "$RESOLVE_BADCFG_OUTPUT" && echo correct || echo misattributed)" "correct"
+
+# --- the REAL manifest must satisfy the verifier's version grep -------------
+#
+# The verifier's fixture is synthetic, so nothing else pins that `^version = "`
+# picks the PACKAGE version out of the real manifest. A move to
+# `version.workspace = true`, or a sub-table whose `version = "..."` sorts
+# first, would break every release at the guard with no other warning.
+REAL_MANIFEST="$SCRIPT_DIR/../crates/core/Cargo.toml"
+REAL_VERSION=$(grep -m1 -E '^version = "' "$REAL_MANIFEST" | cut -d'"' -f2 || true)
+check "the verifier's grep finds a version in the real core manifest" \
+  "$([[ "$REAL_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]] && echo found || echo "missing($REAL_VERSION)")" "found"
+check "the real core manifest's first '^version =' is the package version" \
+  "$(awk '/^\[/{sec=$0} /^version = "/{print sec; exit}' "$REAL_MANIFEST")" "[package]"
 
 if [ "$FAILURES" -eq 0 ]; then
     echo "PASS: release.yml is merge-queue-compatible, reports failed merge-group CI, and is pinned to one validated commit."

--- a/scripts/release_mergequeue_test.sh
+++ b/scripts/release_mergequeue_test.sh
@@ -303,6 +303,14 @@ check "publish_crates job body was located" \
 check "create_release job body was located" \
   "$([ -n "$CREATE_RELEASE_JOB" ] && echo present || echo missing)" "present"
 
+# A sed range whose closing anchor is renamed silently runs to EOF, so the
+# job-scoped pins below would start matching neighbouring jobs and pass
+# vacuously. Assert each range actually terminated on its anchor.
+check "publish_crates range is bounded by the next job" \
+  "$([ "$(tail -n1 <<< "$PUBLISH_JOB")" = "  create_release:" ] && echo bounded || echo ran-to-eof)" "bounded"
+check "create_release range is bounded by the next job" \
+  "$([ "$(tail -n1 <<< "$CREATE_RELEASE_JOB")" = "  summary:" ] && echo bounded || echo ran-to-eof)" "bounded"
+
 # The bug itself: no job may resolve a moving reference.
 check "release.yml never checks out 'ref: main'" \
   "$(grep -qE '^[[:space:]]*ref:[[:space:]]*main[[:space:]]*$' "$RELEASE_YML" && echo moving-ref || echo pinned)" "pinned"
@@ -331,6 +339,11 @@ for job_name in publish_crates create_release; do
     # shellcheck disable=SC2016
     check "$job_name exports RELEASE_SHA for the verifier" \
       "$(grep -qF 'RELEASE_SHA: ${{ needs.wait_for_pr.outputs.release_sha' <<< "$JOB_BODY" && echo present || echo missing)" "present"
+    # Without this the verifier degenerates to comparing the checkout ref
+    # against itself, which cannot fail.
+    # shellcheck disable=SC2016
+    check "$job_name gives the verifier an independent version oracle" \
+      "$(grep -qF 'EXPECTED_VERSION: ${{ needs.validate.outputs.version }}' <<< "$JOB_BODY" && echo present || echo missing)" "present"
 done
 
 # create_release can only read the output if wait_for_pr is in its needs.
@@ -345,19 +358,23 @@ check "release notes are generated for the pinned commit, not main" \
 
 # --- behavioural: scripts/verify_release_checkout.sh -------------------------
 
+RELEASE_VERSION="0.2.123"
 VERIFY_REPO="$TEST_TMP/verify-repo"
-mkdir -p "$VERIFY_REPO"
+mkdir -p "$VERIFY_REPO/crates/core"
+printf '[package]\nname = "freenet"\nversion = "%s"\n' "$RELEASE_VERSION" \
+  > "$VERIFY_REPO/crates/core/Cargo.toml"
 (
   cd "$VERIFY_REPO"
   git init -q .
-  git -c user.email=t@example.invalid -c user.name=t commit -q --allow-empty -m "release commit"
+  git add crates/core/Cargo.toml
+  git -c user.email=t@example.invalid -c user.name=t commit -q -m "build: release $RELEASE_VERSION"
 ) >/dev/null 2>&1
 VERIFY_HEAD=$(cd "$VERIFY_REPO" && git rev-parse HEAD)
 
 run_verify() {
-    local expected_sha="$1" output_file="$2" status
+    local expected_sha="$1" expected_version="$2" output_file="$3" status
     set +e
-    ( cd "$VERIFY_REPO" && RELEASE_SHA="$expected_sha" \
+    ( cd "$VERIFY_REPO" && RELEASE_SHA="$expected_sha" EXPECTED_VERSION="$expected_version" \
         bash --noprofile --norc "$VERIFY_SCRIPT" ) > "$output_file" 2>&1
     status=$?
     set -e
@@ -365,34 +382,77 @@ run_verify() {
 }
 
 VERIFY_OK_OUTPUT="$TEST_TMP/verify-ok.txt"
-check "verifier accepts a checkout at the pinned commit" \
-  "$(run_verify "$VERIFY_HEAD" "$VERIFY_OK_OUTPUT")" "0"
+check "verifier accepts the pinned commit carrying the release version" \
+  "$(run_verify "$VERIFY_HEAD" "$RELEASE_VERSION" "$VERIFY_OK_OUTPUT")" "0"
 
 VERIFY_DRIFT_OUTPUT="$TEST_TMP/verify-drift.txt"
 DRIFT_SHA="0123456789012345678901234567890123456789"
 check "verifier rejects a checkout that drifted off the pinned commit" \
-  "$([ "$(run_verify "$DRIFT_SHA" "$VERIFY_DRIFT_OUTPUT")" -ne 0 ] && echo failed || echo passed)" "failed"
+  "$([ "$(run_verify "$DRIFT_SHA" "$RELEASE_VERSION" "$VERIFY_DRIFT_OUTPUT")" -ne 0 ] && echo failed || echo passed)" "failed"
 check "verifier names both SHAs when it rejects" \
   "$(grep -qF "$DRIFT_SHA" "$VERIFY_DRIFT_OUTPUT" && grep -qF "$VERIFY_HEAD" "$VERIFY_DRIFT_OUTPUT" && echo present || echo missing)" "present"
 
-VERIFY_UNSET_OUTPUT="$TEST_TMP/verify-unset.txt"
+# The oracle that is NOT a restatement of the checkout ref: the `|| github.sha`
+# fallback would put us on the launch commit, whose manifest still carries the
+# PREVIOUS version. HEAD would match RELEASE_SHA and only this check fires.
+VERIFY_WRONG_TREE_OUTPUT="$TEST_TMP/verify-wrong-tree.txt"
+check "verifier rejects the right SHA carrying the wrong version" \
+  "$([ "$(run_verify "$VERIFY_HEAD" "0.2.122" "$VERIFY_WRONG_TREE_OUTPUT")" -ne 0 ] && echo failed || echo passed)" "failed"
+check "verifier explains which version it found versus expected" \
+  "$(grep -qF "declares version '$RELEASE_VERSION'" "$VERIFY_WRONG_TREE_OUTPUT" && grep -qF 'this release is 0.2.122' "$VERIFY_WRONG_TREE_OUTPUT" && echo present || echo missing)" "present"
+
+VERIFY_NO_MANIFEST_OUTPUT="$TEST_TMP/verify-no-manifest.txt"
 set +e
-( cd "$VERIFY_REPO" && env -u RELEASE_SHA bash --noprofile --norc "$VERIFY_SCRIPT" ) \
-  > "$VERIFY_UNSET_OUTPUT" 2>&1
-VERIFY_UNSET_STATUS=$?
+( cd "$VERIFY_REPO" && RELEASE_SHA="$VERIFY_HEAD" EXPECTED_VERSION="$RELEASE_VERSION" \
+    MANIFEST="crates/core/Absent.toml" bash --noprofile --norc "$VERIFY_SCRIPT" ) \
+  > "$VERIFY_NO_MANIFEST_OUTPUT" 2>&1
+VERIFY_NO_MANIFEST_STATUS=$?
 set -e
-check "verifier fails closed when no pinned SHA was passed" \
-  "$([ "$VERIFY_UNSET_STATUS" -ne 0 ] && echo failed || echo passed)" "failed"
+check "verifier rejects a checkout with no freenet manifest" \
+  "$([ "$VERIFY_NO_MANIFEST_STATUS" -ne 0 ] && echo failed || echo passed)" "failed"
+
+for missing_var in RELEASE_SHA EXPECTED_VERSION; do
+    VERIFY_UNSET_OUTPUT="$TEST_TMP/verify-unset-$missing_var.txt"
+    set +e
+    ( cd "$VERIFY_REPO" && RELEASE_SHA="$VERIFY_HEAD" EXPECTED_VERSION="$RELEASE_VERSION" \
+        env -u "$missing_var" bash --noprofile --norc "$VERIFY_SCRIPT" ) \
+      > "$VERIFY_UNSET_OUTPUT" 2>&1
+    VERIFY_UNSET_STATUS=$?
+    set -e
+    check "verifier fails closed when $missing_var is unset" \
+      "$([ "$VERIFY_UNSET_STATUS" -ne 0 ] && echo failed || echo passed)" "failed"
+done
 
 # --- behavioural: scripts/resolve_release_sha.sh -----------------------------
 
 RESOLVE_BIN="$TEST_TMP/resolve-bin"
 mkdir -p "$RESOLVE_BIN"
+# The mock asserts the REAL invocation shape. Without this a typo in
+# `--json mergeCommit` or in the jq filter would never turn the suite red — it
+# would only fail closed in production, mid-release.
 cat > "$RESOLVE_BIN/gh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 case "$*" in
   *"pr view"*)
+    for expected in \
+      '--repo freenet/freenet-core' \
+      '--json mergeCommit' \
+      '--jq .mergeCommit.oid // empty'; do
+      if [[ "$*" != *"$expected"* ]]; then
+        echo "missing expected gh pr view argument: $expected" >&2
+        exit 3
+      fi
+    done
+    # Fail the first N calls to exercise the retry path.
+    calls=0
+    if [ -s "$MOCK_RESOLVE_CALLS" ]; then calls=$(< "$MOCK_RESOLVE_CALLS"); fi
+    calls=$((calls + 1))
+    printf '%s\n' "$calls" > "$MOCK_RESOLVE_CALLS"
+    if [ "$calls" -le "${MOCK_FAIL_FIRST:-0}" ]; then
+      echo "simulated transient API failure" >&2
+      exit 1
+    fi
     [ -n "${MOCK_MERGE_SHA:-}" ] || exit 2
     printf '%s\n' "$MOCK_MERGE_SHA"
     ;;
@@ -412,8 +472,11 @@ LAUNCHED_SHA="2222222222222222222222222222222222222222"
 
 run_resolve() {
     # run_resolve <merge_sha> <compare_body> <output_file> <github_output_file>
-    local merge_sha="$1" compare="$2" output_file="$3" gh_output="$4" status
+    #             [fail_first] [attempts]
+    local merge_sha="$1" compare="$2" output_file="$3" gh_output="$4"
+    local fail_first="${5:-0}" attempts="${6:-1}" status
     : > "$gh_output"
+    : > "${gh_output}.calls"
     set +e
     PATH="$RESOLVE_BIN:$PATH" \
       GITHUB_REPOSITORY="freenet/freenet-core" \
@@ -422,6 +485,10 @@ run_resolve() {
       GITHUB_OUTPUT="$gh_output" \
       MOCK_MERGE_SHA="$merge_sha" \
       MOCK_COMPARE="$compare" \
+      MOCK_FAIL_FIRST="$fail_first" \
+      MOCK_RESOLVE_CALLS="${gh_output}.calls" \
+      RESOLVE_ATTEMPTS="$attempts" \
+      RESOLVE_RETRY_INTERVAL="0" \
       bash --noprofile --norc "$RESOLVE_SCRIPT" > "$output_file" 2>&1
     status=$?
     set -e
@@ -464,6 +531,29 @@ RESOLVE_JUNK_OUTPUT="$TEST_TMP/resolve-junk.txt"
 RESOLVE_JUNK_GH_OUTPUT="$TEST_TMP/resolve-junk.env"
 check "resolver rejects a non-SHA merge commit rather than checking it out" \
   "$([ "$(run_resolve "main" "$BUMP_ONLY" "$RESOLVE_JUNK_OUTPUT" "$RESOLVE_JUNK_GH_OUTPUT")" -ne 0 ] && echo failed || echo passed)" "failed"
+
+# This step runs after the bump PR has already merged, so a single transient
+# API failure must not strand the release half-done.
+RESOLVE_RETRY_OUTPUT="$TEST_TMP/resolve-retry.txt"
+RESOLVE_RETRY_GH_OUTPUT="$TEST_TMP/resolve-retry.env"
+check "resolver survives transient API failures and still resolves" \
+  "$(run_resolve "$MERGED_SHA" "$BUMP_ONLY" "$RESOLVE_RETRY_OUTPUT" "$RESOLVE_RETRY_GH_OUTPUT" 2 4)" "0"
+check "resolver exports the SHA it eventually resolved" \
+  "$(grep -qF "sha=$MERGED_SHA" "$RESOLVE_RETRY_GH_OUTPUT" && echo present || echo missing)" "present"
+check "resolver reports each retry attempt" \
+  "$(grep -qF 'attempt 1/4' "$RESOLVE_RETRY_OUTPUT" && echo present || echo missing)" "present"
+check "resolver actually retried rather than succeeding first try" \
+  "$(cat "${RESOLVE_RETRY_GH_OUTPUT}.calls")" "3"
+
+# Exhausting the budget must blame the API, not the pull request.
+RESOLVE_EXHAUST_OUTPUT="$TEST_TMP/resolve-exhaust.txt"
+RESOLVE_EXHAUST_GH_OUTPUT="$TEST_TMP/resolve-exhaust.env"
+check "resolver fails when every attempt hits an API failure" \
+  "$([ "$(run_resolve "$MERGED_SHA" "$BUMP_ONLY" "$RESOLVE_EXHAUST_OUTPUT" "$RESOLVE_EXHAUST_GH_OUTPUT" 3 3)" -ne 0 ] && echo failed || echo passed)" "failed"
+check "resolver blames the API, not the PR, when the API was unreachable" \
+  "$(grep -qF 'GitHub API could not be queried after 3 attempts' "$RESOLVE_EXHAUST_OUTPUT" && echo correct || echo misattributed)" "correct"
+check "resolver tells the operator the bump already merged and to re-run" \
+  "$(grep -qF 'gh run rerun --failed' "$RESOLVE_EXHAUST_OUTPUT" && echo present || echo missing)" "present"
 
 if [ "$FAILURES" -eq 0 ]; then
     echo "PASS: release.yml is merge-queue-compatible, reports failed merge-group CI, and is pinned to one validated commit."

--- a/scripts/release_mergequeue_test.sh
+++ b/scripts/release_mergequeue_test.sh
@@ -375,9 +375,9 @@ for job_name in publish_crates create_release; do
     # Presence is not enough. A guard placed AFTER the publish or the tag push
     # verifies nothing — the irreversible act has already happened — so assert
     # ORDER. Line numbers are relative to the extracted job body.
-    VERIFY_LINE=$(grep -nE '^[[:space:]]*run: (bash )?scripts/verify_release_checkout\.sh[[:space:]]*$' <<< "$JOB_BODY" | head -1 | cut -d: -f1)
-    CHECKOUT_LINE=$(grep -nE '^[[:space:]]*ref: \$\{\{ needs\.wait_for_pr\.outputs\.release_sha' <<< "$JOB_BODY" | head -1 | cut -d: -f1)
-    IRREVERSIBLE_LINE=$(grep -nE "^[^#]*${IRREVERSIBLE}" <<< "$JOB_BODY" | head -1 | cut -d: -f1)
+    VERIFY_LINE=$(grep -nE '^[[:space:]]*run: (bash )?scripts/verify_release_checkout\.sh[[:space:]]*$' <<< "$JOB_BODY" | head -1 | cut -d: -f1 || true)
+    CHECKOUT_LINE=$(grep -nE '^[[:space:]]*ref: \$\{\{ needs\.wait_for_pr\.outputs\.release_sha' <<< "$JOB_BODY" | head -1 | cut -d: -f1 || true)
+    IRREVERSIBLE_LINE=$(grep -nE "^[^#]*${IRREVERSIBLE}" <<< "$JOB_BODY" | head -1 | cut -d: -f1 || true)
 
     check "$job_name's irreversible step was located" \
       "$([ -n "$IRREVERSIBLE_LINE" ] && echo found || echo missing)" "found"

--- a/scripts/resolve_release_sha.sh
+++ b/scripts/resolve_release_sha.sh
@@ -46,10 +46,15 @@ fi
 
 MERGE_SHA=""
 GH_UNREACHABLE=false
+# Keep the last stderr rather than discarding it: when this fails it fails
+# mid-release, and "could not be queried" without the 403/404/rate-limit body
+# is the least useful message possible at that moment.
+GH_STDERR=$(mktemp)
+trap 'rm -f "$GH_STDERR"' EXIT
 
 for attempt in $(seq 1 "$ATTEMPTS"); do
     if MERGE_SHA=$(gh pr view "$PR_NUMBER" --repo "$REPOSITORY" \
-        --json mergeCommit --jq '.mergeCommit.oid // empty' 2>/dev/null); then
+        --json mergeCommit --jq '.mergeCommit.oid // empty' 2>"$GH_STDERR"); then
         GH_UNREACHABLE=false
     else
         # Distinguish "the API call failed" from "the PR has no merge commit";
@@ -75,6 +80,10 @@ if [[ ! "$MERGE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
         REASON="PR #$PR_NUMBER reported merge commit '${MERGE_SHA}', which is not a commit SHA"
     fi
     echo "::error title=Could not resolve the release commit::${REASON}. Refusing to fall back to a moving 'main' reference — that is the #5233 bug. The version bump has already merged, so re-run this job (\`gh run rerun --failed\`) once the PR's merge commit is visible."
+    if [ "$GH_UNREACHABLE" = true ] && [ -s "$GH_STDERR" ]; then
+        echo "Last error from gh:"
+        sed 's/^/  /' "$GH_STDERR"
+    fi
     exit 1
 fi
 
@@ -86,6 +95,10 @@ if [ -z "$LAUNCH_SHA" ] || [ "$LAUNCH_SHA" = "$MERGE_SHA" ]; then
     exit 0
 fi
 
+# `.commits` is capped at 250 by the compare API. That is unreachable inside a
+# ~20-minute merge-queue window, and this whole section is advisory anyway, so
+# counting the listed commits is fine; if it ever saturates, the count would
+# understate and `.total_commits` would be the authoritative field.
 if ! RANGE=$(gh api "repos/$REPOSITORY/compare/$LAUNCH_SHA...$MERGE_SHA" \
     --jq '.commits[] | "  \(.sha[0:9]) \(.commit.message | split("\n")[0])"' 2>/dev/null); then
     # Never claim "main did not move" on the strength of a call that failed.

--- a/scripts/resolve_release_sha.sh
+++ b/scripts/resolve_release_sha.sh
@@ -29,12 +29,46 @@ OUTPUT_FILE="${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
 # The commit the release run was dispatched from. Best-effort context for the
 # divergence report; its absence must not block the release.
 LAUNCH_SHA="${LAUNCH_SHA:-}"
+# This step runs AFTER the bump PR has already merged to main, so failing here
+# leaves a half-done release (version bump landed, nothing published or
+# tagged) that needs a human to re-run. The waiter before it retries transient
+# API failures for its whole budget; do the same rather than letting one blip
+# strand the release. GitHub can also lag briefly in exposing `mergeCommit`
+# after a merge-queue merge.
+ATTEMPTS="${RESOLVE_ATTEMPTS:-6}"
+RETRY_INTERVAL="${RESOLVE_RETRY_INTERVAL:-10}"
 
-MERGE_SHA=$(gh pr view "$PR_NUMBER" --repo "$REPOSITORY" \
-  --json mergeCommit --jq '.mergeCommit.oid // empty' 2>/dev/null || true)
+MERGE_SHA=""
+GH_UNREACHABLE=false
+
+for attempt in $(seq 1 "$ATTEMPTS"); do
+    if MERGE_SHA=$(gh pr view "$PR_NUMBER" --repo "$REPOSITORY" \
+        --json mergeCommit --jq '.mergeCommit.oid // empty' 2>/dev/null); then
+        GH_UNREACHABLE=false
+    else
+        # Distinguish "the API call failed" from "the PR has no merge commit";
+        # otherwise the error blames the PR for an API fault.
+        GH_UNREACHABLE=true
+        MERGE_SHA=""
+    fi
+
+    if [[ "$MERGE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+        break
+    fi
+
+    if [ "$attempt" -lt "$ATTEMPTS" ]; then
+        echo "  ⚠️  merge commit for PR #$PR_NUMBER not resolvable yet (attempt $attempt/$ATTEMPTS), retrying in ${RETRY_INTERVAL}s"
+        sleep "$RETRY_INTERVAL"
+    fi
+done
 
 if [[ ! "$MERGE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
-    echo "::error title=Could not resolve the release commit::Version-bump PR #$PR_NUMBER reported merge commit '${MERGE_SHA}', which is not a commit SHA. Refusing to fall back to a moving 'main' reference — that is the #5233 bug. Re-run the release once the PR's merge commit is visible."
+    if [ "$GH_UNREACHABLE" = true ]; then
+        REASON="the GitHub API could not be queried after $ATTEMPTS attempts"
+    else
+        REASON="PR #$PR_NUMBER reported merge commit '${MERGE_SHA}', which is not a commit SHA"
+    fi
+    echo "::error title=Could not resolve the release commit::${REASON}. Refusing to fall back to a moving 'main' reference — that is the #5233 bug. The version bump has already merged, so re-run this job (\`gh run rerun --failed\`) once the PR's merge commit is visible."
     exit 1
 fi
 

--- a/scripts/resolve_release_sha.sh
+++ b/scripts/resolve_release_sha.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Resolve the ONE immutable commit a release is cut from.
+#
+# release.yml's publish and tag jobs used to check out `ref: main`, which is a
+# MOVING reference. `wait_for_pr` blocks for ~20 minutes on the merge queue, so
+# anything that landed on main in that window silently became part of the
+# release and of the tag, with no signal in the run log (#5233 — v0.2.122
+# shipped an unrelated commit this way, defeating a deliberate scope decision).
+#
+# The commit we want is the one the version-bump PR actually merged AS. That is
+# the tree the merge queue's full-suite release gate validated, and it is
+# immutable: later merges move `main` past it but never change it.
+#
+# Emits `sha=<40-hex>` to $GITHUB_OUTPUT for downstream jobs to check out
+# explicitly. Fails closed — it never falls back to a moving reference.
+#
+# Also reports (as a warning, not a failure) when main moved between the commit
+# the release run was launched from and the commit it will ship, so the "this
+# release contains more than the version bump" case stops being silent.
+#
+# Run manually with: bash scripts/resolve_release_sha.sh
+# Tests: scripts/release_mergequeue_test.sh
+
+set -euo pipefail
+
+PR_NUMBER="${PR_NUMBER:?PR_NUMBER is required}"
+REPOSITORY="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+OUTPUT_FILE="${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+# The commit the release run was dispatched from. Best-effort context for the
+# divergence report; its absence must not block the release.
+LAUNCH_SHA="${LAUNCH_SHA:-}"
+
+MERGE_SHA=$(gh pr view "$PR_NUMBER" --repo "$REPOSITORY" \
+  --json mergeCommit --jq '.mergeCommit.oid // empty' 2>/dev/null || true)
+
+if [[ ! "$MERGE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "::error title=Could not resolve the release commit::Version-bump PR #$PR_NUMBER reported merge commit '${MERGE_SHA}', which is not a commit SHA. Refusing to fall back to a moving 'main' reference — that is the #5233 bug. Re-run the release once the PR's merge commit is visible."
+    exit 1
+fi
+
+echo "sha=$MERGE_SHA" >> "$OUTPUT_FILE"
+echo "📌 Release pinned to $MERGE_SHA (merge commit of version-bump PR #$PR_NUMBER)"
+
+# Everything below is advisory. A failure here must not fail the release.
+if [ -z "$LAUNCH_SHA" ] || [ "$LAUNCH_SHA" = "$MERGE_SHA" ]; then
+    exit 0
+fi
+
+RANGE=$(gh api "repos/$REPOSITORY/compare/$LAUNCH_SHA...$MERGE_SHA" \
+  --jq '.commits[] | "  \(.sha[0:9]) \(.commit.message | split("\n")[0])"' 2>/dev/null || true)
+
+# The version-bump commit itself is expected; anything beyond it is a commit
+# that won the race with the merge queue during `wait_for_pr`.
+EXTRA_COUNT=$(printf '%s' "$RANGE" | grep -c . || true)
+if [ "${EXTRA_COUNT:-0}" -le 1 ]; then
+    echo "✅ main did not move during this release: the version bump is the only new commit."
+    exit 0
+fi
+
+echo "::warning title=main moved during this release::${EXTRA_COUNT} commits landed between the launch commit ($LAUNCH_SHA) and the release commit ($MERGE_SHA), so this release contains more than the version bump. The release is still cut from ONE validated commit; this is a scope notice, not a correctness failure."
+printf '%s\n' "$RANGE"

--- a/scripts/resolve_release_sha.sh
+++ b/scripts/resolve_release_sha.sh
@@ -37,6 +37,12 @@ LAUNCH_SHA="${LAUNCH_SHA:-}"
 # after a merge-queue merge.
 ATTEMPTS="${RESOLVE_ATTEMPTS:-6}"
 RETRY_INTERVAL="${RESOLVE_RETRY_INTERVAL:-10}"
+# A zero or non-numeric budget would run the loop zero times and then blame the
+# PR for what is really a configuration error.
+if [[ ! "$ATTEMPTS" =~ ^[1-9][0-9]*$ ]]; then
+    echo "::error title=Bad resolver configuration::RESOLVE_ATTEMPTS must be a positive integer, got '$ATTEMPTS'."
+    exit 1
+fi
 
 MERGE_SHA=""
 GH_UNREACHABLE=false
@@ -80,16 +86,26 @@ if [ -z "$LAUNCH_SHA" ] || [ "$LAUNCH_SHA" = "$MERGE_SHA" ]; then
     exit 0
 fi
 
-RANGE=$(gh api "repos/$REPOSITORY/compare/$LAUNCH_SHA...$MERGE_SHA" \
-  --jq '.commits[] | "  \(.sha[0:9]) \(.commit.message | split("\n")[0])"' 2>/dev/null || true)
+if ! RANGE=$(gh api "repos/$REPOSITORY/compare/$LAUNCH_SHA...$MERGE_SHA" \
+    --jq '.commits[] | "  \(.sha[0:9]) \(.commit.message | split("\n")[0])"' 2>/dev/null); then
+    # Never claim "main did not move" on the strength of a call that failed.
+    # #5233's complaint was that the divergence was silent; a FALSE all-clear is
+    # worse, because it terminates the investigation.
+    echo "::warning title=Could not check whether main moved::The compare API call failed, so it is unknown whether commits other than the version bump are in this release. The release is still pinned to $MERGE_SHA."
+    exit 0
+fi
 
-# The version-bump commit itself is expected; anything beyond it is a commit
-# that won the race with the merge queue during `wait_for_pr`.
-EXTRA_COUNT=$(printf '%s' "$RANGE" | grep -c . || true)
-if [ "${EXTRA_COUNT:-0}" -le 1 ]; then
+# The version-bump commit itself is expected; anything beyond it won the race
+# with the merge queue while `wait_for_pr` was blocked.
+COMMIT_COUNT=$(printf '%s' "$RANGE" | grep -c . || true)
+COMMIT_COUNT=${COMMIT_COUNT:-0}
+if [ "$COMMIT_COUNT" -le 1 ]; then
     echo "✅ main did not move during this release: the version bump is the only new commit."
     exit 0
 fi
 
-echo "::warning title=main moved during this release::${EXTRA_COUNT} commits landed between the launch commit ($LAUNCH_SHA) and the release commit ($MERGE_SHA), so this release contains more than the version bump. The release is still cut from ONE validated commit; this is a scope notice, not a correctness failure."
+# Report the number of UNINTENDED commits, not the total. The bump is not an
+# extra, and an operator reading "3 commits" would count three surprises.
+EXTRA_COUNT=$((COMMIT_COUNT - 1))
+echo "::warning title=main moved during this release::${EXTRA_COUNT} commit(s) landed on main between the launch commit ($LAUNCH_SHA) and the release commit ($MERGE_SHA) in ADDITION to the version bump, so this release contains more than was intended. The release is still cut from ONE validated commit; this is a scope notice, not a correctness failure. Full range:"
 printf '%s\n' "$RANGE"

--- a/scripts/resolve_release_sha.sh
+++ b/scripts/resolve_release_sha.sh
@@ -7,9 +7,12 @@
 # release and of the tag, with no signal in the run log (#5233 — v0.2.122
 # shipped an unrelated commit this way, defeating a deliberate scope decision).
 #
-# The commit we want is the one the version-bump PR actually merged AS. That is
-# the tree the merge queue's full-suite release gate validated, and it is
-# immutable: later merges move `main` past it but never change it.
+# The commit we want is the one the version-bump PR actually merged AS. It is
+# immutable: later merges move `main` past it but never change it. It is also
+# the tree the merge queue gated (the full release suite runs when the bump is
+# the last entry in its merge group; a PR queued behind it shifts which group
+# head gets the full run, so read this as "the commit the queue merged",
+# not a guarantee about which suite ran).
 #
 # Emits `sha=<40-hex>` to $GITHUB_OUTPUT for downstream jobs to check out
 # explicitly. Fails closed — it never falls back to a moving reference.
@@ -100,11 +103,15 @@ fi
 # counting the listed commits is fine; if it ever saturates, the count would
 # understate and `.total_commits` would be the authoritative field.
 if ! RANGE=$(gh api "repos/$REPOSITORY/compare/$LAUNCH_SHA...$MERGE_SHA" \
-    --jq '.commits[] | "  \(.sha[0:9]) \(.commit.message | split("\n")[0])"' 2>/dev/null); then
+    --jq '.commits[] | "  \(.sha[0:9]) \(.commit.message | split("\n")[0])"' 2>"$GH_STDERR"); then
     # Never claim "main did not move" on the strength of a call that failed.
     # #5233's complaint was that the divergence was silent; a FALSE all-clear is
     # worse, because it terminates the investigation.
     echo "::warning title=Could not check whether main moved::The compare API call failed, so it is unknown whether commits other than the version bump are in this release. The release is still pinned to $MERGE_SHA."
+    if [ -s "$GH_STDERR" ]; then
+        echo "Last error from gh:"
+        sed 's/^/  /' "$GH_STDERR"
+    fi
     exit 0
 fi
 
@@ -112,7 +119,14 @@ fi
 # with the merge queue while `wait_for_pr` was blocked.
 COMMIT_COUNT=$(printf '%s' "$RANGE" | grep -c . || true)
 COMMIT_COUNT=${COMMIT_COUNT:-0}
-if [ "$COMMIT_COUNT" -le 1 ]; then
+if [ "$COMMIT_COUNT" -eq 0 ]; then
+    # Not an all-clear: the launch commit is not an ancestor of the release
+    # commit (force-push, or a rewritten base). Say so rather than implying the
+    # bump was the only change.
+    echo "::warning title=Could not check whether main moved::The compare from $LAUNCH_SHA to $MERGE_SHA returned no commits, which means the launch commit is not an ancestor of the release commit. The release is still pinned to $MERGE_SHA."
+    exit 0
+fi
+if [ "$COMMIT_COUNT" -eq 1 ]; then
     echo "✅ main did not move during this release: the version bump is the only new commit."
     exit 0
 fi

--- a/scripts/verify_release_checkout.sh
+++ b/scripts/verify_release_checkout.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Defence in depth for #5233: prove the working tree is the commit the release
+# was pinned to before anything irreversible happens to it.
+#
+# The pin itself (`ref: $RELEASE_SHA` on actions/checkout) is what fixes the
+# bug. This guard exists because the failure it catches is otherwise SILENT:
+# the release simply ships a different tree and nothing in the run log says so.
+# Keep it even though the pin makes it redundant today — a future edit that
+# reintroduces a moving reference, or a `git pull` slipped back in, then turns
+# into a red job instead of a silently wrong artifact.
+#
+# Must run AFTER checkout and BEFORE publishing or tagging.
+#
+# Run manually with: RELEASE_SHA=<sha> bash scripts/verify_release_checkout.sh
+# Tests: scripts/release_mergequeue_test.sh
+
+set -euo pipefail
+
+RELEASE_SHA="${RELEASE_SHA:?RELEASE_SHA is required}"
+
+ACTUAL_SHA=$(git rev-parse HEAD)
+
+if [ "$ACTUAL_SHA" != "$RELEASE_SHA" ]; then
+    echo "::error title=Release checkout drifted::Expected to build the release from $RELEASE_SHA but the checkout is at $ACTUAL_SHA. Refusing to publish or tag a commit the pipeline did not validate (#5233)."
+    exit 1
+fi
+
+echo "✅ Release checkout verified at $ACTUAL_SHA"

--- a/scripts/verify_release_checkout.sh
+++ b/scripts/verify_release_checkout.sh
@@ -27,8 +27,18 @@ set -euo pipefail
 
 RELEASE_SHA="${RELEASE_SHA:?RELEASE_SHA is required}"
 EXPECTED_VERSION="${EXPECTED_VERSION:?EXPECTED_VERSION is required}"
+# Empty exactly when `wait_for_pr` produced no SHA and the job fell back to the
+# launch commit. Reported separately so the failure names the real cause
+# instead of blaming the tree for a version mismatch it was always going to
+# have. Unset (rather than empty) means "not wired up", which is not an error.
+RELEASE_SHA_RESOLVED="${RELEASE_SHA_RESOLVED-unset}"
 # Overridable so the tests can point at a fixture manifest.
 MANIFEST="${MANIFEST:-crates/core/Cargo.toml}"
+
+if [ -z "$RELEASE_SHA_RESOLVED" ]; then
+    echo "::error title=No validated release commit::wait_for_pr did not resolve a release commit, so this job fell back to the launch commit $RELEASE_SHA. That commit predates the version bump, so it is not the release. Fix whatever made wait_for_pr fail and re-run (#5233)."
+    exit 1
+fi
 
 ACTUAL_SHA=$(git rev-parse HEAD)
 
@@ -42,7 +52,11 @@ if [ ! -f "$MANIFEST" ]; then
     exit 1
 fi
 
-ACTUAL_VERSION=$(grep -m1 -E '^version = "' "$MANIFEST" | cut -d'"' -f2)
+# Split the grep from the cut: under `pipefail` a no-match grep would abort
+# the script HERE, killing it before the message below that explains what is
+# wrong — turning a legible failure into a blank step.
+VERSION_LINE=$(grep -m1 -E '^version = "' "$MANIFEST" || true)
+ACTUAL_VERSION=$(printf '%s' "$VERSION_LINE" | cut -d'"' -f2)
 
 if [ "$ACTUAL_VERSION" != "$EXPECTED_VERSION" ]; then
     echo "::error title=Release checkout is the wrong tree::Commit $ACTUAL_SHA declares version '$ACTUAL_VERSION' in $MANIFEST, but this release is $EXPECTED_VERSION. The checkout is not the version-bump commit — publishing or tagging it would ship a crate whose version disagrees with the tag (#5233)."

--- a/scripts/verify_release_checkout.sh
+++ b/scripts/verify_release_checkout.sh
@@ -1,22 +1,34 @@
 #!/usr/bin/env bash
-# Defence in depth for #5233: prove the working tree is the commit the release
-# was pinned to before anything irreversible happens to it.
+# Prove the working tree is the commit the release was pinned to, before
+# anything irreversible (a crates.io publish, a tag push) happens to it.
 #
-# The pin itself (`ref: $RELEASE_SHA` on actions/checkout) is what fixes the
-# bug. This guard exists because the failure it catches is otherwise SILENT:
-# the release simply ships a different tree and nothing in the run log says so.
-# Keep it even though the pin makes it redundant today — a future edit that
-# reintroduces a moving reference, or a `git pull` slipped back in, then turns
-# into a red job instead of a silently wrong artifact.
+# Two checks, deliberately of different kinds:
 #
-# Must run AFTER checkout and BEFORE publishing or tagging.
+#   1. HEAD == $RELEASE_SHA. Cheap, but note it is NEARLY a tautology: the
+#      same expression feeds `ref:` on actions/checkout, which guarantees the
+#      match. It earns its place only against an edit that changes one and not
+#      the other, or that reintroduces a `git pull` after checkout.
 #
-# Run manually with: RELEASE_SHA=<sha> bash scripts/verify_release_checkout.sh
+#   2. The checked-out manifest carries $EXPECTED_VERSION. This is the real
+#      oracle. It is derived independently of the SHA — from `validate`'s
+#      resolved version rather than from `wait_for_pr`'s output — so it fails
+#      on ANY wrong tree, including the one case check 1 cannot see: the
+#      `|| github.sha` fallback silently engaging and putting us on the LAUNCH
+#      commit, which does not contain the version bump. Publishing or tagging
+#      that tree would ship a crate whose version disagrees with the tag.
+#
+# Must run AFTER checkout and BEFORE publishing or tagging. See #5233.
+#
+# Run manually with:
+#   RELEASE_SHA=<sha> EXPECTED_VERSION=<x.y.z> bash scripts/verify_release_checkout.sh
 # Tests: scripts/release_mergequeue_test.sh
 
 set -euo pipefail
 
 RELEASE_SHA="${RELEASE_SHA:?RELEASE_SHA is required}"
+EXPECTED_VERSION="${EXPECTED_VERSION:?EXPECTED_VERSION is required}"
+# Overridable so the tests can point at a fixture manifest.
+MANIFEST="${MANIFEST:-crates/core/Cargo.toml}"
 
 ACTUAL_SHA=$(git rev-parse HEAD)
 
@@ -25,4 +37,16 @@ if [ "$ACTUAL_SHA" != "$RELEASE_SHA" ]; then
     exit 1
 fi
 
-echo "✅ Release checkout verified at $ACTUAL_SHA"
+if [ ! -f "$MANIFEST" ]; then
+    echo "::error title=Release checkout is not a freenet tree::Expected $MANIFEST in the checkout at $ACTUAL_SHA, but it is missing."
+    exit 1
+fi
+
+ACTUAL_VERSION=$(grep -m1 -E '^version = "' "$MANIFEST" | cut -d'"' -f2)
+
+if [ "$ACTUAL_VERSION" != "$EXPECTED_VERSION" ]; then
+    echo "::error title=Release checkout is the wrong tree::Commit $ACTUAL_SHA declares version '$ACTUAL_VERSION' in $MANIFEST, but this release is $EXPECTED_VERSION. The checkout is not the version-bump commit — publishing or tagging it would ship a crate whose version disagrees with the tag (#5233)."
+    exit 1
+fi
+
+echo "✅ Release checkout verified: $ACTUAL_SHA declares version $ACTUAL_VERSION"


### PR DESCRIPTION
## Problem

`release.yml`'s `publish_crates` and `create_release` jobs checked out `ref: main` and then `git pull origin main`. Both run **after** `wait_for_pr`, which blocks ~20 minutes waiting for the version-bump PR to clear the merge queue. `main` is a moving reference, so anything that landed during that window silently became part of the published crates and of the release tag.

This is observed, not hypothetical. Release v0.2.122 ([run 31231116377](https://github.com/freenet/freenet-core/actions/runs/31231116377)) launched from `242affb1e`; PR #5224 merged at 01:08:45Z; the publish job checked out at 01:09:20Z and got `48c166c46`. The tag `v0.2.122` dereferences to `48c166c46`, while the version-bump PR #5231 merged as `9c12b7961` — the tag is one commit past the tree that carries the bump, and `cross-compile.yml` built the shipped binaries from it. That release was deliberately scoped to be minimal, because 0.2.120/0.2.121 cannot auto-update (#5221) and every operator has to install it by hand. The scope decision was load-bearing and the mechanism defeated it.

Three consequences: a minimal release is unachievable in principle, the CI signal describes a different tree than the one that ships, and it is completely silent.

## Solution

Resolve `main` to **one immutable SHA, once**, and have everything downstream check out that SHA explicitly.

`wait_for_pr` now ends by resolving the version-bump PR's **merge commit** (`scripts/resolve_release_sha.sh`) and exporting it as a job output. That commit is the right anchor rather than the launch SHA: it is the tree the merge queue's full-suite release gate actually validated, it contains the version bump, and later merges move `main` past it without changing it.

- The resolver **fails closed** — it never falls back to a moving reference — and **retries** (6 × 10s), because it runs *after* the bump PR has merged, so a single API blip would otherwise strand a half-done release (bump on main, nothing published or tagged). It distinguishes "the API could not be queried" from "the PR has no merge commit" so the error does not blame the PR for an API fault.
- It **warns loudly**, listing the commits, when `main` moved between the launch commit and the release commit. That is the "silent" consequence above. It is a warning rather than a hard failure because failing after the bump PR has already merged leaves an awkward recovery state — happy to make it hard-fail if you'd prefer. If the compare call itself fails it says so, rather than printing a false all-clear.
- `publish_crates` and `create_release` check out that SHA; both `git pull origin main` steps are gone. The release notes' `target_commitish` is pinned too — the tag does not exist yet at that point, so `main` there meant the notes could describe commits not in the release.
- `scripts/verify_release_checkout.sh` runs after each checkout and before anything irreversible. It checks HEAD against the pinned SHA **and** that the checked-out `crates/core/Cargo.toml` declares the release version. The second check is the load-bearing one: the SHA comparison is nearly a tautology (the same expression feeds `ref:`), whereas the version is derived independently, so it catches any wrong tree — including the `|| github.sha` fallback landing on the launch commit, which would publish a crate whose version disagrees with the tag.

`create_release` gains `wait_for_pr` in `needs` purely so the output is in scope; the ordering it implies was already enforced through `publish_crates`.

### What this does not fix

Pinning does **not** exclude the commits that raced in. The merge queue builds the version bump on top of whatever landed first, so those commits are ancestors of the pinned SHA either way. What changes is narrower: publish, tag and the release notes now agree on **one immutable commit** instead of re-resolving a moving branch three times, and the divergence is **reported** instead of silent — the run log names every commit that landed between launch and release. Genuinely excluding racing commits would need a queue-level hold, which is a different change.

### Bundled: the #4118 token-coalesce guard has never worked

`check-token-coalesce.yml` filtered diff headers with `grep -v '^\+\+\+'`. In GNU BRE `\+` is the one-or-more operator, so that matches **every** line starting with `+` — the guard's input was always empty and it has flagged nothing since it was written. Verified against GNU grep 3.11 (the ubuntu-latest version): the old filter misses a bare `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` line, the fixed one catches it.

This is bundled rather than split because this PR adds two new bare-`GITHUB_TOKEN` lines and rests on that guard to police them; claiming the guard passes while knowing it cannot fail would be asserting a green signal already shown to be meaningless. The job now self-tests before checking the real diff, using the same two detector functions the real check uses — sharing only the line-filter was not enough, because duplicated regexes meant breaking the real one still left the self-test green. The self-test asserts both detectors fire on bare tokens *and* stay quiet on coalesced and `coalesce-exempt` lines; five mutations of the guard's own logic, including the original BRE bug, all turn it red.

Worth recording: **the self-test failed on its first CI run, correctly.** `${{ secrets.GITHUB_TOKEN }}` written literally inside a `run:` block is not a literal — Actions evaluates it before the shell sees it, so the fixture became the real token value and stopped resembling the pattern. The guard refused to certify itself rather than reporting a meaningless pass. Fixed by assembling the fixture so the raw YAML carries no expression marker.

Arming it also required exempting two pre-existing read-only lookups (`binstall-smoke-test.yml`, and the guard's own doc comment) that would otherwise false-positive on any future PR touching those lines.

## What is and is not verified

Being explicit, because this workflow is how we ship.

**Verified:**
- `scripts/release_mergequeue_test.sh` (already run by `ci.yml`) goes from 22 to 101 checks and passes. Job-scoped pins use `sed` ranges that now assert they terminated on their closing anchor, so renaming a job cannot silently widen a range to EOF.
- **All 22 mutations tested turn the suite red**, including every one two review rounds found it had missed: commenting the guard out rather than deleting it, *moving* the guard to after `cargo publish` / after the tag push, and re-pointing the checkout with `git reset --hard` / `git checkout main` / `git merge` rather than `git pull`. The harness asserts each mutation actually changed the tree, so a `sed` that fails to apply is reported rather than counted as a pass.
- Behavioural tests drive both new scripts with a mocked `gh` that asserts the real invocation shape (`--json mergeCommit`, the jq filter) and models real `gh` faithfully — an unmerged PR exits 0 printing nothing, which I verified against a live PR; modelling it as an error had left the "PR has no merge commit" branch with no coverage.
- `actionlint` clean, and shown **non-vacuous**: pointing `needs.wait_for_pr.outputs.release_sha` at a nonexistent output name makes it error at all four sites, which is what actually proves `create_release` can read the new output.
- `shellcheck` clean on all three scripts.
- The `RELEASE_PAT` coalesce is unchanged on every checkout and `gh` step; both new `gh` steps are read-only and carry `# coalesce-exempt:` markers. I simulated the (fixed) guard against this PR's own diff: it passes.

**Not verified:**
- **This cannot be exercised end to end without cutting a real release, and I did not cut one.** The job wiring is reasoned and statically checked, not run. Specifically unexercised: that `actions/checkout` resolves a bare merge-commit SHA at default `fetch-depth` on the first attempt; that `gh pr view --json mergeCommit` is populated promptly after a *merge-queue* merge rather than lagging (the retry loop exists for exactly this and is itself untested against real lag); and that `generate-notes` accepts a full SHA as `target_commitish`.
- The shipped retry budget (6 × 10s) is overridden in every test, so the real wait is untested. It fails closed.
- The `|| github.sha` fallback is reachable only on the dry-run-with-failed-`wait_for_pr` path. It now fails there with an explicit "wait_for_pr did not resolve a release commit" error, where previously that dry run passed. That is a deliberate behaviour change: a dry run sitting on the pre-bump commit is not dry-running the release.

## Other moving-reference patterns

Surveyed the rest of the cascade; details in a comment below. `cross-compile.yml`, `gateway-update.yml`, `release-announce.yml` and `binstall-smoke-test.yml` are **not** affected. `scripts/release.sh` (the legacy local path) has the same bug and is **not** fixed here — see the comment for why and the follow-up issue.

Closes #5233

[AI-assisted - Claude]
