### PR TITLE
fix(rollback): announce the post-update probation commit on stderr (#5232)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -80,6 +80,21 @@ slow-timeout = { period = "300s", terminate-after = 2 }
 filter = "test(test_placement_migration_at_scale_renewal_load_stays_bounded) | test(test_connection_growth_plateau_diagnostic) | test(test_connection_growth_stall_regression)"
 slow-timeout = { period = "150s", terminate-after = 2 }
 
+# The post-update probation tests (#5232) spawn the real `freenet` binary and
+# wait out the rollback machinery's own 60s commit window, which is a hard-coded
+# constant in the binary under test — so ~65s of the runtime is a deliberate
+# sleep, not slack, and the default 120s period leaves little room for a cold
+# debug-build node start on a loaded runner.
+#
+# retries = 0 for the same reason as the canary above: this is brick-safety
+# equipment, and an intermittent failure here is a finding, not noise to absorb.
+# A retry would turn "the commit sometimes does not happen" — the exact bug class
+# #5232 was filed about — back into a green run.
+[[profile.ci.overrides]]
+filter = "test(/probation_(is_committed|survives)/)"
+slow-timeout = { period = "300s", terminate-after = 2 }
+retries = 0
+
 [profile.nightly]
 # Nightly tests run longer by design; no retries since failures need investigation.
 retries = 0

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -70,6 +70,21 @@ filter = "test(graceful_shutdown_on_sigterm_exits_zero)"
 retries = 0
 slow-timeout = { period = "300s", terminate-after = 2 }
 
+# The post-update probation tests (#5232) spawn the real `freenet` binary and
+# wait out the rollback machinery's own 60s commit window, which is a hard-coded
+# constant in the binary under test — so ~65s of the runtime is a deliberate
+# sleep, not slack, and the default 120s period leaves little room for a cold
+# debug-build node start on a loaded runner.
+#
+# retries = 0 for the same reason as the canary above: this is brick-safety
+# equipment, and an intermittent failure here is a finding, not noise to absorb.
+# A retry would turn "the commit sometimes does not happen" — the exact bug class
+# #5232 was filed about — back into a green run.
+[[profile.ci.overrides]]
+filter = "test(/probation_(is_committed|survives)/)"
+slow-timeout = { period = "300s", terminate-after = 2 }
+retries = 0
+
 [profile.nightly]
 # Nightly tests run longer by design; no retries since failures need investigation.
 retries = 0

--- a/crates/core/src/bin/commands/rollback.rs
+++ b/crates/core/src/bin/commands/rollback.rs
@@ -486,19 +486,53 @@ fn remove_probation_at(dir: &Path) {
 /// Clear probation if the running version matches the marker (it has proven
 /// healthy). A marker for a DIFFERENT version is stale (e.g. left over after a
 /// rollback or external install) and is also removed.
+///
+/// Both outcomes DISARM rollback for the marker's version, so both are reported
+/// on stderr as well as through `tracing` (#5232). The node's `tracing` output
+/// goes to the rolling log files under the log dir, which systemd does NOT
+/// capture — only the process's stdout/stderr reach the journal. An operator
+/// (or an agent) reading `journalctl -u freenet` therefore saw the crash-count
+/// and rollback lines, which the installer prints on stderr, but never the
+/// commit that disarms them. #5232 was filed on exactly that asymmetry: the
+/// commit had been working all along and looked, from the journal, as though it
+/// had never once run. The other two decisions in this module are already on
+/// stderr; this puts the third one where the first two are.
+///
+/// The volume is bounded: at most one line per node start, and only when a
+/// probation marker actually exists.
 pub fn commit_probation(current_version: &str) {
     if let Some(dir) = state_dir() {
         match commit_probation_at(dir.as_path(), current_version) {
-            CommitOutcome::Committed => tracing::info!(
-                version = current_version,
-                "Auto-update probation passed: new version ran healthily for \
-                 {COMMIT_HEALTHY_UPTIME_SECS}s; committing (rollback disarmed)."
-            ),
-            CommitOutcome::ClearedStale { marker_version } => tracing::debug!(
-                running = current_version,
-                marker = %marker_version,
-                "Cleared stale auto-update probation marker for a different version."
-            ),
+            CommitOutcome::Committed => {
+                eprintln!(
+                    "Freenet {current_version}: post-update probation passed (ran healthily for \
+                     {COMMIT_HEALTHY_UPTIME_SECS}s); committed, auto-rollback disarmed."
+                );
+                tracing::info!(
+                    version = current_version,
+                    "Auto-update probation passed: new version ran healthily for \
+                     {COMMIT_HEALTHY_UPTIME_SECS}s; committing (rollback disarmed)."
+                );
+            }
+            CommitOutcome::ClearedStale { marker_version } => {
+                // Deliberately louder than the `debug!` this used to be. A
+                // release build compiles `debug!` out entirely, so this branch
+                // — which drops rollback protection for `marker_version`
+                // without committing anything — was completely silent in the
+                // field. It is the branch a version-comparison regression would
+                // take, and it is indistinguishable from a healthy commit by
+                // the state directory alone (both just delete the marker).
+                eprintln!(
+                    "Freenet {current_version}: discarded a post-update probation marker \
+                     belonging to {marker_version} (not the running version); auto-rollback \
+                     protection for {marker_version} is gone."
+                );
+                tracing::warn!(
+                    running = current_version,
+                    marker = %marker_version,
+                    "Cleared stale auto-update probation marker for a different version."
+                );
+            }
             CommitOutcome::Nothing => {}
         }
     }

--- a/crates/core/src/bin/commands/rollback.rs
+++ b/crates/core/src/bin/commands/rollback.rs
@@ -574,15 +574,25 @@ pub(crate) fn commit_announcement(
 /// evidence the mechanism does not have.
 pub fn commit_probation(current_version: &str) {
     if let Some(dir) = state_dir() {
-        // Announce AFTER the state transition, never before. `eprintln!` panics
-        // on a write error (EPIPE once the supervisor's reader is gone), and a
-        // panic in front of the removal would leave a healthy node's marker
-        // armed — turning an observability line into a rollback bug. In this
-        // order the worst case is a lost announcement.
+        // `eprintln!` is the ONLY fallible step here, so it goes last.
+        //
+        // It panics on a write error (EPIPE once the supervisor's reader is
+        // gone; a Windows child that inherited invalid standard handles), and a
+        // panic unwinds this whole task. So anything sequenced after it is lost
+        // when stderr is broken:
+        //
+        //  - Before the removal, a panic would leave a healthy node's marker
+        //    armed — an observability line turned into a rollback bug.
+        //  - Before the `tracing` record, a panic would take that record with
+        //    it, leaving the operator with NEITHER channel on exactly the node
+        //    whose stderr is already broken. That is strictly worse than before
+        //    this announcement existed, when the record always got written.
+        //
+        // Hence: transition, then log, then announce. The message is built up
+        // front because the `match` below consumes `outcome`; building a string
+        // cannot fail, so doing it early costs nothing.
         let outcome = commit_probation_at(dir.as_path(), current_version);
-        if let Some(line) = commit_announcement(&outcome, current_version) {
-            eprintln!("{line}");
-        }
+        let announcement = commit_announcement(&outcome, current_version);
         match outcome {
             CommitOutcome::Committed => tracing::info!(
                 version = current_version,
@@ -607,6 +617,9 @@ pub fn commit_probation(current_version: &str) {
                 "Probation passed but the marker could not be removed; rollback is STILL armed."
             ),
             CommitOutcome::Nothing => {}
+        }
+        if let Some(line) = announcement {
+            eprintln!("{line}");
         }
     }
 }

--- a/crates/core/src/bin/commands/rollback.rs
+++ b/crates/core/src/bin/commands/rollback.rs
@@ -483,56 +483,95 @@ fn remove_probation_at(dir: &Path) {
     let _rm = std::fs::remove_file(dir.join(PROBATION_FILE));
 }
 
+/// The operator-facing line for a marker-clearing outcome, or `None` when
+/// nothing happened. Split out from [`commit_probation`] so both branches are
+/// unit-testable: `commit_probation` itself reads the process-global `$HOME`
+/// through [`state_dir`] and so cannot be driven from a test.
+///
+/// ## Why these go to stderr and not only to `tracing` (#5232)
+///
+/// **This is the canonical explanation; the other comments point here.** Under
+/// the shipped systemd deployment the node's `tracing` output goes to the
+/// rolling log files under the log dir (`tracing::tracer::init_tracer` adds the
+/// console layer only when stdout is a terminal, which it is not under a service
+/// manager), while the unit records `StandardOutput=journal` /
+/// `StandardError=journal`. So `tracing` does not reach the journal and
+/// stdout/stderr does. The three other decisions in this flow — the crash count,
+/// the rollback, and rollback-unavailable — are all `eprintln!` in
+/// [`super::update`], so `journalctl -u freenet` showed strikes accumulating
+/// against a probationary version and never once showed the commit that disarms
+/// them. #5232 was filed reading exactly that asymmetry. This puts the
+/// marker-clearing decisions on the same channel as the decisions they cancel.
+///
+/// (The fallback tracer — used when no log dir resolves, or when
+/// `FREENET_LOG_TO_STDERR` is set — does write to stdout, so on those paths the
+/// `tracing` line reaches the journal too and the operator sees both.)
+///
+/// Volume is bounded: at most one line per node start, and only when a probation
+/// marker actually exists.
+pub(crate) fn commit_announcement(
+    outcome: &CommitOutcome,
+    current_version: &str,
+) -> Option<String> {
+    match outcome {
+        CommitOutcome::Committed => Some(format!(
+            "Freenet {current_version}: post-update probation passed (ran healthily for \
+             {COMMIT_HEALTHY_UPTIME_SECS}s); committed, auto-rollback disarmed."
+        )),
+        // Deliberately as loud as the commit. This branch drops rollback
+        // protection for `marker_version` WITHOUT committing anything, it is the
+        // branch a version-comparison regression would take, and it is
+        // indistinguishable from a healthy commit by the state directory alone
+        // (both just delete the marker).
+        CommitOutcome::ClearedStale { marker_version } => Some(format!(
+            "Freenet {current_version}: discarded a post-update probation marker belonging to \
+             {marker_version} (not the running version); auto-rollback protection for \
+             {marker_version} is gone."
+        )),
+        CommitOutcome::Nothing => None,
+    }
+}
+
 /// Clear probation if the running version matches the marker (it has proven
-/// healthy). A marker for a DIFFERENT version is stale (e.g. left over after a
-/// rollback or external install) and is also removed.
+/// healthy). A marker for a DIFFERENT version is stale (e.g. an external install
+/// replaced the binary, or two binaries share a `$HOME`) and is also removed.
 ///
-/// Both outcomes DISARM rollback for the marker's version, so both are reported
-/// on stderr as well as through `tracing` (#5232). The node's `tracing` output
-/// goes to the rolling log files under the log dir, which systemd does NOT
-/// capture — only the process's stdout/stderr reach the journal. An operator
-/// (or an agent) reading `journalctl -u freenet` therefore saw the crash-count
-/// and rollback lines, which the installer prints on stderr, but never the
-/// commit that disarms them. #5232 was filed on exactly that asymmetry: the
-/// commit had been working all along and looked, from the journal, as though it
-/// had never once run. The other two decisions in this module are already on
-/// stderr; this puts the third one where the first two are.
+/// Both outcomes DISARM rollback for the marker's version, so both are announced
+/// on stderr as well as through `tracing` — see [`commit_announcement`] for why
+/// stderr specifically.
 ///
-/// The volume is bounded: at most one line per node start, and only when a
-/// probation marker actually exists.
+/// Reached only from the node's commit timer, so "survived the window ⇒
+/// committed" holds for a process that actually ran the network. A node parked
+/// by `freenet service disable` (`run_disabled_idle`) never reaches it and keeps
+/// its marker until the [`PROBATION_MAX_AGE_SECS`] TTL retires it. That is
+/// deliberate: a process that never joined the network has not demonstrated the
+/// health this probation tests for, so committing there would disarm rollback on
+/// evidence the mechanism does not have.
 pub fn commit_probation(current_version: &str) {
     if let Some(dir) = state_dir() {
-        match commit_probation_at(dir.as_path(), current_version) {
-            CommitOutcome::Committed => {
-                eprintln!(
-                    "Freenet {current_version}: post-update probation passed (ran healthily for \
-                     {COMMIT_HEALTHY_UPTIME_SECS}s); committed, auto-rollback disarmed."
-                );
-                tracing::info!(
-                    version = current_version,
-                    "Auto-update probation passed: new version ran healthily for \
-                     {COMMIT_HEALTHY_UPTIME_SECS}s; committing (rollback disarmed)."
-                );
-            }
-            CommitOutcome::ClearedStale { marker_version } => {
-                // Deliberately louder than the `debug!` this used to be. A
-                // release build compiles `debug!` out entirely, so this branch
-                // — which drops rollback protection for `marker_version`
-                // without committing anything — was completely silent in the
-                // field. It is the branch a version-comparison regression would
-                // take, and it is indistinguishable from a healthy commit by
-                // the state directory alone (both just delete the marker).
-                eprintln!(
-                    "Freenet {current_version}: discarded a post-update probation marker \
-                     belonging to {marker_version} (not the running version); auto-rollback \
-                     protection for {marker_version} is gone."
-                );
-                tracing::warn!(
-                    running = current_version,
-                    marker = %marker_version,
-                    "Cleared stale auto-update probation marker for a different version."
-                );
-            }
+        // Announce AFTER the state transition, never before. `eprintln!` panics
+        // on a write error (EPIPE once the supervisor's reader is gone), and a
+        // panic in front of the removal would leave a healthy node's marker
+        // armed — turning an observability line into a rollback bug. In this
+        // order the worst case is a lost announcement.
+        let outcome = commit_probation_at(dir.as_path(), current_version);
+        if let Some(line) = commit_announcement(&outcome, current_version) {
+            eprintln!("{line}");
+        }
+        match outcome {
+            CommitOutcome::Committed => tracing::info!(
+                version = current_version,
+                "Auto-update probation passed: new version ran healthily for \
+                 {COMMIT_HEALTHY_UPTIME_SECS}s; committing (rollback disarmed)."
+            ),
+            // Was `debug!`, which a release build compiles out entirely
+            // (`release_max_level_info`), so this branch was completely silent
+            // in the field. See `commit_announcement` for why that matters.
+            CommitOutcome::ClearedStale { marker_version } => tracing::warn!(
+                running = current_version,
+                marker = %marker_version,
+                "Cleared stale auto-update probation marker for a different version."
+            ),
             CommitOutcome::Nothing => {}
         }
     }
@@ -1051,6 +1090,52 @@ mod tests {
         assert!(read_probation_at(dir).is_none());
         // Idempotent.
         assert_eq!(commit_probation_at(dir, "0.2.84"), CommitOutcome::Nothing);
+    }
+
+    /// Both marker-clearing outcomes MUST announce themselves, and `Nothing`
+    /// must stay silent.
+    ///
+    /// The end-to-end test `tests/post_update_probation_commit.rs` greps the
+    /// node's stderr for a substring of the Committed line; these assertions are
+    /// what make a reword of either line fail in microseconds instead of after
+    /// that test's 60s window (and they are the only coverage the ClearedStale
+    /// line has, since reaching it end-to-end needs a second 60s node boot).
+    #[test]
+    fn both_marker_clearing_outcomes_are_announced() {
+        let committed = commit_announcement(&CommitOutcome::Committed, "0.2.123")
+            .expect("a commit must be announced");
+        assert!(
+            committed.contains("post-update probation passed"),
+            "the e2e test greps for this substring; keep them in step: {committed}"
+        );
+        assert!(committed.contains("0.2.123"), "{committed}");
+
+        let stale = commit_announcement(
+            &CommitOutcome::ClearedStale {
+                marker_version: "0.2.122".to_string(),
+            },
+            "0.2.123",
+        )
+        .expect("discarding a marker disarms rollback and must be announced");
+        assert!(
+            stale.contains("discarded a post-update probation marker"),
+            "{stale}"
+        );
+        // Both versions have to appear: which marker was dropped is the whole
+        // diagnostic value, and the running version is what distinguishes this
+        // from a healthy commit.
+        assert!(stale.contains("0.2.122"), "{stale}");
+        assert!(stale.contains("0.2.123"), "{stale}");
+        assert!(
+            !stale.contains("post-update probation passed"),
+            "a discarded marker must NOT read as a passed probation: {stale}"
+        );
+
+        assert_eq!(
+            commit_announcement(&CommitOutcome::Nothing, "0.2.123"),
+            None,
+            "no marker means no decision was made, so there is nothing to report"
+        );
     }
 
     #[test]

--- a/crates/core/src/bin/commands/rollback.rs
+++ b/crates/core/src/bin/commands/rollback.rs
@@ -479,8 +479,19 @@ fn write_probation_at(dir: &Path, state: &ProbationState) -> Result<()> {
     atomic_write(&dir.join(PROBATION_FILE), &raw)
 }
 
-fn remove_probation_at(dir: &Path) {
-    let _rm = std::fs::remove_file(dir.join(PROBATION_FILE));
+/// Remove the probation marker, reporting whether it is actually gone.
+///
+/// The result is NOT decorative: every caller has just decided that rollback
+/// should no longer fire, and a failed unlink leaves the marker ARMED. A caller
+/// that announces the decision must not announce it when this failed (#5232).
+///
+/// "Already absent" is success — the post-condition is "no marker", not "I
+/// deleted something".
+fn remove_probation_at(dir: &Path) -> std::io::Result<()> {
+    match std::fs::remove_file(dir.join(PROBATION_FILE)) {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        other => other,
+    }
 }
 
 /// The operator-facing line for a marker-clearing outcome, or `None` when
@@ -528,6 +539,20 @@ pub(crate) fn commit_announcement(
              {marker_version} (not the running version); auto-rollback protection for \
              {marker_version} is gone."
         )),
+        // The state change did NOT happen, so this must not read like the two
+        // above. The marker is still on disk and still inside its TTL, so an
+        // ordinary crash in the next hour can still roll this node back off a
+        // version that just proved itself — and the commit timer fires once per
+        // process, so nothing retries.
+        CommitOutcome::ClearFailed {
+            marker_version,
+            error,
+        } => Some(format!(
+            "Freenet {current_version}: ran healthily for {COMMIT_HEALTHY_UPTIME_SECS}s, but the \
+             post-update probation marker for {marker_version} could NOT be removed ({error}); \
+             auto-rollback is STILL ARMED and a crash within the next hour can still roll this \
+             node back. Check the permissions and free space on the Freenet state directory."
+        )),
         CommitOutcome::Nothing => None,
     }
 }
@@ -572,6 +597,15 @@ pub fn commit_probation(current_version: &str) {
                 marker = %marker_version,
                 "Cleared stale auto-update probation marker for a different version."
             ),
+            CommitOutcome::ClearFailed {
+                marker_version,
+                error,
+            } => tracing::error!(
+                running = current_version,
+                marker = %marker_version,
+                error = %error,
+                "Probation passed but the marker could not be removed; rollback is STILL armed."
+            ),
             CommitOutcome::Nothing => {}
         }
     }
@@ -583,22 +617,37 @@ pub(crate) enum CommitOutcome {
     Committed,
     /// A marker for a different version was found and removed as stale.
     ClearedStale { marker_version: String },
+    /// The marker could NOT be removed, so rollback is still ARMED even though
+    /// this version has proven healthy. Kept distinct from the two success
+    /// outcomes so the announcement cannot claim a disarm that did not happen.
+    ClearFailed {
+        marker_version: String,
+        error: String,
+    },
     /// No probation marker present.
     Nothing,
 }
 
 pub(crate) fn commit_probation_at(dir: &Path, current_version: &str) -> CommitOutcome {
     match read_probation_at(dir) {
-        Some(state) if state.new_version == current_version => {
-            remove_probation_at(dir);
-            CommitOutcome::Committed
-        }
+        Some(state) if state.new_version == current_version => match remove_probation_at(dir) {
+            Ok(()) => CommitOutcome::Committed,
+            Err(e) => CommitOutcome::ClearFailed {
+                marker_version: state.new_version,
+                error: e.to_string(),
+            },
+        },
         Some(state) => {
             // Running a different version healthily than the marker describes:
             // the marker can no longer protect anything, so drop it.
-            remove_probation_at(dir);
-            CommitOutcome::ClearedStale {
-                marker_version: state.new_version,
+            match remove_probation_at(dir) {
+                Ok(()) => CommitOutcome::ClearedStale {
+                    marker_version: state.new_version,
+                },
+                Err(e) => CommitOutcome::ClearFailed {
+                    marker_version: state.new_version,
+                    error: e.to_string(),
+                },
             }
         }
         None => CommitOutcome::Nothing,
@@ -824,7 +873,12 @@ pub(crate) fn handle_post_stop_at(
         // The marker describes a different version than the one that just
         // stopped — stale (e.g. an external install changed the binary). Drop
         // it and fall through to the normal flow rather than acting on it.
-        remove_probation_at(dir);
+        //
+        // A failed unlink is tolerable HERE, unlike in `commit_probation_at`:
+        // nothing is announced, and the next stop re-reads the marker and takes
+        // this same branch again, so the removal effectively retries. Reporting
+        // it would need an output channel this process does not have — see #5244.
+        let _retried_next_stop = remove_probation_at(dir);
         return PostStopOutcome::Proceed;
     }
 
@@ -832,7 +886,8 @@ pub(crate) fn handle_post_stop_at(
     // been around far longer than any boot-wedge would survive. Treat as
     // committed/stale so a much-later transient crash can't trigger a rollback.
     if now_unix().saturating_sub(state.installed_at_unix) > PROBATION_MAX_AGE_SECS {
-        remove_probation_at(dir);
+        // Same as above: not announced, and re-attempted on the next stop.
+        let _retried_next_stop = remove_probation_at(dir);
         return PostStopOutcome::Proceed;
     }
 
@@ -868,7 +923,7 @@ pub(crate) fn handle_post_stop_at(
         // Never delete the only working binary: with no retained known-good we
         // cannot restore. Stop counting (the supervisor's own bound takes over)
         // and surface the situation for the operator.
-        remove_probation_at(dir);
+        let _retried_next_stop = remove_probation_at(dir);
         return PostStopOutcome::RollbackUnavailable {
             reason: format!(
                 "no retained known-good binary at {}",
@@ -886,7 +941,7 @@ pub(crate) fn handle_post_stop_at(
             // Definitively corrupt: this rollback target is unusable. Drop the
             // marker so we stop re-attempting it; the next crash falls through
             // to the normal update flow (which may self-heal forward).
-            remove_probation_at(dir);
+            let _retried_next_stop = remove_probation_at(dir);
             return PostStopOutcome::RollbackUnavailable {
                 reason: format!(
                     "known-good integrity check failed (size {size} vs expected {}, or SHA-256 \
@@ -916,7 +971,10 @@ pub(crate) fn handle_post_stop_at(
 
     match restore_binary(&state.rollback_binary, &state.target_binary) {
         Ok(()) => {
-            remove_probation_at(dir);
+            // If this fails the marker names the version we just replaced, so
+            // the restored binary's next stop sees a version mismatch and takes
+            // the stale branch above. Self-healing, hence not surfaced here.
+            let _cleared_by_version_mismatch = remove_probation_at(dir);
             PostStopOutcome::RolledBack {
                 restored_version: state.previous_version.clone(),
                 bad_version: state.new_version.clone(),
@@ -1100,6 +1158,123 @@ mod tests {
     /// what make a reword of either line fail in microseconds instead of after
     /// that test's 60s window (and they are the only coverage the ClearedStale
     /// line has, since reaching it end-to-end needs a second 60s node boot).
+    /// A commit announcement must never claim a disarm that did not happen.
+    ///
+    /// `remove_probation_at` can fail (read-only or full state dir — the same
+    /// condition that breaks the rest of the update machinery, see #5244). The
+    /// marker then stays on disk and stays inside its TTL, so a crash within the
+    /// hour can still roll the node back. Announcing "rollback disarmed" there
+    /// would reintroduce, at the moment of fixing it, exactly the misleading-
+    /// journal problem this whole change exists to remove (#5232).
+    #[test]
+    fn a_failed_clear_is_never_announced_as_a_pass() {
+        let line = commit_announcement(
+            &CommitOutcome::ClearFailed {
+                marker_version: "0.2.123".to_string(),
+                error: "Permission denied (os error 13)".to_string(),
+            },
+            "0.2.123",
+        )
+        .expect("a marker that could not be cleared must be reported");
+
+        assert!(
+            line.contains("STILL ARMED"),
+            "the operator must be told rollback is still live: {line}"
+        );
+        assert!(
+            line.contains("Permission denied (os error 13)"),
+            "the cause is what makes this actionable: {line}"
+        );
+        assert!(
+            !line.contains("disarmed"),
+            "MUST NOT claim a disarm that did not happen: {line}"
+        );
+        // `tests/post_update_probation_commit.rs` greps stderr for the success
+        // line's needle to conclude the node committed. If a FAILED clear also
+        // contained that substring, the end-to-end guard would pass while
+        // rollback was still armed — the exact false-green this PR exists to
+        // prevent. Assert the two are disjoint, in both directions.
+        let committed = commit_announcement(&CommitOutcome::Committed, "0.2.123")
+            .expect("a commit must be announced");
+        let needle = "committed, auto-rollback disarmed";
+        assert!(committed.contains(needle), "{committed}");
+        assert!(
+            !line.contains(needle),
+            "a failed clear must not contain the committed-branch needle: {line}"
+        );
+    }
+
+    /// "Already absent" is the post-condition we want, so it is success — not a
+    /// spurious ClearFailed warning on every idempotent re-commit.
+    #[test]
+    fn removing_an_absent_marker_succeeds() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(
+            remove_probation_at(dir.path()).is_ok(),
+            "a missing marker means the post-condition already holds"
+        );
+        assert_eq!(
+            commit_probation_at(dir.path(), "0.2.123"),
+            CommitOutcome::Nothing
+        );
+    }
+
+    /// End-to-end through `commit_probation_at`: an unremovable marker yields
+    /// ClearFailed rather than a false Committed.
+    ///
+    /// Unlink permission lives on the DIRECTORY, so the marker is made
+    /// unremovable by dropping write permission on its parent. Root bypasses
+    /// that check entirely, so the test skips rather than failing when it would
+    /// be testing nothing (containers commonly run tests as root).
+    #[test]
+    #[cfg(unix)]
+    fn an_unremovable_marker_reports_clear_failed_not_committed() {
+        use std::os::unix::fs::PermissionsExt;
+
+        // SAFETY: `geteuid` reads the calling process's effective uid. It takes
+        // no arguments, touches no memory, and cannot fail.
+        if unsafe { libc::geteuid() } == 0 {
+            eprintln!("skipping: running as root, which bypasses directory write permissions");
+            return;
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let live = dir.path().join("freenet");
+        write_dummy_binary(&live, b"NEWER");
+        let meta = KnownGoodMeta {
+            size: 5,
+            sha256: "x".repeat(64),
+        };
+        begin_probation_at(dir.path(), "0.2.123", "0.2.122", &live, &meta).unwrap();
+
+        let mut perms = std::fs::metadata(dir.path()).unwrap().permissions();
+        let original = perms.mode();
+        perms.set_mode(0o555);
+        std::fs::set_permissions(dir.path(), perms).unwrap();
+
+        let outcome = commit_probation_at(dir.path(), "0.2.123");
+
+        // Restore before asserting so a failure cannot leave an undeletable
+        // tempdir behind.
+        let mut restore = std::fs::metadata(dir.path()).unwrap().permissions();
+        restore.set_mode(original);
+        std::fs::set_permissions(dir.path(), restore).unwrap();
+
+        match outcome {
+            CommitOutcome::ClearFailed { marker_version, .. } => {
+                assert_eq!(marker_version, "0.2.123");
+            }
+            other => panic!(
+                "an unremovable marker must NOT report as committed — rollback is still armed. \
+                 Got: {other:?}"
+            ),
+        }
+        assert!(
+            read_probation_at(dir.path()).is_some(),
+            "premise check: the marker really did survive"
+        );
+    }
+
     #[test]
     fn both_marker_clearing_outcomes_are_announced() {
         let committed = commit_announcement(&CommitOutcome::Committed, "0.2.123")

--- a/crates/core/src/bin/commands/rollback.rs
+++ b/crates/core/src/bin/commands/rollback.rs
@@ -1264,7 +1264,14 @@ mod tests {
             CommitOutcome::ClearFailed { marker_version, .. } => {
                 assert_eq!(marker_version, "0.2.123");
             }
-            other => panic!(
+            // Enumerated, not `other =>`: `wildcard_enum_match_arm` exists so a
+            // new `CommitOutcome` variant breaks every match site rather than
+            // silently falling through here — and this test's own PR is what
+            // added `ClearFailed`, so a wildcard would have swallowed exactly
+            // the kind of variant it is meant to catch.
+            other @ (CommitOutcome::Committed
+            | CommitOutcome::ClearedStale { .. }
+            | CommitOutcome::Nothing) => panic!(
                 "an unremovable marker must NOT report as committed — rollback is still armed. \
                  Got: {other:?}"
             ),

--- a/crates/core/tests/post_update_probation_commit.rs
+++ b/crates/core/tests/post_update_probation_commit.rs
@@ -1,0 +1,354 @@
+//! End-to-end guard for the post-update probation COMMIT path (#5232, #4073).
+//!
+//! The crash-loop auto-rollback machinery (`commands::rollback`) arms a
+//! probation marker when a new version is installed, and the node is supposed
+//! to clear it once it has run healthily for `COMMIT_HEALTHY_UPTIME_SECS`
+//! (60s). If that commit ever stops happening, the marker stays armed and every
+//! later non-clean stop is scored as a crash of a probationary version — three
+//! of them roll the node BACK off the release it just installed and pin that
+//! release as known-bad locally. That is the failure #5232 was filed for.
+//!
+//! ## Why this test spawns the real binary
+//!
+//! The commit is not a property of `commit_probation_at` — that function is
+//! already unit-tested and works. It is a property of its ONLY caller: a
+//! fire-and-forget `GlobalExecutor::spawn` in `bin/freenet.rs`'s
+//! `run_network_node_with_signals`, whose handle is dropped and which is
+//! aborted at shutdown. A unit test on `commit_probation_at` passes happily
+//! while that task never runs, never fires, or commits a version string that
+//! does not match the marker the installer wrote. Nothing short of running the
+//! node and watching the marker disappear covers that seam.
+//!
+//! ## What it asserts (the two observable halves of #5232)
+//!
+//! 1. A node that has been up longer than the commit window has NO probation
+//!    marker left on disk, AND its log says it COMMITTED (rather than silently
+//!    dropping the marker as stale — see below).
+//! 2. A subsequent clean stop of that node records NO crash: the post-stop
+//!    `freenet update` must not report "during post-update probation".
+//!
+//! ## Why assertion 1 checks the log line and not just the file
+//!
+//! `commit_probation_at` removes the marker down BOTH of its branches: a
+//! version-matched `Committed`, and a `ClearedStale` for a marker belonging to
+//! some other version. So "the file is gone" alone would still pass if the
+//! version comparison regressed and every marker were dropped as stale — which
+//! would disable rollback entirely, a worse bug than the one this guards. The
+//! INFO line is the only artifact that distinguishes the two paths, so it is
+//! asserted too. (`ClearedStale` logs at DEBUG, which release builds compile
+//! out — that is precisely why this whole class was invisible in the field.)
+//!
+//! ## Runtime
+//!
+//! This test necessarily spends the real commit window (60s) waiting, because
+//! the window is a hard-coded constant in the binary under test. Budget ~90s.
+
+// Unix-only: the second half stops the node with SIGTERM, which is what a
+// supervisor sends and what makes the stop a *graceful* one worth asserting on.
+// Windows has no equivalent that exercises the same node path.
+#![cfg(unix)]
+
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+/// The version the node under test reports. `build_info::VERSION` in the binary
+/// is `env!("CARGO_PKG_VERSION")` of this very crate, so the marker we plant
+/// carries the exact string the node will try to commit — a mismatch here would
+/// make the test vacuous (the node would clear our marker as stale instead of
+/// committing it, which assertion 1's log check also catches).
+const NODE_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Mirrors `commands::rollback::COMMIT_HEALTHY_UPTIME_SECS`, which is
+/// `pub(crate)` in the binary crate and so not importable here. If that
+/// constant is ever raised, this test fails on the poll deadline below rather
+/// than passing silently — which is the correct outcome, since lengthening the
+/// window is a real behavioural change to the rollback machinery.
+const COMMIT_HEALTHY_UPTIME_SECS: u64 = 60;
+
+/// Generous slack over the commit window for a cold-started debug-build node.
+const COMMIT_POLL_DEADLINE: Duration = Duration::from_secs(COMMIT_HEALTHY_UPTIME_SECS + 90);
+
+/// Substring of the INFO line `commit_probation` emits on the `Committed`
+/// branch only.
+const COMMITTED_LOG_NEEDLE: &str = "Auto-update probation passed";
+
+/// Substring of the stderr line `freenet update` prints when it counts a crash
+/// against an armed probation marker.
+const CRASH_RECORDED_NEEDLE: &str = "during post-update probation";
+
+// ---------------------------------------------------------------------------
+// Binary / path resolution (mirrors persistence_roundtrip.rs)
+// ---------------------------------------------------------------------------
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("workspace layout: crates/core/../../ should resolve")
+        .to_path_buf()
+}
+
+fn target_dir() -> PathBuf {
+    std::env::var_os("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| workspace_root().join("target"))
+}
+
+fn freenet_bin() -> PathBuf {
+    let debug = target_dir().join("debug").join("freenet");
+    if debug.exists() {
+        return debug;
+    }
+    let release = target_dir().join("release").join("freenet");
+    assert!(
+        release.exists(),
+        "freenet binary not found at {debug:?} or {release:?}. Build it first: \
+         `cargo build --bin freenet` (CI's test_unit job builds it before tests)."
+    );
+    release
+}
+
+// ---------------------------------------------------------------------------
+// Probation state fixture
+// ---------------------------------------------------------------------------
+
+/// The auto-updater's state directory, as `commands::auto_update::state_dir`
+/// computes it: `dirs::home_dir()/.local/state/freenet`. The node resolves it
+/// from `$HOME`, NOT from `--config-dir`/`--data-dir`, so the test isolates it
+/// by giving the child process its own `HOME`.
+fn state_dir(home: &Path) -> PathBuf {
+    home.join(".local/state/freenet")
+}
+
+/// Write a probation marker for `version` that is armed right now: a genuine
+/// `ProbationState` as `begin_probation_at` would have written it immediately
+/// after installing `version` over the previous binary.
+///
+/// `installed_at_unix` is NOW on purpose. A marker older than
+/// `PROBATION_MAX_AGE_SECS` (1h) is treated as stale by both the commit and the
+/// post-stop paths, so a backdated fixture would make both assertions pass for
+/// the wrong reason.
+fn arm_probation(home: &Path, version: &str) {
+    let dir = state_dir(home);
+    std::fs::create_dir_all(&dir).expect("create state dir");
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock after epoch")
+        .as_secs();
+    let rollback_binary = dir.join("known_good_binary");
+    let target_binary = home.join(".local/bin/freenet");
+    // Written as JSON rather than by constructing `ProbationState`, which is
+    // `pub(crate)` to the binary crate. The shape is pinned by the binary's own
+    // serde round-trip tests in `rollback.rs`; a field rename there would make
+    // this parse as "no probation" and assertion 2 would stop being able to
+    // fail, so the fixture is re-read and checked below before the node starts.
+    let marker = format!(
+        r#"{{"new_version":"{version}","previous_version":"0.0.0",
+            "rollback_binary":"{}","target_binary":"{}",
+            "rollback_size":1,"rollback_sha256":"00","installed_at_unix":{now},
+            "crash_count":0}}"#,
+        rollback_binary.display(),
+        target_binary.display(),
+    );
+    std::fs::write(probation_path(home), marker).expect("write probation marker");
+}
+
+fn probation_path(home: &Path) -> PathBuf {
+    state_dir(home).join("update_probation.json")
+}
+
+// ---------------------------------------------------------------------------
+// Subprocess node lifecycle
+// ---------------------------------------------------------------------------
+
+/// A `freenet network` subprocess, killed and reaped on drop so a panicking
+/// assertion never leaks a node.
+struct NodeProcess {
+    child: Child,
+}
+
+impl NodeProcess {
+    /// Spawn a self-contained, isolated gateway node rooted at `dir`, with
+    /// `HOME` pointed at `dir` so the auto-updater state directory (and hence
+    /// the probation marker) is the test's own.
+    fn spawn(dir: &Path, ws_port: u16, network_port: u16, log_dir: &Path) -> Self {
+        let child = Command::new(freenet_bin())
+            .arg("network")
+            // Same #4366 contamination guard as persistence_roundtrip.rs: this
+            // is the real binary, not an in-process test node, so telemetry
+            // would otherwise default ON and POST to the production collector.
+            .env("FREENET_TELEMETRY_ENABLED", "false")
+            // The whole point: the node must read ITS state dir, not the
+            // developer's or CI runner's real one.
+            .env("HOME", dir)
+            .args(["--ws-api-address", "127.0.0.1"])
+            .args(["--ws-api-port", &ws_port.to_string()])
+            .args(["--network-address", "127.0.0.1"])
+            .args(["--network-port", &network_port.to_string()])
+            .args(["--public-network-address", "127.0.0.1"])
+            .args(["--public-network-port", &network_port.to_string()])
+            .arg("--is-gateway")
+            .arg("--skip-load-from-network")
+            .arg("--ignore-protocol-checking")
+            // Keep the node from reaching GitHub and, worse, deciding a newer
+            // release exists and exiting 42 before the commit window elapses —
+            // which would make this test flaky against the real release feed.
+            // It does NOT gate the commit task, which is spawned
+            // unconditionally; if that ever changes, this test fails, correctly.
+            .arg("--disable-auto-update")
+            .args(["--location", "0.5"])
+            .args(["--config-dir", &dir.to_string_lossy()])
+            .args(["--data-dir", &dir.to_string_lossy()])
+            .args(["--log-dir", &log_dir.to_string_lossy()])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn freenet network");
+        Self { child }
+    }
+
+    fn has_exited(&mut self) -> bool {
+        matches!(self.child.try_wait(), Ok(Some(_)))
+    }
+
+    /// Stop the node the way a supervisor does, and return its exit status.
+    fn stop_gracefully(mut self) -> std::process::ExitStatus {
+        // SIGTERM is what `systemctl stop` sends; the node's signal handler
+        // turns it into a graceful shutdown.
+        let pid = self.child.id() as i32;
+        // SAFETY: `kill(2)` with a pid we own and a valid signal number; the
+        // child is reaped immediately below, so the pid cannot be recycled
+        // between the call and the wait.
+        unsafe {
+            libc::kill(pid, libc::SIGTERM);
+        }
+        self.child.wait().expect("reap node")
+    }
+}
+
+impl Drop for NodeProcess {
+    fn drop(&mut self) {
+        if self.child.kill().is_ok() {
+            let _reaped = self.child.wait().is_ok();
+        }
+    }
+}
+
+fn reserve_port() -> u16 {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+    listener.local_addr().expect("local addr").port()
+}
+
+/// Concatenate every rolling log file the node wrote under `log_dir`.
+fn read_node_logs(log_dir: &Path) -> String {
+    let Ok(entries) = std::fs::read_dir(log_dir) else {
+        return String::new();
+    };
+    entries
+        .filter_map(Result::ok)
+        .filter(|e| {
+            e.file_name()
+                .to_str()
+                .is_some_and(|n| n.starts_with("freenet") && n.ends_with(".log"))
+        })
+        .filter_map(|e| std::fs::read_to_string(e.path()).ok())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+// ---------------------------------------------------------------------------
+// The test
+// ---------------------------------------------------------------------------
+
+/// #5232: a node up past the commit window must have committed its probation,
+/// and a clean stop after that must not be scored as a crash.
+#[test]
+#[cfg(unix)]
+fn probation_is_committed_after_a_healthy_uptime_window() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let home = tmp.path();
+    let log_dir = home.join("logs");
+    std::fs::create_dir_all(&log_dir).expect("create log dir");
+
+    arm_probation(home, NODE_VERSION);
+    assert!(
+        probation_path(home).exists(),
+        "fixture precondition: the probation marker must exist before the node starts"
+    );
+
+    let mut node = NodeProcess::spawn(home, reserve_port(), reserve_port(), &log_dir);
+
+    // ---- Assertion 1: the marker is cleared, and cleared by COMMITTING ----
+    let deadline = Instant::now() + COMMIT_POLL_DEADLINE;
+    let mut committed = false;
+    while Instant::now() < deadline {
+        if !probation_path(home).exists() {
+            committed = true;
+            break;
+        }
+        assert!(
+            !node.has_exited(),
+            "the node exited before the probation commit window elapsed, so this test \
+             proved nothing about the commit path. Node logs:\n{}",
+            read_node_logs(&log_dir)
+        );
+        std::thread::sleep(Duration::from_secs(2));
+    }
+
+    assert!(
+        committed,
+        "#5232: the node ran for more than {COMMIT_HEALTHY_UPTIME_SECS}s but the post-update \
+         probation marker at {} is STILL armed. Every later non-clean stop will now be scored \
+         as a crash of a probationary version, and three of them roll this node back off the \
+         release it just installed. Node logs:\n{}",
+        probation_path(home).display(),
+        read_node_logs(&log_dir)
+    );
+
+    let logs = read_node_logs(&log_dir);
+    assert!(
+        logs.contains(COMMITTED_LOG_NEEDLE),
+        "the probation marker was removed, but the node never logged {COMMITTED_LOG_NEEDLE:?} — \
+         so it was dropped down the ClearedStale branch (a marker for a DIFFERENT version) \
+         rather than committed. That disables rollback protection entirely. Node logs:\n{logs}"
+    );
+
+    // ---- Assertion 2: the clean stop that follows is not scored as a crash ----
+    let status = node.stop_gracefully();
+
+    // Reproduce what a supervisor does after the node stops: run `freenet
+    // update` with the node's stop status forwarded. `--check` is used so the
+    // test can never download and overwrite the binary it is testing; the
+    // probation/crash-counting branch runs BEFORE the check/install split, so
+    // it is exercised identically either way.
+    //
+    // Deliberately forwarding "1" rather than the observed status: 1 is what a
+    // graceful shutdown actually exits with today (#5227) and is classified as
+    // a crash, so this is the strictest input. If #5227's fix lands and clean
+    // stops exit 0, this assertion still holds and still tests the probation
+    // gate rather than the exit-code classifier.
+    let post_stop = Command::new(freenet_bin())
+        .arg("update")
+        .arg("--check")
+        .arg("--quiet")
+        .env("HOME", home)
+        .env("FREENET_TELEMETRY_ENABLED", "false")
+        .env("FREENET_POST_STOP_EXIT_CODE", "1")
+        .output()
+        .expect("run post-stop freenet update");
+    let post_stop_stderr = String::from_utf8_lossy(&post_stop.stderr);
+
+    assert!(
+        !post_stop_stderr.contains(CRASH_RECORDED_NEEDLE),
+        "#5232: a clean stop of a node that had already committed its probation was still \
+         counted as a probation crash. Three of these roll the node back. \
+         Node stop status was {status:?}; post-stop `freenet update` said:\n{post_stop_stderr}"
+    );
+    assert!(
+        !probation_path(home).exists(),
+        "the post-stop `freenet update` re-armed a probation marker that had already been \
+         committed at {}",
+        probation_path(home).display()
+    );
+}

--- a/crates/core/tests/post_update_probation_commit.rs
+++ b/crates/core/tests/post_update_probation_commit.rs
@@ -27,16 +27,23 @@
 //! 2. A subsequent clean stop of that node records NO crash: the post-stop
 //!    `freenet update` must not report "during post-update probation".
 //!
-//! ## Why assertion 1 checks the log line and not just the file
+//! ## Why assertion 1 checks the announcement and not just the file
 //!
 //! `commit_probation_at` removes the marker down BOTH of its branches: a
 //! version-matched `Committed`, and a `ClearedStale` for a marker belonging to
 //! some other version. So "the file is gone" alone would still pass if the
 //! version comparison regressed and every marker were dropped as stale — which
 //! would disable rollback entirely, a worse bug than the one this guards. The
-//! INFO line is the only artifact that distinguishes the two paths, so it is
-//! asserted too. (`ClearedStale` logs at DEBUG, which release builds compile
-//! out — that is precisely why this whole class was invisible in the field.)
+//! commit announcement is the only artifact that distinguishes the two paths.
+//!
+//! It is asserted on the node's **stderr**, not on its log files, and that is
+//! the point of the fix this test accompanies. `tracing` output goes to the
+//! rolling log files under the log dir; systemd captures only stdout/stderr. So
+//! the crash-count and rollback lines (printed by the installer on stderr) were
+//! in the journal while the commit that disarms them was not, and #5232 was
+//! filed reading a journal that showed three strikes accumulating and no commit
+//! ever happening. Asserting the log file instead would pass on a build where
+//! the journal is silent again — i.e. it would not hold the fix.
 //!
 //! ## Runtime
 //!
@@ -69,9 +76,10 @@ const COMMIT_HEALTHY_UPTIME_SECS: u64 = 60;
 /// Generous slack over the commit window for a cold-started debug-build node.
 const COMMIT_POLL_DEADLINE: Duration = Duration::from_secs(COMMIT_HEALTHY_UPTIME_SECS + 90);
 
-/// Substring of the INFO line `commit_probation` emits on the `Committed`
-/// branch only.
-const COMMITTED_LOG_NEEDLE: &str = "Auto-update probation passed";
+/// Substring of the line `commit_probation` announces on the `Committed`
+/// branch only. Matched against the node's stderr, which is what a supervisor
+/// records — see the module docs.
+const COMMITTED_STDERR_NEEDLE: &str = "post-update probation passed";
 
 /// Substring of the stderr line `freenet update` prints when it counts a crash
 /// against an armed probation marker.
@@ -172,7 +180,12 @@ impl NodeProcess {
     /// Spawn a self-contained, isolated gateway node rooted at `dir`, with
     /// `HOME` pointed at `dir` so the auto-updater state directory (and hence
     /// the probation marker) is the test's own.
+    ///
+    /// stderr is captured to a file rather than a pipe: the assertions read it
+    /// while the node is still running, and a pipe nobody drains would block
+    /// the node once its buffer filled.
     fn spawn(dir: &Path, ws_port: u16, network_port: u16, log_dir: &Path) -> Self {
+        let stderr = std::fs::File::create(stderr_path(dir)).expect("create node stderr file");
         let child = Command::new(freenet_bin())
             .arg("network")
             // Same #4366 contamination guard as persistence_roundtrip.rs: this
@@ -202,7 +215,7 @@ impl NodeProcess {
             .args(["--data-dir", &dir.to_string_lossy()])
             .args(["--log-dir", &log_dir.to_string_lossy()])
             .stdout(Stdio::null())
-            .stderr(Stdio::null())
+            .stderr(Stdio::from(stderr))
             .spawn()
             .expect("spawn freenet network");
         Self { child }
@@ -238,6 +251,16 @@ impl Drop for NodeProcess {
 fn reserve_port() -> u16 {
     let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
     listener.local_addr().expect("local addr").port()
+}
+
+/// Where the node's stderr is captured. This stands in for the journal: it is
+/// the channel a service supervisor records.
+fn stderr_path(dir: &Path) -> PathBuf {
+    dir.join("node.stderr")
+}
+
+fn read_node_stderr(dir: &Path) -> String {
+    std::fs::read_to_string(stderr_path(dir)).unwrap_or_default()
 }
 
 /// Concatenate every rolling log file the node wrote under `log_dir`.
@@ -306,12 +329,17 @@ fn probation_is_committed_after_a_healthy_uptime_window() {
         read_node_logs(&log_dir)
     );
 
-    let logs = read_node_logs(&log_dir);
+    let stderr = read_node_stderr(home);
     assert!(
-        logs.contains(COMMITTED_LOG_NEEDLE),
-        "the probation marker was removed, but the node never logged {COMMITTED_LOG_NEEDLE:?} — \
-         so it was dropped down the ClearedStale branch (a marker for a DIFFERENT version) \
-         rather than committed. That disables rollback protection entirely. Node logs:\n{logs}"
+        stderr.contains(COMMITTED_STDERR_NEEDLE),
+        "#5232: the probation marker was removed, but the node never announced \
+         {COMMITTED_STDERR_NEEDLE:?} on stderr. Either it was dropped down the ClearedStale \
+         branch (a marker for a DIFFERENT version) rather than committed — which disables \
+         rollback protection entirely — or the commit happened silently, leaving an operator \
+         reading `journalctl -u freenet` unable to tell a committed node from one still \
+         accumulating strikes. That is the misreading #5232 was filed on. Node stderr:\n{stderr}\
+         \n\nNode logs:\n{}",
+        read_node_logs(&log_dir)
     );
 
     // ---- Assertion 2: the clean stop that follows is not scored as a crash ----

--- a/crates/core/tests/post_update_probation_commit.rs
+++ b/crates/core/tests/post_update_probation_commit.rs
@@ -26,7 +26,10 @@
 //!   window ⇒ marker gone, commit announced, and a following post-stop
 //!   `freenet update` records NO crash.
 //! * `probation_survives_a_stop_inside_the_commit_window` — stopped INSIDE the
-//!   window ⇒ marker retained and the stop IS counted, `1/3`.
+//!   window ⇒ the marker is retained, and a crash of that still-uncommitted
+//!   version counts `1/3`. Two separable claims, and the test asserts both: the
+//!   retention is from a real graceful stop, the counting from a forwarded crash
+//!   status (see `post_stop_update`).
 //!
 //! The second is not decoration. It is the positive control for the first: it
 //! proves the fixture actually parses as a `ProbationState`, that
@@ -34,9 +37,13 @@
 //! the state dir, and that the crash line is producible in this harness at all.
 //! Without it, the first test's "no crash was recorded" would also hold if the
 //! post-stop command failed for some entirely unrelated reason — an assertion
-//! that cannot fail. It is also the half that produced the user-visible rollback
-//! in #5232 (three fast restarts), and it costs ~15s rather than ~65s because it
-//! never waits out the window.
+//! that cannot fail. It is also the half the user-visible rollback ran through:
+//! three stops landing inside the window, before anything could commit. (What
+//! made those stops COUNT was #5227 — a graceful shutdown exited 1, which
+//! classifies as a crash. Since #5230 it exits 0, so ordinary restarts no longer
+//! accumulate strikes; the retention behaviour this test pins is what still
+//! decides the outcome for a genuinely crashing release.) It costs ~15s rather
+//! than ~65s because it never waits out the window.
 //!
 //! ## Why the commit assertion reads stderr, not the log files
 //!
@@ -367,11 +374,13 @@ fn reserve_port() -> u16 {
 /// they are testing; the probation/crash-counting branch runs BEFORE the
 /// check/install split, so it is exercised identically either way.
 ///
-/// The forwarded status is always `"1"`, not the node's observed status: 1 is
-/// what a graceful shutdown exits with today (#5227) and classifies as a crash,
-/// so it is the strictest input. If #5227's fix lands and clean stops exit 0,
-/// these assertions keep testing the probation gate rather than silently
-/// becoming a test of the exit-code classifier.
+/// The forwarded status is always `"1"`, never the node's observed status.
+/// Since #5230 a graceful shutdown exits 0, and `classify_stop` short-circuits
+/// `"0"` to `NotCrash` BEFORE `handle_post_stop_at` ever reads the marker — so
+/// forwarding the real status would mean neither test touched the probation
+/// logic at all, and the in-window test would lose its ability to fail. `"1"`
+/// classifies as a crash, which keeps both tests aimed at the probation gate
+/// rather than at the exit-code classifier that #5230 already owns.
 fn post_stop_update(home: &Path) -> String {
     let out = Command::new(freenet_bin())
         .arg("update")
@@ -460,9 +469,10 @@ fn probation_is_committed_after_a_healthy_uptime_window() {
     let post_stop_stderr = post_stop_update(home);
     assert!(
         !post_stop_stderr.contains(CRASH_RECORDED_NEEDLE),
-        "#5232: a clean stop of a node that had already committed its probation was still \
-         counted as a probation crash. Three of these roll the node back. Node stop status was \
-         {status:?}; post-stop `freenet update` said:\n{post_stop_stderr}"
+        "#5232: once probation is committed, NOTHING may be counted against it — this forwards \
+         a crash status (the strictest input) and it still must not register, because the marker \
+         is gone. Three that do register roll the node back. Node stop status was {status:?}; \
+         post-stop `freenet update` said:\n{post_stop_stderr}"
     );
     assert_eq!(
         probation_crash_count(home),
@@ -471,9 +481,14 @@ fn probation_is_committed_after_a_healthy_uptime_window() {
     );
 }
 
-/// The other half of the contract, and the positive control for the test above:
-/// a node stopped INSIDE the commit window keeps its marker, and the stop IS
-/// counted against it.
+/// The other half of the contract, and the positive control for the test above.
+///
+/// Two claims, both asserted here. First, a node stopped INSIDE the commit
+/// window keeps its marker — that is what leaves a genuinely crash-looping
+/// release rollback-eligible, and it is asserted against a REAL graceful stop.
+/// Second, a crash of that still-uncommitted version is counted `1/3` and
+/// persisted — asserted against a forwarded crash status, because since #5230 a
+/// graceful stop is deliberately not a crash (see `post_stop_update`).
 ///
 /// This is what makes the committed test's "no crash was recorded" meaningful.
 /// That assertion is a negative on a subprocess's stderr, so on its own it would
@@ -508,7 +523,9 @@ fn probation_survives_a_stop_inside_the_commit_window() {
         probation_crash_count(home),
         Some(0),
         "a node stopped inside the commit window must keep its armed marker: that is what lets \
-         a genuinely crash-looping release be rolled back. Node stop status: {status:?}"
+         a genuinely crash-looping release still be rolled back. This was a real graceful stop, \
+         so it is the retention that is under test here, not the classification. Node stop \
+         status: {status:?}"
     );
 
     let post_stop_stderr = post_stop_update(home);

--- a/crates/core/tests/post_update_probation_commit.rs
+++ b/crates/core/tests/post_update_probation_commit.rs
@@ -1,88 +1,97 @@
-//! End-to-end guard for the post-update probation COMMIT path (#5232, #4073).
+//! End-to-end guard for the post-update probation lifecycle (#5232, #4073).
 //!
 //! The crash-loop auto-rollback machinery (`commands::rollback`) arms a
-//! probation marker when a new version is installed, and the node is supposed
-//! to clear it once it has run healthily for `COMMIT_HEALTHY_UPTIME_SECS`
-//! (60s). If that commit ever stops happening, the marker stays armed and every
-//! later non-clean stop is scored as a crash of a probationary version — three
-//! of them roll the node BACK off the release it just installed and pin that
-//! release as known-bad locally. That is the failure #5232 was filed for.
+//! probation marker when a new version is installed. The node clears it once it
+//! has run healthily for `COMMIT_HEALTHY_UPTIME_SECS` (60s); until then, each
+//! non-clean stop counts a crash, and three of them roll the node BACK off the
+//! release it just installed and pin that release as known-bad. #5232 was filed
+//! believing the commit half never happened.
 //!
-//! ## Why this test spawns the real binary
+//! ## Why these tests spawn the real binary
 //!
 //! The commit is not a property of `commit_probation_at` — that function is
 //! already unit-tested and works. It is a property of its ONLY caller: a
-//! fire-and-forget `GlobalExecutor::spawn` in `bin/freenet.rs`'s
-//! `run_network_node_with_signals`, whose handle is dropped and which is
-//! aborted at shutdown. A unit test on `commit_probation_at` passes happily
-//! while that task never runs, never fires, or commits a version string that
-//! does not match the marker the installer wrote. Nothing short of running the
-//! node and watching the marker disappear covers that seam.
+//! `GlobalExecutor::spawn` in `bin/freenet.rs`'s `run_network_node_with_signals`
+//! whose handle nothing awaits or monitors (it is retained only to `.abort()` it
+//! at shutdown). A unit test on `commit_probation_at` passes happily while that
+//! task never runs, never fires, or commits a version string that does not match
+//! the marker the installer wrote. Nothing short of running the node and
+//! watching the marker covers that seam, and `commands::rollback` lives in the
+//! bin crate behind a `$HOME`-derived state dir, so no in-process harness
+//! (`#[freenet_test]`, `SimNetwork`) can reach it either.
 //!
-//! ## What it asserts (the two observable halves of #5232)
+//! ## The two halves, and why both are here
 //!
-//! 1. A node that has been up longer than the commit window has NO probation
-//!    marker left on disk, AND its log says it COMMITTED (rather than silently
-//!    dropping the marker as stale — see below).
-//! 2. A subsequent clean stop of that node records NO crash: the post-stop
-//!    `freenet update` must not report "during post-update probation".
+//! * `probation_is_committed_after_a_healthy_uptime_window` — up past the
+//!   window ⇒ marker gone, commit announced, and a following post-stop
+//!   `freenet update` records NO crash.
+//! * `probation_survives_a_stop_inside_the_commit_window` — stopped INSIDE the
+//!   window ⇒ marker retained and the stop IS counted, `1/3`.
 //!
-//! ## Why assertion 1 checks the announcement and not just the file
+//! The second is not decoration. It is the positive control for the first: it
+//! proves the fixture actually parses as a `ProbationState`, that
+//! `FREENET_POST_STOP_EXIT_CODE` is spelled right, that `HOME` really relocates
+//! the state dir, and that the crash line is producible in this harness at all.
+//! Without it, the first test's "no crash was recorded" would also hold if the
+//! post-stop command failed for some entirely unrelated reason — an assertion
+//! that cannot fail. It is also the half that produced the user-visible rollback
+//! in #5232 (three fast restarts), and it costs ~15s rather than ~65s because it
+//! never waits out the window.
 //!
-//! `commit_probation_at` removes the marker down BOTH of its branches: a
-//! version-matched `Committed`, and a `ClearedStale` for a marker belonging to
-//! some other version. So "the file is gone" alone would still pass if the
-//! version comparison regressed and every marker were dropped as stale — which
-//! would disable rollback entirely, a worse bug than the one this guards. The
-//! commit announcement is the only artifact that distinguishes the two paths.
+//! ## Why the commit assertion reads stderr, not the log files
 //!
-//! It is asserted on the node's **stderr**, not on its log files, and that is
-//! the point of the fix this test accompanies. `tracing` output goes to the
-//! rolling log files under the log dir; systemd captures only stdout/stderr. So
-//! the crash-count and rollback lines (printed by the installer on stderr) were
-//! in the journal while the commit that disarms them was not, and #5232 was
-//! filed reading a journal that showed three strikes accumulating and no commit
-//! ever happening. Asserting the log file instead would pass on a build where
-//! the journal is silent again — i.e. it would not hold the fix.
+//! Under the shipped systemd deployment `tracing` output goes to the rolling log
+//! files under the log dir and only stdout/stderr reach the journal, so the
+//! crash-count and rollback lines (printed by the installer on stderr) were in
+//! the journal while the commit that disarms them was not. #5232 was filed
+//! reading a journal that showed strikes accumulating and no commit ever
+//! happening. Asserting the log file would pass on a build where the journal is
+//! silent again, i.e. it would not hold the fix. `crates/core/src/bin/commands/
+//! rollback.rs::commit_announcement` carries the full rationale.
 //!
-//! ## Runtime
-//!
-//! This test necessarily spends the real commit window (60s) waiting, because
-//! the window is a hard-coded constant in the binary under test. Budget ~90s.
+//! Note that CI sets `RUST_LOG=error`, which filters the `tracing::info!` out
+//! entirely — another reason the log files are the wrong thing to assert on.
 
-// Unix-only: the second half stops the node with SIGTERM, which is what a
-// supervisor sends and what makes the stop a *graceful* one worth asserting on.
-// Windows has no equivalent that exercises the same node path.
+// Unix-only: both tests stop the node with SIGTERM, which is what a supervisor
+// sends and what makes the stop a *graceful* one worth asserting on. Windows has
+// no equivalent that exercises the same node path.
 #![cfg(unix)]
 
 use std::path::{Path, PathBuf};
-use std::process::{Child, Command, Stdio};
+use std::process::{Child, Command, ExitStatus, Stdio};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 /// The version the node under test reports. `build_info::VERSION` in the binary
 /// is `env!("CARGO_PKG_VERSION")` of this very crate, so the marker we plant
-/// carries the exact string the node will try to commit — a mismatch here would
-/// make the test vacuous (the node would clear our marker as stale instead of
-/// committing it, which assertion 1's log check also catches).
+/// carries the exact string the node will try to commit.
 const NODE_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Mirrors `commands::rollback::COMMIT_HEALTHY_UPTIME_SECS`, which is
-/// `pub(crate)` in the binary crate and so not importable here. If that
-/// constant is ever raised, this test fails on the poll deadline below rather
-/// than passing silently — which is the correct outcome, since lengthening the
-/// window is a real behavioural change to the rollback machinery.
+/// `pub(crate)` in the binary crate and so not importable here. Raising the real
+/// constant past the deadline below fails these tests rather than passing
+/// silently — the correct outcome, since lengthening the window is a real
+/// behavioural change to the rollback machinery.
 const COMMIT_HEALTHY_UPTIME_SECS: u64 = 60;
 
-/// Generous slack over the commit window for a cold-started debug-build node.
-const COMMIT_POLL_DEADLINE: Duration = Duration::from_secs(COMMIT_HEALTHY_UPTIME_SECS + 90);
+/// How long to wait for the commit AFTER the node is up (not after spawn):
+/// readiness is waited for separately, so this budget covers only the window
+/// itself plus scheduling slack.
+const COMMIT_POLL_DEADLINE: Duration = Duration::from_secs(COMMIT_HEALTHY_UPTIME_SECS + 45);
 
-/// Substring of the line `commit_probation` announces on the `Committed`
-/// branch only. Matched against the node's stderr, which is what a supervisor
-/// records — see the module docs.
+/// How long a cold debug-build node may take to bind its WS port. Matches the
+/// budget `persistence_roundtrip.rs` allows for the same thing.
+const NODE_READY_DEADLINE: Duration = Duration::from_secs(60);
+
+/// Substring of the line `commit_probation` announces on the `Committed` branch
+/// only. Pinned against a reword by
+/// `rollback.rs::tests::both_marker_clearing_outcomes_are_announced`, which
+/// fails in microseconds rather than after this test's 60s window.
 const COMMITTED_STDERR_NEEDLE: &str = "post-update probation passed";
 
-/// Substring of the stderr line `freenet update` prints when it counts a crash
-/// against an armed probation marker.
+/// Substring of the line `freenet update` prints when it counts a crash against
+/// an armed probation marker. Asserted PRESENT by the in-window test and ABSENT
+/// by the committed test — so a reword breaks the former loudly instead of
+/// silently disarming the latter.
 const CRASH_RECORDED_NEEDLE: &str = "during post-update probation";
 
 // ---------------------------------------------------------------------------
@@ -117,26 +126,57 @@ fn freenet_bin() -> PathBuf {
     release
 }
 
+/// Fail early and unambiguously if the binary on disk is not the one this test
+/// source describes. A stale `target/debug/freenet` from before a version bump
+/// would take the ClearedStale branch instead of committing, and the failure
+/// would read as a rollback regression rather than "rebuild your binary".
+fn assert_binary_matches_crate_version() {
+    let out = Command::new(freenet_bin())
+        .arg("--version")
+        .output()
+        .expect("run freenet --version");
+    let reported = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        reported.contains(NODE_VERSION),
+        "the freenet binary at {} reports {reported:?}, which does not contain this crate's \
+         version {NODE_VERSION}. Rebuild it (`cargo build --bin freenet`) — a stale binary makes \
+         these tests fail in a way that looks like a rollback bug.",
+        freenet_bin().display()
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Probation state fixture
 // ---------------------------------------------------------------------------
 
 /// The auto-updater's state directory, as `commands::auto_update::state_dir`
 /// computes it: `dirs::home_dir()/.local/state/freenet`. The node resolves it
-/// from `$HOME`, NOT from `--config-dir`/`--data-dir`, so the test isolates it
-/// by giving the child process its own `HOME`.
+/// from `$HOME`, NOT from `--config-dir`/`--data-dir`, so the tests isolate it by
+/// giving the child process its own `HOME`.
 fn state_dir(home: &Path) -> PathBuf {
     home.join(".local/state/freenet")
 }
 
-/// Write a probation marker for `version` that is armed right now: a genuine
-/// `ProbationState` as `begin_probation_at` would have written it immediately
-/// after installing `version` over the previous binary.
+fn probation_path(home: &Path) -> PathBuf {
+    state_dir(home).join("update_probation.json")
+}
+
+/// Write a probation marker for `version`, armed right now — a `ProbationState`
+/// as `begin_probation_at` would have written it immediately after installing
+/// `version` over the previous binary.
 ///
-/// `installed_at_unix` is NOW on purpose. A marker older than
+/// `installed_at_unix` is NOW on purpose: a marker older than
 /// `PROBATION_MAX_AGE_SECS` (1h) is treated as stale by both the commit and the
-/// post-stop paths, so a backdated fixture would make both assertions pass for
+/// post-stop paths, so a backdated fixture would make the assertions pass for
 /// the wrong reason.
+///
+/// This is hand-written JSON because `ProbationState` is `pub(crate)` to the bin
+/// crate and cannot be constructed here. If a field is renamed in `rollback.rs`,
+/// `read_probation_at` returns `None` and the node behaves as if there were no
+/// probation at all. Nothing silently passes — but the failure surfaces in
+/// `probation_survives_a_stop_inside_the_commit_window`, which takes ~15s and
+/// reports "no crash was recorded", rather than in the 65s test. That is the
+/// intended ordering: the cheap test is the fixture's canary.
 fn arm_probation(home: &Path, version: &str) {
     let dir = state_dir(home);
     std::fs::create_dir_all(&dir).expect("create state dir");
@@ -144,36 +184,54 @@ fn arm_probation(home: &Path, version: &str) {
         .duration_since(UNIX_EPOCH)
         .expect("system clock after epoch")
         .as_secs();
-    let rollback_binary = dir.join("known_good_binary");
-    let target_binary = home.join(".local/bin/freenet");
-    // Written as JSON rather than by constructing `ProbationState`, which is
-    // `pub(crate)` to the binary crate. The shape is pinned by the binary's own
-    // serde round-trip tests in `rollback.rs`; a field rename there would make
-    // this parse as "no probation" and assertion 2 would stop being able to
-    // fail, so the fixture is re-read and checked below before the node starts.
-    let marker = format!(
-        r#"{{"new_version":"{version}","previous_version":"0.0.0",
-            "rollback_binary":"{}","target_binary":"{}",
-            "rollback_size":1,"rollback_sha256":"00","installed_at_unix":{now},
-            "crash_count":0}}"#,
-        rollback_binary.display(),
-        target_binary.display(),
-    );
-    std::fs::write(probation_path(home), marker).expect("write probation marker");
+    let marker = serde_json::json!({
+        "new_version": version,
+        "previous_version": "0.0.0",
+        "rollback_binary": dir.join("known_good_binary"),
+        "target_binary": home.join(".local/bin/freenet"),
+        "rollback_size": 1,
+        "rollback_sha256": "00",
+        "installed_at_unix": now,
+        "crash_count": 0,
+    });
+    std::fs::write(
+        probation_path(home),
+        serde_json::to_vec(&marker).expect("serialize probation fixture"),
+    )
+    .expect("write probation marker");
 }
 
-fn probation_path(home: &Path) -> PathBuf {
-    state_dir(home).join("update_probation.json")
+/// The marker's `crash_count`, or `None` if there is no marker.
+fn probation_crash_count(home: &Path) -> Option<u64> {
+    let raw = std::fs::read_to_string(probation_path(home)).ok()?;
+    let parsed: serde_json::Value =
+        serde_json::from_str(&raw).expect("marker must stay valid JSON");
+    Some(
+        parsed["crash_count"]
+            .as_u64()
+            .expect("marker must carry a numeric crash_count"),
+    )
 }
 
 // ---------------------------------------------------------------------------
 // Subprocess node lifecycle
 // ---------------------------------------------------------------------------
 
+/// Where the node's stderr is captured. This stands in for the journal: it is
+/// the channel a service supervisor records.
+fn stderr_path(dir: &Path) -> PathBuf {
+    dir.join("node.stderr")
+}
+
+fn read_node_stderr(dir: &Path) -> String {
+    std::fs::read_to_string(stderr_path(dir)).unwrap_or_default()
+}
+
 /// A `freenet network` subprocess, killed and reaped on drop so a panicking
 /// assertion never leaks a node.
 struct NodeProcess {
     child: Child,
+    ws_port: u16,
 }
 
 impl NodeProcess {
@@ -181,10 +239,10 @@ impl NodeProcess {
     /// `HOME` pointed at `dir` so the auto-updater state directory (and hence
     /// the probation marker) is the test's own.
     ///
-    /// stderr is captured to a file rather than a pipe: the assertions read it
-    /// while the node is still running, and a pipe nobody drains would block
-    /// the node once its buffer filled.
-    fn spawn(dir: &Path, ws_port: u16, network_port: u16, log_dir: &Path) -> Self {
+    /// stderr goes to a file rather than a pipe: the assertions read it while
+    /// the node is still running, and a pipe nobody drains would block the node
+    /// once its buffer filled.
+    fn spawn(dir: &Path, ws_port: u16, network_port: u16) -> Self {
         let stderr = std::fs::File::create(stderr_path(dir)).expect("create node stderr file");
         let child = Command::new(freenet_bin())
             .arg("network")
@@ -204,39 +262,88 @@ impl NodeProcess {
             .arg("--is-gateway")
             .arg("--skip-load-from-network")
             .arg("--ignore-protocol-checking")
-            // Keep the node from reaching GitHub and, worse, deciding a newer
-            // release exists and exiting 42 before the commit window elapses —
-            // which would make this test flaky against the real release feed.
-            // It does NOT gate the commit task, which is spawned
-            // unconditionally; if that ever changes, this test fails, correctly.
+            // Keeps the node from reaching GitHub and, worse, deciding a newer
+            // release exists and exiting 42 before the window elapses — which
+            // would make these tests flaky against the real release feed. It
+            // does NOT gate the commit task, which is spawned unconditionally;
+            // if that ever changes, these tests fail, correctly.
             .arg("--disable-auto-update")
             .args(["--location", "0.5"])
             .args(["--config-dir", &dir.to_string_lossy()])
             .args(["--data-dir", &dir.to_string_lossy()])
-            .args(["--log-dir", &log_dir.to_string_lossy()])
+            // Deliberately the state dir, not a separate directory: on Linux the
+            // log dir IS the auto-updater state dir in production, so the log
+            // pruner and the probation marker share it. Pointing this elsewhere
+            // would hide a pruner regression that started matching
+            // `update_probation.json` (see `tracer.rs::rotating_log_family`).
+            .args(["--log-dir", &state_dir(dir).to_string_lossy()])
             .stdout(Stdio::null())
             .stderr(Stdio::from(stderr))
             .spawn()
             .expect("spawn freenet network");
-        Self { child }
+        Self { child, ws_port }
     }
 
     fn has_exited(&mut self) -> bool {
         matches!(self.child.try_wait(), Ok(Some(_)))
     }
 
+    /// Block until the WS API accepts a TCP connection, so the commit window is
+    /// timed from a node that is actually up rather than from `spawn`.
+    fn wait_until_ready(&mut self, dir: &Path) {
+        let deadline = Instant::now() + NODE_READY_DEADLINE;
+        while Instant::now() < deadline {
+            if std::net::TcpStream::connect(("127.0.0.1", self.ws_port)).is_ok() {
+                return;
+            }
+            assert!(
+                !self.has_exited(),
+                "the node exited before its WS API came up.{}",
+                self.diagnostics(dir)
+            );
+            std::thread::sleep(Duration::from_millis(500));
+        }
+        panic!(
+            "the node's WS API never came up within {NODE_READY_DEADLINE:?}.{}",
+            self.diagnostics(dir)
+        );
+    }
+
+    /// Everything worth knowing when an assertion fails. The node's own stderr
+    /// is included because the likeliest failures here — a port collision, a
+    /// bind error, a rejected flag — report themselves there, possibly before
+    /// `tracing` is even initialised.
+    fn diagnostics(&mut self, dir: &Path) -> String {
+        format!(
+            "\n--- node exit status: {:?}\n--- node stderr:\n{}",
+            self.child.try_wait(),
+            read_node_stderr(dir)
+        )
+    }
+
     /// Stop the node the way a supervisor does, and return its exit status.
-    fn stop_gracefully(mut self) -> std::process::ExitStatus {
+    /// Bounded: a shutdown hang is a real regression class here, and blocking
+    /// forever would surface as an opaque harness timeout with no output.
+    fn stop_gracefully(mut self, dir: &Path) -> ExitStatus {
         // SIGTERM is what `systemctl stop` sends; the node's signal handler
         // turns it into a graceful shutdown.
         let pid = self.child.id() as i32;
-        // SAFETY: `kill(2)` with a pid we own and a valid signal number; the
-        // child is reaped immediately below, so the pid cannot be recycled
-        // between the call and the wait.
+        // SAFETY: `kill(2)` with a pid we own and a valid signal number. The
+        // child is only reaped below, so the pid cannot be recycled in between.
         unsafe {
             libc::kill(pid, libc::SIGTERM);
         }
-        self.child.wait().expect("reap node")
+        let deadline = Instant::now() + Duration::from_secs(60);
+        while Instant::now() < deadline {
+            if let Some(status) = self.child.try_wait().expect("poll node exit") {
+                return status;
+            }
+            std::thread::sleep(Duration::from_millis(200));
+        }
+        let diagnostics = self.diagnostics(dir);
+        let _kill = self.child.kill();
+        let _reap = self.child.wait();
+        panic!("the node did not exit within 60s of SIGTERM.{diagnostics}");
     }
 }
 
@@ -253,110 +360,20 @@ fn reserve_port() -> u16 {
     listener.local_addr().expect("local addr").port()
 }
 
-/// Where the node's stderr is captured. This stands in for the journal: it is
-/// the channel a service supervisor records.
-fn stderr_path(dir: &Path) -> PathBuf {
-    dir.join("node.stderr")
-}
-
-fn read_node_stderr(dir: &Path) -> String {
-    std::fs::read_to_string(stderr_path(dir)).unwrap_or_default()
-}
-
-/// Concatenate every rolling log file the node wrote under `log_dir`.
-fn read_node_logs(log_dir: &Path) -> String {
-    let Ok(entries) = std::fs::read_dir(log_dir) else {
-        return String::new();
-    };
-    entries
-        .filter_map(Result::ok)
-        .filter(|e| {
-            e.file_name()
-                .to_str()
-                .is_some_and(|n| n.starts_with("freenet") && n.ends_with(".log"))
-        })
-        .filter_map(|e| std::fs::read_to_string(e.path()).ok())
-        .collect::<Vec<_>>()
-        .join("\n")
-}
-
-// ---------------------------------------------------------------------------
-// The test
-// ---------------------------------------------------------------------------
-
-/// #5232: a node up past the commit window must have committed its probation,
-/// and a clean stop after that must not be scored as a crash.
-#[test]
-#[cfg(unix)]
-fn probation_is_committed_after_a_healthy_uptime_window() {
-    let tmp = tempfile::tempdir().expect("tempdir");
-    let home = tmp.path();
-    let log_dir = home.join("logs");
-    std::fs::create_dir_all(&log_dir).expect("create log dir");
-
-    arm_probation(home, NODE_VERSION);
-    assert!(
-        probation_path(home).exists(),
-        "fixture precondition: the probation marker must exist before the node starts"
-    );
-
-    let mut node = NodeProcess::spawn(home, reserve_port(), reserve_port(), &log_dir);
-
-    // ---- Assertion 1: the marker is cleared, and cleared by COMMITTING ----
-    let deadline = Instant::now() + COMMIT_POLL_DEADLINE;
-    let mut committed = false;
-    while Instant::now() < deadline {
-        if !probation_path(home).exists() {
-            committed = true;
-            break;
-        }
-        assert!(
-            !node.has_exited(),
-            "the node exited before the probation commit window elapsed, so this test \
-             proved nothing about the commit path. Node logs:\n{}",
-            read_node_logs(&log_dir)
-        );
-        std::thread::sleep(Duration::from_secs(2));
-    }
-
-    assert!(
-        committed,
-        "#5232: the node ran for more than {COMMIT_HEALTHY_UPTIME_SECS}s but the post-update \
-         probation marker at {} is STILL armed. Every later non-clean stop will now be scored \
-         as a crash of a probationary version, and three of them roll this node back off the \
-         release it just installed. Node logs:\n{}",
-        probation_path(home).display(),
-        read_node_logs(&log_dir)
-    );
-
-    let stderr = read_node_stderr(home);
-    assert!(
-        stderr.contains(COMMITTED_STDERR_NEEDLE),
-        "#5232: the probation marker was removed, but the node never announced \
-         {COMMITTED_STDERR_NEEDLE:?} on stderr. Either it was dropped down the ClearedStale \
-         branch (a marker for a DIFFERENT version) rather than committed — which disables \
-         rollback protection entirely — or the commit happened silently, leaving an operator \
-         reading `journalctl -u freenet` unable to tell a committed node from one still \
-         accumulating strikes. That is the misreading #5232 was filed on. Node stderr:\n{stderr}\
-         \n\nNode logs:\n{}",
-        read_node_logs(&log_dir)
-    );
-
-    // ---- Assertion 2: the clean stop that follows is not scored as a crash ----
-    let status = node.stop_gracefully();
-
-    // Reproduce what a supervisor does after the node stops: run `freenet
-    // update` with the node's stop status forwarded. `--check` is used so the
-    // test can never download and overwrite the binary it is testing; the
-    // probation/crash-counting branch runs BEFORE the check/install split, so
-    // it is exercised identically either way.
-    //
-    // Deliberately forwarding "1" rather than the observed status: 1 is what a
-    // graceful shutdown actually exits with today (#5227) and is classified as
-    // a crash, so this is the strictest input. If #5227's fix lands and clean
-    // stops exit 0, this assertion still holds and still tests the probation
-    // gate rather than the exit-code classifier.
-    let post_stop = Command::new(freenet_bin())
+/// Run the post-stop `freenet update` a supervisor runs after the node stops,
+/// and return its stderr.
+///
+/// `--check` is used so the tests can never download and overwrite the binary
+/// they are testing; the probation/crash-counting branch runs BEFORE the
+/// check/install split, so it is exercised identically either way.
+///
+/// The forwarded status is always `"1"`, not the node's observed status: 1 is
+/// what a graceful shutdown exits with today (#5227) and classifies as a crash,
+/// so it is the strictest input. If #5227's fix lands and clean stops exit 0,
+/// these assertions keep testing the probation gate rather than silently
+/// becoming a test of the exit-code classifier.
+fn post_stop_update(home: &Path) -> String {
+    let out = Command::new(freenet_bin())
         .arg("update")
         .arg("--check")
         .arg("--quiet")
@@ -365,18 +382,154 @@ fn probation_is_committed_after_a_healthy_uptime_window() {
         .env("FREENET_POST_STOP_EXIT_CODE", "1")
         .output()
         .expect("run post-stop freenet update");
-    let post_stop_stderr = String::from_utf8_lossy(&post_stop.stderr);
+    String::from_utf8_lossy(&out.stderr).into_owned()
+}
 
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// #5232: a node up past the commit window must have committed its probation —
+/// visibly — and a clean stop after that must not be scored as a crash.
+#[test]
+fn probation_is_committed_after_a_healthy_uptime_window() {
+    assert_binary_matches_crate_version();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let home = tmp.path();
+
+    arm_probation(home, NODE_VERSION);
+    assert_eq!(
+        probation_crash_count(home),
+        Some(0),
+        "fixture precondition: an armed marker with no crashes yet"
+    );
+
+    let mut node = NodeProcess::spawn(home, reserve_port(), reserve_port());
+    node.wait_until_ready(home);
+
+    // ---- Assertion 1: committed, and said so ----
+    //
+    // Polls for the ANNOUNCEMENT rather than for the marker's absence.
+    // `commit_probation_at` deletes the file before `commit_probation` prints,
+    // so a poll on the file can observe "gone" microseconds before the line is
+    // written — and the announcement is the specific artifact this guards.
+    let deadline = Instant::now() + COMMIT_POLL_DEADLINE;
+    let mut announced = false;
+    while Instant::now() < deadline {
+        if read_node_stderr(home).contains(COMMITTED_STDERR_NEEDLE) {
+            announced = true;
+            break;
+        }
+        assert!(
+            !node.has_exited(),
+            "the node exited before the probation commit window elapsed, so this test proved \
+             nothing about the commit path.{}",
+            node.diagnostics(home)
+        );
+        std::thread::sleep(Duration::from_secs(2));
+    }
+
+    let stderr = read_node_stderr(home);
+    assert!(
+        announced,
+        "#5232: the node ran for more than {COMMIT_HEALTHY_UPTIME_SECS}s but never announced \
+         {COMMITTED_STDERR_NEEDLE:?} on stderr. Either it did not commit — in which case the \
+         marker is still armed, every later non-clean stop is scored as a crash of a \
+         probationary version, and three of them roll this node back off the release it just \
+         installed — or it committed silently, leaving an operator reading `journalctl -u \
+         freenet` unable to tell a committed node from one accumulating strikes. That is the \
+         misreading #5232 was filed on. Marker crash_count now: {:?}\n--- node stderr:\n{stderr}",
+        probation_crash_count(home),
+    );
+    assert!(
+        !stderr.contains("discarded a post-update probation marker"),
+        "the marker was DISCARDED as belonging to another version rather than committed, so \
+         rollback protection was dropped without the version ever proving itself. The planted \
+         marker names {NODE_VERSION}, the same string the node commits, so this means the \
+         version comparison regressed (the #5104 `v`-prefix class).\n--- node stderr:\n{stderr}"
+    );
+    assert_eq!(
+        probation_crash_count(home),
+        None,
+        "the commit was announced but the marker is still on disk at {}",
+        probation_path(home).display()
+    );
+
+    // ---- Assertion 2: the clean stop that follows is not scored as a crash ----
+    let status = node.stop_gracefully(home);
+    let post_stop_stderr = post_stop_update(home);
     assert!(
         !post_stop_stderr.contains(CRASH_RECORDED_NEEDLE),
         "#5232: a clean stop of a node that had already committed its probation was still \
-         counted as a probation crash. Three of these roll the node back. \
-         Node stop status was {status:?}; post-stop `freenet update` said:\n{post_stop_stderr}"
+         counted as a probation crash. Three of these roll the node back. Node stop status was \
+         {status:?}; post-stop `freenet update` said:\n{post_stop_stderr}"
+    );
+    assert_eq!(
+        probation_crash_count(home),
+        None,
+        "the post-stop `freenet update` re-armed a marker that had already been committed"
+    );
+}
+
+/// The other half of the contract, and the positive control for the test above:
+/// a node stopped INSIDE the commit window keeps its marker, and the stop IS
+/// counted against it.
+///
+/// This is what makes the committed test's "no crash was recorded" meaningful.
+/// That assertion is a negative on a subprocess's stderr, so on its own it would
+/// also hold if the post-stop command never reached the probation branch at all
+/// — a wrong env var name, a `HOME` that did not relocate the state dir, an
+/// unparseable fixture, or a reworded needle. Here the same fixture, the same
+/// env var and the same needle must produce a crash line, so all of it is
+/// pinned. Runs in ~15s and makes no network call: the crash branch exits before
+/// `freenet update` probes GitHub.
+#[test]
+fn probation_survives_a_stop_inside_the_commit_window() {
+    assert_binary_matches_crate_version();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let home = tmp.path();
+
+    arm_probation(home, NODE_VERSION);
+
+    let mut node = NodeProcess::spawn(home, reserve_port(), reserve_port());
+    node.wait_until_ready(home);
+    // Stop well inside the window. `wait_until_ready` returns as soon as the WS
+    // port answers, which is before the commit task's sleep elapses, so there is
+    // no race to lose here — but assert it rather than trusting it.
+    let stderr_at_stop = read_node_stderr(home);
+    assert!(
+        !stderr_at_stop.contains(COMMITTED_STDERR_NEEDLE),
+        "the node committed before this test could stop it, so it is no longer testing an \
+         in-window stop. Did COMMIT_HEALTHY_UPTIME_SECS shrink?\n{stderr_at_stop}"
+    );
+    let status = node.stop_gracefully(home);
+
+    assert_eq!(
+        probation_crash_count(home),
+        Some(0),
+        "a node stopped inside the commit window must keep its armed marker: that is what lets \
+         a genuinely crash-looping release be rolled back. Node stop status: {status:?}"
+    );
+
+    let post_stop_stderr = post_stop_update(home);
+    assert!(
+        post_stop_stderr.contains(CRASH_RECORDED_NEEDLE),
+        "a crash of an uncommitted probationary version must be counted, and reported on stderr \
+         where the supervisor records it. If this fails, the committed test's \"no crash was \
+         recorded\" assertion is no longer able to fail either — check the fixture parses, \
+         `FREENET_POST_STOP_EXIT_CODE` is still the env var name, and the needle \
+         {CRASH_RECORDED_NEEDLE:?} still matches what `freenet update` prints.\n\
+         post-stop `freenet update` said:\n{post_stop_stderr}"
     );
     assert!(
-        !probation_path(home).exists(),
-        "the post-stop `freenet update` re-armed a probation marker that had already been \
-         committed at {}",
-        probation_path(home).display()
+        post_stop_stderr.contains("1/3"),
+        "the first crash of a probationary version must count as 1 of 3, not something else:\n\
+         {post_stop_stderr}"
+    );
+    assert_eq!(
+        probation_crash_count(home),
+        Some(1),
+        "the crash must be PERSISTED, or crashes cannot accumulate toward the rollback threshold \
+         across restarts and a genuinely bad release is never rolled back"
     );
 }

--- a/crates/core/tests/post_update_probation_commit.rs
+++ b/crates/core/tests/post_update_probation_commit.rs
@@ -90,10 +90,15 @@ const COMMIT_POLL_DEADLINE: Duration = Duration::from_secs(COMMIT_HEALTHY_UPTIME
 const NODE_READY_DEADLINE: Duration = Duration::from_secs(60);
 
 /// Substring of the line `commit_probation` announces on the `Committed` branch
-/// only. Pinned against a reword by
-/// `rollback.rs::tests::both_marker_clearing_outcomes_are_announced`, which
-/// fails in microseconds rather than after this test's 60s window.
-const COMMITTED_STDERR_NEEDLE: &str = "post-update probation passed";
+/// ONLY.
+///
+/// Deliberately not the leading "post-update probation passed" phrase: the
+/// ClearFailed branch — marker could not be removed, so rollback is still armed
+/// — needs to say the version ran healthily too, and a needle both lines shared
+/// would let this test report a commit while rollback was live.
+/// `rollback.rs::tests::a_failed_clear_is_never_announced_as_a_pass` pins the
+/// two apart in microseconds, rather than after this test's 60s window.
+const COMMITTED_STDERR_NEEDLE: &str = "committed, auto-rollback disarmed";
 
 /// Substring of the line `freenet update` prints when it counts a crash against
 /// an armed probation marker. Asserted PRESENT by the in-window test and ABSENT


### PR DESCRIPTION
## Problem

#5232 reported that post-update probation is never committed — so a node stays probationary indefinitely after an update, every later clean stop is scored as a crash, and the third one rolls the node back off the release it just installed and pins that release as known-bad. A real user hit exactly that outcome on 0.2.122.

**`commit_probation` was never broken.** It fires at exactly 60s on every healthy boot, and this PR changes no rollback decision, threshold, or state transition. What was broken is that you could not see it from where the report was written.

Under the shipped systemd deployment the node's `tracing` output goes to the rolling log files under the log dir (the console layer is added only when stdout is a terminal, which it is not under a service manager), while the unit records `StandardOutput=journal` / `StandardError=journal`. The three other decisions in this flow — the crash count, the rollback, and rollback-unavailable — are all `eprintln!` in `commands::update`, so they reach the journal. The commit that disarms them did not. `journalctl -u freenet` therefore showed strikes accumulating against a probationary version and never once showed a commit.

Evidence that the commit does work, from the same node the issue was filed against, in `~/.local/state/freenet/freenet.*.log` and absent from that host's journal:

```
2026-08-05T13:53:29Z INFO freenet::commands::rollback: Auto-update probation passed ... version="0.2.119"
2026-08-05T17:50:40Z INFO ... version="0.2.120"
2026-08-07T23:25:54Z INFO ... version="0.2.121"
2026-08-08T02:43:00Z INFO ... version="0.2.122"
```

Four commits, one per version, each exactly 60s after that boot's start banner. Confirmed independently by running the real binary with an armed marker in a scratch `HOME`: the marker is removed at ~65s.

The issue's other two observations resolve the same way. The `1/3` seen twice was two different nodes: that host's boot banners show `23:15:18Z version="0.2.120"` and `23:24:54Z version="0.2.121"`, so the node that stopped was 0.2.120 while the `ExecStopPost` binary matching the marker was 0.2.121 — a hand-driven test bench with the binary swapped underneath, not a counter that resets. And the marker and `build_info::VERSION` strings match exactly (`0.2.121` both sides), so the `v`-prefix concern does not apply here.

## Solution

Announce both marker-clearing outcomes on stderr, alongside the decisions they cancel. One line per node start at most, and only when a probation marker exists. The wording lives in `commit_announcement`, a pure function over `CommitOutcome`, so both branches are unit-testable — `commit_probation` itself reads the process-global `$HOME` and cannot be driven from a test.

**Scope note, stated plainly because it goes beyond the reported symptom:** the `ClearedStale` branch is also escalated, from `debug!` (compiled out of release builds by `release_max_level_info`, so it was completely silent in the field) to `warn!` plus the stderr line. That branch *discards* a marker belonging to a different version **without committing anything**, so rollback protection for that version disappears. It is indistinguishable from a healthy commit by the state directory alone — both just delete the marker — and it is the branch a version-comparison regression would take, the #5104 `v`-prefix class.

One case is deliberately left alone and now documented rather than changed: a node parked by `freenet service disable` (`run_disabled_idle`) returns before the commit timer is spawned and keeps its marker until the 1h TTL retires it. Committing there would disarm rollback on evidence the mechanism does not have — that process never joined the network, so it has not demonstrated the health probation is testing for.

## Testing

`crates/core/tests/post_update_probation_commit.rs` spawns the real `freenet network` binary with its own `HOME` and covers both halves of the contract:

| Test | Asserts | Runtime |
|---|---|---|
| `probation_is_committed_after_a_healthy_uptime_window` | up past the window ⇒ marker gone, commit announced on stderr, and the following post-stop `freenet update` records no crash | ~65s |
| `probation_survives_a_stop_inside_the_commit_window` | stopped inside the window ⇒ marker retained, the stop IS counted `1/3`, and `crash_count` is persisted | ~15s |

Three deliberate choices, each load-bearing:

- **It drives the real binary.** The commit is not a property of `commit_probation_at`, which is already unit-tested and correct. It is a property of its only caller — a `GlobalExecutor::spawn` in `run_network_node_with_signals` that nothing awaits or monitors. A unit test on `commit_probation_at` passes happily while that task never runs. `commands::rollback` also lives in the bin crate behind a `$HOME`-derived state dir, so no in-process harness can reach it.
- **It asserts stderr, not the log files.** Asserting the log file would pass on a build where the journal is silent again, i.e. it would not hold this fix. (CI also sets `RUST_LOG=error`, which filters the `tracing::info!` out entirely.)
- **The second test is the positive control for the first.** "No crash was recorded" is a negative assertion on a subprocess's stderr, and the preceding assertion has already established the marker is gone — so on its own it could not fail, and would equally have passed with a misspelled `FREENET_POST_STOP_EXIT_CODE`, a `HOME` that did not relocate the state dir, an unparseable fixture, or a reworded needle. The in-window test forces the same fixture, env var and needle to produce a crash line. It is also the half that produced the user-visible rollback in #5232 (three fast restarts), and it makes no network call — the crash branch exits before `freenet update` probes GitHub.

Mutation-tested; each of these fails the suite:

| Mutation | Result |
|---|---|
| Delete the `commit_probation` call (the failure #5232 hypothesised) | FAILED |
| `v`-prefix version mismatch — marker removed as stale, never committed | FAILED |
| Revert this PR's `eprintln` (tracing-only, pre-fix state) | FAILED |

The second is the one that matters for test design: the marker *is* removed, so a file-existence check alone would have passed it while rollback protection was silently gone.

`rollback.rs::tests::both_marker_clearing_outcomes_are_announced` pins both announcement strings (and the silent `Nothing` case) in microseconds, so a reword fails there rather than after the 60s window.

nextest override: 300s period, `retries = 0`. Retrying brick-safety equipment would turn "the commit sometimes does not happen" — the exact bug class #5232 was filed about — back into a green run.

## A worked example of the failure mode this area keeps producing

Worth reading even if you skim the rest, because it happened *inside the fix*.

`commit_probation` announces "committed, auto-rollback disarmed". `remove_probation_at` discarded its `remove_file` result, so that line printed whether or not the marker was actually gone — and a failed unlink leaves rollback armed inside its 1h TTL. The fix for a misleading journal was itself capable of misleading the journal.

Fixing that introduced a second instance. The new `ClearFailed` message began *"post-update probation passed, but the marker could NOT be removed…"* — which **contains** the exact substring the end-to-end test greps for to conclude the node committed. A failed clear would have passed the guard while rollback was still armed: the same false-green, one level up, inside the test written to prevent it.

Both are now closed: `commit_probation_at` reports `ClearFailed` instead of a false `Committed`, the e2e keys on `"committed, auto-rollback disarmed"` which only the success branch can produce, and a unit test pins the two disjoint in both directions.

The pattern to watch for: **a success signal and a failure signal that share a substring, or a message emitted before the state change it describes.** Both produce a green check over a broken invariant.

## Review

Three independent lenses (skeptical, testing, code-first). No blocking findings; every should-fix is addressed in the second commit, including several assertions that could not fail, three comments that described things that were not true, a poll that raced the announcement, and the missing `ClearedStale` coverage.

## Not in scope

- **#5227** (a graceful shutdown exits 1, so it is scored as a crash) is the real cause of the user-visible rollback and is fixed separately in #5230. Rolling back needs three crashes recorded while the marker is alive, and the marker dies 60s into the first healthy boot — so it takes three stops each inside a 60s window, which is a fast restart loop, which is what that user's `StartLimitBurst` trip says they had.
- Nodes on ≤0.2.121 log `Startup update check: failed to parse latest version 'v0.2.121'`, so update detection is dead there and a node already rolled back onto one cannot auto-update out of it. Separate issue, separately owned. (The known-bad pin is not the trap: it is exact-version, so a newer release is never blocked by it.)

Refs #5232

[AI-assisted - Claude]


---

## Addendum: ejected by the merge queue, and the lint that caught this PR with its own construct

This PR sat green and `mergeable=CLEAN` for 27 days, was enqueued, and was **ejected** on a clippy error its branch CI never reported:

```
error: wildcard match will also match any future added variants
    --> crates/core/src/bin/commands/rollback.rs:1267:13
1267 |             other => panic!(
     = note: `-D clippy::wildcard-enum-match-arm` implied by `-D warnings`
```

Ruled out first: not a conflict (`git merge-tree --write-tree` against current main is clean, so no rebase was needed), not a toolchain bump (1.94.0 both sides), not a new lint (already configured at the merge-base). What changed is the lint's **reach** — #5292 extended lint coverage to test code after this branch last ran CI. The diff was never wrong; only the merged combination fails, so only a merge-group run or a local build with main merged in could have surfaced it.

**The irony is worth stating, because it is the argument for the lint.** `wildcard_enum_match_arm` exists in this repo so that adding an enum variant forces a compile error at every match site rather than silently falling through a wildcard. This is the PR that **adds** `CommitOutcome::ClearFailed` — and its own new test matched on `CommitOutcome` with `other =>`, the exact construct that would swallow the next variant someone adds. The lint caught the PR introducing a variant using the thing that would have hidden the following one.

Fixed by enumerating the three arms, not with `#[allow]`. An `#[allow]` would have silenced the lint and disarmed that guarantee for precisely the enum this PR extends, inside the test whose job is to tell the outcomes apart. With the arms enumerated, a fourth `CommitOutcome` variant breaks this match — which is the property the lint is there to preserve.

Verified with clippy against the **merged** tree, not the branch alone: a stale branch still carries old copies of files main has since rewritten, so a branch-only run tests a tree that will never exist after merge.

[AI-assisted - Claude]
