### PR TITLE
fix(service): don't count a deliberate systemd stop as a crash

### DIFF
--- a/crates/core/src/bin/commands/service.rs
+++ b/crates/core/src/bin/commands/service.rs
@@ -1446,8 +1446,10 @@ mod tests {
         );
         // #4073 / #4551: ExecStopPost must fire `freenet update` for ANY
         // non-graceful exit — every status except 0 (graceful) and 43 (another
-        // instance) — so it covers the voluntary update-needed 42, the fast-crash
-        // 45, AND the panic/signal/early-error codes the watchdog never produces.
+        // instance), and, since #5227, except a deliberate stop identified by
+        // $SERVICE_RESULT ahead of this case — so it covers the voluntary
+        // update-needed 42, the fast-crash 45, AND the panic/signal/early-error
+        // codes the watchdog never produces.
         // Firing broadly preserves the #4549 self-heal AND enables crash-loop
         // rollback (#4073); 45 and the crash codes staying out of
         // SuccessExitStatus still count toward StartLimitBurst. A `case` (not
@@ -1456,7 +1458,10 @@ mod tests {
             service_content.contains("case \"$$EXIT_STATUS\" in 0|43) ;; *)")
                 && service_content.contains("update --quiet"),
             "ExecStopPost must run `freenet update` for any non-graceful exit via a \
-             case that skips only 0 and 43 (#4073 broadened crash coverage; #4551)"
+             case that skips 0 and 43 (#4073 broadened crash coverage; #4551). Since \
+             #5227 a deliberate stop is skipped as well, by a separate \
+             $SERVICE_RESULT guard ahead of this case — see \
+             service::linux::tests::exec_stop_post_counts_crashes_and_skips_deliberate_stops"
         );
         assert!(
             !service_content.contains("42|45)"),
@@ -1555,12 +1560,16 @@ mod tests {
             "ExecStopPost must use the doubled $$EXIT_STATUS (single-$ revert breaks auto-update)"
         );
         // #4073 / #4551: ExecStopPost fires `freenet update` for ANY non-graceful
-        // exit (every status except 0 and 43) — system unit too.
+        // exit (every status except 0 and 43, and since #5227 except a deliberate
+        // stop identified by $SERVICE_RESULT) — system unit too.
         assert!(
             service_content.contains("case \"$$EXIT_STATUS\" in 0|43) ;; *)")
                 && service_content.contains("update --quiet"),
             "ExecStopPost must run `freenet update` for any non-graceful exit via a \
-             case that skips only 0 and 43 (#4073 broadened crash coverage; #4551)"
+             case that skips 0 and 43 (#4073 broadened crash coverage; #4551). Since \
+             #5227 a deliberate stop is skipped as well, by a separate \
+             $SERVICE_RESULT guard ahead of this case — see \
+             service::linux::tests::exec_stop_post_counts_crashes_and_skips_deliberate_stops"
         );
         assert!(
             !service_content.contains("42|45)"),

--- a/crates/core/src/bin/commands/service/linux.rs
+++ b/crates/core/src/bin/commands/service/linux.rs
@@ -536,7 +536,32 @@ TimeoutStopSec=45
 # `freenet update` so #4073 can tell a post-stop restart from a manual update
 # and classify the crash; an OLD binary (e.g. one we rolled back TO) ignores the
 # unknown env var.
-ExecStopPost=-/bin/sh -c 'case "$$EXIT_STATUS" in 0|43) ;; *) {post_stop_env}="$$EXIT_STATUS" {binary} update --quiet ;; esac'
+#
+# A DELIBERATE STOP IS NOT A CRASH (#5227). The leading guard skips the hook when
+# systemd reports the unit's $SERVICE_RESULT as "success" AND $EXIT_CODE as
+# "killed" — i.e. systemd itself considers this a clean stop and the process died
+# from a signal rather than by exiting. Per `man systemd.exec` ($SERVICE_RESULT
+# table) that combination is precisely "killed by HUP/INT/TERM/PIPE under the
+# default disposition", which is what happens when a `systemctl stop` lands
+# BEFORE the node has installed its own SIGTERM handler (it is installed after
+# the redb open and contract-store load, which on a large gateway is not brief).
+# systemd then passes $EXIT_STATUS as the signal NAME "TERM"; the $EXIT_STATUS
+# case below has no arm for names, so it fell through to `*)` and rollback.rs
+# scored a clean stop as a post-update probation crash.
+#
+# The guard is narrow ON PURPOSE. This hook is not only the self-heal — it is
+# also what COUNTS crashes for the #4073 rollback, so an over-broad skip would
+# silently disarm rollback, which is worse than the bug it fixes. Still counted:
+#   "exit-code"  panic 101, fast-crash 45, early-startup error 1 (EXIT_CODE=exited)
+#   "signal" / "core-dump"   SEGV, ABRT
+#   "oom-kill"   EXIT_CODE IS "killed", but the result is not "success"
+#   "timeout"    a stop that hung past TimeoutStopSec and was escalated
+#   "watchdog"   keep-alive deadline missed
+# The voluntary update exit 42 also still runs the updater: SuccessExitStatus=42
+# does make its $SERVICE_RESULT "success", but its $EXIT_CODE is "exited", not
+# "killed", so the guard does not match. On systemd < 232 $SERVICE_RESULT is unset,
+# the guard can never match, and the unit degrades to exactly the old behaviour.
+ExecStopPost=-/bin/sh -c 'case "$$SERVICE_RESULT $$EXIT_CODE" in "success killed") exit 0 ;; esac; case "$$EXIT_STATUS" in 0|43) ;; *) {post_stop_env}="$$EXIT_STATUS" {binary} update --quiet ;; esac'
 # Exit 42 (auto-update) and 43 (another instance) are clean exits, so they are
 # not counted as failures — without this, rapid update cycles (exit 42 →
 # ExecStopPost → restart) could exhaust the burst limit and kill the service.
@@ -694,7 +719,32 @@ TimeoutStopSec=45
 # `freenet update` so #4073 can tell a post-stop restart from a manual update
 # and classify the crash; an OLD binary (e.g. one we rolled back TO) ignores the
 # unknown env var.
-ExecStopPost=-/bin/sh -c 'case "$$EXIT_STATUS" in 0|43) ;; *) {post_stop_env}="$$EXIT_STATUS" {binary} update --quiet ;; esac'
+#
+# A DELIBERATE STOP IS NOT A CRASH (#5227). The leading guard skips the hook when
+# systemd reports the unit's $SERVICE_RESULT as "success" AND $EXIT_CODE as
+# "killed" — i.e. systemd itself considers this a clean stop and the process died
+# from a signal rather than by exiting. Per `man systemd.exec` ($SERVICE_RESULT
+# table) that combination is precisely "killed by HUP/INT/TERM/PIPE under the
+# default disposition", which is what happens when a `systemctl stop` lands
+# BEFORE the node has installed its own SIGTERM handler (it is installed after
+# the redb open and contract-store load, which on a large gateway is not brief).
+# systemd then passes $EXIT_STATUS as the signal NAME "TERM"; the $EXIT_STATUS
+# case below has no arm for names, so it fell through to `*)` and rollback.rs
+# scored a clean stop as a post-update probation crash.
+#
+# The guard is narrow ON PURPOSE. This hook is not only the self-heal — it is
+# also what COUNTS crashes for the #4073 rollback, so an over-broad skip would
+# silently disarm rollback, which is worse than the bug it fixes. Still counted:
+#   "exit-code"  panic 101, fast-crash 45, early-startup error 1 (EXIT_CODE=exited)
+#   "signal" / "core-dump"   SEGV, ABRT
+#   "oom-kill"   EXIT_CODE IS "killed", but the result is not "success"
+#   "timeout"    a stop that hung past TimeoutStopSec and was escalated
+#   "watchdog"   keep-alive deadline missed
+# The voluntary update exit 42 also still runs the updater: SuccessExitStatus=42
+# does make its $SERVICE_RESULT "success", but its $EXIT_CODE is "exited", not
+# "killed", so the guard does not match. On systemd < 232 $SERVICE_RESULT is unset,
+# the guard can never match, and the unit degrades to exactly the old behaviour.
+ExecStopPost=-/bin/sh -c 'case "$$SERVICE_RESULT $$EXIT_CODE" in "success killed") exit 0 ;; esac; case "$$EXIT_STATUS" in 0|43) ;; *) {post_stop_env}="$$EXIT_STATUS" {binary} update --quiet ;; esac'
 # Exit 42 (auto-update) and 43 (another instance) are clean exits, so they are
 # not counted as failures — without this, rapid update cycles (exit 42 →
 # ExecStopPost → restart) could exhaust the burst limit and kill the service.
@@ -1064,6 +1114,286 @@ mod tests {
                 "{name} unit still uses the narrow 42|45 ExecStopPost guard, missing \
                  panic/signal/early-error crashes (#4073 M1)"
             );
+        }
+    }
+
+    // ── ExecStopPost decision matrix, executed against a real /bin/sh ──────
+    //
+    // The hook does TWO jobs: it self-heals (#4549) and it COUNTS crashes for
+    // the #4073 post-update rollback. So the interesting property is not "a
+    // deliberate stop is skipped" on its own — a test pinning only that would
+    // stay green if someone disabled crash counting outright. Every case below
+    // asserts the decision in BOTH directions, and the crash cases are the
+    // load-bearing half.
+    //
+    // Rather than string-matching the template we extract the script systemd
+    // would hand to `/bin/sh`, undo systemd's `$$` escaping, and actually run it
+    // with the environment systemd documents for each scenario. That exercises
+    // the real shell quoting/`case` semantics; only systemd's own choice of
+    // variable VALUES is modelled, and those come straight from the
+    // `$SERVICE_RESULT` table in `man systemd.exec`.
+
+    /// Extract the `/bin/sh -c '<script>'` body from a unit's `ExecStopPost=`
+    /// line, undoing systemd's `$$` → `$` escaping.
+    fn exec_stop_post_script(unit: &str) -> String {
+        let line = unit
+            .lines()
+            .find(|l| l.starts_with("ExecStopPost="))
+            .expect("unit must contain an ExecStopPost= line");
+        let start = line
+            .find('\'')
+            .expect("ExecStopPost must single-quote its script for systemd");
+        let end = line
+            .rfind('\'')
+            .expect("ExecStopPost script must be closed by a single quote");
+        assert!(end > start, "ExecStopPost script must not be empty");
+        line[start + 1..end].replace("$$", "$")
+    }
+
+    /// One row of the systemd `$SERVICE_RESULT` table (`man systemd.exec`).
+    struct StopPostCase {
+        /// What produced this combination on a real node.
+        scenario: &'static str,
+        /// `None` models systemd < 232, where the variable is not set at all.
+        service_result: Option<&'static str>,
+        exit_code: Option<&'static str>,
+        exit_status: &'static str,
+        /// Must `freenet update` run (i.e. must this stop be counted / healed)?
+        expect_update: bool,
+    }
+
+    /// Run the extracted hook under `/bin/sh` with one scenario's environment.
+    /// Returns whether the hook invoked the (faked) `freenet update`, and the
+    /// `$EXIT_STATUS` it forwarded through the env var when it did.
+    fn run_hook(script: &str, dir: &Path, case: &StopPostCase) -> (bool, String) {
+        let marker = dir.join("update-ran");
+        let _ = std::fs::remove_file(&marker);
+
+        let mut cmd = std::process::Command::new("/bin/sh");
+        cmd.arg("-c").arg(script);
+        // systemd sets exactly these three; start from a known-clean slate so an
+        // inherited value from the test runner cannot mask a missing guard.
+        cmd.env_remove("SERVICE_RESULT");
+        cmd.env_remove("EXIT_CODE");
+        cmd.env_remove("EXIT_STATUS");
+        if let Some(v) = case.service_result {
+            cmd.env("SERVICE_RESULT", v);
+        }
+        if let Some(v) = case.exit_code {
+            cmd.env("EXIT_CODE", v);
+        }
+        cmd.env("EXIT_STATUS", case.exit_status);
+
+        let status = cmd.status().expect("failed to spawn /bin/sh");
+        assert!(
+            status.success(),
+            "ExecStopPost script exited {status} for scenario {:?}; a syntax error here \
+             would make systemd skip the hook (and thus crash counting) on every stop",
+            case.scenario
+        );
+
+        match std::fs::read_to_string(&marker) {
+            Ok(forwarded) => (true, forwarded.trim().to_string()),
+            Err(_) => (false, String::new()),
+        }
+    }
+
+    /// Write a stand-in for the `freenet` binary that records that it ran and
+    /// which `$EXIT_STATUS` the hook forwarded to it.
+    fn write_fake_binary(dir: &Path) -> std::path::PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+        let bin = dir.join("freenet");
+        let marker = dir.join("update-ran");
+        // Read the forwarded status through the SAME constant the template
+        // interpolates, so a rename cannot leave this test silently checking a
+        // variable nothing sets.
+        let env = super::super::super::rollback::POST_STOP_EXIT_CODE_ENV_VAR;
+        std::fs::write(
+            &bin,
+            format!(
+                "#!/bin/sh\nprintf '%s' \"${env}\" > '{}'\n",
+                marker.display()
+            ),
+        )
+        .unwrap();
+        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+        bin
+    }
+
+    /// #5227 / #4073. A deliberate `systemctl stop` must NOT be counted as a
+    /// crash even when the SIGTERM lands before the node installs its own
+    /// handler (so the process dies under the default disposition and systemd
+    /// reports `$EXIT_STATUS` as the signal NAME "TERM") — while every genuine
+    /// fault MUST still reach `freenet update`, because that hook is what counts
+    /// crashes for the post-update rollback.
+    #[test]
+    fn exec_stop_post_counts_crashes_and_skips_deliberate_stops() {
+        let cases = [
+            // ── Deliberate stops: must NOT be counted ──────────────────────
+            StopPostCase {
+                scenario: "systemctl stop, node handled SIGTERM and exited 0",
+                service_result: Some("success"),
+                exit_code: Some("exited"),
+                exit_status: "0",
+                expect_update: false,
+            },
+            StopPostCase {
+                // The #5227 regression: SIGTERM before the handler is installed.
+                scenario: "systemctl stop during startup, killed by SIGTERM (default disposition)",
+                service_result: Some("success"),
+                exit_code: Some("killed"),
+                exit_status: "TERM",
+                expect_update: false,
+            },
+            StopPostCase {
+                scenario: "Ctrl+C / SIGINT before the handler is installed",
+                service_result: Some("success"),
+                exit_code: Some("killed"),
+                exit_status: "INT",
+                expect_update: false,
+            },
+            StopPostCase {
+                scenario: "another instance already holds the port (exit 43)",
+                service_result: Some("success"),
+                exit_code: Some("exited"),
+                exit_status: "43",
+                expect_update: false,
+            },
+            // ── Faults and the voluntary update: MUST still run the hook ───
+            StopPostCase {
+                // Load-bearing: SuccessExitStatus=42 makes systemd call this
+                // result "success" too, so a guard keyed on $SERVICE_RESULT
+                // ALONE would silently disable auto-update entirely.
+                scenario: "voluntary update-needed exit 42",
+                service_result: Some("success"),
+                exit_code: Some("exited"),
+                exit_status: "42",
+                expect_update: true,
+            },
+            StopPostCase {
+                scenario: "panic (exit 101)",
+                service_result: Some("exit-code"),
+                exit_code: Some("exited"),
+                exit_status: "101",
+                expect_update: true,
+            },
+            StopPostCase {
+                scenario: "fast crash / boot wedge (exit 45, #4551)",
+                service_result: Some("exit-code"),
+                exit_code: Some("exited"),
+                exit_status: "45",
+                expect_update: true,
+            },
+            StopPostCase {
+                scenario: "early startup error (exit 1)",
+                service_result: Some("exit-code"),
+                exit_code: Some("exited"),
+                exit_status: "1",
+                expect_update: true,
+            },
+            StopPostCase {
+                scenario: "SIGSEGV with core dump",
+                service_result: Some("core-dump"),
+                exit_code: Some("dumped"),
+                exit_status: "SEGV",
+                expect_update: true,
+            },
+            StopPostCase {
+                scenario: "SIGABRT",
+                service_result: Some("signal"),
+                exit_code: Some("killed"),
+                exit_status: "ABRT",
+                expect_update: true,
+            },
+            StopPostCase {
+                // $EXIT_CODE is "killed" here too — proof the guard needs BOTH
+                // variables and cannot key on the disposition alone.
+                scenario: "OOM killer",
+                service_result: Some("oom-kill"),
+                exit_code: Some("killed"),
+                exit_status: "KILL",
+                expect_update: true,
+            },
+            StopPostCase {
+                // Likewise "killed", but a hung shutdown is a fault. systemd
+                // documents both TERM and KILL for a timeout; a local systemd
+                // 255 probe produced KILL, so both are covered.
+                scenario: "shutdown hung past TimeoutStopSec, escalated to SIGKILL",
+                service_result: Some("timeout"),
+                exit_code: Some("killed"),
+                exit_status: "KILL",
+                expect_update: true,
+            },
+            StopPostCase {
+                scenario: "shutdown timed out while systemd was still on SIGTERM",
+                service_result: Some("timeout"),
+                exit_code: Some("killed"),
+                exit_status: "TERM",
+                expect_update: true,
+            },
+            StopPostCase {
+                scenario: "watchdog keep-alive deadline missed",
+                service_result: Some("watchdog"),
+                exit_code: Some("killed"),
+                exit_status: "TERM",
+                expect_update: true,
+            },
+            // ── systemd < 232 has no $SERVICE_RESULT: degrade to the old rule ──
+            StopPostCase {
+                scenario: "legacy systemd (<232), no $SERVICE_RESULT, clean exit 0",
+                service_result: None,
+                exit_code: None,
+                exit_status: "0",
+                expect_update: false,
+            },
+            StopPostCase {
+                scenario: "legacy systemd (<232), no $SERVICE_RESULT, panic",
+                service_result: None,
+                exit_code: None,
+                exit_status: "101",
+                expect_update: true,
+            },
+        ];
+
+        for unit_kind in ["user", "system"] {
+            let tmp = tempfile::tempdir().unwrap();
+            let bin = write_fake_binary(tmp.path());
+            let log_dir = tmp.path().join("logs");
+
+            let unit = match unit_kind {
+                "user" => generate_user_service_file(&bin, &log_dir),
+                _ => generate_system_service_file(&bin, &log_dir, "testuser", tmp.path()),
+            };
+            let script = exec_stop_post_script(&unit);
+
+            for case in &cases {
+                let (ran, forwarded) = run_hook(&script, tmp.path(), case);
+                assert_eq!(
+                    ran,
+                    case.expect_update,
+                    "{unit_kind} unit, scenario {:?} (SERVICE_RESULT={:?} EXIT_CODE={:?} \
+                     EXIT_STATUS={:?}): expected `freenet update` to {}, but it {}. \
+                     Skipping a genuine fault silently disarms the #4073 crash-loop rollback.",
+                    case.scenario,
+                    case.service_result,
+                    case.exit_code,
+                    case.exit_status,
+                    if case.expect_update {
+                        "run"
+                    } else {
+                        "be skipped"
+                    },
+                    if ran { "ran" } else { "was skipped" },
+                );
+                if ran {
+                    assert_eq!(
+                        forwarded, case.exit_status,
+                        "{unit_kind} unit, scenario {:?}: the hook must forward the node's \
+                         stop status to `freenet update` so #4073 can classify it",
+                        case.scenario
+                    );
+                }
+            }
         }
     }
 }

