### PR TITLE
feat(obs): count contract-exec WASM calls apart from the cache hits

### DIFF
--- a/crates/core/src/contract/executor/pool_tests/summarize_delta_cache_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/summarize_delta_cache_tests.rs
@@ -810,6 +810,132 @@ async fn repeated_delta_counts_a_fast_hit_and_no_wasm_call() {
     );
 }
 
+/// Delta twin of `cold_detector_over_unchanged_state_counts_a_reload_hit`.
+/// The delta cache is keyed on (state-hash, peer-summary-hash), so a cold
+/// detector re-derives the state hash and finds the SAME key — a reload hit,
+/// not a WASM call.
+#[tokio::test(flavor = "current_thread")]
+async fn delta_cold_detector_over_unchanged_state_counts_a_reload_hit() {
+    let storage = MockStateStorage::new();
+    let (op_manager, _guards) = build_op_manager("exec_counts_delta_reload").await;
+    let mut exec = Executor::new_mock_wasm_uncached_with_op_manager(
+        "exec_counts_delta_reload",
+        storage.clone(),
+        op_manager.clone(),
+    )
+    .await
+    .expect("create uncached executor with op_manager");
+
+    let contract = test_contract(b"exec_counts_delta_reload");
+    let key = contract.key();
+    let peer_summary = StateSummary::from(vec![3u8; 4]);
+    exec.upsert_contract_state(
+        key,
+        Either::Left(WrappedState::new(vec![8, 8, 8, 1])),
+        RelatedContracts::default(),
+        Some(contract.clone()),
+    )
+    .await
+    .expect("PUT");
+    let _ = exec
+        .get_contract_state_delta(key, peer_summary.clone())
+        .await
+        .expect("warm the delta cache");
+
+    exec.state_store.cache_invalidator().invalidate(&key);
+
+    let before = exec_counts(&op_manager);
+    let _ = exec
+        .get_contract_state_delta(key, peer_summary)
+        .await
+        .expect("delta with cold detector");
+    let after = exec_counts(&op_manager);
+    assert_eq!(
+        after.delta_reload_hits - before.delta_reload_hits,
+        1,
+        "a cold detector over unchanged state must be counted as a delta reload hit"
+    );
+    assert_eq!(
+        after.delta_wasm_calls, before.delta_wasm_calls,
+        "the cached delta still matched, so no WASM ran and none may be counted"
+    );
+    assert_eq!(
+        after.delta_fast_hits, before.delta_fast_hits,
+        "the detector was cold, so this is not a FAST hit"
+    );
+}
+
+/// The client-notification fan-out computes a per-subscriber delta with NO
+/// cache in front of it. That work must land on the `uncached` arm — not on
+/// `delta_wasm_calls`, which would inflate the cached path's miss count and
+/// make a healthy cache look like it was thrashing.
+///
+/// This arm is the one most likely to dominate `get_state_delta` volume on a
+/// client-facing node, so it gets its own coverage rather than riding on the
+/// cached-path tests.
+#[tokio::test(flavor = "current_thread")]
+async fn client_notification_fanout_delta_counts_as_uncached() {
+    use crate::contract::executor::ClientId;
+
+    let storage = MockStateStorage::new();
+    let (op_manager, _guards) = build_op_manager("exec_counts_fanout").await;
+    let mut exec = Executor::new_mock_wasm_uncached_with_op_manager(
+        "exec_counts_fanout",
+        storage.clone(),
+        op_manager.clone(),
+    )
+    .await
+    .expect("create uncached executor with op_manager");
+
+    let contract = test_contract(b"exec_counts_fanout");
+    let key = contract.key();
+    exec.upsert_contract_state(
+        key,
+        Either::Left(WrappedState::new(vec![1, 1, 1, 1])),
+        RelatedContracts::default(),
+        Some(contract.clone()),
+    )
+    .await
+    .expect("PUT");
+
+    // A subscriber WITH a cached summary is what makes the fan-out take the
+    // delta arm rather than shipping full state.
+    let (tx, _rx) = tokio::sync::mpsc::channel(16);
+    exec.register_contract_notifier(
+        *key.id(),
+        ClientId::FIRST,
+        tx,
+        Some(StateSummary::from(vec![2u8; 4])),
+    )
+    .expect("register subscriber");
+
+    let before = exec_counts(&op_manager);
+    exec.upsert_contract_state(
+        key,
+        Either::Left(WrappedState::new(vec![5, 5, 5, 5, 5])),
+        RelatedContracts::default(),
+        None,
+    )
+    .await
+    .expect("UPDATE drives the fan-out");
+    let after = exec_counts(&op_manager);
+
+    assert_eq!(
+        after.delta_wasm_uncached - before.delta_wasm_uncached,
+        1,
+        "the per-subscriber fan-out delta must be counted on the UNCACHED arm"
+    );
+    assert_eq!(
+        after.delta_wasm_calls, before.delta_wasm_calls,
+        "the fan-out delta has no cache in front of it, so it must NOT inflate \
+         the cached path's miss count"
+    );
+    assert_eq!(
+        after.delta_fast_hits, before.delta_fast_hits,
+        "the fan-out delta is not a cache hit"
+    );
+}
+
 /// The cached path's three arms must PARTITION its calls exactly: every call to
 /// `summarize_contract_state` lands on exactly one of fast hit / reload hit /
 /// WASM call, so no consumer ever has to subtract one counter from another to
@@ -840,20 +966,48 @@ async fn summarize_arms_partition_every_call_exactly_once() {
     .await
     .expect("PUT");
 
-    let before = exec_counts(&op_manager);
+    // Accumulate the measured window in SEGMENTS, so that nothing but a
+    // `summarize_contract_state` call ever falls inside one. Putting the UPDATE
+    // inside the window would make this test fail if a future change routed
+    // upsert through the cached summarize path — pointing the next debugger at
+    // the counter instead of at their own change.
+    let mut recorded = 0u64;
     let mut calls = 0u64;
+    let mut fast = 0u64;
+    let mut reload = 0u64;
+    let mut wasm = 0u64;
 
-    // Mix all three outcomes: cold cache, warm cache, cold detector, and a
-    // post-write recompute.
+    // Segment 1: cold cache, then four warm repeats.
+    let before = exec_counts(&op_manager);
     let _ = exec.summarize_contract_state(key).await.expect("cold");
-    calls += 1;
     for _ in 0..4 {
         let _ = exec.summarize_contract_state(key).await.expect("warm");
-        calls += 1;
     }
+    let after = exec_counts(&op_manager);
+    recorded += (after.summarize_fast_hits - before.summarize_fast_hits)
+        + (after.summarize_reload_hits - before.summarize_reload_hits)
+        + (after.summarize_wasm_calls - before.summarize_wasm_calls);
+    calls += 5;
+    fast += after.summarize_fast_hits - before.summarize_fast_hits;
+    reload += after.summarize_reload_hits - before.summarize_reload_hits;
+    wasm += after.summarize_wasm_calls - before.summarize_wasm_calls;
+
+    // Segment 2: cold detector over unchanged state (the invalidate is outside
+    // the measured window and records nothing by construction).
     exec.state_store.cache_invalidator().invalidate(&key);
+    let before = exec_counts(&op_manager);
     let _ = exec.summarize_contract_state(key).await.expect("reload");
+    let after = exec_counts(&op_manager);
+    recorded += (after.summarize_fast_hits - before.summarize_fast_hits)
+        + (after.summarize_reload_hits - before.summarize_reload_hits)
+        + (after.summarize_wasm_calls - before.summarize_wasm_calls);
     calls += 1;
+    fast += after.summarize_fast_hits - before.summarize_fast_hits;
+    reload += after.summarize_reload_hits - before.summarize_reload_hits;
+    wasm += after.summarize_wasm_calls - before.summarize_wasm_calls;
+
+    // Segment 3: post-write recompute. The UPDATE is deliberately outside the
+    // measured window.
     exec.upsert_contract_state(
         key,
         Either::Left(WrappedState::new(vec![2, 2, 4, 6, 8])),
@@ -862,13 +1016,17 @@ async fn summarize_arms_partition_every_call_exactly_once() {
     )
     .await
     .expect("UPDATE");
+    let before = exec_counts(&op_manager);
     let _ = exec.summarize_contract_state(key).await.expect("recompute");
-    calls += 1;
-
     let after = exec_counts(&op_manager);
-    let recorded = (after.summarize_fast_hits - before.summarize_fast_hits)
+    recorded += (after.summarize_fast_hits - before.summarize_fast_hits)
         + (after.summarize_reload_hits - before.summarize_reload_hits)
         + (after.summarize_wasm_calls - before.summarize_wasm_calls);
+    calls += 1;
+    fast += after.summarize_fast_hits - before.summarize_fast_hits;
+    reload += after.summarize_reload_hits - before.summarize_reload_hits;
+    wasm += after.summarize_wasm_calls - before.summarize_wasm_calls;
+
     assert_eq!(
         recorded, calls,
         "the three cached-path arms must partition every summarize call exactly \
@@ -876,7 +1034,13 @@ async fn summarize_arms_partition_every_call_exactly_once() {
     );
     // Non-vacuity: all three arms must actually have fired, or the partition
     // would hold trivially for a counter that only ever records one of them.
-    assert!(after.summarize_fast_hits > before.summarize_fast_hits);
-    assert!(after.summarize_reload_hits > before.summarize_reload_hits);
-    assert!(after.summarize_wasm_calls > before.summarize_wasm_calls);
+    assert!(fast > 0, "no fast hit fired: the partition holds vacuously");
+    assert!(
+        reload > 0,
+        "no reload hit fired: the partition holds vacuously"
+    );
+    assert!(
+        wasm > 0,
+        "no WASM call fired: the partition holds vacuously"
+    );
 }

--- a/crates/core/src/contract/executor/pool_tests/summarize_delta_cache_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/summarize_delta_cache_tests.rs
@@ -807,6 +807,132 @@ async fn repeated_delta_counts_a_fast_hit_and_no_wasm_call() {
     );
 }
 
+/// Delta twin of `cold_detector_over_unchanged_state_counts_a_reload_hit`.
+/// The delta cache is keyed on (state-hash, peer-summary-hash), so a cold
+/// detector re-derives the state hash and finds the SAME key — a reload hit,
+/// not a WASM call.
+#[tokio::test(flavor = "current_thread")]
+async fn delta_cold_detector_over_unchanged_state_counts_a_reload_hit() {
+    let storage = MockStateStorage::new();
+    let (op_manager, _guards) = build_op_manager("exec_counts_delta_reload").await;
+    let mut exec = Executor::new_mock_wasm_uncached_with_op_manager(
+        "exec_counts_delta_reload",
+        storage.clone(),
+        op_manager.clone(),
+    )
+    .await
+    .expect("create uncached executor with op_manager");
+
+    let contract = test_contract(b"exec_counts_delta_reload");
+    let key = contract.key();
+    let peer_summary = StateSummary::from(vec![3u8; 4]);
+    exec.upsert_contract_state(
+        key,
+        Either::Left(WrappedState::new(vec![8, 8, 8, 1])),
+        RelatedContracts::default(),
+        Some(contract.clone()),
+    )
+    .await
+    .expect("PUT");
+    let _ = exec
+        .get_contract_state_delta(key, peer_summary.clone())
+        .await
+        .expect("warm the delta cache");
+
+    exec.state_store.cache_invalidator().invalidate(&key);
+
+    let before = exec_counts(&op_manager);
+    let _ = exec
+        .get_contract_state_delta(key, peer_summary)
+        .await
+        .expect("delta with cold detector");
+    let after = exec_counts(&op_manager);
+    assert_eq!(
+        after.delta_reload_hits - before.delta_reload_hits,
+        1,
+        "a cold detector over unchanged state must be counted as a delta reload hit"
+    );
+    assert_eq!(
+        after.delta_wasm_calls, before.delta_wasm_calls,
+        "the cached delta still matched, so no WASM ran and none may be counted"
+    );
+    assert_eq!(
+        after.delta_fast_hits, before.delta_fast_hits,
+        "the detector was cold, so this is not a FAST hit"
+    );
+}
+
+/// The client-notification fan-out computes a per-subscriber delta with NO
+/// cache in front of it. That work must land on the `uncached` arm — not on
+/// `delta_wasm_calls`, which would inflate the cached path's miss count and
+/// make a healthy cache look like it was thrashing.
+///
+/// This arm is the one most likely to dominate `get_state_delta` volume on a
+/// client-facing node, so it gets its own coverage rather than riding on the
+/// cached-path tests.
+#[tokio::test(flavor = "current_thread")]
+async fn client_notification_fanout_delta_counts_as_uncached() {
+    use crate::contract::executor::ClientId;
+
+    let storage = MockStateStorage::new();
+    let (op_manager, _guards) = build_op_manager("exec_counts_fanout").await;
+    let mut exec = Executor::new_mock_wasm_uncached_with_op_manager(
+        "exec_counts_fanout",
+        storage.clone(),
+        op_manager.clone(),
+    )
+    .await
+    .expect("create uncached executor with op_manager");
+
+    let contract = test_contract(b"exec_counts_fanout");
+    let key = contract.key();
+    exec.upsert_contract_state(
+        key,
+        Either::Left(WrappedState::new(vec![1, 1, 1, 1])),
+        RelatedContracts::default(),
+        Some(contract.clone()),
+    )
+    .await
+    .expect("PUT");
+
+    // A subscriber WITH a cached summary is what makes the fan-out take the
+    // delta arm rather than shipping full state.
+    let (tx, _rx) = tokio::sync::mpsc::channel(16);
+    exec.register_contract_notifier(
+        *key.id(),
+        ClientId::FIRST,
+        tx,
+        Some(StateSummary::from(vec![2u8; 4])),
+    )
+    .expect("register subscriber");
+
+    let before = exec_counts(&op_manager);
+    exec.upsert_contract_state(
+        key,
+        Either::Left(WrappedState::new(vec![5, 5, 5, 5, 5])),
+        RelatedContracts::default(),
+        None,
+    )
+    .await
+    .expect("UPDATE drives the fan-out");
+    let after = exec_counts(&op_manager);
+
+    assert_eq!(
+        after.delta_wasm_uncached - before.delta_wasm_uncached,
+        1,
+        "the per-subscriber fan-out delta must be counted on the UNCACHED arm"
+    );
+    assert_eq!(
+        after.delta_wasm_calls, before.delta_wasm_calls,
+        "the fan-out delta has no cache in front of it, so it must NOT inflate \
+         the cached path's miss count"
+    );
+    assert_eq!(
+        after.delta_fast_hits, before.delta_fast_hits,
+        "the fan-out delta is not a cache hit"
+    );
+}
+
 /// The cached path's three arms must PARTITION its calls exactly: every call to
 /// `summarize_contract_state` lands on exactly one of fast hit / reload hit /
 /// WASM call, so no consumer ever has to subtract one counter from another to
@@ -837,20 +963,48 @@ async fn summarize_arms_partition_every_call_exactly_once() {
     .await
     .expect("PUT");
 
-    let before = exec_counts(&op_manager);
+    // Accumulate the measured window in SEGMENTS, so that nothing but a
+    // `summarize_contract_state` call ever falls inside one. Putting the UPDATE
+    // inside the window would make this test fail if a future change routed
+    // upsert through the cached summarize path — pointing the next debugger at
+    // the counter instead of at their own change.
+    let mut recorded = 0u64;
     let mut calls = 0u64;
+    let mut fast = 0u64;
+    let mut reload = 0u64;
+    let mut wasm = 0u64;
 
-    // Mix all three outcomes: cold cache, warm cache, cold detector, and a
-    // post-write recompute.
+    // Segment 1: cold cache, then four warm repeats.
+    let before = exec_counts(&op_manager);
     let _ = exec.summarize_contract_state(key).await.expect("cold");
-    calls += 1;
     for _ in 0..4 {
         let _ = exec.summarize_contract_state(key).await.expect("warm");
-        calls += 1;
     }
+    let after = exec_counts(&op_manager);
+    recorded += (after.summarize_fast_hits - before.summarize_fast_hits)
+        + (after.summarize_reload_hits - before.summarize_reload_hits)
+        + (after.summarize_wasm_calls - before.summarize_wasm_calls);
+    calls += 5;
+    fast += after.summarize_fast_hits - before.summarize_fast_hits;
+    reload += after.summarize_reload_hits - before.summarize_reload_hits;
+    wasm += after.summarize_wasm_calls - before.summarize_wasm_calls;
+
+    // Segment 2: cold detector over unchanged state (the invalidate is outside
+    // the measured window and records nothing by construction).
     exec.state_store.cache_invalidator().invalidate(&key);
+    let before = exec_counts(&op_manager);
     let _ = exec.summarize_contract_state(key).await.expect("reload");
+    let after = exec_counts(&op_manager);
+    recorded += (after.summarize_fast_hits - before.summarize_fast_hits)
+        + (after.summarize_reload_hits - before.summarize_reload_hits)
+        + (after.summarize_wasm_calls - before.summarize_wasm_calls);
     calls += 1;
+    fast += after.summarize_fast_hits - before.summarize_fast_hits;
+    reload += after.summarize_reload_hits - before.summarize_reload_hits;
+    wasm += after.summarize_wasm_calls - before.summarize_wasm_calls;
+
+    // Segment 3: post-write recompute. The UPDATE is deliberately outside the
+    // measured window.
     exec.upsert_contract_state(
         key,
         Either::Left(WrappedState::new(vec![2, 2, 4, 6, 8])),
@@ -859,13 +1013,17 @@ async fn summarize_arms_partition_every_call_exactly_once() {
     )
     .await
     .expect("UPDATE");
+    let before = exec_counts(&op_manager);
     let _ = exec.summarize_contract_state(key).await.expect("recompute");
-    calls += 1;
-
     let after = exec_counts(&op_manager);
-    let recorded = (after.summarize_fast_hits - before.summarize_fast_hits)
+    recorded += (after.summarize_fast_hits - before.summarize_fast_hits)
         + (after.summarize_reload_hits - before.summarize_reload_hits)
         + (after.summarize_wasm_calls - before.summarize_wasm_calls);
+    calls += 1;
+    fast += after.summarize_fast_hits - before.summarize_fast_hits;
+    reload += after.summarize_reload_hits - before.summarize_reload_hits;
+    wasm += after.summarize_wasm_calls - before.summarize_wasm_calls;
+
     assert_eq!(
         recorded, calls,
         "the three cached-path arms must partition every summarize call exactly \
@@ -873,7 +1031,13 @@ async fn summarize_arms_partition_every_call_exactly_once() {
     );
     // Non-vacuity: all three arms must actually have fired, or the partition
     // would hold trivially for a counter that only ever records one of them.
-    assert!(after.summarize_fast_hits > before.summarize_fast_hits);
-    assert!(after.summarize_reload_hits > before.summarize_reload_hits);
-    assert!(after.summarize_wasm_calls > before.summarize_wasm_calls);
+    assert!(fast > 0, "no fast hit fired: the partition holds vacuously");
+    assert!(
+        reload > 0,
+        "no reload hit fired: the partition holds vacuously"
+    );
+    assert!(
+        wasm > 0,
+        "no WASM call fired: the partition holds vacuously"
+    );
 }

--- a/crates/core/src/contract/executor/pool_tests/summarize_delta_cache_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/summarize_delta_cache_tests.rs
@@ -510,3 +510,370 @@ async fn summary_cache_covers_live_hosted_count_not_fixed_cap() {
         );
     }
 }
