### PR TITLE
fix(wasm_runtime): issue WASM instance ids from one process-global allocator

### DIFF
--- a/crates/core/src/wasm_runtime/engine.rs
+++ b/crates/core/src/wasm_runtime/engine.rs
@@ -165,6 +165,10 @@ pub(crate) trait WasmEngine: Send {
     /// `CONTRACT_IO` maps, so a caller-chosen id could collide with a LIVE
     /// instance belonging to another engine in the same process and make
     /// [`Self::drop_instance`] evict that instance's entry (#4213 / #5023).
+    ///
+    /// Any future backend implementing this trait MUST allocate the same way;
+    /// `create_instance_allocates_its_own_instance_id` in the wasmtime backend
+    /// pins that for the one implementation that exists today.
     fn create_instance(
         &mut self,
         module: &Self::Module,

--- a/crates/core/src/wasm_runtime/engine.rs
+++ b/crates/core/src/wasm_runtime/engine.rs
@@ -155,6 +155,10 @@ pub(crate) trait WasmEngine: Send {
     /// `CONTRACT_IO` maps, so a caller-chosen id could collide with a LIVE
     /// instance belonging to another engine in the same process and make
     /// [`Self::drop_instance`] evict that instance's entry (#4213 / #5023).
+    ///
+    /// Any future backend implementing this trait MUST allocate the same way;
+    /// `create_instance_allocates_its_own_instance_id` in the wasmtime backend
+    /// pins that for the one implementation that exists today.
     fn create_instance(
         &mut self,
         module: &Self::Module,

--- a/crates/core/src/wasm_runtime/engine.rs
+++ b/crates/core/src/wasm_runtime/engine.rs
@@ -148,10 +148,16 @@ pub(crate) trait WasmEngine: Send {
     ///
     /// Sets up imports, calls `__frnt_set_id`, records memory address,
     /// and ensures sufficient memory for `req_bytes`.
+    ///
+    /// The instance id is NOT a parameter: it is issued by
+    /// `native_api::next_instance_id` and returned in the [`InstanceHandle`].
+    /// Instance ids key the process-global `MEM_ADDR` / `DELEGATE_ENV` /
+    /// `CONTRACT_IO` maps, so a caller-chosen id could collide with a LIVE
+    /// instance belonging to another engine in the same process and make
+    /// [`Self::drop_instance`] evict that instance's entry (#4213 / #5023).
     fn create_instance(
         &mut self,
         module: &Self::Module,
-        id: i64,
         req_bytes: usize,
     ) -> Result<InstanceHandle, WasmError>;
 

--- a/crates/core/src/wasm_runtime/engine.rs
+++ b/crates/core/src/wasm_runtime/engine.rs
@@ -158,10 +158,16 @@ pub(crate) trait WasmEngine: Send {
     ///
     /// Sets up imports, calls `__frnt_set_id`, records memory address,
     /// and ensures sufficient memory for `req_bytes`.
+    ///
+    /// The instance id is NOT a parameter: it is issued by
+    /// `native_api::next_instance_id` and returned in the [`InstanceHandle`].
+    /// Instance ids key the process-global `MEM_ADDR` / `DELEGATE_ENV` /
+    /// `CONTRACT_IO` maps, so a caller-chosen id could collide with a LIVE
+    /// instance belonging to another engine in the same process and make
+    /// [`Self::drop_instance`] evict that instance's entry (#4213 / #5023).
     fn create_instance(
         &mut self,
         module: &Self::Module,
-        id: i64,
         req_bytes: usize,
     ) -> Result<InstanceHandle, WasmError>;
 

--- a/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
+++ b/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
@@ -2910,8 +2910,18 @@ mod tests {
             .find("    fn create_instance(")
             .expect("create_instance not found");
         let body = &src[start..];
+        // `+ 1` because this `find` searches `body[1..]`, so its index is one
+        // short of the position in `body`. Without it the slice drops the byte
+        // before the next method -- harmless today (it is the ASCII newline
+        // closing this method), but `&body[..end]` would then slice at an
+        // arbitrary byte, and this file is full of multi-byte em dashes: one
+        // landing there turns the pin into a "byte index is not a char
+        // boundary" panic that says nothing about what it guards. Matches
+        // `create_instance_recovers_store_on_guest_entry_failure` below, which
+        // this test's rustdoc claims to follow.
         let end = body[1..]
             .find("\n    fn ")
+            .map(|i| i + 1)
             .expect("create_instance body must end at the next method");
         let body = &body[..end];
         assert!(

--- a/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
+++ b/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
@@ -2893,7 +2893,19 @@ mod tests {
     /// `create_instance_recovers_store_on_guest_entry_failure` below.
     #[test]
     fn create_instance_allocates_its_own_instance_id() {
-        let src = include_str!("wasmtime_engine.rs");
+        // Cut the test module off BEFORE scraping. `include_str!` pulls in the
+        // whole file, this module included, and the needle below occurs here as
+        // a string literal. Without the cut, renaming `create_instance` would
+        // not panic: `find` would fall through to this function's own source,
+        // and the region would then be this test's tail -- whose assertion
+        // message contains `native_api::next_instance_id()`, so the pin would
+        // scrape its own error string and PASS while guarding nothing.
+        // Same remedy as `contract_ops.rs::production_source`; see #5450.
+        let full = include_str!("wasmtime_engine.rs");
+        let cutoff = full
+            .find("\n#[cfg(test)]\nmod tests {")
+            .expect("wasmtime_engine.rs must have a top-level #[cfg(test)] mod tests");
+        let src = &full[..cutoff];
         let start = src
             .find("    fn create_instance(")
             .expect("create_instance not found");
@@ -3843,7 +3855,7 @@ mod tests {
 
         // Charge one instance to learn what the arena actually retains per
         // instance, then set a budget only a few instances wide.
-        let handle = engine.create_instance(&module, 0, 1024).unwrap();
+        let handle = engine.create_instance(&module, 1024).unwrap();
         engine.drop_instance(&handle);
         let per_instance = engine.retired_instance_bytes;
         assert!(
@@ -3859,8 +3871,8 @@ mod tests {
         // here is attributable to the byte bound alone.
         let creations = 40;
         assert!(creations < STORE_REFRESH_THRESHOLD);
-        for i in 1..=creations {
-            let handle = engine.create_instance(&module, i as i64, 1024).unwrap();
+        for _ in 1..=creations {
+            let handle = engine.create_instance(&module, 1024).unwrap();
             engine.drop_instance(&handle);
             if engine.lifetime_instances <= previous {
                 refreshes += 1;
@@ -3886,7 +3898,7 @@ mod tests {
             "engine must stay healthy across byte-budget refreshes"
         );
         let handle = engine
-            .create_instance(&module, 999_999, 1024)
+            .create_instance(&module, 1024)
             .expect("should create instance after byte-budget refresh");
         engine.drop_instance(&handle);
     }
@@ -3919,7 +3931,7 @@ mod tests {
 
         for i in 0..12 {
             let handle = engine
-                .create_instance(&module, i as i64, 1024)
+                .create_instance(&module, 1024)
                 .unwrap_or_else(|e| panic!("instance {i} must still be creatable: {e}"));
             assert_eq!(
                 engine.lifetime_instances, 1,

--- a/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
+++ b/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
@@ -790,9 +790,11 @@ impl WasmEngine for WasmtimeEngine {
     fn create_instance(
         &mut self,
         module: &Module,
-        id: i64,
         req_bytes: usize,
     ) -> Result<InstanceHandle, WasmError> {
+        // Ids come from the one process-global allocator, never from the
+        // caller. See `native_api::NEXT_INSTANCE_ID` for why (#4213 / #5023).
+        let id = native_api::next_instance_id();
         {
             let store = self
                 .store
@@ -2273,7 +2275,7 @@ mod tests {
         let module = engine
             .compile(SIMPLE_WASM)
             .expect("offloaded compile should succeed");
-        let handle = engine.create_instance(&module, 0, 1024).unwrap();
+        let handle = engine.create_instance(&module, 1024).unwrap();
         engine.drop_instance(&handle);
         assert!(engine.module_compiled_size(&module) > 0);
     }
@@ -2292,7 +2294,7 @@ mod tests {
         let module = engine
             .compile(SIMPLE_WASM)
             .expect("inline compile should succeed");
-        let handle = engine.create_instance(&module, 0, 1024).unwrap();
+        let handle = engine.create_instance(&module, 1024).unwrap();
         engine.drop_instance(&handle);
         assert!(engine.module_compiled_size(&module) > 0);
     }
@@ -2509,7 +2511,7 @@ mod tests {
         let start = std::time::Instant::now();
         // create_instance runs the start function via instantiate_async; the
         // global epoch ticker preempts it once the armed 3-tick deadline elapses.
-        let result = engine.create_instance(&module, 1, 0);
+        let result = engine.create_instance(&module, 0);
         let elapsed = start.elapsed();
 
         // `InstanceHandle` is not Debug, so match rather than `{result:?}`.
@@ -2754,7 +2756,7 @@ mod tests {
             .compile(SIMPLE_WASM)
             .expect("compile under current_thread+offload must succeed (no panic)");
         let handle = engine
-            .create_instance(&module, 0, 1024)
+            .create_instance(&module, 1024)
             .expect("module must be instantiable");
         engine.drop_instance(&handle);
         assert!(engine.module_compiled_size(&module) > 0);
@@ -2804,7 +2806,7 @@ mod tests {
             .compile(SIMPLE_WASM)
             .expect("compile with no runtime + offload must succeed inline");
         let handle = engine
-            .create_instance(&module, 0, 1024)
+            .create_instance(&module, 1024)
             .expect("module must be instantiable");
         engine.drop_instance(&handle);
         assert!(engine.module_compiled_size(&module) > 0);
@@ -2974,7 +2976,7 @@ mod tests {
         // default 10,000 limit. Without our ResourceLimiter override this would fail.
         for i in 0..10_001 {
             let handle = engine
-                .create_instance(&module, i, 1024)
+                .create_instance(&module, 1024)
                 .unwrap_or_else(|e| panic!("instance {i} should succeed: {e}"));
             engine.drop_instance(&handle);
         }
@@ -3325,7 +3327,7 @@ mod tests {
         );
 
         let handle = engine
-            .create_instance(&module, 999, 1024)
+            .create_instance(&module, 1024)
             .expect("create instance");
 
         let result = engine.call_3i64_async_imports(&handle, "process", 0, 0, 0);
@@ -3336,6 +3338,78 @@ mod tests {
         );
 
         engine.drop_instance(&handle);
+    }
+
+    /// Regression test for #4213 / #5023: instance ids are a PROCESS-GLOBAL
+    /// namespace, so one engine's instance churn must never disturb another
+    /// engine's LIVE instance.
+    ///
+    /// `MEM_ADDR` (and `DELEGATE_ENV`, `CONTRACT_IO`) are process-global maps
+    /// keyed by instance id, and `drop_instance` removes the entry for the id
+    /// it is handed. While `create_instance` took a caller-supplied id, the
+    /// engine tests in this module passed hand-picked ones: `0..10_001` in
+    /// `test_instance_limit_override_allows_many_instances`, and
+    /// `0..STORE_REFRESH_THRESHOLD` in the store-refresh tests. Their
+    /// `drop_instance` calls removed the `MEM_ADDR` entry of whatever LIVE
+    /// delegate or contract instance in a concurrently-running test had been
+    /// issued the same id. Every host function on the victim then returned
+    /// `ERR_NOT_IN_PROCESS`, which the stdlib collapses into "not found":
+    /// `SecretResult(None)` from `test_large_secret_data` and
+    /// `test_store_and_retrieve_secret`, `error_code: -1` from
+    /// `test_v2_delegate_update_existing_state`.
+    ///
+    /// Ids now come from `native_api::next_instance_id`, so a collision is
+    /// unrepresentable. This test pins the property that makes it so: two live
+    /// engines are never issued the same id, and B's churn leaves A's entry
+    /// intact.
+    #[test]
+    fn instance_ids_are_globally_unique_across_engines() {
+        use crate::wasm_runtime::runtime::{InstanceInfo, Key};
+        use freenet_stdlib::prelude::ContractInstanceId;
+
+        let config = RuntimeConfig::default();
+
+        let mut engine_a = WasmtimeEngine::new(&config, false).unwrap();
+        let module_a = engine_a.compile(SIMPLE_WASM).unwrap();
+        let live = engine_a
+            .create_instance(&module_a, 1024)
+            .expect("engine A instance");
+        // `RunningInstance::new` is what records the MEM_ADDR entry in
+        // production; stand in for it so an eviction would be observable.
+        let (ptr, size) = engine_a.memory_info(&live).unwrap();
+        MEM_ADDR.insert(
+            live.id,
+            InstanceInfo::new(
+                ptr as i64,
+                size,
+                Key::Contract(ContractInstanceId::new([0u8; 32])),
+            ),
+        );
+
+        // A second engine churns instances the way the store-refresh and
+        // instance-limit tests do, while A's instance stays live.
+        let mut engine_b = WasmtimeEngine::new(&config, false).unwrap();
+        let module_b = engine_b.compile(SIMPLE_WASM).unwrap();
+        for _ in 0..64 {
+            let churn = engine_b
+                .create_instance(&module_b, 1024)
+                .expect("engine B instance");
+            assert_ne!(
+                churn.id, live.id,
+                "engine B was issued engine A's LIVE instance id; instance ids \
+                 must come from the one process-global allocator"
+            );
+            engine_b.drop_instance(&churn);
+        }
+
+        assert!(
+            MEM_ADDR.get(&live.id).is_some(),
+            "another engine's instance churn evicted a LIVE instance's MEM_ADDR \
+             entry; every host function on that instance would now return \
+             ERR_NOT_IN_PROCESS"
+        );
+
+        engine_a.drop_instance(&live);
     }
 
     /// Deterministic regression test for #3248: stale memory base pointer.
@@ -3374,10 +3448,12 @@ mod tests {
         "#;
 
         let module = engine.compile(wat.as_bytes()).unwrap();
-        let instance_id: i64 = 42_000;
         let handle = engine
-            .create_instance(&module, instance_id, 1024)
+            .create_instance(&module, 1024)
             .expect("create instance");
+        // The engine issues the id; `RunningInstance::new` is what normally
+        // records the MEM_ADDR entry, so stand in for it here.
+        let instance_id = handle.id;
 
         let (init_ptr, init_size) = engine.memory_info(&handle).unwrap();
         MEM_ADDR.insert(
@@ -3444,7 +3520,7 @@ mod tests {
         // The last drop_instance should trigger a store refresh.
         for i in 0..STORE_REFRESH_THRESHOLD {
             let handle = engine
-                .create_instance(&module, i as i64, 1024)
+                .create_instance(&module, 1024)
                 .unwrap_or_else(|e| panic!("instance {i} should succeed: {e}"));
             engine.drop_instance(&handle);
         }
@@ -3461,7 +3537,7 @@ mod tests {
             "engine should be healthy after refresh"
         );
         let handle = engine
-            .create_instance(&module, 999_999, 1024)
+            .create_instance(&module, 1024)
             .expect("should create instance after refresh");
         engine.drop_instance(&handle);
     }
@@ -3479,7 +3555,7 @@ mod tests {
         let burn = STORE_REFRESH_THRESHOLD - 3;
         for i in 0..burn {
             let handle = engine
-                .create_instance(&module, i as i64, 1024)
+                .create_instance(&module, 1024)
                 .unwrap_or_else(|e| panic!("instance {i} should succeed: {e}"));
             engine.drop_instance(&handle);
         }
@@ -3489,7 +3565,7 @@ mod tests {
         let mut handles = Vec::new();
         for i in burn..STORE_REFRESH_THRESHOLD {
             let handle = engine
-                .create_instance(&module, i as i64, 1024)
+                .create_instance(&module, 1024)
                 .unwrap_or_else(|e| panic!("instance {i} should succeed: {e}"));
             handles.push(handle);
         }
@@ -3521,9 +3597,9 @@ mod tests {
         let module = engine.compile(SIMPLE_WASM).unwrap();
 
         // Create some instances to bump the counter
-        for i in 0..10 {
+        for _ in 0..10 {
             let handle = engine
-                .create_instance(&module, i, 1024)
+                .create_instance(&module, 1024)
                 .expect("should succeed");
             engine.drop_instance(&handle);
         }
@@ -3538,7 +3614,7 @@ mod tests {
 
         // Engine should still work after recovery
         let handle = engine
-            .create_instance(&module, 999, 1024)
+            .create_instance(&module, 1024)
             .expect("should create instance after recovery");
         engine.drop_instance(&handle);
     }
@@ -3557,7 +3633,7 @@ mod tests {
         // Create and drop enough instances to trigger refresh
         for i in 0..STORE_REFRESH_THRESHOLD {
             let handle = engine
-                .create_instance(&module, i as i64, 1024)
+                .create_instance(&module, 1024)
                 .unwrap_or_else(|e| panic!("instance {i} should succeed: {e}"));
             engine.drop_instance(&handle);
         }
@@ -3567,7 +3643,7 @@ mod tests {
         // Verify that instance creation and WASM execution still work after
         // refresh — the replacement store must have fuel set correctly.
         let handle = engine
-            .create_instance(&module, 999_999, 1024)
+            .create_instance(&module, 1024)
             .expect("should create instance after metered refresh");
         engine.drop_instance(&handle);
     }
@@ -3631,7 +3707,7 @@ mod tests {
         // Create and drop instances just below the threshold (no refresh yet).
         for i in 0..STORE_REFRESH_THRESHOLD - 1 {
             let handle = engine
-                .create_instance(&module, i as i64, 1024)
+                .create_instance(&module, 1024)
                 .unwrap_or_else(|e| panic!("instance {i} should succeed: {e}"));
             engine.drop_instance(&handle);
         }
@@ -3646,7 +3722,7 @@ mod tests {
 
         // One more instance hits the threshold and triggers refresh.
         let handle = engine
-            .create_instance(&module, STORE_REFRESH_THRESHOLD as i64, 1024)
+            .create_instance(&module, 1024)
             .expect("final instance should succeed");
         engine.drop_instance(&handle);
 
@@ -3741,7 +3817,7 @@ mod tests {
         "#;
         let module = engine.compile(wat.as_bytes()).unwrap();
 
-        let result = engine.create_instance(&module, 0, 1024);
+        let result = engine.create_instance(&module, 1024);
         assert!(
             result.is_err(),
             "Module declaring 5000 initial pages (>cap of 4096) must be \
@@ -3822,7 +3898,7 @@ mod tests {
         // taking the baseline so they don't get charged to the per-instance
         // measurement.
         {
-            let h = engine.create_instance(&module, -1, 1024).unwrap();
+            let h = engine.create_instance(&module, 1024).unwrap();
             engine.drop_instance(&h);
         }
         let baseline = read_vm_size_bytes();
@@ -3832,15 +3908,13 @@ mod tests {
         const N_INSTANCES: i64 = 4;
         let mut handles = Vec::with_capacity(N_INSTANCES as usize);
         for i in 0..N_INSTANCES {
-            let h = engine
-                .create_instance(&module, i, 1024)
-                .unwrap_or_else(|e| {
-                    panic!(
-                        "instance {i} should succeed (regression: wasmtime memory \
+            let h = engine.create_instance(&module, 1024).unwrap_or_else(|e| {
+                panic!(
+                    "instance {i} should succeed (regression: wasmtime memory \
                      reservation may be too large for the host's overcommit \
                      limit, see #3986): {e}"
-                    )
-                });
+                )
+            });
             handles.push(h);
         }
         let after = read_vm_size_bytes();

--- a/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
+++ b/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
@@ -928,9 +928,11 @@ impl WasmEngine for WasmtimeEngine {
     fn create_instance(
         &mut self,
         module: &Module,
-        id: i64,
         req_bytes: usize,
     ) -> Result<InstanceHandle, WasmError> {
+        // Ids come from the one process-global allocator, never from the
+        // caller. See `native_api::NEXT_INSTANCE_ID` for why (#4213 / #5023).
+        let id = native_api::next_instance_id();
         {
             let store = self
                 .store
@@ -2557,7 +2559,7 @@ mod tests {
         let module = engine
             .compile(SIMPLE_WASM)
             .expect("offloaded compile should succeed");
-        let handle = engine.create_instance(&module, 0, 1024).unwrap();
+        let handle = engine.create_instance(&module, 1024).unwrap();
         engine.drop_instance(&handle);
         assert!(engine.module_compiled_size(&module) > 0);
     }
@@ -2576,7 +2578,7 @@ mod tests {
         let module = engine
             .compile(SIMPLE_WASM)
             .expect("inline compile should succeed");
-        let handle = engine.create_instance(&module, 0, 1024).unwrap();
+        let handle = engine.create_instance(&module, 1024).unwrap();
         engine.drop_instance(&handle);
         assert!(engine.module_compiled_size(&module) > 0);
     }
@@ -2793,7 +2795,7 @@ mod tests {
         let start = std::time::Instant::now();
         // create_instance runs the start function via instantiate_async; the
         // global epoch ticker preempts it once the armed 3-tick deadline elapses.
-        let result = engine.create_instance(&module, 1, 0);
+        let result = engine.create_instance(&module, 0);
         let elapsed = start.elapsed();
 
         // `InstanceHandle` is not Debug, so match rather than `{result:?}`.
@@ -3038,7 +3040,7 @@ mod tests {
             .compile(SIMPLE_WASM)
             .expect("compile under current_thread+offload must succeed (no panic)");
         let handle = engine
-            .create_instance(&module, 0, 1024)
+            .create_instance(&module, 1024)
             .expect("module must be instantiable");
         engine.drop_instance(&handle);
         assert!(engine.module_compiled_size(&module) > 0);
@@ -3088,7 +3090,7 @@ mod tests {
             .compile(SIMPLE_WASM)
             .expect("compile with no runtime + offload must succeed inline");
         let handle = engine
-            .create_instance(&module, 0, 1024)
+            .create_instance(&module, 1024)
             .expect("module must be instantiable");
         engine.drop_instance(&handle);
         assert!(engine.module_compiled_size(&module) > 0);
@@ -3258,7 +3260,7 @@ mod tests {
         // default 10,000 limit. Without our ResourceLimiter override this would fail.
         for i in 0..10_001 {
             let handle = engine
-                .create_instance(&module, i, 1024)
+                .create_instance(&module, 1024)
                 .unwrap_or_else(|e| panic!("instance {i} should succeed: {e}"));
             engine.drop_instance(&handle);
         }
@@ -3609,7 +3611,7 @@ mod tests {
         );
 
         let handle = engine
-            .create_instance(&module, 999, 1024)
+            .create_instance(&module, 1024)
             .expect("create instance");
 
         let result = engine.call_3i64_async_imports(&handle, "process", 0, 0, 0);
@@ -3620,6 +3622,78 @@ mod tests {
         );
 
         engine.drop_instance(&handle);
+    }
+
+    /// Regression test for #4213 / #5023: instance ids are a PROCESS-GLOBAL
+    /// namespace, so one engine's instance churn must never disturb another
+    /// engine's LIVE instance.
+    ///
+    /// `MEM_ADDR` (and `DELEGATE_ENV`, `CONTRACT_IO`) are process-global maps
+    /// keyed by instance id, and `drop_instance` removes the entry for the id
+    /// it is handed. While `create_instance` took a caller-supplied id, the
+    /// engine tests in this module passed hand-picked ones: `0..10_001` in
+    /// `test_instance_limit_override_allows_many_instances`, and
+    /// `0..STORE_REFRESH_THRESHOLD` in the store-refresh tests. Their
+    /// `drop_instance` calls removed the `MEM_ADDR` entry of whatever LIVE
+    /// delegate or contract instance in a concurrently-running test had been
+    /// issued the same id. Every host function on the victim then returned
+    /// `ERR_NOT_IN_PROCESS`, which the stdlib collapses into "not found":
+    /// `SecretResult(None)` from `test_large_secret_data` and
+    /// `test_store_and_retrieve_secret`, `error_code: -1` from
+    /// `test_v2_delegate_update_existing_state`.
+    ///
+    /// Ids now come from `native_api::next_instance_id`, so a collision is
+    /// unrepresentable. This test pins the property that makes it so: two live
+    /// engines are never issued the same id, and B's churn leaves A's entry
+    /// intact.
+    #[test]
+    fn instance_ids_are_globally_unique_across_engines() {
+        use crate::wasm_runtime::runtime::{InstanceInfo, Key};
+        use freenet_stdlib::prelude::ContractInstanceId;
+
+        let config = RuntimeConfig::default();
+
+        let mut engine_a = WasmtimeEngine::new(&config, false).unwrap();
+        let module_a = engine_a.compile(SIMPLE_WASM).unwrap();
+        let live = engine_a
+            .create_instance(&module_a, 1024)
+            .expect("engine A instance");
+        // `RunningInstance::new` is what records the MEM_ADDR entry in
+        // production; stand in for it so an eviction would be observable.
+        let (ptr, size) = engine_a.memory_info(&live).unwrap();
+        MEM_ADDR.insert(
+            live.id,
+            InstanceInfo::new(
+                ptr as i64,
+                size,
+                Key::Contract(ContractInstanceId::new([0u8; 32])),
+            ),
+        );
+
+        // A second engine churns instances the way the store-refresh and
+        // instance-limit tests do, while A's instance stays live.
+        let mut engine_b = WasmtimeEngine::new(&config, false).unwrap();
+        let module_b = engine_b.compile(SIMPLE_WASM).unwrap();
+        for _ in 0..64 {
+            let churn = engine_b
+                .create_instance(&module_b, 1024)
+                .expect("engine B instance");
+            assert_ne!(
+                churn.id, live.id,
+                "engine B was issued engine A's LIVE instance id; instance ids \
+                 must come from the one process-global allocator"
+            );
+            engine_b.drop_instance(&churn);
+        }
+
+        assert!(
+            MEM_ADDR.get(&live.id).is_some(),
+            "another engine's instance churn evicted a LIVE instance's MEM_ADDR \
+             entry; every host function on that instance would now return \
+             ERR_NOT_IN_PROCESS"
+        );
+
+        engine_a.drop_instance(&live);
     }
 
     /// Deterministic regression test for #3248: stale memory base pointer.
@@ -3658,10 +3732,12 @@ mod tests {
         "#;
 
         let module = engine.compile(wat.as_bytes()).unwrap();
-        let instance_id: i64 = 42_000;
         let handle = engine
-            .create_instance(&module, instance_id, 1024)
+            .create_instance(&module, 1024)
             .expect("create instance");
+        // The engine issues the id; `RunningInstance::new` is what normally
+        // records the MEM_ADDR entry, so stand in for it here.
+        let instance_id = handle.id;
 
         let (init_ptr, init_size) = engine.memory_info(&handle).unwrap();
         MEM_ADDR.insert(
@@ -3896,7 +3972,7 @@ mod tests {
         // The last drop_instance should trigger a store refresh.
         for i in 0..STORE_REFRESH_THRESHOLD {
             let handle = engine
-                .create_instance(&module, i as i64, 1024)
+                .create_instance(&module, 1024)
                 .unwrap_or_else(|e| panic!("instance {i} should succeed: {e}"));
             engine.drop_instance(&handle);
         }
@@ -3913,7 +3989,7 @@ mod tests {
             "engine should be healthy after refresh"
         );
         let handle = engine
-            .create_instance(&module, 999_999, 1024)
+            .create_instance(&module, 1024)
             .expect("should create instance after refresh");
         engine.drop_instance(&handle);
     }
@@ -3935,7 +4011,7 @@ mod tests {
         let burn = STORE_REFRESH_THRESHOLD - 3;
         for i in 0..burn {
             let handle = engine
-                .create_instance(&module, i as i64, 1024)
+                .create_instance(&module, 1024)
                 .unwrap_or_else(|e| panic!("instance {i} should succeed: {e}"));
             engine.drop_instance(&handle);
         }
@@ -3945,7 +4021,7 @@ mod tests {
         let mut handles = Vec::new();
         for i in burn..STORE_REFRESH_THRESHOLD {
             let handle = engine
-                .create_instance(&module, i as i64, 1024)
+                .create_instance(&module, 1024)
                 .unwrap_or_else(|e| panic!("instance {i} should succeed: {e}"));
             handles.push(handle);
         }
@@ -3981,9 +4057,9 @@ mod tests {
         let module = engine.compile(SIMPLE_WASM).unwrap();
 
         // Create some instances to bump the counter
-        for i in 0..10 {
+        for _ in 0..10 {
             let handle = engine
-                .create_instance(&module, i, 1024)
+                .create_instance(&module, 1024)
                 .expect("should succeed");
             engine.drop_instance(&handle);
         }
@@ -3998,7 +4074,7 @@ mod tests {
 
         // Engine should still work after recovery
         let handle = engine
-            .create_instance(&module, 999, 1024)
+            .create_instance(&module, 1024)
             .expect("should create instance after recovery");
         engine.drop_instance(&handle);
     }
@@ -4021,7 +4097,7 @@ mod tests {
         // Create and drop enough instances to trigger refresh
         for i in 0..STORE_REFRESH_THRESHOLD {
             let handle = engine
-                .create_instance(&module, i as i64, 1024)
+                .create_instance(&module, 1024)
                 .unwrap_or_else(|e| panic!("instance {i} should succeed: {e}"));
             engine.drop_instance(&handle);
         }
@@ -4031,7 +4107,7 @@ mod tests {
         // Verify that instance creation and WASM execution still work after
         // refresh — the replacement store must have fuel set correctly.
         let handle = engine
-            .create_instance(&module, 999_999, 1024)
+            .create_instance(&module, 1024)
             .expect("should create instance after metered refresh");
         engine.drop_instance(&handle);
     }
@@ -4099,7 +4175,7 @@ mod tests {
         // Create and drop instances just below the threshold (no refresh yet).
         for i in 0..STORE_REFRESH_THRESHOLD - 1 {
             let handle = engine
-                .create_instance(&module, i as i64, 1024)
+                .create_instance(&module, 1024)
                 .unwrap_or_else(|e| panic!("instance {i} should succeed: {e}"));
             engine.drop_instance(&handle);
         }
@@ -4114,7 +4190,7 @@ mod tests {
 
         // One more instance hits the threshold and triggers refresh.
         let handle = engine
-            .create_instance(&module, STORE_REFRESH_THRESHOLD as i64, 1024)
+            .create_instance(&module, 1024)
             .expect("final instance should succeed");
         engine.drop_instance(&handle);
 
@@ -4209,7 +4285,7 @@ mod tests {
         "#;
         let module = engine.compile(wat.as_bytes()).unwrap();
 
-        let result = engine.create_instance(&module, 0, 1024);
+        let result = engine.create_instance(&module, 1024);
         assert!(
             result.is_err(),
             "Module declaring 5000 initial pages (>cap of 4096) must be \
@@ -4290,7 +4366,7 @@ mod tests {
         // taking the baseline so they don't get charged to the per-instance
         // measurement.
         {
-            let h = engine.create_instance(&module, -1, 1024).unwrap();
+            let h = engine.create_instance(&module, 1024).unwrap();
             engine.drop_instance(&h);
         }
         let baseline = read_vm_size_bytes();
@@ -4300,15 +4376,13 @@ mod tests {
         const N_INSTANCES: i64 = 4;
         let mut handles = Vec::with_capacity(N_INSTANCES as usize);
         for i in 0..N_INSTANCES {
-            let h = engine
-                .create_instance(&module, i, 1024)
-                .unwrap_or_else(|e| {
-                    panic!(
-                        "instance {i} should succeed (regression: wasmtime memory \
+            let h = engine.create_instance(&module, 1024).unwrap_or_else(|e| {
+                panic!(
+                    "instance {i} should succeed (regression: wasmtime memory \
                      reservation may be too large for the host's overcommit \
                      limit, see #3986): {e}"
-                    )
-                });
+                )
+            });
             handles.push(h);
         }
         let after = read_vm_size_bytes();

--- a/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
+++ b/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
@@ -2886,11 +2886,13 @@ mod tests {
     /// Source pin (#4213 / #5023): `create_instance` MUST allocate its instance
     /// id from the one process-global allocator.
     ///
-    /// The type system stops a CALLER passing an id, but nothing stops this
+    /// The signature stops a CALLER passing an id, but nothing stops this
     /// method itself from reverting to a per-engine counter, which is exactly
     /// the shape that made ids collide across engines in one process. The
     /// bounded-region scrape follows the `fn_body` convention used by
-    /// `create_instance_recovers_store_on_guest_entry_failure` below.
+    /// `create_instance_recovers_store_on_guest_entry_failure` below, including
+    /// the test-module cutoff that keeps either pin from scraping its own
+    /// source.
     #[test]
     fn create_instance_allocates_its_own_instance_id() {
         // Cut the test module off BEFORE scraping. `include_str!` pulls in the
@@ -2941,7 +2943,16 @@ mod tests {
     /// memory that never triggers a count-based refresh.
     #[test]
     fn create_instance_recovers_store_on_guest_entry_failure() {
-        let src = include_str!("wasmtime_engine.rs");
+        // Same cutoff as `create_instance_allocates_its_own_instance_id` above,
+        // and for the same reason: `include_str!` pulls in this test module,
+        // whose source contains `fn create_instance(` as a string literal. With
+        // the whole file in scope, renaming the production method would let
+        // `find` fall through into the test module rather than panicking.
+        let full = include_str!("wasmtime_engine.rs");
+        let cutoff = full
+            .find("\n#[cfg(test)]\nmod tests {")
+            .expect("wasmtime_engine.rs must have a top-level #[cfg(test)] mod tests");
+        let src = &full[..cutoff];
         let start = src
             .find("fn create_instance(")
             .expect("create_instance not found");
@@ -3692,12 +3703,16 @@ mod tests {
     /// `test_store_and_retrieve_secret`, `error_code: -1` from
     /// `test_v2_delegate_update_existing_state`.
     ///
-    /// Ids now come from `native_api::next_instance_id`, which makes a
-    /// caller-supplied id a compile error rather than something a test can
-    /// catch. What this test pins is the one property still expressible at
-    /// runtime, and the one a future change could quietly break: the allocator
-    /// is process-global, not per-engine. Two live engines are never issued the
-    /// same id, so B's churn leaves A's entry intact.
+    /// Ids now come from `native_api::next_instance_id`, so a `create_instance`
+    /// CALLER can no longer pass one -- that surface is closed by the signature.
+    /// It is not closed everywhere: `InstanceHandle.id` is `pub(super)`, so code
+    /// inside `wasm_runtime` can still hand `drop_instance` a fabricated handle
+    /// (`delegate/test.rs` builds `InstanceHandle { id: 0 }` twice today, inert
+    /// only because `process_outbound` ignores it). What this test pins is the
+    /// one property still expressible at runtime, and the one a future change
+    /// could quietly break: the allocator is process-global, not per-engine. Two
+    /// live engines are never issued the same id, so B's churn leaves A's entry
+    /// intact.
     #[test]
     fn instance_ids_are_globally_unique_across_engines() {
         use crate::wasm_runtime::runtime::{InstanceInfo, Key};

--- a/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
+++ b/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
@@ -2883,6 +2883,34 @@ mod tests {
         }
     }
 
+    /// Source pin (#4213 / #5023): `create_instance` MUST allocate its instance
+    /// id from the one process-global allocator.
+    ///
+    /// The type system stops a CALLER passing an id, but nothing stops this
+    /// method itself from reverting to a per-engine counter, which is exactly
+    /// the shape that made ids collide across engines in one process. The
+    /// bounded-region scrape follows the `fn_body` convention used by
+    /// `create_instance_recovers_store_on_guest_entry_failure` below.
+    #[test]
+    fn create_instance_allocates_its_own_instance_id() {
+        let src = include_str!("wasmtime_engine.rs");
+        let start = src
+            .find("    fn create_instance(")
+            .expect("create_instance not found");
+        let body = &src[start..];
+        let end = body[1..]
+            .find("\n    fn ")
+            .expect("create_instance body must end at the next method");
+        let body = &body[..end];
+        assert!(
+            body.contains("native_api::next_instance_id()"),
+            "create_instance must draw its instance id from \
+             native_api::next_instance_id(); a per-engine counter lets two \
+             engines in one process issue the same id, and drop_instance then \
+             evicts the other engine's live MEM_ADDR entry (#4213 / #5023)"
+        );
+    }
+
     /// #4864 round-9 item 2 pin: `create_instance` MUST recover the store on a
     /// guest-entry (instantiate / `__frnt_set_id`) failure. Without it, a timeout
     /// that returns before `instances.insert` / `lifetime_instances += 1` leaves
@@ -3642,10 +3670,12 @@ mod tests {
     /// `test_store_and_retrieve_secret`, `error_code: -1` from
     /// `test_v2_delegate_update_existing_state`.
     ///
-    /// Ids now come from `native_api::next_instance_id`, so a collision is
-    /// unrepresentable. This test pins the property that makes it so: two live
-    /// engines are never issued the same id, and B's churn leaves A's entry
-    /// intact.
+    /// Ids now come from `native_api::next_instance_id`, which makes a
+    /// caller-supplied id a compile error rather than something a test can
+    /// catch. What this test pins is the one property still expressible at
+    /// runtime, and the one a future change could quietly break: the allocator
+    /// is process-global, not per-engine. Two live engines are never issued the
+    /// same id, so B's churn leaves A's entry intact.
     #[test]
     fn instance_ids_are_globally_unique_across_engines() {
         use crate::wasm_runtime::runtime::{InstanceInfo, Key};

--- a/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
+++ b/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
@@ -2599,6 +2599,34 @@ mod tests {
         }
     }
 
+    /// Source pin (#4213 / #5023): `create_instance` MUST allocate its instance
+    /// id from the one process-global allocator.
+    ///
+    /// The type system stops a CALLER passing an id, but nothing stops this
+    /// method itself from reverting to a per-engine counter, which is exactly
+    /// the shape that made ids collide across engines in one process. The
+    /// bounded-region scrape follows the `fn_body` convention used by
+    /// `create_instance_recovers_store_on_guest_entry_failure` below.
+    #[test]
+    fn create_instance_allocates_its_own_instance_id() {
+        let src = include_str!("wasmtime_engine.rs");
+        let start = src
+            .find("    fn create_instance(")
+            .expect("create_instance not found");
+        let body = &src[start..];
+        let end = body[1..]
+            .find("\n    fn ")
+            .expect("create_instance body must end at the next method");
+        let body = &body[..end];
+        assert!(
+            body.contains("native_api::next_instance_id()"),
+            "create_instance must draw its instance id from \
+             native_api::next_instance_id(); a per-engine counter lets two \
+             engines in one process issue the same id, and drop_instance then \
+             evicts the other engine's live MEM_ADDR entry (#4213 / #5023)"
+        );
+    }
+
     /// #4864 round-9 item 2 pin: `create_instance` MUST recover the store on a
     /// guest-entry (instantiate / `__frnt_set_id`) failure. Without it, a timeout
     /// that returns before `instances.insert` / `lifetime_instances += 1` leaves
@@ -3358,10 +3386,12 @@ mod tests {
     /// `test_store_and_retrieve_secret`, `error_code: -1` from
     /// `test_v2_delegate_update_existing_state`.
     ///
-    /// Ids now come from `native_api::next_instance_id`, so a collision is
-    /// unrepresentable. This test pins the property that makes it so: two live
-    /// engines are never issued the same id, and B's churn leaves A's entry
-    /// intact.
+    /// Ids now come from `native_api::next_instance_id`, which makes a
+    /// caller-supplied id a compile error rather than something a test can
+    /// catch. What this test pins is the one property still expressible at
+    /// runtime, and the one a future change could quietly break: the allocator
+    /// is process-global, not per-engine. Two live engines are never issued the
+    /// same id, so B's churn leaves A's entry intact.
     #[test]
     fn instance_ids_are_globally_unique_across_engines() {
         use crate::wasm_runtime::runtime::{InstanceInfo, Key};

--- a/crates/core/src/wasm_runtime/native_api.rs
+++ b/crates/core/src/wasm_runtime/native_api.rs
@@ -297,8 +297,15 @@ pub(super) type InstanceId = i64;
 /// alive at the same time (two simulated nodes, two pooled executors, or two
 /// tests running in parallel in one test binary) must never be issued the same
 /// id. Every id therefore comes from this one counter, handed out by
-/// [`next_instance_id`] inside `WasmEngine::create_instance` and returned to
-/// the caller in the `InstanceHandle`; no caller can supply an id of its own.
+/// [`next_instance_id`] inside `WasmEngine::create_instance` and returned in
+/// the `InstanceHandle`, so no CALLER of `create_instance` can pick an id.
+///
+/// Scope, stated precisely: this closes the `create_instance` surface only. The
+/// WASM ABI is a separate id surface that this does NOT validate: four host
+/// functions (`__frnt__logger__info`, `__frnt__rand__rand_bytes`,
+/// `__frnt__time__utc_now`, `__frnt__fill_buffer`) take an instance id as a
+/// guest-supplied parameter and look it up in these same maps. Do not read the
+/// paragraph above as "every id reaching these maps was issued here".
 ///
 /// Regression this shape prevents (#4213 / #5023): `create_instance` used to
 /// take a caller-supplied id, and the engine unit tests passed hand-picked ones
@@ -308,6 +315,11 @@ pub(super) type InstanceId = i64;
 /// same id here, and every host function on the victim instance began returning
 /// `ERR_NOT_IN_PROCESS`, surfacing as `SecretResult(None)` from a delegate
 /// secret read, or `error_code: -1` from a delegate contract call.
+///
+/// That needs the two tests to share a process, so it bites `cargo test`
+/// (one process per test binary), which is what AGENTS.md tells contributors
+/// to run and what both issues reported. CI runs `cargo nextest`, which gives
+/// each test its own process, so CI was never affected.
 static NEXT_INSTANCE_ID: AtomicI64 = AtomicI64::new(0);
 
 /// Issue the next process-globally unique [`InstanceId`].

--- a/crates/core/src/wasm_runtime/native_api.rs
+++ b/crates/core/src/wasm_runtime/native_api.rs
@@ -298,8 +298,15 @@ pub(super) type InstanceId = i64;
 /// alive at the same time (two simulated nodes, two pooled executors, or two
 /// tests running in parallel in one test binary) must never be issued the same
 /// id. Every id therefore comes from this one counter, handed out by
-/// [`next_instance_id`] inside `WasmEngine::create_instance` and returned to
-/// the caller in the `InstanceHandle`; no caller can supply an id of its own.
+/// [`next_instance_id`] inside `WasmEngine::create_instance` and returned in
+/// the `InstanceHandle`, so no CALLER of `create_instance` can pick an id.
+///
+/// Scope, stated precisely: this closes the `create_instance` surface only. The
+/// WASM ABI is a separate id surface that this does NOT validate: four host
+/// functions (`__frnt__logger__info`, `__frnt__rand__rand_bytes`,
+/// `__frnt__time__utc_now`, `__frnt__fill_buffer`) take an instance id as a
+/// guest-supplied parameter and look it up in these same maps. Do not read the
+/// paragraph above as "every id reaching these maps was issued here".
 ///
 /// Regression this shape prevents (#4213 / #5023): `create_instance` used to
 /// take a caller-supplied id, and the engine unit tests passed hand-picked ones
@@ -309,6 +316,11 @@ pub(super) type InstanceId = i64;
 /// same id here, and every host function on the victim instance began returning
 /// `ERR_NOT_IN_PROCESS`, surfacing as `SecretResult(None)` from a delegate
 /// secret read, or `error_code: -1` from a delegate contract call.
+///
+/// That needs the two tests to share a process, so it bites `cargo test`
+/// (one process per test binary), which is what AGENTS.md tells contributors
+/// to run and what both issues reported. CI runs `cargo nextest`, which gives
+/// each test its own process, so CI was never affected.
 static NEXT_INSTANCE_ID: AtomicI64 = AtomicI64::new(0);
 
 /// Issue the next process-globally unique [`InstanceId`].

--- a/crates/core/src/wasm_runtime/native_api.rs
+++ b/crates/core/src/wasm_runtime/native_api.rs
@@ -308,6 +308,14 @@ pub(super) type InstanceId = i64;
 /// guest-supplied parameter and look it up in these same maps. Do not read the
 /// paragraph above as "every id reaching these maps was issued here".
 ///
+/// Nor is it a type-level guarantee. `InstanceHandle.id` is `pub(super)`, so
+/// anything inside `wasm_runtime` can still construct a handle with a chosen id
+/// and hand it to `drop_instance`; `delegate/test.rs` does exactly that twice,
+/// harmlessly, because `process_outbound` binds the handle as `_handle` and
+/// never touches these maps. What the signature closes is the `create_instance`
+/// parameter, which is where every id that actually reached these maps came
+/// from.
+///
 /// Regression this shape prevents (#4213 / #5023): `create_instance` used to
 /// take a caller-supplied id, and the engine unit tests passed hand-picked ones
 /// (`0..10_001`, `0..STORE_REFRESH_THRESHOLD`, `999`, ...). Their

--- a/crates/core/src/wasm_runtime/native_api.rs
+++ b/crates/core/src/wasm_runtime/native_api.rs
@@ -8,7 +8,7 @@ use freenet_stdlib::prelude::{
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::sync::LazyLock;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicI64, AtomicUsize, Ordering};
 
 use super::contract_store::ContractStore;
 use super::delegate_store::DelegateStore;
@@ -290,6 +290,31 @@ thread_local! {
 }
 
 pub(super) type InstanceId = i64;
+
+/// The single allocator for WASM instance ids.
+///
+/// [`MEM_ADDR`], [`DELEGATE_ENV`] and [`CONTRACT_IO`] are process-GLOBAL maps
+/// keyed by instance id, so the id namespace is process-global too: two engines
+/// alive at the same time (two simulated nodes, two pooled executors, or two
+/// tests running in parallel in one test binary) must never be issued the same
+/// id. Every id therefore comes from this one counter, handed out by
+/// [`next_instance_id`] inside `WasmEngine::create_instance` and returned to
+/// the caller in the `InstanceHandle`; no caller can supply an id of its own.
+///
+/// Regression this shape prevents (#4213 / #5023): `create_instance` used to
+/// take a caller-supplied id, and the engine unit tests passed hand-picked ones
+/// (`0..10_001`, `0..STORE_REFRESH_THRESHOLD`, `999`, ...). Their
+/// `drop_instance` then removed the `MEM_ADDR` entry of a LIVE delegate or
+/// contract instance in a concurrently-running test that had been issued the
+/// same id here, and every host function on the victim instance began returning
+/// `ERR_NOT_IN_PROCESS`, surfacing as `SecretResult(None)` from a delegate
+/// secret read, or `error_code: -1` from a delegate contract call.
+static NEXT_INSTANCE_ID: AtomicI64 = AtomicI64::new(0);
+
+/// Issue the next process-globally unique [`InstanceId`].
+pub(super) fn next_instance_id() -> InstanceId {
+    NEXT_INSTANCE_ID.fetch_add(1, Ordering::SeqCst)
+}
 
 // ---------------------------------------------------------------------------
 // Contract I/O: streaming refill buffers

--- a/crates/core/src/wasm_runtime/native_api.rs
+++ b/crates/core/src/wasm_runtime/native_api.rs
@@ -8,7 +8,7 @@ use freenet_stdlib::prelude::{
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::sync::LazyLock;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicI64, AtomicUsize, Ordering};
 
 use super::contract_store::ContractStore;
 use super::delegate_store::DelegateStore;
@@ -289,6 +289,31 @@ thread_local! {
 }
 
 pub(super) type InstanceId = i64;
+
+/// The single allocator for WASM instance ids.
+///
+/// [`MEM_ADDR`], [`DELEGATE_ENV`] and [`CONTRACT_IO`] are process-GLOBAL maps
+/// keyed by instance id, so the id namespace is process-global too: two engines
+/// alive at the same time (two simulated nodes, two pooled executors, or two
+/// tests running in parallel in one test binary) must never be issued the same
+/// id. Every id therefore comes from this one counter, handed out by
+/// [`next_instance_id`] inside `WasmEngine::create_instance` and returned to
+/// the caller in the `InstanceHandle`; no caller can supply an id of its own.
+///
+/// Regression this shape prevents (#4213 / #5023): `create_instance` used to
+/// take a caller-supplied id, and the engine unit tests passed hand-picked ones
+/// (`0..10_001`, `0..STORE_REFRESH_THRESHOLD`, `999`, ...). Their
+/// `drop_instance` then removed the `MEM_ADDR` entry of a LIVE delegate or
+/// contract instance in a concurrently-running test that had been issued the
+/// same id here, and every host function on the victim instance began returning
+/// `ERR_NOT_IN_PROCESS`, surfacing as `SecretResult(None)` from a delegate
+/// secret read, or `error_code: -1` from a delegate contract call.
+static NEXT_INSTANCE_ID: AtomicI64 = AtomicI64::new(0);
+
+/// Issue the next process-globally unique [`InstanceId`].
+pub(super) fn next_instance_id() -> InstanceId {
+    NEXT_INSTANCE_ID.fetch_add(1, Ordering::SeqCst)
+}
 
 // ---------------------------------------------------------------------------
 // Contract I/O: streaming refill buffers

--- a/crates/core/src/wasm_runtime/runtime.rs
+++ b/crates/core/src/wasm_runtime/runtime.rs
@@ -16,7 +16,6 @@ use freenet_stdlib::{
     prelude::*,
 };
 use std::path::Path;
-use std::sync::atomic::AtomicI64;
 use std::sync::{Arc, Mutex};
 
 use super::ModuleCache;
@@ -272,8 +271,6 @@ fn decide_host_clock_warning(
     true
 }
 
-static INSTANCE_ID: AtomicI64 = AtomicI64::new(0);
-
 /// A live WASM instance with RAII cleanup.
 ///
 /// On drop, removes the MEM_ADDR entry. The WASM `Instance` is cleaned
@@ -296,12 +293,16 @@ impl RunningInstance {
         key: Key,
         req_bytes: usize,
     ) -> RuntimeResult<Self> {
-        let id = INSTANCE_ID.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         // Route the guest-entry call through classify_result so an epoch interrupt
         // during a runaway module start function normalizes to
         // MaxComputeTimeExceeded (Timeout class), not the generic "execution
         // timeout" that is_wasm_timeout misses (#4864 round-5).
-        let handle = super::classify_result(engine.create_instance(module, id, req_bytes))?;
+        //
+        // The engine issues the instance id from the single process-global
+        // allocator (`native_api::next_instance_id`) and hands it back in the
+        // handle. See that allocator's docs for why no caller may pick one.
+        let handle = super::classify_result(engine.create_instance(module, req_bytes))?;
+        let id = handle.id;
 
         // Record memory address and size for host function pointer arithmetic
         let (ptr, size) = engine.memory_info(&handle)?;

--- a/crates/core/src/wasm_runtime/runtime.rs
+++ b/crates/core/src/wasm_runtime/runtime.rs
@@ -15,7 +15,6 @@ use freenet_stdlib::{
     },
     prelude::*,
 };
-use std::sync::atomic::AtomicI64;
 use std::sync::{Arc, Mutex};
 
 use super::ModuleCache;
@@ -41,8 +40,6 @@ use super::ModuleCache;
 ///   count, which a count cap could not (1024 large modules ≫ 1024 small ones).
 pub(crate) type SharedModuleCache<K> = Arc<Mutex<ModuleCache<K, <Engine as WasmEngine>::Module>>>;
 
-static INSTANCE_ID: AtomicI64 = AtomicI64::new(0);
-
 /// A live WASM instance with RAII cleanup.
 ///
 /// On drop, removes the MEM_ADDR entry. The WASM `Instance` is cleaned
@@ -65,12 +62,16 @@ impl RunningInstance {
         key: Key,
         req_bytes: usize,
     ) -> RuntimeResult<Self> {
-        let id = INSTANCE_ID.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         // Route the guest-entry call through classify_result so an epoch interrupt
         // during a runaway module start function normalizes to
         // MaxComputeTimeExceeded (Timeout class), not the generic "execution
         // timeout" that is_wasm_timeout misses (#4864 round-5).
-        let handle = super::classify_result(engine.create_instance(module, id, req_bytes))?;
+        //
+        // The engine issues the instance id from the single process-global
+        // allocator (`native_api::next_instance_id`) and hands it back in the
+        // handle. See that allocator's docs for why no caller may pick one.
+        let handle = super::classify_result(engine.create_instance(module, req_bytes))?;
+        let id = handle.id;
 
         // Record memory address and size for host function pointer arithmetic
         let (ptr, size) = engine.memory_info(&handle)?;


### PR DESCRIPTION
## Problem

`wasm_runtime::delegate::test::test_large_secret_data` and its siblings fail intermittently under the full parallel lib suite and never in isolation. Tracked as #4213 and #5023, with two distinct symptom shapes:

- `test_large_secret_data` / `test_store_and_retrieve_secret`: `Expected SecretResult(Some(...)), got SecretResult(None)`
- `test_v2_delegate_update_existing_state`: `error_code: -1` / `ContractNotFound`

Both have the same cause, and it is provable by reading the code, independent of any observed flake rate.

`MEM_ADDR`, `DELEGATE_ENV` and `CONTRACT_IO` are process-**global** DashMaps keyed by WASM instance id, so the id namespace is process-global too. But `WasmEngine::create_instance` took a caller-supplied `id: i64`, and only `RunningInstance::new` drew one from the shared `INSTANCE_ID` counter. The engine unit tests in `wasmtime_engine.rs` picked their own ids:

- `0..10_001` in `test_instance_limit_override_allows_many_instances`
- `0..STORE_REFRESH_THRESHOLD` (500) in the three store-refresh tests
- literals such as `999`, `0`, `1`

Those tests' `drop_instance` calls do `MEM_ADDR.remove(&id)`. Running in the same test binary as the delegate tests, they removed the entry belonging to a **live** delegate or contract instance in a concurrently-running test that had been issued the same id from the counter. Every host function on the victim instance then took its "no MEM_ADDR entry" branch and returned `ERR_NOT_IN_PROCESS`, which the stdlib's `DelegateCtx` collapses into "not found" (`result < 0` → `None`).

That is why the flake needs the `wasm_runtime::` or full-lib filter and has never reproduced under `wasm_runtime::delegate` alone (#5023 reports 24 consecutive clean runs there): the offending engine tests are filtered out.

**Scope:** the collision needs two tests to share a process, so it bites `cargo test`, which is what AGENTS.md tells contributors to run and what both issues reported. CI runs `cargo nextest` (`ci.yml:893-903`), which gives each test its own process. **A green CI tick is therefore not coverage for this defect class** — nextest cannot observe it at any repeat count, before or after the fix.

### Evidence

Captured with temporary instrumentation on the host-function early-return paths, which are otherwise `tracing::warn!`-only and invisible in a test run:

```
---- wasm_runtime::delegate::test::test_large_secret_data stdout ----
set_secret id=77 delegate=9XS1At... val_len=1048576 ok=true
refresh_mem_addr NO-MEM_ADDR-ENTRY id=89
get_secret EARLY no MEM_ADDR id=89
panicked: Expected SecretResult(Some(...)), got SecretResult(None)

---- wasm_runtime::delegate::test::test_v2_delegate_update_existing_state stdout ----
refresh_mem_addr NO-MEM_ADDR-ENTRY id=91
panicked: Expected ContractState, got ContractNotFound { ..., error_code: -1 }
```

`get_secret_len` for id 89 had already succeeded (no miss logged), so the entry existed and then vanished between two host calls on the same live instance. Both observed ids fall inside the `0..500` and `0..10_001` ranges the engine tests iterate.

### On the failure rate — read this before citing a number

The original author measured 3 failures in 9 `cargo test -p freenet --lib wasm_runtime::` runs on one machine, consistent with the ~1/8 in #5023.

**That rate has NOT been independently reproduced.** A later attempt saw 0 failures in 20 runs, but correctly established that its own measurement could not have detected the defect: it ran 538 of 5267 lib tests in ~20s, which strips most of the parallel load #4213 names as the trigger. So neither the 3/9 nor the 0/20 should be treated as a measurement of this bug's rate, and no before/after rate comparison in this PR should be read as validation.

**This change stands on the mechanism, not on a rate.** Two independent issuers writing into one process-global keyspace is visible by reading `create_instance` against `MEM_ADDR`; the fix removes the second issuer.

## Approach

Renumbering the offending tests would fix today's collision and leave the hazard for the next test that picks an id. Instead the collision is made unrepresentable:

- `native_api.rs` owns the single `NEXT_INSTANCE_ID` allocator, sited next to the global maps whose keyspace it defines, exposed as `next_instance_id()`.
- `WasmEngine::create_instance` no longer takes an `id`. It allocates one and returns it in the `InstanceHandle`, so no caller of `create_instance` can supply one.
- `RunningInstance::new` reads `handle.id`; the local `INSTANCE_ID` static is gone.
- Engine test call sites updated (mechanical: drop the id argument), 25 in total.

Production behaviour is unchanged: the same counter semantics, the same monotonic ids, the same single production caller (`runtime.rs:304`, still wrapped in `classify_result` per the #4864 invariant, and still counted 1/1 by the `guest_entry_calls_route_through_classify_result` pin in `contract/executor.rs`).

**What this does and does not close**, stated precisely because the docs previously overstated it:

- It closes the `create_instance` parameter, which is where every id that actually reached these maps came from.
- It is **not** a type-level guarantee. `InstanceHandle.id` is `pub(super)`, so code inside `wasm_runtime` can still construct a handle with a chosen id (`delegate/test.rs` does, twice, inertly — `process_outbound` binds it as `_handle` and never touches the maps). Both the allocator rustdoc and the regression test's rustdoc now say so.
- The WASM ABI is a separate id surface this does not validate: four host functions take a guest-supplied instance id. Called out in the `NEXT_INSTANCE_ID` docs so the invariant is not over-read.

## Testing

Two new tests:

- `instance_ids_are_globally_unique_across_engines`: engine A holds a live instance with a recorded `MEM_ADDR` entry while engine B churns 64 instances the way the store-refresh and instance-limit tests do. Asserts B is never issued A's id and that A's entry survives. Mutation-tested: with `create_instance` reverted to a per-engine id (`self.lifetime_instances as i64`) it fails with `left: 0, right: 0`.
- `create_instance_allocates_its_own_instance_id`: bounded-region source pin. The signature stops a *caller* passing an id, but nothing stops `create_instance` itself from reverting to a per-engine counter. Mutation-tested against exactly that change. It cuts the file at the `#[cfg(test)]` module before scraping, so it cannot match its own assertion message and pass while guarding nothing.

One pre-existing pin hardened in passing: `create_instance_recovers_store_on_guest_entry_failure` scraped the whole file with no test-module cutoff, so a rename of `create_instance` would have let its `find` fall through into the test module instead of panicking. It fails closed today only by the accident of which string literal happens to sit earliest. Same cutoff applied.

Because `cargo nextest` cannot see this defect class, the meaningful signal is plain `cargo test` in one process: `cargo test -p freenet --lib wasm_runtime` is green on this head, as is `cargo check --all-targets` and `cargo fmt`.

Closes #4213
Closes #5023

[AI-assisted - Claude]