--- a/crates/core/src/bin/commands/service/linux.rs
+++ b/crates/core/src/bin/commands/service/linux.rs
@@ -1235,7 +1235,19 @@ mod tests {
     /// `$EXIT_STATUS` it forwarded through the env var when it did.
     fn run_hook(script: &str, dir: &Path, case: &StopPostCase) -> (bool, String) {
         let marker = dir.join("update-ran");
-        let _ = std::fs::remove_file(&marker);
+        // Not `let _ =`: a marker left behind by the previous scenario would make
+        // the NEXT one report `freenet update` as having run when it did not, so
+        // every "must skip" row would pass while measuring the wrong thing. The
+        // absent case is the normal one and is the only tolerated error.
+        match std::fs::remove_file(&marker) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => panic!(
+                "could not clear the {} marker between scenarios ({e}); a stale \
+                 marker would make this matrix report skipped hooks as having run",
+                marker.display()
+            ),
+        }
 
         let mut cmd = std::process::Command::new("/bin/sh");
         cmd.arg("-c").arg(script);

--- a/crates/core/src/bin/commands/service/linux.rs
+++ b/crates/core/src/bin/commands/service/linux.rs
@@ -551,16 +551,40 @@ TimeoutStopSec=45
 #
 # The guard is narrow ON PURPOSE. This hook is not only the self-heal — it is
 # also what COUNTS crashes for the #4073 rollback, so an over-broad skip would
-# silently disarm rollback, which is worse than the bug it fixes. Still counted:
-#   "exit-code"  panic 101, fast-crash 45, early-startup error 1 (EXIT_CODE=exited)
-#   "signal" / "core-dump"   SEGV, ABRT
-#   "oom-kill"   EXIT_CODE IS "killed", but the result is not "success"
-#   "timeout"    a stop that hung past TimeoutStopSec and was escalated
-#   "watchdog"   keep-alive deadline missed
+# silently disarm rollback, which is worse than the bug it fixes. Every other
+# $SERVICE_RESULT still reaches `freenet update` and is still counted:
+#   "exit-code"       panic 101, fast-crash 45, early-startup error 1
+#   "signal"          ABRT/KILL etc. NOT sent as part of a stop job
+#   "core-dump"       SEGV, ABRT with a core
+#   "oom-kill"        $EXIT_CODE IS "killed", but the result is not "success"
+#   "timeout"         a stop that hung past TimeoutStopSec and was escalated
+#   "exec-condition"  ExecCondition= failed
+#   "protocol", "start-limit-hit", "resources"
+# ("watchdog" is also unaffected but is UNREACHABLE for these units: neither sets
+# WatchdogSec=. Do not cite it as evidence that the guard is narrow.)
 # The voluntary update exit 42 also still runs the updater: SuccessExitStatus=42
 # does make its $SERVICE_RESULT "success", but its $EXIT_CODE is "exited", not
 # "killed", so the guard does not match. On systemd < 232 $SERVICE_RESULT is unset,
 # the guard can never match, and the unit degrades to exactly the old behaviour.
+#
+# TWO CONSEQUENCES TO KEEP IN MIND BEFORE CHANGING ANYTHING NEARBY:
+#
+# 1. The node must NEVER die by SIGTERM/SIGINT/SIGHUP/SIGPIPE as a way of
+#    reporting a FAULT. systemd cannot tell who sent a signal, so all four are
+#    indistinguishable from an operator's stop and are now uncounted. There is
+#    no such path today (the fatal-listener and redb-poison aborts use
+#    `process::exit`, and Rust's runtime sets SIGPIPE to SIG_IGN). If you add
+#    one — `libc::raise`, restoring the default SIGPIPE disposition, an abort
+#    routed through TERM — that fault becomes permanently invisible to rollback.
+#    Exit with a CODE instead.
+#
+# 2. A release that HANGS in this pre-handler window (rather than crashing) no
+#    longer produces any rollback signal at all: it never exits, so
+#    StartLimitBurst never trips, and an operator's `systemctl stop` is now
+#    (correctly) not counted. That rescue path was an accident of the very
+#    ambiguity that caused #5227 and cannot be kept without reinstating the bug.
+#    Detecting a startup HANG needs a real mechanism — WatchdogSec=, or
+#    installing the signal handler before the heavy startup work — not this hook.
 ExecStopPost=-/bin/sh -c 'case "$$SERVICE_RESULT $$EXIT_CODE" in "success killed") exit 0 ;; esac; case "$$EXIT_STATUS" in 0|43) ;; *) {post_stop_env}="$$EXIT_STATUS" {binary} update --quiet ;; esac'
 # Exit 42 (auto-update) and 43 (another instance) are clean exits, so they are
 # not counted as failures — without this, rapid update cycles (exit 42 →
@@ -734,16 +758,40 @@ TimeoutStopSec=45
 #
 # The guard is narrow ON PURPOSE. This hook is not only the self-heal — it is
 # also what COUNTS crashes for the #4073 rollback, so an over-broad skip would
-# silently disarm rollback, which is worse than the bug it fixes. Still counted:
-#   "exit-code"  panic 101, fast-crash 45, early-startup error 1 (EXIT_CODE=exited)
-#   "signal" / "core-dump"   SEGV, ABRT
-#   "oom-kill"   EXIT_CODE IS "killed", but the result is not "success"
-#   "timeout"    a stop that hung past TimeoutStopSec and was escalated
-#   "watchdog"   keep-alive deadline missed
+# silently disarm rollback, which is worse than the bug it fixes. Every other
+# $SERVICE_RESULT still reaches `freenet update` and is still counted:
+#   "exit-code"       panic 101, fast-crash 45, early-startup error 1
+#   "signal"          ABRT/KILL etc. NOT sent as part of a stop job
+#   "core-dump"       SEGV, ABRT with a core
+#   "oom-kill"        $EXIT_CODE IS "killed", but the result is not "success"
+#   "timeout"         a stop that hung past TimeoutStopSec and was escalated
+#   "exec-condition"  ExecCondition= failed
+#   "protocol", "start-limit-hit", "resources"
+# ("watchdog" is also unaffected but is UNREACHABLE for these units: neither sets
+# WatchdogSec=. Do not cite it as evidence that the guard is narrow.)
 # The voluntary update exit 42 also still runs the updater: SuccessExitStatus=42
 # does make its $SERVICE_RESULT "success", but its $EXIT_CODE is "exited", not
 # "killed", so the guard does not match. On systemd < 232 $SERVICE_RESULT is unset,
 # the guard can never match, and the unit degrades to exactly the old behaviour.
+#
+# TWO CONSEQUENCES TO KEEP IN MIND BEFORE CHANGING ANYTHING NEARBY:
+#
+# 1. The node must NEVER die by SIGTERM/SIGINT/SIGHUP/SIGPIPE as a way of
+#    reporting a FAULT. systemd cannot tell who sent a signal, so all four are
+#    indistinguishable from an operator's stop and are now uncounted. There is
+#    no such path today (the fatal-listener and redb-poison aborts use
+#    `process::exit`, and Rust's runtime sets SIGPIPE to SIG_IGN). If you add
+#    one — `libc::raise`, restoring the default SIGPIPE disposition, an abort
+#    routed through TERM — that fault becomes permanently invisible to rollback.
+#    Exit with a CODE instead.
+#
+# 2. A release that HANGS in this pre-handler window (rather than crashing) no
+#    longer produces any rollback signal at all: it never exits, so
+#    StartLimitBurst never trips, and an operator's `systemctl stop` is now
+#    (correctly) not counted. That rescue path was an accident of the very
+#    ambiguity that caused #5227 and cannot be kept without reinstating the bug.
+#    Detecting a startup HANG needs a real mechanism — WatchdogSec=, or
+#    installing the signal handler before the heavy startup work — not this hook.
 ExecStopPost=-/bin/sh -c 'case "$$SERVICE_RESULT $$EXIT_CODE" in "success killed") exit 0 ;; esac; case "$$EXIT_STATUS" in 0|43) ;; *) {post_stop_env}="$$EXIT_STATUS" {binary} update --quiet ;; esac'
 # Exit 42 (auto-update) and 43 (another instance) are clean exits, so they are
 # not counted as failures — without this, rapid update cycles (exit 42 →
@@ -1083,14 +1131,17 @@ mod tests {
 
     #[test]
     fn systemd_units_pass_node_exit_code_to_post_stop_update() {
-        // #4073 crash-loop auto-rollback: ExecStopPost must (a) fire on ANY
-        // non-graceful exit (every status except 0 and 43) so panics / signals /
-        // early errors are covered, and (b) forward the node's stop status to
-        // `freenet update` via the env var so the updater can classify the
-        // crash. systemd escapes `$$` to a literal `$`.
+        // #4073 crash-loop auto-rollback: ExecStopPost must (a) fire on any
+        // non-graceful exit — every status except 0 and 43, and, since #5227,
+        // except a deliberate stop identified by $SERVICE_RESULT (see
+        // `exec_stop_post_counts_crashes_and_skips_deliberate_stops` for the
+        // full decision matrix) — so panics / signals / early errors are
+        // covered, and (b) forward the node's stop status to `freenet update`
+        // via the env var so the updater can classify the crash. systemd
+        // escapes `$$` to a literal `$`.
         let env = super::super::super::rollback::POST_STOP_EXIT_CODE_ENV_VAR;
-        // Broadened guard: skip only 0 and 43; run update (with the status
-        // forwarded) for everything else.
+        // Skip 0 and 43; run update (with the status forwarded) for everything
+        // else that gets past the #5227 deliberate-stop guard.
         let expected = format!(r#"case "$$EXIT_STATUS" in 0|43) ;; *) {env}="$$EXIT_STATUS""#);
         let user_unit = generate_user_service_file(
             Path::new("/usr/local/bin/freenet"),
@@ -1114,6 +1165,20 @@ mod tests {
                 "{name} unit still uses the narrow 42|45 ExecStopPost guard, missing \
                  panic/signal/early-error crashes (#4073 M1)"
             );
+            // #5227: the deliberate-stop variables must ALSO be doubled. A
+            // single-`$` revert is invisible to the decision-matrix test — it
+            // un-doubles `$$` before running the script, so both spellings
+            // produce identical text there — which is exactly why the doubling
+            // is pinned here, on the raw template, alongside $$EXIT_STATUS.
+            for var in ["$$SERVICE_RESULT", "$$EXIT_CODE"] {
+                assert!(
+                    unit.contains(var),
+                    "{name} unit must use the doubled {var} so systemd passes a literal \
+                     ${} through to sh (a single-$ revert makes the guard compare empty \
+                     strings, so a deliberate stop is counted as a crash again, #5227)",
+                    var.trim_start_matches('$')
+                );
+            }
         }
     }
 
@@ -1156,8 +1221,11 @@ mod tests {
         scenario: &'static str,
         /// `None` models systemd < 232, where the variable is not set at all.
         service_result: Option<&'static str>,
+        /// `None` models the results for which systemd sets neither $EXIT_CODE
+        /// nor $EXIT_STATUS, because it never identified a main process
+        /// ("protocol", "start-limit-hit").
         exit_code: Option<&'static str>,
-        exit_status: &'static str,
+        exit_status: Option<&'static str>,
         /// Must `freenet update` run (i.e. must this stop be counted / healed)?
         expect_update: bool,
     }
@@ -1182,13 +1250,17 @@ mod tests {
         if let Some(v) = case.exit_code {
             cmd.env("EXIT_CODE", v);
         }
-        cmd.env("EXIT_STATUS", case.exit_status);
+        if let Some(v) = case.exit_status {
+            cmd.env("EXIT_STATUS", v);
+        }
 
         let status = cmd.status().expect("failed to spawn /bin/sh");
         assert!(
             status.success(),
-            "ExecStopPost script exited {status} for scenario {:?}; a syntax error here \
-             would make systemd skip the hook (and thus crash counting) on every stop",
+            "ExecStopPost script exited {status} for scenario {:?}. A shell syntax error \
+             here would make systemd skip the hook (and thus crash counting) on every \
+             stop. Status 126 instead means the stand-in binary could not be executed \
+             (a noexec $TMPDIR), which is an environment problem, not a template bug.",
             case.scenario
         );
 
@@ -1234,7 +1306,7 @@ mod tests {
                 scenario: "systemctl stop, node handled SIGTERM and exited 0",
                 service_result: Some("success"),
                 exit_code: Some("exited"),
-                exit_status: "0",
+                exit_status: Some("0"),
                 expect_update: false,
             },
             StopPostCase {
@@ -1242,21 +1314,43 @@ mod tests {
                 scenario: "systemctl stop during startup, killed by SIGTERM (default disposition)",
                 service_result: Some("success"),
                 exit_code: Some("killed"),
-                exit_status: "TERM",
+                exit_status: Some("TERM"),
                 expect_update: false,
             },
             StopPostCase {
                 scenario: "Ctrl+C / SIGINT before the handler is installed",
                 service_result: Some("success"),
                 exit_code: Some("killed"),
-                exit_status: "INT",
+                exit_status: Some("INT"),
+                expect_update: false,
+            },
+            // HUP and PIPE complete the "success"/"killed" cell of the
+            // $SERVICE_RESULT table, so the guard covers them too. Recorded
+            // explicitly rather than left implicit: this IS a widening of what
+            // counts as a deliberate stop, and it is only safe while the node
+            // never dies by one of these signals to report a fault (see the
+            // "TWO CONSEQUENCES" note on the ExecStopPost line). Neither is
+            // reachable today — systemd sends TERM, and Rust sets SIGPIPE to
+            // SIG_IGN — but if that changes, this decision must be revisited.
+            StopPostCase {
+                scenario: "killed by SIGHUP under the default disposition",
+                service_result: Some("success"),
+                exit_code: Some("killed"),
+                exit_status: Some("HUP"),
+                expect_update: false,
+            },
+            StopPostCase {
+                scenario: "killed by SIGPIPE under the default disposition",
+                service_result: Some("success"),
+                exit_code: Some("killed"),
+                exit_status: Some("PIPE"),
                 expect_update: false,
             },
             StopPostCase {
                 scenario: "another instance already holds the port (exit 43)",
                 service_result: Some("success"),
                 exit_code: Some("exited"),
-                exit_status: "43",
+                exit_status: Some("43"),
                 expect_update: false,
             },
             // ── Faults and the voluntary update: MUST still run the hook ───
@@ -1267,42 +1361,42 @@ mod tests {
                 scenario: "voluntary update-needed exit 42",
                 service_result: Some("success"),
                 exit_code: Some("exited"),
-                exit_status: "42",
+                exit_status: Some("42"),
                 expect_update: true,
             },
             StopPostCase {
                 scenario: "panic (exit 101)",
                 service_result: Some("exit-code"),
                 exit_code: Some("exited"),
-                exit_status: "101",
+                exit_status: Some("101"),
                 expect_update: true,
             },
             StopPostCase {
                 scenario: "fast crash / boot wedge (exit 45, #4551)",
                 service_result: Some("exit-code"),
                 exit_code: Some("exited"),
-                exit_status: "45",
+                exit_status: Some("45"),
                 expect_update: true,
             },
             StopPostCase {
                 scenario: "early startup error (exit 1)",
                 service_result: Some("exit-code"),
                 exit_code: Some("exited"),
-                exit_status: "1",
+                exit_status: Some("1"),
                 expect_update: true,
             },
             StopPostCase {
                 scenario: "SIGSEGV with core dump",
                 service_result: Some("core-dump"),
                 exit_code: Some("dumped"),
-                exit_status: "SEGV",
+                exit_status: Some("SEGV"),
                 expect_update: true,
             },
             StopPostCase {
                 scenario: "SIGABRT",
                 service_result: Some("signal"),
                 exit_code: Some("killed"),
-                exit_status: "ABRT",
+                exit_status: Some("ABRT"),
                 expect_update: true,
             },
             StopPostCase {
@@ -1311,7 +1405,7 @@ mod tests {
                 scenario: "OOM killer",
                 service_result: Some("oom-kill"),
                 exit_code: Some("killed"),
-                exit_status: "KILL",
+                exit_status: Some("KILL"),
                 expect_update: true,
             },
             StopPostCase {
@@ -1321,21 +1415,51 @@ mod tests {
                 scenario: "shutdown hung past TimeoutStopSec, escalated to SIGKILL",
                 service_result: Some("timeout"),
                 exit_code: Some("killed"),
-                exit_status: "KILL",
+                exit_status: Some("KILL"),
                 expect_update: true,
             },
             StopPostCase {
                 scenario: "shutdown timed out while systemd was still on SIGTERM",
                 service_result: Some("timeout"),
                 exit_code: Some("killed"),
-                exit_status: "TERM",
+                exit_status: Some("TERM"),
                 expect_update: true,
             },
             StopPostCase {
+                // Unreachable for these units (neither sets WatchdogSec=), kept
+                // so that adding WatchdogSec= later does not silently land in
+                // an untested arm.
                 scenario: "watchdog keep-alive deadline missed",
                 service_result: Some("watchdog"),
                 exit_code: Some("killed"),
-                exit_status: "TERM",
+                exit_status: Some("TERM"),
+                expect_update: true,
+            },
+            StopPostCase {
+                scenario: "ExecCondition= failed",
+                service_result: Some("exec-condition"),
+                exit_code: Some("exited"),
+                exit_status: Some("1"),
+                expect_update: true,
+            },
+            // ── Results for which systemd identifies no main process, so it
+            // sets NEITHER $EXIT_CODE nor $EXIT_STATUS. The hook still fires and
+            // forwards an EMPTY status; `rollback::post_stop_status_from_env`
+            // maps empty to None, so nothing is counted. That is pre-existing
+            // behaviour, unchanged here — pinned so the guard cannot quietly
+            // start swallowing these instead.
+            StopPostCase {
+                scenario: "protocol violation (no main process identified)",
+                service_result: Some("protocol"),
+                exit_code: None,
+                exit_status: None,
+                expect_update: true,
+            },
+            StopPostCase {
+                scenario: "start limit hit (#4551 terminal stop)",
+                service_result: Some("start-limit-hit"),
+                exit_code: None,
+                exit_status: None,
                 expect_update: true,
             },
             // ── systemd < 232 has no $SERVICE_RESULT: degrade to the old rule ──
@@ -1343,14 +1467,25 @@ mod tests {
                 scenario: "legacy systemd (<232), no $SERVICE_RESULT, clean exit 0",
                 service_result: None,
                 exit_code: None,
-                exit_status: "0",
+                exit_status: Some("0"),
                 expect_update: false,
             },
             StopPostCase {
                 scenario: "legacy systemd (<232), no $SERVICE_RESULT, panic",
                 service_result: None,
                 exit_code: None,
-                exit_status: "101",
+                exit_status: Some("101"),
+                expect_update: true,
+            },
+            StopPostCase {
+                // The #5227 case as an OLD systemd would report it: no
+                // $SERVICE_RESULT means the guard cannot fire, so the stop is
+                // still (wrongly) counted. Pinned to keep the degradation
+                // honest rather than implying <232 is covered.
+                scenario: "legacy systemd (<232), no $SERVICE_RESULT, killed by SIGTERM",
+                service_result: None,
+                exit_code: None,
+                exit_status: Some("TERM"),
                 expect_update: true,
             },
         ];
@@ -1386,8 +1521,12 @@ mod tests {
                     if ran { "ran" } else { "was skipped" },
                 );
                 if ran {
+                    // When systemd identified no main process it sets no
+                    // $EXIT_STATUS, and the hook forwards an empty string;
+                    // `rollback::post_stop_status_from_env` maps that to None.
                     assert_eq!(
-                        forwarded, case.exit_status,
+                        forwarded,
+                        case.exit_status.unwrap_or(""),
                         "{unit_kind} unit, scenario {:?}: the hook must forward the node's \
                          stop status to `freenet update` so #4073 can classify it",
                         case.scenario


### PR DESCRIPTION
## Problem

#5230 (0.2.123) closed the main path: a *requested* graceful shutdown now exits 0, so an ordinary `systemctl stop` of a **running** node is no longer scored as a post-update-probation crash.

A second path to the same symptom remained, and it is the one that overlaps the rollout scenario.

The node installs its SIGTERM handler in `run_network_node_with_signals` (`crates/core/src/bin/freenet.rs:367`), which `run_network` only reaches after `serve_client_api` (`:227`), `NodeConfig::new` (`:236`) and `node_config.build()` — the redb open plus contract-store load. A SIGTERM arriving before that point kills the process under the **default disposition**. systemd then reports `$EXIT_STATUS` as the signal *name* `TERM`; the unit's `ExecStopPost` `case` has no arm for names, so it fell through to `*)` and ran `freenet update --quiet`; and `rollback.rs::classify_stop` likewise has no arm for names, so it fell through to `_ => StopClass::Crash`.

The window coincides with probation by construction: a node inside its post-update probation window has *just* restarted, so it is also near the front of its boot. On a gateway with a large contract store, `build()` is not brief. That is exactly when an operator or a deploy script is most likely to stop it.

## Solution

Gate the hook on systemd's `$SERVICE_RESULT` in addition to `$EXIT_STATUS`. The hook is skipped only when the result is `success` **and** `$EXIT_CODE` is `killed` — which `man systemd.exec` documents as precisely "killed by HUP/INT/TERM/PIPE under the default disposition".

```diff
-ExecStopPost=-/bin/sh -c 'case "$$EXIT_STATUS" in 0|43) ;; *) …update --quiet ;; esac'
+ExecStopPost=-/bin/sh -c 'case "$$SERVICE_RESULT $$EXIT_CODE" in "success killed") exit 0 ;; esac; case "$$EXIT_STATUS" in 0|43) ;; *) …update --quiet ;; esac'
```

**The guard is narrow on purpose.** This hook does two jobs: it is the #4549 self-heal *and* it is what **counts crashes** for the #4073 crash-loop rollback. An over-broad skip would silently disarm rollback — a node crash-looping on a bad release would have no way back. That failure is silent and strictly worse than the bug being fixed.

The brief for this change proposed that `$SERVICE_RESULT` is `success` for a stop job *however* the process died. **That is not what systemd does**, and gating on `$SERVICE_RESULT` alone would have been a serious regression. Two concrete traps the narrow form avoids:

- `SuccessExitStatus=42 43` makes the **voluntary update exit 42** report `$SERVICE_RESULT=success`. Skipping on the result alone would have disabled auto-update entirely. (Confirmed against real systemd, not just the man page.)
- `oom-kill` and `timeout` also report `$EXIT_CODE=killed`. Skipping on the disposition alone would have stopped counting OOM kills and hung shutdowns.

## systemd `$SERVICE_RESULT` semantics

Source: `man systemd.exec`, "$SERVICE_RESULT" (Table 5 and the `$SERVICE_RESULT`/`$EXIT_CODE`/`$EXIT_STATUS` combination table). Rows marked **probed** were additionally reproduced against real systemd 255 (255.4-1ubuntu8.16) using transient `systemd-run --user` units.

| Scenario | `$SERVICE_RESULT` | `$EXIT_CODE` | `$EXIT_STATUS` | Hook | Verified |
|---|---|---|---|---|---|
| `systemctl stop`, node handled SIGTERM, exit 0 | `success` | `exited` | `0` | **skip** | probed |
| `systemctl stop` during startup, killed by SIGTERM (**the #5227 window**) | `success` | `killed` | `TERM` | **skip** | probed |
| Ctrl+C / SIGINT before the handler is installed | `success` | `killed` | `INT` | **skip** | documented |
| Killed by SIGHUP under the default disposition | `success` | `killed` | `HUP` | **skip** | documented |
| Killed by SIGPIPE under the default disposition | `success` | `killed` | `PIPE` | **skip** | documented |
| Another instance holds the port (exit 43) | `success` | `exited` | `43` | **skip** | probed |
| Voluntary update-needed exit 42 (`SuccessExitStatus=42`) | `success` | `exited` | `42` | **run** | probed |
| Panic (exit 101) | `exit-code` | `exited` | `101` | **run** | probed |
| Fast crash / boot wedge (exit 45, #4551) | `exit-code` | `exited` | `45` | **run** | probed |
| Early startup error (exit 1) | `exit-code` | `exited` | `1` | **run** | probed |
| SIGABRT | `signal` | `killed` | `ABRT` | **run** | probed |
| SIGSEGV with core dump | `core-dump` | `dumped` | `SEGV` | **run** | documented |
| SIGKILL from outside (OOM-shaped) | `signal` | `killed` | `KILL` | **run** | probed |
| OOM killer | `oom-kill` | `killed` | `TERM`/`KILL` | **run** | documented only |
| Stop hung past `TimeoutStopSec`, escalated | `timeout` | `killed` | `KILL` | **run** | probed |
| `ExecCondition=` failed | `exec-condition` | `exited` | `1`…`254` | **run** | documented |
| Protocol violation / start limit hit | `protocol`, `start-limit-hit` | *unset* | *unset* | **run** (forwards empty) | documented |
| Watchdog deadline missed | `watchdog` | `killed`/`dumped`/`exited` | various | **run** | **unreachable** — neither unit sets `WatchdogSec=` |
| systemd < 232 (`$SERVICE_RESULT` unset) | *unset* | *unset* | as before | unchanged | documented (added in v232) |

Notes on cases the brief asked about specifically:

- **A stop job while the process is mid-startup** — this is the bug. `success`/`killed`/`TERM`; now skipped. Probed.
- **SIGKILL during a stop job** — probed via a unit that traps and ignores SIGTERM with `TimeoutStopSec=2`. systemd escalates and reports `timeout`, not `success`, so the hook still runs and the crash is still counted. Behaviour unchanged from today; a shutdown that hangs past its timeout remains classified as a fault.
- **A crash with `Restart=always` in effect** — `Restart=` does not enter into `$SERVICE_RESULT`; it selects what happens *after* `ExecStopPost`. Probed exit 101 / 45 / 1 with the units' real `Restart=always` semantics unchanged; all still run the hook.
- **A failed start** — an `ExecStart` that exits non-zero immediately is `exit-code`/`exited`/`N` and still runs the hook, preserving the #4549 self-heal. Probed via exit 1.
- **`systemctl restart`** — the stop half behaves exactly like `systemctl stop` (both rows above). The start half is a normal start.

**What I could not verify by probe:** a genuine kernel OOM kill (`oom-kill`), a real `core-dump`, `exec-condition`, and the `protocol`/`start-limit-hit` family. These rest on the documented table only. All are `$SERVICE_RESULT` values other than `success`, so they take the unchanged `$EXIT_STATUS` path regardless. The `oom-kill` row is the one worth calling out, because it is the case where `$EXIT_CODE=killed` and the guard must *not* fire; the externally-SIGKILLed probe (`signal`/`killed`/`KILL`) exercises the same shape.

## Two consequences, stated explicitly

Both are recorded in a comment at the hook itself, not just here.

**1. The node must never die by TERM/INT/HUP/PIPE to report a *fault*.** systemd cannot tell who sent a signal, so all four members of the `success`/`killed` cell are now indistinguishable from an operator's stop and are uncounted. This is a genuine widening beyond the TERM case that motivated the change. It is safe **today**: I grepped the crate and there is no self-signal path — the fatal-listener and redb-poison aborts use `process::exit`, and Rust's runtime sets SIGPIPE to `SIG_IGN`. If anyone later adds a `libc::raise`, restores the default SIGPIPE disposition, or routes an abort through TERM, that fault becomes permanently invisible to rollback. The guard comment says so.

**2. A release that *hangs* in the pre-handler window no longer produces any rollback signal.** Previously, an operator's `systemctl stop` of a wedged node was counted as a crash, so three of them triggered a rollback. That is gone. Being honest about it: **that rescue path was an accident of the exact ambiguity that caused #5227** — it is the same event, and it cannot be kept without reinstating the bug it caused. A release that *crashes* in that window is unaffected and still counts (probed). Detecting a startup **hang** needs a real mechanism — `WatchdogSec=`, or installing the signal handler before the heavy startup work — which is follow-up work, not something this hook can do. Raised by adversarial review; I judged it non-blocking for this PR but it should not be lost.

## Testing

Two layers.

**1. In CI — `exec_stop_post_counts_crashes_and_skips_deliberate_stops`** (`service/linux.rs`). Rather than string-matching the template, it extracts the script systemd would hand to `/bin/sh`, undoes the `$$` escaping, and **runs it under a real shell** with the environment systemd documents for each scenario, for both the user and the system unit. 19 rows; every row asserts the decision in **both** directions, and each run that fires also asserts the status was forwarded through `POST_STOP_EXIT_CODE_ENV_VAR` (referenced via the constant, so a rename cannot leave the test checking a variable nothing sets).

A test that pinned only the skip would let someone disable crash counting entirely and stay green, so the crash rows are the load-bearing half. Mutation-tested — each mutation applied to the committed tree, the pin re-run, then reverted:

| Mutation | Result |
|---|---|
| **M1** revert the guard (restore the old `ExecStopPost`) | **FAILS** on `"systemctl stop during startup, killed by SIGTERM"` |
| **M2** over-broad: skip on `$SERVICE_RESULT=success` alone | **FAILS** on `"voluntary update-needed exit 42"` |
| **M3** over-broad: skip on `$EXIT_CODE=killed` alone | **FAILS** on `"SIGABRT"` (and 4 more rows) |
| **M4** single-`$` revert of the two new variables | **FAILS** in `systemd_units_pass_node_exit_code_to_post_stop_update` |

M4 exists because the decision-matrix test un-doubles `$$` before running the script, so `$SERVICE_RESULT` and `$$SERVICE_RESULT` are byte-identical to it. A single-`$` revert would make the guard compare empty strings and silently restore the bug, so the doubling is pinned on the raw template alongside the pre-existing `$$EXIT_STATUS` pin.

**2. Manually, against real systemd 255** — not checked in, because GitHub runners have no systemd user session. I generated the unit with a stand-in binary, took the `ExecStopPost` line **the template actually emits**, passed it to `systemd-run --user` as a transient unit property, and checked whether the stand-in `freenet update` really ran for each of 10 scenarios. All 10 matched the table above. Re-running that harness under mutation **M2** correctly failed the exit-42 row, so it is not vacuous either. This is what closes the seam between "the shell script decides correctly" and "systemd sets the variables I think it does".

Also corrected in this PR: three pre-existing comments and assert messages claimed `ExecStopPost` "skips only 0 and 43". There is now a third exemption, so they had become false.

## Scope limits — please read, these are real

- **Linux/systemd only.** The macOS (`launchd` + wrapper script) and Windows wrappers do not use these units. Their equivalent of this startup window **stays open**; this PR does not touch them.
- **The deployed fleet is not fixed the moment this merges.** An existing install keeps its current unit until the unit is re-templated. Three routes, in order of speed:
  - `freenet service doctor` re-templates immediately (`service/purge.rs::service_doctor` → `install_service`), as does a reinstall.
  - **Automatically, with roughly a one-release lag**: `freenet update` calls `ensure_service_file_updated` (`update.rs:789`), which re-renders the unit from the template compiled into the **running** binary. So a node updating *away from* the first release containing this change writes the new unit. Correcting an earlier version of this section, which implied only the manual routes existed.
  - A plain `systemctl restart` does **not** re-template.
  - Caveat on the automatic route: `#4287`'s sidecar-hash check deliberately leaves a **hand-edited** unit alone, so an operator who customised their unit keeps the old hook until they reconcile it.
- **The node-side window itself is untouched.** Installing the signal handler before the heavy startup work (candidate 1 in the issue) remains unbuilt; this is candidate 2. They are complementary. This one fixes the class rather than one instance and has a much smaller blast radius, but a node that dies to an *unhandled* signal in that window still exits under the default disposition — the change here is only that systemd and the updater no longer misread that as a crash.
- **Deployed nodes running the old unit still mis-classify a signal-name stop**, because `rollback.rs::classify_stop` has no arm for signal names either. Adding one would cover the fleet without a re-template, but it also carries a real under-counting risk (a start/stop-timeout death would stop counting), so I did not smuggle it into this PR. Worth a separate decision.
- **A stop whose graceful shutdown itself errors** still exits non-zero, so it is still counted as a crash. Unchanged, and out of scope here.

## Required pre-release smoke test (framework machine)

This change alters the **unit template**, so `cargo test` and CI cannot see the thing that actually matters: whether a real `systemctl stop` of a real node still gets scored as a crash. The general release smoke test does not cover it. Run this specifically:

1. Let the framework node auto-update onto a build containing this change, **and confirm its unit was re-templated** — the fix does nothing until it is:
   ```
   grep -c 'success killed' ~/.config/systemd/user/freenet.service   # expect 1
   ```
   If it is 0, the node updated but is still on the old unit; force it with `freenet service doctor` before continuing, otherwise the test is vacuous.
2. Note the probation state before the stop:
   ```
   cat ~/.local/state/freenet/probation.json 2>/dev/null
   ```
3. `systemctl --user stop freenet`, then start it again.
4. **Assert no probation crash was recorded** — the crash count must be unchanged from step 2, and the journal must NOT contain the `crash N/3 during post-update probation` line:
   ```
   journalctl --user -u freenet --since '5 min ago' | grep -i 'probation'
   ```
5. Repeat once with the stop issued **during startup** (stop within a second or two of starting, before the node is ready). This is the actual #5227 window — step 3 alone exercises only the path #5230 already fixed, so **skipping step 5 makes the whole test vacuous for this change.**

Negative control, so the test can fail: `freenet update` must still be invoked for a genuine crash. `kill -ABRT` the node and confirm the probation counter *does* increment.

## Suggested release-note wording

> A deliberate `systemctl stop` is no longer counted as a crash by the post-update rollback, even when the stop arrives while the node is still starting up. New and repaired systemd installs get this immediately; existing installs pick it up automatically about one release later (when the node next updates), or right away via `freenet service doctor`. A hand-customised unit is left alone and keeps the old behaviour until reconciled. macOS and Windows are unaffected.

Refs #5227

[AI-assisted - Claude]


---

## Addendum: ejected by the merge queue, and why the branch's green could not see it

This PR sat green and `mergeable=CLEAN` for 27 days, was enqueued, and was **ejected** by the merge queue on a clippy error that its own branch CI never reported:

```
error: non-binding `let` on an expression with `#[must_use]` type
  --> crates/core/src/bin/commands/service/linux.rs:1238:9
1238 |         let _ = std::fs::remove_file(&marker);
   = note: requested on the command line with `-D clippy::let-underscore-must-use`
```

Three explanations ruled out before landing on the real one: not a conflict (`git merge-tree --write-tree` against current main is clean, so no rebase was needed and none was done), not a toolchain bump (`rust-toolchain.toml` pins 1.94.0 at the merge-base and on main), and not a newly-added lint (already `deny` at the merge-base). What changed on main is the lint's **reach** — #5292 extended lint coverage to test code after this branch last ran CI, and the offending line is in test code this PR adds.

**The diff was never wrong; only the merged combination fails.** No amount of re-reviewing this PR would have found it, and the branch's own checks are structurally incapable of reporting it.

The fix handles the value rather than using the `let _rm = ...` named-binding idiom found elsewhere in this tree. That idiom silences the lint and would have left a real defect: `run_hook` decides whether the hook ran by testing for this marker *after* running the script, so a marker left behind by the previous scenario makes the next one report a **skipped** hook as having run — every "must skip" row in the decision matrix would pass while measuring the wrong thing. Only `NotFound` is tolerated; anything else panics, because at that point the matrix can no longer measure what it claims to.

Verified with clippy against the **merged** tree (this branch merged onto current main), not the branch alone — a stale branch still carries old copies of files main has since rewritten, so a branch-only run reports unrelated errors and tests a tree that will never exist after merge.

[AI-assisted - Claude]