+
+// =========================================================================
+// PRODUCTION OBSERVABILITY (the cache-hit / WASM-miss split)
+// =========================================================================
+//
+// The tests above prove the cache WORKS, using `MockStateStorage::get_count`
+// as an indirect proxy: no state reload, therefore no WASM call. That proxy is
+// unavailable in production and, more importantly, cannot separate the two
+// no-WASM outcomes — a reload HIT does load the state and would score as a
+// "miss" under it.
+//
+// `ContractExecMetrics` records each outcome at its own decision point, so the
+// tests below assert what an operator actually reads. They are the oracle the
+// suite lacked: a mutation that miscounts a cache hit as a WASM call (or the
+// reverse) passes every `get_count` assertion above and fails here.
+
+/// Snapshot the executor's per-node contract-exec counters.
+fn exec_counts(
+    op_manager: &Arc<OpManager>,
+) -> crate::ring::contract_exec_metrics::ContractExecSnapshot {
+    op_manager.ring.contract_exec_metrics().snapshot()
+}
+
+/// A repeated summarize of UNCHANGED state must be counted as a fast cache hit,
+/// and must NOT be counted as a WASM invocation.
+///
+/// This is the distinction the production signal could not make: the
+/// handler-entry span at `contract.rs`'s `info_span!("summarize_contract_state")`
+/// fires once per call regardless of which arm runs, which is why every rate
+/// quoted across the #4473 / #4610 / #5040 / #5238 storm investigations was
+/// undifferentiated. Deltas are measured around each call so the PUT's own
+/// uncached WASM work cannot mask a miscount.
+#[tokio::test(flavor = "current_thread")]
+async fn repeated_summarize_counts_a_fast_hit_and_no_wasm_call() {
+    let storage = MockStateStorage::new();
+    let (op_manager, _guards) = build_op_manager("exec_counts_summarize").await;
+    let mut exec = Executor::new_mock_wasm_uncached_with_op_manager(
+        "exec_counts_summarize",
+        storage.clone(),
+        op_manager.clone(),
+    )
+    .await
+    .expect("create uncached executor with op_manager");
+
+    let contract = test_contract(b"exec_counts_summarize");
+    let key = contract.key();
+    let state = WrappedState::new(vec![1, 2, 3, 4, 5]);
+    exec.upsert_contract_state(
+        key,
+        Either::Left(state.clone()),
+        RelatedContracts::default(),
+        Some(contract.clone()),
+    )
+    .await
+    .expect("PUT");
+
+    // Cold: no cached summary for this contract, so the WASM must run.
+    let before = exec_counts(&op_manager);
+    let _ = exec
+        .summarize_contract_state(key)
+        .await
+        .expect("summarize 1");
+    let after_cold = exec_counts(&op_manager);
+    assert_eq!(
+        after_cold.summarize_wasm_calls - before.summarize_wasm_calls,
+        1,
+        "the cold summarize must be counted as one WASM invocation"
+    );
+    assert_eq!(
+        after_cold.summarize_fast_hits, before.summarize_fast_hits,
+        "a cold summarize is not a cache hit"
+    );
+
+    // Warm, unchanged state: fast path, no WASM.
+    for _ in 0..3 {
+        let _ = exec
+            .summarize_contract_state(key)
+            .await
+            .expect("warm summarize");
+    }
+    let after_warm = exec_counts(&op_manager);
+    assert_eq!(
+        after_warm.summarize_fast_hits - after_cold.summarize_fast_hits,
+        3,
+        "each repeated summarize of unchanged state must be counted as a fast cache hit"
+    );
+    assert_eq!(
+        after_warm.summarize_wasm_calls, after_cold.summarize_wasm_calls,
+        "a warm summarize must NOT be counted as WASM work — conflating these is \
+         precisely the blindness this counter exists to remove"
+    );
+    assert_eq!(
+        after_warm.summarize_reload_hits, after_cold.summarize_reload_hits,
+        "a fast hit must not also be counted as a reload hit"
+    );
+}
+
+/// After a state WRITE the detector is invalidated and the cached summary is
+/// stale, so the next summarize must be counted as a WASM invocation. Without
+/// this, `repeated_summarize_counts_a_fast_hit_and_no_wasm_call` would still
+/// pass under a mutation that counted EVERYTHING as a fast hit.
+#[tokio::test(flavor = "current_thread")]
+async fn summarize_after_a_write_counts_a_wasm_call_not_a_hit() {
+    let storage = MockStateStorage::new();
+    let (op_manager, _guards) = build_op_manager("exec_counts_after_write").await;
+    let mut exec = Executor::new_mock_wasm_uncached_with_op_manager(
+        "exec_counts_after_write",
+        storage.clone(),
+        op_manager.clone(),
+    )
+    .await
+    .expect("create uncached executor with op_manager");
+
+    let contract = test_contract(b"exec_counts_after_write");
+    let key = contract.key();
+    exec.upsert_contract_state(
+        key,
+        Either::Left(WrappedState::new(vec![1, 2, 3])),
+        RelatedContracts::default(),
+        Some(contract.clone()),
+    )
+    .await
+    .expect("PUT");
+    let _ = exec
+        .summarize_contract_state(key)
+        .await
+        .expect("warm the cache");
+
+    exec.upsert_contract_state(
+        key,
+        Either::Left(WrappedState::new(vec![9, 8, 7, 6])),
+        RelatedContracts::default(),
+        None,
+    )
+    .await
+    .expect("UPDATE");
+
+    let before = exec_counts(&op_manager);
+    let _ = exec
+        .summarize_contract_state(key)
+        .await
+        .expect("summarize after write");
+    let after = exec_counts(&op_manager);
+    assert_eq!(
+        after.summarize_wasm_calls - before.summarize_wasm_calls,
+        1,
+        "a summarize of CHANGED state must be counted as a WASM invocation"
+    );
+    assert_eq!(
+        after.summarize_fast_hits, before.summarize_fast_hits,
+        "a changed-state summarize is not a cache hit"
+    );
+    assert_eq!(
+        after.summarize_reload_hits, before.summarize_reload_hits,
+        "a changed-state summarize is not a reload hit either"
+    );
+}
+
+/// A COLD DETECTOR over UNCHANGED state (the post-restart / post-eviction shape)
+/// must be counted as a reload hit: the state is loaded and hashed, but the
+/// cached summary still matches, so the WASM call is elided.
+///
+/// This arm is invisible to the `get_count` proxy the rest of the suite uses —
+/// it looks exactly like a miss there — which is why it needs its own counter
+/// and its own test. Telling "the cache is cold" apart from "the detector is
+/// cold" is what says whether a storm is a cache-sizing problem or a
+/// state-churn problem.
+#[tokio::test(flavor = "current_thread")]
+async fn cold_detector_over_unchanged_state_counts_a_reload_hit() {
+    let storage = MockStateStorage::new();
+    let (op_manager, _guards) = build_op_manager("exec_counts_reload").await;
+    let mut exec = Executor::new_mock_wasm_uncached_with_op_manager(
+        "exec_counts_reload",
+        storage.clone(),
+        op_manager.clone(),
+    )
+    .await
+    .expect("create uncached executor with op_manager");
+
+    let contract = test_contract(b"exec_counts_reload");
+    let key = contract.key();
+    exec.upsert_contract_state(
+        key,
+        Either::Left(WrappedState::new(vec![4, 5, 6, 7])),
+        RelatedContracts::default(),
+        Some(contract.clone()),
+    )
+    .await
+    .expect("PUT");
+    let _ = exec
+        .summarize_contract_state(key)
+        .await
+        .expect("warm the summary cache");
+
+    // Drop the change detector WITHOUT changing the state or the executor's
+    // summary cache — the restart/eviction shape.
+    exec.state_store.cache_invalidator().invalidate(&key);
+
+    let before = exec_counts(&op_manager);
+    let _ = exec
+        .summarize_contract_state(key)
+        .await
+        .expect("summarize with cold detector");
+    let after = exec_counts(&op_manager);
+    assert_eq!(
+        after.summarize_reload_hits - before.summarize_reload_hits,
+        1,
+        "a cold detector over unchanged state must be counted as a reload hit"
+    );
+    assert_eq!(
+        after.summarize_wasm_calls, before.summarize_wasm_calls,
+        "the cached summary still matched, so no WASM ran and none may be counted"
+    );
+    assert_eq!(
+        after.summarize_fast_hits, before.summarize_fast_hits,
+        "the detector was cold, so this is not a FAST hit"
+    );
+}
+
+/// Delta sibling of `repeated_summarize_counts_a_fast_hit_and_no_wasm_call`.
+/// This path runs per-SUBSCRIBER during broadcast fan-out, so it is the hotter
+/// of the two and the one whose hit rate matters most.
+#[tokio::test(flavor = "current_thread")]
+async fn repeated_delta_counts_a_fast_hit_and_no_wasm_call() {
+    let storage = MockStateStorage::new();
+    let (op_manager, _guards) = build_op_manager("exec_counts_delta").await;
+    let mut exec = Executor::new_mock_wasm_uncached_with_op_manager(
+        "exec_counts_delta",
+        storage.clone(),
+        op_manager.clone(),
+    )
+    .await
+    .expect("create uncached executor with op_manager");
+
+    let contract = test_contract(b"exec_counts_delta");
+    let key = contract.key();
+    let peer_summary = StateSummary::from(vec![7u8; 3]);
+    exec.upsert_contract_state(
+        key,
+        Either::Left(WrappedState::new(vec![5, 4, 3, 2, 1])),
+        RelatedContracts::default(),
+        Some(contract.clone()),
+    )
+    .await
+    .expect("PUT");
+
+    let before = exec_counts(&op_manager);
+    let _ = exec
+        .get_contract_state_delta(key, peer_summary.clone())
+        .await
+        .expect("delta 1");
+    let after_cold = exec_counts(&op_manager);
+    assert_eq!(
+        after_cold.delta_wasm_calls - before.delta_wasm_calls,
+        1,
+        "the cold delta must be counted as one WASM invocation"
+    );
+
+    for _ in 0..3 {
+        let _ = exec
+            .get_contract_state_delta(key, peer_summary.clone())
+            .await
+            .expect("warm delta");
+    }
+    let after_warm = exec_counts(&op_manager);
+    assert_eq!(
+        after_warm.delta_fast_hits - after_cold.delta_fast_hits,
+        3,
+        "each repeated delta against the same peer summary and unchanged state \
+         must be counted as a fast cache hit"
+    );
+    assert_eq!(
+        after_warm.delta_wasm_calls, after_cold.delta_wasm_calls,
+        "a warm delta must NOT be counted as WASM work"
+    );
+
+    // A DIFFERENT peer summary against the same state is a genuine miss: the
+    // delta cache is keyed on (state, peer-summary). Pins that the fast-hit
+    // count is not simply "the state didn't change".
+    let other_summary = StateSummary::from(vec![1u8; 3]);
+    let _ = exec
+        .get_contract_state_delta(key, other_summary)
+        .await
+        .expect("delta for a new peer summary");
+    let after_other = exec_counts(&op_manager);
+    assert_eq!(
+        after_other.delta_wasm_calls - after_warm.delta_wasm_calls,
+        1,
+        "an unseen peer summary must be counted as a WASM invocation even though \
+         the state is unchanged"
+    );
+    assert_eq!(
+        after_other.delta_fast_hits, after_warm.delta_fast_hits,
+        "an unseen peer summary is not a fast hit"
+    );
+}
+
+/// The cached path's three arms must PARTITION its calls exactly: every call to
+/// `summarize_contract_state` lands on exactly one of fast hit / reload hit /
+/// WASM call, so no consumer ever has to subtract one counter from another to
+/// get an answer (the "metric describing a filtering decision" rule).
+///
+/// A mutation that records two arms for one call, or none, fails here even
+/// though each individual arm's test would still pass.
+#[tokio::test(flavor = "current_thread")]
+async fn summarize_arms_partition_every_call_exactly_once() {
+    let storage = MockStateStorage::new();
+    let (op_manager, _guards) = build_op_manager("exec_counts_partition").await;
+    let mut exec = Executor::new_mock_wasm_uncached_with_op_manager(
+        "exec_counts_partition",
+        storage.clone(),
+        op_manager.clone(),
+    )
+    .await
+    .expect("create uncached executor with op_manager");
+
+    let contract = test_contract(b"exec_counts_partition");
+    let key = contract.key();
+    exec.upsert_contract_state(
+        key,
+        Either::Left(WrappedState::new(vec![1, 1, 2, 3])),
+        RelatedContracts::default(),
+        Some(contract.clone()),
+    )
+    .await
+    .expect("PUT");
+
+    let before = exec_counts(&op_manager);
+    let mut calls = 0u64;
+
+    // Mix all three outcomes: cold cache, warm cache, cold detector, and a
+    // post-write recompute.
+    let _ = exec.summarize_contract_state(key).await.expect("cold");
+    calls += 1;
+    for _ in 0..4 {
+        let _ = exec.summarize_contract_state(key).await.expect("warm");
+        calls += 1;
+    }
+    exec.state_store.cache_invalidator().invalidate(&key);
+    let _ = exec.summarize_contract_state(key).await.expect("reload");
+    calls += 1;
+    exec.upsert_contract_state(
+        key,
+        Either::Left(WrappedState::new(vec![2, 2, 4, 6, 8])),
+        RelatedContracts::default(),
+        None,
+    )
+    .await
+    .expect("UPDATE");
+    let _ = exec.summarize_contract_state(key).await.expect("recompute");
+    calls += 1;
+
+    let after = exec_counts(&op_manager);
+    let recorded = (after.summarize_fast_hits - before.summarize_fast_hits)
+        + (after.summarize_reload_hits - before.summarize_reload_hits)
+        + (after.summarize_wasm_calls - before.summarize_wasm_calls);
+    assert_eq!(
+        recorded, calls,
+        "the three cached-path arms must partition every summarize call exactly \
+         once (recorded {recorded} for {calls} calls)"
+    );
+    // Non-vacuity: all three arms must actually have fired, or the partition
+    // would hold trivially for a counter that only ever records one of them.
+    assert!(after.summarize_fast_hits > before.summarize_fast_hits);
+    assert!(after.summarize_reload_hits > before.summarize_reload_hits);
+    assert!(after.summarize_wasm_calls > before.summarize_wasm_calls);
+}

--- a/crates/core/src/contract/executor/pool_tests/summarize_delta_cache_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/summarize_delta_cache_tests.rs
@@ -513,3 +513,370 @@ async fn summary_cache_covers_live_hosted_count_not_fixed_cap() {
         );
     }
 }
+
+// =========================================================================
+// PRODUCTION OBSERVABILITY (the cache-hit / WASM-miss split)
+// =========================================================================
+//
+// The tests above prove the cache WORKS, using `MockStateStorage::get_count`
+// as an indirect proxy: no state reload, therefore no WASM call. That proxy is
+// unavailable in production and, more importantly, cannot separate the two
+// no-WASM outcomes — a reload HIT does load the state and would score as a
+// "miss" under it.
+//
+// `ContractExecMetrics` records each outcome at its own decision point, so the
+// tests below assert what an operator actually reads. They are the oracle the
+// suite lacked: a mutation that miscounts a cache hit as a WASM call (or the
+// reverse) passes every `get_count` assertion above and fails here.
+
+/// Snapshot the executor's per-node contract-exec counters.
+fn exec_counts(
+    op_manager: &Arc<OpManager>,
+) -> crate::ring::contract_exec_metrics::ContractExecSnapshot {
+    op_manager.ring.contract_exec_metrics().snapshot()
+}
+
+/// A repeated summarize of UNCHANGED state must be counted as a fast cache hit,
+/// and must NOT be counted as a WASM invocation.
+///
+/// This is the distinction the production signal could not make: the
+/// handler-entry span at `contract.rs`'s `info_span!("summarize_contract_state")`
+/// fires once per call regardless of which arm runs, which is why every rate
+/// quoted across the #4473 / #4610 / #5040 / #5238 storm investigations was
+/// undifferentiated. Deltas are measured around each call so the PUT's own
+/// uncached WASM work cannot mask a miscount.
+#[tokio::test(flavor = "current_thread")]
+async fn repeated_summarize_counts_a_fast_hit_and_no_wasm_call() {
+    let storage = MockStateStorage::new();
+    let (op_manager, _guards) = build_op_manager("exec_counts_summarize").await;
+    let mut exec = Executor::new_mock_wasm_uncached_with_op_manager(
+        "exec_counts_summarize",
+        storage.clone(),
+        op_manager.clone(),
+    )
+    .await
+    .expect("create uncached executor with op_manager");
+
+    let contract = test_contract(b"exec_counts_summarize");
+    let key = contract.key();
+    let state = WrappedState::new(vec![1, 2, 3, 4, 5]);
+    exec.upsert_contract_state(
+        key,
+        Either::Left(state.clone()),
+        RelatedContracts::default(),
+        Some(contract.clone()),
+    )
+    .await
+    .expect("PUT");
+
+    // Cold: no cached summary for this contract, so the WASM must run.
+    let before = exec_counts(&op_manager);
+    let _ = exec
+        .summarize_contract_state(key)
+        .await
+        .expect("summarize 1");
+    let after_cold = exec_counts(&op_manager);
+    assert_eq!(
+        after_cold.summarize_wasm_calls - before.summarize_wasm_calls,
+        1,
+        "the cold summarize must be counted as one WASM invocation"
+    );
+    assert_eq!(
+        after_cold.summarize_fast_hits, before.summarize_fast_hits,
+        "a cold summarize is not a cache hit"
+    );
+
+    // Warm, unchanged state: fast path, no WASM.
+    for _ in 0..3 {
+        let _ = exec
+            .summarize_contract_state(key)
+            .await
+            .expect("warm summarize");
+    }
+    let after_warm = exec_counts(&op_manager);
+    assert_eq!(
+        after_warm.summarize_fast_hits - after_cold.summarize_fast_hits,
+        3,
+        "each repeated summarize of unchanged state must be counted as a fast cache hit"
+    );
+    assert_eq!(
+        after_warm.summarize_wasm_calls, after_cold.summarize_wasm_calls,
+        "a warm summarize must NOT be counted as WASM work — conflating these is \
+         precisely the blindness this counter exists to remove"
+    );
+    assert_eq!(
+        after_warm.summarize_reload_hits, after_cold.summarize_reload_hits,
+        "a fast hit must not also be counted as a reload hit"
+    );
+}
+
+/// After a state WRITE the detector is invalidated and the cached summary is
+/// stale, so the next summarize must be counted as a WASM invocation. Without
+/// this, `repeated_summarize_counts_a_fast_hit_and_no_wasm_call` would still
+/// pass under a mutation that counted EVERYTHING as a fast hit.
+#[tokio::test(flavor = "current_thread")]
+async fn summarize_after_a_write_counts_a_wasm_call_not_a_hit() {
+    let storage = MockStateStorage::new();
+    let (op_manager, _guards) = build_op_manager("exec_counts_after_write").await;
+    let mut exec = Executor::new_mock_wasm_uncached_with_op_manager(
+        "exec_counts_after_write",
+        storage.clone(),
+        op_manager.clone(),
+    )
+    .await
+    .expect("create uncached executor with op_manager");
+
+    let contract = test_contract(b"exec_counts_after_write");
+    let key = contract.key();
+    exec.upsert_contract_state(
+        key,
+        Either::Left(WrappedState::new(vec![1, 2, 3])),
+        RelatedContracts::default(),
+        Some(contract.clone()),
+    )
+    .await
+    .expect("PUT");
+    let _ = exec
+        .summarize_contract_state(key)
+        .await
+        .expect("warm the cache");
+
+    exec.upsert_contract_state(
+        key,
+        Either::Left(WrappedState::new(vec![9, 8, 7, 6])),
+        RelatedContracts::default(),
+        None,
+    )
+    .await
+    .expect("UPDATE");
+
+    let before = exec_counts(&op_manager);
+    let _ = exec
+        .summarize_contract_state(key)
+        .await
+        .expect("summarize after write");
+    let after = exec_counts(&op_manager);
+    assert_eq!(
+        after.summarize_wasm_calls - before.summarize_wasm_calls,
+        1,
+        "a summarize of CHANGED state must be counted as a WASM invocation"
+    );
+    assert_eq!(
+        after.summarize_fast_hits, before.summarize_fast_hits,
+        "a changed-state summarize is not a cache hit"
+    );
+    assert_eq!(
+        after.summarize_reload_hits, before.summarize_reload_hits,
+        "a changed-state summarize is not a reload hit either"
+    );
+}
+
+/// A COLD DETECTOR over UNCHANGED state (the post-restart / post-eviction shape)
+/// must be counted as a reload hit: the state is loaded and hashed, but the
+/// cached summary still matches, so the WASM call is elided.
+///
+/// This arm is invisible to the `get_count` proxy the rest of the suite uses —
+/// it looks exactly like a miss there — which is why it needs its own counter
+/// and its own test. Telling "the cache is cold" apart from "the detector is
+/// cold" is what says whether a storm is a cache-sizing problem or a
+/// state-churn problem.
+#[tokio::test(flavor = "current_thread")]
+async fn cold_detector_over_unchanged_state_counts_a_reload_hit() {
+    let storage = MockStateStorage::new();
+    let (op_manager, _guards) = build_op_manager("exec_counts_reload").await;
+    let mut exec = Executor::new_mock_wasm_uncached_with_op_manager(
+        "exec_counts_reload",
+        storage.clone(),
+        op_manager.clone(),
+    )
+    .await
+    .expect("create uncached executor with op_manager");
+
+    let contract = test_contract(b"exec_counts_reload");
+    let key = contract.key();
+    exec.upsert_contract_state(
+        key,
+        Either::Left(WrappedState::new(vec![4, 5, 6, 7])),
+        RelatedContracts::default(),
+        Some(contract.clone()),
+    )
+    .await
+    .expect("PUT");
+    let _ = exec
+        .summarize_contract_state(key)
+        .await
+        .expect("warm the summary cache");
+
+    // Drop the change detector WITHOUT changing the state or the executor's
+    // summary cache — the restart/eviction shape.
+    exec.state_store.cache_invalidator().invalidate(&key);
+
+    let before = exec_counts(&op_manager);
+    let _ = exec
+        .summarize_contract_state(key)
+        .await
+        .expect("summarize with cold detector");
+    let after = exec_counts(&op_manager);
+    assert_eq!(
+        after.summarize_reload_hits - before.summarize_reload_hits,
+        1,
+        "a cold detector over unchanged state must be counted as a reload hit"
+    );
+    assert_eq!(
+        after.summarize_wasm_calls, before.summarize_wasm_calls,
+        "the cached summary still matched, so no WASM ran and none may be counted"
+    );
+    assert_eq!(
+        after.summarize_fast_hits, before.summarize_fast_hits,
+        "the detector was cold, so this is not a FAST hit"
+    );
+}
+
+/// Delta sibling of `repeated_summarize_counts_a_fast_hit_and_no_wasm_call`.
+/// This path runs per-SUBSCRIBER during broadcast fan-out, so it is the hotter
+/// of the two and the one whose hit rate matters most.
+#[tokio::test(flavor = "current_thread")]
+async fn repeated_delta_counts_a_fast_hit_and_no_wasm_call() {
+    let storage = MockStateStorage::new();
+    let (op_manager, _guards) = build_op_manager("exec_counts_delta").await;
+    let mut exec = Executor::new_mock_wasm_uncached_with_op_manager(
+        "exec_counts_delta",
+        storage.clone(),
+        op_manager.clone(),
+    )
+    .await
+    .expect("create uncached executor with op_manager");
+
+    let contract = test_contract(b"exec_counts_delta");
+    let key = contract.key();
+    let peer_summary = StateSummary::from(vec![7u8; 3]);
+    exec.upsert_contract_state(
+        key,
+        Either::Left(WrappedState::new(vec![5, 4, 3, 2, 1])),
+        RelatedContracts::default(),
+        Some(contract.clone()),
+    )
+    .await
+    .expect("PUT");
+
+    let before = exec_counts(&op_manager);
+    let _ = exec
+        .get_contract_state_delta(key, peer_summary.clone())
+        .await
+        .expect("delta 1");
+    let after_cold = exec_counts(&op_manager);
+    assert_eq!(
+        after_cold.delta_wasm_calls - before.delta_wasm_calls,
+        1,
+        "the cold delta must be counted as one WASM invocation"
+    );
+
+    for _ in 0..3 {
+        let _ = exec
+            .get_contract_state_delta(key, peer_summary.clone())
+            .await
+            .expect("warm delta");
+    }
+    let after_warm = exec_counts(&op_manager);
+    assert_eq!(
+        after_warm.delta_fast_hits - after_cold.delta_fast_hits,
+        3,
+        "each repeated delta against the same peer summary and unchanged state \
+         must be counted as a fast cache hit"
+    );
+    assert_eq!(
+        after_warm.delta_wasm_calls, after_cold.delta_wasm_calls,
+        "a warm delta must NOT be counted as WASM work"
+    );
+
+    // A DIFFERENT peer summary against the same state is a genuine miss: the
+    // delta cache is keyed on (state, peer-summary). Pins that the fast-hit
+    // count is not simply "the state didn't change".
+    let other_summary = StateSummary::from(vec![1u8; 3]);
+    let _ = exec
+        .get_contract_state_delta(key, other_summary)
+        .await
+        .expect("delta for a new peer summary");
+    let after_other = exec_counts(&op_manager);
+    assert_eq!(
+        after_other.delta_wasm_calls - after_warm.delta_wasm_calls,
+        1,
+        "an unseen peer summary must be counted as a WASM invocation even though \
+         the state is unchanged"
+    );
+    assert_eq!(
+        after_other.delta_fast_hits, after_warm.delta_fast_hits,
+        "an unseen peer summary is not a fast hit"
+    );
+}
+
+/// The cached path's three arms must PARTITION its calls exactly: every call to
+/// `summarize_contract_state` lands on exactly one of fast hit / reload hit /
+/// WASM call, so no consumer ever has to subtract one counter from another to
+/// get an answer (the "metric describing a filtering decision" rule).
+///
+/// A mutation that records two arms for one call, or none, fails here even
+/// though each individual arm's test would still pass.
+#[tokio::test(flavor = "current_thread")]
+async fn summarize_arms_partition_every_call_exactly_once() {
+    let storage = MockStateStorage::new();
+    let (op_manager, _guards) = build_op_manager("exec_counts_partition").await;
+    let mut exec = Executor::new_mock_wasm_uncached_with_op_manager(
+        "exec_counts_partition",
+        storage.clone(),
+        op_manager.clone(),
+    )
+    .await
+    .expect("create uncached executor with op_manager");
+
+    let contract = test_contract(b"exec_counts_partition");
+    let key = contract.key();
+    exec.upsert_contract_state(
+        key,
+        Either::Left(WrappedState::new(vec![1, 1, 2, 3])),
+        RelatedContracts::default(),
+        Some(contract.clone()),
+    )
+    .await
+    .expect("PUT");
+
+    let before = exec_counts(&op_manager);
+    let mut calls = 0u64;
+
+    // Mix all three outcomes: cold cache, warm cache, cold detector, and a
+    // post-write recompute.
+    let _ = exec.summarize_contract_state(key).await.expect("cold");
+    calls += 1;
+    for _ in 0..4 {
+        let _ = exec.summarize_contract_state(key).await.expect("warm");
+        calls += 1;
+    }
+    exec.state_store.cache_invalidator().invalidate(&key);
+    let _ = exec.summarize_contract_state(key).await.expect("reload");
+    calls += 1;
+    exec.upsert_contract_state(
+        key,
+        Either::Left(WrappedState::new(vec![2, 2, 4, 6, 8])),
+        RelatedContracts::default(),
+        None,
+    )
+    .await
+    .expect("UPDATE");
+    let _ = exec.summarize_contract_state(key).await.expect("recompute");
+    calls += 1;
+
+    let after = exec_counts(&op_manager);
+    let recorded = (after.summarize_fast_hits - before.summarize_fast_hits)
+        + (after.summarize_reload_hits - before.summarize_reload_hits)
+        + (after.summarize_wasm_calls - before.summarize_wasm_calls);
+    assert_eq!(
+        recorded, calls,
+        "the three cached-path arms must partition every summarize call exactly \
+         once (recorded {recorded} for {calls} calls)"
+    );
+    // Non-vacuity: all three arms must actually have fired, or the partition
+    // would hold trivially for a counter that only ever records one of them.
+    assert!(after.summarize_fast_hits > before.summarize_fast_hits);
+    assert!(after.summarize_reload_hits > before.summarize_reload_hits);
+    assert!(after.summarize_wasm_calls > before.summarize_wasm_calls);
+}

--- a/crates/core/src/contract/executor/runtime/contract_ops.rs
+++ b/crates/core/src/contract/executor/runtime/contract_ops.rs
@@ -863,3 +863,77 @@ impl Executor<Runtime> {
         Ok(retry_result)
     }
 }
