### PR TITLE
fix(netcheck): make the report able to support the diagnosis it exists for

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4231,6 +4231,7 @@ dependencies = [
  "futures 0.3.32",
  "hex",
  "rand 0.9.4",
+ "rand_chacha 0.9.0",
  "reqwest 0.12.28",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4228,6 +4228,7 @@ dependencies = [
  "chrono",
  "clap",
  "freenet-stdlib 0.8.5",
+ "futures 0.3.32",
  "hex",
  "rand 0.9.4",
  "reqwest 0.12.28",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ chrono = { version = "0.4", default-features = true }
 
 # Random
 rand = "0.9"
+rand_chacha = "0.9"
 
 # Observability
 opentelemetry = "0.32"

--- a/crates/netcheck/Cargo.toml
+++ b/crates/netcheck/Cargo.toml
@@ -14,6 +14,9 @@ clap = { workspace = true, features = ["derive"] }
 freenet-stdlib = { workspace = true, features = ["net"] }
 hex = { workspace = true }
 rand = { workspace = true }
+# Version-stable RNG for the run-order shuffle: StdRng's algorithm is
+# explicitly not reproducible across rand releases.
+rand_chacha = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/netcheck/Cargo.toml
+++ b/crates/netcheck/Cargo.toml
@@ -21,3 +21,8 @@ tempfile = { workspace = true }
 tokio = { workspace = true }
 tokio-tungstenite = { workspace = true }
 x25519-dalek = { workspace = true }
+
+[dev-dependencies]
+# Driving the fake node in `client`'s tests: Sink/Stream extensions for the
+# server half of the websocket.
+futures = { workspace = true }

--- a/crates/netcheck/README.md
+++ b/crates/netcheck/README.md
@@ -20,7 +20,11 @@ Each `put-get` run:
    contract is" and "how late in the run the GET was issued" were the same
    variable, so an age effect could not be told apart from a
    within-run session effect. The order is shuffled from a seed derived
-   from the run id, and that seed is logged, so a run stays reproducible.
+   from the run id, and that seed is logged next to the order it produced,
+   so a run's order can be read back from its own report. (The seed alone
+   does not regenerate it: the permutation also depends on how many ops
+   the run had, which varies with which retention windows the manifest
+   had populated.)
 4. Prints one JSON line per operation on stdout and exits non-zero if
    anything failed. No retries by design: an operation that only succeeds
    on retry is the regression netcheck exists to surface.
@@ -69,7 +73,7 @@ One `"event":"run"` line with the conditions of the run, then one
  "freenet_version":"Freenet version: 0.2.106 (c707af0f786e)",
  "pinned_gateways":["100.27.151.80:31337,c28123df…"],
  "ephemeral_peers":["100.27.151.80:31337"]}
-{"event":"op","op":"get","age":"24h","label":"20260725-030000/small-0",…,"ok":true,"latency_ms":412}
+{"event":"op","seq":7,"op":"get","age":"24h","label":"20260725-030000/small-0",…,"ok":true,"latency_ms":412,"errors_ignored":0}
 ```
 
 `freenet_version` is what separates "the network broke" from "the release
@@ -81,6 +85,31 @@ long it actually took, not the configured `--op-timeout-secs`: reporting
 the deadline for every failure hid the difference between a fast terminal
 error from the node and the client giving up waiting, which is the
 distinction the field exists to draw.
+
+`seq` is the operation's 0-based position in the order the run actually
+executed. It has to be recorded because nothing else preserves it: every
+record of a run is published with the same timestamp, and line order is
+lost once the report is parsed. Before the GET order was shuffled,
+position could be recovered from `age`; now it cannot, so without `seq`
+the shuffle would destroy the very information it was introduced to
+disentangle.
+
+`errors_ignored` counts incoming errors this operation attributed to
+another contract and skipped. A server-side error for an op that already
+hit its own deadline arrives during the *next* op's wait window; charging
+it to that op stamps the wrong contract's key into the reported error.
+Zero is emitted too — "no stale error arrived during this op" is a
+measurement, and an absent field would be indistinguishable from a run
+that never counted. Errors that name no contract stay unattributable and
+still fail whichever op is waiting, so this can never swallow a real
+failure silently.
+
+Both fields reach the jsonl report. Neither reaches the telemetry
+dashboard yet: `insert_check_op` writes a fixed column list that has no
+`seq` or `errors_ignored` column, so `netcheck emit` publishes them and
+the ingest drops them without erroring. Read run order and skipped-error
+counts from the jsonl artifact until that table gains the columns
+(freenet/freenet-telemetry-dashboard#21).
 
 ## Production use (nova)
 

--- a/crates/netcheck/README.md
+++ b/crates/netcheck/README.md
@@ -98,11 +98,14 @@ disentangle.
 another contract and skipped. A server-side error for an op that already
 hit its own deadline arrives during the *next* op's wait window; charging
 it to that op stamps the wrong contract's key into the reported error.
-Zero is emitted too — "no stale error arrived during this op" is a
-measurement, and an absent field would be indistinguishable from a run
-that never counted. Errors that name no contract stay unattributable and
-still fail whichever op is waiting, so this can never swallow a real
-failure silently.
+Zero is emitted too, because an absent field would be indistinguishable
+from a run that never counted. Read it precisely: it counts errors the
+key filter skipped inside an op'''s own wait window. Errors arriving in the
+gap *between* ops are discarded by the pre-op drain, unfiltered and
+uncounted, so a zero means "the filter did not fire during this op", not
+"no stale error existed anywhere near it". Errors that name no contract
+stay unattributable and still fail whichever op is waiting, so this can
+never swallow a real failure silently.
 
 Both fields reach the jsonl report. Neither reaches the telemetry
 dashboard yet: `insert_check_op` writes a fixed column list that has no

--- a/crates/netcheck/README.md
+++ b/crates/netcheck/README.md
@@ -12,11 +12,16 @@ Each `put-get` run:
 2. Boots an **ephemeral peer** (`freenet network` child process with an
    empty data dir) that joins the network **through a different gateway**.
    Having no replicas of its own, it cannot answer any of its own GETs.
-3. GETs this run's contracts through that peer and verifies byte-identity.
-4. Re-GETs contracts published by previous runs (24 h / 48 h / 7 d windows,
-   tracked in a persistent JSON manifest) and verifies their blake3 state
-   hashes.
-5. Prints one JSON line per operation on stdout and exits non-zero if
+3. GETs this run's contracts through that peer (verifying byte-identity)
+   together with contracts published by previous runs (24 h / 48 h / 7 d
+   windows, tracked in a persistent JSON manifest, verified against their
+   blake3 state hashes). The two are issued as **one interleaved
+   sequence**: with a fixed 0 h → 24 h → 48 h → 7 d order, "how old the
+   contract is" and "how late in the run the GET was issued" were the same
+   variable, so an age effect could not be told apart from a
+   within-run session effect. The order is shuffled from a seed derived
+   from the run id, and that seed is logged, so a run stays reproducible.
+4. Prints one JSON line per operation on stdout and exits non-zero if
    anything failed. No retries by design: an operation that only succeeds
    on retry is the regression netcheck exists to surface.
 
@@ -70,6 +75,12 @@ One `"event":"run"` line with the conditions of the run, then one
 `freenet_version` is what separates "the network broke" from "the release
 that landed last night broke". Without it a failure cannot be attributed
 after the fact.
+
+`latency_ms` is a measurement on **both** arms. A failed op reports how
+long it actually took, not the configured `--op-timeout-secs`: reporting
+the deadline for every failure hid the difference between a fast terminal
+error from the node and the client giving up waiting, which is the
+distinction the field exists to draw.
 
 ## Production use (nova)
 

--- a/crates/netcheck/src/client.rs
+++ b/crates/netcheck/src/client.rs
@@ -146,7 +146,15 @@ fn error_contract_ids(err: &ClientError) -> Vec<ContractInstanceId> {
         ErrorKind::IncorrectState(key) => vec![*key.id()],
         // The shape terminal network failures actually arrive in: no key
         // field, the id written into the prose. See `contract_ids_in_text`.
-        ErrorKind::OperationError { cause } => contract_ids_in_text(cause.as_ref()),
+        //
+        // `Unhandled` is the same shape and matters for the same reason: it is
+        // what `ClientError::from(String)` produces, which is the sink stdlib's
+        // own stream-assembly failure path uses -- and stream assembly is the
+        // motivating failure class here, so leaving it unscanned would exempt
+        // the very errors this filter exists to attribute.
+        ErrorKind::OperationError { cause } | ErrorKind::Unhandled { cause } => {
+            contract_ids_in_text(cause.as_ref())
+        }
         // `ErrorKind` is `#[non_exhaustive]` too, and the same reasoning
         // applies: unrecognised means unattributed means fatal.
         _ => Vec::new(),
@@ -233,6 +241,30 @@ fn classify_get(
             match contract {
                 Some(contract) => Reaction::Done((contract, state)),
                 None => Reaction::Fatal(anyhow!("GET {label} ({id}) returned no contract")),
+            }
+        }
+        // A dead-ended GET does NOT arrive as `Err`. The node answers
+        // `Ok(NotFound)` on purpose, so a client can tell "contract genuinely
+        // absent" from "operation failed" -- see the comment on the arm that
+        // publishes it in `operations/get/op_ctx_task.rs`, which calls this
+        // "the dominant production `not_found` mode".
+        //
+        // Falling through to `Ignore` here is what made defect 2 survive its
+        // own fix: netcheck would discard the node's terminal answer, keep
+        // waiting, and report `latency_ms: 120000` -- the configured deadline
+        // again, for the single most common failure, now dressed as a
+        // measurement instead of an acknowledged constant. `NotFound` carries
+        // `instance_id`, so it is key-filtered exactly like every other
+        // terminal reply.
+        Ok(HostResponse::ContractResponse(ContractResponse::NotFound { instance_id })) => {
+            if instance_id != id {
+                Reaction::Ignore(format!(
+                    "GET {label}: NotFound for different key {instance_id}, ignoring"
+                ))
+            } else {
+                Reaction::Fatal(anyhow!(
+                    "GET {label} ({id}): node answered NotFound (contract not located)"
+                ))
             }
         }
         Ok(other) => Reaction::Ignore(format!(
@@ -459,6 +491,15 @@ mod tests {
 
     fn id_of(byte: u8) -> ContractInstanceId {
         ContractInstanceId::new([byte; 32])
+    }
+
+    fn reaction_name<T>(r: &Reaction<T>) -> &'static str {
+        match r {
+            Reaction::Done(_) => "Done",
+            Reaction::Ignore(_) => "Ignore",
+            Reaction::IgnoredError(_) => "IgnoredError",
+            Reaction::Fatal(_) => "Fatal",
+        }
     }
 
     /// A structured terminal GET failure: the API names the contract in a key
@@ -762,6 +803,54 @@ mod tests {
                 Reaction::Fatal(_) => {}
                 _ => panic!("a related-contract key must not be read as the error's subject"),
             }
+        }
+    }
+
+    #[test]
+    fn a_notfound_for_this_contract_fails_the_get_immediately() {
+        // The dominant production failure shape. Before this arm existed it
+        // fell through to `Ok(other) => Ignore`, so netcheck discarded the
+        // node's terminal answer and burned the full op timeout — reporting
+        // `latency_ms: 120000` for the most common failure there is, which is
+        // exactly the constant-latency defect this PR set out to remove.
+        let id = id_of(3);
+        match classify_get(
+            id,
+            "0h small-0",
+            Ok(HostResponse::ContractResponse(ContractResponse::NotFound {
+                instance_id: id,
+            })),
+        ) {
+            Reaction::Fatal(e) => {
+                let msg = e.to_string();
+                assert!(
+                    msg.contains("NotFound"),
+                    "the reported cause must say the node answered NotFound, got: {msg}"
+                );
+            }
+            other => panic!(
+                "a NotFound naming this contract is a terminal answer and must fail the GET                  fast, not be ignored into a synthetic timeout: {}",
+                reaction_name(&other)
+            ),
+        }
+    }
+
+    #[test]
+    fn a_notfound_for_another_contract_is_ignored() {
+        // Key-filtered exactly like every other terminal reply: a NotFound
+        // answering an op that already gave up must not kill this one.
+        match classify_get(
+            id_of(3),
+            "0h small-0",
+            Ok(HostResponse::ContractResponse(ContractResponse::NotFound {
+                instance_id: id_of(9),
+            })),
+        ) {
+            Reaction::Ignore(_) => {}
+            other => panic!(
+                "a NotFound naming a different contract must be ignored: {}",
+                reaction_name(&other)
+            ),
         }
     }
 

--- a/crates/netcheck/src/client.rs
+++ b/crates/netcheck/src/client.rs
@@ -5,8 +5,8 @@ use std::time::{Duration, Instant};
 
 use anyhow::{Result, anyhow, bail, ensure};
 use freenet_stdlib::client_api::{
-    ClientRequest, ContractRequest, ContractResponse, HostResponse, NodeQuery, QueryResponse,
-    WebApi,
+    ClientError, ClientRequest, ContractError, ContractRequest, ContractResponse, ErrorKind,
+    HostResponse, NodeQuery, QueryResponse, RequestError, WebApi,
 };
 use freenet_stdlib::prelude::*;
 use tokio_tungstenite::connect_async;
@@ -61,17 +61,138 @@ async fn drain_stray_responses(client: &mut WebApi) {
     }
 }
 
