### PR TITLE
fix(transport): stop poll_next ending a relayed stream one fragment early

### DIFF
--- a/.claude/rules/bug-prevention-patterns.md
+++ b/.claude/rules/bug-prevention-patterns.md
@@ -158,6 +158,52 @@ arms, the INFO-level checks on `MARKER_CHECK_COMPLETE` and
 canary still runs, and still runs before `--draft=false` — is pinned by
 `scripts/release_canary_wiring_test.sh`.
 
+## A completion predicate that is a proxy for the real termination condition
+
+**A cheap proxy that *usually* agrees with the real condition reads as
+equivalent, gets copied to each new consumer, and diverges in the one
+case nobody tests.** freenet-core has three implementations of "is this
+stream finished" over the same fragment buffer, and two of them shipped
+the same off-by-one.
+
+The proxy here is a FRAGMENT COUNT; the real condition is
+`bytes_delivered >= advertised_bytes`. Two properties make this genre
+expensive out of proportion to the bug:
+
+- **The failure is silent at the site that causes it.** The truncating
+  peer reports success. The victim is the *downstream* peer, which dies
+  on an inactivity timeout naming neither the cause nor the culprit — so
+  the error surfaces in a different process from the defect, and the
+  telemetry that would prompt an audit says everything was fine (#5445).
+- **Each copy looks locally reasonable**, so fixing one consumer leaves
+  the others and nothing flags the asymmetry.
+
+The buffer allocates `base + 1` fragment slots, where
+`base = ceil(total_bytes / FRAGMENT_PAYLOAD_SIZE)`, because embedding
+metadata in fragment #1 (#2757) reduces that fragment's payload and makes
+the sender emit one extra fragment. `is_complete()` is
+`contiguous >= base` — the BASE count — so it goes true **one fragment
+early** on exactly those streams.
+
+| Consumer | State |
+|---|---|
+| `streaming_buffer::assemble()` | Correct: discriminates on assembled length vs `total_size`, keeps waiting when `is_complete()` is true but bytes are short. |
+| `StreamingInboundStream::poll_next` | Was wrong; fixed in #5270. Ended on `is_complete()` alone, so `pipe_stream` forwarded short and the downstream peer sat in `assemble()` until its 5 s inactivity timeout. |
+| `PipedStream` | Still wrong, currently dead code — #5440. Computes `total_fragments` as the base count, so it declares completion early AND then rejects the genuine final fragment as out of range. |
+
+**The rule:** the discriminator is the BYTE total, never the fragment
+count. A fragment count is an estimate derived from an assumption about
+payload sizes; `total_bytes` is what the sender actually advertised.
+
+**And the transferable half:** when a predicate this load-bearing has more
+than one implementation, the bug is the duplication, not any one copy.
+Before adding a fourth, ask whether it can call the existing one. When
+auditing a fix to one, grep for the others — #5440 was found only because
+the #5270 review enumerated every `is_complete()` call site, and it had
+been wrong since it was written. A truncation that reports success is
+also invisible in telemetry (#5445), so nothing prompts the audit on its
+own.
+
 ## Cross-test interference through process-global state: CI cannot see it
 
 A guard whose two inputs rot from one cause. Every CI job runs `cargo
@@ -228,6 +274,49 @@ hand-rolling a `split_once`. It:
 **Prefer a cross-file scrape.** A pin that lives in `auto_update.rs` and
 scrapes `update.rs` cannot be satisfied by its own assertion literal at
 all — a structural guarantee rather than a check someone must remember.
+
+### The variant `fn_body()` does not catch: the anchor survives the deletion
+
+`fn_body()` fixes a *moved* anchor. It does nothing about an anchor that
+is still exactly where the pin expects because the call was **commented
+out**. `// interleave(&mut ops, seed);` contains the string
+`interleave(&mut ops, seed);`, so `split_once` finds it, the region
+splits where it always did, the before/after assertions still hold, and
+the pin stays green over a shuffle that no longer runs. Deleting the line
+outright fails loudly; disabling it does not — and disabling it is what a
+person actually does while debugging, which is precisely when the pin is
+the only thing left watching.
+
+Found in review of #5271, where the PR's own new pin AND the pre-existing
+one it was modelled on both survived commenting out the call they guard.
+Verified by doing it: both stayed green before the fix, both go red after.
+
+**The rule:** a pin that guards a *call* must require the call at
+statement position — the call text preceded on its line by nothing but
+whitespace — not merely present in the region. A few lines:
+
+```rust
+fn split_at_call<'a>(body: &'a str, call: &str) -> (&'a str, &'a str) {
+    let at = body
+        .match_indices(call)
+        .find(|(i, _)| {
+            let line_start = body[..*i].rfind('\n').map_or(0, |n| n + 1);
+            body[line_start..*i].trim().is_empty()
+        })
+        .map(|(i, _)| i)
+        .unwrap_or_else(|| panic!("`{call}` is not called at statement position"));
+    (&body[..at], &body[at + call.len()..])
+}
+```
+
+**The generalisation, which is the part worth carrying:** a source-scrape
+pin asserts that *text exists*, while the property it is standing in for
+is that *code runs*. Every gap between those two is a way for the pin to
+pass vacuously — a moved anchor, a self-matched literal, a commented-out
+call, a call moved inside a branch that is never taken. When writing one,
+ask what the cheapest edit is that keeps the text and removes the
+behaviour, then make that edit fail. **And test the pin by performing that
+edit**, because a pin nobody mutated is a pin nobody has evidence about.
 
 ### The same class without `include_str!`: an expectation stored as a copy
 

--- a/crates/core/src/transport/peer_connection.rs
+++ b/crates/core/src/transport/peer_connection.rs
@@ -1602,11 +1602,26 @@ impl<S: super::Socket, T: TimeSource> PeerConnection<S, T> {
     /// ```ignore
     /// if let Some(handle) = peer_conn.recv_stream_handle(stream_id) {
     ///     let mut stream = handle.stream();
-    ///     while let Some(chunk) = stream.next().await {
+    ///     loop {
+    ///         // Bound the wait. See the note below on why `stream.next()`
+    ///         // must never be awaited unbounded.
+    ///         let next = tokio::select! {
+    ///             r = stream.next() => r,
+    ///             _ = time_source.sleep(STREAM_INACTIVITY_TIMEOUT) => break,
+    ///         };
+    ///         let Some(chunk) = next else { break };
     ///         process_chunk(chunk?);
     ///     }
     /// }
     /// ```
+    ///
+    /// **Always bound the wait.** `StreamingInboundStream::poll_next` yields
+    /// `Pending` until every advertised byte has been delivered, so a peer that
+    /// advertises a `total_length_bytes` it never sends, or a lost final
+    /// fragment, leaves an unbounded `stream.next().await` hanging forever. The
+    /// one production consumer, `pipe_stream`, wraps it in exactly this
+    /// `select!` against `STREAM_INACTIVITY_TIMEOUT` and reports a diagnostic
+    /// failure; anything new must do the same.
     #[allow(dead_code)]
     pub(crate) fn recv_stream_handle(
         &self,

--- a/crates/core/src/transport/peer_connection/streaming.rs
+++ b/crates/core/src/transport/peer_connection/streaming.rs
@@ -1860,7 +1860,9 @@ mod tests {
                     assert_eq!(data.len(), expected);
                     yielded += data.len();
                 }
-                other => panic!("expected fragment of {expected} bytes, got {other:?}"),
+                other @ (Poll::Ready(_) | Poll::Pending) => {
+                    panic!("expected fragment of {expected} bytes, got {other:?}")
+                }
             }
         }
 
@@ -1889,7 +1891,9 @@ mod tests {
                 assert_eq!(data.len(), overflow_size);
                 yielded += data.len();
             }
-            other => panic!("expected the overflow fragment, got {other:?}"),
+            other @ (Poll::Ready(_) | Poll::Pending) => {
+                panic!("expected the overflow fragment, got {other:?}")
+            }
         }
 
         assert_eq!(
@@ -1928,7 +1932,9 @@ mod tests {
         for _ in 0..2 {
             match stream.poll_next_unpin(&mut cx) {
                 Poll::Ready(Some(Ok(data))) => yielded += data.len(),
-                other => panic!("expected a fragment, got {other:?}"),
+                other @ (Poll::Ready(_) | Poll::Pending) => {
+                    panic!("expected a fragment, got {other:?}")
+                }
             }
         }
         assert_eq!(yielded, total as usize);

--- a/crates/core/src/transport/peer_connection/streaming.rs
+++ b/crates/core/src/transport/peer_connection/streaming.rs
@@ -552,8 +552,20 @@ impl Stream for StreamingInboundStream {
         //
         // The byte count is the discriminator, exactly as in `assemble()` (which
         // keeps waiting when `is_complete()` is true but the assembled length is
-        // short). Keep the two paths in agreement — they consume the same buffer
-        // and must reach the same conclusion about when a stream has ended.
+        // short). They consume the same buffer and must reach the same
+        // conclusion about when a stream has ended.
+        //
+        // Scope, precisely: this brings the two paths into agreement at THIS
+        // exit. The `next_idx > total_fragments` exit above is still unguarded,
+        // and a sender that filled every `base + 1` slot with short payloads
+        // would leave through it with `bytes_read < total_bytes` — where
+        // `assemble()` returns `None` (a failure) but this returns
+        // `Ready(None)` (a success), and `pipe_stream` reports a successful
+        // transfer with a short byte count. No conforming sender does that:
+        // `send_stream` fragments `stream_to_send` exactly. Tracked as #5445,
+        // which is where the guard that would make the agreement universal
+        // belongs — it is a production behaviour change and wants its own
+        // review rather than a late addition here.
         if self.handle.buffer.is_complete()
             && self.handle.buffer.get(next_idx).is_none()
             && self.bytes_read >= self.handle.buffer.total_bytes()
@@ -912,20 +924,34 @@ mod tests {
 
     #[tokio::test]
     async fn test_streaming_inbound_stream_basic() {
-        let handle = StreamHandle::new(make_stream_id(), 15);
+        // The advertised total must equal the bytes actually pushed. This said
+        // 15 while pushing 5, which no sender ever does -- `send_stream` sets
+        // `total_length_bytes` from `stream_to_send.len()` and `pipe_stream`
+        // forwards `inbound_handle.total_bytes()`, so both are exact. The
+        // inconsistency was invisible while `poll_next` ended a stream on
+        // `is_complete()` alone, and it is worth noting that `assemble()`
+        // already rejected this same buffer (its length check fails at 5 of
+        // 15 bytes): the two paths disagreed, which is the defect the
+        // `bytes_read >= total_bytes()` conjunct fixes.
+        let payload = Bytes::from_static(b"hello");
+        let handle = StreamHandle::new(make_stream_id(), payload.len() as u64);
 
-        // Push all fragments
-        handle
-            .push_fragment(1, Bytes::from_static(b"hello"))
-            .unwrap();
+        handle.push_fragment(1, payload.clone()).unwrap();
 
         let mut stream = handle.stream();
         let chunk = stream.next().await;
         assert!(chunk.is_some());
-        assert_eq!(chunk.unwrap().unwrap(), Bytes::from_static(b"hello"));
+        assert_eq!(chunk.unwrap().unwrap(), payload);
 
-        // Stream should be exhausted
-        let chunk = stream.next().await;
+        // Stream should be exhausted. Bounded so a regression that stops the
+        // stream ending reports THAT, rather than hanging until nextest's
+        // 240 s slow-timeout kills the process with no diagnosis.
+        let chunk = tokio::time::timeout(std::time::Duration::from_secs(5), stream.next())
+            .await
+            .expect(
+                "stream never ended: every advertised byte was delivered, so `poll_next` must \
+                 return Ready(None) rather than waiting for the unused overflow slot",
+            );
         assert!(chunk.is_none());
     }
 
@@ -1329,10 +1355,15 @@ mod tests {
 
     #[tokio::test]
     async fn test_bytes_read_tracking() {
-        let handle = StreamHandle::new(make_stream_id(), 15);
-        handle
-            .push_fragment(1, Bytes::from_static(b"hello world!!!"))
-            .unwrap();
+        // Advertised total must equal the bytes pushed, as at
+        // `test_streaming_inbound_stream_basic`. This said 15 while pushing 14.
+        // It does not hang today only because it polls once and never reaches
+        // the terminal poll -- so it is a landmine rather than a failure: the
+        // next person to add an end-of-stream assertion here rediscovers the
+        // hang instead of the bug they were chasing.
+        let payload = Bytes::from_static(b"hello world!!!");
+        let handle = StreamHandle::new(make_stream_id(), payload.len() as u64);
+        handle.push_fragment(1, payload).unwrap();
 
         let mut stream = handle.stream();
         assert_eq!(stream.bytes_read(), 0);

--- a/crates/core/src/transport/peer_connection/streaming.rs
+++ b/crates/core/src/transport/peer_connection/streaming.rs
@@ -1819,7 +1819,11 @@ mod tests {
         let mut stream = handle.stream();
 
         let mut yielded = 0usize;
-        for expected in [reduced_payload, FRAGMENT_PAYLOAD_SIZE, FRAGMENT_PAYLOAD_SIZE] {
+        for expected in [
+            reduced_payload,
+            FRAGMENT_PAYLOAD_SIZE,
+            FRAGMENT_PAYLOAD_SIZE,
+        ] {
             match stream.poll_next_unpin(&mut cx) {
                 Poll::Ready(Some(Ok(data))) => {
                     assert_eq!(data.len(), expected);

--- a/crates/core/src/transport/peer_connection/streaming.rs
+++ b/crates/core/src/transport/peer_connection/streaming.rs
@@ -1903,6 +1903,69 @@ mod tests {
         assert!(matches!(stream.poll_next_unpin(&mut cx), Poll::Ready(None)));
     }
 
+    /// The contract this fix establishes, stated where a future debugger will
+    /// find it: **a stream short of its advertised total stalls; it does not
+    /// end.**
+    ///
+    /// This case used to live in the tree by accident.
+    /// `test_streaming_inbound_stream_basic` advertised 15 bytes while pushing
+    /// 5, and correcting that data removed the only in-tree artefact of the
+    /// behaviour. Without something naming it, the next person to hit a stall
+    /// while debugging has every incentive to "fix" it by re-widening the
+    /// condition — which is precisely the truncation #5270 removed, restored.
+    ///
+    /// The stall is deliberate. It is what makes `poll_next` agree with
+    /// `assemble()`, which returns `None` for this same buffer rather than
+    /// handing back a short result. Ending the stream instead would forward a
+    /// truncated payload while reporting success, and strand the downstream
+    /// peer in `assemble()` until its inactivity timeout. A caller that cannot
+    /// wait forever bounds the wait — `pipe_stream` wraps this in a `select!`
+    /// against `STREAM_INACTIVITY_TIMEOUT` and reports a diagnostic failure.
+    /// No conforming sender produces this shape: `send_stream` sets
+    /// `total_length_bytes` from `stream_to_send.len()`.
+    #[test]
+    fn a_stream_short_of_its_advertised_total_stalls_rather_than_ending_early() {
+        use futures::StreamExt;
+
+        let payload = Bytes::from_static(b"hello");
+        // Advertise three times what we deliver.
+        let total = (payload.len() * 3) as u64;
+        let handle = StreamHandle::new(make_stream_id(), total);
+        handle.push_fragment(1, payload.clone()).unwrap();
+
+        // The buffer calls itself complete: one contiguous fragment meets the
+        // base count for a total this small. That is the trap the byte check
+        // exists for.
+        assert!(handle.is_complete());
+        assert!(
+            handle.try_assemble().is_none(),
+            "assemble() must refuse a buffer short of its total — if this ever \
+             returns Some, the two paths have diverged again"
+        );
+
+        let waker = futures::task::noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        let mut stream = handle.stream();
+
+        match stream.poll_next_unpin(&mut cx) {
+            Poll::Ready(Some(Ok(data))) => assert_eq!(data, payload),
+            other @ (Poll::Ready(_) | Poll::Pending) => {
+                panic!("the delivered fragment must come out first, got {other:?}")
+            }
+        }
+
+        assert!(
+            matches!(stream.poll_next_unpin(&mut cx), Poll::Pending),
+            "a stream short of its advertised total must STALL, not end. Ending \
+             here returns Ready(None) to `pipe_stream`, which forwards a \
+             truncated payload and reports a successful transfer, and the \
+             downstream peer then waits in assemble() for a fragment that will \
+             never arrive. If you are here because something is stalling, the \
+             bug is upstream — a sender advertising more than it sent — not \
+             this condition."
+        );
+    }
+
     /// The early-end path must still fire when the overflow slot is genuinely
     /// unused, or every such stream would hang until its inactivity timeout.
     ///

--- a/crates/core/src/transport/peer_connection/streaming.rs
+++ b/crates/core/src/transport/peer_connection/streaming.rs
@@ -533,10 +533,31 @@ impl Stream for StreamingInboundStream {
             return Poll::Ready(None); // Stream complete
         }
 
-        // If the stream has enough data but this fragment slot is empty, we're done.
-        // The overflow slot (allocated for potential metadata overhead in fragment #1)
-        // may not be used when fragment #1 has full payload capacity.
-        if self.handle.buffer.is_complete() && self.handle.buffer.get(next_idx).is_none() {
+        // If every advertised byte has been yielded and this fragment slot is
+        // empty, we're done. The overflow slot (allocated for potential metadata
+        // overhead in fragment #1) may not be used when fragment #1 has full
+        // payload capacity, so it can stay empty forever.
+        //
+        // `is_complete()` alone is NOT sufficient to end the stream: it is
+        // `contiguous >= min_complete_fragments`, the BASE fragment count. When
+        // the sender embeds metadata in fragment #1 (fix #2757) that fragment
+        // carries a reduced payload, so the sender emits `base + 1` fragments —
+        // and `is_complete()` therefore fires one fragment EARLY, while the
+        // final overflow fragment is still in flight. Ending here on that signal
+        // truncates the stream: `pipe_stream` (the relay forwarding path, see
+        // `outbound_stream.rs`) stops forwarding short of the
+        // `total_length_bytes` it advertised, and the downstream peer waits in
+        // `assemble()` for a fragment that will never be sent until its
+        // inactivity timeout fires.
+        //
+        // The byte count is the discriminator, exactly as in `assemble()` (which
+        // keeps waiting when `is_complete()` is true but the assembled length is
+        // short). Keep the two paths in agreement — they consume the same buffer
+        // and must reach the same conclusion about when a stream has ended.
+        if self.handle.buffer.is_complete()
+            && self.handle.buffer.get(next_idx).is_none()
+            && self.bytes_read >= self.handle.buffer.total_bytes()
+        {
             return Poll::Ready(None);
         }
 
@@ -1739,5 +1760,150 @@ mod tests {
         assert!(result.is_ok(), "assemble should succeed: {:?}", result);
         let data = result.unwrap();
         assert_eq!(data.len(), total as usize);
+    }
+
+    /// Regression test: the `Stream` impl must wait for the overflow fragment
+    /// instead of silently ending the stream early.
+    ///
+    /// Counterpart to `test_assemble_waits_for_overflow_fragment` above. That
+    /// test pins the `assemble()` path, which was fixed after it truncated
+    /// River web-app payloads. `poll_next` had the same defect and was NOT
+    /// fixed, and it is the path relays use: `pipe_stream` forwards a GET/PUT
+    /// response hop-by-hop via `inbound_handle.stream()`.
+    ///
+    /// The mechanism: `is_complete()` is `contiguous >= min_complete_fragments`,
+    /// which is the base fragment count. When the sender embeds metadata in
+    /// fragment #1 (fix #2757) that fragment carries a reduced payload, so the
+    /// sender emits `base + 1` fragments. `is_complete()` therefore fires one
+    /// fragment EARLY — while the final overflow fragment is still in flight.
+    /// A consumer polling in that window saw `is_complete() && get(next) == None`
+    /// and returned `Poll::Ready(None)`, ending the relayed stream short of its
+    /// advertised `total_length_bytes`. The downstream peer then sits in
+    /// `assemble()` waiting for a fragment that will never be sent and fails
+    /// with `StreamError::InactivityTimeout` — "stream assembly: no fragments
+    /// received within inactivity timeout".
+    ///
+    /// Polling is driven manually with a no-op waker so the assertion lands on
+    /// the exact poll in that window; there is no sleep and no timing race.
+    #[test]
+    fn test_stream_waits_for_overflow_fragment() {
+        use super::super::streaming_buffer::FRAGMENT_PAYLOAD_SIZE;
+        use futures::StreamExt;
+
+        // Same shape as the sender: fragment #1 carries a reduced payload
+        // because metadata is embedded, so `base + 1` fragments are needed.
+        let total = (FRAGMENT_PAYLOAD_SIZE * 3) as u64;
+        let handle = StreamHandle::new(make_stream_id(), total);
+
+        let reduced_payload = FRAGMENT_PAYLOAD_SIZE / 2;
+        let remaining = total as usize - reduced_payload;
+        let overflow_size = remaining - 2 * FRAGMENT_PAYLOAD_SIZE;
+
+        handle
+            .push_fragment(1, Bytes::from(vec![1u8; reduced_payload]))
+            .unwrap();
+        handle
+            .push_fragment(2, Bytes::from(vec![2u8; FRAGMENT_PAYLOAD_SIZE]))
+            .unwrap();
+        handle
+            .push_fragment(3, Bytes::from(vec![3u8; FRAGMENT_PAYLOAD_SIZE]))
+            .unwrap();
+
+        // The buffer reports complete (3 contiguous >= min_complete_fragments)
+        // even though the bytes present are short of `total`.
+        assert!(handle.is_complete());
+        assert!(handle.try_assemble().is_none());
+
+        let waker = futures::task::noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        let mut stream = handle.stream();
+
+        let mut yielded = 0usize;
+        for expected in [reduced_payload, FRAGMENT_PAYLOAD_SIZE, FRAGMENT_PAYLOAD_SIZE] {
+            match stream.poll_next_unpin(&mut cx) {
+                Poll::Ready(Some(Ok(data))) => {
+                    assert_eq!(data.len(), expected);
+                    yielded += data.len();
+                }
+                other => panic!("expected fragment of {expected} bytes, got {other:?}"),
+            }
+        }
+
+        // The defect: with the overflow fragment not yet arrived, this poll
+        // returned `Ready(None)` and the relay ended the stream having
+        // forwarded only `yielded` of `total` bytes.
+        match stream.poll_next_unpin(&mut cx) {
+            Poll::Pending => {}
+            Poll::Ready(None) => panic!(
+                "stream ended early: forwarded {yielded} of {total} bytes. \
+                 `is_complete()` fires at the base fragment count, so the \
+                 overflow fragment was still in flight; ending here truncates \
+                 the relayed stream and strands the downstream peer in \
+                 assemble() until its inactivity timeout."
+            ),
+            other => panic!("expected Pending while awaiting the overflow fragment, got {other:?}"),
+        }
+
+        // Overflow arrives: the stream must deliver it and only then end.
+        handle
+            .push_fragment(4, Bytes::from(vec![4u8; overflow_size]))
+            .unwrap();
+
+        match stream.poll_next_unpin(&mut cx) {
+            Poll::Ready(Some(Ok(data))) => {
+                assert_eq!(data.len(), overflow_size);
+                yielded += data.len();
+            }
+            other => panic!("expected the overflow fragment, got {other:?}"),
+        }
+
+        assert_eq!(
+            yielded, total as usize,
+            "the stream must forward every advertised byte"
+        );
+        assert!(matches!(stream.poll_next_unpin(&mut cx), Poll::Ready(None)));
+    }
+
+    /// The early-end path must still fire when the overflow slot is genuinely
+    /// unused, or every such stream would hang until its inactivity timeout.
+    ///
+    /// This is the case the `is_complete() && get(next).is_none()` check exists
+    /// for: when fragment #1 carries a full payload the sender emits exactly
+    /// `base` fragments and the extra allocated slot stays empty forever.
+    #[test]
+    fn test_stream_ends_when_overflow_slot_unused() {
+        use super::super::streaming_buffer::FRAGMENT_PAYLOAD_SIZE;
+        use futures::StreamExt;
+
+        let total = (FRAGMENT_PAYLOAD_SIZE * 2) as u64;
+        let handle = StreamHandle::new(make_stream_id(), total);
+
+        handle
+            .push_fragment(1, Bytes::from(vec![1u8; FRAGMENT_PAYLOAD_SIZE]))
+            .unwrap();
+        handle
+            .push_fragment(2, Bytes::from(vec![2u8; FRAGMENT_PAYLOAD_SIZE]))
+            .unwrap();
+
+        let waker = futures::task::noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        let mut stream = handle.stream();
+
+        let mut yielded = 0usize;
+        for _ in 0..2 {
+            match stream.poll_next_unpin(&mut cx) {
+                Poll::Ready(Some(Ok(data))) => yielded += data.len(),
+                other => panic!("expected a fragment, got {other:?}"),
+            }
+        }
+        assert_eq!(yielded, total as usize);
+
+        // All advertised bytes delivered and slot 3 will never be filled: the
+        // stream must end rather than wait.
+        assert!(
+            matches!(stream.poll_next_unpin(&mut cx), Poll::Ready(None)),
+            "stream must end once every advertised byte has been forwarded, \
+             even though the allocated overflow slot is still empty"
+        );
     }
 }


### PR DESCRIPTION
## Problem

`StreamingInboundStream::poll_next` ended a stream as soon as
`buffer.is_complete()` was true and the next fragment slot was empty.

But `is_complete()` is `contiguous >= min_complete_fragments` — the **base**
fragment count. When the sender embeds metadata in fragment #1 (#2757), that
fragment carries a reduced payload, so the sender emits `base + 1` fragments.
`is_complete()` therefore fires **one fragment early**, while the final
overflow fragment is still in flight.

`pipe_stream` — the relay forwarding path in `outbound_stream.rs` — drives this
`Stream`. So a relay stopped forwarding short of the `total_length_bytes` it had
itself advertised. The downstream peer then waited in `assemble()` for a fragment
that would never be sent, and failed with `StreamError::InactivityTimeout`:

```
stream assembly: no fragments received within inactivity timeout
```

which is verbatim the error string appearing in nightly netcheck runs.

**`assemble()` already had this guard** (it keeps waiting when `is_complete()` is
true but the assembled length is short of `total`) — added after the same
truncation caused blank pages in the River web app. `poll_next` never received
the equivalent. This PR closes that asymmetry.

Why this path is reached in practice: the GET **originator** uses `assemble()`,
but the GET **relay** pipes via `poll_next`
(`get/op_ctx_task.rs` → `pipe_stream` → `peer_connection.rs` →
`outbound_stream.rs`, `inbound_handle.stream()`). PUT relaying has the same
shape.

Precisely how often, corrected: **this needs two or more relay hops on the response
path, not one.** A single-relay GET response goes `relay_send_found` ->
`conn_manager.send_stream`, and the originator consumes it with `assemble()`, which was
already guarded. `pipe_stream` is reached only from the "Forward path (remote
upstream)" branch at `get/op_ctx_task.rs:4048`, which runs when a peer forwards an
inbound stream it itself received. An earlier revision of this description said "any GET
that is relayed at least once exercises it", which is wrong.

## Approach

Make the byte count the discriminator, exactly as `assemble()` does: only end the
stream when every advertised byte has actually been yielded.

```rust
if self.handle.buffer.is_complete()
    && self.handle.buffer.get(next_idx).is_none()
    && self.bytes_read >= self.handle.buffer.total_bytes()
```

The two paths consume the same buffer and must reach the same conclusion about
when a stream has ended; they now do. The existing behaviour is preserved for the
common case where fragment #1 has full payload capacity and the overflow slot is
legitimately never used.

## Testing

Adds `test_stream_waits_for_overflow_fragment`. It constructs the exact shape the
sender produces (fragment #1 with reduced payload, so `base + 1` fragments needed),
asserts the buffer reports `is_complete()` while `try_assemble()` still returns
`None`, then drives `poll_next` manually with a no-op waker so the assertion lands
on the precise poll inside that window. **No sleeps and no timing race.**

## Scope — please read before assuming this fixes the nightly

This removes **one contributing failure mode**. It will **not** by itself turn the
nightly netcheck green.

- It requires two conditions, not one: a payload-length condition **and** the
  relay's reader reaching the last fragment before it arrives.

  Calling the second a coin-flip race, as an earlier revision did, understates it in
  the other direction. Once the length condition holds, truncation is closer to the
  DEFAULT than to 50/50: `is_complete()` being true implies slots `1..base` are
  already filled, so the only slot `poll_next` can find empty in that state is exactly
  `base + 1` -- the last one. A reader that is not backlogged reaches it, and
  not-backlogged is the normal steady state for a relay whose downstream keeps up. The
  bug is *avoided* mainly when the relay is downstream-bottlenecked enough that the
  final fragment has already landed. So the expected rate is nearer "the payload-length
  fraction of >=2-hop relayed streams" than "that fraction times a small race
  probability" -- which argues this fix is worth somewhat more than the rest of this
  section claims, not less.
- An earlier revision of this description put the payload-length condition at
  "roughly 15% of payloads". That number is not supported by anything in the code
  and has been removed. The window is `m / FRAGMENT_PAYLOAD_SIZE` where `m` is the
  embedded metadata size, so with `FRAGMENT_PAYLOAD_SIZE = 1130` (`1200 - 1 - 12 -
  16 - 41`) 15% would imply ~161 bytes of metadata. A GET relay's
  `GetMsg::ResponseStreaming` is on the order of ~110 bytes, i.e. nearer 10%; PUT's
  `PutMsg::RequestStreaming` carries a `skip_list` that grows per hop, so it is
  larger and variable. Order of magnitude right, precise figure unfounded.
- It produces a ~5s failure signature — that is `STREAM_INACTIVITY_TIMEOUT`, the
  downstream peer's wait in `assemble()`. Treat it as a floor rather than a
  fingerprint: 5s is what several unrelated stream failures also cost, so timing
  alone does not attribute a failure to this defect. Of 38 observed netcheck
  failures it is *consistent with* the four at 6.5–7.6s. It does **not** explain the
  60s-multiple or 120.2s populations.

Related but explicitly **not** addressed here: #5054 (cwnd-wait stall) remains the
best-supported hypothesis for the bulk of the failures and is untouched by this
change, and #5266 records three defects in netcheck's own reporting that mean some
residual signal may be measurement artefact rather than network fault.

## Relationship to #5256

This is item 3 of #5256 ("four defects and a coverage gap in the streaming/fragment path"),
which names this defect at this line with this reasoning. Referenced as a **partial** fix, not
`Closes`: item 2 (`packet_size` wire-vs-payload over-charge) and item 4 (`take()` never advances
`consumed_frontier`) are still open. Items 1 and 5 have since been fixed on main independently.

## Review

Full-tier review (transport is a named high-risk surface here), four independent blind Claude
lenses: code-first, testing, skeptical, big-picture. No BLOCKER from any lens. Changes made:

- **CI was red and is now green.** The pre-existing `test_streaming_inbound_stream_basic` HUNG
  under this change — 240s timeout on all three nextest retries. It advertised
  `StreamHandle::new(id, 15)` while pushing a single 5-byte fragment. That data is
  self-inconsistent rather than a real scenario: senders set `total_length_bytes` exactly
  (`send_stream` from `stream_to_send.len()`, `pipe_stream` from `inbound_handle.total_bytes()`),
  and `assemble()` already rejected that same buffer, so the old `poll_next` was the path that
  disagreed with the rest of the module. It now advertises `payload.len()`, and its terminal
  await is bounded by a 5s timeout so a future regression reports itself instead of hanging
  until nextest's kill with no diagnosis.
- **A second test carried the same landmine.** `test_bytes_read_tracking` advertised 15 while
  pushing 14 bytes; it survives only because it polls once and never reaches the terminal poll.
  Fixed the same way, so the next person to add an end-of-stream assertion there does not
  rediscover the hang instead of the bug they were chasing.
- **The added comment overclaimed and has been scoped.** It said the two paths "must reach the
  same conclusion about when a stream has ended". The `next_idx > total_fragments` exit is still
  unguarded, so that is not universally true; the comment now says which exit it fixes and points
  at #5445 for the rest.
- **Two impact claims were wrong in opposite directions** and are corrected above:
  reachability needs two or more relay hops rather than any relayed GET, and the second
  condition is nearer the default outcome than a coin flip.
- **The RED-without-fix claim is now discharged.** The description flagged it as the authoring
  agent's unverified claim. Reverting the production hunk locally and re-running:
  `test_stream_waits_for_overflow_fragment` fails with *"stream ended early: forwarded 2825 of
  3390 bytes"*. Restoring the hunk turns it green. All 43 streaming tests pass.

Filed rather than folded in, both found by the `is_complete()` call-site audit this review ran:

- **#5440** — `PipedStream` computes `total_fragments` as the base count with no allowance for
  the overflow fragment, so it would declare completion early *and* reject the genuine final
  fragment. Currently dead code (`#![allow(dead_code)]`, "not yet wired into the main forwarding
  path"), so latent rather than live — but it is the third implementation of this predicate and
  the second to get it wrong.
- **#5445** — `pipe_stream` reports a successful transfer after forwarding fewer bytes than it
  advertised, because the loop's other exit is unguarded. Not reachable from a conforming sender.
  Deliberately not fixed here: it is a production behaviour change on a high-risk path and wants
  its own review rather than a late addition to this one.

`.claude/rules/bug-prevention-patterns.md` gains the generalisable lesson: the discriminator is
the byte total, never the fragment count, and when a predicate this load-bearing has three
implementations the duplication is the bug.

## Provenance

Authored by an agent that terminated on a quota limit before it could open this PR;
its work was committed and pushed intact rather than lost. The RED-without-fix
reproduction is the authoring agent's claim and is **flagged in the commit message as
not independently re-verified** — a reviewer should confirm the test fails with the
production hunk reverted.

Refs #5256

[AI-assisted - Claude]

