### PR TITLE
test(node): pin shutdown_requested to a single signal-handler store

### DIFF
--- a/crates/core/src/bin/freenet.rs
+++ b/crates/core/src/bin/freenet.rs
@@ -1472,9 +1472,22 @@ mod tests {
     /// region would widen to the whole file and the pin would pass vacuously.
     /// Refuse instead. (Same fail-closed reasoning as `commands::auto_update`'s
     /// `fn_body`; see `.claude/rules/bug-prevention-patterns.md`.)
+    ///
+    /// Uniqueness is asserted rather than taking the first match: a second
+    /// `#[cfg(test)] mod` added ABOVE this one would truncate the region early
+    /// and hide any production code below it — fail-OPEN in exactly the
+    /// direction a bounded region exists to protect.
     fn production_region(src: &str) -> &str {
+        let anchor = "\n#[cfg(test)]\nmod ";
+        assert_eq!(
+            src.matches(anchor).count(),
+            1,
+            "expected exactly one `#[cfg(test)] mod` in this file — the region this \
+             pin counts over is bounded by it, and an earlier one would truncate \
+             the region and hide production code"
+        );
         let tests_at = src
-            .find("\n#[cfg(test)]\nmod ")
+            .find(anchor)
             .expect("test module not located — this pin cannot bound anything");
         &src[..tests_at]
     }
@@ -1528,32 +1541,37 @@ mod tests {
     /// `run_network_node_with_signals`, which also calls `shutdown_handle
     /// .shutdown()` but is NOT an operator stop (it must keep exiting 42).
     ///
-    /// So: exactly one store in production code, inside the signal-handler task.
+    /// So: exactly one way to raise the flag, in the signal-handler task, only
+    /// after a signal has actually arrived — and `finish_run` must be fed the
+    /// flag rather than a constant.
     #[test]
     fn shutdown_requested_is_stored_only_by_the_signal_handler() {
         let src = strip_line_comments(include_str!("freenet.rs"));
         let prod = production_region(&src);
-        let signal_task = braced_block(prod, "let signal_task = {");
+        let flat = squeeze(prod);
+        let signal_task = squeeze(braced_block(prod, "let signal_task = {"));
 
         // Anti-vacuity: if brace matching ran past the block, these markers from
         // later in `run_network_node_with_signals` would be inside it, and the
         // containment assertion below would prove nothing.
         for escaped in ["run_network_node(", "UpdateNeededError", "finish_run("] {
             assert!(
-                !signal_task.contains(escaped),
+                !signal_task.contains(&squeeze(escaped)),
                 "the scoped signal-task block escaped its braces (found `{escaped}`) — \
                  this pin would pass vacuously"
             );
         }
-        // Anti-vacuity, other direction: confirm we scoped the right block.
-        assert!(
-            squeeze(signal_task).contains(&squeeze("shutdown_handle.shutdown().await")),
-            "scoped block is not the signal-handler task"
-        );
+        // Anti-vacuity, other direction: confirm we scoped the right block. The
+        // marker must be one the TEMPTING block does not share — awaiting a
+        // signal is unique to this task, whereas `shutdown_handle.shutdown()`
+        // appears in the auto-update arm too and so would not discriminate.
+        let awaits_a_signal = signal_task
+            .rfind(&squeeze("ctrl_c()"))
+            .expect("scoped block is not the signal-handler task: it awaits no signal");
 
         let needle = squeeze("shutdown_requested.store(");
         assert_eq!(
-            squeeze(prod).matches(&needle).count(),
+            flat.matches(&needle).count(),
             1,
             "production code must set `shutdown_requested` in exactly ONE place. A \
              second store — most temptingly in the auto-update arm, which also calls \
@@ -1561,11 +1579,56 @@ mod tests {
              clean exit 0, so the service manager skips its self-heal and the node \
              stays dead (#5230)"
         );
+        let store_at = signal_task.find(&needle).unwrap_or_else(|| {
+            panic!(
+                "the one store must live in the signal-handler task, which is the \
+                 only place that knows an operator (SIGTERM/SIGINT) asked us to \
+                 stop (#5230)"
+            )
+        });
+        // Location alone is not the invariant: a store hoisted ABOVE the signal
+        // await would still sit inside this block, yet would raise the flag
+        // unconditionally at startup and launder EVERY fault into a clean exit 0.
+        assert!(
+            store_at > awaits_a_signal,
+            "the store must come AFTER the signal await, not before it — a hoisted \
+             store raises the flag at startup, so every fault exits 0 (#5230)"
+        );
+
+        // The needle above pins one spelling. These are the other ways to raise an
+        // `AtomicBool`, or to obtain a second handle to raise it through, each of
+        // which reopens the same hole while leaving the count at 1.
+        for alias in [
+            "shutdown_requested.swap(",
+            "shutdown_requested.fetch_or(",
+            "shutdown_requested.fetch_and(",
+            "shutdown_requested.compare_exchange",
+            "shutdown_requested.clone()",
+            "AtomicBool::store(",
+        ] {
+            assert!(
+                !flat.contains(&squeeze(alias)),
+                "`{alias}` is another way to raise `shutdown_requested` that the \
+                 single-store count above cannot see — route every request through \
+                 the one signal-handler store instead (#5230)"
+            );
+        }
         assert_eq!(
-            squeeze(signal_task).matches(&needle).count(),
+            flat.matches(&squeeze("Arc::clone(&shutdown_requested)"))
+                .count(),
             1,
-            "the one store must live in the signal-handler task, which is the only \
-             place that knows an operator (SIGTERM/SIGINT) asked us to stop (#5230)"
+            "only the signal-handler task may hold a second handle to the flag; \
+             another clone is a store site the count above cannot attribute (#5230)"
+        );
+
+        // The write site is only half of it. `finish_run` must be fed the FLAG: a
+        // constant `true` reopens the identical hole, and every other test in the
+        // repo either takes the bool as a parameter or drives it with a real
+        // signal, so none of them would notice.
+        assert!(
+            flat.contains(&squeeze("finish_run(result, shutdown_requested.load(")),
+            "`finish_run` must receive the live `shutdown_requested` flag — a \
+             constant would make every fault exit 0 (#5230)"
         );
     }
 

--- a/crates/core/src/bin/freenet.rs
+++ b/crates/core/src/bin/freenet.rs
@@ -1499,9 +1499,16 @@ mod tests {
     /// anchor fails LOUDLY rather than silently widening the scoped region —
     /// the #5102 failure mode that shipped twice.
     fn braced_block<'a>(src: &'a str, opener: &str) -> &'a str {
+        delimited_block(src, opener, '{', '}')
+    }
+
+    /// As `braced_block`, for an arbitrary delimiter pair — used to slice a call's
+    /// argument list, where asserting on a substring would let a widened
+    /// expression through (`shutdown_requested.load(..) || whatever`).
+    fn delimited_block<'a>(src: &'a str, opener: &str, open: char, close: char) -> &'a str {
         assert!(
-            opener.ends_with('{'),
-            "opener must end at the block's opening brace: {opener}"
+            opener.ends_with(open),
+            "opener must end at the opening delimiter: {opener}"
         );
         let at = src
             .find(opener)
@@ -1509,18 +1516,16 @@ mod tests {
         let body_start = at + opener.len();
         let mut depth = 1usize;
         for (i, c) in src[body_start..].char_indices() {
-            match c {
-                '{' => depth += 1,
-                '}' => {
-                    depth -= 1;
-                    if depth == 0 {
-                        return &src[body_start..body_start + i];
-                    }
+            if c == open {
+                depth += 1;
+            } else if c == close {
+                depth -= 1;
+                if depth == 0 {
+                    return &src[body_start..body_start + i];
                 }
-                _ => {}
             }
         }
-        panic!("braces never balanced after: {opener}");
+        panic!("delimiters never balanced after: {opener}");
     }
 
     /// #5230 rests entirely on `shutdown_requested` meaning EXACTLY "an operator
@@ -1541,20 +1546,35 @@ mod tests {
     /// `run_network_node_with_signals`, which also calls `shutdown_handle
     /// .shutdown()` but is NOT an operator stop (it must keep exiting 42).
     ///
-    /// So: exactly one way to raise the flag, in the signal-handler task, only
-    /// after a signal has actually arrived — and `finish_run` must be fed the
-    /// flag rather than a constant.
+    /// So: the flag is mentioned in production only in the four ways below, its
+    /// one store is in the signal-handler task, and it happens only after a
+    /// signal has actually arrived.
+    ///
+    /// The check is CLOSED-WORLD — an enumeration of every permitted mention —
+    /// rather than a blocklist of forbidden spellings. A blocklist was the first
+    /// attempt and it leaked badly: `(*shutdown_requested).store(..)`,
+    /// `shutdown_requested.as_ref().store(..)`, and passing `&shutdown_requested`
+    /// to a helper that stores through it all raise the flag while matching no
+    /// banned string. Enumerating what is ALLOWED needs no foresight about how
+    /// the next author might spell it.
     #[test]
     fn shutdown_requested_is_stored_only_by_the_signal_handler() {
         let src = strip_line_comments(include_str!("freenet.rs"));
         let prod = production_region(&src);
-        let flat = squeeze(prod);
         let signal_task = squeeze(braced_block(prod, "let signal_task = {"));
 
         // Anti-vacuity: if brace matching ran past the block, these markers from
         // later in `run_network_node_with_signals` would be inside it, and the
-        // containment assertion below would prove nothing.
-        for escaped in ["run_network_node(", "UpdateNeededError", "finish_run("] {
+        // containment assertion below would prove nothing. `update_tx` and
+        // `startup_update_check` bound the NEAR side of an over-run (the update
+        // loop, immediately after this block); the rest bound the far side.
+        for escaped in [
+            "update_tx",
+            "startup_update_check",
+            "run_network_node(",
+            "UpdateNeededError",
+            "finish_run(",
+        ] {
             assert!(
                 !signal_task.contains(&squeeze(escaped)),
                 "the scoped signal-task block escaped its braces (found `{escaped}`) — \
@@ -1564,28 +1584,57 @@ mod tests {
         // Anti-vacuity, other direction: confirm we scoped the right block. The
         // marker must be one the TEMPTING block does not share — awaiting a
         // signal is unique to this task, whereas `shutdown_handle.shutdown()`
-        // appears in the auto-update arm too and so would not discriminate.
-        let awaits_a_signal = signal_task
-            .rfind(&squeeze("ctrl_c()"))
+        // appears in the auto-update arm too and so would not discriminate. A set
+        // rather than one literal, so extracting the cfg-gated wait into a helper
+        // (a legitimate refactor) does not panic with a misleading message.
+        let awaits_a_signal = ["ctrl_c()", "sigterm.recv()", "shutdown_signal("]
+            .iter()
+            .filter_map(|m| signal_task.rfind(&squeeze(m)))
+            .max()
             .expect("scoped block is not the signal-handler task: it awaits no signal");
 
-        let needle = squeeze("shutdown_requested.store(");
+        // Every mention of the flag in production, in source order, identified by
+        // what FOLLOWS it. Anything else — any spelling, any new call site, any
+        // borrow handed to a helper — changes this list and fails.
+        let flat = squeeze(prod);
+        let follows: Vec<String> = flat
+            .split("shutdown_requested")
+            .skip(1)
+            .map(|after| after.chars().take(13).collect())
+            .collect();
+        let expected = [
+            // The `Arc<AtomicBool>` in `run_network_node_with_signals`:
+            "=Arc::new(std", // the declaration
+            "=Arc::clone(&", // the signal task's own handle
+            ");GlobalExecu", // ... the argument to that clone
+            ".store(true,s", // THE one write, in the signal task
+            ".load(std::sy", // the read that feeds `finish_run`
+            // `finish_run`'s parameter of the same name is a DISTINCT binding, a
+            // plain `bool`, so it cannot raise the flag:
+            ":bool)->anyho", // the parameter
+            "&&freenet::li", // the guard that consumes it
+        ];
         assert_eq!(
-            flat.matches(&needle).count(),
-            1,
-            "production code must set `shutdown_requested` in exactly ONE place. A \
-             second store — most temptingly in the auto-update arm, which also calls \
-             `shutdown_handle.shutdown()` — makes `finish_run` report a FAULT as a \
-             clean exit 0, so the service manager skips its self-heal and the node \
-             stays dead (#5230)"
+            follows, expected,
+            "production mentions `shutdown_requested` in a way this pin does not \
+             recognise. Every mention is enumerated on purpose: a new one is a new \
+             way to raise the flag (`(*flag).store(..)`, `flag.as_ref().store(..)`, \
+             `helper(&flag)`, `swap`/`fetch_or`/`compare_exchange`, a second \
+             `Arc::clone`), and raising it outside an operator stop makes \
+             `finish_run` report a FAULT as a clean exit 0 — the service manager \
+             skips its self-heal and the node stays dead (#5230). If the change is \
+             legitimate, extend the list deliberately"
         );
-        let store_at = signal_task.find(&needle).unwrap_or_else(|| {
-            panic!(
-                "the one store must live in the signal-handler task, which is the \
-                 only place that knows an operator (SIGTERM/SIGINT) asked us to \
-                 stop (#5230)"
-            )
-        });
+
+        let store_at = signal_task
+            .find(&squeeze("shutdown_requested.store("))
+            .unwrap_or_else(|| {
+                panic!(
+                    "the one store must live in the signal-handler task, which is \
+                     the only place that knows an operator (SIGTERM/SIGINT) asked \
+                     us to stop (#5230)"
+                )
+            });
         // Location alone is not the invariant: a store hoisted ABOVE the signal
         // await would still sit inside this block, yet would raise the flag
         // unconditionally at startup and launder EVERY fault into a clean exit 0.
@@ -1594,42 +1643,39 @@ mod tests {
             "the store must come AFTER the signal await, not before it — a hoisted \
              store raises the flag at startup, so every fault exits 0 (#5230)"
         );
+    }
 
-        // The needle above pins one spelling. These are the other ways to raise an
-        // `AtomicBool`, or to obtain a second handle to raise it through, each of
-        // which reopens the same hole while leaving the count at 1.
-        for alias in [
-            "shutdown_requested.swap(",
-            "shutdown_requested.fetch_or(",
-            "shutdown_requested.fetch_and(",
-            "shutdown_requested.compare_exchange",
-            "shutdown_requested.clone()",
-            "AtomicBool::store(",
-        ] {
+    /// The write site is only half of #5230: `finish_run` must be FED the flag.
+    ///
+    /// `finish_run(result, true)` reopens the identical hole without touching the
+    /// store, and so does widening the argument
+    /// (`shutdown_requested.load(..) || transports_lost`) — which is not
+    /// hypothetical, since lost client transports are one of the two faults that
+    /// must keep exiting non-zero. No other test covers this: the truth-table test
+    /// takes the bool as a parameter and `tests/graceful_shutdown_exit_code.rs`
+    /// drives it with a real signal.
+    ///
+    /// So the whole argument list is matched, not a prefix of it.
+    #[test]
+    fn finish_run_is_fed_the_live_shutdown_flag() {
+        let src = strip_line_comments(include_str!("freenet.rs"));
+        let prod = production_region(&src);
+        // `= finish_run(` is the CALL; `fn finish_run(` is the definition. Keying
+        // on the `=` identifies the call wherever it sits in the file.
+        let args = squeeze(delimited_block(prod, "= finish_run(", '(', ')'));
+        assert!(
+            args.contains(&squeeze("shutdown_requested.load(")),
+            "`finish_run` must receive the live `shutdown_requested` flag — a \
+             constant would make every fault exit 0 (#5230); got `{args}`"
+        );
+        for widened in ["||", "&&", "true", "false"] {
             assert!(
-                !flat.contains(&squeeze(alias)),
-                "`{alias}` is another way to raise `shutdown_requested` that the \
-                 single-store count above cannot see — route every request through \
-                 the one signal-handler store instead (#5230)"
+                !args.contains(widened),
+                "`finish_run`'s argument must be the flag ALONE: `{widened}` widens \
+                 the operator-stop test to cover something else, which is the #5230 \
+                 fault-laundering hole in a new spelling; got `{args}`"
             );
         }
-        assert_eq!(
-            flat.matches(&squeeze("Arc::clone(&shutdown_requested)"))
-                .count(),
-            1,
-            "only the signal-handler task may hold a second handle to the flag; \
-             another clone is a store site the count above cannot attribute (#5230)"
-        );
-
-        // The write site is only half of it. `finish_run` must be fed the FLAG: a
-        // constant `true` reopens the identical hole, and every other test in the
-        // repo either takes the bool as a parameter or drives it with a real
-        // signal, so none of them would notice.
-        assert!(
-            flat.contains(&squeeze("finish_run(result, shutdown_requested.load(")),
-            "`finish_run` must receive the live `shutdown_requested` flag — a \
-             constant would make every fault exit 0 (#5230)"
-        );
     }
 
     #[test]

--- a/crates/core/src/bin/freenet.rs
+++ b/crates/core/src/bin/freenet.rs
@@ -1452,6 +1452,123 @@ mod tests {
         assert!(finish_run(Ok(()), false).is_ok());
     }
 
+    /// Whitespace-stripped view of source text, so a source-scrape pin survives
+    /// `rustfmt` re-wrapping a call across lines (`shutdown_requested\n
+    /// .store(..)` would otherwise stop matching a contiguous needle).
+    fn squeeze(src: &str) -> String {
+        src.chars().filter(|c| !c.is_whitespace()).collect()
+    }
+
+    /// The part of this file BEFORE its `#[cfg(test)] mod tests`, i.e. production
+    /// code only.
+    ///
+    /// A pin that counts occurrences across the whole file counts its own
+    /// assertion literals too (`include_str!` pulls in the test module), so it
+    /// can never assert "exactly once". Cutting the region here is a structural
+    /// fix rather than the `concat!("a", "b")` needle-splitting used elsewhere in
+    /// this module, which only holds until someone writes the contiguous string.
+    ///
+    /// `.expect`, not a silent fallback: if the attribute stops matching, the
+    /// region would widen to the whole file and the pin would pass vacuously.
+    /// Refuse instead. (Same fail-closed reasoning as `commands::auto_update`'s
+    /// `fn_body`; see `.claude/rules/bug-prevention-patterns.md`.)
+    fn production_region(src: &str) -> &str {
+        let tests_at = src
+            .find("\n#[cfg(test)]\nmod ")
+            .expect("test module not located — this pin cannot bound anything");
+        &src[..tests_at]
+    }
+
+    /// Slice `src` from `opener` (which must end at the block's `{`) to its
+    /// brace-matched close.
+    ///
+    /// Panics when the anchor is missing or the braces never balance, so a moved
+    /// anchor fails LOUDLY rather than silently widening the scoped region —
+    /// the #5102 failure mode that shipped twice.
+    fn braced_block<'a>(src: &'a str, opener: &str) -> &'a str {
+        assert!(
+            opener.ends_with('{'),
+            "opener must end at the block's opening brace: {opener}"
+        );
+        let at = src
+            .find(opener)
+            .unwrap_or_else(|| panic!("block anchor not found: {opener}"));
+        let body_start = at + opener.len();
+        let mut depth = 1usize;
+        for (i, c) in src[body_start..].char_indices() {
+            match c {
+                '{' => depth += 1,
+                '}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return &src[body_start..body_start + i];
+                    }
+                }
+                _ => {}
+            }
+        }
+        panic!("braces never balanced after: {opener}");
+    }
+
+    /// #5230 rests entirely on `shutdown_requested` meaning EXACTLY "an operator
+    /// asked THIS process to stop". `finish_run` maps
+    /// `EventLoopExitReason::GracefulShutdown` to a success exit only when that
+    /// flag is set, because the identical sentinel is ALSO raised by faults — a
+    /// dead critical `p2p_protoc` channel, or `client_events` losing every client
+    /// transport. Those must keep exiting non-zero, or systemd skips the unit's
+    /// `ExecStopPost` self-heal and the macOS/Windows wrappers read "normal
+    /// shutdown" and leave the node DOWN.
+    ///
+    /// The whole discrimination therefore depends on there being exactly ONE
+    /// place that sets the flag. `finish_run_maps_only_a_requested_graceful_stop_to_success`
+    /// above takes it as a parameter, so it cannot see WHERE it is set: a second
+    /// store elsewhere would launder a fault into a success exit — the node exits
+    /// 0, looks healthy, and stays dead — with the entire suite green. The
+    /// tempting site is the auto-update arm of the `select!` in
+    /// `run_network_node_with_signals`, which also calls `shutdown_handle
+    /// .shutdown()` but is NOT an operator stop (it must keep exiting 42).
+    ///
+    /// So: exactly one store in production code, inside the signal-handler task.
+    #[test]
+    fn shutdown_requested_is_stored_only_by_the_signal_handler() {
+        let src = strip_line_comments(include_str!("freenet.rs"));
+        let prod = production_region(&src);
+        let signal_task = braced_block(prod, "let signal_task = {");
+
+        // Anti-vacuity: if brace matching ran past the block, these markers from
+        // later in `run_network_node_with_signals` would be inside it, and the
+        // containment assertion below would prove nothing.
+        for escaped in ["run_network_node(", "UpdateNeededError", "finish_run("] {
+            assert!(
+                !signal_task.contains(escaped),
+                "the scoped signal-task block escaped its braces (found `{escaped}`) — \
+                 this pin would pass vacuously"
+            );
+        }
+        // Anti-vacuity, other direction: confirm we scoped the right block.
+        assert!(
+            squeeze(signal_task).contains(&squeeze("shutdown_handle.shutdown().await")),
+            "scoped block is not the signal-handler task"
+        );
+
+        let needle = squeeze("shutdown_requested.store(");
+        assert_eq!(
+            squeeze(prod).matches(&needle).count(),
+            1,
+            "production code must set `shutdown_requested` in exactly ONE place. A \
+             second store — most temptingly in the auto-update arm, which also calls \
+             `shutdown_handle.shutdown()` — makes `finish_run` report a FAULT as a \
+             clean exit 0, so the service manager skips its self-heal and the node \
+             stays dead (#5230)"
+        );
+        assert_eq!(
+            squeeze(signal_task).matches(&needle).count(),
+            1,
+            "the one store must live in the signal-handler task, which is the only \
+             place that knows an operator (SIGTERM/SIGINT) asked us to stop (#5230)"
+        );
+    }
+
     #[test]
     fn auto_update_default_stays_enabled_flag_and_dirty_disable() {
         use super::auto_update_is_disabled;

--- a/crates/core/src/bin/freenet.rs
+++ b/crates/core/src/bin/freenet.rs
@@ -1510,6 +1510,16 @@ mod tests {
             opener.ends_with(open),
             "opener must end at the opening delimiter: {opener}"
         );
+        // Uniqueness, for the same reason `production_region` asserts it: this
+        // returns the FIRST match, so a second anchor would be sliced past in
+        // silence and every assertion below would describe the wrong block —
+        // fail-OPEN, the direction a bounded region exists to prevent.
+        assert_eq!(
+            src.matches(opener).count(),
+            1,
+            "expected exactly one `{opener}` in the scanned region; this slice \
+             takes the first, so any other is invisible to the pin that consumes it"
+        );
         let at = src
             .find(opener)
             .unwrap_or_else(|| panic!("block anchor not found: {opener}"));
@@ -1626,6 +1636,31 @@ mod tests {
              legitimate, extend the list deliberately"
         );
 
+        // The enumeration above identifies each mention by only the first 13
+        // characters that follow it, which stops well short of the initialiser:
+        // `AtomicBool::new(true)` leaves all seven windows byte-identical, keeps
+        // the single store where it belongs, and still raises the flag before any
+        // signal arrives — so EVERY fault exits 0. That is the #5230 hole itself,
+        // reached without tripping anything else in this file or in
+        // `tests/graceful_shutdown_exit_code.rs`, which asserts SIGTERM => 0 and
+        // is equally satisfied by a flag that is never false.
+        //
+        // Pinned separately rather than by widening the windows: reaching `false`
+        // needs ~50 characters, which would drag that much incidental following
+        // text into all seven entries and make every adjacent edit churn the list.
+        assert_eq!(
+            flat.matches(&squeeze(
+                "shutdown_requested = Arc::new(std::sync::atomic::AtomicBool::new(false))"
+            ))
+            .count(),
+            1,
+            "the flag must be DECLARED false, exactly once. It means `an operator \
+             asked THIS process to stop`, so any initialiser that can be true \
+             before the signal task observes a signal makes `finish_run` report a \
+             FAULT as a clean exit 0 — the service manager skips its self-heal and \
+             the node stays dead (#5230)"
+        );
+
         let store_at = signal_task
             .find(&squeeze("shutdown_requested.store("))
             .unwrap_or_else(|| {
@@ -1662,6 +1697,18 @@ mod tests {
         let prod = production_region(&src);
         // `= finish_run(` is the CALL; `fn finish_run(` is the definition. Keying
         // on the `=` identifies the call wherever it sits in the file.
+        //
+        // `delimited_block` asserts `= finish_run(` is unique, but a second call
+        // written `return finish_run(result, true);` carries no `=`, so it would
+        // slip past that check while re-opening the hole this pin is named for.
+        // Exactly two mentions: the one call, and the definition.
+        assert_eq!(
+            prod.matches("finish_run(").count(),
+            2,
+            "expected exactly one `finish_run` CALL and one definition in \
+             production. A second call site is not inspected by this pin, so it \
+             could be fed a constant and make every fault exit 0 (#5230)"
+        );
         let args = squeeze(delimited_block(prod, "= finish_run(", '(', ')'));
         assert!(
             args.contains(&squeeze("shutdown_requested.load(")),


### PR DESCRIPTION
## Problem

#5230 (shipped as 0.2.123) makes a requested graceful shutdown exit 0. It does that only when an `AtomicBool` confirms **this** process asked the node to stop:

```rust
Err(e) if shutdown_requested && freenet::listener_exit_is_graceful(&e) => Ok(()),
```

The second conjunct is load-bearing. The same `EventLoopExitReason::GracefulShutdown` sentinel is also raised by genuine faults — a critical `p2p_protoc` channel dying (`ChannelCloseReason::{Bridge, Controller, Notification, OpExecution}`), and `client_events.rs` losing every client transport. Those must keep exiting non-zero, or systemd skips the unit's `ExecStopPost` self-heal and does not count the crash toward probation, and the macOS/Windows wrappers read exit 0 as "normal shutdown" and stand down, leaving the node dead.

So the whole fault-vs-operator-stop discrimination rests on `shutdown_requested` meaning exactly "an operator asked us to stop".

Nothing tested that. `finish_run_maps_only_a_requested_graceful_stop_to_success` takes the flag as a parameter and `tests/graceful_shutdown_exit_code.rs` drives it with a real signal, so neither can see how the flag comes to be set, nor what is fed to `finish_run`. Several one-line edits reopen fault-laundering — the node exits 0, looks healthy, and stays dead — with a completely green test suite. The most tempting site is the auto-update arm of the `select!` in `run_network_node_with_signals`, which also calls `shutdown_handle.shutdown()` but is not an operator stop and must keep exiting 42.

Found by adversarial review of #5230, which rated it the highest-value follow-up.

## Approach

Test-only; no production logic is touched. Two pins.

**`shutdown_requested_is_stored_only_by_the_signal_handler`** — the flag is raised in exactly one place, in the signal-handler task, only after a signal has actually arrived.

The core of it is **closed-world**: an enumeration of every permitted mention of `shutdown_requested` in production, in source order, identified by what follows it. A blocklist of forbidden spellings was the first attempt and it leaked badly — `(*shutdown_requested).store(..)`, `shutdown_requested.as_ref().store(..)`, and handing `&shutdown_requested` to a helper that stores through it all raise the flag while matching no banned string and leaving the single-store count at 1. Enumerating what is forbidden needs foresight about how the next author will spell it; enumerating what is allowed does not. Writing the check immediately found two mentions I had not accounted for (`finish_run`'s own same-named parameter), which is the check working.

On top of that: the one `.store(` must sit inside the brace-matched `let signal_task = { … }` block, and **after** the signal await — a store hoisted to the top of that block stays inside it and keeps the count at 1, but raises the flag unconditionally at startup so every fault exits 0.

**`finish_run_is_fed_the_live_shutdown_flag`** — the write site is only half of it. `finish_run(result, true)` reopens the identical hole without touching the store. So does widening the argument (`shutdown_requested.load(..) || transports_lost`) — not hypothetical, since lost client transports are one of the two faults that must keep exiting non-zero. The whole paren-matched argument list is matched and `||`, `&&`, `true`, `false` rejected, rather than asserting a substring.

This repo has shipped two broken source-scrape pins (#5102), so the mechanics follow `.claude/rules/bug-prevention-patterns.md` deliberately:

- **The scanned region is bounded to the source before `#[cfg(test)] mod`** (`production_region`). A pin scanning the whole file would match its own assertion literals — `include_str!` pulls in the test module. Cutting the region is a structural fix, unlike the `concat!("a", "b")` needle-splitting used by the neighbouring pins in this file, which only holds until someone writes the contiguous string. The anchor is asserted **unique** rather than taking the first match: an earlier `#[cfg(test)] mod` would truncate the region and hide production code, fail-open in the one direction a bounded region exists to prevent.
- **Blocks are brace/paren-matched** (`braced_block`, `delimited_block`), not `split_once`'d. A bare `split_once` does not fail when its anchor moves; it matches a later occurrence and the region balloons silently. A missing anchor or unbalanced delimiters panics.
- **Anti-vacuity guards run both ways.** If brace matching escaped the signal-task block, one of `update_tx`, `startup_update_check`, `run_network_node(`, `UpdateNeededError`, `finish_run(` would be inside it — the first two bound the near side of an over-run, the rest the far side. Conversely the block must contain a signal await; that marker is a *set*, so extracting the cfg-gated wait into a helper (a legitimate refactor) fails informatively rather than panicking that the block is not the signal handler. The marker also had to be one the auto-update arm does not share: the first draft used `shutdown_handle.shutdown().await`, which appears in both, so it could not discriminate.
- **All matching is whitespace-stripped** (`squeeze`) so the pins survive `rustfmt` re-wrapping a call across lines.

## Testing

Eleven mutations. Each is applied to production code and its diff verified non-empty before running, so none is a mutation that failed to mutate; the driver reverts between runs and re-checks the baseline at the end.

| Mutation | Result | Assertion that fired |
|---|---|---|
| second `store(true, …)` in the auto-update arm | FAILED | closed-world mention list |
| **move** the store to the auto-update arm | FAILED | store not in the signal task |
| **hoist** the store above the signal await | FAILED | store-after-signal-await ordering |
| `shutdown_requested.swap(true, …)` in the arm | FAILED | closed-world mention list |
| `let sr = Arc::clone(&…); sr.store(…)` in the arm | FAILED | closed-world mention list |
| `(*shutdown_requested).store(true, …)` in the arm | FAILED | closed-world mention list |
| `shutdown_requested.as_ref().store(true, …)` in the arm | FAILED | closed-world mention list |
| helper `fn mark(flag: &AtomicBool)` + `mark(&shutdown_requested)` | FAILED | closed-world mention list |
| `finish_run(result, true)` | FAILED | both pins |
| `finish_run(result, …load(..) \|\| true)` | FAILED | argument-widening ban |
| `finish_run(result, …load(..) \|\| client_transports_lost)` | FAILED | argument-widening ban |

The last four in that list are the ones the *earlier* blocklist version of this pin let through; they are why it was rewritten closed-world.

Representative output:

```
MUTATION: helper-borrow-store-in-auto-update-arm
+fn mark_stop_requested(flag: &std::sync::atomic::AtomicBool) {
+    flag.store(true, std::sync::atomic::Ordering::SeqCst);
+}
+                    mark_stop_requested(&shutdown_requested);

test tests::shutdown_requested_is_stored_only_by_the_signal_handler ... FAILED
panicked at crates/core/src/bin/freenet.rs:1622:9:
production mentions `shutdown_requested` in a way this pin does not recognise. ...
test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 368 filtered out
```

```
MUTATION: finish_run-arg-widened-or-variable
+    let client_transports_lost = false;
-        shutdown_requested.load(std::sync::atomic::Ordering::SeqCst),
+        shutdown_requested.load(std::sync::atomic::Ordering::SeqCst) || client_transports_lost,

test tests::finish_run_is_fed_the_live_shutdown_flag ... FAILED
panicked at crates/core/src/bin/freenet.rs:1673:13:
`finish_run`'s argument must be the flag ALONE: `||` widens the operator-stop test to
cover something else, which is the #5230 fault-laundering hole in a new spelling; got
`result,shutdown_requested.load(std::sync::atomic::Ordering::SeqCst)||client_transports_lost,`
test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 368 filtered out
```

Reverted baseline, full `freenet` bin test module:

```
test result: ok. 370 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
git status: (clean)
```

## Known limits

These pins are source scrapes and inherit the class's limits: cutting the whole `#[cfg(test)] mod tests` disarms them, and they reason about text rather than semantics. Specific gaps left open, stated rather than papered over:

- The pins prove the correct `finish_run` call *exists*; they do not prove it *dominates* the exit code. Re-mapping `result` after the call would not be caught.
- **The flag's initial value is not pinned.** The enumeration records only the first 13 characters after each mention, so the declaration's window is `"=Arc::new(std"` and the initialiser sits past the cut. `AtomicBool::new(true)` therefore passes both pins while laundering every fault into a clean exit 0 — the #5230 hole itself. Nothing else in the tree catches it. Tracked in #5575.
- **Only the first `= finish_run(` call site is inspected.** `delimited_block` takes the first match with no uniqueness assertion, unlike `production_region`. A later `return finish_run(result, true);` passes both pins. Distinct from the re-mapping limit above, because it is a `finish_run` call fed a constant. Tracked in #5575.
- Lesser, also in #5575: the widening check is a blocklist (leaks single `|`, `^`, `.max()`); the anti-vacuity escape markers are never asserted to exist, so renaming one silently disarms that guard; and `shutdown_signal(` matches nothing in the file, so the claim that the marker set lets a helper extraction "fail informatively" holds only if the helper is named with that substring. The "all matching is whitespace-stripped" note applies to block *contents*, not to the three anchors, which are matched against unsqueezed text.
- Review raised a stronger alternative: replace the `Arc<AtomicBool>` with a `oneshot::Sender`, which is `!Clone` and consumed by `send`, making "exactly one raiser, exactly once" a compile-time property and deleting the need for the scrape. That is a production-logic change and out of scope for this test-only PR.

Follow-up to #5230.

[AI-assisted - Claude]