-/// Issue a single PUT and wait for the matching response. Returns latency.
+/// What an incoming message means for the request currently outstanding.
+enum Reaction<T> {
+    /// The response this request was waiting for.
+    Done(T),
+    /// Not this request's: log the reason and keep waiting.
+    Ignore(String),
+    /// This request's, and it ends it.
+    Fatal(anyhow::Error),
+}
+
+/// Which contract an error is about, when the API says.
+///
+/// `None` means the error names no contract, so it cannot be attributed to any
+/// one request and the caller has to treat it as its own (see the `Err` arms of
+/// [`classify_put`] / [`classify_get`]).
+fn error_contract_id(err: &ClientError) -> Option<ContractInstanceId> {
+    match err.kind() {
+        ErrorKind::RequestError(RequestError::ContractError(contract_err)) => {
+            Some(match contract_err {
+                ContractError::Get { key, .. }
+                | ContractError::Put { key, .. }
+                | ContractError::Update { key, .. }
+                | ContractError::Subscribe { key, .. } => *key.id(),
+                ContractError::ContractStackOverflow { key }
+                | ContractError::MissingRelated { key }
+                | ContractError::MissingContract { key } => *key,
+                _ => return None,
+            })
+        }
+        ErrorKind::IncorrectState(key) => Some(*key.id()),
+        _ => None,
+    }
+}
+
+/// Decide what an incoming message means for the PUT of `expected_key`.
+fn classify_put(
+    expected_key: &ContractKey,
+    label: &str,
+    incoming: Result<HostResponse, ClientError>,
+) -> Reaction<()> {
+    match incoming {
+        Ok(HostResponse::ContractResponse(ContractResponse::PutResponse { key })) => {
+            if key != *expected_key {
+                // Late reply to an earlier PUT that already timed out.
+                // Failing this one on it would cascade bogus failures
+                // through every remaining PUT.
+                Reaction::Ignore(format!(
+                    "PUT {label}: response for different key {key}, ignoring"
+                ))
+            } else {
+                Reaction::Done(())
+            }
+        }
+        Ok(other) => Reaction::Ignore(format!(
+            "PUT {label}: skipping unexpected response: {other:?}"
+        )),
+        Err(e) => match error_contract_id(&e) {
+            Some(other) if other != *expected_key.id() => Reaction::Ignore(format!(
+                "PUT {label}: error for different key {other}, ignoring: {e}"
+            )),
+            _ => Reaction::Fatal(anyhow!("PUT {label}: websocket error: {e}")),
+        },
+    }
+}
+
+/// Decide what an incoming message means for the GET of `id`.
+///
+/// Errors are filtered by contract key exactly as successful responses are: a
+/// server-side error for a *previous* op that already hit its own client-side
+/// deadline arrives during the *next* op's wait window, and attributing it to
+/// that op stamps the wrong contract's key into the reported error text.
+fn classify_get(
+    id: ContractInstanceId,
+    label: &str,
+    incoming: Result<HostResponse, ClientError>,
+) -> Reaction<(ContractContainer, WrappedState)> {
+    match incoming {
+        Ok(HostResponse::ContractResponse(ContractResponse::GetResponse {
+            key,
+            contract,
+            state,
+        })) => {
+            if *key.id() != id {
+                return Reaction::Ignore(format!(
+                    "GET {label}: response for different key {key}, ignoring"
+                ));
+            }
+            match contract {
+                Some(contract) => Reaction::Done((contract, state)),
+                None => Reaction::Fatal(anyhow!("GET {label} ({id}) returned no contract")),
+            }
+        }
+        Ok(other) => Reaction::Ignore(format!(
+            "GET {label}: skipping unexpected response: {other:?}"
+        )),
+        Err(e) => match error_contract_id(&e) {
+            Some(other) if other != id => Reaction::Ignore(format!(
+                "GET {label}: error for different key {other}, ignoring: {e}"
+            )),
+            _ => Reaction::Fatal(anyhow!("GET {label} ({id}): websocket error: {e}")),
+        },
+    }
+}
+
+/// Issue a single PUT and wait for the matching response.
+///
+/// Returns the outcome together with how long the operation actually took.
+/// The duration is measured on **both** arms: a failure's latency has to be a
+/// measurement, not the configured timeout echoed back (see the doc on
+/// [`get`]).
 pub async fn put(
     client: &mut WebApi,
     contract: ContractContainer,
     state: WrappedState,
     label: &str,
     timeout: Duration,
-) -> Result<Duration> {
-    let expected_key = contract.key();
+) -> (Result<()>, Duration) {
     drain_stray_responses(client).await;
     let started = Instant::now();
+    let outcome = put_inner(client, contract, state, label, timeout, started).await;
+    (outcome, started.elapsed())
+}
+
+async fn put_inner(
+    client: &mut WebApi,
+    contract: ContractContainer,
+    state: WrappedState,
+    label: &str,
+    timeout: Duration,
+    started: Instant,
+) -> Result<()> {
+    let expected_key = contract.key();
     client
         .send(ClientRequest::ContractOp(ContractRequest::Put {
             contract,
@@ -88,33 +209,42 @@ pub async fn put(
             .checked_duration_since(Instant::now())
             .ok_or_else(|| anyhow!("PUT {label} timed out after {timeout:?}"))?;
         match tokio::time::timeout(remaining, client.recv()).await {
-            Ok(Ok(HostResponse::ContractResponse(ContractResponse::PutResponse { key }))) => {
-                if key != expected_key {
-                    // Late reply to an earlier PUT that already timed out.
-                    // Failing this one on it would cascade bogus failures
-                    // through every remaining PUT.
-                    eprintln!("PUT {label}: response for different key {key}, ignoring");
-                    continue;
-                }
-                return Ok(started.elapsed());
-            }
-            Ok(Ok(other)) => eprintln!("PUT {label}: skipping unexpected response: {other:?}"),
-            Ok(Err(e)) => bail!("PUT {label}: websocket error: {e}"),
+            Ok(incoming) => match classify_put(&expected_key, label, incoming) {
+                Reaction::Done(()) => return Ok(()),
+                Reaction::Ignore(why) => eprintln!("{why}"),
+                Reaction::Fatal(e) => return Err(e),
+            },
             Err(_) => bail!("PUT {label} timed out after {timeout:?}"),
         }
     }
 }
 
 /// Issue a single GET and wait for the matching response within one overall
-/// deadline. Responses for other keys are skipped.
+/// deadline. Responses and errors for other keys are skipped.
+///
+/// Returns the outcome together with how long the operation actually took.
+/// The duration is measured on **both** arms: reporting the configured timeout
+/// for every failure makes a fast terminal failure indistinguishable from the
+/// client giving up, which is the distinction the latency field exists to draw.
 pub async fn get(
     client: &mut WebApi,
     id: ContractInstanceId,
     label: &str,
     timeout: Duration,
-) -> Result<(ContractContainer, WrappedState, Duration)> {
+) -> (Result<(ContractContainer, WrappedState)>, Duration) {
     drain_stray_responses(client).await;
     let started = Instant::now();
+    let outcome = get_inner(client, id, label, timeout, started).await;
+    (outcome, started.elapsed())
+}
+
+async fn get_inner(
+    client: &mut WebApi,
+    id: ContractInstanceId,
+    label: &str,
+    timeout: Duration,
+    started: Instant,
+) -> Result<(ContractContainer, WrappedState)> {
     client
         .send(ClientRequest::ContractOp(ContractRequest::Get {
             key: id,
@@ -130,21 +260,11 @@ pub async fn get(
             .checked_duration_since(Instant::now())
             .ok_or_else(|| anyhow!("GET {label} ({id}) timed out after {timeout:?}"))?;
         match tokio::time::timeout(remaining, client.recv()).await {
-            Ok(Ok(HostResponse::ContractResponse(ContractResponse::GetResponse {
-                key,
-                contract,
-                state,
-            }))) => {
-                if *key.id() != id {
-                    eprintln!("GET {label}: response for different key {key}, ignoring");
-                    continue;
-                }
-                let contract =
-                    contract.ok_or_else(|| anyhow!("GET {label} ({id}) returned no contract"))?;
-                return Ok((contract, state, started.elapsed()));
-            }
-            Ok(Ok(other)) => eprintln!("GET {label}: skipping unexpected response: {other:?}"),
-            Ok(Err(e)) => bail!("GET {label} ({id}): websocket error: {e}"),
+            Ok(incoming) => match classify_get(id, label, incoming) {
+                Reaction::Done(found) => return Ok(found),
+                Reaction::Ignore(why) => eprintln!("{why}"),
+                Reaction::Fatal(e) => return Err(e),
+            },
             Err(_) => bail!("GET {label} ({id}) timed out after {timeout:?}"),
         }
     }
@@ -181,5 +301,178 @@ pub async fn wait_for_ring_join(client: &mut WebApi, timeout: Duration) -> Resul
             "ephemeral node did not join the ring within {timeout:?}"
         );
         tokio::time::sleep(jittered(Duration::from_secs(2))).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::Ipv4Addr;
+    use std::sync::Arc;
+
+    use freenet_stdlib::prelude::bincode;
+    use futures::{SinkExt, StreamExt};
+    use tokio::net::TcpListener;
+    use tokio_tungstenite::tungstenite::Message;
+
+    use super::*;
+
+    /// A message as it appears on the wire between node and client.
+    type HostResult = Result<HostResponse, ClientError>;
+
+    fn id_of(byte: u8) -> ContractInstanceId {
+        ContractInstanceId::new([byte; 32])
+    }
+
+    /// The error shape the live network actually produced in the runs that
+    /// motivated the key filter: a terminal GET failure that names its
+    /// contract.
+    fn get_error_for(id: ContractInstanceId) -> ClientError {
+        ErrorKind::RequestError(RequestError::ContractError(ContractError::Get {
+            key: ContractKey::from_id_and_code(id, CodeHash::new([0; 32])),
+            cause: "stream assembly: no fragments received within inactivity timeout".into(),
+        }))
+        .into()
+    }
+
+    /// A contract a fake node can hand back, plus its state.
+    fn test_contract() -> (ContractContainer, WrappedState) {
+        let code = ContractCode::from(vec![1u8, 2, 3, 4]);
+        let contract = ContractContainer::Wasm(ContractWasmAPIVersion::V1(WrappedContract::new(
+            Arc::new(code),
+            Parameters::from(vec![]),
+        )));
+        (contract, WrappedState::new(vec![7u8; 32]))
+    }
+
+    /// Accept one websocket connection, wait for the client's request, then
+    /// send `responses` in order. Stays open afterwards so the client sees the
+    /// responses rather than a connection close.
+    async fn fake_node(listener: TcpListener, responses: Vec<HostResult>) {
+        let (stream, _) = listener.accept().await.expect("accept");
+        let mut ws = tokio_tungstenite::accept_async(stream)
+            .await
+            .expect("ws handshake");
+        ws.next().await.expect("client request").expect("ws frame");
+        for response in responses {
+            let bytes = bincode::serialize(&response).expect("serialize response");
+            ws.send(Message::Binary(bytes.into())).await.expect("send");
+        }
+        // Hold the socket open; the test finishes long before this elapses.
+        tokio::time::sleep(Duration::from_secs(60)).await;
+    }
+
+    async fn start_fake_node(responses: Vec<HostResult>) -> WebApi {
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0u16))
+            .await
+            .expect("bind");
+        let port = listener.local_addr().expect("local addr").port();
+        tokio::spawn(fake_node(listener, responses));
+        connect(
+            &format!("ws://{}:{port}", Ipv4Addr::LOCALHOST),
+            TEST_TIMEOUT,
+        )
+        .await
+        .expect("connect to fake node")
+    }
+
+    const TEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+    // ---- defect 3: errors must be key-filtered like successes ----
+
+    #[test]
+    fn an_error_naming_another_contract_is_ignored_not_attributed() {
+        let waiting_on = id_of(1);
+        let stale = id_of(2);
+        match classify_get(waiting_on, "7d run/small-2", Err(get_error_for(stale))) {
+            Reaction::Ignore(why) => assert!(
+                why.contains(&stale.to_string()),
+                "the log line should name the contract the error was really about, got: {why}"
+            ),
+            Reaction::Fatal(e) => panic!(
+                "a late error for {stale} was attributed to the op waiting on {waiting_on}: {e:#}"
+            ),
+            Reaction::Done(_) => panic!("an error cannot complete a GET"),
+        }
+    }
+
+    #[test]
+    fn an_error_naming_the_waiting_contract_still_fails_it() {
+        let waiting_on = id_of(1);
+        match classify_get(waiting_on, "0h small-0", Err(get_error_for(waiting_on))) {
+            Reaction::Fatal(e) => assert!(
+                format!("{e:#}").contains("stream assembly"),
+                "the real cause must survive into the report, got: {e:#}"
+            ),
+            _ => panic!("an error for this op's own contract must fail it"),
+        }
+    }
+
+    #[test]
+    fn an_error_naming_no_contract_still_fails_the_waiting_op() {
+        // Unattributable errors (a dropped channel, a disconnect) keep the old
+        // conservative behaviour: they belong to whoever is waiting. Silently
+        // ignoring them would hang the op until its deadline.
+        match classify_get(id_of(1), "0h small-0", Err(ErrorKind::Disconnect.into())) {
+            Reaction::Fatal(_) => {}
+            _ => panic!("an error with no contract key must still fail the waiting op"),
+        }
+    }
+
+    #[test]
+    fn put_errors_are_key_filtered_the_same_way() {
+        let mine = ContractKey::from_id_and_code(id_of(1), CodeHash::new([0; 32]));
+        match classify_put(&mine, "small-0", Err(get_error_for(id_of(2)))) {
+            Reaction::Ignore(_) => {}
+            _ => panic!("a late error for another contract must not fail this PUT"),
+        }
+        match classify_put(&mine, "small-0", Err(get_error_for(id_of(1)))) {
+            Reaction::Fatal(_) => {}
+            _ => panic!("an error for this PUT's own contract must fail it"),
+        }
+    }
+
+    #[tokio::test]
+    async fn a_late_error_during_a_get_does_not_fail_that_get() {
+        // The race from the nightly logs: a previous op's server-side error
+        // lands inside the *next* op's wait window, ahead of that op's own
+        // response.
+        let (contract, state) = test_contract();
+        let key = contract.key();
+        let mut client = start_fake_node(vec![
+            Err(get_error_for(id_of(9))),
+            Ok(HostResponse::ContractResponse(
+                ContractResponse::GetResponse {
+                    key,
+                    contract: Some(contract.clone()),
+                    state: state.clone(),
+                },
+            )),
+        ])
+        .await;
+
+        let (outcome, _elapsed) = get(&mut client, *key.id(), "0h small-0", TEST_TIMEOUT).await;
+        let (got_contract, got_state) =
+            outcome.expect("the stale error must not fail this GET, whose response did arrive");
+        assert_eq!(got_contract, contract);
+        assert_eq!(got_state, state);
+    }
+
+    // ---- defect 2: a failure's latency is measured, not the timeout ----
+
+    #[tokio::test]
+    async fn a_fast_failure_reports_the_time_it_took_not_the_op_timeout() {
+        // A terminal error from the node, well inside the 120s deadline the
+        // nightly run configures.
+        let op_timeout = Duration::from_secs(120);
+        let id = id_of(1);
+        let mut client = start_fake_node(vec![Err(get_error_for(id))]).await;
+
+        let (outcome, elapsed) = get(&mut client, id, "7d run/small-2", op_timeout).await;
+        assert!(outcome.is_err(), "the node returned a terminal error");
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "a failure that resolved immediately reported {elapsed:?}; the whole point is that \
+             this is a measurement and not the {op_timeout:?} deadline"
+        );
     }
 }

--- a/crates/netcheck/src/client.rs
+++ b/crates/netcheck/src/client.rs
@@ -829,7 +829,7 @@ mod tests {
                 );
             }
             other => panic!(
-                "a NotFound naming this contract is a terminal answer and must fail the GET                  fast, not be ignored into a synthetic timeout: {}",
+                "a NotFound naming this contract is a terminal answer and must fail the GET fast, not be ignored into a synthetic timeout: {}",
                 reaction_name(&other)
             ),
         }