+
+/// Source-scrape pin for the UNCACHED WASM `summarize_state` counters.
+///
+/// These three sites live in `impl Executor<Runtime>` — a real compiled WASM
+/// runtime — so the `MockWasmRuntime` harness that covers every other arm in
+/// `pool_tests::summarize_delta_cache_tests` cannot reach them, and a runtime
+/// test would need the full `wasm_conformance_tests` fixture. Pinned from
+/// source instead, which is the cheaper guard against the failure that actually
+/// threatens them: a copy-paste slip recording `record_summarize_wasm_call`
+/// here would inflate the CACHED path's miss count with work that never had a
+/// cache in front of it, making a healthy cache look like it was thrashing.
+#[cfg(test)]
+mod uncached_summarize_counter_pins {
+    /// The file's production source, with comment lines removed so a needle
+    /// cannot match the prose that describes the code (the same guard as in
+    /// `executor_impl::contract_exec_counter_pins`, where that trap was
+    /// actually hit), and truncated before this test module so a needle cannot
+    /// match its own assertion strings.
+    fn production_source() -> String {
+        let src = include_str!("contract_ops.rs");
+        let cutoff = src
+            .find("\n#[cfg(test)]\nmod ")
+            .expect("contract_ops.rs must have a top-level #[cfg(test)] mod section");
+        src[..cutoff]
+            .lines()
+            .filter(|line| !line.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn every_uncached_summarize_site_is_counted_as_uncached() {
+        let src = production_source();
+        let norm = src.split_whitespace().collect::<Vec<_>>().join(" ");
+
+        assert_eq!(
+            norm.matches(".summarize_state(").count(),
+            3,
+            "expected exactly 3 WASM summarize_state sites in contract_ops; a new one \
+             needs its own record_summarize_wasm_uncached() call, or the WASM total \
+             silently under-reports"
+        );
+        assert_eq!(
+            norm.matches("m.record_summarize_wasm_uncached();").count(),
+            3,
+            "each of the 3 uncached summarize_state sites must record the UNCACHED arm"
+        );
+        assert_eq!(
+            norm.matches("record_summarize_wasm_call()").count(),
+            0,
+            "no site here may record the CACHED-path arm — these calls have no cache \
+             in front of them, and counting them there would make a healthy cache \
+             look like it was thrashing"
+        );
+
+        // Each recorder must PRECEDE its own call, not trail the previous one.
+        let mut cursor = 0usize;
+        for i in 0..3 {
+            let rec = norm[cursor..]
+                .find("m.record_summarize_wasm_uncached();")
+                .unwrap_or_else(|| panic!("uncached recorder #{i} not found"))
+                + cursor;
+            let call = norm[rec..]
+                .find(".summarize_state(")
+                .unwrap_or_else(|| panic!("summarize_state call #{i} not found after recorder"))
+                + rec;
+            assert!(
+                !norm[rec + 1..call].contains("m.record_summarize_wasm_uncached();"),
+                "recorder #{i} is not the one guarding its own summarize_state call"
+            );
+            cursor = call;
+        }
+    }
+}

--- a/crates/core/src/contract/executor/runtime/contract_ops.rs
+++ b/crates/core/src/contract/executor/runtime/contract_ops.rs
@@ -53,6 +53,14 @@ impl Executor<Runtime> {
                     WrappedState::new(s.into_bytes())
                 }
                 _ => {
+                    // Uncached WASM `summarize_state`: this PUT/UPSERT response
+                    // site has no summary cache in front of it, so it is counted
+                    // on the `uncached` arm — keeping the cached path's
+                    // hit/miss partition exact while the WASM TOTAL stays
+                    // honest. See `ring::contract_exec_metrics`.
+                    if let Some(m) = self.contract_exec_metrics() {
+                        m.record_summarize_wasm_uncached();
+                    }
                     let summary = self
                         .runtime
                         .summarize_state(&key, &params, &current_state)
@@ -125,6 +133,10 @@ impl Executor<Runtime> {
 
             self.broadcast_state_change(key, new_state.clone()).await;
 
+            // Uncached WASM `summarize_state` (PUT response summary).
+            if let Some(m) = self.contract_exec_metrics() {
+                m.record_summarize_wasm_uncached();
+            }
             let summary = self
                 .runtime
                 .summarize_state(&key, &params, &new_state)
@@ -183,6 +195,10 @@ impl Executor<Runtime> {
             let new_state = self
                 .get_updated_state(&parameters, current_state, key, updates)
                 .await?;
+            // Uncached WASM `summarize_state` (local-mode UPDATE response).
+            if let Some(m) = self.contract_exec_metrics() {
+                m.record_summarize_wasm_uncached();
+            }
             let summary = self
                 .runtime
                 .summarize_state(&key, &parameters, &new_state)

--- a/crates/core/src/contract/executor/runtime/contract_ops.rs
+++ b/crates/core/src/contract/executor/runtime/contract_ops.rs
@@ -814,3 +814,77 @@ impl Executor<Runtime> {
         Ok(retry_result)
     }
 }
+
+/// Source-scrape pin for the UNCACHED WASM `summarize_state` counters.
+///
+/// These three sites live in `impl Executor<Runtime>` — a real compiled WASM
+/// runtime — so the `MockWasmRuntime` harness that covers every other arm in
+/// `pool_tests::summarize_delta_cache_tests` cannot reach them, and a runtime
+/// test would need the full `wasm_conformance_tests` fixture. Pinned from
+/// source instead, which is the cheaper guard against the failure that actually
+/// threatens them: a copy-paste slip recording `record_summarize_wasm_call`
+/// here would inflate the CACHED path's miss count with work that never had a
+/// cache in front of it, making a healthy cache look like it was thrashing.
+#[cfg(test)]
+mod uncached_summarize_counter_pins {
+    /// The file's production source, with comment lines removed so a needle
+    /// cannot match the prose that describes the code (the same guard as in
+    /// `executor_impl::contract_exec_counter_pins`, where that trap was
+    /// actually hit), and truncated before this test module so a needle cannot
+    /// match its own assertion strings.
+    fn production_source() -> String {
+        let src = include_str!("contract_ops.rs");
+        let cutoff = src
+            .find("\n#[cfg(test)]\nmod ")
+            .expect("contract_ops.rs must have a top-level #[cfg(test)] mod section");
+        src[..cutoff]
+            .lines()
+            .filter(|line| !line.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn every_uncached_summarize_site_is_counted_as_uncached() {
+        let src = production_source();
+        let norm = src.split_whitespace().collect::<Vec<_>>().join(" ");
+
+        assert_eq!(
+            norm.matches(".summarize_state(").count(),
+            3,
+            "expected exactly 3 WASM summarize_state sites in contract_ops; a new one \
+             needs its own record_summarize_wasm_uncached() call, or the WASM total \
+             silently under-reports"
+        );
+        assert_eq!(
+            norm.matches("m.record_summarize_wasm_uncached();").count(),
+            3,
+            "each of the 3 uncached summarize_state sites must record the UNCACHED arm"
+        );
+        assert_eq!(
+            norm.matches("record_summarize_wasm_call()").count(),
+            0,
+            "no site here may record the CACHED-path arm — these calls have no cache \
+             in front of them, and counting them there would make a healthy cache \
+             look like it was thrashing"
+        );
+
+        // Each recorder must PRECEDE its own call, not trail the previous one.
+        let mut cursor = 0usize;
+        for i in 0..3 {
+            let rec = norm[cursor..]
+                .find("m.record_summarize_wasm_uncached();")
+                .unwrap_or_else(|| panic!("uncached recorder #{i} not found"))
+                + cursor;
+            let call = norm[rec..]
+                .find(".summarize_state(")
+                .unwrap_or_else(|| panic!("summarize_state call #{i} not found after recorder"))
+                + rec;
+            assert!(
+                !norm[rec + 1..call].contains("m.record_summarize_wasm_uncached();"),
+                "recorder #{i} is not the one guarding its own summarize_state call"
+            );
+            cursor = call;
+        }
+    }
+}

--- a/crates/core/src/contract/executor/runtime/executor_impl.rs
+++ b/crates/core/src/contract/executor/runtime/executor_impl.rs
@@ -2696,17 +2696,27 @@ where
         // through `Arc<DashMap>`, not `&mut self`), and leaves this false.
         let mut local_entry_became_empty = false;
 
-        // Owned handle, resolved before either fan-out arm takes its `&mut`
-        // borrows: both arms hold two executor maps mutably for the whole loop,
-        // so the borrowing accessor is unusable inside them. One `Arc` clone per
-        // fan-out (not per subscriber). Neither delta below has a cache in front
-        // of it, so they land on the `uncached` arm — see
-        // `ring::contract_exec_metrics` for why the cached and uncached WASM
-        // totals are kept as separate counters rather than one.
+        // Resolved before either fan-out arm takes its `&mut` borrows: both arms
+        // hold two executor maps mutably for the whole loop, so the
+        // `self.contract_exec_metrics()` accessor (which borrows ALL of `self`)
+        // is unusable inside them.
+        //
+        // Deliberately the FIELD, not that accessor and not an `Arc` clone: this
+        // borrows only `self.op_manager`, which is disjoint from
+        // `self.update_notifications`, `self.subscriber_summaries` and
+        // `self.runtime`, so the borrow checker allows it and the cost is a
+        // pointer. An `Arc` clone here would instead charge two atomic RMWs to
+        // every committed update on the zero-local-subscriber path — the
+        // overwhelmingly common one for a contract this node hosts for the
+        // network, which returns below without recording anything.
+        //
+        // Neither delta below has a cache in front of it, so they land on the
+        // `uncached` arm — see `ring::contract_exec_metrics` for why the cached
+        // and uncached WASM totals are separate counters.
         let exec_metrics = self
             .op_manager
             .as_ref()
-            .map(|om| om.ring.contract_exec_metrics_arc());
+            .map(|om| om.ring.contract_exec_metrics());
 
         if let (Some(shared_notifications), Some(shared_summaries)) = (
             self.shared_notifications.as_ref(),
@@ -2860,7 +2870,7 @@ where
                         if delta_computations < super::MAX_DELTA_COMPUTATIONS_PER_FANOUT =>
                     {
                         delta_computations += 1;
-                        if let Some(m) = exec_metrics.as_deref() {
+                        if let Some(m) = exec_metrics {
                             m.record_delta_wasm_uncached();
                         }
                         self.runtime
@@ -3042,7 +3052,7 @@ where
                         if delta_computations < super::MAX_DELTA_COMPUTATIONS_PER_FANOUT =>
                     {
                         delta_computations += 1;
-                        if let Some(m) = exec_metrics.as_deref() {
+                        if let Some(m) = exec_metrics {
                             m.record_delta_wasm_uncached();
                         }
                         self.runtime

--- a/crates/core/src/contract/executor/runtime/executor_impl.rs
+++ b/crates/core/src/contract/executor/runtime/executor_impl.rs
@@ -15,6 +15,23 @@ where
     S: crate::wasm_runtime::StateStorage + Send + Sync + 'static,
     <S as crate::wasm_runtime::StateStorage>::Error: Into<anyhow::Error>,
 {
+    /// This node's contract-exec WASM counters, or `None` for an executor with
+    /// no `OpManager` (unit-test and local-only executors have no `Ring` to
+    /// attribute the work to, and nothing reads the counters there).
+    ///
+    /// Returns a borrow rather than an `Arc` clone so a counter bump on the
+    /// contract-handling loop costs one `Relaxed` `fetch_add` and nothing else —
+    /// see `ring::contract_exec_metrics` for the cost note and for why an
+    /// undifferentiated handler-entry span could not answer the storm question.
+    #[inline]
+    pub(super) fn contract_exec_metrics(
+        &self,
+    ) -> Option<&crate::ring::contract_exec_metrics::ContractExecMetrics> {
+        self.op_manager
+            .as_ref()
+            .map(|om| om.ring.contract_exec_metrics())
+    }
+
     /// Grow the summary/delta caches' COUNT target to cover the node's live
     /// hosted-contract count before a summarize/delta computation, so the
     /// interest-heartbeat's hosted working set stays cached across cycles (no
@@ -1268,10 +1285,24 @@ where
         // secret export) MUST stay read-only w.r.t. contract state, or it could
         // populate the detector against a state a concurrent write has changed.
         if let Some(detector_hash) = self.state_store.cached_state_hash(&key) {
-            if let Some((cached_hash, cached_summary)) = self.summary_cache.get(&key) {
-                if *cached_hash == detector_hash {
-                    return Ok(cached_summary.clone());
+            // Resolve the hit to an owned value BEFORE recording: `LruCache::get`
+            // borrows the executor mutably (it reorders the recency list), so the
+            // counter read cannot overlap it. The clone is the same one the
+            // return did before; it just moves ahead of the borrow's end.
+            let hit = self
+                .summary_cache
+                .get(&key)
+                .and_then(|(hash, summary)| (*hash == detector_hash).then(|| summary.clone()));
+            if let Some(cached_summary) = hit {
+                // Field-visible cache-HIT count. Without this, the only
+                // production signal for this function was a handler-entry span
+                // that fires identically here and on the WASM path below, so
+                // every storm rate ever quoted conflated the two. See
+                // `ring::contract_exec_metrics`.
+                if let Some(m) = self.contract_exec_metrics() {
+                    m.record_summarize_fast_hit();
                 }
+                return Ok(cached_summary);
             }
         }
 
@@ -1297,10 +1328,18 @@ where
         // The summary may already be cached under this exact hash even when the
         // detector was cold (the summary cache is per-executor; the detector is
         // shared). Reuse it to skip the WASM call.
-        if let Some((cached_hash, cached_summary)) = self.summary_cache.get(&key) {
-            if *cached_hash == state_hash {
-                return Ok(cached_summary.clone());
+        let reload_hit = self
+            .summary_cache
+            .get(&key)
+            .and_then(|(hash, summary)| (*hash == state_hash).then(|| summary.clone()));
+        if let Some(cached_summary) = reload_hit {
+            // Reached the slow path (loaded + hashed the state) but still elided
+            // the WASM call. Counted separately from the fast hit so a cold
+            // detector is distinguishable from a cold cache.
+            if let Some(m) = self.contract_exec_metrics() {
+                m.record_summarize_reload_hit();
             }
+            return Ok(cached_summary);
         }
 
         let params = self
@@ -1322,11 +1361,26 @@ where
         // work whose per-heartbeat × per-neighbor multiplication was the storm.
         // Under the working cache it scales with the STATE-CHANGE rate, not with
         // hosted-set size or neighbor overlap — every-hop placement's "summarize
-        // load stays flat vs hosted-set size" invariant. No-op outside a sim (the
-        // record fn reads the sim-only network-name thread-local). This runs on
-        // the contract-handling loop thread, not a spawn_blocking closure, so the
-        // thread-local is set.
+        // load stays flat vs hosted-set size" invariant.
+        //
+        // TWO sinks, deliberately, because they answer to different readers and
+        // neither can serve the other:
+        //   * `ring.contract_exec_metrics()` is the PRODUCTION counter, read on
+        //     the `router_snapshot` cadence. Always live.
+        //   * `topology_registry` is the SIMULATION counter, keyed by peer
+        //     address so `SimNetwork` can aggregate across nodes; it is a no-op
+        //     outside a sim (the record fn reads the sim-only network-name
+        //     thread-local) and its `get_own_addr()` lookup is deliberately kept
+        //     off the hot path by living here on the WASM slow path. This runs on
+        //     the contract-handling loop thread, not a `spawn_blocking` closure,
+        //     so the thread-local is set.
+        // `summarize_wasm_call_records_both_sinks` pins that they cannot drift
+        // apart.
         if let Some(op_manager) = &self.op_manager {
+            op_manager
+                .ring
+                .contract_exec_metrics()
+                .record_summarize_wasm_call();
             if let Some(own_addr) = op_manager.ring.connection_manager.get_own_addr() {
                 crate::ring::topology_registry::record_summarize_wasm_call(own_addr);
             }
@@ -1377,8 +1431,17 @@ where
         // contract state.
         if let Some(detector_hash) = self.state_store.cached_state_hash(&key) {
             let cache_key = (key, detector_hash, summary_hash);
-            if let Some(cached_delta) = self.delta_cache.get(&cache_key) {
-                return Ok(cached_delta.clone());
+            // Owned before recording: `LruCache::get` borrows mutably (see the
+            // summarize twin above).
+            let hit = self.delta_cache.get(&cache_key).cloned();
+            if let Some(cached_delta) = hit {
+                // Field-visible cache-HIT count; see the summarize twin above
+                // and `ring::contract_exec_metrics`. This arm runs per-SUBSCRIBER
+                // during broadcast fan-out, so it is the hotter of the two.
+                if let Some(m) = self.contract_exec_metrics() {
+                    m.record_delta_fast_hit();
+                }
+                return Ok(cached_delta);
             }
         }
 
@@ -1401,8 +1464,14 @@ where
         self.state_store.cache_state_hash(key, state_hash);
 
         let cache_key = (key, state_hash, summary_hash);
-        if let Some(cached_delta) = self.delta_cache.get(&cache_key) {
-            return Ok(cached_delta.clone());
+        let reload_hit = self.delta_cache.get(&cache_key).cloned();
+        if let Some(cached_delta) = reload_hit {
+            // Slow path reached (state loaded + hashed) but the WASM call was
+            // still elided; see the summarize twin above.
+            if let Some(m) = self.contract_exec_metrics() {
+                m.record_delta_reload_hit();
+            }
+            return Ok(cached_delta);
         }
 
         let params = self
@@ -1416,6 +1485,13 @@ where
                     cause: "contract parameters not found".into(),
                 })
             })?;
+
+        // The delta twin of the summarize slow-path counter: a true cache miss
+        // that actually runs the contract's WASM `get_state_delta`. Recorded at
+        // the decision, immediately before the call it describes.
+        if let Some(m) = self.contract_exec_metrics() {
+            m.record_delta_wasm_call();
+        }
 
         let delta = self
             .runtime
@@ -2620,6 +2696,18 @@ where
         // through `Arc<DashMap>`, not `&mut self`), and leaves this false.
         let mut local_entry_became_empty = false;
 
+        // Owned handle, resolved before either fan-out arm takes its `&mut`
+        // borrows: both arms hold two executor maps mutably for the whole loop,
+        // so the borrowing accessor is unusable inside them. One `Arc` clone per
+        // fan-out (not per subscriber). Neither delta below has a cache in front
+        // of it, so they land on the `uncached` arm — see
+        // `ring::contract_exec_metrics` for why the cached and uncached WASM
+        // totals are kept as separate counters rather than one.
+        let exec_metrics = self
+            .op_manager
+            .as_ref()
+            .map(|om| om.ring.contract_exec_metrics_arc());
+
         if let (Some(shared_notifications), Some(shared_summaries)) = (
             self.shared_notifications.as_ref(),
             self.shared_summaries.as_ref(),
@@ -2772,6 +2860,9 @@ where
                         if delta_computations < super::MAX_DELTA_COMPUTATIONS_PER_FANOUT =>
                     {
                         delta_computations += 1;
+                        if let Some(m) = exec_metrics.as_deref() {
+                            m.record_delta_wasm_uncached();
+                        }
                         self.runtime
                             .get_state_delta(&key, params, new_state, summary)
                             .map_err(|err| {
@@ -2951,6 +3042,9 @@ where
                         if delta_computations < super::MAX_DELTA_COMPUTATIONS_PER_FANOUT =>
                     {
                         delta_computations += 1;
+                        if let Some(m) = exec_metrics.as_deref() {
+                            m.record_delta_wasm_uncached();
+                        }
                         self.runtime
                             .get_state_delta(&key, params, new_state, &*summary)
                             .map_err(|err| {
@@ -3437,6 +3531,116 @@ mod conformance_capture_pins {
             "the conformance capture hook awaits on the merge path. It must not: a \
              slow or stuck writer would then stall contract synchronization. Use \
              `try_send` and drop on full, per .claude/rules/channel-safety.md"
+        );
+    }
+}
+
+/// Source-scrape pin for the contract-exec WASM counters' PRODUCTION liveness.
+///
+/// The failure this guards against already happened once, and is the whole
+/// reason this instrumentation exists: a counter sat on exactly the right line
+/// for a year and was a no-op in the field, because the only sink it wrote to
+/// (`topology_registry`) keys on a thread-local that `SimNetwork` sets and a
+/// production node never does. The simulation asserted the invariant held, the
+/// field suggested it did not, and the counter that would have adjudicated was
+/// switched off precisely where it mattered.
+///
+/// Two sinks now share the site. A runtime test cannot cover both — the unit
+/// fixtures have no bound listener, so `get_own_addr()` returns `None` and the
+/// simulation sink never fires there — so the ordering invariant is pinned from
+/// source instead: the PRODUCTION record must not be nested inside the
+/// `get_own_addr()` guard, which is exactly the shape that would re-create the
+/// original bug.
+#[cfg(test)]
+mod contract_exec_counter_pins {
+    /// Slice `bridged_summarize_contract_state`'s CODE (its signature to the
+    /// next method's signature), with comment lines removed.
+    ///
+    /// Both bounds matter. The slice stops a needle matching a later occurrence
+    /// elsewhere in the file — including this test module's own assertion
+    /// strings, which `include_str!` also pulls in. Dropping comment lines stops
+    /// a needle matching the PROSE that describes the code: the first draft of
+    /// `summarize_wasm_call_records_both_sinks` failed because `get_own_addr()`
+    /// appears in the block comment above the call as well as in the call, and
+    /// the comment came first. A pin that matches its own explanation is not
+    /// pinning anything.
+    fn summarize_body() -> String {
+        let src = include_str!("executor_impl.rs");
+        let start = src
+            .find("pub(in crate::contract::executor) async fn bridged_summarize_contract_state(")
+            .expect("bridged_summarize_contract_state not found");
+        let after = &src[start..];
+        let end = after
+            .find("pub(in crate::contract::executor) async fn bridged_get_contract_state_delta(")
+            .expect("next method after bridged_summarize_contract_state not found");
+        after[..end]
+            .lines()
+            .filter(|line| !line.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn summarize_wasm_call_records_both_sinks() {
+        let body = summarize_body();
+
+        let production_pos = body
+            .find(".record_summarize_wasm_call();")
+            .expect("the production ContractExecMetrics counter must be recorded here");
+        let own_addr_pos = body
+            .find("if let Some(own_addr) = op_manager.ring.connection_manager.get_own_addr()")
+            .expect("the simulation sink's own-address guard must still be here");
+        let sim_pos = body
+            .find("topology_registry::record_summarize_wasm_call(own_addr)")
+            .expect("the simulation topology_registry sink must still be recorded here");
+
+        assert!(
+            production_pos < own_addr_pos,
+            "the PRODUCTION counter ({production_pos}) must be recorded BEFORE the \
+             get_own_addr() lookup ({own_addr_pos}), i.e. outside its `if let Some` \
+             guard. Nesting it inside would make the production counter conditional \
+             on a lookup that returns None on a node with no bound listener, \
+             recreating the sim-only-counter bug this instrumentation exists to fix."
+        );
+        assert!(
+            own_addr_pos < sim_pos,
+            "the simulation sink ({sim_pos}) still takes its peer address from the \
+             get_own_addr() guard ({own_addr_pos})"
+        );
+    }
+
+    /// The counter must sit on the WASM SLOW path: after both cache-hit early
+    /// returns, and immediately before the `summarize_state` call it describes.
+    /// A counter that drifted above the cache checks would count cache hits as
+    /// WASM work — the exact conflation the handler-entry span already makes,
+    /// and the reason its numbers could not be acted on.
+    #[test]
+    fn summarize_wasm_counter_sits_after_both_cache_hit_returns() {
+        let body = summarize_body();
+
+        let fast_hit_pos = body
+            .find(".record_summarize_fast_hit();")
+            .expect("fast-path cache-hit counter not found");
+        let reload_hit_pos = body
+            .find(".record_summarize_reload_hit();")
+            .expect("reload-path cache-hit counter not found");
+        let wasm_pos = body
+            .find(".record_summarize_wasm_call();")
+            .expect("WASM-call counter not found");
+        let summarize_state_pos = body
+            .find(".summarize_state(&key, &params, &state)")
+            .expect("the WASM summarize_state call not found");
+
+        assert!(
+            fast_hit_pos < reload_hit_pos && reload_hit_pos < wasm_pos,
+            "counter order must follow the path order: fast hit ({fast_hit_pos}) < \
+             reload hit ({reload_hit_pos}) < WASM call ({wasm_pos})"
+        );
+        assert!(
+            wasm_pos < summarize_state_pos,
+            "the WASM counter ({wasm_pos}) must be recorded at the decision, \
+             immediately before the summarize_state call it describes \
+             ({summarize_state_pos})"
         );
     }
 }

--- a/crates/core/src/contract/executor/runtime/executor_impl.rs
+++ b/crates/core/src/contract/executor/runtime/executor_impl.rs
@@ -15,6 +15,23 @@ where
     S: crate::wasm_runtime::StateStorage + Send + Sync + 'static,
     <S as crate::wasm_runtime::StateStorage>::Error: Into<anyhow::Error>,
 {
+    /// This node's contract-exec WASM counters, or `None` for an executor with
+    /// no `OpManager` (unit-test and local-only executors have no `Ring` to
+    /// attribute the work to, and nothing reads the counters there).
+    ///
+    /// Returns a borrow rather than an `Arc` clone so a counter bump on the
+    /// contract-handling loop costs one `Relaxed` `fetch_add` and nothing else —
+    /// see `ring::contract_exec_metrics` for the cost note and for why an
+    /// undifferentiated handler-entry span could not answer the storm question.
+    #[inline]
+    pub(super) fn contract_exec_metrics(
+        &self,
+    ) -> Option<&crate::ring::contract_exec_metrics::ContractExecMetrics> {
+        self.op_manager
+            .as_ref()
+            .map(|om| om.ring.contract_exec_metrics())
+    }
+
     /// Grow the summary/delta caches' COUNT target to cover the node's live
     /// hosted-contract count before a summarize/delta computation, so the
     /// interest-heartbeat's hosted working set stays cached across cycles (no
@@ -1242,10 +1259,24 @@ where
         // secret export) MUST stay read-only w.r.t. contract state, or it could
         // populate the detector against a state a concurrent write has changed.
         if let Some(detector_hash) = self.state_store.cached_state_hash(&key) {
-            if let Some((cached_hash, cached_summary)) = self.summary_cache.get(&key) {
-                if *cached_hash == detector_hash {
-                    return Ok(cached_summary.clone());
+            // Resolve the hit to an owned value BEFORE recording: `LruCache::get`
+            // borrows the executor mutably (it reorders the recency list), so the
+            // counter read cannot overlap it. The clone is the same one the
+            // return did before; it just moves ahead of the borrow's end.
+            let hit = self
+                .summary_cache
+                .get(&key)
+                .and_then(|(hash, summary)| (*hash == detector_hash).then(|| summary.clone()));
+            if let Some(cached_summary) = hit {
+                // Field-visible cache-HIT count. Without this, the only
+                // production signal for this function was a handler-entry span
+                // that fires identically here and on the WASM path below, so
+                // every storm rate ever quoted conflated the two. See
+                // `ring::contract_exec_metrics`.
+                if let Some(m) = self.contract_exec_metrics() {
+                    m.record_summarize_fast_hit();
                 }
+                return Ok(cached_summary);
             }
         }
 
@@ -1271,10 +1302,18 @@ where
         // The summary may already be cached under this exact hash even when the
         // detector was cold (the summary cache is per-executor; the detector is
         // shared). Reuse it to skip the WASM call.
-        if let Some((cached_hash, cached_summary)) = self.summary_cache.get(&key) {
-            if *cached_hash == state_hash {
-                return Ok(cached_summary.clone());
+        let reload_hit = self
+            .summary_cache
+            .get(&key)
+            .and_then(|(hash, summary)| (*hash == state_hash).then(|| summary.clone()));
+        if let Some(cached_summary) = reload_hit {
+            // Reached the slow path (loaded + hashed the state) but still elided
+            // the WASM call. Counted separately from the fast hit so a cold
+            // detector is distinguishable from a cold cache.
+            if let Some(m) = self.contract_exec_metrics() {
+                m.record_summarize_reload_hit();
             }
+            return Ok(cached_summary);
         }
 
         let params = self
@@ -1296,11 +1335,26 @@ where
         // work whose per-heartbeat × per-neighbor multiplication was the storm.
         // Under the working cache it scales with the STATE-CHANGE rate, not with
         // hosted-set size or neighbor overlap — every-hop placement's "summarize
-        // load stays flat vs hosted-set size" invariant. No-op outside a sim (the
-        // record fn reads the sim-only network-name thread-local). This runs on
-        // the contract-handling loop thread, not a spawn_blocking closure, so the
-        // thread-local is set.
+        // load stays flat vs hosted-set size" invariant.
+        //
+        // TWO sinks, deliberately, because they answer to different readers and
+        // neither can serve the other:
+        //   * `ring.contract_exec_metrics()` is the PRODUCTION counter, read on
+        //     the `router_snapshot` cadence. Always live.
+        //   * `topology_registry` is the SIMULATION counter, keyed by peer
+        //     address so `SimNetwork` can aggregate across nodes; it is a no-op
+        //     outside a sim (the record fn reads the sim-only network-name
+        //     thread-local) and its `get_own_addr()` lookup is deliberately kept
+        //     off the hot path by living here on the WASM slow path. This runs on
+        //     the contract-handling loop thread, not a `spawn_blocking` closure,
+        //     so the thread-local is set.
+        // `summarize_wasm_call_records_both_sinks` pins that they cannot drift
+        // apart.
         if let Some(op_manager) = &self.op_manager {
+            op_manager
+                .ring
+                .contract_exec_metrics()
+                .record_summarize_wasm_call();
             if let Some(own_addr) = op_manager.ring.connection_manager.get_own_addr() {
                 crate::ring::topology_registry::record_summarize_wasm_call(own_addr);
             }
@@ -1351,8 +1405,17 @@ where
         // contract state.
         if let Some(detector_hash) = self.state_store.cached_state_hash(&key) {
             let cache_key = (key, detector_hash, summary_hash);
-            if let Some(cached_delta) = self.delta_cache.get(&cache_key) {
-                return Ok(cached_delta.clone());
+            // Owned before recording: `LruCache::get` borrows mutably (see the
+            // summarize twin above).
+            let hit = self.delta_cache.get(&cache_key).cloned();
+            if let Some(cached_delta) = hit {
+                // Field-visible cache-HIT count; see the summarize twin above
+                // and `ring::contract_exec_metrics`. This arm runs per-SUBSCRIBER
+                // during broadcast fan-out, so it is the hotter of the two.
+                if let Some(m) = self.contract_exec_metrics() {
+                    m.record_delta_fast_hit();
+                }
+                return Ok(cached_delta);
             }
         }
 
@@ -1375,8 +1438,14 @@ where
         self.state_store.cache_state_hash(key, state_hash);
 
         let cache_key = (key, state_hash, summary_hash);
-        if let Some(cached_delta) = self.delta_cache.get(&cache_key) {
-            return Ok(cached_delta.clone());
+        let reload_hit = self.delta_cache.get(&cache_key).cloned();
+        if let Some(cached_delta) = reload_hit {
+            // Slow path reached (state loaded + hashed) but the WASM call was
+            // still elided; see the summarize twin above.
+            if let Some(m) = self.contract_exec_metrics() {
+                m.record_delta_reload_hit();
+            }
+            return Ok(cached_delta);
         }
 
         let params = self
@@ -1390,6 +1459,13 @@ where
                     cause: "contract parameters not found".into(),
                 })
             })?;
+
+        // The delta twin of the summarize slow-path counter: a true cache miss
+        // that actually runs the contract's WASM `get_state_delta`. Recorded at
+        // the decision, immediately before the call it describes.
+        if let Some(m) = self.contract_exec_metrics() {
+            m.record_delta_wasm_call();
+        }
 
         let delta = self
             .runtime
@@ -2453,6 +2529,18 @@ where
         // through `Arc<DashMap>`, not `&mut self`), and leaves this false.
         let mut local_entry_became_empty = false;
 
+        // Owned handle, resolved before either fan-out arm takes its `&mut`
+        // borrows: both arms hold two executor maps mutably for the whole loop,
+        // so the borrowing accessor is unusable inside them. One `Arc` clone per
+        // fan-out (not per subscriber). Neither delta below has a cache in front
+        // of it, so they land on the `uncached` arm — see
+        // `ring::contract_exec_metrics` for why the cached and uncached WASM
+        // totals are kept as separate counters rather than one.
+        let exec_metrics = self
+            .op_manager
+            .as_ref()
+            .map(|om| om.ring.contract_exec_metrics_arc());
+
         if let (Some(shared_notifications), Some(shared_summaries)) = (
             self.shared_notifications.as_ref(),
             self.shared_summaries.as_ref(),
@@ -2605,6 +2693,9 @@ where
                         if delta_computations < super::MAX_DELTA_COMPUTATIONS_PER_FANOUT =>
                     {
                         delta_computations += 1;
+                        if let Some(m) = exec_metrics.as_deref() {
+                            m.record_delta_wasm_uncached();
+                        }
                         self.runtime
                             .get_state_delta(&key, params, new_state, summary)
                             .map_err(|err| {
@@ -2784,6 +2875,9 @@ where
                         if delta_computations < super::MAX_DELTA_COMPUTATIONS_PER_FANOUT =>
                     {
                         delta_computations += 1;
+                        if let Some(m) = exec_metrics.as_deref() {
+                            m.record_delta_wasm_uncached();
+                        }
                         self.runtime
                             .get_state_delta(&key, params, new_state, &*summary)
                             .map_err(|err| {
@@ -3032,6 +3126,116 @@ mod full_state_version_gate_pins {
             "recovery ordering must be: validate local ({local_valid_pos}) < \
              keep-local-when-valid ({keep_local_pos}) < recovery ({recovery_pos}) — \
              recovery may only replace state the contract itself calls invalid"
+        );
+    }
+}
+
+/// Source-scrape pin for the contract-exec WASM counters' PRODUCTION liveness.
+///
+/// The failure this guards against already happened once, and is the whole
+/// reason this instrumentation exists: a counter sat on exactly the right line
+/// for a year and was a no-op in the field, because the only sink it wrote to
+/// (`topology_registry`) keys on a thread-local that `SimNetwork` sets and a
+/// production node never does. The simulation asserted the invariant held, the
+/// field suggested it did not, and the counter that would have adjudicated was
+/// switched off precisely where it mattered.
+///
+/// Two sinks now share the site. A runtime test cannot cover both — the unit
+/// fixtures have no bound listener, so `get_own_addr()` returns `None` and the
+/// simulation sink never fires there — so the ordering invariant is pinned from
+/// source instead: the PRODUCTION record must not be nested inside the
+/// `get_own_addr()` guard, which is exactly the shape that would re-create the
+/// original bug.
+#[cfg(test)]
+mod contract_exec_counter_pins {
+    /// Slice `bridged_summarize_contract_state`'s CODE (its signature to the
+    /// next method's signature), with comment lines removed.
+    ///
+    /// Both bounds matter. The slice stops a needle matching a later occurrence
+    /// elsewhere in the file — including this test module's own assertion
+    /// strings, which `include_str!` also pulls in. Dropping comment lines stops
+    /// a needle matching the PROSE that describes the code: the first draft of
+    /// `summarize_wasm_call_records_both_sinks` failed because `get_own_addr()`
+    /// appears in the block comment above the call as well as in the call, and
+    /// the comment came first. A pin that matches its own explanation is not
+    /// pinning anything.
+    fn summarize_body() -> String {
+        let src = include_str!("executor_impl.rs");
+        let start = src
+            .find("pub(in crate::contract::executor) async fn bridged_summarize_contract_state(")
+            .expect("bridged_summarize_contract_state not found");
+        let after = &src[start..];
+        let end = after
+            .find("pub(in crate::contract::executor) async fn bridged_get_contract_state_delta(")
+            .expect("next method after bridged_summarize_contract_state not found");
+        after[..end]
+            .lines()
+            .filter(|line| !line.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn summarize_wasm_call_records_both_sinks() {
+        let body = summarize_body();
+
+        let production_pos = body
+            .find(".record_summarize_wasm_call();")
+            .expect("the production ContractExecMetrics counter must be recorded here");
+        let own_addr_pos = body
+            .find("if let Some(own_addr) = op_manager.ring.connection_manager.get_own_addr()")
+            .expect("the simulation sink's own-address guard must still be here");
+        let sim_pos = body
+            .find("topology_registry::record_summarize_wasm_call(own_addr)")
+            .expect("the simulation topology_registry sink must still be recorded here");
+
+        assert!(
+            production_pos < own_addr_pos,
+            "the PRODUCTION counter ({production_pos}) must be recorded BEFORE the \
+             get_own_addr() lookup ({own_addr_pos}), i.e. outside its `if let Some` \
+             guard. Nesting it inside would make the production counter conditional \
+             on a lookup that returns None on a node with no bound listener, \
+             recreating the sim-only-counter bug this instrumentation exists to fix."
+        );
+        assert!(
+            own_addr_pos < sim_pos,
+            "the simulation sink ({sim_pos}) still takes its peer address from the \
+             get_own_addr() guard ({own_addr_pos})"
+        );
+    }
+
+    /// The counter must sit on the WASM SLOW path: after both cache-hit early
+    /// returns, and immediately before the `summarize_state` call it describes.
+    /// A counter that drifted above the cache checks would count cache hits as
+    /// WASM work — the exact conflation the handler-entry span already makes,
+    /// and the reason its numbers could not be acted on.
+    #[test]
+    fn summarize_wasm_counter_sits_after_both_cache_hit_returns() {
+        let body = summarize_body();
+
+        let fast_hit_pos = body
+            .find(".record_summarize_fast_hit();")
+            .expect("fast-path cache-hit counter not found");
+        let reload_hit_pos = body
+            .find(".record_summarize_reload_hit();")
+            .expect("reload-path cache-hit counter not found");
+        let wasm_pos = body
+            .find(".record_summarize_wasm_call();")
+            .expect("WASM-call counter not found");
+        let summarize_state_pos = body
+            .find(".summarize_state(&key, &params, &state)")
+            .expect("the WASM summarize_state call not found");
+
+        assert!(
+            fast_hit_pos < reload_hit_pos && reload_hit_pos < wasm_pos,
+            "counter order must follow the path order: fast hit ({fast_hit_pos}) < \
+             reload hit ({reload_hit_pos}) < WASM call ({wasm_pos})"
+        );
+        assert!(
+            wasm_pos < summarize_state_pos,
+            "the WASM counter ({wasm_pos}) must be recorded at the decision, \
+             immediately before the summarize_state call it describes \
+             ({summarize_state_pos})"
         );
     }
 }

--- a/crates/core/src/contract/executor/runtime/executor_impl.rs
+++ b/crates/core/src/contract/executor/runtime/executor_impl.rs
@@ -2529,17 +2529,27 @@ where
         // through `Arc<DashMap>`, not `&mut self`), and leaves this false.
         let mut local_entry_became_empty = false;
 
-        // Owned handle, resolved before either fan-out arm takes its `&mut`
-        // borrows: both arms hold two executor maps mutably for the whole loop,
-        // so the borrowing accessor is unusable inside them. One `Arc` clone per
-        // fan-out (not per subscriber). Neither delta below has a cache in front
-        // of it, so they land on the `uncached` arm — see
-        // `ring::contract_exec_metrics` for why the cached and uncached WASM
-        // totals are kept as separate counters rather than one.
+        // Resolved before either fan-out arm takes its `&mut` borrows: both arms
+        // hold two executor maps mutably for the whole loop, so the
+        // `self.contract_exec_metrics()` accessor (which borrows ALL of `self`)
+        // is unusable inside them.
+        //
+        // Deliberately the FIELD, not that accessor and not an `Arc` clone: this
+        // borrows only `self.op_manager`, which is disjoint from
+        // `self.update_notifications`, `self.subscriber_summaries` and
+        // `self.runtime`, so the borrow checker allows it and the cost is a
+        // pointer. An `Arc` clone here would instead charge two atomic RMWs to
+        // every committed update on the zero-local-subscriber path — the
+        // overwhelmingly common one for a contract this node hosts for the
+        // network, which returns below without recording anything.
+        //
+        // Neither delta below has a cache in front of it, so they land on the
+        // `uncached` arm — see `ring::contract_exec_metrics` for why the cached
+        // and uncached WASM totals are separate counters.
         let exec_metrics = self
             .op_manager
             .as_ref()
-            .map(|om| om.ring.contract_exec_metrics_arc());
+            .map(|om| om.ring.contract_exec_metrics());
 
         if let (Some(shared_notifications), Some(shared_summaries)) = (
             self.shared_notifications.as_ref(),
@@ -2693,7 +2703,7 @@ where
                         if delta_computations < super::MAX_DELTA_COMPUTATIONS_PER_FANOUT =>
                     {
                         delta_computations += 1;
-                        if let Some(m) = exec_metrics.as_deref() {
+                        if let Some(m) = exec_metrics {
                             m.record_delta_wasm_uncached();
                         }
                         self.runtime
@@ -2875,7 +2885,7 @@ where
                         if delta_computations < super::MAX_DELTA_COMPUTATIONS_PER_FANOUT =>
                     {
                         delta_computations += 1;
-                        if let Some(m) = exec_metrics.as_deref() {
+                        if let Some(m) = exec_metrics {
                             m.record_delta_wasm_uncached();
                         }
                         self.runtime

--- a/crates/core/src/contract/executor/runtime/executor_impl.rs
+++ b/crates/core/src/contract/executor/runtime/executor_impl.rs
@@ -3575,7 +3575,20 @@ mod contract_exec_counter_pins {
     /// the comment came first. A pin that matches its own explanation is not
     /// pinning anything.
     fn summarize_body() -> String {
-        let src = include_str!("executor_impl.rs");
+        // Cut the test modules off FIRST. Both bounds below are searched for as
+        // literal signatures, and both literals also occur in this helper's own
+        // source, which `include_str!` pulls in. Without this truncation a
+        // rename of the delta method would not panic: `find` would fall through
+        // to the copy of the string on the line just below, silently widening
+        // the region from ~135 lines to everything up to this module — which is
+        // the "expect that can never fire" shape the module doc claims to have
+        // closed, and which `contract_ops.rs::production_source` avoids the
+        // same way.
+        let full = include_str!("executor_impl.rs");
+        let cutoff = full
+            .find("\n#[cfg(test)]\nmod ")
+            .expect("executor_impl.rs must have a top-level #[cfg(test)] mod section");
+        let src = &full[..cutoff];
         let start = src
             .find("pub(in crate::contract::executor) async fn bridged_summarize_contract_state(")
             .expect("bridged_summarize_contract_state not found");
@@ -3652,5 +3665,70 @@ mod contract_exec_counter_pins {
              immediately before the summarize_state call it describes \
              ({summarize_state_pos})"
         );
+    }
+
+    /// Production source with the test modules cut off, so no needle below can
+    /// match this module's own assertion strings via `include_str!`.
+    fn production_source() -> String {
+        let src = include_str!("executor_impl.rs");
+        let cutoff = src
+            .find("\n#[cfg(test)]\nmod ")
+            .expect("executor_impl.rs must have a top-level #[cfg(test)] mod section");
+        src[..cutoff]
+            .lines()
+            .filter(|line| !line.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    /// Pin: BOTH client-notification fan-out arms must count their uncached
+    /// delta.
+    ///
+    /// The fan-out has two mutually exclusive arms — one for the shared
+    /// notification/summary maps, one for the `else` — and each runs its own
+    /// WASM `get_state_delta`. Only one of them is reachable from any single
+    /// test fixture, so the behavioral test
+    /// `client_notification_fanout_delta_counts_as_uncached` covers exactly one
+    /// and leaves the other free to lose its counter with CI still green.
+    ///
+    /// That is precisely the failure this whole module exists to remove: a
+    /// counter that is a no-op on the path that actually matters, with a
+    /// passing test standing over it. Counting the sites from source covers
+    /// both arms without needing a fixture that can reach each one.
+    #[test]
+    fn both_fanout_delta_arms_count_an_uncached_delta() {
+        let src = production_source();
+        let norm = src.split_whitespace().collect::<Vec<_>>().join(" ");
+
+        let recorders = norm.matches("m.record_delta_wasm_uncached();").count();
+        assert_eq!(
+            recorders, 2,
+            "expected exactly 2 uncached-delta recorders (one per fan-out arm), \
+             found {recorders} — a new arm needs its own recorder, and a removed \
+             one means an arm now runs WASM uncounted"
+        );
+
+        // Each recorder must be the thing immediately before a `get_state_delta`
+        // call, not merely present somewhere in the file. Anchored on the call's
+        // API surface rather than on local variable names, which drift.
+        for (i, tail) in norm
+            .match_indices("m.record_delta_wasm_uncached();")
+            .map(|(pos, _)| &norm[pos..])
+            .enumerate()
+        {
+            let next_delta = tail.find(".get_state_delta(").unwrap_or_else(|| {
+                panic!("recorder {i} is not followed by a get_state_delta call")
+            });
+            let next_recorder = tail[1..]
+                .find("m.record_delta_wasm_uncached();")
+                .map(|p| p + 1)
+                .unwrap_or(usize::MAX);
+            assert!(
+                next_delta < next_recorder,
+                "recorder {i} must bind to its OWN get_state_delta call — another \
+                 recorder ({next_recorder}) intervenes before the next call \
+                 ({next_delta}), so one arm is counting the other arm's work"
+            );
+        }
     }
 }

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -2116,6 +2116,32 @@ impl Ring {
             // one, because it terminates the investigation.
             let ce = ring.contract_exec_metrics.snapshot();
             let ce_d = ce.window_deltas(&mut prev_exec);
+            // Exhaustive destructure with no `..` rest pattern, on BOTH the
+            // lifetime snapshot and the window deltas. A 9th counter arm then
+            // fails to COMPILE here until it is exported, which is strictly
+            // stronger than the source-scrape pin below: a scrape that hardcodes
+            // today's eight names passes unchanged when a ninth is added, which
+            // is exactly how a counter ends up recorded but never exported.
+            let contract_exec_metrics::ContractExecSnapshot {
+                summarize_fast_hits: _,
+                summarize_reload_hits: _,
+                summarize_wasm_calls: _,
+                summarize_wasm_uncached: _,
+                delta_fast_hits: _,
+                delta_reload_hits: _,
+                delta_wasm_calls: _,
+                delta_wasm_uncached: _,
+            } = ce;
+            let contract_exec_metrics::ContractExecSnapshot {
+                summarize_fast_hits: _,
+                summarize_reload_hits: _,
+                summarize_wasm_calls: _,
+                summarize_wasm_uncached: _,
+                delta_fast_hits: _,
+                delta_reload_hits: _,
+                delta_wasm_calls: _,
+                delta_wasm_uncached: _,
+            } = ce_d;
             snapshot.contract_exec_summarize_fast_hits_total = Some(ce.summarize_fast_hits);
             snapshot.contract_exec_summarize_reload_hits_total = Some(ce.summarize_reload_hits);
             snapshot.contract_exec_summarize_wasm_calls_total = Some(ce.summarize_wasm_calls);

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -896,18 +896,6 @@ impl Ring {
         &self.contract_exec_metrics
     }
 
-    /// Owned handle on the same counters, for call sites that must hold the
-    /// sink across an outstanding `&mut self` borrow of the executor (the
-    /// client-notification fan-out borrows two executor maps mutably for the
-    /// whole loop, so the borrowing accessor above is unusable there). Cloned
-    /// ONCE per fan-out, not once per subscriber.
-    #[inline]
-    pub(crate) fn contract_exec_metrics_arc(
-        &self,
-    ) -> Arc<contract_exec_metrics::ContractExecMetrics> {
-        self.contract_exec_metrics.clone()
-    }
-
     /// Shared per-node placement-migration counter sink (#4404 follow-up). The
     /// migration send/receive sites clone this to increment `sent` / `received`
     /// / `acted`; the snapshot task reads it on the `router_snapshot` cadence.
@@ -2117,15 +2105,17 @@ impl Ring {
             // is a warm cache doing cheap work; the two converging means the
             // change-detector has stopped covering the load and the storm class
             // (#4473 / #4610 / #5040 / #5238) has re-armed.
+            //
+            // EVERY arm is windowed, not a chosen headline subset. Emitting some
+            // arms as a 5-minute delta and others as a lifetime total, under
+            // parallel names on one log line, invites reading them as comparable
+            // magnitudes — and the arm that would be understated that way is
+            // `delta_wasm_uncached`, the per-local-subscriber fan-out delta that
+            // has no cache in front of it at all and can dominate on a
+            // client-facing node. An overstated saving is worse than a missing
+            // one, because it terminates the investigation.
             let ce = ring.contract_exec_metrics.snapshot();
-            let ce_summarize_fast_hits_delta =
-                window_delta(ce.summarize_fast_hits, &mut prev_exec.summarize_fast_hits);
-            let ce_summarize_wasm_calls_delta =
-                window_delta(ce.summarize_wasm_calls, &mut prev_exec.summarize_wasm_calls);
-            let ce_delta_fast_hits_delta =
-                window_delta(ce.delta_fast_hits, &mut prev_exec.delta_fast_hits);
-            let ce_delta_wasm_calls_delta =
-                window_delta(ce.delta_wasm_calls, &mut prev_exec.delta_wasm_calls);
+            let ce_d = ce.window_deltas(&mut prev_exec);
             snapshot.contract_exec_summarize_fast_hits_total = Some(ce.summarize_fast_hits);
             snapshot.contract_exec_summarize_reload_hits_total = Some(ce.summarize_reload_hits);
             snapshot.contract_exec_summarize_wasm_calls_total = Some(ce.summarize_wasm_calls);
@@ -2135,11 +2125,18 @@ impl Ring {
             snapshot.contract_exec_delta_wasm_calls_total = Some(ce.delta_wasm_calls);
             snapshot.contract_exec_delta_wasm_uncached_total = Some(ce.delta_wasm_uncached);
             snapshot.contract_exec_summarize_fast_hits_last_snapshot =
-                Some(ce_summarize_fast_hits_delta);
+                Some(ce_d.summarize_fast_hits);
+            snapshot.contract_exec_summarize_reload_hits_last_snapshot =
+                Some(ce_d.summarize_reload_hits);
             snapshot.contract_exec_summarize_wasm_calls_last_snapshot =
-                Some(ce_summarize_wasm_calls_delta);
-            snapshot.contract_exec_delta_fast_hits_last_snapshot = Some(ce_delta_fast_hits_delta);
-            snapshot.contract_exec_delta_wasm_calls_last_snapshot = Some(ce_delta_wasm_calls_delta);
+                Some(ce_d.summarize_wasm_calls);
+            snapshot.contract_exec_summarize_wasm_uncached_last_snapshot =
+                Some(ce_d.summarize_wasm_uncached);
+            snapshot.contract_exec_delta_fast_hits_last_snapshot = Some(ce_d.delta_fast_hits);
+            snapshot.contract_exec_delta_reload_hits_last_snapshot = Some(ce_d.delta_reload_hits);
+            snapshot.contract_exec_delta_wasm_calls_last_snapshot = Some(ce_d.delta_wasm_calls);
+            snapshot.contract_exec_delta_wasm_uncached_last_snapshot =
+                Some(ce_d.delta_wasm_uncached);
 
             // Placement-quality gauge (#4404 follow-up): host-to-hosted-key
             // ring-distance distribution. If the SubscribeHint placement
@@ -2376,18 +2373,20 @@ impl Ring {
                 broadcast_stream_attempts_total = bs.streaming_attempts_total,
                 broadcast_stream_failures_total = bs.streaming_failures_total,
                 broadcast_stream_failures_last_snapshot = broadcast_stream_failures_delta,
-                // The per-window arms are logged (not just the lifetime totals)
-                // so a local operator reading `journalctl` gets the answer from
-                // ONE line. `info!` survives `release_max_level_info`; `debug!`
-                // would not.
-                contract_exec_summarize_fast_hits_last_snapshot = ce_summarize_fast_hits_delta,
-                contract_exec_summarize_wasm_calls_last_snapshot = ce_summarize_wasm_calls_delta,
-                contract_exec_summarize_reload_hits_total = ce.summarize_reload_hits,
-                contract_exec_summarize_wasm_uncached_total = ce.summarize_wasm_uncached,
-                contract_exec_delta_fast_hits_last_snapshot = ce_delta_fast_hits_delta,
-                contract_exec_delta_wasm_calls_last_snapshot = ce_delta_wasm_calls_delta,
-                contract_exec_delta_reload_hits_total = ce.delta_reload_hits,
-                contract_exec_delta_wasm_uncached_total = ce.delta_wasm_uncached,
+                // The per-window arms are logged (not the lifetime totals) so a
+                // local operator reading `journalctl` gets the answer from ONE
+                // line, and ALL EIGHT are logged in the same unit — mixing
+                // 5-minute deltas with lifetime totals under parallel names
+                // would invite reading them as comparable magnitudes. `info!`
+                // survives `release_max_level_info`; `debug!` would not.
+                contract_exec_summarize_fast_hits_last_snapshot = ce_d.summarize_fast_hits,
+                contract_exec_summarize_reload_hits_last_snapshot = ce_d.summarize_reload_hits,
+                contract_exec_summarize_wasm_calls_last_snapshot = ce_d.summarize_wasm_calls,
+                contract_exec_summarize_wasm_uncached_last_snapshot = ce_d.summarize_wasm_uncached,
+                contract_exec_delta_fast_hits_last_snapshot = ce_d.delta_fast_hits,
+                contract_exec_delta_reload_hits_last_snapshot = ce_d.delta_reload_hits,
+                contract_exec_delta_wasm_calls_last_snapshot = ce_d.delta_wasm_calls,
+                contract_exec_delta_wasm_uncached_last_snapshot = ce_d.delta_wasm_uncached,
                 hosted_contracts_count = ?snapshot.hosted_contracts_count,
                 hosted_key_distance_median = ?snapshot.hosted_key_distance_median,
                 hosted_key_distance_p90 = ?snapshot.hosted_key_distance_p90,
@@ -7633,30 +7632,38 @@ mod k_closest_source_tests {
             "delta_wasm_uncached",
         ];
         for field in fields {
-            let expected = format!("snapshot.contract_exec_{field}_total = Some(ce.{field});");
-            assert!(
-                norm.contains(&expected),
-                "mirror-seam: export must contain `{expected}` — a field swap here \
-                 silently reports one arm's count under another arm's name"
-            );
+            // Every arm is exported in BOTH units. A lifetime total sitting on
+            // a line of otherwise-parallel `_last_snapshot` names reads as a
+            // comparable magnitude and understates nothing visibly — which is
+            // why the pin demands both rather than either.
+            for expected in [
+                format!("snapshot.contract_exec_{field}_total = Some(ce.{field});"),
+                format!("snapshot.contract_exec_{field}_last_snapshot = Some(ce_d.{field});"),
+            ] {
+                assert!(
+                    norm.contains(&expected),
+                    "mirror-seam: export must contain `{expected}` — a field swap here \
+                     silently reports one arm's count under another arm's name"
+                );
+            }
         }
 
-        // The four per-window deltas must each difference their OWN total
-        // against their OWN previous value. Crossing these would emit a delta
-        // that is the difference of two different counters, i.e. noise.
-        for field in [
-            "summarize_fast_hits",
-            "summarize_wasm_calls",
-            "delta_fast_hits",
-            "delta_wasm_calls",
-        ] {
-            let expected = format!("window_delta(ce.{field}, &mut prev_exec.{field});");
-            assert!(
-                norm.contains(&expected),
-                "mirror-seam: the per-window delta must contain `{expected}` — \
-                 differencing one arm against another's previous value emits noise"
-            );
-        }
+        // The delta computation itself is NOT scraped: it is
+        // `ContractExecSnapshot::window_deltas`, one function whose field
+        // correspondence is structural and unit-tested by
+        // `each_field_differences_its_own_twin`. What must be pinned here is
+        // that the emitter uses it rather than re-deriving eight deltas by hand
+        // at the call site, which is where a cross-wiring hides.
+        assert!(
+            norm.contains("let ce_d = ce.window_deltas(&mut prev_exec);"),
+            "the emitter must delegate to ContractExecSnapshot::window_deltas, not \
+             hand-difference each arm at the call site"
+        );
+        assert!(
+            !norm.contains("window_delta(ce."),
+            "no hand-written per-arm window_delta call may remain — that is the \
+             shape in which one arm gets differenced against another's previous value"
+        );
     }
 }
 

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -85,6 +85,7 @@ mod broken_invariants;
 mod connection_backoff;
 mod connection_manager;
 pub(crate) mod contract_ban_list;
+pub(crate) mod contract_exec_metrics;
 pub(crate) mod delta_incompat;
 /// Shadow-mode detector for repairs that never converge (see the module docs).
 pub(crate) mod futile_repair;
@@ -318,6 +319,15 @@ pub(crate) struct Ring {
     /// task *reads* it. Threading the `Arc` (rather than a process-global)
     /// keeps the gauges per-node so unit tests stay isolated (#4488).
     module_cache_metrics: Arc<crate::wasm_runtime::ModuleCacheMetrics>,
+    /// Per-node contract-exec WASM counters: how many `summarize_state` /
+    /// `get_state_delta` invocations this node actually ran, split from the
+    /// cache hits that elided them. Constructed once here and shared via `Arc`:
+    /// the executor increments it through `op_manager.ring`, while
+    /// `emit_router_snapshot_telemetry` reads it. Threading the `Arc` (rather
+    /// than a process-global) keeps the counters per-node so unit tests stay
+    /// isolated (#4488). See [`contract_exec_metrics`] for why an
+    /// undifferentiated span count could not answer the storm question.
+    contract_exec_metrics: Arc<contract_exec_metrics::ContractExecMetrics>,
     /// Per-node placement-migration activity counters (#4404 follow-up).
     /// Constructed once here and shared via `Arc`: the migration SEND site
     /// (`p2p_protoc::migration`) and the two RECEIVE sites (`node::process_message`)
@@ -704,6 +714,7 @@ impl Ring {
             // (the `RuntimePool` reaches it through `op_manager.ring`). See
             // the field docs and #4488.
             module_cache_metrics: Arc::new(crate::wasm_runtime::ModuleCacheMetrics::new()),
+            contract_exec_metrics: Arc::new(contract_exec_metrics::ContractExecMetrics::default()),
             // One placement-migration counter sink per node, shared with the
             // migration send/receive sites via the `Arc` (reached through
             // `op_manager.ring`). See the field docs.
@@ -873,6 +884,28 @@ impl Ring {
     /// this `Arc` is what replaced the old `MODULE_CACHE_METRICS` process-global.
     pub(crate) fn module_cache_metrics(&self) -> Arc<crate::wasm_runtime::ModuleCacheMetrics> {
         self.module_cache_metrics.clone()
+    }
+
+    /// Shared per-node contract-exec WASM counters. Returns a BORROW, not an
+    /// `Arc` clone: the increment sites sit on the contract-handling loop's hot
+    /// path (tens of calls/sec per node), where an `Arc` refcount bump would be
+    /// a needless atomic RMW on top of the counter's own. The snapshot reader
+    /// borrows the same way on its 5-minute cadence.
+    #[inline]
+    pub(crate) fn contract_exec_metrics(&self) -> &contract_exec_metrics::ContractExecMetrics {
+        &self.contract_exec_metrics
+    }
+
+    /// Owned handle on the same counters, for call sites that must hold the
+    /// sink across an outstanding `&mut self` borrow of the executor (the
+    /// client-notification fan-out borrows two executor maps mutably for the
+    /// whole loop, so the borrowing accessor above is unusable there). Cloned
+    /// ONCE per fan-out, not once per subscriber.
+    #[inline]
+    pub(crate) fn contract_exec_metrics_arc(
+        &self,
+    ) -> Arc<contract_exec_metrics::ContractExecMetrics> {
+        self.contract_exec_metrics.clone()
     }
 
     /// Shared per-node placement-migration counter sink (#4404 follow-up). The
@@ -1697,6 +1730,13 @@ impl Ring {
         let mut prev_broadcast_stream_failures_total: u64 = crate::node::BROADCAST_STREAM_METRICS
             .snapshot()
             .streaming_failures_total;
+        // Same shape for the contract-exec WASM counters: the monotonic totals
+        // are emitted for collector-side differencing, and these loop-local
+        // previous values turn the four headline arms into per-window deltas so
+        // a SINGLE snapshot says whether this node's summarize/delta load was
+        // cache hits or real WASM work. Seeded from the current values so the
+        // first emitted window covers only elapsed-since-start work.
+        let mut prev_exec = ring.contract_exec_metrics.snapshot();
         // The diagnostic block is substantially wider than the ordinary
         // snapshot gauges. Its counters are lifetime-monotonic, so collecting
         // locally on every event but exporting one in six snapshots preserves
@@ -2072,6 +2112,35 @@ impl Ring {
             snapshot.broadcast_stream_failures_last_snapshot =
                 Some(broadcast_stream_failures_delta);
 
+            // Contract-exec WASM counters: the split that makes a summarize rate
+            // interpretable. A high `fast_hits` rate with a low `wasm_calls` rate
+            // is a warm cache doing cheap work; the two converging means the
+            // change-detector has stopped covering the load and the storm class
+            // (#4473 / #4610 / #5040 / #5238) has re-armed.
+            let ce = ring.contract_exec_metrics.snapshot();
+            let ce_summarize_fast_hits_delta =
+                window_delta(ce.summarize_fast_hits, &mut prev_exec.summarize_fast_hits);
+            let ce_summarize_wasm_calls_delta =
+                window_delta(ce.summarize_wasm_calls, &mut prev_exec.summarize_wasm_calls);
+            let ce_delta_fast_hits_delta =
+                window_delta(ce.delta_fast_hits, &mut prev_exec.delta_fast_hits);
+            let ce_delta_wasm_calls_delta =
+                window_delta(ce.delta_wasm_calls, &mut prev_exec.delta_wasm_calls);
+            snapshot.contract_exec_summarize_fast_hits_total = Some(ce.summarize_fast_hits);
+            snapshot.contract_exec_summarize_reload_hits_total = Some(ce.summarize_reload_hits);
+            snapshot.contract_exec_summarize_wasm_calls_total = Some(ce.summarize_wasm_calls);
+            snapshot.contract_exec_summarize_wasm_uncached_total = Some(ce.summarize_wasm_uncached);
+            snapshot.contract_exec_delta_fast_hits_total = Some(ce.delta_fast_hits);
+            snapshot.contract_exec_delta_reload_hits_total = Some(ce.delta_reload_hits);
+            snapshot.contract_exec_delta_wasm_calls_total = Some(ce.delta_wasm_calls);
+            snapshot.contract_exec_delta_wasm_uncached_total = Some(ce.delta_wasm_uncached);
+            snapshot.contract_exec_summarize_fast_hits_last_snapshot =
+                Some(ce_summarize_fast_hits_delta);
+            snapshot.contract_exec_summarize_wasm_calls_last_snapshot =
+                Some(ce_summarize_wasm_calls_delta);
+            snapshot.contract_exec_delta_fast_hits_last_snapshot = Some(ce_delta_fast_hits_delta);
+            snapshot.contract_exec_delta_wasm_calls_last_snapshot = Some(ce_delta_wasm_calls_delta);
+
             // Placement-quality gauge (#4404 follow-up): host-to-hosted-key
             // ring-distance distribution. If the SubscribeHint placement
             // migration is working, hosting drifts toward each contract's key,
@@ -2307,6 +2376,18 @@ impl Ring {
                 broadcast_stream_attempts_total = bs.streaming_attempts_total,
                 broadcast_stream_failures_total = bs.streaming_failures_total,
                 broadcast_stream_failures_last_snapshot = broadcast_stream_failures_delta,
+                // The per-window arms are logged (not just the lifetime totals)
+                // so a local operator reading `journalctl` gets the answer from
+                // ONE line. `info!` survives `release_max_level_info`; `debug!`
+                // would not.
+                contract_exec_summarize_fast_hits_last_snapshot = ce_summarize_fast_hits_delta,
+                contract_exec_summarize_wasm_calls_last_snapshot = ce_summarize_wasm_calls_delta,
+                contract_exec_summarize_reload_hits_total = ce.summarize_reload_hits,
+                contract_exec_summarize_wasm_uncached_total = ce.summarize_wasm_uncached,
+                contract_exec_delta_fast_hits_last_snapshot = ce_delta_fast_hits_delta,
+                contract_exec_delta_wasm_calls_last_snapshot = ce_delta_wasm_calls_delta,
+                contract_exec_delta_reload_hits_total = ce.delta_reload_hits,
+                contract_exec_delta_wasm_uncached_total = ce.delta_wasm_uncached,
                 hosted_contracts_count = ?snapshot.hosted_contracts_count,
                 hosted_key_distance_median = ?snapshot.hosted_key_distance_median,
                 hosted_key_distance_p90 = ?snapshot.hosted_key_distance_p90,

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -85,6 +85,7 @@ mod broken_invariants;
 mod connection_backoff;
 mod connection_manager;
 pub(crate) mod contract_ban_list;
+pub(crate) mod contract_exec_metrics;
 pub(crate) mod delta_incompat;
 pub(crate) use connection_manager::ConnectionManager;
 // Nearest-neighbor ring lattice (successor+predecessor base edges).
@@ -288,6 +289,15 @@ pub(crate) struct Ring {
     /// task *reads* it. Threading the `Arc` (rather than a process-global)
     /// keeps the gauges per-node so unit tests stay isolated (#4488).
     module_cache_metrics: Arc<crate::wasm_runtime::ModuleCacheMetrics>,
+    /// Per-node contract-exec WASM counters: how many `summarize_state` /
+    /// `get_state_delta` invocations this node actually ran, split from the
+    /// cache hits that elided them. Constructed once here and shared via `Arc`:
+    /// the executor increments it through `op_manager.ring`, while
+    /// `emit_router_snapshot_telemetry` reads it. Threading the `Arc` (rather
+    /// than a process-global) keeps the counters per-node so unit tests stay
+    /// isolated (#4488). See [`contract_exec_metrics`] for why an
+    /// undifferentiated span count could not answer the storm question.
+    contract_exec_metrics: Arc<contract_exec_metrics::ContractExecMetrics>,
     /// Per-node placement-migration activity counters (#4404 follow-up).
     /// Constructed once here and shared via `Arc`: the migration SEND site
     /// (`p2p_protoc::migration`) and the two RECEIVE sites (`node::process_message`)
@@ -674,6 +684,7 @@ impl Ring {
             // (the `RuntimePool` reaches it through `op_manager.ring`). See
             // the field docs and #4488.
             module_cache_metrics: Arc::new(crate::wasm_runtime::ModuleCacheMetrics::new()),
+            contract_exec_metrics: Arc::new(contract_exec_metrics::ContractExecMetrics::default()),
             // One placement-migration counter sink per node, shared with the
             // migration send/receive sites via the `Arc` (reached through
             // `op_manager.ring`). See the field docs.
@@ -820,6 +831,28 @@ impl Ring {
     /// this `Arc` is what replaced the old `MODULE_CACHE_METRICS` process-global.
     pub(crate) fn module_cache_metrics(&self) -> Arc<crate::wasm_runtime::ModuleCacheMetrics> {
         self.module_cache_metrics.clone()
+    }
+
+    /// Shared per-node contract-exec WASM counters. Returns a BORROW, not an
+    /// `Arc` clone: the increment sites sit on the contract-handling loop's hot
+    /// path (tens of calls/sec per node), where an `Arc` refcount bump would be
+    /// a needless atomic RMW on top of the counter's own. The snapshot reader
+    /// borrows the same way on its 5-minute cadence.
+    #[inline]
+    pub(crate) fn contract_exec_metrics(&self) -> &contract_exec_metrics::ContractExecMetrics {
+        &self.contract_exec_metrics
+    }
+
+    /// Owned handle on the same counters, for call sites that must hold the
+    /// sink across an outstanding `&mut self` borrow of the executor (the
+    /// client-notification fan-out borrows two executor maps mutably for the
+    /// whole loop, so the borrowing accessor above is unusable there). Cloned
+    /// ONCE per fan-out, not once per subscriber.
+    #[inline]
+    pub(crate) fn contract_exec_metrics_arc(
+        &self,
+    ) -> Arc<contract_exec_metrics::ContractExecMetrics> {
+        self.contract_exec_metrics.clone()
     }
 
     /// Shared per-node placement-migration counter sink (#4404 follow-up). The
@@ -1644,6 +1677,13 @@ impl Ring {
         let mut prev_broadcast_stream_failures_total: u64 = crate::node::BROADCAST_STREAM_METRICS
             .snapshot()
             .streaming_failures_total;
+        // Same shape for the contract-exec WASM counters: the monotonic totals
+        // are emitted for collector-side differencing, and these loop-local
+        // previous values turn the four headline arms into per-window deltas so
+        // a SINGLE snapshot says whether this node's summarize/delta load was
+        // cache hits or real WASM work. Seeded from the current values so the
+        // first emitted window covers only elapsed-since-start work.
+        let mut prev_exec = ring.contract_exec_metrics.snapshot();
         // The diagnostic block is substantially wider than the ordinary
         // snapshot gauges. Its counters are lifetime-monotonic, so collecting
         // locally on every event but exporting one in six snapshots preserves
@@ -2019,6 +2059,35 @@ impl Ring {
             snapshot.broadcast_stream_failures_last_snapshot =
                 Some(broadcast_stream_failures_delta);
 
+            // Contract-exec WASM counters: the split that makes a summarize rate
+            // interpretable. A high `fast_hits` rate with a low `wasm_calls` rate
+            // is a warm cache doing cheap work; the two converging means the
+            // change-detector has stopped covering the load and the storm class
+            // (#4473 / #4610 / #5040 / #5238) has re-armed.
+            let ce = ring.contract_exec_metrics.snapshot();
+            let ce_summarize_fast_hits_delta =
+                window_delta(ce.summarize_fast_hits, &mut prev_exec.summarize_fast_hits);
+            let ce_summarize_wasm_calls_delta =
+                window_delta(ce.summarize_wasm_calls, &mut prev_exec.summarize_wasm_calls);
+            let ce_delta_fast_hits_delta =
+                window_delta(ce.delta_fast_hits, &mut prev_exec.delta_fast_hits);
+            let ce_delta_wasm_calls_delta =
+                window_delta(ce.delta_wasm_calls, &mut prev_exec.delta_wasm_calls);
+            snapshot.contract_exec_summarize_fast_hits_total = Some(ce.summarize_fast_hits);
+            snapshot.contract_exec_summarize_reload_hits_total = Some(ce.summarize_reload_hits);
+            snapshot.contract_exec_summarize_wasm_calls_total = Some(ce.summarize_wasm_calls);
+            snapshot.contract_exec_summarize_wasm_uncached_total = Some(ce.summarize_wasm_uncached);
+            snapshot.contract_exec_delta_fast_hits_total = Some(ce.delta_fast_hits);
+            snapshot.contract_exec_delta_reload_hits_total = Some(ce.delta_reload_hits);
+            snapshot.contract_exec_delta_wasm_calls_total = Some(ce.delta_wasm_calls);
+            snapshot.contract_exec_delta_wasm_uncached_total = Some(ce.delta_wasm_uncached);
+            snapshot.contract_exec_summarize_fast_hits_last_snapshot =
+                Some(ce_summarize_fast_hits_delta);
+            snapshot.contract_exec_summarize_wasm_calls_last_snapshot =
+                Some(ce_summarize_wasm_calls_delta);
+            snapshot.contract_exec_delta_fast_hits_last_snapshot = Some(ce_delta_fast_hits_delta);
+            snapshot.contract_exec_delta_wasm_calls_last_snapshot = Some(ce_delta_wasm_calls_delta);
+
             // Placement-quality gauge (#4404 follow-up): host-to-hosted-key
             // ring-distance distribution. If the SubscribeHint placement
             // migration is working, hosting drifts toward each contract's key,
@@ -2238,6 +2307,18 @@ impl Ring {
                 broadcast_stream_attempts_total = bs.streaming_attempts_total,
                 broadcast_stream_failures_total = bs.streaming_failures_total,
                 broadcast_stream_failures_last_snapshot = broadcast_stream_failures_delta,
+                // The per-window arms are logged (not just the lifetime totals)
+                // so a local operator reading `journalctl` gets the answer from
+                // ONE line. `info!` survives `release_max_level_info`; `debug!`
+                // would not.
+                contract_exec_summarize_fast_hits_last_snapshot = ce_summarize_fast_hits_delta,
+                contract_exec_summarize_wasm_calls_last_snapshot = ce_summarize_wasm_calls_delta,
+                contract_exec_summarize_reload_hits_total = ce.summarize_reload_hits,
+                contract_exec_summarize_wasm_uncached_total = ce.summarize_wasm_uncached,
+                contract_exec_delta_fast_hits_last_snapshot = ce_delta_fast_hits_delta,
+                contract_exec_delta_wasm_calls_last_snapshot = ce_delta_wasm_calls_delta,
+                contract_exec_delta_reload_hits_total = ce.delta_reload_hits,
+                contract_exec_delta_wasm_uncached_total = ce.delta_wasm_uncached,
                 hosted_contracts_count = ?snapshot.hosted_contracts_count,
                 hosted_key_distance_median = ?snapshot.hosted_key_distance_median,
                 hosted_key_distance_p90 = ?snapshot.hosted_key_distance_p90,

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -7604,6 +7604,60 @@ mod k_closest_source_tests {
         }
         assert_eq!(checked, 24, "expected exactly 24 export assignments");
     }
+
+    /// Same mirror seam, for the contract-exec WASM counters. The export block
+    /// hand-copies each `ContractExecSnapshot` field into its `RouterSnapshotInfo`
+    /// twin, so a swap — feeding `..._wasm_calls_total` from `fast_hits`, say —
+    /// compiles cleanly and emits a plausible number that is measuring the
+    /// opposite thing.
+    ///
+    /// That failure mode is not hypothetical here: mistaking cache hits for WASM
+    /// work is the exact blindness these counters exist to remove, and an
+    /// overstated saving is worse than a missing one because it terminates the
+    /// investigation. Assert every assignment reads its own field.
+    /// Whitespace-normalized so rustfmt line-wrapping is irrelevant.
+    #[test]
+    fn contract_exec_export_maps_each_field_to_its_own_counter() {
+        let src = production_source();
+        let block = extract_fn_body(src, "async fn emit_router_snapshot_telemetry(");
+        let norm = block.split_whitespace().collect::<Vec<_>>().join(" ");
+
+        let fields = [
+            "summarize_fast_hits",
+            "summarize_reload_hits",
+            "summarize_wasm_calls",
+            "summarize_wasm_uncached",
+            "delta_fast_hits",
+            "delta_reload_hits",
+            "delta_wasm_calls",
+            "delta_wasm_uncached",
+        ];
+        for field in fields {
+            let expected = format!("snapshot.contract_exec_{field}_total = Some(ce.{field});");
+            assert!(
+                norm.contains(&expected),
+                "mirror-seam: export must contain `{expected}` — a field swap here \
+                 silently reports one arm's count under another arm's name"
+            );
+        }
+
+        // The four per-window deltas must each difference their OWN total
+        // against their OWN previous value. Crossing these would emit a delta
+        // that is the difference of two different counters, i.e. noise.
+        for field in [
+            "summarize_fast_hits",
+            "summarize_wasm_calls",
+            "delta_fast_hits",
+            "delta_wasm_calls",
+        ] {
+            let expected = format!("window_delta(ce.{field}, &mut prev_exec.{field});");
+            assert!(
+                norm.contains(&expected),
+                "mirror-seam: the per-window delta must contain `{expected}` — \
+                 differencing one arm against another's previous value emits noise"
+            );
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -7474,6 +7474,60 @@ mod k_closest_source_tests {
         }
         assert_eq!(checked, 24, "expected exactly 24 export assignments");
     }
+
+    /// Same mirror seam, for the contract-exec WASM counters. The export block
+    /// hand-copies each `ContractExecSnapshot` field into its `RouterSnapshotInfo`
+    /// twin, so a swap — feeding `..._wasm_calls_total` from `fast_hits`, say —
+    /// compiles cleanly and emits a plausible number that is measuring the
+    /// opposite thing.
+    ///
+    /// That failure mode is not hypothetical here: mistaking cache hits for WASM
+    /// work is the exact blindness these counters exist to remove, and an
+    /// overstated saving is worse than a missing one because it terminates the
+    /// investigation. Assert every assignment reads its own field.
+    /// Whitespace-normalized so rustfmt line-wrapping is irrelevant.
+    #[test]
+    fn contract_exec_export_maps_each_field_to_its_own_counter() {
+        let src = production_source();
+        let block = extract_fn_body(src, "async fn emit_router_snapshot_telemetry(");
+        let norm = block.split_whitespace().collect::<Vec<_>>().join(" ");
+
+        let fields = [
+            "summarize_fast_hits",
+            "summarize_reload_hits",
+            "summarize_wasm_calls",
+            "summarize_wasm_uncached",
+            "delta_fast_hits",
+            "delta_reload_hits",
+            "delta_wasm_calls",
+            "delta_wasm_uncached",
+        ];
+        for field in fields {
+            let expected = format!("snapshot.contract_exec_{field}_total = Some(ce.{field});");
+            assert!(
+                norm.contains(&expected),
+                "mirror-seam: export must contain `{expected}` — a field swap here \
+                 silently reports one arm's count under another arm's name"
+            );
+        }
+
+        // The four per-window deltas must each difference their OWN total
+        // against their OWN previous value. Crossing these would emit a delta
+        // that is the difference of two different counters, i.e. noise.
+        for field in [
+            "summarize_fast_hits",
+            "summarize_wasm_calls",
+            "delta_fast_hits",
+            "delta_wasm_calls",
+        ] {
+            let expected = format!("window_delta(ce.{field}, &mut prev_exec.{field});");
+            assert!(
+                norm.contains(&expected),
+                "mirror-seam: the per-window delta must contain `{expected}` — \
+                 differencing one arm against another's previous value emits noise"
+            );
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -843,18 +843,6 @@ impl Ring {
         &self.contract_exec_metrics
     }
 
-    /// Owned handle on the same counters, for call sites that must hold the
-    /// sink across an outstanding `&mut self` borrow of the executor (the
-    /// client-notification fan-out borrows two executor maps mutably for the
-    /// whole loop, so the borrowing accessor above is unusable there). Cloned
-    /// ONCE per fan-out, not once per subscriber.
-    #[inline]
-    pub(crate) fn contract_exec_metrics_arc(
-        &self,
-    ) -> Arc<contract_exec_metrics::ContractExecMetrics> {
-        self.contract_exec_metrics.clone()
-    }
-
     /// Shared per-node placement-migration counter sink (#4404 follow-up). The
     /// migration send/receive sites clone this to increment `sent` / `received`
     /// / `acted`; the snapshot task reads it on the `router_snapshot` cadence.
@@ -2064,15 +2052,17 @@ impl Ring {
             // is a warm cache doing cheap work; the two converging means the
             // change-detector has stopped covering the load and the storm class
             // (#4473 / #4610 / #5040 / #5238) has re-armed.
+            //
+            // EVERY arm is windowed, not a chosen headline subset. Emitting some
+            // arms as a 5-minute delta and others as a lifetime total, under
+            // parallel names on one log line, invites reading them as comparable
+            // magnitudes — and the arm that would be understated that way is
+            // `delta_wasm_uncached`, the per-local-subscriber fan-out delta that
+            // has no cache in front of it at all and can dominate on a
+            // client-facing node. An overstated saving is worse than a missing
+            // one, because it terminates the investigation.
             let ce = ring.contract_exec_metrics.snapshot();
-            let ce_summarize_fast_hits_delta =
-                window_delta(ce.summarize_fast_hits, &mut prev_exec.summarize_fast_hits);
-            let ce_summarize_wasm_calls_delta =
-                window_delta(ce.summarize_wasm_calls, &mut prev_exec.summarize_wasm_calls);
-            let ce_delta_fast_hits_delta =
-                window_delta(ce.delta_fast_hits, &mut prev_exec.delta_fast_hits);
-            let ce_delta_wasm_calls_delta =
-                window_delta(ce.delta_wasm_calls, &mut prev_exec.delta_wasm_calls);
+            let ce_d = ce.window_deltas(&mut prev_exec);
             snapshot.contract_exec_summarize_fast_hits_total = Some(ce.summarize_fast_hits);
             snapshot.contract_exec_summarize_reload_hits_total = Some(ce.summarize_reload_hits);
             snapshot.contract_exec_summarize_wasm_calls_total = Some(ce.summarize_wasm_calls);
@@ -2082,11 +2072,18 @@ impl Ring {
             snapshot.contract_exec_delta_wasm_calls_total = Some(ce.delta_wasm_calls);
             snapshot.contract_exec_delta_wasm_uncached_total = Some(ce.delta_wasm_uncached);
             snapshot.contract_exec_summarize_fast_hits_last_snapshot =
-                Some(ce_summarize_fast_hits_delta);
+                Some(ce_d.summarize_fast_hits);
+            snapshot.contract_exec_summarize_reload_hits_last_snapshot =
+                Some(ce_d.summarize_reload_hits);
             snapshot.contract_exec_summarize_wasm_calls_last_snapshot =
-                Some(ce_summarize_wasm_calls_delta);
-            snapshot.contract_exec_delta_fast_hits_last_snapshot = Some(ce_delta_fast_hits_delta);
-            snapshot.contract_exec_delta_wasm_calls_last_snapshot = Some(ce_delta_wasm_calls_delta);
+                Some(ce_d.summarize_wasm_calls);
+            snapshot.contract_exec_summarize_wasm_uncached_last_snapshot =
+                Some(ce_d.summarize_wasm_uncached);
+            snapshot.contract_exec_delta_fast_hits_last_snapshot = Some(ce_d.delta_fast_hits);
+            snapshot.contract_exec_delta_reload_hits_last_snapshot = Some(ce_d.delta_reload_hits);
+            snapshot.contract_exec_delta_wasm_calls_last_snapshot = Some(ce_d.delta_wasm_calls);
+            snapshot.contract_exec_delta_wasm_uncached_last_snapshot =
+                Some(ce_d.delta_wasm_uncached);
 
             // Placement-quality gauge (#4404 follow-up): host-to-hosted-key
             // ring-distance distribution. If the SubscribeHint placement
@@ -2307,18 +2304,20 @@ impl Ring {
                 broadcast_stream_attempts_total = bs.streaming_attempts_total,
                 broadcast_stream_failures_total = bs.streaming_failures_total,
                 broadcast_stream_failures_last_snapshot = broadcast_stream_failures_delta,
-                // The per-window arms are logged (not just the lifetime totals)
-                // so a local operator reading `journalctl` gets the answer from
-                // ONE line. `info!` survives `release_max_level_info`; `debug!`
-                // would not.
-                contract_exec_summarize_fast_hits_last_snapshot = ce_summarize_fast_hits_delta,
-                contract_exec_summarize_wasm_calls_last_snapshot = ce_summarize_wasm_calls_delta,
-                contract_exec_summarize_reload_hits_total = ce.summarize_reload_hits,
-                contract_exec_summarize_wasm_uncached_total = ce.summarize_wasm_uncached,
-                contract_exec_delta_fast_hits_last_snapshot = ce_delta_fast_hits_delta,
-                contract_exec_delta_wasm_calls_last_snapshot = ce_delta_wasm_calls_delta,
-                contract_exec_delta_reload_hits_total = ce.delta_reload_hits,
-                contract_exec_delta_wasm_uncached_total = ce.delta_wasm_uncached,
+                // The per-window arms are logged (not the lifetime totals) so a
+                // local operator reading `journalctl` gets the answer from ONE
+                // line, and ALL EIGHT are logged in the same unit — mixing
+                // 5-minute deltas with lifetime totals under parallel names
+                // would invite reading them as comparable magnitudes. `info!`
+                // survives `release_max_level_info`; `debug!` would not.
+                contract_exec_summarize_fast_hits_last_snapshot = ce_d.summarize_fast_hits,
+                contract_exec_summarize_reload_hits_last_snapshot = ce_d.summarize_reload_hits,
+                contract_exec_summarize_wasm_calls_last_snapshot = ce_d.summarize_wasm_calls,
+                contract_exec_summarize_wasm_uncached_last_snapshot = ce_d.summarize_wasm_uncached,
+                contract_exec_delta_fast_hits_last_snapshot = ce_d.delta_fast_hits,
+                contract_exec_delta_reload_hits_last_snapshot = ce_d.delta_reload_hits,
+                contract_exec_delta_wasm_calls_last_snapshot = ce_d.delta_wasm_calls,
+                contract_exec_delta_wasm_uncached_last_snapshot = ce_d.delta_wasm_uncached,
                 hosted_contracts_count = ?snapshot.hosted_contracts_count,
                 hosted_key_distance_median = ?snapshot.hosted_key_distance_median,
                 hosted_key_distance_p90 = ?snapshot.hosted_key_distance_p90,
@@ -7503,30 +7502,38 @@ mod k_closest_source_tests {
             "delta_wasm_uncached",
         ];
         for field in fields {
-            let expected = format!("snapshot.contract_exec_{field}_total = Some(ce.{field});");
-            assert!(
-                norm.contains(&expected),
-                "mirror-seam: export must contain `{expected}` — a field swap here \
-                 silently reports one arm's count under another arm's name"
-            );
+            // Every arm is exported in BOTH units. A lifetime total sitting on
+            // a line of otherwise-parallel `_last_snapshot` names reads as a
+            // comparable magnitude and understates nothing visibly — which is
+            // why the pin demands both rather than either.
+            for expected in [
+                format!("snapshot.contract_exec_{field}_total = Some(ce.{field});"),
+                format!("snapshot.contract_exec_{field}_last_snapshot = Some(ce_d.{field});"),
+            ] {
+                assert!(
+                    norm.contains(&expected),
+                    "mirror-seam: export must contain `{expected}` — a field swap here \
+                     silently reports one arm's count under another arm's name"
+                );
+            }
         }
 
-        // The four per-window deltas must each difference their OWN total
-        // against their OWN previous value. Crossing these would emit a delta
-        // that is the difference of two different counters, i.e. noise.
-        for field in [
-            "summarize_fast_hits",
-            "summarize_wasm_calls",
-            "delta_fast_hits",
-            "delta_wasm_calls",
-        ] {
-            let expected = format!("window_delta(ce.{field}, &mut prev_exec.{field});");
-            assert!(
-                norm.contains(&expected),
-                "mirror-seam: the per-window delta must contain `{expected}` — \
-                 differencing one arm against another's previous value emits noise"
-            );
-        }
+        // The delta computation itself is NOT scraped: it is
+        // `ContractExecSnapshot::window_deltas`, one function whose field
+        // correspondence is structural and unit-tested by
+        // `each_field_differences_its_own_twin`. What must be pinned here is
+        // that the emitter uses it rather than re-deriving eight deltas by hand
+        // at the call site, which is where a cross-wiring hides.
+        assert!(
+            norm.contains("let ce_d = ce.window_deltas(&mut prev_exec);"),
+            "the emitter must delegate to ContractExecSnapshot::window_deltas, not \
+             hand-difference each arm at the call site"
+        );
+        assert!(
+            !norm.contains("window_delta(ce."),
+            "no hand-written per-arm window_delta call may remain — that is the \
+             shape in which one arm gets differenced against another's previous value"
+        );
     }
 }
 

--- a/crates/core/src/ring/contract_exec_metrics.rs
+++ b/crates/core/src/ring/contract_exec_metrics.rs
@@ -34,10 +34,24 @@
 //! total WASM get_state_delta invocations = delta_wasm_calls     + delta_wasm_uncached
 //! ```
 //!
-//! (Both partitions hold only for a call that RETURNS; an error return — state
-//! missing, params missing, WASM trap — exits without recording a terminal arm.
-//! Those are already loud in their own right, and a silent counter drift would
-//! be worse than a small under-count.)
+//! Four exceptions to the partition, all deliberate:
+//!
+//! 1. **A call that never returns records nothing.** An early error — state
+//!    missing, params missing — exits before any terminal arm. So does a
+//!    cancelled future: both cached functions `await` a state load before the
+//!    slow-path arms are reached.
+//! 2. **A WASM trap still counts as a WASM call.** The `*_wasm_calls` arms are
+//!    recorded immediately BEFORE the invocation they describe, so a trapping
+//!    or timing-out `summarize_state` increments the arm and then returns
+//!    `Err`. That is the intended sign: these arms answer "how much WASM work
+//!    is this peer attempting", and a trap costs the same CPU up to the trap.
+//!    It does mean the arms count ATTEMPTS, so during a trap storm
+//!    `*_wasm_calls` exceeds the successful returns. The hit arms have no
+//!    fallible step after them and so count only successes.
+//! 3. **An executor with no `OpManager` records nothing at all** (unit-test and
+//!    local-only executors have no `Ring` to attribute the work to). Every
+//!    production executor is built by `RuntimePool` with an `OpManager`.
+//! 4. **A snapshot can land mid-call.** See [`ContractExecSnapshot`].
 //!
 //! # What each counter answers
 //!
@@ -58,11 +72,20 @@
 //!
 //! # Cost
 //!
-//! One `Relaxed` `fetch_add` on a `u64` per contract-handler call — a few ns,
-//! uncontended (the contract-handling loop has concurrency exactly 1, enforced
-//! by `&mut self`). The fast path takes exactly one increment; the slow paths
-//! take one more, alongside a state load and a WASM invocation that dwarf it.
-//! Nothing allocates and nothing locks.
+//! One `Relaxed` `fetch_add` on a `u64` per contract-handler call — a few ns.
+//! The fast path takes exactly one increment; the slow paths take one more,
+//! alongside a state load and a WASM invocation that dwarf it. Nothing
+//! allocates and nothing locks.
+//!
+//! The two CACHED entry points are reached only through `RuntimePool`'s
+//! `&mut self` methods, so they are serialized on the contract-handling loop and
+//! the atomics are uncontended there. The `*_uncached` sites are NOT all on that
+//! loop — the `contract_ops` PUT/UPDATE sites are reachable from
+//! `run_local_node`, and `executor_impl.rs` documents that off-loop work can
+//! hold an executor — so treat "uncontended" as the common case, not a
+//! guarantee. `fetch_add` is correct under any contention; `Relaxed` is
+//! sufficient because each counter is read on its own and publishes no other
+//! memory alongside it.
 //!
 //! # How this is read
 //!
@@ -70,10 +93,14 @@
 //! a process global, so unit tests stay isolated — the #4488 rationale that
 //! `ModuleCacheMetrics` was moved off a global for). The executor increments it
 //! through `op_manager.ring`; `emit_router_snapshot_telemetry` reads it on the
-//! existing 5-minute `router_snapshot` cadence and emits both the monotonic
-//! lifetime totals (collector-side differencing) and the per-window deltas for
-//! the four headline arms, so a single snapshot answers "was this peer's
-//! summarize load cache hits or real WASM work" without a stateful reader.
+//! existing 5-minute `router_snapshot` cadence and emits, for EVERY arm, both
+//! the monotonic lifetime total (collector-side differencing) and the per-window
+//! delta, so a single snapshot answers "was this peer's summarize load cache
+//! hits or real WASM work" without a stateful reader. All eight, not a headline
+//! subset: mixing 5-minute deltas with lifetime totals under parallel names on
+//! one log line invites reading them as comparable magnitudes, and the arm that
+//! would be understated that way is `delta_wasm_uncached` — the fan-out delta
+//! with no cache in front of it, which can dominate on a client-facing node.
 //!
 //! Note the deliberate choice of an EXISTING telemetry stream: `router_snapshot`
 //! already carries this class of per-node monotonic counter
@@ -118,6 +145,12 @@ pub(crate) struct ContractExecMetrics {
 }
 
 /// A point-in-time read of [`ContractExecMetrics`] for telemetry emission.
+///
+/// The eight loads are independent and `Relaxed`, so a snapshot taken while the
+/// contract loop is running can land between two arms of one call and violate
+/// the module-level partition identity by one. That is fine for a rate and for
+/// the collector's differencing; do NOT build an alert that asserts the identity
+/// holds exactly on a single snapshot, it would flap.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(crate) struct ContractExecSnapshot {
     pub summarize_fast_hits: u64,
@@ -128,6 +161,51 @@ pub(crate) struct ContractExecSnapshot {
     pub delta_reload_hits: u64,
     pub delta_wasm_calls: u64,
     pub delta_wasm_uncached: u64,
+}
+
+impl ContractExecSnapshot {
+    /// Difference this snapshot against `prev` field-by-field, advancing `prev`
+    /// to this snapshot. Returns the per-window deltas.
+    ///
+    /// This exists as ONE function rather than eight hand-written
+    /// `window_delta(ce.x, &mut prev.x)` calls at the emit site, because a
+    /// hand-written set is exactly where a cross-wiring — differencing one arm
+    /// against another arm's previous value — hides. Such a slip emits a
+    /// plausible number that is pure noise, and the whole point of these
+    /// counters is that a plausible-but-wrong number is worse than none. Here
+    /// the correspondence is structural and `each_field_differences_its_own_twin`
+    /// pins it with distinct per-field values.
+    ///
+    /// `saturating_sub` can only mask a decrease, and these counters are
+    /// monotonic for a process lifetime (nothing resets them — see
+    /// `snapshot_is_non_destructive`), so a non-zero mask means the caller
+    /// passed a `prev` from a different source.
+    pub(crate) fn window_deltas(&self, prev: &mut ContractExecSnapshot) -> ContractExecSnapshot {
+        let deltas = ContractExecSnapshot {
+            summarize_fast_hits: self
+                .summarize_fast_hits
+                .saturating_sub(prev.summarize_fast_hits),
+            summarize_reload_hits: self
+                .summarize_reload_hits
+                .saturating_sub(prev.summarize_reload_hits),
+            summarize_wasm_calls: self
+                .summarize_wasm_calls
+                .saturating_sub(prev.summarize_wasm_calls),
+            summarize_wasm_uncached: self
+                .summarize_wasm_uncached
+                .saturating_sub(prev.summarize_wasm_uncached),
+            delta_fast_hits: self.delta_fast_hits.saturating_sub(prev.delta_fast_hits),
+            delta_reload_hits: self
+                .delta_reload_hits
+                .saturating_sub(prev.delta_reload_hits),
+            delta_wasm_calls: self.delta_wasm_calls.saturating_sub(prev.delta_wasm_calls),
+            delta_wasm_uncached: self
+                .delta_wasm_uncached
+                .saturating_sub(prev.delta_wasm_uncached),
+        };
+        *prev = *self;
+        deltas
+    }
 }
 
 impl ContractExecMetrics {
@@ -238,6 +316,52 @@ mod tests {
         assert_eq!(s.delta_reload_hits, 6);
         assert_eq!(s.delta_wasm_calls, 7);
         assert_eq!(s.delta_wasm_uncached, 8);
+    }
+
+    /// Every per-window delta must difference its OWN twin. A cross-wiring here
+    /// emits the difference of two unrelated arms — a plausible number that is
+    /// pure noise — which is the failure these counters exist to prevent, not
+    /// to commit. Distinct per-field values, so a swap cannot pass.
+    #[test]
+    fn each_field_differences_its_own_twin() {
+        let mut prev = ContractExecSnapshot {
+            summarize_fast_hits: 10,
+            summarize_reload_hits: 20,
+            summarize_wasm_calls: 30,
+            summarize_wasm_uncached: 40,
+            delta_fast_hits: 50,
+            delta_reload_hits: 60,
+            delta_wasm_calls: 70,
+            delta_wasm_uncached: 80,
+        };
+        let now = ContractExecSnapshot {
+            summarize_fast_hits: 11,
+            summarize_reload_hits: 22,
+            summarize_wasm_calls: 33,
+            summarize_wasm_uncached: 44,
+            delta_fast_hits: 55,
+            delta_reload_hits: 66,
+            delta_wasm_calls: 77,
+            delta_wasm_uncached: 88,
+        };
+
+        let d = now.window_deltas(&mut prev);
+        assert_eq!(d.summarize_fast_hits, 1);
+        assert_eq!(d.summarize_reload_hits, 2);
+        assert_eq!(d.summarize_wasm_calls, 3);
+        assert_eq!(d.summarize_wasm_uncached, 4);
+        assert_eq!(d.delta_fast_hits, 5);
+        assert_eq!(d.delta_reload_hits, 6);
+        assert_eq!(d.delta_wasm_calls, 7);
+        assert_eq!(d.delta_wasm_uncached, 8);
+
+        // `prev` advanced to `now`, so an immediately repeated window is all
+        // zeroes rather than re-reporting the same work.
+        assert_eq!(prev, now);
+        assert_eq!(
+            now.window_deltas(&mut prev),
+            ContractExecSnapshot::default()
+        );
     }
 
     #[test]

--- a/crates/core/src/ring/contract_exec_metrics.rs
+++ b/crates/core/src/ring/contract_exec_metrics.rs
@@ -1,0 +1,256 @@
+//! Contract-exec WASM observability (#5168 sibling; #4440 / #4473 / #4610 /
+//! #5238 storm lineage).
+//!
+//! # Why this exists
+//!
+//! Every rate figure quoted in the recurring "summarize storm" investigations
+//! (#4473 ~40/sec, #4610 ~70-80/sec, #5040 ~49-57/sec, #5238 ~50-95/sec) came
+//! from the DROPPED-LINE counter of the tracing rate limiter
+//! (`crate::util::rate_limit_layer`), which caps LOG EVENTS at 30/sec per
+//! callsite and has no effect whatsoever on work done. Worse, the span it
+//! counts (`contract.rs`'s `info_span!("summarize_contract_state")`) is opened
+//! at HANDLER ENTRY, so it fires identically for a state-hash cache HIT and for
+//! a real WASM `summarize_state` invocation.
+//!
+//! Those two are separated by orders of magnitude in cost — the cache is the
+//! entire reason the observed rate is survivable — so the headline number could
+//! not distinguish "this peer is burning CPU in WASM" from "this peer is
+//! serving a warm cache". Five PRs in five weeks bounded or gated call sites
+//! against that undifferentiated number.
+//!
+//! These counters close that gap. They are recorded BY the code that makes each
+//! decision (never re-derived by a caller from set sizes — see the "metric
+//! describing a filtering decision" row in `bug-prevention-patterns.md`), and
+//! they PARTITION each cached path exactly, so no consumer ever has to subtract
+//! one counter from another to get an answer:
+//!
+//! ```text
+//! calls to bridged_summarize_contract_state
+//!   = summarize_fast_hits + summarize_reload_hits + summarize_wasm_calls
+//! calls to bridged_get_contract_state_delta
+//!   = delta_fast_hits     + delta_reload_hits     + delta_wasm_calls
+//!
+//! total WASM summarize_state invocations = summarize_wasm_calls + summarize_wasm_uncached
+//! total WASM get_state_delta invocations = delta_wasm_calls     + delta_wasm_uncached
+//! ```
+//!
+//! (Both partitions hold only for a call that RETURNS; an error return — state
+//! missing, params missing, WASM trap — exits without recording a terminal arm.
+//! Those are already loud in their own right, and a silent counter drift would
+//! be worse than a small under-count.)
+//!
+//! # What each counter answers
+//!
+//! - `*_fast_hits` — the state-change detector held a hash for the contract's
+//!   current state AND a summary/delta was cached against exactly that hash.
+//!   Neither the state nor the WASM module was touched. This is the arm that
+//!   makes a 50/sec anti-entropy cadence cheap.
+//! - `*_reload_hits` — the detector was cold (restart, eviction) so the full
+//!   state was loaded and hashed, but the cache already held an entry for the
+//!   recomputed hash. Real I/O and hashing, no WASM. A high value here means the
+//!   detector is being invalidated more than the cache is.
+//! - `*_wasm_calls` — the WASM module actually ran, from the cached path. This
+//!   is the expensive work every storm fix was trying to bound.
+//! - `*_wasm_uncached` — the WASM module ran from a call site that has NO cache
+//!   in front of it (the PUT/UPDATE summary sites in `contract_ops`, the local
+//!   client-notification delta fan-out). Counted separately so the cached-path
+//!   partition above stays exact while the WASM TOTAL stays honest.
+//!
+//! # Cost
+//!
+//! One `Relaxed` `fetch_add` on a `u64` per contract-handler call — a few ns,
+//! uncontended (the contract-handling loop has concurrency exactly 1, enforced
+//! by `&mut self`). The fast path takes exactly one increment; the slow paths
+//! take one more, alongside a state load and a WASM invocation that dwarf it.
+//! Nothing allocates and nothing locks.
+//!
+//! # How this is read
+//!
+//! Constructed once per node in `Ring::new` and shared via `Arc` (per-node, not
+//! a process global, so unit tests stay isolated — the #4488 rationale that
+//! `ModuleCacheMetrics` was moved off a global for). The executor increments it
+//! through `op_manager.ring`; `emit_router_snapshot_telemetry` reads it on the
+//! existing 5-minute `router_snapshot` cadence and emits both the monotonic
+//! lifetime totals (collector-side differencing) and the per-window deltas for
+//! the four headline arms, so a single snapshot answers "was this peer's
+//! summarize load cache hits or real WASM work" without a stateful reader.
+//!
+//! Note the deliberate choice of an EXISTING telemetry stream: `router_snapshot`
+//! already carries this class of per-node monotonic counter
+//! (`contract_module_cache_evictions_total`, `broadcast_stream_*_total`), so
+//! these fields cost no shadow-rollup budget slot (`MAX_SHADOW_EVENTS_PER_SECOND`
+//! is 6 with one slot of headroom) and land in a `tracing::info!` line that
+//! survives `release_max_level_info` for local `journalctl` reading.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Cumulative lifetime counts of contract-exec WASM invocations and the cache
+/// hits that elided them. See the module docs for the partition and cost.
+#[derive(Debug, Default)]
+pub(crate) struct ContractExecMetrics {
+    /// `bridged_summarize_contract_state` returned a cached summary from the
+    /// fast path: detector hash present and matching a cached summary. No state
+    /// load, no hash, no WASM.
+    summarize_fast_hits: AtomicU64,
+    /// `bridged_summarize_contract_state` reached the slow path (state loaded
+    /// and hashed) but the summary cache already held an entry for the
+    /// recomputed hash, so the WASM call was still elided.
+    summarize_reload_hits: AtomicU64,
+    /// WASM `summarize_state` ran from the CACHED path
+    /// (`bridged_summarize_contract_state`) — a true cache miss.
+    summarize_wasm_calls: AtomicU64,
+    /// WASM `summarize_state` ran from a call site with no cache in front of it
+    /// (the PUT/UPDATE response-summary sites in `contract_ops`).
+    summarize_wasm_uncached: AtomicU64,
+    /// `bridged_get_contract_state_delta` returned a cached delta from the fast
+    /// path: detector hash present and a delta cached for that exact
+    /// (state, peer-summary) pair.
+    delta_fast_hits: AtomicU64,
+    /// `bridged_get_contract_state_delta` reached the slow path (state loaded
+    /// and hashed) but the delta cache already held the recomputed key.
+    delta_reload_hits: AtomicU64,
+    /// WASM `get_state_delta` ran from the CACHED path
+    /// (`bridged_get_contract_state_delta`) — a true cache miss.
+    delta_wasm_calls: AtomicU64,
+    /// WASM `get_state_delta` ran from a call site with no cache in front of it
+    /// (the per-subscriber local client-notification fan-out).
+    delta_wasm_uncached: AtomicU64,
+}
+
+/// A point-in-time read of [`ContractExecMetrics`] for telemetry emission.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct ContractExecSnapshot {
+    pub summarize_fast_hits: u64,
+    pub summarize_reload_hits: u64,
+    pub summarize_wasm_calls: u64,
+    pub summarize_wasm_uncached: u64,
+    pub delta_fast_hits: u64,
+    pub delta_reload_hits: u64,
+    pub delta_wasm_calls: u64,
+    pub delta_wasm_uncached: u64,
+}
+
+impl ContractExecMetrics {
+    /// Record a summary served from the fast path (no state load, no WASM).
+    #[inline]
+    pub(crate) fn record_summarize_fast_hit(&self) {
+        self.summarize_fast_hits.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record a summary served from the cache after a state reload+rehash.
+    #[inline]
+    pub(crate) fn record_summarize_reload_hit(&self) {
+        self.summarize_reload_hits.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record a WASM `summarize_state` invocation on the cached path.
+    #[inline]
+    pub(crate) fn record_summarize_wasm_call(&self) {
+        self.summarize_wasm_calls.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record a WASM `summarize_state` invocation on an uncached call site.
+    #[inline]
+    pub(crate) fn record_summarize_wasm_uncached(&self) {
+        self.summarize_wasm_uncached.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record a delta served from the fast path (no state load, no WASM).
+    #[inline]
+    pub(crate) fn record_delta_fast_hit(&self) {
+        self.delta_fast_hits.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record a delta served from the cache after a state reload+rehash.
+    #[inline]
+    pub(crate) fn record_delta_reload_hit(&self) {
+        self.delta_reload_hits.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record a WASM `get_state_delta` invocation on the cached path.
+    #[inline]
+    pub(crate) fn record_delta_wasm_call(&self) {
+        self.delta_wasm_calls.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record a WASM `get_state_delta` invocation on an uncached call site.
+    #[inline]
+    pub(crate) fn record_delta_wasm_uncached(&self) {
+        self.delta_wasm_uncached.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Read all counters for telemetry.
+    pub(crate) fn snapshot(&self) -> ContractExecSnapshot {
+        ContractExecSnapshot {
+            summarize_fast_hits: self.summarize_fast_hits.load(Ordering::Relaxed),
+            summarize_reload_hits: self.summarize_reload_hits.load(Ordering::Relaxed),
+            summarize_wasm_calls: self.summarize_wasm_calls.load(Ordering::Relaxed),
+            summarize_wasm_uncached: self.summarize_wasm_uncached.load(Ordering::Relaxed),
+            delta_fast_hits: self.delta_fast_hits.load(Ordering::Relaxed),
+            delta_reload_hits: self.delta_reload_hits.load(Ordering::Relaxed),
+            delta_wasm_calls: self.delta_wasm_calls.load(Ordering::Relaxed),
+            delta_wasm_uncached: self.delta_wasm_uncached.load(Ordering::Relaxed),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn each_recorder_lands_on_its_own_counter() {
+        let m = ContractExecMetrics::default();
+        assert_eq!(m.snapshot(), ContractExecSnapshot::default());
+
+        // Distinct counts per arm: a copy-paste slip that made two recorders
+        // share a field would still produce a plausible non-zero snapshot, so
+        // the multiplicities have to differ for the assertions to bite.
+        m.record_summarize_fast_hit();
+        for _ in 0..2 {
+            m.record_summarize_reload_hit();
+        }
+        for _ in 0..3 {
+            m.record_summarize_wasm_call();
+        }
+        for _ in 0..4 {
+            m.record_summarize_wasm_uncached();
+        }
+        for _ in 0..5 {
+            m.record_delta_fast_hit();
+        }
+        for _ in 0..6 {
+            m.record_delta_reload_hit();
+        }
+        for _ in 0..7 {
+            m.record_delta_wasm_call();
+        }
+        for _ in 0..8 {
+            m.record_delta_wasm_uncached();
+        }
+
+        let s = m.snapshot();
+        assert_eq!(s.summarize_fast_hits, 1);
+        assert_eq!(s.summarize_reload_hits, 2);
+        assert_eq!(s.summarize_wasm_calls, 3);
+        assert_eq!(s.summarize_wasm_uncached, 4);
+        assert_eq!(s.delta_fast_hits, 5);
+        assert_eq!(s.delta_reload_hits, 6);
+        assert_eq!(s.delta_wasm_calls, 7);
+        assert_eq!(s.delta_wasm_uncached, 8);
+    }
+
+    #[test]
+    fn snapshot_is_non_destructive() {
+        let m = ContractExecMetrics::default();
+        m.record_summarize_wasm_call();
+        assert_eq!(m.snapshot().summarize_wasm_calls, 1);
+        // Unlike the drained rollup windows (`outbound_message_mix`,
+        // `broadcast_payload_mix`), these are monotonic lifetime totals:
+        // reading must not reset them, or a dropped telemetry event would lose
+        // that interval permanently.
+        assert_eq!(m.snapshot().summarize_wasm_calls, 1);
+        m.record_summarize_wasm_call();
+        assert_eq!(m.snapshot().summarize_wasm_calls, 2);
+    }
+}

--- a/crates/core/src/ring/contract_exec_metrics.rs
+++ b/crates/core/src/ring/contract_exec_metrics.rs
@@ -30,11 +30,18 @@
 //! calls to bridged_get_contract_state_delta
 //!   = delta_fast_hits     + delta_reload_hits     + delta_wasm_calls
 //!
-//! total WASM summarize_state invocations = summarize_wasm_calls + summarize_wasm_uncached
-//! total WASM get_state_delta invocations = delta_wasm_calls     + delta_wasm_uncached
+//! executor-mediated summarize_state invocations
+//!   = summarize_wasm_calls + summarize_wasm_uncached
+//! executor-mediated get_state_delta invocations
+//!   = delta_wasm_calls     + delta_wasm_uncached
 //! ```
 //!
-//! Four exceptions to the partition, all deliberate:
+//! Note the qualifier on the last two: **executor-mediated**, not "total". These
+//! arms count WASM driven through the contract executor, which is every
+//! invocation on the request and fan-out paths. They are deliberately NOT a
+//! whole-process total — see exception 5.
+//!
+//! Five exceptions to the partition, all deliberate:
 //!
 //! 1. **A call that never returns records nothing.** An early error — state
 //!    missing, params missing — exits before any terminal arm. So does a
@@ -52,6 +59,17 @@
 //!    local-only executors have no `Ring` to attribute the work to). Every
 //!    production executor is built by `RuntimePool` with an `OpManager`.
 //! 4. **A snapshot can land mid-call.** See [`ContractExecSnapshot`].
+//! 5. **The conformance oracle's WASM is not counted.**
+//!    `conformance::runtime_oracle::RuntimeOracle` calls `Runtime`'s
+//!    `summarize_state` / `get_state_delta` directly rather than through the
+//!    executor, and it runs on a real node (`conformance::shadow`'s opt-in probe
+//!    loop constructs one per focus contract). Its work is therefore real WASM
+//!    execution that these arms do not see. That is why the identity above says
+//!    "executor-mediated" rather than "total": the oracle is a diagnostic
+//!    probe whose cost belongs to the conformance budget, not to the request
+//!    path these counters are read to size. If the oracle ever moves onto the
+//!    executor, fold it in and delete this exception — but do NOT quietly
+//!    restore the word "total" while a second uncounted WASM caller exists.
 //!
 //! # What each counter answers
 //!

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -736,6 +736,10 @@ pub(crate) struct RouterSnapshotInfo {
     /// them across the cadence); `*_last_snapshot` are the per-window deltas
     /// `Ring` samples directly, so ONE snapshot answers "was this peer's
     /// summarize load cache hits or real WASM work" without a stateful reader.
+    /// EVERY arm gets both, deliberately: emitting some arms as a delta and
+    /// others as a lifetime total, under parallel names, invites reading them as
+    /// comparable magnitudes and would understate exactly the uncached fan-out
+    /// arm most likely to dominate on a client-facing node.
     /// `None` until the node has a `Ring`-backed executor.
     pub contract_exec_summarize_fast_hits_total: Option<u64>,
     pub contract_exec_summarize_reload_hits_total: Option<u64>,
@@ -746,9 +750,13 @@ pub(crate) struct RouterSnapshotInfo {
     pub contract_exec_delta_wasm_calls_total: Option<u64>,
     pub contract_exec_delta_wasm_uncached_total: Option<u64>,
     pub contract_exec_summarize_fast_hits_last_snapshot: Option<u64>,
+    pub contract_exec_summarize_reload_hits_last_snapshot: Option<u64>,
     pub contract_exec_summarize_wasm_calls_last_snapshot: Option<u64>,
+    pub contract_exec_summarize_wasm_uncached_last_snapshot: Option<u64>,
     pub contract_exec_delta_fast_hits_last_snapshot: Option<u64>,
+    pub contract_exec_delta_reload_hits_last_snapshot: Option<u64>,
     pub contract_exec_delta_wasm_calls_last_snapshot: Option<u64>,
+    pub contract_exec_delta_wasm_uncached_last_snapshot: Option<u64>,
     /// Placement-quality gauges (#4404 follow-up), populated by `Ring` on the
     /// snapshot cadence from the contracts this node hosts. They make the
     /// effect of the SubscribeHint placement migration observable: the migration
@@ -1773,9 +1781,13 @@ impl Router {
             contract_exec_delta_wasm_calls_total: None,
             contract_exec_delta_wasm_uncached_total: None,
             contract_exec_summarize_fast_hits_last_snapshot: None,
+            contract_exec_summarize_reload_hits_last_snapshot: None,
             contract_exec_summarize_wasm_calls_last_snapshot: None,
+            contract_exec_summarize_wasm_uncached_last_snapshot: None,
             contract_exec_delta_fast_hits_last_snapshot: None,
+            contract_exec_delta_reload_hits_last_snapshot: None,
             contract_exec_delta_wasm_calls_last_snapshot: None,
+            contract_exec_delta_wasm_uncached_last_snapshot: None,
             broadcast_stream_failures_last_snapshot: None,
             // Placement-quality + placement-migration gauges populated by Ring on
             // the snapshot cadence (#4404 follow-up).

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -637,6 +637,10 @@ pub(crate) struct RouterSnapshotInfo {
     /// them across the cadence); `*_last_snapshot` are the per-window deltas
     /// `Ring` samples directly, so ONE snapshot answers "was this peer's
     /// summarize load cache hits or real WASM work" without a stateful reader.
+    /// EVERY arm gets both, deliberately: emitting some arms as a delta and
+    /// others as a lifetime total, under parallel names, invites reading them as
+    /// comparable magnitudes and would understate exactly the uncached fan-out
+    /// arm most likely to dominate on a client-facing node.
     /// `None` until the node has a `Ring`-backed executor.
     pub contract_exec_summarize_fast_hits_total: Option<u64>,
     pub contract_exec_summarize_reload_hits_total: Option<u64>,
@@ -647,9 +651,13 @@ pub(crate) struct RouterSnapshotInfo {
     pub contract_exec_delta_wasm_calls_total: Option<u64>,
     pub contract_exec_delta_wasm_uncached_total: Option<u64>,
     pub contract_exec_summarize_fast_hits_last_snapshot: Option<u64>,
+    pub contract_exec_summarize_reload_hits_last_snapshot: Option<u64>,
     pub contract_exec_summarize_wasm_calls_last_snapshot: Option<u64>,
+    pub contract_exec_summarize_wasm_uncached_last_snapshot: Option<u64>,
     pub contract_exec_delta_fast_hits_last_snapshot: Option<u64>,
+    pub contract_exec_delta_reload_hits_last_snapshot: Option<u64>,
     pub contract_exec_delta_wasm_calls_last_snapshot: Option<u64>,
+    pub contract_exec_delta_wasm_uncached_last_snapshot: Option<u64>,
     /// Placement-quality gauges (#4404 follow-up), populated by `Ring` on the
     /// snapshot cadence from the contracts this node hosts. They make the
     /// effect of the SubscribeHint placement migration observable: the migration
@@ -1674,9 +1682,13 @@ impl Router {
             contract_exec_delta_wasm_calls_total: None,
             contract_exec_delta_wasm_uncached_total: None,
             contract_exec_summarize_fast_hits_last_snapshot: None,
+            contract_exec_summarize_reload_hits_last_snapshot: None,
             contract_exec_summarize_wasm_calls_last_snapshot: None,
+            contract_exec_summarize_wasm_uncached_last_snapshot: None,
             contract_exec_delta_fast_hits_last_snapshot: None,
+            contract_exec_delta_reload_hits_last_snapshot: None,
             contract_exec_delta_wasm_calls_last_snapshot: None,
+            contract_exec_delta_wasm_uncached_last_snapshot: None,
             broadcast_stream_failures_last_snapshot: None,
             // Placement-quality + placement-migration gauges populated by Ring on
             // the snapshot cadence (#4404 follow-up).

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -618,6 +618,38 @@ pub(crate) struct RouterSnapshotInfo {
     pub broadcast_stream_attempts_total: Option<u64>,
     pub broadcast_stream_failures_total: Option<u64>,
     pub broadcast_stream_failures_last_snapshot: Option<u64>,
+    /// Contract-exec WASM counters, populated by `Ring` from the per-node
+    /// `ContractExecMetrics` the executor publishes into. These separate the
+    /// EXPENSIVE work (a WASM `summarize_state` / `get_state_delta`
+    /// invocation) from the cache hits that elide it — a distinction the only
+    /// prior production signal, a handler-entry span, could not make, which is
+    /// why every rate quoted across the #4473 / #4610 / #5040 / #5238 storm
+    /// investigations was undifferentiated. See
+    /// `ring::contract_exec_metrics` for the exact partition each arm belongs
+    /// to; briefly:
+    ///
+    /// - `*_fast_hits` — served from cache, no state load, no WASM
+    /// - `*_reload_hits` — state loaded and hashed, cache hit, no WASM
+    /// - `*_wasm_calls` — WASM ran, on the cached path (a true miss)
+    /// - `*_wasm_uncached` — WASM ran, at a site with no cache in front of it
+    ///
+    /// `*_total` are monotonic lifetime counters (the collector differences
+    /// them across the cadence); `*_last_snapshot` are the per-window deltas
+    /// `Ring` samples directly, so ONE snapshot answers "was this peer's
+    /// summarize load cache hits or real WASM work" without a stateful reader.
+    /// `None` until the node has a `Ring`-backed executor.
+    pub contract_exec_summarize_fast_hits_total: Option<u64>,
+    pub contract_exec_summarize_reload_hits_total: Option<u64>,
+    pub contract_exec_summarize_wasm_calls_total: Option<u64>,
+    pub contract_exec_summarize_wasm_uncached_total: Option<u64>,
+    pub contract_exec_delta_fast_hits_total: Option<u64>,
+    pub contract_exec_delta_reload_hits_total: Option<u64>,
+    pub contract_exec_delta_wasm_calls_total: Option<u64>,
+    pub contract_exec_delta_wasm_uncached_total: Option<u64>,
+    pub contract_exec_summarize_fast_hits_last_snapshot: Option<u64>,
+    pub contract_exec_summarize_wasm_calls_last_snapshot: Option<u64>,
+    pub contract_exec_delta_fast_hits_last_snapshot: Option<u64>,
+    pub contract_exec_delta_wasm_calls_last_snapshot: Option<u64>,
     /// Placement-quality gauges (#4404 follow-up), populated by `Ring` on the
     /// snapshot cadence from the contracts this node hosts. They make the
     /// effect of the SubscribeHint placement migration observable: the migration
@@ -1633,6 +1665,18 @@ impl Router {
             // populated by Ring on the snapshot cadence (#4440).
             broadcast_stream_attempts_total: None,
             broadcast_stream_failures_total: None,
+            contract_exec_summarize_fast_hits_total: None,
+            contract_exec_summarize_reload_hits_total: None,
+            contract_exec_summarize_wasm_calls_total: None,
+            contract_exec_summarize_wasm_uncached_total: None,
+            contract_exec_delta_fast_hits_total: None,
+            contract_exec_delta_reload_hits_total: None,
+            contract_exec_delta_wasm_calls_total: None,
+            contract_exec_delta_wasm_uncached_total: None,
+            contract_exec_summarize_fast_hits_last_snapshot: None,
+            contract_exec_summarize_wasm_calls_last_snapshot: None,
+            contract_exec_delta_fast_hits_last_snapshot: None,
+            contract_exec_delta_wasm_calls_last_snapshot: None,
             broadcast_stream_failures_last_snapshot: None,
             // Placement-quality + placement-migration gauges populated by Ring on
             // the snapshot cadence (#4404 follow-up).

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -717,6 +717,38 @@ pub(crate) struct RouterSnapshotInfo {
     pub broadcast_stream_attempts_total: Option<u64>,
     pub broadcast_stream_failures_total: Option<u64>,
     pub broadcast_stream_failures_last_snapshot: Option<u64>,
+    /// Contract-exec WASM counters, populated by `Ring` from the per-node
+    /// `ContractExecMetrics` the executor publishes into. These separate the
+    /// EXPENSIVE work (a WASM `summarize_state` / `get_state_delta`
+    /// invocation) from the cache hits that elide it — a distinction the only
+    /// prior production signal, a handler-entry span, could not make, which is
+    /// why every rate quoted across the #4473 / #4610 / #5040 / #5238 storm
+    /// investigations was undifferentiated. See
+    /// `ring::contract_exec_metrics` for the exact partition each arm belongs
+    /// to; briefly:
+    ///
+    /// - `*_fast_hits` — served from cache, no state load, no WASM
+    /// - `*_reload_hits` — state loaded and hashed, cache hit, no WASM
+    /// - `*_wasm_calls` — WASM ran, on the cached path (a true miss)
+    /// - `*_wasm_uncached` — WASM ran, at a site with no cache in front of it
+    ///
+    /// `*_total` are monotonic lifetime counters (the collector differences
+    /// them across the cadence); `*_last_snapshot` are the per-window deltas
+    /// `Ring` samples directly, so ONE snapshot answers "was this peer's
+    /// summarize load cache hits or real WASM work" without a stateful reader.
+    /// `None` until the node has a `Ring`-backed executor.
+    pub contract_exec_summarize_fast_hits_total: Option<u64>,
+    pub contract_exec_summarize_reload_hits_total: Option<u64>,
+    pub contract_exec_summarize_wasm_calls_total: Option<u64>,
+    pub contract_exec_summarize_wasm_uncached_total: Option<u64>,
+    pub contract_exec_delta_fast_hits_total: Option<u64>,
+    pub contract_exec_delta_reload_hits_total: Option<u64>,
+    pub contract_exec_delta_wasm_calls_total: Option<u64>,
+    pub contract_exec_delta_wasm_uncached_total: Option<u64>,
+    pub contract_exec_summarize_fast_hits_last_snapshot: Option<u64>,
+    pub contract_exec_summarize_wasm_calls_last_snapshot: Option<u64>,
+    pub contract_exec_delta_fast_hits_last_snapshot: Option<u64>,
+    pub contract_exec_delta_wasm_calls_last_snapshot: Option<u64>,
     /// Placement-quality gauges (#4404 follow-up), populated by `Ring` on the
     /// snapshot cadence from the contracts this node hosts. They make the
     /// effect of the SubscribeHint placement migration observable: the migration
@@ -1732,6 +1764,18 @@ impl Router {
             // populated by Ring on the snapshot cadence (#4440).
             broadcast_stream_attempts_total: None,
             broadcast_stream_failures_total: None,
+            contract_exec_summarize_fast_hits_total: None,
+            contract_exec_summarize_reload_hits_total: None,
+            contract_exec_summarize_wasm_calls_total: None,
+            contract_exec_summarize_wasm_uncached_total: None,
+            contract_exec_delta_fast_hits_total: None,
+            contract_exec_delta_reload_hits_total: None,
+            contract_exec_delta_wasm_calls_total: None,
+            contract_exec_delta_wasm_uncached_total: None,
+            contract_exec_summarize_fast_hits_last_snapshot: None,
+            contract_exec_summarize_wasm_calls_last_snapshot: None,
+            contract_exec_delta_fast_hits_last_snapshot: None,
+            contract_exec_delta_wasm_calls_last_snapshot: None,
             broadcast_stream_failures_last_snapshot: None,
             // Placement-quality + placement-migration gauges populated by Ring on
             // the snapshot cadence (#4404 follow-up).

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -2770,16 +2770,32 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                         snapshot.contract_exec_summarize_fast_hits_last_snapshot,
                     ),
                     (
+                        "contract_exec_summarize_reload_hits_last_snapshot",
+                        snapshot.contract_exec_summarize_reload_hits_last_snapshot,
+                    ),
+                    (
                         "contract_exec_summarize_wasm_calls_last_snapshot",
                         snapshot.contract_exec_summarize_wasm_calls_last_snapshot,
+                    ),
+                    (
+                        "contract_exec_summarize_wasm_uncached_last_snapshot",
+                        snapshot.contract_exec_summarize_wasm_uncached_last_snapshot,
                     ),
                     (
                         "contract_exec_delta_fast_hits_last_snapshot",
                         snapshot.contract_exec_delta_fast_hits_last_snapshot,
                     ),
                     (
+                        "contract_exec_delta_reload_hits_last_snapshot",
+                        snapshot.contract_exec_delta_reload_hits_last_snapshot,
+                    ),
+                    (
                         "contract_exec_delta_wasm_calls_last_snapshot",
                         snapshot.contract_exec_delta_wasm_calls_last_snapshot,
+                    ),
+                    (
+                        "contract_exec_delta_wasm_uncached_last_snapshot",
+                        snapshot.contract_exec_delta_wasm_uncached_last_snapshot,
                     ),
                 ] {
                     obj.insert(name.to_string(), serde_json::json!(value));
@@ -4269,9 +4285,13 @@ mod tests {
         info.contract_exec_delta_wasm_calls_total = Some(107);
         info.contract_exec_delta_wasm_uncached_total = Some(108);
         info.contract_exec_summarize_fast_hits_last_snapshot = Some(109);
-        info.contract_exec_summarize_wasm_calls_last_snapshot = Some(110);
-        info.contract_exec_delta_fast_hits_last_snapshot = Some(111);
-        info.contract_exec_delta_wasm_calls_last_snapshot = Some(112);
+        info.contract_exec_summarize_reload_hits_last_snapshot = Some(110);
+        info.contract_exec_summarize_wasm_calls_last_snapshot = Some(111);
+        info.contract_exec_summarize_wasm_uncached_last_snapshot = Some(112);
+        info.contract_exec_delta_fast_hits_last_snapshot = Some(113);
+        info.contract_exec_delta_reload_hits_last_snapshot = Some(114);
+        info.contract_exec_delta_wasm_calls_last_snapshot = Some(115);
+        info.contract_exec_delta_wasm_uncached_last_snapshot = Some(116);
         let json = event_kind_to_json(&EventKind::RouterSnapshot(Box::new(info)));
         for (key, want) in [
             ("contract_exec_summarize_fast_hits_total", 101),
@@ -4283,9 +4303,13 @@ mod tests {
             ("contract_exec_delta_wasm_calls_total", 107),
             ("contract_exec_delta_wasm_uncached_total", 108),
             ("contract_exec_summarize_fast_hits_last_snapshot", 109),
-            ("contract_exec_summarize_wasm_calls_last_snapshot", 110),
-            ("contract_exec_delta_fast_hits_last_snapshot", 111),
-            ("contract_exec_delta_wasm_calls_last_snapshot", 112),
+            ("contract_exec_summarize_reload_hits_last_snapshot", 110),
+            ("contract_exec_summarize_wasm_calls_last_snapshot", 111),
+            ("contract_exec_summarize_wasm_uncached_last_snapshot", 112),
+            ("contract_exec_delta_fast_hits_last_snapshot", 113),
+            ("contract_exec_delta_reload_hits_last_snapshot", 114),
+            ("contract_exec_delta_wasm_calls_last_snapshot", 115),
+            ("contract_exec_delta_wasm_uncached_last_snapshot", 116),
         ] {
             assert_eq!(json[key], want, "{key} must reach the OTLP body");
         }

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -2761,16 +2761,32 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                         snapshot.contract_exec_summarize_fast_hits_last_snapshot,
                     ),
                     (
+                        "contract_exec_summarize_reload_hits_last_snapshot",
+                        snapshot.contract_exec_summarize_reload_hits_last_snapshot,
+                    ),
+                    (
                         "contract_exec_summarize_wasm_calls_last_snapshot",
                         snapshot.contract_exec_summarize_wasm_calls_last_snapshot,
+                    ),
+                    (
+                        "contract_exec_summarize_wasm_uncached_last_snapshot",
+                        snapshot.contract_exec_summarize_wasm_uncached_last_snapshot,
                     ),
                     (
                         "contract_exec_delta_fast_hits_last_snapshot",
                         snapshot.contract_exec_delta_fast_hits_last_snapshot,
                     ),
                     (
+                        "contract_exec_delta_reload_hits_last_snapshot",
+                        snapshot.contract_exec_delta_reload_hits_last_snapshot,
+                    ),
+                    (
                         "contract_exec_delta_wasm_calls_last_snapshot",
                         snapshot.contract_exec_delta_wasm_calls_last_snapshot,
+                    ),
+                    (
+                        "contract_exec_delta_wasm_uncached_last_snapshot",
+                        snapshot.contract_exec_delta_wasm_uncached_last_snapshot,
                     ),
                 ] {
                     obj.insert(name.to_string(), serde_json::json!(value));
@@ -4165,9 +4181,13 @@ mod tests {
         info.contract_exec_delta_wasm_calls_total = Some(107);
         info.contract_exec_delta_wasm_uncached_total = Some(108);
         info.contract_exec_summarize_fast_hits_last_snapshot = Some(109);
-        info.contract_exec_summarize_wasm_calls_last_snapshot = Some(110);
-        info.contract_exec_delta_fast_hits_last_snapshot = Some(111);
-        info.contract_exec_delta_wasm_calls_last_snapshot = Some(112);
+        info.contract_exec_summarize_reload_hits_last_snapshot = Some(110);
+        info.contract_exec_summarize_wasm_calls_last_snapshot = Some(111);
+        info.contract_exec_summarize_wasm_uncached_last_snapshot = Some(112);
+        info.contract_exec_delta_fast_hits_last_snapshot = Some(113);
+        info.contract_exec_delta_reload_hits_last_snapshot = Some(114);
+        info.contract_exec_delta_wasm_calls_last_snapshot = Some(115);
+        info.contract_exec_delta_wasm_uncached_last_snapshot = Some(116);
         let json = event_kind_to_json(&EventKind::RouterSnapshot(Box::new(info)));
         for (key, want) in [
             ("contract_exec_summarize_fast_hits_total", 101),
@@ -4179,9 +4199,13 @@ mod tests {
             ("contract_exec_delta_wasm_calls_total", 107),
             ("contract_exec_delta_wasm_uncached_total", 108),
             ("contract_exec_summarize_fast_hits_last_snapshot", 109),
-            ("contract_exec_summarize_wasm_calls_last_snapshot", 110),
-            ("contract_exec_delta_fast_hits_last_snapshot", 111),
-            ("contract_exec_delta_wasm_calls_last_snapshot", 112),
+            ("contract_exec_summarize_reload_hits_last_snapshot", 110),
+            ("contract_exec_summarize_wasm_calls_last_snapshot", 111),
+            ("contract_exec_summarize_wasm_uncached_last_snapshot", 112),
+            ("contract_exec_delta_fast_hits_last_snapshot", 113),
+            ("contract_exec_delta_reload_hits_last_snapshot", 114),
+            ("contract_exec_delta_wasm_calls_last_snapshot", 115),
+            ("contract_exec_delta_wasm_uncached_last_snapshot", 116),
         ] {
             assert_eq!(json[key], want, "{key} must reach the OTLP body");
         }

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -2725,6 +2725,65 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                     "network_efficiency_v1".to_string(),
                     serde_json::json!(snapshot.network_efficiency_v1),
                 );
+                // Contract-exec WASM counters: the cache-hit / WASM-miss split
+                // that makes a summarize or delta rate interpretable at all.
+                // Same hand-mirroring footgun as everything else in this block —
+                // a new `RouterSnapshotInfo` field is invisible to the collector
+                // unless added here. Pinned by
+                // `router_snapshot_json_includes_contract_exec_counters`, which
+                // asserts the FULL set so a partially-mirrored addition fails.
+                for (name, value) in [
+                    (
+                        "contract_exec_summarize_fast_hits_total",
+                        snapshot.contract_exec_summarize_fast_hits_total,
+                    ),
+                    (
+                        "contract_exec_summarize_reload_hits_total",
+                        snapshot.contract_exec_summarize_reload_hits_total,
+                    ),
+                    (
+                        "contract_exec_summarize_wasm_calls_total",
+                        snapshot.contract_exec_summarize_wasm_calls_total,
+                    ),
+                    (
+                        "contract_exec_summarize_wasm_uncached_total",
+                        snapshot.contract_exec_summarize_wasm_uncached_total,
+                    ),
+                    (
+                        "contract_exec_delta_fast_hits_total",
+                        snapshot.contract_exec_delta_fast_hits_total,
+                    ),
+                    (
+                        "contract_exec_delta_reload_hits_total",
+                        snapshot.contract_exec_delta_reload_hits_total,
+                    ),
+                    (
+                        "contract_exec_delta_wasm_calls_total",
+                        snapshot.contract_exec_delta_wasm_calls_total,
+                    ),
+                    (
+                        "contract_exec_delta_wasm_uncached_total",
+                        snapshot.contract_exec_delta_wasm_uncached_total,
+                    ),
+                    (
+                        "contract_exec_summarize_fast_hits_last_snapshot",
+                        snapshot.contract_exec_summarize_fast_hits_last_snapshot,
+                    ),
+                    (
+                        "contract_exec_summarize_wasm_calls_last_snapshot",
+                        snapshot.contract_exec_summarize_wasm_calls_last_snapshot,
+                    ),
+                    (
+                        "contract_exec_delta_fast_hits_last_snapshot",
+                        snapshot.contract_exec_delta_fast_hits_last_snapshot,
+                    ),
+                    (
+                        "contract_exec_delta_wasm_calls_last_snapshot",
+                        snapshot.contract_exec_delta_wasm_calls_last_snapshot,
+                    ),
+                ] {
+                    obj.insert(name.to_string(), serde_json::json!(value));
+                }
                 obj.insert(
                     "hosted_contracts_count".to_string(),
                     serde_json::json!(snapshot.hosted_contracts_count),
@@ -4177,6 +4236,56 @@ mod tests {
             ("broadcast_stream_attempts_total", 37),
             ("broadcast_stream_failures_total", 41),
             ("broadcast_stream_failures_last_snapshot", 43),
+        ] {
+            assert_eq!(json[key], want, "{key} must reach the OTLP body");
+        }
+    }
+
+    /// The contract-exec WASM counters must reach the hand-mirrored OTLP body.
+    ///
+    /// These are the fields that make a summarize/delta rate interpretable —
+    /// without them, the only production signal is a handler-entry span that
+    /// counts cache hits and WASM invocations identically, which is how five
+    /// consecutive storm fixes were sized against an undifferentiated number.
+    /// Losing one to the hand-mirroring footgun would re-blind us in exactly the
+    /// way this change exists to fix, so the assertion covers the FULL set: a
+    /// partially-mirrored addition fails here rather than shipping half-visible.
+    ///
+    /// Every value below is DISTINCT, so a copy-paste slip that mirrors one
+    /// field's value under another field's key fails too — an all-`Some(1)`
+    /// fixture would pass under that mutation.
+    #[test]
+    fn router_snapshot_json_includes_contract_exec_counters() {
+        use arbitrary::{Arbitrary, Unstructured};
+        let mut u = Unstructured::new(&[0u8; 4096]);
+        let mut info = crate::router::RouterSnapshotInfo::arbitrary(&mut u)
+            .expect("construct RouterSnapshotInfo for test");
+        info.contract_exec_summarize_fast_hits_total = Some(101);
+        info.contract_exec_summarize_reload_hits_total = Some(102);
+        info.contract_exec_summarize_wasm_calls_total = Some(103);
+        info.contract_exec_summarize_wasm_uncached_total = Some(104);
+        info.contract_exec_delta_fast_hits_total = Some(105);
+        info.contract_exec_delta_reload_hits_total = Some(106);
+        info.contract_exec_delta_wasm_calls_total = Some(107);
+        info.contract_exec_delta_wasm_uncached_total = Some(108);
+        info.contract_exec_summarize_fast_hits_last_snapshot = Some(109);
+        info.contract_exec_summarize_wasm_calls_last_snapshot = Some(110);
+        info.contract_exec_delta_fast_hits_last_snapshot = Some(111);
+        info.contract_exec_delta_wasm_calls_last_snapshot = Some(112);
+        let json = event_kind_to_json(&EventKind::RouterSnapshot(Box::new(info)));
+        for (key, want) in [
+            ("contract_exec_summarize_fast_hits_total", 101),
+            ("contract_exec_summarize_reload_hits_total", 102),
+            ("contract_exec_summarize_wasm_calls_total", 103),
+            ("contract_exec_summarize_wasm_uncached_total", 104),
+            ("contract_exec_delta_fast_hits_total", 105),
+            ("contract_exec_delta_reload_hits_total", 106),
+            ("contract_exec_delta_wasm_calls_total", 107),
+            ("contract_exec_delta_wasm_uncached_total", 108),
+            ("contract_exec_summarize_fast_hits_last_snapshot", 109),
+            ("contract_exec_summarize_wasm_calls_last_snapshot", 110),
+            ("contract_exec_delta_fast_hits_last_snapshot", 111),
+            ("contract_exec_delta_wasm_calls_last_snapshot", 112),
         ] {
             assert_eq!(json[key], want, "{key} must reach the OTLP body");
         }

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -2716,6 +2716,65 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                     "network_efficiency_v1".to_string(),
                     serde_json::json!(snapshot.network_efficiency_v1),
                 );
+                // Contract-exec WASM counters: the cache-hit / WASM-miss split
+                // that makes a summarize or delta rate interpretable at all.
+                // Same hand-mirroring footgun as everything else in this block —
+                // a new `RouterSnapshotInfo` field is invisible to the collector
+                // unless added here. Pinned by
+                // `router_snapshot_json_includes_contract_exec_counters`, which
+                // asserts the FULL set so a partially-mirrored addition fails.
+                for (name, value) in [
+                    (
+                        "contract_exec_summarize_fast_hits_total",
+                        snapshot.contract_exec_summarize_fast_hits_total,
+                    ),
+                    (
+                        "contract_exec_summarize_reload_hits_total",
+                        snapshot.contract_exec_summarize_reload_hits_total,
+                    ),
+                    (
+                        "contract_exec_summarize_wasm_calls_total",
+                        snapshot.contract_exec_summarize_wasm_calls_total,
+                    ),
+                    (
+                        "contract_exec_summarize_wasm_uncached_total",
+                        snapshot.contract_exec_summarize_wasm_uncached_total,
+                    ),
+                    (
+                        "contract_exec_delta_fast_hits_total",
+                        snapshot.contract_exec_delta_fast_hits_total,
+                    ),
+                    (
+                        "contract_exec_delta_reload_hits_total",
+                        snapshot.contract_exec_delta_reload_hits_total,
+                    ),
+                    (
+                        "contract_exec_delta_wasm_calls_total",
+                        snapshot.contract_exec_delta_wasm_calls_total,
+                    ),
+                    (
+                        "contract_exec_delta_wasm_uncached_total",
+                        snapshot.contract_exec_delta_wasm_uncached_total,
+                    ),
+                    (
+                        "contract_exec_summarize_fast_hits_last_snapshot",
+                        snapshot.contract_exec_summarize_fast_hits_last_snapshot,
+                    ),
+                    (
+                        "contract_exec_summarize_wasm_calls_last_snapshot",
+                        snapshot.contract_exec_summarize_wasm_calls_last_snapshot,
+                    ),
+                    (
+                        "contract_exec_delta_fast_hits_last_snapshot",
+                        snapshot.contract_exec_delta_fast_hits_last_snapshot,
+                    ),
+                    (
+                        "contract_exec_delta_wasm_calls_last_snapshot",
+                        snapshot.contract_exec_delta_wasm_calls_last_snapshot,
+                    ),
+                ] {
+                    obj.insert(name.to_string(), serde_json::json!(value));
+                }
                 obj.insert(
                     "hosted_contracts_count".to_string(),
                     serde_json::json!(snapshot.hosted_contracts_count),
@@ -4073,6 +4132,56 @@ mod tests {
             ("broadcast_stream_attempts_total", 37),
             ("broadcast_stream_failures_total", 41),
             ("broadcast_stream_failures_last_snapshot", 43),
+        ] {
+            assert_eq!(json[key], want, "{key} must reach the OTLP body");
+        }
+    }
+
+    /// The contract-exec WASM counters must reach the hand-mirrored OTLP body.
+    ///
+    /// These are the fields that make a summarize/delta rate interpretable —
+    /// without them, the only production signal is a handler-entry span that
+    /// counts cache hits and WASM invocations identically, which is how five
+    /// consecutive storm fixes were sized against an undifferentiated number.
+    /// Losing one to the hand-mirroring footgun would re-blind us in exactly the
+    /// way this change exists to fix, so the assertion covers the FULL set: a
+    /// partially-mirrored addition fails here rather than shipping half-visible.
+    ///
+    /// Every value below is DISTINCT, so a copy-paste slip that mirrors one
+    /// field's value under another field's key fails too — an all-`Some(1)`
+    /// fixture would pass under that mutation.
+    #[test]
+    fn router_snapshot_json_includes_contract_exec_counters() {
+        use arbitrary::{Arbitrary, Unstructured};
+        let mut u = Unstructured::new(&[0u8; 4096]);
+        let mut info = crate::router::RouterSnapshotInfo::arbitrary(&mut u)
+            .expect("construct RouterSnapshotInfo for test");
+        info.contract_exec_summarize_fast_hits_total = Some(101);
+        info.contract_exec_summarize_reload_hits_total = Some(102);
+        info.contract_exec_summarize_wasm_calls_total = Some(103);
+        info.contract_exec_summarize_wasm_uncached_total = Some(104);
+        info.contract_exec_delta_fast_hits_total = Some(105);
+        info.contract_exec_delta_reload_hits_total = Some(106);
+        info.contract_exec_delta_wasm_calls_total = Some(107);
+        info.contract_exec_delta_wasm_uncached_total = Some(108);
+        info.contract_exec_summarize_fast_hits_last_snapshot = Some(109);
+        info.contract_exec_summarize_wasm_calls_last_snapshot = Some(110);
+        info.contract_exec_delta_fast_hits_last_snapshot = Some(111);
+        info.contract_exec_delta_wasm_calls_last_snapshot = Some(112);
+        let json = event_kind_to_json(&EventKind::RouterSnapshot(Box::new(info)));
+        for (key, want) in [
+            ("contract_exec_summarize_fast_hits_total", 101),
+            ("contract_exec_summarize_reload_hits_total", 102),
+            ("contract_exec_summarize_wasm_calls_total", 103),
+            ("contract_exec_summarize_wasm_uncached_total", 104),
+            ("contract_exec_delta_fast_hits_total", 105),
+            ("contract_exec_delta_reload_hits_total", 106),
+            ("contract_exec_delta_wasm_calls_total", 107),
+            ("contract_exec_delta_wasm_uncached_total", 108),
+            ("contract_exec_summarize_fast_hits_last_snapshot", 109),
+            ("contract_exec_summarize_wasm_calls_last_snapshot", 110),
+            ("contract_exec_delta_fast_hits_last_snapshot", 111),
+            ("contract_exec_delta_wasm_calls_last_snapshot", 112),
         ] {
             assert_eq!(json[key], want, "{key} must reach the OTLP body");
         }


### PR DESCRIPTION
## Problem

Contract-exec WASM volume is not measurable in production, so none of the last month's storm work can be evaluated.

The only production signal for `summarize_contract_state` is a span opened at **handler entry** (`contract.rs`, `info_span!("summarize_contract_state", %key)`). It fires identically for a state-hash cache HIT and for a real WASM `summarize_state` invocation. The cache is the entire reason the observed cadence is survivable, so the two differ by orders of magnitude in cost — and the span cannot tell them apart.

The published "rates" are not even that span's count. Every figure quoted across #4473 (~40/sec), #4610 (~70-80/sec), #5040 (~49-57/sec) and #5238 (~50-95/sec) comes from the **dropped-line counter of a tracing rate limiter** (`util/rate_limit_layer.rs`), which caps LOG EVENTS at 30/sec per callsite and has no effect on work done.

So nobody can currently say whether a peer at ~50/sec is doing 50 WASM invocations or 50 cache hits. Five PRs in five weeks bounded or gated call sites against that undifferentiated number.

A counter for exactly this **already sat on the WASM slow path** (`executor_impl.rs`, with a comment describing the invariant) and was a no-op in the field: it writes only to `topology_registry`, which keys on a thread-local that `SimNetwork` sets and a production node never does. The simulation asserted the invariant held, the field suggested it did not, and the counter that would adjudicate was switched off precisely where it mattered.

## Approach

`ring::contract_exec_metrics::ContractExecMetrics` — eight monotonic per-node counters, each recorded **by the code that makes the decision** rather than re-derived by a caller (the "metric describing a filtering decision" rule in `bug-prevention-patterns.md`), partitioning each cached path exactly so nothing ever has to be subtracted:

```
calls to bridged_summarize_contract_state
  = summarize_fast_hits + summarize_reload_hits + summarize_wasm_calls
calls to bridged_get_contract_state_delta
  = delta_fast_hits     + delta_reload_hits     + delta_wasm_calls

total WASM summarize_state = summarize_wasm_calls + summarize_wasm_uncached
total WASM get_state_delta = delta_wasm_calls     + delta_wasm_uncached
```

| arm | meaning |
|---|---|
| `*_fast_hits` | detector hash present and matching a cached summary/delta. No state load, no WASM. The arm that makes a 50/sec anti-entropy cadence cheap. |
| `*_reload_hits` | detector cold (restart, eviction) so the state was loaded and hashed, but the cache still matched. Real I/O, no WASM. |
| `*_wasm_calls` | WASM ran, on the cached path. The expensive work every storm fix was trying to bound. |
| `*_wasm_uncached` | WASM ran at a site with no cache in front of it (PUT/UPDATE response summaries in `contract_ops`, the per-subscriber client-notification delta fan-out). Separate so the cached partition stays exact while the WASM TOTAL stays honest. |

The delta path is included because it is the same seam with the same ambiguity, and it runs **per-subscriber** during broadcast fan-out — the hotter of the two.

`*_reload_hits` is the arm the existing tests could not see at all. The cache suite's oracle is `MockStateStorage::get_count` (no state reload ⇒ no WASM call), which scores a reload hit as a miss. Separating it says whether a storm is a cache-sizing problem or a state-churn problem.

### Why this surface, and not a new one

Two existing readouts, both free:

- **`router_snapshot`** (5-min cadence, `EventKind::RouterSnapshot`) already carries this class of per-node monotonic counter — `contract_module_cache_evictions_total`, `broadcast_stream_*_total`. Adding fields to it costs **no shadow-rollup budget slot** (`MAX_SHADOW_EVENTS_PER_SECOND` is 6, with one slot of headroom that the two mix rollups already crowd).
- **the `tracing::info!` line that event already emits**, so a local operator reads it from `journalctl` with no collector at all. `info!` survives `release_max_level_info`; a `debug!` would be compiled out of release builds.

Both lifetime totals (for collector-side differencing) and **per-window deltas** for the four headline arms are emitted, so a single snapshot answers the question without a stateful reader.

### How an operator reads it

One `router_snapshot` line per node every 5 minutes:

```
journalctl -u freenet -o cat | grep router_snapshot | tail -1
```

```
contract_exec_summarize_fast_hits_last_snapshot=14903
contract_exec_summarize_wasm_calls_last_snapshot=31
contract_exec_summarize_reload_hits_total=…
contract_exec_summarize_wasm_uncached_total=…
contract_exec_delta_fast_hits_last_snapshot=…
contract_exec_delta_wasm_calls_last_snapshot=…
```

Divide by 300 s. That example reads as ~49.7 summarize calls/sec of which **0.1/sec is real WASM** — the cache is doing its job and the storm rate is not CPU. The two rates converging is the signal that the change detector has stopped covering the load.

The same field names appear in the `router_snapshot` OTLP body for the collector.

## Cost

**One `Relaxed` `fetch_add` on a `u64` per contract-handler call** — a few ns, uncontended (the contract-handling loop has concurrency exactly 1, enforced by `&mut self`). The fast path takes exactly one increment; the slow paths take one more, alongside a state load and a WASM invocation that dwarf it. Nothing allocates and nothing locks.

Two details keep it there:

- the counters hang off `Ring` via `Arc` (not a process global) so unit tests stay isolated, per the #4488 rationale that moved `ModuleCacheMetrics` off a global — and the hot accessor returns a **borrow**, so a bump costs no `Arc` refcount RMW on top of the counter's own atomic;
- the client-notification fan-out clones the `Arc` **once per fan-out**, not per subscriber, because both fan-out arms hold two executor maps mutably for the whole loop.

The two cache-hit sites each moved one already-existing `.clone()` of the cached value ahead of the borrow's end (`LruCache::get` takes `&mut self`). Same clone, same count, different line.

## Behaviour

Pure instrumentation. Nothing a node *does* changes; no hosting, placement, or eviction path is touched (`hosting-invariants.md` reviewed — no invariant is in scope).

## Testing

Six behavioural tests driving a real `OpManager`/`Ring`-backed executor (`summarize_delta_cache_tests.rs`):

- repeated summarize of unchanged state counts a fast hit and **no** WASM call
- summarize after a write counts a WASM call and **not** a hit (without this, a mutation counting everything as a fast hit would still pass the first test)
- cold detector over unchanged state counts a **reload hit**, not a fast hit and not a WASM call
- delta sibling, plus: an unseen peer summary against unchanged state is a genuine miss (pins that the fast-hit count is not simply "the state didn't change")
- the three cached arms **partition every call exactly once**, with non-vacuity assertions that all three actually fired

Plus four pins:

- `summarize_wasm_call_records_both_sinks` — the production record must **not** be nested inside the `get_own_addr()` guard, which is the exact shape that made the original counter sim-only. A runtime test cannot cover this: the unit fixtures have no bound listener, so `get_own_addr()` returns `None` and the sim sink never fires there.
- `summarize_wasm_counter_sits_after_both_cache_hit_returns` — the counter must sit on the slow path, after both early returns, immediately before the call it describes.
- `contract_exec_export_maps_each_field_to_its_own_counter` — the `ring.rs` → `RouterSnapshotInfo` mirror seam, in the shape of `reconcile_shadow_export_maps_each_field_to_its_own_site`. A field swap there compiles cleanly and reports one arm's count under another's name.
- `router_snapshot_json_includes_contract_exec_counters` — the hand-mirrored OTLP `json!` block, asserting the **full** set with distinct per-field values so a partially-mirrored or cross-wired addition fails rather than shipping half-visible. That block has silently dropped fields before.

Both source-scrape pins strip comment lines before matching. The first draft of `summarize_wasm_call_records_both_sinks` failed because `get_own_addr()` appears in the block comment above the call as well as in the call, and the comment came first — a pin that matches its own explanation is not pinning anything.

### Mutation-tested (each applied to a committed tree, then reverted)

| mutation | caught by |
|---|---|
| nest the production record inside the `get_own_addr()` guard | `summarize_wasm_call_records_both_sinks` |
| record a reload hit as a fast hit (copy-paste slip) | `cold_detector_over_unchanged_state_counts_a_reload_hit` + the partition test's non-vacuity |
| drop one field from the OTLP `json!` mirror | `router_snapshot_json_includes_contract_exec_counters` |
| feed `_wasm_calls_total` from `fast_hits` in the export | `contract_exec_export_maps_each_field_to_its_own_counter` |

## Scope note

#5168 asks for entries-and-bytes per fallback summary reply. That is a different measurement (reply sizing on the `outbound_message_mix` rollup) and is left open; this PR is the sibling it names in spirit — the counter that says whether the work being bounded is expensive at all. `Refs`, not `Closes`.

Refs #5168, #5238, #4440.

[AI-assisted - Claude]