--- a/crates/netcheck/src/client.rs
+++ b/crates/netcheck/src/client.rs
@@ -67,32 +67,114 @@ enum Reaction<T> {
     Done(T),
     /// Not this request's: log the reason and keep waiting.
     Ignore(String),
+    /// An error belonging to a *different* contract: log it, keep waiting, and
+    /// count it. Separate from [`Reaction::Ignore`] so the report can carry how
+    /// often the key filter fired, which is what makes the filter's own
+    /// behaviour auditable from the artifact rather than only from stderr.
+    IgnoredError(String),
     /// This request's, and it ends it.
     Fatal(anyhow::Error),
 }
 
-/// Which contract an error is about, when the API says.
+/// Base58 length bounds for a 32-byte contract id: 32 zero bytes encode to 32
+/// `1`s, and the largest 32-byte value needs `ceil(256 / log2(58))` = 44
+/// characters. A token outside this range cannot be one.
+const CONTRACT_ID_B58_LEN: std::ops::RangeInclusive<usize> = 32..=44;
+
+/// A character of the bitcoin base58 alphabet, which is what
+/// [`ContractInstanceId`] encodes to.
+fn is_base58(c: char) -> bool {
+    c.is_ascii_alphanumeric() && !matches!(c, '0' | 'O' | 'I' | 'l')
+}
+
+/// Contract ids named in free text.
 ///
-/// `None` means the error names no contract, so it cannot be attributed to any
-/// one request and the caller has to treat it as its own (see the `Err` arms of
-/// [`classify_put`] / [`classify_get`]).
-fn error_contract_id(err: &ClientError) -> Option<ContractInstanceId> {
+/// Terminal network failures reach a client as [`ErrorKind::OperationError`],
+/// which has **no key field**: the id is written into the human-readable
+/// `cause` by the node (`synthesized_get_error_cause` in freenet-core). Reading
+/// it back out of the prose is the only way the key filter reaches the failures
+/// netcheck actually receives.
+///
+/// Parsing prose is only acceptable if it cannot yield a *wrong* id, because a
+/// wrong id that is not ours makes the filter discard a real failure. Two
+/// bounds rule that out:
+///
+/// * the token must round-trip — decode then re-encode must reproduce it
+///   exactly. `from_base58` zero-pads short input, so without this any
+///   base58-spelled English word (`after`, `for`, `retries`) would decode to a
+///   well-formed id that is definitely not ours;
+/// * a token shorter or longer than a 32-byte id is rejected before decoding.
+///
+/// Whatever fails these is simply not found, which leaves the error
+/// unattributed and therefore fatal for the waiting op. That is the
+/// conservative direction: see [`error_about_another_contract`].
+fn contract_ids_in_text(text: &str) -> Vec<ContractInstanceId> {
+    text.split(|c: char| !is_base58(c))
+        .filter(|token| CONTRACT_ID_B58_LEN.contains(&token.len()))
+        .filter_map(|token| {
+            let id = ContractInstanceId::from_base58(token).ok()?;
+            (id.encode() == token).then_some(id)
+        })
+        .collect()
+}
+
+/// Every contract an error definitively names as its own subject.
+///
+/// Empty means the error names no contract that can be trusted to be its
+/// subject, so it cannot be attributed to any one request.
+fn error_contract_ids(err: &ClientError) -> Vec<ContractInstanceId> {
     match err.kind() {
-        ErrorKind::RequestError(RequestError::ContractError(contract_err)) => {
-            Some(match contract_err {
-                ContractError::Get { key, .. }
-                | ContractError::Put { key, .. }
-                | ContractError::Update { key, .. }
-                | ContractError::Subscribe { key, .. } => *key.id(),
-                ContractError::ContractStackOverflow { key }
-                | ContractError::MissingRelated { key }
-                | ContractError::MissingContract { key } => *key,
-                _ => return None,
-            })
-        }
-        ErrorKind::IncorrectState(key) => Some(*key.id()),
-        _ => None,
+        ErrorKind::RequestError(RequestError::ContractError(contract_err)) => match contract_err {
+            ContractError::Get { key, .. }
+            | ContractError::Put { key, .. }
+            | ContractError::Update { key, .. }
+            | ContractError::Subscribe { key, .. } => vec![*key.id()],
+            ContractError::MissingContract { key } => vec![*key],
+            // These name the RELATED contract — the dependency the failing
+            // operation could not resolve — not the operation's own. Treating
+            // that key as the error's subject would ignore a real failure of
+            // whatever contract we are actually waiting on.
+            ContractError::MissingRelated { .. } | ContractError::ContractStackOverflow { .. } => {
+                Vec::new()
+            }
+            // `ContractError` is `#[non_exhaustive]`. A future variant that
+            // carries a key lands here and stays unattributed, i.e. fatal for
+            // the waiting op: the safe direction, but it does mean a new
+            // key-carrying variant needs an arm above to be filtered on.
+            _ => Vec::new(),
+        },
+        ErrorKind::IncorrectState(key) => vec![*key.id()],
+        // The shape terminal network failures actually arrive in: no key
+        // field, the id written into the prose. See `contract_ids_in_text`.
+        ErrorKind::OperationError { cause } => contract_ids_in_text(cause.as_ref()),
+        // `ErrorKind` is `#[non_exhaustive]` too, and the same reasoning
+        // applies: unrecognised means unattributed means fatal.
+        _ => Vec::new(),
     }
+}
+
+/// Whether `err` definitively belongs to some contract other than `id`.
+///
+/// `Some(named)` — it names contracts and none of them is `id`, so it is a late
+/// reply to an operation that already gave up; `named` is what to log.
+///
+/// `None` — it names `id`, names `id` among others, or names nothing
+/// recognisable. All three stay fatal for the waiting op. Ignoring an error
+/// nobody can attribute would hang that op to its deadline and then report the
+/// deadline instead of the real cause, which is worse than blaming the wrong op
+/// loudly.
+fn error_about_another_contract(err: &ClientError, id: &ContractInstanceId) -> Option<String> {
+    let named = error_contract_ids(err);
+    if named.is_empty() || named.contains(id) {
+        return None;
+    }
+    Some(
+        named
+            .iter()
+            .map(|id| id.to_string())
+            .collect::<Vec<_>>()
+            .join(", "),
+    )
 }
 
 /// Decide what an incoming message means for the PUT of `expected_key`.
@@ -117,11 +199,11 @@ fn classify_put(
         Ok(other) => Reaction::Ignore(format!(
             "PUT {label}: skipping unexpected response: {other:?}"
         )),
-        Err(e) => match error_contract_id(&e) {
-            Some(other) if other != *expected_key.id() => Reaction::Ignore(format!(
+        Err(e) => match error_about_another_contract(&e, expected_key.id()) {
+            Some(other) => Reaction::IgnoredError(format!(
                 "PUT {label}: error for different key {other}, ignoring: {e}"
             )),
-            _ => Reaction::Fatal(anyhow!("PUT {label}: websocket error: {e}")),
+            None => Reaction::Fatal(anyhow!("PUT {label}: websocket error: {e}")),
         },
     }
 }
@@ -156,32 +238,73 @@ fn classify_get(
         Ok(other) => Reaction::Ignore(format!(
             "GET {label}: skipping unexpected response: {other:?}"
         )),
-        Err(e) => match error_contract_id(&e) {
-            Some(other) if other != id => Reaction::Ignore(format!(
+        Err(e) => match error_about_another_contract(&e, &id) {
+            Some(other) => Reaction::IgnoredError(format!(
                 "GET {label}: error for different key {other}, ignoring: {e}"
             )),
-            _ => Reaction::Fatal(anyhow!("GET {label} ({id}): websocket error: {e}")),
+            None => Reaction::Fatal(anyhow!("GET {label} ({id}): websocket error: {e}")),
         },
     }
 }
 
-/// Issue a single PUT and wait for the matching response.
+/// One completed operation: what it produced, and what was observed while it
+/// ran.
 ///
-/// Returns the outcome together with how long the operation actually took.
-/// The duration is measured on **both** arms: a failure's latency has to be a
-/// measurement, not the configured timeout echoed back (see the doc on
-/// [`get`]).
+/// The measurements travel with the outcome rather than being reconstructed by
+/// the caller, because both of them are things only this module sees: the
+/// caller knows the configured timeout, not the elapsed time, and knows nothing
+/// at all about errors that arrived for other contracts.
+pub struct Attempt<T> {
+    pub outcome: Result<T>,
+    /// How long the operation actually took, measured on **both** arms. A
+    /// failure's latency has to be a measurement, not the configured timeout
+    /// echoed back (see the doc on [`get`]).
+    pub latency: Duration,
+    /// Incoming errors this operation attributed to another contract and
+    /// skipped. Zero is the ordinary case; a non-zero count is how a run
+    /// records that the key filter fired.
+    pub errors_ignored: usize,
+}
+
+impl<T> Attempt<T> {
+    /// Check a successful outcome, keeping the measurements. Used for the
+    /// GET verification step, which can turn a delivered response into a
+    /// failure without changing how long it took to arrive.
+    pub fn and_then<U>(self, check: impl FnOnce(T) -> Result<U>) -> Attempt<U> {
+        Attempt {
+            outcome: self.outcome.and_then(check),
+            latency: self.latency,
+            errors_ignored: self.errors_ignored,
+        }
+    }
+}
+
+/// Issue a single PUT and wait for the matching response.
 pub async fn put(
     client: &mut WebApi,
     contract: ContractContainer,
     state: WrappedState,
     label: &str,
     timeout: Duration,
-) -> (Result<()>, Duration) {
+) -> Attempt<()> {
     drain_stray_responses(client).await;
     let started = Instant::now();
-    let outcome = put_inner(client, contract, state, label, timeout, started).await;
-    (outcome, started.elapsed())
+    let mut errors_ignored = 0;
+    let outcome = put_inner(
+        client,
+        contract,
+        state,
+        label,
+        timeout,
+        started,
+        &mut errors_ignored,
+    )
+    .await;
+    Attempt {
+        outcome,
+        latency: started.elapsed(),
+        errors_ignored,
+    }
 }
 
 async fn put_inner(
@@ -191,6 +314,7 @@ async fn put_inner(
     label: &str,
     timeout: Duration,
     started: Instant,
+    errors_ignored: &mut usize,
 ) -> Result<()> {
     let expected_key = contract.key();
     client
@@ -212,6 +336,10 @@ async fn put_inner(
             Ok(incoming) => match classify_put(&expected_key, label, incoming) {
                 Reaction::Done(()) => return Ok(()),
                 Reaction::Ignore(why) => eprintln!("{why}"),
+                Reaction::IgnoredError(why) => {
+                    *errors_ignored += 1;
+                    eprintln!("{why}");
+                }
                 Reaction::Fatal(e) => return Err(e),
             },
             Err(_) => bail!("PUT {label} timed out after {timeout:?}"),
@@ -222,20 +350,25 @@ async fn put_inner(
 /// Issue a single GET and wait for the matching response within one overall
 /// deadline. Responses and errors for other keys are skipped.
 ///
-/// Returns the outcome together with how long the operation actually took.
-/// The duration is measured on **both** arms: reporting the configured timeout
-/// for every failure makes a fast terminal failure indistinguishable from the
-/// client giving up, which is the distinction the latency field exists to draw.
+/// The reported latency is measured on **both** arms: reporting the configured
+/// timeout for every failure makes a fast terminal failure indistinguishable
+/// from the client giving up, which is the distinction the latency field exists
+/// to draw.
 pub async fn get(
     client: &mut WebApi,
     id: ContractInstanceId,
     label: &str,
     timeout: Duration,
-) -> (Result<(ContractContainer, WrappedState)>, Duration) {
+) -> Attempt<(ContractContainer, WrappedState)> {
     drain_stray_responses(client).await;
     let started = Instant::now();
-    let outcome = get_inner(client, id, label, timeout, started).await;
-    (outcome, started.elapsed())
+    let mut errors_ignored = 0;
+    let outcome = get_inner(client, id, label, timeout, started, &mut errors_ignored).await;
+    Attempt {
+        outcome,
+        latency: started.elapsed(),
+        errors_ignored,
+    }
 }
 
 async fn get_inner(
@@ -244,6 +377,7 @@ async fn get_inner(
     label: &str,
     timeout: Duration,
     started: Instant,
+    errors_ignored: &mut usize,
 ) -> Result<(ContractContainer, WrappedState)> {
     client
         .send(ClientRequest::ContractOp(ContractRequest::Get {
@@ -263,6 +397,10 @@ async fn get_inner(
             Ok(incoming) => match classify_get(id, label, incoming) {
                 Reaction::Done(found) => return Ok(found),
                 Reaction::Ignore(why) => eprintln!("{why}"),
+                Reaction::IgnoredError(why) => {
+                    *errors_ignored += 1;
+                    eprintln!("{why}");
+                }
                 Reaction::Fatal(e) => return Err(e),
             },
             Err(_) => bail!("GET {label} ({id}) timed out after {timeout:?}"),
@@ -323,14 +461,44 @@ mod tests {
         ContractInstanceId::new([byte; 32])
     }
 
-    /// The error shape the live network actually produced in the runs that
-    /// motivated the key filter: a terminal GET failure that names its
-    /// contract.
+    /// A structured terminal GET failure: the API names the contract in a key
+    /// field. Real, but not what a terminal *network* failure looks like — for
+    /// that see [`network_error_for`].
     fn get_error_for(id: ContractInstanceId) -> ClientError {
         ErrorKind::RequestError(RequestError::ContractError(ContractError::Get {
             key: ContractKey::from_id_and_code(id, CodeHash::new([0; 32])),
             cause: "stream assembly: no fragments received within inactivity timeout".into(),
         }))
+        .into()
+    }
+
+    /// The error shape the live network actually produces, and the one every
+    /// failure in the nightly runs that motivated the key filter arrived as:
+    /// `ErrorKind::OperationError`, which has no key field at all. The cause is
+    /// the text `synthesized_get_error_cause` writes in freenet-core, verbatim
+    /// apart from the id, which is substituted so a test can name a specific
+    /// contract.
+    ///
+    /// Rendered whole, this is the failure from run 31148314225:
+    ///
+    /// ```text
+    /// GET .../large-1MB (5fSGSjA8...): websocket error: client error: error while
+    /// executing operation in the network: GET response stream assembly failed for
+    /// 5fSGSjA8... after exhausting retries: stream assembly: no fragments received
+    /// within inactivity timeout
+    /// ```
+    fn network_error_for(id: ContractInstanceId) -> ClientError {
+        network_error_because(format!(
+            "GET response stream assembly failed for {id} after exhausting retries: \
+             stream assembly: no fragments received within inactivity timeout"
+        ))
+    }
+
+    /// A terminal network failure carrying an arbitrary cause.
+    fn network_error_because(cause: impl Into<std::borrow::Cow<'static, str>>) -> ClientError {
+        ErrorKind::OperationError {
+            cause: cause.into(),
+        }
         .into()
     }
 
@@ -384,14 +552,14 @@ mod tests {
         let waiting_on = id_of(1);
         let stale = id_of(2);
         match classify_get(waiting_on, "7d run/small-2", Err(get_error_for(stale))) {
-            Reaction::Ignore(why) => assert!(
+            Reaction::IgnoredError(why) => assert!(
                 why.contains(&stale.to_string()),
                 "the log line should name the contract the error was really about, got: {why}"
             ),
             Reaction::Fatal(e) => panic!(
                 "a late error for {stale} was attributed to the op waiting on {waiting_on}: {e:#}"
             ),
-            Reaction::Done(_) => panic!("an error cannot complete a GET"),
+            _ => panic!("an error cannot complete a GET"),
         }
     }
 
@@ -422,12 +590,157 @@ mod tests {
     fn put_errors_are_key_filtered_the_same_way() {
         let mine = ContractKey::from_id_and_code(id_of(1), CodeHash::new([0; 32]));
         match classify_put(&mine, "small-0", Err(get_error_for(id_of(2)))) {
-            Reaction::Ignore(_) => {}
+            Reaction::IgnoredError(_) => {}
             _ => panic!("a late error for another contract must not fail this PUT"),
         }
         match classify_put(&mine, "small-0", Err(get_error_for(id_of(1)))) {
             Reaction::Fatal(_) => {}
             _ => panic!("an error for this PUT's own contract must fail it"),
+        }
+    }
+
+    // ---- defect 3, continued: the shape the network actually sends ----
+
+    #[test]
+    fn a_terminal_network_error_naming_another_contract_is_ignored() {
+        // The one that matters. Every failure in the nightly runs this filter
+        // was built from arrived as OperationError, whose contract id is prose
+        // rather than a field — so a filter that reads only the structured
+        // variants never fires in production, however green its tests are.
+        let waiting_on = id_of(1);
+        let stale = id_of(2);
+        match classify_get(
+            waiting_on,
+            "7d run/large-1MB",
+            Err(network_error_for(stale)),
+        ) {
+            Reaction::IgnoredError(why) => assert!(
+                why.contains(&stale.to_string()),
+                "the log line should name the contract the error was really about, got: {why}"
+            ),
+            Reaction::Fatal(e) => panic!(
+                "the failure shape the live network actually sends was attributed to the op \
+                 waiting on {waiting_on}, which is the misreport this filter exists to stop: {e:#}"
+            ),
+            _ => panic!("an error cannot complete a GET"),
+        }
+    }
+
+    #[test]
+    fn a_terminal_network_error_naming_the_waiting_contract_still_fails_it() {
+        let waiting_on = id_of(1);
+        match classify_get(
+            waiting_on,
+            "0h large-1MB",
+            Err(network_error_for(waiting_on)),
+        ) {
+            Reaction::Fatal(e) => assert!(
+                format!("{e:#}").contains("no fragments received"),
+                "the real cause must survive into the report, got: {e:#}"
+            ),
+            _ => panic!("an error naming this op's own contract must fail it"),
+        }
+    }
+
+    #[test]
+    fn put_errors_from_the_network_are_key_filtered_the_same_way() {
+        let mine = ContractKey::from_id_and_code(id_of(1), CodeHash::new([0; 32]));
+        match classify_put(&mine, "small-0", Err(network_error_for(id_of(2)))) {
+            Reaction::IgnoredError(_) => {}
+            _ => panic!("a late network error for another contract must not fail this PUT"),
+        }
+        match classify_put(&mine, "small-0", Err(network_error_for(id_of(1)))) {
+            Reaction::Fatal(_) => {}
+            _ => panic!("a network error naming this PUT's own contract must fail it"),
+        }
+    }
+
+    #[test]
+    fn a_network_error_naming_several_contracts_including_ours_is_ours() {
+        // Conservative on ambiguity: if we are named at all, the error is
+        // ours. Ignoring it would hang this op to its deadline and then
+        // report the deadline instead of what actually happened.
+        let mine = id_of(1);
+        let cause = format!(
+            "PUT failed for {} while resolving related contract {mine}",
+            id_of(2)
+        );
+        match classify_get(mine, "0h small-0", Err(network_error_because(cause))) {
+            Reaction::Fatal(_) => {}
+            _ => panic!("an error that names us among others must still fail us"),
+        }
+    }
+
+    #[test]
+    fn a_network_error_naming_nothing_parseable_stays_fatal() {
+        // Fail safe. An error nobody can attribute belongs to whoever is
+        // waiting; discarding it would trade a wrong attribution for a
+        // silently hung op, which is worse.
+        for cause in [
+            "operation timed out before any peer answered",
+            // Base58-spelled words. `from_base58` zero-pads short input, so a
+            // parser without the round-trip check would decode these into
+            // well-formed ids that are definitely not ours, and quietly
+            // discard a real failure.
+            "GET failed for after exhausting retries",
+            // A truncated id: right alphabet, wrong length.
+            "GET response stream assembly failed for 5fSGSjA8 after exhausting retries",
+        ] {
+            match classify_get(id_of(1), "0h small-0", Err(network_error_because(cause))) {
+                Reaction::Fatal(_) => {}
+                _ => panic!(
+                    "an error naming no usable contract id must fail the waiting op: {cause}"
+                ),
+            }
+        }
+    }
+
+    #[test]
+    fn only_a_token_that_round_trips_is_read_as_a_contract_id() {
+        let id = id_of(7);
+        let encoded = id.to_string();
+        assert_eq!(
+            contract_ids_in_text(&format!("assembly failed for {encoded} after retries")),
+            vec![id],
+            "an id sitting in prose must be found without relying on its position"
+        );
+        assert_eq!(
+            contract_ids_in_text(&format!("failed for {encoded}x after retries")),
+            Vec::new(),
+            "a token that is one character longer than the id is not the id"
+        );
+        assert_eq!(
+            contract_ids_in_text("failed for 11111111111111111111111111111112 after"),
+            vec![ContractInstanceId::new({
+                let mut bytes = [0u8; 32];
+                bytes[31] = 1;
+                bytes
+            })],
+            "a canonical encoding with leading '1's is still a canonical encoding"
+        );
+        assert_eq!(
+            contract_ids_in_text("1111111111111111111111111111111"),
+            Vec::new(),
+            "31 characters cannot encode a 32-byte id"
+        );
+    }
+
+    #[test]
+    fn an_error_about_a_related_contract_is_not_about_that_contract() {
+        // `MissingRelated` names the DEPENDENCY the operation could not
+        // resolve, not the operation's own contract. Reading it as the
+        // subject would ignore a real failure of whatever we are waiting on.
+        let waiting_on = id_of(1);
+        let dependency = id_of(2);
+        for err in [
+            ContractError::MissingRelated { key: dependency },
+            ContractError::ContractStackOverflow { key: dependency },
+        ] {
+            let err: ClientError = ErrorKind::RequestError(RequestError::ContractError(err)).into();
+            match classify_get(waiting_on, "0h small-0", Err(err)) {
+                Reaction::Fatal(_) => {}
+                _ => panic!("a related-contract key must not be read as the error's subject"),
+            }
         }
     }
 
@@ -450,11 +763,16 @@ mod tests {
         ])
         .await;
 
-        let (outcome, _elapsed) = get(&mut client, *key.id(), "0h small-0", TEST_TIMEOUT).await;
-        let (got_contract, got_state) =
-            outcome.expect("the stale error must not fail this GET, whose response did arrive");
+        let attempt = get(&mut client, *key.id(), "0h small-0", TEST_TIMEOUT).await;
+        let (got_contract, got_state) = attempt
+            .outcome
+            .expect("the stale error must not fail this GET, whose response did arrive");
         assert_eq!(got_contract, contract);
         assert_eq!(got_state, state);
+        assert_eq!(
+            attempt.errors_ignored, 1,
+            "the run must be able to see from the report that the filter fired"
+        );
     }
 
     // ---- defect 2: a failure's latency is measured, not the timeout ----
@@ -467,12 +785,39 @@ mod tests {
         let id = id_of(1);
         let mut client = start_fake_node(vec![Err(get_error_for(id))]).await;
 
-        let (outcome, elapsed) = get(&mut client, id, "7d run/small-2", op_timeout).await;
-        assert!(outcome.is_err(), "the node returned a terminal error");
+        let attempt = get(&mut client, id, "7d run/small-2", op_timeout).await;
         assert!(
-            elapsed < Duration::from_secs(5),
-            "a failure that resolved immediately reported {elapsed:?}; the whole point is that \
-             this is a measurement and not the {op_timeout:?} deadline"
+            attempt.outcome.is_err(),
+            "the node returned a terminal error"
+        );
+        assert!(
+            attempt.latency < Duration::from_secs(5),
+            "a failure that resolved immediately reported {:?}; the whole point is that this is a \
+             measurement and not the {op_timeout:?} deadline",
+            attempt.latency
+        );
+    }
+
+    #[tokio::test]
+    async fn a_fast_put_failure_also_reports_the_time_it_took() {
+        // The PUT path had the identical defect and is fixed the same way, but
+        // nothing pinned it: PUT failures land in the same report under the
+        // same field, so an unmeasured one is just as misleading.
+        let op_timeout = Duration::from_secs(120);
+        let (contract, state) = test_contract();
+        let key = contract.key();
+        let mut client = start_fake_node(vec![Err(get_error_for(*key.id()))]).await;
+
+        let attempt = put(&mut client, contract, state, "small-0", op_timeout).await;
+        assert!(
+            attempt.outcome.is_err(),
+            "the node returned a terminal error"
+        );
+        assert!(
+            attempt.latency < Duration::from_secs(5),
+            "a PUT failure that resolved immediately reported {:?}; that is the configured \
+             {op_timeout:?} deadline, not a measurement",
+            attempt.latency
         );
     }
 }

--- a/crates/netcheck/src/client.rs
+++ b/crates/netcheck/src/client.rs
@@ -707,7 +707,8 @@ mod tests {
         assert_eq!(
             contract_ids_in_text(&format!("failed for {encoded}x after retries")),
             Vec::new(),
-            "a token that is one character longer than the id is not the id"
+            "a 44-character token that does not round-trip is not an id (this case is caught \
+             by the round-trip check, NOT by the length bound: it is inside 32..=44)"
         );
         assert_eq!(
             contract_ids_in_text("failed for 11111111111111111111111111111112 after"),
@@ -722,6 +723,26 @@ mod tests {
             contract_ids_in_text("1111111111111111111111111111111"),
             Vec::new(),
             "31 characters cannot encode a 32-byte id"
+        );
+
+        // The upper end of CONTRACT_ID_B58_LEN, which nothing else reaches:
+        // every other id in this module is [n; 32] for a small n and encodes
+        // to 43 characters, so narrowing the range to `32..=43` would leave
+        // the whole suite green while silently dropping every id at or above
+        // 58^43 (~6% of the id space) out of attribution. Those errors would
+        // then be charged to whichever op happened to be waiting, which is
+        // precisely the defect this filter exists to fix.
+        let widest = id_of(255);
+        let encoded = widest.to_string();
+        assert_eq!(
+            encoded.len(),
+            44,
+            "the all-ones id must exercise the upper bound"
+        );
+        assert_eq!(
+            contract_ids_in_text(&format!("assembly failed for {encoded} after retries")),
+            vec![widest],
+            "the longest id a contract key can have must still be found"
         );
     }
 

--- a/crates/netcheck/src/emit.rs
+++ b/crates/netcheck/src/emit.rs
@@ -73,12 +73,18 @@ struct CheckOp<'a> {
     run_id: &'a str,
     vantage: &'a str,
     op: &'a str,
+    /// Position of this operation in the order the run executed. Every record
+    /// of a run is published with the same timestamp, so this is the only thing
+    /// that says which came first.
+    seq: usize,
     dimension: &'a str,
     dimension_secs: Option<i64>,
     contract_key: &'a str,
     ok: bool,
     latency_ms: u128,
     bytes: usize,
+    /// Errors this operation attributed to another contract and skipped.
+    errors_ignored: usize,
     error: Option<&'a str>,
     extra: serde_json::Value,
 }
@@ -217,12 +223,14 @@ pub async fn run(args: EmitArgs) -> Result<bool> {
                 run_id: &run_id,
                 vantage: &args.vantage,
                 op: &op.op,
+                seq: op.seq,
                 dimension: &op.age,
                 dimension_secs: dimension_secs(&op.age),
                 contract_key: &op.key,
                 ok: op.ok,
                 latency_ms: op.latency_ms,
                 bytes: op.size,
+                errors_ignored: op.errors_ignored,
                 error: op.error.as_deref(),
                 extra: serde_json::json!({ "label": op.label }),
             },
@@ -285,6 +293,7 @@ mod tests {
 
     fn op(op: &str, age: &str, ok: bool) -> OpReport {
         OpReport {
+            seq: 3,
             op: op.to_string(),
             age: age.to_string(),
             label: "small-0".to_string(),
@@ -292,6 +301,7 @@ mod tests {
             ok,
             latency_ms: 42,
             size: 123,
+            errors_ignored: 2,
             error: (!ok).then(|| "boom".to_string()),
         }
     }
@@ -312,6 +322,8 @@ mod tests {
         assert_eq!(read.ok, written.ok);
         assert_eq!(read.size, written.size);
         assert_eq!(read.error, written.error);
+        assert_eq!(read.seq, written.seq);
+        assert_eq!(read.errors_ignored, written.errors_ignored);
     }
 
     #[test]

--- a/crates/netcheck/src/emit.rs
+++ b/crates/netcheck/src/emit.rs
@@ -255,6 +255,12 @@ pub async fn run(args: EmitArgs) -> Result<bool> {
                 "pinned_gateways": run_meta.pinned_gateways,
                 "ephemeral_peers": run_meta.ephemeral_peers,
                 "exit_code": args.exit_code,
+                // The marker for the ordering-methodology change. Unlike
+                // `seq`/`errors_ignored`, this one is NOT blocked on a fixed
+                // column list -- `conditions` is free-form JSON -- so there is
+                // no reason for the dashboard's verdict series to carry no
+                // record of the change. Null on runs from before the shuffle.
+                "order_seed": run_meta.order_seed,
             }),
         },
     )?);
@@ -404,14 +410,22 @@ mod tests {
             .find("\n#[cfg(test)]\nmod ")
             .map(|i| i + 1)
             .expect("test module not located — this guard cannot verify anything");
-        let at = src
-            .find("pub async fn run(args: EmitArgs) -> Result<bool> {")
-            .expect("emit::run not found");
+        let sig = "pub async fn run(args: EmitArgs) -> Result<bool> {";
+        let at = src.find(sig).expect("emit::run not found");
         assert!(
             at < tests_at,
             "anchor matched inside the test module — this pin would scrape its own source"
         );
-        let body = &src[at..tests_at];
+        // Bound to `run`'s own body. Slicing to the test module instead would
+        // be tight only for as long as `run` is the last item in the file: add
+        // a function after it and the window silently widens, at which point
+        // this pin passes with the mirrors living in that new function while
+        // `CheckOp` is zeroed.
+        let after_sig = &src[at + sig.len()..];
+        let end = after_sig
+            .find("\n}\n")
+            .expect("could not locate the end of emit::run");
+        let body = &after_sig[..end];
         for mirror in ["seq: op.seq,", "errors_ignored: op.errors_ignored,"] {
             assert!(
                 body.contains(mirror),

--- a/crates/netcheck/src/emit.rs
+++ b/crates/netcheck/src/emit.rs
@@ -383,4 +383,42 @@ mod tests {
         assert_eq!(dimension_secs("hop-1"), None);
         assert_eq!(dimension_secs(""), None);
     }
+
+    /// The OTLP half of the report is hand-mirrored from `OpReport` into
+    /// `CheckOp`, field by field, inside `run`. Nothing type-checks that the
+    /// mirror is faithful: replacing `seq: op.seq` with `seq: 0` compiles,
+    /// clippy-passes, and leaves every other test in this crate green, because
+    /// the only round-trip test covers the jsonl artifact and not the
+    /// published record.
+    ///
+    /// That is the "manually-mirrored telemetry field" shape in
+    /// `.claude/rules/bug-prevention-patterns.md`, whose prescribed remedy is a
+    /// source-scrape pin in the emitting module. `seq` in particular has no
+    /// second source: every record of a run is published with the same
+    /// timestamp, so a zeroed `seq` loses the run's order with no error
+    /// anywhere.
+    #[test]
+    fn the_published_record_mirrors_the_reports_seq_and_errors_ignored() {
+        let src = include_str!("emit.rs");
+        let tests_at = src
+            .find("\n#[cfg(test)]\nmod ")
+            .map(|i| i + 1)
+            .expect("test module not located — this guard cannot verify anything");
+        let at = src
+            .find("pub async fn run(args: EmitArgs) -> Result<bool> {")
+            .expect("emit::run not found");
+        assert!(
+            at < tests_at,
+            "anchor matched inside the test module — this pin would scrape its own source"
+        );
+        let body = &src[at..tests_at];
+        for mirror in ["seq: op.seq,", "errors_ignored: op.errors_ignored,"] {
+            assert!(
+                body.contains(mirror),
+                "`{mirror}` is gone from the CheckOp built in `run`. The published record no \
+                 longer carries what the report recorded, and no other test in this crate can \
+                 tell: substituting a literal for either field is invisible to all of them."
+            );
+        }
+    }
 }

--- a/crates/netcheck/src/report.rs
+++ b/crates/netcheck/src/report.rs
@@ -54,6 +54,18 @@ impl RunMeta {
 
 #[derive(Serialize, Deserialize)]
 pub struct OpReport {
+    /// 0-based position in the order the run actually executed.
+    ///
+    /// The GET order is shuffled per run, so position is no longer a
+    /// deterministic function of `age` and survives nowhere else: every record
+    /// is emitted with the same timestamp, and line order is lost once the
+    /// report is parsed. Without this field the shuffle only destroys the
+    /// age/position information it was meant to disentangle.
+    ///
+    /// Assigned by [`Report::push`], never by the caller — see
+    /// [`Report::SEQ_ASSIGNED_ON_PUSH`].
+    #[serde(default)]
+    pub seq: usize,
     pub op: String,
     /// What was read: "0h" for this run's own contracts, otherwise the
     /// retention window of the run that published them.
@@ -63,6 +75,12 @@ pub struct OpReport {
     pub ok: bool,
     pub latency_ms: u128,
     pub size: usize,
+    /// How many incoming errors this operation attributed to another contract
+    /// and skipped. Always emitted, including as zero: "no stale error arrived
+    /// during this op" is a measurement, and a missing field would be
+    /// indistinguishable from a run that never counted.
+    #[serde(default)]
+    pub errors_ignored: usize,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
 }
@@ -97,9 +115,19 @@ pub struct Report {
 }
 
 impl Report {
+    /// Placeholder for [`OpReport::seq`] at construction sites: [`Report::push`]
+    /// overwrites it with the record's real position.
+    ///
+    /// Position is stamped by the recorder rather than passed in by the caller,
+    /// so it cannot drift from the order the run actually executed — the same
+    /// reason a filter's own count must come from the filter and not from
+    /// arithmetic at the call site.
+    pub const SEQ_ASSIGNED_ON_PUSH: usize = 0;
+
     /// Record an operation and print its line as it happens, so a run that
     /// dies half way still leaves the operations it completed.
-    pub fn push(&mut self, op: OpReport) {
+    pub fn push(&mut self, mut op: OpReport) {
+        op.seq = self.ops.len();
         print_line(op_line(&op), "report");
         if !op.ok {
             eprintln!(
@@ -135,6 +163,45 @@ impl Report {
             total - failed,
             total,
             if failed > 0 { ", FAILURES PRESENT" } else { "" }
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn op(label: &str, seq: usize) -> OpReport {
+        OpReport {
+            seq,
+            op: "get".to_string(),
+            age: "0h".to_string(),
+            label: label.to_string(),
+            key: "abc123".to_string(),
+            ok: true,
+            latency_ms: 1,
+            size: 1,
+            errors_ignored: 0,
+            error: None,
+        }
+    }
+
+    #[test]
+    fn every_record_carries_its_position_in_the_run() {
+        // The whole point of the field: an analysis asking "did this fail
+        // because it was late in the run?" needs the position of each record,
+        // and the shuffled GET order means it can no longer be inferred from
+        // the age. Seeded deliberately wrong here, because a caller that
+        // passes the wrong index must not be able to publish it.
+        let mut report = Report::default();
+        report.push(op("small-0", 99));
+        report.push(op("small-1", 99));
+        report.push(op("small-2", 99));
+
+        assert_eq!(
+            report.ops().iter().map(|o| o.seq).collect::<Vec<_>>(),
+            vec![0, 1, 2],
+            "position must be stamped by the recorder, in the order records arrive"
         );
     }
 }

--- a/crates/netcheck/src/report.rs
+++ b/crates/netcheck/src/report.rs
@@ -19,6 +19,19 @@ pub struct RunMeta {
     pub pinned_gateways: Vec<String>,
     pub ephemeral_peers: Vec<String>,
     pub duration_ms: u128,
+    /// Seed the run's operation order was shuffled from, derived from
+    /// `run_id`.
+    ///
+    /// In the artifact rather than only on stderr because the uploaded
+    /// artifact is stdout, and because this records a METHODOLOGY change:
+    /// before the shuffle, every 0h GET ran in the first few slots right after
+    /// settle, and afterwards a 0h GET can be the run's last operation minutes
+    /// later. Success rates either side of that change are not comparable, and
+    /// a longitudinal metric whose method changed silently is how a reporting
+    /// artefact gets read as a network event. A run with no seed recorded is a
+    /// run from before the shuffle.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub order_seed: Option<u64>,
 }
 
 #[derive(Serialize)]
@@ -44,6 +57,7 @@ impl RunMeta {
             pinned_gateways,
             ephemeral_peers: Vec::new(),
             duration_ms: 0,
+            order_seed: None,
         }
     }
 

--- a/crates/netcheck/src/report.rs
+++ b/crates/netcheck/src/report.rs
@@ -114,6 +114,13 @@ impl Report {
         self.ops.push(op);
     }
 
+    /// The operations recorded so far, in the order they ran. Exists so a test
+    /// can read back what was recorded; the run itself only ever writes.
+    #[cfg(test)]
+    pub fn ops(&self) -> &[OpReport] {
+        &self.ops
+    }
+
     /// Whether every recorded operation succeeded.
     pub fn all_ok(&self) -> bool {
         self.ops.iter().all(|o| o.ok)

--- a/crates/netcheck/src/report.rs
+++ b/crates/netcheck/src/report.rs
@@ -76,9 +76,16 @@ pub struct OpReport {
     pub latency_ms: u128,
     pub size: usize,
     /// How many incoming errors this operation attributed to another contract
-    /// and skipped. Always emitted, including as zero: "no stale error arrived
-    /// during this op" is a measurement, and a missing field would be
-    /// indistinguishable from a run that never counted.
+    /// and skipped. Always emitted, including as zero, because a missing field
+    /// would be indistinguishable from a run that never counted.
+    ///
+    /// Precisely: errors the key filter skipped inside this op's own wait
+    /// window. Errors that arrive in the gap BETWEEN ops are discarded by
+    /// `client::drain_stray_responses` before the window opens; those are
+    /// logged to stderr and are deliberately not counted here, because they
+    /// are a different event (an unfiltered pre-op drain, not a filtering
+    /// decision this op made). So a zero means "the filter did not fire
+    /// during this op", not "no stale error existed anywhere near it".
     #[serde(default)]
     pub errors_ignored: usize,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/netcheck/src/scenarios/put_get.rs
+++ b/crates/netcheck/src/scenarios/put_get.rs
@@ -52,13 +52,33 @@ pub async fn run(args: PutGetArgs) -> Result<bool> {
     );
 
     let mut report = Report::default();
+    let seed = interleave_seed(&run_id);
+    meta.order_seed = Some(seed);
 
     // ---- PUT phase, via the existing gateway ----
+    //
+    // Shuffled for the same reason the GET phase is. `build_run_contracts`
+    // appends `large-1MB` after the smalls, so issuing them in vector order
+    // put the only large contract last every single night: "the 1 MB PUT
+    // failed" and "the last PUT failed" were one variable, which is the
+    // age/position confound again on the size axis. Fixing one phase and not
+    // the other would leave the report unable to answer the size question
+    // while claiming to have fixed the ordering problem.
+    let mut put_order: Vec<&contracts::RunContract> = run_contracts.iter().collect();
+    interleave(&mut put_order, seed);
+    eprintln!(
+        "PUT order for this run (interleave seed {seed}): {:?}",
+        put_order
+            .iter()
+            .map(|c| c.label.as_str())
+            .collect::<Vec<_>>()
+    );
+
     let mut gw = client::connect(&args.gateway_ws, Duration::from_secs(15))
         .await
         .context("connecting to gateway ws api")?;
     let mut put_ok: Vec<&contracts::RunContract> = Vec::new();
-    for c in &run_contracts {
+    for c in put_order {
         let key = c.contract.key();
         let attempt = client::put(
             &mut gw,
@@ -149,7 +169,6 @@ pub async fn run(args: PutGetArgs) -> Result<bool> {
             });
         }
     }
-    let seed = interleave_seed(&run_id);
     interleave(&mut ops, seed);
     eprintln!(
         "GET order for this run (interleave seed {seed}, derived from run id {run_id}): {:?}",
@@ -265,7 +284,14 @@ fn interleave<T>(ops: &mut [T], seed: u64) {
     use rand::SeedableRng;
     use rand::seq::SliceRandom;
 
-    let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+    // `ChaCha8Rng`, not `StdRng`. `rand` documents `StdRng`'s algorithm as
+    // explicitly NOT reproducible across versions, so a dependabot bump would
+    // silently invalidate every historical replay while
+    // `the_order_is_reproducible_from_the_run_id` kept passing -- it only
+    // compares one build against itself. `rand_chacha` carries a portability
+    // guarantee, which is what makes the claim on `interleave_seed` true
+    // rather than merely intended.
+    let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed);
     ops.shuffle(&mut rng);
 }
 
@@ -511,6 +537,31 @@ mod tests {
         assert_eq!(report.ops().last().expect("one op").errors_ignored, 2);
     }
 
+    /// Split `body` at a call that is actually executed.
+    ///
+    /// `split_once` on the call text alone is not enough: commenting the call
+    /// out leaves the string in place, so the pin passes while the call is
+    /// gone. That is the same vacuity `fn_body` guards against one level up,
+    /// and it was reachable here — verified by commenting the call out and
+    /// watching the pin stay green. Requiring the call to begin its line, after
+    /// nothing but whitespace, is what makes deleting or disabling it fail.
+    fn split_at_call<'a>(body: &'a str, call: &str) -> (&'a str, &'a str) {
+        let at = body
+            .match_indices(call)
+            .find(|(i, _)| {
+                let line_start = body[..*i].rfind('\n').map_or(0, |n| n + 1);
+                body[line_start..*i].trim().is_empty()
+            })
+            .map(|(i, _)| i)
+            .unwrap_or_else(|| {
+                panic!(
+                    "`{call}` is not called at statement position in this function — it is \
+                     missing, or commented out, or buried inside another expression"
+                )
+            });
+        (&body[..at], &body[at + call.len()..])
+    }
+
     /// The body of a column-0 free function, bounded to that function.
     ///
     /// Copied from `commands::auto_update`, which carries the incident this
@@ -557,9 +608,7 @@ mod tests {
             include_str!("put_get.rs"),
             "pub async fn run(args: PutGetArgs) -> Result<bool> {",
         );
-        let (before, after) = body
-            .split_once("interleave(&mut ops, seed);")
-            .expect("run() must shuffle the op list it is about to issue");
+        let (before, after) = split_at_call(body, "interleave(&mut ops, seed);");
 
         assert!(
             before.contains("for c in &put_ok {"),
@@ -573,6 +622,46 @@ mod tests {
         assert!(
             after.contains("for op in &ops {"),
             "the GETs must be issued after the shuffle, or it changed nothing"
+        );
+    }
+
+    /// The PUT phase has the same confound on the size axis and needs the same
+    /// call-site pin, for the same reason: shuffling a synthetic vector in a
+    /// unit test says nothing about what `run` actually issues.
+    #[test]
+    fn the_run_shuffles_the_puts_so_the_large_contract_is_not_always_last() {
+        let body = fn_body(
+            include_str!("put_get.rs"),
+            "pub async fn run(args: PutGetArgs) -> Result<bool> {",
+        );
+        let (before, after) = split_at_call(body, "interleave(&mut put_order, seed);");
+
+        assert!(
+            before.contains("let mut put_order: Vec<&contracts::RunContract> ="),
+            "the shuffle must come after the PUT order is collected"
+        );
+        assert!(
+            after.contains("for c in put_order {"),
+            "the PUTs must be issued from the shuffled order, or it changed nothing — \
+             `build_run_contracts` appends `large-1MB` last, so vector order puts the only \
+             large contract at the end of every run and confounds size with position"
+        );
+    }
+
+    #[test]
+    fn the_put_order_is_not_always_the_build_order() {
+        // The property the call-site pin cannot check: that the shuffle
+        // actually moves `large-1MB` off the end across runs.
+        let last: HashSet<&str> = (0..20)
+            .map(|i| {
+                let mut order = vec!["small-0", "small-1", "small-2", "small-3", "large-1MB"];
+                interleave(&mut order, interleave_seed(&format!("2026081{i}-051006")));
+                *order.last().expect("non-empty")
+            })
+            .collect();
+        assert!(
+            last.len() > 1,
+            "the last PUT of a run was always {last:?}; size is still confounded with position"
         );
     }
 }

--- a/crates/netcheck/src/scenarios/put_get.rs
+++ b/crates/netcheck/src/scenarios/put_get.rs
@@ -42,7 +42,7 @@ pub async fn run(args: PutGetArgs) -> Result<bool> {
     let wasm = contracts::compile_contract_wasm(&args.contract_dir)?;
     let run_contracts = contracts::build_run_contracts(&wasm, &run_id, args.small_contracts)?;
     let mut manifest = Manifest::load(&args.manifest)?;
-    let retention: Vec<(&str, &RunRecord)> = manifest.retention_targets(now);
+    let retention: Vec<(&'static str, &RunRecord)> = manifest.retention_targets(now);
     eprintln!(
         "retention targets this run: {:?}",
         retention
@@ -60,38 +60,29 @@ pub async fn run(args: PutGetArgs) -> Result<bool> {
     let mut put_ok: Vec<&contracts::RunContract> = Vec::new();
     for c in &run_contracts {
         let key = c.contract.key();
-        match client::put(
+        // `latency` comes back on both arms: a failed PUT reports the time it
+        // actually took, never the configured timeout.
+        let (outcome, latency) = client::put(
             &mut gw,
             c.contract.clone(),
             c.state.clone(),
             &c.label,
             op_timeout,
         )
-        .await
-        {
-            Ok(latency) => {
-                report.push(OpReport {
-                    op: "put".to_string(),
-                    age: "0h".to_string(),
-                    label: c.label.clone(),
-                    key: key.to_string(),
-                    ok: true,
-                    latency_ms: latency.as_millis(),
-                    size: c.state.as_ref().len(),
-                    error: None,
-                });
-                put_ok.push(c);
-            }
-            Err(e) => report.push(OpReport {
-                op: "put".to_string(),
-                age: "0h".to_string(),
-                label: c.label.clone(),
-                key: key.to_string(),
-                ok: false,
-                latency_ms: op_timeout.as_millis(),
-                size: c.state.as_ref().len(),
-                error: Some(format!("{e:#}")),
-            }),
+        .await;
+        let ok = outcome.is_ok();
+        report.push(OpReport {
+            op: "put".to_string(),
+            age: "0h".to_string(),
+            label: c.label.clone(),
+            key: key.to_string(),
+            ok,
+            latency_ms: latency.as_millis(),
+            size: c.state.as_ref().len(),
+            error: outcome.err().map(|e| format!("{e:#}")),
+        });
+        if ok {
+            put_ok.push(c);
         }
     }
     client::disconnect(&mut gw).await;
@@ -136,12 +127,45 @@ pub async fn run(args: PutGetArgs) -> Result<bool> {
         }
     }
 
-    // Today's contracts: full byte-identity check against what we just PUT.
+    // One sequence covering this run's own contracts and every retention
+    // window, interleaved so age is not the same variable as position in the
+    // run (see `interleave`).
+    let mut ops: Vec<GetOp> = Vec::new();
     for c in &put_ok {
         let key = c.contract.key();
-        let outcome = client::get(&mut peer, *key.id(), &c.label, op_timeout)
-            .await
-            .and_then(|(contract, state, latency)| {
+        ops.push(GetOp {
+            age: "0h",
+            label: c.label.clone(),
+            id: *key.id(),
+            key: key.to_string(),
+            size: c.state.as_ref().len(),
+            verify: Verify::Identity(c),
+        });
+    }
+    for (window, run) in &retention {
+        for rec in &run.contracts {
+            ops.push(GetOp {
+                age: window,
+                label: format!("{}/{}", run.run_id, rec.label),
+                id: rec.id,
+                key: rec.id.to_string(),
+                size: rec.size,
+                verify: Verify::Hash(&rec.state_hash),
+            });
+        }
+    }
+    let seed = interleave_seed(&run_id);
+    interleave(&mut ops, seed);
+    eprintln!(
+        "GET order for this run (interleave seed {seed}, derived from run id {run_id}): {:?}",
+        ops.iter().map(|o| o.age).collect::<Vec<_>>()
+    );
+
+    for op in &ops {
+        // `latency` comes back on both arms; see the PUT loop above.
+        let (outcome, latency) = client::get(&mut peer, op.id, &op.label, op_timeout).await;
+        let outcome = outcome.and_then(|(contract, state)| match op.verify {
+            Verify::Identity(c) => {
                 anyhow::ensure!(
                     contract == c.contract,
                     "returned contract differs from what was PUT"
@@ -152,44 +176,26 @@ pub async fn run(args: PutGetArgs) -> Result<bool> {
                     state.as_ref().len(),
                     c.state.as_ref().len()
                 );
-                Ok(latency)
-            });
+                Ok(())
+            }
+            Verify::Hash(want) => {
+                let hash = blake3::hash(state.as_ref()).to_hex().to_string();
+                anyhow::ensure!(
+                    hash == want,
+                    "state hash mismatch (got {hash}, want {want})"
+                );
+                Ok(())
+            }
+        });
         push_get_report(
             &mut report,
-            "0h",
-            &c.label,
-            key.to_string(),
-            c.state.as_ref().len(),
+            op.age,
+            &op.label,
+            op.key.clone(),
+            op.size,
             outcome,
-            op_timeout,
+            latency,
         );
-    }
-
-    // Previous runs: verify state via the recorded blake3 hash.
-    for (window, run) in &retention {
-        for rec in &run.contracts {
-            let label = format!("{}/{}", run.run_id, rec.label);
-            let outcome = client::get(&mut peer, rec.id, &label, op_timeout)
-                .await
-                .and_then(|(_contract, state, latency)| {
-                    let hash = blake3::hash(state.as_ref()).to_hex().to_string();
-                    anyhow::ensure!(
-                        hash == rec.state_hash,
-                        "state hash mismatch (got {hash}, want {})",
-                        rec.state_hash
-                    );
-                    Ok(latency)
-                });
-            push_get_report(
-                &mut report,
-                window,
-                &label,
-                rec.id.to_string(),
-                rec.size,
-                outcome,
-                op_timeout,
-            );
-        }
     }
 
     client::disconnect(&mut peer).await;
@@ -223,35 +229,203 @@ pub async fn run(args: PutGetArgs) -> Result<bool> {
     Ok(report.all_ok())
 }
 
+/// One GET the run will perform, and how to check what comes back.
+struct GetOp<'a> {
+    age: &'static str,
+    label: String,
+    id: ContractInstanceId,
+    key: String,
+    size: usize,
+    verify: Verify<'a>,
+}
+
+enum Verify<'a> {
+    /// This run's own contract: must come back byte-identical to what was PUT.
+    Identity(&'a contracts::RunContract),
+    /// A previous run's contract: checked against the recorded blake3.
+    Hash(&'a str),
+}
+
+/// Seed for this run's GET ordering, derived from the run id.
+///
+/// Deterministic on purpose: the order is randomised to break the confound
+/// described on [`interleave`], but an order nobody can reproduce trades one
+/// diagnostic problem for another. The seed is logged next to the order it
+/// produced, and re-deriving it from the run id replays that run exactly.
+fn interleave_seed(run_id: &str) -> u64 {
+    let digest = blake3::hash(run_id.as_bytes());
+    let head: [u8; 8] = digest.as_bytes()[..8]
+        .try_into()
+        .expect("blake3 digest is 32 bytes");
+    u64::from_le_bytes(head)
+}
+
+/// Shuffle the GET sequence so the age windows interleave.
+///
+/// The order used to be fixed: this run's 0h contracts, then 24h, then 48h,
+/// then 7d, every night. That made "how old the contract is" and "how late in
+/// the run the GET was issued" the same variable, so a failure clustered at the
+/// end of a run could not be told apart from a failure of the oldest
+/// contracts — which is exactly the question this check exists to answer.
+fn interleave<T>(ops: &mut [T], seed: u64) {
+    use rand::SeedableRng;
+    use rand::seq::SliceRandom;
+
+    let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+    ops.shuffle(&mut rng);
+}
+
+/// Record a GET.
+///
+/// `latency` is what the operation actually took and is used on both arms.
+/// A failure used to report the configured op timeout instead, which looked
+/// like a measurement while being a constant: it made a fast terminal failure
+/// from the node indistinguishable from the client giving up at its deadline.
 fn push_get_report(
     report: &mut Report,
     age: &'static str,
     label: &str,
     key: String,
     size: usize,
-    outcome: Result<Duration>,
-    op_timeout: Duration,
+    outcome: Result<()>,
+    latency: Duration,
 ) {
-    match outcome {
-        Ok(latency) => report.push(OpReport {
-            op: "get".to_string(),
-            age: age.to_string(),
-            label: label.to_string(),
-            key,
-            ok: true,
-            latency_ms: latency.as_millis(),
-            size,
-            error: None,
-        }),
-        Err(e) => report.push(OpReport {
-            op: "get".to_string(),
-            age: age.to_string(),
-            label: label.to_string(),
-            key,
-            ok: false,
-            latency_ms: op_timeout.as_millis(),
-            size,
-            error: Some(format!("{e:#}")),
-        }),
+    report.push(OpReport {
+        op: "get".to_string(),
+        age: age.to_string(),
+        label: label.to_string(),
+        key,
+        ok: outcome.is_ok(),
+        latency_ms: latency.as_millis(),
+        size,
+        error: outcome.err().map(|e| format!("{e:#}")),
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use super::*;
+
+    /// The GET sequence as it was built before interleaving: this run's own
+    /// contracts, then each retention window in `WINDOWS` order. Items are
+    /// unique so a shuffle that drops or duplicates one is visible.
+    fn fixed_sequence() -> Vec<(&'static str, usize)> {
+        let mut ops = Vec::new();
+        for age in ["0h", "24h", "48h", "7d"] {
+            for i in 0..3 {
+                ops.push((age, i));
+            }
+        }
+        ops
+    }
+
+    /// The sequence a run with this id would actually issue.
+    fn sequence_for(run_id: &str) -> Vec<(&'static str, usize)> {
+        let mut ops = fixed_sequence();
+        interleave(&mut ops, interleave_seed(run_id));
+        ops
+    }
+
+    #[test]
+    fn the_get_order_is_not_the_fixed_age_sequence() {
+        assert_ne!(
+            sequence_for("20260811-051006"),
+            fixed_sequence(),
+            "the run must not issue 0h, then 24h, then 48h, then 7d in that order"
+        );
+    }
+
+    #[test]
+    fn the_oldest_contracts_are_not_always_last() {
+        // The confound this fixes: with a fixed order the 7d GETs were always
+        // at the end of every run, so "old contract" and "late in the run"
+        // could not be told apart.
+        let last: HashSet<&str> = (0..20)
+            .map(|i| {
+                sequence_for(&format!("2026081{i}-051006"))
+                    .last()
+                    .expect("sequence is non-empty")
+                    .0
+            })
+            .collect();
+        assert!(
+            last.len() > 1,
+            "the last GET of a run was always the {last:?} bucket across 20 runs; age is still \
+             confounded with position in the run"
+        );
+    }
+
+    #[test]
+    fn interleaving_keeps_every_op_exactly_once() {
+        // A shuffle that silently drops or duplicates an op would trade one
+        // reporting defect for a worse one.
+        let mut want = fixed_sequence();
+        let mut got = sequence_for("20260811-051006");
+        want.sort_unstable();
+        got.sort_unstable();
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    fn the_order_is_reproducible_from_the_run_id() {
+        // Randomness nobody can replay is its own diagnostic problem: the seed
+        // is derived from the run id and logged, so a run can be re-issued in
+        // the order it actually used.
+        assert_eq!(
+            sequence_for("20260811-051006"),
+            sequence_for("20260811-051006")
+        );
+        assert_eq!(
+            interleave_seed("20260811-051006"),
+            interleave_seed("20260811-051006")
+        );
+    }
+
+    #[test]
+    fn different_runs_get_different_orders() {
+        let orders: HashSet<Vec<(&str, usize)>> = (0..20)
+            .map(|i| sequence_for(&format!("2026081{i}-051006")))
+            .collect();
+        assert!(
+            orders.len() > 1,
+            "every run produced the same order; the seed is not reaching the shuffle"
+        );
+    }
+
+    #[test]
+    fn a_failed_get_reports_the_time_it_actually_took() {
+        // The nightly's configured deadline. Before the fix every failure
+        // reported exactly this, whatever it had really taken.
+        let op_timeout = Duration::from_secs(120);
+        let measured = Duration::from_millis(37);
+
+        let mut report = Report::default();
+        push_get_report(
+            &mut report,
+            "7d",
+            "20260730-051006/small-2",
+            "some-key".to_string(),
+            1024,
+            Err(anyhow::anyhow!(
+                "stream assembly: no fragments received within inactivity timeout"
+            )),
+            measured,
+        );
+
+        let op = report.ops().last().expect("one op was recorded");
+        assert!(!op.ok);
+        assert_eq!(
+            op.latency_ms,
+            measured.as_millis(),
+            "a failed op must carry its measured latency"
+        );
+        assert_ne!(
+            op.latency_ms,
+            op_timeout.as_millis(),
+            "reporting the configured timeout makes a fast terminal failure look like the client \
+             giving up at its deadline"
+        );
     }
 }

--- a/crates/netcheck/src/scenarios/put_get.rs
+++ b/crates/netcheck/src/scenarios/put_get.rs
@@ -60,9 +60,7 @@ pub async fn run(args: PutGetArgs) -> Result<bool> {
     let mut put_ok: Vec<&contracts::RunContract> = Vec::new();
     for c in &run_contracts {
         let key = c.contract.key();
-        // `latency` comes back on both arms: a failed PUT reports the time it
-        // actually took, never the configured timeout.
-        let (outcome, latency) = client::put(
+        let attempt = client::put(
             &mut gw,
             c.contract.clone(),
             c.state.clone(),
@@ -70,17 +68,14 @@ pub async fn run(args: PutGetArgs) -> Result<bool> {
             op_timeout,
         )
         .await;
-        let ok = outcome.is_ok();
-        report.push(OpReport {
-            op: "put".to_string(),
-            age: "0h".to_string(),
-            label: c.label.clone(),
-            key: key.to_string(),
-            ok,
-            latency_ms: latency.as_millis(),
-            size: c.state.as_ref().len(),
-            error: outcome.err().map(|e| format!("{e:#}")),
-        });
+        let ok = attempt.outcome.is_ok();
+        push_put_report(
+            &mut report,
+            &c.label,
+            key.to_string(),
+            c.state.as_ref().len(),
+            attempt,
+        );
         if ok {
             put_ok.push(c);
         }
@@ -162,39 +157,38 @@ pub async fn run(args: PutGetArgs) -> Result<bool> {
     );
 
     for op in &ops {
-        // `latency` comes back on both arms; see the PUT loop above.
-        let (outcome, latency) = client::get(&mut peer, op.id, &op.label, op_timeout).await;
-        let outcome = outcome.and_then(|(contract, state)| match op.verify {
-            Verify::Identity(c) => {
-                anyhow::ensure!(
-                    contract == c.contract,
-                    "returned contract differs from what was PUT"
-                );
-                anyhow::ensure!(
-                    state == c.state,
-                    "returned state differs (got {} bytes, want {})",
-                    state.as_ref().len(),
-                    c.state.as_ref().len()
-                );
-                Ok(())
-            }
-            Verify::Hash(want) => {
-                let hash = blake3::hash(state.as_ref()).to_hex().to_string();
-                anyhow::ensure!(
-                    hash == want,
-                    "state hash mismatch (got {hash}, want {want})"
-                );
-                Ok(())
-            }
-        });
+        let attempt = client::get(&mut peer, op.id, &op.label, op_timeout)
+            .await
+            .and_then(|(contract, state)| match op.verify {
+                Verify::Identity(c) => {
+                    anyhow::ensure!(
+                        contract == c.contract,
+                        "returned contract differs from what was PUT"
+                    );
+                    anyhow::ensure!(
+                        state == c.state,
+                        "returned state differs (got {} bytes, want {})",
+                        state.as_ref().len(),
+                        c.state.as_ref().len()
+                    );
+                    Ok(())
+                }
+                Verify::Hash(want) => {
+                    let hash = blake3::hash(state.as_ref()).to_hex().to_string();
+                    anyhow::ensure!(
+                        hash == want,
+                        "state hash mismatch (got {hash}, want {want})"
+                    );
+                    Ok(())
+                }
+            });
         push_get_report(
             &mut report,
             op.age,
             &op.label,
             op.key.clone(),
             op.size,
-            outcome,
-            latency,
+            attempt,
         );
     }
 
@@ -277,28 +271,56 @@ fn interleave<T>(ops: &mut [T], seed: u64) {
 
 /// Record a GET.
 ///
-/// `latency` is what the operation actually took and is used on both arms.
-/// A failure used to report the configured op timeout instead, which looked
-/// like a measurement while being a constant: it made a fast terminal failure
-/// from the node indistinguishable from the client giving up at its deadline.
+/// The latency written is what the operation actually took, on both arms. A
+/// failure used to report the configured op timeout instead, which looked like
+/// a measurement while being a constant: it made a fast terminal failure from
+/// the node indistinguishable from the client giving up at its deadline. The
+/// timeout is deliberately not a parameter here, so no path through this
+/// function can synthesize one.
 fn push_get_report(
     report: &mut Report,
     age: &'static str,
     label: &str,
     key: String,
     size: usize,
-    outcome: Result<()>,
-    latency: Duration,
+    attempt: client::Attempt<()>,
 ) {
     report.push(OpReport {
+        seq: Report::SEQ_ASSIGNED_ON_PUSH,
         op: "get".to_string(),
         age: age.to_string(),
         label: label.to_string(),
         key,
-        ok: outcome.is_ok(),
-        latency_ms: latency.as_millis(),
+        ok: attempt.outcome.is_ok(),
+        latency_ms: attempt.latency.as_millis(),
         size,
-        error: outcome.err().map(|e| format!("{e:#}")),
+        errors_ignored: attempt.errors_ignored,
+        error: attempt.outcome.err().map(|e| format!("{e:#}")),
+    });
+}
+
+/// Record a PUT. Same contract as [`push_get_report`], and for the same
+/// reason: the PUT loop had the identical hardcoded-timeout defect, and its
+/// failures land in the same report with the same field.
+fn push_put_report(
+    report: &mut Report,
+    label: &str,
+    key: String,
+    size: usize,
+    attempt: client::Attempt<()>,
+) {
+    report.push(OpReport {
+        seq: Report::SEQ_ASSIGNED_ON_PUSH,
+        op: "put".to_string(),
+        // Every PUT is this run's own contract, so there is no other age.
+        age: "0h".to_string(),
+        label: label.to_string(),
+        key,
+        ok: attempt.outcome.is_ok(),
+        latency_ms: attempt.latency.as_millis(),
+        size,
+        errors_ignored: attempt.errors_ignored,
+        error: attempt.outcome.err().map(|e| format!("{e:#}")),
     });
 }
 
@@ -394,6 +416,17 @@ mod tests {
         );
     }
 
+    /// A failed operation that took `latency`, as the client would return it.
+    fn failed_after(latency: Duration) -> client::Attempt<()> {
+        client::Attempt {
+            outcome: Err(anyhow::anyhow!(
+                "stream assembly: no fragments received within inactivity timeout"
+            )),
+            latency,
+            errors_ignored: 0,
+        }
+    }
+
     #[test]
     fn a_failed_get_reports_the_time_it_actually_took() {
         // The nightly's configured deadline. Before the fix every failure
@@ -408,10 +441,7 @@ mod tests {
             "20260730-051006/small-2",
             "some-key".to_string(),
             1024,
-            Err(anyhow::anyhow!(
-                "stream assembly: no fragments received within inactivity timeout"
-            )),
-            measured,
+            failed_after(measured),
         );
 
         let op = report.ops().last().expect("one op was recorded");
@@ -426,6 +456,123 @@ mod tests {
             op_timeout.as_millis(),
             "reporting the configured timeout makes a fast terminal failure look like the client \
              giving up at its deadline"
+        );
+    }
+
+    #[test]
+    fn a_failed_put_reports_the_time_it_actually_took() {
+        // The PUT loop had the identical defect. Its failures land in the same
+        // report under the same field, so it needs the same guard.
+        let op_timeout = Duration::from_secs(120);
+        let measured = Duration::from_millis(37);
+
+        let mut report = Report::default();
+        push_put_report(
+            &mut report,
+            "small-2",
+            "some-key".to_string(),
+            1024,
+            failed_after(measured),
+        );
+
+        let op = report.ops().last().expect("one op was recorded");
+        assert!(!op.ok);
+        assert_eq!(
+            op.latency_ms,
+            measured.as_millis(),
+            "a failed PUT must carry its measured latency"
+        );
+        assert_ne!(
+            op.latency_ms,
+            op_timeout.as_millis(),
+            "reporting the configured timeout makes a fast terminal PUT failure look like the \
+             client giving up at its deadline"
+        );
+    }
+
+    #[test]
+    fn a_report_records_how_many_errors_the_key_filter_absorbed() {
+        // Without this the count reaches stderr only, i.e. the workflow log
+        // rather than the artifact people analyse: "was there a stale error
+        // during this run?" becomes unanswerable from `last-run.jsonl`.
+        let mut report = Report::default();
+        push_get_report(
+            &mut report,
+            "0h",
+            "small-0",
+            "some-key".to_string(),
+            1024,
+            client::Attempt {
+                outcome: Ok(()),
+                latency: Duration::from_millis(12),
+                errors_ignored: 2,
+            },
+        );
+        assert_eq!(report.ops().last().expect("one op").errors_ignored, 2);
+    }
+
+    /// The body of a column-0 free function, bounded to that function.
+    ///
+    /// Copied from `commands::auto_update`, which carries the incident this
+    /// exists for (#5102): a bare `split_once` on a moved anchor does not fail,
+    /// it matches a later occurrence — usually the pin's own assertion string —
+    /// and the pin then passes vacuously under a name that says it is covered.
+    fn fn_body<'a>(src: &'a str, signature: &str) -> &'a str {
+        let at = src
+            .find(signature)
+            .unwrap_or_else(|| panic!("definition not found: {signature}"));
+        let tests_at = src
+            .find("\n#[cfg(test)]\nmod ")
+            .map(|i| i + 1)
+            .expect("test module not located — this guard cannot verify anything");
+        assert!(
+            at < tests_at,
+            "`{signature}` matched inside the test module — this pin is scraping its own source \
+             and would pass vacuously"
+        );
+        assert!(
+            at == 0 || src.as_bytes()[at - 1] == b'\n',
+            "fn_body only supports column-0 free functions; `{signature}` is indented (a \
+             method?), where the `\\n}}\\n` end-anchor would slice to the end of the enclosing impl"
+        );
+        let after = &src[at + signature.len()..];
+        let (body, _) = after
+            .split_once("\n}\n")
+            .unwrap_or_else(|| panic!("could not locate end of: {signature}"));
+        assert!(
+            !body.contains("\n#[cfg(test)]\nmod "),
+            "scoped region for `{signature}` escaped into the test module — this pin would pass \
+             vacuously"
+        );
+        body
+    }
+
+    #[test]
+    fn the_run_shuffles_the_real_op_list_after_both_loops_have_filled_it() {
+        // Every other ordering test drives `interleave` against a synthetic
+        // vector, which says nothing about the call site. Moving the call three
+        // lines up — above the retention loop — restores the exact confound
+        // this change removes, every night, with tests and clippy green.
+        let body = fn_body(
+            include_str!("put_get.rs"),
+            "pub async fn run(args: PutGetArgs) -> Result<bool> {",
+        );
+        let (before, after) = body
+            .split_once("interleave(&mut ops, seed);")
+            .expect("run() must shuffle the op list it is about to issue");
+
+        assert!(
+            before.contains("for c in &put_ok {"),
+            "the shuffle must come after this run's own contracts are added, or they are not in it"
+        );
+        assert!(
+            before.contains("for (window, run) in &retention {"),
+            "the shuffle must come after the retention windows are added, or the oldest contracts \
+             are back at the end of every run — the confound this exists to remove"
+        );
+        assert!(
+            after.contains("for op in &ops {"),
+            "the GETs must be issued after the shuffle, or it changed nothing"
         );
     }
 }

--- a/crates/netcheck/src/scenarios/put_get.rs
+++ b/crates/netcheck/src/scenarios/put_get.rs
@@ -264,7 +264,11 @@ enum Verify<'a> {
 /// Deterministic on purpose: the order is randomised to break the confound
 /// described on [`interleave`], but an order nobody can reproduce trades one
 /// diagnostic problem for another. The seed is logged next to the order it
-/// produced, and re-deriving it from the run id replays that run exactly.
+/// produced, and re-deriving it from the run id replays that run exactly --
+/// on any `rand` version, because [`interleave`] pins the generator, the seed
+/// expansion, and the shuffle algorithm rather than inheriting any of them.
+/// (The permutation still depends on how many ops the run had, which varies
+/// with which retention windows the manifest had populated.)
 fn interleave_seed(run_id: &str) -> u64 {
     let digest = blake3::hash(run_id.as_bytes());
     let head: [u8; 8] = digest.as_bytes()[..8]
@@ -281,18 +285,42 @@ fn interleave_seed(run_id: &str) -> u64 {
 /// end of a run could not be told apart from a failure of the oldest
 /// contracts — which is exactly the question this check exists to answer.
 fn interleave<T>(ops: &mut [T], seed: u64) {
-    use rand::SeedableRng;
-    use rand::seq::SliceRandom;
+    use rand::RngCore;
 
-    // `ChaCha8Rng`, not `StdRng`. `rand` documents `StdRng`'s algorithm as
-    // explicitly NOT reproducible across versions, so a dependabot bump would
-    // silently invalidate every historical replay while
-    // `the_order_is_reproducible_from_the_run_id` kept passing -- it only
-    // compares one build against itself. `rand_chacha` carries a portability
-    // guarantee, which is what makes the claim on `interleave_seed` true
-    // rather than merely intended.
-    let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed);
-    ops.shuffle(&mut rng);
+    // Everything the permutation depends on is pinned here on purpose, because
+    // a replay that is only usually reproducible is not reproducible.
+    //
+    // Three separate things in the `rand` stack are version-unstable, and
+    // fixing one of them is not enough:
+    //
+    //  1. `StdRng`'s algorithm. Documented as NOT stable across releases. This
+    //     is why the generator below is `ChaCha8Rng` from `rand_chacha`, which
+    //     carries a portability guarantee.
+    //  2. `SeedableRng::seed_from_u64`. It is `rand_core`'s DEFAULT expansion,
+    //     not a ChaCha guarantee, and its own doc calls changing it merely
+    //     "a value-breaking change" -- a convention, not a promise. So the
+    //     seed bytes are built here rather than expanded by it.
+    //  3. `SliceRandom::shuffle`. This is the one that is easy to miss: the
+    //     algorithm lives in `rand`, not in the generator, and it changed
+    //     between 0.8 and 0.9 (reverse Fisher-Yates with `gen_index`, vs. a
+    //     forward pass driven by `IncreasingUniform`). Same seed, same
+    //     byte-identical ChaCha stream, different permutation. So the shuffle
+    //     is written out below rather than delegated.
+    //
+    // Every one of those would break replay silently while
+    // `the_order_is_reproducible_from_the_run_id` stayed green, since that test
+    // only compares one build against itself.
+    let mut seed_bytes = [0u8; 32];
+    seed_bytes[..8].copy_from_slice(&seed.to_le_bytes());
+    let mut rng = <rand_chacha::ChaCha8Rng as rand::SeedableRng>::from_seed(seed_bytes);
+
+    // Fisher-Yates. The modulo bias is bounded by `len / 2^64` and `len` here
+    // is at most a few dozen ops, so it is many orders of magnitude below the
+    // point where it could shape a diagnosis.
+    for i in (1..ops.len()).rev() {
+        let j = (rng.next_u64() % (i as u64 + 1)) as usize;
+        ops.swap(i, j);
+    }
 }
 
 /// Record a GET.


### PR DESCRIPTION
## Problem

`crates/netcheck` is the nightly synthetic check against the live network. It has been failing every night since 2026-07-30, and while using its report to diagnose those failures we found three defects in the harness's own reporting. They are not network bugs — they are the reason the report cannot support conclusions drawn from it.

**1. Deterministic op ordering confounded contract age with position-in-run.** `manifest.rs::retention_targets` walks a fixed `WINDOWS` const, and `put_get.rs` processed this run's 0h contracts first and then the windows in that order. Every run, deterministically: 0h GETs first, 7d GETs last. Observed failures cluster toward the end of each run's op sequence, so "old contracts fail" and "later ops fail" were the *same variable* and could not be told apart — which is precisely the question the harness is used to answer.

**2. `latency_ms` was a constant on failure.** Every failed op reported exactly the configured `op_timeout` (120000 ms), including ops whose `error` field shows the node returned a specific terminal error well before the client's deadline. This is worse than an absent field: it looks like a measurement. It made "the client gave up waiting" and "the server failed fast" indistinguishable from the field designed to draw that distinction.

**3. The error arm was not key-filtered.** `client.rs` correctly skips *successful* responses carrying another contract's key, but the `Err` arm bailed on the first error seen regardless of provenance. A late error from an already-timed-out, already-reported op got attributed to whatever op was next in flight, with the wrong contract's key baked into the reported error text. Confirmed in GH Actions runs 31073282100 (2026-08-06) and 31148314225 (2026-08-07), where a `7d` FAIL line carries the key of the *preceding* FAIL line. Scope of the *defect*, precisely: it corrupts error **text** only. It does not affect `ok`/fail classification or op counts by size/age/label. **The fix does** — see "What this changes about the nightly's numbers" below. An earlier revision of this description carried the defect's scope sentence over to the fix, which was wrong.

## Approach

**Ordering.** The GET phase now builds one `Vec<GetOp>` covering this run's contracts and every retention window (each carrying how to verify what comes back — byte-identity for this run's own, recorded blake3 for previous runs'), then shuffles it before issuing anything.

Shuffle rather than round-robin, because round-robin over windows of unequal length still leaves systematic structure (the longest window trails the tail of every run). The shuffle is seeded from `blake3(run_id)` and the seed is logged next to the order it produced: randomness nobody can replay would trade one diagnostic problem for another, and a run needs to be reproducible from its own report.

**Latency.** `client::put`/`client::get` now return an `Attempt<T>` — the outcome, the measured elapsed time, and the count of errors skipped by the key filter, travelling together — measured on both arms, and both report sites use it. Returning the duration outside the `Result` is deliberate: it removes the code path where a constant could be substituted for a measurement, rather than relying on a future editor remembering to measure the error path.

**Key filter.** The recv-loop match body is extracted into `classify_put` / `classify_get`, returning `Done` / `Ignore` / `Fatal`. Errors that name a contract (`ContractError::{Get,Put,Update,Subscribe,...}`, `ErrorKind::IncorrectState`) are now filtered by key exactly as responses are.

Structured key fields alone would not have made the filter fire in production, though. The shape a terminal *network* failure actually arrives in is `ErrorKind::OperationError { cause }`, which has no key field and writes the id into the prose. So the filter also extracts contract ids from free text, guarded so an English word cannot become an id: a token must be 32..=44 base58 characters **and** round-trip (decode then re-encode must reproduce it exactly, since `from_base58` zero-pads short input). Anything failing those guards is simply not found, which leaves the error unattributed and therefore fatal — the conservative direction. Errors that name **no** contract keep the old conservative behaviour and still fail the waiting op — silently ignoring a disconnect would hang the op until its deadline. Extracting the classifier also makes the decision testable without a live node.

## Testing

Every fix has a test that was verified RED by mutating the fix away, not merely observed green:

| Mutation applied | Tests that went RED |
|---|---|
| `interleave` made a no-op | `the_get_order_is_not_the_fixed_age_sequence` ("must not issue 0h, then 24h, then 48h, then 7d"), `the_oldest_contracts_are_not_always_last` (`the last GET of a run was always the {"7d"} bucket across 20 runs`), `different_runs_get_different_orders` |
| `push_get_report` hardcodes 120 s on failure | `a_failed_get_reports_the_time_it_actually_took` (left: 120000, right: 37) |
| `client::get` returns `timeout` on the error arm | `a_fast_failure_reports_the_time_it_took_not_the_op_timeout` |
| `classify_get`'s `Err` arm loses its key check | `an_error_naming_another_contract_is_ignored_not_attributed`, `a_late_error_during_a_get_does_not_fail_that_get` — both fail with the wrong contract's key in the message, reproducing the exact log signature from runs 31073282100 / 31148314225 |
| `classify_put`'s `Err` arm loses its key check | `put_errors_are_key_filtered_the_same_way` |

Two of the key-filter tests run end to end against an in-process fake node (a localhost websocket speaking the same bincode `HostResult` frames the real node does), so the race is exercised through `client::get`'s actual loop: a stale error for another contract arrives inside the wait window, ahead of this op's own response, and the GET still succeeds.

The ordering tests also pin the properties a shuffle could quietly break — `interleaving_keeps_every_op_exactly_once` (no dropped or duplicated ops) and `the_order_is_reproducible_from_the_run_id`. Neither goes red under the no-op mutation, correctly: they guard the fix, they do not detect the bug.

27 tests pass; `cargo fmt --all --check` and `cargo clippy -p netcheck --all-targets -- -D warnings` are clean. No existing test was changed or removed.

## What this changes about the nightly's numbers

Read this before interpreting the first post-merge run.

The key filter changes `ok` classification, not just error text. Where a stale error from an
already-timed-out op previously killed the *next* op too, that op now keeps waiting and can
succeed. `a_late_error_during_a_get_does_not_fail_that_get` exists to assert exactly that.

So **the failed-op count can drop, and that drop is not a network improvement.** It is main
having double-counted a single genuine failure as two: the op that actually timed out, plus
the innocent op that inherited its error. The new count is the honest one. On a check that
has been red every night since 2026-07-30, a number moving in the good direction for a
reporting reason has to be declared, or it will be read as a recovery.

Second-order effect: an op that a stale error used to kill immediately now runs to its full
`--op-timeout-secs` (120 s default). Runs on a bad night get slower and will sit nearer the
workflow's 45-minute ceiling, which was already sized for 4 PUTs plus up to 16 GETs.

## Not covered

The issue's fix note for defect 3 mentions correlating on a transaction id as an alternative. The client API surfaces no tx id on errors, so this filters on the contract key. Errors that name no contract at all (`ChannelClosed`, `Disconnect`, `FailedOperation`, `NodeUnavailable`) remain unattributable and still fail whichever op is waiting — that residue is unchanged and cannot be closed without a protocol change.

`errors_ignored` counts only what the key filter skipped inside an op's own wait window. Errors arriving in the gap *between* ops are discarded by `drain_stray_responses` before the window opens; they are logged to stderr but not counted, because an unfiltered pre-op drain is a different event from a filtering decision an op made. The field's rustdoc says so, so a zero is not read as "no stale error existed anywhere near this op".

**`seq` and `errors_ignored` do not reach the telemetry dashboard yet.** `netcheck emit` publishes both, but the ingest writes a fixed column list (`insert_check_op`) that has no column for either, so it drops them without erroring. The jsonl artifact carries them, and that is where run order and skipped-error counts have to be read until the `check_ops` table gains the columns. Worth stating plainly because `seq` exists precisely so the shuffle would not destroy ordering information: in the jsonl it does its job, in the DB the ordering that used to be recoverable from the fixed `age` sequence is now recoverable from nothing. Noted in the README too, and filed as freenet/freenet-telemetry-dashboard#21.

None of this explains the live-network GET failures netcheck has been reporting nightly. That investigation is separate; this only makes the report trustworthy enough to run it.

## Review

Full-tier review (transport/diagnostics surface), four independent blind Claude lenses:
code-first, testing, skeptical, big-picture. Findings addressed in-branch:

- The description denied an `ok`-classification change the PR's own test pins — corrected
  above, no code change.
- `CONTRACT_ID_B58_LEN`'s upper bound was unpinned: every id in the tests encodes to 43
  base58 characters, so narrowing the range to `32..=43` left the whole suite green while
  silently dropping every id at or above 58^43 (~6% of the id space) out of attribution.
  Added `id_of(255)` — the all-ones id, 44 characters — as a positive case.
- The OTLP record hand-mirrors `seq` and `errors_ignored` from `OpReport` into `CheckOp`, and
  substituting a literal for either was invisible to every test. Added a source-scrape pin in
  `emit.rs`, the remedy `.claude/rules/bug-prevention-patterns.md` prescribes for
  manually-mirrored telemetry fields, with the same anti-vacuity guard the crate's `fn_body`
  helper uses.
- `errors_ignored`'s rustdoc overclaimed what a zero means, given `drain_stray_responses`
  discards pre-op errors uncounted. Tightened to state the window it actually measures.
- README documents `seq` and `errors_ignored`, no longer overstates replayability from the
  seed alone, and records the dashboard-ingest gap.
- A misleading assertion comment (a "one character longer" token that is in fact inside the
  length bound and rejected by the round-trip) corrected.

Closes #5266

[AI-assisted - Claude]

